### PR TITLE
fix: improve v5 auto-dispatch idle/busy detection

### DIFF
--- a/scripts/notify-hook/team-dispatch.js
+++ b/scripts/notify-hook/team-dispatch.js
@@ -21,6 +21,34 @@ async function writeJsonAtomic(path, value) {
 
 // Keep stale-timeout semantics aligned with src/team/state.ts LOCK_STALE_MS.
 const DISPATCH_LOCK_STALE_MS = 5 * 60 * 1000;
+const DEFAULT_ISSUE_DISPATCH_COOLDOWN_MS = 15 * 60 * 1000;
+const ISSUE_DISPATCH_COOLDOWN_ENV = 'OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS';
+
+function resolveIssueDispatchCooldownMs(env = process.env) {
+  const raw = safeString(env[ISSUE_DISPATCH_COOLDOWN_ENV]).trim();
+  if (raw === '') return DEFAULT_ISSUE_DISPATCH_COOLDOWN_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_ISSUE_DISPATCH_COOLDOWN_MS;
+  return parsed;
+}
+
+function extractIssueKey(triggerMessage) {
+  const match = safeString(triggerMessage).match(/\b([A-Z][A-Z0-9]+-\d+)\b/i);
+  return match?.[1]?.toUpperCase() || null;
+}
+
+function issueCooldownStatePath(teamDirPath) {
+  return join(teamDirPath, 'dispatch', 'issue-cooldown.json');
+}
+
+async function readIssueCooldownState(teamDirPath) {
+  const fallback = { by_issue: {} };
+  const parsed = await readJson(issueCooldownStatePath(teamDirPath), fallback);
+  if (!parsed || typeof parsed !== 'object' || typeof parsed.by_issue !== 'object' || parsed.by_issue === null) {
+    return fallback;
+  }
+  return parsed;
+}
 
 async function withDispatchLock(teamDirPath, fn) {
   const lockDir = join(teamDirPath, 'dispatch', '.lock');
@@ -163,6 +191,7 @@ function paneHasActiveTask(captured) {
     .map((line) => line.replace(/\r/g, '').trim())
     .filter((line) => line.length > 0);
   const tail = lines.slice(-40);
+  if (tail.some((line) => /\b\d+\s+background terminal running\b/i.test(line))) return true;
   if (tail.some((line) => /esc to interrupt/i.test(line))) return true;
   if (tail.some((line) => /\bbackground terminal running\b/i.test(line))) return true;
   if (tail.some((line) => /^•\s.+\(.+•\s*esc to interrupt\)$/i.test(line))) return true;
@@ -302,6 +331,7 @@ export async function drainPendingTeamDispatch({
   let processed = 0;
   let skipped = 0;
   let failed = 0;
+  const issueCooldownMs = resolveIssueDispatchCooldownMs();
 
   for (const teamName of teams) {
     if (processed >= maxPerTick) break;
@@ -315,6 +345,9 @@ export async function drainPendingTeamDispatch({
     await withDispatchLock(teamDirPath, async () => {
       const requests = await readJson(requestsPath, []);
       if (!Array.isArray(requests)) return;
+      const issueCooldownState = await readIssueCooldownState(teamDirPath);
+      const issueCooldownByIssue = issueCooldownState.by_issue || {};
+      const nowMs = Date.now();
 
       let mutated = false;
       for (const request of requests) {
@@ -325,7 +358,20 @@ export async function drainPendingTeamDispatch({
           continue;
         }
 
+        const issueKey = extractIssueKey(request.trigger_message);
+        if (issueCooldownMs > 0 && issueKey) {
+          const lastInjectedMs = Number(issueCooldownByIssue[issueKey]);
+          if (Number.isFinite(lastInjectedMs) && lastInjectedMs > 0 && nowMs - lastInjectedMs < issueCooldownMs) {
+            skipped += 1;
+            continue;
+          }
+        }
+
         const result = await injector(request, config, resolve(cwd));
+        if (issueKey && issueCooldownMs > 0) {
+          issueCooldownByIssue[issueKey] = Date.now();
+          mutated = true;
+        }
         const nowIso = new Date().toISOString();
         request.attempt_count = Number.isFinite(request.attempt_count) ? Math.max(0, request.attempt_count + 1) : 1;
         request.updated_at = nowIso;
@@ -401,6 +447,8 @@ export async function drainPendingTeamDispatch({
       }
 
       if (mutated) {
+        issueCooldownState.by_issue = issueCooldownByIssue;
+        await writeJsonAtomic(issueCooldownStatePath(teamDirPath), issueCooldownState);
         await writeJsonAtomic(requestsPath, requests);
       }
     });

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -401,6 +401,96 @@ describe('notify-hook team dispatch consumer', () => {
     }
   });
 
+  it('applies per-issue cooldown to avoid repeated reinjection in one drain tick', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const previousIssueCooldown = process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS;
+    try {
+      process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS = '900000';
+      await initTeamState('alpha', 'task', 'executor', 2, cwd);
+      const first = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: '› IND-123 only...',
+      }, cwd);
+      const second = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-2',
+        worker_index: 2,
+        trigger_message: 'IND-123 only...',
+      }, cwd);
+
+      const modulePath = new URL('../../../scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => ({ ok: true, reason: 'injected_for_test' }),
+      });
+      assert.equal(result.processed, 1);
+      assert.ok(result.skipped >= 1);
+
+      const firstReq = await readDispatchRequest('alpha', first.request.request_id, cwd);
+      const secondReq = await readDispatchRequest('alpha', second.request.request_id, cwd);
+      assert.equal(firstReq?.status, 'notified');
+      assert.equal(secondReq?.status, 'pending');
+      assert.equal(secondReq?.attempt_count, 0);
+    } finally {
+      if (typeof previousIssueCooldown === 'string') process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS = previousIssueCooldown;
+      else delete process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips repeated same-issue reinjection during per-issue cooldown window', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const previousCooldown = process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS;
+    let injectCount = 0;
+    try {
+      process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS = '900000';
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      const first = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: 'IND-123 only...',
+      }, cwd);
+      const second = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: 'IND-123 only: retry',
+      }, cwd);
+
+      const modulePath = new URL('../../../scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const injector = async () => {
+        injectCount += 1;
+        return { ok: true, reason: 'tmux_send_keys_unconfirmed' };
+      };
+
+      const firstTick = await mod.drainPendingTeamDispatch({ cwd, maxPerTick: 5, injector });
+      const secondTick = await mod.drainPendingTeamDispatch({ cwd, maxPerTick: 5, injector });
+
+      assert.equal(firstTick.processed, 0);
+      assert.ok(firstTick.skipped >= 1);
+      assert.equal(secondTick.processed, 0);
+      assert.ok(secondTick.skipped >= 2);
+      assert.equal(injectCount, 1, 'same issue should not be reinjected while cooldown is active');
+
+      const firstRequest = await readDispatchRequest('alpha', first.request.request_id, cwd);
+      const secondRequest = await readDispatchRequest('alpha', second.request.request_id, cwd);
+      assert.equal(firstRequest?.status, 'pending');
+      assert.equal(firstRequest?.attempt_count, 1);
+      assert.equal(secondRequest?.status, 'pending');
+      assert.equal(secondRequest?.attempt_count, 0, 'cooldown-blocked request should remain untouched');
+    } finally {
+      if (typeof previousCooldown === 'string') process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS = previousCooldown;
+      else delete process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('skips non-hook transport preferences in hook consumer', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
     try {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -285,6 +285,14 @@ describe('shouldAttemptAdaptiveRetry', () => {
     );
   });
 
+  it('returns false when latest capture shows background terminal running status', () => {
+    const activeCapture = '2 background terminal running\n❯ hello';
+    assert.equal(
+      shouldAttemptAdaptiveRetry('auto', true, true, activeCapture, 'hello'),
+      false,
+    );
+  });
+
   it('does not treat non-ellipsis Claude bullet text as active generation', () => {
     const readyCapture = '· Caramelizing\n❯ hello';
     assert.equal(
@@ -356,6 +364,14 @@ describe('paneLooksReady gate: status-only is not ready (#391)', () => {
     assert.equal(
       shouldAttemptAdaptiveRetry('auto', true, true, loadingCapture, 'hello'),
       false,
+    );
+  });
+
+  it('shouldAttemptAdaptiveRetry treats issue-only prompt as ready even without glyph', () => {
+    const issuePromptCapture = 'IND-123 only...';
+    assert.equal(
+      shouldAttemptAdaptiveRetry('auto', true, true, issuePromptCapture, 'IND-123 only...'),
+      true,
     );
   });
 });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -993,6 +993,11 @@ export function paneLooksReady(captured: string): boolean {
   const hasClaudePromptLine = lines.some((line) => /^\s*❯\s*/u.test(line));
   if (hasCodexPromptLine || hasClaudePromptLine) return true;
 
+  // Custom per-issue prompts (e.g. "› IND-123 only..."). Capture output can
+  // occasionally omit the glyph, so accept both with/without leading prompt char.
+  const hasIssuePromptLine = lines.some((line) => /^\s*(?:[›>❯]\s*)?[A-Z][A-Z0-9]+-\d+\s+only(?:\s*(?:…|\.{3}))?\s*$/iu.test(line));
+  if (hasIssuePromptLine) return true;
+
   // Status-only markers (model name in status bar, token budget) are NOT
   // sufficient on their own — they can appear during bootstrap before the CLI
   // accepts input.  Require an actual prompt character (checked above).
@@ -1017,6 +1022,8 @@ export function paneHasActiveTask(captured: string): boolean {
     .filter((line) => line.length > 0);
 
   const tail = lines.slice(-40);
+  // Codex v5 status line can appear without "esc to interrupt"; treat as busy first.
+  if (tail.some((line) => /\b\d+\s+background terminal running\b/i.test(line))) return true;
   if (tail.some((line) => /esc to interrupt/i.test(line))) return true;
   if (tail.some((line) => /\bbackground terminal running\b/i.test(line))) return true;
   // Typical Codex activity line: "• Doing X (3m 12s • esc to interrupt)"


### PR DESCRIPTION
## Summary
- improve v5 idle 판정 to treat custom issue prompts like `IND-123 only...` as input-ready (including glyph-omitted captures)
- prioritize `N background terminal running` as busy in active-task detection
- add per-issue dispatch cooldown (default 15m, env: `OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS`) to prevent repeated reinjection of the same issue

## Changes
- `src/team/tmux-session.ts`
- `scripts/notify-hook/team-dispatch.js`
- `src/team/__tests__/tmux-session.test.ts`
- `src/hooks/__tests__/notify-hook-team-dispatch.test.ts`

## Verification
- `npm run build`
- `node --test dist/team/__tests__/tmux-session.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js`

Closes #476
