### PR TITLE
fix(doctor): clarify onboarding warning wording for first-time setup

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error?: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const r = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
+}
+
+function shouldSkipForSpawnPermissions(err?: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+describe('omx doctor onboarding warning copy', () => {
+  it('explains first-setup expectation for config and MCP onboarding warnings', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-copy-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        `
+[mcp_servers.non_omx]
+command = "node"
+`.trimStart(),
+      );
+
+      const res = runOmx(wd, ['doctor'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Config: config\.toml exists but no OMX entries yet \(expected before first setup; run "omx setup --force" once\)/,
+      );
+      assert.match(
+        res.stdout,
+        /MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -415,7 +415,11 @@ async function checkConfig(configPath: string): Promise<Check> {
     if (hasOmx) {
       return { name: 'Config', status: 'pass', message: 'config.toml has OMX entries' };
     }
-    return { name: 'Config', status: 'warn', message: 'config.toml exists but no OMX entries' };
+    return {
+      name: 'Config',
+      status: 'warn',
+      message: 'config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)',
+    };
   } catch {
     return { name: 'Config', status: 'fail', message: 'cannot read config.toml' };
   }
@@ -475,7 +479,11 @@ async function checkMcpServers(configPath: string): Promise<Check> {
       if (hasOmx) {
         return { name: 'MCP Servers', status: 'pass', message: `${mcpCount} servers configured (OMX present)` };
       }
-      return { name: 'MCP Servers', status: 'warn', message: `${mcpCount} servers but no OMX servers` };
+      return {
+        name: 'MCP Servers',
+        status: 'warn',
+        message: `${mcpCount} servers but no OMX servers yet (expected before first setup; run "omx setup --force" once)`,
+      };
     }
     return { name: 'MCP Servers', status: 'warn', message: 'no MCP servers configured' };
   } catch {


### PR DESCRIPTION
## Summary
- clarify doctor warning copy for pre-setup onboarding state so it is not misread as a failure
- update `Config` warning to explicitly say this is expected before first setup
- update `MCP Servers` warning with the same onboarding guidance
- add regression test covering both warning lines

## Testing
- npm run build
- node --test dist/cli/__tests__/doctor-warning-copy.test.js dist/cli/__tests__/setup-scope.test.js

Closes #460