### PR TITLE
Wave 3: hardening automation and non-blocking updates

### DIFF
--- a/bin/omx.js
+++ b/bin/omx.js
@@ -17,7 +17,7 @@ const srcEntry = join(root, 'src', 'cli', 'index.ts');
 
 if (existsSync(distEntry)) {
   const { main } = await import(distEntry);
-  main(process.argv.slice(2));
+  await main(process.argv.slice(2));
 } else {
   // Direct TS execution requires tsx or similar
   console.error('oh-my-codex: run "npm run build" first, or use tsx/ts-node');

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,7 @@
+# Skills Reference (Drift-Checked)
+
+This file is used by CI to detect drift between documentation and the shipped skills in `skills/*/SKILL.md`.
+
+Available skills:
+`$analyze` `$autopilot` `$build-fix` `$cancel` `$code-review` `$configure-discord` `$configure-telegram` `$deepinit` `$deepsearch` `$doctor` `$ecomode` `$frontend-ui-ux` `$git-master` `$help` `$hud` `$learn-about-omx` `$learner` `$note` `$omx-setup` `$pipeline` `$plan` `$project-session-manager` `$psm` `$ralph` `$ralph-init` `$ralplan` `$release` `$research` `$review` `$security-review` `$skill` `$swarm` `$tdd` `$team` `$trace` `$ultrapilot` `$ultraqa` `$ultrawork` `$writer-memory`
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "tsc --watch",
     "setup": "node bin/omx.js setup",
     "doctor": "node bin/omx.js doctor",
+    "check:skills-drift": "node scripts/check-skills-drift.mjs",
     "test": "npm run build && node --test dist/**/*.test.js"
   },
   "engines": {

--- a/scripts/check-skills-drift.mjs
+++ b/scripts/check-skills-drift.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * CI-friendly drift check:
+ * Verifies docs/skills/README.md lists the same skill set as repo skill dirs.
+ *
+ * This is intentionally lightweight and does not require building TS output.
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function repoRoot() {
+  // scripts/ is at repo root
+  return join(dirname(fileURLToPath(import.meta.url)), '..');
+}
+
+function listRepoSkills(rootDir) {
+  const skillsDir = join(rootDir, 'skills');
+  if (!existsSync(skillsDir)) return [];
+  return readdirSync(skillsDir)
+    .filter((name) => {
+      try {
+        return statSync(join(skillsDir, name)).isDirectory()
+          && existsSync(join(skillsDir, name, 'SKILL.md'));
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function parseDocsSkills(rootDir) {
+  const docsPath = join(rootDir, 'docs', 'skills', 'README.md');
+  if (!existsSync(docsPath)) {
+    return { path: docsPath, skills: null };
+  }
+
+  const content = readFileSync(docsPath, 'utf-8');
+  const lines = content.split(/\r?\n/);
+  const skills = new Set();
+
+  for (const line of lines) {
+    // Accept `$name` tokens anywhere in the line.
+    for (const m of line.matchAll(/\$[a-z0-9][a-z0-9-]*/gi)) {
+      skills.add(m[0].slice(1));
+    }
+  }
+
+  return { path: docsPath, skills: Array.from(skills).sort() };
+}
+
+function diff(a, b) {
+  const as = new Set(a);
+  const bs = new Set(b);
+  const onlyA = [...as].filter((x) => !bs.has(x)).sort();
+  const onlyB = [...bs].filter((x) => !as.has(x)).sort();
+  return { onlyA, onlyB };
+}
+
+function main() {
+  const root = repoRoot();
+
+  const repoSkills = listRepoSkills(root);
+  const { path: docsPath, skills: docsSkills } = parseDocsSkills(root);
+
+  if (!docsSkills) {
+    console.error(`[skills-drift] Missing ${docsPath}`);
+    process.exit(2);
+  }
+
+  const { onlyA: missingInDocs, onlyB: extraInDocs } = diff(repoSkills, docsSkills);
+  if (missingInDocs.length === 0 && extraInDocs.length === 0) {
+    console.log(`[skills-drift] OK (${repoSkills.length} skills)`);
+    return;
+  }
+
+  console.error('[skills-drift] Drift detected between docs and repo skills.');
+  if (missingInDocs.length > 0) {
+    console.error(`- Missing in docs: ${missingInDocs.map(s => `$${s}`).join(' ')}`);
+  }
+  if (extraInDocs.length > 0) {
+    console.error(`- Extra in docs:   ${extraInDocs.map(s => `$${s}`).join(' ')}`);
+  }
+  process.exit(1);
+}
+
+main();

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -1,10 +1,45 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile, readFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { tmpdir } from 'os';
-import { spawnSync } from 'child_process';
-import { fileURLToPath } from 'url';
+import { main } from '../index.js';
+
+async function runMain(args: string[], cwd: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  const originalCwd = process.cwd();
+  let exitCode = 0;
+
+  console.log = (...parts: unknown[]) => { stdout.push(parts.join(' ')); };
+  console.error = (...parts: unknown[]) => { stderr.push(parts.join(' ')); };
+  process.exit = ((code?: number) => {
+    const normalized = typeof code === 'number' ? code : 0;
+    throw new Error(`__TEST_EXIT__${normalized}`);
+  }) as typeof process.exit;
+
+  try {
+    process.chdir(cwd);
+    await main(args);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.startsWith('__TEST_EXIT__')) {
+      exitCode = Number(msg.replace('__TEST_EXIT__', '')) || 0;
+    } else {
+      throw err;
+    }
+  } finally {
+    process.chdir(originalCwd);
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+
+  return { stdout: stdout.join('\n'), stderr: stderr.join('\n'), exitCode };
+}
 
 describe('CLI session-scoped state parity', () => {
   it('status and cancel include session-scoped states', async () => {
@@ -17,22 +52,12 @@ describe('CLI session-scoped state parity', () => {
         current_phase: 'execution',
       }));
 
-      const testDir = dirname(fileURLToPath(import.meta.url));
-      const repoRoot = join(testDir, '..', '..', '..');
-      const omxBin = join(repoRoot, 'bin', 'omx.js');
-
-      const statusResult = spawnSync(process.execPath, [omxBin, 'status'], {
-        cwd: wd,
-        encoding: 'utf-8',
-      });
-      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      const statusResult = await runMain(['status'], wd);
+      assert.equal(statusResult.exitCode, 0, statusResult.stderr || statusResult.stdout);
       assert.match(statusResult.stdout, /team: ACTIVE/);
 
-      const cancelResult = spawnSync(process.execPath, [omxBin, 'cancel'], {
-        cwd: wd,
-        encoding: 'utf-8',
-      });
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      const cancelResult = await runMain(['cancel'], wd);
+      assert.equal(cancelResult.exitCode, 0, cancelResult.stderr || cancelResult.stdout);
       assert.match(cancelResult.stdout, /Cancelled: team/);
 
       const updated = JSON.parse(await readFile(join(scopedDir, 'team-state.json'), 'utf-8'));
@@ -44,4 +69,3 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 });
-

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldPromptForUpdate } from '../update.js';
+
+describe('shouldPromptForUpdate', () => {
+  it('is false by default', () => {
+    const prev = process.env.OMX_AUTO_UPDATE_PROMPT;
+    delete process.env.OMX_AUTO_UPDATE_PROMPT;
+    try {
+      assert.equal(shouldPromptForUpdate(), false);
+    } finally {
+      if (prev === undefined) delete process.env.OMX_AUTO_UPDATE_PROMPT;
+      else process.env.OMX_AUTO_UPDATE_PROMPT = prev;
+    }
+  });
+
+  it('is true when OMX_AUTO_UPDATE_PROMPT=1', () => {
+    const prev = process.env.OMX_AUTO_UPDATE_PROMPT;
+    process.env.OMX_AUTO_UPDATE_PROMPT = '1';
+    try {
+      assert.equal(shouldPromptForUpdate(), true);
+    } finally {
+      if (prev === undefined) delete process.env.OMX_AUTO_UPDATE_PROMPT;
+      else process.env.OMX_AUTO_UPDATE_PROMPT = prev;
+    }
+  });
+});
+

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -141,11 +141,9 @@ async function launchWithHud(args: string[]): Promise<void> {
   const normalizedArgs = normalizeCodexLaunchArgs(args);
   const sessionId = `omx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
-  try {
-    await maybeCheckAndPromptUpdate(cwd);
-  } catch {
+  void maybeCheckAndPromptUpdate(cwd).catch(() => {
     // Non-fatal: update checks must never block launch
-  }
+  });
 
   // ── Phase 1: preLaunch ──────────────────────────────────────────────────
   try {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -124,6 +124,10 @@ async function askYesNo(question: string): Promise<boolean> {
   }
 }
 
+export function shouldPromptForUpdate(): boolean {
+  return process.env.OMX_AUTO_UPDATE_PROMPT === '1';
+}
+
 export async function maybeCheckAndPromptUpdate(cwd: string): Promise<void> {
   if (process.env.OMX_AUTO_UPDATE === '0') return;
 
@@ -144,6 +148,16 @@ export async function maybeCheckAndPromptUpdate(cwd: string): Promise<void> {
   if (!current || !latest || !isNewerVersion(current, latest)) return;
 
   console.log(`[omx] Update available: v${current} -> v${latest}.`);
+
+  if (!shouldPromptForUpdate()) {
+    await notify({
+      title: 'OMX Update Available',
+      message: `New version available: v${current} -> v${latest}. Set OMX_AUTO_UPDATE_PROMPT=1 to prompt for update.`,
+      type: 'info',
+      projectPath: cwd,
+    });
+    return;
+  }
 
   const approved = await askYesNo('[omx] Update now? [Y/n] ');
   if (!approved) {


### PR DESCRIPTION
Summary:\n- Make launch-time update check non-blocking by default\n- Add opt-in prompt gating for interactive update confirmation\n- Add skills drift check script + package script + inventory file\n- Add update behavior tests\n\nScope:\n- Wave 3 (P2 hardening/automation)\n\nVerification:\n- npm run check:skills-drift\n- npm test (worktree: /tmp/omx-wave3-ux-p2-hardening)