### PR TITLE
team: adaptive trigger submit fallback for stuck panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,13 @@ OMX_TEAM_WORKER_CLI=auto    # default; uses claude when worker --model contains 
 OMX_TEAM_WORKER_CLI=codex   # force Codex CLI workers
 OMX_TEAM_WORKER_CLI=claude  # force Claude CLI workers
 OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # per-worker CLI mix (len=1 or worker count)
-OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # optional: disable auto queue->interrupt->resend escalation
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # optional: disable adaptive queue->resend fallback
 ```
 
 Notes:
 - Worker launch args are still shared via `OMX_TEAM_WORKER_LAUNCH_ARGS`.
 - `OMX_TEAM_WORKER_CLI_MAP` overrides `OMX_TEAM_WORKER_CLI` for per-worker selection.
-- Trigger submission uses adaptive retries by default (queue/submit, then interrupt+resend fallback when needed).
+- Trigger submission uses adaptive retries by default (queue/submit, then safe clear-line+resend fallback when needed).
 - In Claude worker mode, OMX spawns workers as `claude --dangerously-skip-permissions` and intentionally ignores explicit `--model` / `--config` / `--effort` overrides so Claude uses default `settings.json`.
 
 ## What `omx setup` writes

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -195,7 +195,7 @@ Useful runtime env vars:
   - When present, overrides `OMX_TEAM_WORKER_CLI`
 - `OMX_TEAM_AUTO_INTERRUPT_RETRY`
   - Trigger submit fallback (default: enabled)
-  - `0` disables adaptive queue->interrupt->resend escalation
+  - `0` disables adaptive queue->resend escalation
 - `OMX_TEAM_LEADER_NUDGE_MS`
   - Leader nudge interval in ms (default 120000)
 - `OMX_TEAM_STRICT_SUBMIT=1`


### PR DESCRIPTION
## Summary
- add adaptive team trigger submission fallback for busy/stuck worker panes
- keep deterministic submit rounds, then escalate with interrupt + resend when needed
- document new env knob  to disable escalation

## Details
-  now:
  1. sends trigger text
  2. attempts submit rounds (queue-first when appropriate)
  3. if still visible, auto-escalates with , , resend, and retry rounds
- extracted local helpers for readability (, )

## Verification
- 
> oh-my-codex@0.5.1 build
> tsc
- ▶ runtime
  ✔ resolveCanonicalTeamStateRoot resolves to leader .omx/state (0.818145ms)
  ✔ resolveWorkerLaunchArgsFromEnv injects low-complexity default model when missing (0.796464ms)
  ✔ resolveWorkerLaunchArgsFromEnv does not inject low-complexity default for standard agent types (0.182843ms)
  ✔ resolveWorkerLaunchArgsFromEnv treats *-low aliases as low complexity (0.143309ms)
  ✔ resolveWorkerLaunchArgsFromEnv preserves explicit model in either syntax (0.204142ms)
  ✔ resolveWorkerLaunchArgsFromEnv uses inherited leader model for all agent types (0.141135ms)
  ✔ resolveWorkerLaunchArgsFromEnv uses inherited leader model over low-complexity default (0.143118ms)
  ✔ resolveWorkerLaunchArgsFromEnv prefers explicit env model over inherited leader model (0.139762ms)
  ✔ startTeam rejects nested team invocation inside worker context (8.359156ms)
  ✔ startTeam throws when tmux is not available (2.938871ms)
  ✔ monitorTeam returns null for non-existent team (1.161399ms)
  ✔ monitorTeam returns correct task counts from state files (25.512056ms)
  ✔ monitorTeam emits worker_idle and task_completed events based on transitions (15.803658ms)
  ✔ shutdownTeam cleans up state even when tmux session doesn't exist (29.457524ms)
  ✔ shutdownTeam returns rejection error when worker rejects shutdown and force is false (15.131738ms)
  ✔ shutdownTeam emits shutdown_ack event when worker ack is received (18.030354ms)
  ✔ shutdownTeam emits shutdown_ack event with accept reason for accepted acks (31.417391ms)
  ✔ shutdownTeam force=true ignores rejection and cleans up team state (30.841219ms)
  ✔ shutdownTeam ignores stale rejection ack from a prior request (29.675393ms)
  ✔ resumeTeam returns null for non-existent team (0.853231ms)
  ✔ assignTask enforces delegation_only policy for leader-fixed worker (5.237411ms)
  ✔ assignTask does not claim task when worker does not exist (5.719037ms)
  ✔ assignTask rolls back claim when notification transport fails (19.583076ms)
  ✔ assignTask rolls back claim when inbox write fails after claim (10.757875ms)
  ✔ assignTask enforces plan approval for code-change tasks when required (5.697256ms)
  ✔ monitorTeam does not re-notify already-notified mailbox messages (issue #116) (16.021386ms)
  ✔ monitorTeam only notifies once per new message even without notified_at (issue #116) (19.581654ms)
  ✔ monitorTeam does not emit duplicate task_completed when transitionTaskStatus completed the task first (issue #161) (18.838209ms)
  ✔ sendWorkerMessage allows worker to message leader-fixed mailbox (21.460216ms)
✔ runtime (336.855077ms)
▶ sanitizeTeamName
  ✔ lowercases and strips invalid chars (0.620694ms)
  ✔ truncates to 30 chars (0.150943ms)
  ✔ rejects empty after sanitization (0.363251ms)
✔ sanitizeTeamName (1.944717ms)
▶ chooseTeamLeaderPaneId
  ✔ keeps preferred pane when it is not HUD (0.24526ms)
  ✔ switches away from HUD preferred pane to first non-HUD pane (0.171542ms)
  ✔ falls back to preferred pane when all panes are HUD panes (0.102933ms)
✔ chooseTeamLeaderPaneId (0.696175ms)
▶ sendToWorker validation
  ✔ rejects text over 200 chars (0.285876ms)
  ✔ rejects injection marker (0.166983ms)
✔ sendToWorker validation (0.629281ms)
▶ buildWorkerStartupCommand
  ✔ auto-selects claude worker CLI from claude model (0.630022ms)
  ✔ respects explicit OMX_TEAM_WORKER_CLI override (0.276679ms)
  ✔ translates codex-only flags for claude workers (0.165019ms)
  ✔ maps --madmax to claude skip-permissions in claude mode (0.142757ms)
  ✔ uses zsh with ~/.zshrc and exec codex (0.120806ms)
  ✔ uses bash with ~/.bashrc and preserves launch args (0.142888ms)
  ✔ injects canonical team state env vars when provided (0.132508ms)
  ✔ inherits bypass flag from process argv once (0.132709ms)
  ✔ maps --madmax to bypass flag in worker command (0.126737ms)
  ✔ preserves reasoning override args in worker command (0.119654ms)
  ✔ injects model_instructions_file override by default (0.210175ms)
  ✔ does not inject model_instructions_file override when disabled (0.123061ms)
  ✔ does not inject model_instructions_file when already provided in launch args (0.172644ms)
✔ buildWorkerStartupCommand (2.827322ms)
▶ team worker CLI helpers
  ✔ resolveTeamWorkerCli auto-detects claude models (0.191178ms)
  ✔ translateWorkerLaunchArgsForCli preserves args for codex (0.604403ms)
  ✔ translateWorkerLaunchArgsForCli maps reasoning override for claude (0.078648ms)
  ✔ assertTeamWorkerCliBinaryAvailable throws clear error when binary missing (0.137789ms)
  ✔ resolveTeamWorkerCliPlan supports mixed per-worker CLI map (0.213721ms)
  ✔ resolveTeamWorkerCliPlan accepts single-value map and expands to all workers (0.12818ms)
  ✔ resolveTeamWorkerCliPlan supports auto entries in CLI map (0.098645ms)
  ✔ resolveTeamWorkerCliPlan auto entries ignore OMX_TEAM_WORKER_CLI override (0.10101ms)
  ✔ resolveTeamWorkerCliPlan rejects map lengths that do not match workerCount (0.135594ms)
  ✔ resolveTeamWorkerCliPlan rejects empty entries in CLI map (0.132118ms)
  ✔ resolveTeamWorkerCliPlan reports invalid entry errors with OMX_TEAM_WORKER_CLI_MAP (0.137919ms)
✔ team worker CLI helpers (2.28183ms)
▶ tmux-dependent functions when tmux is unavailable
  ✔ isTmuxAvailable returns false (2.871155ms)
  ✔ createTeamSession throws (2.113484ms)
  ✔ listTeamSessions returns empty (1.827106ms)
  ✔ waitForWorkerReady returns false on timeout (1.83445ms)
✔ tmux-dependent functions when tmux is unavailable (8.866088ms)
▶ isWorkerAlive
  ✔ does not require pane_current_command to match "codex" (1.726809ms)
✔ isWorkerAlive (1.851001ms)
▶ isWsl2
  ✔ returns true when WSL_DISTRO_NAME is set (0.184556ms)
  ✔ returns true when WSL_INTEROP is set and WSL_DISTRO_NAME is absent (3.289869ms)
  ✔ returns a boolean without throwing when no WSL env vars are present (0.184756ms)
✔ isWsl2 (3.777224ms)
▶ enableMouseScrolling
  ✔ returns false when tmux is unavailable (1.460379ms)
  ✔ returns false for empty session target when tmux unavailable (1.547422ms)
  ✔ returns false in WSL2 environment when tmux is unavailable (1.594751ms)
✔ enableMouseScrolling (4.801223ms)
▶ killWorkerByPaneId leader pane guard
  ✔ skips kill when workerPaneId matches leaderPaneId (guard fires before tmux is called) (0.291146ms)
  ✔ does not skip kill when pane ids differ (falls through to tmux attempt) (1.282555ms)
  ✔ skips kill for non-percent pane id without reaching tmux (0.115857ms)
  ✔ skips kill when no leaderPaneId provided and pane id is valid percent id (2.205627ms)
✔ killWorkerByPaneId leader pane guard (4.084201ms)
▶ sleepFractionalSeconds
  ✔ uses ceil(ms) so sub-millisecond positive values still sleep (0.171872ms)
  ✔ ignores invalid values and clamps extreme sleeps to 60s max (0.128812ms)
✔ sleepFractionalSeconds (0.370595ms)
▶ buildScrollCopyBindings (issue #206)
  ✔ returns a non-empty array of tmux command arg arrays (0.182523ms)
  ✔ includes WheelUpPane binding that enters copy-mode (fixes viewport scroll) (0.088426ms)
  ✔ WheelUpPane binding is in the root key table (-n flag) (0.069831ms)
  ✔ includes MouseDragEnd1Pane binding that copies selection to clipboard (fixes copy) (0.061325ms)
  ✔ MouseDragEnd1Pane binding is in copy-mode key table (-T copy-mode) (0.070863ms)
✔ buildScrollCopyBindings (issue #206) (0.583905ms)
▶ enableMouseScrolling scroll and copy setup (issue #206)
  ✔ returns false gracefully when scroll-copy setup fails because tmux is unavailable (1.245926ms)
  ✔ does not throw when WSL2 env is set and tmux is unavailable (regression + #206) (1.501807ms)
✔ enableMouseScrolling scroll and copy setup (issue #206) (2.881042ms)
▶ killWorker leader pane guard
  ✔ returns immediately when workerPaneId matches leaderPaneId (0.236764ms)
  ✔ proceeds (gracefully) when pane ids differ (1005.411553ms)
  ✔ proceeds when leaderPaneId is not provided (1006.078783ms)
✔ killWorker leader pane guard (2011.926383ms)
ℹ tests 88
ℹ suites 15
ℹ pass 88
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 2167.409252
