### PR TITLE
feat: add win32 startup warning when native Windows detected

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,7 +31,7 @@ import {
 import {
   readSessionState, isSessionStale, writeSessionStart, writeSessionEnd, resetSessionMetrics,
 } from '../hooks/session.js';
-import { enableMouseScrolling, isWsl2 } from '../team/tmux-session.js';
+import { enableMouseScrolling, isNativeWindows, isWsl2 } from '../team/tmux-session.js';
 import { getPackageRoot } from '../utils/package.js';
 import { codexConfigPath } from '../utils/paths.js';
 import { buildHookEvent } from '../hooks/extensibility/events.js';
@@ -365,6 +365,20 @@ async function reasoningCommand(args: string[]): Promise<void> {
 }
 
 export async function launchWithHud(args: string[]): Promise<void> {
+  // ── Win32 guard ──────────────────────────────────────────────────────
+  if (isNativeWindows()) {
+    console.error(
+      '[omx] OMX requires tmux, which is not available on native Windows.\n' +
+      '[omx] Please use one of the following supported environments:\n' +
+      '[omx]   - WSL2 (Windows Subsystem for Linux 2)\n' +
+      '[omx]   - macOS\n' +
+      '[omx]   - Linux\n' +
+      '[omx] See: https://docs.microsoft.com/en-us/windows/wsl/install',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   const launchCwd = process.cwd();
   const parsedWorktree = parseWorktreeMode(args);
   const workerSparkModel = resolveWorkerSparkModel(parsedWorktree.remainingArgs);

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -7,6 +7,7 @@ import {
   chooseTeamLeaderPaneId,
   createTeamSession,
   enableMouseScrolling,
+  isNativeWindows,
   isTmuxAvailable,
   isWsl2,
   isWorkerAlive,
@@ -598,6 +599,60 @@ describe('isWsl2', () => {
       else delete process.env.WSL_DISTRO_NAME;
       if (typeof prevInterop === 'string') process.env.WSL_INTEROP = prevInterop;
       else delete process.env.WSL_INTEROP;
+    }
+  });
+});
+
+describe('isNativeWindows', () => {
+  it('returns true when process.platform is win32 and not WSL2', () => {
+    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const prevDistro = process.env.WSL_DISTRO_NAME;
+    const prevInterop = process.env.WSL_INTEROP;
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.WSL_INTEROP;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      assert.equal(isNativeWindows(), true);
+    } finally {
+      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      if (typeof prevDistro === 'string') process.env.WSL_DISTRO_NAME = prevDistro;
+      else delete process.env.WSL_DISTRO_NAME;
+      if (typeof prevInterop === 'string') process.env.WSL_INTEROP = prevInterop;
+      else delete process.env.WSL_INTEROP;
+    }
+  });
+
+  it('returns false when process.platform is win32 but WSL2 is detected', () => {
+    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const prevDistro = process.env.WSL_DISTRO_NAME;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    process.env.WSL_DISTRO_NAME = 'Ubuntu-22.04';
+    try {
+      assert.equal(isNativeWindows(), false);
+    } finally {
+      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      if (typeof prevDistro === 'string') process.env.WSL_DISTRO_NAME = prevDistro;
+      else delete process.env.WSL_DISTRO_NAME;
+    }
+  });
+
+  it('returns false on Linux', () => {
+    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    try {
+      assert.equal(isNativeWindows(), false);
+    } finally {
+      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+    }
+  });
+
+  it('returns false on macOS', () => {
+    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    try {
+      assert.equal(isNativeWindows(), false);
+    } finally {
+      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
     }
   });
 });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -395,6 +395,14 @@ export function isWsl2(): boolean {
   }
 }
 
+/**
+ * Detect whether the process is running on native Windows (not WSL2).
+ * OMX requires tmux, which is unavailable on native Windows.
+ */
+export function isNativeWindows(): boolean {
+  return process.platform === 'win32' && !isWsl2();
+}
+
 // Check if tmux is available
 export function isTmuxAvailable(): boolean {
   const result = spawnSync('tmux', ['-V'], { encoding: 'utf-8' });


### PR DESCRIPTION
## Summary

Closes #224

- Adds `isNativeWindows()` detection function in `src/team/tmux-session.ts` that checks `process.platform === 'win32'` while excluding WSL2
- Adds a startup guard in `launchWithHud()` that prints a clear warning and exits with code 1 when running on native Windows
- Warning recommends WSL2, macOS, or Linux as supported environments
- Adds 4 unit tests covering: native win32 detection, WSL2 exclusion, Linux, and macOS

## Test plan

- [x] `isNativeWindows()` returns `true` on native win32
- [x] `isNativeWindows()` returns `false` when WSL2 env vars are present
- [x] `isNativeWindows()` returns `false` on Linux
- [x] `isNativeWindows()` returns `false` on macOS
- [x] All 70 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)