### PR TITLE
feat(setup): simplify scopes from 3 to 2 (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ All notable changes to this project are documented in this file.
 
 ### Added
 - Consolidated the prompt/skill catalog and hardened team runtime contracts after the mainline merge (PR #137).
-- Added setup scope-aware install modes (`user`, `project-local`, `project`) with persisted scope behavior.
+- Added setup scope-aware install modes (`user`, `project`) with persisted scope behavior.
 - Added spark worker routing via `--spark` / `--madmax-spark` so team workers can use `gpt-5.3-codex-spark` without forcing the leader model.
 - Added notifier verbosity levels for CCNotifier output control.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ omx --xhigh --madmax
 
 ## New in v0.5.0
 
-- **Scope-aware setup** with `omx setup --scope user|project-local|project` for flexible install modes.
+- **Scope-aware setup** with `omx setup --scope user|project` for flexible install modes.
 - **Spark worker routing** via `--spark` / `--madmax-spark` so team workers can use `gpt-5.3-codex-spark` without forcing the leader model.
 - **Catalog consolidation** — removed deprecated prompts (`deep-executor`, `scientist`) and 9 deprecated skills for a leaner surface.
 - **Notifier verbosity levels** for fine-grained CCNotifier output control.
@@ -141,7 +141,7 @@ See `docs/hooks-extension.md` for the full extension workflow and event model.
 --force
 --dry-run
 --verbose
---scope <user|project-local|project>  # setup only
+--scope <user|project>  # setup only
 ```
 
 `--madmax` maps to Codex `--dangerously-bypass-approvals-and-sandbox`.
@@ -207,11 +207,10 @@ Notes:
 - `.omx/setup-scope.json` (persisted setup scope)
 - Scope-dependent installs:
   - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
-  - `project-local`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
-  - `project`: skips prompt/skill/config/native-agent installs
-- Launch behavior: if persisted scope is `project-local`, `omx` launch auto-uses `CODEX_HOME=./.codex` (unless `CODEX_HOME` is already set).
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Launch behavior: if persisted scope is `project`, `omx` launch auto-uses `CODEX_HOME=./.codex` (unless `CODEX_HOME` is already set).
 - Existing `AGENTS.md` is preserved unless `--force` is used (and active-session safety checks still apply).
-- `config.toml` updates (for `user`/`project-local` scopes):
+- `config.toml` updates (for both scopes):
   - `notify = ["node", "..."]`
   - `model_reasoning_effort = "high"`
   - `developer_instructions = "..."`
@@ -223,8 +222,8 @@ Notes:
 
 ## Agents and Skills
 
-- Prompts: `prompts/*.md` (installed to `~/.codex/prompts/` for `user`, `./.codex/prompts/` for `project-local`)
-- Skills: `skills/*/SKILL.md` (installed to `~/.agents/skills/` for `user`, `./.agents/skills/` for `project-local`)
+- Prompts: `prompts/*.md` (installed to `~/.codex/prompts/` for `user`, `./.codex/prompts/` for `project`)
+- Skills: `skills/*/SKILL.md` (installed to `~/.agents/skills/` for `user`, `./.agents/skills/` for `project`)
 
 Examples:
 - Agents: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`

--- a/docs/migration-mainline-post-v0.4.4.md
+++ b/docs/migration-mainline-post-v0.4.4.md
@@ -15,7 +15,7 @@ You are affected if you:
 ## What changed (high level)
 
 - Catalog consolidation for prompts/skills and cleanup of deprecated entries.
-- `omx setup` now supports scope-aware install modes.
+- `omx setup` now supports scope-aware install modes (`user`, `project`). Legacy `project-local` values are auto-migrated.
 - Spark worker routing added for team workers (`--spark`, `--madmax-spark`).
 - Notifier verbosity controls added.
 - tmux runtime hardening updates landed, including post-review pane capture/input hardening.
@@ -73,7 +73,7 @@ Run this checklist after pulling latest mainline:
   ```
 - [ ] Validate setup scope options are available:
   ```bash
-  omx help | rg -e "--scope|project-local|project"
+  omx help | rg -e "--scope|project"
   ```
 - [ ] Validate team/tmux health checks:
   ```bash

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -10,14 +10,14 @@ Use this skill when users want to install or refresh oh-my-codex for the **curre
 ## Command
 
 ```bash
-omx setup [--force] [--dry-run] [--verbose] [--scope <user|project-local|project>]
+omx setup [--force] [--dry-run] [--verbose] [--scope <user|project>]
 ```
 
 Supported setup flags (current implementation):
 - `--force`: overwrite/reinstall managed artifacts where applicable
 - `--dry-run`: print actions without mutating files
 - `--verbose`: print per-file/per-step details
-- `--scope`: choose install scope (`user`, `project-local`, `project`)
+- `--scope`: choose install scope (`user`, `project`)
 
 ## What this setup actually does
 
@@ -25,20 +25,14 @@ Supported setup flags (current implementation):
 
 1. Resolve setup scope:
    - `--scope` explicit value
-   - else persisted `./.omx/setup-scope.json`
+   - else persisted `./.omx/setup-scope.json` (with automatic migration of legacy values)
    - else interactive prompt on TTY (default `user`)
    - else default `user` (safe for CI/tests)
-2. Create project OMX directories (`./.omx/state`, `./.omx/plans`, `./.omx/logs`) and persist effective scope
-3. For `user`/`project-local` scope:
-   - install prompts
-   - remove legacy prompt shims
-   - install native agent configs
-   - install skills
-   - merge OMX config.toml
-4. For `project` scope: skip prompt/skill/config/native-agent installs with console messages
-6. Verify required team MCP comm tool exports exist in built `dist/mcp/state-server.js`
-7. Generate project-root `./AGENTS.md` from `templates/AGENTS.md` (or skip when existing and no force)
-8. Configure notify hook references and write `./.omx/hud-config.json`
+2. Create directories and persist effective scope
+3. Install prompts, native agent configs, skills, and merge config.toml (scope determines target directories)
+4. Verify required team MCP comm tool exports exist in built `dist/mcp/state-server.js`
+5. Generate project-root `./AGENTS.md` from `templates/AGENTS.md` (or skip when existing and no force)
+6. Configure notify hook references and write `./.omx/hud-config.json`
 
 ## Important behavior notes
 
@@ -46,10 +40,10 @@ Supported setup flags (current implementation):
 - Local project orchestration file is `./AGENTS.md` (project root).
 - Scope targets:
   - `user`: user directories (`~/.codex`, `~/.agents/skills`, `~/.omx/agents`)
-  - `project-local`: local directories (`./.codex`, `./.agents/skills`, `./.omx/agents`)
-  - `project`: project-only OMX setup (`./.omx/*`, `AGENTS.md`, HUD)
-- If persisted scope is `project-local`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
+  - `project`: local directories (`./.codex`, `./.agents/skills`, `./.omx/agents`)
+- If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - With `--force`, AGENTS overwrite may still be skipped if an active OMX session is detected (safety guard).
+- Legacy persisted scope values (`project-local`) are automatically migrated to `project` with a one-time warning.
 
 ## Recommended workflow
 
@@ -70,8 +64,8 @@ omx doctor
 ## Expected verification indicators
 
 From `omx doctor`, expect:
-- Prompts installed (scope-dependent: user or project-local)
-- Skills installed (scope-dependent: user or project-local)
+- Prompts installed (scope-dependent: user or project)
+- Skills installed (scope-dependent: user or project)
 - AGENTS.md found in project root
 - `.omx/state` exists
 - OMX MCP servers configured in scope target `config.toml` (`~/.codex/config.toml` or `./.codex/config.toml`)

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -215,7 +215,7 @@ describe('resolveSetupScopeArg', () => {
   });
 
   it('parses --scope <value> form', () => {
-    assert.equal(resolveSetupScopeArg(['--dry-run', '--scope', 'project-local']), 'project-local');
+    assert.equal(resolveSetupScopeArg(['--dry-run', '--scope', 'project']), 'project');
   });
 
   it('parses --scope=<value> form', () => {
@@ -237,13 +237,13 @@ describe('resolveSetupScopeArg', () => {
   });
 });
 
-describe('project-local launch scope helpers', () => {
+describe('project launch scope helpers', () => {
   it('reads persisted setup scope when valid', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-scope-'));
     try {
       await mkdir(join(wd, '.omx'), { recursive: true });
-      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project-local' }));
-      assert.equal(readPersistedSetupScope(wd), 'project-local');
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      assert.equal(readPersistedSetupScope(wd), 'project');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -260,11 +260,11 @@ describe('project-local launch scope helpers', () => {
     }
   });
 
-  it('uses project-local CODEX_HOME when persisted scope is project-local', async () => {
+  it('uses project CODEX_HOME when persisted scope is project', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-scope-'));
     try {
       await mkdir(join(wd, '.omx'), { recursive: true });
-      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project-local' }));
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
       assert.equal(resolveCodexHomeForLaunch(wd, {}), join(wd, '.codex'));
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -275,8 +275,30 @@ describe('project-local launch scope helpers', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-scope-'));
     try {
       await mkdir(join(wd, '.omx'), { recursive: true });
-      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project-local' }));
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
       assert.equal(resolveCodexHomeForLaunch(wd, { CODEX_HOME: '/tmp/explicit-codex-home' }), '/tmp/explicit-codex-home');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates legacy "project-local" persisted scope to "project"', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-scope-'));
+    try {
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project-local' }));
+      assert.equal(readPersistedSetupScope(wd), 'project');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves CODEX_HOME for legacy "project-local" persisted scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-scope-'));
+    try {
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project-local' }));
+      assert.equal(resolveCodexHomeForLaunch(wd, {}), join(wd, '.codex'));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Rename `project-local` scope to `project` and remove the old `project` (minimal) scope entirely
- Both scopes (`user`, `project`) now perform full asset installs; the only difference is target directories (user-global vs project-local)
- Add automatic migration: persisted `setup-scope.json` files with legacy `project-local` value are mapped to `project` with a one-time warning
- Update all docs (README, SKILL.md, CHANGELOG, migration guide), help text, setup prompts, and tests

## Changed files

- `src/cli/setup.ts` — core scope definitions, migration logic, removed minimal-mode conditionals
- `src/cli/index.ts` — launch scope helpers with migration support, help text
- `src/cli/__tests__/setup-scope.test.ts` — updated tests + new migration test
- `src/cli/__tests__/index.test.ts` — updated tests + new migration tests
- `skills/omx-setup/SKILL.md`, `README.md`, `CHANGELOG.md`, `docs/migration-mainline-post-v0.4.4.md`

## Test plan

- [x] All 1037 existing tests pass
- [x] New migration test: legacy `project-local` in `setup-scope.json` → migrated to `project`
- [x] New migration test: `readPersistedSetupScope` migrates `project-local` → `project` (sync version)
- [x] New test: `resolveCodexHomeForLaunch` works with legacy `project-local` persisted scope
- [x] Existing scope tests updated to use `project` instead of `project-local`
- [x] Old `project` minimal-scope test removed (scope no longer exists)

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)