### PR TITLE
chore(ci): run PR size label workflow on pull_request_target

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,7 +1,7 @@
 name: PR Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
## Summary
- Switch the PR Check trigger from pull_request to pull_request_target so PR size labeling can run for fork -> upstream PRs.

## Tests

## Notes
- CI workflow change only: .github/workflows/pr-check.yml