### PR TITLE
fix: wire verification protocol into runtime completion gates

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -382,6 +382,52 @@ process.on('SIGTERM', () => process.exit(0));
     }
   });
 
+  it('monitorTeam keeps phase in team-verify when completed code tasks lack verification evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-verify-gate-'));
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      await initTeamState('team-verify-gate', 'verification gate test', 'executor', 1, cwd);
+      const task = await createTask(
+        'team-verify-gate',
+        {
+          subject: 'code change',
+          description: 'implement feature',
+          status: 'completed',
+          owner: 'worker-1',
+          requires_code_change: true,
+        },
+        cwd,
+      );
+
+      const first = await monitorTeam('team-verify-gate', cwd);
+      assert.ok(first);
+      assert.equal(first?.phase, 'team-verify');
+      assert.equal(
+        first?.recommendations.some((r) => r.includes(`task-${task.id}`) && r.includes('Verification evidence missing')),
+        true,
+      );
+
+      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-verify-gate', 'tasks', `task-${task.id}.json`);
+      const fromDisk = JSON.parse(await readFile(taskPath, 'utf-8')) as Record<string, unknown>;
+      fromDisk.result = [
+        'Summary: done',
+        'Verification:',
+        '- PASS build: `npm run build`',
+        '- PASS tests: `node --test dist/foo.test.js`',
+      ].join('\n');
+      await writeAtomic(taskPath, JSON.stringify(fromDisk, null, 2));
+
+      const second = await monitorTeam('team-verify-gate', cwd);
+      assert.ok(second);
+      assert.equal(second?.phase, 'complete');
+    } finally {
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('monitorTeam emits worker_idle and task_completed events based on transitions', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     try {

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -183,6 +183,8 @@ describe('worker bootstrap', () => {
     assert.match(inbox, /\*\*Task 2\*\*: Second task/);
     assert.match(inbox, /Resolve canonical team state root/);
     assert.match(inbox, /<team_state_root>\/team\/team-inbox\/tasks\/task-<id>\.json/);
+    assert.match(inbox, /Verification Requirements/);
+    assert.match(inbox, /Fix-Verify Loop/);
   });
 
   it('generateInitialInbox shows blocked_by info for blocked tasks', () => {
@@ -208,6 +210,8 @@ describe('worker bootstrap', () => {
     assert.match(inbox, /Implement parser update/);
     assert.match(inbox, /team_state_root/);
     assert.match(inbox, /team\/team-followup\/tasks\/task-42\.json/);
+    assert.match(inbox, /Verification Requirements/);
+    assert.match(inbox, /PASS\/FAIL/);
   });
 
   it('generateShutdownInbox contains exit instruction and concrete ack path', () => {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -84,6 +84,7 @@ import {
 } from './model-contract.js';
 import { inferPhaseTargetFromTaskCounts, reconcilePhaseStateForMonitor } from './phase-controller.js';
 import { getTeamTmuxSessions } from '../notifications/tmux.js';
+import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
 import {
   ensureWorktree,
   planWorktreeTarget,
@@ -798,10 +799,23 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
     failed: allTasks.filter(t => t.status === 'failed').length,
   };
 
+  const verificationPendingTasks = allTasks.filter(
+    (task) => task.status === 'completed'
+      && task.requires_code_change === true
+      && !hasStructuredVerificationEvidence(task.result),
+  );
+  if (verificationPendingTasks.length > 0) {
+    for (const task of verificationPendingTasks) {
+      recommendations.push(`Verification evidence missing for task-${task.id}; require structured PASS/FAIL evidence before terminal success`);
+    }
+  }
+
   const allTasksTerminal = taskCounts.pending === 0 && taskCounts.blocked === 0 && taskCounts.in_progress === 0;
 
   const persistedPhase = await readTeamPhaseState(sanitized, cwd);
-  const targetPhase = inferPhaseTargetFromTaskCounts(taskCounts);
+  const targetPhase = inferPhaseTargetFromTaskCounts(taskCounts, {
+    verificationPending: verificationPendingTasks.length > 0,
+  });
   const phaseState: TeamPhaseState = reconcilePhaseStateForMonitor(persistedPhase, targetPhase);
   await writeTeamPhaseState(sanitized, phaseState, cwd);
   const phase: TeamPhase | TerminalPhase = phaseState.current_phase;

--- a/src/verification/__tests__/verifier.test.ts
+++ b/src/verification/__tests__/verifier.test.ts
@@ -4,6 +4,7 @@ import {
   getVerificationInstructions,
   determineTaskSize,
   getFixLoopInstructions,
+  hasStructuredVerificationEvidence,
 } from '../verifier.js';
 
 describe('determineTaskSize', () => {
@@ -110,5 +111,30 @@ describe('getFixLoopInstructions', () => {
     assert.ok(result.includes('escalate'));
     assert.ok(result.includes('What was attempted'));
     assert.ok(result.includes('Recommended next steps'));
+  });
+});
+
+describe('hasStructuredVerificationEvidence', () => {
+  it('returns true for structured verification summaries', () => {
+    const summary = `
+Summary: done
+Verification Evidence:
+- PASS build: \`npm run build\`
+- PASS tests: \`node --test dist/foo.test.js\`
+`;
+    assert.equal(hasStructuredVerificationEvidence(summary), true);
+  });
+
+  it('returns false for unstructured summaries', () => {
+    assert.equal(
+      hasStructuredVerificationEvidence('Implemented fix and opened PR.'),
+      false,
+    );
+  });
+
+  it('returns false for missing input', () => {
+    assert.equal(hasStructuredVerificationEvidence(undefined), false);
+    assert.equal(hasStructuredVerificationEvidence(null), false);
+    assert.equal(hasStructuredVerificationEvidence(''), false);
   });
 });

--- a/src/verification/verifier.ts
+++ b/src/verification/verifier.ts
@@ -21,6 +21,26 @@ export interface VerificationEvidence {
 }
 
 /**
+ * Heuristic check for structured verification evidence in a task completion summary.
+ * Intended for runtime completion gating (best-effort, backward-compatible).
+ */
+export function hasStructuredVerificationEvidence(summary: string | null | undefined): boolean {
+  if (typeof summary !== 'string') return false;
+  const text = summary.trim();
+  if (text === '') return false;
+
+  const hasVerificationSection = /verification(?:\s+evidence)?\s*:/i.test(text)
+    || /##\s*verification/i.test(text);
+  if (!hasVerificationSection) return false;
+
+  const hasEvidenceSignal = /\b(pass|passed|fail|failed)\b/i.test(text)
+    || /`[^`]+`/.test(text)
+    || /\b(command|test|build|typecheck|lint)\b/i.test(text);
+
+  return hasEvidenceSignal;
+}
+
+/**
  * Generate verification instructions for a given task size
  */
 export function getVerificationInstructions(


### PR DESCRIPTION
## Summary
- wire verification helpers into team runtime by gating terminal success when code-change tasks lack structured verification evidence
- route such cases back to `team-verify` and emit actionable recommendations
- wire verifier guidance into worker task inbox templates so runtime task execution includes explicit verification + fix-loop protocol
- add tests for phase inference, runtime verification gating, worker bootstrap guidance, and structured evidence detection

## Testing
- npm run build
- env -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_WORKER node --test dist/verification/__tests__/verifier.test.js dist/team/__tests__/phase-controller.test.js dist/team/__tests__/worker-bootstrap.test.js
- env -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_WORKER node manual simulation for dist/team/runtime.js verification gating

Closes #298
