### PR TITLE
perf: parallelize listTasks file reads with Promise.all (fix #174)

### DIFF
--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -491,6 +491,24 @@ describe('team state', () => {
     }
   });
 
+  it('listTasks reads task files in parallel', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-list-parallel-'));
+    try {
+      await initTeamState('team-parallel', 't', 'executor', 1, cwd);
+      const N = 20;
+      for (let i = 0; i < N; i++) {
+        await createTask('team-parallel', { subject: `task-${i}`, description: 'd', status: 'pending' }, cwd);
+      }
+      const tasks = await listTasks('team-parallel', cwd);
+      assert.equal(tasks.length, N);
+      // IDs should be consecutive strings '1'..'N' in sorted order
+      const ids = tasks.map((t) => t.id);
+      assert.deepEqual(ids, Array.from({ length: N }, (_, i) => String(i + 1)));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('readTask returns null for non-existent task', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-state-'));
     try {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1019,10 +1019,12 @@ export async function listTasks(teamName: string, cwd: string): Promise<TeamTask
   const files = await readdir(tasksRoot);
   const tasks: TeamTaskV2[] = [];
 
-  for (const f of files) {
+  const matched = files.flatMap((f: string) => {
     const m = /^task-(\d+)\.json$/.exec(f);
-    if (!m) continue;
-    const t = await readTask(teamName, m[1], cwd);
+    return m ? [m[1]] : [];
+  });
+  const results = await Promise.all(matched.map((id: string) => readTask(teamName, id, cwd)));
+  for (const t of results) {
     if (t) tasks.push(normalizeTask(t));
   }
 


### PR DESCRIPTION
## Summary

- `listTasks()` in `src/team/state.ts` was reading each `task-*.json` file sequentially (`await` inside a `for` loop), causing status/monitor latency to grow linearly with task count.
- Replaced the sequential loop with `Promise.all` so all file reads happen concurrently.
- Added a regression test verifying correctness with 20 tasks.

## Changes

- `src/team/state.ts`: replace sequential `for`/`await` loop in `listTasks()` with `flatMap` + `Promise.all`
- `src/team/__tests__/state.test.ts`: new test `'listTasks reads task files in parallel'`

## Test plan

- [x] `npm install && npm run build` — clean build, no new errors
- [x] `node --test $(find dist -name '*.test.js')` — 861/861 pass
- [x] `node scripts/generate-catalog-docs.js --check` — catalog check ok

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)