### PR TITLE
feat: add session lifecycle notifications to CLI (#49)

### DIFF
--- a/src/cli/__tests__/lifecycle-notifications.test.ts
+++ b/src/cli/__tests__/lifecycle-notifications.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  formatSessionStart,
+  formatSessionEnd,
+  formatSessionIdle,
+} from '../../notifications/formatter.js';
+import type { FullNotificationPayload } from '../../notifications/types.js';
+
+describe('lifecycle notification payload formatting', () => {
+  const basePayload: FullNotificationPayload = {
+    event: 'session-start',
+    sessionId: 'omx-test-456',
+    message: '',
+    timestamp: '2026-02-16T12:00:00.000Z',
+    projectPath: '/home/user/my-project',
+    projectName: 'my-project',
+  };
+
+  it('session-start includes session ID and project name', () => {
+    const msg = formatSessionStart(basePayload);
+    assert.ok(msg.includes('Session Started'));
+    assert.ok(msg.includes('omx-test-456'));
+    assert.ok(msg.includes('my-project'));
+  });
+
+  it('session-end includes duration and reason', () => {
+    const msg = formatSessionEnd({
+      ...basePayload,
+      event: 'session-end',
+      durationMs: 3661000, // 1h 1m 1s
+      reason: 'session_exit',
+    });
+    assert.ok(msg.includes('Session Ended'));
+    assert.ok(msg.includes('1h 1m 1s'));
+    assert.ok(msg.includes('session_exit'));
+  });
+
+  it('session-end shows unknown duration when durationMs is missing', () => {
+    const msg = formatSessionEnd({
+      ...basePayload,
+      event: 'session-end',
+      reason: 'session_exit',
+    });
+    assert.ok(msg.includes('unknown'));
+  });
+
+  it('session-idle includes idle message and project', () => {
+    const msg = formatSessionIdle({
+      ...basePayload,
+      event: 'session-idle',
+    });
+    assert.ok(msg.includes('Session Idle'));
+    assert.ok(msg.includes('waiting for input'));
+    assert.ok(msg.includes('my-project'));
+  });
+});


### PR DESCRIPTION
## Summary
Add `notifyLifecycle()` calls to the OMX CLI so that Discord/Telegram notifications fire on session lifecycle events.

### Changes
- `src/cli/index.ts`: Call `notifyLifecycle('session-start')` after `writeSessionStart()`, `notifyLifecycle('session-end')` after `writeSessionEnd()`
- `src/cli/__tests__/lifecycle-notifications.test.ts`: Tests for lifecycle notification payload formatting
- Session idle detection via notify-fallback watcher

### QA Verification (Live Discord)
- ✅ Session Started notification with tmux session name
- ✅ Session Ended notification with duration
- ✅ Session Idle notification
- ✅ All notifications include mention tag and tmux info

### Tests
- 395/398 pass (3 pre-existing tmux.test.js failures from PR #48)

Closes #49

🤖 repo owner's gaebal-gajae (clawdbot) 🦞