### PR TITLE
fix(setup): prompt before overwriting existing AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Notes:
   - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
   - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
 - Launch behavior: if persisted scope is `project`, `omx` launch auto-uses `CODEX_HOME=./.codex` (unless `CODEX_HOME` is already set).
-- Existing `AGENTS.md` is preserved unless `--force` is used (and active-session safety checks still apply).
+- Existing `AGENTS.md` is preserved by default. In interactive TTY runs, setup prompts before overwrite; `--force` overwrites without prompt (active-session safety checks still apply).
 - `config.toml` updates (for both scopes):
   - `notify = ["node", "..."]`
   - `model_reasoning_effort = "high"`

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -38,6 +38,7 @@ Supported setup flags (current implementation):
 
 - `omx setup` only prompts for scope when no scope is provided/persisted and stdin/stdout are TTY.
 - Local project orchestration file is `./AGENTS.md` (project root).
+- If `AGENTS.md` exists and `--force` is not used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
 - Scope targets:
   - `user`: user directories (`~/.codex`, `~/.agents/skills`, `~/.omx/agents`)
   - `project`: local directories (`./.codex`, `./.agents/skills`, `./.omx/agents`)

--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setup } from '../setup.js';
+
+function setMockTty(value: boolean): () => void {
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value,
+    configurable: true,
+  });
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value,
+    configurable: true,
+  });
+  return () => {
+    delete (process.stdin as unknown as { isTTY?: boolean }).isTTY;
+    delete (process.stdout as unknown as { isTTY?: boolean }).isTTY;
+  };
+}
+
+async function runSetupWithCapturedLogs(
+  cwd: string,
+  options: Parameters<typeof setup>[0]
+): Promise<string> {
+  const previousCwd = process.cwd();
+  const logs: string[] = [];
+  const originalLog = console.log;
+  process.chdir(cwd);
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((arg) => String(arg)).join(' '));
+  };
+  try {
+    await setup(options);
+    return logs.join('\n');
+  } finally {
+    console.log = originalLog;
+    process.chdir(previousCwd);
+  }
+}
+
+describe('omx setup AGENTS overwrite prompt behavior', () => {
+  it('overwrites existing AGENTS.md when prompt accepts in TTY', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(true);
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), '# old agents file\n');
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        agentsOverwritePrompt: async () => true,
+      });
+
+      const agentsContent = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      assert.match(output, /Generated AGENTS\.md in project root\./);
+      assert.match(agentsContent, /# oh-my-codex - Intelligent Multi-Agent Orchestration/);
+      assert.doesNotMatch(agentsContent, /# old agents file/);
+    } finally {
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves existing AGENTS.md when prompt declines in TTY', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(true);
+    const existing = '# keep me\n';
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        agentsOverwritePrompt: async () => false,
+      });
+
+      assert.match(output, /AGENTS\.md already exists \(use --force to overwrite\)\./);
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
+    } finally {
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips overwrite during active session even when prompt accepts in TTY', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(true);
+    const existing = '# active session file\n';
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({
+          session_id: 'sess-test',
+          started_at: new Date().toISOString(),
+          cwd: wd,
+          pid: process.pid,
+        }, null, 2)
+      );
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        agentsOverwritePrompt: async () => true,
+      });
+
+      assert.match(output, /WARNING: Active omx session detected/);
+      assert.match(output, /Skipping AGENTS\.md overwrite to avoid corrupting runtime overlay\./);
+      assert.match(output, /re-run setup and approve overwrite \(or use --force\)\./);
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
+    } finally {
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add interactive overwrite prompt for existing `AGENTS.md` during `omx setup` when running in TTY and `--force` is not set.
- Keep non-interactive behavior unchanged: preserve existing `AGENTS.md` unless `--force` is explicitly passed.
- Preserve active-session safety guard and make guidance explicit for both forced and prompted overwrite flows.

## Changes
- `src/cli/setup.ts`
  - Added `promptForAgentsOverwrite()`.
  - Added optional `agentsOverwritePrompt` hook in `SetupOptions` for testability.
  - Added TTY prompt path for existing `AGENTS.md` when `--force` is absent.
  - Refined active-session warning message based on overwrite intent source.
- `src/cli/__tests__/setup-scope.test.ts`
  - Added non-interactive preserve/force coverage for existing `AGENTS.md`.
- `src/cli/__tests__/setup-agents-overwrite.test.ts` (new)
  - Added interactive prompt yes/no behavior coverage.
  - Added active-session + prompt-yes guard coverage.
- `README.md`, `skills/omx-setup/SKILL.md`
  - Updated docs for new interactive overwrite behavior.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-agents-overwrite.test.js`
- Manual real CLI checks in isolated `dev-null` workspace:
  - no `AGENTS.md` -> generated
  - existing + non-TTY + no `--force` -> preserved
  - existing + non-TTY + `--force` -> overwritten
  - existing + TTY + `n` -> preserved
  - existing + TTY + `y` -> overwritten
  - active session + TTY + `y` -> overwrite blocked
  - active session + `--force` -> overwrite blocked
  - `--dry-run --force` -> no file mutation

## Notes
- Full `npm test` currently fails in this environment due an existing flaky/unrelated suite:
  - `dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
  - failing case: `nudges when worker panes are alive and leader is stale (no recent HUD turn)`
