### PR TITLE
fix: prevent in-progress claim takeover when expected_version is omitted

### DIFF
--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -358,7 +358,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           team_name: { type: 'string', description: 'Sanitized team name' },
           task_id: { type: 'string', description: 'Task ID to claim' },
           worker: { type: 'string', description: 'Worker name claiming the task' },
-          expected_version: { type: 'number', description: 'Expected task version for optimistic locking (null to skip)' },
+          expected_version: { type: 'number', description: 'Expected task version for optimistic locking. Omitting does not allow claiming an already in-progress task.' },
           workingDirectory: { type: 'string' },
         },
         required: ['team_name', 'task_id', 'worker'],

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1069,6 +1069,9 @@ export async function claimTask(
     if (v.status === 'completed' || v.status === 'failed') {
       return { ok: false as const, error: 'already_terminal' as const };
     }
+    if (v.status === 'in_progress') {
+      return { ok: false as const, error: 'claim_conflict' as const };
+    }
 
     const claimToken = randomUUID();
     const leasedUntil = new Date(Date.now() + DEFAULT_CLAIM_LEASE_MS).toISOString();


### PR DESCRIPTION
## Summary

- **Bug**: `team_claim_task` allowed a second worker to steal an already in-progress task when `expected_version` was omitted (passed as `null`), because the optimistic-lock check was skipped and only `completed`/`failed` statuses were blocked.
- **Fix**: Added an explicit `in_progress` status guard in `claimTask` (`src/team/state.ts`) that returns `claim_conflict` unconditionally, regardless of `expectedVersion`. An active claim can only be taken over after it is released via `releaseTaskClaim`.
- **Schema**: Updated the `team_claim_task` MCP tool description to remove the misleading "(null to skip)" hint.

## Test plan

- [ ] `claimTask rejects in-progress claim takeover when expectedVersion is null (issue-172)` — unit test via `claimTask` directly
- [ ] `claimTask rejects in-progress claim takeover even with a matching version` — confirms the guard holds even when the correct version is supplied
- [ ] `team_claim_task rejects in-progress takeover when expected_version is omitted (issue-172)` — integration test via the MCP handler
- [ ] All 40 existing tests continue to pass (`node --test dist/team/__tests__/state.test.js dist/mcp/__tests__/state-server-team-tools.test.js`)

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)