### PR TITLE
fix(team): block prompt-mode resume when dispatch is unavailable

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm, writeFile, readFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
+import { spawn } from 'child_process';
 import {
   initTeamState,
   createTask,
@@ -665,6 +666,48 @@ process.on('SIGTERM', () => process.exit(0));
       const runtime = await resumeTeam('missing-team', cwd);
       assert.equal(runtime, null);
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('resumeTeam returns null for prompt teams when worker handles are missing after restart', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-resume-'));
+    const sleeper = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+      detached: false,
+    });
+    let sleeperPid = sleeper.pid ?? 0;
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const prevLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_LEADER_CWD;
+
+    try {
+      await initTeamState('team-prompt-resume', 'prompt resume test', 'executor', 1, cwd);
+      const configPath = join(cwd, '.omx', 'state', 'team', 'team-prompt-resume', 'config.json');
+      const config = JSON.parse(await readFile(configPath, 'utf-8')) as any;
+      config.worker_launch_mode = 'prompt';
+      config.tmux_session = 'prompt-team-prompt-resume';
+      config.leader_pane_id = null;
+      config.hud_pane_id = null;
+      config.workers[0].pid = sleeperPid;
+      config.workers[0].pane_id = null;
+      await writeFile(configPath, JSON.stringify(config, null, 2));
+
+      const runtime = await resumeTeam('team-prompt-resume', cwd);
+      assert.equal(runtime, null);
+    } finally {
+      if (sleeperPid > 0) {
+        try {
+          process.kill(sleeperPid, 'SIGKILL');
+        } catch {
+          // already exited
+        }
+      }
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof prevLeaderCwd === 'string') process.env.OMX_TEAM_LEADER_CWD = prevLeaderCwd;
+      else delete process.env.OMX_TEAM_LEADER_CWD;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1134,7 +1134,35 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
   const config = await readTeamConfig(sanitized, cwd);
   if (!config) return null;
 
-  if (config.worker_launch_mode !== 'prompt') {
+  if (config.worker_launch_mode === 'prompt') {
+    const hasLivePromptWorker = config.workers.some((worker) => isPromptWorkerAlive(config, worker));
+    if (!hasLivePromptWorker) return null;
+
+    const missingHandles = config.workers
+      .filter((worker) => {
+        if (!Number.isFinite(worker.pid) || (worker.pid ?? 0) <= 0) return false;
+        try {
+          process.kill(worker.pid as number, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .filter((worker) => !getPromptWorkerHandle(sanitized, worker.name));
+    if (missingHandles.length > 0) {
+      const detail = missingHandles.map((worker) => `${worker.name}:${worker.pid ?? 'unknown'}`).join(',');
+      await appendTeamEvent(
+        sanitized,
+        {
+          type: 'worker_stopped',
+          worker: 'leader-fixed',
+          reason: `prompt_resume_unavailable:missing_handle:${detail}`,
+        },
+        cwd,
+      ).catch(() => {});
+      return null;
+    }
+  } else {
     // Check if tmux session still exists
     const baseSession = config.tmux_session.split(':')[0];
     const teamSessions = getTeamTmuxSessions(sanitized);


### PR DESCRIPTION
## Summary
- treat prompt-mode team resume as unavailable when live worker PIDs exist but process-local prompt handles are missing
- emit a deterministic team event describing prompt resume unavailability details
- add regression coverage for leader-restart style resume with missing prompt transport handles

Closes #297