### PR TITLE
Fix PID-reuse false positives in session stale detection

### DIFF
--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isSessionStale, type SessionState } from '../session.js';
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    session_id: 'sess-1',
+    started_at: '2026-02-26T00:00:00.000Z',
+    cwd: '/tmp/project',
+    pid: 12345,
+    ...overrides,
+  };
+}
+
+describe('isSessionStale', () => {
+  it('returns false for a live Linux process when identity matches', () => {
+    const state = makeState({
+      pid_start_ticks: 111,
+      pid_cmdline: 'node omx',
+    });
+
+    const stale = isSessionStale(state, {
+      platform: 'linux',
+      isPidAlive: () => true,
+      readLinuxIdentity: () => ({ startTicks: 111, cmdline: 'node omx' }),
+    });
+
+    assert.equal(stale, false);
+  });
+
+  it('returns true for PID reuse on Linux when start ticks mismatch', () => {
+    const state = makeState({
+      pid_start_ticks: 111,
+      pid_cmdline: 'node omx',
+    });
+
+    const stale = isSessionStale(state, {
+      platform: 'linux',
+      isPidAlive: () => true,
+      readLinuxIdentity: () => ({ startTicks: 222, cmdline: 'node omx' }),
+    });
+
+    assert.equal(stale, true);
+  });
+
+  it('returns true on Linux when identity metadata is missing', () => {
+    const state = makeState();
+
+    const stale = isSessionStale(state, {
+      platform: 'linux',
+      isPidAlive: () => true,
+      readLinuxIdentity: () => ({ startTicks: 111, cmdline: 'node omx' }),
+    });
+
+    assert.equal(stale, true);
+  });
+
+  it('returns true on Linux when live identity cannot be read', () => {
+    const state = makeState({ pid_start_ticks: 111 });
+
+    const stale = isSessionStale(state, {
+      platform: 'linux',
+      isPidAlive: () => true,
+      readLinuxIdentity: () => null,
+    });
+
+    assert.equal(stale, true);
+  });
+
+  it('returns true when PID is not alive', () => {
+    const state = makeState({ pid_start_ticks: 111 });
+
+    const stale = isSessionStale(state, {
+      platform: 'linux',
+      isPidAlive: () => false,
+    });
+
+    assert.equal(stale, true);
+  });
+
+  it('falls back to PID liveness on non-Linux platforms', () => {
+    const state = makeState();
+
+    const stale = isSessionStale(state, {
+      platform: 'darwin',
+      isPidAlive: () => true,
+      readLinuxIdentity: () => null,
+    });
+
+    assert.equal(stale, false);
+  });
+});

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -2,6 +2,7 @@ import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { join } from 'path';
 import { homedir } from 'os';
+import { existsSync } from 'fs';
 import {
   codexHome,
   codexConfigPath,
@@ -13,6 +14,7 @@ import {
   omxNotepadPath,
   omxPlansDir,
   omxLogsDir,
+  packageRoot,
 } from '../paths.js';
 
 describe('codexHome', () => {
@@ -152,5 +154,12 @@ describe('omxLogsDir', () => {
 
   it('defaults to cwd when no projectRoot given', () => {
     assert.equal(omxLogsDir(), join(process.cwd(), '.omx', 'logs'));
+  });
+});
+
+describe('packageRoot', () => {
+  it('resolves to a directory containing package.json', () => {
+    const root = packageRoot();
+    assert.equal(existsSync(join(root, 'package.json')), true);
   });
 });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -3,8 +3,10 @@
  * Resolves Codex CLI config, skills, prompts, and state directories
  */
 
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+import { existsSync } from 'fs';
 
 /** Codex CLI home directory (~/.codex/) */
 export function codexHome(): string {
@@ -63,13 +65,19 @@ export function omxAgentsConfigDir(): string {
 
 /** Get the package root directory (where agents/, skills/, prompts/ live) */
 export function packageRoot(): string {
-  // From dist/utils/ or src/utils/, go up two levels
-  const { dirname } = require('path');
-  const { fileURLToPath } = require('url');
   try {
     const __filename = fileURLToPath(import.meta.url);
-    return join(dirname(__filename), '..', '..');
+    const __dirname = dirname(__filename);
+    const candidate = join(__dirname, '..', '..');
+    if (existsSync(join(candidate, 'package.json'))) {
+      return candidate;
+    }
+    const candidate2 = join(__dirname, '..');
+    if (existsSync(join(candidate2, 'package.json'))) {
+      return candidate2;
+    }
   } catch {
-    return join(__dirname, '..', '..');
+    // fall through to cwd fallback
   }
+  return process.cwd();
 }


### PR DESCRIPTION
## Summary
- strengthen isSessionStale() on Linux by validating PID identity via /proc/<pid>/stat start ticks
- persist process identity metadata in session.json at session start
- add dedicated stale-detection unit tests (PID reuse, missing metadata, identity-read failures)
- update setup active-session test fixture to include Linux start ticks

## Issue mapping evidence
- Fixes #305
- Evidence path: src/hooks/session.ts now compares stored pid_start_ticks against live /proc/<pid>/stat start ticks before treating a session as active

## Verification
- npm run build
- node --test dist/hooks/__tests__/session.test.js dist/cli/__tests__/setup-agents-overwrite.test.js