### PR TITLE
fix: #321 add direct tests for uncovered core modules

### DIFF
--- a/src/agents/__tests__/definitions.test.ts
+++ b/src/agents/__tests__/definitions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AGENT_DEFINITIONS,
+  getAgent,
+  getAgentNames,
+  getAgentsByCategory,
+  type AgentDefinition,
+} from '../definitions.js';
+
+describe('agents/definitions', () => {
+  it('returns known agents and undefined for unknown names', () => {
+    assert.equal(getAgent('executor'), AGENT_DEFINITIONS.executor);
+    assert.equal(getAgent('does-not-exist'), undefined);
+  });
+
+  it('keeps key/name contract aligned', () => {
+    const names = getAgentNames();
+    assert.ok(names.length > 20, 'expected non-trivial agent catalog');
+
+    for (const name of names) {
+      const agent = AGENT_DEFINITIONS[name];
+      assert.equal(agent.name, name);
+      assert.ok(agent.description.length > 0);
+    }
+  });
+
+  it('filters agents by category', () => {
+    const buildAgents = getAgentsByCategory('build');
+    assert.ok(buildAgents.length > 0);
+    assert.ok(buildAgents.some((agent) => agent.name === 'executor'));
+
+    const allowed: AgentDefinition['category'][] = [
+      'build',
+      'review',
+      'domain',
+      'product',
+      'coordination',
+    ];
+
+    for (const category of allowed) {
+      const agents = getAgentsByCategory(category);
+      assert.ok(agents.every((agent) => agent.category === category));
+    }
+  });
+});

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AgentDefinition } from '../definitions.js';
+import { generateAgentToml, installNativeAgentConfigs } from '../native-config.js';
+
+describe('agents/native-config', () => {
+  it('generates TOML with stripped frontmatter and escaped triple quotes', () => {
+    const agent: AgentDefinition = {
+      name: 'executor',
+      description: 'Code implementation',
+      model: 'sonnet',
+      tools: 'execution',
+      category: 'build',
+    };
+
+    const prompt = `---\ntitle: demo\n---\n\nInstruction line\n\"\"\"danger\"\"\"`;
+    const toml = generateAgentToml(agent, prompt);
+
+    assert.match(toml, /# oh-my-codex agent: executor/);
+    assert.match(toml, /model_reasoning_effort = "medium"/);
+    assert.ok(!toml.includes('title: demo'));
+    assert.ok(toml.includes('Instruction line'));
+
+    const tripleQuoteBlocks = toml.match(/"""/g) || [];
+    assert.equal(tripleQuoteBlocks.length, 2, 'only TOML delimiters should remain as raw triple quotes');
+  });
+
+  it('installs only agents with prompt files and skips existing files without force', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-native-config-'));
+    const promptsDir = join(root, 'prompts');
+    const outDir = join(root, 'agents-out');
+
+    try {
+      await mkdir(promptsDir, { recursive: true });
+      await writeFile(join(promptsDir, 'executor.md'), 'executor prompt');
+      await writeFile(join(promptsDir, 'planner.md'), 'planner prompt');
+
+      const created = await installNativeAgentConfigs(root, { agentsDir: outDir });
+      assert.equal(created, 2);
+      assert.equal(existsSync(join(outDir, 'executor.toml')), true);
+      assert.equal(existsSync(join(outDir, 'planner.toml')), true);
+
+      const executorToml = await readFile(join(outDir, 'executor.toml'), 'utf8');
+      assert.match(executorToml, /model_reasoning_effort = "medium"/);
+
+      const skipped = await installNativeAgentConfigs(root, { agentsDir: outDir });
+      assert.equal(skipped, 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/catalog-contract.test.ts
+++ b/src/cli/__tests__/catalog-contract.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getCatalogExpectations, getCatalogHeadlineCounts } from '../catalog-contract.js';
+
+describe('cli/catalog-contract', () => {
+  it('derives expectations from current manifest counts', () => {
+    const headline = getCatalogHeadlineCounts();
+    assert.ok(headline, 'expected catalog headline counts when manifest exists');
+
+    const expectations = getCatalogExpectations();
+    assert.equal(expectations.promptMin, Math.max(1, headline!.prompts - 2));
+    assert.equal(expectations.skillMin, Math.max(1, headline!.skills - 2));
+  });
+
+  it('never returns non-positive minimum expectations', () => {
+    const expectations = getCatalogExpectations();
+    assert.ok(expectations.promptMin >= 1);
+    assert.ok(expectations.skillMin >= 1);
+  });
+});

--- a/src/mcp/__tests__/code-intel-server.test.ts
+++ b/src/mcp/__tests__/code-intel-server.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const REQUIRED_TOOLS = [
+  'lsp_diagnostics',
+  'lsp_diagnostics_directory',
+  'lsp_document_symbols',
+  'lsp_workspace_symbols',
+  'lsp_hover',
+  'lsp_find_references',
+  'lsp_servers',
+  'ast_grep_search',
+  'ast_grep_replace',
+] as const;
+
+describe('mcp/code-intel-server module contract', () => {
+  it('declares expected MCP tools and diagnostics command shape', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/code-intel-server.ts'), 'utf8');
+
+    const toolNames = Array.from(src.matchAll(/name:\s*'([^']+)'/g)).map((m) => m[1]);
+    for (const tool of REQUIRED_TOOLS) {
+      assert.ok(toolNames.includes(tool), `missing tool declaration: ${tool}`);
+    }
+
+    assert.match(src, /const args = \['--noEmit', '--pretty', 'false'\]/);
+    assert.match(src, /new Server\(\s*\{ name: 'omx-code-intel', version: '0\.1\.0' \}/);
+  });
+
+  it('keeps stdio auto-connect bootstrap', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/code-intel-server.ts'), 'utf8');
+    assert.match(src, /const transport = new StdioServerTransport\(\);/);
+    assert.match(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
+  });
+});

--- a/src/mcp/__tests__/memory-server.test.ts
+++ b/src/mcp/__tests__/memory-server.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const REQUIRED_TOOLS = [
+  'project_memory_read',
+  'project_memory_write',
+  'project_memory_add_note',
+  'project_memory_add_directive',
+  'notepad_read',
+  'notepad_write_priority',
+  'notepad_write_working',
+  'notepad_write_manual',
+  'notepad_prune',
+  'notepad_stats',
+] as const;
+
+describe('mcp/memory-server module contract', () => {
+  it('declares expected memory and notepad MCP tools', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/memory-server.ts'), 'utf8');
+    const toolNames = Array.from(src.matchAll(/name:\s*'([^']+)'/g)).map((m) => m[1]);
+
+    for (const tool of REQUIRED_TOOLS) {
+      assert.ok(toolNames.includes(tool), `missing tool declaration: ${tool}`);
+    }
+  });
+
+  it('retains section helpers and stdio bootstrap', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/memory-server.ts'), 'utf8');
+    assert.match(src, /function extractSection\(content: string, section: string\): string/);
+    assert.match(src, /function replaceSection\(content: string, section: string, newContent: string\): string/);
+    assert.match(src, /function appendToSection\(content: string, section: string, entry: string\): string/);
+    assert.match(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
+  });
+});


### PR DESCRIPTION
## Summary
- add direct tests for `src/agents/definitions.ts`
- add direct tests for `src/agents/native-config.ts`
- add direct tests for `src/cli/catalog-contract.ts`
- add module-contract tests for `src/mcp/code-intel-server.ts` and `src/mcp/memory-server.ts`

## Verification
- npm run build
- node --test dist/agents/__tests__/definitions.test.js dist/agents/__tests__/native-config.test.js dist/cli/__tests__/catalog-contract.test.js dist/mcp/__tests__/code-intel-server.test.js dist/mcp/__tests__/memory-server.test.js

Closes #321
