### PR TITLE
fix(config): restore array default for notify to match Codex schema

### DIFF
--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -14,18 +14,21 @@ interface MergeOptions {
 function selectNotifyFormat(): 'string' | 'array' {
   const forced = (process.env.OMX_NOTIFY_FORMAT || '').trim().toLowerCase();
   if (forced === 'string' || forced === 'array') return forced;
-  // Default to string for compatibility with environments expecting TOML string.
-  // Array format is available with OMX_NOTIFY_FORMAT=array.
-  return 'string';
+  // Default to array to match Codex schema (notify expects a sequence).
+  // String format is available with OMX_NOTIFY_FORMAT=string for legacy environments.
+  return 'array';
 }
 
 function getNotifyConfigLine(notifyHookPath: string): string {
   const format = selectNotifyFormat();
+  const escapedNotifyHookPath = notifyHookPath
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"');
   const notifyCommand = `node "${notifyHookPath}"`
     .replace(/\\/g, '\\\\')
     .replace(/"/g, '\\"');
   if (format === 'array') {
-    return `notify = ["node", "${notifyHookPath}"]`;
+    return `notify = ["node", "${escapedNotifyHookPath}"]`;
   }
   return `notify = "${notifyCommand}"`;
 }


### PR DESCRIPTION
Reverts regression from #7 follow-up (c4067ce) where `omx setup` defaulted notify to TOML string format. Codex CLI expects notify as a sequence (array<string>), so string defaults cause startup failure with "expected a sequence".

- Change selectNotifyFormat() default from 'string' to 'array'
- Update tests to assert array as default
- Add explicit test for OMX_NOTIFY_FORMAT=string override
- Add test for paths with spaces in array format

Closes #16

## Summary

After the #7 follow-up change (commit c4067ce), `omx setup` generates `notify` as a TOML string (`notify = "node \"...\""`) by default. Codex CLI's config parser expects `notify` to be a sequence (`array<string>`) per the [official schema](https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/config.schema.json), causing a startup failure: `invalid type: string "...", expected a sequence`.

Additional Codex references:
- [Config Reference](https://developers.openai.com/codex/config-reference)
- [Core config type (`notify: Option<Vec<String>>`)](https://github.com/openai/codex/blob/main/codex-rs/core/src/config/mod.rs)

This PR restores the array default while keeping the string format available as an explicit opt-in via `OMX_NOTIFY_FORMAT=string`.

## Changes

- `src/config/generator.ts`: Change `selectNotifyFormat()` default from `'string'` to `'array'`
- `src/config/__tests__/generator-notify.test.ts`: Rewrite tests to assert array as default, add string override test, add spaces-in-path test

## Validation

- [x] `npm run build`
- [x] `npm test` (73/73 pass)
- [x] `omx setup --force` generates `notify = ["node", "..."]`
- [x] README already documents array as default (no doc change needed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #16
