### PR TITLE
feat(team): async tmux, message identity hardening, MCP team tools

### DIFF
--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -11,8 +11,13 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { readFile, writeFile, readdir, mkdir, unlink, rename } from 'fs/promises';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { dirname, join, resolve as resolvePath } from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+import { homedir } from 'os';
+import { killWorkerPanes } from '../team/tmux-session.js';
+import { NudgeTracker } from '../team/idle-nudge.js';
 import {
   getAllScopedStatePaths,
   getReadScopedStateDirs,
@@ -113,6 +118,57 @@ const TEAM_COMM_TOOL_NAMES = new Set([
   'team_read_task_approval',
   'team_write_task_approval',
 ]);
+
+const TEAM_RUN_TOOL_NAMES = new Set([
+  'omx_run_team_start',
+  'omx_run_team_status',
+  'omx_run_team_wait',
+  'omx_run_team_cleanup',
+]);
+
+// ---------------------------------------------------------------------------
+// omx_run_team_* job state: in-memory Map + file backup (survives MCP restart)
+// ---------------------------------------------------------------------------
+
+interface OmxTeamJob {
+  status: 'running' | 'completed' | 'failed' | 'timeout';
+  result?: string;
+  stderr?: string;
+  startedAt: number;
+  pid?: number;
+  paneIds?: string[];
+  leaderPaneId?: string;
+  teamName?: string;
+  cwd?: string;
+  cleanedUpAt?: string;
+}
+
+const omxTeamJobs = new Map<string, OmxTeamJob>();
+const OMX_JOBS_DIR = join(homedir(), '.omx', 'team-jobs');
+
+function persistJob(jobId: string, job: OmxTeamJob): void {
+  try {
+    if (!existsSync(OMX_JOBS_DIR)) mkdirSync(OMX_JOBS_DIR, { recursive: true });
+    writeFileSync(join(OMX_JOBS_DIR, `${jobId}.json`), JSON.stringify(job), 'utf-8');
+  } catch { /* best-effort */ }
+}
+
+function loadJobFromDisk(jobId: string): OmxTeamJob | undefined {
+  try {
+    return JSON.parse(readFileSync(join(OMX_JOBS_DIR, `${jobId}.json`), 'utf-8')) as OmxTeamJob;
+  } catch { return undefined; }
+}
+
+async function loadPaneIds(jobId: string): Promise<{ paneIds: string[]; leaderPaneId: string } | null> {
+  try { return JSON.parse(await readFile(join(OMX_JOBS_DIR, `${jobId}-panes.json`), 'utf-8')); }
+  catch { return null; }
+}
+
+function validateJobId(jobId: string): void {
+  if (!/^omx-[a-z0-9]{1,12}$/.test(jobId)) {
+    throw new Error(`Invalid job_id: "${jobId}". Must match /^omx-[a-z0-9]{1,12}$/`);
+  }
+}
 
 const TEAM_UPDATE_TASK_MUTABLE_FIELDS = new Set(['subject', 'description', 'blocked_by', 'requires_code_change']);
 const TEAM_UPDATE_TASK_REQUEST_FIELDS = new Set(['team_name', 'task_id', 'workingDirectory', ...TEAM_UPDATE_TASK_MUTABLE_FIELDS]);
@@ -738,6 +794,70 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['team_name', 'task_id', 'status', 'reviewer', 'decision_reason'],
       },
     },
+    // omx_run_team_* tools
+    {
+      name: 'omx_run_team_start',
+      description: 'Spawn tmux CLI workers (codex/claude) in the background. Returns jobId immediately. Poll with omx_run_team_status.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          teamName: { type: 'string', description: 'Slug name for the team' },
+          agentTypes: { type: 'array', items: { type: 'string' }, description: '"codex" or "claude" per worker' },
+          tasks: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                subject: { type: 'string' },
+                description: { type: 'string' },
+              },
+              required: ['subject', 'description'],
+            },
+            description: 'Tasks to distribute to workers',
+          },
+          cwd: { type: 'string', description: 'Working directory (absolute path)' },
+        },
+        required: ['teamName', 'agentTypes', 'tasks', 'cwd'],
+      },
+    },
+    {
+      name: 'omx_run_team_status',
+      description: 'Non-blocking status check for a background omx_run_team job. Returns status and result when done.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          job_id: { type: 'string', description: 'Job ID returned by omx_run_team_start' },
+        },
+        required: ['job_id'],
+      },
+    },
+    {
+      name: 'omx_run_team_wait',
+      description: 'Block (poll internally) until a background omx_run_team job reaches a terminal state (completed or failed). Returns the result when done. One call instead of N polling calls. Uses exponential backoff (500ms to 2000ms). Auto-nudges idle teammate panes via tmux send-keys. If this wait call times out, workers are left running -- call omx_run_team_wait again to keep waiting, or omx_run_team_cleanup to stop them explicitly.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          job_id: { type: 'string', description: 'Job ID returned by omx_run_team_start' },
+          timeout_ms: { type: 'number', description: 'Maximum wait time in ms (default: 300000, max: 3600000)' },
+          nudge_delay_ms: { type: 'number', description: 'Milliseconds a pane must be idle before nudging (default: 30000)' },
+          nudge_max_count: { type: 'number', description: 'Maximum nudges per pane (default: 3)' },
+          nudge_message: { type: 'string', description: 'Message sent as nudge (default: "Continue working on your assigned task.")' },
+        },
+        required: ['job_id'],
+      },
+    },
+    {
+      name: 'omx_run_team_cleanup',
+      description: 'Explicitly clean up worker panes when you want to stop workers. Kills all worker panes recorded for the job without touching the leader pane or the user session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          job_id: { type: 'string', description: 'Job ID returned by omx_run_team_start' },
+          grace_ms: { type: 'number', description: 'Grace period in ms before force-killing panes (default: 10000)' },
+        },
+        required: ['job_id'],
+      },
+    },
   ],
 }));
 
@@ -971,7 +1091,16 @@ export async function handleStateToolCall(request: {
       const fromWorker = String((args as Record<string, unknown>).from_worker || '').trim();
       const toWorker = String((args as Record<string, unknown>).to_worker || '').trim();
       const body = String((args as Record<string, unknown>).body || '').trim();
-      if (!teamName || !fromWorker || !toWorker || !body) {
+      if (!fromWorker) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({
+            error: 'from_worker is required. You must identify yourself. Check your worker name in your inbox file or AGENTS.md overlay.',
+            hint: 'Your worker name was set when you were spawned (e.g., "worker-1", "worker-2", or "leader-fixed").'
+          }) }],
+          isError: true,
+        };
+      }
+      if (!teamName || !toWorker || !body) {
         return {
           content: [{ type: 'text', text: JSON.stringify({ error: 'team_name, from_worker, to_worker, body are required' }) }],
           isError: true,
@@ -1426,6 +1555,180 @@ export async function handleStateToolCall(request: {
         decided_at: new Date().toISOString(),
       }, cwd);
       return { content: [{ type: 'text', text: JSON.stringify({ ok: true, task_id: taskId, status }) }] };
+    }
+
+    // -----------------------------------------------------------------------
+    // omx_run_team_* tools
+    // -----------------------------------------------------------------------
+
+    case 'omx_run_team_start': {
+      const teamName = String((args as Record<string, unknown>).teamName ?? '').trim();
+      const agentTypes = (args as Record<string, unknown>).agentTypes as string[] | undefined;
+      const tasks = (args as Record<string, unknown>).tasks as Array<{ subject: string; description: string }> | undefined;
+      const inputCwd = String((args as Record<string, unknown>).cwd ?? '').trim();
+
+      if (!teamName) return { content: [{ type: 'text', text: JSON.stringify({ error: 'teamName is required' }) }], isError: true };
+      if (!agentTypes || !Array.isArray(agentTypes) || agentTypes.length === 0) return { content: [{ type: 'text', text: JSON.stringify({ error: 'agentTypes is required (non-empty array)' }) }], isError: true };
+      if (!tasks || !Array.isArray(tasks) || tasks.length === 0) return { content: [{ type: 'text', text: JSON.stringify({ error: 'tasks is required (non-empty array)' }) }], isError: true };
+      if (!inputCwd) return { content: [{ type: 'text', text: JSON.stringify({ error: 'cwd is required' }) }], isError: true };
+
+      const jobId = `omx-${Date.now().toString(36)}`;
+      const runtimeCliPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'team', 'runtime-cli.js');
+
+      const job: OmxTeamJob = { status: 'running', startedAt: Date.now(), teamName, cwd: inputCwd };
+      omxTeamJobs.set(jobId, job);
+
+      const child = spawn('node', [runtimeCliPath], {
+        env: { ...process.env, OMX_JOB_ID: jobId, OMX_JOBS_DIR },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      job.pid = child.pid;
+      persistJob(jobId, job);
+
+      child.stdin.write(JSON.stringify({ teamName, agentTypes, tasks, cwd: inputCwd }));
+      child.stdin.end();
+
+      const outChunks: Buffer[] = [];
+      const errChunks: Buffer[] = [];
+      child.stdout.on('data', (c: Buffer) => outChunks.push(c));
+      child.stderr.on('data', (c: Buffer) => errChunks.push(c));
+
+      child.on('close', (code) => {
+        const stdout = Buffer.concat(outChunks).toString('utf-8').trim();
+        const stderr = Buffer.concat(errChunks).toString('utf-8').trim();
+        if (stdout) {
+          try {
+            const parsed = JSON.parse(stdout) as { status?: string };
+            const s = parsed.status;
+            if (job.status === 'running') {
+              job.status = (s === 'completed' || s === 'failed') ? s : 'failed';
+            }
+          } catch {
+            if (job.status === 'running') job.status = 'failed';
+          }
+          job.result = stdout;
+        }
+        if (job.status === 'running') {
+          if (code === 0) job.status = 'completed';
+          else job.status = 'failed';
+        }
+        if (stderr) job.stderr = stderr;
+        persistJob(jobId, job);
+      });
+
+      child.on('error', (err: Error) => {
+        job.status = 'failed';
+        job.stderr = `spawn error: ${err.message}`;
+        persistJob(jobId, job);
+      });
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ jobId, pid: job.pid, message: 'Team started. Poll with omx_run_team_status.' }) }],
+      };
+    }
+
+    case 'omx_run_team_status': {
+      const jobId = String((args as Record<string, unknown>).job_id ?? '').trim();
+      validateJobId(jobId);
+      const job = omxTeamJobs.get(jobId) ?? loadJobFromDisk(jobId);
+      if (!job) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: `No job found: ${jobId}` }) }] };
+      }
+      const elapsed = ((Date.now() - job.startedAt) / 1000).toFixed(1);
+      const out: Record<string, unknown> = { jobId, status: job.status, elapsedSeconds: elapsed };
+      if (job.result) { try { out.result = JSON.parse(job.result) as unknown; } catch { out.result = job.result; } }
+      if (job.stderr) out.stderr = job.stderr;
+      return { content: [{ type: 'text', text: JSON.stringify(out) }] };
+    }
+
+    case 'omx_run_team_wait': {
+      const jobId = String((args as Record<string, unknown>).job_id ?? '').trim();
+      const timeoutMs = Number((args as Record<string, unknown>).timeout_ms ?? 300_000);
+      const nudgeDelayMs = (args as Record<string, unknown>).nudge_delay_ms as number | undefined;
+      const nudgeMaxCount = (args as Record<string, unknown>).nudge_max_count as number | undefined;
+      const nudgeMessage = (args as Record<string, unknown>).nudge_message as string | undefined;
+
+      validateJobId(jobId);
+      const deadline = Date.now() + Math.min(timeoutMs, 3_600_000);
+      let pollDelay = 500;
+
+      const nudgeTracker = new NudgeTracker({
+        ...(nudgeDelayMs != null ? { delayMs: nudgeDelayMs } : {}),
+        ...(nudgeMaxCount != null ? { maxCount: nudgeMaxCount } : {}),
+        ...(nudgeMessage != null ? { message: nudgeMessage } : {}),
+      });
+
+      while (Date.now() < deadline) {
+        const job = omxTeamJobs.get(jobId) ?? loadJobFromDisk(jobId);
+        if (!job) {
+          return { content: [{ type: 'text', text: JSON.stringify({ error: `No job found: ${jobId}` }) }] };
+        }
+        // Detect orphan PIDs: if job is 'running' but the process is dead,
+        // mark it failed immediately rather than polling forever.
+        if (job.status === 'running' && job.pid != null) {
+          try {
+            process.kill(job.pid, 0);
+          } catch (e: unknown) {
+            if ((e as NodeJS.ErrnoException).code === 'ESRCH') {
+              job.status = 'failed';
+              if (!job.result) job.result = JSON.stringify({ error: 'Process no longer alive (MCP restart?)' });
+              persistJob(jobId, job);
+              const elapsed = ((Date.now() - job.startedAt) / 1000).toFixed(1);
+              return { content: [{ type: 'text', text: JSON.stringify({ jobId, status: 'failed', elapsedSeconds: elapsed, error: 'Process no longer alive (MCP restart?)' }) }] };
+            }
+          }
+        }
+        if (job.status !== 'running') {
+          const elapsed = ((Date.now() - job.startedAt) / 1000).toFixed(1);
+          const out: Record<string, unknown> = { jobId, status: job.status, elapsedSeconds: elapsed };
+          if (job.result) { try { out.result = JSON.parse(job.result) as unknown; } catch { out.result = job.result; } }
+          if (job.stderr) out.stderr = job.stderr;
+          if (nudgeTracker.totalNudges > 0) out.nudges = nudgeTracker.getSummary();
+          return { content: [{ type: 'text', text: JSON.stringify(out) }] };
+        }
+        // Yield to Node.js event loop -- lets child.on('close', ...) fire between polls.
+        await new Promise<void>(r => setTimeout(r, pollDelay));
+        pollDelay = Math.min(Math.floor(pollDelay * 1.5), 2000);
+
+        // Auto-nudge idle panes
+        try {
+          const panes = await loadPaneIds(jobId);
+          if (panes?.paneIds?.length) {
+            await nudgeTracker.checkAndNudge(
+              panes.paneIds,
+              panes.leaderPaneId,
+              job.teamName ?? '',
+            );
+          }
+        } catch { /* nudge is best-effort */ }
+      }
+
+      // Timeout: leave workers running
+      const elapsed = ((Date.now() - (omxTeamJobs.get(jobId)?.startedAt ?? Date.now())) / 1000).toFixed(1);
+      const timeoutOut: Record<string, unknown> = {
+        error: `Timed out waiting for job ${jobId} after ${(timeoutMs / 1000).toFixed(0)}s -- workers are still running; call omx_run_team_wait again to keep waiting or omx_run_team_cleanup to stop them`,
+        jobId,
+        status: 'running',
+        elapsedSeconds: elapsed,
+      };
+      if (nudgeTracker.totalNudges > 0) timeoutOut.nudges = nudgeTracker.getSummary();
+      return { content: [{ type: 'text', text: JSON.stringify(timeoutOut) }] };
+    }
+
+    case 'omx_run_team_cleanup': {
+      const jobId = String((args as Record<string, unknown>).job_id ?? '').trim();
+      const graceMs = Number((args as Record<string, unknown>).grace_ms ?? 10_000);
+      validateJobId(jobId);
+      const job = omxTeamJobs.get(jobId) ?? loadJobFromDisk(jobId);
+      if (!job) return { content: [{ type: 'text', text: `Job ${jobId} not found` }] };
+      const panes = await loadPaneIds(jobId);
+      if (!panes?.paneIds?.length) {
+        return { content: [{ type: 'text', text: 'No pane IDs recorded for this job -- nothing to clean up.' }] };
+      }
+      await killWorkerPanes(panes.paneIds, panes.leaderPaneId, graceMs);
+      job.cleanedUpAt = new Date().toISOString();
+      persistJob(jobId, job);
+      return { content: [{ type: 'text', text: `Cleaned up ${panes.paneIds.length} worker pane(s).` }] };
     }
 
     default:

--- a/src/team/idle-nudge.ts
+++ b/src/team/idle-nudge.ts
@@ -1,0 +1,185 @@
+/**
+ * Idle Pane Nudge for Team MCP Wait
+ *
+ * Detects idle teammate panes during omx_run_team_wait polling and sends
+ * tmux send-keys continuation nudges. Only nudges worker panes (never the
+ * leader) in the current team session.
+ *
+ * Idle = pane shows a prompt (paneLooksReady) AND no active task running
+ * (paneHasActiveTask is false).
+ *
+ * Ported from OMC with adapted sendToWorker signature.
+ */
+
+import { execFile } from 'child_process';
+import { paneLooksReady, paneHasActiveTask, sendToWorker } from './tmux-session.js';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface NudgeConfig {
+  /** Milliseconds a pane must be idle before the first nudge (default: 30000) */
+  delayMs: number;
+  /** Maximum number of nudges per pane per wait call (default: 3) */
+  maxCount: number;
+  /** Text sent to the pane as a nudge (default below) */
+  message: string;
+}
+
+export const DEFAULT_NUDGE_CONFIG: NudgeConfig = {
+  delayMs: 30_000,
+  maxCount: 3,
+  message: 'Continue working on your assigned task.',
+};
+
+// ---------------------------------------------------------------------------
+// Pane capture + idle detection
+// ---------------------------------------------------------------------------
+
+/** Capture the last 80 lines of a tmux pane. Returns '' on error. */
+export function capturePane(paneId: string): Promise<string> {
+  return new Promise((resolve) => {
+    execFile('tmux', ['capture-pane', '-t', paneId, '-p', '-S', '-80'], (err, stdout) => {
+      if (err) resolve('');
+      else resolve(stdout ?? '');
+    });
+  });
+}
+
+/**
+ * A pane is idle when it shows a prompt (ready for input) but has no
+ * active task running.
+ */
+export async function isPaneIdle(paneId: string): Promise<boolean> {
+  const captured = await capturePane(paneId);
+  if (!captured) return false;
+  return paneLooksReady(captured) && !paneHasActiveTask(captured);
+}
+
+// ---------------------------------------------------------------------------
+// sendToWorker adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Thin wrapper to call OMX's sendToWorker by pane ID only (for NudgeTracker).
+ * workerIndex=0 is a dummy — paneTarget() prefers workerPaneId when provided.
+ */
+async function sendToWorkerByPaneId(
+  sessionName: string,
+  paneId: string,
+  message: string,
+): Promise<boolean> {
+  try {
+    await sendToWorker(sessionName, 0, message, paneId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NudgeTracker
+// ---------------------------------------------------------------------------
+
+interface PaneNudgeState {
+  nudgeCount: number;
+  firstIdleAt: number | null;
+  lastNudgeAt: number | null;
+}
+
+export class NudgeTracker {
+  private readonly config: NudgeConfig;
+  private readonly states = new Map<string, PaneNudgeState>();
+  /** Minimum interval between idle-detection scans (ms). */
+  private readonly scanIntervalMs = 5_000;
+  private lastScanAt = 0;
+
+  constructor(config?: Partial<NudgeConfig>) {
+    this.config = { ...DEFAULT_NUDGE_CONFIG, ...config };
+  }
+
+  /**
+   * Check worker panes for idle state and nudge when appropriate.
+   * Returns pane IDs that were nudged in this call.
+   *
+   * @param paneIds   - Worker pane IDs from the job's panes file
+   * @param leaderPaneId - Leader pane ID (never nudged)
+   * @param sessionName  - Tmux session name (passed to sendToWorker)
+   */
+  async checkAndNudge(
+    paneIds: string[],
+    leaderPaneId: string | undefined,
+    sessionName: string,
+  ): Promise<string[]> {
+    const now = Date.now();
+
+    // Throttle: skip if last scan was too recent
+    if (now - this.lastScanAt < this.scanIntervalMs) return [];
+    this.lastScanAt = now;
+
+    const nudged: string[] = [];
+
+    for (const paneId of paneIds) {
+      // Never nudge the leader pane
+      if (paneId === leaderPaneId) continue;
+
+      let state = this.states.get(paneId);
+      if (!state) {
+        state = { nudgeCount: 0, firstIdleAt: null, lastNudgeAt: null };
+        this.states.set(paneId, state);
+      }
+
+      // Max nudges reached for this pane — skip
+      if (state.nudgeCount >= this.config.maxCount) continue;
+
+      const idle = await isPaneIdle(paneId);
+
+      if (!idle) {
+        // Pane is active — reset idle tracking
+        state.firstIdleAt = null;
+        continue;
+      }
+
+      // Record when we first detected idle
+      if (state.firstIdleAt === null) {
+        state.firstIdleAt = now;
+      }
+
+      // Has the pane been idle long enough?
+      if (now - state.firstIdleAt < this.config.delayMs) continue;
+
+      // Send the nudge
+      const ok = await sendToWorkerByPaneId(sessionName, paneId, this.config.message);
+      if (ok) {
+        state.nudgeCount++;
+        state.lastNudgeAt = now;
+        // Reset idle timer so the next nudge waits another full delay
+        state.firstIdleAt = null;
+        nudged.push(paneId);
+      }
+    }
+
+    return nudged;
+  }
+
+  /** Summary of nudge activity per pane. */
+  getSummary(): Record<string, { nudgeCount: number; lastNudgeAt: number | null }> {
+    const out: Record<string, { nudgeCount: number; lastNudgeAt: number | null }> = {};
+    for (const [paneId, state] of this.states) {
+      if (state.nudgeCount > 0) {
+        out[paneId] = { nudgeCount: state.nudgeCount, lastNudgeAt: state.lastNudgeAt };
+      }
+    }
+    return out;
+  }
+
+  /** Total nudges sent across all panes. */
+  get totalNudges(): number {
+    let total = 0;
+    for (const state of this.states.values()) {
+      total += state.nudgeCount;
+    }
+    return total;
+  }
+}

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -17,7 +17,7 @@ export interface TeamNotifierTarget {
   paneId?: string;
 }
 
-export type DispatchTransport = 'hook' | 'prompt_stdin' | 'tmux_send_keys' | 'none';
+export type DispatchTransport = 'hook' | 'prompt_stdin' | 'tmux_send_keys' | 'mailbox' | 'none';
 
 export interface DispatchOutcome {
   ok: boolean;

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -1,0 +1,258 @@
+/**
+ * CLI entry point for team runtime.
+ * Reads JSON config from stdin, runs startTeam/monitorTeam/shutdownTeam,
+ * writes structured JSON result to stdout.
+ *
+ * Spawned by omx_run_team_start in state-server.ts.
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { writeFile, rename } from 'fs/promises';
+import { join } from 'path';
+import { startTeam, monitorTeam, shutdownTeam } from './runtime.js';
+import type { TeamRuntime } from './runtime.js';
+
+interface CliInput {
+  teamName: string;
+  workerCount?: number;
+  agentTypes: string[];
+  tasks: Array<{ subject: string; description: string }>;
+  cwd: string;
+  pollIntervalMs?: number;
+}
+
+interface TaskResult {
+  taskId: string;
+  status: string;
+  summary: string;
+}
+
+interface CliOutput {
+  status: 'completed' | 'failed';
+  teamName: string;
+  taskResults: TaskResult[];
+  duration: number;
+  workerCount: number;
+}
+
+async function writePanesFile(
+  jobId: string | undefined,
+  paneIds: string[],
+  leaderPaneId: string,
+): Promise<void> {
+  const omxJobsDir = process.env.OMX_JOBS_DIR;
+  if (!jobId || !omxJobsDir) return;
+
+  const panesPath = join(omxJobsDir, `${jobId}-panes.json`);
+  await writeFile(
+    panesPath + '.tmp',
+    JSON.stringify({ paneIds: [...paneIds], leaderPaneId }),
+  );
+  await rename(panesPath + '.tmp', panesPath);
+}
+
+function collectTaskResults(stateRoot: string, teamName: string): TaskResult[] {
+  const tasksDir = join(stateRoot, 'team', teamName, 'tasks');
+  try {
+    const files = readdirSync(tasksDir).filter(f => f.endsWith('.json'));
+    return files.map(f => {
+      try {
+        const raw = readFileSync(join(tasksDir, f), 'utf-8');
+        const task = JSON.parse(raw) as { id?: string; status?: string; result?: string; summary?: string };
+        return {
+          taskId: task.id ?? f.replace('.json', ''),
+          status: task.status ?? 'unknown',
+          summary: (task.result ?? task.summary) ?? '',
+        };
+      } catch {
+        return { taskId: f.replace('.json', ''), status: 'unknown', summary: '' };
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+async function main(): Promise<void> {
+  const startTime = Date.now();
+
+  // Read stdin
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  const rawInput = Buffer.concat(chunks).toString('utf-8').trim();
+
+  let input: CliInput;
+  try {
+    input = JSON.parse(rawInput) as CliInput;
+  } catch (err) {
+    process.stderr.write(`[runtime-cli] Failed to parse stdin JSON: ${err}\n`);
+    process.exit(1);
+  }
+
+  // Validate required fields
+  const missing: string[] = [];
+  if (!input.teamName) missing.push('teamName');
+  if (!input.agentTypes || !Array.isArray(input.agentTypes) || input.agentTypes.length === 0) missing.push('agentTypes');
+  if (!input.tasks || !Array.isArray(input.tasks) || input.tasks.length === 0) missing.push('tasks');
+  if (!input.cwd) missing.push('cwd');
+  if (missing.length > 0) {
+    process.stderr.write(`[runtime-cli] Missing required fields: ${missing.join(', ')}\n`);
+    process.exit(1);
+  }
+
+  const {
+    teamName,
+    agentTypes,
+    tasks,
+    cwd,
+    pollIntervalMs = 5000,
+  } = input;
+
+  const workerCount = input.workerCount ?? agentTypes.length;
+  const stateRoot = join(cwd, '.omx', 'state');
+
+  let runtime: TeamRuntime | null = null;
+  let finalStatus: 'completed' | 'failed' = 'failed';
+  let pollActive = true;
+
+  function exitCodeFor(status: 'completed' | 'failed'): number {
+    return status === 'completed' ? 0 : 1;
+  }
+
+  async function doShutdown(status: 'completed' | 'failed'): Promise<void> {
+    pollActive = false;
+    finalStatus = status;
+
+    // 1. Collect task results
+    const taskResults = collectTaskResults(stateRoot, teamName);
+
+    // 2. Shutdown team
+    if (runtime) {
+      try {
+        await shutdownTeam(runtime.teamName, runtime.cwd);
+      } catch (err) {
+        process.stderr.write(`[runtime-cli] shutdownTeam error: ${err}\n`);
+      }
+    }
+
+    const duration = (Date.now() - startTime) / 1000;
+    const output: CliOutput = {
+      status: finalStatus,
+      teamName,
+      taskResults,
+      duration,
+      workerCount,
+    };
+
+    // 3. Write result to stdout
+    process.stdout.write(JSON.stringify(output) + '\n');
+
+    // 4. Exit
+    process.exit(exitCodeFor(status));
+  }
+
+  // Register signal handlers before poll loop
+  process.on('SIGINT', () => {
+    process.stderr.write('[runtime-cli] Received SIGINT, shutting down...\n');
+    doShutdown('failed').catch(() => process.exit(1));
+  });
+  process.on('SIGTERM', () => {
+    process.stderr.write('[runtime-cli] Received SIGTERM, shutting down...\n');
+    doShutdown('failed').catch(() => process.exit(1));
+  });
+
+  // Start the team — OMX's startTeam takes individual parameters
+  const agentType = agentTypes[0] ?? 'codex';
+  try {
+    runtime = await startTeam(
+      teamName,
+      tasks.map(t => t.subject).join('; '),
+      agentType,
+      workerCount,
+      tasks,
+      cwd,
+    );
+  } catch (err) {
+    process.stderr.write(`[runtime-cli] startTeam failed: ${err}\n`);
+    process.exit(1);
+  }
+
+  // Extract pane IDs from the runtime config
+  const workerPaneIds = runtime.config.workers
+    .map(w => w.pane_id)
+    .filter((id): id is string => !!id);
+  const leaderPaneId = runtime.config.leader_pane_id ?? '';
+
+  // Persist pane IDs so MCP server can clean up explicitly via omx_run_team_cleanup.
+  const jobId = process.env.OMX_JOB_ID;
+  try {
+    await writePanesFile(jobId, workerPaneIds, leaderPaneId);
+  } catch (err) {
+    process.stderr.write(`[runtime-cli] Failed to persist pane IDs: ${err}\n`);
+  }
+
+  // Poll loop
+  while (pollActive) {
+    await new Promise(r => setTimeout(r, pollIntervalMs));
+
+    if (!pollActive) break;
+
+    let snap;
+    try {
+      snap = await monitorTeam(teamName, cwd);
+    } catch (err) {
+      process.stderr.write(`[runtime-cli] monitorTeam error: ${err}\n`);
+      continue;
+    }
+
+    if (!snap) {
+      process.stderr.write(`[runtime-cli] monitorTeam returned null\n`);
+      continue;
+    }
+
+    // Refresh pane IDs (workers may have scaled)
+    try {
+      const currentPaneIds = runtime.config.workers
+        .map(w => w.pane_id)
+        .filter((id): id is string => !!id);
+      await writePanesFile(jobId, currentPaneIds, leaderPaneId);
+    } catch (err) {
+      process.stderr.write(`[runtime-cli] Failed to persist pane IDs: ${err}\n`);
+    }
+
+    const perfMs = snap.performance?.total_ms ?? 0;
+    process.stderr.write(
+      `[runtime-cli] phase=${snap.phase} pending=${snap.tasks.pending} inProgress=${snap.tasks.in_progress} completed=${snap.tasks.completed} failed=${snap.tasks.failed} dead=${snap.deadWorkers.length} monitorMs=${perfMs.toFixed(0)}\n`,
+    );
+
+    // Check completion
+    if (snap.phase === 'complete') {
+      await doShutdown('completed');
+      return;
+    }
+    if (snap.phase === 'failed' || snap.phase === 'cancelled') {
+      await doShutdown('failed');
+      return;
+    }
+
+    // Check failure heuristics
+    const allWorkersDead = workerPaneIds.length > 0 && snap.deadWorkers.length >= workerPaneIds.length;
+    const hasOutstandingWork = (snap.tasks.pending + snap.tasks.in_progress) > 0;
+
+    const deadWorkerFailure = allWorkersDead && hasOutstandingWork;
+    const fixingWithNoWorkers = snap.phase === 'team-fix' && allWorkersDead;
+
+    if (deadWorkerFailure || fixingWithNoWorkers) {
+      process.stderr.write(`[runtime-cli] Failure detected: deadWorkerFailure=${deadWorkerFailure} fixingWithNoWorkers=${fixingWithNoWorkers}\n`);
+      await doShutdown('failed');
+      return;
+    }
+  }
+}
+
+main().catch(err => {
+  process.stderr.write(`[runtime-cli] Fatal error: ${err}\n`);
+  process.exit(1);
+});

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -22,6 +22,7 @@ import {
   getWorkerPanePid,
   killWorker,
   killWorkerByPaneId,
+  killWorkerByPaneIdAsync,
   unregisterResizeHook,
   destroyTeamSession,
   listTeamSessions,
@@ -44,6 +45,7 @@ import {
   teamAppendEvent as appendTeamEvent,
   teamReadTaskApproval as readTaskApproval,
   teamListMailbox as listMailboxMessages,
+  teamMarkMessageDelivered as markMessageDelivered,
   teamMarkMessageNotified as markMessageNotified,
   teamEnqueueDispatchRequest as enqueueDispatchRequest,
   teamMarkDispatchRequestNotified as markDispatchRequestNotified,
@@ -790,10 +792,10 @@ export async function startTeam(
       // In split-pane topology, we must not kill the entire tmux session; kill only created panes.
       if (sessionName.includes(':')) {
         for (const paneId of createdWorkerPaneIds) {
-          try { killWorkerByPaneId(paneId, createdLeaderPaneId); } catch { /* ignore */ }
+          try { await killWorkerByPaneIdAsync(paneId, createdLeaderPaneId); } catch { /* ignore */ }
         }
         if (config?.hud_pane_id) {
-          try { killWorkerByPaneId(config.hud_pane_id, createdLeaderPaneId); } catch { /* ignore */ }
+          try { await killWorkerByPaneIdAsync(config.hud_pane_id, createdLeaderPaneId); } catch { /* ignore */ }
         }
       } else {
         try {
@@ -982,6 +984,21 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
     cwd
   );
   const mailboxDeliveryMs = performance.now() - mailboxDeliveryStartMs;
+
+  // Prune ephemeral status messages from leader mailbox (TTL: 60s)
+  try {
+    const leaderMailbox = await listMailboxMessages(sanitized, 'leader-fixed', cwd);
+    const now = Date.now();
+    for (const msg of leaderMailbox) {
+      if (msg.from_worker === 'system' && msg.created_at) {
+        const age = now - new Date(msg.created_at).getTime();
+        if (age > 60_000) {
+          await markMessageDelivered(sanitized, 'leader-fixed', msg.message_id, cwd);
+        }
+      }
+    }
+  } catch { /* best-effort */ }
+
   const updatedAt = new Date().toISOString();
   const totalMs = performance.now() - monitorStartMs;
   await writeMonitorSnapshot(
@@ -1089,7 +1106,7 @@ export async function assignTask(
         if (dismissTrustPromptIfPresent(config.tmux_session, workerInfo.index, workerInfo.pane_id)) {
           waitForWorkerReady(config.tmux_session, workerInfo.index, 15_000, workerInfo.pane_id);
         } else {
-          sleepFractionalSeconds(assignRetryDelayS);
+          await new Promise<void>(r => setTimeout(r, assignRetryDelayS * 1000));
         }
       }
     }
@@ -1305,7 +1322,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         if (leaderPaneId && w.pane_id === leaderPaneId) continue;
         if (hudPaneId && w.pane_id === hudPaneId) continue;
         if (isWorkerAlive(sessionName, w.index, w.pane_id)) {
-          killWorker(sessionName, w.index, w.pane_id, leaderPaneId ?? undefined);
+          await killWorker(sessionName, w.index, w.pane_id, leaderPaneId ?? undefined);
         }
       } catch { /* ignore */ }
     }
@@ -1523,7 +1540,7 @@ async function emitMonitorDerivedEvents(
   }
 }
 
-function notifyWorkerOutcome(config: TeamConfig, workerIndex: number, message: string, workerPaneId?: string): DispatchOutcome {
+async function notifyWorkerOutcome(config: TeamConfig, workerIndex: number, message: string, workerPaneId?: string): Promise<DispatchOutcome> {
   const worker = config.workers.find((candidate) => candidate.index === workerIndex);
   if (!worker) return { ok: false, transport: 'none', reason: 'worker_not_found' };
 
@@ -1546,7 +1563,7 @@ function notifyWorkerOutcome(config: TeamConfig, workerIndex: number, message: s
     return { ok: false, transport: 'tmux_send_keys', reason: 'tmux_unavailable' };
   }
   try {
-    sendToWorker(config.tmux_session, workerIndex, message, workerPaneId, worker.worker_cli);
+    await sendToWorker(config.tmux_session, workerIndex, message, workerPaneId, worker.worker_cli);
     return { ok: true, transport: 'tmux_send_keys', reason: 'tmux_send_keys_sent' };
   } catch (error) {
     return {
@@ -1637,7 +1654,7 @@ async function dispatchCriticalInboxInstruction(params: {
     return { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: queued.request_id };
   }
   if (receipt?.status === 'failed') {
-    const fallback = notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
+    const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
     if (fallback.ok) {
       await transitionDispatchRequest(
         teamName,
@@ -1670,7 +1687,7 @@ async function dispatchCriticalInboxInstruction(params: {
     };
   }
 
-  const fallback = notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
+  const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
   if (fallback.ok) {
     const marked = await markDispatchRequestNotified(
       teamName,
@@ -1726,7 +1743,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   config: TeamConfig;
   dispatchPolicy: TeamPolicy;
   cwd: string;
-  fallbackNotify?: () => DispatchOutcome;
+  fallbackNotify?: () => DispatchOutcome | Promise<DispatchOutcome>;
 }): Promise<DispatchOutcome> {
   const {
     teamName,
@@ -1751,9 +1768,9 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   }
 
   const fallback: DispatchOutcome = fallbackNotify
-    ? fallbackNotify()
+    ? await fallbackNotify()
     : (typeof workerIndex === 'number'
-      ? notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId)
+      ? await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId)
       : { ok: false, transport: 'none', reason: 'missing_worker_index' });
   if (receipt?.status === 'failed') {
     if (fallback.ok) {
@@ -1843,6 +1860,12 @@ function notifyLeader(config: TeamConfig, message: string): boolean {
   return notifyLeaderStatus(config.tmux_session, message);
 }
 
+async function notifyLeaderAsync(config: TeamConfig, message: string, cwd: string): Promise<boolean> {
+  if (!config.tmux_session) return false;
+  const { notifyLeaderMailboxAsync } = await import('./tmux-session.js');
+  return notifyLeaderMailboxAsync(config.name, 'system', message, cwd);
+}
+
 async function deliverPendingMailboxMessages(
   teamName: string,
   config: TeamConfig,
@@ -1917,7 +1940,7 @@ async function deliverPendingMailboxMessages(
           cwd,
         });
       } else {
-        const direct = notifyWorkerOutcome(config, workerInfo.index, triggerMessage, workerInfo.pane_id);
+        const direct = await notifyWorkerOutcome(config, workerInfo.index, triggerMessage, workerInfo.pane_id);
         outcome = { ...direct, request_id: queued.request.request_id, message_id: msg.message_id };
         if (outcome.ok) {
           await markMessageNotified(teamName, worker.name, msg.message_id, cwd).catch(() => false);
@@ -1970,10 +1993,10 @@ export async function sendWorkerMessage(
       cwd,
       transportPreference: leaderTransportPreference,
       fallbackAllowed: leaderTransportPreference === 'hook_preferred_with_fallback',
-      notify: (_target, message) => (
+      notify: async (_target, message) => (
         leaderTransportPreference === 'hook_preferred_with_fallback'
           ? { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }
-          : { ok: notifyLeader(config, message), transport: 'tmux_send_keys', reason: 'leader_notified' }
+          : { ok: await notifyLeaderAsync(config, message, cwd), transport: 'mailbox', reason: 'leader_mailbox_notified' }
       ),
     });
     let finalOutcome = outcome;
@@ -1992,10 +2015,10 @@ export async function sendWorkerMessage(
         config,
         dispatchPolicy,
         cwd,
-        fallbackNotify: () => ({
-          ok: notifyLeader(config, leaderTriggerMessage),
-          transport: 'tmux_send_keys',
-          reason: 'leader_notified',
+        fallbackNotify: async () => ({
+          ok: await notifyLeaderAsync(config, leaderTriggerMessage, cwd),
+          transport: 'mailbox' as const,
+          reason: 'leader_mailbox_notified',
         }),
       });
     }
@@ -2021,10 +2044,10 @@ export async function sendWorkerMessage(
     cwd,
     transportPreference,
     fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
-    notify: (_target, message) => (
+    notify: async (_target, message) => (
       transportPreference === 'hook_preferred_with_fallback'
         ? { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }
-        : notifyWorkerOutcome(config, recipient.index, message, recipient.pane_id)
+        : await notifyWorkerOutcome(config, recipient.index, message, recipient.pane_id)
     ),
   });
   let finalOutcome = outcome;
@@ -2072,11 +2095,11 @@ export async function broadcastWorkerMessage(
     triggerFor: (workerName) => generateMailboxTriggerMessage(workerName, sanitized, 1),
     transportPreference,
     fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
-    notify: (target, message) =>
+    notify: async (target, message) =>
       transportPreference === 'hook_preferred_with_fallback'
         ? { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }
         : (typeof target.workerIndex === 'number'
-        ? notifyWorkerOutcome(config, target.workerIndex, message, target.paneId)
+        ? await notifyWorkerOutcome(config, target.workerIndex, message, target.paneId)
         : { ok: false, transport: 'none', reason: 'missing_worker_index' }),
   });
   const finalizedOutcomes: DispatchOutcome[] = [];

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1,6 +1,9 @@
-import { spawnSync } from 'child_process';
+import { spawnSync, execFile } from 'child_process';
+import { promisify } from 'util';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+
+const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 
 export interface TeamSession {
@@ -179,6 +182,62 @@ export function sleepFractionalSeconds(
   const ms = toFractionalSleepMs(seconds);
   if (ms <= 0) return;
   sleepImpl(ms);
+}
+
+// ── Async tmux helpers ──────────────────────────────────────────────────────
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+async function runTmuxAsync(args: string[]): Promise<{ok: true; stdout: string} | {ok: false; stderr: string}> {
+  try {
+    const { stdout, stderr } = await execFileAsync('tmux', args, { encoding: 'utf-8' });
+    return { ok: true, stdout: (stdout || '').trim() };
+  } catch (error: unknown) {
+    const err = error as { stderr?: string; message?: string };
+    return { ok: false, stderr: (err.stderr || err.message || '').trim() || 'tmux command failed' };
+  }
+}
+
+async function sendKeyAsync(target: string, key: string): Promise<void> {
+  const result = await runTmuxAsync(['send-keys', '-t', target, key]);
+  if (!result.ok) {
+    throw new Error(`sendKeyAsync: failed to send ${key}: ${result.stderr}`);
+  }
+}
+
+async function capturePaneAsync(target: string): Promise<string> {
+  const result = await runTmuxAsync(['capture-pane', '-t', target, '-p', '-S', '-80']);
+  if (!result.ok) return '';
+  return result.stdout;
+}
+
+async function isWorkerAliveAsync(sessionName: string, workerIndex: number, workerPaneId?: string): Promise<boolean> {
+  const result = await runTmuxAsync([
+    'list-panes',
+    '-t', paneTarget(sessionName, workerIndex, workerPaneId),
+    '-F',
+    '#{pane_dead} #{pane_pid}',
+  ]);
+  if (!result.ok) return false;
+
+  const line = result.stdout.split('\n')[0]?.trim();
+  if (!line) return false;
+
+  const parts = line.split(/\s+/);
+  if (parts.length < 2) return false;
+
+  const paneDead = parts[0];
+  const pid = Number.parseInt(parts[1], 10);
+
+  if (paneDead === '1') return false;
+  if (!Number.isFinite(pid)) return false;
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function shellQuoteSingle(value: string): string {
@@ -904,7 +963,7 @@ export function paneIsBootstrapping(lines: string[]): boolean {
   );
 }
 
-function paneLooksReady(captured: string): boolean {
+export function paneLooksReady(captured: string): boolean {
   const content = captured.trimEnd();
   if (content === '') return false;
 
@@ -946,7 +1005,7 @@ function paneHasTrustPrompt(captured: string): boolean {
   return hasQuestion && hasActiveChoices;
 }
 
-function paneHasActiveTask(captured: string): boolean {
+export function paneHasActiveTask(captured: string): boolean {
   const lines = captured
     .split('\n')
     .map((line) => line.replace(/\r/g, '').trim())
@@ -1062,31 +1121,32 @@ function sendLiteralTextOrThrow(target: string, text: string): void {
   }
 }
 
-function attemptSubmitRounds(
+async function attemptSubmitRounds(
   target: string,
   text: string,
   rounds: number,
   queueFirstRound: boolean,
   submitKeyPressesPerRound: number,
-): boolean {
+): Promise<boolean> {
   const presses = Math.max(1, Math.floor(submitKeyPressesPerRound));
   for (let round = 0; round < rounds; round++) {
-    sleepFractionalSeconds(0.1);
+    await sleep(100);
     if (round === 0 && queueFirstRound) {
-      sendKeyOrThrow(target, 'Tab', 'Tab');
-      sleepFractionalSeconds(0.08);
-      sendKeyOrThrow(target, 'C-m', 'C-m');
+      await sendKeyAsync(target, 'Tab');
+      await sleep(80);
+      await sendKeyAsync(target, 'C-m');
     } else {
       for (let press = 0; press < presses; press++) {
-        sendKeyOrThrow(target, 'C-m', 'C-m');
+        await sendKeyAsync(target, 'C-m');
         if (press < presses - 1) {
-          sleepFractionalSeconds(0.2);
+          await sleep(200);
         }
       }
     }
-    sleepFractionalSeconds(0.14);
-    if (!paneTailContainsLiteralLine(target, text)) return true;
-    sleepFractionalSeconds(0.14);
+    await sleep(140);
+    const captured = await capturePaneAsync(target);
+    if (!normalizeTmuxCapture(captured).includes(normalizeTmuxCapture(text))) return true;
+    await sleep(140);
   }
   return false;
 }
@@ -1213,13 +1273,13 @@ export function sendToWorkerStdin(
 // Send SHORT text (<200 chars) to worker via tmux send-keys
 // Validates: text < 200 chars, no injection marker
 // Throws on violation
-export function sendToWorker(
+export async function sendToWorker(
   sessionName: string,
   workerIndex: number,
   text: string,
   workerPaneId?: string,
   workerCli?: TeamWorkerCli,
-): void {
+): Promise<void> {
   assertWorkerTriggerText(text);
 
   const target = paneTarget(sessionName, workerIndex, workerPaneId);
@@ -1228,32 +1288,32 @@ export function sendToWorker(
 
   // Guard: if the trust prompt is still present, advance it first so our trigger text
   // doesn't get typed into the trust screen and ignored.
-  const captured = runTmux(['capture-pane', '-t', target, '-p', '-S', '-80']);
-  const paneBusy = captured.ok ? paneHasActiveTask(captured.stdout) : false;
-  if (captured.ok && paneHasTrustPrompt(captured.stdout)) {
-    sendKeyOrThrow(target, 'C-m', 'C-m');
-    sleepFractionalSeconds(0.12);
-    sendKeyOrThrow(target, 'C-m', 'C-m');
-    sleepFractionalSeconds(0.2);
+  const capturedStr = await capturePaneAsync(target);
+  const paneBusy = paneHasActiveTask(capturedStr);
+  if (paneHasTrustPrompt(capturedStr)) {
+    await sendKeyAsync(target, 'C-m');
+    await sleep(120);
+    await sendKeyAsync(target, 'C-m');
+    await sleep(200);
   }
 
   sendLiteralTextOrThrow(target, text);
 
   // Allow the input buffer to settle before sending C-m
-  sleepFractionalSeconds(0.15);
+  await sleep(150);
 
   const allowAutoInterruptRetry = process.env[OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV] !== '0';
   const submitPlan = buildWorkerSubmitPlan(strategy, resolvedWorkerCli, paneBusy, allowAutoInterruptRetry);
   if (submitPlan.shouldInterrupt) {
     // Explicit interrupt mode: abort current turn first, then submit the new command.
-    sendKeyOrThrow(target, 'C-c', 'C-c');
-    sleepFractionalSeconds(0.1);
+    await sendKeyAsync(target, 'C-c');
+    await sleep(100);
   }
 
   // Submit deterministically using CLI-specific plan:
   // - Codex: queue-first Tab+C-m when configured/busy, then double C-m rounds.
   // - Claude: direct C-m rounds only (never queue-first Tab).
-  if (attemptSubmitRounds(
+  if (await attemptSubmitRounds(
     target,
     text,
     submitPlan.rounds,
@@ -1263,15 +1323,14 @@ export function sendToWorker(
 
   // Adaptive escalation for "likely unsent trigger text at ready prompt" cases:
   // clear line, re-send trigger, then re-submit with deterministic C-m rounds.
-  const latestCaptureResult = runTmux(['capture-pane', '-t', target, '-p', '-S', '-80']);
-  const latestCapture = latestCaptureResult.ok ? latestCaptureResult.stdout : null;
-  if (shouldAttemptAdaptiveRetry(strategy, paneBusy, submitPlan.allowAdaptiveRetry, latestCapture, text)) {
+  const latestCapture = await capturePaneAsync(target);
+  if (shouldAttemptAdaptiveRetry(strategy, paneBusy, submitPlan.allowAdaptiveRetry, latestCapture || null, text)) {
     // Keep this branch non-interrupting to avoid canceling active turns on false positives.
-    sendKeyOrThrow(target, 'C-u', 'C-u');
-    sleepFractionalSeconds(0.08);
+    await sendKeyAsync(target, 'C-u');
+    await sleep(80);
     sendLiteralTextOrThrow(target, text);
-    sleepFractionalSeconds(0.12);
-    if (attemptSubmitRounds(target, text, 4, false, submitPlan.submitKeyPressesPerRound)) return;
+    await sleep(120);
+    if (await attemptSubmitRounds(target, text, 4, false, submitPlan.submitKeyPressesPerRound)) return;
   }
 
   // Fail-open by default: Codex may keep the last submitted line visible even after executing it.
@@ -1282,21 +1341,21 @@ export function sendToWorker(
   }
 
   // One last best-effort double C-m nudge, then verify.
-  runTmux(['send-keys', '-t', target, 'C-m']);
-  sleepFractionalSeconds(0.12);
-  runTmux(['send-keys', '-t', target, 'C-m']);
+  await sendKeyAsync(target, 'C-m');
+  await sleep(120);
+  await sendKeyAsync(target, 'C-m');
 
   // Post-submit verification: wait briefly and confirm the worker consumed the
   // trigger (draft disappeared or active-task indicator appeared). Fixes #391.
-  sleepFractionalSeconds(0.3);
-  const verifyResult = runTmux(['capture-pane', '-t', target, '-p', '-S', '-80']);
-  if (verifyResult.ok) {
-    if (paneHasActiveTask(verifyResult.stdout)) return;
-    if (!paneTailContainsLiteralLine(target, text)) return;
+  await sleep(300);
+  const verifyCapture = await capturePaneAsync(target);
+  if (verifyCapture) {
+    if (paneHasActiveTask(verifyCapture)) return;
+    if (!normalizeTmuxCapture(verifyCapture).includes(normalizeTmuxCapture(text))) return;
     // Draft still visible and no active task — one more C-m attempt.
-    sendKeyOrThrow(target, 'C-m', 'C-m');
-    sleepFractionalSeconds(0.15);
-    sendKeyOrThrow(target, 'C-m', 'C-m');
+    await sendKeyAsync(target, 'C-m');
+    await sleep(150);
+    await sendKeyAsync(target, 'C-m');
   }
 }
 
@@ -1354,20 +1413,20 @@ export function isWorkerAlive(sessionName: string, workerIndex: number, workerPa
 
 // Kill a specific worker: send C-c, then C-d, then kill-pane if still alive.
 // leaderPaneId: when provided, the kill is skipped entirely if workerPaneId matches it.
-export function killWorker(sessionName: string, workerIndex: number, workerPaneId?: string, leaderPaneId?: string): void {
+export async function killWorker(sessionName: string, workerIndex: number, workerPaneId?: string, leaderPaneId?: string): Promise<void> {
   // Guard: never kill the leader's own pane.
   if (leaderPaneId && workerPaneId === leaderPaneId) return;
 
-  runTmux(['send-keys', '-t', paneTarget(sessionName, workerIndex, workerPaneId), 'C-c']);
-  sleepSeconds(1);
+  await runTmuxAsync(['send-keys', '-t', paneTarget(sessionName, workerIndex, workerPaneId), 'C-c']);
+  await sleep(1000);
 
-  if (isWorkerAlive(sessionName, workerIndex, workerPaneId)) {
-    runTmux(['send-keys', '-t', paneTarget(sessionName, workerIndex, workerPaneId), 'C-d']);
-    sleepSeconds(1);
+  if (await isWorkerAliveAsync(sessionName, workerIndex, workerPaneId)) {
+    await runTmuxAsync(['send-keys', '-t', paneTarget(sessionName, workerIndex, workerPaneId), 'C-d']);
+    await sleep(1000);
   }
 
-  if (isWorkerAlive(sessionName, workerIndex, workerPaneId)) {
-    runTmux(['kill-pane', '-t', paneTarget(sessionName, workerIndex, workerPaneId)]);
+  if (await isWorkerAliveAsync(sessionName, workerIndex, workerPaneId)) {
+    await runTmuxAsync(['kill-pane', '-t', paneTarget(sessionName, workerIndex, workerPaneId)]);
   }
 }
 
@@ -1377,6 +1436,22 @@ export function killWorkerByPaneId(workerPaneId: string, leaderPaneId?: string):
   // Guard: never kill the leader's own pane.
   if (leaderPaneId && workerPaneId === leaderPaneId) return;
   runTmux(['kill-pane', '-t', workerPaneId]);
+}
+
+export async function killWorkerByPaneIdAsync(workerPaneId: string, leaderPaneId?: string): Promise<void> {
+  if (!workerPaneId.startsWith('%')) return;
+  // Guard: never kill the leader's own pane.
+  if (leaderPaneId && workerPaneId === leaderPaneId) return;
+  await runTmuxAsync(['kill-pane', '-t', workerPaneId]);
+}
+
+export async function killWorkerPanes(paneIds: string[], leaderPaneId: string, graceMs: number = 2000): Promise<void> {
+  const perPaneGrace = paneIds.length > 0 ? Math.max(100, Math.floor(graceMs / paneIds.length)) : 0;
+  for (const paneId of paneIds) {
+    if (paneId === leaderPaneId) continue; // never kill leader
+    await killWorkerByPaneIdAsync(paneId, leaderPaneId);
+    await sleep(perPaneGrace);
+  }
 }
 
 // Kill entire tmux session. Tolerates already-dead sessions.
@@ -1398,4 +1473,23 @@ export function listTeamSessions(): string[] {
     .map(line => line.trim())
     .filter(Boolean)
     .map(baseSessionName);
+}
+
+/**
+ * Notify the leader via mailbox instead of tmux display-message.
+ * This is the async mailbox-based replacement for notifyLeaderStatus.
+ */
+export async function notifyLeaderMailboxAsync(
+  teamName: string,
+  fromWorker: string,
+  message: string,
+  cwd: string,
+): Promise<boolean> {
+  try {
+    const { sendDirectMessage } = await import('./state.js');
+    await sendDirectMessage(teamName, fromWorker, 'leader-fixed', message, cwd);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -57,6 +57,16 @@ You are a team worker in team "${teamName}". Your identity and assigned tasks ar
 12. Check your mailbox for messages at <team_state_root>/team/${teamName}/mailbox/{your-name}.json
 13. For team_* MCP tools, do not pass workingDirectory unless the lead explicitly tells you to
 
+## Message Protocol
+When calling team_send_message, you MUST always include:
+- from_worker: "<your-worker-name>" (your identity — check your inbox file for your worker name, never omit this)
+- to_worker: "leader-fixed" (to message the leader) or "worker-N" (for peers)
+
+Example:
+team_send_message({ team_name: "${teamName}", from_worker: "<your-worker-name>", to_worker: "leader-fixed", body: "Task completed" })
+
+CRITICAL: Never omit from_worker. The MCP server cannot auto-detect your identity.
+
 ## Rules
 - Do NOT edit files outside the paths listed in your task description
 - If you need to modify a shared file, report to the lead by writing to your status file with state "blocked"
@@ -281,6 +291,13 @@ ${taskList}
 10. Write \`{"state": "idle", "updated_at": "<current ISO timestamp>"}\` to \`${teamStateRoot}/team/${teamName}/workers/${workerName}/status.json\`
 11. Wait for the next instruction from the lead
 12. For team_* MCP tools, do not pass \`workingDirectory\` unless the lead explicitly asks (if resolution fails, use leader cwd: \`${leaderCwd}\`)
+
+## Message Protocol
+When using team_send_message MCP tool, ALWAYS include from_worker with YOUR worker name:
+- from_worker: "${workerName}"
+- to_worker: "leader-fixed" (for leader) or "worker-N" (for peers)
+
+Example: team_send_message({ team_name: "${teamName}", from_worker: "${workerName}", to_worker: "leader-fixed", body: "ACK: initialized" })
 
 ${buildVerificationSection('each assigned task')}
 


### PR DESCRIPTION
## Summary
- **Async tmux helpers**: Convert sync `spawnSync`/`Atomics.wait` tmux operations to async `execFile` + `await sleep()` with isolated C-m key presses for reliability
- **Message identity hardening**: Add Message Protocol sections to worker bootstrap overlays/inbox, validate `from_worker` field in MCP handler to prevent leader/worker message mix-ups
- **MCP team tools**: Add `omx_run_team_start`, `omx_run_team_status`, `omx_run_team_wait`, `omx_run_team_cleanup` tools with `NudgeTracker` for idle pane detection and `runtime-cli.ts` background runner

## Files Changed
| File | Change |
|------|--------|
| `src/team/tmux-session.ts` | +200 lines: async helpers (`runTmuxAsync`, `sendKeyAsync`, `capturePaneAsync`), async `sendToWorker`/`killWorker`, `notifyLeaderMailboxAsync` |
| `src/team/runtime.ts` | +67 lines: async notify callbacks, `notifyLeaderAsync`, awaited kill calls |
| `src/team/scaling.ts` | +16 lines: async `notifyWorkerPaneOutcome`, awaited kills |
| `src/team/mcp-comm.ts` | Added `'mailbox'` to `DispatchTransport` type |
| `src/team/worker-bootstrap.ts` | +17 lines: Message Protocol sections in overlay and inbox |
| `src/mcp/state-server.ts` | +307 lines: `from_worker` validation, 4 `omx_run_team_*` tool handlers |
| `src/team/idle-nudge.ts` | NEW: `NudgeTracker` ported from OMC for idle pane detection |
| `src/team/runtime-cli.ts` | NEW: Background team runner (stdin JSON → startTeam/monitorTeam/shutdownTeam) |

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Verify async tmux operations work with `sendToWorker` and `killWorker`
- [ ] Verify worker bootstrap overlay includes Message Protocol section
- [ ] Verify `from_worker` missing in `team_send_message` returns clear error
- [ ] Test `omx_run_team_start/status/wait/cleanup` MCP tool lifecycle
- [ ] Test `NudgeTracker` idle detection and nudge messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)