### PR TITLE
fix: reset keyword activated_at on skill changes

### DIFF
--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -135,7 +135,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const nowIso = input.nowIso ?? new Date().toISOString();
   const statePath = join(input.stateDir, SKILL_ACTIVE_STATE_FILE);
   const previous = await readJsonIfExists<Partial<SkillActiveState> | null>(statePath, null);
-  const activatedAt = typeof previous?.activated_at === 'string' && previous.activated_at !== ''
+  const sameSkillLifecycle = previous?.active === true
+    && typeof previous.skill === 'string'
+    && previous.skill === match.skill
+    && typeof previous.keyword === 'string'
+    && previous.keyword.toLowerCase() === match.keyword.toLowerCase();
+  const activatedAt = sameSkillLifecycle && typeof previous?.activated_at === 'string' && previous.activated_at !== ''
     ? previous.activated_at
     : nowIso;
 


### PR DESCRIPTION
## Summary
- fix `recordSkillActivation()` to preserve `activated_at` only when activation continues the same active skill lifecycle
- reset `activated_at` to the current timestamp when skill/keyword changes
- add regression tests for same-skill continuation and skill-switch reset behavior

## Testing
- npm run build
- env -u OMX_TEAM_STATE_ROOT -u OMX_TEAM_WORKER node --test dist/hooks/__tests__/keyword-detector.test.js

Closes #290
