### PR TITLE
fix: append [OMX_TMUX_INJECT] suffix to all hook tmux injections (#72)

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -23,6 +23,7 @@ import {
   pickActiveMode,
   evaluateInjectionGuards,
   buildSendKeysArgv,
+  DEFAULT_MARKER,
 } from './tmux-hook-engine.js';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -373,7 +374,8 @@ async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
   try {
     // Send the response text as literal bytes, then submit with double C-m
     // Codex CLI needs C-m sent twice with a short delay for reliable prompt submission
-    await runProcess('tmux', ['send-keys', '-t', paneId, '-l', config.response], 3000);
+    const markedResponse = `${config.response} ${DEFAULT_MARKER}`;
+    await runProcess('tmux', ['send-keys', '-t', paneId, '-l', markedResponse], 3000);
     await new Promise(r => setTimeout(r, 100));
     await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
     await new Promise(r => setTimeout(r, 100));
@@ -757,9 +759,10 @@ async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderS
       text = `Team ${teamName} active. Run: omx team status ${teamName}`;
     }
     const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
+    const markedText = `${capped} ${DEFAULT_MARKER}`;
 
     try {
-      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, '-l', capped], 3000);
+      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, '-l', markedText], 3000);
       await new Promise(r => setTimeout(r, 100));
       await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'C-m'], 3000);
       await new Promise(r => setTimeout(r, 100));

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -115,7 +115,7 @@ describe('notify-hook auto-nudge', () => {
 
       assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should send nudge response');
+      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should send nudge response with injection marker');
       // Codex CLI needs C-m sent twice with a delay for reliable submission
       const cmMatches = tmuxLog.match(/send-keys -t %99 C-m/g);
       assert.ok(cmMatches && cmMatches.length >= 2, `should send C-m twice, got ${cmMatches?.length ?? 0}`);
@@ -156,7 +156,7 @@ describe('notify-hook auto-nudge', () => {
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /capture-pane/, 'should have tried capture-pane');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should send nudge via capture-pane fallback');
+      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should send nudge via capture-pane fallback with marker');
     });
   });
 
@@ -293,7 +293,7 @@ describe('notify-hook auto-nudge', () => {
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l continue now/, 'should use custom response');
+      assert.match(tmuxLog, /send-keys -t %99 -l continue now \[OMX_TMUX_INJECT\]/, 'should use custom response with marker');
     });
   });
 
@@ -371,7 +371,7 @@ describe('notify-hook auto-nudge', () => {
 
         assert.ok(existsSync(tmuxLogPath), `tmux should be called for pattern: "${message}"`);
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-        assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, `should nudge for: "${message}"`);
+        assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, `should nudge with marker for: "${message}"`);
       });
     }
   });
@@ -425,7 +425,7 @@ describe('notify-hook auto-nudge', () => {
       assert.equal(result2.status, 0);
 
       const log2 = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(log2, /send-keys -t %99 -l yes, proceed/, 'custom pattern should trigger nudge');
+      assert.match(log2, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'custom pattern should trigger nudge with marker');
     });
   });
 
@@ -455,7 +455,7 @@ describe('notify-hook auto-nudge', () => {
 
       assert.ok(existsSync(tmuxLogPath), 'tmux should be called with defaults');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should nudge with default config');
+      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should nudge with default config and marker');
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -120,6 +120,7 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /send-keys/);
       assert.match(tmuxLog, /-t devsess:0/);
       assert.match(tmuxLog, /Team alpha:/);
+      assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
     });
   });
 
@@ -166,6 +167,7 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /Team beta:/);
       assert.match(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /pane\(s\) still active/);
+      assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
     });
   });
 
@@ -314,6 +316,7 @@ describe('notify-hook team leader nudge', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /msg\(s\) pending/);
+      assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
 
       // Verify event reason
       const eventsPath = join(eventsDir, 'events.ndjson');

--- a/src/hooks/extensibility/sdk.ts
+++ b/src/hooks/extensibility/sdk.ts
@@ -17,6 +17,8 @@ interface HookPluginSdkOptions {
   sideEffectsEnabled?: boolean;
 }
 
+const INJECTION_MARKER = '[OMX_TMUX_INJECT]';
+
 interface PluginTmuxState {
   last_sent_at: number;
   recent_keys: Record<string, number>;
@@ -176,7 +178,8 @@ async function sendTmuxKeys(
     return { ok: false, reason: 'duplicate_event', target: targetResolution.target, paneId: targetResolution.target };
   }
 
-  const typed = runTmux(['send-keys', '-t', targetResolution.target, '-l', text]);
+  const markedText = `${text} ${INJECTION_MARKER}`;
+  const typed = runTmux(['send-keys', '-t', targetResolution.target, '-l', markedText]);
   if (!typed.ok) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary
Fixes #72

All tmux injections from hooks now include `[OMX_TMUX_INJECT]` suffix.

### Changes
1. **scripts/notify-hook.js** — team leader nudge text: append marker
2. **scripts/notify-hook.js** — auto-nudge response: append marker
3. **src/hooks/extensibility/sdk.ts** — sendToPane: append marker

### Tests
433 tests pass ✅

🤖 repo owner's gaebal-gajae (clawdbot) 🦞