### PR TITLE
Harden MCP team tool validation and schema consistency

### DIFF
--- a/docs/interop-team-mutation-contract.md
+++ b/docs/interop-team-mutation-contract.md
@@ -28,3 +28,5 @@ Direct writes to `.omx/state/team/...` are unsupported and may violate runtime i
 - `team_transition_task_status` is the claim-safe terminal transition path.
   - Runtime enforces this as `in_progress -> completed|failed`; other transitions return `invalid_transition`.
 - `team_release_task_claim` intentionally resets the task to `pending`; it is not a completion operation.
+- `team_update_task` only accepts `subject`, `description`, `blocked_by`, and `requires_code_change` as mutable fields.
+- `team_append_event.type` and `team_write_task_approval.status` enforce strict enum validation.

--- a/src/mcp/__tests__/state-server-schema.test.ts
+++ b/src/mcp/__tests__/state-server-schema.test.ts
@@ -15,14 +15,16 @@ const ALL_EVENT_TYPES = [
 ] as const;
 
 describe('team_append_event schema validation', () => {
-  it('schema enum contains exactly 8 event types including team_leader_nudge', async () => {
+  it('schema enum is sourced from TEAM_EVENT_TYPES and contains expected values', async () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/state-server.ts'), 'utf8');
 
-    // Find the enum array for the team_append_event type field
-    const match = src.match(/name:\s*'team_append_event'[\s\S]*?enum:\s*\[([^\]]+)\]/);
-    assert.ok(match, 'Expected to find team_append_event enum in state-server.ts');
+    const constMatch = src.match(/const TEAM_EVENT_TYPES = \[([\s\S]*?)\] as const;/);
+    assert.ok(constMatch, 'Expected to find TEAM_EVENT_TYPES constant in state-server.ts');
 
-    const enumValues = match[1]
+    const enumRefMatch = src.match(/name:\s*'team_append_event'[\s\S]*?enum:\s*\[\.\.\.TEAM_EVENT_TYPES\]/);
+    assert.ok(enumRefMatch, 'Expected team_append_event schema to reference TEAM_EVENT_TYPES');
+
+    const enumValues = constMatch[1]
       .split(',')
       .map((s: string) => s.trim().replace(/^'|'$/g, ''))
       .filter(Boolean);


### PR DESCRIPTION
## Summary
- centralize team task/event/approval enum constants used by MCP schemas and runtime validation
- tighten `team_update_task`, `team_claim_task`, `team_append_event`, and `team_write_task_approval` input validation/normalization in `src/mcp/state-server.ts`
- add regression tests for invalid payloads and update schema test to assert constant-backed enum wiring
- document stricter team mutation contract expectations

## Validation
- `npm run build`
- `OMX_TEAM_STATE_ROOT= OMX_TEAM_WORKER= node --test dist/mcp/__tests__/state-server-team-tools.test.js dist/mcp/__tests__/state-server-schema.test.js dist/mcp/__tests__/path-traversal.test.js`
- `OMX_TEAM_STATE_ROOT= OMX_TEAM_WORKER= node --test $(find dist/mcp/__tests__ -name '*.test.js' | tr '\n' ' ')`
- `OMX_TEAM_STATE_ROOT= OMX_TEAM_WORKER= node --test $(find dist/team/__tests__ -name '*.test.js' | tr '\n' ' ')`