### PR TITLE
fix: #319 centralize team/state contracts to reduce coupling

### DIFF
--- a/src/mcp/__tests__/state-server-schema.test.ts
+++ b/src/mcp/__tests__/state-server-schema.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { TEAM_EVENT_TYPES } from '../../team/contracts.js';
 
 const ALL_EVENT_TYPES = [
   'task_completed',
@@ -15,19 +16,13 @@ const ALL_EVENT_TYPES = [
 ] as const;
 
 describe('team_append_event schema validation', () => {
-  it('schema enum is sourced from TEAM_EVENT_TYPES and contains expected values', async () => {
+  it('schema enum is sourced from shared TEAM_EVENT_TYPES contract and contains expected values', async () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/state-server.ts'), 'utf8');
-
-    const constMatch = src.match(/const TEAM_EVENT_TYPES = \[([\s\S]*?)\] as const;/);
-    assert.ok(constMatch, 'Expected to find TEAM_EVENT_TYPES constant in state-server.ts');
 
     const enumRefMatch = src.match(/name:\s*'team_append_event'[\s\S]*?enum:\s*\[\.\.\.TEAM_EVENT_TYPES\]/);
     assert.ok(enumRefMatch, 'Expected team_append_event schema to reference TEAM_EVENT_TYPES');
 
-    const enumValues = constMatch[1]
-      .split(',')
-      .map((s: string) => s.trim().replace(/^'|'$/g, ''))
-      .filter(Boolean);
+    const enumValues = [...TEAM_EVENT_TYPES];
 
     assert.equal(
       enumValues.length,

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -28,6 +28,17 @@ import { ensureTmuxHookInitialized } from '../cli/tmux-hook.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import {
+  TEAM_NAME_SAFE_PATTERN,
+  WORKER_NAME_SAFE_PATTERN,
+  TASK_ID_SAFE_PATTERN,
+  TEAM_TASK_STATUSES,
+  TEAM_EVENT_TYPES,
+  TEAM_TASK_APPROVAL_STATUSES,
+  type TeamTaskStatus,
+  type TeamEventType,
+  type TeamTaskApprovalStatus,
+} from '../team/contracts.js';
+import {
   teamSendMessage as sendDirectMessage,
   teamBroadcast as broadcastMessage,
   teamListMailbox as listMailboxMessages,
@@ -104,27 +115,8 @@ const TEAM_COMM_TOOL_NAMES = new Set([
   'team_write_task_approval',
 ]);
 
-const TEAM_NAME_SAFE_PATTERN = /^[a-z0-9][a-z0-9-]{0,29}$/;
-const WORKER_NAME_SAFE_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
-const TASK_ID_SAFE_PATTERN = /^\d{1,20}$/;
-const TEAM_TASK_STATUSES = ['pending', 'blocked', 'in_progress', 'completed', 'failed'] as const;
-const TEAM_EVENT_TYPES = [
-  'task_completed',
-  'task_failed',
-  'worker_idle',
-  'worker_stopped',
-  'message_received',
-  'shutdown_ack',
-  'approval_decision',
-  'team_leader_nudge',
-] as const;
-const TEAM_TASK_APPROVAL_STATUSES = ['pending', 'approved', 'rejected'] as const;
 const TEAM_UPDATE_TASK_MUTABLE_FIELDS = new Set(['subject', 'description', 'blocked_by', 'requires_code_change']);
 const TEAM_UPDATE_TASK_REQUEST_FIELDS = new Set(['team_name', 'task_id', 'workingDirectory', ...TEAM_UPDATE_TASK_MUTABLE_FIELDS]);
-
-type TeamTaskStatus = typeof TEAM_TASK_STATUSES[number];
-type TeamEventType = typeof TEAM_EVENT_TYPES[number];
-type TeamTaskApprovalStatus = typeof TEAM_TASK_APPROVAL_STATUSES[number];
 
 function isFiniteInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && Number.isFinite(value);

--- a/src/team/contracts.ts
+++ b/src/team/contracts.ts
@@ -1,0 +1,38 @@
+export const TEAM_NAME_SAFE_PATTERN = /^[a-z0-9][a-z0-9-]{0,29}$/;
+export const WORKER_NAME_SAFE_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+export const TASK_ID_SAFE_PATTERN = /^\d{1,20}$/;
+
+export const TEAM_TASK_STATUSES = ['pending', 'blocked', 'in_progress', 'completed', 'failed'] as const;
+export type TeamTaskStatus = (typeof TEAM_TASK_STATUSES)[number];
+
+export const TEAM_TERMINAL_TASK_STATUSES: ReadonlySet<TeamTaskStatus> = new Set(['completed', 'failed']);
+export const TEAM_TASK_STATUS_TRANSITIONS: Readonly<Record<TeamTaskStatus, readonly TeamTaskStatus[]>> = {
+  pending: [],
+  blocked: [],
+  in_progress: ['completed', 'failed'],
+  completed: [],
+  failed: [],
+};
+
+export function isTerminalTeamTaskStatus(status: TeamTaskStatus): boolean {
+  return TEAM_TERMINAL_TASK_STATUSES.has(status);
+}
+
+export function canTransitionTeamTaskStatus(from: TeamTaskStatus, to: TeamTaskStatus): boolean {
+  return TEAM_TASK_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export const TEAM_EVENT_TYPES = [
+  'task_completed',
+  'task_failed',
+  'worker_idle',
+  'worker_stopped',
+  'message_received',
+  'shutdown_ack',
+  'approval_decision',
+  'team_leader_nudge',
+] as const;
+export type TeamEventType = (typeof TEAM_EVENT_TYPES)[number];
+
+export const TEAM_TASK_APPROVAL_STATUSES = ['pending', 'approved', 'rejected'] as const;
+export type TeamTaskApprovalStatus = (typeof TEAM_TASK_APPROVAL_STATUSES)[number];

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -5,6 +5,14 @@ import { randomUUID } from 'crypto';
 import { performance } from 'perf_hooks';
 import { omxStateDir } from '../utils/paths.js';
 import { type TeamPhase, type TerminalPhase } from './orchestrator.js';
+import {
+  TEAM_NAME_SAFE_PATTERN,
+  WORKER_NAME_SAFE_PATTERN,
+  TASK_ID_SAFE_PATTERN,
+  TEAM_TASK_STATUSES,
+  canTransitionTeamTaskStatus,
+  isTerminalTeamTaskStatus,
+} from './contracts.js';
 
 export interface TeamConfig {
   name: string;
@@ -230,25 +238,14 @@ export const ABSOLUTE_MAX_WORKERS = 20;
 const DEFAULT_CLAIM_LEASE_MS = 15 * 60 * 1000;
 const LOCK_STALE_MS = 5 * 60 * 1000;
 
-const WORKER_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
-const TASK_ID_PATTERN = /^\d{1,20}$/;
 type TeamTaskStatus = TeamTask['status'];
 
-const TERMINAL_TASK_STATUSES: ReadonlySet<TeamTaskStatus> = new Set(['completed', 'failed']);
-const TASK_STATUS_TRANSITIONS: Readonly<Record<TeamTaskStatus, readonly TeamTaskStatus[]>> = {
-  pending: [],
-  blocked: [],
-  in_progress: ['completed', 'failed'],
-  completed: [],
-  failed: [],
-};
-
 function isTerminalTaskStatus(status: TeamTaskStatus): boolean {
-  return TERMINAL_TASK_STATUSES.has(status);
+  return isTerminalTeamTaskStatus(status);
 }
 
 function canTransitionTaskStatus(from: TeamTaskStatus, to: TeamTaskStatus): boolean {
-  return TASK_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
+  return canTransitionTeamTaskStatus(from, to);
 }
 
 function assertPathWithinDir(filePath: string, rootDir: string): void {
@@ -260,7 +257,7 @@ function assertPathWithinDir(filePath: string, rootDir: string): void {
 }
 
 function validateWorkerName(name: string): void {
-  if (!WORKER_NAME_PATTERN.test(name)) {
+  if (!WORKER_NAME_SAFE_PATTERN.test(name)) {
     throw new Error(
       `Invalid worker name: "${name}". Must match /^[a-z0-9][a-z0-9-]{0,63}$/ (lowercase alphanumeric + hyphens, max 64 chars).`
     );
@@ -268,7 +265,7 @@ function validateWorkerName(name: string): void {
 }
 
 function validateTaskId(taskId: string): void {
-  if (!TASK_ID_PATTERN.test(taskId)) {
+  if (!TASK_ID_SAFE_PATTERN.test(taskId)) {
     throw new Error(
       `Invalid task ID: "${taskId}". Must be a positive integer (digits only, max 20 digits).`
     );
@@ -450,8 +447,7 @@ function summarySnapshotPath(teamName: string, cwd: string): string {
 
 // Validate team name: alphanumeric + hyphens only, max 30 chars
 function validateTeamName(name: string): void {
-  const re = /^[a-z0-9][a-z0-9-]{0,29}$/;
-  if (!re.test(name)) {
+  if (!TEAM_NAME_SAFE_PATTERN.test(name)) {
     throw new Error(
       `Invalid team name: "${name}". Team name must match /^[a-z0-9][a-z0-9-]{0,29}$/ (lowercase alphanumeric + hyphens, max 30 chars).`
     );
@@ -481,11 +477,10 @@ function isWorkerStatus(value: unknown): value is WorkerStatus {
 function isTeamTask(value: unknown): value is TeamTask {
   if (!value || typeof value !== 'object') return false;
   const v = value as Record<string, unknown>;
-  const allowed = ['pending', 'blocked', 'in_progress', 'completed', 'failed'];
   if (typeof v.id !== 'string') return false;
   if (typeof v.subject !== 'string') return false;
   if (typeof v.description !== 'string') return false;
-  if (typeof v.status !== 'string' || !allowed.includes(v.status)) return false;
+  if (typeof v.status !== 'string' || !TEAM_TASK_STATUSES.includes(v.status as TeamTaskStatus)) return false;
   if (typeof v.created_at !== 'string') return false;
   return true;
 }


### PR DESCRIPTION
## Summary
- add `src/team/contracts.ts` to centralize shared team/state contracts (name/worker/task patterns, task statuses/transitions, event types, approval statuses)
- refactor `src/team/state.ts` to consume shared contracts for validation and transition checks
- refactor `src/mcp/state-server.ts` to consume shared contracts instead of duplicating enums/patterns
- update schema test to validate against the shared contract source

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/state-server-schema.test.js`
- `env -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_WORKER -u OMX_TEAM_LEADER_CWD -u OMX_TEAM_WORKTREE_PATH -u OMX_TEAM_WORKTREE_BRANCH -u OMX_TEAM_WORKTREE_DETACHED node --test dist/team/__tests__/state.test.js`
- `env -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_WORKER -u OMX_TEAM_LEADER_CWD -u OMX_TEAM_WORKTREE_PATH -u OMX_TEAM_WORKTREE_BRANCH -u OMX_TEAM_WORKTREE_DETACHED node --test dist/mcp/__tests__/state-server-team-tools.test.js`

Closes #319
