### PR TITLE
fix(tmux): enable mouse scrolling to separate scroll from arrow-key history (#103)

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   buildWorkerStartupCommand,
   createTeamSession,
+  enableMouseScrolling,
   isTmuxAvailable,
   isWorkerAlive,
   listTeamSessions,
@@ -247,6 +248,22 @@ describe('isWorkerAlive', () => {
     // which caused workers to be treated as dead and the leader to clean up state too early.
     withEmptyPath(() => {
       assert.equal(isWorkerAlive('omx-team-x', 1), false);
+    });
+  });
+});
+
+describe('enableMouseScrolling', () => {
+  it('returns false when tmux is unavailable', () => {
+    // When tmux is not on PATH, enableMouseScrolling should gracefully return false
+    // rather than throwing, so callers do not need to guard against errors.
+    withEmptyPath(() => {
+      assert.equal(enableMouseScrolling('omx-team-x'), false);
+    });
+  });
+
+  it('returns false for empty session target when tmux unavailable', () => {
+    withEmptyPath(() => {
+      assert.equal(enableMouseScrolling(''), false);
     });
   });
 });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -276,7 +276,27 @@ export function createTeamSession(
   runTmux(['select-pane', '-t', leaderPaneId]);
   sleepSeconds(0.5);
 
+  // Enable mouse scrolling so agent output panes can be scrolled with the
+  // mouse wheel without conflicting with keyboard up/down arrow-key input
+  // history navigation in the Codex CLI input field. (issue #103)
+  // Opt-out: set OMX_TEAM_MOUSE=0 in the environment.
+  if (process.env.OMX_TEAM_MOUSE !== '0') {
+    enableMouseScrolling(sessionName);
+  }
+
   return { name: teamTarget, workerCount, cwd, workerPaneIds };
+}
+
+/**
+ * Enable tmux mouse mode for a session so users can scroll pane content
+ * (e.g. long agent output) with the mouse wheel instead of arrow keys.
+ * Arrow keys remain reserved for Codex CLI input-history navigation.
+ *
+ * Returns true if the option was set successfully, false otherwise.
+ */
+export function enableMouseScrolling(sessionTarget: string): boolean {
+  const result = runTmux(['set-option', '-t', sessionTarget, 'mouse', 'on']);
+  return result.ok;
 }
 
 function paneTarget(sessionName: string, workerIndex: number, workerPaneId?: string): string {


### PR DESCRIPTION
## Summary

Fixes #103 — scrolling and keyboard up/down key behavior conflict in tmux panes.

- **Enable mouse scrolling** (`mouse on`) in the tmux session created by `createTeamSession()`, so users can scroll long agent output with the mouse wheel
- **Arrow keys remain exclusively for input history** in the Codex CLI input field — no more conflict
- Opt-out escape hatch: set `OMX_TEAM_MOUSE=0` in the environment to disable

## Changes

| File | Change |
|---|---|
| `src/team/tmux-session.ts` | Add `enableMouseScrolling(sessionTarget)` exported function; call it at end of `createTeamSession()` |
| `src/team/__tests__/tmux-session.test.ts` | Add `enableMouseScrolling` test suite (no-tmux fallback path) |

## How it works

After worker panes are created and the layout is applied, `createTeamSession()` calls:

```ts
runTmux(['set-option', '-t', sessionName, 'mouse', 'on']);
```

This sets the tmux `mouse` option for the session, enabling mouse-wheel scrolling in all panes (worker output panes included). Users can now scroll agent output with the mouse wheel; pressing up/down arrow keys continues to navigate Codex CLI input history as expected.

## Test plan

- [x] All existing tests pass (`npm test` — 0 failures)
- [x] New `enableMouseScrolling` tests added and passing
- [x] Opt-out via `OMX_TEAM_MOUSE=0` implemented and documented in code comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)