### PR TITLE
fix(code-simplifier): fix CI test failures from trim() and homedir()

### DIFF
--- a/src/hooks/code-simplifier/__tests__/index.test.ts
+++ b/src/hooks/code-simplifier/__tests__/index.test.ts
@@ -42,6 +42,7 @@ function writeEnabledCodeSimplifierConfig(homeDir: string): void {
     'utf-8',
   );
 }
+
 describe('code-simplifier trigger marker', () => {
   let stateDir: string;
 
@@ -186,40 +187,22 @@ describe('processCodeSimplifier', () => {
   let stateDir: string;
   let cwd: string;
   let homeDir: string;
-  let originalHome: string | undefined;
-  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     stateDir = makeTmpDir();
     cwd = makeTmpDir();
     homeDir = makeTmpDir();
-    originalHome = process.env.HOME;
-    originalUserProfile = process.env.USERPROFILE;
-    process.env.HOME = homeDir;
-    process.env.USERPROFILE = homeDir;
   });
 
   afterEach(() => {
-    if (typeof originalHome === 'string') {
-      process.env.HOME = originalHome;
-    } else {
-      delete process.env.HOME;
-    }
-
-    if (typeof originalUserProfile === 'string') {
-      process.env.USERPROFILE = originalUserProfile;
-    } else {
-      delete process.env.USERPROFILE;
-    }
-
     rmSync(stateDir, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
     rmSync(homeDir, { recursive: true, force: true });
   });
 
   it('returns not triggered when disabled (no config)', () => {
-    // processCodeSimplifier reads ~/.omx/config.json and is disabled by default.
-    const result = processCodeSimplifier(cwd, stateDir);
+    // Pass homeDir as configDir — no config file exists there, so disabled.
+    const result = processCodeSimplifier(cwd, stateDir, homeDir);
 
     assert.equal(result.triggered, false);
     assert.equal(result.message, '');


### PR DESCRIPTION
## Summary
- **Root cause 1**: `getModifiedFiles` used `output.trim()` which stripped the leading space from git status porcelain format (`" M file.ts"` → `"M file.ts"`), corrupting status parsing and truncating file paths (`"tracked.ts"` → `"racked.ts"`). Fixed by using `trimEnd()` instead.
- **Root cause 2**: `readOmxConfig`/`isCodeSimplifierEnabled`/`processCodeSimplifier` used `os.homedir()` with no override, making tests depend on `process.env.HOME` being respected — unreliable in CI. Added optional `configDir` parameter threaded through all three functions.
- Upgraded `getModifiedFiles` from `git diff HEAD --name-only` to `git status --porcelain` to properly handle untracked, renamed, and deleted files.

## Test plan
- [x] Both previously-failing tests now pass: "triggers deterministically when enabled config and modified files are present" and "clears marker on second call after a successful trigger (cycle prevention)"
- [x] New test coverage for modified/untracked/renamed/deleted file detection
- [x] All existing code-simplifier tests continue to pass
- [x] `npm run build` succeeds with zero type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)