### PR TITLE
chore: deprecate /research skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning |
 | "team", "swarm", "coordinated team", "coordinated swarm" | `$team` | Read `~/.agents/skills/team/SKILL.md`, start team orchestration (swarm compatibility alias) |
 | "ecomode", "eco", "budget" | `$ecomode` | Read `~/.agents/skills/ecomode/SKILL.md`, enable token-efficient mode |
-| "research", "analyze data" | `$research` | Read `~/.agents/skills/research/SKILL.md`, start parallel research |
+| "research", "analyze data" | `$scientist` | Use `scientist` agent (deprecated `$research` alias; prefer `/scientist` or `/external-context`) |
 | "cancel", "stop", "abort" | `$cancel` | Read `~/.agents/skills/cancel/SKILL.md`, cancel active modes |
 | "tdd", "test first" | `$tdd` | Read `~/.agents/skills/tdd/SKILL.md`, start test-driven workflow |
 | "fix build", "type errors" | `$build-fix` | Read `~/.agents/skills/build-fix/SKILL.md`, fix build errors |
@@ -182,7 +182,7 @@ Workflow Skills:
 - `ultraqa`: QA cycling -- test, verify, fix, repeat
 - `plan`: Strategic planning with optional consensus mode
 - `ralplan`: Iterative consensus planning (planner + architect + critic)
-- `research`: Parallel research agents for comprehensive analysis
+- `research`: ⚠️ **Deprecated** — use `/scientist` or `/external-context` instead
 
 Agent Shortcuts:
 - `analyze` -> debugger: Investigation and root-cause analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Deprecated
+- Deprecated `/research` skill; use `/scientist` for data and codebase analysis, or `/external-context` for external documentation lookup.
+
 ## [0.5.0] - 2026-02-21
 
 ### Added

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: research
-description: Orchestrate parallel researcher agents for comprehensive research with AUTO mode
+description: "⚠️ DEPRECATED: Use /scientist or /external-context instead"
 argument-hint: <research goal>
+deprecated: true
 ---
+
+> **⚠️ Deprecated:** The `/research` skill is deprecated. Use `/scientist` for data and codebase analysis, or `/external-context` for external documentation lookup. This skill will be removed in a future release.
 
 # Research Skill
 


### PR DESCRIPTION
## Summary

- Added deprecation notice to `skills/research/SKILL.md` (frontmatter + visible callout) pointing users to `/scientist` or `/external-context`
- Updated `AGENTS.md`: keyword detection table now routes `"research"` triggers to `$scientist`; skills list entry marked as deprecated
- Added `### Deprecated` entry to `CHANGELOG.md` under `[Unreleased]`

## Changes

| File | Change |
|------|--------|
| `skills/research/SKILL.md` | Added `deprecated: true` to frontmatter and deprecation callout at top |
| `AGENTS.md` | Keyword table redirects to `$scientist`; skill listing notes deprecation |
| `CHANGELOG.md` | Added `### Deprecated` entry under `[Unreleased]` |

## Test plan

- [ ] `/research` still loads but shows deprecation notice at top
- [ ] `/scientist` and `/external-context` serve as the recommended replacements
- [ ] CHANGELOG entry is visible under `[Unreleased]`

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)