### PR TITLE
feat(team): auto-assign thinking level from model name at worker spawn (restore #220)

### DIFF
--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -103,20 +103,27 @@ Important:
 - Worker ACKs go to `mailbox/leader-fixed.json`
 - Notify hook updates worker heartbeat and nudges leader during active team mode
 
-### Team worker model resolution (current contract)
+### Team worker model + thinking resolution (current contract)
 
-Team mode resolves worker model flags from one shared launch-arg set (not per-worker model selection).
+Team mode resolves worker **model flags** from one shared launch-arg set (not per-worker model selection).
 
-Precedence (highest to lowest):
+Model precedence (highest to lowest):
 1. Explicit worker model in `OMX_TEAM_WORKER_LAUNCH_ARGS`
 2. Inherited leader `--model` flag
 3. Injected low-complexity default: `gpt-5.3-codex-spark` (only when 1+2 are absent and team `agentType` is low-complexity)
+
+Thinking-level rule (critical):
+- **No model-name heuristic mapping.**
+- Team runtime must **not** infer `model_reasoning_effort` from model strings (e.g., `spark`, `opus`, `mini`).
+- Worker thinking level is applied **only when explicitly provided** (leader/user launch args or explicit config).
+- If no explicit thinking value is provided, runtime leaves `model_reasoning_effort` unset.
 
 Normalization requirements:
 - Parse both `--model <value>` and `--model=<value>`
 - Remove duplicate/conflicting model flags
 - Emit exactly one final canonical flag: `--model <value>`
 - Preserve unrelated args in worker launch config
+- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise do not inject one
 
 ## Required Lifecycle (Operator Contract)
 

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -97,3 +97,34 @@ describe('team model contract', () => {
     assert.equal(isLowComplexityAgentType('executor-low'), true);
   });
 });
+
+describe('resolveTeamWorkerLaunchArgs - explicit thinking only', () => {
+  it('does not auto-inject thinking level for fallback model', () => {
+    const result = resolveTeamWorkerLaunchArgs({
+      fallbackModel: TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+    });
+    const joined = result.join(' ');
+    assert.ok(!joined.includes('model_reasoning_effort'), `Expected no auto-injected thinking level in: ${joined}`);
+  });
+
+  it('preserves explicit reasoning override', () => {
+    const result = resolveTeamWorkerLaunchArgs({
+      existingRaw: '-c model_reasoning_effort="high"',
+      fallbackModel: TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+    });
+    const joined = result.join(' ');
+    // Should contain the explicit high level
+    assert.ok(joined.includes('model_reasoning_effort="high"'), `Expected explicit high level in: ${joined}`);
+    // Should appear exactly once
+    const matches = joined.match(/model_reasoning_effort/g) ?? [];
+    assert.equal(matches.length, 1, 'reasoning override should appear exactly once');
+  });
+
+  it('does not inject thinking when model is explicit but reasoning is omitted', () => {
+    const result = resolveTeamWorkerLaunchArgs({
+      existingRaw: '--model claude-opus-4',
+    });
+    const joined = result.join(' ');
+    assert.ok(!joined.includes('model_reasoning_effort'), `Expected no reasoning in: ${joined}`);
+  });
+});

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -132,7 +132,6 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
   const inheritedModel = normalizeOptionalModel(parseTeamWorkerLaunchArgs(inheritedArgs).modelOverride);
   const fallbackModel = normalizeOptionalModel(options.fallbackModel);
   const selectedModel = envModel ?? inheritedModel ?? fallbackModel;
-
   return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel);
 }
 


### PR DESCRIPTION
Restoring previously reverted PR #220 onto dev for hold/review per owner instruction.

- This PR contains the same patch that was reverted by commit 87d5f7a.
- Re-opened for explicit owner-controlled handling.

Hold until owner decision.