### PR TITLE
fix: add Windows native support for ESM paths and TOML config generation

### DIFF
--- a/bin/omx.js
+++ b/bin/omx.js
@@ -3,7 +3,7 @@
 // oh-my-codex CLI entry point
 // Supports both compiled (dist/) and direct TypeScript execution
 
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 
@@ -16,7 +16,7 @@ const distEntry = join(root, 'dist', 'cli', 'index.js');
 const srcEntry = join(root, 'src', 'cli', 'index.ts');
 
 if (existsSync(distEntry)) {
-  const { main } = await import(distEntry);
+  const { main } = await import(pathToFileURL(distEntry).href);
   await main(process.argv.slice(2));
   process.exit(process.exitCode ?? 0);
 } else {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -214,10 +214,14 @@ function getAgentEntries(): string[] {
  * Contains ONLY [table] sections — no bare keys.
  */
 function getOmxTablesBlock(pkgRoot: string): string {
-  const stateServerPath = join(pkgRoot, 'dist', 'mcp', 'state-server.js');
-  const memoryServerPath = join(pkgRoot, 'dist', 'mcp', 'memory-server.js');
-  const codeIntelServerPath = join(pkgRoot, 'dist', 'mcp', 'code-intel-server.js');
-  const traceServerPath = join(pkgRoot, 'dist', 'mcp', 'trace-server.js');
+  const stateServerPath = join(pkgRoot, 'dist', 'mcp', 'state-server.js')
+    .replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const memoryServerPath = join(pkgRoot, 'dist', 'mcp', 'memory-server.js')
+    .replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const codeIntelServerPath = join(pkgRoot, 'dist', 'mcp', 'code-intel-server.js')
+    .replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const traceServerPath = join(pkgRoot, 'dist', 'mcp', 'trace-server.js')
+    .replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
   return [
     '',


### PR DESCRIPTION
## Summary

- Use `pathToFileURL` in `bin/omx.js` to fix `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows where `C:` is interpreted as a URL scheme by the ESM loader
- Escape backslashes in MCP server paths when generating `config.toml`, matching the existing convention already used for `notify` (line 37-38) and agent `config_file` paths (line 200-201)

## Problem

On native Windows (not WSL), `omx` fails immediately on launch:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node
are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs.
Received protocol 'c:'
```

Additionally, `omx setup` generates invalid TOML in `config.toml` because Windows backslash paths like `C:\Users\...` contain `\U` which TOML interprets as a unicode escape sequence.

## Changes

| File | Lines changed | Description |
|------|:---:|---|
| `bin/omx.js` | 2 | Add `pathToFileURL` import and wrap `import(distEntry)` |
| `src/config/generator.ts` | 4 | Add `.replace(/\/g, '\\').replace(/"/g, '\\"')` to MCP server paths |

## Cross-platform safety

- **macOS/Linux**: `pathToFileURL` produces valid `file:///` URLs. `.replace(/\/g, ...)` is a no-op since paths use `/` only.
- **Windows**: Fixes both the ESM loader error and invalid TOML generation.
- The same escape pattern is already used in 2 other places in `generator.ts` (lines 37-38, 200-201) without issues on macOS/Linux.

## Test plan

- [x] Verified `omx help` runs without ESM errors on native Windows
- [x] Verified `omx setup` generates properly escaped `\` paths in `config.toml`
- [x] Verified MCP server responds to JSON-RPC initialize handshake