### PR TITLE
fix(deps): pin ajv>=8.18.0 and hono>=4.11.10 to resolve npm audit advisories (#170)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
+      "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,9 @@
   "devDependencies": {
     "@types/node": "^22.19.11",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "ajv": ">=8.18.0",
+    "hono": ">=4.11.10"
   }
 }

--- a/src/utils/__tests__/dep-versions.test.ts
+++ b/src/utils/__tests__/dep-versions.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+function readInstalledVersion(pkg: string): string {
+  const pkgJson = JSON.parse(
+    readFileSync(join('node_modules', pkg, 'package.json'), 'utf8'),
+  ) as { version: string };
+  return pkgJson.version;
+}
+
+function semverGte(version: string, minimum: string): boolean {
+  const parse = (v: string) => v.split('.').map(Number) as [number, number, number];
+  const [ma, mi, pa] = parse(version);
+  const [mb, mib, pb] = parse(minimum);
+  if (ma !== mb) return ma > mb;
+  if (mi !== mib) return mi > mib;
+  return pa >= pb;
+}
+
+describe('transitive dependency minimum safe versions (issue #170)', () => {
+  it('ajv is at least 8.18.0 (fixes GHSA-2g4f-4pwh-qvx6 ReDoS)', () => {
+    const version = readInstalledVersion('ajv');
+    assert.ok(
+      semverGte(version, '8.18.0'),
+      `ajv@${version} is below the minimum safe version 8.18.0`,
+    );
+  });
+
+  it('hono is at least 4.11.10 (fixes GHSA-gq3j-xvxp-8hrf timing attack)', () => {
+    const version = readInstalledVersion('hono');
+    assert.ok(
+      semverGte(version, '4.11.10'),
+      `hono@${version} is below the minimum safe version 4.11.10`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two known security advisories in transitive dependencies pulled by `@modelcontextprotocol/sdk`:

- **ajv** — [GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6): ReDoS when using the `$data` option (moderate). Fixed in `>=8.18.0`; was pinned at `8.17.1`.
- **hono** — [GHSA-gq3j-xvxp-8hrf](https://github.com/advisories/GHSA-gq3j-xvxp-8hrf): Timing attack in `basicAuth`/`bearerAuth` (low). Fixed in `>=4.11.10`; was pinned at `4.11.9`.

## Changes

- Added `overrides` block in `package.json` to force minimum safe versions for both packages.
- Updated `package-lock.json` accordingly (`npm audit --omit=dev` now reports **0 vulnerabilities**).
- Added `src/utils/__tests__/dep-versions.test.ts` — asserts installed versions meet the minimums so CI catches any future regression.

## Test plan

- [x] `npm audit --omit=dev` reports 0 vulnerabilities
- [x] New `dep-versions.test.ts` passes (2/2)
- [x] Full test suite passes (862/862)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)