### PR TITLE
fix: #318 require canonical for alias/merged catalog entries

### DIFF
--- a/src/catalog/__tests__/schema.test.ts
+++ b/src/catalog/__tests__/schema.test.ts
@@ -25,6 +25,31 @@ describe('catalog schema', () => {
     assert.throws(() => validateCatalogManifest(broken), /missing_core_skill:team/);
   });
 
+  it('requires canonical for alias/merged skill entries', () => {
+    const broken = JSON.parse(JSON.stringify(readSourceManifest()));
+    const idx = broken.skills.findIndex((s: { status: string }) => s.status === 'alias');
+    delete broken.skills[idx].canonical;
+
+    assert.throws(
+      () => validateCatalogManifest(broken),
+      /skills\[\d+\]\.canonical/,
+    );
+  });
+
+  it('requires canonical for alias/merged agent entries', () => {
+    const broken = JSON.parse(JSON.stringify(readSourceManifest()));
+    broken.agents.push({
+      name: 'tmp-merged-agent',
+      category: 'build',
+      status: 'merged',
+    });
+
+    assert.throws(
+      () => validateCatalogManifest(broken),
+      /agents\[\d+\]\.canonical/,
+    );
+  });
+
   it('summarizes counts', () => {
     const parsed = validateCatalogManifest(readSourceManifest());
     const counts = summarizeCatalogCounts(parsed);

--- a/src/catalog/schema.ts
+++ b/src/catalog/schema.ts
@@ -74,6 +74,10 @@ export function validateCatalogManifest(input: unknown): CatalogManifest {
       ? entry.canonical.trim()
       : undefined;
 
+    if ((entry.status === 'alias' || entry.status === 'merged') && !canonical) {
+      throw new Error(`catalog_manifest_invalid:skills[${index}].canonical`);
+    }
+
     return {
       name,
       category: entry.category as CatalogSkillCategory,
@@ -105,6 +109,10 @@ export function validateCatalogManifest(input: unknown): CatalogManifest {
     const canonical = typeof entry.canonical === 'string' && entry.canonical.trim() !== ''
       ? entry.canonical.trim()
       : undefined;
+
+    if ((entry.status === 'alias' || entry.status === 'merged') && !canonical) {
+      throw new Error(`catalog_manifest_invalid:agents[${index}].canonical`);
+    }
 
     return {
       name,


### PR DESCRIPTION
## Summary
- enforce `canonical` as required for skill entries with `status` alias/merged
- enforce `canonical` as required for agent entries with `status` alias/merged
- add schema tests covering missing canonical in both skill and agent paths

## Verification
- npm run build
- node --test dist/catalog/__tests__/schema.test.js

Closes #318
