### PR TITLE
fix(cli): add --help guard before subcommand execution

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -355,6 +355,11 @@ export async function main(args: string[]): Promise<void> {
     team: flags.has('--team'),
   };
 
+  if (flags.has('--help') || flags.has('-h')) {
+    console.log(HELP);
+    return;
+  }
+
   try {
     switch (command) {
       case 'launch':


### PR DESCRIPTION
## Summary
- Running `omx uninstall --help` was executing the actual uninstall instead of showing help text
- Added a `--help`/`-h` flag check before the command switch so all subcommands correctly show help when requested
- Found during smoke testing of main...dev changes

## Test plan
- [x] `omx uninstall --help` shows help text instead of executing uninstall
- [x] `omx setup --help` shows help text
- [x] `npx tsc --noEmit` passes
- [x] 673/673 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)