### PR TITLE
test: add unit tests for hud/ module (colors, render, types)

### DIFF
--- a/src/hud/__tests__/colors.test.ts
+++ b/src/hud/__tests__/colors.test.ts
@@ -1,0 +1,245 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  RESET,
+  green,
+  yellow,
+  red,
+  cyan,
+  dim,
+  bold,
+  getRalphColor,
+  getTodoColor,
+  coloredBar,
+} from '../colors.js';
+
+const GREEN = '\x1b[32m';
+const YELLOW_CODE = '\x1b[33m';
+const RED_CODE = '\x1b[31m';
+const CYAN_CODE = '\x1b[36m';
+const DIM_CODE = '\x1b[2m';
+const BOLD_CODE = '\x1b[1m';
+
+describe('RESET', () => {
+  it('is the ANSI reset escape code', () => {
+    assert.equal(RESET, '\x1b[0m');
+  });
+});
+
+describe('green', () => {
+  it('wraps text with green ANSI codes', () => {
+    assert.equal(green('hello'), `${GREEN}hello${RESET}`);
+  });
+
+  it('handles empty string', () => {
+    assert.equal(green(''), `${GREEN}${RESET}`);
+  });
+
+  it('starts with GREEN and ends with RESET', () => {
+    const result = green('test');
+    assert.ok(result.startsWith(GREEN));
+    assert.ok(result.endsWith(RESET));
+  });
+});
+
+describe('yellow', () => {
+  it('wraps text with yellow ANSI codes', () => {
+    assert.equal(yellow('warning'), `${YELLOW_CODE}warning${RESET}`);
+  });
+
+  it('handles empty string', () => {
+    assert.equal(yellow(''), `${YELLOW_CODE}${RESET}`);
+  });
+});
+
+describe('red', () => {
+  it('wraps text with red ANSI codes', () => {
+    assert.equal(red('error'), `${RED_CODE}error${RESET}`);
+  });
+
+  it('handles empty string', () => {
+    assert.equal(red(''), `${RED_CODE}${RESET}`);
+  });
+});
+
+describe('cyan', () => {
+  it('wraps text with cyan ANSI codes', () => {
+    assert.equal(cyan('info'), `${CYAN_CODE}info${RESET}`);
+  });
+
+  it('handles empty string', () => {
+    assert.equal(cyan(''), `${CYAN_CODE}${RESET}`);
+  });
+});
+
+describe('dim', () => {
+  it('wraps text with dim ANSI codes', () => {
+    assert.equal(dim('muted'), `${DIM_CODE}muted${RESET}`);
+  });
+
+  it('handles empty string', () => {
+    assert.equal(dim(''), `${DIM_CODE}${RESET}`);
+  });
+});
+
+describe('bold', () => {
+  it('wraps text with bold ANSI codes', () => {
+    assert.equal(bold('important'), `${BOLD_CODE}important${RESET}`);
+  });
+
+  it('handles empty string', () => {
+    assert.equal(bold(''), `${BOLD_CODE}${RESET}`);
+  });
+});
+
+describe('getRalphColor', () => {
+  // With maxIterations=10: warningThreshold=7, criticalThreshold=9
+
+  it('returns GREEN for low iterations', () => {
+    assert.equal(getRalphColor(0, 10), GREEN);
+    assert.equal(getRalphColor(6, 10), GREEN);
+  });
+
+  it('returns YELLOW at and above warning threshold', () => {
+    // floor(10 * 0.7) = 7
+    assert.equal(getRalphColor(7, 10), YELLOW_CODE);
+    assert.equal(getRalphColor(8, 10), YELLOW_CODE);
+  });
+
+  it('returns RED at and above critical threshold', () => {
+    // floor(10 * 0.9) = 9
+    assert.equal(getRalphColor(9, 10), RED_CODE);
+    assert.equal(getRalphColor(10, 10), RED_CODE);
+  });
+
+  it('handles the exact warning boundary', () => {
+    // maxIterations=100: warning=70, critical=90
+    assert.equal(getRalphColor(69, 100), GREEN);
+    assert.equal(getRalphColor(70, 100), YELLOW_CODE);
+  });
+
+  it('handles the exact critical boundary', () => {
+    assert.equal(getRalphColor(89, 100), YELLOW_CODE);
+    assert.equal(getRalphColor(90, 100), RED_CODE);
+  });
+
+  it('handles floor rounding in thresholds', () => {
+    // maxIterations=7: warning=floor(4.9)=4, critical=floor(6.3)=6
+    assert.equal(getRalphColor(3, 7), GREEN);
+    assert.equal(getRalphColor(4, 7), YELLOW_CODE);
+    assert.equal(getRalphColor(6, 7), RED_CODE);
+  });
+});
+
+describe('getTodoColor', () => {
+  it('returns DIM when total is 0', () => {
+    assert.equal(getTodoColor(0, 0), DIM_CODE);
+    assert.equal(getTodoColor(5, 0), DIM_CODE);
+  });
+
+  it('returns GREEN when 80% or more is complete', () => {
+    assert.equal(getTodoColor(8, 10), GREEN);   // 80%
+    assert.equal(getTodoColor(10, 10), GREEN);  // 100%
+    assert.equal(getTodoColor(9, 10), GREEN);   // 90%
+  });
+
+  it('returns YELLOW when 50% to 79% is complete', () => {
+    assert.equal(getTodoColor(5, 10), YELLOW_CODE);    // 50%
+    assert.equal(getTodoColor(7, 10), YELLOW_CODE);    // 70%
+    assert.equal(getTodoColor(79, 100), YELLOW_CODE);  // 79%
+  });
+
+  it('returns CYAN when less than 50% is complete', () => {
+    assert.equal(getTodoColor(0, 10), CYAN_CODE);    // 0%
+    assert.equal(getTodoColor(4, 10), CYAN_CODE);    // 40%
+    assert.equal(getTodoColor(49, 100), CYAN_CODE);  // 49%
+  });
+
+  it('handles single item fully completed', () => {
+    assert.equal(getTodoColor(1, 1), GREEN);  // 100%
+  });
+});
+
+describe('coloredBar', () => {
+  it('returns a non-empty string', () => {
+    const bar = coloredBar(50, 10);
+    assert.ok(typeof bar === 'string' && bar.length > 0);
+  });
+
+  it('ends with RESET', () => {
+    assert.ok(coloredBar(50, 10).endsWith(RESET));
+    assert.ok(coloredBar(0, 10).endsWith(RESET));
+    assert.ok(coloredBar(100, 10).endsWith(RESET));
+  });
+
+  it('uses GREEN for below 70%', () => {
+    assert.ok(coloredBar(0, 10).startsWith(GREEN));
+    assert.ok(coloredBar(69, 10).startsWith(GREEN));
+  });
+
+  it('uses YELLOW for 70% to 84%', () => {
+    assert.ok(coloredBar(70, 10).startsWith(YELLOW_CODE));
+    assert.ok(coloredBar(84, 10).startsWith(YELLOW_CODE));
+  });
+
+  it('uses RED for 85% or more', () => {
+    assert.ok(coloredBar(85, 10).startsWith(RED_CODE));
+    assert.ok(coloredBar(100, 10).startsWith(RED_CODE));
+  });
+
+  it('produces correct filled block count at 50% with default width', () => {
+    const bar = coloredBar(50);
+    // Math.round(0.5 * 10) = 5 filled
+    assert.equal((bar.match(/█/g) || []).length, 5);
+    assert.equal((bar.match(/░/g) || []).length, 5);
+  });
+
+  it('produces correct filled/empty counts for 40% width=10', () => {
+    const bar = coloredBar(40, 10);
+    // Math.round(0.4 * 10) = 4 filled, 6 empty
+    assert.equal((bar.match(/█/g) || []).length, 4);
+    assert.equal((bar.match(/░/g) || []).length, 6);
+  });
+
+  it('fills all blocks at 100%', () => {
+    const bar = coloredBar(100, 10);
+    assert.equal((bar.match(/█/g) || []).length, 10);
+    assert.equal((bar.match(/░/g) || []).length, 0);
+  });
+
+  it('empties all blocks at 0%', () => {
+    const bar = coloredBar(0, 10);
+    assert.equal((bar.match(/█/g) || []).length, 0);
+    assert.equal((bar.match(/░/g) || []).length, 10);
+  });
+
+  it('clamps percent above 100 to 100', () => {
+    const bar = coloredBar(200, 10);
+    assert.equal((bar.match(/█/g) || []).length, 10);
+    assert.equal((bar.match(/░/g) || []).length, 0);
+  });
+
+  it('clamps percent below 0 to 0', () => {
+    const bar = coloredBar(-50, 10);
+    assert.equal((bar.match(/█/g) || []).length, 0);
+    assert.equal((bar.match(/░/g) || []).length, 10);
+  });
+
+  it('treats non-finite percent as 0', () => {
+    const bar = coloredBar(NaN, 10);
+    assert.equal((bar.match(/█/g) || []).length, 0);
+    assert.equal((bar.match(/░/g) || []).length, 10);
+  });
+
+  it('treats non-finite width as 0 – no blocks', () => {
+    const bar = coloredBar(50, NaN);
+    assert.equal((bar.match(/█/g) || []).length, 0);
+    assert.equal((bar.match(/░/g) || []).length, 0);
+  });
+
+  it('handles zero width – no blocks', () => {
+    const bar = coloredBar(50, 0);
+    assert.equal((bar.match(/█/g) || []).length, 0);
+    assert.equal((bar.match(/░/g) || []).length, 0);
+  });
+});

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -1,0 +1,526 @@
+import { describe, it, mock, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderHud } from '../render.js';
+import type { HudRenderContext } from '../types.js';
+
+const RESET = '\x1b[0m';
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+function emptyCtx(): HudRenderContext {
+  return {
+    version: null,
+    gitBranch: null,
+    ralph: null,
+    ultrawork: null,
+    autopilot: null,
+    team: null,
+    ecomode: null,
+    pipeline: null,
+    metrics: null,
+    hudNotify: null,
+    session: null,
+  };
+}
+
+// ── Empty context ─────────────────────────────────────────────────────────────
+
+describe('renderHud – empty context', () => {
+  it('shows "No active modes." when nothing is active', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(result.includes('No active modes.'));
+  });
+
+  it('includes the [OMX] label', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(result.includes('[OMX]'));
+  });
+});
+
+// ── Version ───────────────────────────────────────────────────────────────────
+
+describe('renderHud – version', () => {
+  it('strips the "v" prefix from a semver version', () => {
+    const ctx = { ...emptyCtx(), version: 'v1.2.3' };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('[OMX#1.2.3]'));
+  });
+
+  it('keeps a plain version number as-is', () => {
+    const ctx = { ...emptyCtx(), version: '2.0.0' };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('[OMX#2.0.0]'));
+  });
+
+  it('omits hash suffix when version is null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(result.includes('[OMX]'));
+    assert.ok(!result.includes('[OMX#'));
+  });
+});
+
+// ── Git branch ────────────────────────────────────────────────────────────────
+
+describe('renderHud – gitBranch', () => {
+  it('renders the branch name wrapped in cyan', () => {
+    const ctx = { ...emptyCtx(), gitBranch: 'main' };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${CYAN}main${RESET}`));
+  });
+
+  it('omits the branch element when null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('main'));
+  });
+});
+
+// ── Ralph ─────────────────────────────────────────────────────────────────────
+
+describe('renderHud – ralph', () => {
+  it('renders ralph iteration info', () => {
+    const ctx = { ...emptyCtx(), ralph: { active: true, iteration: 3, max_iterations: 10 } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('ralph:3/10'));
+  });
+
+  it('omits ralph when null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('ralph'));
+  });
+});
+
+// ── Ultrawork ─────────────────────────────────────────────────────────────────
+
+describe('renderHud – ultrawork', () => {
+  it('renders "ultrawork" in cyan', () => {
+    const ctx = { ...emptyCtx(), ultrawork: { active: true } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${CYAN}ultrawork${RESET}`));
+  });
+
+  it('omits ultrawork when null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('ultrawork'));
+  });
+});
+
+// ── Autopilot ─────────────────────────────────────────────────────────────────
+
+describe('renderHud – autopilot', () => {
+  it('renders autopilot with the current phase', () => {
+    const ctx = { ...emptyCtx(), autopilot: { active: true, current_phase: 'planning' } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${YELLOW}autopilot:planning${RESET}`));
+  });
+
+  it('defaults phase to "active" when not set', () => {
+    const ctx = { ...emptyCtx(), autopilot: { active: true } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('autopilot:active'));
+  });
+
+  it('omits autopilot when null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('autopilot'));
+  });
+});
+
+// ── Team ──────────────────────────────────────────────────────────────────────
+
+describe('renderHud – team', () => {
+  it('renders agent count when count > 0', () => {
+    const ctx = { ...emptyCtx(), team: { active: true, agent_count: 3 } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${GREEN}team:3 workers${RESET}`));
+  });
+
+  it('renders team name when count is absent', () => {
+    const ctx = { ...emptyCtx(), team: { active: true, team_name: 'my-team' } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${GREEN}team:my-team${RESET}`));
+  });
+
+  it('renders bare "team" when neither count nor name is set', () => {
+    const ctx = { ...emptyCtx(), team: { active: true } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${GREEN}team${RESET}`));
+  });
+
+  it('skips the count branch when agent_count is 0', () => {
+    const ctx = { ...emptyCtx(), team: { active: true, agent_count: 0 } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(!result.includes('workers'));
+    // Falls through to bare "team"
+    assert.ok(result.includes(`${GREEN}team${RESET}`));
+  });
+
+  it('omits team when null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('team'));
+  });
+});
+
+// ── Ecomode ───────────────────────────────────────────────────────────────────
+
+describe('renderHud – ecomode', () => {
+  it('renders "ecomode" as dim text', () => {
+    const ctx = { ...emptyCtx(), ecomode: { active: true } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${DIM}ecomode${RESET}`));
+  });
+
+  it('omits ecomode when null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('ecomode'));
+  });
+});
+
+// ── Pipeline ──────────────────────────────────────────────────────────────────
+
+describe('renderHud – pipeline', () => {
+  it('renders pipeline with the current phase', () => {
+    const ctx = { ...emptyCtx(), pipeline: { active: true, current_phase: 'exec' } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes(`${CYAN}pipeline:exec${RESET}`));
+  });
+
+  it('defaults phase to "active" when not set', () => {
+    const ctx = { ...emptyCtx(), pipeline: { active: true } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('pipeline:active'));
+  });
+
+  it('omits pipeline when null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('pipeline'));
+  });
+});
+
+// ── Metrics – turns ───────────────────────────────────────────────────────────
+
+describe('renderHud – metrics (turns)', () => {
+  it('renders session turn count', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 100, session_turns: 5, last_activity: '' },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('turns:5'));
+  });
+
+  it('omits turns when metrics is null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('turns'));
+  });
+
+  it('does not render stale metrics (last_activity before session start)', () => {
+    const ctx = {
+      ...emptyCtx(),
+      session: { session_id: 's1', started_at: '2024-06-01T10:00:00Z' },
+      metrics: {
+        total_turns: 50,
+        session_turns: 3,
+        last_activity: '2024-06-01T09:00:00Z',  // before session start
+      },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(!result.includes('turns:3'));
+  });
+});
+
+// ── Metrics – tokens ──────────────────────────────────────────────────────────
+
+describe('renderHud – metrics (tokens)', () => {
+  it('renders session_total_tokens formatted as "k"', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 10, session_turns: 3, last_activity: '', session_total_tokens: 5000 },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('tokens:5.0k'));
+  });
+
+  it('sums input and output tokens when session_total_tokens is absent', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: {
+        total_turns: 10,
+        session_turns: 3,
+        last_activity: '',
+        session_input_tokens: 2000,
+        session_output_tokens: 3000,
+      },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('tokens:5.0k'));
+  });
+
+  it('formats values in millions', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 10, session_turns: 3, last_activity: '', session_total_tokens: 2_500_000 },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('tokens:2.5M'));
+  });
+
+  it('formats small values without suffix', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 10, session_turns: 3, last_activity: '', session_total_tokens: 500 },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('tokens:500'));
+  });
+
+  it('omits tokens when total is 0', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 10, session_turns: 3, last_activity: '', session_total_tokens: 0 },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(!result.includes('tokens'));
+  });
+});
+
+// ── Metrics – quota ───────────────────────────────────────────────────────────
+
+describe('renderHud – metrics (quota)', () => {
+  it('renders both 5-hour and weekly limits', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: {
+        total_turns: 10,
+        session_turns: 3,
+        last_activity: '',
+        five_hour_limit_pct: 42.7,
+        weekly_limit_pct: 15.3,
+      },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('quota:5h:43%,wk:15%'));
+  });
+
+  it('renders only 5-hour limit when weekly is absent', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: {
+        total_turns: 10,
+        session_turns: 3,
+        last_activity: '',
+        five_hour_limit_pct: 60,
+      },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('quota:5h:60%'));
+    assert.ok(!result.includes('wk:'));
+  });
+
+  it('omits quota when both limits are absent', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 10, session_turns: 3, last_activity: '' },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(!result.includes('quota'));
+  });
+
+  it('omits quota when both limits are 0', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: {
+        total_turns: 10,
+        session_turns: 3,
+        last_activity: '',
+        five_hour_limit_pct: 0,
+        weekly_limit_pct: 0,
+      },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(!result.includes('quota'));
+  });
+});
+
+// ── HudNotify – last activity ─────────────────────────────────────────────────
+
+describe('renderHud – hudNotify (last activity)', () => {
+  it('renders last activity in seconds', () => {
+    const fixedNow = 1_700_000_030_000;
+    const lastTurnAt = new Date(fixedNow - 30_000).toISOString();
+    mock.method(Date, 'now', () => fixedNow);
+
+    const ctx = { ...emptyCtx(), hudNotify: { last_turn_at: lastTurnAt, turn_count: 5 } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('last:30s ago'));
+  });
+
+  it('renders last activity in minutes', () => {
+    const fixedNow = 1_700_000_120_000;
+    const lastTurnAt = new Date(fixedNow - 120_000).toISOString();
+    mock.method(Date, 'now', () => fixedNow);
+
+    const ctx = { ...emptyCtx(), hudNotify: { last_turn_at: lastTurnAt, turn_count: 5 } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('last:2m ago'));
+  });
+
+  it('omits last activity when hudNotify is null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('last:'));
+  });
+});
+
+// ── Session duration ──────────────────────────────────────────────────────────
+
+describe('renderHud – session duration', () => {
+  it('renders session duration in seconds', () => {
+    const fixedNow = 1_700_000_030_000;
+    const startedAt = new Date(fixedNow - 30_000).toISOString();
+    mock.method(Date, 'now', () => fixedNow);
+
+    const ctx = { ...emptyCtx(), session: { session_id: 's1', started_at: startedAt } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('session:30s'));
+  });
+
+  it('renders session duration in minutes', () => {
+    const fixedNow = 1_700_000_300_000;
+    const startedAt = new Date(fixedNow - 300_000).toISOString();  // 5 minutes
+    mock.method(Date, 'now', () => fixedNow);
+
+    const ctx = { ...emptyCtx(), session: { session_id: 's1', started_at: startedAt } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('session:5m'));
+  });
+
+  it('renders session duration in hours and minutes', () => {
+    const fixedNow = 1_700_010_920_000;
+    const startedAt = new Date(fixedNow - 7_320_000).toISOString();  // 2h 2m
+    mock.method(Date, 'now', () => fixedNow);
+
+    const ctx = { ...emptyCtx(), session: { session_id: 's1', started_at: startedAt } };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(result.includes('session:2h2m'));
+  });
+
+  it('omits session duration when session is null', () => {
+    const result = renderHud(emptyCtx(), 'focused');
+    assert.ok(!result.includes('session:'));
+  });
+});
+
+// ── Total turns ───────────────────────────────────────────────────────────────
+
+describe('renderHud – total turns (full preset)', () => {
+  it('renders total-turns in full preset', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 200, session_turns: 5, last_activity: '' },
+    };
+    const result = renderHud(ctx, 'full');
+    assert.ok(result.includes('total-turns:200'));
+  });
+
+  it('omits total-turns in focused preset', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 200, session_turns: 5, last_activity: '' },
+    };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(!result.includes('total-turns'));
+  });
+
+  it('omits total-turns when total_turns is 0', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 0, session_turns: 5, last_activity: '' },
+    };
+    const result = renderHud(ctx, 'full');
+    assert.ok(!result.includes('total-turns'));
+  });
+});
+
+// ── Presets ───────────────────────────────────────────────────────────────────
+
+describe('renderHud – presets', () => {
+  it('minimal preset includes gitBranch, ralph, ultrawork, team, turns', () => {
+    const ctx = {
+      ...emptyCtx(),
+      gitBranch: 'feat/x',
+      ralph: { active: true, iteration: 1, max_iterations: 5 },
+      ultrawork: { active: true },
+      team: { active: true, agent_count: 2 },
+      metrics: { total_turns: 10, session_turns: 3, last_activity: '' },
+    };
+    const result = renderHud(ctx, 'minimal');
+    assert.ok(result.includes('feat/x'));
+    assert.ok(result.includes('ralph:1/5'));
+    assert.ok(result.includes('ultrawork'));
+    assert.ok(result.includes('workers'));
+    assert.ok(result.includes('turns:3'));
+  });
+
+  it('minimal preset excludes autopilot, ecomode, pipeline, quota', () => {
+    const ctx = {
+      ...emptyCtx(),
+      autopilot: { active: true, current_phase: 'exec' },
+      ecomode: { active: true },
+      pipeline: { active: true, current_phase: 'run' },
+      metrics: {
+        total_turns: 10,
+        session_turns: 3,
+        last_activity: '',
+        five_hour_limit_pct: 50,
+      },
+    };
+    const result = renderHud(ctx, 'minimal');
+    assert.ok(!result.includes('autopilot'));
+    assert.ok(!result.includes('ecomode'));
+    assert.ok(!result.includes('pipeline'));
+    assert.ok(!result.includes('quota'));
+  });
+
+  it('full preset includes all elements including total-turns', () => {
+    const ctx = {
+      ...emptyCtx(),
+      metrics: { total_turns: 99, session_turns: 5, last_activity: '' },
+    };
+    const result = renderHud(ctx, 'full');
+    assert.ok(result.includes('total-turns:99'));
+  });
+
+  it('focused preset is the default for unrecognised preset values', () => {
+    // TypeScript prevents invalid values, but we can test the focused default
+    const ctx = { ...emptyCtx(), ecomode: { active: true } };
+    // focused includes ecomode; minimal does not
+    assert.ok(renderHud(ctx, 'focused').includes('ecomode'));
+    assert.ok(!renderHud(ctx, 'minimal').includes('ecomode'));
+  });
+});
+
+// ── Separator ─────────────────────────────────────────────────────────────────
+
+describe('renderHud – separator', () => {
+  it('joins multiple elements with a dim pipe separator', () => {
+    const ctx = {
+      ...emptyCtx(),
+      gitBranch: 'main',
+      ralph: { active: true, iteration: 2, max_iterations: 10 },
+    };
+    const result = renderHud(ctx, 'focused');
+    // SEP = dim(' | ') = '\x1b[2m | \x1b[0m'
+    assert.ok(result.includes(`${DIM} | ${RESET}`));
+  });
+
+  it('does not include the separator when only one element is present', () => {
+    const ctx = { ...emptyCtx(), gitBranch: 'solo' };
+    const result = renderHud(ctx, 'focused');
+    assert.ok(!result.includes(' | '));
+  });
+});

--- a/src/hud/__tests__/types.test.ts
+++ b/src/hud/__tests__/types.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { DEFAULT_HUD_CONFIG } from '../types.js';
+
+describe('DEFAULT_HUD_CONFIG', () => {
+  it('has preset set to "focused"', () => {
+    assert.equal(DEFAULT_HUD_CONFIG.preset, 'focused');
+  });
+
+  it('is an object with a preset property', () => {
+    assert.equal(typeof DEFAULT_HUD_CONFIG, 'object');
+    assert.ok('preset' in DEFAULT_HUD_CONFIG);
+  });
+
+  it('preset is a valid HudPreset value', () => {
+    const validPresets = ['minimal', 'focused', 'full'];
+    assert.ok(validPresets.includes(DEFAULT_HUD_CONFIG.preset));
+  });
+});


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for `src/hud/colors.ts` — all color helpers, `getRalphColor`, `getTodoColor`, and `coloredBar` including edge cases (NaN, clamping, zero width)
- Add unit tests for `src/hud/render.ts` — `renderHud` covering all element renderers, all three presets (minimal/focused/full), version rendering, separator, and time-dependent elements via `mock.method(Date, 'now', ...)`
- Add unit tests for `src/hud/types.ts` — `DEFAULT_HUD_CONFIG` constant

Total: **94 tests, 28 suites, 0 failures**

Fixes #88

## Test plan

- [x] `npm run build` compiles all new test files without errors
- [x] `node --test dist/hud/__tests__/colors.test.js dist/hud/__tests__/render.test.js dist/hud/__tests__/types.test.js` → 94 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)