### PR TITLE
fix(team): increase worker hard cap to 20

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { parseTeamStartArgs } from '../team.js';
+import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
 
 describe('parseTeamStartArgs', () => {
   it('parses default team start args without worktree', () => {
@@ -29,5 +30,17 @@ describe('parseTeamStartArgs', () => {
     assert.equal(result.parsed.agentType, 'executor');
     assert.equal(result.parsed.task, 'ship it');
     assert.equal(result.parsed.teamName, 'ship-it');
+  });
+
+  it('accepts the maximum supported worker count', () => {
+    const result = parseTeamStartArgs([`${DEFAULT_MAX_WORKERS}:executor`, 'ship', 'it']);
+    assert.equal(result.parsed.workerCount, DEFAULT_MAX_WORKERS);
+  });
+
+  it('rejects worker count above the supported maximum', () => {
+    assert.throws(
+      () => parseTeamStartArgs([`${DEFAULT_MAX_WORKERS + 1}:executor`, 'ship', 'it']),
+      new RegExp(`Expected 1-${DEFAULT_MAX_WORKERS}`),
+    );
   });
 });

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,5 +1,6 @@
 import { updateModeState, startMode, readModeState } from '../modes/base.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime } from '../team/runtime.js';
+import { DEFAULT_MAX_WORKERS } from '../team/state.js';
 import { sanitizeTeamName } from '../team/tmux-session.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 
@@ -14,6 +15,8 @@ interface ParsedTeamArgs {
   teamName: string;
   ralph: boolean;
 }
+
+const MIN_WORKER_COUNT = 1;
 
 export interface ParsedTeamStartArgs {
   parsed: ParsedTeamArgs;
@@ -44,8 +47,8 @@ function parseTeamArgs(args: string[]): ParsedTeamArgs {
   const match = first.match(/^(\d+)(?::([a-z][a-z0-9-]*))?$/i);
   if (match) {
     const count = Number.parseInt(match[1], 10);
-    if (!Number.isFinite(count) || count < 1 || count > 20) {
-      throw new Error(`Invalid worker count "${match[1]}". Expected 1-20.`);
+    if (!Number.isFinite(count) || count < MIN_WORKER_COUNT || count > DEFAULT_MAX_WORKERS) {
+      throw new Error(`Invalid worker count "${match[1]}". Expected ${MIN_WORKER_COUNT}-${DEFAULT_MAX_WORKERS}.`);
     }
     workerCount = count;
     if (match[2]) agentType = match[2];


### PR DESCRIPTION
## Summary\n- replace the hardcoded team worker CLI max with named constants\n- keep CLI validation aligned with the shared team max worker constant (20)\n- add boundary tests for max worker count acceptance/rejection\n\n## Verification\n- npm test\n- npm run build\n\nFixes #331