### PR TITLE
fix(team): guard leader and HUD panes from worker cleanup (closes #109)

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -138,6 +138,20 @@ describe('tmux HUD pane helpers', () => {
   it('buildHudPaneCleanupTargets de-dupes pane ids and includes created pane', () => {
     assert.deepEqual(buildHudPaneCleanupTargets(['%3', '%3', 'invalid'], '%4'), ['%3', '%4']);
   });
+
+  it('buildHudPaneCleanupTargets excludes leader pane from existing ids', () => {
+    // %5 is the leader pane — it must not be included even if findHudWatchPaneIds let it through.
+    assert.deepEqual(buildHudPaneCleanupTargets(['%3', '%5'], '%4', '%5'), ['%3', '%4']);
+  });
+
+  it('buildHudPaneCleanupTargets excludes leader pane even when it matches the created HUD pane id', () => {
+    // Defensive edge case: if createHudWatchPane somehow returned the leader pane id, guard protects it.
+    assert.deepEqual(buildHudPaneCleanupTargets(['%3'], '%5', '%5'), ['%3']);
+  });
+
+  it('buildHudPaneCleanupTargets is a no-op guard when leaderPaneId is absent', () => {
+    assert.deepEqual(buildHudPaneCleanupTargets(['%3'], '%4'), ['%3', '%4']);
+  });
 });
 
 describe('buildTmuxShellCommand', () => {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -14,6 +14,10 @@ export interface TeamConfig {
   created_at: string;
   tmux_session: string; // "omx-team-{name}"
   next_task_id: number;
+  /** Leader's own tmux pane ID — must never be killed during worker cleanup. */
+  leader_pane_id?: string;
+  /** HUD pane spawned below the leader column — excluded from worker pane cleanup. */
+  hud_pane_id?: string;
 }
 
 export interface WorkerInfo {


### PR DESCRIPTION
## Summary

- `leaderPaneId` was a local variable inside `createTeamSession` and never propagated, so the worker cleanup routines had no way to exclude the leader's own pane
- `killWorker` and `killWorkerByPaneId` lacked any guard against being called with the leader's pane ID
- The HUD pane spawned below the leader column was untracked and unprotected

## Changes

- **`TeamSession`** now carries `leaderPaneId` and `hudPaneId`
- **`TeamConfig`** persists `leader_pane_id` and `hud_pane_id` to disk so `shutdownTeam` can read them on resume
- **`createTeamSession`** captures the HUD pane ID with `-P -F '#{pane_id}'` flags
- **`killWorker` / `killWorkerByPaneId`** accept an optional `leaderPaneId` and return early when the target matches it
- **`shutdownTeam`** skips any worker entry whose `pane_id` matches `leader_pane_id` or `hud_pane_id` before the force-kill step
- **`startTeam` rollback** passes `createdLeaderPaneId` to `killWorkerByPaneId`
- **`buildHudPaneCleanupTargets`** accepts an optional `leaderPaneId` and removes it from the kill set as defence-in-depth; `runCodex` passes `currentPaneId` (`TMUX_PANE`) as the guard value

## Test plan

- [x] `killWorkerByPaneId` guard: skips kill when `workerPaneId === leaderPaneId`, proceeds for differing IDs
- [x] `killWorker` guard: returns immediately when `workerPaneId === leaderPaneId`
- [x] `buildHudPaneCleanupTargets`: leader pane excluded from existing IDs, excluded even when it matches the created HUD pane ID, no-op when `leaderPaneId` absent
- [x] All 657 non-MCP tests pass (MCP tests fail due to pre-existing missing `@modelcontextprotocol/sdk` package, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)