### PR TITLE
fix: enforce max-iteration termination for notify-updated mode states

### DIFF
--- a/src/hooks/__tests__/notify-hook-session-scope.test.ts
+++ b/src/hooks/__tests__/notify-hook-session-scope.test.ts
@@ -48,4 +48,58 @@ describe('notify-hook session-scoped iteration updates', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('marks active mode state complete when max_iterations is reached', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-test-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess1';
+      const sessionScopedDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionScopedDir, { recursive: true });
+
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(
+        join(sessionScopedDir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          iteration: 1,
+          max_iterations: 2,
+          current_phase: 'executing',
+        })
+      );
+
+      const payload = {
+        cwd: wd,
+        type: 'agent-turn-complete',
+        thread_id: 'th2',
+        turn_id: 'tu2',
+        input_messages: [],
+        last_assistant_message: 'ok',
+      };
+
+      const testDir = dirname(fileURLToPath(import.meta.url));
+      const repoRoot = join(testDir, '..', '..', '..');
+      const result = spawnSync(process.execPath, ['scripts/notify-hook.js', JSON.stringify(payload)], {
+        cwd: repoRoot,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          OMX_TEAM_WORKER: '',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const updated = JSON.parse(await readFile(join(sessionScopedDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(updated.iteration, 2);
+      assert.equal(updated.active, false);
+      assert.equal(updated.current_phase, 'complete');
+      assert.equal(updated.stop_reason, 'max_iterations_reached');
+      assert.ok(typeof updated.completed_at === 'string' && updated.completed_at.length > 0);
+      assert.ok(typeof updated.last_turn_at === 'string' && updated.last_turn_at.length > 0);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -168,10 +168,3 @@ export async function listActiveModes(projectRoot?: string): Promise<Array<{ mod
   }
   return active;
 }
-
-/**
- * Check if mode should continue (not exceeded max iterations, still active)
- */
-export function shouldContinue(state: ModeState): boolean {
-  return state.active && state.iteration < state.max_iterations;
-}


### PR DESCRIPTION
## Summary
- stop active mode state updates when a notify-hook iteration reaches `max_iterations`
- mark the mode state inactive with completion metadata and stop reason
- add regression coverage for session-scoped max-iteration termination and remove unused `shouldContinue()` helper

Closes #301