### PR TITLE
feat(team): add dedicated tmux session mode for worker isolation

### DIFF
--- a/scripts/notify-hook/team-dispatch.js
+++ b/scripts/notify-hook/team-dispatch.js
@@ -123,7 +123,12 @@ function defaultInjectTarget(request, config) {
     if (worker?.pane_id) return { type: 'pane', value: worker.pane_id };
   }
   if (typeof request.worker_index === 'number' && config.tmux_session) {
-    return { type: 'pane', value: `${config.tmux_session}:${request.worker_index}` };
+    if (config.tmux_session.includes(':')) {
+      // split-pane topology: session:window.paneIndex
+      return { type: 'pane', value: `${config.tmux_session}.${request.worker_index}` };
+    }
+    // dedicated session topology: all workers in window 0 as panes
+    return { type: 'pane', value: `${config.tmux_session}:0.${request.worker_index - 1}` };
   }
   if (config.tmux_session) return { type: 'session', value: config.tmux_session };
   return null;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -18,6 +18,8 @@ import {
   buildHudPaneTarget,
   chooseTeamLeaderPaneId,
   createTeamSession,
+  createDedicatedTeamSession,
+  generateSessionTimestamp,
   enableMouseScrolling,
   isMsysOrGitBash,
   isNativeWindows,
@@ -1301,5 +1303,65 @@ describe('killWorker leader pane guard', () => {
     withEmptyPath(() => {
       assert.doesNotThrow(() => killWorker('omx-team-x:0', 1, '%5'));
     });
+  });
+});
+
+describe('generateSessionTimestamp', () => {
+  it('returns YYYYMMDD-HHmmss format', () => {
+    const ts = generateSessionTimestamp();
+    assert.match(ts, /^\d{8}-\d{6}$/);
+  });
+
+  it('does not contain colons or spaces', () => {
+    const ts = generateSessionTimestamp();
+    assert.equal(ts.includes(':'), false);
+    assert.equal(ts.includes(' '), false);
+  });
+
+  it('produces a valid date prefix', () => {
+    const ts = generateSessionTimestamp();
+    const year = Number(ts.slice(0, 4));
+    const month = Number(ts.slice(4, 6));
+    const day = Number(ts.slice(6, 8));
+    assert.ok(year >= 2024 && year <= 2100);
+    assert.ok(month >= 1 && month <= 12);
+    assert.ok(day >= 1 && day <= 31);
+  });
+});
+
+describe('createDedicatedTeamSession', () => {
+  it('throws when tmux is not available', () => {
+    withEmptyPath(() => {
+      assert.throws(
+        () => createDedicatedTeamSession('My Team', 1, process.cwd()),
+        /tmux is not available/i
+      );
+    });
+  });
+
+  it('does not require process.env.TMUX', () => {
+    // createDedicatedTeamSession should not throw "requires running inside tmux"
+    // even when TMUX is unset (it will still fail on tmux binary if unavailable).
+    const prev = process.env.TMUX;
+    delete process.env.TMUX;
+    try {
+      withEmptyPath(() => {
+        assert.throws(
+          () => createDedicatedTeamSession('My Team', 1, process.cwd()),
+          /tmux is not available/i  // fails at tmux check, NOT at TMUX env check
+        );
+      });
+    } finally {
+      if (typeof prev === 'string') process.env.TMUX = prev;
+      else delete process.env.TMUX;
+    }
+  });
+
+  it('dedicated session name has no colon', () => {
+    // Verify the session name format pattern: omx-team-{name}-YYYYMMDD-HHmmss
+    const ts = generateSessionTimestamp();
+    const expectedPattern = `omx-team-test-${ts}`;
+    assert.equal(expectedPattern.includes(':'), false);
+    assert.ok(expectedPattern.startsWith('omx-team-'));
   });
 });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -812,6 +812,202 @@ export function createTeamSession(
 }
 
 /**
+ * Generate a timestamp string for dedicated session naming.
+ * Format: YYYYMMDD-HHmmss
+ */
+export function generateSessionTimestamp(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+}
+
+/**
+ * Create a dedicated tmux session for team workers, completely isolated from
+ * the leader's existing tmux session. All workers live as panes within
+ * window 0 of the new session.
+ *
+ * Unlike createTeamSession() which splits the leader's current window, this
+ * function creates an entirely new tmux session (`omx-team-{name}-YYYYMMDD-HHmmss`)
+ * so the leader's layout is never touched.
+ *
+ * The returned TeamSession.name does NOT contain ':' — this allows existing
+ * cleanup logic (`sessionName.includes(':')`) to route to destroyTeamSession()
+ * automatically.
+ *
+ * Does NOT require process.env.TMUX — dedicated sessions can be created from
+ * outside tmux.
+ */
+export function createDedicatedTeamSession(
+  teamName: string,
+  workerCount: number,
+  cwd: string,
+  workerLaunchArgs: string[] = [],
+  workerStartups: Array<{ cwd?: string; env?: Record<string, string> }> = [],
+): TeamSession {
+  if (!isTmuxAvailable()) {
+    throw new Error('tmux is not available');
+  }
+  if (!Number.isInteger(workerCount) || workerCount < 1) {
+    throw new Error(`workerCount must be >= 1 (got ${workerCount})`);
+  }
+  const normalizedWorkerLaunchArgs = resolveWorkerLaunchArgs(workerLaunchArgs, cwd);
+  const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, normalizedWorkerLaunchArgs, process.env);
+  for (const workerCli of new Set(workerCliPlan)) {
+    assertTeamWorkerCliBinaryAvailable(workerCli);
+  }
+
+  const safeTeamName = sanitizeTeamName(teamName);
+  const dedicatedSessionName = `omx-team-${safeTeamName}-${generateSessionTimestamp()}`;
+  let registeredResizeHook: { name: string; target: string } | null = null;
+  let sessionCreated = false;
+
+  try {
+    // Detect leader pane ID without modifying existing session layout.
+    // When running outside tmux, use a placeholder — the leader pane ID is
+    // only used to guard against accidentally killing the leader during cleanup.
+    let leaderPaneId = '';
+    if (process.env.TMUX) {
+      const context = runTmux(['display-message', '-p', '#{pane_id}']);
+      if (context.ok) {
+        leaderPaneId = context.stdout.trim();
+      }
+    }
+    if (!leaderPaneId) {
+      leaderPaneId = 'leader-external';
+    }
+
+    const workerPaneIds: string[] = [];
+
+    // Create dedicated session with first worker
+    const firstStartup = workerStartups[0] || {};
+    const firstWorkerCwd = firstStartup.cwd || cwd;
+    const firstCmd = buildWorkerStartupCommand(
+      safeTeamName,
+      1,
+      workerLaunchArgs,
+      firstWorkerCwd,
+      firstStartup.env || {},
+      workerCliPlan[0],
+    );
+
+    const newSession = runTmux([
+      'new-session', '-d', '-s', dedicatedSessionName,
+      '-x', '200', '-y', '50',
+      '-c', translatePathForMsys(firstWorkerCwd),
+      '-P', '-F', '#{pane_id}',
+      firstCmd,
+    ]);
+    if (!newSession.ok) {
+      throw new Error(`failed to create dedicated team session: ${newSession.stderr}`);
+    }
+    sessionCreated = true;
+    const firstPaneId = newSession.stdout.split('\n')[0]?.trim();
+    if (!firstPaneId || !firstPaneId.startsWith('%')) {
+      throw new Error(`failed to capture first worker pane id: ${newSession.stdout}`);
+    }
+    workerPaneIds.push(firstPaneId);
+
+    // Create remaining workers by splitting within the dedicated session
+    for (let i = 2; i <= workerCount; i++) {
+      const startup = workerStartups[i - 1] || {};
+      const workerCwd = startup.cwd || cwd;
+      const cmd = buildWorkerStartupCommand(
+        safeTeamName,
+        i,
+        workerLaunchArgs,
+        workerCwd,
+        startup.env || {},
+        workerCliPlan[i - 1],
+      );
+      const split = runTmux([
+        'split-window', '-v',
+        '-t', `${dedicatedSessionName}:0`,
+        '-d', '-P', '-F', '#{pane_id}',
+        '-c', translatePathForMsys(workerCwd),
+        cmd,
+      ]);
+      if (!split.ok) {
+        throw new Error(`failed to create worker pane ${i}: ${split.stderr}`);
+      }
+      const paneId = split.stdout.split('\n')[0]?.trim();
+      if (!paneId || !paneId.startsWith('%')) {
+        throw new Error(`failed to capture worker pane id for worker ${i}`);
+      }
+      workerPaneIds.push(paneId);
+    }
+
+    // Apply even-vertical layout so all workers get equal height
+    runTmux(['select-layout', '-t', `${dedicatedSessionName}:0`, 'even-vertical']);
+
+    // Create HUD pane at the bottom of the dedicated session
+    let hudPaneId: string | null = null;
+    let resizeHookName: string | null = null;
+    let resizeHookTarget: string | null = null;
+    const omxEntry = process.argv[1];
+    if (omxEntry && omxEntry.trim() !== '') {
+      const hudCmd = `node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+      const hudCwd = translatePathForMsys(cwd);
+      const hudResult = runTmux([
+        'split-window', '-v', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES),
+        '-t', `${dedicatedSessionName}:0`,
+        '-d', '-P', '-F', '#{pane_id}',
+        '-c', hudCwd,
+        hudCmd,
+      ]);
+      if (hudResult.ok) {
+        const id = hudResult.stdout.split('\n')[0]?.trim() ?? '';
+        if (id.startsWith('%')) {
+          hudPaneId = id;
+
+          resizeHookTarget = `${dedicatedSessionName}:0`;
+          resizeHookName = buildResizeHookName(safeTeamName, dedicatedSessionName, '0', hudPaneId);
+          const registerHook = runTmux(buildRegisterResizeHookArgs(resizeHookTarget, resizeHookName, hudPaneId));
+          if (!registerHook.ok) {
+            throw new Error(`failed to register resize hook ${resizeHookName}: ${registerHook.stderr}`);
+          }
+          registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
+
+          const delayed = runTmux(buildScheduleDelayedHudResizeArgs(hudPaneId));
+          if (!delayed.ok) {
+            throw new Error(`failed to schedule delayed HUD resize: ${delayed.stderr}`);
+          }
+          const reconcile = runTmux(buildReconcileHudResizeArgs(hudPaneId));
+          if (!reconcile.ok) {
+            throw new Error(`failed to reconcile HUD resize: ${reconcile.stderr}`);
+          }
+        }
+      }
+    }
+
+    sleepSeconds(0.5);
+
+    // Enable mouse scrolling for the dedicated session only
+    if (process.env.OMX_TEAM_MOUSE !== '0') {
+      enableMouseScrolling(dedicatedSessionName);
+    }
+
+    return {
+      name: dedicatedSessionName,
+      workerCount,
+      cwd,
+      workerPaneIds,
+      leaderPaneId,
+      hudPaneId,
+      resizeHookName,
+      resizeHookTarget,
+    };
+  } catch (error) {
+    if (registeredResizeHook) {
+      runTmux(buildUnregisterResizeHookArgs(registeredResizeHook.target, registeredResizeHook.name));
+    }
+    if (sessionCreated) {
+      runTmux(['kill-session', '-t', dedicatedSessionName]);
+    }
+    throw error;
+  }
+}
+
+/**
  * Returns the tmux argv arrays for the scroll-and-copy key bindings applied
  * by enableMouseScrolling. Exported as a pure function so tests can verify
  * the binding configuration without requiring a live tmux session.


### PR DESCRIPTION
## Summary

- **Dedicated tmux session**: `createDedicatedTeamSession()` spawns workers in a separate session (`omx-team-{name}-YYYYMMDD-HHmmss`), preserving the leader's existing tmux layout
- **Env-based routing**: `OMX_TEAM_DEDICATED_SESSION` env var toggles between dedicated session (default) and legacy split-pane mode (`=0`)
- **Dispatch fallback fix**: `defaultInjectTarget()` now correctly distinguishes dedicated session (`session:0.paneIndex`) and split-pane (`session:window.paneIndex`) topologies

## Motivation

The existing `createTeamSession()` splits the leader's current tmux window via `split-window` to create worker panes. This causes:
1. The user's existing tmux layout to be invaded by worker panes
2. The notify-hook's CWD-based pane discovery to inject into wrong panes

```
[Before] Split inside leader session
main:0 → Leader | Worker1 | Worker2 | HUD

[After] Isolated dedicated session
main:0 → Leader (untouched)
omx-team-foo-20260301-143022:0 → Worker1 | Worker2 | HUD (isolated)
```

The session name deliberately omits `:` so that existing cleanup logic (`sessionName.includes(':')`) automatically routes to `destroyTeamSession()` for the dedicated session, while preserving per-pane cleanup for the legacy split-pane topology.

## Changed Files

| File | Change |
|---|---|
| `src/team/tmux-session.ts` | Add `createDedicatedTeamSession()` + `generateSessionTimestamp()` |
| `src/team/runtime.ts` | Add `OMX_TEAM_DEDICATED_SESSION` routing, relax TMUX guard |
| `scripts/notify-hook/team-dispatch.js` | Fix `defaultInjectTarget()` fallback for both topologies |
| `src/team/__tests__/tmux-session.test.ts` | Add timestamp format, session naming, and tmux guard tests |

## Test plan

- [x] `generateSessionTimestamp` format validation (YYYYMMDD-HHmmss, no colon)
- [x] `createDedicatedTeamSession` throws when tmux is unavailable
- [x] `createDedicatedTeamSession` works without `process.env.TMUX`
- [x] Dedicated session name contains no `:`
- [x] TypeScript compilation passes
- [ ] Start team in tmux → verify separate session created (`tmux list-sessions`)
- [ ] Verify leader session layout is untouched
- [ ] Verify `OMX_TEAM_DEDICATED_SESSION=0` falls back to split-pane mode

HyunjunJeon