### PR TITLE
Fix HUD tmux behavior for --help and pane dedupe

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readGitBranch } from '../state.js';
+
+describe('readGitBranch', () => {
+  it('returns null in a non-git directory without printing git fatal noise', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-state-'));
+    const stderrChunks: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+
+    const patchedWrite = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((err?: Error | null) => void), callback?: (err?: Error | null) => void) => {
+      const text = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+      stderrChunks.push(text);
+      if (typeof encodingOrCallback === 'function') encodingOrCallback(null);
+      if (typeof callback === 'function') callback(null);
+      return true;
+    }) as typeof process.stderr.write;
+
+    process.stderr.write = patchedWrite;
+
+    try {
+      assert.equal(readGitBranch(cwd), null);
+    } finally {
+      process.stderr.write = originalWrite;
+      await rm(cwd, { recursive: true, force: true });
+    }
+
+    assert.equal(stderrChunks.join('').includes('not a git repository'), false);
+  });
+});

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -95,7 +95,12 @@ export function readVersion(): string | null {
 
 export function readGitBranch(cwd: string): string | null {
   try {
-    const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd, encoding: 'utf-8', timeout: 2000 }).trim();
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 2000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
     const remote = execSync('git remote get-url origin', { cwd, encoding: 'utf-8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
     // Extract repo name from URL: https://github.com/user/repo.git -> repo
     const repoMatch = remote.match(/\/([^/]+?)(?:\.git)?$/);


### PR DESCRIPTION
## Summary\n- make Codex CLI

If no subcommand is specified, options will be forwarded to the interactive CLI.

Usage: codex [OPTIONS] [PROMPT]
       codex [OPTIONS] <COMMAND> [ARGS]

Commands:
  exec        Run Codex non-interactively [aliases: e]
  review      Run a code review non-interactively
  login       Manage login
  logout      Remove stored authentication credentials
  mcp         [experimental] Run Codex as an MCP server and manage MCP servers
  mcp-server  [experimental] Run the Codex MCP server (stdio transport)
  app-server  [experimental] Run the app server or related tooling
  completion  Generate shell completion scripts
  sandbox     Run commands within a Codex-provided sandbox
  debug       Debugging tools
  apply       Apply the latest diff produced by Codex agent as a `git apply` to your local working
              tree [aliases: a]
  resume      Resume a previous interactive session (picker by default; use --last to continue the
              most recent)
  fork        Fork a previous interactive session (picker by default; use --last to fork the most
              recent)
  cloud       [EXPERIMENTAL] Browse tasks from Codex Cloud and apply changes locally
  features    Inspect feature flags
  help        Print this message or the help of the given subcommand(s)

Arguments:
  [PROMPT]
          Optional user prompt to start the session

Options:
  -c, --config <key=value>
          Override a configuration value that would otherwise be loaded from `~/.codex/config.toml`.
          Use a dotted path (`foo.bar.baz`) to override nested values. The `value` portion is parsed
          as TOML. If it fails to parse as TOML, the raw string is used as a literal.
          
          Examples: - `-c model="o3"` - `-c 'sandbox_permissions=["disk-full-read-access"]'` - `-c
          shell_environment_policy.inherit=all`

      --enable <FEATURE>
          Enable a feature (repeatable). Equivalent to `-c features.<name>=true`

      --disable <FEATURE>
          Disable a feature (repeatable). Equivalent to `-c features.<name>=false`

  -i, --image <FILE>...
          Optional image(s) to attach to the initial prompt

  -m, --model <MODEL>
          Model the agent should use

      --oss
          Convenience flag to select the local open source model provider. Equivalent to -c
          model_provider=oss; verifies a local LM Studio or Ollama server is running

      --local-provider <OSS_PROVIDER>
          Specify which local provider to use (lmstudio or ollama). If not specified with --oss,
          will use config default or show selection

  -p, --profile <CONFIG_PROFILE>
          Configuration profile from config.toml to specify default options

  -s, --sandbox <SANDBOX_MODE>
          Select the sandbox policy to use when executing model-generated shell commands
          
          [possible values: read-only, workspace-write, danger-full-access]

  -a, --ask-for-approval <APPROVAL_POLICY>
          Configure when the model requires human approval before executing a command

          Possible values:
          - untrusted:  Only run "trusted" commands (e.g. ls, cat, sed) without asking for user
            approval. Will escalate to the user if the model proposes a command that is not in the
            "trusted" set
          - on-failure: Run all commands without asking for user approval. Only asks for approval if
            a command fails to execute, in which case it will escalate to the user to ask for
            un-sandboxed execution
          - on-request: The model decides when to ask the user for approval
          - never:      Never ask for user approval Execution failures are immediately returned to
            the model

      --full-auto
          Convenience alias for low-friction sandboxed automatic execution (-a on-request, --sandbox
          workspace-write)

      --dangerously-bypass-approvals-and-sandbox
          Skip all confirmation prompts and execute commands without sandboxing. EXTREMELY
          DANGEROUS. Intended solely for running in environments that are externally sandboxed

  -C, --cd <DIR>
          Tell the agent to use the specified directory as its working root

      --search
          Enable live web search. When enabled, the native Responses `web_search` tool is available
          to the model (no per‑call approval)

      --add-dir <DIR>
          Additional directories that should be writable alongside the primary workspace

      --no-alt-screen
          Disable alternate screen mode
          
          Runs the TUI in inline mode, preserving terminal scrollback history. This is useful in
          terminal multiplexers like Zellij that follow the xterm spec strictly and disable
          scrollback in alternate screen buffers.

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version and 
oh-my-codex (omx) - Multi-agent orchestration for Codex CLI

Usage:
  omx           Launch Codex CLI + HUD in tmux (or just Codex if no tmux)
  omx setup     Install skills, prompts, MCP servers, and AGENTS.md
  omx doctor    Check installation health
  omx doctor --team  Check team/swarm runtime health diagnostics
  omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
  omx version   Show version information
  omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
  omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
  omx help      Show this help message
  omx status    Show active modes and state
  omx cancel    Cancel active execution modes
  omx reasoning Show or set model reasoning effort (low|medium|high|xhigh)

Options:
  --yolo        Launch Codex in yolo mode (shorthand for: omx launch --yolo)
  --high        Launch Codex with high reasoning effort
                (shorthand for: -c model_reasoning_effort="high")
  --xhigh       Launch Codex with xhigh reasoning effort
                (shorthand for: -c model_reasoning_effort="xhigh")
  --madmax      DANGEROUS: bypass Codex approvals and sandbox
                (alias for --dangerously-bypass-approvals-and-sandbox)
  --force       Force reinstall (overwrite existing files)
  --dry-run     Show what would be done without doing it
  --verbose     Show detailed output resolve to help output instead of launch flow\n- change non-tmux launch policy to run Codex directly in current terminal (no forced tmux attach)\n- inside tmux, remove stale HUD watch panes before launch and clean HUD pane(s) after Codex exits to avoid stacking\n- suppress git fatal noise in HUD branch detection for non-git directories\n- add unit tests for invocation resolution, launch policy, HUD pane helpers, and non-git HUD noise behavior\n\n## Verification\n- 
> oh-my-codex@0.3.6 build
> tsc\n- 
> oh-my-codex@0.3.6 test
> npm run build && node --test dist/**/*.test.js


> oh-my-codex@0.3.6 build
> tsc

▶ omx doctor --team
  ✔ exits non-zero and prints resume_blocker when team state references missing tmux session (75.35165ms)
  ✔ does not emit resume_blocker when tmux is unavailable (61.932857ms)
  ✔ prints slow_shutdown when shutdown request is stale and ack missing (58.776817ms)
  ✔ prints delayed_status_lag when worker is working and heartbeat is stale (60.112237ms)
  ✔ prints orphan_tmux_session when tmux session exists without matching team state (56.013245ms)
  ✔ does not emit orphan_tmux_session when tmux reports no server running (56.05691ms)
✔ omx doctor --team (369.742506ms)
▶ normalizeCodexLaunchArgs
  ✔ maps --madmax to codex bypass flag (1.107088ms)
  ✔ does not forward --madmax and preserves other args (0.118678ms)
  ✔ avoids duplicate bypass flags when both are present (0.132164ms)
  ✔ deduplicates repeated bypass-related flags (0.124209ms)
  ✔ leaves unrelated args unchanged (0.129819ms)
  ✔ maps --high to reasoning override (0.124599ms)
  ✔ maps --xhigh to reasoning override (0.106705ms)
  ✔ uses the last reasoning shorthand when both are present (0.10923ms)
  ✔ maps --xhigh --madmax to codex-native flags only (0.174675ms)
✔ normalizeCodexLaunchArgs (3.196204ms)
▶ resolveCliInvocation
  ✔ resolves --help to the help command instead of launch (0.243838ms)
  ✔ keeps unknown long flags as launch passthrough args (0.09884ms)
✔ resolveCliInvocation (0.487617ms)
▶ resolveCodexLaunchPolicy
  ✔ launches directly when outside tmux (0.164326ms)
  ✔ uses tmux-aware launch path when already inside tmux (0.080194ms)
✔ resolveCodexLaunchPolicy (0.329383ms)
▶ tmux HUD pane helpers
  ✔ findHudWatchPaneIds detects stale HUD watch panes and excludes current pane (0.40552ms)
  ✔ buildHudPaneCleanupTargets de-dupes pane ids and includes created pane (0.108759ms)
✔ tmux HUD pane helpers (0.596457ms)
▶ buildTmuxShellCommand
  ✔ preserves quoted config values for tmux shell-command execution (0.116805ms)
✔ buildTmuxShellCommand (0.181018ms)
▶ buildTmuxSessionName
  ✔ uses omx-directory-branch-session format (3.185323ms)
  ✔ sanitizes invalid characters (1.534119ms)
✔ buildTmuxSessionName (4.835566ms)
▶ team worker launch arg inheritance helpers
  ✔ collectInheritableTeamWorkerArgs extracts bypass and reasoning overrides (0.246815ms)
  ✔ resolveTeamWorkerLaunchArgsEnv merges and normalizes with de-dupe + last reasoning wins (0.229611ms)
  ✔ resolveTeamWorkerLaunchArgsEnv can opt out of leader inheritance (0.077158ms)
✔ team worker launch arg inheritance helpers (0.685478ms)
▶ readTopLevelTomlString
  ✔ reads a top-level string value (0.319294ms)
  ✔ ignores table-local values (0.126103ms)
✔ readTopLevelTomlString (0.522324ms)
▶ injectModelInstructionsBypassArgs
  ✔ appends model_instructions_file override by default (0.231154ms)
  ✔ does not append when bypass is disabled via env (0.091335ms)
  ✔ does not append when model_instructions_file is already set (0.11454ms)
  ✔ respects OMX_MODEL_INSTRUCTIONS_FILE env override (0.091887ms)
✔ injectModelInstructionsBypassArgs (0.658606ms)
▶ upsertTopLevelTomlString
  ✔ replaces an existing top-level key (0.302341ms)
  ✔ inserts before the first table when key is missing (0.131723ms)
✔ upsertTopLevelTomlString (0.536301ms)
▶ CLI session-scoped state parity
  ✔ status and cancel include session-scoped states (122.541445ms)
✔ CLI session-scoped state parity (123.390147ms)
▶ omx setup (gh star hint)
  ✔ prints a star hint when GitHub CLI is configured (66.779932ms)
  ✔ does not print a star hint when GitHub CLI is missing (65.192632ms)
✔ omx setup (gh star hint) (132.997755ms)
▶ config generator
  ✔ places top-level keys before [features] (6.645144ms)
  ✔ writes notify as a TOML array (2.720359ms)
  ✔ writes model_reasoning_effort and developer_instructions (1.092801ms)
  ✔ handles paths with spaces in notify array (1.361738ms)
  ✔ re-runs setup replacing OMX config cleanly (1.907347ms)
  ✔ preserves existing user top-level config (1.388299ms)
  ✔ migrates a legacy OMX block and preserves user settings (1.255443ms)
  ✔ merges into existing [features] table without duplicating it (1.288928ms)
✔ config generator (18.905102ms)
▶ generateOverlay
  ✔ generates overlay with no state files (empty but valid) (3.373726ms)
  ✔ generates overlay with active modes (1.909821ms)
  ✔ generates overlay with session-scoped active modes for current session (1.516234ms)
  ✔ generates overlay with notepad priority content (1.27457ms)
  ✔ generates overlay with project memory summary (1.436491ms)
  ✔ enforces size cap (overlay <= 2000 chars) (1.679198ms)
  ✔ skips inactive modes (1.343502ms)
✔ generateOverlay (18.613251ms)
▶ applyOverlay + stripOverlay roundtrip
  ✔ apply then strip restores original (roundtrip) (5.345425ms)
  ✔ applyOverlay is idempotent (apply twice, no duplication) (3.023181ms)
  ✔ handles stale markers from previous session (1.89887ms)
  ✔ stripOverlay is no-op when no overlay exists (1.465888ms)
  ✔ creates AGENTS.md if it does not exist during apply (1.506566ms)
✔ applyOverlay + stripOverlay roundtrip (15.196863ms)
▶ hasOverlay
  ✔ returns true when both markers present (0.126954ms)
  ✔ returns false when no markers (0.075455ms)
  ✔ returns false when only start marker (0.059745ms)
✔ hasOverlay (0.369891ms)
▶ keyword detector swarm/team compatibility
  ✔ maps "coordinated team" phrase to team orchestration skill (2.167977ms)
  ✔ maps "swarm" to team orchestration skill (0.687431ms)
  ✔ maps "coordinated swarm" phrase to team orchestration skill (1.168516ms)
  ✔ keeps swarm trigger priority aligned with team trigger (0.322631ms)
✔ keyword detector swarm/team compatibility (5.999453ms)
▶ keyword detection guidance generation
  ✔ includes swarm alias activation guidance (0.407243ms)
✔ keyword detection guidance generation (0.642836ms)
▶ notify-fallback watcher
  ✔ one-shot mode forwards only recent task_complete events (89.701676ms)
  ✔ streaming mode tails from EOF and does not replay backlog (758.5955ms)
✔ notify-fallback watcher (849.42829ms)
▶ notify-hook linked team -> ralph terminal sync
  ✔ updates root ralph state when linked team enters terminal phase (52.886674ms)
  ✔ updates session-scoped ralph state when linked session team enters terminal phase (49.942788ms)
  ✔ does not update ralph state when team/ralph are not linked (48.047172ms)
✔ notify-hook linked team -> ralph terminal sync (151.976128ms)
▶ notify-hook session-scoped iteration updates
  ✔ increments iteration for active session-scoped mode states (56.622616ms)
✔ notify-hook session-scoped iteration updates (57.480095ms)
▶ notify-hook team leader nudge
  ✔ nudges leader via tmux display-message when team is active and mailbox has messages (65.87394ms)
✔ notify-hook team leader nudge (66.831101ms)
▶ notify-hook tmux target healing
  ✔ falls back to current tmux pane and heals stale session target (173.491607ms)
  ✔ skips injection when fallback pane cwd does not match hook cwd (61.929901ms)
  ✔ falls back by matching pane cwd when TMUX_PANE is unavailable (119.89592ms)
  ✔ prefers active mode state tmux_pane_id when present (125.468962ms)
✔ notify-hook tmux target healing (481.928825ms)
▶ normalizeTmuxHookConfig
  ✔ returns safe disabled defaults for missing config (0.892005ms)
  ✔ normalizes valid config (0.460235ms)
  ✔ treats placeholder/unset target values as invalid (0.17681ms)
✔ normalizeTmuxHookConfig (2.372641ms)
▶ pickActiveMode
  ✔ chooses by allowed mode order (0.292772ms)
  ✔ returns null when no allowed mode is active (0.140601ms)
✔ pickActiveMode (0.708162ms)
▶ evaluateInjectionGuards
  ✔ blocks when disabled (0.351246ms)
  ✔ blocks input marker loop (0.167642ms)
  ✔ blocks with invalid_config when enabled target is placeholder/unset (1.172795ms)
  ✔ blocks duplicates and cooldown and session cap (0.692071ms)
  ✔ supports legacy session_counts when pane_counts is absent (0.214693ms)
✔ evaluateInjectionGuards (2.910184ms)
▶ buildSendKeysArgv
  ✔ builds argv safely and supports dry-run (0.18193ms)
✔ buildSendKeysArgv (0.25491ms)
▶ VULNERABILITY – old string-interpolation approach
  ✔ cwd containing $() is injectable via double-quote context (0.791342ms)
  ✔ cwd containing backticks is injectable via double-quote context (0.124459ms)
  ✔ omxBin containing single quote breaks out of the '-quoted command (0.158054ms)
✔ VULNERABILITY – old string-interpolation approach (2.064729ms)
▶ shellEscape
  ✔ wraps a plain string in single quotes (0.323402ms)
  ✔ escapes embedded single quotes (0.124169ms)
  ✔ handles multiple single quotes (0.124189ms)
  ✔ passes through $() literally inside single quotes (0.106835ms)
  ✔ passes through backticks literally inside single quotes (0.129109ms)
  ✔ handles empty string (0.119169ms)
✔ shellEscape (1.272185ms)
▶ buildTmuxSplitArgs – shell injection hardening
  ✔ produces correct argv for normal inputs (2.078465ms)
  ✔ cwd is an isolated array element – never shell-interpreted (0.114279ms)
  ✔ cwd with backticks is isolated from the shell command (0.090003ms)
  ✔ omxBin with single quote is properly escaped in command string (0.087829ms)
  ✔ omxBin with $() is neutralised by single-quote wrapping (0.110322ms)
  ✔ omxBin with backticks is neutralised by single-quote wrapping (0.094842ms)
  ✔ omxBin with ';command' breakout attempt is neutralised (0.104631ms)
  ✔ preset is appended safely (0.09914ms)
  ✔ absent preset produces no --preset flag (0.07276ms)
  ✔ invalid preset is dropped (defense in depth) (0.071357ms)
✔ buildTmuxSplitArgs – shell injection hardening (3.274775ms)
▶ readGitBranch
  ✔ returns null in a non-git directory without printing git fatal noise (8.067468ms)
✔ readGitBranch (9.609632ms)
▶ validateSessionId
  ✔ accepts undefined and valid ids (4.290838ms)
  ✔ rejects invalid ids (0.429014ms)
✔ validateSessionId (5.536332ms)
▶ state paths
  ✔ builds global state paths (0.300939ms)
  ✔ builds session state paths (0.135661ms)
  ✔ enumerates global-only path (9.696159ms)
  ✔ enumerates session-scoped paths (2.215489ms)
  ✔ enumerates state directories across all scopes (1.852941ms)
  ✔ enumerates global and session-scoped paths together (1.505414ms)
  ✔ ignores invalid session directory names (1.542225ms)
✔ state paths (17.82201ms)
▶ state-server team comm tools
  ✔ team_send_message + team_mailbox_list + team_mailbox_mark_delivered (137.856618ms)
  ✔ team_broadcast sends to all workers except sender (5.354132ms)
✔ state-server team comm tools (144.121881ms)
▶ state-server directory initialization
  ✔ creates .omx/state for state tools without setup (148.94419ms)
  ✔ creates session-scoped state directory when session_id is provided (11.147229ms)
✔ state-server directory initialization (161.002992ms)
▶ trace-server session-scoped mode discovery
  ✔ includes mode events from session-scoped state files (153.286358ms)
✔ trace-server session-scoped mode discovery (154.194183ms)
▶ modes/base tmux pane capture
  ✔ captures tmux_pane_id in mode state on startMode() (9.104422ms)
✔ modes/base tmux pane capture (10.111778ms)
▶ withModeRuntimeContext
  ✔ captures tmux_pane_id on activation when env has TMUX_PANE (0.658396ms)
  ✔ does not overwrite tmux_pane_id once set (0.128797ms)
  ✔ does nothing when TMUX_PANE is missing (0.148175ms)
✔ withModeRuntimeContext (1.799178ms)
▶ mcp-comm
  ✔ queueInboxInstruction writes inbox before notifying (9.52453ms)
  ✔ queueDirectMailboxMessage writes message and marks notified only on successful notify (6.937025ms)
  ✔ queueBroadcastMailboxMessage notifies and marks notified per recipient (6.319528ms)
✔ mcp-comm (23.73076ms)
▶ isValidTransition
  ✔ accepts canonical pipeline transitions (0.585285ms)
  ✔ rejects invalid transitions (0.118768ms)
✔ isValidTransition (1.641265ms)
▶ transitionPhase
  ✔ does not mutate input state when entering team-fix (0.652614ms)
  ✔ enforces bounded team-fix loop and transitions to failed with reason (0.314524ms)
  ✔ prevents transitions from terminal phases (0.452089ms)
  ✔ marks state non-resumable for failed and cancelled (0.198191ms)
  ✔ throws on structurally invalid transition attempts (0.224542ms)
  ✔ preserves explicit reason and appends exactly one transition record (0.299005ms)
  ✔ marks complete as terminal and keeps fix attempt unchanged (0.320876ms)
✔ transitionPhase (2.95466ms)
▶ canResumeTeamState
  ✔ returns false for non-terminal inactive state (0.197119ms)
✔ canResumeTeamState (0.292332ms)
▶ runtime
  ✔ startTeam rejects nested team invocation inside worker context (5.774312ms)
  ✔ startTeam throws when tmux is not available (4.009337ms)
  ✔ monitorTeam returns null for non-existent team (1.349394ms)
  ✔ monitorTeam returns correct task counts from state files (27.145282ms)
  ✔ monitorTeam emits worker_idle and task_completed events based on transitions (17.352297ms)
  ✔ shutdownTeam cleans up state even when tmux session doesn't exist (30.571969ms)
  ✔ shutdownTeam returns rejection error when worker rejects shutdown and force is false (16.588528ms)
  ✔ shutdownTeam force=true ignores rejection and cleans up team state (33.704372ms)
  ✔ shutdownTeam ignores stale rejection ack from a prior request (30.709203ms)
  ✔ resumeTeam returns null for non-existent team (1.054067ms)
  ✔ assignTask enforces delegation_only policy for leader-fixed worker (4.290939ms)
  ✔ assignTask does not claim task when worker does not exist (4.39067ms)
  ✔ assignTask rolls back claim when notification transport fails (17.668615ms)
  ✔ assignTask rolls back claim when inbox write fails after claim (7.085961ms)
  ✔ assignTask enforces plan approval for code-change tasks when required (4.414496ms)
  ✔ sendWorkerMessage allows worker to message leader-fixed mailbox (23.266025ms)
✔ runtime (231.366953ms)
▶ team state
  ✔ initTeamState creates correct directory structure and config.json (9.923578ms)
  ✔ migrateV1ToV2 writes manifest.v2.json idempotently from legacy config.json (4.98356ms)
  ✔ claimTask enforces dependency readiness (blocked_dependency) (8.385239ms)
  ✔ claimTask claim locking yields deterministic claim_conflict (31.433646ms)
  ✔ claimTask recovers a stale task claim lock and proceeds (6.220748ms)
  ✔ claimTask owner write failure cleans up claim lock without orphan lock dir (4.093619ms)
  ✔ transitionTaskStatus returns invalid_transition for illegal transition (6.135734ms)
  ✔ transitionTaskStatus appends task_completed event when task completes (6.188056ms)
  ✔ releaseTaskClaim reverts a claimed task back to pending under claim lock (6.566202ms)
  ✔ releaseTaskClaim can recover with owner match when claim token changed (6.822816ms)
  ✔ mailbox APIs: DM, broadcast, and mark delivered (5.422875ms)
  ✔ markMessageNotified stores notified_at without forcing delivered_at (5.803646ms)
  ✔ mailbox does not lose messages under concurrent sends (626.442099ms)
  ✔ writeTaskApproval writes record and emits approval_decision event (6.476229ms)
  ✔ initTeamState rejects workerCount > max_workers (0.989422ms)
  ✔ initTeamState rejects maxWorkers > ABSOLUTE_MAX_WORKERS (0.723751ms)
  ✔ createTask auto-increments IDs (6.340339ms)
  ✔ createTask does not overwrite existing tasks when config next_task_id is missing (legacy) (6.467603ms)
  ✔ listTasks returns sorted by ID (9.740154ms)
  ✔ readTask returns null for non-existent task (3.198488ms)
  ✔ readTask returns null for malformed JSON (3.00155ms)
  ✔ updateTask merges updates correctly (7.257491ms)
  ✔ updateTask is safe under concurrent calls (no lost updates) (30.971417ms)
  ✔ writeAtomic creates file and is safe to call concurrently (basic) (1.26946ms)
  ✔ readWorkerStatus returns {state:'unknown'} on missing file (2.892571ms)
  ✔ readWorkerHeartbeat returns null on missing file (3.02771ms)
  ✔ writeWorkerInbox writes content to the correct path (4.217107ms)
  ✔ getTeamSummary aggregates task counts correctly (20.785107ms)
  ✔ cleanupTeamState removes the directory (3.04877ms)
  ✔ validateTeamName rejects invalid names (via initTeamState throwing) (0.822882ms)
  ✔ initTeamState snapshots permissions and display mode from env (3.5999ms)
✔ team state (846.797525ms)
▶ sanitizeTeamName
  ✔ lowercases and strips invalid chars (0.708372ms)
  ✔ truncates to 30 chars (0.142494ms)
  ✔ rejects empty after sanitization (0.369109ms)
✔ sanitizeTeamName (2.045983ms)
▶ sendToWorker validation
  ✔ rejects text over 200 chars (0.286711ms)
  ✔ rejects injection marker (0.146932ms)
✔ sendToWorker validation (0.601145ms)
▶ buildWorkerStartupCommand
  ✔ uses zsh with ~/.zshrc and exec codex (0.464614ms)
  ✔ uses bash with ~/.bashrc and preserves launch args (0.254279ms)
  ✔ inherits bypass flag from process argv once (0.279277ms)
  ✔ maps --madmax to bypass flag in worker command (0.227578ms)
  ✔ preserves reasoning override args in worker command (0.238378ms)
  ✔ injects model_instructions_file override by default (0.233689ms)
  ✔ does not inject model_instructions_file override when disabled (0.153295ms)
  ✔ does not inject model_instructions_file when already provided in launch args (0.175187ms)
✔ buildWorkerStartupCommand (2.416115ms)
▶ tmux-dependent functions when tmux is unavailable
  ✔ isTmuxAvailable returns false (2.14332ms)
  ✔ createTeamSession throws (1.868261ms)
  ✔ listTeamSessions returns empty (2.32528ms)
  ✔ waitForWorkerReady returns false on timeout (1.891186ms)
✔ tmux-dependent functions when tmux is unavailable (9.115143ms)
▶ isWorkerAlive
  ✔ does not require pane_current_command to match "codex" (1.59186ms)
✔ isWorkerAlive (1.69559ms)
▶ worker bootstrap
  ✔ generateWorkerOverlay produces markdown with correct start/end markers (1.576621ms)
  ✔ generateWorkerOverlay includes the team name (0.142705ms)
  ✔ applyWorkerOverlay appends to existing AGENTS.md content (7.903685ms)
  ✔ applyWorkerOverlay is idempotent (calling twice doesn't duplicate) (2.010585ms)
  ✔ stripWorkerOverlay removes the overlay section (1.319216ms)
  ✔ stripWorkerOverlay is idempotent (calling on already-stripped is no-op) (1.353612ms)
  ✔ applyWorkerOverlay works on non-existent file (creates it) (1.106948ms)
  ✔ generateInitialInbox includes worker name, team name, and all tasks (0.493889ms)
  ✔ generateInitialInbox shows blocked_by info for blocked tasks (0.148967ms)
  ✔ generateTaskAssignmentInbox includes task ID and description (0.216205ms)
  ✔ generateShutdownInbox contains exit instruction and concrete ack path (0.118868ms)
  ✔ generateTriggerMessage is always < 200 characters (0.123197ms)
  ✔ generateTriggerMessage does not contain [OMX_TMUX_INJECT] (0.070946ms)
  ✔ generateTriggerMessage contains the inbox path (0.066227ms)
  ✔ generateMailboxTriggerMessage is always < 200 characters (0.095493ms)
  ✔ generateMailboxTriggerMessage contains mailbox path and count (0.07318ms)
✔ worker bootstrap (18.137378ms)
ℹ tests 220
ℹ suites 51
ℹ pass 220
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1022.00481\n\nCloses #30