### PR TITLE
fix(worktree): --worktree <branch> space-separated form leaks branch into Codex shell (closes #203)

### DIFF
--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -50,6 +50,38 @@ describe('worktree parser', () => {
     assert.deepEqual(parsed.mode, { enabled: false });
     assert.deepEqual(parsed.remainingArgs, ['team', '2:executor', 'task']);
   });
+
+  // Regression tests for issue #203: branch name passed as separate arg must not
+  // leak into the Codex shell as input.
+  it('parses named branch from --worktree <name> (space-separated)', () => {
+    const parsed = parseWorktreeMode(['--worktree', 'my-branch']);
+    assert.deepEqual(parsed.mode, { enabled: true, detached: false, name: 'my-branch' });
+    assert.deepEqual(parsed.remainingArgs, []);
+  });
+
+  it('parses named branch from -w <name> (space-separated)', () => {
+    const parsed = parseWorktreeMode(['-w', 'my-branch']);
+    assert.deepEqual(parsed.mode, { enabled: true, detached: false, name: 'my-branch' });
+    assert.deepEqual(parsed.remainingArgs, []);
+  });
+
+  it('does not leak branch name into remainingArgs when --worktree <name> is used with trailing args', () => {
+    const parsed = parseWorktreeMode(['--worktree', 'feat/issue-203', '--yolo']);
+    assert.deepEqual(parsed.mode, { enabled: true, detached: false, name: 'feat/issue-203' });
+    assert.deepEqual(parsed.remainingArgs, ['--yolo']);
+  });
+
+  it('treats --worktree at end of args as detached', () => {
+    const parsed = parseWorktreeMode(['--worktree']);
+    assert.deepEqual(parsed.mode, { enabled: true, detached: true, name: null });
+    assert.deepEqual(parsed.remainingArgs, []);
+  });
+
+  it('treats -w at end of args as detached', () => {
+    const parsed = parseWorktreeMode(['-w']);
+    assert.deepEqual(parsed.mode, { enabled: true, detached: true, name: null });
+    assert.deepEqual(parsed.remainingArgs, []);
+  });
 });
 
 describe('worktree ensure + rollback', () => {

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -172,11 +172,22 @@ export function parseWorktreeMode(args: string[]): ParsedWorktreeMode {
   let mode: WorktreeMode = { enabled: false };
   const remaining: string[] = [];
 
-  for (const rawArg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const rawArg = args[i];
     const arg = String(rawArg || '');
 
     if (arg === '--worktree' || arg === '-w') {
-      mode = { enabled: true, detached: true, name: null };
+      // Peek at the next argument: if it looks like a git branch name (not a
+      // flag and not a team worker spec like "3:debugger"), consume it as the
+      // branch name. Colons are not valid in git branch names, so we use that
+      // to distinguish branch names from other positional args.
+      const next = args[i + 1];
+      if (typeof next === 'string' && next.length > 0 && !next.startsWith('-') && !next.includes(':')) {
+        mode = { enabled: true, detached: false, name: next };
+        i += 1;
+      } else {
+        mode = { enabled: true, detached: true, name: null };
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary

- **Bug**: `omx --worktree my-branch` passed `my-branch` as input to Codex instead of creating a worktree on that branch. The `parseWorktreeMode` parser only handled the `--worktree=name` form; the space-separated `--worktree name` form left the branch name in `remainingArgs` where it was forwarded to Codex.
- **Fix**: Switched `parseWorktreeMode` to index-based iteration so it can peek at the next argument. When `--worktree` / `-w` appears standalone, the next arg is consumed as the branch name if it is a plausible git branch name (no leading `-`, no `:` — colons are invalid in git branch names and distinguish branch names from team worker-specs like `3:debugger`).
- **Tests**: Added five regression tests in `src/team/__tests__/worktree.test.ts` covering the space-separated forms, trailing-flag preservation, and the standalone-at-end detached fallback.

## Test plan

- [x] `npm run build` — clean TypeScript compile
- [x] `node --test $(find dist -name '*.test.js')` — 941 tests, 0 failures
- [x] Existing team CLI test `['--worktree', '3:debugger', ...]` still passes (colon guard prevents consuming worker-spec as branch name)
- [x] New regression tests for `--worktree <name>` and `-w <name>` forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)