### PR TITLE
fix: require valid claim token in releaseTaskClaim

### DIFF
--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -618,7 +618,7 @@ describe('team state', () => {
     }
   });
 
-  it('releaseTaskClaim can recover with owner match when claim token changed', async () => {
+  it('releaseTaskClaim returns claim_conflict when claim token changed, even for the owner', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-release-owner-'));
     try {
       await initTeamState('team-release-owner', 't', 'executor', 1, cwd);
@@ -634,12 +634,8 @@ describe('team state', () => {
       await writeFile(taskPath, JSON.stringify(current, null, 2));
 
       const released = await releaseTaskClaim('team-release-owner', t.id, claim.claimToken, 'worker-1', cwd);
-      assert.equal(released.ok, true);
-
-      const reread = await readTask('team-release-owner', t.id, cwd);
-      assert.equal(reread?.status, 'pending');
-      assert.equal(reread?.owner, undefined);
-      assert.equal(reread?.claim, undefined);
+      assert.equal(released.ok, false);
+      assert.equal(released.ok ? 'x' : released.error, 'claim_conflict');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -721,7 +717,7 @@ describe('team state', () => {
     }
   });
 
-  it('releaseTaskClaim returns claim_conflict when lease has expired and caller is not the owner', async () => {
+  it('releaseTaskClaim returns lease_expired when lease has expired and caller is not the owner', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-lease-release-'));
     try {
       await initTeamState('team-lease-release', 't', 'executor', 1, cwd);
@@ -739,13 +735,13 @@ describe('team state', () => {
       // Different worker tries to release with the expired token.
       const result = await releaseTaskClaim('team-lease-release', t.id, claim.claimToken, 'worker-2', cwd);
       assert.equal(result.ok, false);
-      assert.equal(result.ok ? 'x' : result.error, 'claim_conflict');
+      assert.equal(result.ok ? 'x' : result.error, 'lease_expired');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('releaseTaskClaim succeeds via owner match when lease has expired', async () => {
+  it('releaseTaskClaim returns lease_expired when lease has expired, even for the owner', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-lease-release-owner-'));
     try {
       await initTeamState('team-lease-release-owner', 't', 'executor', 1, cwd);
@@ -754,19 +750,16 @@ describe('team state', () => {
       assert.equal(claim.ok, true);
       if (!claim.ok) return;
 
-      // Backdate leased_until so tokenMatches fails, but ownerMatches still holds.
+      // Backdate leased_until so the claim token is no longer valid.
       const taskPath = join(cwd, '.omx', 'state', 'team', 'team-lease-release-owner', 'tasks', `task-${t.id}.json`);
       const current = JSON.parse(await readFile(taskPath, 'utf-8')) as any;
       current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
       await writeFile(taskPath, JSON.stringify(current, null, 2));
 
-      // Same worker releases — should succeed via owner match.
+      // Same worker releases — should now fail because owner-only bypass is removed.
       const result = await releaseTaskClaim('team-lease-release-owner', t.id, claim.claimToken, 'worker-1', cwd);
-      assert.equal(result.ok, true);
-
-      const reread = await readTask('team-lease-release-owner', t.id, cwd);
-      assert.equal(reread?.status, 'pending');
-      assert.equal(reread?.claim, undefined);
+      assert.equal(result.ok, false);
+      assert.equal(result.ok ? 'x' : result.error, 'lease_expired');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -256,7 +256,7 @@ export type TransitionTaskResult =
 
 export type ReleaseTaskClaimResult =
   | { ok: true; task: TeamTaskV2 }
-  | { ok: false; error: 'claim_conflict' | 'task_not_found' | 'already_terminal' };
+  | { ok: false; error: 'claim_conflict' | 'task_not_found' | 'already_terminal' | 'lease_expired' };
 
 export interface TeamSummary {
   teamName: string;
@@ -1564,7 +1564,7 @@ export async function releaseTaskClaim(
   teamName: string,
   taskId: string,
   claimToken: string,
-  workerName: string,
+  _workerName: string,
   cwd: string
 ): Promise<ReleaseTaskClaimResult> {
   const lock = await withTaskClaimLock(teamName, taskId, cwd, async () => {
@@ -1579,12 +1579,10 @@ export async function releaseTaskClaim(
       return { ok: false as const, error: 'already_terminal' as const };
     }
 
-    const leaseActive = Boolean(v.claim && new Date(v.claim.leased_until) > new Date());
-    const tokenMatches = Boolean(v.claim && v.claim.token === claimToken && leaseActive);
-    const ownerMatches = v.status === 'in_progress' && v.owner === workerName;
-    if (!tokenMatches && !ownerMatches) {
+    if (!v.owner || !v.claim || v.claim.owner !== v.owner || v.claim.token !== claimToken) {
       return { ok: false as const, error: 'claim_conflict' as const };
     }
+    if (new Date(v.claim.leased_until) <= new Date()) return { ok: false as const, error: 'lease_expired' as const };
 
     const updated: TeamTaskV2 = {
       ...v,


### PR DESCRIPTION
## Summary
- harden `releaseTaskClaim` to require a matching, active claim token
- remove owner-only fallback bypass so stale/changed tokens cannot release claims
- add regression coverage for changed-token and expired-lease owner scenarios

## Testing
- npm run build
- node --test dist/team/__tests__/state.test.js
- node --test dist/mcp/__tests__/state-server-team-tools.test.js

Fixes #450