### PR TITLE
feat: add verbosity levels to CCNotifier (#126)

### DIFF
--- a/src/notifications/__tests__/verbosity.test.ts
+++ b/src/notifications/__tests__/verbosity.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getVerbosity,
+  isEventAllowedByVerbosity,
+  shouldIncludeTmuxTail,
+  isEventEnabled,
+} from '../config.js';
+import { formatSessionEnd, formatSessionIdle, formatSessionStop } from '../formatter.js';
+import type { FullNotificationConfig, FullNotificationPayload, VerbosityLevel } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<FullNotificationConfig> = {}): FullNotificationConfig {
+  return {
+    enabled: true,
+    discord: { enabled: true, webhookUrl: 'https://discord.com/api/webhooks/test' },
+    ...overrides,
+  };
+}
+
+const basePayload: FullNotificationPayload = {
+  event: 'session-end',
+  sessionId: 'test-session-1',
+  message: '',
+  timestamp: '2026-02-19T12:00:00.000Z',
+  projectPath: '/home/user/my-project',
+  projectName: 'my-project',
+};
+
+// ---------------------------------------------------------------------------
+// getVerbosity
+// ---------------------------------------------------------------------------
+
+describe('getVerbosity', () => {
+  const origEnv = process.env.OMX_NOTIFY_VERBOSITY;
+
+  afterEach(() => {
+    if (origEnv === undefined) {
+      delete process.env.OMX_NOTIFY_VERBOSITY;
+    } else {
+      process.env.OMX_NOTIFY_VERBOSITY = origEnv;
+    }
+  });
+
+  it('defaults to "session" when no config or env var', () => {
+    delete process.env.OMX_NOTIFY_VERBOSITY;
+    assert.equal(getVerbosity(makeConfig()), 'session');
+  });
+
+  it('reads verbosity from config', () => {
+    delete process.env.OMX_NOTIFY_VERBOSITY;
+    assert.equal(getVerbosity(makeConfig({ verbosity: 'minimal' })), 'minimal');
+  });
+
+  it('env var overrides config', () => {
+    process.env.OMX_NOTIFY_VERBOSITY = 'verbose';
+    assert.equal(getVerbosity(makeConfig({ verbosity: 'minimal' })), 'verbose');
+  });
+
+  it('ignores invalid env var and falls back to config', () => {
+    process.env.OMX_NOTIFY_VERBOSITY = 'invalid';
+    assert.equal(getVerbosity(makeConfig({ verbosity: 'agent' })), 'agent');
+  });
+
+  it('ignores invalid config value and falls back to default', () => {
+    delete process.env.OMX_NOTIFY_VERBOSITY;
+    assert.equal(getVerbosity(makeConfig({ verbosity: 'bogus' as VerbosityLevel })), 'session');
+  });
+
+  it('handles null config gracefully', () => {
+    delete process.env.OMX_NOTIFY_VERBOSITY;
+    assert.equal(getVerbosity(null), 'session');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isEventAllowedByVerbosity
+// ---------------------------------------------------------------------------
+
+describe('isEventAllowedByVerbosity', () => {
+  // Minimal: start, stop, end only
+  it('minimal allows session-start', () => {
+    assert.equal(isEventAllowedByVerbosity('minimal', 'session-start'), true);
+  });
+  it('minimal allows session-stop', () => {
+    assert.equal(isEventAllowedByVerbosity('minimal', 'session-stop'), true);
+  });
+  it('minimal allows session-end', () => {
+    assert.equal(isEventAllowedByVerbosity('minimal', 'session-end'), true);
+  });
+  it('minimal rejects session-idle', () => {
+    assert.equal(isEventAllowedByVerbosity('minimal', 'session-idle'), false);
+  });
+  it('minimal rejects ask-user-question', () => {
+    assert.equal(isEventAllowedByVerbosity('minimal', 'ask-user-question'), false);
+  });
+
+  // Session: includes idle
+  it('session allows session-idle', () => {
+    assert.equal(isEventAllowedByVerbosity('session', 'session-idle'), true);
+  });
+  it('session rejects ask-user-question', () => {
+    assert.equal(isEventAllowedByVerbosity('session', 'ask-user-question'), false);
+  });
+
+  // Agent: includes ask-user-question
+  it('agent allows ask-user-question', () => {
+    assert.equal(isEventAllowedByVerbosity('agent', 'ask-user-question'), true);
+  });
+  it('agent allows session-idle', () => {
+    assert.equal(isEventAllowedByVerbosity('agent', 'session-idle'), true);
+  });
+
+  // Verbose: allows everything
+  it('verbose allows all events', () => {
+    assert.equal(isEventAllowedByVerbosity('verbose', 'session-start'), true);
+    assert.equal(isEventAllowedByVerbosity('verbose', 'session-stop'), true);
+    assert.equal(isEventAllowedByVerbosity('verbose', 'session-end'), true);
+    assert.equal(isEventAllowedByVerbosity('verbose', 'session-idle'), true);
+    assert.equal(isEventAllowedByVerbosity('verbose', 'ask-user-question'), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldIncludeTmuxTail
+// ---------------------------------------------------------------------------
+
+describe('shouldIncludeTmuxTail', () => {
+  it('returns false for minimal', () => {
+    assert.equal(shouldIncludeTmuxTail('minimal'), false);
+  });
+  it('returns true for session', () => {
+    assert.equal(shouldIncludeTmuxTail('session'), true);
+  });
+  it('returns true for agent', () => {
+    assert.equal(shouldIncludeTmuxTail('agent'), true);
+  });
+  it('returns true for verbose', () => {
+    assert.equal(shouldIncludeTmuxTail('verbose'), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isEventEnabled with verbosity
+// ---------------------------------------------------------------------------
+
+describe('isEventEnabled with verbosity', () => {
+  const origEnv = process.env.OMX_NOTIFY_VERBOSITY;
+
+  afterEach(() => {
+    if (origEnv === undefined) {
+      delete process.env.OMX_NOTIFY_VERBOSITY;
+    } else {
+      process.env.OMX_NOTIFY_VERBOSITY = origEnv;
+    }
+  });
+
+  it('minimal config blocks session-idle', () => {
+    delete process.env.OMX_NOTIFY_VERBOSITY;
+    const config = makeConfig({ verbosity: 'minimal' });
+    assert.equal(isEventEnabled(config, 'session-idle'), false);
+  });
+
+  it('minimal config allows session-end', () => {
+    delete process.env.OMX_NOTIFY_VERBOSITY;
+    const config = makeConfig({ verbosity: 'minimal' });
+    assert.equal(isEventEnabled(config, 'session-end'), true);
+  });
+
+  it('session config allows session-idle', () => {
+    delete process.env.OMX_NOTIFY_VERBOSITY;
+    const config = makeConfig({ verbosity: 'session' });
+    assert.equal(isEventEnabled(config, 'session-idle'), true);
+  });
+
+  it('session config blocks ask-user-question', () => {
+    delete process.env.OMX_NOTIFY_VERBOSITY;
+    const config = makeConfig({ verbosity: 'session' });
+    assert.equal(isEventEnabled(config, 'ask-user-question'), false);
+  });
+
+  it('env var override takes precedence', () => {
+    process.env.OMX_NOTIFY_VERBOSITY = 'verbose';
+    const config = makeConfig({ verbosity: 'minimal' });
+    assert.equal(isEventEnabled(config, 'ask-user-question'), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formatter tmux tail inclusion
+// ---------------------------------------------------------------------------
+
+describe('formatter tmux tail inclusion', () => {
+  it('formatSessionEnd includes tmux tail when present', () => {
+    const msg = formatSessionEnd({
+      ...basePayload,
+      durationMs: 60000,
+      reason: 'session_exit',
+      tmuxTail: '$ npm test\nAll tests passed\n$',
+    });
+    assert.ok(msg.includes('Recent output:'));
+    assert.ok(msg.includes('npm test'));
+    assert.ok(msg.includes('All tests passed'));
+  });
+
+  it('formatSessionEnd omits tmux tail when absent', () => {
+    const msg = formatSessionEnd({
+      ...basePayload,
+      durationMs: 60000,
+      reason: 'session_exit',
+    });
+    assert.ok(!msg.includes('Recent output:'));
+  });
+
+  it('formatSessionIdle includes tmux tail when present', () => {
+    const msg = formatSessionIdle({
+      ...basePayload,
+      event: 'session-idle',
+      tmuxTail: 'waiting for input...',
+    });
+    assert.ok(msg.includes('Recent output:'));
+    assert.ok(msg.includes('waiting for input...'));
+  });
+
+  it('formatSessionStop includes tmux tail when present', () => {
+    const msg = formatSessionStop({
+      ...basePayload,
+      event: 'session-stop',
+      tmuxTail: 'iteration 3/10 complete',
+    });
+    assert.ok(msg.includes('Recent output:'));
+    assert.ok(msg.includes('iteration 3/10 complete'));
+  });
+});

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -29,6 +29,11 @@ function projectDisplay(payload: FullNotificationPayload): string {
   return "unknown";
 }
 
+function buildTmuxTailBlock(payload: FullNotificationPayload): string {
+  if (!payload.tmuxTail) return "";
+  return `\n**Recent output:**\n\`\`\`\n${payload.tmuxTail}\n\`\`\``;
+}
+
 function buildFooter(payload: FullNotificationPayload, markdown: boolean): string {
   const parts: string[] = [];
 
@@ -83,6 +88,9 @@ export function formatSessionStop(payload: FullNotificationPayload): string {
     lines.push(`**Incomplete tasks:** ${payload.incompleteTasks}`);
   }
 
+  const tail = buildTmuxTailBlock(payload);
+  if (tail) lines.push(tail);
+
   lines.push("");
   lines.push(buildFooter(payload, true));
 
@@ -114,6 +122,9 @@ export function formatSessionEnd(payload: FullNotificationPayload): string {
     lines.push("", `**Summary:** ${payload.contextSummary}`);
   }
 
+  const tail = buildTmuxTailBlock(payload);
+  if (tail) lines.push(tail);
+
   lines.push("");
   lines.push(buildFooter(payload, true));
 
@@ -133,6 +144,9 @@ export function formatSessionIdle(payload: FullNotificationPayload): string {
   if (payload.modesUsed && payload.modesUsed.length > 0) {
     lines.push(`**Modes:** ${payload.modesUsed.join(", ")}`);
   }
+
+  const tail = buildTmuxTailBlock(payload);
+  if (tail) lines.push(tail);
 
   lines.push("");
   lines.push(buildFooter(payload, true));

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -124,6 +124,31 @@ export function getTeamTmuxSessions(teamName: string): string[] {
 }
 
 /**
+ * Capture the last N lines of output from a tmux pane.
+ * Used to include a tail snippet in session-level notifications.
+ * Returns null if capture fails or tmux is not available.
+ */
+export function captureTmuxPane(paneId?: string | null, lines: number = 12): string | null {
+  const target = paneId || process.env.TMUX_PANE;
+  if (!target) return null;
+  if (!process.env.TMUX && !paneId) return null;
+
+  try {
+    const output = execSync(
+      `tmux capture-pane -t ${target} -p -l ${lines}`,
+      {
+        encoding: "utf-8",
+        timeout: 3000,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    ).trim();
+    return output || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Format tmux session info for human-readable display.
  * Returns null if not in tmux.
  */

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -14,6 +14,16 @@ export type NotificationEvent =
   | "session-idle"
   | "ask-user-question";
 
+/**
+ * Verbosity levels for notification filtering.
+ *
+ * - verbose: all text/tool call output
+ * - agent:   per-agent-call events (includes ask-user-question)
+ * - session: start/idle/stop/end + tmux tail snippet [DEFAULT]
+ * - minimal: start/stop/end only, no idle, no tmux tail
+ */
+export type VerbosityLevel = "verbose" | "agent" | "session" | "minimal";
+
 /** Supported notification platforms */
 export type NotificationPlatform =
   | "discord"
@@ -104,6 +114,9 @@ export interface FullNotificationConfig {
   /** Global enable/disable for all notifications */
   enabled: boolean;
 
+  /** Notification verbosity level (default: "session") */
+  verbosity?: VerbosityLevel;
+
   /** Default platform configs (used when event-specific config is not set) */
   discord?: DiscordNotificationConfig;
   "discord-bot"?: DiscordBotNotificationConfig;
@@ -161,6 +174,8 @@ export interface FullNotificationPayload {
   incompleteTasks?: number;
   /** tmux pane ID for reply injection target */
   tmuxPaneId?: string;
+  /** Captured tmux pane output (tail lines) for session-level notifications */
+  tmuxTail?: string;
 }
 
 /** Result of a notification send attempt */


### PR DESCRIPTION
## Summary

- Add configurable verbosity levels (`verbose`, `agent`, `session`, `minimal`) to the notification system
- `session` (default) dispatches start/idle/stop/end events with a tmux tail snippet (12 lines)
- `minimal` dispatches start/stop/end only, no idle, no tmux tail
- `agent`/`verbose` additionally include `ask-user-question` events
- Config via `notifications.verbosity` in `.omx-config.json` or `OMX_NOTIFY_VERBOSITY` env var

## Changes

| File | Change |
|------|--------|
| `src/notifications/types.ts` | Add `VerbosityLevel` type, `verbosity` config field, `tmuxTail` payload field |
| `src/notifications/config.ts` | Add `getVerbosity()`, `isEventAllowedByVerbosity()`, `shouldIncludeTmuxTail()`; integrate verbosity gate into `isEventEnabled()` |
| `src/notifications/tmux.ts` | Add `captureTmuxPane()` for tmux tail capture |
| `src/notifications/formatter.ts` | Include tmux tail block in idle/stop/end messages |
| `src/notifications/index.ts` | Wire verbosity + tmux capture into `notifyLifecycle()`; re-export new symbols |
| `src/notifications/__tests__/verbosity.test.ts` | 29 tests covering all verbosity levels, config resolution, env override, and formatter output |

## Config example

```json
{
  "notifications": {
    "enabled": true,
    "verbosity": "session",
    "discord": { "enabled": true, "webhookUrl": "..." }
  }
}
```

## Test plan

- [x] 29 new verbosity tests pass (getVerbosity, isEventAllowedByVerbosity, shouldIncludeTmuxTail, isEventEnabled integration, formatter tmux tail)
- [x] 46 existing notification tests pass (no regressions)
- [ ] Manual: set `verbosity: "minimal"` and verify idle notifications are suppressed
- [ ] Manual: set `verbosity: "session"` and verify tmux tail appears in idle/end messages

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)