### PR TITLE
fix: #317 standardize MCP server bootstrap guards

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldAutoStartMcpServer } from '../bootstrap.js';
+
+describe('mcp bootstrap auto-start guard', () => {
+  it('allows auto-start by default', () => {
+    assert.equal(shouldAutoStartMcpServer('state', {}), true);
+    assert.equal(shouldAutoStartMcpServer('memory', {}), true);
+    assert.equal(shouldAutoStartMcpServer('code_intel', {}), true);
+    assert.equal(shouldAutoStartMcpServer('trace', {}), true);
+  });
+
+  it('disables all servers when global disable flag is set', () => {
+    const env = { OMX_MCP_SERVER_DISABLE_AUTO_START: '1' };
+    assert.equal(shouldAutoStartMcpServer('state', env), false);
+    assert.equal(shouldAutoStartMcpServer('memory', env), false);
+    assert.equal(shouldAutoStartMcpServer('code_intel', env), false);
+    assert.equal(shouldAutoStartMcpServer('trace', env), false);
+  });
+
+  it('disables per-server using server-specific flags', () => {
+    assert.equal(shouldAutoStartMcpServer('state', { OMX_STATE_SERVER_DISABLE_AUTO_START: '1' }), false);
+    assert.equal(shouldAutoStartMcpServer('memory', { OMX_MEMORY_SERVER_DISABLE_AUTO_START: '1' }), false);
+    assert.equal(shouldAutoStartMcpServer('code_intel', { OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START: '1' }), false);
+    assert.equal(shouldAutoStartMcpServer('trace', { OMX_TRACE_SERVER_DISABLE_AUTO_START: '1' }), false);
+  });
+});
+

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -1,0 +1,20 @@
+export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace';
+
+const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
+  state: 'OMX_STATE_SERVER_DISABLE_AUTO_START',
+  memory: 'OMX_MEMORY_SERVER_DISABLE_AUTO_START',
+  code_intel: 'OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START',
+  trace: 'OMX_TRACE_SERVER_DISABLE_AUTO_START',
+};
+
+const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
+
+export function shouldAutoStartMcpServer(
+  server: McpServerName,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const globalDisabled = env[GLOBAL_DISABLE_ENV] === '1';
+  const serverDisabled = env[SERVER_DISABLE_ENV[server]] === '1';
+  return !globalDisabled && !serverDisabled;
+}
+

--- a/src/mcp/code-intel-server.ts
+++ b/src/mcp/code-intel-server.ts
@@ -15,6 +15,7 @@ import { readFile, readdir } from 'fs/promises';
 import { join, relative, extname, basename, resolve } from 'path';
 import { existsSync } from 'fs';
 import { promisify } from 'util';
+import { shouldAutoStartMcpServer } from './bootstrap.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -629,5 +630,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-const transport = new StdioServerTransport();
-server.connect(transport).catch(console.error);
+if (shouldAutoStartMcpServer('code_intel')) {
+  const transport = new StdioServerTransport();
+  server.connect(transport).catch(console.error);
+}

--- a/src/mcp/memory-server.ts
+++ b/src/mcp/memory-server.ts
@@ -14,6 +14,7 @@ import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { parseNotepadPruneDaysOld } from './memory-validation.js';
+import { shouldAutoStartMcpServer } from './bootstrap.js';
 
 function getMemoryPath(wd?: string): string {
   return join(wd || process.cwd(), '.omx', 'project-memory.json');
@@ -394,5 +395,7 @@ function appendToSection(content: string, section: string, entry: string): strin
   return content.slice(0, nextHeader) + entry + content.slice(nextHeader);
 }
 
-const transport = new StdioServerTransport();
-server.connect(transport).catch(console.error);
+if (shouldAutoStartMcpServer('memory')) {
+  const transport = new StdioServerTransport();
+  server.connect(transport).catch(console.error);
+}

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -27,6 +27,7 @@ import { withModeRuntimeContext } from '../state/mode-state-context.js';
 import { ensureTmuxHookInitialized } from '../cli/tmux-hook.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
+import { shouldAutoStartMcpServer } from './bootstrap.js';
 import {
   TEAM_NAME_SAFE_PATTERN,
   WORKER_NAME_SAFE_PATTERN,
@@ -1391,7 +1392,7 @@ export async function handleStateToolCall(request: {
 server.setRequestHandler(CallToolRequestSchema, handleStateToolCall);
 
 // Start server
-if (process.env.OMX_STATE_SERVER_DISABLE_AUTO_START !== '1') {
+if (shouldAutoStartMcpServer('state')) {
   const transport = new StdioServerTransport();
   server.connect(transport).catch(console.error);
 }

--- a/src/mcp/trace-server.ts
+++ b/src/mcp/trace-server.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 import { createReadStream, existsSync } from 'fs';
 import { createInterface } from 'readline';
 import { listModeStateFilesWithScopePreference } from './state-paths.js';
+import { shouldAutoStartMcpServer } from './bootstrap.js';
 
 function text(data: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
@@ -320,7 +321,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-if (process.env.OMX_TRACE_SERVER_DISABLE_AUTO_START !== '1') {
+if (shouldAutoStartMcpServer('trace')) {
   const transport = new StdioServerTransport();
   server.connect(transport).catch(console.error);
 }


### PR DESCRIPTION
## Summary
- add a shared MCP bootstrap guard helper to standardize server startup behavior
- apply the same guard contract to all MCP servers (`state`, `memory`, `code_intel`, `trace`) to avoid import-time unconditional auto-start side effects
- support both per-server disable flags and a global disable flag (`OMX_MCP_SERVER_DISABLE_AUTO_START=1`)
- add focused tests for bootstrap guard behavior

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/state-server.test.js dist/mcp/__tests__/trace-server.test.js`
