### PR TITLE
CI: run core checks on Node 20/22 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,26 +12,34 @@ concurrency:
 
 jobs:
   typecheck:
-    name: Typecheck
+    name: Typecheck (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npm run check:no-unused
 
   test:
-    name: Test
+    name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ OMX is an add-on, not a fork. It uses Codex-native extension points.
 ## Requirements
 
 - macOS or Linux (Windows via WSL2)
-- Node.js >= 20
+- Node.js >= 20 (CI validates Node 20 and current LTS, currently Node 22)
 - Codex CLI installed (`npm install -g @openai/codex`)
 - Codex auth configured
 


### PR DESCRIPTION
## Summary
- run core CI checks (typecheck, test) on a Node matrix: 20 and 22
- keep canonical build/persistence jobs on Node 20
- document supported Node policy in README requirements section

## Validation
- npx tsc --noEmit
- npm run check:no-unused
- npm test (1694 passed, 0 failed; catalog check ok)

Refs #456
