### PR TITLE
fix: #315 replace silent lifecycle catches with warning logs

### DIFF
--- a/src/cli/__tests__/error-handling-warnings.test.ts
+++ b/src/cli/__tests__/error-handling-warnings.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+async function readSource(relativePath: string): Promise<string> {
+  return readFile(join(process.cwd(), relativePath), 'utf8');
+}
+
+describe('error-handling warning guards', () => {
+  it('removes silent shutdown mode-state swallow in team command', async () => {
+    const source = await readSource('src/cli/team.ts');
+    assert.match(source, /failed to persist team mode shutdown state/);
+    assert.ok(!source.includes("completed_at: new Date().toISOString(),\n    }).catch(() => {});"));
+  });
+
+  it('uses warning logs for watcher lifecycle best-effort failures', async () => {
+    const source = await readSource('src/cli/index.ts');
+
+    assert.ok(!source.includes("await mkdir(join(cwd, '.omx', 'state'), { recursive: true }).catch(() => {});"));
+    assert.ok(!source.includes('await unlink(pidPath).catch(() => {});'));
+
+    assert.match(source, /failed to write notify fallback watcher pid file/);
+    assert.match(source, /failed to write hook-derived watcher pid file/);
+    assert.match(source, /failed to remove notify fallback watcher pid file/);
+    assert.match(source, /failed to remove hook-derived watcher pid file/);
+  });
+
+  it('replaces silent log-write catches with warning logs', async () => {
+    const loggingSource = await readSource('src/hooks/extensibility/logging.ts');
+    const dispatchSource = await readSource('src/hooks/extensibility/dispatcher.ts');
+    const keywordSource = await readSource('src/hooks/keyword-detector.ts');
+
+    assert.ok(!loggingSource.includes('.catch(() => {});'));
+    assert.ok(!dispatchSource.includes('.catch(() => {});'));
+    assert.ok(!keywordSource.includes('.catch(() => {});'));
+
+    assert.match(loggingSource, /failed to append hook plugin log entry/);
+    assert.match(dispatchSource, /failed to append hook dispatch log entry/);
+    assert.match(keywordSource, /failed to persist keyword activation state/);
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1226,12 +1226,20 @@ async function startNotifyFallbackWatcher(cwd: string): Promise<void> {
       if (prev && typeof prev.pid === 'number') {
         process.kill(prev.pid, 'SIGTERM');
       }
-    } catch {
-      // Ignore stale PID parse/kill errors.
+    } catch (error: unknown) {
+      console.warn('[omx] warning: failed to stop stale notify fallback watcher', {
+        path: pidPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
-  await mkdir(join(cwd, '.omx', 'state'), { recursive: true }).catch(() => {});
+  await mkdir(join(cwd, '.omx', 'state'), { recursive: true }).catch((error: unknown) => {
+    console.warn('[omx] warning: failed to create notify fallback watcher state directory', {
+      cwd,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
   const child = spawn(
     process.execPath,
     [watcherScript, '--cwd', cwd, '--notify-script', notifyScript],
@@ -1246,7 +1254,12 @@ async function startNotifyFallbackWatcher(cwd: string): Promise<void> {
   await writeFile(
     pidPath,
     JSON.stringify({ pid: child.pid, started_at: new Date().toISOString() }, null, 2)
-  ).catch(() => {});
+  ).catch((error: unknown) => {
+    console.warn('[omx] warning: failed to write notify fallback watcher pid file', {
+      path: pidPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 async function startHookDerivedWatcher(cwd: string): Promise<void> {
@@ -1264,12 +1277,20 @@ async function startHookDerivedWatcher(cwd: string): Promise<void> {
       if (prev && typeof prev.pid === 'number') {
         process.kill(prev.pid, 'SIGTERM');
       }
-    } catch {
-      // Ignore stale PID parse/kill errors.
+    } catch (error: unknown) {
+      console.warn('[omx] warning: failed to stop stale hook-derived watcher', {
+        path: pidPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
-  await mkdir(join(cwd, '.omx', 'state'), { recursive: true }).catch(() => {});
+  await mkdir(join(cwd, '.omx', 'state'), { recursive: true }).catch((error: unknown) => {
+    console.warn('[omx] warning: failed to create hook-derived watcher state directory', {
+      cwd,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
   const child = spawn(
     process.execPath,
     [watcherScript, '--cwd', cwd],
@@ -1285,7 +1306,12 @@ async function startHookDerivedWatcher(cwd: string): Promise<void> {
   await writeFile(
     pidPath,
     JSON.stringify({ pid: child.pid, started_at: new Date().toISOString() }, null, 2)
-  ).catch(() => {});
+  ).catch((error: unknown) => {
+    console.warn('[omx] warning: failed to write hook-derived watcher pid file', {
+      path: pidPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 async function stopNotifyFallbackWatcher(cwd: string): Promise<void> {
@@ -1298,11 +1324,19 @@ async function stopNotifyFallbackWatcher(cwd: string): Promise<void> {
     if (parsed && typeof parsed.pid === 'number') {
       process.kill(parsed.pid, 'SIGTERM');
     }
-  } catch {
-    // Ignore stop errors.
+  } catch (error: unknown) {
+    console.warn('[omx] warning: failed to stop notify fallback watcher process', {
+      path: pidPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
-  await unlink(pidPath).catch(() => {});
+  await unlink(pidPath).catch((error: unknown) => {
+    console.warn('[omx] warning: failed to remove notify fallback watcher pid file', {
+      path: pidPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 async function stopHookDerivedWatcher(cwd: string): Promise<void> {
@@ -1315,11 +1349,19 @@ async function stopHookDerivedWatcher(cwd: string): Promise<void> {
     if (parsed && typeof parsed.pid === 'number') {
       process.kill(parsed.pid, 'SIGTERM');
     }
-  } catch {
-    // Ignore stop errors.
+  } catch (error: unknown) {
+    console.warn('[omx] warning: failed to stop hook-derived watcher process', {
+      path: pidPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
-  await unlink(pidPath).catch(() => {});
+  await unlink(pidPath).catch((error: unknown) => {
+    console.warn('[omx] warning: failed to remove hook-derived watcher pid file', {
+      path: pidPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 async function flushNotifyFallbackOnce(cwd: string): Promise<void> {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -173,7 +173,12 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
       active: false,
       current_phase: 'cancelled',
       completed_at: new Date().toISOString(),
-    }).catch(() => {});
+    }).catch((error: unknown) => {
+      console.warn('[omx] warning: failed to persist team mode shutdown state', {
+        team: name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
     console.log(`Team shutdown complete: ${name}`);
     return;
   }

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -32,7 +32,12 @@ function hooksLogPath(cwd: string): string {
 
 async function appendHooksLog(cwd: string, payload: Record<string, unknown>): Promise<void> {
   await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
-  await appendFile(hooksLogPath(cwd), `${JSON.stringify({ timestamp: new Date().toISOString(), ...payload })}\n`).catch(() => {});
+  await appendFile(hooksLogPath(cwd), `${JSON.stringify({ timestamp: new Date().toISOString(), ...payload })}\n`).catch((error: unknown) => {
+    console.warn('[omx] warning: failed to append hook dispatch log entry', {
+      cwd,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 function isTeamWorker(env: NodeJS.ProcessEnv): boolean {

--- a/src/hooks/extensibility/logging.ts
+++ b/src/hooks/extensibility/logging.ts
@@ -14,5 +14,10 @@ export async function appendHookPluginLog(cwd: string, entry: HookPluginLogConte
     timestamp: entry.timestamp || new Date().toISOString(),
     ...entry,
   };
-  await appendFile(path, JSON.stringify(payload) + '\n').catch(() => {});
+  await appendFile(path, JSON.stringify(payload) + '\n').catch((error: unknown) => {
+    console.warn('[omx] warning: failed to append hook plugin log entry', {
+      path,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -129,7 +129,13 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     ...(input.turnId ? { turn_id: input.turnId } : {}),
   };
 
-  await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
+  await writeFile(statePath, JSON.stringify(state, null, 2)).catch((error: unknown) => {
+    console.warn('[omx] warning: failed to persist keyword activation state', {
+      path: statePath,
+      skill: state.skill,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
   return state;
 }
 


### PR DESCRIPTION
## Summary
- replace silent lifecycle/state best-effort catches with structured warning logs in team shutdown and watcher lifecycle paths
- replace silent hook logging and keyword activation persistence catches with warning logs including path/context
- add regression coverage that guards against reintroducing silent swallow patterns
- add keyword-detector test asserting warning emission on persistence failure

## Verification
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js dist/cli/__tests__/error-handling-warnings.test.js

Closes #315
