### PR TITLE
feat(skills): add built-in ask-claude and ask-gemini skills

### DIFF
--- a/skills/ask-claude/SKILL.md
+++ b/skills/ask-claude/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ask-claude
+description: Ask Claude directly via MCP
+---
+
+# Ask Claude
+
+Use Claude as a direct external advisor for focused questions, reviews, or second opinions.
+
+## Usage
+
+```bash
+/ask-claude <question or task>
+```
+
+## Routing
+
+### Preferred: MCP Direct
+Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
+Use `mcp__c__ask_claude` with the user's request.
+
+### Fallback
+If Claude MCP is unavailable, explain that Claude MCP is not configured and continue with `mcp__x__ask_codex`.
+
+Task: {{ARGUMENTS}}

--- a/skills/ask-gemini/SKILL.md
+++ b/skills/ask-gemini/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ask-gemini
+description: Ask Gemini directly via MCP
+---
+
+# Ask Gemini
+
+Use Gemini as a direct external advisor for brainstorming, design feedback, and second opinions.
+
+## Usage
+
+```bash
+/ask-gemini <question or task>
+```
+
+## Routing
+
+### Preferred: MCP Direct
+Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools.
+Use `mcp__g__ask_gemini` with the user's request.
+
+### Fallback
+If Gemini MCP is unavailable, explain that Gemini MCP is not configured and continue with `mcp__x__ask_codex`.
+
+Task: {{ARGUMENTS}}

--- a/src/catalog/__tests__/generator.test.ts
+++ b/src/catalog/__tests__/generator.test.ts
@@ -40,6 +40,8 @@ describe('catalog reader/contract', () => {
     assert.ok(contract.aliases.some((a) => a.name === 'swarm' && a.canonical === 'team'));
     assert.ok(contract.internalHidden.includes('worker'));
     assert.ok(contract.coreSkills.includes('autopilot'));
+    assert.ok(contract.skills.some((s) => s.name === 'ask-claude' && s.status === 'active'));
+    assert.ok(contract.skills.some((s) => s.name === 'ask-gemini' && s.status === 'active'));
   });
 
   it('template manifest can be synced from source manifest', async () => {

--- a/src/catalog/__tests__/schema.test.ts
+++ b/src/catalog/__tests__/schema.test.ts
@@ -58,4 +58,13 @@ describe('catalog schema', () => {
     assert.ok(counts.activeSkillCount > 0);
     assert.ok(counts.activeAgentCount > 0);
   });
+
+  it('includes ask-claude and ask-gemini as active built-in skills', () => {
+    const parsed = validateCatalogManifest(readSourceManifest());
+    const askClaude = parsed.skills.find((skill) => skill.name === 'ask-claude');
+    const askGemini = parsed.skills.find((skill) => skill.name === 'ask-gemini');
+
+    assert.equal(askClaude?.status, 'active');
+    assert.equal(askGemini?.status, 'active');
+  });
 });

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-02-28T00:15:18.714Z",
+  "generatedAt": "2026-03-02T16:07:41.105Z",
   "version": "2026.02.20.1",
   "counts": {
-    "skillCount": 30,
+    "skillCount": 32,
     "promptCount": 29,
-    "activeSkillCount": 16,
+    "activeSkillCount": 18,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -151,6 +151,20 @@
       "category": "shortcut",
       "status": "alias",
       "canonical": "plan --review",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "ask-claude",
+      "category": "shortcut",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "ask-gemini",
+      "category": "shortcut",
+      "status": "active",
       "core": false,
       "internalRequired": false
     },

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -22,6 +22,8 @@
     { "name": "frontend-ui-ux", "category": "shortcut", "status": "alias", "canonical": "designer" },
     { "name": "git-master", "category": "shortcut", "status": "alias", "canonical": "git-master" },
     { "name": "review", "category": "shortcut", "status": "alias", "canonical": "plan --review" },
+    { "name": "ask-claude", "category": "shortcut", "status": "active" },
+    { "name": "ask-gemini", "category": "shortcut", "status": "active" },
 
     { "name": "cancel", "category": "utility", "status": "active" },
     { "name": "doctor", "category": "utility", "status": "active" },

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -132,6 +132,8 @@ describe('omx setup scope behavior', () => {
       assert.equal(existsSync(localAgents), true);
       assert.equal(existsSync(join(localAgents, 'executor.toml')), true);
       assert.equal(existsSync(join(localSkills, 'omx-setup', 'SKILL.md')), true);
+      assert.equal(existsSync(join(localSkills, 'ask-claude', 'SKILL.md')), true);
+      assert.equal(existsSync(join(localSkills, 'ask-gemini', 'SKILL.md')), true);
       assert.ok((await readdir(localPrompts)).length > 0, 'local prompts should be installed');
       assert.equal(existsSync(agentsMdPath), true);
 

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -142,6 +142,20 @@
       "internalRequired": false
     },
     {
+      "name": "ask-claude",
+      "category": "shortcut",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "ask-gemini",
+      "category": "shortcut",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "cancel",
       "category": "utility",
       "status": "active",


### PR DESCRIPTION
## Summary
Add built-in `ask-claude` and `ask-gemini` skills so users can invoke Claude/Gemini directly as first-class OMX skills.

## Changes
- Added new built-in skill files:
  - `skills/ask-claude/SKILL.md`
  - `skills/ask-gemini/SKILL.md`
- Registered both skills in catalog manifests:
  - `src/catalog/manifest.json`
  - `templates/catalog-manifest.json`
  - regenerated `src/catalog/generated/public-catalog.json`
- Added tests to verify catalog presence and setup installation:
  - `src/catalog/__tests__/schema.test.ts`
  - `src/catalog/__tests__/generator.test.ts`
  - `src/cli/__tests__/setup-scope.test.ts`

## Validation
- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (not required; no setup/config behavior change)

## Checklist
- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related
Closes #457
