### PR TITLE
fix(cli): add Ralph/PRD guidance to omx ralph --help

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { extractRalphTaskDescription } from '../ralph.js';
+import { extractRalphTaskDescription, normalizeRalphCliArgs, ralphCommand } from '../ralph.js';
+import { main } from '../index.js';
 
 describe('extractRalphTaskDescription', () => {
   it('returns plain task text from positional args', () => {
@@ -131,5 +132,71 @@ describe('extractRalphTaskDescription', () => {
       extractRalphTaskDescription(['-c=model_reasoning_effort="high"', 'fix', 'bug']),
       'fix bug'
     );
+  });
+});
+
+describe('normalizeRalphCliArgs', () => {
+  it('converts --prd value into positional task text', () => {
+    assert.deepEqual(
+      normalizeRalphCliArgs(['--prd', 'ship release checklist']),
+      ['ship release checklist']
+    );
+  });
+
+  it('converts --prd=value into positional task text', () => {
+    assert.deepEqual(
+      normalizeRalphCliArgs(['--prd=ship release checklist']),
+      ['ship release checklist']
+    );
+  });
+
+  it('preserves non-prd codex args', () => {
+    assert.deepEqual(
+      normalizeRalphCliArgs(['--model', 'gpt-5', '--prd', 'fix tests']),
+      ['--model', 'gpt-5', 'fix tests']
+    );
+  });
+});
+
+describe('ralph --help contract', () => {
+  it('prints PRD mode usage, options, and examples', async () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map(String).join(' '));
+    };
+
+    try {
+      await ralphCommand(['--help']);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+    assert.match(output, /Usage:/);
+    assert.match(output, /omx ralph --prd "<task text>"/);
+    assert.match(output, /--help, -h/);
+    assert.match(output, /--prd <task text>/);
+    assert.match(output, /PRD mode:/);
+    assert.match(output, /Common patterns:/);
+    assert.match(output, /omx ralph --model gpt-5 "Refactor state hydration"/);
+  });
+
+  it('routes omx ralph --help to Ralph help (not global help)', async () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map(String).join(' '));
+    };
+
+    try {
+      await main(['ralph', '--help']);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+    assert.match(output, /PRD mode:/);
+    assert.doesNotMatch(output, /oh-my-codex \(omx\) - Multi-agent orchestration for Codex CLI/);
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -348,6 +348,7 @@ export async function main(args: string[]): Promise<void> {
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
   const flags = new Set(args.filter(a => a.startsWith('--')));
+  const ralphHelpRequested = firstArg === 'ralph' && (args[1] === '--help' || args[1] === '-h');
   const options = {
     force: flags.has('--force'),
     dryRun: flags.has('--dry-run'),
@@ -355,7 +356,7 @@ export async function main(args: string[]): Promise<void> {
     team: flags.has('--team'),
   };
 
-  if (flags.has('--help') || flags.has('-h')) {
+  if (flags.has('--help') && !ralphHelpRequested) {
     console.log(HELP);
     return;
   }

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -1,16 +1,28 @@
 import { startMode, updateModeState } from '../modes/base.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 
-const RALPH_HELP = `omx ralph - Launch Codex with ralph persistence mode active
+export const RALPH_HELP = `omx ralph - Launch Codex with ralph persistence mode active
 
 Usage:
-  omx ralph [codex-args...]   Initialize ralph state and launch Codex
+  omx ralph [task text...]
+  omx ralph --prd "<task text>"
+  omx ralph [ralph-options] [codex-args...] [task text...]
 
 Options:
-  --help, -h    Show this help message
+  --help, -h           Show this help message
+  --prd <task text>    PRD mode shortcut: mark the task text explicitly
+  --prd=<task text>    Same as --prd "<task text>"
 
-Ralph persistence mode initializes state tracking so the OMC ralph loop
-can maintain context across Codex sessions.
+PRD mode:
+  Ralph initializes persistence artifacts in .omx/ so PRD and progress
+  state can survive across Codex sessions. Provide task text either as
+  positional words or with --prd.
+
+Common patterns:
+  omx ralph "Fix flaky notify-hook tests"
+  omx ralph --prd "Ship release checklist automation"
+  omx ralph --model gpt-5 "Refactor state hydration"
+  omx ralph -- --task-with-leading-dash
 `;
 
 /**
@@ -79,10 +91,45 @@ export function extractRalphTaskDescription(args: readonly string[]): string {
   return words.join(' ') || 'ralph-cli-launch';
 }
 
+export function normalizeRalphCliArgs(args: readonly string[]): string[] {
+  const normalized: string[] = [];
+  let i = 0;
+
+  while (i < args.length) {
+    const token = args[i];
+
+    if (token === '--prd') {
+      const next = args[i + 1];
+      if (next && next !== '--' && !next.startsWith('-')) {
+        normalized.push(next);
+        i += 2;
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    if (token.startsWith('--prd=')) {
+      const value = token.slice('--prd='.length);
+      if (value.length > 0) {
+        normalized.push(value);
+      }
+      i++;
+      continue;
+    }
+
+    normalized.push(token);
+    i++;
+  }
+
+  return normalized;
+}
+
 export async function ralphCommand(args: string[]): Promise<void> {
+  const normalizedArgs = normalizeRalphCliArgs(args);
   const cwd = process.cwd();
 
-  if (args[0] === '--help' || args[0] === '-h') {
+  if (normalizedArgs[0] === '--help' || normalizedArgs[0] === '-h') {
     console.log(RALPH_HELP);
     return;
   }
@@ -91,7 +138,7 @@ export async function ralphCommand(args: string[]): Promise<void> {
   const artifacts = await ensureCanonicalRalphArtifacts(cwd);
 
   // Write initial ralph mode state
-  const task = extractRalphTaskDescription(args);
+  const task = extractRalphTaskDescription(normalizedArgs);
   await startMode('ralph', task, 50);
   await updateModeState('ralph', {
     current_phase: 'starting',
@@ -110,5 +157,5 @@ export async function ralphCommand(args: string[]): Promise<void> {
 
   // Dynamic import avoids a circular dependency with index.ts
   const { launchWithHud } = await import('./index.js');
-  await launchWithHud(args);
+  await launchWithHud(normalizedArgs);
 }


### PR DESCRIPTION
## Summary
- route `omx ralph --help` to the Ralph subcommand help instead of top-level help
- expand Ralph help text with PRD-specific invocation guidance
- document Ralph-specific options and common invocation patterns with concrete examples

## What changed
- `src/cli/index.ts`
  - avoid intercepting `omx ralph --help` in global help handling
- `src/cli/ralph.ts`
  - expanded `RALPH_HELP` content:
    - PRD mode usage (`--prd <task text>` and `--prd=<task text>`)
    - option descriptions
    - common usage examples
  - added `normalizeRalphCliArgs()` to normalize `--prd` forms into task text before launch/state extraction
- `src/cli/__tests__/ralph.test.ts`
  - added tests for `normalizeRalphCliArgs`
  - added help-contract tests asserting PRD mode/options/examples are present
  - added routing test to ensure `main(['ralph', '--help'])` prints Ralph help (not global help)

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/ralph.test.js`
- `npm test`
- `node bin/omx.js ralph --help`

Closes #479
