### PR TITLE
fix: replace remaining Enter with C-m in sendToWorker submit loop (#63)

### DIFF
--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -454,19 +454,19 @@ export function sendToWorker(sessionName: string, workerIndex: number, text: str
     sleepFractionalSeconds(0.1);
   }
 
-  // Submit deterministically: Enter twice with short sleep between presses.
-  // When worker is busy, first attempt uses Tab+Enter to leverage Codex queue semantics.
-  // If that fails, fall back to legacy Enter-based submit rounds.
+  // Submit deterministically: C-m twice with short sleep between presses.
+  // When worker is busy, first attempt uses Tab+C-m to leverage Codex queue semantics.
+  // If that fails, fall back to legacy C-m-based submit rounds.
   const submitRounds = 6;
   for (let round = 0; round < submitRounds; round++) {
     if (round === 0 && shouldQueueFirst) {
       sendKeyOrThrow(target, 'Tab', 'Tab');
       sleepFractionalSeconds(0.08);
-      sendKeyOrThrow(target, 'Enter', 'Enter');
+      sendKeyOrThrow(target, 'C-m', 'C-m');
     } else {
-      sendKeyOrThrow(target, 'Enter', 'Enter');
+      sendKeyOrThrow(target, 'C-m', 'C-m');
       sleepFractionalSeconds(0.12);
-      sendKeyOrThrow(target, 'Enter', 'Enter');
+      sendKeyOrThrow(target, 'C-m', 'C-m');
     }
     sleepFractionalSeconds(0.14);
     if (!paneTailContainsLiteralLine(target, text)) return;


### PR DESCRIPTION
## Summary
Fixes #63

PR #59 standardized most tmux `send-keys` calls from `Enter` to `C-m`, but missed the submit loop in `sendToWorker()`.

### Changes
- `src/team/tmux-session.ts`: Replace 3x `'Enter'` with `'C-m'` in the sendToWorker submit loop (lines 465-469)

### Root Cause
In team mode, when stale hook triggers and injects text into the main panel (leader), the `Enter` key name doesn't register properly because Codex CLI uses raw input mode.

### Tests
Pre-existing tests pass. The change is a 1:1 string replacement consistent with PR #59.

🤖 repo owner's gaebal-gajae (clawdbot) 🦞