### PR TITLE
docs(skill): remove stale deepinit references

### DIFF
--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -751,7 +751,6 @@ Good skills are:
 
 - `/learner` - Extract a skill from current conversation
 - `/note` - Save quick notes (less formal than skills)
-- `/deepinit` - Generate AGENTS.md codebase hierarchy
 
 ---
 
@@ -824,7 +823,6 @@ What would you like to do?
 
 - `/learner` - Extract a skill from current conversation
 - `/note` - Save quick notes (less formal than skills)
-- `/deepinit` - Generate AGENTS.md codebase hierarchy
 
 ---
 


### PR DESCRIPTION
## Summary
- remove stale `/deepinit` related-skill references from `skills/skill/SKILL.md`
- keep migration/changelog coverage references intact (those describe removal history)

## Changes
- deleted 2 obsolete lines that still advertised `/deepinit` as available

## Why
Issue #222 noted user confusion from leftover docs after `deepinit` removal. This patch aligns the skill guide with current catalog reality.

Refs #222