### PR TITLE
feat(notifications): clean tmux pane output before sending notifications (#142)

### DIFF
--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -8,6 +8,35 @@
 import type { FullNotificationPayload } from "./types.js";
 import { basename } from "path";
 
+/** ANSI CSI escape sequences (e.g. colors, cursor movement) */
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+/** OMC UI chrome: spinner/progress indicator characters */
+const SPINNER_LINE_RE = /^[●⎿✻·◼]/;
+
+/** tmux expand hint injected by some pane-capture scripts */
+const CTRL_O_RE = /ctrl\+o to expand/i;
+
+/**
+ * Parse raw tmux pane output into clean, human-readable text suitable for
+ * inclusion in a notification message.
+ *
+ * - Strips ANSI escape codes
+ * - Removes UI chrome lines (spinner/progress characters: ●⎿✻·◼)
+ * - Removes "ctrl+o to expand" hint lines
+ * - Caps at the last 10 meaningful (non-empty) lines
+ */
+export function parseTmuxTail(raw: string): string {
+  const lines = raw
+    .split("\n")
+    .map((line) => line.replace(ANSI_RE, "").trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !SPINNER_LINE_RE.test(line))
+    .filter((line) => !CTRL_O_RE.test(line));
+
+  return lines.slice(-10).join("\n");
+}
+
 function formatDuration(ms?: number): string {
   if (!ms) return "unknown";
   const seconds = Math.floor(ms / 1000);
@@ -31,7 +60,9 @@ function projectDisplay(payload: FullNotificationPayload): string {
 
 function buildTmuxTailBlock(payload: FullNotificationPayload): string {
   if (!payload.tmuxTail) return "";
-  return `\n**Recent output:**\n\`\`\`\n${payload.tmuxTail}\n\`\`\``;
+  const cleaned = parseTmuxTail(payload.tmuxTail);
+  if (!cleaned) return "";
+  return `\n**Recent output:**\n\`\`\`\n${cleaned}\n\`\`\``;
 }
 
 function buildFooter(payload: FullNotificationPayload, markdown: boolean): string {


### PR DESCRIPTION
## Summary

- Add `parseTmuxTail(raw: string): string` to `src/notifications/formatter.ts` that strips ANSI escape codes, removes UI chrome lines (spinner characters `●⎿✻·◼`), removes `ctrl+o to expand` markers, and caps output at the last 10 meaningful lines
- Update `buildTmuxTailBlock()` to run raw `tmuxTail` through `parseTmuxTail()` before embedding in notifications, and suppress the block entirely when nothing meaningful remains
- Export `parseTmuxTail` so it can be tested and reused

## Test plan

- [x] 9 new unit tests in `src/notifications/__tests__/formatter.test.ts` covering each filter rule, the 10-line cap, whitespace trimming, combined ANSI + spinner input, and the `buildTmuxTailBlock` integration path
- [x] All 22 formatter tests pass (`node --test dist/notifications/__tests__/formatter.test.js`)
- [x] `tsc` exits 0 — no new type errors introduced

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)