### PR TITLE
fix: add -l flag and double C-m to team nudge and SDK sendToPane (#70)

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -759,7 +759,11 @@ async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderS
     const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
 
     try {
-      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, capped, 'C-m', 'C-m'], 1200);
+      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, '-l', capped], 3000);
+      await new Promise(r => setTimeout(r, 100));
+      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'C-m'], 3000);
+      await new Promise(r => setTimeout(r, 100));
+      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'C-m'], 3000);
       nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '' };
 
       // Emit team event for the nudge

--- a/src/hooks/extensibility/sdk.ts
+++ b/src/hooks/extensibility/sdk.ts
@@ -85,6 +85,11 @@ function hashDedupeKey(target: string, text: string): string {
   return createHash('sha256').update(`${target}|${text}`).digest('hex');
 }
 
+function sleepFractionalSeconds(seconds: number): void {
+  if (!Number.isFinite(seconds) || seconds <= 0) return;
+  spawnSync('sleep', [String(seconds)], { encoding: 'utf-8' });
+}
+
 function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
   const result = spawnSync('tmux', args, { encoding: 'utf-8' });
   if (result.error) return { ok: false, stderr: result.error.message };
@@ -184,7 +189,8 @@ async function sendTmuxKeys(
 
   if (options.submit !== false) {
     const submitA = runTmux(['send-keys', '-t', targetResolution.target, 'C-m']);
-    const submitB = runTmux(['send-keys', '-t', targetResolution.target, 'Enter']);
+    sleepFractionalSeconds(0.1);
+    const submitB = runTmux(['send-keys', '-t', targetResolution.target, 'C-m']);
     if (!submitA.ok && !submitB.ok) {
       return {
         ok: false,


### PR DESCRIPTION
## Summary
Fixes #70

### Changes
1. **scripts/notify-hook.js** (team leader nudge): Split single `send-keys` call into literal text send (`-l` flag) + double `C-m` with 100ms delay
2. **src/hooks/extensibility/sdk.ts** (hook SDK): Replace `C-m` + `Enter` fallback with double `C-m` + `sleepFractionalSeconds(0.1)`

### Why
- Without `-l` flag, tmux may interpret text as key names
- Single `C-m` unreliable in Codex raw input mode
- `Enter` key name unreliable — `C-m` is the correct approach

### Tests
433 tests pass ✅

🤖 repo owner's gaebal-gajae (clawdbot) 🦞