### PR TITLE
fix: inject translation reminder for non-Latin input

### DIFF
--- a/scripts/notify-hook/tmux-injection.js
+++ b/scripts/notify-hook/tmux-injection.js
@@ -245,13 +245,13 @@ export async function handleTmuxInjection({
     return;
   }
 
-  const { renderPrompt } = await import('./payload-parser.js');
-  const prompt = renderPrompt(config.prompt_template, {
+  const { renderPrompt, injectLanguageReminder } = await import('./payload-parser.js');
+  const prompt = injectLanguageReminder(renderPrompt(config.prompt_template, {
     mode: mode || 'unknown',
     threadId,
     turnId,
     timestamp: nowIso,
-  });
+  }), sourceText);
   const fallbackPane = safeString(process.env.TMUX_PANE || '');
   const resolution = await resolvePaneTarget(config.target, fallbackPane, cwd, modePane);
   if (!resolution.paneTarget) {

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -284,3 +284,29 @@ describe('notify-hook/state-io – normalizeNotifyState', () => {
     assert.equal(s.last_event_at, '2025-01-01T00:00:00Z');
   });
 });
+
+// ---------------------------------------------------------------------------
+// payload-parser.js – non-Latin detection + language reminder injection
+// ---------------------------------------------------------------------------
+describe('notify-hook/payload-parser – language reminder injection', () => {
+  it('detects non-Latin script in user input', async () => {
+    const { hasNonLatinScript } = await loadModule('notify-hook/payload-parser.js');
+    assert.equal(hasNonLatinScript('Привет, как дела?'), true);
+    assert.equal(hasNonLatinScript('こんにちは、お願いします'), true);
+    assert.equal(hasNonLatinScript('hello world'), false);
+  });
+
+  it('injects language reminder for non-Latin input', async () => {
+    const { injectLanguageReminder, LANGUAGE_REMINDER_MARKER } = await loadModule('notify-hook/payload-parser.js');
+    const prompt = injectLanguageReminder('Continue from current mode state. [OMX_TMUX_INJECT]', '帮我修复这个问题');
+    assert.match(prompt, /\[OMX_LANG_REMINDER\]/);
+    assert.match(prompt, /Continue in the user's language\./);
+    assert.match(prompt, new RegExp(LANGUAGE_REMINDER_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  it('does not inject reminder for Latin-only text', async () => {
+    const { injectLanguageReminder } = await loadModule('notify-hook/payload-parser.js');
+    const prompt = injectLanguageReminder('Continue [OMX_TMUX_INJECT]', 'Please fix issue 253');
+    assert.equal(prompt, 'Continue [OMX_TMUX_INJECT]');
+  });
+});


### PR DESCRIPTION
## Summary
- detect non-Latin script input in notify-hook payload parsing
- inject a language reminder marker into tmux prompt injection when non-Latin input is present
- add notify-hook module tests for detection and reminder injection behavior

## Verification
- targeted assertions for `hasNonLatinScript`/`injectLanguageReminder` via `node --input-type=module -e ...` ✅
- `npm run build` ❌ (pre-existing TypeScript MCP SDK import/type errors in `src/mcp/*`)
- `npm test` ❌ (fails at the same pre-existing `npm run build` stage)

Fixes #253
