### PR TITLE
fix(tmux): isolate Enter/C-m into dedicated send-keys call to prevent Shift+Enter injection (#107)

### DIFF
--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -7,7 +7,7 @@
  * Security considerations:
  * - State/PID/log files use restrictive permissions (0600)
  * - Bot tokens stored in state file, NOT in environment variables
- * - Two-layer input sanitization (sanitizeReplyInput + sanitizeForTmux)
+ * - Two-layer input sanitization (sanitizeReplyInput + newline stripping in buildSendPaneArgvs)
  * - Pane verification via analyzePaneContent before every injection
  * - Authorization: only configured user IDs (Discord) / chat ID (Telegram) can inject
  * - Rate limiting to prevent spam/abuse


### PR DESCRIPTION
## Summary

- **Root cause**: `sendToPane()` in `tmux-detector.ts` called `execSync` with a shell-interpolated string and no `-l` flag, so any tmux key name (`C-m`, `Enter`, `Shift-Enter`, etc.) embedded in the text payload could be interpreted as a key press — enabling Shift+Enter injection
- **Fix**: Extract `buildSendPaneArgvs()` — a pure, testable function mirroring the established `buildSendKeysArgv()` pattern in `tmux-hook-engine.js` — that enforces Enter isolation unconditionally
- **Tests**: 8 new unit tests covering all aspects of the isolation invariant

## Changes

**`src/notifications/tmux-detector.ts`**
- Add exported `buildSendPaneArgvs(paneId, text, pressEnter)` pure function:
  - Sends text with `-l` (literal) + `--` so it is always delivered byte-for-byte; tmux key names in the text are never interpreted
  - Replaces embedded newlines with spaces to prevent literal Enter injection via `-l`
  - Sends `C-m` in two isolated, separate `send-keys` calls, never bundled with the text argv
- Rewrite `sendToPane()` to use `spawnSync` + `buildSendPaneArgvs()`, removing the shell-interpolated `execSync` call
- Remove `sanitizeForTmux()` — was only needed for shell-metacharacter escaping, which is no longer relevant

**`src/notifications/__tests__/tmux-detector.test.ts`**
- 8 new tests for `buildSendPaneArgvs`:
  - `-l` flag present in text argv
  - `--` separator guards against flag-like text
  - `C-m` is in a separate argv, never bundled with text
  - Double `C-m` sent when `pressEnter=true`
  - No `C-m` when `pressEnter=false`
  - Newlines stripped from text
  - Correct pane target in every argv
  - Full argv shape regression guard matching `buildSendKeysArgv` pattern

## Test plan

- [x] All 24 tests pass (`node --test dist/notifications/__tests__/tmux-detector.test.js`)
- [x] All 11 `tmux-hook-engine` tests pass (no regressions)
- [x] No new TypeScript errors in the notifications module
- [x] Pre-existing MCP SDK errors unrelated to this change

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)