### PR TITLE
feat(team): default low-complexity workers to gpt-5.3-codex-spark

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,23 @@ Resume: detect existing team state and resume from the last incomplete stage.
 
 ---
 
+<team_model_resolution>
+Team/Swarm worker startup currently uses one shared `agentType` and one shared launch-arg set for all workers in a team run.
+
+For worker model selection, apply this precedence (highest to lowest):
+1. Explicit model already present in `OMX_TEAM_WORKER_LAUNCH_ARGS`
+2. Inherited leader `--model` (when inheritance is enabled)
+3. Injected low-complexity default model: `gpt-5.3-codex-spark` (only when 1+2 are absent and team `agentType` is low-complexity)
+
+Model flag normalization contract:
+- Accept both `--model <value>` and `--model=<value>`
+- Remove duplicates/conflicts
+- Emit exactly one final canonical model flag: `--model <value>`
+- Preserve unrelated worker launch args
+</team_model_resolution>
+
+---
+
 <verification>
 Verify before claiming completion. The goal is evidence-backed confidence, not ceremony.
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -77,6 +77,21 @@ Important:
 - Worker ACKs go to `mailbox/leader-fixed.json`
 - Notify hook updates worker heartbeat and nudges leader during active team mode
 
+### Team worker model resolution (current contract)
+
+Team mode resolves worker model flags from one shared launch-arg set (not per-worker model selection).
+
+Precedence (highest to lowest):
+1. Explicit worker model in `OMX_TEAM_WORKER_LAUNCH_ARGS`
+2. Inherited leader `--model` flag
+3. Injected low-complexity default: `gpt-5.3-codex-spark` (only when 1+2 are absent and team `agentType` is low-complexity)
+
+Normalization requirements:
+- Parse both `--model <value>` and `--model=<value>`
+- Remove duplicate/conflicting model flags
+- Emit exactly one final canonical flag: `--model <value>`
+- Preserve unrelated args in worker launch config
+
 ## Required Lifecycle (Operator Contract)
 
 Follow this exact lifecycle when running `$team`:

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -14,7 +14,16 @@ import {
   writeAtomic,
   readTask,
 } from '../state.js';
-import { monitorTeam, shutdownTeam, resumeTeam, startTeam, assignTask, sendWorkerMessage } from '../runtime.js';
+import {
+  monitorTeam,
+  shutdownTeam,
+  resumeTeam,
+  startTeam,
+  assignTask,
+  sendWorkerMessage,
+  resolveWorkerLaunchArgsFromEnv,
+  TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+} from '../runtime.js';
 
 function withEmptyPath<T>(fn: () => T): T {
   const prev = process.env.PATH;
@@ -27,7 +36,52 @@ function withEmptyPath<T>(fn: () => T): T {
   }
 }
 
+function withoutTeamWorkerEnv<T>(fn: () => T): T {
+  const prev = process.env.OMX_TEAM_WORKER;
+  delete process.env.OMX_TEAM_WORKER;
+  try {
+    return fn();
+  } finally {
+    if (typeof prev === 'string') process.env.OMX_TEAM_WORKER = prev;
+  }
+}
+
 describe('runtime', () => {
+  it('resolveWorkerLaunchArgsFromEnv injects low-complexity default model when missing', () => {
+    const args = resolveWorkerLaunchArgsFromEnv(
+      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+      'explore',
+    );
+    assert.deepEqual(args, ['--no-alt-screen', '--model', TEAM_LOW_COMPLEXITY_DEFAULT_MODEL]);
+  });
+
+  it('resolveWorkerLaunchArgsFromEnv does not inject default model for non-low agentType', () => {
+    const args = resolveWorkerLaunchArgsFromEnv(
+      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+      'executor',
+    );
+    assert.deepEqual(args, ['--no-alt-screen']);
+  });
+
+  it('resolveWorkerLaunchArgsFromEnv treats *-low aliases as low complexity', () => {
+    const args = resolveWorkerLaunchArgsFromEnv(
+      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+      'executor-low',
+    );
+    assert.deepEqual(args, ['--no-alt-screen', '--model', TEAM_LOW_COMPLEXITY_DEFAULT_MODEL]);
+  });
+
+  it('resolveWorkerLaunchArgsFromEnv preserves explicit model in either syntax', () => {
+    assert.deepEqual(
+      resolveWorkerLaunchArgsFromEnv({ OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gpt-5' }, 'explore'),
+      ['--model', 'gpt-5'],
+    );
+    assert.deepEqual(
+      resolveWorkerLaunchArgsFromEnv({ OMX_TEAM_WORKER_LAUNCH_ARGS: '--model=gpt-5.3' }, 'explore'),
+      ['--model=gpt-5.3'],
+    );
+  });
+
   it('startTeam rejects nested team invocation inside worker context', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     const prev = process.env.OMX_TEAM_WORKER;
@@ -48,10 +102,10 @@ describe('runtime', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     try {
       await assert.rejects(
-        () =>
+        () => withoutTeamWorkerEnv(() =>
           withEmptyPath(() =>
             startTeam('team-a', 'task', 'executor', 1, [{ subject: 's', description: 'd' }], cwd),
-          ),
+          )),
         /requires tmux/i,
       );
     } finally {

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -234,6 +234,23 @@ Resume: detect existing team state and resume from the last incomplete stage.
 
 ---
 
+<team_model_resolution>
+Team/Swarm worker startup currently uses one shared `agentType` and one shared launch-arg set for all workers in a team run.
+
+For worker model selection, apply this precedence (highest to lowest):
+1. Explicit model already present in `OMX_TEAM_WORKER_LAUNCH_ARGS`
+2. Inherited leader `--model` (when inheritance is enabled)
+3. Injected low-complexity default model: `gpt-5.3-codex-spark` (only when 1+2 are absent and team `agentType` is low-complexity)
+
+Model flag normalization contract:
+- Accept both `--model <value>` and `--model=<value>`
+- Remove duplicates/conflicts
+- Emit exactly one final canonical model flag: `--model <value>`
+- Preserve unrelated worker launch args
+</team_model_resolution>
+
+---
+
 <verification>
 Verify before claiming completion. The goal is evidence-backed confidence, not ceremony.
 


### PR DESCRIPTION
### Summary
- Default low-complexity Team/Swarm worker sessions to `gpt-5.3-codex-spark` (team-level, shared launch args).
- Add CLI worker launch arg model parsing/normalization supporting `--model X` and `--model=X`.
- Document the precedence contract (env > inherited > default) in `AGENTS.md`, `templates/AGENTS.md`, and `skills/team/SKILL.md`.

### Behavior
Model precedence (highest → lowest):
1) Explicit model in `OMX_TEAM_WORKER_LAUNCH_ARGS`
2) Inherited leader `--model` (when enabled)
3) Injected low-complexity default `gpt-5.3-codex-spark`

Normalization:
- Remove duplicates/conflicts and emit exactly one canonical `--model <value>`.

### Verification
- `npm ci`
- `npm test`
