### PR TITLE
feat: add say-go continuation patterns to auto-nudge (#81)

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -257,6 +257,11 @@ const DEFAULT_STALL_PATTERNS = [
   'ready to proceed',
   'should i',
   'whenever you',
+  'say go',
+  'say yes',
+  'type continue',
+  'and i\'ll continue',
+  'and i\'ll proceed',
 ];
 
 function normalizeAutoNudgeConfig(raw) {

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -347,6 +347,11 @@ describe('notify-hook auto-nudge', () => {
       'READY TO PROCEED with the next step.',
       'Should I go ahead and deploy?',
       'Whenever You are ready, I can start.',
+      'Say Go when you are ready.',
+      'Say Yes to confirm the changes.',
+      'Type Continue to proceed with the next step.',
+      "And I'll Continue once you confirm.",
+      "And I'll Proceed with the deployment.",
     ];
 
     for (const message of patterns) {


### PR DESCRIPTION
## Summary
Fixes #81

Adds continuation-waiting patterns to auto-nudge stall detection.

### New patterns
- `say go`
- `say yes`
- `type continue`
- `and i'll continue`
- `and i'll proceed`

### Tests
11 auto-nudge tests pass ✅

🤖 repo owner's gaebal-gajae (clawdbot) 🦞