### PR TITLE
fix: MSYS2/Git Bash tmux worker compatibility

### DIFF
--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -54,6 +54,8 @@ interface TmuxPaneInfo {
   startCommand: string;
 }
 
+type SpawnSyncLike = typeof spawnSync;
+
 function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
   const result = spawnSync('tmux', args, { encoding: 'utf-8' });
   if (result.error) {
@@ -63,6 +65,42 @@ function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; st
     return { ok: false, stderr: (result.stderr || '').trim() || `tmux exited ${result.status}` };
   }
   return { ok: true, stdout: (result.stdout || '').trim() };
+}
+
+export function isMsysOrGitBash(env: NodeJS.ProcessEnv = process.env, platform: NodeJS.Platform = process.platform): boolean {
+  if (platform !== 'win32') return false;
+  const msystem = String(env.MSYSTEM ?? '').trim();
+  if (msystem !== '') return true;
+  const ostype = String(env.OSTYPE ?? '').trim();
+  if (/(msys|mingw|cygwin)/i.test(ostype)) return true;
+  return false;
+}
+
+function fallbackMsysPathTranslation(value: string): string {
+  const drivePathMatch = value.match(/^([A-Za-z]):[\\/](.*)$/);
+  if (!drivePathMatch) return value;
+  const drive = drivePathMatch[1]?.toLowerCase();
+  const tail = drivePathMatch[2]?.replace(/\\/g, '/');
+  if (!drive || !tail) return value;
+  return `/${drive}/${tail}`;
+}
+
+export function translatePathForMsys(
+  value: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+  spawnImpl: SpawnSyncLike = spawnSync,
+): string {
+  if (typeof value !== 'string' || value.trim() === '') return value;
+  if (!isMsysOrGitBash(env, platform)) return value;
+
+  const result = spawnImpl('cygpath', ['-u', value], { encoding: 'utf-8' });
+  if (!result.error && result.status === 0) {
+    const translated = (result.stdout || '').trim();
+    if (translated !== '') return translated;
+  }
+
+  return fallbackMsysPathTranslation(value);
 }
 
 function baseSessionName(target: string): string {
@@ -430,7 +468,7 @@ function shouldBypassDefaultSystemPrompt(env: NodeJS.ProcessEnv): boolean {
 }
 
 function buildModelInstructionsOverride(cwd: string, env: NodeJS.ProcessEnv): string {
-  const filePath = env[OMX_MODEL_INSTRUCTIONS_FILE_ENV] || join(cwd, 'AGENTS.md');
+  const filePath = translatePathForMsys(env[OMX_MODEL_INSTRUCTIONS_FILE_ENV] || join(cwd, 'AGENTS.md'));
   return `${MODEL_INSTRUCTIONS_FILE_KEY}="${escapeTomlString(filePath)}"`;
 }
 
@@ -510,7 +548,7 @@ export function isWsl2(): boolean {
  * OMX requires tmux, which is unavailable on native Windows.
  */
 export function isNativeWindows(): boolean {
-  return process.platform === 'win32' && !isWsl2();
+  return process.platform === 'win32' && !isWsl2() && !isMsysOrGitBash();
 }
 
 // Check if tmux is available
@@ -573,6 +611,7 @@ export function createTeamSession(
     for (let i = 1; i <= workerCount; i++) {
       const startup = workerStartups[i - 1] || {};
       const workerCwd = startup.cwd || cwd;
+      const tmuxWorkerCwd = translatePathForMsys(workerCwd);
       const workerEnv = startup.env || {};
       const cmd = buildWorkerStartupCommand(
         safeTeamName,
@@ -595,7 +634,7 @@ export function createTeamSession(
         '-F',
         '#{pane_id}',
         '-c',
-        workerCwd,
+        tmuxWorkerCwd,
         cmd,
       ]);
       if (!split.ok) {
@@ -632,9 +671,10 @@ export function createTeamSession(
     let resizeHookTarget: string | null = null;
     const omxEntry = process.argv[1];
     if (omxEntry && omxEntry.trim() !== '') {
-      const hudCmd = `node ${shellQuoteSingle(omxEntry)} hud --watch`;
+      const hudCmd = `node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+      const hudCwd = translatePathForMsys(cwd);
       const hudResult = runTmux([
-        'split-window', '-v', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', leaderPaneId, '-d', '-P', '-F', '#{pane_id}', '-c', cwd, hudCmd,
+        'split-window', '-v', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', leaderPaneId, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
       ]);
       if (hudResult.ok) {
         const id = hudResult.stdout.split('\n')[0]?.trim() ?? '';


### PR DESCRIPTION
## Summary
Fix tmux worker startup on Windows MSYS2/Git Bash by detecting MSYS shells and translating Windows paths before passing them into tmux worker/HUD spawn paths.

## Changes
- Added MSYS2/Git Bash detection helper (`isMsysOrGitBash`) in `src/team/tmux-session.ts`.
- Added `translatePathForMsys` with `cygpath -u` conversion + safe fallback when `cygpath` is unavailable.
- Updated native Windows guard logic so win32 + MSYS2/Git Bash is treated as supported (still excluding true native Windows without WSL/MSYS).
- Applied path translation to tmux worker pane cwd (`split-window -c`), HUD split cwd, HUD entry path, and model instructions path.
- Added tests for MSYS detection, path translation + fallback, worker startup path translation, and updated native Windows behavior.

## Validation
- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (not needed for this change)

## Checklist
- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed (not needed)
- [x] Backward-compatibility impact considered

## Related
Fixes #257
