### PR TITLE
fix: remove deprecated collab flag from generated config (#123)

### DIFF
--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -104,6 +104,14 @@ function upsertFeatureFlags(config: string): string {
     }
   }
 
+  // Remove deprecated 'collab' key (superseded by multi_agent)
+  for (let i = sectionEnd - 1; i > featuresStart; i--) {
+    if (/^\s*collab\s*=/.test(lines[i])) {
+      lines.splice(i, 1);
+      sectionEnd -= 1;
+    }
+  }
+
   let multiAgentIdx = -1;
   let childAgentsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {


### PR DESCRIPTION
## Summary
- Strips the deprecated `collab = true` key from the `[features]` section during config upsert
- The installer already adds `multi_agent = true` but never cleaned up the legacy `collab` key
- Adds test verifying `collab` removal while preserving other user flags

## Test plan
- [x] New test: `removes deprecated collab flag from [features]` — passes
- [x] All 9 existing generator tests pass
- [x] Verified no type regressions in changed files

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)