### PR TITLE
fix: #295 make ast_grep_replace apply rewrites when dryRun=false

### DIFF
--- a/src/mcp/__tests__/code-intel-server.test.ts
+++ b/src/mcp/__tests__/code-intel-server.test.ts
@@ -33,4 +33,17 @@ describe('mcp/code-intel-server module contract', () => {
     assert.match(src, /const transport = new StdioServerTransport\(\);/);
     assert.match(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
   });
+
+  it('applies ast-grep rewrites only when dryRun=false', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/code-intel-server.ts'), 'utf8');
+    assert.match(src, /export function buildAstGrepRunArgs/);
+    assert.match(src, /if \(!options\.dryRun\) \{\s*args\.push\('--update-all'\);/);
+    assert.match(src, /args\.push\('--rewrite', options\.replacement\);/);
+  });
+
+  it('keeps dry-run/search behavior distinct from apply mode', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/code-intel-server.ts'), 'utf8');
+    assert.match(src, /if \(options\.replacement\) \{/);
+    assert.match(src, /else \{\s*args\.push\('--json'\);/);
+  });
 });

--- a/src/mcp/code-intel-server.ts
+++ b/src/mcp/code-intel-server.ts
@@ -187,10 +187,41 @@ async function findSgBinary(): Promise<string | null> {
   return null;
 }
 
+interface AstGrepRunOptions {
+  path?: string;
+  maxResults?: number;
+  context?: number;
+  replacement?: string;
+  dryRun?: boolean;
+}
+
+export function buildAstGrepRunArgs(
+  pattern: string,
+  language: string,
+  options: AstGrepRunOptions,
+): string[] {
+  const args: string[] = ['run', '--pattern', pattern, '--lang', language];
+
+  if (options.replacement) {
+    args.push('--rewrite', options.replacement);
+    if (!options.dryRun) {
+      args.push('--update-all');
+    }
+  } else {
+    args.push('--json');
+  }
+
+  if (options.path) {
+    args.push(options.path);
+  }
+
+  return args;
+}
+
 async function runAstGrep(
   pattern: string,
   language: string,
-  options: { path?: string; maxResults?: number; context?: number; replacement?: string; dryRun?: boolean }
+  options: AstGrepRunOptions
 ): Promise<{ matches: unknown[]; command: string }> {
   const sg = await findSgBinary();
   if (!sg) {
@@ -203,20 +234,7 @@ async function runAstGrep(
     args.push('--yes', '@ast-grep/cli');
   }
 
-  if (options.replacement && !options.dryRun) {
-    // Rewrite mode
-    args.push('run', '--pattern', pattern, '--rewrite', options.replacement, '--lang', language);
-  } else if (options.replacement && options.dryRun) {
-    // Dry run rewrite
-    args.push('run', '--pattern', pattern, '--rewrite', options.replacement, '--lang', language);
-  } else {
-    // Search mode
-    args.push('run', '--pattern', pattern, '--lang', language, '--json');
-  }
-
-  if (options.path) {
-    args.push(options.path);
-  }
+  args.push(...buildAstGrepRunArgs(pattern, language, options));
 
   try {
     const { stdout } = await exec(cmd, args, { timeout: 30000 });


### PR DESCRIPTION
## Summary
- fix ast-grep replace apply mode by adding `--update-all` when `dryRun=false`
- keep dry-run rewrite behavior unchanged (no apply flag)
- refactor command argument assembly into `buildAstGrepRunArgs()` to make mode behavior explicit and testable
- extend MCP code-intel tests to verify apply-mode and dry-run command contracts

## Verification
- npm run build
- node --test dist/mcp/__tests__/code-intel-server.test.js

Closes #295
