### PR TITLE
fix: ensure process exits cleanly after /exit command

### DIFF
--- a/bin/omx.js
+++ b/bin/omx.js
@@ -17,7 +17,8 @@ const srcEntry = join(root, 'src', 'cli', 'index.ts');
 
 if (existsSync(distEntry)) {
   const { main } = await import(distEntry);
-  main(process.argv.slice(2));
+  await main(process.argv.slice(2));
+  process.exit(process.exitCode ?? 0);
 } else {
   // Direct TS execution requires tsx or similar
   console.error('oh-my-codex: run "npm run build" first, or use tsx/ts-node');


### PR DESCRIPTION
## Summary

- Fixes #99: `omx` required Ctrl+C to terminate after the user typed `/exit` in Codex
- Root cause: `bin/omx.js` called `main()` without `await`, and after `postLaunch` completed its async work (HTTPS notification dispatches, hook plugin dispatches), lingering open socket/timer handles kept the Node.js event loop alive indefinitely
- Fix: `await main()` and call `process.exit(process.exitCode ?? 0)` to force clean termination while respecting any non-zero exit code already set (e.g. by `omx doctor --team` which uses `process.exitCode = 1`)

## Root Cause

In `bin/omx.js`, `main()` returned a Promise that was fire-and-forget:
```js
// Before
main(process.argv.slice(2));
```

`postLaunch` dispatches lifecycle notifications (Discord/Telegram/Slack via HTTPS) and hook plugin events. These create open socket handles that keep the event loop alive after `main()` resolves, requiring Ctrl+C to kill the process.

## Fix

```js
// After
await main(process.argv.slice(2));
process.exit(process.exitCode ?? 0);
```

Using `process.exitCode ?? 0` (rather than a hardcoded `0`) preserves exit codes set via `process.exitCode = 1` (used by `omx doctor --team` for failure signaling), while `process.exit(1)` calls inside `main()` terminate the process immediately before this line is reached.

## Test plan

- [x] Build passes (`npm run build`)
- [x] Test suite: 659 pass, 3 fail (same 3 pre-existing failures as `main` branch — unrelated `collab` config key assertions)
- [x] `omx doctor --team` failure tests still exit with code 1 (verified by running test suite)
- [x] `omx status` and `omx cancel` still exit with code 0 (verified by `session-scoped-runtime` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)