### PR TITLE
refactor: #304 unify keyword registry + longest-match resolution

### DIFF
--- a/src/hooks/emulator.ts
+++ b/src/hooks/emulator.ts
@@ -21,6 +21,8 @@
  * - OMX: AGENTS.md instructs model -> model self-detects keyword -> model loads skill
  */
 
+import { KEYWORD_TRIGGER_DEFINITIONS } from './keyword-registry.js';
+
 /**
  * Hook event types (for compatibility with OMC concepts)
  */
@@ -94,22 +96,16 @@ export const HOOK_MAPPING: Record<HookEvent, {
  * Keyword detection configuration (embedded in AGENTS.md)
  * Instead of external hook detection, the model is instructed to self-detect
  */
-export const KEYWORD_TRIGGERS: Record<string, string> = {
-  'autopilot': 'Activate autopilot skill for autonomous execution',
-  'ralph': 'Activate ralph persistence loop with verification (planning-gated: require PRD + test spec before implementation tools)',
-  'ultrawork': 'Activate ultrawork parallel execution mode',
-  'ulw': 'Activate ultrawork parallel execution mode',
-  'ecomode': 'Activate ecomode for token-efficient execution',
-  'eco': 'Activate ecomode for token-efficient execution',
-  'plan': 'Activate planning skill',
-  'ralplan': 'Activate consensus planning (planner + architect + critic) and complete PRD + test spec before implementation',
-  'team': 'Activate coordinated team mode',
-  'coordinated team': 'Activate coordinated team mode',
-  'swarm': 'Activate coordinated team mode (swarm is a compatibility alias for team)',
-  'coordinated swarm': 'Activate coordinated team mode (swarm is a compatibility alias for team)',
-  'research': 'Activate parallel research mode',
-  'cancel': 'Cancel active execution modes',
-};
+export const KEYWORD_TRIGGERS: Record<string, string> = Object.fromEntries(
+  KEYWORD_TRIGGER_DEFINITIONS.map((entry) => {
+    const guidance = entry.skill === 'ralph'
+      ? `${entry.guidance} (planning-gated: require PRD + test spec before implementation tools)`
+      : entry.skill === 'ralplan'
+        ? `${entry.guidance} and complete PRD + test spec before implementation`
+        : entry.guidance;
+    return [entry.keyword, guidance];
+  }),
+);
 
 /**
  * Generate the keyword detection section for AGENTS.md

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -1,0 +1,56 @@
+export interface KeywordTriggerDefinition {
+  keyword: string;
+  skill: string;
+  priority: number;
+  guidance: string;
+}
+
+export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = [
+  { keyword: 'ralph', skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
+  { keyword: "don't stop", skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
+  { keyword: 'must complete', skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
+  { keyword: 'keep going', skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
+
+  { keyword: 'autopilot', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
+  { keyword: 'build me', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
+  { keyword: 'I want a', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
+
+  { keyword: 'ultrawork', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
+  { keyword: 'ulw', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
+  { keyword: 'parallel', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
+
+  { keyword: 'plan this', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
+  { keyword: 'plan the', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
+  { keyword: "let's plan", skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
+
+  { keyword: 'ralplan', skill: 'ralplan', priority: 11, guidance: 'Activate consensus planning (planner + architect + critic)' },
+  { keyword: 'consensus plan', skill: 'ralplan', priority: 11, guidance: 'Activate consensus planning (planner + architect + critic)' },
+
+  { keyword: 'team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
+  { keyword: 'swarm', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode (swarm is a compatibility alias for team)' },
+  { keyword: 'coordinated team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
+  { keyword: 'coordinated swarm', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode (swarm is a compatibility alias for team)' },
+
+  { keyword: 'ecomode', skill: 'ecomode', priority: 10, guidance: 'Activate ecomode for token-efficient execution' },
+  { keyword: 'eco', skill: 'ecomode', priority: 10, guidance: 'Activate ecomode for token-efficient execution' },
+  { keyword: 'budget', skill: 'ecomode', priority: 10, guidance: 'Activate ecomode for token-efficient execution' },
+
+  { keyword: 'cancel', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
+  { keyword: 'stop', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
+  { keyword: 'abort', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
+
+  { keyword: 'tdd', skill: 'tdd', priority: 6, guidance: 'Activate test-driven workflow' },
+  { keyword: 'test first', skill: 'tdd', priority: 6, guidance: 'Activate test-driven workflow' },
+
+  { keyword: 'fix build', skill: 'build-fix', priority: 6, guidance: 'Activate build-fix workflow' },
+  { keyword: 'type errors', skill: 'build-fix', priority: 6, guidance: 'Activate build-fix workflow' },
+
+  { keyword: 'review code', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
+  { keyword: 'security review', skill: 'security-review', priority: 6, guidance: 'Activate security-review workflow' },
+] as const;
+
+export function compareKeywordMatches(a: { priority: number; keyword: string }, b: { priority: number; keyword: string }): number {
+  if (b.priority !== a.priority) return b.priority - a.priority;
+  if (b.keyword.length !== a.keyword.length) return b.keyword.length - a.keyword.length;
+  return a.keyword.localeCompare(b.keyword);
+}


### PR DESCRIPTION
## Summary
- establish a single source-of-truth keyword trigger registry for hooks orchestration keywords
- make both `keyword-detector` and `emulator` consume the shared registry
- implement deterministic conflict resolution with longest-match tie-breaker after priority
- add parity tests to ensure template keyword table stays in sync with runtime registry

## Details
- Added `src/hooks/keyword-registry.ts` with canonical keyword definitions (keyword, skill, priority, guidance)
- Updated `src/hooks/keyword-detector.ts` to build patterns from registry and sort matches by:
  1) priority desc
  2) keyword length desc (most specific/longest match)
  3) keyword lexical order
- Updated `src/hooks/emulator.ts` to generate guidance keywords from same registry
- Extended `src/hooks/__tests__/keyword-detector.test.ts` to validate:
  - longest-match tie-breaker behavior
  - template keyword table parity with registry

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/keyword-detector.test.js`

Closes #304
