### PR TITLE
feat(cli): add omx uninstall command

### DIFF
--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -1,0 +1,479 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {}
+): { status: number | null; stdout: string; stderr: string; error: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const result = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message || '',
+  };
+}
+
+function shouldSkipForSpawnPermissions(err: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+/** Build a realistic OMX config.toml for testing */
+function buildOmxConfig(): string {
+  return [
+    '# oh-my-codex top-level settings (must be before any [table])',
+    'notify = ["node", "/path/to/notify-hook.js"]',
+    'model_reasoning_effort = "high"',
+    'developer_instructions = "You have oh-my-codex installed."',
+    '',
+    '[features]',
+    'multi_agent = true',
+    'child_agents_md = true',
+    '',
+    '# ============================================================',
+    '# oh-my-codex (OMX) Configuration',
+    '# Managed by omx setup - manual edits preserved on next setup',
+    '# ============================================================',
+    '',
+    '# OMX State Management MCP Server',
+    '[mcp_servers.omx_state]',
+    'command = "node"',
+    'args = ["/path/to/state-server.js"]',
+    'enabled = true',
+    'startup_timeout_sec = 5',
+    '',
+    '# OMX Project Memory MCP Server',
+    '[mcp_servers.omx_memory]',
+    'command = "node"',
+    'args = ["/path/to/memory-server.js"]',
+    'enabled = true',
+    'startup_timeout_sec = 5',
+    '',
+    '# OMX Code Intelligence MCP Server',
+    '[mcp_servers.omx_code_intel]',
+    'command = "node"',
+    'args = ["/path/to/code-intel-server.js"]',
+    'enabled = true',
+    'startup_timeout_sec = 10',
+    '',
+    '# OMX Trace MCP Server',
+    '[mcp_servers.omx_trace]',
+    'command = "node"',
+    'args = ["/path/to/trace-server.js"]',
+    'enabled = true',
+    'startup_timeout_sec = 5',
+    '',
+    '[agents.executor]',
+    'description = "Code implementation"',
+    'config_file = "/path/to/executor.toml"',
+    '',
+    '# OMX TUI StatusLine (Codex CLI v0.101.0+)',
+    '[tui]',
+    'status_line = ["model-with-reasoning", "git-branch"]',
+    '',
+    '# ============================================================',
+    '# End oh-my-codex',
+    '',
+  ].join('\n');
+}
+
+/** Build a config with OMX entries mixed with user entries */
+function buildMixedConfig(): string {
+  return [
+    '# User settings',
+    'model = "o4-mini"',
+    '',
+    '# oh-my-codex top-level settings (must be before any [table])',
+    'notify = ["node", "/path/to/notify-hook.js"]',
+    'model_reasoning_effort = "high"',
+    'developer_instructions = "You have oh-my-codex installed."',
+    '',
+    '[features]',
+    'multi_agent = true',
+    'child_agents_md = true',
+    'web_search = true',
+    '',
+    '[mcp_servers.user_custom]',
+    'command = "custom"',
+    'args = ["--flag"]',
+    '',
+    '# ============================================================',
+    '# oh-my-codex (OMX) Configuration',
+    '# Managed by omx setup - manual edits preserved on next setup',
+    '# ============================================================',
+    '',
+    '[mcp_servers.omx_state]',
+    'command = "node"',
+    'args = ["/path/to/state-server.js"]',
+    'enabled = true',
+    '',
+    '[mcp_servers.omx_memory]',
+    'command = "node"',
+    'args = ["/path/to/memory-server.js"]',
+    'enabled = true',
+    '',
+    '[mcp_servers.omx_code_intel]',
+    'command = "node"',
+    'args = ["/path/to/code-intel-server.js"]',
+    'enabled = true',
+    '',
+    '[mcp_servers.omx_trace]',
+    'command = "node"',
+    'args = ["/path/to/trace-server.js"]',
+    'enabled = true',
+    '',
+    '[agents.executor]',
+    'description = "Code implementation"',
+    'config_file = "/path/to/executor.toml"',
+    '',
+    '[tui]',
+    'status_line = ["model-with-reasoning"]',
+    '',
+    '# ============================================================',
+    '# End oh-my-codex',
+    '',
+  ].join('\n');
+}
+
+describe('omx uninstall', () => {
+  it('removes OMX block from config.toml with --dry-run', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
+
+      const res = runOmx(wd, ['uninstall', '--dry-run'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /dry-run mode/);
+      assert.match(res.stdout, /OMX configuration block/);
+      assert.match(res.stdout, /omx_state/);
+
+      // Config should NOT have been modified
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.match(config, /oh-my-codex \(OMX\) Configuration/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes OMX block from config.toml', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /Removed OMX configuration block/);
+
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.doesNotMatch(config, /oh-my-codex \(OMX\) Configuration/);
+      assert.doesNotMatch(config, /omx_state/);
+      assert.doesNotMatch(config, /omx_memory/);
+      assert.doesNotMatch(config, /omx_code_intel/);
+      assert.doesNotMatch(config, /omx_trace/);
+      assert.doesNotMatch(config, /\[agents\.executor\]/);
+      assert.doesNotMatch(config, /\[tui\]/);
+      assert.doesNotMatch(config, /notify\s*=/);
+      assert.doesNotMatch(config, /model_reasoning_effort\s*=/);
+      assert.doesNotMatch(config, /developer_instructions\s*=/);
+      assert.doesNotMatch(config, /multi_agent\s*=/);
+      assert.doesNotMatch(config, /child_agents_md\s*=/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves user config entries when removing OMX', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildMixedConfig());
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      // User settings preserved
+      assert.match(config, /model = "o4-mini"/);
+      assert.match(config, /\[mcp_servers\.user_custom\]/);
+      assert.match(config, /web_search = true/);
+      // OMX entries removed
+      assert.doesNotMatch(config, /omx_state/);
+      assert.doesNotMatch(config, /omx_memory/);
+      assert.doesNotMatch(config, /notify\s*=.*node/);
+      assert.doesNotMatch(config, /multi_agent/);
+      assert.doesNotMatch(config, /child_agents_md/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('--keep-config skips config.toml cleanup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
+
+      const res = runOmx(wd, ['uninstall', '--keep-config'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /--keep-config/);
+
+      // Config should NOT have been modified
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.match(config, /oh-my-codex \(OMX\) Configuration/);
+      assert.match(config, /omx_state/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('--purge removes .omx/ cache directory', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+      // Create .omx/ directory with some files
+      const omxDir = join(wd, '.omx');
+      await mkdir(join(omxDir, 'state'), { recursive: true });
+      await writeFile(join(omxDir, 'setup-scope.json'), JSON.stringify({ scope: 'user' }));
+      await writeFile(join(omxDir, 'notepad.md'), '# notes');
+      await writeFile(join(omxDir, 'state', 'ralph-state.json'), '{}');
+
+      const res = runOmx(wd, ['uninstall', '--keep-config', '--purge'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /\.omx\/ cache directory/);
+
+      assert.equal(existsSync(omxDir), false, '.omx/ directory should be removed');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('works with project scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+
+      // Create project-scoped setup
+      const omxDir = join(wd, '.omx');
+      const codexDir = join(wd, '.codex');
+      await mkdir(omxDir, { recursive: true });
+      await mkdir(join(codexDir, 'prompts'), { recursive: true });
+      await writeFile(join(omxDir, 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
+      // Install a prompt
+      await writeFile(join(codexDir, 'prompts', 'executor.md'), '# executor');
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /Resolved scope: project/);
+
+      // Project-local config.toml should be cleaned
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.doesNotMatch(config, /oh-my-codex \(OMX\) Configuration/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('handles missing config.toml gracefully', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /Nothing to remove/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('shows summary of what was removed', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /Uninstall summary/);
+      assert.match(res.stdout, /MCP servers: omx_state, omx_memory, omx_code_intel, omx_trace/);
+      assert.match(res.stdout, /Agent entries: 1/);
+      assert.match(res.stdout, /TUI status line section/);
+      assert.match(res.stdout, /Top-level keys/);
+      assert.match(res.stdout, /Feature flags/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('--dry-run --purge does not actually remove .omx/ directory', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+      const omxDir = join(wd, '.omx');
+      await mkdir(join(omxDir, 'state'), { recursive: true });
+      await writeFile(join(omxDir, 'setup-scope.json'), JSON.stringify({ scope: 'user' }));
+      await writeFile(join(omxDir, 'notepad.md'), '# notes');
+
+      const res = runOmx(wd, ['uninstall', '--keep-config', '--purge', '--dry-run'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /dry-run mode/);
+      assert.match(res.stdout, /\.omx\/ cache directory/);
+
+      // .omx/ should still exist
+      assert.equal(existsSync(omxDir), true, '.omx/ should NOT be removed in dry-run');
+      assert.equal(existsSync(join(omxDir, 'notepad.md')), true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('second uninstall run reports nothing to remove (idempotent)', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
+
+      const first = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(first.error)) return;
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+      assert.match(first.stdout, /Removed OMX configuration block/);
+
+      const second = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(second.error)) return;
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+      assert.match(second.stdout, /Nothing to remove/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not delete user AGENTS.md that merely mentions oh-my-codex', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+      const userAgentsMd = '# My Agents\n\nDo not use oh-my-codex for this project.\n';
+      await writeFile(join(wd, 'AGENTS.md'), userAgentsMd);
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      // User AGENTS.md should be preserved
+      assert.equal(existsSync(join(wd, 'AGENTS.md')), true);
+      const content = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      assert.equal(content, userAgentsMd);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes setup-scope.json and hud-config.json without --purge', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+      const omxDir = join(wd, '.omx');
+      await mkdir(omxDir, { recursive: true });
+      await writeFile(join(omxDir, 'setup-scope.json'), JSON.stringify({ scope: 'user' }));
+      await writeFile(join(omxDir, 'hud-config.json'), JSON.stringify({ preset: 'focused' }));
+      await writeFile(join(omxDir, 'notepad.md'), '# keep this');
+
+      const res = runOmx(wd, ['uninstall', '--keep-config'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      assert.equal(existsSync(join(omxDir, 'setup-scope.json')), false);
+      assert.equal(existsSync(join(omxDir, 'hud-config.json')), false);
+      // notepad.md should still exist (not purged)
+      assert.equal(existsSync(join(omxDir, 'notepad.md')), true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('stripOmxFeatureFlags', () => {
+  it('removes OMX feature flags and preserves user flags', async () => {
+    const { stripOmxFeatureFlags } = await import('../../config/generator.js');
+
+    const config = [
+      '[features]',
+      'multi_agent = true',
+      'child_agents_md = true',
+      'web_search = true',
+      '',
+    ].join('\n');
+
+    const result = stripOmxFeatureFlags(config);
+    assert.doesNotMatch(result, /multi_agent/);
+    assert.doesNotMatch(result, /child_agents_md/);
+    assert.match(result, /web_search = true/);
+    assert.match(result, /\[features\]/);
+  });
+
+  it('removes [features] section if it becomes empty', async () => {
+    const { stripOmxFeatureFlags } = await import('../../config/generator.js');
+
+    const config = [
+      '[features]',
+      'multi_agent = true',
+      'child_agents_md = true',
+      '',
+    ].join('\n');
+
+    const result = stripOmxFeatureFlags(config);
+    assert.doesNotMatch(result, /\[features\]/);
+    assert.doesNotMatch(result, /multi_agent/);
+  });
+
+  it('handles config without [features] section', async () => {
+    const { stripOmxFeatureFlags } = await import('../../config/generator.js');
+
+    const config = 'model = "o4-mini"\n';
+    const result = stripOmxFeatureFlags(config);
+    assert.equal(result, config);
+  });
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -39,7 +39,7 @@ const LEGACY_SCOPE_MIGRATION: Record<string, 'project'> = {
 export const SETUP_SCOPES = ['user', 'project'] as const;
 export type SetupScope = typeof SETUP_SCOPES[number];
 
-interface ScopeDirectories {
+export interface ScopeDirectories {
   codexConfigFile: string;
   codexHomeDir: string;
   nativeAgentsDir: string;
@@ -80,7 +80,7 @@ function getScopeFilePath(projectRoot: string): string {
   return join(projectRoot, '.omx', 'setup-scope.json');
 }
 
-function resolveScopeDirectories(scope: SetupScope, projectRoot: string): ScopeDirectories {
+export function resolveScopeDirectories(scope: SetupScope, projectRoot: string): ScopeDirectories {
   if (scope === 'project') {
     const codexHomeDir = join(projectRoot, '.codex');
     return {

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -1,0 +1,411 @@
+/**
+ * omx uninstall - Remove oh-my-codex configuration and installed artifacts
+ */
+
+import { readFile, writeFile, readdir, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, basename } from 'path';
+import {
+  stripExistingOmxBlocks,
+  stripOmxTopLevelKeys,
+  stripOmxFeatureFlags,
+} from '../config/generator.js';
+import { getPackageRoot } from '../utils/package.js';
+import { AGENT_DEFINITIONS } from '../agents/definitions.js';
+import { resolveScopeDirectories, type SetupScope } from './setup.js';
+import { readPersistedSetupScope } from './index.js';
+
+export interface UninstallOptions {
+  dryRun?: boolean;
+  keepConfig?: boolean;
+  verbose?: boolean;
+  purge?: boolean;
+  scope?: SetupScope;
+}
+
+interface UninstallSummary {
+  configCleaned: boolean;
+  mcpServersRemoved: string[];
+  agentEntriesRemoved: number;
+  tuiSectionRemoved: boolean;
+  topLevelKeysRemoved: boolean;
+  featureFlagsRemoved: boolean;
+  promptsRemoved: number;
+  skillsRemoved: number;
+  agentConfigsRemoved: number;
+  agentsMdRemoved: boolean;
+  cacheDirectoryRemoved: boolean;
+}
+
+const OMX_MCP_SERVERS = ['omx_state', 'omx_memory', 'omx_code_intel', 'omx_trace'];
+
+function detectOmxConfigArtifacts(config: string): {
+  hasMcpServers: string[];
+  hasAgentEntries: number;
+  hasTuiSection: boolean;
+  hasTopLevelKeys: boolean;
+  hasFeatureFlags: boolean;
+} {
+  const hasMcpServers = OMX_MCP_SERVERS.filter((name) =>
+    new RegExp(`\\[mcp_servers\\.${name}\\]`).test(config)
+  );
+
+  const agentNames = Object.keys(AGENT_DEFINITIONS);
+  let hasAgentEntries = 0;
+  for (const name of agentNames) {
+    const tableKey = name.includes('-') ? `agents."${name}"` : `agents.${name}`;
+    if (config.includes(`[${tableKey}]`)) {
+      hasAgentEntries++;
+    }
+  }
+
+  const hasTuiSection = /^\[tui\]/m.test(config) &&
+    config.includes('oh-my-codex (OMX) Configuration');
+
+  const hasTopLevelKeys =
+    /^\s*notify\s*=.*node/m.test(config) ||
+    /^\s*model_reasoning_effort\s*=/m.test(config) ||
+    /^\s*developer_instructions\s*=.*oh-my-codex/m.test(config);
+
+  const hasFeatureFlags =
+    /^\s*multi_agent\s*=\s*true/m.test(config) ||
+    /^\s*child_agents_md\s*=\s*true/m.test(config);
+
+  return { hasMcpServers, hasAgentEntries, hasTuiSection, hasTopLevelKeys, hasFeatureFlags };
+}
+
+async function cleanConfig(
+  configPath: string,
+  options: Pick<UninstallOptions, 'dryRun' | 'verbose'>,
+): Promise<Pick<UninstallSummary,
+  'configCleaned' | 'mcpServersRemoved' | 'agentEntriesRemoved' |
+  'tuiSectionRemoved' | 'topLevelKeysRemoved' | 'featureFlagsRemoved'
+>> {
+  const result = {
+    configCleaned: false,
+    mcpServersRemoved: [] as string[],
+    agentEntriesRemoved: 0,
+    tuiSectionRemoved: false,
+    topLevelKeysRemoved: false,
+    featureFlagsRemoved: false,
+  };
+
+  if (!existsSync(configPath)) {
+    if (options.verbose) console.log('  config.toml not found, skipping.');
+    return result;
+  }
+
+  const original = await readFile(configPath, 'utf-8');
+  const detected = detectOmxConfigArtifacts(original);
+
+  result.mcpServersRemoved = detected.hasMcpServers;
+  result.agentEntriesRemoved = detected.hasAgentEntries;
+  result.tuiSectionRemoved = detected.hasTuiSection;
+  result.topLevelKeysRemoved = detected.hasTopLevelKeys;
+  result.featureFlagsRemoved = detected.hasFeatureFlags;
+
+  // Strip OMX tables block (MCP servers, agents, tui)
+  let config = original;
+  const { cleaned } = stripExistingOmxBlocks(config);
+  config = cleaned;
+
+  // Strip top-level keys
+  config = stripOmxTopLevelKeys(config);
+
+  // Strip feature flags
+  config = stripOmxFeatureFlags(config);
+
+  // Normalize trailing whitespace
+  config = config.trimEnd() + '\n';
+
+  if (config !== original) {
+    result.configCleaned = true;
+    if (!options.dryRun) {
+      await writeFile(configPath, config);
+    }
+    if (options.verbose) {
+      console.log(`  ${options.dryRun ? 'Would clean' : 'Cleaned'} ${configPath}`);
+    }
+  } else {
+    if (options.verbose) console.log('  No OMX config entries found.');
+  }
+
+  return result;
+}
+
+async function removeInstalledPrompts(
+  promptsDir: string,
+  pkgRoot: string,
+  options: Pick<UninstallOptions, 'dryRun' | 'verbose'>,
+): Promise<number> {
+  const srcPromptsDir = join(pkgRoot, 'prompts');
+  if (!existsSync(srcPromptsDir) || !existsSync(promptsDir)) return 0;
+
+  let removed = 0;
+  const sourceFiles = await readdir(srcPromptsDir);
+
+  for (const file of sourceFiles) {
+    if (!file.endsWith('.md')) continue;
+    const installed = join(promptsDir, file);
+    if (!existsSync(installed)) continue;
+
+    if (!options.dryRun) {
+      await rm(installed, { force: true });
+    }
+    if (options.verbose) console.log(`  ${options.dryRun ? 'Would remove' : 'Removed'} prompt: ${file}`);
+    removed++;
+  }
+
+  return removed;
+}
+
+async function removeInstalledSkills(
+  skillsDir: string,
+  pkgRoot: string,
+  options: Pick<UninstallOptions, 'dryRun' | 'verbose'>,
+): Promise<number> {
+  const srcSkillsDir = join(pkgRoot, 'skills');
+  if (!existsSync(srcSkillsDir) || !existsSync(skillsDir)) return 0;
+
+  let removed = 0;
+  const sourceEntries = await readdir(srcSkillsDir, { withFileTypes: true });
+
+  for (const entry of sourceEntries) {
+    if (!entry.isDirectory()) continue;
+    const installed = join(skillsDir, entry.name);
+    if (!existsSync(installed)) continue;
+
+    if (!options.dryRun) {
+      await rm(installed, { recursive: true, force: true });
+    }
+    if (options.verbose) console.log(`  ${options.dryRun ? 'Would remove' : 'Removed'} skill: ${entry.name}/`);
+    removed++;
+  }
+
+  return removed;
+}
+
+async function removeAgentConfigs(
+  agentsDir: string,
+  options: Pick<UninstallOptions, 'dryRun' | 'verbose'>,
+): Promise<number> {
+  if (!existsSync(agentsDir)) return 0;
+
+  let removed = 0;
+  const agentNames = Object.keys(AGENT_DEFINITIONS);
+
+  for (const name of agentNames) {
+    const configFile = join(agentsDir, `${name}.toml`);
+    if (!existsSync(configFile)) continue;
+
+    if (!options.dryRun) {
+      await rm(configFile, { force: true });
+    }
+    if (options.verbose) console.log(`  ${options.dryRun ? 'Would remove' : 'Removed'} agent config: ${name}.toml`);
+    removed++;
+  }
+
+  // If the agents dir is now empty, remove it too
+  if (!options.dryRun && existsSync(agentsDir)) {
+    try {
+      const remaining = await readdir(agentsDir);
+      if (remaining.length === 0) {
+        await rm(agentsDir, { recursive: true, force: true });
+        if (options.verbose) console.log('  Removed empty agents directory.');
+      }
+    } catch {
+      // Ignore errors when cleaning up empty dir
+    }
+  }
+
+  return removed;
+}
+
+async function removeAgentsMd(
+  projectRoot: string,
+  options: Pick<UninstallOptions, 'dryRun' | 'verbose'>,
+): Promise<boolean> {
+  const agentsMdPath = join(projectRoot, 'AGENTS.md');
+  if (!existsSync(agentsMdPath)) return false;
+
+  try {
+    const content = await readFile(agentsMdPath, 'utf-8');
+    // Only remove if it's the OMX-generated template (check for machine-parseable marker
+    // or the exact template title line to avoid false positives on user files)
+    const isOmxGenerated =
+      content.includes('# oh-my-codex - Intelligent Multi-Agent Orchestration') ||
+      content.includes('<!-- omx:generated:agents-md -->');
+    if (!isOmxGenerated) {
+      if (options.verbose) console.log('  AGENTS.md is not OMX-generated, skipping.');
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  if (!options.dryRun) {
+    await rm(agentsMdPath, { force: true });
+  }
+  if (options.verbose) console.log(`  ${options.dryRun ? 'Would remove' : 'Removed'} AGENTS.md`);
+  return true;
+}
+
+async function removeCacheDirectory(
+  projectRoot: string,
+  options: Pick<UninstallOptions, 'dryRun' | 'verbose'>,
+): Promise<boolean> {
+  const omxDir = join(projectRoot, '.omx');
+  if (!existsSync(omxDir)) return false;
+
+  if (!options.dryRun) {
+    await rm(omxDir, { recursive: true, force: true });
+  }
+  if (options.verbose) console.log(`  ${options.dryRun ? 'Would remove' : 'Removed'} ${omxDir}`);
+  return true;
+}
+
+function printSummary(summary: UninstallSummary, dryRun: boolean): void {
+  const prefix = dryRun ? '[dry-run] Would remove' : 'Removed';
+
+  console.log('\nUninstall summary:');
+
+  if (summary.configCleaned) {
+    console.log(`  ${prefix} OMX configuration block from config.toml`);
+    if (summary.mcpServersRemoved.length > 0) {
+      console.log(`    MCP servers: ${summary.mcpServersRemoved.join(', ')}`);
+    }
+    if (summary.agentEntriesRemoved > 0) {
+      console.log(`    Agent entries: ${summary.agentEntriesRemoved}`);
+    }
+    if (summary.tuiSectionRemoved) {
+      console.log('    TUI status line section');
+    }
+    if (summary.topLevelKeysRemoved) {
+      console.log('    Top-level keys (notify, model_reasoning_effort, developer_instructions)');
+    }
+    if (summary.featureFlagsRemoved) {
+      console.log('    Feature flags (multi_agent, child_agents_md)');
+    }
+  } else if (!summary.configCleaned && summary.mcpServersRemoved.length === 0) {
+    console.log('  config.toml: no OMX entries found (or --keep-config used)');
+  }
+
+  if (summary.promptsRemoved > 0) {
+    console.log(`  ${prefix} ${summary.promptsRemoved} agent prompt(s)`);
+  }
+  if (summary.skillsRemoved > 0) {
+    console.log(`  ${prefix} ${summary.skillsRemoved} skill(s)`);
+  }
+  if (summary.agentConfigsRemoved > 0) {
+    console.log(`  ${prefix} ${summary.agentConfigsRemoved} native agent config(s)`);
+  }
+  if (summary.agentsMdRemoved) {
+    console.log(`  ${prefix} AGENTS.md`);
+  }
+  if (summary.cacheDirectoryRemoved) {
+    console.log(`  ${prefix} .omx/ cache directory`);
+  }
+
+  const totalActions =
+    (summary.configCleaned ? 1 : 0) +
+    summary.promptsRemoved +
+    summary.skillsRemoved +
+    summary.agentConfigsRemoved +
+    (summary.agentsMdRemoved ? 1 : 0) +
+    (summary.cacheDirectoryRemoved ? 1 : 0);
+
+  if (totalActions === 0) {
+    console.log('  Nothing to remove. oh-my-codex does not appear to be installed.');
+  }
+}
+
+export async function uninstall(options: UninstallOptions = {}): Promise<void> {
+  const {
+    dryRun = false,
+    keepConfig = false,
+    verbose = false,
+    purge = false,
+  } = options;
+
+  const projectRoot = process.cwd();
+  const pkgRoot = getPackageRoot();
+
+  // Resolve scope (explicit --scope overrides persisted scope)
+  const scope = options.scope ?? readPersistedSetupScope(projectRoot) ?? 'user';
+  const scopeDirs = resolveScopeDirectories(scope, projectRoot);
+
+  console.log('oh-my-codex uninstall');
+  console.log('=====================\n');
+  if (dryRun) {
+    console.log('[dry-run mode] No files will be modified.\n');
+  }
+  console.log(`Resolved scope: ${scope}\n`);
+
+  const summary: UninstallSummary = {
+    configCleaned: false,
+    mcpServersRemoved: [],
+    agentEntriesRemoved: 0,
+    tuiSectionRemoved: false,
+    topLevelKeysRemoved: false,
+    featureFlagsRemoved: false,
+    promptsRemoved: 0,
+    skillsRemoved: 0,
+    agentConfigsRemoved: 0,
+    agentsMdRemoved: false,
+    cacheDirectoryRemoved: false,
+  };
+
+  // Step 1: Clean config.toml
+  if (keepConfig) {
+    console.log('[1/5] Skipping config.toml cleanup (--keep-config).');
+  } else {
+    console.log('[1/5] Cleaning config.toml...');
+    const configResult = await cleanConfig(scopeDirs.codexConfigFile, { dryRun, verbose });
+    Object.assign(summary, configResult);
+  }
+  console.log();
+
+  // Step 2: Remove installed prompts
+  console.log('[2/5] Removing agent prompts...');
+  summary.promptsRemoved = await removeInstalledPrompts(scopeDirs.promptsDir, pkgRoot, { dryRun, verbose });
+  console.log(`  ${dryRun ? 'Would remove' : 'Removed'} ${summary.promptsRemoved} prompt(s).`);
+  console.log();
+
+  // Step 3: Remove native agent configs
+  console.log('[3/5] Removing native agent configs...');
+  summary.agentConfigsRemoved = await removeAgentConfigs(scopeDirs.nativeAgentsDir, { dryRun, verbose });
+  console.log(`  ${dryRun ? 'Would remove' : 'Removed'} ${summary.agentConfigsRemoved} agent config(s).`);
+  console.log();
+
+  // Step 4: Remove installed skills
+  console.log('[4/5] Removing skills...');
+  summary.skillsRemoved = await removeInstalledSkills(scopeDirs.skillsDir, pkgRoot, { dryRun, verbose });
+  console.log(`  ${dryRun ? 'Would remove' : 'Removed'} ${summary.skillsRemoved} skill(s).`);
+  console.log();
+
+  // Step 5: Remove AGENTS.md and optionally .omx/ cache directory
+  console.log('[5/5] Cleaning up...');
+  summary.agentsMdRemoved = await removeAgentsMd(projectRoot, { dryRun, verbose });
+  if (purge) {
+    summary.cacheDirectoryRemoved = await removeCacheDirectory(projectRoot, { dryRun, verbose });
+  } else {
+    // Always clean up setup-scope.json and hud-config.json
+    const scopeFile = join(projectRoot, '.omx', 'setup-scope.json');
+    const hudConfig = join(projectRoot, '.omx', 'hud-config.json');
+    for (const f of [scopeFile, hudConfig]) {
+      if (existsSync(f)) {
+        if (!dryRun) await rm(f, { force: true });
+        if (verbose) console.log(`  ${dryRun ? 'Would remove' : 'Removed'} ${basename(f)}`);
+      }
+    }
+  }
+  console.log();
+
+  printSummary(summary, dryRun);
+
+  if (!dryRun) {
+    console.log('\noh-my-codex has been uninstalled. Run "omx setup" to reinstall.');
+  } else {
+    console.log('\nRun without --dry-run to apply changes.');
+  }
+}

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -52,7 +52,7 @@ function getOmxTopLevelLines(pkgRoot: string): string[] {
  * Remove any existing OMX-owned top-level keys so we can re-insert them
  * cleanly.  Also removes the comment line that precedes them.
  */
-function stripOmxTopLevelKeys(config: string): string {
+export function stripOmxTopLevelKeys(config: string): string {
   let lines = config.split(/\r?\n/);
 
   // Remove the OMX top-level comment line
@@ -141,11 +141,60 @@ function upsertFeatureFlags(config: string): string {
   return lines.join('\n');
 }
 
+/**
+ * Remove OMX-owned feature flags from the [features] section.
+ * If the section becomes empty after removal, remove the section header too.
+ */
+export function stripOmxFeatureFlags(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const featuresStart = lines.findIndex((line) => /^\s*\[features\]\s*$/.test(line));
+
+  if (featuresStart < 0) return config;
+
+  let sectionEnd = lines.length;
+  for (let i = featuresStart + 1; i < lines.length; i++) {
+    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+
+  const omxFlags = ['multi_agent', 'child_agents_md', 'collab'];
+  const filtered: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (i > featuresStart && i < sectionEnd) {
+      const isOmxFlag = omxFlags.some((f) =>
+        new RegExp(`^\\s*${f}\\s*=`).test(lines[i])
+      );
+      if (isOmxFlag) continue;
+    }
+    filtered.push(lines[i]);
+  }
+
+  // If [features] section is now empty, remove the header too
+  const newFeaturesStart = filtered.findIndex((l) => /^\s*\[features\]\s*$/.test(l));
+  if (newFeaturesStart >= 0) {
+    let newSectionEnd = filtered.length;
+    for (let i = newFeaturesStart + 1; i < filtered.length; i++) {
+      if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(filtered[i])) {
+        newSectionEnd = i;
+        break;
+      }
+    }
+    const sectionContent = filtered.slice(newFeaturesStart + 1, newSectionEnd);
+    if (sectionContent.every((l) => l.trim() === '')) {
+      filtered.splice(newFeaturesStart, newSectionEnd - newFeaturesStart);
+    }
+  }
+
+  return filtered.join('\n');
+}
+
 // ---------------------------------------------------------------------------
 // OMX [table] sections block (appended at end of file)
 // ---------------------------------------------------------------------------
 
-function stripExistingOmxBlocks(config: string): { cleaned: string; removed: number } {
+export function stripExistingOmxBlocks(config: string): { cleaned: string; removed: number } {
   const marker = 'oh-my-codex (OMX) Configuration';
   const endMarker = '# End oh-my-codex';
   let cleaned = config;


### PR DESCRIPTION
## Summary

- Adds `omx uninstall` CLI command that cleanly reverses `omx setup`
- Removes OMX configuration block from config.toml (MCP servers: omx_state, omx_memory, omx_code_intel, omx_trace; agent entries; tui section; top-level keys; feature flags)
- Preserves all user-defined config entries
- Removes installed prompts, skills, and native agent configs
- Removes OMX-generated AGENTS.md (with ownership marker check to avoid deleting user files)
- Supports `--dry-run` to preview changes without modifying files
- Supports `--keep-config` to skip config.toml cleanup
- Supports `--purge` to remove `.omx/` cache directory
- Supports `--scope` override for scope recovery
- Shows detailed summary of what was removed

### Implementation details

- Exports `stripExistingOmxBlocks`, `stripOmxTopLevelKeys` from `src/config/generator.ts`
- Adds `stripOmxFeatureFlags` for `[features]` section cleanup
- Exports `ScopeDirectories` and `resolveScopeDirectories` from `src/cli/setup.ts`
- New `src/cli/uninstall.ts` with full uninstall logic
- Registered in CLI switch, knownCommands, HELP, and CliCommand type

## Test plan

- [x] 15 tests in `src/cli/__tests__/uninstall.test.ts` (all passing)
- [x] Config cleanup: removes OMX block, preserves user entries
- [x] `--dry-run`: previews without modifying
- [x] `--keep-config`: skips config.toml cleanup
- [x] `--purge`: removes `.omx/` cache directory
- [x] `--dry-run --purge`: does NOT delete `.omx/`
- [x] Project scope: resolves and cleans project-local paths
- [x] Missing config.toml: handles gracefully
- [x] Summary output: lists MCP servers, agent entries, tui, top-level keys, feature flags
- [x] Idempotency: second run reports "Nothing to remove"
- [x] AGENTS.md safety: does not delete user files that merely mention oh-my-codex
- [x] Full test suite: 1505 tests pass, 0 failures

Fixes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)