### PR TITLE
fix: resolve team worker model selection from config

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -161,6 +161,19 @@ describe('resolveWorkerSparkModel', () => {
   it('returns undefined for empty args', () => {
     assert.equal(resolveWorkerSparkModel([]), undefined);
   });
+
+  it('reads low-complexity team model from config when codexHomeOverride is provided', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-codex-home-'));
+    try {
+      await writeFile(
+        join(codexHome, '.omx-config.json'),
+        JSON.stringify({ models: { team_low_complexity: 'gpt-4.1-mini' } }),
+      );
+      assert.equal(resolveWorkerSparkModel(['--spark'], codexHome), 'gpt-4.1-mini');
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('resolveTeamWorkerLaunchArgsEnv (spark)', () => {

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { getModelForMode } from '../models.js';
+import { getModelForMode, getTeamLowComplexityModel } from '../models.js';
 
 describe('getModelForMode', () => {
   let tempDir: string;
@@ -77,5 +77,15 @@ describe('getModelForMode', () => {
   it('returns hardcoded default for malformed JSON', async () => {
     await writeFile(join(tempDir, '.omx-config.json'), 'not-json');
     assert.equal(getModelForMode('team'), 'gpt-5.3-codex');
+  });
+
+  it('returns low-complexity team model when configured', async () => {
+    await writeConfig({ models: { team_low_complexity: 'gpt-4.1-mini' } });
+    assert.equal(getTeamLowComplexityModel(), 'gpt-4.1-mini');
+  });
+
+  it('returns hardcoded low-complexity fallback when not configured', async () => {
+    await writeConfig({ models: { team: 'gpt-4.1' } });
+    assert.equal(getTeamLowComplexityModel(), 'gpt-5.3-codex-spark');
   });
 });

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,3 +1,5 @@
+import { getTeamLowComplexityModel, HARDCODED_TEAM_LOW_COMPLEXITY_MODEL } from '../config/models.js';
+
 const MADMAX_FLAG = '--madmax';
 const CODEX_BYPASS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
 const MODEL_FLAG = '--model';
@@ -11,7 +13,7 @@ const LOW_COMPLEXITY_AGENT_TYPES = new Set([
   'writer',
 ]);
 
-export const TEAM_LOW_COMPLEXITY_DEFAULT_MODEL = 'gpt-5.3-codex-spark';
+export const TEAM_LOW_COMPLEXITY_DEFAULT_MODEL = HARDCODED_TEAM_LOW_COMPLEXITY_MODEL;
 
 export interface ParsedTeamWorkerLaunchArgs {
   passthrough: string[];
@@ -141,4 +143,8 @@ export function isLowComplexityAgentType(agentType?: string): boolean {
   if (normalized === '') return false;
   if (normalized.endsWith('-low')) return true;
   return LOW_COMPLEXITY_AGENT_TYPES.has(normalized);
+}
+
+export function resolveTeamLowComplexityDefaultModel(codexHomeOverride?: string): string {
+  return getTeamLowComplexityModel(codexHomeOverride);
 }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -74,6 +74,7 @@ import {
   isLowComplexityAgentType,
   resolveTeamWorkerLaunchArgs,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+  resolveTeamLowComplexityDefaultModel,
   parseTeamWorkerLaunchArgs,
   splitWorkerLaunchArgs,
 } from './model-contract.js';
@@ -189,7 +190,7 @@ export function resolveWorkerLaunchArgsFromEnv(
     ? ['--model', inheritedLeaderModel.trim()]
     : [];
   const fallbackModel = isLowComplexityAgentType(agentType)
-    ? TEAM_LOW_COMPLEXITY_DEFAULT_MODEL
+    ? resolveTeamLowComplexityDefaultModel(env.CODEX_HOME)
     : undefined;
 
   // Detect if an explicit reasoning override exists before resolving (for log source labelling)


### PR DESCRIPTION
## Summary
- remove hardcoded model IDs from team/sub-agent worker selection paths
- resolve low-complexity worker defaults through config-aware helpers
- wire spark worker model resolution to config (including CODEX_HOME override)
- add tests for config-driven low-complexity model resolution in CLI/runtime/config

## Verification
- npm test
- npm run build

Fixes #255