### PR TITLE
fix: replace spawnSync sleep with Atomics.wait (issue #171)

### DIFF
--- a/src/hooks/extensibility/sdk.ts
+++ b/src/hooks/extensibility/sdk.ts
@@ -89,7 +89,7 @@ function hashDedupeKey(target: string, text: string): string {
 
 function sleepFractionalSeconds(seconds: number): void {
   if (!Number.isFinite(seconds) || seconds <= 0) return;
-  spawnSync('sleep', [String(seconds)], { encoding: 'utf-8' });
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.round(seconds * 1000));
 }
 
 function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -12,6 +12,7 @@ import {
   listTeamSessions,
   sanitizeTeamName,
   sendToWorker,
+  sleepFractionalSeconds,
   waitForWorkerReady,
 } from '../tmux-session.js';
 
@@ -356,6 +357,28 @@ describe('killWorkerByPaneId leader pane guard', () => {
     // Without leaderPaneId the guard is not active; tmux call fails gracefully.
     withEmptyPath(() => {
       assert.doesNotThrow(() => killWorkerByPaneId('%5'));
+    });
+  });
+});
+
+describe('sleepFractionalSeconds', () => {
+  it('actually delays even when sleep binary is unavailable', () => {
+    withEmptyPath(() => {
+      const start = Date.now();
+      sleepFractionalSeconds(0.1);
+      const elapsed = Date.now() - start;
+      assert.ok(elapsed >= 80, `expected ~100ms delay but elapsed only ${elapsed}ms`);
+    });
+  });
+
+  it('returns immediately for zero, negative, or NaN values', () => {
+    withEmptyPath(() => {
+      const start = Date.now();
+      sleepFractionalSeconds(0);
+      sleepFractionalSeconds(-1);
+      sleepFractionalSeconds(NaN);
+      const elapsed = Date.now() - start;
+      assert.ok(elapsed < 50, `expected no delay but elapsed ${elapsed}ms`);
     });
   });
 });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -75,14 +75,17 @@ function findHudPaneIds(target: string, leaderPaneId: string): string[] {
     .map((pane) => pane.paneId);
 }
 
-function sleepSeconds(seconds: number): void {
-  // shelling out keeps implementation consistent with the project's pattern
-  spawnSync('sleep', [String(seconds)], { encoding: 'utf-8' });
+function sleepMs(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-function sleepFractionalSeconds(seconds: number): void {
+function sleepSeconds(seconds: number): void {
+  sleepMs(Math.round(seconds * 1000));
+}
+
+export function sleepFractionalSeconds(seconds: number): void {
   if (!Number.isFinite(seconds) || seconds <= 0) return;
-  spawnSync('sleep', [String(seconds)], { encoding: 'utf-8' });
+  sleepMs(Math.round(seconds * 1000));
 }
 
 function shellQuoteSingle(value: string): string {


### PR DESCRIPTION
## Summary

- Replace `spawnSync('sleep', ...)` with `Atomics.wait()` in all three call sites:
  - `sleepSeconds()` in `src/team/tmux-session.ts`
  - `sleepFractionalSeconds()` in `src/team/tmux-session.ts`
  - `sleepFractionalSeconds()` in `src/hooks/extensibility/sdk.ts`
- Export `sleepFractionalSeconds` from `tmux-session.ts` to enable direct testing

## Root cause

The previous implementation shelled out to the external `sleep` binary via `spawnSync`. When `sleep` is not on `PATH`, `spawnSync` sets `result.error` (ENOENT) but all three call sites ignored `result.error`, causing the intended timing guard to be silently skipped.

## Fix

`Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)` is a built-in Node.js synchronous sleep with no external binary dependency. Node ≥20 is already required by this project.

## Test plan

- [x] New `sleepFractionalSeconds` describe block in `src/team/__tests__/tmux-session.test.ts`
  - Verifies ~100ms delay occurs even with empty `PATH` (no `sleep` binary available)
  - Verifies zero/negative/NaN values return immediately without delay
- [x] All 862 existing tests pass (`npm run build && npm test`)

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)