### PR TITLE
fix(hooks): fallback watcher + tmux hook test

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ omx --yolo    # Launch Codex with low-friction execution flags
 omx --madmax  # Launch Codex with full approval+sandbox bypass (dangerous)
 omx setup     # Install and configure OMX
 omx doctor    # Run 9 installation health checks
-omx tmux-hook # Manage tmux prompt-injection workaround (init/status/validate)
+omx tmux-hook # Manage tmux prompt-injection workaround (init/status/validate/test)
 omx status    # Show active mode state
 omx cancel    # Cancel active execution modes
 omx hud       # Show HUD statusline (--watch, --json, --preset=NAME)
@@ -251,9 +251,19 @@ Validate tmux target:
 omx tmux-hook validate
 ```
 
+Run an end-to-end synthetic hook turn:
+
+```bash
+omx tmux-hook test
+```
+
 Config file: `.omx/tmux-hook.json`  
 Runtime state: `.omx/state/tmux-hook-state.json`  
 Structured logs: `.omx/logs/tmux-hook-YYYY-MM-DD.jsonl`
+
+Compatibility note:
+- OMX writes `notify` as a TOML array by default.
+- Override with `OMX_NOTIFY_FORMAT=string` before `omx setup` for environments that require string notify syntax.
 
 ## Setup Details
 

--- a/scripts/notify-fallback-watcher.js
+++ b/scripts/notify-fallback-watcher.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'fs';
+import { appendFile, mkdir, readFile, readdir, stat, writeFile } from 'fs/promises';
+import { spawnSync } from 'child_process';
+import { dirname, join, resolve } from 'path';
+import { homedir } from 'os';
+
+function argValue(name, fallback = '') {
+  const idx = process.argv.indexOf(name);
+  if (idx < 0 || idx + 1 >= process.argv.length) return fallback;
+  return process.argv[idx + 1];
+}
+
+const cwd = resolve(argValue('--cwd', process.cwd()));
+const notifyScript = resolve(argValue('--notify-script', join(cwd, 'scripts', 'notify-hook.js')));
+const pollMs = Number(argValue('--poll-ms', '700')) || 700;
+const runOnce = process.argv.includes('--once');
+const startedAt = Date.now();
+const fileWindowMs = runOnce ? 15000 : 30000;
+
+const omxDir = join(cwd, '.omx');
+const logsDir = join(omxDir, 'logs');
+const stateDir = join(omxDir, 'state');
+const statePath = join(stateDir, 'notify-fallback-state.json');
+const logPath = join(logsDir, `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+const fileState = new Map();
+const seenTurnKeys = new Set();
+let stopping = false;
+
+function safeString(v) {
+  return typeof v === 'string' ? v : '';
+}
+
+function eventLog(event) {
+  return appendFile(logPath, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
+}
+
+function sessionDirs() {
+  const now = new Date();
+  const today = join(
+    homedir(),
+    '.codex',
+    'sessions',
+    String(now.getUTCFullYear()),
+    String(now.getUTCMonth() + 1).padStart(2, '0'),
+    String(now.getUTCDate()).padStart(2, '0')
+  );
+  const yesterdayDate = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const yesterday = join(
+    homedir(),
+    '.codex',
+    'sessions',
+    String(yesterdayDate.getUTCFullYear()),
+    String(yesterdayDate.getUTCMonth() + 1).padStart(2, '0'),
+    String(yesterdayDate.getUTCDate()).padStart(2, '0')
+  );
+  return Array.from(new Set([today, yesterday]));
+}
+
+async function readFirstLine(path) {
+  const content = await readFile(path, 'utf-8');
+  const idx = content.indexOf('\n');
+  return idx >= 0 ? content.slice(0, idx) : content;
+}
+
+function shouldTrackSessionMeta(line) {
+  let parsed;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!parsed || parsed.type !== 'session_meta' || !parsed.payload) return null;
+  const payload = parsed.payload;
+  if (safeString(payload.cwd) !== cwd) return null;
+  const threadId = safeString(payload.id);
+  return threadId || null;
+}
+
+async function discoverRolloutFiles() {
+  const discovered = [];
+  for (const dir of sessionDirs()) {
+    if (!existsSync(dir)) continue;
+    const names = await readdir(dir).catch(() => []);
+    for (const name of names) {
+      if (!name.startsWith('rollout-') || !name.endsWith('.jsonl')) continue;
+      const path = join(dir, name);
+      const st = await stat(path).catch(() => null);
+      if (!st) continue;
+      if (st.mtimeMs < startedAt - fileWindowMs) continue;
+      discovered.push(path);
+    }
+  }
+  discovered.sort();
+  return discovered;
+}
+
+function turnKey(threadId, turnId) {
+  return `${threadId || 'no-thread'}|${turnId || 'no-turn'}`;
+}
+
+function buildNotifyPayload(threadId, turnId, lastMessage) {
+  return {
+    type: 'agent-turn-complete',
+    cwd,
+    'thread-id': threadId,
+    'turn-id': turnId,
+    'input-messages': ['[notify-fallback] synthesized from rollout task_complete'],
+    'last-assistant-message': lastMessage || '',
+    source: 'notify-fallback-watcher',
+  };
+}
+
+async function invokeNotifyHook(payload, filePath) {
+  const result = spawnSync(process.execPath, [notifyScript, JSON.stringify(payload)], {
+    cwd,
+    encoding: 'utf-8',
+  });
+  const ok = result.status === 0;
+  await eventLog({
+    type: 'fallback_notify',
+    ok,
+    thread_id: payload['thread-id'],
+    turn_id: payload['turn-id'],
+    file: filePath,
+    reason: ok ? 'sent' : 'notify_hook_failed',
+    error: ok ? undefined : (result.stderr || result.stdout || '').trim().slice(0, 240),
+  });
+}
+
+async function processLine(meta, line, filePath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  if (!parsed || parsed.type !== 'event_msg' || !parsed.payload) return;
+  if (parsed.payload.type !== 'task_complete') return;
+
+  const turnId = safeString(parsed.payload.turn_id);
+  if (!turnId) return;
+
+  const evtTs = Date.parse(safeString(parsed.timestamp));
+  if (Number.isFinite(evtTs) && evtTs < startedAt - 3000) return;
+
+  const key = turnKey(meta.threadId, turnId);
+  if (seenTurnKeys.has(key)) return;
+  seenTurnKeys.add(key);
+
+  const payload = buildNotifyPayload(
+    meta.threadId,
+    turnId,
+    safeString(parsed.payload.last_agent_message)
+  );
+  await invokeNotifyHook(payload, filePath);
+}
+
+async function ensureTrackedFiles() {
+  const files = await discoverRolloutFiles();
+  for (const path of files) {
+    if (fileState.has(path)) continue;
+    const line = await readFirstLine(path).catch(() => '');
+    const threadId = shouldTrackSessionMeta(line);
+    if (!threadId) continue;
+    const size = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
+    // In streaming mode, tail from current EOF to avoid replaying old events.
+    // In one-shot mode, read from start to catch just-finished turns.
+    const offset = runOnce ? 0 : size;
+    fileState.set(path, { threadId, offset, size, partial: '' });
+  }
+}
+
+async function pollFiles() {
+  for (const [path, meta] of fileState.entries()) {
+    const currentSize = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
+    if (currentSize <= meta.offset) continue;
+    const content = await readFile(path, 'utf-8').catch(() => '');
+    if (!content) continue;
+    const delta = content.slice(meta.offset);
+    meta.offset = currentSize;
+    const merged = meta.partial + delta;
+    const lines = merged.split('\n');
+    meta.partial = lines.pop() || '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      await processLine(meta, line, path);
+    }
+  }
+}
+
+async function writeState() {
+  await mkdir(stateDir, { recursive: true }).catch(() => {});
+  const state = {
+    pid: process.pid,
+    started_at: new Date(startedAt).toISOString(),
+    cwd,
+    notify_script: notifyScript,
+    poll_ms: pollMs,
+    tracked_files: fileState.size,
+    seen_turns: seenTurnKeys.size,
+  };
+  await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
+}
+
+async function tick() {
+  if (stopping) return;
+  await ensureTrackedFiles();
+  await pollFiles();
+  await writeState();
+  setTimeout(tick, pollMs);
+}
+
+function shutdown(signal) {
+  stopping = true;
+  eventLog({ type: 'watcher_stop', signal }).finally(() => process.exit(0));
+}
+
+async function main() {
+  await mkdir(logsDir, { recursive: true }).catch(() => {});
+  await mkdir(stateDir, { recursive: true }).catch(() => {});
+  if (!existsSync(notifyScript)) {
+    await eventLog({ type: 'watcher_error', reason: 'notify_script_missing', notify_script: notifyScript });
+    process.exit(1);
+  }
+
+  await eventLog({
+    type: 'watcher_start',
+    cwd,
+    notify_script: notifyScript,
+    poll_ms: pollMs,
+    once: runOnce,
+  });
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGHUP', () => shutdown('SIGHUP'));
+
+  if (runOnce) {
+    await ensureTrackedFiles();
+    await pollFiles();
+    await writeState();
+    await eventLog({ type: 'watcher_once_complete', seen_turns: seenTurnKeys.size });
+    process.exit(0);
+  }
+
+  await tick();
+}
+
+main().catch(async (err) => {
+  await mkdir(dirname(logPath), { recursive: true }).catch(() => {});
+  await eventLog({
+    type: 'watcher_error',
+    reason: 'fatal',
+    error: err instanceof Error ? err.message : safeString(err),
+  });
+  process.exit(1);
+});

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1,0 +1,177 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+
+async function appendLine(path: string, line: object): Promise<void> {
+  const prev = await readFile(path, 'utf-8');
+  const content = prev + `${JSON.stringify(line)}\n`;
+  await writeFile(path, content);
+}
+
+function todaySessionDir(baseHome: string): string {
+  const now = new Date();
+  return join(
+    baseHome,
+    '.codex',
+    'sessions',
+    String(now.getUTCFullYear()),
+    String(now.getUTCMonth() + 1).padStart(2, '0'),
+    String(now.getUTCDate()).padStart(2, '0')
+  );
+}
+
+async function readLines(path: string): Promise<string[]> {
+  const content = await readFile(path, 'utf-8').catch(() => '');
+  return content.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('notify-fallback watcher', () => {
+  it('one-shot mode forwards only recent task_complete events', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-once-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-home-'));
+    const sid = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const sessionDir = todaySessionDir(tempHome);
+    const rolloutPath = join(sessionDir, `rollout-test-fallback-once-${sid}.jsonl`);
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+
+      const staleIso = new Date(Date.now() - 60_000).toISOString();
+      const freshIso = new Date(Date.now() + 2_000).toISOString();
+      const threadId = `thread-${sid}`;
+      const staleTurn = `turn-stale-${sid}`;
+      const freshTurn = `turn-fresh-${sid}`;
+
+      const lines = [
+        {
+          timestamp: freshIso,
+          type: 'session_meta',
+          payload: { id: threadId, cwd: wd },
+        },
+        {
+          timestamp: staleIso,
+          type: 'event_msg',
+          payload: {
+            type: 'task_complete',
+            turn_id: staleTurn,
+            last_agent_message: 'stale message',
+          },
+        },
+        {
+          timestamp: freshIso,
+          type: 'event_msg',
+          payload: {
+            type: 'task_complete',
+            turn_id: freshTurn,
+            last_agent_message: 'fresh message',
+          },
+        },
+      ];
+      await writeFile(rolloutPath, `${lines.map(v => JSON.stringify(v)).join('\n')}\n`);
+
+      const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env: { ...process.env, HOME: tempHome } }
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const turnLog = join(wd, '.omx', 'logs', `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const turnLines = await readLines(turnLog);
+      assert.equal(turnLines.length, 1);
+      assert.match(turnLines[0], new RegExp(freshTurn));
+      assert.doesNotMatch(turnLines[0], new RegExp(staleTurn));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+      await rm(rolloutPath, { force: true });
+    }
+  });
+
+  it('streaming mode tails from EOF and does not replay backlog', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-stream-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-home-'));
+    const sid = randomUUID();
+    const sessionDir = todaySessionDir(tempHome);
+    const rolloutPath = join(sessionDir, `rollout-test-fallback-stream-${sid}.jsonl`);
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+
+      const nowIso = new Date().toISOString();
+      const threadId = `thread-${sid}`;
+      const oldTurn = `turn-old-${sid}`;
+      const newTurn = `turn-new-${sid}`;
+
+      await writeFile(
+        rolloutPath,
+        `${JSON.stringify({
+          timestamp: nowIso,
+          type: 'session_meta',
+          payload: { id: threadId, cwd: wd },
+        })}\n${
+          JSON.stringify({
+            timestamp: nowIso,
+            type: 'event_msg',
+            payload: {
+              type: 'task_complete',
+              turn_id: oldTurn,
+              last_agent_message: 'old message',
+            },
+          })
+        }\n`
+      );
+
+      const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+      const child = spawn(
+        process.execPath,
+        [watcherScript, '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '75'],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: { ...process.env, HOME: tempHome },
+        }
+      );
+      await sleep(150);
+
+      await appendLine(rolloutPath, {
+        timestamp: new Date(Date.now() + 500).toISOString(),
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: newTurn,
+          last_agent_message: 'new message',
+        },
+      });
+
+      await sleep(500);
+      child.kill('SIGTERM');
+      await sleep(100);
+
+      const turnLog = join(wd, '.omx', 'logs', `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const turnLines = await readLines(turnLog);
+      assert.equal(turnLines.length, 1);
+      assert.match(turnLines[0], new RegExp(newTurn));
+      assert.doesNotMatch(turnLines[0], new RegExp(oldTurn));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+      await rm(rolloutPath, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- Add rollout-based notify fallback watcher (start/stop on launch + one-shot flush at postLaunch)\n- Add  for end-to-end validation\n- Add turn-level notify-hook dedupe to avoid double-processing\n- Add regression tests for fallback watcher (once + streaming tail)\n\n## Verification\n- 
> oh-my-codex@0.2.0 test
> npm run build && node --test dist/**/*.test.js


> oh-my-codex@0.2.0 build
> tsc

▶ normalizeCodexLaunchArgs
  ✔ maps --madmax to codex bypass flag (1.489916ms)
  ✔ does not forward --madmax and preserves other args (0.186449ms)
  ✔ avoids duplicate bypass flags when both are present (0.136002ms)
  ✔ deduplicates repeated bypass-related flags (0.10928ms)
  ✔ leaves unrelated args unchanged (0.10956ms)
✔ normalizeCodexLaunchArgs (3.27488ms)
▶ CLI session-scoped state parity
  ✔ status and cancel include session-scoped states (92.902889ms)
✔ CLI session-scoped state parity (94.280249ms)
▶ generateOverlay
  ✔ generates overlay with no state files (empty but valid) (6.059446ms)
  ✔ generates overlay with active modes (1.60612ms)
  ✔ generates overlay with session-scoped active modes for current session (1.108142ms)
  ✔ generates overlay with notepad priority content (0.828935ms)
  ✔ generates overlay with project memory summary (0.896996ms)
  ✔ enforces size cap (overlay <= 2000 chars) (1.380826ms)
  ✔ skips inactive modes (1.377339ms)
✔ generateOverlay (18.903834ms)
▶ applyOverlay + stripOverlay roundtrip
  ✔ apply then strip restores original (roundtrip) (3.593323ms)
  ✔ applyOverlay is idempotent (apply twice, no duplication) (2.051366ms)
  ✔ handles stale markers from previous session (1.198055ms)
  ✔ stripOverlay is no-op when no overlay exists (1.091008ms)
  ✔ creates AGENTS.md if it does not exist during apply (1.127739ms)
✔ applyOverlay + stripOverlay roundtrip (10.839121ms)
▶ hasOverlay
  ✔ returns true when both markers present (0.116434ms)
  ✔ returns false when no markers (0.058993ms)
  ✔ returns false when only start marker (0.054365ms)
✔ hasOverlay (0.325386ms)
▶ notify-fallback watcher
  ✔ one-shot mode forwards only recent task_complete events (95.470238ms)
  ✔ streaming mode tails from EOF and does not replay backlog (758.59059ms)
✔ notify-fallback watcher (855.075019ms)
▶ notify-hook linked team -> ralph terminal sync
  ✔ updates root ralph state when linked team enters terminal phase (75.762909ms)
  ✔ updates session-scoped ralph state when linked session team enters terminal phase (46.706324ms)
  ✔ does not update ralph state when team/ralph are not linked (43.413422ms)
✔ notify-hook linked team -> ralph terminal sync (167.096158ms)
▶ notify-hook session-scoped iteration updates
  ✔ increments iteration for active session-scoped mode states (71.533162ms)
✔ notify-hook session-scoped iteration updates (72.344663ms)
▶ normalizeTmuxHookConfig
  ✔ returns safe disabled defaults for missing config (0.664488ms)
  ✔ normalizes valid config (0.419757ms)
✔ normalizeTmuxHookConfig (1.807757ms)
▶ pickActiveMode
  ✔ chooses by allowed mode order (0.179235ms)
  ✔ returns null when no allowed mode is active (0.119801ms)
✔ pickActiveMode (0.444585ms)
▶ evaluateInjectionGuards
  ✔ blocks when disabled (0.250682ms)
  ✔ blocks input marker loop (0.11945ms)
  ✔ blocks duplicates and cooldown and session cap (0.545991ms)
✔ evaluateInjectionGuards (1.125485ms)
▶ buildSendKeysArgv
  ✔ builds argv safely and supports dry-run (0.767557ms)
✔ buildSendKeysArgv (0.877869ms)
▶ validateSessionId
  ✔ accepts undefined and valid ids (1.205288ms)
  ✔ rejects invalid ids (0.371154ms)
✔ validateSessionId (2.298451ms)
▶ state paths
  ✔ builds global state paths (0.271042ms)
  ✔ builds session state paths (0.127896ms)
  ✔ enumerates global-only path (9.075638ms)
  ✔ enumerates session-scoped paths (2.145838ms)
  ✔ enumerates state directories across all scopes (1.819029ms)
  ✔ enumerates global and session-scoped paths together (1.969669ms)
  ✔ ignores invalid session directory names (1.530264ms)
✔ state paths (17.403689ms)
▶ trace-server session-scoped mode discovery
  ✔ includes mode events from session-scoped state files (143.004234ms)
✔ trace-server session-scoped mode discovery (143.784785ms)
▶ isValidTransition
  ✔ accepts canonical pipeline transitions (0.558264ms)
  ✔ rejects invalid transitions (0.112807ms)
✔ isValidTransition (1.421915ms)
▶ transitionPhase
  ✔ does not mutate input state when entering team-fix (0.625743ms)
  ✔ enforces bounded team-fix loop and transitions to failed with reason (0.293285ms)
  ✔ prevents transitions from terminal phases (0.397895ms)
  ✔ marks state non-resumable for failed and cancelled (0.129279ms)
  ✔ throws on structurally invalid transition attempts (3.302874ms)
  ✔ preserves explicit reason and appends exactly one transition record (0.207008ms)
  ✔ marks complete as terminal and keeps fix attempt unchanged (0.149588ms)
✔ transitionPhase (5.506192ms)
▶ canResumeTeamState
  ✔ returns false for non-terminal inactive state (0.212599ms)
✔ canResumeTeamState (0.307041ms)
ℹ tests 55
ℹ suites 18
ℹ pass 55
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 954.81487\n- Live validation: tmux injection  with active  state\n- Live validation:  emits fallback_notify + turn log entry\n\nNotes:\n- Runtime artifacts (, ) intentionally excluded from this PR.