### PR TITLE
fix: harden detached tmux resize-hook regression path

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -337,12 +337,13 @@ describe('detached tmux new-session sequencing', () => {
     );
     assert.deepEqual(steps.map((step) => step.name), ['new-session', 'split-and-capture-hud-pane']);
     assert.equal(steps[1]?.args[3], String(HUD_TMUX_HEIGHT_LINES));
+    assert.equal(steps[1]?.args[6], 'omx-demo');
     assert.equal(steps[1]?.args.includes('-P'), true);
     assert.equal(steps[1]?.args.includes('#{pane_id}'), true);
   });
 
   it('buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach', () => {
-    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', true, false);
+    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', true, false);
     const names = steps.map((step) => step.name);
     const scheduleIndex = names.indexOf('schedule-delayed-resize');
     const attachIndex = names.indexOf('attach-session');
@@ -355,13 +356,11 @@ describe('detached tmux new-session sequencing', () => {
   it('buildDetachedSessionRollbackSteps unregisters hook before killing session', () => {
     const steps = buildDetachedSessionRollbackSteps('omx-demo', 'omx-demo:0', 'omx_resize_launch_demo_0_12');
     assert.deepEqual(steps.map((step) => step.name), ['unregister-resize-hook', 'kill-session']);
-    assert.deepEqual(steps[0]?.args, [
-      'set-hook',
-      '-u',
-      '-t',
-      'omx-demo:0',
-      'client-resized[omx_resize_launch_demo_0_12]',
-    ]);
+    assert.equal(steps[0]?.args[0], 'set-hook');
+    assert.equal(steps[0]?.args[1], '-u');
+    assert.equal(steps[0]?.args[2], '-t');
+    assert.equal(steps[0]?.args[3], 'omx-demo:0');
+    assert.match(steps[0]?.args[4] ?? '', /^client-resized\[\d+\]$/);
     assert.deepEqual(steps[1]?.args, ['kill-session', '-t', 'omx-demo']);
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -99,24 +99,19 @@ describe('HUD resize hook command builders', () => {
     assert.equal(buildHudPaneTarget('41'), '%41');
   });
 
-  it('buildRegisterResizeHookArgs uses window target and client-resized hook slot', () => {
-    assert.deepEqual(
-      buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1'),
-      [
-        'set-hook',
-        '-t',
-        'my-session:0',
-        'client-resized[omx_resize_team_session_0_1]',
-        `run-shell -b 'tmux resize-pane -t %1 -y ${HUD_TMUX_HEIGHT_LINES}'`,
-      ],
-    );
+  it('buildRegisterResizeHookArgs uses window target and numeric client-resized hook slot', () => {
+    const args = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1');
+    assert.equal(args[0], 'set-hook');
+    assert.equal(args[1], '-t');
+    assert.equal(args[2], 'my-session:0');
+    assert.match(args[3] ?? '', /^client-resized\[\d+\]$/);
+    assert.equal(args[4], `run-shell -b 'tmux resize-pane -t %1 -y ${HUD_TMUX_HEIGHT_LINES}'`);
   });
 
-  it('buildUnregisterResizeHookArgs removes the exact hook slot', () => {
-    assert.deepEqual(
-      buildUnregisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1'),
-      ['set-hook', '-u', '-t', 'my-session:0', 'client-resized[omx_resize_team_session_0_1]'],
-    );
+  it('buildUnregisterResizeHookArgs removes the exact numeric hook slot', () => {
+    const registered = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1');
+    const unregistered = buildUnregisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1');
+    assert.deepEqual(unregistered, ['set-hook', '-u', '-t', 'my-session:0', registered[3] as string]);
   });
 
   it('buildScheduleDelayedHudResizeArgs schedules tmux-side delayed reconcile', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -166,13 +166,21 @@ function buildHudResizeCommand(hudPaneId: string): string {
   return `resize-pane -t ${buildHudPaneTarget(hudPaneId)} -y ${HUD_TMUX_HEIGHT_LINES}`;
 }
 
+function buildResizeHookSlot(hookName: string): string {
+  let hash = 0;
+  for (let i = 0; i < hookName.length; i++) {
+    hash = (hash * 31 + hookName.charCodeAt(i)) >>> 0;
+  }
+  return `client-resized[${hash}]`;
+}
+
 export function buildRegisterResizeHookArgs(hookTarget: string, hookName: string, hudPaneId: string): string[] {
   const resizeCommand = shellQuoteSingle(`tmux ${buildHudResizeCommand(hudPaneId)}`);
-  return ['set-hook', '-t', hookTarget, `client-resized[${hookName}]`, `run-shell -b ${resizeCommand}`];
+  return ['set-hook', '-t', hookTarget, buildResizeHookSlot(hookName), `run-shell -b ${resizeCommand}`];
 }
 
 export function buildUnregisterResizeHookArgs(hookTarget: string, hookName: string): string[] {
-  return ['set-hook', '-u', '-t', hookTarget, `client-resized[${hookName}]`];
+  return ['set-hook', '-u', '-t', hookTarget, buildResizeHookSlot(hookName)];
 }
 
 export function unregisterResizeHook(hookTarget: string, hookName: string): boolean {


### PR DESCRIPTION
## Summary\n- use session-targeted split-window for detached bootstrap instead of hardcoded :0\n- detect detached window index and only register resize hooks when both pane id and window index resolve\n- derive tmux numeric hook slots from a stable hash and make tests resilient to slot normalization\n- tolerate non-critical finalize step failures while still surfacing attach failure\n\n## Verification\n- npm run build\n- node --test dist/cli/__tests__/index.test.js dist/team/__tests__/tmux-session.test.js