### PR TITLE
ci: add CI Status gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,24 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+
+  ci-status:
+    name: CI Status
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [typecheck, test, ralph-persistence-gate, build]
+    steps:
+      - name: Check required job results
+        run: |
+          if [[ "${{ needs.typecheck.result }}" != "success" ]] ||
+             [[ "${{ needs.test.result }}" != "success" ]] ||
+             [[ "${{ needs.ralph-persistence-gate.result }}" != "success" ]] ||
+             [[ "${{ needs.build.result }}" != "success" ]]; then
+            echo "::error::One or more required CI jobs failed"
+            echo "  typecheck: ${{ needs.typecheck.result }}"
+            echo "  test: ${{ needs.test.result }}"
+            echo "  ralph-persistence-gate: ${{ needs.ralph-persistence-gate.result }}"
+            echo "  build: ${{ needs.build.result }}"
+            exit 1
+          fi
+          echo "All required CI checks passed"


### PR DESCRIPTION
## Summary
- Adds a `ci-status` summary job to `.github/workflows/ci.yml` that aggregates all CI check results (typecheck, test, ralph-persistence-gate, build) into a single required status check
- Uses `if: always()` so the gate job runs even when upstream jobs fail, reporting clear error messages
- Branch protection rules can now reference the single check name **"CI Status"** instead of tracking individual jobs

## Test plan
- [x] `npx tsc --noEmit` passes locally
- [x] `npm run check:no-unused` passes locally
- [x] `npm test` passes locally (1602/1602 tests)
- [ ] Verify CI workflow runs on this PR and "CI Status" check appears

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)