### PR TITLE
fix: #307 escape Windows MCP server args in mergeConfig

### DIFF
--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -253,4 +253,33 @@ describe('config generator', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('escapes Windows-style backslashes for MCP server args', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      const windowsPkgRoot = 'C:\\Users\\alice\\oh-my-codex';
+      await mergeConfig(configPath, windowsPkgRoot);
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.match(
+        toml,
+        /args = \["C:\\\\Users\\\\alice\\\\oh-my-codex\/dist\/mcp\/state-server\.js"\]/,
+      );
+      assert.match(
+        toml,
+        /args = \["C:\\\\Users\\\\alice\\\\oh-my-codex\/dist\/mcp\/memory-server\.js"\]/,
+      );
+      assert.match(
+        toml,
+        /args = \["C:\\\\Users\\\\alice\\\\oh-my-codex\/dist\/mcp\/code-intel-server\.js"\]/,
+      );
+      assert.match(
+        toml,
+        /args = \["C:\\\\Users\\\\alice\\\\oh-my-codex\/dist\/mcp\/trace-server\.js"\]/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -21,6 +21,10 @@ interface MergeOptions {
   verbose?: boolean;
 }
 
+function escapeTomlString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 // ---------------------------------------------------------------------------
 // Top-level OMX keys (must live before any [table] header)
 // ---------------------------------------------------------------------------
@@ -34,9 +38,7 @@ const OMX_TOP_LEVEL_KEYS = [
 
 function getOmxTopLevelLines(pkgRoot: string): string[] {
   const notifyHookPath = join(pkgRoot, 'scripts', 'notify-hook.js');
-  const escapedPath = notifyHookPath
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"');
+  const escapedPath = escapeTomlString(notifyHookPath);
 
   return [
     '# oh-my-codex top-level settings (must be before any [table])',
@@ -194,9 +196,7 @@ function getAgentEntries(agentsConfigDir: string): string[] {
   for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
     // TOML table headers with special chars need quoting
     const tableKey = name.includes('-') ? `agents."${name}"` : `agents.${name}`;
-    const configFile = join(agentsConfigDir, `${name}.toml`)
-      .replace(/\\/g, '\\\\')
-      .replace(/"/g, '\\"');
+    const configFile = escapeTomlString(join(agentsConfigDir, `${name}.toml`));
 
     entries.push('');
     entries.push(`[${tableKey}]`);
@@ -212,10 +212,10 @@ function getAgentEntries(agentsConfigDir: string): string[] {
  * Contains ONLY [table] sections — no bare keys.
  */
 function getOmxTablesBlock(pkgRoot: string, agentsConfigDir: string): string {
-  const stateServerPath = join(pkgRoot, 'dist', 'mcp', 'state-server.js');
-  const memoryServerPath = join(pkgRoot, 'dist', 'mcp', 'memory-server.js');
-  const codeIntelServerPath = join(pkgRoot, 'dist', 'mcp', 'code-intel-server.js');
-  const traceServerPath = join(pkgRoot, 'dist', 'mcp', 'trace-server.js');
+  const stateServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'state-server.js'));
+  const memoryServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'memory-server.js'));
+  const codeIntelServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'code-intel-server.js'));
+  const traceServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'trace-server.js'));
 
   return [
     '',


### PR DESCRIPTION
## Summary
- fix `mergeConfig` path serialization so MCP server `args` are TOML-safe on Windows
- centralize TOML string escaping in `escapeTomlString()` and apply it to notify path, MCP server script paths, and agent config paths
- add regression test that verifies Windows-style backslashes are escaped in generated MCP args

## Verification
- `npm run build`
- `node --test dist/config/__tests__/generator-notify.test.js`
