### PR TITLE
feat: add next-i-can to auto-nudge stall patterns (#75)

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -245,6 +245,7 @@ const DEFAULT_STALL_PATTERNS = [
   'if you want',
   'would you like',
   'shall i',
+  'next i can',
   'do you want me to',
   'let me know if',
   'i can also',

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -336,6 +336,7 @@ describe('notify-hook auto-nudge', () => {
       'If You Want me to make changes',
       'Would You Like me to continue?',
       'Shall I proceed with the implementation?',
+      'Next I Can refactor the module for clarity.',
       'Do You Want Me To apply this fix?',
       'Let Me Know If you need anything else.',
       'I Can Also refactor the tests.',


### PR DESCRIPTION
## Summary
Fixes #75

Adds `next i can` to `DEFAULT_STALL_PATTERNS` so Codex's "Next I can..." permission-asking is auto-nudged.

### Changes
- `scripts/notify-hook.js`: Added `'next i can'` to stall patterns
- Updated related test

🤖 repo owner's gaebal-gajae (clawdbot) 🦞