### PR TITLE
fix(cli): make omx launch work on Windows and surface codex launch failures

### DIFF
--- a/bin/omx.js
+++ b/bin/omx.js
@@ -3,7 +3,7 @@
 // oh-my-codex CLI entry point
 // Supports both compiled (dist/) and direct TypeScript execution
 
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 
@@ -16,8 +16,8 @@ const distEntry = join(root, 'dist', 'cli', 'index.js');
 const srcEntry = join(root, 'src', 'cli', 'index.ts');
 
 if (existsSync(distEntry)) {
-  const { main } = await import(distEntry);
-  main(process.argv.slice(2));
+  const { main } = await import(pathToFileURL(distEntry).href);
+  await main(process.argv.slice(2));
 } else {
   // Direct TS execution requires tsx or similar
   console.error('oh-my-codex: run "npm run build" first, or use tsx/ts-node');

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import {
   buildTmuxSessionName,
   resolveCliInvocation,
   resolveCodexLaunchPolicy,
+  resolveCodexExecInvocation,
   parseTmuxPaneSnapshot,
   findHudWatchPaneIds,
   buildHudPaneCleanupTargets,
@@ -112,6 +113,28 @@ describe('resolveCodexLaunchPolicy', () => {
 
   it('uses tmux-aware launch path when already inside tmux', () => {
     assert.equal(resolveCodexLaunchPolicy({ TMUX: '/tmp/tmux-1000/default,123,0' }), 'inside-tmux');
+  });
+});
+
+describe('resolveCodexExecInvocation', () => {
+  it('wraps codex with cmd.exe on win32', () => {
+    assert.deepEqual(
+      resolveCodexExecInvocation(['--version'], 'win32'),
+      {
+        command: 'cmd.exe',
+        args: ['/d', '/s', '/c', 'codex', '--version'],
+      }
+    );
+  });
+
+  it('uses codex directly on non-win32 platforms', () => {
+    assert.deepEqual(
+      resolveCodexExecInvocation(['--version'], 'linux'),
+      {
+        command: 'codex',
+        args: ['--version'],
+      }
+    );
   });
 });
 


### PR DESCRIPTION
PR Title

  fix(cli): make omx launch work on Windows and surface codex launch failures

  PR Description

  ## Summary

  This PR fixes Windows launch issues for `omx` and improves launch error
  visibility.

  ## Problems

  1. `bin/omx.js` used `await import(distEntry)` with a Windows absolute path
  (`C:\...`), which triggers:
     `ERR_UNSUPPORTED_ESM_URL_SCHEME`.
  2. `bin/omx.js` called `main(...)` without `await`, which can cause early
  process exit in async flows.
  3. CLI launch path used `execFileSync('codex', ...)` directly; on Windows
  `codex` is a shim (`.cmd`/`.ps1`) and can fail to spawn correctly.
  4. launch failures were swallowed in `catch {}` blocks, causing silent exits.

  ## Changes

  - `bin/omx.js`
    - use `pathToFileURL(distEntry).href` for dynamic import
    - await `main(process.argv.slice(2))`

  - `src/cli/index.ts`
    - add `resolveCodexExecInvocation(...)`
      - `win32`: use `cmd.exe /d /s /c codex ...args`
      - other platforms: use `codex ...args`
    - add `runCodexCommand(...)` and replace direct `execFileSync('codex', ...)`
  calls
    - on launch failure, print `[omx] Codex launch failed: ...` and set non-zero
  exit code

  - `src/cli/__tests__/index.test.ts`
    - add tests for `resolveCodexExecInvocation` on Windows and non-Windows
  paths

  ## Validation

  - `npm run build` passes
  - new unit tests for `resolveCodexExecInvocation` pass

Fixes Windows `ERR_UNSUPPORTED_ESM_URL_SCHEME` during `omx` startup.