### PR TITLE
fix(tmux): clamp hook indices to signed 32-bit range

### DIFF
--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -185,20 +185,23 @@ function buildBestEffortShellCommand(command: string): string {
   return `${command} >/dev/null 2>&1 || true`;
 }
 
+/** Upper bound for tmux hook indices (signed 32-bit max). */
+const TMUX_HOOK_INDEX_MAX = 2147483647;
+
 function buildResizeHookSlot(hookName: string): string {
   let hash = 0;
   for (let i = 0; i < hookName.length; i++) {
-    hash = (hash * 31 + hookName.charCodeAt(i)) >>> 0;
+    hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
   }
-  return `client-resized[${hash}]`;
+  return `client-resized[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
 function buildClientAttachedHookSlot(hookName: string): string {
   let hash = 0;
   for (let i = 0; i < hookName.length; i++) {
-    hash = (hash * 31 + hookName.charCodeAt(i)) >>> 0;
+    hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
   }
-  return `client-attached[${hash}]`;
+  return `client-attached[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
 export function buildRegisterResizeHookArgs(


### PR DESCRIPTION
## Summary
- `buildResizeHookSlot` and `buildClientAttachedHookSlot` used `>>> 0` producing unsigned 32-bit values up to 4,294,967,295, but tmux uses signed 32-bit integers for hook indices (max 2,147,483,647)
- Replaced `>>> 0` with `| 0` (signed 32-bit coercion) and `Math.abs(hash) % 2147483647` to clamp indices within the valid signed range
- Added tests verifying hook indices stay within bounds and remain deterministic

## Test plan
- [x] New test: hook indices stay within signed 32-bit range (issue #240)
- [x] New test: hook indices are deterministic across calls
- [x] All 1035 existing tests pass
- [x] `npm run build` succeeds

Fixes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)