### PR TITLE
fix: drop orphan --model flag to prevent duplicate model flags in worker argv (#168)

### DIFF
--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -58,6 +58,37 @@ describe('team model contract', () => {
     );
   });
 
+  it('drops orphan --model flag and emits exactly one canonical --model', () => {
+    // Orphan --model with no following value must not leak into passthrough and cause duplicate flags
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: '--model',
+        inheritedArgs: ['--model', 'inherited-model'],
+      }),
+      ['--model', 'inherited-model'],
+    );
+  });
+
+  it('drops orphan --model mixed with other flags and does not emit duplicate flags', () => {
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: '--no-alt-screen --model',
+        inheritedArgs: ['--model', 'sonic-model'],
+      }),
+      ['--no-alt-screen', '--model', 'sonic-model'],
+    );
+  });
+
+  it('drops --model= with empty value and falls back to inherited model', () => {
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: '--model=',
+        inheritedArgs: ['--model', 'inherited-model'],
+      }),
+      ['--model', 'inherited-model'],
+    );
+  });
+
   it('detects low-complexity agent types', () => {
     assert.equal(isLowComplexityAgentType('explore'), true);
     assert.equal(isLowComplexityAgentType('writer'), true);

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -66,9 +66,8 @@ export function parseTeamWorkerLaunchArgs(args: string[]): ParsedTeamWorkerLaunc
       if (typeof maybeValue === 'string' && isValidModelValue(maybeValue)) {
         modelOverride = maybeValue.trim();
         i += 1;
-        continue;
       }
-      passthrough.push(arg);
+      // Orphan --model with no valid value is silently dropped (never passthrough)
       continue;
     }
 
@@ -76,9 +75,8 @@ export function parseTeamWorkerLaunchArgs(args: string[]): ParsedTeamWorkerLaunc
       const inlineValue = arg.slice(`${MODEL_FLAG}=`.length).trim();
       if (isValidModelValue(inlineValue)) {
         modelOverride = inlineValue;
-        continue;
       }
-      passthrough.push(arg);
+      // --model= with empty/invalid value is silently dropped (never passthrough)
       continue;
     }
 


### PR DESCRIPTION
## Summary

- Orphan `--model` token (no valid value following it) in `OMX_TEAM_WORKER_LAUNCH_ARGS` was pushed to `passthrough` instead of being discarded
- When merged with inherited args and re-parsed, the orphan consumed the next `--model` as an invalid value, leaving both in passthrough
- Final normalization then appended the canonical `--model <value>`, producing `["--model", "--model", "value"]`

## Fix

In `parseTeamWorkerLaunchArgs` (`src/team/model-contract.ts`):
- Orphan `--model` (no valid next token) is silently dropped — never added to `passthrough`
- `--model=` with empty/invalid inline value is silently dropped — never added to `passthrough`

The contract "exactly one final canonical `--model <value>`" is now enforced regardless of malformed input.

## Test plan

- [x] `drops orphan --model flag and emits exactly one canonical --model`
- [x] `drops orphan --model mixed with other flags and does not emit duplicate flags`
- [x] `drops --model= with empty value and falls back to inherited model`
- [x] All existing model-contract tests continue to pass
- [x] Full test suite: `npm test` — 0 failures

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)