### PR TITLE
Improve UX: auto-init state/tmux-hook and fix HUD skill frontmatter

### DIFF
--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: hud
-description: Show or configure the OMX HUD (two-layer statusline)
-role: display
-scope: .omx/**
+name: "hud"
+description: "Show or configure the OMX HUD (two-layer statusline)"
+role: "display"
+scope: ".omx/**"
 ---
 
 # HUD Skill
@@ -46,6 +46,7 @@ The OMX HUD uses a two-layer architecture:
 `omx setup` automatically configures both layers:
 - Adds `[tui] status_line` to `~/.codex/config.toml` (Layer 1)
 - Writes `.omx/hud-config.json` with default preset (Layer 2)
+- Default preset is `focused`; if HUD/statusline changes do not appear, restart Codex CLI once.
 
 ## Layer 1: Codex Built-in StatusLine
 

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('state-server directory initialization', () => {
+  it('creates .omx/state for state tools without setup', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-test-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_list_active',
+          arguments: { workingDirectory: wd },
+        },
+      });
+
+      assert.equal(existsSync(stateDir), true);
+      assert.equal(existsSync(tmuxHookConfig), true);
+      assert.deepEqual(
+        JSON.parse(response.content[0]?.text || '{}'),
+        { active_modes: [] }
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('creates session-scoped state directory when session_id is provided', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-test-'));
+    try {
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', 'sess1');
+      assert.equal(existsSync(sessionDir), false);
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_get_status',
+          arguments: { workingDirectory: wd, session_id: 'sess1' },
+        },
+      });
+
+      assert.equal(existsSync(sessionDir), true);
+      assert.deepEqual(
+        JSON.parse(response.content[0]?.text || '{}'),
+        { statuses: {} }
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- auto-create \.omx/state and session-scoped state dirs for state_* MCP calls
- auto-initialize \.omx/tmux-hook.json when state tools are used (best-effort)
- simplify omx tmux-hook UX with missing-config auto-bootstrap and stronger target auto-detection
- fix malformed YAML frontmatter in skills/hud/SKILL.md (scope quoted)
- add tests for state-server initialization behavior

## Verification
- npm test
- result: 72 passed, 0 failed

## Notes
- excluded unrelated runtime overlay changes in AGENTS.md from this PR