### PR TITLE
fix(cli): route --version flags to OMX version command

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -217,6 +217,20 @@ describe('resolveCliInvocation', () => {
     });
   });
 
+  it('resolves --version to the version command instead of launch', () => {
+    assert.deepEqual(resolveCliInvocation(['--version']), {
+      command: 'version',
+      launchArgs: [],
+    });
+  });
+
+  it('resolves -v to the version command instead of launch', () => {
+    assert.deepEqual(resolveCliInvocation(['-v']), {
+      command: 'version',
+      launchArgs: [],
+    });
+  });
+
   it('keeps unknown long flags as launch passthrough args', () => {
     assert.deepEqual(resolveCliInvocation(['--model', 'gpt-5']), {
       command: 'launch',

--- a/src/cli/__tests__/version.test.ts
+++ b/src/cli/__tests__/version.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { version } from '../version.js';
+
+describe('version', () => {
+  it('prints OMX version from this repository package.json', () => {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as { version: string };
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      version();
+    } finally {
+      console.log = originalLog;
+    }
+
+    assert.equal(logs[0], `oh-my-codex v${pkg.version}`);
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -196,6 +196,9 @@ export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
   if (firstArg === '--help' || firstArg === '-h') {
     return { command: 'help', launchArgs: [] };
   }
+  if (firstArg === '--version' || firstArg === '-v') {
+    return { command: 'version', launchArgs: [] };
+  }
   if (!firstArg || firstArg.startsWith('--')) {
     return { command: 'launch', launchArgs: firstArg ? args : [] };
   }


### PR DESCRIPTION
## Summary
- route `omx --version` and `omx -v` to the internal `version` command in CLI invocation resolution
- prevent passthrough to Codex CLI in this path so the non-TTY Codex terminal error is avoided
- add tests for CLI flag routing and verify version output is sourced from this repository's `package.json`

## Verification
- npm run build
- node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/version.test.js
- npm test
- node bin/omx.js --version

Closes #478
