### PR TITLE
chore: #312 remove production dead code + add CI unused-symbol gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx tsc --noEmit
+      - run: npm run check:no-unused
 
   test:
     name: Test

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "check:no-unused": "tsc -p tsconfig.no-unused.json",
     "dev": "tsc --watch",
     "setup": "node bin/omx.js setup",
     "doctor": "node bin/omx.js doctor",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,7 +18,6 @@ import {
   getBaseStateDir,
   getStateDir,
   listModeStateFilesWithScopePreference,
-  resolveStateScope,
 } from '../mcp/state-paths.js';
 import { maybeCheckAndPromptUpdate } from './update.js';
 import { maybePromptGithubStar } from './star-prompt.js';
@@ -528,10 +527,6 @@ export function resolveWorkerSparkModel(args: string[], codexHomeOverride?: stri
     }
   }
   return undefined;
-}
-
-function isReasoningOverride(value: string): boolean {
-  return new RegExp(`^${REASONING_KEY}\\s*=`).test(value.trim());
 }
 
 function isModelInstructionsOverride(value: string): boolean {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -9,7 +9,6 @@ import { join } from 'path';
 import { spawnSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { getPackageRoot } from '../utils/package.js';
-import { notify } from '../notifications/notifier.js';
 
 interface UpdateState {
   last_checked_at: string;

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -18,7 +18,7 @@ import { readFile, writeFile, mkdir, rm, readdir } from 'fs/promises';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 import { omxNotepadPath, omxProjectMemoryPath } from '../utils/paths.js';
-import { getBaseStateDir, getStateDir, listModeStateFilesWithScopePreference } from '../mcp/state-paths.js';
+import { getStateDir, listModeStateFilesWithScopePreference } from '../mcp/state-paths.js';
 import { generateCodebaseMap } from './codebase-map.js';
 
 const START_MARKER = '<!-- OMX:RUNTIME:START -->';
@@ -119,13 +119,6 @@ function capBodyToMax(sections: OverlaySection[], maxBody: number): string {
 }
 
 // ── Overlay generation ───────────────────────────────────────────────────────
-
-interface OverlayData {
-  sessionId: string;
-  activeModes: string;
-  notepadPriority: string;
-  projectMemory: string;
-}
 
 async function isRalphActive(cwd: string, sessionId?: string): Promise<boolean> {
   const refs = await listModeStateFilesWithScopePreference(cwd, sessionId);

--- a/src/hooks/extensibility/sdk.ts
+++ b/src/hooks/extensibility/sdk.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { appendFile, mkdir, readFile, unlink, writeFile } from 'fs/promises';
 import { createHash } from 'crypto';
-import { dirname, join, resolve } from 'path';
+import { dirname, join } from 'path';
 import { spawnSync } from 'child_process';
 import type {
   HookEventEnvelope,

--- a/src/mcp/code-intel-server.ts
+++ b/src/mcp/code-intel-server.ts
@@ -20,10 +20,6 @@ const execFileAsync = promisify(execFile);
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function cwd(wd?: string): string {
-  return wd || process.cwd();
-}
-
 function text(data: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
 }

--- a/src/mcp/memory-server.ts
+++ b/src/mcp/memory-server.ts
@@ -10,7 +10,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { readFile, writeFile, mkdir, appendFile } from 'fs/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -56,7 +56,6 @@ import {
   teamWriteMonitorSnapshot,
   teamReadTaskApproval,
   teamWriteTaskApproval,
-  teamSaveConfig,
   type TeamMonitorSnapshotState,
 } from '../team/team-ops.js';
 
@@ -65,7 +64,6 @@ const SUPPORTED_MODES = [
   'ralph', 'ultrawork', 'ultraqa', 'ecomode', 'ralplan',
 ] as const;
 
-type Mode = typeof SUPPORTED_MODES[number];
 const STATE_TOOL_NAMES = new Set([
   'state_read',
   'state_write',

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -91,7 +91,7 @@ import type {
   FullNotificationPayload,
   DispatchResult,
 } from "./types.js";
-import { getNotificationConfig, isEventEnabled, getActiveProfileName, getVerbosity, shouldIncludeTmuxTail } from "./config.js";
+import { getNotificationConfig, isEventEnabled, getVerbosity, shouldIncludeTmuxTail } from "./config.js";
 import { formatNotification } from "./formatter.js";
 import { dispatchNotifications } from "./dispatcher.js";
 import { getCurrentTmuxSession, captureTmuxPane } from "./tmux.js";

--- a/src/notifications/notifier.ts
+++ b/src/notifications/notifier.ts
@@ -152,7 +152,6 @@ async function sendTelegramNotification(
   botToken: string,
   chatId: string
 ): Promise<void> {
-  const iconMap = { info: 'info', success: 'white_check_mark', warning: 'warning', error: 'x' };
   const text = `*[OMX] ${payload.title}*\n${payload.message}`;
 
   try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -55,7 +55,6 @@ import {
   type WorkerHeartbeat,
   type WorkerStatus,
   type TeamTask,
-  type ShutdownAck,
   type TeamMonitorSnapshotState,
   type TeamPhaseState,
 } from './team-ops.js';

--- a/tsconfig.no-unused.json
+++ b/tsconfig.no-unused.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}


### PR DESCRIPTION
## Summary
- remove confirmed unused production code/imports/types/functions across CLI, hooks, MCP, notifications, and team runtime modules
- add a production unused-symbol typecheck gate via `tsconfig.no-unused.json` and `npm run check:no-unused`
- wire the new gate into CI so future dead production symbols fail quickly

## Key changes
- removed unused imports/helpers in:
  - `src/cli/index.ts`, `src/cli/update.ts`
  - `src/hooks/agents-overlay.ts`, `src/hooks/codebase-map.ts`, `src/hooks/extensibility/sdk.ts`
  - `src/mcp/code-intel-server.ts`, `src/mcp/memory-server.ts`, `src/mcp/state-server.ts`
  - `src/notifications/index.ts`, `src/notifications/notifier.ts`
  - `src/team/runtime.ts`
- added `tsconfig.no-unused.json` (excludes test files)
- added `check:no-unused` script in `package.json`
- added CI step in `.github/workflows/ci.yml` to run `npm run check:no-unused`

## Verification
- `npm run check:no-unused`
- `npm run build`
- `node --test dist/hooks/__tests__/codebase-map.test.js dist/hooks/__tests__/keyword-detector.test.js dist/notifications/__tests__/notifier.test.js`

Closes #312
