### PR TITLE
fix(team): fix leader pane targeting in dispatch fallback and runtime notification

### DIFF
--- a/scripts/notify-hook/team-dispatch.js
+++ b/scripts/notify-hook/team-dispatch.js
@@ -122,6 +122,13 @@ function defaultInjectTarget(request, config) {
     const worker = config.workers.find((candidate) => Number(candidate?.index) === request.worker_index);
     if (worker?.pane_id) return { type: 'pane', value: worker.pane_id };
   }
+  // Leader-fixed fallback: use config.leader_pane_id when request has no
+  // pane_id or worker_index (leader is not a worker). Without this, leader
+  // dispatch falls through to the session target which hits the active pane
+  // (likely a worker). Fixes #433.
+  if (request.to_worker === 'leader-fixed' && config.leader_pane_id) {
+    return { type: 'pane', value: config.leader_pane_id };
+  }
   if (typeof request.worker_index === 'number' && config.tmux_session) {
     if (config.tmux_session.includes(':')) {
       // split-pane topology: session:window.paneIndex

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1659,6 +1659,27 @@ export function listTeamSessions(): string[] {
 }
 
 /**
+ * Send a trigger message directly to the leader pane via tmux send-keys.
+ * Used as the direct-inject fallback when hook-based dispatch to the leader
+ * times out. Unlike notifyLeaderMailboxAsync (which only writes to the
+ * mailbox file), this actually injects text into the leader's tmux pane
+ * so the leader sees it immediately. Fixes #437.
+ */
+export async function sendToLeaderPane(
+  leaderPaneId: string,
+  text: string,
+): Promise<void> {
+  const send = runTmux(['send-keys', '-t', leaderPaneId, '-l', '--', text]);
+  if (!send.ok) {
+    throw new Error(`sendToLeaderPane: failed to send text: ${send.stderr}`);
+  }
+  await sleep(150);
+  await sendKeyAsync(leaderPaneId, 'C-m');
+  await sleep(100);
+  await sendKeyAsync(leaderPaneId, 'C-m');
+}
+
+/**
  * Notify the leader via mailbox instead of tmux display-message.
  * This is the async mailbox-based replacement for notifyLeaderStatus.
  */


### PR DESCRIPTION
## Summary

- **#433**: `defaultInjectTarget` in `scripts/notify-hook/team-dispatch.js` now checks `config.leader_pane_id` for `leader-fixed` dispatch requests before falling through to the session-level target (which hit the active pane — likely a worker, not the leader)
- **#437**: `notifyLeaderAsync` in `src/team/runtime.ts` now injects directly into the leader's tmux pane via new `sendToLeaderPane()` when hook-based dispatch times out, instead of only writing to the mailbox file (which the leader wouldn't read until the next hook cycle)

Closes #433, closes #437.

## Changes

| File | Change |
|------|--------|
| `scripts/notify-hook/team-dispatch.js` | Add `leader-fixed` + `config.leader_pane_id` check in `defaultInjectTarget` before session fallback |
| `src/team/tmux-session.ts` | Add `sendToLeaderPane()` — direct tmux send-keys to leader pane |
| `src/team/runtime.ts` | Update `notifyLeaderAsync` to try tmux injection via `sendToLeaderPane` before mailbox fallback |

## Test plan

- [x] `runtime.test.ts` — 50/50 pass (including `sendWorkerMessage hook-preferred path for leader`)
- [x] `state.test.ts` — 60/60 pass
- [x] `tmux-session.test.ts` — 123/123 pass
- [x] `notify-hook-team-leader-nudge.test.ts` — 6/6 pass
- [x] `notify-hook-worker-idle.test.ts` + `notify-hook-all-workers-idle.test.ts` — 23/23 pass
- [x] TypeScript compilation clean (no new errors in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)