### PR TITLE
perf: #306 stream trace logs and bound timeline memory

### DIFF
--- a/src/mcp/__tests__/trace-server.test.ts
+++ b/src/mcp/__tests__/trace-server.test.ts
@@ -64,3 +64,66 @@ describe('trace-server session-scoped mode discovery', () => {
     }
   });
 });
+
+describe('trace-server large log processing', () => {
+  it('readTurnTimeline keeps only last N entries while reporting total availability', async () => {
+    process.env.OMX_TRACE_SERVER_DISABLE_AUTO_START = '1';
+    const { readTurnTimeline } = await import('../trace-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-trace-timeline-'));
+    try {
+      const logsDir = join(wd, '.omx', 'logs');
+      await mkdir(logsDir, { recursive: true });
+
+      const lines: string[] = [];
+      for (let i = 0; i < 2000; i++) {
+        lines.push(JSON.stringify({
+          timestamp: `2026-01-01T00:00:${String(i % 60).padStart(2, '0')}.${String(i).padStart(3, '0')}Z`,
+          type: i % 2 === 0 ? 'user' : 'assistant',
+          turn_id: `turn-${i}`,
+        }));
+      }
+      await writeFile(join(logsDir, 'turns-2026-01-01.jsonl'), `${lines.join('\n')}\n`);
+
+      const timeline = await readTurnTimeline(logsDir, 25);
+      assert.equal(timeline.totalAvailable, 2000);
+      assert.equal(timeline.entries.length, 25);
+      assert.match(timeline.entries[0].turn_id ?? '', /^turn-\d+$/);
+      assert.match(timeline.entries[24].turn_id ?? '', /^turn-\d+$/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('summarizeTurns aggregates counts incrementally without materializing full logs', async () => {
+    process.env.OMX_TRACE_SERVER_DISABLE_AUTO_START = '1';
+    const { summarizeTurns } = await import('../trace-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-trace-summary-'));
+    try {
+      const logsDir = join(wd, '.omx', 'logs');
+      await mkdir(logsDir, { recursive: true });
+
+      const dayOne = [
+        { timestamp: '2026-01-01T00:00:00.000Z', type: 'user' },
+        { timestamp: '2026-01-01T00:00:01.000Z', type: 'assistant' },
+        { timestamp: '2026-01-01T00:00:02.000Z', type: 'assistant' },
+      ];
+      const dayTwo = [
+        { timestamp: '2026-01-02T00:00:00.000Z', type: 'user' },
+        { timestamp: '2026-01-02T00:00:01.000Z', type: 'tool' },
+        { timestamp: '2026-01-02T00:00:02.000Z', type: 'assistant' },
+      ];
+      await writeFile(join(logsDir, 'turns-2026-01-01.jsonl'), `${dayOne.map((v) => JSON.stringify(v)).join('\n')}\n`);
+      await writeFile(join(logsDir, 'turns-2026-01-02.jsonl'), `${dayTwo.map((v) => JSON.stringify(v)).join('\n')}\n`);
+
+      const summary = await summarizeTurns(logsDir);
+      assert.equal(summary.total, 6);
+      assert.deepEqual(summary.byType, { user: 2, assistant: 3, tool: 1 });
+      assert.equal(summary.firstAt, '2026-01-01T00:00:00.000Z');
+      assert.equal(summary.lastAt, '2026-01-02T00:00:02.000Z');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- refactor trace log reading to iterate JSONL entries via stream/readline instead of loading entire files into memory
- implement bounded retention for `trace_timeline --last N` turn data
- aggregate `trace_summary` incrementally without materializing full turn history arrays
- add large synthetic log tests covering bounded timeline behavior and incremental summary aggregation

## Details
- Added streaming helpers in `src/mcp/trace-server.ts`:
  - `iterateTurnEntries`
  - `readTurnTimeline`
  - `summarizeTurns`
- `trace_timeline` now uses bounded in-memory retention for turn entries when `last` is requested
- `trace_summary` now computes counts/first/last timestamps incrementally
- Added tests in `src/mcp/__tests__/trace-server.test.ts` for:
  - large-log `last N` retention behavior
  - incremental summary aggregation correctness

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/trace-server.test.js`

Closes #306
