### PR TITLE
fix(team): prevent duplicate task_completed events from monitorTeam (issue #161)

### DIFF
--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1141,7 +1141,24 @@ export async function transitionTaskStatus(
   });
 
   if (!lock.ok) return { ok: false, error: 'claim_conflict' };
-  void emittedEvent;
+  // If a task_completed event was emitted via this claim-safe path, record the task ID in
+  // the monitor snapshot so that emitMonitorDerivedEvents does not emit a duplicate event
+  // on the next monitorTeam poll (issue #161).
+  if (to === 'completed') {
+    const existingSnap = await readMonitorSnapshot(teamName, cwd);
+    const updatedSnap: TeamMonitorSnapshotState = existingSnap
+      ? { ...existingSnap, completedEventTaskIds: { ...(existingSnap.completedEventTaskIds ?? {}), [taskId]: true } }
+      : {
+          taskStatusById: {},
+          workerAliveByName: {},
+          workerStateByName: {},
+          workerTurnCountByName: {},
+          workerTaskIdByName: {},
+          mailboxNotifiedByMessageId: {},
+          completedEventTaskIds: { [taskId]: true },
+        };
+    await writeMonitorSnapshot(teamName, updatedSnap, cwd);
+  }
   return lock.value;
 }
 
@@ -1483,6 +1500,8 @@ export interface TeamMonitorSnapshotState {
   workerTurnCountByName: Record<string, number>;
   workerTaskIdByName: Record<string, string>;
   mailboxNotifiedByMessageId: Record<string, string>;
+  /** Task IDs for which a task_completed event has already been emitted (from any path). */
+  completedEventTaskIds: Record<string, boolean>;
 }
 
 export interface TeamPhaseState {
@@ -1518,6 +1537,7 @@ export async function readMonitorSnapshot(
       workerTurnCountByName: parsed.workerTurnCountByName ?? {},
       workerTaskIdByName: parsed.workerTaskIdByName ?? {},
       mailboxNotifiedByMessageId: parsed.mailboxNotifiedByMessageId ?? {},
+      completedEventTaskIds: parsed.completedEventTaskIds ?? {},
     };
   } catch {
     return null;


### PR DESCRIPTION
## Summary

- **Root cause**: Two independent code paths both emitted `task_completed` for the same task. `transitionTaskStatus` (claim-safe path) emitted the event immediately inside the claim lock, then `emitMonitorDerivedEvents` saw the same `in_progress → completed` transition on the next `monitorTeam` poll and emitted a second event.
- **Fix**: Added a `completedEventTaskIds` field to `TeamMonitorSnapshotState`. When `transitionTaskStatus` successfully emits a `task_completed` event it records the task ID in that field. `emitMonitorDerivedEvents` skips emission for any task ID already present. The field is carried forward on every `monitorTeam` snapshot write so the guard persists across polls.
- No existing tests were broken; one new regression test was added.

## Test plan

- [x] Build passes: `npm run build`
- [x] All 135 tests pass: `node --test $(find dist/team -name '*.test.js')`
- [x] New test: `monitorTeam does not emit duplicate task_completed when transitionTaskStatus completed the task first (issue #161)` — verifies exactly one `task_completed` event appears in the event log after the claim-safe path completes a task followed by a `monitorTeam` poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)