### PR TITLE
fix: reject ghost worker IDs in claimTask (issue #179)

### DIFF
--- a/src/mcp/__tests__/state-server-team-tools.test.ts
+++ b/src/mcp/__tests__/state-server-team-tools.test.ts
@@ -285,7 +285,8 @@ describe('state-server team comm tools', () => {
 
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-team-tools-'));
     try {
-      await initTeamState('delta-team', 'transition test', 'executor', 1, wd);
+      // Use 2 workers so worker-2 is registered and the reclaim below reaches the already_terminal check.
+      await initTeamState('delta-team', 'transition test', 'executor', 2, wd);
 
       const createResp = await handleStateToolCall({
         params: {


### PR DESCRIPTION
## Summary

- `claimTask()` accepted any `workerName` string without checking whether that worker is registered in the team config, allowing ghost worker IDs to claim tasks and corrupt team state integrity.
- Added a worker-existence check before the claim lock: reads `TeamConfig.workers` and returns `{ ok: false, error: 'worker_not_found' }` for unregistered names.
- Added `'worker_not_found'` to the `ClaimTaskResult` error union.

## Changes

- **`src/team/state.ts`**: validate `workerName` against `cfg.workers` in `claimTask()` before proceeding; added `'worker_not_found'` error variant to `ClaimTaskResult`.
- **`src/team/__tests__/state.test.ts`**: new regression test `'claimTask rejects a ghost worker ID (worker_not_found)'`; fixed the concurrent-claim test to use a 2-worker team (it was already passing `worker-2` to a 1-worker team).
- **`src/mcp/__tests__/state-server-team-tools.test.ts`**: fixed MCP integration test that attempted to reclaim a completed task as `worker-2` on a 1-worker team.

## Test plan

- [x] `npm run build` succeeds with zero type errors
- [x] `node --test $(find dist -name '*.test.js')` — 861 pass, 0 fail
- [x] New test `claimTask rejects a ghost worker ID (worker_not_found)` covers the exact bug scenario
- [x] All existing `claimTask` tests continue to pass

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)