### PR TITLE
fix(tmux): skip injection when pane returns to shell (#441)

### DIFF
--- a/scripts/notify-hook/tmux-injection.js
+++ b/scripts/notify-hook/tmux-injection.js
@@ -22,6 +22,8 @@ import {
   evaluateInjectionGuards,
   buildSendKeysArgv,
   buildPaneInModeArgv,
+  buildPaneCurrentCommandArgv,
+  isPaneRunningShell,
 } from '../tmux-hook-engine.js';
 
 export async function resolveSessionToPane(sessionName) {
@@ -354,6 +356,30 @@ export async function handleTmuxInjection({
     } catch {
       // Non-fatal: if querying copy-mode state fails, proceed with injection.
     }
+  }
+
+  // Shell-detection guard: skip injection when the agent process has exited
+  // and the pane has returned to an interactive shell (zsh, bash, etc.).
+  // Sending the inject marker to a shell causes glob errors like
+  // "zsh: no matches found: [OMX_TMUX_INJECT]".  See #441.
+  try {
+    const cmdResult = await runProcess('tmux', buildPaneCurrentCommandArgv(paneTarget), 1000);
+    const currentCmd = safeString(cmdResult.stdout).trim();
+    if (isPaneRunningShell(currentCmd)) {
+      state.last_reason = 'agent_not_running';
+      state.last_event_at = nowIso;
+      await writeFile(hookStatePath, JSON.stringify(state, null, 2)).catch(() => {});
+      await logTmuxHookEvent(logsDir, {
+        ...baseLog,
+        event: 'injection_skipped',
+        reason: 'agent_not_running',
+        pane_target: paneTarget,
+        pane_current_command: currentCmd,
+      });
+      return;
+    }
+  } catch {
+    // Non-fatal: if querying pane command fails, proceed with injection.
   }
 
   if (config.dry_run) {

--- a/scripts/tmux-hook-engine.js
+++ b/scripts/tmux-hook-engine.js
@@ -154,6 +154,30 @@ export function buildPaneInModeArgv(paneTarget) {
   return ['display-message', '-p', '-t', paneTarget, '#{pane_in_mode}'];
 }
 
+/**
+ * Returns the tmux argv to query the current foreground command of a pane.
+ * Used to detect when the agent process has exited and the pane has returned
+ * to a shell (zsh, bash, fish, etc.).
+ */
+export function buildPaneCurrentCommandArgv(paneTarget) {
+  return ['display-message', '-p', '-t', paneTarget, '#{pane_current_command}'];
+}
+
+const SHELL_COMMANDS = new Set(['zsh', 'bash', 'fish', 'sh', 'dash', 'ksh', 'csh', 'tcsh', 'login']);
+
+/**
+ * Returns true when the pane's foreground process is an interactive shell,
+ * meaning the agent has exited and injection would land on a bare prompt.
+ */
+export function isPaneRunningShell(paneCurrentCommand) {
+  if (typeof paneCurrentCommand !== 'string') return false;
+  const cmd = paneCurrentCommand.trim().toLowerCase();
+  if (cmd === '') return false;
+  // Handle paths like /bin/zsh -> zsh, and flags like -zsh -> zsh
+  const base = cmd.split('/').pop().replace(/^-/, '');
+  return SHELL_COMMANDS.has(base);
+}
+
 export function buildCapturePaneArgv(paneTarget, tailLines = 80) {
   return ['capture-pane', '-t', paneTarget, '-p', '-S', `-${tailLines}`];
 }

--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -7,6 +7,8 @@ import {
   pickActiveMode,
   evaluateInjectionGuards,
   buildSendKeysArgv,
+  buildPaneCurrentCommandArgv,
+  isPaneRunningShell,
 } from '../../../scripts/tmux-hook-engine.js';
 
 describe('normalizeTmuxHookConfig', () => {
@@ -215,6 +217,50 @@ describe('evaluateInjectionGuards', () => {
     });
     assert.equal(legacyCap.allow, false);
     assert.equal(legacyCap.reason, 'pane_cap_reached');
+  });
+});
+
+describe('buildPaneCurrentCommandArgv', () => {
+  it('builds argv to query pane_current_command', () => {
+    assert.deepEqual(
+      buildPaneCurrentCommandArgv('%5'),
+      ['display-message', '-p', '-t', '%5', '#{pane_current_command}'],
+    );
+  });
+});
+
+describe('isPaneRunningShell', () => {
+  it('detects common shells', () => {
+    assert.equal(isPaneRunningShell('zsh'), true);
+    assert.equal(isPaneRunningShell('bash'), true);
+    assert.equal(isPaneRunningShell('fish'), true);
+    assert.equal(isPaneRunningShell('sh'), true);
+    assert.equal(isPaneRunningShell('dash'), true);
+    assert.equal(isPaneRunningShell('ksh'), true);
+    assert.equal(isPaneRunningShell('login'), true);
+  });
+
+  it('detects shells with path prefix', () => {
+    assert.equal(isPaneRunningShell('/bin/zsh'), true);
+    assert.equal(isPaneRunningShell('/usr/bin/bash'), true);
+  });
+
+  it('detects login shells with leading dash', () => {
+    assert.equal(isPaneRunningShell('-zsh'), true);
+    assert.equal(isPaneRunningShell('-bash'), true);
+  });
+
+  it('returns false for agent processes', () => {
+    assert.equal(isPaneRunningShell('node'), false);
+    assert.equal(isPaneRunningShell('codex'), false);
+    assert.equal(isPaneRunningShell('claude'), false);
+    assert.equal(isPaneRunningShell('python'), false);
+  });
+
+  it('returns false for non-string or empty input', () => {
+    assert.equal(isPaneRunningShell(''), false);
+    assert.equal(isPaneRunningShell(null as any), false);
+    assert.equal(isPaneRunningShell(undefined as any), false);
   });
 });
 

--- a/src/types/tmux-hook-engine.d.ts
+++ b/src/types/tmux-hook-engine.d.ts
@@ -45,6 +45,8 @@ declare module '*tmux-hook-engine.js' {
   }): { allow: boolean; reason: string; dedupeKey?: string };
   export function buildCapturePaneArgv(paneTarget: string, tailLines?: number): string[];
   export function buildPaneInModeArgv(paneTarget: string): string[];
+  export function buildPaneCurrentCommandArgv(paneTarget: string): string[];
+  export function isPaneRunningShell(paneCurrentCommand: string): boolean;
   export function buildSendKeysArgv(args: {
     paneTarget: string;
     prompt: string;


### PR DESCRIPTION
## Summary

- Add `pane_current_command` check in the tmux-hook injection path to detect when the agent has exited and the pane is running an interactive shell (zsh, bash, fish, etc.)
- Skip injection with reason `agent_not_running` when a shell is detected, preventing zsh glob errors like `no matches found: [OMX_TMUX_INJECT]`
- Add `buildPaneCurrentCommandArgv()` and `isPaneRunningShell()` helpers to the tmux-hook-engine, with full test coverage

## Test plan

- [x] `buildPaneCurrentCommandArgv` builds correct tmux argv
- [x] `isPaneRunningShell` detects zsh, bash, fish, sh, dash, ksh, login (bare, with path prefix, with login dash)
- [x] `isPaneRunningShell` returns false for agent processes (node, codex, claude, python)
- [x] `isPaneRunningShell` handles null/undefined/empty gracefully
- [x] Types-sync test passes (new exports declared in `.d.ts`)
- [x] Full type-check clean (`tsc --noEmit`)

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)