### PR TITLE
refactor(team): extract canonical team state-root resolver

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -28,7 +28,6 @@ import {
   assignTask,
   sendWorkerMessage,
   resolveWorkerLaunchArgsFromEnv,
-  resolveCanonicalTeamStateRoot,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   type TeamRuntime,
 } from '../runtime.js';
@@ -55,13 +54,6 @@ function withoutTeamWorkerEnv<T>(fn: () => T): T {
 }
 
 describe('runtime', () => {
-  it('resolveCanonicalTeamStateRoot resolves to leader .omx/state', () => {
-    assert.equal(
-      resolveCanonicalTeamStateRoot('/tmp/demo/project'),
-      '/tmp/demo/project/.omx/state',
-    );
-  });
-
   it('resolveWorkerLaunchArgsFromEnv injects low-complexity default model when missing', () => {
     const args = resolveWorkerLaunchArgsFromEnv(
       { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },

--- a/src/team/__tests__/state-root.test.ts
+++ b/src/team/__tests__/state-root.test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveCanonicalTeamStateRoot } from '../state-root.js';
+
+describe('state-root', () => {
+  it('resolveCanonicalTeamStateRoot resolves to leader .omx/state', () => {
+    assert.equal(
+      resolveCanonicalTeamStateRoot('/tmp/demo/project'),
+      '/tmp/demo/project/.omx/state',
+    );
+  });
+});
+

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -95,6 +95,7 @@ import {
   parseTeamWorkerLaunchArgs,
   splitWorkerLaunchArgs,
 } from './model-contract.js';
+import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { inferPhaseTargetFromTaskCounts, reconcilePhaseStateForMonitor } from './phase-controller.js';
 import { getTeamTmuxSessions } from '../notifications/tmux.js';
 import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
@@ -367,9 +368,7 @@ function isPromptWorkerAlive(config: TeamConfig, worker: WorkerInfo): boolean {
 
 export { TEAM_LOW_COMPLEXITY_DEFAULT_MODEL };
 
-export function resolveCanonicalTeamStateRoot(leaderCwd: string): string {
-  return resolve(join(leaderCwd, '.omx', 'state'));
-}
+export { resolveCanonicalTeamStateRoot };
 
 function spawnPromptWorker(
   teamName: string,

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -57,10 +57,7 @@ import {
   isLowComplexityAgentType,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
 } from './model-contract.js';
-// Inlined to avoid circular dependency with runtime.ts
-function resolveCanonicalTeamStateRoot(leaderCwd: string): string {
-  return resolve(join(leaderCwd, '.omx', 'state'));
-}
+import { resolveCanonicalTeamStateRoot } from './state-root.js';
 
 // ── Environment gate ──────────────────────────────────────────────────────────
 

--- a/src/team/state-root.ts
+++ b/src/team/state-root.ts
@@ -1,0 +1,9 @@
+import { join, resolve } from 'path';
+
+/**
+ * Resolve the canonical OMX team state root for a leader working directory.
+ */
+export function resolveCanonicalTeamStateRoot(leaderCwd: string): string {
+  return resolve(join(leaderCwd, '.omx', 'state'));
+}
+


### PR DESCRIPTION
## Summary
- extract canonical team state-root resolution into shared src/team/state-root.ts utility
- replace duplicated runtime/scaling resolver logic with shared import
- keep behavior identical and move resolver coverage into dedicated test

## Testing
- npm run build
- node --test dist/team/__tests__/state-root.test.js
- node --test --test-name-pattern "resolveWorkerLaunchArgsFromEnv" dist/team/__tests__/runtime.test.js
- node --test --test-name-pattern "isScalingEnabled|Monotonic worker index counter" dist/team/__tests__/scaling.test.js
- node --test dist/team/__tests__/state-root.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/scaling.test.js (known unrelated failures in runtime/scaling suites in this env)

Refs #451