### PR TITLE
fix(team): force cleanup, await worktree rollback, refresh dead-worker panes

### DIFF
--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -163,7 +163,7 @@ describe('worktree ensure + rollback', () => {
       assert.equal(existsSync(ensured.worktreePath), true);
       assert.equal(branchExists(repo, 'feature/rollback'), true);
 
-      rollbackProvisionedWorktrees([ensured]);
+      await rollbackProvisionedWorktrees([ensured]);
       assert.equal(existsSync(ensured.worktreePath), false);
       assert.equal(branchExists(repo, 'feature/rollback'), false);
     } finally {
@@ -188,7 +188,7 @@ describe('worktree ensure + rollback', () => {
       assert.equal(existsSync(ensured.worktreePath), true);
       assert.equal(branchExists(repo, 'feature/ralph-keep'), true);
 
-      rollbackProvisionedWorktrees([ensured], { skipBranchDeletion: true });
+      await rollbackProvisionedWorktrees([ensured], { skipBranchDeletion: true });
       assert.equal(existsSync(ensured.worktreePath), false);
       // Branch is preserved when skipBranchDeletion is true (ralph policy)
       assert.equal(branchExists(repo, 'feature/ralph-keep'), true);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -849,7 +849,7 @@ export async function startTeam(
     }
     if (provisionedWorktrees.length > 0) {
       try {
-        rollbackProvisionedWorktrees(provisionedWorktrees, {
+        await rollbackProvisionedWorktrees(provisionedWorktrees, {
           skipBranchDeletion: options.ralph === true,
         });
       } catch (cleanupError) {


### PR DESCRIPTION
## Summary

Three targeted fixes in team runtime cleanup paths:

- **#434**: `runtime-cli` now passes `force: true` to `shutdownTeam` when a run ends in `failed` state, so the shutdown gate doesn't block cleanup of failed/cancelled runs
- **#435**: `rollbackProvisionedWorktrees` converted from sync (`spawnSync`) to async (`execFile`) and is now properly `await`ed in `startTeam` error cleanup, preventing race conditions with concurrent async teardown
- **#436**: Dead-worker heuristic in the `runtime-cli` poll loop now re-derives worker pane IDs from `runtime.config.workers` each iteration instead of using the stale startup snapshot

Closes #434, closes #435, closes #436.

## Test plan

- [x] `node --test dist/team/__tests__/worktree.test.js` — 12/12 pass (rollback tests now async)
- [x] `node --test dist/team/__tests__/runtime.test.js` — 50/50 pass
- [x] `npx tsc --noEmit` — no new type errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)