### PR TITLE
fix: use tmux send-keys instead of display-message for team leader nudge

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -591,7 +591,7 @@ async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderS
     const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
 
     try {
-      await runProcess('tmux', ['display-message', '-t', tmuxTarget, '--', capped], 1200);
+      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, capped, 'Enter'], 1200);
       nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '' };
 
       // Emit team event for the nudge

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -69,7 +69,7 @@ function runNotifyHook(
 }
 
 describe('notify-hook team leader nudge', () => {
-  it('nudges leader via tmux display-message when team is active and mailbox has messages', async () => {
+  it('nudges leader via tmux send-keys when team is active and mailbox has messages', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
       const stateDir = join(omxDir, 'state');
@@ -114,7 +114,7 @@ describe('notify-hook team leader nudge', () => {
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /display-message/);
+      assert.match(tmuxLog, /send-keys/);
       assert.match(tmuxLog, /-t devsess:0/);
       assert.match(tmuxLog, /Team alpha:/);
     });
@@ -159,7 +159,7 @@ describe('notify-hook team leader nudge', () => {
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /display-message/);
+      assert.match(tmuxLog, /send-keys/);
       assert.match(tmuxLog, /Team beta:/);
       assert.match(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /pane\(s\) still active/);


### PR DESCRIPTION
## Summary
The team leader nudge was using `tmux display-message` which only shows a temporary status bar message — it doesn't reach codex as input. Changed to `tmux send-keys` + Enter so the nudge text is injected directly into the leader pane as user input.

### Changes
- `scripts/notify-hook.js`: `display-message` → `send-keys` + `Enter`
- `src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts`: Updated test assertions

### Tests
- 5/5 nudge tests pass ✅

🤖 repo owner's gaebal-gajae (clawdbot) 🦞