### PR TITLE
fix: replace remaining deprecated 'collab' references with 'multi_agent' (#98)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ For non-trivial SDK/API/framework usage, delegate to `dependency-expert` to chec
 </delegation_rules>
 
 <child_agent_protocol>
-Codex CLI spawns child agents via the `spawn_agent` tool (requires `collab = true`).
+Codex CLI spawns child agents via the `spawn_agent` tool (requires `multi_agent = true`).
 To inject role-specific behavior, the parent MUST read the role prompt and pass it in the spawned agent message.
 
 Delegation steps:

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -23,7 +23,7 @@
 | Keyword Detection | 17 keywords | 17 keywords | 100% |
 | Hook Pipeline | 9 events | 6 full + 3 partial | ~89% |
 | HUD/Status Line | 1 | 1 (built-in + CLI) | 100% |
-| Subagent Tracking | 1 | partial (via collab) | 50% |
+| Subagent Tracking | 1 | partial (via multi_agent) | 50% |
 | Python REPL | 1 tool | 0 tools | 0% |
 | **TOTAL** | | | **~95%** |
 
@@ -116,8 +116,8 @@
 | PreToolUse | AGENTS.md inline guidance | PARTIAL (no interception) |
 | PostToolUse | notify config hook + tmux prompt injection workaround | FULL* |
 | UserPromptSubmit | AGENTS.md self-detection | PARTIAL (model-side detection) |
-| SubagentStart | Codex CLI collab native | FULL |
-| SubagentStop | Codex CLI collab native | FULL |
+| SubagentStart | Codex CLI multi_agent native | FULL |
+| SubagentStop | Codex CLI multi_agent native | FULL |
 | PreCompact | AGENTS.md overlay compaction protocol | PARTIAL (instructions only) |
 | Stop | notify config + postLaunch cleanup | FULL |
 | SessionEnd | omx postLaunch lifecycle phase | PARTIAL (post-exit cleanup) |

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Important rule: do not shutdown while tasks are still `in_progress` unless abort
   - `notify = ["node", "..."]`
   - `model_reasoning_effort = "high"`
   - `developer_instructions = "..."`
-  - `[features] collab = true, child_agents_md = true`
+  - `[features] multi_agent = true, child_agents_md = true`
   - MCP server entries (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
   - `[tui] status_line`
 - Project `AGENTS.md`

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -101,7 +101,7 @@ describe('config generator', () => {
 
       // Features correct
       assert.equal((rerun.match(/^\[features\]$/gm) ?? []).length, 1);
-      assert.match(rerun, /^collab = true$/m);
+      assert.match(rerun, /^multi_agent = true$/m);
       assert.match(rerun, /^child_agents_md = true$/m);
 
       // User content preserved
@@ -148,7 +148,7 @@ describe('config generator', () => {
       assert.match(toml, /^web_search = true$/m);
 
       // OMX feature flags added
-      assert.match(toml, /^collab = true$/m);
+      assert.match(toml, /^multi_agent = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -213,7 +213,7 @@ describe('config generator', () => {
 
       assert.equal((merged.match(/^\[features\]$/gm) ?? []).length, 1);
       assert.match(merged, /^custom_user_flag = false$/m);
-      assert.match(merged, /^collab = true$/m);
+      assert.match(merged, /^multi_agent = true$/m);
       assert.match(merged, /^child_agents_md = true$/m);
       assert.match(merged, /^\[user.settings\]$/m);
       assert.match(merged, /^name = "kept"$/m);

--- a/src/hooks/emulator.ts
+++ b/src/hooks/emulator.ts
@@ -8,7 +8,7 @@
  * 2. PreToolUse -> AGENTS.md instructions (inline guidance, no hook needed)
  * 3. PostToolUse -> notify config (fire-and-forget, no context injection)
  * 4. UserPromptSubmit -> AGENTS.md keyword detection instructions
- * 5. SubagentStart/Stop -> Codex CLI collab system (native tracking)
+ * 5. SubagentStart/Stop -> Codex CLI multi_agent system (native tracking)
  * 6. PreCompact -> Not available (Codex manages compaction internally)
  * 7. Stop -> notify config (can detect turn completion)
  *
@@ -29,8 +29,8 @@ export type HookEvent =
   | 'PreToolUse'         // -> AGENTS.md inline guidance
   | 'PostToolUse'        // -> notify config
   | 'UserPromptSubmit'   // -> AGENTS.md keyword detection
-  | 'SubagentStart'      // -> Codex CLI collab tracking
-  | 'SubagentStop'       // -> Codex CLI collab tracking
+  | 'SubagentStart'      // -> Codex CLI multi_agent tracking
+  | 'SubagentStop'       // -> Codex CLI multi_agent tracking
   | 'PreCompact'         // -> Not available
   | 'Stop'               // -> notify config
   | 'SessionEnd';        // -> Not directly available
@@ -64,14 +64,14 @@ export const HOOK_MAPPING: Record<HookEvent, {
     notes: 'Model detects keywords via AGENTS.md instructions instead of external hook',
   },
   SubagentStart: {
-    mechanism: 'Codex CLI collab system',
+    mechanism: 'Codex CLI multi_agent system',
     capability: 'full',
-    notes: 'Native sub-agent lifecycle tracking via collab feature',
+    notes: 'Native sub-agent lifecycle tracking via multi_agent feature',
   },
   SubagentStop: {
-    mechanism: 'Codex CLI collab system',
+    mechanism: 'Codex CLI multi_agent system',
     capability: 'full',
-    notes: 'Native sub-agent lifecycle tracking via collab feature',
+    notes: 'Native sub-agent lifecycle tracking via multi_agent feature',
   },
   PreCompact: {
     mechanism: 'AGENTS.md overlay compaction protocol',

--- a/src/team/orchestrator.ts
+++ b/src/team/orchestrator.ts
@@ -1,7 +1,7 @@
 /**
  * Team Orchestration for oh-my-codex
  *
- * Leverages Codex CLI's native collab feature for multi-agent coordination.
+ * Leverages Codex CLI's native multi_agent feature for multi-agent coordination.
  * Provides the staged pipeline: plan -> prd -> exec -> verify -> fix (loop)
  */
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -44,7 +44,7 @@ For non-trivial SDK/API/framework usage, delegate to `dependency-expert` to chec
 </delegation_rules>
 
 <child_agent_protocol>
-Codex CLI spawns child agents via the `spawn_agent` tool (requires `collab = true`).
+Codex CLI spawns child agents via the `spawn_agent` tool (requires `multi_agent = true`).
 To inject role-specific behavior, the parent MUST read the role prompt and pass it in the spawned agent message.
 
 Delegation steps:


### PR DESCRIPTION
## Summary

Follow-up to #94/#95 which updated the config generator. This PR completes the migration by replacing all remaining deprecated `collab` config key references with `multi_agent` (required by Codex v0.104.0) across tests, documentation, and source comments.

- **Tests** (`src/config/__tests__/generator-notify.test.ts`): 3 assertions still matched `/^collab = true$/m` — updated to `/^multi_agent = true$/m`
- **README.md**: updated `[features]` example in the setup docs
- **COVERAGE.md**: updated hook pipeline table and feature matrix
- **AGENTS.md / templates/AGENTS.md**: updated `child_agent_protocol` section
- **src/team/orchestrator.ts**: updated file-header comment
- **src/hooks/emulator.ts**: updated mechanism labels and inline comments

## Test plan

- [x] All 662 existing tests pass (`ℹ pass 662  ℹ fail 0`)
- [x] No new TypeScript errors introduced (only pre-existing MCP SDK import errors unrelated to this change)
- [x] Verified no remaining `collab` config-key references in config/source/docs (only unrelated English "collaboration" words remain)

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)