### PR TITLE
team: keep Claude workers plain and Codex reasoning-only semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Notes:
 - Worker launch args are still shared via `OMX_TEAM_WORKER_LAUNCH_ARGS`.
 - `OMX_TEAM_WORKER_CLI_MAP` overrides `OMX_TEAM_WORKER_CLI` for per-worker selection.
 - Trigger submission uses adaptive retries by default (queue/submit, then safe clear-line+resend fallback when needed).
-- In Claude worker mode, OMX spawns workers as `claude --dangerously-skip-permissions` and intentionally ignores explicit `--model` / `--config` / `--effort` overrides so Claude uses default `settings.json`.
+- In Claude worker mode, OMX spawns workers as plain `claude` (no extra launch args) and ignores explicit `--model` / `--config` / `--effort` overrides so Claude uses default `settings.json`.
 
 ## What `omx setup` writes
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -212,7 +212,7 @@ Useful runtime env vars:
 - `OMX_TEAM_WORKER_CLI`
   - Worker CLI selector: `auto|codex|claude` (default: `auto`)
   - `auto` chooses `claude` when worker `--model` contains `claude`, otherwise `codex`
-  - In `claude` mode, workers launch as `claude --dangerously-skip-permissions` and ignore explicit model/config/effort launch overrides (uses default `settings.json`)
+  - In `claude` mode, workers launch as plain `claude` and ignore explicit model/config/effort launch overrides (uses default `settings.json`)
 - `OMX_TEAM_WORKER_CLI_MAP`
   - Per-worker CLI selector (comma-separated `auto|codex|claude`)
   - Length must be `1` (broadcast) or exactly the team worker count

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -15,7 +15,6 @@ export interface TeamSession {
 
 const INJECTION_MARKER = '[OMX_TMUX_INJECT]';
 const CODEX_BYPASS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
-const CLAUDE_BYPASS_FLAG = '--dangerously-skip-permissions';
 const MADMAX_FLAG = '--madmax';
 const CONFIG_FLAG = '-c';
 const LONG_CONFIG_FLAG = '--config';
@@ -251,48 +250,11 @@ export function resolveTeamWorkerCliPlan(
 export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: string[]): string[] {
   if (workerCli === 'codex') return [...args];
 
-  // Claude teammates should use default settings.json behavior.
-  // Intentionally drop model/config/effort overrides and force skip-permissions.
-  const translated: string[] = [CLAUDE_BYPASS_FLAG];
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    if (arg === CODEX_BYPASS_FLAG || arg === MADMAX_FLAG) {
-      continue;
-    }
-    if (arg === CLAUDE_BYPASS_FLAG) {
-      continue;
-    }
-
-    if (arg === MODEL_FLAG) {
-      const maybeValue = args[i + 1];
-      if (typeof maybeValue === 'string') i += 1;
-      continue;
-    }
-    if (arg.startsWith(`${MODEL_FLAG}=`)) continue;
-
-    if (arg === '--effort') {
-      const maybeValue = args[i + 1];
-      if (typeof maybeValue === 'string') i += 1;
-      continue;
-    }
-    if (arg.startsWith('--effort=')) continue;
-
-    if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
-      const maybeValue = args[i + 1];
-      if (typeof maybeValue === 'string') {
-        i += 1;
-      }
-      continue;
-    }
-    if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) continue;
-
-    // Drop all remaining explicit launch args in claude mode to preserve
-    // default claude settings.json behavior.
-  }
-
-  return translated;
+  // Claude workers must launch as plain `claude` with no extra args.
+  // This preserves Claude defaults from settings.json and avoids passing
+  // Codex-only flags, model overrides, or config/reasoning overrides.
+  void args;
+  return [];
 }
 
 function commandExists(binary: string): boolean {


### PR DESCRIPTION
## Summary
- Launch Claude team workers as plain `claude` with no extra launch args (no skip-permissions/model/config/reasoning overrides), so local `settings.json` is authoritative.
- Keep Codex worker behavior unchanged (including explicit reasoning handling).
- Make leader startup resolution logging Claude-aware: when effective worker CLI is Claude, log `model=claude source=local-settings` and omit `thinking_level`.
- Update docs to match new Claude worker behavior in README and `skills/team/SKILL.md`.

## Why
This fixes the inconsistency where Claude paths still surfaced Codex-style reasoning semantics at startup and still launched with extra Claude flags, despite expectation that Claude should run with local defaults.

## Verification
- `npm run build`
- `node --test dist/team/__tests__/runtime.test.js dist/team/__tests__/tmux-session.test.js`

Result: pass (99 tests, 0 failed)

## Notes
- Codex model/reasoning precedence remains unchanged.
- Added regression tests for:
  - Claude startup log omits `thinking_level`
  - Mixed `OMX_TEAM_WORKER_CLI_MAP` still keeps Codex thinking behavior
  - Claude worker arg translation returns empty args