### PR TITLE
Fix dev CI baseline (code-simplifier parsing + Ralph contract test regex)

### DIFF
--- a/src/hooks/code-simplifier/index.ts
+++ b/src/hooks/code-simplifier/index.ts
@@ -84,15 +84,16 @@ export function getModifiedFiles(
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
     });
-    const trimmedOutput = output.trim();
-    if (trimmedOutput.length === 0) {
+    const lines = output
+      .split('\n')
+      .map((line) => line.trimEnd())
+      .filter((line) => line.trim().length > 0);
+
+    if (lines.length === 0) {
       return [];
     }
 
-    const candidates = trimmedOutput
-      .split('\n')
-      .map((line) => line.trimEnd())
-      .filter((line) => line.length > 0)
+    const candidates = lines
       .flatMap((line) => {
         if (line.startsWith('?? ')) {
           return [line.slice(3).trim()];

--- a/src/modes/__tests__/base-ralph-contract.test.ts
+++ b/src/modes/__tests__/base-ralph-contract.test.ts
@@ -12,7 +12,7 @@ describe('modes/base ralph contract integration', () => {
     try {
       await assert.rejects(
         () => startMode('ralph', 'demo', 0, wd),
-        /ralph\.max_iterations must be a finite number > 0/,
+        /ralph\.max_iterations must be a finite (number|integer) > 0/,
       );
       assert.equal(existsSync(join(wd, '.omx', 'state', 'ralph-state.json')), false);
     } finally {
@@ -58,4 +58,3 @@ describe('modes/base ralph contract integration', () => {
     }
   });
 });
-


### PR DESCRIPTION
Unblocks PR CI on branches targeting `dev` by fixing two shared test failures:

- preserve leading porcelain status column in code-simplifier modified-file parsing
- relax Ralph contract test expectation to accept the current "finite integer" validation wording

Validated locally with targeted tests after build:
- dist/hooks/code-simplifier/__tests__/index.test.js
- dist/modes/__tests__/base-ralph-contract.test.js