### PR TITLE
fix: #310 make utils/paths.packageRoot ESM-safe

### DIFF
--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -2,6 +2,7 @@ import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { join } from 'path';
 import { homedir } from 'os';
+import { existsSync } from 'fs';
 import {
   codexHome,
   codexConfigPath,
@@ -13,6 +14,7 @@ import {
   omxNotepadPath,
   omxPlansDir,
   omxLogsDir,
+  packageRoot,
 } from '../paths.js';
 
 describe('codexHome', () => {
@@ -152,5 +154,12 @@ describe('omxLogsDir', () => {
 
   it('defaults to cwd when no projectRoot given', () => {
     assert.equal(omxLogsDir(), join(process.cwd(), '.omx', 'logs'));
+  });
+});
+
+describe('packageRoot', () => {
+  it('resolves to a directory containing package.json', () => {
+    const root = packageRoot();
+    assert.equal(existsSync(join(root, 'package.json')), true);
   });
 });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -3,8 +3,10 @@
  * Resolves Codex CLI config, skills, prompts, and state directories
  */
 
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+import { existsSync } from 'fs';
 
 /** Codex CLI home directory (~/.codex/) */
 export function codexHome(): string {
@@ -63,13 +65,19 @@ export function omxAgentsConfigDir(): string {
 
 /** Get the package root directory (where agents/, skills/, prompts/ live) */
 export function packageRoot(): string {
-  // From dist/utils/ or src/utils/, go up two levels
-  const { dirname } = require('path');
-  const { fileURLToPath } = require('url');
   try {
     const __filename = fileURLToPath(import.meta.url);
-    return join(dirname(__filename), '..', '..');
+    const __dirname = dirname(__filename);
+    const candidate = join(__dirname, '..', '..');
+    if (existsSync(join(candidate, 'package.json'))) {
+      return candidate;
+    }
+    const candidate2 = join(__dirname, '..');
+    if (existsSync(join(candidate2, 'package.json'))) {
+      return candidate2;
+    }
   } catch {
-    return join(__dirname, '..', '..');
+    // fall through to cwd fallback
   }
+  return process.cwd();
 }


### PR DESCRIPTION
## Summary
- remove CommonJS `require()` usage from `packageRoot()` in `src/utils/paths.ts`
- switch to ESM-safe resolution via `fileURLToPath(import.meta.url)` + `dirname`
- keep robust root fallback by validating `package.json` presence and falling back to `process.cwd()`
- add regression coverage in `src/utils/__tests__/paths.test.ts` for `packageRoot()`

## Verification
- `npm run build`
- `node --test dist/utils/__tests__/paths.test.js`
