### PR TITLE
fix: write notify config as TOML string (issue #7)

### DIFF
--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mergeConfig } from '../generator.js';
+
+describe('config generator notify', () => {
+  it('writes notify as a TOML string (not an array)', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.match(toml, /^notify = ".*"$/m);
+      assert.doesNotMatch(toml, /^notify = \[/m);
+      assert.match(toml, /notify = "node /);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('quotes notify hook path so spaces are preserved', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'omx config gen space-'));
+    // Add a space in the pkgRoot path itself.
+    const wd = join(base, 'pkg root');
+    try {
+      await mkdir(wd, { recursive: true });
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, 'utf-8');
+
+      const m = toml.match(/^notify = "(.*)"$/m);
+      assert.ok(m, 'notify string not found');
+
+      const notify = m[1];
+      assert.match(notify, /^node /);
+      // The path part should be quoted inside the command string.
+      assert.ok(notify.startsWith('node \\"'));
+      assert.ok(notify.endsWith('notify-hook.js\\"'));
+      assert.match(notify, /pkg root/);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -20,6 +20,7 @@ function getOmxConfigBlock(pkgRoot: string): string {
   const codeIntelServerPath = join(pkgRoot, 'dist', 'mcp', 'code-intel-server.js');
   const traceServerPath = join(pkgRoot, 'dist', 'mcp', 'trace-server.js');
   const notifyHookPath = join(pkgRoot, 'scripts', 'notify-hook.js');
+  const notifyCommand = `node "${notifyHookPath}"`.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
   return [
     '',
@@ -32,7 +33,7 @@ function getOmxConfigBlock(pkgRoot: string): string {
     `developer_instructions = "You have oh-my-codex installed. Use /prompts:architect, /prompts:executor, /prompts:planner for specialized agent roles. Workflow skills via $name: $ralph, $autopilot, $plan. AGENTS.md is your orchestration brain."`,
     '',
     '# Notification hook - fires after each agent turn',
-    `notify = ["node", "${notifyHookPath}"]`,
+    `notify = "${notifyCommand}"`,
     '',
     '# Feature flags for sub-agent orchestration',
     '[features]',


### PR DESCRIPTION
## Summary
- fix config generation to emit `notify` as a TOML string instead of an array
- escape and quote notify command so hook paths with spaces remain valid
- add regression tests for string format and space-containing paths

## Verification
- `npm run build`
- `npm test` (55 passed, 0 failed)
- lsp diagnostics: 0 errors in modified files

Closes #7