### PR TITLE
fix(tmux): target correct session when spawning team panes

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1017,7 +1017,11 @@ function runCodex(
     // Opt-out: set OMX_MOUSE=0. (closes #128)
     if (process.env.OMX_MOUSE !== '0') {
       try {
-        const tmuxSession = execFileSync('tmux', ['display-message', '-p', '#S'], { encoding: 'utf-8' }).trim();
+        const tmuxPaneTarget = process.env.TMUX_PANE;
+        const displayArgs = tmuxPaneTarget
+          ? ['display-message', '-p', '-t', tmuxPaneTarget, '#S']
+          : ['display-message', '-p', '#S'];
+        const tmuxSession = execFileSync('tmux', displayArgs, { encoding: 'utf-8' }).trim();
         if (tmuxSession) enableMouseScrolling(tmuxSession);
       } catch {
         // Non-fatal: mouse scrolling is a convenience feature

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -24,7 +24,12 @@ export function getCurrentTmuxSession(): string | null {
   // Fast path: $TMUX is set (we're directly inside tmux)
   if (process.env.TMUX) {
     try {
-      const sessionName = execSync("tmux display-message -p '#S'", {
+      const tmuxPaneTarget = process.env.TMUX_PANE;
+      const paneTargetSafe = tmuxPaneTarget && TMUX_PANE_TARGET_RE.test(tmuxPaneTarget) ? tmuxPaneTarget : null;
+      const displayCmd = paneTargetSafe
+        ? `tmux display-message -p -t ${paneTargetSafe} '#S'`
+        : "tmux display-message -p '#S'";
+      const sessionName = execSync(displayCmd, {
         encoding: "utf-8",
         timeout: 3000,
         stdio: ["pipe", "pipe", "pipe"],
@@ -172,7 +177,11 @@ export function getCurrentTmuxPaneId(): string | null {
   const envPane = process.env.TMUX_PANE;
   if (process.env.TMUX && envPane && /^%\d+$/.test(envPane)) return envPane;
 
-  // Try tmux display-message if $TMUX is set
+  // Try tmux display-message if $TMUX is set.
+  // NOTE: This fallback is intentionally untargeted -- it is only reached when
+  // TMUX_PANE is absent or invalid, so there is no env-based pane target
+  // available. In the multi-session case this may resolve to the wrong client,
+  // but it is still better than nothing and matches the PID-walk fallback below.
   if (process.env.TMUX) {
     try {
       const paneId = execSync("tmux display-message -p '#{pane_id}'", {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -664,9 +664,14 @@ export function createTeamSession(
   let registeredResizeHook: { name: string; target: string } | null = null;
   const rollbackPaneIds: string[] = [];
   try {
-    const context = runTmux(['display-message', '-p', '#S:#I #{pane_id}']);
+    const tmuxPaneTarget = process.env.TMUX_PANE;
+    const displayArgs = tmuxPaneTarget
+      ? ['display-message', '-p', '-t', tmuxPaneTarget, '#S:#I #{pane_id}']
+      : ['display-message', '-p', '#S:#I #{pane_id}'];
+    const context = runTmux(displayArgs);
     if (!context.ok) {
-      throw new Error(`failed to detect current tmux target: ${context.stderr}`);
+      const paneHint = tmuxPaneTarget ? ` (TMUX_PANE=${tmuxPaneTarget})` : '';
+      throw new Error(`failed to detect current tmux target${paneHint}: ${context.stderr}`);
     }
     const [sessionAndWindow = '', detectedLeaderPaneId = ''] = context.stdout.split(' ');
     const [sessionName, windowIndex] = (sessionAndWindow || '').split(':');


### PR DESCRIPTION
## Summary

- Fix bug where `omx team` spawns worker panes in the wrong tmux session when multiple sessions are attached
- Root cause: `tmux display-message -p` called without `-t` target resolves to the most recently active client, not the session the process runs in
- Fix: use `process.env.TMUX_PANE` as `-t` target for deterministic session detection (pattern already proven in `tmux-hook.ts`)

## Changes (3 files, +23/-5)

| File | Fix |
|------|-----|
| `src/team/tmux-session.ts:667` | **Primary** — `createTeamSession()` targets correct pane; error message includes `TMUX_PANE` for debugging |
| `src/cli/index.ts:1020` | Mouse scrolling targets correct session |
| `src/notifications/tmux.ts:27,178` | Session detection targets correctly (with shell injection guard via `TMUX_PANE_TARGET_RE`); documented why fallback at line 178 is intentionally untargeted |

All changes gracefully fall back to untargeted behavior when `TMUX_PANE` is not set.

## Test plan

- [x] `npx tsc` compiles cleanly
- [x] 1586/1588 tests pass (2 pre-existing failures from missing optional deps `ajv`/`hono`)
- [ ] Manual: attach two tmux sessions, run `omx team`, verify panes spawn in the correct session


🤖 Generated with [Claude Code](https://claude.com/claude-code)