### PR TITLE
fix(ralplan): default to non-interactive consensus mode, add --interactive flag

### DIFF
--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -11,7 +11,15 @@ Ralplan is a shorthand alias for `/plan --consensus`. It triggers iterative plan
 
 ```
 /ralplan "task description"
+/ralplan --interactive "task description"
 ```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| *(none)* | Default non-interactive mode: auto-proceeds through all steps without pausing |
+| `--interactive` | Pauses at draft feedback (step 2) and final approval (step 6) to prompt the user |
 
 ## Behavior
 
@@ -19,16 +27,20 @@ This skill invokes the Plan skill in consensus mode:
 
 ```
 /plan --consensus <arguments>
+/plan --consensus --interactive <arguments>
 ```
 
-The consensus workflow:
+The consensus workflow (default — non-interactive):
 1. **Planner** creates initial plan
-2. **User feedback**: **MUST** use `AskUserQuestion` to present the draft plan before review (Proceed to review / Request changes / Skip review)
+2. *(skipped in default mode)* Auto-proceeds to Architect review
 3. **Architect** reviews for architectural soundness
 4. **Critic** evaluates against quality criteria
 5. If Critic rejects: iterate with feedback (max 5 iterations)
-6. On Critic approval: **MUST** use `AskUserQuestion` to present the plan with approval options
-7. User chooses: Approve, Request changes, or Reject
-8. On approval: **MUST** invoke `/ralph` for execution -- never implement directly
+6. *(skipped in default mode)* Auto-approves on Critic approval
+7. **MUST** invoke `/ralph` for execution -- never implement directly
+
+With `--interactive` flag, steps 2 and 6 pause to ask the user via `AskUserQuestion`:
+- Step 2 options: Proceed to review / Request changes / Skip review
+- Step 6 options: Approve and execute / Request changes / Reject
 
 Follow the Plan skill's full documentation for consensus mode details.


### PR DESCRIPTION
## Summary

- `/ralplan` and `/plan --consensus` now **auto-proceed** through all steps without pausing for user input (default non-interactive behavior)
- `AskUserQuestion` calls at the draft feedback step (step 2) and final approval step (step 6) are now guarded behind `--interactive` mode only
- Added `--interactive` flag documentation to both `skills/ralplan/SKILL.md` and `skills/plan/SKILL.md`

## Changes

- `skills/plan/SKILL.md`: Added `Consensus Interactive` mode row to mode table; rewrote Consensus Mode steps 2 and 6 with `--interactive`-only guard; updated `Execution_Policy`, `Tool_Usage`, `Escalation_And_Stop_Conditions`, and `Final_Checklist` sections
- `skills/ralplan/SKILL.md`: Added Flags table documenting `--interactive`; updated behavior description to show default non-interactive workflow

## Usage after fix

```
# Default — fully automated, no user prompts
/ralplan "task description"
/plan --consensus "task description"

# Interactive — pauses at draft feedback and final approval
/ralplan --interactive "task description"
/plan --consensus --interactive "task description"
```

## Test plan

- [ ] Run `/ralplan "some task"` — confirm it completes the Planner→Architect→Critic loop and invokes `/ralph` without any `AskUserQuestion` prompts
- [ ] Run `/ralplan --interactive "some task"` — confirm it pauses at step 2 (draft feedback) and step 6 (final approval) with clickable options
- [ ] Run `/plan --consensus "some task"` — same as default ralplan above
- [ ] Run `/plan --consensus --interactive "some task"` — same as interactive ralplan above

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)