### PR TITLE
fix(tmux): dedupe retry injection and enforce isolated C-m submits

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
@@ -32,6 +32,75 @@ async function readLines(path: string): Promise<string[]> {
 
 async function sleep(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function buildFakeTmux(tmuxLogPath: string): string {
+  return `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "capture-pane" ]]; then
+  if [[ -n "\${OMX_TEST_CAPTURE_SEQUENCE_FILE:-}" && -f "\${OMX_TEST_CAPTURE_SEQUENCE_FILE}" ]]; then
+    counterFile="\${OMX_TEST_CAPTURE_COUNTER_FILE:-\${OMX_TEST_CAPTURE_SEQUENCE_FILE}.idx}"
+    idx=0
+    if [[ -f "$counterFile" ]]; then idx="$(cat "$counterFile")"; fi
+    lineNo=$((idx + 1))
+    line="$(sed -n "\${lineNo}p" "\${OMX_TEST_CAPTURE_SEQUENCE_FILE}" || true)"
+    if [[ -z "$line" ]]; then
+      line="$(tail -n 1 "\${OMX_TEST_CAPTURE_SEQUENCE_FILE}" || true)"
+    fi
+    printf "%s\\n" "$line"
+    echo "$lineNo" > "$counterFile"
+    exit 0
+  fi
+  if [[ -n "\${OMX_TEST_CAPTURE_FILE:-}" && -f "\${OMX_TEST_CAPTURE_FILE}" ]]; then
+    cat "\${OMX_TEST_CAPTURE_FILE}"
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  fmt=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -t)
+        shift
+        target="$1"
+        ;;
+      *)
+        fmt="$1"
+        ;;
+    esac
+    shift || true
+  done
+  if [[ "$fmt" == "#{pane_in_mode}" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_id}" ]]; then
+    echo "\${target:-%42}"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_path}" ]]; then
+    pwd
+    exit 0
+  fi
+  if [[ "$fmt" == "#S" ]]; then
+    echo "session-test"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%42 1"
+  exit 0
+fi
+exit 0
+`;
 }
 
 describe('notify-fallback watcher', () => {
@@ -222,6 +291,118 @@ describe('notify-fallback watcher', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
       const request = await readDispatchRequest('dispatch-team', queued.request.request_id, wd);
       assert.equal(request?.status, 'pending');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('watcher retry does not retype when pre-capture still contains trigger', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-dispatch-cm-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const captureFile = join(wd, 'capture.txt');
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(captureFile, 'dispatch ping');
+
+      await initTeamState('dispatch-team', 'task', 'executor', 1, wd);
+      const queued = await enqueueDispatchRequest('dispatch-team', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        pane_id: '%42',
+        trigger_message: 'dispatch ping',
+      }, wd);
+
+      const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...process.env,
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+        OMX_TEST_CAPTURE_FILE: captureFile,
+      };
+
+      const first = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50', '--dispatch-max-per-tick', '1'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+
+      const second = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50', '--dispatch-max-per-tick', '1'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      const typeMatches = tmuxLog.match(/send-keys -t %42 -l dispatch ping/g) || [];
+      assert.equal(typeMatches.length, 1, 'watcher retries should be submit-only when draft remains visible');
+      assert.ok(!/send-keys[^\n]*-l[^\n]*C-m/.test(tmuxLog), 'must keep -l payload and C-m submits isolated');
+
+      const request = await readDispatchRequest('dispatch-team', queued.request.request_id, wd);
+      assert.equal(request?.status, 'pending');
+      assert.equal(request?.last_reason, 'tmux_send_keys_unconfirmed');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('watcher retry allows one fallback retype only when pre-capture misses trigger', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-dispatch-cm-fallback-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const captureSeqFile = join(wd, 'capture-seq.txt');
+    const captureCounterFile = join(wd, 'capture-seq.idx');
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(captureSeqFile, [
+        'dispatch ping', 'dispatch ping', 'dispatch ping',
+        'ready',
+        'dispatch ping', 'dispatch ping', 'dispatch ping',
+        'ready',
+        'dispatch ping', 'dispatch ping', 'dispatch ping',
+      ].join('\n'));
+
+      await initTeamState('dispatch-team', 'task', 'executor', 1, wd);
+      const queued = await enqueueDispatchRequest('dispatch-team', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        pane_id: '%42',
+        trigger_message: 'dispatch ping',
+      }, wd);
+
+      const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...process.env,
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+        OMX_TEST_CAPTURE_SEQUENCE_FILE: captureSeqFile,
+        OMX_TEST_CAPTURE_COUNTER_FILE: captureCounterFile,
+      };
+
+      for (let i = 0; i < 3; i += 1) {
+        const run = spawnSync(
+          process.execPath,
+          [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50', '--dispatch-max-per-tick', '1'],
+          { encoding: 'utf-8', env },
+        );
+        assert.equal(run.status, 0, run.stderr || run.stdout);
+      }
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      const typeMatches = tmuxLog.match(/send-keys -t %42 -l dispatch ping/g) || [];
+      assert.equal(typeMatches.length, 2, 'fresh + one retry fallback retype max');
+
+      const request = await readDispatchRequest('dispatch-team', queued.request.request_id, wd);
+      assert.equal(request?.status, 'failed');
+      assert.equal(request?.last_reason, 'unconfirmed_after_max_retries');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/notifications/__tests__/tmux-detector.test.ts
+++ b/src/notifications/__tests__/tmux-detector.test.ts
@@ -92,8 +92,8 @@ describe('analyzePaneContent', () => {
   });
 });
 
-// issue #107: Enter/C-m must be sent in an isolated, separate send-keys call —
-// never bundled with text — to prevent Shift+Enter injection.
+// issue #107: C-m must be sent in an isolated, separate send-keys call —
+// never bundled with text — to prevent submit injection.
 describe('buildSendPaneArgvs', () => {
   it('sends text with -l (literal) flag so key names in text are not interpreted', () => {
     const argvs = buildSendPaneArgvs('%3', 'hello world', false);
@@ -110,7 +110,7 @@ describe('buildSendPaneArgvs', () => {
     assert.equal(textArgv[sepIdx + 1], '-flag-like', 'text must come immediately after --');
   });
 
-  it('sends Enter as an isolated separate argv — never bundled with text', () => {
+  it('sends C-m as an isolated separate argv — never bundled with text', () => {
     const argvs = buildSendPaneArgvs('%3', 'hello', true);
     assert.ok(argvs.length >= 2, 'must have at least text argv + one C-m argv');
 
@@ -140,7 +140,7 @@ describe('buildSendPaneArgvs', () => {
     assert.ok(!argvs[0].includes('C-m'), 'no C-m when pressEnter=false');
   });
 
-  it('strips newlines from text to prevent literal Enter injection via -l', () => {
+  it('strips newlines from text to prevent literal submit injection via -l', () => {
     const argvs = buildSendPaneArgvs('%3', 'line1\nline2\r\nline3', false);
     const textArgv = argvs[0];
     const text = textArgv[textArgv.length - 1];

--- a/src/notifications/tmux-detector.ts
+++ b/src/notifications/tmux-detector.ts
@@ -76,14 +76,14 @@ export function analyzePaneContent(content: string): PaneAnalysis {
  * Builds the ordered list of tmux send-keys argv arrays needed to type text
  * into a pane and optionally submit it.
  *
- * Enter (C-m) is always sent in its own dedicated send-keys call, never
- * bundled with the text payload. This prevents Shift+Enter injection: without
+ * C-m (carriage return) is always sent in its own dedicated send-keys call, never
+ * bundled with the text payload. This prevents newline/submit injection: without
  * this isolation a C-m (or any other tmux key name) embedded in the text
  * could be interpreted as a key press by tmux when sent without -l (issue #107).
  *
  * @param paneId     tmux pane identifier, e.g. "%3"
  * @param text       text to type; embedded newlines are replaced with spaces
- *                   to prevent them from acting as Enter when sent literally
+ *                   to prevent them from acting as submit keypresses when sent literally
  * @param pressEnter when true, appends two isolated C-m submit calls
  * @returns          array of argv arrays, one per send-keys invocation
  */
@@ -92,7 +92,7 @@ export function buildSendPaneArgvs(
   text: string,
   pressEnter: boolean = true,
 ): string[][] {
-  // Replace newlines with spaces so they cannot act as Enter when the text
+  // Replace newlines with spaces so they cannot act as submit keypresses when the text
   // is delivered byte-for-byte via -l (literal) mode.
   const safe = text.replace(/\r?\n/g, ' ');
 
@@ -102,8 +102,8 @@ export function buildSendPaneArgvs(
   const argvs: string[][] = [['send-keys', '-t', paneId, '-l', '--', safe]];
 
   if (pressEnter) {
-    // Codex CLI uses raw input mode where 'Enter' key name is unreliable;
-    // send C-m (carriage return) twice for reliable prompt submission.
+    // Codex CLI uses raw input mode; send C-m (carriage return) twice
+    // for reliable prompt submission.
     // Each C-m is an isolated send-keys call — never bundled with the text
     // above (issue #107).
     argvs.push(['send-keys', '-t', paneId, 'C-m']);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1109,7 +1109,7 @@ export function waitForWorkerReady(
   const sendRobustEnter = (): void => {
     const target = paneTarget(sessionName, workerIndex, workerPaneId);
     // Trust + follow-up splash can require two submits in Codex TUI.
-    // Use C-m (carriage return) instead of Enter for raw-mode compatibility.
+    // Use C-m (carriage return) for raw-mode compatibility.
     runTmux(['send-keys', '-t', target, 'C-m']);
     sleepFractionalSeconds(0.12);
     runTmux(['send-keys', '-t', target, 'C-m']);
@@ -1167,7 +1167,7 @@ export function dismissTrustPromptIfPresent(
   const result = runTmux(['capture-pane', '-t', target, '-p']);
   if (!result.ok) return false;
   if (!paneHasTrustPrompt(result.stdout)) return false;
-  // Trust prompt detected; send Enter twice to dismiss (trust + follow-up splash)
+  // Trust prompt detected; send C-m twice to dismiss (trust + follow-up splash)
   runTmux(['send-keys', '-t', target, 'C-m']);
   sleepFractionalSeconds(0.12);
   runTmux(['send-keys', '-t', target, 'C-m']);
@@ -1239,7 +1239,7 @@ export function sendToWorker(
 
   sendLiteralTextOrThrow(target, text);
 
-  // Allow the input buffer to settle before sending Enter
+  // Allow the input buffer to settle before sending C-m
   sleepFractionalSeconds(0.15);
 
   const allowAutoInterruptRetry = process.env[OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV] !== '0';


### PR DESCRIPTION
## Summary\n- prevent duplicate/mixed tmux trigger text on dispatch retries by making retry attempts submit-only when draft text is still present\n- allow at most one bounded fallback retype when retry pre-capture no longer contains the trigger\n- keep reason ownership intact: injector emits only `tmux_send_keys_confirmed|tmux_send_keys_unconfirmed`, drain remains owner of `unconfirmed_after_max_retries`\n- normalize remaining Enter wording to C-m-focused wording in tmux submit docs/comments/tests\n\n## Validation\n- npm run build\n- node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/notifications/__tests__/tmux-detector.test.js\n- rg checks for runtime Enter submit and mixed `-l`+`C-m` call patterns (only test regex matches remain)\n