### PR TITLE
feat(team): add per-worker idle notification to leader pane

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -44,6 +44,7 @@ import {
   resolveTeamStateDirForWorker,
   updateWorkerHeartbeat,
   maybeNotifyLeaderAllWorkersIdle,
+  maybeNotifyLeaderWorkerIdle,
 } from './notify-hook/team-worker.js';
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 
@@ -245,6 +246,15 @@ async function main() {
       }
     } catch {
       // Non-critical: heartbeat write failure should never block the hook
+    }
+  }
+
+  // 4.55. Notify leader when individual worker transitions to idle (worker session only)
+  if (isTeamWorker && parsedTeamWorker) {
+    try {
+      await maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, parsedTeamWorker });
+    } catch {
+      // Non-critical
     }
   }
 

--- a/scripts/notify-hook/team-worker.js
+++ b/scripts/notify-hook/team-worker.js
@@ -68,6 +68,21 @@ export function parseTeamWorkerEnv(rawValue) {
   return { teamName: match[1], workerName: match[2] };
 }
 
+export function resolveWorkerIdleNotifyEnabled() {
+  const raw = safeString(process.env.OMX_TEAM_WORKER_IDLE_NOTIFY || '').trim().toLowerCase();
+  // Default: enabled. Disable with "false", "0", or "off".
+  if (raw === 'false' || raw === '0' || raw === 'off') return false;
+  return true;
+}
+
+export function resolveWorkerIdleCooldownMs() {
+  const raw = safeString(process.env.OMX_TEAM_WORKER_IDLE_COOLDOWN_MS || '');
+  const parsed = asNumber(raw);
+  // Default: 30 seconds. Guard against unreasonable values.
+  if (parsed !== null && parsed >= 5_000 && parsed <= 10 * 60_000) return parsed;
+  return 30_000;
+}
+
 export function resolveAllWorkersIdleCooldownMs() {
   const raw = safeString(process.env.OMX_TEAM_ALL_IDLE_COOLDOWN_MS || '');
   const parsed = asNumber(raw);
@@ -205,6 +220,133 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
     await logTmuxHookEvent(logsDir, {
       timestamp: nowIso,
       type: 'all_workers_idle_notification',
+      team: teamName,
+      tmux_target: tmuxTarget,
+      worker: workerName,
+      error: err instanceof Error ? err.message : safeString(err),
+    }).catch(() => {});
+  }
+}
+
+export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, parsedTeamWorker }) {
+  if (!resolveWorkerIdleNotifyEnabled()) return;
+
+  const { teamName, workerName } = parsedTeamWorker;
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  // Read current worker status (full object for task context)
+  const workerDir = join(stateDir, 'team', teamName, 'workers', workerName);
+  const statusPath = join(workerDir, 'status.json');
+  let currentState = 'unknown';
+  let currentTaskId = '';
+  let currentReason = '';
+  try {
+    if (existsSync(statusPath)) {
+      const parsed = JSON.parse(await readFile(statusPath, 'utf-8'));
+      if (parsed && typeof parsed.state === 'string') currentState = parsed.state;
+      if (parsed && typeof parsed.current_task_id === 'string') currentTaskId = parsed.current_task_id;
+      if (parsed && typeof parsed.reason === 'string') currentReason = parsed.reason;
+    }
+  } catch { /* ignore */ }
+
+  // Read and update previous state for transition detection
+  const prevStatePath = join(workerDir, 'prev-notify-state.json');
+  let prevState = 'unknown';
+  try {
+    if (existsSync(prevStatePath)) {
+      const parsed = JSON.parse(await readFile(prevStatePath, 'utf-8'));
+      if (parsed && typeof parsed.state === 'string') prevState = parsed.state;
+    }
+  } catch { /* ignore */ }
+
+  // Always update prev state (atomic write)
+  try {
+    await mkdir(workerDir, { recursive: true });
+    const tmpPath = prevStatePath + '.tmp.' + process.pid;
+    await writeFile(tmpPath, JSON.stringify({ state: currentState, updated_at: nowIso }, null, 2));
+    await rename(tmpPath, prevStatePath);
+  } catch { /* best effort */ }
+
+  // Only fire on working->idle transition (non-idle to idle)
+  if (currentState !== 'idle') return;
+  if (prevState === 'idle' || prevState === 'done') return;
+
+  // Check per-worker cooldown
+  const cooldownPath = join(workerDir, 'worker-idle-notify.json');
+  const cooldownMs = resolveWorkerIdleCooldownMs();
+  let lastNotifiedMs = 0;
+  try {
+    if (existsSync(cooldownPath)) {
+      const parsed = JSON.parse(await readFile(cooldownPath, 'utf-8'));
+      lastNotifiedMs = asNumber(parsed && parsed.last_notified_at_ms) ?? 0;
+    }
+  } catch { /* ignore */ }
+  if ((nowMs - lastNotifiedMs) < cooldownMs) return;
+
+  // Read team config for tmux target
+  const teamInfo = await readTeamWorkersForIdleCheck(stateDir, teamName);
+  if (!teamInfo) return;
+  const { tmuxSession, leaderPaneId } = teamInfo;
+  const tmuxTarget = leaderPaneId || tmuxSession;
+  if (!tmuxTarget) return;
+
+  // Build notification message with context
+  const parts = [`[OMX] ${workerName} idle`];
+  if (prevState && prevState !== 'unknown') parts.push(`(was: ${prevState})`);
+  if (currentTaskId) parts.push(`task: ${currentTaskId}`);
+  if (currentReason) parts.push(`reason: ${currentReason}`);
+  const message = `${parts.join('. ')}. ${DEFAULT_MARKER}`;
+
+  try {
+    await runProcess('tmux', ['send-keys', '-t', tmuxTarget, '-l', message], 3000);
+    await new Promise(r => setTimeout(r, 100));
+    await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'C-m'], 3000);
+    await new Promise(r => setTimeout(r, 100));
+    await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'C-m'], 3000);
+
+    // Update cooldown state
+    try {
+      const tmpPath = cooldownPath + '.tmp.' + process.pid;
+      await writeFile(tmpPath, JSON.stringify({
+        last_notified_at_ms: nowMs,
+        last_notified_at: nowIso,
+        prev_state: prevState,
+      }, null, 2));
+      await rename(tmpPath, cooldownPath);
+    } catch { /* best effort */ }
+
+    // Write event to events.ndjson
+    const eventsDir = join(stateDir, 'team', teamName, 'events');
+    const eventsPath = join(eventsDir, 'events.ndjson');
+    try {
+      await mkdir(eventsDir, { recursive: true });
+      const event = {
+        event_id: `worker-idle-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+        team: teamName,
+        type: 'worker_idle',
+        worker: workerName,
+        prev_state: prevState,
+        task_id: currentTaskId || null,
+        reason: currentReason || null,
+        created_at: nowIso,
+      };
+      await appendFile(eventsPath, JSON.stringify(event) + '\n');
+    } catch { /* best effort */ }
+
+    await logTmuxHookEvent(logsDir, {
+      timestamp: nowIso,
+      type: 'worker_idle_notification',
+      team: teamName,
+      tmux_target: tmuxTarget,
+      worker: workerName,
+      prev_state: prevState,
+      task_id: currentTaskId || null,
+    });
+  } catch (err) {
+    await logTmuxHookEvent(logsDir, {
+      timestamp: nowIso,
+      type: 'worker_idle_notification',
       team: teamName,
       tmux_target: tmuxTarget,
       worker: workerName,

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -1,0 +1,568 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const NOTIFY_HOOK_SCRIPT = new URL('../../../scripts/notify-hook.js', import.meta.url);
+
+async function withTempWorkingDir(run: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-notify-worker-idle-'));
+  try {
+    await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(join(path, '..'), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+function buildFakeTmux(tmuxLogPath: string): string {
+  return `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+}
+
+function runNotifyHookAsWorker(
+  cwd: string,
+  fakeBinDir: string,
+  workerEnv: string,
+  extraEnv: Record<string, string> = {},
+): ReturnType<typeof spawnSync> {
+  const payload = {
+    cwd,
+    type: 'agent-turn-complete',
+    'thread-id': 'thread-worker',
+    'turn-id': `turn-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    'input-messages': ['working'],
+    'last-assistant-message': 'task done',
+  };
+
+  return spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      OMX_TEAM_WORKER: workerEnv,
+      OMX_TEAM_WORKER_IDLE_COOLDOWN_MS: '500',
+      OMX_TEAM_ALL_IDLE_COOLDOWN_MS: '600000', // suppress all-idle to isolate per-worker
+      TMUX: '',
+      TMUX_PANE: '',
+      // Isolate from inherited team env (same pattern as all-workers-idle tests)
+      OMX_TEAM_STATE_ROOT: '',
+      OMX_TEAM_LEADER_CWD: '',
+      ...extraEnv,
+    },
+  });
+}
+
+describe('notify-hook per-worker idle notification', () => {
+  it('fires notification on working->idle transition', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'idle-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      // Worker is now idle
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        current_task_id: 'task-42',
+        reason: 'task complete',
+        updated_at: new Date().toISOString(),
+      });
+
+      // Previous state was working
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys/, 'should use send-keys to notify leader');
+      assert.match(tmuxLog, /worker-1 idle/, 'should include worker name in message');
+      assert.match(tmuxLog, /was: working/, 'should include previous state');
+      assert.match(tmuxLog, /task: task-42/, 'should include task id');
+      assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
+    });
+  });
+
+  it('does not fire when worker was already idle (idle->idle)', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'no-transition';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      // Worker is idle
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        updated_at: new Date().toISOString(),
+      });
+
+      // Previous state was also idle
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'idle',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /worker-1 idle/, 'should NOT fire for idle->idle');
+      }
+    });
+  });
+
+  it('does not fire when worker is still working', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'still-working';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      // Worker is still working
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'working',
+        updated_at: new Date().toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /worker-1 idle/, 'should NOT fire when worker is not idle');
+      }
+    });
+  });
+
+  it('respects per-worker cooldown', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'cooldown-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      // Worker is idle with working->idle transition
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      // Pre-populate cooldown state with a recent notification
+      await writeJson(join(workersDir, 'worker-1', 'worker-idle-notify.json'), {
+        last_notified_at_ms: Date.now() - 100, // 100ms ago
+        last_notified_at: new Date().toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`, {
+        OMX_TEAM_WORKER_IDLE_COOLDOWN_MS: '600000', // 10 minute cooldown
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /worker-1 idle/, 'cooldown should block per-worker idle notification');
+      }
+    });
+  });
+
+  it('can be disabled via OMX_TEAM_WORKER_IDLE_NOTIFY=false', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'disabled-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      // Working->idle transition
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`, {
+        OMX_TEAM_WORKER_IDLE_NOTIFY: 'false',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /worker-1 idle/, 'should NOT fire when disabled');
+      }
+    });
+  });
+
+  it('writes worker_idle event to events.ndjson', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'event-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const eventsDir = join(teamDir, 'events');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(eventsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        current_task_id: 'task-99',
+        reason: 'finished',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const eventsPath = join(eventsDir, 'events.ndjson');
+      assert.ok(existsSync(eventsPath), 'events.ndjson should exist');
+      const content = await readFile(eventsPath, 'utf-8');
+      const events = content.trim().split('\n').map(line => JSON.parse(line));
+      const workerIdleEvent = events.find((e: { type: string }) => e.type === 'worker_idle');
+      assert.ok(workerIdleEvent, 'should have a worker_idle event');
+      assert.equal(workerIdleEvent.team, teamName);
+      assert.equal(workerIdleEvent.worker, 'worker-1');
+      assert.equal(workerIdleEvent.prev_state, 'working');
+      assert.equal(workerIdleEvent.task_id, 'task-99');
+      assert.equal(workerIdleEvent.reason, 'finished');
+      assert.ok(workerIdleEvent.event_id, 'event should have an event_id');
+      assert.ok(workerIdleEvent.created_at, 'event should have a created_at');
+    });
+  });
+
+  it('targets leader_pane_id when available', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'pane-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        leader_pane_id: '%55',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /-t %55/, 'should target leader pane when available');
+      assert.doesNotMatch(tmuxLog, /-t devsess:0/, 'should not target session when leader pane is available');
+    });
+  });
+
+  it('does not fire for leader (non-team-worker) context', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'leader-test';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      // Run as LEADER (no OMX_TEAM_WORKER env var)
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        'thread-id': 'thread-leader',
+        'turn-id': `turn-${Date.now()}`,
+        'input-messages': ['leader turn'],
+        'last-assistant-message': 'done',
+      };
+      const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_WORKER: '',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /worker-1 idle/, 'leader context should not send per-worker idle notification');
+      }
+    });
+  });
+
+  it('fires on first invocation when no prev state file exists (unknown->idle)', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'first-run';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      // Worker is idle, but NO prev-notify-state.json exists
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        updated_at: new Date().toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /worker-1 idle/, 'should fire on unknown->idle transition');
+    });
+  });
+
+  it('existing all-workers-idle hook still fires alongside per-worker', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'both-hooks';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      // Single worker: working->idle transition should fire BOTH hooks
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`, {
+        OMX_TEAM_ALL_IDLE_COOLDOWN_MS: '500', // re-enable all-idle
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /worker-1 idle/, 'per-worker idle should fire');
+      assert.match(tmuxLog, /All 1 worker idle/, 'all-workers-idle should also fire');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add individual worker working->idle transition detection that fires a notification to the leader pane with worker id and context (fixes #329)
- The existing all-workers-idle hook continues to work alongside the new per-worker notification
- Configurable via `OMX_TEAM_WORKER_IDLE_NOTIFY` (enable/disable) and `OMX_TEAM_WORKER_IDLE_COOLDOWN_MS` (cooldown period)

## Changes

- `scripts/notify-hook/team-worker.js`: New `maybeNotifyLeaderWorkerIdle()` function with transition tracking via `prev-notify-state.json`, per-worker cooldown via `worker-idle-notify.json`, and `worker_idle` event recording
- `scripts/notify-hook.js`: Wire new per-worker idle hook (step 4.55) between heartbeat update and all-workers-idle check
- `src/hooks/__tests__/notify-hook-worker-idle.test.ts`: 10 comprehensive tests covering transition detection, cooldown, disable flag, events, leader pane targeting, and coexistence with all-workers-idle

## Configuration

| Env Var | Default | Range | Description |
|---------|---------|-------|-------------|
| `OMX_TEAM_WORKER_IDLE_NOTIFY` | `true` | `true/false/0/off` | Enable/disable per-worker idle notifications |
| `OMX_TEAM_WORKER_IDLE_COOLDOWN_MS` | `30000` | 5s-10m | Cooldown between per-worker notifications |

## Test plan

- [x] 10 new tests for per-worker idle notification (all pass)
- [x] 9 existing all-workers-idle tests (no regression)
- [x] Full test suite: 1087 tests pass, 0 failures
- [x] Build passes (tsc)

Fixes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)