### PR TITLE
feat(team,setup): role-based worker reasoning defaults + setup gh star hint

### DIFF
--- a/src/cli/__tests__/setup-gh-star.test.ts
+++ b/src/cli/__tests__/setup-gh-star.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error?: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const r = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
+}
+
+function shouldSkipForSpawnPermissions(err?: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+describe('omx setup (gh star hint)', () => {
+  it('prints a star hint when GitHub CLI is configured', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-gh-'));
+    try {
+      const fakeBin = join(wd, 'bin');
+      await mkdir(fakeBin, { recursive: true });
+      const ghPath = join(fakeBin, 'gh');
+      await writeFile(
+        ghPath,
+        '#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"status\" ]; then exit 0; fi\nexit 1\n',
+      );
+      await chmod(ghPath, 0o755);
+
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+
+      const res = runOmx(wd, ['setup', '--dry-run'], { PATH: `${fakeBin}:${process.env.PATH || ''}`, HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /gh repo star Yeachan-Heo\/oh-my-codex/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not print a star hint when GitHub CLI is missing', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-gh-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+
+      const res = runOmx(wd, ['setup', '--dry-run'], { PATH: '', HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.doesNotMatch(res.stdout, /gh repo star Yeachan-Heo\/oh-my-codex/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -6,7 +6,7 @@
 import { mkdir, copyFile, readdir, readFile, writeFile, stat } from 'fs/promises';
 import { join, dirname } from 'path';
 import { existsSync } from 'fs';
-import { homedir } from 'os';
+import { spawnSync } from 'child_process';
 import {
   codexHome, codexConfigPath, codexPromptsDir,
   userSkillsDir, omxStateDir, omxPlansDir, omxLogsDir,
@@ -27,6 +27,7 @@ const REQUIRED_TEAM_COMM_MCP_TOOLS = [
   'team_mailbox_list',
   'team_mailbox_mark_delivered',
 ] as const;
+const GITHUB_REPO_SLUG = 'Yeachan-Heo/oh-my-codex';
 
 export async function setup(options: SetupOptions = {}): Promise<void> {
   const { force = false, dryRun = false, verbose = false } = options;
@@ -135,6 +136,10 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   console.log();
 
   console.log('Setup complete! Run "omx doctor" to verify installation.');
+  if (isGitHubCliConfigured()) {
+    console.log('\nOptional: If oh-my-codex helps you, consider starring the repo:');
+    console.log(`  gh repo star ${GITHUB_REPO_SLUG}`);
+  }
   console.log('\nNext steps:');
   console.log('  1. Start Codex CLI in your project directory');
   console.log('  2. Use /prompts:architect, /prompts:executor, /prompts:planner as slash commands');
@@ -229,5 +234,14 @@ async function verifyTeamCommMcpTools(pkgRoot: string): Promise<{ ok: true } | {
     return { ok: true };
   } catch {
     return { ok: false, message: `cannot read ${stateServerPath}` };
+  }
+}
+
+function isGitHubCliConfigured(): boolean {
+  try {
+    const result = spawnSync('gh', ['auth', 'status'], { stdio: 'ignore' });
+    return result.status === 0;
+  } catch {
+    return false;
   }
 }

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -115,6 +115,34 @@ describe('buildWorkerStartupCommand', () => {
       else delete process.env.SHELL;
     }
   });
+
+  it('applies low reasoning effort for exploration roles', () => {
+    const cmd = buildWorkerStartupCommand('alpha', 1, [], 'explore');
+    assert.match(cmd, /model_reasoning_effort="low"/);
+  });
+
+  it('applies xhigh reasoning effort for review roles', () => {
+    const cmd = buildWorkerStartupCommand('alpha', 1, [], 'security-reviewer');
+    assert.match(cmd, /model_reasoning_effort="xhigh"/);
+  });
+
+  it('applies xhigh reasoning effort for architecture roles', () => {
+    const cmd = buildWorkerStartupCommand('alpha', 1, [], 'information-architect');
+    assert.match(cmd, /model_reasoning_effort="xhigh"/);
+  });
+
+  it('does not append default reasoning when launch args already override it', () => {
+    const cmd = buildWorkerStartupCommand(
+      'alpha',
+      1,
+      ['-c', 'model_reasoning_effort="medium"'],
+      'architect',
+    );
+    const matches = cmd.match(/model_reasoning_effort=/g) || [];
+    assert.equal(matches.length, 1);
+    assert.match(cmd, /model_reasoning_effort="medium"/);
+    assert.doesNotMatch(cmd, /model_reasoning_effort="xhigh"/);
+  });
 });
 
 describe('tmux-dependent functions when tmux is unavailable', () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -143,6 +143,17 @@ describe('buildWorkerStartupCommand', () => {
     assert.match(cmd, /model_reasoning_effort="medium"/);
     assert.doesNotMatch(cmd, /model_reasoning_effort="xhigh"/);
   });
+
+  it('does not append default reasoning when override is provided as spaced tokens', () => {
+    const cmd = buildWorkerStartupCommand(
+      'alpha',
+      1,
+      ['-c', 'model_reasoning_effort', '=', 'medium'],
+      'architect',
+    );
+    // Default for architect would be xhigh; ensure it was NOT appended.
+    assert.doesNotMatch(cmd, /model_reasoning_effort="xhigh"/);
+  });
 });
 
 describe('tmux-dependent functions when tmux is unavailable', () => {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -198,7 +198,7 @@ export async function startTeam(
     overlayApplied = true;
 
     // 6. Create tmux session with workers
-    const createdSession = createTeamSession(sanitized, workerCount, cwd, workerLaunchArgs);
+    const createdSession = createTeamSession(sanitized, workerCount, cwd, workerLaunchArgs, agentType);
     sessionName = createdSession.name;
     createdWorkerPaneIds.push(...createdSession.workerPaneIds);
     config.tmux_session = sessionName;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -108,8 +108,20 @@ function resolveReasoningEffort(agentType: string): ReasoningEffort {
 function hasReasoningOverride(args: string[]): boolean {
   for (let i = 0; i < args.length; i++) {
     if (args[i] !== '-c') continue;
-    const next = args[i + 1] || '';
+    const next = (args[i + 1] || '').trim();
+
+    // Common form: `-c model_reasoning_effort="high"`
     if (next.startsWith(`${REASONING_KEY}=`)) return true;
+
+    // Allow whitespace around '=' when args are tokenized oddly (e.g. from env splitting):
+    // `-c model_reasoning_effort = "high"` -> ['-c','model_reasoning_effort','=','"high"']
+    if (next === REASONING_KEY) {
+      const after = (args[i + 2] || '').trim();
+      if (after === '=' || after.startsWith('=')) return true;
+    }
+
+    // More tolerant: `-c "model_reasoning_effort = \"high\""` (if it survives as one arg)
+    if (/^\s*model_reasoning_effort\s*=/.test(next)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- Team worker launches now default `model_reasoning_effort` by role:
  - `explore`/`explore-*`/`style-reviewer`/`writer` => `low`
  - `architect`/`*-architect`/`critic`/`*-reviewer` => `xhigh`
  - all others => `high`
- Kept explicit launch override authoritative: if worker launch args include `-c model_reasoning_effort=...`, no default is appended.
- Hardened override detection for spaced-token `-c` forms to avoid duplicate reasoning settings.
- `omx setup` now prints an optional `gh repo star Yeachan-Heo/oh-my-codex` hint when `gh auth status` succeeds.
- Added tests for team reasoning mapping/override handling and setup star-hint behavior.

## Testing
- `npm run build`
- `npm test`
