### PR TITLE
fix(cli): include repo name in tmux session name for worktree launches

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -452,6 +452,16 @@ describe('buildTmuxSessionName', () => {
     assert.equal(name.includes('_'), false);
     assert.equal(name.includes(' '), false);
   });
+
+  it('includes repo name when cwd is inside .omx-worktrees', () => {
+    const name = buildTmuxSessionName('/home/user/my-repo.omx-worktrees/launch-feature-x', 'omx-123-abc');
+    assert.match(name, /^omx-my-repo-launch-feature-x-/);
+  });
+
+  it('includes repo name for detached worktree paths', () => {
+    const name = buildTmuxSessionName('/projects/cool-project.omx-worktrees/launch-detached', 'omx-456-def');
+    assert.match(name, /^omx-cool-project-launch-detached-/);
+  });
 });
 
 describe('team worker launch arg inheritance helpers', () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -674,7 +674,11 @@ function sanitizeTmuxToken(value: string): string {
 }
 
 export function buildTmuxSessionName(cwd: string, sessionId: string): string {
-  const dirToken = sanitizeTmuxToken(basename(cwd));
+  const parentDir = basename(dirname(cwd));
+  const dirName = basename(cwd);
+  const dirToken = parentDir.endsWith('.omx-worktrees')
+    ? sanitizeTmuxToken(`${parentDir.slice(0, -'.omx-worktrees'.length)}-${dirName}`)
+    : sanitizeTmuxToken(dirName);
   let branchToken = 'detached';
   try {
     const branch = execSync('git rev-parse --abbrev-ref HEAD', {


### PR DESCRIPTION
## Summary
- When `omx` is launched with `--worktree` or `-w`, the tmux session name now includes the repository name extracted from the `.omx-worktrees` parent directory
- Previously, the session name only used `basename(cwd)` which gave generic names like `launch-feature-x` — now it produces `my-repo-launch-feature-x` so users can identify which repo each session belongs to
- Added 2 new tests covering worktree and detached worktree session naming

## Test plan
- [x] `buildTmuxSessionName` includes repo name when cwd is inside `.omx-worktrees`
- [x] `buildTmuxSessionName` includes repo name for detached worktree paths
- [x] Existing tests still pass (non-worktree paths unchanged)
- [x] All 72 index tests pass, 1165/1168 full suite pass (3 pre-existing failures)

Fixes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)