### PR TITLE
fix: #309 validate non-negative daysOld for notepad_prune

### DIFF
--- a/src/mcp/__tests__/memory-validation.test.ts
+++ b/src/mcp/__tests__/memory-validation.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseNotepadPruneDaysOld } from '../memory-validation.js';
+
+describe('parseNotepadPruneDaysOld', () => {
+  it('rejects negative values', () => {
+    const parsed = parseNotepadPruneDaysOld(-1);
+    assert.equal(parsed.ok, false);
+    if (!parsed.ok) {
+      assert.match(parsed.error, /non-negative integer/i);
+    }
+  });
+
+  it('accepts zero', () => {
+    const parsed = parseNotepadPruneDaysOld(0);
+    assert.deepEqual(parsed, { ok: true, days: 0 });
+  });
+
+  it('accepts large positive integers', () => {
+    const parsed = parseNotepadPruneDaysOld(3650);
+    assert.deepEqual(parsed, { ok: true, days: 3650 });
+  });
+
+  it('rejects non-integer values', () => {
+    const parsed = parseNotepadPruneDaysOld(1.5);
+    assert.equal(parsed.ok, false);
+  });
+
+  it('uses default for undefined input', () => {
+    const parsed = parseNotepadPruneDaysOld(undefined);
+    assert.deepEqual(parsed, { ok: true, days: 7 });
+  });
+});

--- a/src/mcp/memory-server.ts
+++ b/src/mcp/memory-server.ts
@@ -10,9 +10,10 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { readFile, writeFile, mkdir, appendFile } from 'fs/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { parseNotepadPruneDaysOld } from './memory-validation.js';
 
 function getMemoryPath(wd?: string): string {
   return join(wd || process.cwd(), '.omx', 'project-memory.json');
@@ -144,7 +145,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       inputSchema: {
         type: 'object',
         properties: {
-          daysOld: { type: 'integer', description: 'Prune entries older than this many days (default: 7)' },
+          daysOld: { type: 'integer', minimum: 0, description: 'Prune entries older than this many days (default: 7)' },
           workingDirectory: { type: 'string' },
         },
       },
@@ -282,7 +283,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       if (!existsSync(notePath)) {
         return text({ pruned: 0, message: 'No notepad file found' });
       }
-      const days = (a.daysOld as number) || 7;
+      const parsedDays = parseNotepadPruneDaysOld(a.daysOld);
+      if (!parsedDays.ok) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: parsedDays.error }) }],
+          isError: true,
+        };
+      }
+      const days = parsedDays.days;
       const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
       const content = await readFile(notePath, 'utf-8');
       const workingSection = extractSection(content, 'WORKING MEMORY');

--- a/src/mcp/memory-validation.ts
+++ b/src/mcp/memory-validation.ts
@@ -1,0 +1,14 @@
+export const DEFAULT_NOTEPAD_PRUNE_DAYS_OLD = 7;
+
+export function parseNotepadPruneDaysOld(
+  value: unknown,
+  defaultDays = DEFAULT_NOTEPAD_PRUNE_DAYS_OLD,
+): { ok: true; days: number } | { ok: false; error: string } {
+  if (value === undefined || value === null) {
+    return { ok: true, days: defaultDays };
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    return { ok: false, error: 'daysOld must be a non-negative integer' };
+  }
+  return { ok: true, days: value };
+}


### PR DESCRIPTION
## Summary
- add explicit non-negative integer validation for `notepad_prune.daysOld`
- return an explicit MCP error when `daysOld` is invalid
- tighten tool schema by adding `minimum: 0` for `daysOld`
- add dedicated tests for `daysOld` parsing/validation cases

## Details
- Added `parseNotepadPruneDaysOld` helper in `src/mcp/memory-validation.ts`
- Updated `notepad_prune` handler in `src/mcp/memory-server.ts` to use helper and reject invalid values
- Added test coverage in `src/mcp/__tests__/memory-validation.test.ts` for:
  - `daysOld = -1`
  - `daysOld = 0`
  - large positive values
  - non-integer values
  - default behavior when omitted

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/memory-validation.test.js`

Closes #309
