### PR TITLE
feat: add deep-interview skill and pre-PRD ralph interview gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
 | "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
+| "interview", "deep interview", "gather requirements" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run structured requirements interview workflow |
 | "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
 | "team", "swarm", "coordinated team", "coordinated swarm" | `$team` | Read `~/.agents/skills/team/SKILL.md`, start team orchestration (swarm compatibility alias) |
 | "ecomode", "eco", "budget" | `$ecomode` | Read `~/.agents/skills/ecomode/SKILL.md`, enable token-efficient mode |
@@ -186,6 +187,7 @@ Workflow Skills:
 - `swarm`: N coordinated agents on shared task list (compatibility facade over team)
 - `ultraqa`: QA cycling -- test, verify, fix, repeat
 - `plan`: Strategic planning with optional RALPLAN-DR consensus mode
+- `deep-interview`: Structured requirement interview workflow with quick/standard/deep depth
 - `ralplan`: Iterative consensus planning with RALPLAN-DR structured deliberation (planner + architect + critic); supports `--deliberate` for high-risk work
 
 Agent Shortcuts:

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: deep-interview
+description: Structured requirement interviews with depth control and transcript output
+---
+
+<Purpose>
+Deep Interview runs a structured requirements interview before planning or implementation. It clarifies goals, scope, constraints, and success criteria so downstream work is grounded in explicit requirements.
+</Purpose>
+
+<Trigger_Keywords>
+- "interview"
+- "deep interview"
+- "gather requirements"
+</Trigger_Keywords>
+
+<Use_When>
+- Requirements are ambiguous or underspecified
+- Stakeholders need alignment before PRD/planning
+- You need explicit constraints, priorities, and validation criteria
+</Use_When>
+
+<Depth_Levels>
+- **Quick**: 3-5 focused questions for rapid clarification (default for pre-PRD checks)
+- **Standard**: 6-10 questions covering full planning inputs
+- **Deep**: 12+ questions with scenario probing, edge cases, and risk exploration
+</Depth_Levels>
+
+<Workflow_Stages>
+1. **Context gathering**: establish current system/task context and known facts
+2. **Goal clarification**: define desired outcomes and success signals
+3. **Scope**: identify in-scope/out-of-scope boundaries
+4. **Constraints**: capture technical, timeline, compliance, and resource limits
+5. **Validation**: confirm acceptance criteria, risks, and open questions
+</Workflow_Stages>
+
+<Cross_Platform_Tool_Abstraction>
+Interactive question collection varies by runtime:
+- **Codex CLI**: use `request_user_input` for structured multiple-choice questions
+- **Claude Code**: use `AskUserQuestion` for equivalent structured prompts
+
+When writing or maintaining this skill, preserve behavior parity across tools:
+- Ask equivalent questions in the same stage order
+- Keep option semantics aligned (recommended/default choices first)
+- Record responses in a normalized transcript format regardless of tool
+</Cross_Platform_Tool_Abstraction>
+
+<Execution_Policy>
+- Pick depth level from user intent (`--quick`, `--standard`, `--deep`)
+- If no flag is provided, default to **Standard**
+- Keep questions atomic and non-leading
+- Summarize assumptions explicitly before closing
+</Execution_Policy>
+
+<Output_Contract>
+After interview completion, write transcript/summary to:
+
+`.omx/interviews/{slug}-{timestamp}.md`
+
+Where:
+- `slug` = short task slug (kebab-case)
+- `timestamp` = UTC timestamp (e.g., `20260303T071500Z`)
+
+Output must include:
+- Interview metadata (date, depth, participants/context)
+- Stage-by-stage Q&A summary
+- Confirmed requirements
+- Open questions / risks
+- Recommended next step (e.g., proceed to PRD)
+</Output_Contract>
+
+Task: {{ARGUMENTS}}

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -162,11 +162,15 @@ Example:
 `ralph -i refs/hn.png -i refs/hn-item.png --images-dir ./screenshots "match HackerNews layout"`
 
 ### PRD Workflow
-1. Create canonical PRD/progress artifacts:
+1. Run deep-interview in quick mode before creating PRD artifacts:
+   - Execute: `$deep-interview --quick <task>`
+   - Complete a compact requirements pass (context, goals, scope, constraints, validation)
+   - Persist interview output to `.omx/interviews/{slug}-{timestamp}.md`
+2. Create canonical PRD/progress artifacts:
    - PRD: `.omx/plans/prd-{slug}.md`
    - Progress ledger: `.omx/state/{scope}/ralph-progress.json` (session scope when available, else root scope)
-2. Parse the task (everything after `--prd` flag)
-3. Break down into user stories:
+3. Parse the task (everything after `--prd` flag)
+4. Break down into user stories:
 
 ```json
 {
@@ -186,9 +190,9 @@ Example:
 }
 ```
 
-4. Initialize canonical progress ledger at `.omx/state/{scope}/ralph-progress.json`
-5. Guidelines: right-sized stories (one session each), verifiable criteria, independent stories, priority order (foundational work first)
-6. Proceed to normal ralph loop using user stories as the task list
+5. Initialize canonical progress ledger at `.omx/state/{scope}/ralph-progress.json`
+6. Guidelines: right-sized stories (one session each), verifiable criteria, independent stories, priority order (foundational work first)
+7. Proceed to normal ralph loop using user stories as the task list
 
 ### Example
 User input: `--prd build a todo app with React and TypeScript`

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-03-03T06:42:55.204Z",
+  "generatedAt": "2026-03-03T08:10:14.452Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 33,
+    "skillCount": 34,
     "promptCount": 29,
-    "activeSkillCount": 19,
+    "activeSkillCount": 20,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -80,6 +80,13 @@
       "status": "active",
       "canonical": "plan",
       "core": true,
+      "internalRequired": false
+    },
+    {
+      "name": "deep-interview",
+      "category": "planning",
+      "status": "active",
+      "core": false,
       "internalRequired": false
     },
     {

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -12,6 +12,8 @@
 
     { "name": "plan", "category": "planning", "status": "active" },
     { "name": "ralplan", "category": "planning", "status": "active", "core": true, "canonical": "plan" },
+    { "name": "deep-interview", "category": "planning", "status": "active" },
+
 
     { "name": "analyze", "category": "shortcut", "status": "alias", "canonical": "debugger" },
     { "name": "deepsearch", "category": "shortcut", "status": "alias", "canonical": "explore" },

--- a/src/cli/__tests__/ralph-prd-deep-interview.test.ts
+++ b/src/cli/__tests__/ralph-prd-deep-interview.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ralphSkill = readFileSync(join(__dirname, '../../../skills/ralph/SKILL.md'), 'utf-8');
+
+describe('ralph PRD mode deep interview gate', () => {
+  it('requires deep-interview --quick before PRD artifact creation', () => {
+    assert.match(ralphSkill, /Run deep-interview in quick mode before creating PRD artifacts/i);
+    assert.match(ralphSkill, /\$deep-interview\s+--quick/i);
+    assert.match(ralphSkill, /\.omx\/interviews\/\{slug\}-\{timestamp\}\.md/);
+  });
+});

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -87,6 +87,30 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match.skill, 'team');
     assert.equal(match.keyword.toLowerCase(), 'coordinated swarm');
   });
+
+  it('maps "deep interview" phrase to deep-interview skill', () => {
+    const match = detectPrimaryKeyword('please run a deep interview before planning');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'deep-interview');
+    assert.equal(match.keyword.toLowerCase(), 'deep interview');
+  });
+
+  it('maps "gather requirements" to deep-interview skill', () => {
+    const match = detectPrimaryKeyword('let us gather requirements first');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'deep-interview');
+    assert.equal(match.keyword.toLowerCase(), 'gather requirements');
+  });
+
+  it('prefers "deep interview" over "interview" for deterministic longest-match behavior', () => {
+    const match = detectPrimaryKeyword('deep interview this request first');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'deep-interview');
+    assert.equal(match.keyword.toLowerCase(), 'deep interview');
+  });
 });
 
 describe('keyword detection guidance generation', () => {

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -19,6 +19,10 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'ulw', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'parallel', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
 
+  { keyword: 'deep interview', skill: 'deep-interview', priority: 8, guidance: 'Activate structured requirement interview workflow' },
+  { keyword: 'gather requirements', skill: 'deep-interview', priority: 8, guidance: 'Activate structured requirement interview workflow' },
+  { keyword: 'interview', skill: 'deep-interview', priority: 8, guidance: 'Activate structured requirement interview workflow' },
+
   { keyword: 'plan this', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
   { keyword: 'plan the', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
   { keyword: "let's plan", skill: 'plan', priority: 8, guidance: 'Activate planning skill' },

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -150,6 +150,7 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
 | "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
+| "interview", "deep interview", "gather requirements" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run structured requirements interview workflow |
 | "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
 | "team", "swarm", "coordinated team", "coordinated swarm" | `$team` | Read `~/.agents/skills/team/SKILL.md`, start team orchestration (swarm compatibility alias) |
 | "ecomode", "eco", "budget" | `$ecomode` | Read `~/.agents/skills/ecomode/SKILL.md`, enable token-efficient mode |
@@ -186,6 +187,7 @@ Workflow Skills:
 - `swarm`: N coordinated agents on shared task list (compatibility facade over team)
 - `ultraqa`: QA cycling -- test, verify, fix, repeat
 - `plan`: Strategic planning with optional RALPLAN-DR consensus mode
+- `deep-interview`: Structured requirement interview workflow with quick/standard/deep depth
 - `ralplan`: Iterative consensus planning with RALPLAN-DR structured deliberation (planner + architect + critic); supports `--deliberate` for high-risk work
 
 Agent Shortcuts:

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -70,6 +70,13 @@
       "internalRequired": false
     },
     {
+      "name": "deep-interview",
+      "category": "planning",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "analyze",
       "category": "shortcut",
       "status": "alias",


### PR DESCRIPTION
## Summary
- add a standalone `deep-interview` skill with structured interview workflow, depth levels (Quick/Standard/Deep), and cross-platform question tooling guidance (`request_user_input` vs `AskUserQuestion`)
- integrate Ralph PRD mode with a required `$deep-interview --quick` step before PRD artifact generation
- add deep-interview keyword triggers to AGENTS docs/templates and runtime keyword registry
- add deep-interview to catalog manifests and regenerate public catalog contract
- add tests for keyword detection and Ralph PRD deep-interview gate

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/emulator.test.js dist/catalog/__tests__/schema.test.js dist/catalog/__tests__/generator.test.js dist/cli/__tests__/ralph-prd-deep-interview.test.js`
- `npm test`

Closes #484
