### PR TITLE
feat(cli): add omx ralph subcommand (closes #153)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { tmuxHookCommand } from './tmux-hook.js';
 import { hooksCommand } from './hooks.js';
 import { hudCommand } from '../hud/index.js';
 import { teamCommand } from './team.js';
+import { ralphCommand } from './ralph.js';
 import {
   getBaseStateDir,
   getStateDir,
@@ -49,6 +50,7 @@ Usage:
   omx doctor    Check installation health
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
+  omx ralph     Launch Codex with ralph persistence mode active
   omx version   Show version information
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
   omx hooks     Manage hook plugins (init|status|validate|test)
@@ -221,7 +223,7 @@ export function buildHudPaneCleanupTargets(existingPaneIds: string[], createdPan
 
 export async function main(args: string[]): Promise<void> {
   const knownCommands = new Set([
-    'launch', 'setup', 'doctor', 'team', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
+    'launch', 'setup', 'doctor', 'team', 'ralph', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
   ]);
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
@@ -251,6 +253,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case 'team':
         await teamCommand(args.slice(1), options);
+        break;
+      case 'ralph':
+        await ralphCommand(args.slice(1));
         break;
       case 'version':
         version();
@@ -352,7 +357,7 @@ async function reasoningCommand(args: string[]): Promise<void> {
   console.log(`Set ${REASONING_KEY}="${mode}" in ${configPath}`);
 }
 
-async function launchWithHud(args: string[]): Promise<void> {
+export async function launchWithHud(args: string[]): Promise<void> {
   const cwd = process.cwd();
   const workerSparkModel = resolveWorkerSparkModel(args);
   const normalizedArgs = normalizeCodexLaunchArgs(args);

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -1,0 +1,48 @@
+import { startMode, updateModeState } from '../modes/base.js';
+import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
+
+const RALPH_HELP = `omx ralph - Launch Codex with ralph persistence mode active
+
+Usage:
+  omx ralph [codex-args...]   Initialize ralph state and launch Codex
+
+Options:
+  --help, -h    Show this help message
+
+Ralph persistence mode initializes state tracking so the OMC ralph loop
+can maintain context across Codex sessions.
+`;
+
+export async function ralphCommand(args: string[]): Promise<void> {
+  const cwd = process.cwd();
+
+  if (args[0] === '--help' || args[0] === '-h') {
+    console.log(RALPH_HELP);
+    return;
+  }
+
+  // Initialize ralph persistence artifacts (state dirs, legacy PRD/progress migration)
+  const artifacts = await ensureCanonicalRalphArtifacts(cwd);
+
+  // Write initial ralph mode state
+  const task = args.filter((a) => !a.startsWith('-')).join(' ') || 'ralph-cli-launch';
+  await startMode('ralph', task, 50);
+  await updateModeState('ralph', {
+    current_phase: 'starting',
+    canonical_progress_path: artifacts.canonicalProgressPath,
+    ...(artifacts.canonicalPrdPath ? { canonical_prd_path: artifacts.canonicalPrdPath } : {}),
+  });
+
+  if (artifacts.migratedPrd) {
+    console.log(`[ralph] Migrated legacy PRD -> ${artifacts.canonicalPrdPath}`);
+  }
+  if (artifacts.migratedProgress) {
+    console.log(`[ralph] Migrated legacy progress -> ${artifacts.canonicalProgressPath}`);
+  }
+
+  console.log('[ralph] Ralph persistence mode active. Launching Codex...');
+
+  // Dynamic import avoids a circular dependency with index.ts
+  const { launchWithHud } = await import('./index.js');
+  await launchWithHud(args);
+}


### PR DESCRIPTION
## Summary

- Add `src/cli/ralph.ts` with `ralphCommand` that initializes ralph persistence artifacts then launches Codex with ralph mode active
- Register `omx ralph` in `src/cli/index.ts`: import, switch case, help text, and `knownCommands` set
- Export `launchWithHud` from `index.ts`; `ralph.ts` imports it via dynamic `import()` to avoid circular dependency
- `omx ralph --help` prints usage; `omx ralph [codex-args...]` initializes ralph state and hands off to the standard Codex launch sequence

## Test plan

- [x] `npm run build` passes (TypeScript compiles cleanly after `npm install`)
- [x] `omx ralph --help` prints help text
- [x] `omx ralph` no longer returns "Unknown command: ralph"
- [ ] Manual: run `omx ralph` in a project directory and verify ralph state file is written to `.omx/state/ralph-state.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)