### PR TITLE
fix(concurrency): shutdown guard, notepad atomic writes, timer cleanup, scaling rollback (#516, #518, #521, #522)

### DIFF
--- a/src/mcp/memory-server.ts
+++ b/src/mcp/memory-server.ts
@@ -10,7 +10,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, rename } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { parseNotepadPruneDaysOld } from './memory-validation.js';
@@ -262,9 +262,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const notePath = getNotepadPath(wd);
       await mkdir(join(wd, '.omx'), { recursive: true });
       const content = a.content as string;
-      let existing = existsSync(notePath) ? await readFile(notePath, 'utf-8') : '';
+      let existing: string;
+      try {
+        existing = await readFile(notePath, 'utf-8');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          existing = '';
+        } else {
+          throw err;
+        }
+      }
       existing = replaceSection(existing, 'PRIORITY', content.slice(0, 500));
-      await writeFile(notePath, existing);
+      const tmpPath = notePath + '.tmp.' + process.pid;
+      await writeFile(tmpPath, existing);
+      await rename(tmpPath, notePath);
       return text({ success: true });
     }
 
@@ -272,9 +283,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const notePath = getNotepadPath(wd);
       await mkdir(join(wd, '.omx'), { recursive: true });
       const entry = `\n[${new Date().toISOString()}] ${a.content as string}`;
-      let existing = existsSync(notePath) ? await readFile(notePath, 'utf-8') : '';
+      let existing: string;
+      try {
+        existing = await readFile(notePath, 'utf-8');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          existing = '';
+        } else {
+          throw err;
+        }
+      }
       existing = appendToSection(existing, 'WORKING MEMORY', entry);
-      await writeFile(notePath, existing);
+      const tmpPath = notePath + '.tmp.' + process.pid;
+      await writeFile(tmpPath, existing);
+      await rename(tmpPath, notePath);
       return text({ success: true });
     }
 
@@ -282,9 +304,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const notePath = getNotepadPath(wd);
       await mkdir(join(wd, '.omx'), { recursive: true });
       const entry = `\n${a.content as string}`;
-      let existing = existsSync(notePath) ? await readFile(notePath, 'utf-8') : '';
+      let existing: string;
+      try {
+        existing = await readFile(notePath, 'utf-8');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          existing = '';
+        } else {
+          throw err;
+        }
+      }
       existing = appendToSection(existing, 'MANUAL', entry);
-      await writeFile(notePath, existing);
+      const tmpPath = notePath + '.tmp.' + process.pid;
+      await writeFile(tmpPath, existing);
+      await rename(tmpPath, notePath);
       return text({ success: true });
     }
 

--- a/src/notifications/dispatcher.ts
+++ b/src/notifications/dispatcher.ts
@@ -514,12 +514,15 @@ export async function dispatchNotifications(
       }),
     ]);
 
+    if (timer) clearTimeout(timer);
+
     return {
       event,
       results,
       anySuccess: results.some((r) => r.success),
     };
   } catch (error) {
+    if (timer) clearTimeout(timer);
     return {
       event,
       results: [
@@ -531,7 +534,5 @@ export async function dispatchNotifications(
       ],
       anySuccess: false,
     };
-  } finally {
-    if (timer) clearTimeout(timer);
   }
 }

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -201,14 +201,20 @@ async function main(): Promise<void> {
   }
 
   // Register signal handlers before poll loop
-  process.on('SIGINT', () => {
-    process.stderr.write('[runtime-cli] Received SIGINT, shutting down...\n');
-    doShutdown('failed').catch(() => process.exit(1));
-  });
-  process.on('SIGTERM', () => {
-    process.stderr.write('[runtime-cli] Received SIGTERM, shutting down...\n');
-    doShutdown('failed').catch(() => process.exit(1));
-  });
+  let shutdownInProgress = false;
+  const handleShutdown = (signal: string): void => {
+    if (shutdownInProgress) return;
+    shutdownInProgress = true;
+    process.stderr.write(`[runtime-cli] Received ${signal}, shutting down...\n`);
+    doShutdown('failed')
+      .catch((err) => {
+        process.stderr.write(`[runtime-cli] Shutdown error: ${err}\n`);
+      })
+      .finally(() => process.exit(1));
+  };
+
+  process.on('SIGINT', () => handleShutdown('SIGINT'));
+  process.on('SIGTERM', () => handleShutdown('SIGTERM'));
 
   // Start the team — OMX's startTeam takes individual parameters
   const agentType = agentTypes[0] ?? 'codex';

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -24,7 +24,7 @@ import {
   buildWorkerStartupCommand,
   resolveTeamWorkerCliPlan,
 } from './tmux-session.js';
-import { spawnSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import {
   teamReadConfig as readTeamConfig,
   teamSaveConfig as saveTeamConfig,
@@ -171,7 +171,34 @@ export async function scaleUp(
 
     // Resolve the monotonic worker index counter
     let nextIndex = config.next_worker_index ?? (currentCount + 1);
+    const initialNextIndex = nextIndex;
     const addedWorkers: WorkerInfo[] = [];
+
+    const rollbackScaleUp = async (error: string, paneId?: string): Promise<ScaleError> => {
+      for (const w of addedWorkers) {
+        const idx = config.workers.findIndex((worker) => worker.name === w.name);
+        if (idx >= 0) {
+          config.workers.splice(idx, 1);
+        }
+        try {
+          if (w.pane_id) {
+            execFileSync('tmux', ['kill-pane', '-t', w.pane_id], { stdio: 'pipe' });
+          }
+        } catch {}
+      }
+
+      if (paneId) {
+        try {
+          execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'pipe' });
+        } catch {}
+      }
+
+      config.worker_count = config.workers.length;
+      config.next_worker_index = initialNextIndex;
+      await saveTeamConfig(config, leaderCwd);
+
+      return { ok: false, error };
+    };
 
     // Resolve worker launch args
     const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, agentType);
@@ -213,12 +240,12 @@ export async function scaleUp(
       ], { encoding: 'utf-8' });
 
       if (result.status !== 0) {
-        return { ok: false, error: `Failed to create tmux pane for ${workerName}: ${(result.stderr || '').trim()}` };
+        return await rollbackScaleUp(`Failed to create tmux pane for ${workerName}: ${(result.stderr || '').trim()}`);
       }
 
       const paneId = (result.stdout || '').trim().split('\n')[0]?.trim();
       if (!paneId || !paneId.startsWith('%')) {
-        return { ok: false, error: `Failed to capture pane ID for ${workerName}` };
+        return await rollbackScaleUp(`Failed to capture pane ID for ${workerName}`);
       }
 
       // Intentionally avoid forcing `select-layout tiled` here.
@@ -398,17 +425,15 @@ export async function scaleUp(
         }
       }
       if (!outcome.ok) {
-        return { ok: false, error: `scale_up_dispatch_failed:${workerName}:${outcome.reason}` };
+        return await rollbackScaleUp(`scale_up_dispatch_failed:${workerName}:${outcome.reason}`, paneId);
       }
 
       addedWorkers.push(workerInfo);
       config.workers.push(workerInfo);
+      config.worker_count = config.workers.length;
+      config.next_worker_index = nextIndex;
+      await saveTeamConfig(config, leaderCwd);
     }
-
-    // Update config with new workers and next_worker_index
-    config.worker_count = config.workers.length;
-    config.next_worker_index = nextIndex;
-    await saveTeamConfig(config, leaderCwd);
 
     await appendTeamEvent(sanitized, {
       type: 'team_leader_nudge',


### PR DESCRIPTION
## Summary
Fixes 4 concurrency issues: signal handler race, notepad corruption, timer leak, and orphaned tmux panes.

## Issues Fixed
- **#516**: Add idempotent `shutdownInProgress` guard to signal handlers in `runtime-cli.ts`, preventing double `doShutdown` from corrupting team state.
- **#518**: Replace `existsSync + readFile` TOCTOU pattern with atomic try/catch in all 3 notepad write handlers. Use temp file + rename for atomic writes.
- **#521**: Add `clearTimeout(timer)` after `Promise.race` resolves in notification dispatcher, preventing timer/memory leak.
- **#522**: Save team config incrementally after each successful worker creation in `scaleUp`. On mid-loop failure, rollback by killing created panes and removing them from config.

## Verification
- `npm run build` passes
- `lsp_diagnostics` clean on all changed files

Fixes #516, Fixes #518, Fixes #521, Fixes #522