### PR TITLE
fix(team): claimTask returns task_not_found for missing tasks

### DIFF
--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -756,4 +756,16 @@ describe('team state', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('claimTask returns task_not_found for non-existent task id', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-claim-missing-'));
+    try {
+      await initTeamState('team-x', 'task', 'executor', 1, cwd);
+      const result = await claimTask('team-x', 'non-existent-999', 'worker-1', null, cwd);
+      assert.equal(result.ok, false);
+      assert.equal((result as { ok: false; error: string }).error, 'task_not_found');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1054,6 +1054,8 @@ export async function claimTask(
   expectedVersion: number | null,
   cwd: string
 ): Promise<ClaimTaskResult> {
+  const existing = await readTask(teamName, taskId, cwd);
+  if (!existing) return { ok: false, error: 'task_not_found' };
   const readiness = await computeTaskReadiness(teamName, taskId, cwd);
   if (!readiness.ready) {
     return { ok: false, error: 'blocked_dependency', dependencies: readiness.dependencies };


### PR DESCRIPTION
## Summary

- Fixes issue #167: `claimTask` was returning `blocked_dependency` for missing tasks instead of `task_not_found`
- Root cause: `computeTaskReadiness` returned `blocked_dependency` when a task had no `blockedBy` entries resolved, which masked the case where the task itself did not exist
- Fix: added an early `readTask` existence check in `claimTask` before calling `computeTaskReadiness`, so missing tasks now correctly return `task_not_found`

## Test plan

- [ ] Regression test added in `src/team/__tests__/state.test.ts` covering `claimTask` on a non-existent task ID
- [ ] All 861 existing tests pass (`ℹ pass 861`, `ℹ fail 0`)
- [ ] Build succeeds with `npm run build`