### PR TITLE
fix: #320 enforce terminal-task completion gate before team shutdown

### DIFF
--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -144,6 +144,16 @@ export interface TeamStartOptions {
   worktreeMode?: WorktreeMode;
 }
 
+interface ShutdownGateCounts {
+  total: number;
+  pending: number;
+  blocked: number;
+  in_progress: number;
+  completed: number;
+  failed: number;
+  allowed: boolean;
+}
+
 const MODEL_INSTRUCTIONS_FILE_ENV = 'OMX_MODEL_INSTRUCTIONS_FILE';
 const TEAM_STATE_ROOT_ENV = 'OMX_TEAM_STATE_ROOT';
 const TEAM_LEADER_CWD_ENV = 'OMX_TEAM_LEADER_CWD';
@@ -958,6 +968,36 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     await cleanupTeamState(sanitized, cwd);
     restoreTeamModelInstructionsFile(sanitized);
     return;
+  }
+
+  if (!force) {
+    const allTasks = await listTasks(sanitized, cwd);
+    const gate: ShutdownGateCounts = {
+      total: allTasks.length,
+      pending: allTasks.filter((t) => t.status === 'pending').length,
+      blocked: allTasks.filter((t) => t.status === 'blocked').length,
+      in_progress: allTasks.filter((t) => t.status === 'in_progress').length,
+      completed: allTasks.filter((t) => t.status === 'completed').length,
+      failed: allTasks.filter((t) => t.status === 'failed').length,
+      allowed: false,
+    };
+    gate.allowed = gate.pending === 0 && gate.blocked === 0 && gate.in_progress === 0 && gate.failed === 0;
+
+    await appendTeamEvent(
+      sanitized,
+      {
+        type: 'shutdown_gate',
+        worker: 'leader-fixed',
+        reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed}`,
+      },
+      cwd,
+    ).catch(() => {});
+
+    if (!gate.allowed) {
+      throw new Error(
+        `shutdown_gate_blocked:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
+      );
+    }
   }
 
   const sessionName = config.tmux_session;

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -147,6 +147,7 @@ export interface TeamEvent {
     | 'worker_stopped'
     | 'message_received'
     | 'shutdown_ack'
+    | 'shutdown_gate'
     | 'approval_decision'
     | 'team_leader_nudge';
   worker: string;


### PR DESCRIPTION
## Summary
- enforce a terminal-task completion gate before `omx team shutdown` proceeds (blocks on pending/blocked/in_progress/failed unless `--force`)
- emit a `shutdown_gate` team event with task counters for auditability
- add runtime tests for blocked shutdown and force bypass behavior

## Verification
- `npm run build`
- `env -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_LEADER_CWD node --test --test-name-pattern "shutdownTeam blocks when pending tasks remain|shutdownTeam blocks when failed tasks remain|shutdownTeam force=true bypasses shutdown gate" dist/team/__tests__/runtime.test.js`
