### PR TITLE
fix(tmux): enable copy-mode scroll and clipboard copy in xhigh/madmax sessions (closes #206)

### DIFF
--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -330,9 +330,50 @@ export function createTeamSession(
 }
 
 /**
+ * Returns the tmux argv arrays for the scroll-and-copy key bindings applied
+ * by enableMouseScrolling. Exported as a pure function so tests can verify
+ * the binding configuration without requiring a live tmux session.
+ *
+ * The bindings fix two issues that appear in --xhigh and --madmax modes
+ * (closes #206):
+ *
+ *  1. Scroll: Codex CLI TUI claims mouse input, causing tmux to forward wheel
+ *     events to the application where they are interpreted as up/down arrow
+ *     keys (history navigation). The WheelUpPane binding in the root table
+ *     intercepts scroll events before they reach the app and enters tmux
+ *     copy-mode so the user sees viewport scrolling instead.
+ *
+ *  2. Copy: with only "mouse on" set, selecting text with the mouse does not
+ *     reach the system clipboard. The MouseDragEnd1Pane binding in copy-mode
+ *     copies the selection via copy-selection-and-cancel; OSC 52
+ *     (set-clipboard on) then propagates it to the terminal's clipboard.
+ */
+export function buildScrollCopyBindings(): Array<string[]> {
+  return [
+    // On scroll-up: if already in copy-mode forward the event; otherwise
+    // enter copy-mode first so the user gets viewport scroll, not history nav.
+    [
+      'bind-key', '-n', 'WheelUpPane',
+      'if-shell', '-Ft=', '#{pane_in_mode}',
+      'send-keys -M',
+      'select-pane -t=; copy-mode -e; send-keys -M',
+    ],
+    // Copy mouse-selected text to clipboard when the drag ends in copy-mode.
+    [
+      'bind-key', '-T', 'copy-mode', 'MouseDragEnd1Pane',
+      'send-keys', '-X', 'copy-selection-and-cancel',
+    ],
+  ];
+}
+
+/**
  * Enable tmux mouse mode for a session so users can scroll pane content
  * (e.g. long agent output) with the mouse wheel instead of arrow keys.
  * Arrow keys remain reserved for Codex CLI input-history navigation.
+ *
+ * Also configures viewport scrolling via copy-mode on wheel-up and clipboard
+ * copy on mouse selection, fixing scroll and copy issues in --xhigh and
+ * --madmax modes. (closes #206)
  *
  * In WSL2, Windows Terminal uses the SGR mouse protocol but tmux will not
  * activate it unless the terminal advertises the XT capability. Without XT,
@@ -345,6 +386,15 @@ export function createTeamSession(
 export function enableMouseScrolling(sessionTarget: string): boolean {
   const result = runTmux(['set-option', '-t', sessionTarget, 'mouse', 'on']);
   if (!result.ok) return false;
+
+  // Enable OSC 52 so copy-selection-and-cancel propagates selected text to
+  // the terminal's clipboard without requiring xclip or pbcopy. (closes #206)
+  runTmux(['set-option', '-t', sessionTarget, 'set-clipboard', 'on']);
+
+  // Apply the scroll-into-copy-mode and mouse-copy bindings. (closes #206)
+  for (const binding of buildScrollCopyBindings()) {
+    runTmux(binding);
+  }
 
   if (isWsl2()) {
     // Append the XT capability override globally (terminal-overrides is a


### PR DESCRIPTION
## Summary

- **Scroll fix**: In `--xhigh` and `--madmax` modes the Codex CLI TUI claims mouse input, so tmux forwards wheel events to the application which interprets them as up/down arrow-key history navigation. A new `WheelUpPane` binding in the root key table (`-n`) intercepts scroll-up before it reaches the app and enters tmux copy-mode, giving the user viewport scrolling instead.
- **Copy fix**: With only `mouse on` set, mouse-selected text never reached the system clipboard. `set-clipboard on` (OSC 52) is now enabled alongside a `MouseDragEnd1Pane` binding in copy-mode that calls `copy-selection-and-cancel`, propagating the selection to the terminal's clipboard without requiring `xclip` or `pbcopy`.
- **Testability**: The binding configuration is extracted into an exported pure function `buildScrollCopyBindings()` so the tmux argv arrays can be unit-tested without a live tmux session.

## Changes

- `src/team/tmux-session.ts` — add `buildScrollCopyBindings()` export; extend `enableMouseScrolling()` with `set-clipboard on`, the wheel-up binding, and the drag-end copy binding
- `src/team/__tests__/tmux-session.test.ts` — 7 new tests covering binding structure, key-table placement, copy-mode activation, and graceful failure when tmux is unavailable

## Test plan

- [x] `npm run build` — clean compile, 0 errors
- [x] `node --test dist/**/*.test.js` — 955 tests, 0 failures
- [x] `buildScrollCopyBindings` returns WheelUpPane binding with `copy-mode` and `pane_in_mode` check
- [x] WheelUpPane binding uses `-n` (root table) flag
- [x] `MouseDragEnd1Pane` binding uses `-T copy-mode` and `copy-selection-and-cancel`
- [x] `enableMouseScrolling` still returns `false` gracefully when tmux is unavailable (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)