### PR TITLE
fix(team): fix regressions in team/ralph shutdown and resume paths

### DIFF
--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -157,12 +157,16 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
       console.log(`No resumable team found for ${name}`);
       return;
     }
+    const existingState = await readModeState('team').catch(() => null);
+    const preservedRalph = existingState?.active === true
+      && existingState?.team_name === runtime.teamName
+      && existingState?.linked_ralph === true;
     await ensureTeamModeState({
       task: runtime.config.task,
       workerCount: runtime.config.worker_count,
       agentType: runtime.config.agent_type,
       teamName: runtime.teamName,
-      ralph: false,
+      ralph: preservedRalph,
     });
     await renderStartSummary(runtime);
     return;
@@ -175,7 +179,7 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
     const ralphFlag = teamArgs.includes('--ralph');
     const ralphFromState = !ralphFlag
       ? await readModeState('team').then(
-          (s) => s?.active === true && s?.linked_ralph === true,
+          (s) => s?.active === true && s?.linked_ralph === true && s?.team_name === name,
           () => false,
         )
       : false;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1177,8 +1177,9 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     ).catch(() => {});
 
     if (!gate.allowed) {
-      if (ralph) {
-        // Ralph policy: do not force-throw on failure — log and proceed with graceful cleanup.
+      const hasActiveWork = gate.pending > 0 || gate.blocked > 0 || gate.in_progress > 0;
+      if (ralph && !hasActiveWork) {
+        // Ralph policy: bypass on failure-only scenarios (no pending/blocked/in_progress tasks).
         // This allows the ralph loop to retry rather than leaving stale team state.
         await appendTeamEvent(
           sanitized,


### PR DESCRIPTION
## Summary

- **#425 (HIGH)**: Team shutdown now verifies `team_name` matches before reading `linked_ralph` from global team mode state, preventing cross-team Ralph policy leakage
- **#426 (MEDIUM)**: Team resume preserves existing `linked_ralph` state instead of forcing `ralph:false`, which was clearing Ralph linkage on resume
- **#427 (MEDIUM)**: Ralph-mode bypass in `shutdownTeam` now only applies to failure-only scenarios (failed tasks only), not when active work (pending/blocked/in_progress tasks) still exists

Closes #425, closes #426, closes #427.

## Test plan

- [x] Existing `shutdownTeam` gate tests pass (50/50)
- [x] Updated ralph gate bypass test to use failure-only scenario
- [x] Added new test: `shutdownTeam ralph=true still throws when active work exists`
- [x] Team CLI parse tests pass (8/8)
- [x] TypeScript compiles cleanly (no errors in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)