### PR TITLE
fix: enforce ralplan-first execution gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,11 @@ Detection rules:
 - If multiple keywords match, use the most specific (longest match)
 - Conflict resolution: explicit `$name` invocation overrides keyword detection
 - The rest of the user's message (after keyword extraction) becomes the task description
+
+Ralph / Ralplan execution gate:
+- Enforce **ralplan-first** when ralph is active and planning is not complete.
+- Planning is complete only after both `.omx/plans/prd-*.md` and `.omx/plans/test-spec-*.md` exist.
+- Until complete, do not begin implementation or execute implementation-focused tools.
 </keyword_detection>
 
 ---
@@ -282,6 +287,9 @@ Parallelization:
 
 Continuation:
   Before concluding, confirm: zero pending tasks, all features working, tests passing, zero errors, verification evidence collected. If any item is unchecked, continue working.
+
+Ralph planning gate:
+  If ralph is active, verify PRD + test spec artifacts exist before any implementation work/tool execution. If missing, stay in planning and create them first (ralplan-first).
 </execution_protocols>
 
 <cancellation>

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -35,6 +35,13 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.ok(swarmMatch);
     assert.equal(swarmMatch.priority, teamMatch.priority);
   });
+
+  it('prefers ralplan over ralph when both keywords are present', () => {
+    const match = detectPrimaryKeyword('use ralph mode but do ralplan first');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'ralplan');
+  });
 });
 
 describe('keyword detection guidance generation', () => {
@@ -44,5 +51,14 @@ describe('keyword detection guidance generation', () => {
     assert.match(section, /When user says "coordinated team": Activate coordinated team mode/);
     assert.match(section, /When user says "swarm": Activate coordinated team mode \(swarm is a compatibility alias for team\)/);
     assert.match(section, /When user says "coordinated swarm": Activate coordinated team mode \(swarm is a compatibility alias for team\)/);
+  });
+
+  it('includes ralplan-first planning gate guidance', () => {
+    const section = generateKeywordDetectionSection();
+
+    assert.match(section, /Ralplan-first execution gate:/);
+    assert.match(section, /`prd-\*\.md`/);
+    assert.match(section, /`test-spec-\*\.md`/);
+    assert.match(section, /if ralph is active/i);
   });
 });

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -14,7 +14,7 @@
  * - Session metadata
  */
 
-import { readFile, writeFile, mkdir, rm } from 'fs/promises';
+import { readFile, writeFile, mkdir, rm, readdir } from 'fs/promises';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 import { omxNotepadPath, omxProjectMemoryPath } from '../utils/paths.js';
@@ -127,6 +127,31 @@ interface OverlayData {
   projectMemory: string;
 }
 
+async function isRalphActive(cwd: string, sessionId?: string): Promise<boolean> {
+  const refs = await listModeStateFilesWithScopePreference(cwd, sessionId);
+  const ralphRef = refs.find((ref) => ref.mode === 'ralph');
+  if (!ralphRef) return false;
+
+  try {
+    const data = JSON.parse(await readFile(ralphRef.path, 'utf-8'));
+    return data?.active === true;
+  } catch {
+    return false;
+  }
+}
+
+async function readRalphPlanningArtifacts(cwd: string): Promise<{ hasPrd: boolean; hasTestSpec: boolean }> {
+  const plansDir = join(cwd, '.omx', 'plans');
+  if (!existsSync(plansDir)) {
+    return { hasPrd: false, hasTestSpec: false };
+  }
+
+  const files = await readdir(plansDir).catch(() => [] as string[]);
+  const hasPrd = files.some((file) => /^prd-.*\.md$/i.test(file));
+  const hasTestSpec = files.some((file) => /^test-?spec-.*\.md$/i.test(file));
+  return { hasPrd, hasTestSpec };
+}
+
 async function readActiveModes(cwd: string, sessionId?: string): Promise<string> {
   const refs = await listModeStateFilesWithScopePreference(cwd, sessionId);
 
@@ -214,11 +239,13 @@ function getCompactionInstructions(): string {
  * Total output is capped at MAX_OVERLAY_SIZE chars.
  */
 export async function generateOverlay(cwd: string, sessionId?: string): Promise<string> {
-  const [activeModes, notepadPriority, projectMemory, codebaseMap] = await Promise.all([
+  const [activeModes, notepadPriority, projectMemory, codebaseMap, ralphActive, planningArtifacts] = await Promise.all([
     readActiveModes(cwd, sessionId),
     readNotepadPriority(cwd),
     readProjectMemorySummary(cwd),
     generateCodebaseMap(cwd),
+    isRalphActive(cwd, sessionId),
+    readRalphPlanningArtifacts(cwd),
   ]);
 
   // Build sections with deterministic overflow behavior.
@@ -261,6 +288,24 @@ export async function generateOverlay(cwd: string, sessionId?: string): Promise<
       key: 'project_context',
       text: `**Project Context:**\n${truncate(projectMemory, 1000)}`,
       optional: true,
+    });
+  }
+
+  if (ralphActive) {
+    const gateStatus = planningArtifacts.hasPrd && planningArtifacts.hasTestSpec
+      ? 'UNLOCKED'
+      : 'BLOCKED';
+    const missing: string[] = [];
+    if (!planningArtifacts.hasPrd) missing.push('`prd-*.md`');
+    if (!planningArtifacts.hasTestSpec) missing.push('`test-spec-*.md`');
+    const details = missing.length > 0
+      ? `Missing: ${missing.join(', ')}`
+      : 'Planning artifacts present: PRD + test spec';
+
+    sections.push({
+      key: 'ralph_planning_gate',
+      text: `**Ralph Ralplan-First Gate:** ${gateStatus}\n- Requirement: complete planning artifacts before implementation/tool execution.\n- ${details}\n- Path: \`.omx/plans/\``,
+      optional: false,
     });
   }
 

--- a/src/hooks/emulator.ts
+++ b/src/hooks/emulator.ts
@@ -96,13 +96,13 @@ export const HOOK_MAPPING: Record<HookEvent, {
  */
 export const KEYWORD_TRIGGERS: Record<string, string> = {
   'autopilot': 'Activate autopilot skill for autonomous execution',
-  'ralph': 'Activate ralph persistence loop with verification',
+  'ralph': 'Activate ralph persistence loop with verification (planning-gated: require PRD + test spec before implementation tools)',
   'ultrawork': 'Activate ultrawork parallel execution mode',
   'ulw': 'Activate ultrawork parallel execution mode',
   'ecomode': 'Activate ecomode for token-efficient execution',
   'eco': 'Activate ecomode for token-efficient execution',
   'plan': 'Activate planning skill',
-  'ralplan': 'Activate consensus planning (planner + architect + critic)',
+  'ralplan': 'Activate consensus planning (planner + architect + critic) and complete PRD + test spec before implementation',
   'team': 'Activate coordinated team mode',
   'coordinated team': 'Activate coordinated team mode',
   'swarm': 'Activate coordinated team mode (swarm is a compatibility alias for team)',
@@ -123,6 +123,11 @@ export function generateKeywordDetectionSection(): string {
 <keyword_detection>
 When you see these keywords in user messages, activate the corresponding skill:
 ${lines}
+
+Ralplan-first execution gate:
+- Before implementation/tool execution, ensure both artifacts exist in \`.omx/plans/\`: \`prd-*.md\` and \`test-spec-*.md\`.
+- If ralph is active and either artifact is missing, stay in planning mode and do not execute implementation tools.
+- Only begin implementation after the planning gate is complete.
 
 To activate a skill, use the corresponding slash command or invoke the skill directly.
 If a keyword is detected, announce the activation to the user before proceeding.

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -20,12 +20,12 @@ export interface KeywordMatch {
 const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> = [
   // Execution modes
   { pattern: /\bautopilot\b/i, skill: 'autopilot', priority: 10 },
-  { pattern: /\bralph\b/i, skill: 'ralph', priority: 10 },
+  { pattern: /\bralph\b/i, skill: 'ralph', priority: 9 },
   { pattern: /\bultrawork\b|\bulw\b/i, skill: 'ultrawork', priority: 10 },
   { pattern: /\becomode\b|\beco\b/i, skill: 'ecomode', priority: 10 },
 
   // Planning
-  { pattern: /\bralplan\b/i, skill: 'ralplan', priority: 9 },
+  { pattern: /\bralplan\b/i, skill: 'ralplan', priority: 11 },
   { pattern: /\bplan\s+(?:this|the)\b/i, skill: 'plan', priority: 8 },
 
   // Coordination

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -164,6 +164,11 @@ Detection rules:
 - If multiple keywords match, use the most specific (longest match)
 - Conflict resolution: explicit `$name` invocation overrides keyword detection
 - The rest of the user's message (after keyword extraction) becomes the task description
+
+Ralph / Ralplan execution gate:
+- Enforce **ralplan-first** when ralph is active and planning is not complete.
+- Planning is complete only after both `.omx/plans/prd-*.md` and `.omx/plans/test-spec-*.md` exist.
+- Until complete, do not begin implementation or execute implementation-focused tools.
 </keyword_detection>
 
 ---
@@ -282,6 +287,9 @@ Parallelization:
 
 Continuation:
   Before concluding, confirm: zero pending tasks, all features working, tests passing, zero errors, verification evidence collected. If any item is unchecked, continue working.
+
+Ralph planning gate:
+  If ralph is active, verify PRD + test spec artifacts exist before any implementation work/tool execution. If missing, stay in planning and create them first (ralplan-first).
 </execution_protocols>
 
 <cancellation>


### PR DESCRIPTION
## Summary\n- enforce ralplan-first keyword precedence so planning is selected before ralph execution\n- add a runtime Ralph planning gate check for required PRD/test-spec artifacts\n- surface planning-gate guidance in emulator + AGENTS templates\n- add regression tests for keyword precedence and overlay gate states\n\n## Verification\n- npm run build\n- npm test\n\nFixes #259