### PR TITLE
Release v0.3.1: fix #20 #21 #22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   normalizeCodexLaunchArgs,
+  buildTmuxShellCommand,
   buildTmuxSessionName,
   readTopLevelTomlString,
   upsertTopLevelTomlString,
@@ -69,6 +70,22 @@ describe('normalizeCodexLaunchArgs', () => {
     assert.deepEqual(
       normalizeCodexLaunchArgs(['--high', '--xhigh']),
       ['-c', 'model_reasoning_effort="xhigh"']
+    );
+  });
+
+  it('maps --xhigh --madmax to codex-native flags only', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--xhigh', '--madmax']),
+      ['--dangerously-bypass-approvals-and-sandbox', '-c', 'model_reasoning_effort="xhigh"']
+    );
+  });
+});
+
+describe('buildTmuxShellCommand', () => {
+  it('preserves quoted config values for tmux shell-command execution', () => {
+    assert.equal(
+      buildTmuxShellCommand('codex', ['--dangerously-bypass-approvals-and-sandbox', '-c', 'model_reasoning_effort="xhigh"']),
+      `'codex' '--dangerously-bypass-approvals-and-sandbox' '-c' 'model_reasoning_effort="xhigh"'`
     );
   });
 });

--- a/src/cli/__tests__/setup-gh-star.test.ts
+++ b/src/cli/__tests__/setup-gh-star.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {}
+): { status: number | null; stdout: string; stderr: string; error: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const r = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+  return {
+    status: r.status,
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    error: r.error?.message || '',
+  };
+}
+
+function shouldSkipForSpawnPermissions(err: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+describe('omx setup (gh star hint)', () => {
+  it('prints a star hint when GitHub CLI is configured', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-gh-'));
+    try {
+      const fakeBin = join(wd, 'bin');
+      await mkdir(fakeBin, { recursive: true });
+      const ghPath = join(fakeBin, 'gh');
+      await writeFile(
+        ghPath,
+        '#!/bin/sh\nif [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi\nexit 1\n'
+      );
+      await chmod(ghPath, 0o755);
+
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+
+      const res = runOmx(wd, ['setup', '--dry-run'], {
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+        HOME: home,
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /gh repo star Yeachan-Heo\/oh-my-codex/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not print a star hint when GitHub CLI is missing', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-gh-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+
+      const res = runOmx(wd, ['setup', '--dry-run'], { PATH: '', HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.doesNotMatch(res.stdout, /gh repo star Yeachan-Heo\/oh-my-codex/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -7,6 +7,7 @@ import { mkdir, copyFile, readdir, readFile, writeFile, stat } from 'fs/promises
 import { join, dirname } from 'path';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
+import { spawnSync } from 'child_process';
 import {
   codexHome, codexConfigPath, codexPromptsDir,
   userSkillsDir, omxStateDir, omxPlansDir, omxLogsDir,
@@ -140,6 +141,14 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   console.log('  2. Use /prompts:architect, /prompts:executor, /prompts:planner as slash commands');
   console.log('  3. Skills are available via /skills or implicit matching');
   console.log('  4. The AGENTS.md orchestration brain is loaded automatically');
+  if (isGitHubCliConfigured()) {
+    console.log('\nSupport the project: gh repo star Yeachan-Heo/oh-my-codex');
+  }
+}
+
+function isGitHubCliConfigured(): boolean {
+  const result = spawnSync('gh', ['auth', 'status'], { stdio: 'ignore' });
+  return result.status === 0;
 }
 
 async function installDirectory(

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -34,6 +34,27 @@ describe('config generator notify', () => {
     }
   });
 
+  it('always emits notify as a TOML string even when OMX_NOTIFY_FORMAT=array is set', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    const previous = process.env.OMX_NOTIFY_FORMAT;
+    process.env.OMX_NOTIFY_FORMAT = 'array';
+    try {
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.match(toml, /^notify = ".*"$/m);
+      assert.doesNotMatch(toml, /^notify = \[/m);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OMX_NOTIFY_FORMAT;
+      } else {
+        process.env.OMX_NOTIFY_FORMAT = previous;
+      }
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('quotes notify hook path so spaces are preserved', async () => {
     const base = await mkdtemp(join(tmpdir(), 'omx config gen space-'));
     // Add a space in the pkgRoot path itself.
@@ -82,9 +103,117 @@ describe('config generator notify', () => {
         1
       );
       assert.equal((rerun.match(/# End oh-my-codex/g) ?? []).length, 1);
+      assert.equal((rerun.match(/^\[features\]$/gm) ?? []).length, 1);
+      assert.match(rerun, /^collab = true$/m);
+      assert.match(rerun, /^child_agents_md = true$/m);
       assert.match(rerun, /^\[user.settings\]$/m);
       assert.match(rerun, /^name = "kept"$/m);
       assert.match(rerun, /^notify = ".*"$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates a legacy OMX block notify array into a TOML string', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      const legacy = [
+        '[features]',
+        'web_search_request = true',
+        '',
+        '# ============================================================',
+        '# oh-my-codex (OMX) Configuration',
+        '# Managed by omx setup - manual edits preserved on next setup',
+        '# ============================================================',
+        '',
+        'notify = ["node", "/tmp/notify-hook.js"]',
+        '',
+        '[mcp_servers.omx_state]',
+        'command = "node"',
+        'args = ["/tmp/state-server.js"]',
+        '',
+        '# ============================================================',
+        '# End oh-my-codex',
+        '',
+      ].join('\n');
+      await writeFile(configPath, legacy);
+
+      await mergeConfig(configPath, wd);
+      const merged = await readFile(configPath, 'utf-8');
+
+      assert.match(merged, /^notify = ".*"$/m);
+      assert.doesNotMatch(merged, /^notify = \[/m);
+      assert.equal((merged.match(/# oh-my-codex \(OMX\) Configuration/g) ?? []).length, 1);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('merges into existing [features] table without duplicating it', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      const original = [
+        '[features]',
+        'custom_user_flag = false',
+        'child_agents_md = false',
+        '',
+        '[user.settings]',
+        'name = "kept"',
+        '',
+      ].join('\n');
+      await writeFile(configPath, original);
+
+      await mergeConfig(configPath, wd);
+      const merged = await readFile(configPath, 'utf-8');
+
+      assert.equal((merged.match(/^\[features\]$/gm) ?? []).length, 1);
+      assert.match(merged, /^custom_user_flag = false$/m);
+      assert.match(merged, /^collab = true$/m);
+      assert.match(merged, /^child_agents_md = true$/m);
+      assert.match(merged, /^\[user.settings\]$/m);
+      assert.match(merged, /^name = "kept"$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates a legacy OMX block and preserves user settings', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      const legacy = [
+        '[user.before]',
+        'name = "kept-before"',
+        '',
+        '# oh-my-codex (OMX) Configuration',
+        '# legacy block without top divider',
+        'notify = ["node", "/tmp/legacy notify-hook.js"]',
+        '[mcp_servers.omx_state]',
+        'command = "node"',
+        'args = ["/tmp/state-server.js"]',
+        '# End oh-my-codex',
+        '',
+        '[user.after]',
+        'name = "kept-after"',
+        '',
+      ].join('\n');
+      await writeFile(configPath, legacy);
+
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.equal(
+        (toml.match(/oh-my-codex \(OMX\) Configuration/g) ?? []).length,
+        1
+      );
+      assert.match(toml, /^\[user.before\]$/m);
+      assert.match(toml, /^name = "kept-before"$/m);
+      assert.match(toml, /^\[user.after\]$/m);
+      assert.match(toml, /^name = "kept-after"$/m);
+      assert.match(toml, /^notify = ".*"$/m);
+      assert.doesNotMatch(toml, /^notify = \[/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -11,23 +11,101 @@ interface MergeOptions {
   verbose?: boolean;
 }
 
-function selectNotifyFormat(): 'string' | 'array' {
-  const forced = (process.env.OMX_NOTIFY_FORMAT || '').trim().toLowerCase();
-  if (forced === 'string' || forced === 'array') return forced;
-  // Default to string for compatibility with environments expecting TOML string.
-  // Array format is available with OMX_NOTIFY_FORMAT=array.
-  return 'string';
+function upsertFeatureFlags(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const featuresStart = lines.findIndex((line) => /^\s*\[features\]\s*$/.test(line));
+
+  if (featuresStart < 0) {
+    const base = config.trimEnd();
+    const featureBlock = [
+      '[features]',
+      'collab = true',
+      'child_agents_md = true',
+      '',
+    ].join('\n');
+    if (base.length === 0) {
+      return featureBlock;
+    }
+    return `${base}\n${featureBlock}`;
+  }
+
+  let sectionEnd = lines.length;
+  for (let i = featuresStart + 1; i < lines.length; i++) {
+    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+
+  let collabIdx = -1;
+  let childAgentsIdx = -1;
+  for (let i = featuresStart + 1; i < sectionEnd; i++) {
+    if (/^\s*collab\s*=/.test(lines[i])) {
+      collabIdx = i;
+    } else if (/^\s*child_agents_md\s*=/.test(lines[i])) {
+      childAgentsIdx = i;
+    }
+  }
+
+  if (collabIdx >= 0) {
+    lines[collabIdx] = 'collab = true';
+  } else {
+    lines.splice(sectionEnd, 0, 'collab = true');
+    sectionEnd += 1;
+  }
+
+  if (childAgentsIdx >= 0) {
+    lines[childAgentsIdx] = 'child_agents_md = true';
+  } else {
+    lines.splice(sectionEnd, 0, 'child_agents_md = true');
+  }
+
+  return lines.join('\n');
 }
 
 function getNotifyConfigLine(notifyHookPath: string): string {
-  const format = selectNotifyFormat();
   const notifyCommand = `node "${notifyHookPath}"`
     .replace(/\\/g, '\\\\')
     .replace(/"/g, '\\"');
-  if (format === 'array') {
-    return `notify = ["node", "${notifyHookPath}"]`;
-  }
   return `notify = "${notifyCommand}"`;
+}
+
+function stripExistingOmxBlocks(config: string): { cleaned: string; removed: number } {
+  const marker = 'oh-my-codex (OMX) Configuration';
+  const endMarker = '# End oh-my-codex';
+  let cleaned = config;
+  let removed = 0;
+
+  while (true) {
+    const markerIdx = cleaned.indexOf(marker);
+    if (markerIdx < 0) break;
+
+    let blockStart = cleaned.lastIndexOf('\n', markerIdx);
+    blockStart = blockStart >= 0 ? blockStart + 1 : 0;
+
+    const previousLineEnd = blockStart - 1;
+    if (previousLineEnd >= 0) {
+      const previousLineStart = cleaned.lastIndexOf('\n', previousLineEnd - 1);
+      const previousLine = cleaned.slice(previousLineStart + 1, previousLineEnd);
+      if (/^# =+$/.test(previousLine.trim())) {
+        blockStart = previousLineStart >= 0 ? previousLineStart + 1 : 0;
+      }
+    }
+
+    let blockEnd = cleaned.length;
+    const endIdx = cleaned.indexOf(endMarker, markerIdx);
+    if (endIdx >= 0) {
+      const endLineBreak = cleaned.indexOf('\n', endIdx);
+      blockEnd = endLineBreak >= 0 ? endLineBreak + 1 : cleaned.length;
+    }
+
+    const before = cleaned.slice(0, blockStart).trimEnd();
+    const after = cleaned.slice(blockEnd).trimStart();
+    cleaned = [before, after].filter(Boolean).join('\n\n');
+    removed += 1;
+  }
+
+  return { cleaned, removed };
 }
 
 /**
@@ -53,11 +131,6 @@ function getOmxConfigBlock(pkgRoot: string): string {
     '',
     '# Notification hook - fires after each agent turn',
     getNotifyConfigLine(notifyHookPath),
-    '',
-    '# Feature flags for sub-agent orchestration',
-    '[features]',
-    'collab = true',
-    'child_agents_md = true',
     '',
     '# OMX State Management MCP Server',
     '[mcp_servers.omx_state]',
@@ -114,24 +187,14 @@ export async function mergeConfig(
 
   // Check if OMX config is already present
   if (existing.includes('oh-my-codex (OMX) Configuration')) {
-    // Remove existing OMX block and re-add (update)
-    const startMarker = '# ============================================================\n# oh-my-codex (OMX) Configuration';
-    const startIdx = existing.indexOf(startMarker);
-    if (startIdx >= 0) {
-      // Find the end of the OMX block (next non-OMX section or EOF)
-      const endMarker = '\n# ============================================================\n# End oh-my-codex';
-      const endIdx = existing.indexOf(endMarker, startIdx);
-      if (endIdx >= 0) {
-        existing = existing.slice(0, startIdx) + existing.slice(endIdx + endMarker.length);
-      } else {
-        // Remove everything from the marker to EOF
-        existing = existing.slice(0, startIdx);
-      }
-    }
-    if (options.verbose) {
+    const stripped = stripExistingOmxBlocks(existing);
+    existing = stripped.cleaned;
+    if (options.verbose && stripped.removed > 0) {
       console.log('  Updating existing OMX config block.');
     }
   }
+
+  existing = upsertFeatureFlags(existing);
 
   const omxBlock = getOmxConfigBlock(pkgRoot);
   const finalConfig = existing.trimEnd() + '\n' + omxBlock;


### PR DESCRIPTION
Fixes #20, #21, #22 and also addresses #23 (notify array).\n\nChanges:\n- Fix tmux launch quoting so `omx --xhigh --madmax` works reliably\n- Fix config merge to avoid duplicate [features] tables\n- Enforce notify as TOML string and migrate legacy array configs\n- Add/restore setup star-hint behavior + tests\n\nVerification: `npm test`