### PR TITLE
fix(state): make state_write atomic under concurrent updates

### DIFF
--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdtemp, readFile, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -56,6 +56,38 @@ describe('state-server directory initialization', () => {
         JSON.parse(response.content[0]?.text || '{}'),
         { statuses: {} }
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes concurrent state_write calls per mode file and preserves merged fields', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-test-'));
+    try {
+      const writes = Array.from({ length: 16 }, (_, i) => handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+            state: { [`k${i}`]: i },
+          },
+        },
+      }));
+
+      const responses = await Promise.all(writes);
+      for (const response of responses) {
+        assert.equal(response.isError, undefined);
+      }
+
+      const filePath = join(wd, '.omx', 'state', 'team-state.json');
+      const state = JSON.parse(await readFile(filePath, 'utf-8')) as Record<string, unknown>;
+      for (let i = 0; i < 16; i++) {
+        assert.equal(state[`k${i}`], i);
+      }
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -10,7 +10,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { readFile, writeFile, readdir, mkdir, unlink } from 'fs/promises';
+import { readFile, writeFile, readdir, mkdir, unlink, rename } from 'fs/promises';
 import { existsSync, readFileSync } from 'fs';
 import { dirname, join, resolve as resolvePath } from 'path';
 import {
@@ -115,6 +115,38 @@ const TEAM_COMM_TOOL_NAMES = new Set([
 
 const TEAM_UPDATE_TASK_MUTABLE_FIELDS = new Set(['subject', 'description', 'blocked_by', 'requires_code_change']);
 const TEAM_UPDATE_TASK_REQUEST_FIELDS = new Set(['team_name', 'task_id', 'workingDirectory', ...TEAM_UPDATE_TASK_MUTABLE_FIELDS]);
+const stateWriteQueues = new Map<string, Promise<void>>();
+
+async function withStateWriteLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const tail = stateWriteQueues.get(path) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = tail.finally(() => gate);
+  stateWriteQueues.set(path, queued);
+
+  await tail.catch(() => {});
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (stateWriteQueues.get(path) === queued) {
+      stateWriteQueues.delete(path);
+    }
+  }
+}
+
+async function writeAtomicFile(path: string, data: string): Promise<void> {
+  const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  await writeFile(tmpPath, data, 'utf-8');
+  try {
+    await rename(tmpPath, path);
+  } catch (error) {
+    await unlink(tmpPath).catch(() => {});
+    throw error;
+  }
+}
 
 function isFiniteInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && Number.isFinite(value);
@@ -784,14 +816,6 @@ export async function handleStateToolCall(request: {
     case 'state_write': {
       const mode = (args as Record<string, unknown>).mode as string;
       const path = getStatePath(mode, cwd, effectiveSessionId);
-
-      let existing: Record<string, unknown> = {};
-      if (existsSync(path)) {
-        try {
-          existing = JSON.parse(await readFile(path, 'utf-8'));
-        } catch { /* start fresh */ }
-      }
-
       const {
         mode: _m,
         workingDirectory: _w,
@@ -799,36 +823,47 @@ export async function handleStateToolCall(request: {
         state: customState,
         ...fields
       } = args as Record<string, unknown>;
-      const mergedRaw = { ...existing, ...fields, ...(customState as Record<string, unknown> || {}) } as Record<string, unknown>;
+      let validationError: string | null = null;
+      await withStateWriteLock(path, async () => {
+        let existing: Record<string, unknown> = {};
+        if (existsSync(path)) {
+          try {
+            existing = JSON.parse(await readFile(path, 'utf-8'));
+          } catch { /* start fresh */ }
+        }
 
-      if (mode === 'ralph') {
-        const originalPhase = mergedRaw.current_phase;
-        const validation = validateAndNormalizeRalphState(mergedRaw);
-        if (!validation.ok || !validation.state) {
-          return {
-            content: [{
-              type: 'text',
-              text: JSON.stringify({
-                error: validation.error || `ralph.current_phase must be one of: ${RALPH_PHASES.join(', ')}`,
-              }),
-            }],
-            isError: true,
-          };
+        const mergedRaw = { ...existing, ...fields, ...(customState as Record<string, unknown> || {}) } as Record<string, unknown>;
+
+        if (mode === 'ralph') {
+          const originalPhase = mergedRaw.current_phase;
+          const validation = validateAndNormalizeRalphState(mergedRaw);
+          if (!validation.ok || !validation.state) {
+            validationError = validation.error || `ralph.current_phase must be one of: ${RALPH_PHASES.join(', ')}`;
+            return;
+          }
+          if (
+            typeof originalPhase === 'string'
+            && typeof validation.state.current_phase === 'string'
+            && validation.state.current_phase !== originalPhase
+          ) {
+            validation.state.ralph_phase_normalized_from = originalPhase;
+          }
+          Object.assign(mergedRaw, validation.state);
+          await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
         }
-        if (
-          typeof originalPhase === 'string'
-          && typeof validation.state.current_phase === 'string'
-          && validation.state.current_phase !== originalPhase
-        ) {
-          validation.state.ralph_phase_normalized_from = originalPhase;
-        }
-        Object.assign(mergedRaw, validation.state);
-        await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
+
+        const merged = withModeRuntimeContext(existing, mergedRaw);
+        await writeAtomicFile(path, JSON.stringify(merged, null, 2));
+      });
+      if (validationError) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({ error: validationError }),
+          }],
+          isError: true,
+        };
       }
-
-      const merged = withModeRuntimeContext(existing, mergedRaw);
-
-      await writeFile(path, JSON.stringify(merged, null, 2));
       return { content: [{ type: 'text', text: JSON.stringify({ success: true, mode, path }) }] };
     }
 


### PR DESCRIPTION
## Summary
- serialize state_write read/merge/write operations per state file to prevent lost updates
- switch state_write persistence to atomic temp-file + rename writes
- add regression coverage for concurrent state_write calls preserving merged fields

Closes #294