### PR TITLE
feat: add --spark and --madmax-spark flags for Codex spark model

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -87,6 +87,62 @@ describe('normalizeCodexLaunchArgs', () => {
       ['--dangerously-bypass-approvals-and-sandbox', '-c', 'model_reasoning_effort="xhigh"']
     );
   });
+
+  it('--spark injects the spark model', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--spark']),
+      ['--model', 'gpt-5.3-codex-spark']
+    );
+  });
+
+  it('--spark does not override an explicit --model flag', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--model', 'gpt-5', '--spark']),
+      ['--model', 'gpt-5']
+    );
+  });
+
+  it('--spark does not override an explicit --model=value flag', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--model=custom-model', '--spark']),
+      ['--model=custom-model']
+    );
+  });
+
+  it('--spark combines with --xhigh reasoning', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--spark', '--xhigh']),
+      ['-c', 'model_reasoning_effort="xhigh"', '--model', 'gpt-5.3-codex-spark']
+    );
+  });
+
+  it('--madmax-spark injects spark model and bypass flag', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--madmax-spark']),
+      ['--dangerously-bypass-approvals-and-sandbox', '--model', 'gpt-5.3-codex-spark']
+    );
+  });
+
+  it('--madmax-spark does not override an explicit --model flag', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--madmax-spark', '--model', 'custom']),
+      ['--model', 'custom', '--dangerously-bypass-approvals-and-sandbox']
+    );
+  });
+
+  it('--madmax-spark deduplicates bypass flag when --madmax is also present', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--madmax', '--madmax-spark']),
+      ['--dangerously-bypass-approvals-and-sandbox', '--model', 'gpt-5.3-codex-spark']
+    );
+  });
+
+  it('--madmax-spark combines with --xhigh reasoning', () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(['--madmax-spark', '--xhigh']),
+      ['--dangerously-bypass-approvals-and-sandbox', '-c', 'model_reasoning_effort="xhigh"', '--model', 'gpt-5.3-codex-spark']
+    );
+  });
 });
 
 describe('resolveCliInvocation', () => {


### PR DESCRIPTION
## Summary

Closes #131

Adds two new CLI flags leveraging the Codex spark model (~1.3x faster than standard):

- **`--spark`**: Sets `--model gpt-5.3-codex-spark` for the session. Team workers inherit the model via the existing flag-propagation mechanism, so explorer and simple sub-agents automatically use spark without extra config.
- **`--madmax-spark`**: Combines spark model with `--dangerously-bypass-approvals-and-sandbox` for maximum throughput. Intended for pro users who have access to the spark model.

Both flags:
- Are no-ops if the user already provided an explicit `--model` flag (explicit wins)
- Follow the same normalization pattern as `--madmax`, `--high`, and `--xhigh`
- Deduplicate the bypass flag correctly when combined with `--madmax`

## Changes

- `src/cli/index.ts`: Added `SPARK_FLAG`, `MADMAX_SPARK_FLAG`, `SPARK_MODEL` constants; updated `normalizeCodexLaunchArgs` to handle the new flags; updated help text
- `src/cli/__tests__/index.test.ts`: 8 new test cases covering all flag combinations

## Test plan

- [x] `--spark` injects `--model gpt-5.3-codex-spark`
- [x] `--spark` does not override explicit `--model` or `--model=value`
- [x] `--spark` combines correctly with `--xhigh`
- [x] `--madmax-spark` injects spark model + bypass flag
- [x] `--madmax-spark` does not override explicit `--model`
- [x] `--madmax-spark` deduplicates bypass when combined with `--madmax`
- [x] `--madmax-spark` combines correctly with `--xhigh`
- [x] All 734 existing tests continue to pass (2 pre-existing failures in `team/runtime.test.js` are unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)