### PR TITLE
feat: register OMX agents as Codex native agent roles (#120)

### DIFF
--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -1,0 +1,103 @@
+/**
+ * Native agent config generator for Codex CLI multi-agent roles
+ * Generates per-agent .toml files at ~/.omx/agents/<name>.toml
+ */
+
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { AGENT_DEFINITIONS, AgentDefinition } from './definitions.js';
+import { omxAgentsConfigDir } from '../utils/paths.js';
+
+// Map OMX model tiers to Codex reasoning effort levels
+const REASONING_EFFORT_MAP: Record<AgentDefinition['model'], string> = {
+  haiku: 'low',
+  sonnet: 'medium',
+  opus: 'high',
+};
+
+// Agents to skip (deprecated aliases)
+const SKIP_AGENTS = new Set(['deep-executor']);
+
+/**
+ * Strip YAML frontmatter (between --- markers) from markdown content
+ */
+function stripFrontmatter(content: string): string {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  if (match) {
+    return content.slice(match[0].length).trim();
+  }
+  return content.trim();
+}
+
+/**
+ * Escape content for TOML triple-quoted strings.
+ * TOML """ strings only need to escape sequences of 3+ consecutive quotes.
+ */
+function escapeTomlMultiline(s: string): string {
+  // Replace sequences of 3+ double quotes with escaped versions
+  return s.replace(/"{3,}/g, (match) => match.split('').join('\\'));
+}
+
+/**
+ * Generate TOML content for a single agent config file
+ */
+export function generateAgentToml(agent: AgentDefinition, promptContent: string): string {
+  const instructions = stripFrontmatter(promptContent);
+  const effort = REASONING_EFFORT_MAP[agent.model];
+  const escaped = escapeTomlMultiline(instructions);
+
+  return [
+    `# oh-my-codex agent: ${agent.name}`,
+    `model_reasoning_effort = "${effort}"`,
+    `developer_instructions = """`,
+    escaped,
+    `"""`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Install native agent config .toml files to ~/.omx/agents/
+ * Returns the number of agents installed
+ */
+export async function installNativeAgentConfigs(
+  pkgRoot: string,
+  options: { force?: boolean; dryRun?: boolean; verbose?: boolean } = {}
+): Promise<number> {
+  const { force = false, dryRun = false, verbose = false } = options;
+  const agentsDir = omxAgentsConfigDir();
+
+  if (!dryRun) {
+    await mkdir(agentsDir, { recursive: true });
+  }
+
+  let count = 0;
+
+  for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
+    if (SKIP_AGENTS.has(name)) continue;
+
+    const promptPath = join(pkgRoot, 'prompts', `${name}.md`);
+    if (!existsSync(promptPath)) {
+      if (verbose) console.log(`  skip ${name} (no prompt file)`);
+      continue;
+    }
+
+    const dst = join(agentsDir, `${name}.toml`);
+    if (!force && existsSync(dst)) {
+      if (verbose) console.log(`  skip ${name} (already exists)`);
+      continue;
+    }
+
+    const promptContent = await readFile(promptPath, 'utf-8');
+    const toml = generateAgentToml(agent, promptContent);
+
+    if (!dryRun) {
+      await writeFile(dst, toml);
+    }
+    if (verbose) console.log(`  ${name}.toml`);
+    count++;
+  }
+
+  return count;
+}

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -13,6 +13,8 @@
 import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { AGENT_DEFINITIONS } from '../agents/definitions.js';
+import { omxAgentsConfigDir } from '../utils/paths.js';
 
 interface MergeOptions {
   verbose?: boolean;
@@ -171,6 +173,35 @@ function stripExistingOmxBlocks(config: string): { cleaned: string; removed: num
 }
 
 /**
+ * Generate [agents.<name>] entries for Codex native multi-agent support.
+ * Each agent gets a description and config_file pointing to ~/.omx/agents/<name>.toml
+ */
+function getAgentEntries(): string[] {
+  const SKIP_AGENTS = new Set(['deep-executor']);
+  const entries: string[] = [
+    '',
+    '# OMX Native Agent Roles (Codex multi-agent)',
+  ];
+
+  for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
+    if (SKIP_AGENTS.has(name)) continue;
+
+    // TOML table headers with special chars need quoting
+    const tableKey = name.includes('-') ? `agents."${name}"` : `agents.${name}`;
+    const configFile = join(omxAgentsConfigDir(), `${name}.toml`)
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"');
+
+    entries.push('');
+    entries.push(`[${tableKey}]`);
+    entries.push(`description = "${agent.description}"`);
+    entries.push(`config_file = "${configFile}"`);
+  }
+
+  return entries;
+}
+
+/**
  * OMX table-section block (MCP servers, TUI).
  * Contains ONLY [table] sections — no bare keys.
  */
@@ -214,6 +245,7 @@ function getOmxTablesBlock(pkgRoot: string): string {
     `args = ["${traceServerPath}"]`,
     'enabled = true',
     'startup_timeout_sec = 5',
+    ...getAgentEntries(),
     '',
     '# OMX TUI StatusLine (Codex CLI v0.101.0+)',
     '[tui]',

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,5 @@ export { doctor } from './cli/doctor.js';
 export { version } from './cli/version.js';
 export { mergeConfig } from './config/generator.js';
 export { AGENT_DEFINITIONS, type AgentDefinition } from './agents/definitions.js';
+export { generateAgentToml, installNativeAgentConfigs } from './agents/native-config.js';
 export { hudCommand } from './hud/index.js';

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -56,6 +56,11 @@ export function omxLogsDir(projectRoot?: string): string {
   return join(projectRoot || process.cwd(), '.omx', 'logs');
 }
 
+/** oh-my-codex native agent config directory (~/.omx/agents/) */
+export function omxAgentsConfigDir(): string {
+  return join(homedir(), '.omx', 'agents');
+}
+
 /** Get the package root directory (where agents/, skills/, prompts/ live) */
 export function packageRoot(): string {
   // From dist/utils/ or src/utils/, go up two levels


### PR DESCRIPTION
## Summary

- Add Codex native `[agents.<name>]` role registration to generated `config.toml` for all 27 OMX agent types (excluding deprecated `deep-executor`)
- Generate per-agent config files at `~/.omx/agents/<name>.toml` with `model_reasoning_effort` (mapped from OMX tier: haiku→low, sonnet→medium, opus→high) and `developer_instructions` (from prompt markdown with frontmatter stripped)
- Add new setup step `[3/8] Installing native agent configs...` to `omx setup` flow
- Export `generateAgentToml` and `installNativeAgentConfigs` from package index

## Files Changed

| File | Change |
|------|--------|
| `src/agents/native-config.ts` | **New** — generates per-agent `.toml` config files |
| `src/config/generator.ts` | Add `[agents.<name>]` entries to config.toml output |
| `src/cli/setup.ts` | Add step 3/8 for native agent config installation |
| `src/utils/paths.ts` | Add `omxAgentsConfigDir()` → `~/.omx/agents/` |
| `src/index.ts` | Export new native-config functions |

## How It Works

1. `[features] multi_agent = true` was already set — no change needed
2. Each agent gets a `[agents.<name>]` section in `config.toml` with `description` and `config_file` path
3. Each agent gets a dedicated `.toml` at `~/.omx/agents/<name>.toml` with `model_reasoning_effort` and `developer_instructions`
4. Existing `prompts:` system is preserved for backward compatibility

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit --skipLibCheck`)
- [x] LSP diagnostics: zero errors on all modified files
- [x] Existing tests pass (pre-existing vitest config issues unrelated)
- [ ] Run `omx setup --force` and verify `~/.omx/agents/` populated
- [ ] Verify `config.toml` contains `[agents.*]` entries
- [ ] Test Codex CLI recognizes native agent roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)