### PR TITLE
fix(skills): normalize fork-slop OMC references in skill docs

### DIFF
--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -139,7 +139,7 @@ Why bad: This is an exploration/brainstorming request. Respond conversationally 
 Optional settings in `~/.codex/config.toml`:
 
 ```toml
-[omc.autopilot]
+[omx.autopilot]
 maxIterations = 10
 maxQaCycles = 5
 maxValidationRounds = 3
@@ -172,7 +172,7 @@ RALPLAN (consensus planning) -> team-exec (Codex CLI workers) -> ralph-verify (a
 Pipeline configuration options:
 
 ```toml
-[omc.autopilot.pipeline]
+[omx.autopilot.pipeline]
 maxRalphIterations = 10    # Ralph verification iteration ceiling
 workerCount = 2            # Number of Codex CLI team workers
 agentType = "executor"     # Agent type for team workers

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -152,7 +152,7 @@ rm -f ~/.codex/hooks/stop-continuation.sh
 
 ### Fix: Outdated Plugin
 ```bash
-rm -rf ~/.codex/plugins/cache/oh-my-codex
+rm -rf ~/.codex/plugins/cache/omc/oh-my-codex
 echo "Plugin cache cleared. Restart Codex CLI to fetch latest version."
 ```
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -44,7 +44,7 @@ I'll figure out what to stop based on context.
 If you haven't configured OMX yet:
 
 ```
-/omc-setup
+/omx-setup
 ```
 
 This is the **only command** you need to know. It downloads the configuration and you're done.
@@ -134,7 +134,7 @@ Based on patterns found, output recommendations:
 - "Use security-reviewer after auth/API changes"
 
 **If defaultExecutionMode not set:**
-- "Set defaultExecutionMode in /omc-setup for consistent behavior"
+- "Set defaultExecutionMode in /omx-setup for consistent behavior"
 
 ### Step 4: Output Report
 
@@ -179,7 +179,7 @@ No token tracking found. To enable tracking:
 1. Ensure ~/.omx/state/ directory exists
 2. Run any OMX command to start tracking
 
-Tip: Run /omc-setup to configure OMX properly.
+Tip: Run /omx-setup to configure OMX properly.
 ```
 
 ## Need More Help?

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -15,19 +15,19 @@ Meta-skill for managing oh-my-codex skills via CLI-like commands.
 Show all local skills organized by scope.
 
 **Behavior:**
-1. Scan user skills at `~/.codex/skills/omc-learned/`
-2. Scan project skills at `.omx/skills/`
+1. Scan user skills at `~/.agents/skills/`
+2. Scan project skills at `.agents/skills/`
 3. Parse YAML frontmatter for metadata
 4. Display in organized table format:
 
 ```
-USER SKILLS (~/.codex/skills/omc-learned/):
+USER SKILLS (~/.agents/skills/):
 | Name              | Triggers           | Quality | Usage | Scope |
 |-------------------|--------------------|---------|-------|-------|
 | error-handler     | fix, error         | 95%     | 42    | user  |
 | api-builder       | api, endpoint      | 88%     | 23    | user  |
 
-PROJECT SKILLS (.omx/skills/):
+PROJECT SKILLS (.agents/skills/):
 | Name              | Triggers           | Quality | Usage | Scope   |
 |-------------------|--------------------|---------|-------|---------|
 | test-runner       | test, run          | 92%     | 15    | project |
@@ -51,8 +51,8 @@ Interactive wizard for creating a new skill.
 4. **Ask for argument hint** (optional)
    - Example: "<file> [options]"
 5. **Ask for scope:**
-   - `user` → `~/.codex/skills/omc-learned/<name>/SKILL.md`
-   - `project` → `.omx/skills/<name>/SKILL.md`
+   - `user` → `~/.agents/skills/<name>/SKILL.md`
+   - `project` → `.agents/skills/<name>/SKILL.md`
 6. **Create skill file** with template:
 
 ```yaml
@@ -105,7 +105,7 @@ Triggers (comma-separated): log, logger, logging
 Argument hint (optional): <level> [message]
 Scope (user/project): user
 
-✓ Created skill at ~/.codex/skills/omc-learned/custom-logger/SKILL.md
+✓ Created skill at ~/.agents/skills/custom-logger/SKILL.md
 → Edit with: /skill edit custom-logger
 ```
 
@@ -117,13 +117,13 @@ Remove a skill by name.
 
 **Behavior:**
 1. **Search for skill** in both scopes:
-   - `~/.codex/skills/omc-learned/<name>/SKILL.md`
-   - `.omx/skills/<name>/SKILL.md`
+   - `~/.agents/skills/<name>/SKILL.md`
+   - `.agents/skills/<name>/SKILL.md`
 2. **If found:**
    - Display skill info (name, description, scope)
    - **Ask for confirmation:** "Delete '<name>' skill from <scope>? (yes/no)"
 3. **If confirmed:**
-   - Delete entire skill directory (e.g., `~/.codex/skills/omc-learned/<name>/`)
+   - Delete entire skill directory (e.g., `~/.agents/skills/<name>/`)
    - Report: "✓ Removed skill '<name>' from <scope>"
 4. **If not found:**
    - Report: "✗ Skill '<name>' not found in user or project scope"
@@ -135,7 +135,7 @@ Remove a skill by name.
 User: /skill remove old-logger
 Assistant: Found skill 'old-logger' in user scope:
   Description: Legacy logging utility
-  Scope: user (~/.codex/skills/omc-learned/)
+  Scope: user (~/.agents/skills/)
 
 Delete 'old-logger' skill? (yes/no)
 
@@ -251,13 +251,13 @@ Show detailed information about a skill.
 
 ```
 Skill: custom-logger
-Scope: user (~/.codex/skills/omc-learned/custom-logger/)
+Scope: user (~/.agents/skills/custom-logger/)
 Description: Enhanced logging with structured output
 Triggers: log, logger, logging
 Argument Hint: <level> [message]
 Quality: 95% (if available)
 Usage Count: 42 times (if available)
-File Path: /home/user/.codex/skills/omc-learned/custom-logger/SKILL.md
+File Path: /home/user/.agents/skills/custom-logger/SKILL.md
 
 --- FULL CONTENT ---
 [entire markdown content]
@@ -272,7 +272,7 @@ Assistant: Skill: custom-logger
 Scope: user
 Description: Enhanced logging with structured output
 Triggers: log, logger, logging
-File: ~/.codex/skills/omc-learned/custom-logger/SKILL.md
+File: ~/.agents/skills/custom-logger/SKILL.md
 
 --- CONTENT ---
 # Custom Logger Skill
@@ -290,8 +290,8 @@ Sync skills between user and project scopes.
 
 **Behavior:**
 1. **Scan both scopes:**
-   - User skills: `~/.codex/skills/omc-learned/`
-   - Project skills: `.omx/skills/`
+   - User skills: `~/.agents/skills/`
+   - Project skills: `.agents/skills/`
 2. **Compare and categorize:**
    - User-only skills (not in project)
    - Project-only skills (not in user)
@@ -339,7 +339,7 @@ Assistant: Found 5 user-only skills and 2 project-only skills.
 
 Copy 'error-handler' from user to project? (yes/no/skip)
 User: yes
-Assistant: ✓ Copied 'error-handler' to .omx/skills/
+Assistant: ✓ Copied 'error-handler' to .agents/skills/
 
 Copy 'api-builder' from user to project? (yes/no/skip)
 User: skip
@@ -360,7 +360,7 @@ First, check if skill directories exist and create them if needed:
 
 ```bash
 # Check and create user-level skills directory
-USER_SKILLS_DIR="$HOME/.codex/skills/omc-learned"
+USER_SKILLS_DIR="$HOME/.agents/skills"
 if [ -d "$USER_SKILLS_DIR" ]; then
   echo "User skills directory exists: $USER_SKILLS_DIR"
 else
@@ -369,7 +369,7 @@ else
 fi
 
 # Check and create project-level skills directory
-PROJECT_SKILLS_DIR=".omx/skills"
+PROJECT_SKILLS_DIR=".agents/skills"
 if [ -d "$PROJECT_SKILLS_DIR" ]; then
   echo "Project skills directory exists: $PROJECT_SKILLS_DIR"
 else
@@ -384,15 +384,15 @@ Scan both directories and show a comprehensive inventory:
 
 ```bash
 # Scan user-level skills
-echo "=== USER-LEVEL SKILLS (~/.codex/skills/omc-learned/) ==="
-if [ -d "$HOME/.codex/skills/omc-learned" ]; then
-  USER_COUNT=$(find "$HOME/.codex/skills/omc-learned" -name "*.md" 2>/dev/null | wc -l)
+echo "=== USER-LEVEL SKILLS (~/.agents/skills/) ==="
+if [ -d "$HOME/.agents/skills" ]; then
+  USER_COUNT=$(find "$HOME/.agents/skills" -name "*.md" 2>/dev/null | wc -l)
   echo "Total skills: $USER_COUNT"
 
   if [ $USER_COUNT -gt 0 ]; then
     echo ""
     echo "Skills found:"
-    find "$HOME/.codex/skills/omc-learned" -name "*.md" -type f -exec sh -c '
+    find "$HOME/.agents/skills" -name "*.md" -type f -exec sh -c '
       FILE="$1"
       NAME=$(grep -m1 "^name:" "$FILE" 2>/dev/null | sed "s/name: //")
       DESC=$(grep -m1 "^description:" "$FILE" 2>/dev/null | sed "s/description: //")
@@ -408,15 +408,15 @@ else
 fi
 
 echo ""
-echo "=== PROJECT-LEVEL SKILLS (.omx/skills/) ==="
-if [ -d ".omx/skills" ]; then
-  PROJECT_COUNT=$(find ".omx/skills" -name "*.md" 2>/dev/null | wc -l)
+echo "=== PROJECT-LEVEL SKILLS (.agents/skills/) ==="
+if [ -d ".agents/skills" ]; then
+  PROJECT_COUNT=$(find ".agents/skills" -name "*.md" 2>/dev/null | wc -l)
   echo "Total skills: $PROJECT_COUNT"
 
   if [ $PROJECT_COUNT -gt 0 ]; then
     echo ""
     echo "Skills found:"
-    find ".omx/skills" -name "*.md" -type f -exec sh -c '
+    find ".agents/skills" -name "*.md" -type f -exec sh -c '
       FILE="$1"
       NAME=$(grep -m1 "^name:" "$FILE" 2>/dev/null | sed "s/name: //")
       DESC=$(grep -m1 "^description:" "$FILE" 2>/dev/null | sed "s/description: //")
@@ -467,8 +467,8 @@ Ask user to provide either:
 - **Paste content**: Paste skill markdown content directly
 
 Then ask for scope:
-- **User-level** (~/.codex/skills/omc-learned/) - Available across all projects
-- **Project-level** (.omx/skills/) - Only for this project
+- **User-level** (~/.agents/skills/) - Available across all projects
+- **Project-level** (.agents/skills/) - Only for this project
 
 Validate the skill format and save to the chosen location.
 
@@ -715,7 +715,7 @@ When invoked without arguments, run the full guided wizard.
 
 **Automatic Application**: Codex detects triggers and applies skills automatically - no need to remember or search for solutions.
 
-**Version Control**: Project-level skills (.omx/skills/) are committed with your code, so the whole team benefits.
+**Version Control**: Project-level skills (.agents/skills/) are committed with your code, so the whole team benefits.
 
 **Evolving Knowledge**: Skills improve over time as you discover better approaches and refine triggers.
 
@@ -760,8 +760,8 @@ Good skills are:
 > /skill list
 
 Checking skill directories...
-✓ User skills directory exists: ~/.codex/skills/omc-learned/
-✓ Project skills directory exists: .omx/skills/
+✓ User skills directory exists: ~/.agents/skills/
+✓ Project skills directory exists: .agents/skills/
 
 Scanning for skills...
 


### PR DESCRIPTION
## Summary
This PR removes fork-slop OMC residues in skill prompt docs and normalizes them to current OMX canonical forms.

### Updated files
- `skills/help/SKILL.md`
- `skills/autopilot/SKILL.md`
- `skills/doctor/SKILL.md`
- `skills/skill/SKILL.md`

### Key replacements
- `/omc-setup` -> `/omx-setup`
- `[omc.autopilot]` -> `[omx.autopilot]`
- `[omc.autopilot.pipeline]` -> `[omx.autopilot.pipeline]`
- `~/.codex/skills/omc-learned` -> `~/.agents/skills`
- `.omx/skills` -> `.agents/skills`
- `~/.codex/plugins/cache/oh-my-codex` -> `~/.codex/plugins/cache/omc/oh-my-codex`

## Validation
- Residue scan across `prompts/ skills/ docs/ src/` for targeted stale literals: **0 hits** after changes.
- Baseline `npm test`: exit code `2`, `not ok` lines `0`
- Post-change `npm test`: exit code `2`, `not ok` lines `0`
- Result: **equal-or-better vs baseline** (no regression from this change set).
