### PR TITLE
chore: bump version to 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.4.4] - 2026-02-19
+
+### Added
+- Added code-simplifier stop hook for automatic refactoring.
+- Registered OMX agents as Codex native multi-agent agent roles.
+
+### Fixed
+- Fixed team mode notification spam with runtime tests.
+- Removed deprecated `collab` flag from generated config.
+- Fixed tmux session name handling.
+
 ## [0.4.2] - 2026-02-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version 0.4.3 → 0.4.4 across package.json, package-lock.json
- Add CHANGELOG.md entry for 0.4.4 with recent changes:
  - code-simplifier stop hook for auto refactoring
  - OMX agents registered as Codex native multi-agent roles
  - team mode notification spam fix
  - deprecated collab flag removed from generated config
  - tmux session name fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)