### PR TITLE
fix: tighten team/swarm keyword detector intent matching

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -49,12 +49,34 @@ describe('keyword detector swarm/team compatibility', () => {
   });
 
   it('keeps swarm trigger priority aligned with team trigger', () => {
-    const teamMatch = detectKeywords('team agents should handle this').find((entry) => entry.skill === 'team');
-    const swarmMatch = detectKeywords('swarm should handle this').find((entry) => entry.skill === 'team');
+    const teamMatch = detectKeywords('use team agents for this').find((entry) => entry.skill === 'team');
+    const swarmMatch = detectKeywords('use swarm for this').find((entry) => entry.skill === 'team');
 
     assert.ok(teamMatch);
     assert.ok(swarmMatch);
     assert.equal(swarmMatch.priority, teamMatch.priority);
+  });
+
+  it('does not trigger team keyword from filesystem/team-state path text', () => {
+    const match = detectPrimaryKeyword('You have 1 new message(s). Check .omx/state/team/execute-plan/mailbox/worker-3.json');
+    assert.equal(match, null);
+  });
+
+  it('does not trigger team skill from incidental prose usage', () => {
+    const match = detectPrimaryKeyword('the team reviewed the document and shared feedback');
+    assert.equal(match, null);
+  });
+
+  it('still triggers team for explicit $team invocation', () => {
+    const match = detectPrimaryKeyword('please run $team now');
+    assert.ok(match);
+    assert.equal(match.skill, 'team');
+  });
+
+  it('still triggers swarm for explicit /prompts:swarm invocation', () => {
+    const match = detectPrimaryKeyword('use /prompts:swarm for this');
+    assert.ok(match);
+    assert.equal(match.skill, 'team');
   });
 
   it('prefers ralplan over ralph when both keywords are present', () => {


### PR DESCRIPTION
## Summary
- tighten keyword detection semantics for bare `team` / `swarm` triggers to require explicit invocation intent
- keep backward compatibility for explicit aliases (`$team`, `$swarm`, `/prompts:team`, `/prompts:swarm`) and intent phrases (`use/run/... team|swarm`, `team/swarm mode/workflow/agents`)
- prevent false positives from incidental path/prose tokens such as `.omx/state/team/...`
- add regression tests covering false-positive negatives and explicit invocation positives

## Testing
- npm run build
- env -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_WORKER node --test dist/hooks/__tests__/keyword-detector.test.js

Closes #292
