### PR TITLE
fix(tmux): suppress noisy resize-pane failures and use 3-line HUD in team mode

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -356,6 +356,20 @@ describe('detached tmux new-session sequencing', () => {
     assert.equal(names.includes('reconcile-hud-resize'), true);
   });
 
+  it('buildDetachedSessionFinalizeSteps uses quiet best-effort tmux resize commands', () => {
+    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', false, false);
+    const registerHook = steps.find((step) => step.name === 'register-resize-hook');
+    const schedule = steps.find((step) => step.name === 'schedule-delayed-resize');
+    const reconcile = steps.find((step) => step.name === 'reconcile-hud-resize');
+
+    assert.match(registerHook?.args[4] ?? '', />\/dev\/null 2>&1 \|\| true/);
+    assert.match(registerHook?.args[4] ?? '', new RegExp(`-y ${HUD_TMUX_HEIGHT_LINES}\\b`));
+    assert.match(schedule?.args[2] ?? '', />\/dev\/null 2>&1 \|\| true/);
+    assert.match(schedule?.args[2] ?? '', new RegExp(`-y ${HUD_TMUX_HEIGHT_LINES}\\b`));
+    assert.match((reconcile?.args ?? []).join(' '), />\/dev\/null 2>&1 \|\| true/);
+    assert.match((reconcile?.args ?? []).join(' '), new RegExp(`-y ${HUD_TMUX_HEIGHT_LINES}\\b`));
+  });
+
   it('buildDetachedSessionRollbackSteps unregisters hooks before killing session', () => {
     const steps = buildDetachedSessionRollbackSteps(
       'omx-demo',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -743,19 +743,19 @@ export function buildDetachedSessionFinalizeSteps(
     const clientAttachedHookName = buildClientAttachedReconcileHookName('launch', sessionName, hookWindowIndex, hudPaneId);
     steps.push({
       name: 'register-resize-hook',
-      args: buildRegisterResizeHookArgs(hookTarget, hookName, hudPaneId),
+      args: buildRegisterResizeHookArgs(hookTarget, hookName, hudPaneId, HUD_TMUX_HEIGHT_LINES),
     });
     steps.push({
       name: 'register-client-attached-reconcile',
-      args: buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId),
+      args: buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_HEIGHT_LINES),
     });
     steps.push({
       name: 'schedule-delayed-resize',
-      args: buildScheduleDelayedHudResizeArgs(hudPaneId),
+      args: buildScheduleDelayedHudResizeArgs(hudPaneId, undefined, HUD_TMUX_HEIGHT_LINES),
     });
     steps.push({
       name: 'reconcile-hud-resize',
-      args: buildReconcileHudResizeArgs(hudPaneId),
+      args: buildReconcileHudResizeArgs(hudPaneId, HUD_TMUX_HEIGHT_LINES),
     });
   }
 

--- a/src/hud/constants.ts
+++ b/src/hud/constants.ts
@@ -1,2 +1,3 @@
 export const HUD_TMUX_HEIGHT_LINES = 2;
+export const HUD_TMUX_TEAM_HEIGHT_LINES = 3;
 export const HUD_RESIZE_RECONCILE_DELAY_SECONDS = 2;


### PR DESCRIPTION
## Summary

This PR addresses noisy tmux HUD resize artifacts (commonly seen on macOS/iTerm2 as `>1` / `command returned 1`) and improves default HUD sizing in constrained team layouts.

## Changes

- Quieted non-critical HUD resize/reconcile tmux commands using best-effort execution.
- Introduced separate HUD defaults by mode:
  - normal mode: `2` lines
  - team mode: `3` lines
- Wired detached launch finalize-step resize hooks to explicitly keep normal-mode height (`2`).
- Updated tests to validate:
  - quiet resize command generation
  - finalize-step quiet behavior
  - correct height values per mode

## Why

- Resize hook/reconcile operations are non-critical and should not create user-facing noise when pane state changes rapidly.
- Team mode has tighter horizontal/vertical space pressure; 3 lines keeps HUD usable without over-shrinking worker panes.

## Verification

- `npm run build`
- `node --test dist/team/__tests__/tmux-session.test.js dist/cli/__tests__/index.test.js`
