### PR TITLE
fix: security quick wins (#488, #493, #495, #496, #508, #523)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0"
+        "@modelcontextprotocol/sdk": "^1.26.0"
       },
       "bin": {
         "omx": "bin/omx.js"
@@ -866,7 +866,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1180,7 +1179,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2332,7 +2330,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "^1.26.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -5,7 +5,7 @@
 import { existsSync } from 'fs';
 import { readdir, readFile } from 'fs/promises';
 import { join } from 'path';
-import { execSync, spawnSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import {
   codexHome, codexConfigPath, codexPromptsDir,
   userSkillsDir, omxStateDir,
@@ -383,7 +383,7 @@ function listTeamTmuxSessions(): Set<string> | null {
 
 function checkCodexCli(): Check {
   try {
-    const version = execSync('codex --version 2>/dev/null', { encoding: 'utf-8' }).trim();
+    const version = execFileSync('codex', ['--version'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
     return { name: 'Codex CLI', status: 'pass', message: `installed (${version})` };
   } catch {
     return { name: 'Codex CLI', status: 'fail', message: 'not found - install from https://github.com/openai/codex' };

--- a/src/mcp/code-intel-server.ts
+++ b/src/mcp/code-intel-server.ts
@@ -182,7 +182,7 @@ async function findSgBinary(): Promise<string | null> {
   }
   // Try npx
   try {
-    await execFileAsync('npx', ['--yes', '@ast-grep/cli', '--version'], { timeout: 15000 });
+    await execFileAsync('npx', ['@ast-grep/cli', '--version'], { timeout: 15000 });
     return 'npx-ast-grep';
   } catch { /* not available */ }
   return null;

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -139,7 +139,9 @@ function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): void {
 
 export function getBaseStateDir(workingDirectory?: string): string {
   if ((workingDirectory == null || workingDirectory === '') && typeof process.env.OMX_TEAM_STATE_ROOT === 'string' && process.env.OMX_TEAM_STATE_ROOT.trim() !== '') {
-    return resolveWorkingDirectoryForState(process.env.OMX_TEAM_STATE_ROOT.trim());
+    try {
+      return resolveWorkingDirectoryForState(process.env.OMX_TEAM_STATE_ROOT.trim());
+    } catch {}
   }
   return join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state');
 }

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -108,6 +108,7 @@ function normalizePaneId(value: string | null | undefined): string | null {
 
 async function listLiveSessionPaneIds(sessionName: string): Promise<string[]> {
   if (!sessionName || !sessionName.trim()) return [];
+  if (!/^[a-zA-Z0-9_-]+$/.test(sessionName.trim())) return [];
   return await new Promise((resolve) => {
     const child = spawn('tmux', ['list-panes', '-t', sessionName, '-F', '#{pane_id}'], {
       stdio: ['ignore', 'pipe', 'ignore'],

--- a/src/team/orchestrator.ts
+++ b/src/team/orchestrator.ts
@@ -143,6 +143,10 @@ export function getPhaseAgents(phase: TeamPhase): string[] {
       return ['verifier', 'quality-reviewer', 'security-reviewer'];
     case 'team-fix':
       return ['executor', 'build-fixer', 'debugger'];
+    default: {
+      const _exhaustive: never = phase;
+      throw new Error(`Unknown team phase: ${_exhaustive}`);
+    }
   }
 }
 
@@ -161,5 +165,9 @@ export function getPhaseInstructions(phase: TeamPhase): string {
       return 'PHASE: Verification. Use /verifier for evidence collection, /quality-reviewer for review. Output: pass/fail with evidence.';
     case 'team-fix':
       return 'PHASE: Fixing. Use /debugger for root cause, /executor for fixes. Output: fixed code, re-verify needed.';
+    default: {
+      const _exhaustive: never = phase;
+      throw new Error(`Unknown team phase: ${_exhaustive}`);
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixes 6 security and code quality issues with minimal, targeted changes.

## Issues Fixed
- **#523**: Bump `@modelcontextprotocol/sdk` from `^1.0.0` to `^1.26.0` (covers CVE-2025-66414, CVE-2026-0621, CVE-2026-25536)
- **#488**: Remove `--yes` flag from `npx` ast-grep availability check (supply chain risk)
- **#493**: Validate tmux `sessionName` against strict alphanumeric pattern before passing to `spawn`
- **#495**: Wrap `OMX_TEAM_STATE_ROOT` env var in try/catch so it falls back to default path if validation fails
- **#496**: Replace `execSync('codex --version 2>/dev/null')` with `execFileSync('codex', ['--version'])` to eliminate shell injection surface
- **#508**: Add exhaustive `default` branches to `getPhaseAgents`/`getPhaseInstructions` switch statements

## Verification
- `npm run build` passes
- `lsp_diagnostics` clean on all changed files

Fixes #488, Fixes #493, Fixes #495, Fixes #496, Fixes #508, Fixes #523