### PR TITLE
feat: use session-scoped model_instructions_file for runtime overlay

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -194,6 +194,19 @@ describe('injectModelInstructionsBypassArgs', () => {
       ['-c', 'model_instructions_file="/tmp/alt instructions.md"']
     );
   });
+
+  it('uses session-scoped default model_instructions_file when provided', () => {
+    const args = injectModelInstructionsBypassArgs(
+      '/tmp/my-project',
+      ['--model', 'gpt-5'],
+      {},
+      '/tmp/my-project/.omx/state/sessions/session-1/AGENTS.md'
+    );
+    assert.deepEqual(
+      args,
+      ['--model', 'gpt-5', '-c', 'model_instructions_file="/tmp/my-project/.omx/state/sessions/session-1/AGENTS.md"']
+    );
+  });
 });
 
 describe('upsertTopLevelTomlString', () => {


### PR DESCRIPTION
## Summary
- stop mutating `<cwd>/AGENTS.md` during runtime overlay handling
- write a session-scoped instructions file at `.omx/state/sessions/<sessionId>/AGENTS.md`
- inject that session file via `-c model_instructions_file=...` by default at launch
- clean up stale/current session instruction files during pre/post launch without touching project `AGENTS.md`
- add tests for session-scoped injection and session instructions file create/cleanup behavior

## Why
Implements #31 to avoid temporary AGENTS diffs, concurrent session contention, and stray AGENTS file creation when none existed.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/index.test.js dist/hooks/__tests__/agents-overlay.test.js`
- `env -u OMX_TEAM_WORKER npm test`

Closes #31