### PR TITLE
fix(team): improve Claude submit reliability and enforce claude launch flags

### DIFF
--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -102,6 +102,14 @@ Important:
 - Workers may run in separate git worktrees (`omx team --worktree[=<name>]`) while sharing one team state root
 - Worker ACKs go to `mailbox/leader-fixed.json`
 - Notify hook updates worker heartbeat and nudges leader during active team mode
+- Submit routing uses this CLI resolution order per worker trigger:
+  1) explicit worker CLI provided by runtime state (persisted on worker identity/config),
+  2) `OMX_TEAM_WORKER_CLI_MAP` entry for that worker index,
+  3) fallback `OMX_TEAM_WORKER_CLI` / auto detection.
+- Mixed CLI-map teams are supported for both startup and trigger submit behavior.
+- Trigger submit differs by CLI:
+  - Codex may use queue-first `Tab` on busy panes (strategy-dependent).
+  - Claude always uses direct Enter-only (`C-m`) rounds (never queue-first `Tab`).
 
 ### Team worker model + thinking resolution (current contract)
 
@@ -212,7 +220,8 @@ Useful runtime env vars:
 - `OMX_TEAM_WORKER_CLI`
   - Worker CLI selector: `auto|codex|claude` (default: `auto`)
   - `auto` chooses `claude` when worker `--model` contains `claude`, otherwise `codex`
-  - In `claude` mode, workers launch as plain `claude` and ignore explicit model/config/effort launch overrides (uses default `settings.json`)
+  - In `claude` mode, workers launch with exactly one `--dangerously-skip-permissions`
+    and ignore explicit model/config/effort launch overrides (uses default `settings.json`)
 - `OMX_TEAM_WORKER_CLI_MAP`
   - Per-worker CLI selector (comma-separated `auto|codex|claude`)
   - Length must be `1` (broadcast) or exactly the team worker count

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -33,6 +33,7 @@ export interface WorkerInfo {
   name: string; // "worker-1"
   index: number; // tmux window index (1-based)
   role: string; // agent type
+  worker_cli?: 'codex' | 'claude';
   assigned_tasks: string[]; // task IDs
   pid?: number;
   pane_id?: string;


### PR DESCRIPTION
## Summary\n- make worker submit routing CLI-aware with persisted per-worker CLI context\n- keep Codex queue-first behavior on busy panes while using Enter-only submit rounds for Claude\n- harden Claude busy detection for live status markers (e.g. `· ...`, `✻ ...`)\n- enforce Claude worker startup args to exactly `--dangerously-skip-permissions`\n- update team skill docs and add focused tmux-session tests\n\n## Verification\n- npx --yes tsx --test src/team/__tests__/tmux-session.test.ts\n- npx --yes tsx --test src/team/__tests__/runtime.test.ts\n- live tmux smoke checks in OMX shell for Codex/Claude submit behavior\n\n## Notes\n- full `npm run build` still has unrelated pre-existing MCP SDK resolution issues in `src/mcp/*` in this environment.