### PR TITLE
Harden team task claim/transition invariants

### DIFF
--- a/docs/interop-team-mutation-contract.md
+++ b/docs/interop-team-mutation-contract.md
@@ -26,4 +26,5 @@ Direct writes to `.omx/state/team/...` are unsupported and may violate runtime i
 ## Notes
 
 - `team_transition_task_status` is the claim-safe terminal transition path.
+  - Runtime enforces this as `in_progress -> completed|failed`; other transitions return `invalid_transition`.
 - `team_release_task_claim` intentionally resets the task to `pending`; it is not a completion operation.


### PR DESCRIPTION
## Summary\n- centralize task status invariants in  with explicit terminal/transition helpers\n- enforce claim consistency during transition ( must match )\n- reject non-terminal task transitions through both runtime + MCP team tool path\n- harden claim path by re-checking dependency readiness under lock and rejecting residual owner/claim metadata on pending/blocked tasks\n- document terminal-only transition contract in interop docs\n\n## Tests\n- 
> oh-my-codex@0.5.1 build
> tsc\n- ▶ team state
  ✔ initTeamState creates correct directory structure and config.json (11.133413ms)
  ✔ migrateV1ToV2 writes manifest.v2.json idempotently from legacy config.json (5.377602ms)
  ✔ initTeamState persists workspace metadata to config + manifest (2.761211ms)
  ✔ claimTask enforces dependency readiness (blocked_dependency) (8.52148ms)
  ✔ claimTask rejects in-progress claim takeover when expectedVersion is null (issue-172) (7.16006ms)
  ✔ claimTask rejects in-progress claim takeover even with a matching version (7.676344ms)
  ✔ claimTask claim locking yields deterministic claim_conflict (29.701053ms)
  ✔ claimTask recovers a stale task claim lock and proceeds (6.379199ms)
  ✔ claimTask owner write failure cleans up claim lock without orphan lock dir (4.740938ms)
  ✔ claimTask rejects a pending task with residual owner/claim metadata (6.596037ms)
  ✔ transitionTaskStatus returns invalid_transition for illegal transition (5.096712ms)
  ✔ transitionTaskStatus rejects non-terminal transitions from in_progress (5.937008ms)
  ✔ transitionTaskStatus returns claim_conflict when claim owner diverges from task owner (6.503569ms)
  ✔ transitionTaskStatus appends task_completed event when task completes (7.007266ms)
  ✔ transitionTaskStatus appends task_failed event (not worker_stopped) when task fails (7.180509ms)
  ✔ releaseTaskClaim reverts a claimed task back to pending under claim lock (5.569293ms)
  ✔ releaseTaskClaim can recover with owner match when claim token changed (6.439624ms)
  ✔ releaseTaskClaim on a completed task returns already_terminal and does not reopen it (6.365303ms)
  ✔ transitionTaskStatus returns lease_expired when claim lease has passed (6.41556ms)
  ✔ releaseTaskClaim on a failed task returns already_terminal and does not reopen it (7.542215ms)
  ✔ releaseTaskClaim returns claim_conflict when lease has expired and caller is not the owner (5.443811ms)
  ✔ releaseTaskClaim succeeds via owner match when lease has expired (6.927163ms)
  ✔ mailbox APIs: DM, broadcast, and mark delivered (5.519617ms)
  ✔ sendDirectMessage recreates mailbox directory when missing (4.323265ms)
  ✔ sendDirectMessage throws team not found after team cleanup (2.508514ms)
  ✔ markMessageNotified stores notified_at without forcing delivered_at (4.064436ms)
  ✔ mailbox does not lose messages under concurrent sends (626.907962ms)
  ✔ writeTaskApproval writes record and emits approval_decision event (6.033524ms)
  ✔ initTeamState rejects workerCount > max_workers (0.922364ms)
  ✔ initTeamState rejects maxWorkers > ABSOLUTE_MAX_WORKERS (0.8993ms)
  ✔ createTask auto-increments IDs (6.770663ms)
  ✔ createTask does not overwrite existing tasks when config next_task_id is missing (legacy) (10.55563ms)
  ✔ listTasks returns sorted by ID (10.527428ms)
  ✔ listTasks reads task files in parallel (42.916531ms)
  ✔ readTask returns null for non-existent task (3.154176ms)
  ✔ readTask returns null for malformed JSON (3.327459ms)
  ✔ updateTask merges updates correctly (6.036439ms)
  ✔ updateTask rejects empty string status and leaves task readable (5.6772ms)
  ✔ updateTask coerces non-array depends_on to [] so claimTask does not crash (10.257547ms)
  ✔ updateTask is safe under concurrent calls (no lost updates) (30.76983ms)
  ✔ writeAtomic creates file and is safe to call concurrently (basic) (1.360145ms)
  ✔ readWorkerStatus returns {state:'unknown'} on missing file (3.168473ms)
  ✔ readWorkerHeartbeat returns null on missing file (3.2021ms)
  ✔ writeWorkerInbox writes content to the correct path (3.693664ms)
  ✔ getTeamSummary aggregates task counts correctly (15.915901ms)
  ✔ cleanupTeamState removes the directory (6.485193ms)
  ✔ validateTeamName rejects invalid names (via initTeamState throwing) (0.828954ms)
  ✔ initTeamState snapshots permissions and display mode from env (3.670059ms)
  ✔ claimTask returns task_not_found for non-existent task id (8.081022ms)
✔ team state (997.253517ms)
ℹ tests 49
ℹ suites 1
ℹ pass 49
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1090.077906\n- ▶ state-server team comm tools
  ✔ team_send_message + team_mailbox_list + team_mailbox_mark_delivered (152.232118ms)
  ✔ team_broadcast sends to all workers except sender (7.03953ms)
  ✔ team_read_task/team_list_tasks resolve team root from nested workingDirectory (6.90015ms)
  ✔ team_write_worker_identity persists workspace metadata fields (3.841489ms)
  ✔ team tool resolution prefers OMX_TEAM_STATE_ROOT when workingDirectory is omitted (4.766998ms)
  ✔ team_transition_task_status rejects non-terminal transition attempts (7.896497ms)
✔ state-server team comm tools (183.84526ms)
ℹ tests 6
ℹ suites 1
ℹ pass 6
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 248.124668\n- ▶ runtime
  ✔ monitorTeam does not emit duplicate task_completed when transitionTaskStatus completed the task first (issue #161) (35.820956ms)
✔ runtime (37.083394ms)
ℹ tests 1
ℹ suites 1
ℹ pass 1
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 128.011543