### PR TITLE
fix(security): replace shell injection vectors with safe alternatives (#492, #494)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -123,6 +123,11 @@ const REASONING_MODES = ['low', 'medium', 'high', 'xhigh'] as const;
 type ReasoningMode = typeof REASONING_MODES[number];
 const REASONING_MODE_SET = new Set<string>(REASONING_MODES);
 const REASONING_USAGE = 'Usage: omx reasoning <low|medium|high|xhigh>';
+const ALLOWED_SHELLS = new Set([
+  '/bin/sh', '/bin/bash', '/bin/zsh', '/bin/dash', '/bin/fish',
+  '/usr/bin/sh', '/usr/bin/bash', '/usr/bin/zsh', '/usr/bin/dash', '/usr/bin/fish',
+  '/usr/local/bin/bash', '/usr/local/bin/zsh', '/usr/local/bin/fish',
+]);
 
 type CliCommand = 'launch' | 'setup' | 'uninstall' | 'doctor' | 'team' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
 
@@ -1174,7 +1179,8 @@ export function buildTmuxPaneCommand(command: string, args: string[], shellPath:
   } else if (shellPath && /\/bash$/i.test(shellPath)) {
     rcSource = 'if [ -f ~/.bashrc ]; then source ~/.bashrc; fi; ';
   }
-  const shellBin = shellPath && shellPath.trim() !== '' ? shellPath : '/bin/sh';
+  const rawShell = shellPath && shellPath.trim() !== '' ? shellPath.trim() : '/bin/sh';
+  const shellBin = ALLOWED_SHELLS.has(rawShell) ? rawShell : '/bin/sh';
   const inner = `${rcSource}exec ${bareCmd}`;
   return `${quoteShellArg(shellBin)} -lc ${quoteShellArg(inner)}`;
 }

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -89,7 +89,7 @@ function detectTmuxSessionByPid(): string | null {
 
       // Get parent PID
       try {
-        const ppidStr = execSync(`ps -o ppid= -p ${currentPid}`, {
+        const ppidStr = execFileSync("ps", ["-o", "ppid=", "-p", String(currentPid)], {
           encoding: "utf-8",
           timeout: 1000,
           stdio: ["pipe", "pipe", "pipe"],
@@ -235,7 +235,7 @@ function detectTmuxPaneByPid(): string | null {
         return panePids.get(currentPid) || null;
       }
       try {
-        const ppidStr = execSync(`ps -o ppid= -p ${currentPid}`, {
+        const ppidStr = execFileSync("ps", ["-o", "ppid=", "-p", String(currentPid)], {
           encoding: "utf-8",
           timeout: 1000,
           stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
Eliminates two shell injection attack surfaces in tmux PID detection and shell binary selection.

## Issues Fixed
- **#492**: Replace `execSync` template literal interpolation in `detectTmuxSessionByPid` and `detectTmuxPaneByPid` with `execFileSync('ps', [...args])` — no shell interpretation
- **#494**: Add `ALLOWED_SHELLS` allowlist for `process.env.SHELL` in `buildTmuxPaneCommand` — falls back to `/bin/sh` if shell path is not in the allowlist

## Verification
- `npm run build` passes
- `lsp_diagnostics` clean on all changed files

Fixes #492, Fixes #494