### PR TITLE
feat: add keep-driving and self-continuation patterns to auto-nudge (#83)

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -262,6 +262,12 @@ const DEFAULT_STALL_PATTERNS = [
   'type continue',
   'and i\'ll continue',
   'and i\'ll proceed',
+  'keep driving',
+  'keep pushing',
+  'move forward',
+  'drive forward',
+  'proceed from here',
+  'i\'ll continue from',
 ];
 
 function normalizeAutoNudgeConfig(raw) {

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -352,6 +352,12 @@ describe('notify-hook auto-nudge', () => {
       'Type Continue to proceed with the next step.',
       "And I'll Continue once you confirm.",
       "And I'll Proceed with the deployment.",
+      "I'll Keep Driving the implementation forward.",
+      "I'll Keep Pushing on the test coverage.",
+      "I'll Move Forward with the remaining items.",
+      "I'll Drive Forward from here.",
+      "I'll Proceed From Here with the next task.",
+      "I'll Continue From this point onward.",
     ];
 
     for (const message of patterns) {


### PR DESCRIPTION
## Summary
Fixes #83

Adds self-continuation patterns to auto-nudge detection.

### New patterns
- `keep driving`
- `keep pushing`
- `move forward`
- `drive forward`
- `proceed from here`
- `i'll continue from`

### Tests
11 auto-nudge tests pass ✅

🤖 repo owner's gaebal-gajae (clawdbot) 🦞