### PR TITLE
feat(team): add dedicated ralph auto-run cleanup policy (#407)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ omx team shutdown <team-name>
 
 Important rule: do not shutdown while tasks are still `in_progress` unless aborting.
 
+### Ralph Cleanup Policy
+
+When a team runs in ralph mode (`omx team ralph ...`), the shutdown cleanup
+applies a dedicated policy that differs from the normal path:
+
+| Behavior | Normal team | Ralph team |
+|---|---|---|
+| Force shutdown on failure | Throws `shutdown_gate_blocked` | Bypasses gate, logs `ralph_cleanup_policy` event |
+| Auto branch deletion | Deletes worktree branches on rollback | Preserves branches (`skipBranchDeletion`) |
+| Completion logging | Standard `shutdown_gate` event | Additional `ralph_cleanup_summary` event with task breakdown |
+
+The ralph policy is auto-detected from team mode state (`linked_ralph`) or
+can be passed explicitly via `omx team shutdown <name> --ralph`.
+
 Worker CLI selection for team workers:
 
 ```bash

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -201,6 +201,8 @@ export interface TeamEvent {
     | 'shutdown_ack'
     | 'shutdown_gate'
     | 'shutdown_gate_forced'
+    | 'ralph_cleanup_policy'
+    | 'ralph_cleanup_summary'
     | 'approval_decision'
     | 'team_leader_nudge';
   worker: string;

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -316,7 +316,15 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
   };
 }
 
-export function rollbackProvisionedWorktrees(results: Array<EnsureWorktreeResult | { enabled: false }>): void {
+export interface RollbackWorktreeOptions {
+  /** When true, skip `git branch -D` for branches created during provisioning (ralph policy). */
+  skipBranchDeletion?: boolean;
+}
+
+export function rollbackProvisionedWorktrees(
+  results: Array<EnsureWorktreeResult | { enabled: false }>,
+  options: RollbackWorktreeOptions = {},
+): void {
   const created = results
     .filter((result): result is EnsureWorktreeResult => result.enabled === true && result.created)
     .reverse();
@@ -335,6 +343,7 @@ export function rollbackProvisionedWorktrees(results: Array<EnsureWorktreeResult
       continue;
     }
 
+    if (options.skipBranchDeletion) continue;
     if (!result.createdBranch || !result.branchName) continue;
 
     const entriesAfterRemove = listWorktrees(result.repoRoot);


### PR DESCRIPTION
Closes #407

## Summary
- When team runs in ralph mode, shutdown gate failures are bypassed (no `shutdown_gate_blocked` throw), allowing ralph loop to handle retries gracefully
- Worktree branch deletion is skipped during startup rollback (`skipBranchDeletion` option) so ralph can investigate/retry
- Stricter completion logging emits `ralph_cleanup_policy` and `ralph_cleanup_summary` audit events with full task breakdown
- Normal (non-ralph) team shutdown path is completely unchanged
- Ralph mode auto-detected from team state (`linked_ralph`) or explicit `--ralph` flag

## Test plan
- [x] `shutdownTeam ralph=true` bypasses shutdown gate on failed tasks without throwing
- [x] `shutdownTeam ralph=true` emits `ralph_cleanup_policy` event on gate bypass
- [x] `shutdownTeam ralph=true` emits `ralph_cleanup_summary` event
- [x] `shutdownTeam ralph=false` still throws on failed tasks (normal path unchanged)
- [x] `rollbackProvisionedWorktrees` with `skipBranchDeletion` preserves branches
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 1591 pass (2 pre-existing dep-versions failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)