### PR TITLE
fix(perf): MCP server job eviction, trace limits, state caching, connect error handling (#497, #503, #504, #520)

### DIFF
--- a/src/mcp/memory-server.ts
+++ b/src/mcp/memory-server.ts
@@ -406,5 +406,8 @@ function appendToSection(content: string, section: string, entry: string): strin
 
 if (shouldAutoStartMcpServer('memory')) {
   const transport = new StdioServerTransport();
-  server.connect(transport).catch(console.error);
+  server.connect(transport).catch((err) => {
+    console.error('MCP server failed to connect:', err);
+    process.exit(1);
+  });
 }

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -118,6 +118,18 @@ const TEAM_UPDATE_TASK_MUTABLE_FIELDS = new Set(['subject', 'description', 'bloc
 const TEAM_UPDATE_TASK_REQUEST_FIELDS = new Set(['team_name', 'task_id', 'workingDirectory', ...TEAM_UPDATE_TASK_MUTABLE_FIELDS]);
 const stateWriteQueues = new Map<string, Promise<void>>();
 
+interface StateCache {
+  data: Map<string, unknown>;
+  timestamp: number;
+}
+
+const stateCache: StateCache = { data: new Map(), timestamp: 0 };
+const STATE_CACHE_TTL_MS = 500;
+
+function invalidateStateCache(): void {
+  stateCache.timestamp = 0;
+}
+
 async function withStateWriteLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
   const tail = stateWriteQueues.get(path) ?? Promise.resolve();
   let release!: () => void;
@@ -879,6 +891,7 @@ export async function handleStateToolCall(request: {
           isError: true,
         };
       }
+      invalidateStateCache();
       return { content: [{ type: 'text', text: JSON.stringify({ success: true, mode, path }) }] };
     }
 
@@ -891,6 +904,7 @@ export async function handleStateToolCall(request: {
         if (existsSync(path)) {
           await unlink(path);
         }
+        invalidateStateCache();
         return { content: [{ type: 'text', text: JSON.stringify({ cleared: true, mode, path }) }] };
       }
 
@@ -901,6 +915,8 @@ export async function handleStateToolCall(request: {
         await unlink(path);
         removedPaths.push(path);
       }
+
+      invalidateStateCache();
 
       return {
         content: [{
@@ -918,9 +934,18 @@ export async function handleStateToolCall(request: {
     }
 
     case 'state_list_active': {
+      const now = Date.now();
+      if (now - stateCache.timestamp < STATE_CACHE_TTL_MS && stateCache.data.size > 0) {
+        const cachedActive = [...stateCache.data.entries()]
+          .filter(([, data]) => Boolean((data as { active?: unknown }).active))
+          .map(([mode]) => mode);
+        return { content: [{ type: 'text', text: JSON.stringify({ active_modes: cachedActive }) }] };
+      }
+
       const stateDirs = await getReadScopedStateDirs(cwd, explicitSessionId);
       const active: string[] = [];
       const seenModes = new Set<string>();
+      const parsedResults = new Map<string, unknown>();
       for (const stateDir of stateDirs) {
         if (!existsSync(stateDir)) continue;
         const files = await readdir(stateDir);
@@ -931,12 +956,15 @@ export async function handleStateToolCall(request: {
           seenModes.add(mode);
           try {
             const data = JSON.parse(await readFile(join(stateDir, f), 'utf-8'));
+            parsedResults.set(mode, data);
             if (data.active) {
               active.push(mode);
             }
           } catch { /* skip malformed */ }
         }
       }
+      stateCache.data = parsedResults;
+      stateCache.timestamp = Date.now();
       return { content: [{ type: 'text', text: JSON.stringify({ active_modes: active }) }] };
     }
 
@@ -1452,5 +1480,8 @@ server.setRequestHandler(CallToolRequestSchema, handleStateToolCall);
 // Start server
 if (shouldAutoStartMcpServer('state')) {
   const transport = new StdioServerTransport();
-  server.connect(transport).catch(console.error);
+  server.connect(transport).catch((err) => {
+    console.error('MCP server failed to connect:', err);
+    process.exit(1);
+  });
 }

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -10,8 +10,8 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { readFile } from 'fs/promises';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { readFile, writeFile } from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
@@ -59,6 +59,7 @@ interface OmxTeamJob {
   result?: string;
   stderr?: string;
   startedAt: number;
+  completedAt?: number;
   pid?: number;
   paneIds?: string[];
   leaderPaneId?: string;
@@ -69,17 +70,43 @@ interface OmxTeamJob {
 
 const omxTeamJobs = new Map<string, OmxTeamJob>();
 const OMX_JOBS_DIR = join(homedir(), '.omx', 'team-jobs');
+const JOB_TTL_MS = 60 * 60 * 1000;
+const MAX_JOBS = 100;
 
-function persistJob(jobId: string, job: OmxTeamJob): void {
+function evictStaleJobs(): void {
+  const now = Date.now();
+  for (const [id, job] of omxTeamJobs) {
+    if ((job.status === 'completed' || job.status === 'failed')
+      && now - (job.completedAt ?? job.startedAt ?? 0) > JOB_TTL_MS) {
+      omxTeamJobs.delete(id);
+    }
+  }
+
+  if (omxTeamJobs.size > MAX_JOBS) {
+    const completed = [...omxTeamJobs.entries()]
+      .filter(([, job]) => job.status === 'completed' || job.status === 'failed')
+      .sort((a, b) => (a[1].completedAt ?? 0) - (b[1].completedAt ?? 0));
+    for (const [id] of completed) {
+      if (omxTeamJobs.size <= MAX_JOBS) break;
+      omxTeamJobs.delete(id);
+    }
+  }
+}
+
+async function persistJob(jobId: string, job: OmxTeamJob): Promise<void> {
   try {
     if (!existsSync(OMX_JOBS_DIR)) mkdirSync(OMX_JOBS_DIR, { recursive: true });
-    writeFileSync(join(OMX_JOBS_DIR, `${jobId}.json`), JSON.stringify(job), 'utf-8');
+    await writeFile(join(OMX_JOBS_DIR, `${jobId}.json`), JSON.stringify(job), 'utf-8');
   } catch { /* best-effort */ }
 }
 
-function loadJobFromDisk(jobId: string): OmxTeamJob | undefined {
+async function loadJobFromDisk(jobId: string): Promise<OmxTeamJob | undefined> {
+  const cached = omxTeamJobs.get(jobId);
+  if (cached) return cached;
   try {
-    return JSON.parse(readFileSync(join(OMX_JOBS_DIR, `${jobId}.json`), 'utf-8')) as OmxTeamJob;
+    const loaded = JSON.parse(await readFile(join(OMX_JOBS_DIR, `${jobId}.json`), 'utf-8')) as OmxTeamJob;
+    omxTeamJobs.set(jobId, loaded);
+    return loaded;
   } catch { return undefined; }
 }
 
@@ -286,6 +313,7 @@ export async function handleTeamToolCall(request: {
   try {
     switch (name) {
       case 'omx_run_team_start': {
+        evictStaleJobs();
         const { teamName, agentTypes, tasks, cwd: inputCwd } = startSchema.parse(a);
 
         const jobId = `omx-${Date.now().toString(36)}`;
@@ -299,7 +327,7 @@ export async function handleTeamToolCall(request: {
           stdio: ['pipe', 'pipe', 'pipe'],
         });
         job.pid = child.pid;
-        persistJob(jobId, job);
+        void persistJob(jobId, job);
 
         child.stdin.write(JSON.stringify({ teamName, agentTypes, tasks, cwd: inputCwd }));
         child.stdin.end();
@@ -328,14 +356,18 @@ export async function handleTeamToolCall(request: {
             if (code === 0) job.status = 'completed';
             else job.status = 'failed';
           }
+          if (job.status === 'completed' || job.status === 'failed') {
+            job.completedAt = Date.now();
+          }
           if (stderr) job.stderr = stderr;
-          persistJob(jobId, job);
+          void persistJob(jobId, job);
         });
 
         child.on('error', (err: Error) => {
           job.status = 'failed';
+          job.completedAt = Date.now();
           job.stderr = `spawn error: ${err.message}`;
-          persistJob(jobId, job);
+          void persistJob(jobId, job);
         });
 
         return {
@@ -344,8 +376,9 @@ export async function handleTeamToolCall(request: {
       }
 
       case 'omx_run_team_status': {
+        evictStaleJobs();
         const { job_id: jobId } = statusSchema.parse(a);
-        const job = omxTeamJobs.get(jobId) ?? loadJobFromDisk(jobId);
+        const job = omxTeamJobs.get(jobId) ?? await loadJobFromDisk(jobId);
         if (!job) {
           return { content: [{ type: 'text' as const, text: JSON.stringify({ error: `No job found: ${jobId}` }) }] };
         }
@@ -357,6 +390,7 @@ export async function handleTeamToolCall(request: {
       }
 
       case 'omx_run_team_wait': {
+        evictStaleJobs();
         const { job_id: jobId, timeout_ms: timeoutMs, nudge_delay_ms: nudgeDelayMs, nudge_max_count: nudgeMaxCount, nudge_message: nudgeMessage } = waitSchema.parse(a);
 
         const deadline = Date.now() + Math.min(timeoutMs, 3_600_000);
@@ -369,7 +403,7 @@ export async function handleTeamToolCall(request: {
         });
 
         while (Date.now() < deadline) {
-          const job = omxTeamJobs.get(jobId) ?? loadJobFromDisk(jobId);
+          const job = omxTeamJobs.get(jobId) ?? await loadJobFromDisk(jobId);
           if (!job) {
             return { content: [{ type: 'text' as const, text: JSON.stringify({ error: `No job found: ${jobId}` }) }] };
           }
@@ -381,8 +415,9 @@ export async function handleTeamToolCall(request: {
             } catch (e: unknown) {
               if ((e as NodeJS.ErrnoException).code === 'ESRCH') {
                 job.status = 'failed';
+                job.completedAt = Date.now();
                 if (!job.result) job.result = JSON.stringify({ error: 'Process no longer alive (MCP restart?)' });
-                persistJob(jobId, job);
+                await persistJob(jobId, job);
                 const elapsed = ((Date.now() - job.startedAt) / 1000).toFixed(1);
                 return { content: [{ type: 'text' as const, text: JSON.stringify({ jobId, status: 'failed', elapsedSeconds: elapsed, error: 'Process no longer alive (MCP restart?)' }) }] };
               }
@@ -426,8 +461,9 @@ export async function handleTeamToolCall(request: {
       }
 
       case 'omx_run_team_cleanup': {
+        evictStaleJobs();
         const { job_id: jobId, grace_ms: graceMs } = cleanupSchema.parse(a);
-        const job = omxTeamJobs.get(jobId) ?? loadJobFromDisk(jobId);
+        const job = omxTeamJobs.get(jobId) ?? await loadJobFromDisk(jobId);
         if (!job) return { content: [{ type: 'text' as const, text: `Job ${jobId} not found` }] };
         const selected = await resolveCleanupTargets(jobId, job);
         const cleanedUpAt = new Date().toISOString();
@@ -465,7 +501,7 @@ export async function handleTeamToolCall(request: {
           cleaned_up_at: cleanedUpAt,
         };
         job.cleanedUpAt = cleanedUpAt;
-        persistJob(jobId, job);
+        await persistJob(jobId, job);
         return {
           content: [
             {
@@ -494,5 +530,8 @@ server.setRequestHandler(CallToolRequestSchema, handleTeamToolCall);
 
 if (shouldAutoStartMcpServer('team')) {
   const transport = new StdioServerTransport();
-  server.connect(transport).catch(console.error);
+  server.connect(transport).catch((err) => {
+    console.error('MCP server failed to connect:', err);
+    process.exit(1);
+  });
 }

--- a/src/mcp/trace-server.ts
+++ b/src/mcp/trace-server.ts
@@ -34,25 +34,6 @@ function compareTraceTimestamp(a: TraceEntry, b: TraceEntry): number {
   return (a.timestamp || '').localeCompare(b.timestamp || '');
 }
 
-function keepLastEntries(entries: TraceEntry[], entry: TraceEntry, limit: number): void {
-  if (limit <= 0) return;
-
-  if (entries.length < limit) {
-    entries.push(entry);
-    entries.sort(compareTraceTimestamp);
-    return;
-  }
-
-  if (compareTraceTimestamp(entry, entries[0]) <= 0) return;
-
-  entries[0] = entry;
-  let i = 0;
-  while (i + 1 < entries.length && compareTraceTimestamp(entries[i], entries[i + 1]) > 0) {
-    [entries[i], entries[i + 1]] = [entries[i + 1], entries[i]];
-    i++;
-  }
-}
-
 async function* iterateLogEntries(logsDir: string): AsyncGenerator<TraceEntry> {
   if (!existsSync(logsDir)) return;
 
@@ -61,8 +42,14 @@ async function* iterateLogEntries(logsDir: string): AsyncGenerator<TraceEntry> {
     .sort();
 
   for (const file of files) {
+    const stream = createReadStream(join(logsDir, file), { encoding: 'utf-8' });
+    stream.on('error', (err) => {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error(`[trace-server] Error reading log file ${file}:`, err.message);
+      }
+    });
     const rl = createInterface({
-      input: createReadStream(join(logsDir, file), { encoding: 'utf-8' }),
+      input: stream,
       crlfDelay: Infinity,
     });
 
@@ -76,21 +63,14 @@ async function* iterateLogEntries(logsDir: string): AsyncGenerator<TraceEntry> {
 }
 
 export async function readLogFiles(logsDir: string, last?: number): Promise<TraceEntry[]> {
-  if (last && last > 0) {
-    const entries: TraceEntry[] = [];
-    for await (const entry of iterateLogEntries(logsDir)) {
-      keepLastEntries(entries, entry, last);
-    }
-    return entries;
-  }
-
+  const effectiveLast = last ?? 1000;
   const entries: TraceEntry[] = [];
   for await (const entry of iterateLogEntries(logsDir)) {
     entries.push(entry);
   }
 
   entries.sort(compareTraceTimestamp);
-  return entries;
+  return effectiveLast < entries.length ? entries.slice(-effectiveLast) : entries;
 }
 
 interface LogSummary {
@@ -331,5 +311,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 if (shouldAutoStartMcpServer('trace')) {
   const transport = new StdioServerTransport();
-  server.connect(transport).catch(console.error);
+  server.connect(transport).catch((err) => {
+    console.error('MCP server failed to connect:', err);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
## Summary
Fixes 4 performance and reliability issues across all MCP servers.

## Issues Fixed
- **#497**: Add TTL-based eviction and size cap to `omxTeamJobs` Map. Switch `persistJob`/`loadJobFromDisk` to async fs/promises. Add in-memory cache before disk reads.
- **#503**: Add error handler to `createReadStream` in trace-server. Add default limit of 1000 entries when `last` is unspecified.
- **#504**: Add 500ms TTL in-memory cache for `state_list_active`. Invalidate on `state_write`/`state_clear`.
- **#520**: Replace fire-and-forget `server.connect(transport).catch(console.error)` with fail-fast `process.exit(1)` in all 4 MCP servers.

## Verification
- `npm run build` passes
- `lsp_diagnostics` clean on all changed files

Fixes #497, Fixes #503, Fixes #504, Fixes #520