### PR TITLE
Fix Claude worker idle/dispatch detection parity

### DIFF
--- a/scripts/tmux-hook-engine.js
+++ b/scripts/tmux-hook-engine.js
@@ -158,17 +158,18 @@ export function buildCapturePaneArgv(paneTarget, tailLines = 80) {
   return ['capture-pane', '-t', paneTarget, '-p', '-S', `-${tailLines}`];
 }
 
-export function buildSendKeysArgv({ paneTarget, prompt, dryRun }) {
+export function buildSendKeysArgv({ paneTarget, prompt, dryRun, submitKeyPresses = 2 }) {
   if (dryRun) return null;
+  const pressCountRaw = Number.isFinite(submitKeyPresses) ? Math.floor(submitKeyPresses) : 2;
+  const pressCount = Math.max(1, Math.min(4, pressCountRaw));
+  const submitArgv = Array.from({ length: pressCount }, () => ([
+    'send-keys', '-t', paneTarget, 'C-m',
+  ]));
   // Use a 2-step send for reliability:
   // 1) literal prompt bytes, 2) explicit carriage return.
   return {
     typeArgv: ['send-keys', '-t', paneTarget, '-l', prompt],
-    // Codex CLI uses raw input mode where 'Enter' key name is unreliable;
-    // send 'C-m' (carriage return) twice for reliable prompt submission.
-    submitArgv: [
-      ['send-keys', '-t', paneTarget, 'C-m'],
-      ['send-keys', '-t', paneTarget, 'C-m'],
-    ],
+    // Codex generally prefers two presses; Claude typically needs one.
+    submitArgv,
   };
 }

--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -232,6 +232,18 @@ describe('buildSendKeysArgv', () => {
       ],
     });
 
+    assert.deepEqual(buildSendKeysArgv({
+      paneTarget: '%7',
+      prompt: 'continue',
+      dryRun: false,
+      submitKeyPresses: 1,
+    }), {
+      typeArgv: ['send-keys', '-t', '%7', '-l', 'continue'],
+      submitArgv: [
+        ['send-keys', '-t', '%7', 'C-m'],
+      ],
+    });
+
     assert.equal(buildSendKeysArgv({
       paneTarget: '%3',
       prompt: 'continue',

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -989,19 +989,20 @@ export async function updateWorkerHeartbeat(
 
 // Read worker status (returns {state:'unknown'} on missing/malformed)
 export async function readWorkerStatus(teamName: string, workerName: string, cwd: string): Promise<WorkerStatus> {
+  const unknownStatus: WorkerStatus = { state: 'unknown', updated_at: '1970-01-01T00:00:00.000Z' };
   try {
     const p = join(workerDir(teamName, workerName, cwd), 'status.json');
     if (!existsSync(p)) {
-      return { state: 'unknown', updated_at: new Date().toISOString() };
+      return unknownStatus;
     }
     const raw = await readFile(p, 'utf8');
     const parsed = JSON.parse(raw) as unknown;
     if (!isWorkerStatus(parsed)) {
-      return { state: 'unknown', updated_at: new Date().toISOString() };
+      return unknownStatus;
     }
     return parsed;
   } catch {
-    return { state: 'unknown', updated_at: new Date().toISOString() };
+    return unknownStatus;
   }
 }
 

--- a/src/types/tmux-hook-engine.d.ts
+++ b/src/types/tmux-hook-engine.d.ts
@@ -49,5 +49,6 @@ declare module '*tmux-hook-engine.js' {
     paneTarget: string;
     prompt: string;
     dryRun: boolean;
+    submitKeyPresses?: number;
   }): { typeArgv: string[]; submitArgv: string[][] } | null;
 }


### PR DESCRIPTION
## Summary
This PR improves Claude teammate parity with Codex for OMX team idle/dispatch behavior.

### What changed
- Made hook dispatch submit cadence CLI-aware:
  - Claude workers now use single `C-m` submission in hook dispatch injection.
- Hardened dispatch terminal semantics:
  - Unconfirmed trigger submissions now retry up to max attempts and then transition to `failed` with reason `unconfirmed_after_max_retries` (no false `notified`).
- Hardened worker idle notifications:
  - Added status staleness checks (`OMX_TEAM_STATUS_STALE_MS`, default 120000ms).
  - Added heartbeat staleness checks (`OMX_TEAM_HEARTBEAT_STALE_MS`, default 180000ms).
  - Suppressed unknown->idle first-run notifications.
- Prevented synthetic “fresh unknown” status from state API fallbacks:
  - Unknown status now uses stale timestamp sentinel (`1970-01-01T00:00:00.000Z`).
- Added/updated tests for new behavior.

## Files changed
- `scripts/notify-hook/team-dispatch.js`
- `scripts/notify-hook/team-worker.js`
- `scripts/tmux-hook-engine.js`
- `src/team/state.ts`
- `src/types/tmux-hook-engine.d.ts`
- `src/hooks/__tests__/tmux-hook-engine.test.ts`
- `src/hooks/__tests__/notify-hook-team-dispatch.test.ts`
- `src/hooks/__tests__/notify-hook-worker-idle.test.ts`
- `src/hooks/__tests__/notify-hook-all-workers-idle.test.ts`

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/tmux-hook-engine.test.js`
- `node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js`
- `node --test dist/hooks/__tests__/notify-hook-worker-idle.test.js`
- `node --test dist/hooks/__tests__/notify-hook-all-workers-idle.test.js`

All passed.
