### PR TITLE
feat: startup codebase map injection for token-efficient exploration

### DIFF
--- a/src/hooks/__tests__/codebase-map.test.ts
+++ b/src/hooks/__tests__/codebase-map.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for Codebase Map Generator
+ *
+ * Covers: symbol extraction, map generation, entry point detection,
+ * opt-out via OMX_CODEBASE_MAP=0, size cap, and marker boundaries.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  generateCodebaseMap,
+  extractTopSymbols,
+  CODEBASE_MAP_START,
+  CODEBASE_MAP_END,
+} from '../codebase-map.js';
+import { writeSessionModelInstructionsFile } from '../agents-overlay.js';
+import { generateOverlay } from '../agents-overlay.js';
+
+async function makeTempProject(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'omx-codebase-map-test-'));
+  await mkdir(join(dir, '.omx', 'state'), { recursive: true });
+  return dir;
+}
+
+describe('extractTopSymbols', () => {
+  it('extracts TypeScript symbols', () => {
+    const content = [
+      'export function greet(name: string): string {',
+      '  return `Hello, ${name}`;',
+      '}',
+      '',
+      'export class UserService {',
+      '  async findById(id: number) {}',
+      '}',
+      '',
+      'export interface Config {',
+      '  port: number;',
+      '}',
+      '',
+      'export type ID = string;',
+      '',
+      'export const VERSION = "1.0.0";',
+    ].join('\n');
+
+    const symbols = extractTopSymbols(content, 10);
+    assert.ok(symbols.some(s => s.includes('greet')));
+    assert.ok(symbols.some(s => s.includes('UserService')));
+    assert.ok(symbols.some(s => s.includes('Config')));
+    assert.ok(symbols.some(s => s.includes('ID')));
+    assert.ok(symbols.some(s => s.includes('VERSION')));
+  });
+
+  it('extracts Python symbols', () => {
+    const content = [
+      'class MyApp:',
+      '    pass',
+      '',
+      'def main():',
+      '    pass',
+      '',
+      'async def fetch_data():',
+      '    pass',
+    ].join('\n');
+
+    const symbols = extractTopSymbols(content, 10);
+    assert.ok(symbols.some(s => s.includes('MyApp')));
+    assert.ok(symbols.some(s => s.includes('main')));
+    assert.ok(symbols.some(s => s.includes('fetch_data')));
+  });
+
+  it('extracts Go symbols', () => {
+    const content = [
+      'func main() {',
+      '}',
+      '',
+      'type Server struct {',
+      '  Port int',
+      '}',
+      '',
+      'func (s *Server) Start() {',
+      '}',
+    ].join('\n');
+
+    const symbols = extractTopSymbols(content, 10);
+    assert.ok(symbols.some(s => s.includes('main')));
+    assert.ok(symbols.some(s => s.includes('Server')));
+    assert.ok(symbols.some(s => s.includes('Start')));
+  });
+
+  it('respects max symbol limit', () => {
+    const content = Array.from({ length: 20 }, (_, i) =>
+      `export function fn${i}() {}`
+    ).join('\n');
+
+    const symbols = extractTopSymbols(content, 3);
+    assert.equal(symbols.length, 3);
+  });
+
+  it('returns empty for non-source content', () => {
+    const symbols = extractTopSymbols('# README\n\nJust text.\n', 10);
+    assert.equal(symbols.length, 0);
+  });
+});
+
+describe('generateCodebaseMap', () => {
+  let tempDir: string;
+
+  before(async () => {
+    tempDir = await makeTempProject();
+
+    // Create a realistic project structure
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({
+      name: 'test-project',
+      main: 'dist/index.js',
+      bin: { cli: 'bin/cli.js' },
+    }));
+
+    await mkdir(join(tempDir, 'src'), { recursive: true });
+    await mkdir(join(tempDir, 'src', 'utils'), { recursive: true });
+
+    await writeFile(join(tempDir, 'src', 'index.ts'), [
+      'export function main() {}',
+      'export class App {}',
+    ].join('\n'));
+
+    await writeFile(join(tempDir, 'src', 'server.ts'), [
+      'export async function startServer(port: number) {}',
+      'export interface ServerConfig { port: number; }',
+    ].join('\n'));
+
+    await writeFile(join(tempDir, 'src', 'utils', 'helpers.ts'), [
+      'export function formatDate(d: Date): string { return ""; }',
+      'export const DEFAULT_TIMEOUT = 5000;',
+    ].join('\n'));
+  });
+
+  after(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  it('generates map with markers', async () => {
+    const map = await generateCodebaseMap(tempDir);
+    assert.ok(map.includes(CODEBASE_MAP_START));
+    assert.ok(map.includes(CODEBASE_MAP_END));
+    assert.ok(map.includes('<codebase_map>'));
+    assert.ok(map.includes('</codebase_map>'));
+  });
+
+  it('includes file symbols', async () => {
+    const map = await generateCodebaseMap(tempDir);
+    assert.ok(map.includes('main'));
+    assert.ok(map.includes('App'));
+    assert.ok(map.includes('startServer'));
+    assert.ok(map.includes('formatDate'));
+  });
+
+  it('detects entry points from package.json', async () => {
+    const map = await generateCodebaseMap(tempDir);
+    assert.ok(map.includes('dist/index.js'));
+  });
+
+  it('respects OMX_CODEBASE_MAP=0 opt-out', async () => {
+    const orig = process.env.OMX_CODEBASE_MAP;
+    process.env.OMX_CODEBASE_MAP = '0';
+    try {
+      const map = await generateCodebaseMap(tempDir);
+      assert.equal(map, '');
+    } finally {
+      if (orig === undefined) delete process.env.OMX_CODEBASE_MAP;
+      else process.env.OMX_CODEBASE_MAP = orig;
+    }
+  });
+
+  it('returns empty for directory with no source files', async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), 'omx-empty-test-'));
+    await mkdir(join(emptyDir, '.omx', 'state'), { recursive: true });
+    try {
+      const map = await generateCodebaseMap(emptyDir);
+      assert.equal(map, '');
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('enforces size cap', async () => {
+    const map = await generateCodebaseMap(tempDir, 500);
+    assert.ok(map.length <= 500, `Map too large: ${map.length} chars`);
+    assert.ok(map.includes(CODEBASE_MAP_START));
+  });
+
+  it('skips node_modules and dist', async () => {
+    await mkdir(join(tempDir, 'node_modules', 'pkg'), { recursive: true });
+    await writeFile(join(tempDir, 'node_modules', 'pkg', 'index.js'),
+      'export function external() {}');
+    await mkdir(join(tempDir, 'dist'), { recursive: true });
+    await writeFile(join(tempDir, 'dist', 'index.js'),
+      'export function compiled() {}');
+
+    const map = await generateCodebaseMap(tempDir);
+    assert.ok(!map.includes('external'));
+    assert.ok(!map.includes('compiled'));
+  });
+});
+
+describe('codebase map integration with session AGENTS.md', () => {
+  let tempDir: string;
+
+  before(async () => {
+    tempDir = await makeTempProject();
+    await mkdir(join(tempDir, 'src'), { recursive: true });
+    await writeFile(join(tempDir, 'src', 'app.ts'),
+      'export class Application {}\nexport function bootstrap() {}');
+    await writeFile(join(tempDir, 'AGENTS.md'),
+      '# Project AGENTS\n\nProject instructions here.\n');
+  });
+
+  after(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  it('injects codebase map between base and overlay in session file', async () => {
+    const overlay = await generateOverlay(tempDir, 'map-session-1');
+    const codebaseMap = await generateCodebaseMap(tempDir);
+
+    const path = await writeSessionModelInstructionsFile(
+      tempDir, 'map-session-1', overlay, codebaseMap,
+    );
+    const content = await readFile(path, 'utf-8');
+
+    // All three sections present
+    assert.ok(content.includes('# Project AGENTS'));
+    assert.ok(content.includes(CODEBASE_MAP_START));
+    assert.ok(content.includes('<!-- OMX:RUNTIME:START -->'));
+
+    // Order: base → codebase map → overlay
+    const baseIdx = content.indexOf('# Project AGENTS');
+    const mapIdx = content.indexOf(CODEBASE_MAP_START);
+    const overlayIdx = content.indexOf('<!-- OMX:RUNTIME:START -->');
+    assert.ok(baseIdx < mapIdx, 'Base should come before codebase map');
+    assert.ok(mapIdx < overlayIdx, 'Codebase map should come before overlay');
+  });
+
+  it('works without codebase map (backward compatible)', async () => {
+    const overlay = await generateOverlay(tempDir, 'map-session-2');
+    const path = await writeSessionModelInstructionsFile(
+      tempDir, 'map-session-2', overlay,
+    );
+    const content = await readFile(path, 'utf-8');
+
+    assert.ok(content.includes('# Project AGENTS'));
+    assert.ok(content.includes('<!-- OMX:RUNTIME:START -->'));
+    assert.ok(!content.includes(CODEBASE_MAP_START));
+  });
+
+  it('strips codebase map from base AGENTS.md if present', async () => {
+    // Simulate a corrupted AGENTS.md that has a stale codebase map
+    const corrupted = `# Project AGENTS\n\n${CODEBASE_MAP_START}\nstale map\n${CODEBASE_MAP_END}\n`;
+    await writeFile(join(tempDir, 'AGENTS.md'), corrupted);
+
+    const overlay = await generateOverlay(tempDir, 'map-session-3');
+    const freshMap = await generateCodebaseMap(tempDir);
+    const path = await writeSessionModelInstructionsFile(
+      tempDir, 'map-session-3', overlay, freshMap,
+    );
+    const content = await readFile(path, 'utf-8');
+
+    // Should have fresh map, not stale
+    assert.ok(!content.includes('stale map'));
+    assert.ok(content.includes('Application'));
+  });
+});

--- a/src/hooks/codebase-map.ts
+++ b/src/hooks/codebase-map.ts
@@ -1,0 +1,232 @@
+/**
+ * Codebase Map Generator for oh-my-codex
+ *
+ * Generates a lightweight codebase structure map at session start
+ * to reduce agent exploration token waste. Extracts file tree and
+ * top-level symbols (exports, classes, functions) for quick orientation.
+ *
+ * Ref: https://github.com/Yeachan-Heo/oh-my-codex/issues/136
+ */
+
+import { readFile, readdir } from 'fs/promises';
+import { join, relative, extname } from 'path';
+import { existsSync } from 'fs';
+
+export const CODEBASE_MAP_START = '<!-- OMX:CODEBASE_MAP:START -->';
+export const CODEBASE_MAP_END = '<!-- OMX:CODEBASE_MAP:END -->';
+
+const DEFAULT_MAX_CHARS = 1500;
+const MAX_DEPTH = 3;
+const MAX_FILES = 80;
+const MAX_SYMBOLS_PER_FILE = 5;
+
+const SKIP_DIRS = new Set([
+  'node_modules', 'dist', 'build', '.git', '.omx', '.next', '.nuxt',
+  '__pycache__', '.venv', 'venv', '.tox', 'target', '.svelte-kit',
+  'coverage', '.nyc_output', '.cache', '.turbo', '.parcel-cache',
+]);
+
+const CODE_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs',
+  '.java', '.c', '.cpp', '.h', '.cs', '.rb',
+]);
+
+// Top-level symbol patterns (export-level only, not methods/properties)
+const TOP_LEVEL_PATTERNS: Array<{ kind: string; re: RegExp }> = [
+  // TypeScript/JavaScript
+  { kind: 'fn', re: /^(?:export\s+)?(?:async\s+)?function\s+(\w+)/m },
+  { kind: 'class', re: /^(?:export\s+)?(?:abstract\s+)?class\s+(\w+)/m },
+  { kind: 'iface', re: /^(?:export\s+)?interface\s+(\w+)/m },
+  { kind: 'type', re: /^(?:export\s+)?type\s+(\w+)\s*=/m },
+  { kind: 'const', re: /^(?:export\s+)?const\s+(\w+)\s*[=:]/m },
+  // Python
+  { kind: 'def', re: /^(?:async\s+)?def\s+(\w+)/m },
+  { kind: 'class', re: /^class\s+(\w+)/m },
+  // Go
+  { kind: 'func', re: /^func\s+(?:\(\w+\s+\*?\w+\)\s+)?(\w+)/m },
+  { kind: 'type', re: /^type\s+(\w+)\s+(?:struct|interface)/m },
+  // Rust
+  { kind: 'fn', re: /^(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/m },
+  { kind: 'struct', re: /^(?:pub\s+)?struct\s+(\w+)/m },
+];
+
+interface FileSymbols {
+  path: string;
+  symbols: string[];
+}
+
+/**
+ * Extract top-level symbols from source file content.
+ */
+export function extractTopSymbols(content: string, max: number = MAX_SYMBOLS_PER_FILE): string[] {
+  const symbols: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of content.split('\n')) {
+    if (symbols.length >= max) break;
+    for (const { kind, re } of TOP_LEVEL_PATTERNS) {
+      const m = line.match(re);
+      if (m?.[1] && !seen.has(m[1])) {
+        seen.add(m[1]);
+        symbols.push(`${kind} ${m[1]}`);
+        break;
+      }
+    }
+  }
+
+  return symbols;
+}
+
+/**
+ * Detect entry points from package.json or common file patterns.
+ */
+async function detectEntryPoints(cwd: string): Promise<string[]> {
+  const entries: string[] = [];
+
+  const pkgPath = join(cwd, 'package.json');
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+      if (pkg.main) entries.push(pkg.main);
+      if (pkg.bin) {
+        if (typeof pkg.bin === 'string') entries.push(pkg.bin);
+        else if (typeof pkg.bin === 'object') {
+          entries.push(...(Object.values(pkg.bin) as string[]));
+        }
+      }
+    } catch { /* skip malformed */ }
+  }
+
+  const candidates = [
+    'src/index.ts', 'src/main.ts', 'index.ts', 'main.py', 'main.go', 'src/lib.rs',
+  ];
+  for (const c of candidates) {
+    if (existsSync(join(cwd, c)) && !entries.includes(c)) {
+      entries.push(c);
+    }
+  }
+
+  return entries.slice(0, 5);
+}
+
+/**
+ * Recursively walk a directory and extract top-level symbols from source files.
+ */
+async function walkAndExtract(
+  cwd: string,
+  dir: string,
+  depth: number,
+  result: FileSymbols[],
+): Promise<void> {
+  if (depth > MAX_DEPTH || result.length >= MAX_FILES) return;
+
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const dirs = entries
+    .filter(e => e.isDirectory() && !SKIP_DIRS.has(e.name) && !e.name.startsWith('.'))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const files = entries
+    .filter(e => e.isFile() && CODE_EXTENSIONS.has(extname(e.name)))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const file of files) {
+    if (result.length >= MAX_FILES) break;
+    const fullPath = join(dir, file.name);
+    const relPath = relative(cwd, fullPath);
+    try {
+      const content = await readFile(fullPath, 'utf-8');
+      const symbols = extractTopSymbols(content);
+      result.push({ path: relPath, symbols });
+    } catch { /* skip unreadable */ }
+  }
+
+  for (const d of dirs) {
+    if (result.length >= MAX_FILES) break;
+    await walkAndExtract(cwd, join(dir, d.name), depth + 1, result);
+  }
+}
+
+/**
+ * Format file symbols into a compact directory-grouped map.
+ */
+function formatMap(files: FileSymbols[], entryPoints: string[], maxChars: number): string {
+  const parts: string[] = [];
+
+  if (entryPoints.length > 0) {
+    parts.push(`Entry: ${entryPoints.join(', ')}`);
+  }
+
+  // Group by directory
+  const byDir = new Map<string, FileSymbols[]>();
+  for (const f of files) {
+    const dir = f.path.includes('/') ? f.path.slice(0, f.path.lastIndexOf('/')) : '.';
+    if (!byDir.has(dir)) byDir.set(dir, []);
+    byDir.get(dir)!.push(f);
+  }
+
+  for (const [dir, dirFiles] of byDir) {
+    const lines: string[] = [];
+    for (const f of dirFiles) {
+      const name = f.path.includes('/') ? f.path.slice(f.path.lastIndexOf('/') + 1) : f.path;
+      lines.push(f.symbols.length > 0 ? `  ${name}: ${f.symbols.join(', ')}` : `  ${name}`);
+    }
+    parts.push(`${dir}/\n${lines.join('\n')}`);
+  }
+
+  let result = parts.join('\n');
+  if (result.length > maxChars) {
+    result = result.slice(0, maxChars - 3) + '...';
+  }
+
+  return result;
+}
+
+/**
+ * Resolve the source root directory for symbol extraction.
+ * Prefers common source directories (src/, lib/, app/) over project root.
+ */
+function resolveSourceRoot(cwd: string): string {
+  for (const candidate of ['src', 'lib', 'app', 'pkg', 'cmd']) {
+    if (existsSync(join(cwd, candidate))) {
+      return join(cwd, candidate);
+    }
+  }
+  return cwd;
+}
+
+/**
+ * Generate a lightweight codebase structure map.
+ *
+ * Returns a marker-bounded block ready for injection into session AGENTS.md,
+ * or empty string if disabled or no source files found.
+ *
+ * Opt out: set OMX_CODEBASE_MAP=0
+ */
+export async function generateCodebaseMap(
+  cwd: string,
+  maxChars: number = DEFAULT_MAX_CHARS,
+): Promise<string> {
+  if (process.env.OMX_CODEBASE_MAP === '0') return '';
+
+  const [entryPoints, files] = await Promise.all([
+    detectEntryPoints(cwd),
+    (async () => {
+      const result: FileSymbols[] = [];
+      await walkAndExtract(cwd, resolveSourceRoot(cwd), 0, result);
+      return result;
+    })(),
+  ]);
+
+  if (files.length === 0) return '';
+
+  // Reserve space for markers + XML tags
+  const markerOverhead = CODEBASE_MAP_START.length + CODEBASE_MAP_END.length + 40;
+  const body = formatMap(files, entryPoints, maxChars - markerOverhead);
+
+  return `${CODEBASE_MAP_START}\n<codebase_map>\n${body}\n</codebase_map>\n${CODEBASE_MAP_END}`;
+}


### PR DESCRIPTION
## Summary

Implements #136 — injects a lightweight codebase structure map at session start so agents can orient themselves without burning tokens on file exploration.

- **New module** `src/hooks/codebase-map.ts`:
  - Walks source directories (respects `src/`, `lib/`, `app/` conventions)
  - Extracts top-level symbols via regex (TS/JS, Python, Go, Rust)
  - Detects entry points from `package.json` (`main`, `bin`)
  - Formats as compact directory-grouped markdown (~1500 char budget)
  - Skips `node_modules`, `dist`, `.git`, `__pycache__`, etc.
- **Integration** into session AGENTS.md via `writeSessionModelInstructionsFile()`:
  - Uses separate `<!-- OMX:CODEBASE_MAP:START/END -->` markers (doesn't compete with runtime overlay's 2000 char budget)
  - Composition order: base AGENTS.md → codebase map → runtime overlay
  - `stripOverlayContent()` also strips codebase map markers for clean roundtrip
- **Parallel generation** with runtime overlay in `preLaunch()` (no startup latency increase)
- **Opt-out**: `OMX_CODEBASE_MAP=0`

### Example output

```
Entry: dist/index.js, bin/omx.js
src/cli/
  index.ts: fn main, fn launchWithHud, fn preLaunch, fn runCodex, fn postLaunch
  setup.ts: fn setup, const SETUP_SCOPES
  doctor.ts: fn doctor
src/hooks/
  agents-overlay.ts: fn generateOverlay, fn applyOverlay, fn stripOverlay
  codebase-map.ts: fn generateCodebaseMap, fn extractTopSymbols
src/mcp/
  state-server.ts: const server
  code-intel-server.ts: iface DocumentSymbol, fn extractSymbols
```

### Design decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Separate markers | `CODEBASE_MAP_START/END` | Doesn't compete with runtime overlay's 2000 char cap |
| Regex-based extraction | Reuse SYMBOL_PATTERNS approach | Fast, no external dependencies, matches existing code-intel patterns |
| Default ON | `OMX_CODEBASE_MAP=0` to disable | Issue intent is "always inject"; opt-out for edge cases |
| Source root detection | Prefer `src/` > `lib/` > `app/` > cwd | Avoids scanning config/docs directories |

## Test plan

- [x] `npm run build` passes (tsc clean)
- [x] 15 new tests in `src/hooks/__tests__/codebase-map.test.ts`:
  - Symbol extraction: TypeScript, Python, Go, max limit, non-source
  - Map generation: markers, symbols, entry points, opt-out, empty dir, size cap, skip dirs
  - Integration: injection order, backward compat, stale map strip
- [x] Full suite: 816 pass, 0 new failures (1 pre-existing flaky tmux test)

Closes #136

HyunjunJeon