### PR TITLE
fix(team): resolve dispatch lock timeout and binary path mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
 
 Multi-agent orchestration layer for [OpenAI Codex CLI](https://github.com/openai/codex).
 
@@ -271,9 +271,17 @@ npm run build
 npm test
 ```
 
+## Documentation
+
+- **[Full Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** - Complete guide
+- **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** - All `omx` commands, flags, and tools
+- **[Notifications Guide](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** - Discord, Telegram, Slack, and webhook setup
+- **[Recommended Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** - Battle-tested skill chains for common tasks
+- **[Release Notes](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** - What's new in each version
+
 ## Notes
 
-- Release notes: `CHANGELOG.md`
+- Full changelog: `CHANGELOG.md`
 - Migration guide (post-v0.4.4 mainline): `docs/migration-mainline-post-v0.4.4.md`
 - Coverage and parity notes: `COVERAGE.md`
 - Hook extension workflow: `docs/hooks-extension.md`

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -306,7 +306,7 @@ describe('buildWorkerStartupCommand', () => {
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
     try {
       const cmd = buildWorkerStartupCommand('alpha', 1, ['--model', 'claude-3-7-sonnet']);
-      assert.match(cmd, /exec claude/);
+      assert.match(cmd, /exec .*claude/);
       assert.equal((cmd.match(/--dangerously-skip-permissions/g) || []).length, 1);
       assert.doesNotMatch(cmd, /--model/);
       assert.doesNotMatch(cmd, /model_instructions_file=/);
@@ -329,11 +329,11 @@ describe('buildWorkerStartupCommand', () => {
     try {
       process.env.OMX_TEAM_WORKER_CLI = 'codex';
       const codexCmd = buildWorkerStartupCommand('alpha', 1, ['--model', 'claude-3-7-sonnet']);
-      assert.match(codexCmd, /exec codex/);
+      assert.match(codexCmd, /exec .*codex/);
 
       process.env.OMX_TEAM_WORKER_CLI = 'claude';
       const claudeCmd = buildWorkerStartupCommand('alpha', 1, ['--model', 'gpt-5']);
-      assert.match(claudeCmd, /exec claude/);
+      assert.match(claudeCmd, /exec .*claude/);
       assert.equal((claudeCmd.match(/--dangerously-skip-permissions/g) || []).length, 1);
       assert.doesNotMatch(claudeCmd, /--model/);
     } finally {
@@ -360,7 +360,7 @@ describe('buildWorkerStartupCommand', () => {
         {},
         'claude',
       );
-      assert.match(cmd, /exec claude/);
+      assert.match(cmd, /exec .*claude/);
       assert.equal((cmd.match(/--dangerously-skip-permissions/g) || []).length, 1);
       assert.doesNotMatch(cmd, /dangerously-bypass-approvals-and-sandbox/);
       assert.doesNotMatch(cmd, /--model/);
@@ -385,7 +385,7 @@ describe('buildWorkerStartupCommand', () => {
         '-c', 'model_instructions_file="/tmp/custom.md"',
         '--model', 'claude-3-7-sonnet',
       ]);
-      assert.match(cmd, /exec claude/);
+      assert.match(cmd, /exec .*claude/);
       assert.equal((cmd.match(/--dangerously-skip-permissions/g) || []).length, 1);
       assert.doesNotMatch(cmd, /dangerously-bypass-approvals-and-sandbox/);
       assert.doesNotMatch(cmd, /model_instructions_file=/);
@@ -412,7 +412,7 @@ describe('buildWorkerStartupCommand', () => {
     process.argv = [...prevArgv, '--madmax'];
     try {
       const cmd = buildWorkerStartupCommand('alpha', 1);
-      assert.match(cmd, /exec claude/);
+      assert.match(cmd, /exec .*claude/);
       assert.equal((cmd.match(/--dangerously-skip-permissions/g) || []).length, 1);
       assert.doesNotMatch(cmd, /dangerously-bypass-approvals-and-sandbox/);
     } finally {
@@ -436,7 +436,7 @@ describe('buildWorkerStartupCommand', () => {
       assert.match(cmd, /OMX_TEAM_WORKER=alpha\/worker-2/);
       assert.match(cmd, /'\/bin\/zsh' -lc/);
       assert.match(cmd, /source ~\/\.zshrc/);
-      assert.match(cmd, /exec codex/);
+      assert.match(cmd, /exec .*codex/);
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;
       else delete process.env.SHELL;
@@ -453,7 +453,7 @@ describe('buildWorkerStartupCommand', () => {
     try {
       const cmd = buildWorkerStartupCommand('alpha', 1, ['--model', 'gpt-5']);
       assert.match(cmd, /source ~\/\.bashrc/);
-      assert.match(cmd, /exec codex/);
+      assert.match(cmd, /exec .*codex/);
       assert.match(cmd, /--model/);
       assert.match(cmd, /gpt-5/);
     } finally {
@@ -537,7 +537,7 @@ describe('buildWorkerStartupCommand', () => {
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
     try {
       const cmd = buildWorkerStartupCommand('alpha', 1, ['-c', 'model_reasoning_effort="xhigh"']);
-      assert.match(cmd, /exec codex/);
+      assert.match(cmd, /exec .*codex/);
       assert.match(cmd, /'-c'/);
       assert.match(cmd, /'model_reasoning_effort=\"xhigh\"'/);
     } finally {
@@ -780,11 +780,40 @@ describe('team worker launch mode helpers', () => {
         { OMX_TEAM_STATE_ROOT: '/tmp/workspace/.omx/state' },
         'codex',
       );
-      assert.equal(spec.command, 'codex');
+      // command is now the resolved absolute path (or bare binary if which fails)
       assert.equal(spec.workerCli, 'codex');
+      assert.ok(typeof spec.command === 'string' && spec.command.length > 0, 'command must be a non-empty string');
       assert.deepEqual(spec.args, ['--model', 'gpt-5.3-codex']);
       assert.equal(spec.env.OMX_TEAM_WORKER, 'alpha-team/worker-2');
       assert.equal(spec.env.OMX_TEAM_STATE_ROOT, '/tmp/workspace/.omx/state');
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('buildWorkerProcessLaunchSpec includes leader node and CLI path env vars', () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const spec = buildWorkerProcessLaunchSpec(
+        'beta-team',
+        1,
+        [],
+        '/tmp/workspace',
+        {},
+        'codex',
+      );
+      assert.ok(
+        typeof spec.env.OMX_LEADER_NODE_PATH === 'string' && spec.env.OMX_LEADER_NODE_PATH.length > 0,
+        'OMX_LEADER_NODE_PATH must be set',
+      );
+      assert.ok(
+        typeof spec.env.OMX_LEADER_CLI_PATH === 'string' && spec.env.OMX_LEADER_CLI_PATH.length > 0,
+        'OMX_LEADER_CLI_PATH must be set',
+      );
+      // command matches the resolved CLI path stored in env
+      assert.equal(spec.command, spec.env.OMX_LEADER_CLI_PATH);
     } finally {
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -287,6 +287,13 @@ const DEFAULT_DISPATCH_ACK_TIMEOUT_MS = 800;
 const MIN_DISPATCH_ACK_TIMEOUT_MS = 100;
 const MAX_DISPATCH_ACK_TIMEOUT_MS = 10_000;
 
+const OMX_DISPATCH_LOCK_TIMEOUT_ENV = 'OMX_DISPATCH_LOCK_TIMEOUT_MS';
+const DEFAULT_DISPATCH_LOCK_TIMEOUT_MS = 15_000;
+const MIN_DISPATCH_LOCK_TIMEOUT_MS = 1_000;
+const MAX_DISPATCH_LOCK_TIMEOUT_MS = 120_000;
+const DISPATCH_LOCK_INITIAL_POLL_MS = 25;
+const DISPATCH_LOCK_MAX_POLL_MS = 500;
+
 type TeamTaskStatus = TeamTask['status'];
 
 function isTerminalTaskStatus(status: TeamTaskStatus): boolean {
@@ -1688,13 +1695,23 @@ async function writeDispatchRequests(teamName: string, requests: TeamDispatchReq
   await writeAtomic(dispatchRequestsPath(teamName, cwd), JSON.stringify(requests, null, 2));
 }
 
+export function resolveDispatchLockTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[OMX_DISPATCH_LOCK_TIMEOUT_ENV];
+  if (raw === undefined || raw === '') return DEFAULT_DISPATCH_LOCK_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_DISPATCH_LOCK_TIMEOUT_MS;
+  return Math.max(MIN_DISPATCH_LOCK_TIMEOUT_MS, Math.min(MAX_DISPATCH_LOCK_TIMEOUT_MS, Math.floor(parsed)));
+}
+
 async function withDispatchLock<T>(teamName: string, cwd: string, fn: () => Promise<T>): Promise<T> {
   const root = teamDir(teamName, cwd);
   if (!existsSync(root)) throw new Error(`Team ${teamName} not found`);
   const lockDir = dispatchLockDir(teamName, cwd);
   const ownerPath = join(lockDir, 'owner');
   const ownerToken = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
-  const deadline = Date.now() + 5000;
+  const timeoutMs = resolveDispatchLockTimeoutMs(process.env);
+  const deadline = Date.now() + timeoutMs;
+  let pollMs = DISPATCH_LOCK_INITIAL_POLL_MS;
   await mkdir(dirname(lockDir), { recursive: true });
 
   while (true) {
@@ -1719,8 +1736,16 @@ async function withDispatchLock<T>(teamName: string, cwd: string, fn: () => Prom
       } catch {
         // best effort
       }
-      if (Date.now() > deadline) throw new Error(`Timed out acquiring dispatch lock for ${teamName}`);
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      if (Date.now() > deadline) {
+        throw new Error(
+          `Timed out acquiring dispatch lock for ${teamName} after ${timeoutMs}ms. ` +
+          `Set ${OMX_DISPATCH_LOCK_TIMEOUT_ENV} to increase (current: ${timeoutMs}ms, max: ${MAX_DISPATCH_LOCK_TIMEOUT_MS}ms).`
+        );
+      }
+      // Exponential backoff with jitter to reduce thundering herd
+      const jitter = 0.5 + Math.random() * 0.5;
+      await new Promise((resolve) => setTimeout(resolve, Math.floor(pollMs * jitter)));
+      pollMs = Math.min(pollMs * 2, DISPATCH_LOCK_MAX_POLL_MS);
     }
   }
 

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -111,5 +111,8 @@ export { writeWorkerStatus as teamWriteWorkerStatus } from './state.js';
 // === Scaling lock ===
 export { withScalingLock as teamWithScalingLock } from './state.js';
 
+// === Dispatch lock helpers ===
+export { resolveDispatchLockTimeoutMs } from './state.js';
+
 // === Atomic write (shared utility) ===
 export { writeAtomic } from './state.js';


### PR DESCRIPTION
## Summary

Fixes #400 — Team startup fails with `Timed out acquiring dispatch lock` during tmux worker bootstrap.

**Root causes and fixes:**

- **Binary path mismatch**: Fresh worker shells resolve different `node`/`codex`/`claude` paths than the leader due to NVM/shell init differences. Now the leader resolves absolute binary paths via `which` and passes them to workers via `OMX_LEADER_NODE_PATH` and `OMX_LEADER_CLI_PATH` env vars. Worker startup commands use resolved absolute paths and prepend the leader's node directory to `PATH`.

- **Dispatch lock timeout too aggressive**: Default timeout was 5s with fixed 25ms polling. Increased default to 15s, added exponential backoff with jitter (25ms → 500ms cap) to reduce thundering herd contention, and made timeout configurable via `OMX_DISPATCH_LOCK_TIMEOUT_MS` env var (1s–120s range). Error messages now include elapsed time and configuration hints.

## Changes

| File | Change |
|------|--------|
| `src/team/tmux-session.ts` | Add `resolveAbsoluteBinaryPath()`, `resolveLeaderNodePath()`. Pass `OMX_LEADER_NODE_PATH`/`OMX_LEADER_CLI_PATH` env to workers. Use resolved absolute CLI path in `buildWorkerProcessLaunchSpec`. Prepend leader's node dir to worker `PATH`. |
| `src/team/state.ts` | Add `resolveDispatchLockTimeoutMs()` with env-configurable timeout. Replace fixed 25ms poll with exponential backoff + jitter. Increase default from 5s to 15s. Improve error message with config hint. |
| `src/team/team-ops.ts` | Re-export `resolveDispatchLockTimeoutMs` |
| `src/team/__tests__/state.test.ts` | Tests for timeout resolution, clamping, and error message hint |
| `src/team/__tests__/tmux-session.test.ts` | Updated assertions for resolved binary paths; new test for leader path env vars |

## Test plan

- [x] `node --test dist/team/__tests__/state.test.ts` — 60 tests pass (3 new)
- [x] `node --test dist/team/__tests__/tmux-session.test.ts` — 105 tests pass (1 new, ~10 updated)
- [ ] Manual: start a team session with NVM-managed node to verify workers use leader's binary paths
- [ ] Manual: set `OMX_DISPATCH_LOCK_TIMEOUT_MS=30000` and verify the custom timeout is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)