### PR TITLE
fix: update collab→multi_agent assertion in generator-notify tests

### DIFF
--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -101,7 +101,7 @@ describe('config generator', () => {
 
       // Features correct
       assert.equal((rerun.match(/^\[features\]$/gm) ?? []).length, 1);
-      assert.match(rerun, /^collab = true$/m);
+      assert.match(rerun, /^multi_agent = true$/m);
       assert.match(rerun, /^child_agents_md = true$/m);
 
       // User content preserved
@@ -148,7 +148,7 @@ describe('config generator', () => {
       assert.match(toml, /^web_search = true$/m);
 
       // OMX feature flags added
-      assert.match(toml, /^collab = true$/m);
+      assert.match(toml, /^multi_agent = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -213,7 +213,7 @@ describe('config generator', () => {
 
       assert.equal((merged.match(/^\[features\]$/gm) ?? []).length, 1);
       assert.match(merged, /^custom_user_flag = false$/m);
-      assert.match(merged, /^collab = true$/m);
+      assert.match(merged, /^multi_agent = true$/m);
       assert.match(merged, /^child_agents_md = true$/m);
       assert.match(merged, /^\[user.settings\]$/m);
       assert.match(merged, /^name = "kept"$/m);


### PR DESCRIPTION
## Summary
Follow-up to #95.

PR #95 updated the production code (`generator.ts`) to emit `multi_agent = true` instead of the deprecated `collab = true`, but missed updating 3 test assertions in `generator-notify.test.ts`.

**Fixes:**
- Line 104: `/^collab = true$/m` → `/^multi_agent = true$/m`
- Line 151: same
- Line 216: same

Tests: 8/8 pass ✅

🤖 repo owner's gaebal-gajae (clawdbot) 🦞