### PR TITLE
fix: #313 sync tmux-hook-engine declarations with runtime exports

### DIFF
--- a/src/hooks/__tests__/tmux-hook-engine-types-sync.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine-types-sync.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+function collectExports(source: string): Set<string> {
+  const out = new Set<string>();
+  const re = /^\s*export\s+(?:const|function)\s+([A-Za-z_][A-Za-z0-9_]*)/gm;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) out.add(match[1]);
+  return out;
+}
+
+describe('tmux-hook-engine declaration sync', () => {
+  it('covers all runtime exports in src/types/tmux-hook-engine.d.ts', async () => {
+    const root = process.cwd();
+    const runtimeSource = await readFile(join(root, 'scripts', 'tmux-hook-engine.js'), 'utf-8');
+    const declSource = await readFile(join(root, 'src', 'types', 'tmux-hook-engine.d.ts'), 'utf-8');
+
+    const runtimeExports = collectExports(runtimeSource);
+    const declaredExports = collectExports(declSource);
+
+    const missing = [...runtimeExports].filter((name) => !declaredExports.has(name));
+    assert.deepEqual(missing, [], `Missing declaration exports: ${missing.join(', ')}`);
+  });
+});

--- a/src/types/tmux-hook-engine.d.ts
+++ b/src/types/tmux-hook-engine.d.ts
@@ -18,6 +18,7 @@ declare module '*tmux-hook-engine.js' {
     prompt_template: string;
     marker: string;
     dry_run: boolean;
+    skip_if_scrolling: boolean;
     log_level: 'error' | 'info' | 'debug';
   }
 
@@ -42,6 +43,7 @@ declare module '*tmux-hook-engine.js' {
     now: number;
     state: Record<string, unknown>;
   }): { allow: boolean; reason: string; dedupeKey?: string };
+  export function buildPaneInModeArgv(paneTarget: string): string[];
   export function buildSendKeysArgv(args: {
     paneTarget: string;
     prompt: string;


### PR DESCRIPTION
## Summary
- sync `src/types/tmux-hook-engine.d.ts` with runtime exports in `scripts/tmux-hook-engine.js`
- add missing `skip_if_scrolling` field to `NormalizedTmuxHookConfig`
- add missing `buildPaneInModeArgv` declaration
- add a declaration-sync test to prevent future drift between runtime exports and declarations

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/tmux-hook-engine.test.js dist/hooks/__tests__/tmux-hook-engine-types-sync.test.js`
