### PR TITLE
feat: add auto-nudge hook for Codex stall pattern detection (#65)

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -10,12 +10,14 @@
  * 2. Updates state for active workflow modes
  * 3. Tracks subagent activity
  * 4. Triggers desktop notifications if configured
+ * 5. Auto-nudges Codex when it stalls with permission-asking patterns
  */
 
 import { writeFile, appendFile, mkdir, readFile, rename } from 'fs/promises';
 import { join, resolve as resolvePath } from 'path';
 import { existsSync } from 'fs';
 import { spawn } from 'child_process';
+import { homedir } from 'os';
 import {
   normalizeTmuxHookConfig,
   pickActiveMode,
@@ -231,6 +233,168 @@ function readJsonIfExists(path, fallback) {
   return readFile(path, 'utf-8')
     .then(content => JSON.parse(content))
     .catch(() => fallback);
+}
+
+// ---------------------------------------------------------------------------
+// Auto-nudge: detect Codex "asking for permission" stall patterns and
+// automatically send a continuation prompt so the agent keeps working.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STALL_PATTERNS = [
+  'if you want',
+  'would you like',
+  'shall i',
+  'do you want me to',
+  'let me know if',
+  'i can also',
+  'ready to proceed',
+  'should i',
+];
+
+function normalizeAutoNudgeConfig(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return {
+      enabled: true,
+      patterns: DEFAULT_STALL_PATTERNS,
+      response: 'yes, proceed',
+      delaySec: 3,
+      maxNudgesPerSession: Infinity,
+    };
+  }
+  return {
+    enabled: raw.enabled !== false,
+    patterns: Array.isArray(raw.patterns) && raw.patterns.length > 0
+      ? raw.patterns.filter(p => typeof p === 'string' && p.trim() !== '')
+      : DEFAULT_STALL_PATTERNS,
+    response: typeof raw.response === 'string' && raw.response.trim() !== ''
+      ? raw.response
+      : 'yes, proceed',
+    delaySec: typeof raw.delaySec === 'number' && raw.delaySec >= 0 && raw.delaySec <= 60
+      ? raw.delaySec
+      : 3,
+    maxNudgesPerSession: typeof raw.maxNudgesPerSession === 'number' && raw.maxNudgesPerSession > 0
+      ? raw.maxNudgesPerSession
+      : Infinity,
+  };
+}
+
+async function loadAutoNudgeConfig() {
+  const codexHomePath = process.env.CODEX_HOME || join(homedir(), '.codex');
+  const configPath = join(codexHomePath, '.omx-config.json');
+  const raw = await readJsonIfExists(configPath, null);
+  if (!raw || typeof raw !== 'object') return normalizeAutoNudgeConfig(null);
+  return normalizeAutoNudgeConfig(raw.autoNudge);
+}
+
+function detectStallPattern(text, patterns) {
+  if (!text || typeof text !== 'string') return false;
+  // Check the last ~500 characters (roughly last 10 lines) for stall phrases
+  const tail = text.slice(-500).toLowerCase();
+  return patterns.some(p => tail.includes(p.toLowerCase()));
+}
+
+async function capturePane(paneId, lines = 10) {
+  try {
+    const result = await runProcess('tmux', [
+      'capture-pane', '-t', paneId, '-p', '-l', String(lines),
+    ], 3000);
+    return result.stdout || '';
+  } catch {
+    return '';
+  }
+}
+
+async function resolveNudgePaneTarget(stateDir) {
+  // 1. Try TMUX_PANE env var (inherited from the Codex process)
+  const envPane = safeString(process.env.TMUX_PANE || '');
+  if (envPane) return envPane;
+
+  // 2. Fallback: check active mode states for tmux_pane_id
+  try {
+    const scopedDirs = await getScopedStateDirsForCurrentSession(stateDir);
+    for (const dir of scopedDirs) {
+      const files = await readdir(dir).catch(() => []);
+      for (const f of files) {
+        if (!f.endsWith('-state.json')) continue;
+        const path = join(dir, f);
+        try {
+          const state = JSON.parse(await readFile(path, 'utf-8'));
+          if (state && state.active && state.tmux_pane_id) {
+            return safeString(state.tmux_pane_id);
+          }
+        } catch {
+          // skip malformed state
+        }
+      }
+    }
+  } catch {
+    // Non-critical
+  }
+
+  return '';
+}
+
+async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
+  const config = await loadAutoNudgeConfig();
+  if (!config.enabled) return;
+
+  // Check nudge count against session limit
+  const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+  let nudgeState = await readJsonIfExists(nudgeStatePath, null);
+  if (!nudgeState || typeof nudgeState !== 'object') {
+    nudgeState = { nudgeCount: 0, lastNudgeAt: '' };
+  }
+  const nudgeCount = asNumber(nudgeState.nudgeCount) ?? 0;
+  if (Number.isFinite(config.maxNudgesPerSession) && nudgeCount >= config.maxNudgesPerSession) return;
+
+  // Resolve pane target early (needed for both capture-pane check and sending)
+  const paneId = await resolveNudgePaneTarget(stateDir);
+
+  // Check last assistant message for stall patterns (fast path)
+  const lastMessage = safeString(payload['last-assistant-message'] || payload.last_assistant_message || '');
+  let detected = detectStallPattern(lastMessage, config.patterns);
+  let source = 'payload';
+
+  // Fallback: capture the last 10 lines of tmux pane output
+  if (!detected && paneId) {
+    const captured = await capturePane(paneId);
+    detected = detectStallPattern(captured, config.patterns);
+    source = 'capture-pane';
+  }
+
+  if (!detected || !paneId) return;
+
+  // Short delay to let the agent settle before nudging
+  if (config.delaySec > 0) {
+    await new Promise(r => setTimeout(r, config.delaySec * 1000));
+  }
+
+  const nowIso = new Date().toISOString();
+  try {
+    // Send the response text as literal bytes, then submit with C-m
+    await runProcess('tmux', ['send-keys', '-t', paneId, '-l', config.response], 3000);
+    await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
+
+    nudgeState.nudgeCount = nudgeCount + 1;
+    nudgeState.lastNudgeAt = nowIso;
+    await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
+
+    await logTmuxHookEvent(logsDir, {
+      timestamp: nowIso,
+      type: 'auto_nudge',
+      pane_id: paneId,
+      response: config.response,
+      source,
+      nudge_count: nudgeState.nudgeCount,
+    });
+  } catch (err) {
+    await logTmuxHookEvent(logsDir, {
+      timestamp: nowIso,
+      type: 'auto_nudge',
+      pane_id: paneId,
+      error: err instanceof Error ? err.message : safeString(err),
+    }).catch(() => {});
+  }
 }
 
 function runProcess(command, args, timeoutMs = 3000) {
@@ -1191,6 +1355,15 @@ async function main() {
     } catch {
       // Non-fatal: notification module may not be built or config may not exist
     }
+  }
+
+  // 9. Auto-nudge: detect Codex stall patterns ("If you want...", "Shall I...", etc.)
+  //    and automatically send a continuation prompt so the agent keeps working.
+  //    Works for both leader and worker contexts.
+  try {
+    await maybeAutoNudge({ cwd, stateDir, logsDir, payload });
+  } catch {
+    // Non-critical
   }
 }
 

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -1,0 +1,495 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const NOTIFY_HOOK_SCRIPT = new URL('../../../scripts/notify-hook.js', import.meta.url);
+
+async function withTempWorkingDir(run: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-auto-nudge-'));
+  try {
+    await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+/**
+ * Build a fake tmux binary that logs all invocations and optionally returns
+ * capture-pane content from OMX_TEST_CAPTURE_FILE.
+ */
+function buildFakeTmux(tmuxLogPath: string): string {
+  return `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="\$1"
+shift || true
+if [[ "\$cmd" == "capture-pane" ]]; then
+  if [[ -n "\${OMX_TEST_CAPTURE_FILE:-}" && -f "\${OMX_TEST_CAPTURE_FILE}" ]]; then
+    cat "\${OMX_TEST_CAPTURE_FILE}"
+  fi
+  exit 0
+fi
+if [[ "\$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "\$cmd" == "display-message" ]]; then
+  exit 0
+fi
+if [[ "\$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+}
+
+function runNotifyHook(
+  cwd: string,
+  fakeBinDir: string,
+  codexHome: string,
+  payloadOverrides: Record<string, unknown> = {},
+  extraEnv: Record<string, string> = {},
+): ReturnType<typeof spawnSync> {
+  const payload = {
+    cwd,
+    type: 'agent-turn-complete',
+    'thread-id': 'thread-test',
+    'turn-id': `turn-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+    'input-messages': ['test'],
+    'last-assistant-message': 'done',
+    ...payloadOverrides,
+  };
+
+  return spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+    encoding: 'utf8',
+    timeout: 15_000,
+    env: {
+      ...process.env,
+      PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      CODEX_HOME: codexHome,
+      TMUX_PANE: '%99',
+      TMUX: '1',
+      OMX_TEAM_WORKER: '',
+      OMX_TEAM_LEADER_NUDGE_MS: '9999999',
+      OMX_TEAM_LEADER_STALE_MS: '9999999',
+      ...extraEnv,
+    },
+  });
+}
+
+describe('notify-hook auto-nudge', () => {
+  it('sends nudge when stall pattern detected in last-assistant-message', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      // Config: enabled, delaySec=0 for fast tests
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'I analyzed the code. If you want me to make these changes, let me know.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should send nudge response');
+      assert.match(tmuxLog, /send-keys -t %99 C-m/, 'should submit with C-m');
+    });
+  });
+
+  it('sends nudge via capture-pane fallback when payload has no stall pattern', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const captureFile = join(cwd, 'capture-output.txt');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      // capture-pane will return content with a stall pattern
+      await writeFile(captureFile, 'Here are the results.\nWould you like me to continue with the implementation?\n');
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'clean output with no stall',
+      }, {
+        OMX_TEST_CAPTURE_FILE: captureFile,
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /capture-pane/, 'should have tried capture-pane');
+      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should send nudge via capture-pane fallback');
+    });
+  });
+
+  it('does not nudge when no stall pattern is present', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'I completed the refactoring. All tests pass.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should NOT send nudge');
+      }
+    });
+  });
+
+  it('respects enabled=false configuration', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      // Explicitly disabled
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: false, delaySec: 0 },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Would you like me to proceed?',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l/, 'should NOT send nudge when disabled');
+      }
+    });
+  });
+
+  it('respects maxNudgesPerSession limit', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, maxNudgesPerSession: 2 },
+      });
+
+      // Pre-seed nudge state at the limit
+      await writeJson(join(stateDir, 'auto-nudge-state.json'), {
+        nudgeCount: 2,
+        lastNudgeAt: new Date().toISOString(),
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Shall I continue with the next step?',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l/, 'should NOT nudge past max');
+      }
+    });
+  });
+
+  it('uses custom response from config', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, response: 'continue now' },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Do you want me to implement this feature?',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys -t %99 -l continue now/, 'should use custom response');
+    });
+  });
+
+  it('tracks nudge count in auto-nudge-state.json', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Ready to proceed when you are.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+      assert.ok(existsSync(nudgeStatePath), 'auto-nudge-state.json should be created');
+      const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
+      assert.equal(nudgeState.nudgeCount, 1, 'nudge count should be 1');
+      assert.ok(nudgeState.lastNudgeAt, 'should have lastNudgeAt timestamp');
+    });
+  });
+
+  it('detects all default stall patterns case-insensitively', async () => {
+    const patterns = [
+      'If You Want me to make changes',
+      'Would You Like me to continue?',
+      'Shall I proceed with the implementation?',
+      'Do You Want Me To apply this fix?',
+      'Let Me Know If you need anything else.',
+      'I Can Also refactor the tests.',
+      'READY TO PROCEED with the next step.',
+      'Should I go ahead and deploy?',
+    ];
+
+    for (const message of patterns) {
+      await withTempWorkingDir(async (cwd) => {
+        const omxDir = join(cwd, '.omx');
+        const stateDir = join(omxDir, 'state');
+        const logsDir = join(omxDir, 'logs');
+        const codexHome = join(cwd, 'codex-home');
+        const fakeBinDir = join(cwd, 'fake-bin');
+        const tmuxLogPath = join(cwd, 'tmux.log');
+
+        await mkdir(logsDir, { recursive: true });
+        await mkdir(stateDir, { recursive: true });
+        await mkdir(codexHome, { recursive: true });
+        await mkdir(fakeBinDir, { recursive: true });
+
+        await writeJson(join(codexHome, '.omx-config.json'), {
+          autoNudge: { enabled: true, delaySec: 0 },
+        });
+
+        await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+        await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+        const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+          'last-assistant-message': message,
+        });
+        assert.equal(result.status, 0, `hook failed for pattern "${message}": ${result.stderr || result.stdout}`);
+
+        assert.ok(existsSync(tmuxLogPath), `tmux should be called for pattern: "${message}"`);
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, `should nudge for: "${message}"`);
+      });
+    }
+  });
+
+  it('uses custom patterns from config', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      // Custom patterns that replace defaults
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: {
+          enabled: true,
+          delaySec: 0,
+          patterns: ['awaiting approval'],
+        },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      // Default pattern should NOT trigger with custom config
+      const result1 = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Would you like me to proceed?',
+      });
+      assert.equal(result1.status, 0);
+
+      if (existsSync(tmuxLogPath)) {
+        const log1 = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(log1, /send-keys -t %99 -l/, 'default pattern should not match with custom config');
+      }
+
+      // Clean tmux log for second run
+      if (existsSync(tmuxLogPath)) {
+        await writeFile(tmuxLogPath, '');
+      }
+
+      // Custom pattern should trigger
+      const result2 = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Changes ready. Awaiting approval before applying.',
+      });
+      assert.equal(result2.status, 0);
+
+      const log2 = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(log2, /send-keys -t %99 -l yes, proceed/, 'custom pattern should trigger nudge');
+    });
+  });
+
+  it('defaults to enabled when no config file exists', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      // No .omx-config.json at all — should use defaults (enabled=true)
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'If you want, I can fix the remaining issues.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      assert.ok(existsSync(tmuxLogPath), 'tmux should be called with defaults');
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should nudge with default config');
+    });
+  });
+
+  it('does not nudge when TMUX_PANE is not set', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Would you like me to continue?',
+      }, {
+        TMUX_PANE: '',  // No pane available
+        TMUX: '',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys.*-l yes, proceed/, 'should not nudge without pane');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #65

Adds an auto-nudge hook that detects when Codex stalls with confirmation-seeking phrases and automatically sends a "yes, proceed" response.

### Problem
Codex models often output phrases like "If you want me to..." or "Would you like me to..." and then stop working, waiting for user confirmation. This causes sessions to stall unnecessarily.

### Solution
- Monitors tmux pane output when Codex goes idle
- Detects common stall patterns (case-insensitive):
  - `if you want`, `would you like`, `shall i`, `do you want me to`
  - `let me know if`, `i can also`, `ready to proceed`, `should i`
- Sends configurable response (default: "yes, proceed") + C-m
- Short delay before nudging to avoid false positives during streaming

### Configuration
```json
{
  "autoNudge": {
    "enabled": true,
    "patterns": ["if you want", ...],
    "response": "yes, proceed",
    "delaySec": 3,
    "maxNudgesPerSession": null
  }
}
```

- `enabled`: default `true`, disable with `false`
- `maxNudgesPerSession`: default unlimited (Infinity)
- All fields optional with sensible defaults

🤖 repo owner's gaebal-gajae (clawdbot) 🦞