### PR TITLE
Wave 2: CLI recovery, status summary, HUD phase

### DIFF
--- a/bin/omx.js
+++ b/bin/omx.js
@@ -17,7 +17,7 @@ const srcEntry = join(root, 'src', 'cli', 'index.ts');
 
 if (existsSync(distEntry)) {
   const { main } = await import(distEntry);
-  main(process.argv.slice(2));
+  await main(process.argv.slice(2));
 } else {
   // Direct TS execution requires tsx or similar
   console.error('oh-my-codex: run "npm run build" first, or use tsx/ts-node');

--- a/src/cli/__tests__/recovery-status.test.ts
+++ b/src/cli/__tests__/recovery-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { main } from '../index.js';
+
+async function runMain(args: string[], cwd: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  const originalCwd = process.cwd();
+  let exitCode = 0;
+
+  console.log = (...parts: unknown[]) => { stdout.push(parts.join(' ')); };
+  console.error = (...parts: unknown[]) => { stderr.push(parts.join(' ')); };
+  process.exit = ((code?: number) => {
+    const normalized = typeof code === 'number' ? code : 0;
+    throw new Error(`__TEST_EXIT__${normalized}`);
+  }) as typeof process.exit;
+
+  try {
+    process.chdir(cwd);
+    await main(args);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.startsWith('__TEST_EXIT__')) {
+      exitCode = Number(msg.replace('__TEST_EXIT__', '')) || 0;
+    } else {
+      throw err;
+    }
+  } finally {
+    process.chdir(originalCwd);
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+
+  return { stdout: stdout.join('\n'), stderr: stderr.join('\n'), exitCode };
+}
+
+describe('CLI recovery + status output', () => {
+  it('suggests closest command on unknown command', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-recovery-'));
+    try {
+      const result = await runMain(['stauts'], wd);
+      assert.equal(result.exitCode, 1);
+      assert.match(result.stderr, /Unknown command: stauts/);
+      assert.match(result.stderr, /Did you mean: omx status/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('suggests closest tmux-hook subcommand on typo', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-subcommand-'));
+    try {
+      const result = await runMain(['tmux-hook', 'statu'], wd);
+      assert.equal(result.exitCode, 1);
+      assert.match(result.stderr, /Unknown tmux-hook subcommand: statu/);
+      assert.match(result.stderr, /Did you mean: omx tmux-hook status/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('sorts status output and prints a summary', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-status-'));
+    try {
+      const base = join(wd, '.omx', 'state');
+      const sess = join(base, 'sessions', 'sess1');
+      await mkdir(sess, { recursive: true });
+
+      await writeFile(join(base, 'team-state.json'), JSON.stringify({ active: true, current_phase: 'execution' }));
+      await writeFile(join(sess, 'autopilot-state.json'), JSON.stringify({ active: false, current_phase: 'idle' }));
+      await writeFile(join(base, 'ralph-state.json'), JSON.stringify({ active: true, current_phase: 'running' }));
+
+      const result = await runMain(['status'], wd);
+      assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+
+      const lines = result.stdout.split('\n').map(l => l.trim()).filter(Boolean);
+      const autopilotIdx = lines.findIndex(l => l.startsWith('autopilot: '));
+      const ralphIdx = lines.findIndex(l => l.startsWith('ralph: '));
+      const teamIdx = lines.findIndex(l => l.startsWith('team: '));
+      assert.ok(autopilotIdx !== -1 && ralphIdx !== -1 && teamIdx !== -1);
+      assert.ok(autopilotIdx < ralphIdx);
+      assert.ok(ralphIdx < teamIdx);
+
+      assert.match(result.stdout, /Summary: 3 mode\(s\), 2 active, 1 inactive/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -1,10 +1,45 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile, readFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { tmpdir } from 'os';
-import { spawnSync } from 'child_process';
-import { fileURLToPath } from 'url';
+import { main } from '../index.js';
+
+async function runMain(args: string[], cwd: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  const originalCwd = process.cwd();
+  let exitCode = 0;
+
+  console.log = (...parts: unknown[]) => { stdout.push(parts.join(' ')); };
+  console.error = (...parts: unknown[]) => { stderr.push(parts.join(' ')); };
+  process.exit = ((code?: number) => {
+    const normalized = typeof code === 'number' ? code : 0;
+    throw new Error(`__TEST_EXIT__${normalized}`);
+  }) as typeof process.exit;
+
+  try {
+    process.chdir(cwd);
+    await main(args);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.startsWith('__TEST_EXIT__')) {
+      exitCode = Number(msg.replace('__TEST_EXIT__', '')) || 0;
+    } else {
+      throw err;
+    }
+  } finally {
+    process.chdir(originalCwd);
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+
+  return { stdout: stdout.join('\n'), stderr: stderr.join('\n'), exitCode };
+}
 
 describe('CLI session-scoped state parity', () => {
   it('status and cancel include session-scoped states', async () => {
@@ -17,22 +52,12 @@ describe('CLI session-scoped state parity', () => {
         current_phase: 'execution',
       }));
 
-      const testDir = dirname(fileURLToPath(import.meta.url));
-      const repoRoot = join(testDir, '..', '..', '..');
-      const omxBin = join(repoRoot, 'bin', 'omx.js');
-
-      const statusResult = spawnSync(process.execPath, [omxBin, 'status'], {
-        cwd: wd,
-        encoding: 'utf-8',
-      });
-      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      const statusResult = await runMain(['status'], wd);
+      assert.equal(statusResult.exitCode, 0, statusResult.stderr || statusResult.stdout);
       assert.match(statusResult.stdout, /team: ACTIVE/);
 
-      const cancelResult = spawnSync(process.execPath, [omxBin, 'cancel'], {
-        cwd: wd,
-        encoding: 'utf-8',
-      });
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      const cancelResult = await runMain(['cancel'], wd);
+      assert.equal(cancelResult.exitCode, 0, cancelResult.stderr || cancelResult.stdout);
       assert.match(cancelResult.stdout, /Cancelled: team/);
 
       const updated = JSON.parse(await readFile(join(scopedDir, 'team-state.json'), 'utf-8'));
@@ -44,4 +69,3 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 });
-

--- a/src/cli/suggestions.ts
+++ b/src/cli/suggestions.ts
@@ -1,0 +1,44 @@
+export function suggestClosest(input: string, candidates: string[]): string | null {
+  const needle = input.trim().toLowerCase();
+  if (!needle) return null;
+
+  const exact = candidates.find(candidate => candidate.toLowerCase() === needle);
+  if (exact) return exact;
+
+  const prefix = candidates.find(candidate => candidate.toLowerCase().startsWith(needle));
+  if (prefix) return prefix;
+
+  let best: { value: string; distance: number } | null = null;
+  for (const candidate of candidates) {
+    const distance = levenshtein(needle, candidate.toLowerCase());
+    if (!best || distance < best.distance) {
+      best = { value: candidate, distance };
+    }
+  }
+
+  if (!best) return null;
+  const threshold = Math.max(2, Math.floor(needle.length / 2));
+  return best.distance <= threshold ? best.value : null;
+}
+
+function levenshtein(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dp: number[][] = Array.from({ length: rows }, () => Array(cols).fill(0));
+
+  for (let i = 0; i < rows; i++) dp[i][0] = i;
+  for (let j = 0; j < cols; j++) dp[0][j] = j;
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost
+      );
+    }
+  }
+
+  return dp[rows - 1][cols - 1];
+}

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { getPackageRoot } from '../utils/package.js';
+import { suggestClosest } from './suggestions.js';
 
 type TmuxTargetType = 'session' | 'pane';
 
@@ -61,6 +62,7 @@ Usage:
 `;
 
 export async function tmuxHookCommand(args: string[]): Promise<void> {
+  const subcommands = ['init', 'status', 'validate', 'test', 'help'];
   const subcommand = args[0] || 'status';
   switch (subcommand) {
     case 'init':
@@ -81,7 +83,11 @@ export async function tmuxHookCommand(args: string[]): Promise<void> {
       console.log(HELP);
       return;
     default:
-      throw new Error(`Unknown tmux-hook subcommand: ${subcommand}`);
+      {
+        const suggestion = suggestClosest(subcommand, subcommands);
+        const hint = suggestion ? ` Did you mean: omx tmux-hook ${suggestion}` : '';
+        throw new Error(`Unknown tmux-hook subcommand: ${subcommand}.${hint}`);
+      }
   }
 }
 

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderHud } from '../render.js';
+import type { HudRenderContext } from '../types.js';
+
+function contextWithTeam(): HudRenderContext {
+  return {
+    version: 'v0.0.0',
+    gitBranch: null,
+    ralph: null,
+    ultrawork: null,
+    autopilot: null,
+    team: { active: true, current_phase: 'team-exec', agent_count: 3, team_name: 'wave2' },
+    ecomode: null,
+    pipeline: null,
+    metrics: null,
+    hudNotify: null,
+    session: null,
+  };
+}
+
+describe('renderHud team state', () => {
+  it('includes team phase from TeamStateForHud.current_phase', () => {
+    const output = renderHud(contextWithTeam(), 'focused');
+    assert.match(output, /team:team-exec/);
+    assert.match(output, /\(wave2,3 workers\)/);
+  });
+});
+

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -54,15 +54,18 @@ function renderAutopilot(ctx: HudRenderContext): string | null {
 
 function renderTeam(ctx: HudRenderContext): string | null {
   if (!ctx.team) return null;
+  const phase = ctx.team.current_phase || 'active';
   const count = ctx.team.agent_count;
   const name = ctx.team.team_name;
-  if (count !== undefined && count > 0) {
-    return green(`team:${count} workers`);
+  const suffix = [name, count !== undefined && count > 0 ? `${count} workers` : null]
+    .filter((part): part is string => Boolean(part))
+    .join(',');
+
+  if (suffix) {
+    return green(`team:${phase} (${suffix})`);
   }
-  if (name) {
-    return green(`team:${name}`);
-  }
-  return green('team');
+
+  return green(`team:${phase}`);
 }
 
 function renderEcomode(ctx: HudRenderContext): string | null {


### PR DESCRIPTION
Summary:\n- Add command/subcommand suggestion UX for unknown inputs\n- Improve omx status readability with deterministic ordering and summary\n- Render team phase in HUD output\n- Add tests for recovery/status and HUD rendering\n\nScope:\n- Wave 2 (P1 CLI recovery + status/HUD clarity)\n\nVerification:\n- npm test (worktree: /tmp/omx-wave2-ux-p1-recovery)