### PR TITLE
test: #316 add dedicated hooks coverage for session lifecycle + emulator mapping

### DIFF
--- a/src/hooks/__tests__/emulator.test.ts
+++ b/src/hooks/__tests__/emulator.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  HOOK_MAPPING,
+  KEYWORD_TRIGGERS,
+  type HookEvent,
+  generateKeywordDetectionSection,
+} from '../emulator.js';
+
+const ALL_HOOK_EVENTS: HookEvent[] = [
+  'SessionStart',
+  'PreToolUse',
+  'PostToolUse',
+  'UserPromptSubmit',
+  'SubagentStart',
+  'SubagentStop',
+  'PreCompact',
+  'Stop',
+  'SessionEnd',
+];
+
+describe('hook emulator mapping contracts', () => {
+  it('defines mapping metadata for every hook event', () => {
+    const mappingKeys = Object.keys(HOOK_MAPPING).sort();
+    const expectedKeys = [...ALL_HOOK_EVENTS].sort();
+    assert.deepEqual(mappingKeys, expectedKeys);
+
+    for (const event of ALL_HOOK_EVENTS) {
+      const mapped = HOOK_MAPPING[event];
+      assert.ok(mapped, `missing mapping for ${event}`);
+      assert.equal(typeof mapped.mechanism, 'string');
+      assert.equal(mapped.mechanism.length > 0, true);
+      assert.equal(typeof mapped.notes, 'string');
+      assert.equal(mapped.notes.length > 0, true);
+      assert.ok(['full', 'partial', 'none'].includes(mapped.capability));
+    }
+  });
+
+  it('preserves expected session lifecycle capability semantics', () => {
+    assert.equal(HOOK_MAPPING.SessionStart.capability, 'full');
+    assert.equal(HOOK_MAPPING.Stop.capability, 'full');
+    assert.equal(HOOK_MAPPING.SessionEnd.capability, 'partial');
+    assert.match(HOOK_MAPPING.SessionStart.mechanism, /AGENTS\.md/i);
+    assert.match(HOOK_MAPPING.SessionEnd.mechanism, /postLaunch/i);
+  });
+});
+
+describe('hook emulator keyword guidance generation', () => {
+  it('renders every keyword trigger into the generated section', () => {
+    const section = generateKeywordDetectionSection();
+    for (const [keyword, action] of Object.entries(KEYWORD_TRIGGERS)) {
+      assert.match(section, new RegExp(`When user says "${keyword}"`));
+      assert.match(section, new RegExp(action.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+  });
+});

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1,6 +1,29 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { isSessionStale, type SessionState } from '../session.js';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  resetSessionMetrics,
+  writeSessionStart,
+  writeSessionEnd,
+  readSessionState,
+  isSessionStale,
+  type SessionState,
+} from '../session.js';
+
+interface SessionHistoryEntry {
+  session_id: string;
+  started_at: string;
+  ended_at: string;
+  cwd: string;
+  pid: number;
+}
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 function makeState(overrides: Partial<SessionState> = {}): SessionState {
   return {
@@ -11,6 +34,103 @@ function makeState(overrides: Partial<SessionState> = {}): SessionState {
     ...overrides,
   };
 }
+
+describe('session lifecycle manager', () => {
+  it('resets session metrics files with zeroed counters', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-metrics-'));
+    try {
+      await resetSessionMetrics(cwd);
+
+      const metricsPath = join(cwd, '.omx', 'metrics.json');
+      const hudPath = join(cwd, '.omx', 'state', 'hud-state.json');
+      assert.equal(existsSync(metricsPath), true);
+      assert.equal(existsSync(hudPath), true);
+
+      const metrics = JSON.parse(await readFile(metricsPath, 'utf-8')) as {
+        total_turns: number;
+        session_turns: number;
+      };
+      const hud = JSON.parse(await readFile(hudPath, 'utf-8')) as {
+        turn_count: number;
+      };
+
+      assert.equal(metrics.total_turns, 0);
+      assert.equal(metrics.session_turns, 0);
+      assert.equal(hud.turn_count, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('writes session start/end lifecycle artifacts and archives session history', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lifecycle-'));
+    const sessionId = 'sess-lifecycle-1';
+    try {
+      await writeSessionStart(cwd, sessionId);
+
+      const state = await readSessionState(cwd);
+      assert.ok(state);
+      assert.equal(state.session_id, sessionId);
+      assert.equal(state.cwd, cwd);
+      assert.equal(state.pid, process.pid);
+      assert.equal(isSessionStale(state), false);
+
+      const sessionPath = join(cwd, '.omx', 'state', 'session.json');
+      assert.equal(existsSync(sessionPath), true);
+
+      await writeSessionEnd(cwd, sessionId);
+
+      assert.equal(existsSync(sessionPath), false);
+
+      const historyPath = join(cwd, '.omx', 'logs', 'session-history.jsonl');
+      assert.equal(existsSync(historyPath), true);
+
+      const historyLines = (await readFile(historyPath, 'utf-8'))
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+      assert.equal(historyLines.length, 1);
+
+      const historyEntry = JSON.parse(historyLines[0]) as SessionHistoryEntry;
+      assert.equal(historyEntry.session_id, sessionId);
+      assert.equal(historyEntry.cwd, cwd);
+      assert.equal(typeof historyEntry.started_at, 'string');
+      assert.equal(typeof historyEntry.ended_at, 'string');
+
+      const dailyLogPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
+      assert.equal(existsSync(dailyLogPath), true);
+      const dailyLog = await readFile(dailyLogPath, 'utf-8');
+      assert.match(dailyLog, /"event":"session_start"/);
+      assert.match(dailyLog, /"event":"session_end"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats invalid session JSON as absent state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-invalid-'));
+    try {
+      const statePath = join(cwd, '.omx', 'state', 'session.json');
+      await resetSessionMetrics(cwd);
+      await writeFile(statePath, '{ not-json', 'utf-8');
+      const state = await readSessionState(cwd);
+      assert.equal(state, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('marks dead PIDs as stale', () => {
+    const impossiblePid = Number.MAX_SAFE_INTEGER;
+    const stale = isSessionStale({
+      session_id: 'sess-stale',
+      started_at: '2026-01-01T00:00:00.000Z',
+      cwd: '/tmp',
+      pid: impossiblePid,
+    });
+    assert.equal(stale, true);
+  });
+});
 
 describe('isSessionStale', () => {
   it('returns false for a live Linux process when identity matches', () => {


### PR DESCRIPTION
## Summary
- add dedicated hook session-lifecycle tests in `src/hooks/__tests__/session.test.ts`
- add dedicated hook emulator mapping coverage in `src/hooks/__tests__/emulator.test.ts`
- verify mapping contract completeness for all `HookEvent` values and session lifecycle semantics (`SessionStart`, `Stop`, `SessionEnd`)

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/session.test.js dist/hooks/__tests__/emulator.test.js`

Closes #316
