### PR TITLE
feat: add ralph-specific defaults to team auto-run cleanup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,28 @@ Notes:
 - Trigger submission uses adaptive retries by default (queue/submit, then safe clear-line+resend fallback when needed).
 - In Claude worker mode, OMX spawns workers as plain `claude` (no extra launch args) and ignores explicit `--model` / `--config` / `--effort` overrides so Claude uses default `settings.json`.
 
+Optional auto-run + cleanup helper scripts:
+
+```bash
+# Start team, monitor until terminal tasks, then run shutdown/cleanup
+bash ./scripts/team-auto-run.sh --worktree=feature-x ralph 3:executor "ship with verification"
+
+# Standalone cleanup for an existing team
+bash ./scripts/team-post-shutdown-cleanup.sh <team-name>
+```
+
+Dedicated policy for `omx team ralph ...` in `team-auto-run.sh`:
+- default `TEAM_AUTO_FORCE_ON_FAILURE=0` (do not force teardown on failed tasks)
+- default `TEAM_AUTO_DELETE_BRANCHES=0` (preserve branches for re-verify/fix loops)
+- emits explicit guard logs when failures remain
+
+You can override defaults explicitly:
+
+```bash
+TEAM_AUTO_FORCE_ON_FAILURE=1 TEAM_AUTO_DELETE_BRANCHES=1 \
+  bash ./scripts/team-auto-run.sh --worktree=feature-x ralph 3:executor "task"
+```
+
 ## What `omx setup` writes
 
 - `.omx/setup-scope.json` (persisted setup scope)

--- a/scripts/team-auto-run.sh
+++ b/scripts/team-auto-run.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash ./scripts/team-auto-run.sh [omx team args...]
+
+Examples:
+  bash ./scripts/team-auto-run.sh 3:executor "research X"
+  bash ./scripts/team-auto-run.sh --worktree=feature-x ralph 3:executor "ship with verification"
+
+Environment:
+  TEAM_AUTO_POLL_SECONDS=10      # status polling interval
+  TEAM_AUTO_DELETE_BRANCHES=1    # cleanup branch deletion (default: ralph=0, non-ralph=1)
+  TEAM_AUTO_FORCE_ON_FAILURE=1   # force shutdown when failed>0 (default: ralph=0, non-ralph=1)
+  TEAM_AUTO_SKIP_CANCEL=0        # pass --skip-cancel to cleanup
+  TEAM_AUTO_CLEANUP_DRY_RUN=0    # pass --dry-run to cleanup
+EOF
+}
+
+log() {
+  printf "[team-auto] %s\n" "$*"
+}
+
+extract_int() {
+  local line="$1"
+  local key="$2"
+  sed -n "s/.*${key}=\\([0-9][0-9]*\\).*/\\1/p" <<<"${line}" | head -n 1
+}
+
+is_ralph_args() {
+  local arg
+  for arg in "$@"; do
+    if [[ "${arg,,}" == "ralph" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CLEANUP_SCRIPT="${SCRIPT_DIR}/team-post-shutdown-cleanup.sh"
+
+if [[ ! -x "${CLEANUP_SCRIPT}" ]]; then
+  echo "cleanup script not found or not executable: ${CLEANUP_SCRIPT}" >&2
+  exit 1
+fi
+if ! command -v omx >/dev/null 2>&1; then
+  echo "omx command not found in PATH" >&2
+  exit 1
+fi
+
+POLL_SECONDS="${TEAM_AUTO_POLL_SECONDS:-10}"
+IS_RALPH=0
+if is_ralph_args "$@"; then
+  IS_RALPH=1
+fi
+
+# Dedicated default policy for `omx team ralph ...` unless explicitly overridden.
+if [[ -z "${TEAM_AUTO_DELETE_BRANCHES+x}" ]]; then
+  DELETE_BRANCHES=$([[ "${IS_RALPH}" -eq 1 ]] && echo 0 || echo 1)
+else
+  DELETE_BRANCHES="${TEAM_AUTO_DELETE_BRANCHES}"
+fi
+if [[ -z "${TEAM_AUTO_FORCE_ON_FAILURE+x}" ]]; then
+  FORCE_ON_FAILURE=$([[ "${IS_RALPH}" -eq 1 ]] && echo 0 || echo 1)
+else
+  FORCE_ON_FAILURE="${TEAM_AUTO_FORCE_ON_FAILURE}"
+fi
+SKIP_CANCEL="${TEAM_AUTO_SKIP_CANCEL:-0}"
+CLEANUP_DRY_RUN="${TEAM_AUTO_CLEANUP_DRY_RUN:-0}"
+
+TEAM_NAME=""
+
+run_cleanup() {
+  local force_shutdown="${1:-0}"
+  if [[ -z "${TEAM_NAME}" ]]; then
+    return 0
+  fi
+  local cmd=(bash "${CLEANUP_SCRIPT}" "${TEAM_NAME}")
+  [[ "${DELETE_BRANCHES}" == "1" ]] && cmd+=(--delete-branches)
+  [[ "${SKIP_CANCEL}" == "1" ]] && cmd+=(--skip-cancel)
+  [[ "${force_shutdown}" == "1" ]] && cmd+=(--force-shutdown)
+  [[ "${CLEANUP_DRY_RUN}" == "1" ]] && cmd+=(--dry-run)
+  log "running cleanup: ${cmd[*]}"
+  "${cmd[@]}"
+}
+
+on_interrupt() {
+  log "interrupt received; attempting forced cleanup..."
+  run_cleanup 1 || true
+  exit 130
+}
+trap on_interrupt INT TERM
+
+cd "${ROOT_DIR}"
+
+if [[ "${IS_RALPH}" -eq 1 ]]; then
+  log "ralph mode detected: default policy delete_branches=${DELETE_BRANCHES} force_on_failure=${FORCE_ON_FAILURE}"
+else
+  log "standard mode: default policy delete_branches=${DELETE_BRANCHES} force_on_failure=${FORCE_ON_FAILURE}"
+fi
+
+log "starting team: omx team $*"
+START_OUTPUT="$(omx team "$@" 2>&1)"
+printf '%s\n' "${START_OUTPUT}"
+
+TEAM_NAME="$(sed -n 's/^Team started: //p' <<<"${START_OUTPUT}" | tail -n 1 | xargs)"
+if [[ -z "${TEAM_NAME}" ]]; then
+  echo "failed to parse team name from startup output" >&2
+  exit 1
+fi
+
+log "team detected: ${TEAM_NAME}"
+log "monitoring until terminal tasks, then auto-cleanup"
+
+while true; do
+  STATUS_OUTPUT="$(omx team status "${TEAM_NAME}" 2>&1 || true)"
+  if grep -q '^No team state found' <<<"${STATUS_OUTPUT}"; then
+    log "team state already missing (assume cleaned)"
+    break
+  fi
+
+  TASK_LINE="$(grep '^tasks:' <<<"${STATUS_OUTPUT}" || true)"
+  if [[ -z "${TASK_LINE}" ]]; then
+    log "status parse pending; retrying in ${POLL_SECONDS}s"
+    sleep "${POLL_SECONDS}"
+    continue
+  fi
+
+  PENDING="$(extract_int "${TASK_LINE}" "pending")"
+  BLOCKED="$(extract_int "${TASK_LINE}" "blocked")"
+  IN_PROGRESS="$(extract_int "${TASK_LINE}" "in_progress")"
+  COMPLETED="$(extract_int "${TASK_LINE}" "completed")"
+  FAILED="$(extract_int "${TASK_LINE}" "failed")"
+  PENDING="${PENDING:-0}"
+  BLOCKED="${BLOCKED:-0}"
+  IN_PROGRESS="${IN_PROGRESS:-0}"
+  COMPLETED="${COMPLETED:-0}"
+  FAILED="${FAILED:-0}"
+
+  log "status pending=${PENDING} blocked=${BLOCKED} in_progress=${IN_PROGRESS} completed=${COMPLETED} failed=${FAILED}"
+
+  if [[ "${PENDING}" -eq 0 && "${BLOCKED}" -eq 0 && "${IN_PROGRESS}" -eq 0 ]]; then
+    if [[ "${FAILED}" -gt 0 && "${FORCE_ON_FAILURE}" != "1" ]]; then
+      if [[ "${IS_RALPH}" -eq 1 ]]; then
+        log "ralph policy guard: failed tasks present, skipping force-shutdown/cleanup to preserve triage context."
+        log "set TEAM_AUTO_FORCE_ON_FAILURE=1 if you intentionally want forced teardown."
+        exit 3
+      fi
+      run_cleanup 0
+      break
+    fi
+
+    FORCE_SHUTDOWN=0
+    if [[ "${FAILED}" -gt 0 && "${FORCE_ON_FAILURE}" == "1" ]]; then
+      FORCE_SHUTDOWN=1
+      log "failed tasks detected; using forced shutdown cleanup"
+    fi
+    run_cleanup "${FORCE_SHUTDOWN}"
+    break
+  fi
+
+  sleep "${POLL_SECONDS}"
+done
+
+log "auto-run complete"

--- a/scripts/team-post-shutdown-cleanup.sh
+++ b/scripts/team-post-shutdown-cleanup.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash ./scripts/team-post-shutdown-cleanup.sh <team-name> [options]
+
+Options:
+  --force-shutdown   Force shutdown even when tasks are not terminal
+  --delete-branches  Delete worker branches after removing worktrees
+  --skip-cancel      Skip `omx cancel` at the end
+  --dry-run          Print planned actions without executing
+  -h, --help         Show help
+EOF
+}
+
+log() {
+  printf "[team-cleanup] %s\n" "$*"
+}
+
+run_cmd() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf "[team-cleanup][dry-run] "
+    printf "%q " "$@"
+    printf "\n"
+    return 0
+  fi
+  "$@"
+}
+
+team_status_value() {
+  local line="$1"
+  local key="$2"
+  sed -n "s/.*${key}=\\([0-9][0-9]*\\).*/\\1/p" <<<"${line}" | head -n 1
+}
+
+array_contains() {
+  local needle="$1"
+  shift || true
+  local item
+  for item in "$@"; do
+    [[ "${item}" == "${needle}" ]] && return 0
+  done
+  return 1
+}
+
+TEAM_NAME=""
+FORCE_SHUTDOWN=0
+DELETE_BRANCHES=0
+SKIP_CANCEL=0
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force-shutdown)
+      FORCE_SHUTDOWN=1
+      shift
+      ;;
+    --delete-branches)
+      DELETE_BRANCHES=1
+      shift
+      ;;
+    --skip-cancel)
+      SKIP_CANCEL=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [[ -z "${TEAM_NAME}" ]]; then
+        TEAM_NAME="$1"
+        shift
+      else
+        echo "Unexpected extra argument: $1" >&2
+        usage
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "${TEAM_NAME}" ]]; then
+  usage
+  exit 2
+fi
+
+if ! command -v omx >/dev/null 2>&1; then
+  echo "omx command not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git command not found in PATH" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "${ROOT_DIR}"
+
+TEAM_STATE_DIR="${ROOT_DIR}/.omx/state/team/${TEAM_NAME}"
+WORKTREE_PREFIX="${ROOT_DIR}.omx-worktrees/team-${TEAM_NAME}-worker-"
+
+log "repo: ${ROOT_DIR}"
+log "team: ${TEAM_NAME}"
+
+if [[ -d "${TEAM_STATE_DIR}" ]]; then
+  log "team state exists: ${TEAM_STATE_DIR}"
+  STATUS_OUTPUT="$(omx team status "${TEAM_NAME}" 2>&1 || true)"
+  log "status:"
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] && log "  ${line}"
+  done <<<"${STATUS_OUTPUT}"
+
+  TASK_LINE="$(grep '^tasks:' <<<"${STATUS_OUTPUT}" || true)"
+  if [[ -n "${TASK_LINE}" ]]; then
+    PENDING="$(team_status_value "${TASK_LINE}" "pending")"
+    BLOCKED="$(team_status_value "${TASK_LINE}" "blocked")"
+    IN_PROGRESS="$(team_status_value "${TASK_LINE}" "in_progress")"
+    FAILED="$(team_status_value "${TASK_LINE}" "failed")"
+    PENDING="${PENDING:-0}"
+    BLOCKED="${BLOCKED:-0}"
+    IN_PROGRESS="${IN_PROGRESS:-0}"
+    FAILED="${FAILED:-0}"
+    if [[ "${FORCE_SHUTDOWN}" -ne 1 ]] && { [[ "${PENDING}" -gt 0 ]] || [[ "${BLOCKED}" -gt 0 ]] || [[ "${IN_PROGRESS}" -gt 0 ]] || [[ "${FAILED}" -gt 0 ]]; }; then
+      echo "Team is not terminal (pending=${PENDING}, blocked=${BLOCKED}, in_progress=${IN_PROGRESS}, failed=${FAILED})." >&2
+      echo "Re-run with --force-shutdown if you want to bypass the gate." >&2
+      exit 1
+    fi
+  fi
+
+  SHUTDOWN_CMD=(omx team shutdown "${TEAM_NAME}")
+  [[ "${FORCE_SHUTDOWN}" -eq 1 ]] && SHUTDOWN_CMD+=(--force)
+  run_cmd "${SHUTDOWN_CMD[@]}"
+else
+  log "team state dir not found (skip shutdown step): ${TEAM_STATE_DIR}"
+fi
+
+declare -a WORKTREE_ENTRIES=()
+while IFS=$'\t' read -r wt_path branch_ref; do
+  [[ -z "${wt_path}" ]] && continue
+  WORKTREE_ENTRIES+=("${wt_path}"$'\t'"${branch_ref}")
+done < <(
+  git worktree list --porcelain | awk -v prefix="${WORKTREE_PREFIX}" '
+    /^worktree / { wt = substr($0, 10); br = ""; next }
+    /^branch /   { br = substr($0, 8); next }
+    /^$/ {
+      if (wt != "" && index(wt, prefix) == 1) print wt "\t" br
+      wt = ""
+      br = ""
+    }
+    END {
+      if (wt != "" && index(wt, prefix) == 1) print wt "\t" br
+    }
+  '
+)
+
+if [[ "${#WORKTREE_ENTRIES[@]}" -eq 0 ]]; then
+  log "no matching team worktrees found for prefix: ${WORKTREE_PREFIX}"
+else
+  log "found ${#WORKTREE_ENTRIES[@]} matching worktree(s)"
+fi
+
+declare -a BRANCH_CANDIDATES=()
+if [[ "${#WORKTREE_ENTRIES[@]}" -gt 0 ]]; then
+  for entry in "${WORKTREE_ENTRIES[@]}"; do
+    IFS=$'\t' read -r wt_path branch_ref <<<"${entry}"
+    run_cmd git worktree remove --force "${wt_path}"
+    if [[ "${DELETE_BRANCHES}" -eq 1 && "${branch_ref}" == refs/heads/* ]]; then
+      branch_name="${branch_ref#refs/heads/}"
+      if ! array_contains "${branch_name}" "${BRANCH_CANDIDATES[@]-}"; then
+        BRANCH_CANDIDATES+=("${branch_name}")
+      fi
+    fi
+  done
+fi
+
+if [[ "${DELETE_BRANCHES}" -eq 1 && "${#BRANCH_CANDIDATES[@]}" -gt 0 ]]; then
+  for branch_name in "${BRANCH_CANDIDATES[@]}"; do
+    if git worktree list --porcelain | grep -Fq "branch refs/heads/${branch_name}"; then
+      log "skip branch delete (still checked out): ${branch_name}"
+      continue
+    fi
+    if git show-ref --verify --quiet "refs/heads/${branch_name}"; then
+      run_cmd git branch -D "${branch_name}"
+    else
+      log "branch already absent: ${branch_name}"
+    fi
+  done
+fi
+
+if [[ "${SKIP_CANCEL}" -eq 1 ]]; then
+  log "skip omx cancel"
+else
+  run_cmd omx cancel
+fi
+
+if [[ -d "${TEAM_STATE_DIR}" ]]; then
+  log "warning: team state directory still exists: ${TEAM_STATE_DIR}"
+else
+  log "team state cleaned: ${TEAM_STATE_DIR}"
+fi
+
+LEFTOVER_COUNT="$(
+  git worktree list --porcelain | awk -v prefix="${WORKTREE_PREFIX}" '
+    /^worktree / { wt = substr($0, 10) }
+    /^$/ {
+      if (wt != "" && index(wt, prefix) == 1) count += 1
+      wt = ""
+    }
+    END { print count + 0 }
+  '
+)"
+
+if [[ "${LEFTOVER_COUNT}" -gt 0 ]]; then
+  log "warning: ${LEFTOVER_COUNT} matching worktree(s) still remain"
+else
+  log "no leftover worktrees for team prefix"
+fi
+
+log "done"


### PR DESCRIPTION
## Summary
- add `scripts/team-auto-run.sh` for start → monitor → terminal-gated cleanup flow
- add `scripts/team-post-shutdown-cleanup.sh` for shutdown + worktree/branch/state cleanup
- add dedicated `omx team ralph ...` defaults in auto flow:
  - `TEAM_AUTO_FORCE_ON_FAILURE=0` (unless explicitly overridden)
  - `TEAM_AUTO_DELETE_BRANCHES=0` (unless explicitly overridden)
  - explicit guard logging when failed tasks remain
- document helper scripts + ralph policy defaults in `README.md`

## Why
`omx team ralph ...` workflows benefit from stricter teardown behavior than generic team runs. The new defaults preserve triage/retry context by default while still allowing explicit force overrides.

## Verification
- `bash -n scripts/team-auto-run.sh`
- `bash -n scripts/team-post-shutdown-cleanup.sh`
- `bash scripts/team-auto-run.sh --help`
- `bash scripts/team-post-shutdown-cleanup.sh --help`
- `npm run build`

Fixes #407
