### PR TITLE
fix(test): use HOME env for config path, update ralph error regex

### DIFF
--- a/src/hooks/code-simplifier/__tests__/index.test.ts
+++ b/src/hooks/code-simplifier/__tests__/index.test.ts
@@ -230,7 +230,7 @@ describe('processCodeSimplifier', () => {
     writeEnabledCodeSimplifierConfig(homeDir);
     writeFileSync(join(cwd, 'tracked.ts'), 'export const changed = 2;\n', 'utf-8');
 
-    const result = processCodeSimplifier(cwd, stateDir);
+    const result = processCodeSimplifier(cwd, stateDir, homeDir);
 
     assert.equal(result.triggered, true);
     assert.match(result.message, /tracked\.ts/);
@@ -242,11 +242,11 @@ describe('processCodeSimplifier', () => {
     writeEnabledCodeSimplifierConfig(homeDir);
     writeFileSync(join(cwd, 'tracked.ts'), 'export const changed = 2;\n', 'utf-8');
 
-    const first = processCodeSimplifier(cwd, stateDir);
+    const first = processCodeSimplifier(cwd, stateDir, homeDir);
     assert.equal(first.triggered, true);
     assert.equal(isAlreadyTriggered(stateDir), true);
 
-    const second = processCodeSimplifier(cwd, stateDir);
+    const second = processCodeSimplifier(cwd, stateDir, homeDir);
     assert.equal(second.triggered, false);
     assert.equal(isAlreadyTriggered(stateDir), false);
   });

--- a/src/modes/__tests__/base-ralph-contract.test.ts
+++ b/src/modes/__tests__/base-ralph-contract.test.ts
@@ -12,7 +12,7 @@ describe('modes/base ralph contract integration', () => {
     try {
       await assert.rejects(
         () => startMode('ralph', 'demo', 0, wd),
-        /ralph\.max_iterations must be a finite number > 0/,
+        /ralph\.max_iterations must be a finite (number|integer) > 0/,
       );
       assert.equal(existsSync(join(wd, '.omx', 'state', 'ralph-state.json')), false);
     } finally {


### PR DESCRIPTION
Fixes 3 CI test failures on dev introduced by recent merges:

1. **processCodeSimplifier** (2 tests): `readOmxConfig()` used `os.homedir()` which doesn't respect `process.env.HOME` overrides in test/CI. Changed to read `HOME`/`USERPROFILE` env vars first.

2. **ralph contract** (1 test): Error regex expected `number` but PR #355 changed the message to `integer`. Updated regex to accept either.

<!-- repo owner's gaebal-gajae (clawdbot) 🦞 -->