### PR TITLE
fix: send C-m twice with delay in auto-nudge hook (#67)

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -371,8 +371,12 @@ async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
 
   const nowIso = new Date().toISOString();
   try {
-    // Send the response text as literal bytes, then submit with C-m
+    // Send the response text as literal bytes, then submit with double C-m
+    // Codex CLI needs C-m sent twice with a short delay for reliable prompt submission
     await runProcess('tmux', ['send-keys', '-t', paneId, '-l', config.response], 3000);
+    await new Promise(r => setTimeout(r, 100));
+    await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
+    await new Promise(r => setTimeout(r, 100));
     await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
 
     nudgeState.nudgeCount = nudgeCount + 1;

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -116,7 +116,9 @@ describe('notify-hook auto-nudge', () => {
       assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should send nudge response');
-      assert.match(tmuxLog, /send-keys -t %99 C-m/, 'should submit with C-m');
+      // Codex CLI needs C-m sent twice with a delay for reliable submission
+      const cmMatches = tmuxLog.match(/send-keys -t %99 C-m/g);
+      assert.ok(cmMatches && cmMatches.length >= 2, `should send C-m twice, got ${cmMatches?.length ?? 0}`);
     });
   });
 


### PR DESCRIPTION
## Summary
Fixes #67

The auto-nudge hook was sending `C-m` only once after injecting response text. Codex CLI in raw mode needs `C-m` sent twice with a 100ms delay between for reliable prompt submission.

### Changes
- `scripts/notify-hook.js`: Added second `C-m` send with 100ms delay between sends
- Updated related tests

### Pattern
Consistent with the double-`C-m` pattern used elsewhere in the codebase (PR #59, #64).

🤖 repo owner's gaebal-gajae (clawdbot) 🦞