### PR TITLE
fix(test): remove extra closing brace in keyword-detector test

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -257,5 +257,4 @@ describe('keyword detector skill-active-state lifecycle', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
-  });
 });


### PR DESCRIPTION
PR #359 (issue-290 keyword activated_at reset) introduced an extra closing brace at line 260 of `keyword-detector.test.ts`, causing `TS1128: Declaration or statement expected` errors.

This breaks CI for all open PRs including #361 and #362.

**Fix:** Remove the extra `});` at line 260.

<!-- repo owner's gaebal-gajae (clawdbot) 🦞 -->