### PR TITLE
fix(auto-nudge): allow stall nudges when completing phase is stale

### DIFF
--- a/scripts/notify-hook/auto-nudge.js
+++ b/scripts/notify-hook/auto-nudge.js
@@ -201,7 +201,6 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
       skillState.updated_at = new Date().toISOString();
       await persistSkillActiveState(stateDir, skillState);
     }
-    if (skillState.phase === 'completing') return;
   }
 
   // Check nudge count against session limit
@@ -226,6 +225,11 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     detected = detectStallPattern(captured, config.patterns);
     source = 'capture-pane';
   }
+
+  // Preserve completion quietness unless we explicitly see a stall phrase.
+  // This handles stale skill-state files that remain in "completing" while
+  // the assistant still asks for permission ("if you want", etc.).
+  if (skillState?.phase === 'completing' && !detected) return;
 
   if (!detected || !paneId) return;
 


### PR DESCRIPTION
## Summary
- fix stale `skill-active-state` handling in auto-nudge so stall phrases like `if you want` still trigger continuation
- keep quiet behavior for true completion messages with no stall phrase
- update/add regression tests covering both paths

## Root cause
When `skill-active-state.json` stayed at `phase = "completing"`, `maybeAutoNudge` returned before stall-pattern detection. This suppressed nudges even when the assistant asked for permission.

## Changes
- `scripts/notify-hook/auto-nudge.js`
  - move completion-phase early-return to apply only when no stall phrase is detected
- `src/hooks/__tests__/notify-hook-auto-nudge.test.ts`
  - stale-completing + stall phrase now nudges
  - true completion text in completing phase remains no-nudge

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/notify-hook-regression-205.test.js`