### PR TITLE
fix(team): reject claim on completed/failed tasks (closes #160)

### DIFF
--- a/src/mcp/__tests__/state-server-team-tools.test.ts
+++ b/src/mcp/__tests__/state-server-team-tools.test.ts
@@ -260,6 +260,22 @@ describe('state-server team comm tools', () => {
       assert.equal(transitionJson.ok, true);
       assert.equal(transitionJson.task?.status, 'completed');
       assert.equal(typeof transitionJson.task?.completed_at, 'string');
+
+      // Attempting to claim an already-completed task must be rejected
+      const reclaimResp = await handleStateToolCall({
+        params: {
+          name: 'team_claim_task',
+          arguments: {
+            team_name: 'delta-team',
+            task_id: '1',
+            worker: 'worker-2',
+            workingDirectory: wd,
+          },
+        },
+      });
+      const reclaimJson = JSON.parse(reclaimResp.content[0]?.text || '{}') as { ok?: boolean; error?: string };
+      assert.equal(reclaimJson.ok, false);
+      assert.equal(reclaimJson.error, 'already_terminal');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -160,7 +160,7 @@ export type TaskReadiness =
 
 export type ClaimTaskResult =
   | { ok: true; task: TeamTaskV2; claimToken: string }
-  | { ok: false; error: 'claim_conflict' | 'blocked_dependency' | 'task_not_found'; dependencies?: string[] };
+  | { ok: false; error: 'claim_conflict' | 'blocked_dependency' | 'task_not_found' | 'already_terminal'; dependencies?: string[] };
 
 export type TransitionTaskResult =
   | { ok: true; task: TeamTaskV2 }
@@ -1013,6 +1013,9 @@ export async function claimTask(
     const v = normalizeTask(current);
     if (expectedVersion !== null && v.version !== expectedVersion) {
       return { ok: false as const, error: 'claim_conflict' as const };
+    }
+    if (v.status === 'completed' || v.status === 'failed') {
+      return { ok: false as const, error: 'already_terminal' as const };
     }
 
     const claimToken = randomUUID();


### PR DESCRIPTION
## Summary

- `team_claim_task` now checks the current task status inside the claim lock before proceeding
- If the task is already `completed` or `failed`, it returns `{ ok: false, error: 'already_terminal' }` instead of overwriting the state back to `in_progress`
- `ClaimTaskResult` type updated to include `'already_terminal'` as a possible error value

## Test plan

- [x] Added assertions to the existing `team_transition_task_status performs claim-safe terminal transition` test: after transitioning a task to `completed`, a second claim attempt by a different worker must return `{ ok: false, error: 'already_terminal' }`
- [x] All 4 tests in `state-server-team-tools.test.ts` pass
- [x] Full test suite passes (`fail 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)