### PR TITLE
fix: standardize tmux send-keys to use C-m instead of Enter across codebase

### DIFF
--- a/scripts/tmux-hook-engine.js
+++ b/scripts/tmux-hook-engine.js
@@ -149,10 +149,11 @@ export function buildSendKeysArgv({ paneTarget, prompt, dryRun }) {
   // 1) literal prompt bytes, 2) explicit carriage return.
   return {
     typeArgv: ['send-keys', '-t', paneTarget, '-l', prompt],
-    // Some panes/shells swallow one of these key names; send both.
+    // Codex CLI uses raw input mode where 'Enter' key name is unreliable;
+    // send 'C-m' (carriage return) twice for reliable prompt submission.
     submitArgv: [
       ['send-keys', '-t', paneTarget, 'C-m'],
-      ['send-keys', '-t', paneTarget, 'Enter'],
+      ['send-keys', '-t', paneTarget, 'C-m'],
     ],
   };
 }

--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -228,7 +228,7 @@ describe('buildSendKeysArgv', () => {
       typeArgv: ['send-keys', '-t', '%3', '-l', 'continue'],
       submitArgv: [
         ['send-keys', '-t', '%3', 'C-m'],
-        ['send-keys', '-t', '%3', 'Enter'],
+        ['send-keys', '-t', '%3', 'C-m'],
       ],
     });
 

--- a/src/notifications/tmux-detector.ts
+++ b/src/notifications/tmux-detector.ts
@@ -78,11 +78,16 @@ function sanitizeForTmux(text: string): string {
 export function sendToPane(paneId: string, text: string, pressEnter: boolean = true): boolean {
   try {
     const sanitized = sanitizeForTmux(text);
-    const enterSuffix = pressEnter ? ' Enter' : '';
-    execSync(`tmux send-keys -t ${paneId} "${sanitized}"${enterSuffix}`, {
+    execSync(`tmux send-keys -t ${paneId} "${sanitized}"`, {
       timeout: 3000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
+    if (pressEnter) {
+      // Codex CLI uses raw input mode where 'Enter' key name is unreliable;
+      // send 'C-m' (carriage return) twice for reliable prompt submission.
+      execSync(`tmux send-keys -t ${paneId} C-m`, { timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'] });
+      execSync(`tmux send-keys -t ${paneId} C-m`, { timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'] });
+    }
     return true;
   } catch {
     return false;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -368,9 +368,10 @@ export function waitForWorkerReady(
   const sendRobustEnter = (): void => {
     const target = paneTarget(sessionName, workerIndex, workerPaneId);
     // Trust + follow-up splash can require two submits in Codex TUI.
-    runTmux(['send-keys', '-t', target, 'Enter']);
+    // Use C-m (carriage return) instead of Enter for raw-mode compatibility.
+    runTmux(['send-keys', '-t', target, 'C-m']);
     sleepFractionalSeconds(0.12);
-    runTmux(['send-keys', '-t', target, 'Enter']);
+    runTmux(['send-keys', '-t', target, 'C-m']);
   };
 
   const check = (): boolean => {
@@ -434,9 +435,9 @@ export function sendToWorker(sessionName: string, workerIndex: number, text: str
   const captured = runTmux(['capture-pane', '-t', target, '-p', '-S', '-80']);
   const paneBusy = captured.ok ? paneHasActiveTask(captured.stdout) : false;
   if (captured.ok && paneHasTrustPrompt(captured.stdout)) {
-    sendKeyOrThrow(target, 'Enter', 'Enter');
+    sendKeyOrThrow(target, 'C-m', 'C-m');
     sleepFractionalSeconds(0.12);
-    sendKeyOrThrow(target, 'Enter', 'Enter');
+    sendKeyOrThrow(target, 'C-m', 'C-m');
     sleepFractionalSeconds(0.2);
   }
 
@@ -479,10 +480,10 @@ export function sendToWorker(sessionName: string, workerIndex: number, text: str
     throw new Error('sendToWorker: submit_failed (trigger text still visible after retries)');
   }
 
-  // One last best-effort double-enter nudge, then continue.
-  runTmux(['send-keys', '-t', target, 'Enter']);
+  // One last best-effort double C-m nudge, then continue.
+  runTmux(['send-keys', '-t', target, 'C-m']);
   sleepFractionalSeconds(0.12);
-  runTmux(['send-keys', '-t', target, 'Enter']);
+  runTmux(['send-keys', '-t', target, 'C-m']);
 }
 
 export function notifyLeaderStatus(sessionName: string, message: string): boolean {


### PR DESCRIPTION
## Summary
Standardize all tmux `send-keys` calls to use `C-m` (carriage return) instead of `Enter` key name. Codex CLI uses raw input mode where `Enter` doesn't always work reliably.

### Changes
- **scripts/tmux-hook-engine.js**: `Enter` → `C-m`
- **src/notifications/tmux-detector.ts**: `Enter` suffix → separate `C-m` × 2
- **src/team/tmux-session.ts**: All `Enter` refs → `C-m` (sendRobustEnter, trust prompt, nudge)
- **tests**: Updated expectations to match

### Pattern
All tmux send-keys now consistently use:
- `C-m` instead of `Enter`
- Sent twice for codex prompt submission reliability

### Tests
- 45 tests pass ✅

🤖 repo owner's gaebal-gajae (clawdbot) 🦞