### PR TITLE
fix: emit task_failed event instead of worker_stopped on task failure

### DIFF
--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -500,7 +500,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object',
         properties: {
           team_name: { type: 'string', description: 'Sanitized team name' },
-          type: { type: 'string', enum: ['task_completed', 'worker_idle', 'worker_stopped', 'message_received', 'shutdown_ack', 'approval_decision'] },
+          type: { type: 'string', enum: ['task_completed', 'task_failed', 'worker_idle', 'worker_stopped', 'message_received', 'shutdown_ack', 'approval_decision'] },
           worker: { type: 'string', description: 'Worker name associated with the event' },
           task_id: { type: 'string', description: 'Related task ID (optional)' },
           message_id: { type: 'string', description: 'Related message ID (optional)' },
@@ -1091,7 +1091,7 @@ export async function handleStateToolCall(request: {
         return { content: [{ type: 'text', text: JSON.stringify({ error: 'team_name, type, worker are required' }) }], isError: true };
       }
       const event = await teamAppendEvent(teamName, {
-        type: eventType as 'task_completed' | 'worker_idle' | 'worker_stopped' | 'message_received' | 'shutdown_ack' | 'approval_decision',
+        type: eventType as 'task_completed' | 'task_failed' | 'worker_idle' | 'worker_stopped' | 'message_received' | 'shutdown_ack' | 'approval_decision',
         worker,
         task_id: (args as Record<string, unknown>).task_id as string | undefined,
         message_id: ((args as Record<string, unknown>).message_id as string | undefined) ?? null,

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -112,6 +112,7 @@ export interface TeamEvent {
   team: string;
   type:
     | 'task_completed'
+    | 'task_failed'
     | 'worker_idle'
     | 'worker_stopped'
     | 'message_received'
@@ -1128,7 +1129,7 @@ export async function transitionTaskStatus(
       emittedEvent = await appendTeamEvent(
         teamName,
         {
-          type: 'worker_stopped',
+          type: 'task_failed',
           worker: updated.owner || 'unknown',
           task_id: updated.id,
           message_id: null,


### PR DESCRIPTION
## Summary

- `transitionTaskStatus` was emitting a `worker_stopped` event when a task transitioned to `failed`, conflating two distinct facts: task failure vs. worker process death.
- Worker death is already tracked separately in `runtime.ts` based on process liveness checks.
- This PR introduces a `task_failed` event type and emits it from `transitionTaskStatus`, keeping `worker_stopped` exclusive to actual process termination.

## Changes

- **`src/team/state.ts`**: Added `'task_failed'` to `TeamEvent.type` union; changed `transitionTaskStatus` to emit `task_failed` (not `worker_stopped`) when a task fails.
- **`src/mcp/state-server.ts`**: Added `'task_failed'` to the `team_append_event` MCP tool schema enum and the corresponding type cast.
- **`src/team/__tests__/state.test.ts`**: Added regression test asserting that failing a task emits `task_failed` and does **not** emit `worker_stopped`.

## Test plan

- [x] New test `transitionTaskStatus appends task_failed event (not worker_stopped) when task fails` passes
- [x] All 34 existing state tests pass (`ℹ pass 34, ℹ fail 0`)

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)