### PR TITLE
docs: complete multilingual README translations (Mission #12)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,314 @@
+# oh-my-codex (OMX)
+
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Dein Codex ist nicht allein.</em>
+</p>
+
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
+
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+Multi-Agenten-Orchestrierungsschicht für [OpenAI Codex CLI](https://github.com/openai/codex).
+
+## Sprachen
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX verwandelt Codex von einem Einzelsitzungs-Agenten in ein koordiniertes System mit:
+- Role Prompts (`/prompts:name`) für spezialisierte Agenten
+- Workflow Skills (`$name`) für wiederholbare Ausführungsmodi
+- Team-Orchestrierung in tmux (`omx team`, `$team`)
+- Persistenter Zustand und Speicher über MCP-Server
+
+## Warum OMX
+
+Codex CLI ist stark für direkte Aufgaben. OMX fügt Struktur für größere Arbeiten hinzu:
+- Zerlegung und stufenweise Ausführung (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- Persistenter Modus-Lebenszyklus-Zustand (`.omx/state/`)
+- Speicher- und Notepad-Oberflächen für langfristige Sitzungen
+- Operationelle Steuerung für Start, Verifizierung und Abbruch
+
+OMX ist ein Add-on, kein Fork. Es nutzt die nativen Erweiterungspunkte von Codex.
+
+## Voraussetzungen
+
+- macOS oder Linux (Windows über WSL2)
+- Node.js >= 20
+- Codex CLI installiert (`npm install -g @openai/codex`)
+- Codex-Authentifizierung konfiguriert
+
+## Schnellstart (3 Minuten)
+
+```bash
+npm install -g oh-my-codex
+omx setup
+omx doctor
+```
+
+Empfohlenes Startprofil für vertrauenswürdige Umgebungen:
+
+```bash
+omx --xhigh --madmax
+```
+
+## Neu in v0.5.0
+
+- **Bereichsbewusstes Setup** mit `omx setup --scope user|project` für flexible Installationsmodi.
+- **Spark-Worker-Routing** über `--spark` / `--madmax-spark`, damit Team-Worker `gpt-5.3-codex-spark` nutzen können, ohne das Leader-Modell zu erzwingen.
+- **Katalog-Konsolidierung** — veraltete Prompts (`deep-executor`, `scientist`) und 9 veraltete Skills entfernt.
+- **Benachrichtigungs-Detailstufen** für feingranulare CCNotifier-Ausgabesteuerung.
+
+## Erste Sitzung
+
+Innerhalb von Codex:
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+Vom Terminal:
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## Kernmodell
+
+OMX installiert und verbindet diese Schichten:
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (Orchestrierungs-Gehirn)
+    -> ~/.codex/prompts/*.md (Agenten-Prompt-Katalog)
+    -> ~/.agents/skills/*/SKILL.md (Skill-Katalog)
+    -> ~/.codex/config.toml (Features, Benachrichtigungen, MCP)
+    -> .omx/ (Laufzeitzustand, Speicher, Pläne, Protokolle)
+```
+
+## Hauptbefehle
+
+```bash
+omx                # Codex starten (+ HUD in tmux wenn verfügbar)
+omx setup          # Prompts/Skills/Config nach Bereich installieren + Projekt AGENTS.md/.omx
+omx doctor         # Installations-/Laufzeitdiagnose
+omx doctor --team  # Team/Swarm-Diagnose
+omx team ...       # tmux-Team-Worker starten/Status/fortsetzen/herunterfahren
+omx status         # Aktive Modi anzeigen
+omx cancel         # Aktive Ausführungsmodi abbrechen
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (Plugin-Erweiterungs-Workflow)
+omx hud ...        # --watch|--json|--preset
+omx help
+```
+
+## Hooks-Erweiterung (Additive Oberfläche)
+
+OMX enthält jetzt `omx hooks` für Plugin-Gerüstbau und -Validierung.
+
+- `omx tmux-hook` wird weiterhin unterstützt und ist unverändert.
+- `omx hooks` ist additiv und ersetzt keine tmux-hook-Workflows.
+- Plugin-Dateien befinden sich unter `.omx/hooks/*.mjs`.
+- Plugins sind standardmäßig deaktiviert; aktivieren mit `OMX_HOOK_PLUGINS=1`.
+
+Siehe `docs/hooks-extension.md` für den vollständigen Erweiterungs-Workflow und das Ereignismodell.
+
+## Start-Flags
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # nur bei setup
+```
+
+`--madmax` entspricht Codex `--dangerously-bypass-approvals-and-sandbox`.
+Nur in vertrauenswürdigen/externen Sandbox-Umgebungen verwenden.
+
+### MCP workingDirectory-Richtlinie (optionale Härtung)
+
+Standardmäßig akzeptieren MCP-Zustand/Speicher/Trace-Tools das vom Aufrufer bereitgestellte `workingDirectory`.
+Um dies einzuschränken, setzen Sie eine Erlaubnisliste von Wurzelverzeichnissen:
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+Wenn gesetzt, werden `workingDirectory`-Werte außerhalb dieser Wurzeln abgelehnt.
+
+## Codex-First Prompt-Steuerung
+
+Standardmäßig injiziert OMX:
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+Dies schichtet die `AGENTS.md`-Anweisungen des Projekts in die Codex-Startanweisungen.
+Es erweitert das Codex-Verhalten, ersetzt/umgeht aber nicht die Codex-Kernsystemrichtlinien.
+
+Steuerung:
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # AGENTS.md-Injektion deaktivieren
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## Team-Modus
+
+Verwenden Sie den Team-Modus für umfangreiche Arbeiten, die von parallelen Workern profitieren.
+
+Lebenszyklus:
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+Operationelle Befehle:
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+Wichtige Regel: Fahren Sie nicht herunter, während Aufgaben noch `in_progress` sind, es sei denn, Sie brechen ab.
+
+### Ralph-Aufräumrichtlinie
+
+Wenn ein Team im Ralph-Modus läuft (`omx team ralph ...`), wendet die Shutdown-Bereinigung
+eine spezielle Richtlinie an, die sich vom normalen Pfad unterscheidet:
+
+| Verhalten | Normales Team | Ralph-Team |
+|---|---|---|
+| Erzwungenes Herunterfahren bei Fehler | Wirft `shutdown_gate_blocked` | Umgeht Gate, protokolliert `ralph_cleanup_policy`-Ereignis |
+| Automatische Branch-Löschung | Löscht Worktree-Branches bei Rollback | Bewahrt Branches (`skipBranchDeletion`) |
+| Abschluss-Protokollierung | Standard-`shutdown_gate`-Ereignis | Zusätzliches `ralph_cleanup_summary`-Ereignis mit Aufgabenaufschlüsselung |
+
+Die Ralph-Richtlinie wird automatisch aus dem Team-Modus-Zustand (`linked_ralph`) erkannt oder
+kann explizit über `omx team shutdown <name> --ralph` übergeben werden.
+
+Worker-CLI-Auswahl für Team-Worker:
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # Standard; verwendet claude wenn Worker --model "claude" enthält
+OMX_TEAM_WORKER_CLI=codex   # Codex-CLI-Worker erzwingen
+OMX_TEAM_WORKER_CLI=claude  # Claude-CLI-Worker erzwingen
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # CLI-Mix pro Worker (Länge=1 oder Worker-Anzahl)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # optional: adaptiven Queue->Resend-Fallback deaktivieren
+```
+
+Hinweise:
+- Worker-Startargumente werden weiterhin über `OMX_TEAM_WORKER_LAUNCH_ARGS` geteilt.
+- `OMX_TEAM_WORKER_CLI_MAP` überschreibt `OMX_TEAM_WORKER_CLI` für Worker-spezifische Auswahl.
+- Trigger-Übermittlung verwendet standardmäßig adaptive Wiederholungsversuche (Queue/Submit, dann sicherer Clear-Line+Resend-Fallback bei Bedarf).
+- Im Claude-Worker-Modus startet OMX Worker als einfaches `claude` (keine zusätzlichen Startargumente) und ignoriert explizite `--model` / `--config` / `--effort`-Überschreibungen, sodass Claude die Standard-`settings.json` verwendet.
+
+## Was `omx setup` schreibt
+
+- `.omx/setup-scope.json` (persistierter Setup-Bereich)
+- Bereichsabhängige Installationen:
+  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Startverhalten: Wenn der persistierte Bereich `project` ist, verwendet `omx` automatisch `CODEX_HOME=./.codex` (sofern `CODEX_HOME` nicht bereits gesetzt ist).
+- Vorhandene `AGENTS.md` wird standardmäßig beibehalten. Bei interaktiven TTY-Läufen fragt Setup vor dem Überschreiben; `--force` überschreibt ohne Nachfrage (aktive Sitzungs-Sicherheitsprüfungen gelten weiterhin).
+- `config.toml`-Aktualisierungen (für beide Bereiche):
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - MCP-Server-Einträge (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- Projekt-`AGENTS.md`
+- `.omx/`-Laufzeitverzeichnisse und HUD-Konfiguration
+
+## Agenten und Skills
+
+- Prompts: `prompts/*.md` (installiert nach `~/.codex/prompts/` für `user`, `./.codex/prompts/` für `project`)
+- Skills: `skills/*/SKILL.md` (installiert nach `~/.agents/skills/` für `user`, `./.agents/skills/` für `project`)
+
+Beispiele:
+- Agenten: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- Skills: `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## Projektstruktur
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## Entwicklung
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## Dokumentation
+
+- **[Vollständige Dokumentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Kompletter Leitfaden
+- **[CLI-Referenz](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Alle `omx`-Befehle, Flags und Tools
+- **[Benachrichtigungs-Leitfaden](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Discord, Telegram, Slack und Webhook-Einrichtung
+- **[Empfohlene Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Praxiserprobte Skill-Ketten für häufige Aufgaben
+- **[Versionshinweise](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Neuheiten in jeder Version
+
+## Hinweise
+
+- Vollständiges Änderungsprotokoll: `CHANGELOG.md`
+- Migrationsleitfaden (nach v0.4.4 mainline): `docs/migration-mainline-post-v0.4.4.md`
+- Abdeckungs- und Paritätsnotizen: `COVERAGE.md`
+- Hook-Erweiterungs-Workflow: `docs/hooks-extension.md`
+- Setup- und Beitragsdetails: `CONTRIBUTING.md`
+
+## Danksagungen
+
+Inspiriert von [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), angepasst für Codex CLI.
+
+## Lizenz
+
+MIT

--- a/README.es.md
+++ b/README.es.md
@@ -1,10 +1,59 @@
-# oh-my-codex (OMX) README en Español
+# oh-my-codex (OMX)
 
-> Para la documentación completa original, consulta [English README](./README.md).
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Tu codex no está solo.</em>
+</p>
 
-OMX es una capa de orquestación multiagente para OpenAI Codex CLI.
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-## Inicio rápido
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+Capa de orquestación multiagente para [OpenAI Codex CLI](https://github.com/openai/codex).
+
+## Idiomas
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX convierte Codex de un agente de sesión única en un sistema coordinado con:
+- Role prompts (`/prompts:name`) para agentes especializados
+- Workflow skills (`$name`) para modos de ejecución repetibles
+- Orquestación de equipos en tmux (`omx team`, `$team`)
+- Estado persistente y memoria a través de servidores MCP
+
+## Por qué OMX
+
+Codex CLI es potente para tareas directas. OMX añade estructura para trabajo más amplio:
+- Descomposición y ejecución por etapas (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- Estado persistente del ciclo de vida de modos (`.omx/state/`)
+- Superficies de memoria y bloc de notas para sesiones prolongadas
+- Controles operacionales para inicio, verificación y cancelación
+
+OMX es un complemento, no un fork. Utiliza los puntos de extensión nativos de Codex.
+
+## Requisitos
+
+- macOS o Linux (Windows vía WSL2)
+- Node.js >= 20
+- Codex CLI instalado (`npm install -g @openai/codex`)
+- Autenticación de Codex configurada
+
+## Inicio rápido (3 minutos)
 
 ```bash
 npm install -g oh-my-codex
@@ -12,25 +61,254 @@ omx setup
 omx doctor
 ```
 
-## Funcionalidades clave
+Perfil de inicio recomendado para entornos de confianza:
 
-- Ejecución de agentes especializados con prompts de rol (`/prompts:name`)
-- Automatización de flujos repetibles con skills (`$name`)
-- Orquestación en equipo con tmux (`omx team`, `$team`)
-- Estado y memoria persistentes mediante servidores MCP
+```bash
+omx --xhigh --madmax
+```
+
+## Novedades en v0.5.0
+
+- **Configuración con alcance** mediante `omx setup --scope user|project` para modos de instalación flexibles.
+- **Enrutamiento de Spark worker** vía `--spark` / `--madmax-spark` — los workers del equipo pueden usar `gpt-5.3-codex-spark` sin forzar el modelo líder.
+- **Consolidación del catálogo** — se eliminaron prompts obsoletos (`deep-executor`, `scientist`) y 9 skills obsoletos para una superficie más compacta.
+- **Niveles de detalle de notificaciones** para control granular de la salida de CCNotifier.
+
+## Primera sesión
+
+Dentro de Codex:
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+Desde la terminal:
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## Modelo central
+
+OMX instala y conecta estas capas:
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (cerebro de orquestación)
+    -> ~/.codex/prompts/*.md (catálogo de prompts de agentes)
+    -> ~/.agents/skills/*/SKILL.md (catálogo de skills)
+    -> ~/.codex/config.toml (características, notificaciones, MCP)
+    -> .omx/ (estado en ejecución, memoria, planes, registros)
+```
 
 ## Comandos principales
 
 ```bash
-omx
-omx setup
-omx doctor
-omx team <args>
-omx status
-omx cancel
+omx                # Lanzar Codex (+ HUD en tmux cuando está disponible)
+omx setup          # Instalar prompts/skills/config por alcance + proyecto AGENTS.md/.omx
+omx doctor         # Diagnósticos de instalación/ejecución
+omx doctor --team  # Diagnósticos de Team/swarm
+omx team ...       # Iniciar/estado/reanudar/apagar workers tmux del equipo
+omx status         # Mostrar modos activos
+omx cancel         # Cancelar modos de ejecución activos
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (flujo de trabajo de extensión de plugins)
+omx hud ...        # --watch|--json|--preset
+omx help
 ```
 
-## Más información
+## Extensión de Hooks (Superficie adicional)
 
-- Documento principal: [README.md](./README.md)
-- Sitio web: https://yeachan-heo.github.io/oh-my-codex-website/
+OMX ahora incluye `omx hooks` para scaffolding y validación de plugins.
+
+- `omx tmux-hook` sigue siendo compatible y no ha cambiado.
+- `omx hooks` es aditivo y no reemplaza los flujos de trabajo de tmux-hook.
+- Los archivos de plugins se encuentran en `.omx/hooks/*.mjs`.
+- Los plugins están desactivados por defecto; actívalos con `OMX_HOOK_PLUGINS=1`.
+
+Consulta `docs/hooks-extension.md` para el flujo de trabajo completo de extensiones y el modelo de eventos.
+
+## Flags de inicio
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # solo para setup
+```
+
+`--madmax` se mapea a Codex `--dangerously-bypass-approvals-and-sandbox`.
+Úsalo solo en entornos sandbox de confianza o externos.
+
+### Política de workingDirectory MCP (endurecimiento opcional)
+
+Por defecto, las herramientas MCP de state/memory/trace aceptan el `workingDirectory` proporcionado por el llamador.
+Para restringir esto, establece una lista de raíces permitidas:
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+Cuando se establece, los valores de `workingDirectory` fuera de estas raíces son rechazados.
+
+## Control de prompts Codex-First
+
+Por defecto, OMX inyecta:
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+Esto añade las instrucciones del proyecto `AGENTS.md` a los comandos de inicio de Codex.
+Extiende el comportamiento de Codex, pero no reemplaza ni elude las políticas centrales del sistema Codex.
+
+Controles:
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # desactivar inyección de AGENTS.md
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## Modo equipo
+
+Usa el modo equipo para trabajo amplio que se beneficia de workers paralelos.
+
+Ciclo de vida:
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+Comandos operacionales:
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+Regla importante: no apagues mientras las tareas estén en estado `in_progress` a menos que estés abortando.
+
+### Política de limpieza Ralph
+
+Cuando un equipo se ejecuta en modo ralph (`omx team ralph ...`), la limpieza al apagar
+aplica una política dedicada diferente a la ruta normal:
+
+| Comportamiento | Equipo normal | Equipo Ralph |
+|---|---|---|
+| Apagado forzado en caso de fallo | Lanza `shutdown_gate_blocked` | Omite la puerta, registra evento `ralph_cleanup_policy` |
+| Eliminación automática de ramas | Elimina ramas de worktree en rollback | Preserva ramas (`skipBranchDeletion`) |
+| Registro de finalización | Evento estándar `shutdown_gate` | Evento adicional `ralph_cleanup_summary` con desglose de tareas |
+
+La política Ralph se detecta automáticamente del estado del modo equipo (`linked_ralph`) o
+se puede pasar explícitamente vía `omx team shutdown <name> --ralph`.
+
+Selección de Worker CLI para los workers del equipo:
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # predeterminado; usa claude cuando worker --model contiene "claude"
+OMX_TEAM_WORKER_CLI=codex   # forzar workers Codex CLI
+OMX_TEAM_WORKER_CLI=claude  # forzar workers Claude CLI
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # mezcla de CLI por worker (longitud=1 o cantidad de workers)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # opcional: desactivar fallback adaptativo queue->resend
+```
+
+Notas:
+- Los argumentos de inicio de workers se comparten a través de `OMX_TEAM_WORKER_LAUNCH_ARGS`.
+- `OMX_TEAM_WORKER_CLI_MAP` anula `OMX_TEAM_WORKER_CLI` para selección por worker.
+- El envío de triggers usa reintentos adaptativos por defecto (queue/submit, luego fallback seguro clear-line+resend cuando es necesario).
+- En modo Claude worker, OMX lanza workers como `claude` simple (sin argumentos de inicio extra) e ignora anulaciones explícitas de `--model` / `--config` / `--effort` para que Claude use el `settings.json` predeterminado.
+
+## Qué escribe `omx setup`
+
+- `.omx/setup-scope.json` (alcance de instalación persistido)
+- Instalaciones dependientes del alcance:
+  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Comportamiento de inicio: si el alcance persistido es `project`, el lanzamiento de `omx` usa automáticamente `CODEX_HOME=./.codex` (a menos que `CODEX_HOME` ya esté establecido).
+- El `AGENTS.md` existente se preserva por defecto. En ejecuciones TTY interactivas, setup pregunta antes de sobrescribir; `--force` sobrescribe sin preguntar (las verificaciones de seguridad de sesiones activas siguen aplicándose).
+- Actualizaciones de `config.toml` (para ambos alcances):
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - Entradas de servidores MCP (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- `AGENTS.md` del proyecto
+- Directorios `.omx/` de ejecución y configuración de HUD
+
+## Agentes y skills
+
+- Prompts: `prompts/*.md` (instalados en `~/.codex/prompts/` para `user`, `./.codex/prompts/` para `project`)
+- Skills: `skills/*/SKILL.md` (instalados en `~/.agents/skills/` para `user`, `./.agents/skills/` para `project`)
+
+Ejemplos:
+- Agentes: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- Skills: `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## Estructura del proyecto
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## Desarrollo
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## Documentación
+
+- **[Documentación completa](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Guía completa
+- **[Referencia CLI](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Todos los comandos `omx`, flags y herramientas
+- **[Guía de notificaciones](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Configuración de Discord, Telegram, Slack y webhooks
+- **[Flujos de trabajo recomendados](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Cadenas de skills probadas en batalla para tareas comunes
+- **[Notas de versión](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Novedades en cada versión
+
+## Notas
+
+- Registro de cambios completo: `CHANGELOG.md`
+- Guía de migración (post-v0.4.4 mainline): `docs/migration-mainline-post-v0.4.4.md`
+- Notas de cobertura y paridad: `COVERAGE.md`
+- Flujo de trabajo de extensión de hooks: `docs/hooks-extension.md`
+- Detalles de instalación y contribución: `CONTRIBUTING.md`
+
+## Agradecimientos
+
+Inspirado en [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), adaptado para Codex CLI.
+
+## Licencia
+
+MIT

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,314 @@
+# oh-my-codex (OMX)
+
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Votre codex n'est pas seul.</em>
+</p>
+
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
+
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+Couche d'orchestration multi-agents pour [OpenAI Codex CLI](https://github.com/openai/codex).
+
+## Langues
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX transforme Codex d'un agent mono-session en un système coordonné avec :
+- Des role prompts (`/prompts:name`) pour les agents spécialisés
+- Des workflow skills (`$name`) pour les modes d'exécution reproductibles
+- L'orchestration d'équipe dans tmux (`omx team`, `$team`)
+- Un état et une mémoire persistants via les serveurs MCP
+
+## Pourquoi OMX
+
+Codex CLI est performant pour les tâches directes. OMX ajoute de la structure pour les travaux plus importants :
+- Décomposition et exécution par étapes (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- État persistant du cycle de vie des modes (`.omx/state/`)
+- Surfaces de mémoire et notepad pour les sessions longue durée
+- Contrôles opérationnels pour le lancement, la vérification et l'annulation
+
+OMX est un add-on, pas un fork. Il utilise les points d'extension natifs de Codex.
+
+## Prérequis
+
+- macOS ou Linux (Windows via WSL2)
+- Node.js >= 20
+- Codex CLI installé (`npm install -g @openai/codex`)
+- Authentification Codex configurée
+
+## Démarrage rapide (3 minutes)
+
+```bash
+npm install -g oh-my-codex
+omx setup
+omx doctor
+```
+
+Profil de lancement recommandé pour les environnements de confiance :
+
+```bash
+omx --xhigh --madmax
+```
+
+## Nouveautés de la v0.5.0
+
+- **Configuration sensible au scope** avec `omx setup --scope user|project` pour des modes d'installation flexibles.
+- **Routage Spark worker** via `--spark` / `--madmax-spark` pour que les workers d'équipe puissent utiliser `gpt-5.3-codex-spark` sans forcer le modèle leader.
+- **Consolidation du catalogue** — suppression des prompts obsolètes (`deep-executor`, `scientist`) et de 9 skills obsolètes.
+- **Niveaux de verbosité des notifications** pour un contrôle fin de la sortie CCNotifier.
+
+## Première session
+
+Dans Codex :
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+Depuis le terminal :
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## Modèle de base
+
+OMX installe et connecte ces couches :
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (cerveau d'orchestration)
+    -> ~/.codex/prompts/*.md (catalogue de prompts d'agents)
+    -> ~/.agents/skills/*/SKILL.md (catalogue de skills)
+    -> ~/.codex/config.toml (fonctionnalités, notifications, MCP)
+    -> .omx/ (état d'exécution, mémoire, plans, journaux)
+```
+
+## Commandes principales
+
+```bash
+omx                # Lancer Codex (+ HUD dans tmux si disponible)
+omx setup          # Installer prompts/skills/config par scope + projet AGENTS.md/.omx
+omx doctor         # Diagnostics d'installation/exécution
+omx doctor --team  # Diagnostics Team/Swarm
+omx team ...       # Démarrer/statut/reprendre/arrêter les workers d'équipe tmux
+omx status         # Afficher les modes actifs
+omx cancel         # Annuler les modes d'exécution actifs
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (workflow d'extension de plugins)
+omx hud ...        # --watch|--json|--preset
+omx help
+```
+
+## Extension Hooks (Surface additive)
+
+OMX inclut désormais `omx hooks` pour l'échafaudage et la validation de plugins.
+
+- `omx tmux-hook` reste supporté et inchangé.
+- `omx hooks` est additif et ne remplace pas les workflows tmux-hook.
+- Les fichiers de plugins se trouvent dans `.omx/hooks/*.mjs`.
+- Les plugins sont désactivés par défaut ; activez-les avec `OMX_HOOK_PLUGINS=1`.
+
+Consultez `docs/hooks-extension.md` pour le workflow d'extension complet et le modèle d'événements.
+
+## Flags de lancement
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # uniquement pour setup
+```
+
+`--madmax` correspond à Codex `--dangerously-bypass-approvals-and-sandbox`.
+À utiliser uniquement dans des environnements sandbox de confiance/externes.
+
+### Politique MCP workingDirectory (durcissement optionnel)
+
+Par défaut, les outils MCP état/mémoire/trace acceptent le `workingDirectory` fourni par l'appelant.
+Pour restreindre cela, définissez une liste d'autorisation de racines :
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+Lorsque défini, les valeurs `workingDirectory` en dehors de ces racines sont rejetées.
+
+## Contrôle Codex-First des prompts
+
+Par défaut, OMX injecte :
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+Cela superpose les instructions `AGENTS.md` du projet dans les instructions de lancement de Codex.
+Cela étend le comportement de Codex, mais ne remplace/contourne pas les politiques système de base de Codex.
+
+Contrôles :
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # désactiver l'injection AGENTS.md
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## Mode équipe
+
+Utilisez le mode équipe pour les travaux importants qui bénéficient de workers parallèles.
+
+Cycle de vie :
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+Commandes opérationnelles :
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+Règle importante : n'arrêtez pas tant que des tâches sont encore `in_progress`, sauf en cas d'abandon.
+
+### Politique de nettoyage Ralph
+
+Lorsqu'une équipe s'exécute en mode ralph (`omx team ralph ...`), le nettoyage à l'arrêt
+applique une politique dédiée qui diffère du chemin normal :
+
+| Comportement | Équipe normale | Équipe Ralph |
+|---|---|---|
+| Arrêt forcé en cas d'échec | Lance `shutdown_gate_blocked` | Contourne la porte, journalise l'événement `ralph_cleanup_policy` |
+| Suppression automatique des branches | Supprime les branches worktree lors du rollback | Préserve les branches (`skipBranchDeletion`) |
+| Journalisation de complétion | Événement standard `shutdown_gate` | Événement supplémentaire `ralph_cleanup_summary` avec détail des tâches |
+
+La politique ralph est auto-détectée depuis l'état du mode équipe (`linked_ralph`) ou
+peut être passée explicitement via `omx team shutdown <name> --ralph`.
+
+Sélection du CLI worker pour les workers d'équipe :
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # par défaut ; utilise claude quand worker --model contient "claude"
+OMX_TEAM_WORKER_CLI=codex   # forcer les workers Codex CLI
+OMX_TEAM_WORKER_CLI=claude  # forcer les workers Claude CLI
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # mix CLI par worker (longueur=1 ou nombre de workers)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # optionnel : désactiver le fallback adaptatif queue->resend
+```
+
+Notes :
+- Les arguments de lancement des workers sont toujours partagés via `OMX_TEAM_WORKER_LAUNCH_ARGS`.
+- `OMX_TEAM_WORKER_CLI_MAP` remplace `OMX_TEAM_WORKER_CLI` pour la sélection par worker.
+- La soumission de déclencheurs utilise par défaut des tentatives adaptatives (queue/submit, puis fallback sécurisé clear-line+resend si nécessaire).
+- En mode worker Claude, OMX lance les workers en tant que simple `claude` (pas d'arguments de lancement supplémentaires) et ignore les surcharges explicites `--model` / `--config` / `--effort` pour que Claude utilise le `settings.json` par défaut.
+
+## Ce que `omx setup` écrit
+
+- `.omx/setup-scope.json` (scope de setup persisté)
+- Installations dépendantes du scope :
+  - `user` : `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project` : `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Comportement au lancement : si le scope persisté est `project`, le lancement `omx` utilise automatiquement `CODEX_HOME=./.codex` (sauf si `CODEX_HOME` est déjà défini).
+- Le `AGENTS.md` existant est préservé par défaut. Lors des exécutions TTY interactives, setup demande confirmation avant d'écraser ; `--force` écrase sans demander (les vérifications de sécurité de session active s'appliquent toujours).
+- Mises à jour de `config.toml` (pour les deux scopes) :
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - Entrées de serveurs MCP (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- `AGENTS.md` du projet
+- Répertoires d'exécution `.omx/` et configuration HUD
+
+## Agents et Skills
+
+- Prompts : `prompts/*.md` (installés dans `~/.codex/prompts/` pour `user`, `./.codex/prompts/` pour `project`)
+- Skills : `skills/*/SKILL.md` (installés dans `~/.agents/skills/` pour `user`, `./.agents/skills/` pour `project`)
+
+Exemples :
+- Agents : `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- Skills : `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## Structure du projet
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## Développement
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## Documentation
+
+- **[Documentation complète](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Guide complet
+- **[Référence CLI](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Toutes les commandes `omx`, flags et outils
+- **[Guide des notifications](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Configuration Discord, Telegram, Slack et webhooks
+- **[Workflows recommandés](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Chaînes de skills éprouvées pour les tâches courantes
+- **[Notes de version](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Nouveautés de chaque version
+
+## Notes
+
+- Journal des modifications complet : `CHANGELOG.md`
+- Guide de migration (post-v0.4.4 mainline) : `docs/migration-mainline-post-v0.4.4.md`
+- Notes de couverture et parité : `COVERAGE.md`
+- Workflow d'extension hooks : `docs/hooks-extension.md`
+- Détails de configuration et contribution : `CONTRIBUTING.md`
+
+## Remerciements
+
+Inspiré par [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), adapté pour Codex CLI.
+
+## Licence
+
+MIT

--- a/README.it.md
+++ b/README.it.md
@@ -1,0 +1,314 @@
+# oh-my-codex (OMX)
+
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Il tuo codex non è solo.</em>
+</p>
+
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
+
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+Livello di orchestrazione multi-agente per [OpenAI Codex CLI](https://github.com/openai/codex).
+
+## Lingue
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX trasforma Codex da un agente a sessione singola in un sistema coordinato con:
+- Role prompts (`/prompts:name`) per agenti specializzati
+- Workflow skills (`$name`) per modalità di esecuzione ripetibili
+- Orchestrazione team in tmux (`omx team`, `$team`)
+- Stato e memoria persistenti tramite server MCP
+
+## Perché OMX
+
+Codex CLI è efficace per compiti diretti. OMX aggiunge struttura per lavori più ampi:
+- Decomposizione ed esecuzione a stadi (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- Stato persistente del ciclo di vita delle modalità (`.omx/state/`)
+- Superfici di memoria e notepad per sessioni di lunga durata
+- Controlli operativi per avvio, verifica e annullamento
+
+OMX è un add-on, non un fork. Utilizza i punti di estensione nativi di Codex.
+
+## Requisiti
+
+- macOS o Linux (Windows tramite WSL2)
+- Node.js >= 20
+- Codex CLI installato (`npm install -g @openai/codex`)
+- Autenticazione Codex configurata
+
+## Avvio rapido (3 minuti)
+
+```bash
+npm install -g oh-my-codex
+omx setup
+omx doctor
+```
+
+Profilo di avvio consigliato per ambienti fidati:
+
+```bash
+omx --xhigh --madmax
+```
+
+## Novità nella v0.5.0
+
+- **Setup sensibile allo scope** con `omx setup --scope user|project` per modalità di installazione flessibili.
+- **Routing Spark worker** tramite `--spark` / `--madmax-spark` in modo che i worker del team possano usare `gpt-5.3-codex-spark` senza forzare il modello leader.
+- **Consolidamento del catalogo** — rimossi prompt obsoleti (`deep-executor`, `scientist`) e 9 skill obsolete.
+- **Livelli di verbosità delle notifiche** per un controllo dettagliato dell'output CCNotifier.
+
+## Prima sessione
+
+All'interno di Codex:
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+Dal terminale:
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## Modello di base
+
+OMX installa e collega questi livelli:
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (cervello dell'orchestrazione)
+    -> ~/.codex/prompts/*.md (catalogo prompt degli agenti)
+    -> ~/.agents/skills/*/SKILL.md (catalogo skill)
+    -> ~/.codex/config.toml (funzionalità, notifiche, MCP)
+    -> .omx/ (stato di esecuzione, memoria, piani, log)
+```
+
+## Comandi principali
+
+```bash
+omx                # Avvia Codex (+ HUD in tmux se disponibile)
+omx setup          # Installa prompt/skill/config per scope + progetto AGENTS.md/.omx
+omx doctor         # Diagnostica installazione/esecuzione
+omx doctor --team  # Diagnostica Team/Swarm
+omx team ...       # Avvia/stato/riprendi/arresta i worker del team tmux
+omx status         # Mostra le modalità attive
+omx cancel         # Annulla le modalità di esecuzione attive
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (workflow estensione plugin)
+omx hud ...        # --watch|--json|--preset
+omx help
+```
+
+## Estensione Hooks (Superficie additiva)
+
+OMX ora include `omx hooks` per lo scaffolding e la validazione dei plugin.
+
+- `omx tmux-hook` resta supportato e invariato.
+- `omx hooks` è additivo e non sostituisce i workflow tmux-hook.
+- I file dei plugin si trovano in `.omx/hooks/*.mjs`.
+- I plugin sono disattivati per impostazione predefinita; abilitali con `OMX_HOOK_PLUGINS=1`.
+
+Consulta `docs/hooks-extension.md` per il workflow completo di estensione e il modello degli eventi.
+
+## Flag di avvio
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # solo per setup
+```
+
+`--madmax` corrisponde a Codex `--dangerously-bypass-approvals-and-sandbox`.
+Utilizzare solo in ambienti sandbox fidati/esterni.
+
+### Policy MCP workingDirectory (hardening opzionale)
+
+Per impostazione predefinita, gli strumenti MCP stato/memoria/trace accettano il `workingDirectory` fornito dal chiamante.
+Per limitare questo, imposta una lista di directory root consentite:
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+Quando impostato, i valori `workingDirectory` al di fuori di queste root vengono rifiutati.
+
+## Controllo Codex-First dei prompt
+
+Per impostazione predefinita, OMX inietta:
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+Questo sovrappone le istruzioni `AGENTS.md` del progetto alle istruzioni di avvio di Codex.
+Estende il comportamento di Codex, ma non sostituisce/aggira le policy di sistema core di Codex.
+
+Controlli:
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # disabilita l'iniezione AGENTS.md
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## Modalità team
+
+Usa la modalità team per lavori ampi che beneficiano di worker paralleli.
+
+Ciclo di vita:
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+Comandi operativi:
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+Regola importante: non arrestare mentre i task sono ancora `in_progress`, a meno che non si stia abortendo.
+
+### Policy di pulizia Ralph
+
+Quando un team è in esecuzione in modalità ralph (`omx team ralph ...`), la pulizia allo shutdown
+applica una policy dedicata che differisce dal percorso normale:
+
+| Comportamento | Team normale | Team Ralph |
+|---|---|---|
+| Shutdown forzato in caso di errore | Lancia `shutdown_gate_blocked` | Aggira il gate, registra l'evento `ralph_cleanup_policy` |
+| Eliminazione automatica dei branch | Elimina i branch worktree durante il rollback | Preserva i branch (`skipBranchDeletion`) |
+| Logging di completamento | Evento standard `shutdown_gate` | Evento aggiuntivo `ralph_cleanup_summary` con dettaglio dei task |
+
+La policy ralph viene rilevata automaticamente dallo stato della modalità team (`linked_ralph`) o
+può essere passata esplicitamente tramite `omx team shutdown <name> --ralph`.
+
+Selezione CLI worker per i worker del team:
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # predefinito; usa claude quando worker --model contiene "claude"
+OMX_TEAM_WORKER_CLI=codex   # forza i worker Codex CLI
+OMX_TEAM_WORKER_CLI=claude  # forza i worker Claude CLI
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # mix CLI per worker (lunghezza=1 o numero di worker)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # opzionale: disabilita il fallback adattivo queue->resend
+```
+
+Note:
+- Gli argomenti di avvio dei worker sono ancora condivisi tramite `OMX_TEAM_WORKER_LAUNCH_ARGS`.
+- `OMX_TEAM_WORKER_CLI_MAP` sovrascrive `OMX_TEAM_WORKER_CLI` per la selezione per singolo worker.
+- L'invio dei trigger usa per impostazione predefinita tentativi adattivi (queue/submit, poi fallback sicuro clear-line+resend quando necessario).
+- In modalità worker Claude, OMX avvia i worker come semplice `claude` (nessun argomento di avvio aggiuntivo) e ignora le sovrascritture esplicite `--model` / `--config` / `--effort` in modo che Claude usi il `settings.json` predefinito.
+
+## Cosa scrive `omx setup`
+
+- `.omx/setup-scope.json` (scope di setup persistito)
+- Installazioni dipendenti dallo scope:
+  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Comportamento all'avvio: se lo scope persistito è `project`, l'avvio `omx` usa automaticamente `CODEX_HOME=./.codex` (a meno che `CODEX_HOME` non sia già impostato).
+- L'`AGENTS.md` esistente è preservato per impostazione predefinita. Nelle esecuzioni TTY interattive, il setup chiede conferma prima di sovrascrivere; `--force` sovrascrive senza chiedere (i controlli di sicurezza della sessione attiva si applicano comunque).
+- Aggiornamenti `config.toml` (per entrambi gli scope):
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - Voci server MCP (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- `AGENTS.md` del progetto
+- Directory di esecuzione `.omx/` e configurazione HUD
+
+## Agenti e Skill
+
+- Prompt: `prompts/*.md` (installati in `~/.codex/prompts/` per `user`, `./.codex/prompts/` per `project`)
+- Skill: `skills/*/SKILL.md` (installati in `~/.agents/skills/` per `user`, `./.agents/skills/` per `project`)
+
+Esempi:
+- Agenti: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- Skill: `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## Struttura del progetto
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## Sviluppo
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## Documentazione
+
+- **[Documentazione completa](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Guida completa
+- **[Riferimento CLI](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Tutti i comandi `omx`, flag e strumenti
+- **[Guida alle notifiche](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Configurazione Discord, Telegram, Slack e webhook
+- **[Workflow consigliati](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Catene di skill collaudate per i compiti comuni
+- **[Note di rilascio](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Novità di ogni versione
+
+## Note
+
+- Changelog completo: `CHANGELOG.md`
+- Guida alla migrazione (post-v0.4.4 mainline): `docs/migration-mainline-post-v0.4.4.md`
+- Note di copertura e parità: `COVERAGE.md`
+- Workflow estensione hook: `docs/hooks-extension.md`
+- Dettagli setup e contribuzione: `CONTRIBUTING.md`
+
+## Ringraziamenti
+
+Ispirato da [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), adattato per Codex CLI.
+
+## Licenza
+
+MIT

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,10 +1,59 @@
-# oh-my-codex (OMX) 日本語README
+# oh-my-codex (OMX)
 
-> 完全な原文は [English README](./README.md) を参照してください。
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>あなたのcodexは一人じゃない。</em>
+</p>
 
-OMX は OpenAI Codex CLI 向けのマルチエージェント・オーケストレーションレイヤーです。
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-## クイックスタート
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+[OpenAI Codex CLI](https://github.com/openai/codex)のためのマルチエージェントオーケストレーションレイヤー。
+
+## 言語
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMXはCodexをシングルセッションエージェントから協調システムに変換します：
+- 専門エージェント用の role prompts (`/prompts:name`)
+- 再現可能な実行モード用の workflow skills (`$name`)
+- tmuxでのチームオーケストレーション (`omx team`, `$team`)
+- MCPサーバーによる永続的な状態とメモリ
+
+## なぜOMXか
+
+Codex CLIは直接的なタスクに強力です。OMXはより大規模な作業のための構造を追加します：
+- 分解と段階的実行 (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- 永続的なモードライフサイクル状態 (`.omx/state/`)
+- 長期セッション用のメモリとメモ帳サーフェス
+- 起動、検証、キャンセルのための運用制御
+
+OMXはアドオンであり、フォークではありません。Codexのネイティブ拡張ポイントを使用します。
+
+## 要件
+
+- macOSまたはLinux（WindowsはWSL2経由）
+- Node.js >= 20
+- Codex CLIがインストール済み (`npm install -g @openai/codex`)
+- Codex認証が設定済み
+
+## クイックスタート（3分）
 
 ```bash
 npm install -g oh-my-codex
@@ -12,25 +61,254 @@ omx setup
 omx doctor
 ```
 
-## 主な機能
-
-- ロールプロンプト（`/prompts:name`）による専門エージェント実行
-- ワークフロースキル（`$name`）による反復作業の自動化
-- tmux ベースのチーム実行（`omx team`, `$team`）
-- MCP サーバーによる状態・メモリの永続化
-
-## 主なコマンド
+信頼された環境向けの推奨起動プロファイル：
 
 ```bash
-omx
-omx setup
-omx doctor
-omx team <args>
-omx status
-omx cancel
+omx --xhigh --madmax
 ```
 
-## 詳細情報
+## v0.5.0の新機能
 
-- メインドキュメント: [README.md](./README.md)
-- ウェブサイト: https://yeachan-heo.github.io/oh-my-codex-website/
+- `omx setup --scope user|project`による**スコープ対応セットアップ** — 柔軟なインストールモード。
+- `--spark` / `--madmax-spark`による**Sparkワーカールーティング** — チームワーカーがリーダーモデルを強制せずに`gpt-5.3-codex-spark`を使用可能。
+- **カタログ統合** — 非推奨プロンプト（`deep-executor`、`scientist`）と9つの非推奨スキルを削除し、よりスリムなサーフェスに。
+- **通知の詳細レベル** — CCNotifier出力のきめ細かい制御。
+
+## 最初のセッション
+
+Codex内部で：
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+ターミナルから：
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## コアモデル
+
+OMXは以下のレイヤーをインストールして接続します：
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (オーケストレーションブレイン)
+    -> ~/.codex/prompts/*.md (エージェントプロンプトカタログ)
+    -> ~/.agents/skills/*/SKILL.md (スキルカタログ)
+    -> ~/.codex/config.toml (機能、通知、MCP)
+    -> .omx/ (ランタイム状態、メモリ、計画、ログ)
+```
+
+## 主要コマンド
+
+```bash
+omx                # Codexを起動（tmuxでHUD付き）
+omx setup          # スコープ別にプロンプト/スキル/設定をインストール + プロジェクトAGENTS.md/.omx
+omx doctor         # インストール/ランタイム診断
+omx doctor --team  # Team/swarm診断
+omx team ...       # tmuxチームワーカーの開始/ステータス/再開/シャットダウン
+omx status         # アクティブなモードを表示
+omx cancel         # アクティブな実行モードをキャンセル
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test（プラグイン拡張ワークフロー）
+omx hud ...        # --watch|--json|--preset
+omx help
+```
+
+## Hooks拡張（追加サーフェス）
+
+OMXにはプラグインのスキャフォールディングとバリデーション用の`omx hooks`が含まれるようになりました。
+
+- `omx tmux-hook`は引き続きサポートされ、変更されていません。
+- `omx hooks`は追加的であり、tmux-hookワークフローを置き換えません。
+- プラグインファイルは`.omx/hooks/*.mjs`に配置されます。
+- プラグインはデフォルトで無効です；`OMX_HOOK_PLUGINS=1`で有効にします。
+
+完全な拡張ワークフローとイベントモデルについては`docs/hooks-extension.md`を参照してください。
+
+## 起動フラグ
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # setupのみ
+```
+
+`--madmax`はCodexの`--dangerously-bypass-approvals-and-sandbox`にマッピングされます。
+信頼された/外部のサンドボックス環境でのみ使用してください。
+
+### MCP workingDirectoryポリシー（オプションの強化）
+
+デフォルトでは、MCP state/memory/traceツールは呼び出し元が提供する`workingDirectory`を受け入れます。
+これを制限するには、許可されたルートのリストを設定します：
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+設定すると、これらのルート外の`workingDirectory`値は拒否されます。
+
+## Codex-Firstプロンプト制御
+
+デフォルトでは、OMXは以下を注入します：
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+これはプロジェクトの`AGENTS.md`ガイダンスをCodex起動命令にレイヤーします。
+Codexの動作を拡張しますが、Codexのコアシステムポリシーを置き換えたりバイパスしたりしません。
+
+制御：
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # AGENTS.md注入を無効化
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## チームモード
+
+並列ワーカーが有利な大規模作業にはチームモードを使用します。
+
+ライフサイクル：
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+運用コマンド：
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+重要なルール：中断する場合を除き、タスクが`in_progress`状態の間はシャットダウンしないでください。
+
+### Ralphクリーンアップポリシー
+
+チームがralphモード（`omx team ralph ...`）で実行される場合、シャットダウンのクリーンアップは
+通常のパスとは異なる専用ポリシーを適用します：
+
+| 動作 | 通常チーム | Ralphチーム |
+|---|---|---|
+| 失敗時の強制シャットダウン | `shutdown_gate_blocked`をスロー | ゲートをバイパスし、`ralph_cleanup_policy`イベントをログ |
+| 自動ブランチ削除 | ロールバック時にworktreeブランチを削除 | ブランチを保持（`skipBranchDeletion`） |
+| 完了ログ | 標準`shutdown_gate`イベント | タスク内訳付きの追加`ralph_cleanup_summary`イベント |
+
+Ralphポリシーはチームモード状態（`linked_ralph`）から自動検出されるか、
+`omx team shutdown <name> --ralph`で明示的に渡すことができます。
+
+チームワーカー用のWorker CLI選択：
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # デフォルト；worker --modelに"claude"が含まれる場合claudeを使用
+OMX_TEAM_WORKER_CLI=codex   # Codex CLIワーカーを強制
+OMX_TEAM_WORKER_CLI=claude  # Claude CLIワーカーを強制
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # ワーカーごとのCLIミックス（長さ=1またはワーカー数）
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # オプション：適応型queue->resendフォールバックを無効化
+```
+
+注意：
+- ワーカー起動引数は引き続き`OMX_TEAM_WORKER_LAUNCH_ARGS`を通じて共有されます。
+- `OMX_TEAM_WORKER_CLI_MAP`はワーカーごとの選択で`OMX_TEAM_WORKER_CLI`をオーバーライドします。
+- トリガー送信はデフォルトで適応型リトライを使用します（queue/submit、必要に応じて安全なclear-line+resendフォールバック）。
+- Claude workerモードでは、OMXはワーカーをプレーンな`claude`として起動し（追加の起動引数なし）、明示的な`--model` / `--config` / `--effort`オーバーライドを無視して、Claudeがデフォルトの`settings.json`を使用します。
+
+## `omx setup`が書き込む内容
+
+- `.omx/setup-scope.json`（永続化されたセットアップスコープ）
+- スコープ依存のインストール：
+  - `user`：`~/.codex/prompts/`、`~/.agents/skills/`、`~/.codex/config.toml`、`~/.omx/agents/`
+  - `project`：`./.codex/prompts/`、`./.agents/skills/`、`./.codex/config.toml`、`./.omx/agents/`
+- 起動動作：永続化されたスコープが`project`の場合、`omx`起動時に自動的に`CODEX_HOME=./.codex`を使用（`CODEX_HOME`が既に設定されている場合を除く）。
+- 既存の`AGENTS.md`はデフォルトで保持されます。インタラクティブTTY実行では、上書き前にsetupが確認します；`--force`は確認なしで上書きします（アクティブセッションの安全チェックは引き続き適用されます）。
+- `config.toml`の更新（両スコープ共通）：
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - MCPサーバーエントリ（`omx_state`、`omx_memory`、`omx_code_intel`、`omx_trace`）
+  - `[tui] status_line`
+- プロジェクト`AGENTS.md`
+- `.omx/`ランタイムディレクトリとHUD設定
+
+## エージェントとスキル
+
+- プロンプト：`prompts/*.md`（`user`は`~/.codex/prompts/`に、`project`は`./.codex/prompts/`にインストール）
+- スキル：`skills/*/SKILL.md`（`user`は`~/.agents/skills/`に、`project`は`./.agents/skills/`にインストール）
+
+例：
+- エージェント：`architect`、`planner`、`executor`、`debugger`、`verifier`、`security-reviewer`
+- スキル：`autopilot`、`plan`、`team`、`ralph`、`ultrawork`、`cancel`
+
+## プロジェクト構成
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## 開発
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## ドキュメント
+
+- **[完全なドキュメント](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — 完全ガイド
+- **[CLIリファレンス](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — すべての`omx`コマンド、フラグ、ツール
+- **[通知ガイド](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Discord、Telegram、Slack、webhookの設定
+- **[推奨ワークフロー](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — 一般的なタスクのための実戦で検証されたスキルチェーン
+- **[リリースノート](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — 各バージョンの新機能
+
+## 備考
+
+- 完全な変更ログ：`CHANGELOG.md`
+- 移行ガイド（v0.4.4以降のmainline）：`docs/migration-mainline-post-v0.4.4.md`
+- カバレッジとパリティノート：`COVERAGE.md`
+- Hook拡張ワークフロー：`docs/hooks-extension.md`
+- セットアップと貢献の詳細：`CONTRIBUTING.md`
+
+## 謝辞
+
+[oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)にインスパイアされ、Codex CLI向けに適応されました。
+
+## ライセンス
+
+MIT

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,10 +1,59 @@
-# oh-my-codex (OMX) 한국어 README
+# oh-my-codex (OMX)
 
-> 전체 원문 문서는 [English README](./README.md)를 참고하세요.
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>당신의 codex는 혼자가 아닙니다.</em>
+</p>
 
-OMX는 OpenAI Codex CLI를 위한 멀티 에이전트 오케스트레이션 레이어입니다.
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-## 빠른 시작
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+[OpenAI Codex CLI](https://github.com/openai/codex)를 위한 멀티 에이전트 오케스트레이션 레이어.
+
+## 언어
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX는 Codex를 단일 세션 에이전트에서 조율된 시스템으로 전환합니다:
+- 전문 에이전트를 위한 role prompts (`/prompts:name`)
+- 반복 가능한 실행 모드를 위한 workflow skills (`$name`)
+- tmux에서의 팀 오케스트레이션 (`omx team`, `$team`)
+- MCP 서버를 통한 영구 상태 및 메모리
+
+## OMX를 사용하는 이유
+
+Codex CLI는 직접적인 작업에 강합니다. OMX는 더 큰 작업을 위한 구조를 추가합니다:
+- 분해 및 단계적 실행 (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- 영구 모드 라이프사이클 상태 (`.omx/state/`)
+- 장기 세션을 위한 메모리 및 메모장 표면
+- 시작, 검증 및 취소를 위한 운영 제어
+
+OMX는 애드온이며, 포크가 아닙니다. Codex의 네이티브 확장 포인트를 사용합니다.
+
+## 요구사항
+
+- macOS 또는 Linux (Windows는 WSL2를 통해)
+- Node.js >= 20
+- Codex CLI 설치됨 (`npm install -g @openai/codex`)
+- Codex 인증 구성됨
+
+## 빠른 시작 (3분)
 
 ```bash
 npm install -g oh-my-codex
@@ -12,25 +61,254 @@ omx setup
 omx doctor
 ```
 
-## 핵심 기능
+신뢰할 수 있는 환경을 위한 권장 시작 프로필:
 
-- 역할 프롬프트(`/prompts:name`) 기반 전문 에이전트 실행
-- 워크플로우 스킬(`$name`) 기반 반복 작업 자동화
-- tmux 팀 오케스트레이션(`omx team`, `$team`)
-- MCP 서버를 통한 상태/메모리 지속성
+```bash
+omx --xhigh --madmax
+```
+
+## v0.5.0의 새로운 기능
+
+- `omx setup --scope user|project`를 통한 **범위 인식 설정** — 유연한 설치 모드.
+- `--spark` / `--madmax-spark`를 통한 **Spark worker 라우팅** — 팀 워커가 리더 모델을 강제하지 않고 `gpt-5.3-codex-spark`를 사용 가능.
+- **카탈로그 통합** — 더 간결한 표면을 위해 deprecated 프롬프트(`deep-executor`, `scientist`)와 9개의 deprecated 스킬 제거.
+- **알림 상세 레벨** — CCNotifier 출력에 대한 세밀한 제어.
+
+## 첫 번째 세션
+
+Codex 내부에서:
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+터미널에서:
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## 핵심 모델
+
+OMX는 다음 레이어를 설치하고 연결합니다:
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (오케스트레이션 브레인)
+    -> ~/.codex/prompts/*.md (에이전트 프롬프트 카탈로그)
+    -> ~/.agents/skills/*/SKILL.md (스킬 카탈로그)
+    -> ~/.codex/config.toml (기능, 알림, MCP)
+    -> .omx/ (런타임 상태, 메모리, 계획, 로그)
+```
 
 ## 주요 명령어
 
 ```bash
-omx
-omx setup
-omx doctor
-omx team <args>
-omx status
-omx cancel
+omx                # Codex 실행 (tmux에서 HUD와 함께)
+omx setup          # 범위별 프롬프트/스킬/설정 설치 + 프로젝트 AGENTS.md/.omx
+omx doctor         # 설치/런타임 진단
+omx doctor --team  # Team/swarm 진단
+omx team ...       # tmux 팀 워커 시작/상태/재개/종료
+omx status         # 활성 모드 표시
+omx cancel         # 활성 실행 모드 취소
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (플러그인 확장 워크플로우)
+omx hud ...        # --watch|--json|--preset
+omx help
 ```
 
-## 더 알아보기
+## Hooks 확장 (추가 표면)
 
-- 메인 문서: [README.md](./README.md)
-- 웹사이트: https://yeachan-heo.github.io/oh-my-codex-website/
+OMX는 이제 플러그인 스캐폴딩 및 검증을 위한 `omx hooks`를 포함합니다.
+
+- `omx tmux-hook`은 계속 지원되며 변경되지 않았습니다.
+- `omx hooks`는 추가적이며 tmux-hook 워크플로우를 대체하지 않습니다.
+- 플러그인 파일은 `.omx/hooks/*.mjs`에 위치합니다.
+- 플러그인은 기본적으로 비활성화되어 있으며; `OMX_HOOK_PLUGINS=1`로 활성화합니다.
+
+전체 확장 워크플로우 및 이벤트 모델은 `docs/hooks-extension.md`를 참조하세요.
+
+## 시작 플래그
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # setup 전용
+```
+
+`--madmax`는 Codex `--dangerously-bypass-approvals-and-sandbox`에 매핑됩니다.
+신뢰할 수 있는/외부 sandbox 환경에서만 사용하세요.
+
+### MCP workingDirectory 정책 (선택적 강화)
+
+기본적으로 MCP state/memory/trace 도구는 호출자가 제공한 `workingDirectory`를 수락합니다.
+이를 제한하려면 허용된 루트 목록을 설정하세요:
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+설정 시 이 루트 외부의 `workingDirectory` 값은 거부됩니다.
+
+## Codex-First 프롬프트 제어
+
+기본적으로 OMX는 다음을 주입합니다:
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+이것은 프로젝트 `AGENTS.md` 지침을 Codex 시작 명령에 추가합니다.
+Codex 동작을 확장하지만, Codex 핵심 시스템 정책을 대체/우회하지 않습니다.
+
+제어:
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # AGENTS.md 주입 비활성화
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## 팀 모드
+
+병렬 워커가 유리한 대규모 작업에 팀 모드를 사용합니다.
+
+라이프사이클:
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+운영 명령어:
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+중요 규칙: 중단하는 경우가 아니라면 작업이 `in_progress` 상태인 동안 종료하지 마세요.
+
+### Ralph 정리 정책
+
+팀이 ralph 모드(`omx team ralph ...`)로 실행될 때, 종료 정리는
+일반 경로와 다른 전용 정책을 적용합니다:
+
+| 동작 | 일반 팀 | Ralph 팀 |
+|---|---|---|
+| 실패 시 강제 종료 | `shutdown_gate_blocked` 발생 | 게이트를 우회하고 `ralph_cleanup_policy` 이벤트 기록 |
+| 자동 브랜치 삭제 | 롤백 시 worktree 브랜치 삭제 | 브랜치 보존 (`skipBranchDeletion`) |
+| 완료 로깅 | 표준 `shutdown_gate` 이벤트 | 작업 분석이 포함된 추가 `ralph_cleanup_summary` 이벤트 |
+
+Ralph 정책은 팀 모드 상태(`linked_ralph`)에서 자동 감지되거나
+`omx team shutdown <name> --ralph`로 명시적으로 전달할 수 있습니다.
+
+팀 워커를 위한 Worker CLI 선택:
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # 기본값; worker --model에 "claude"가 포함되면 claude 사용
+OMX_TEAM_WORKER_CLI=codex   # Codex CLI 워커 강제
+OMX_TEAM_WORKER_CLI=claude  # Claude CLI 워커 강제
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # 워커별 CLI 혼합 (길이=1 또는 워커 수)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # 선택: 적응형 queue->resend 폴백 비활성화
+```
+
+참고:
+- 워커 시작 인수는 여전히 `OMX_TEAM_WORKER_LAUNCH_ARGS`를 통해 공유됩니다.
+- `OMX_TEAM_WORKER_CLI_MAP`은 워커별 선택을 위해 `OMX_TEAM_WORKER_CLI`를 재정의합니다.
+- 트리거 제출은 기본적으로 적응형 재시도를 사용합니다 (queue/submit, 필요시 안전한 clear-line+resend 폴백).
+- Claude worker 모드에서 OMX는 워커를 일반 `claude`로 시작하고 (추가 시작 인수 없음) 명시적인 `--model` / `--config` / `--effort` 재정의를 무시하여 Claude가 기본 `settings.json`을 사용합니다.
+
+## `omx setup`이 작성하는 것
+
+- `.omx/setup-scope.json` (저장된 설정 범위)
+- 범위에 따른 설치:
+  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- 시작 동작: 저장된 범위가 `project`이면, `omx` 시작 시 자동으로 `CODEX_HOME=./.codex`를 사용합니다 (`CODEX_HOME`이 이미 설정되지 않은 경우).
+- 기존 `AGENTS.md`는 기본적으로 보존됩니다. 대화형 TTY 실행에서 setup은 덮어쓰기 전에 확인합니다; `--force`는 확인 없이 덮어씁니다 (활성 세션 안전 검사는 여전히 적용됩니다).
+- `config.toml` 업데이트 (두 범위 모두):
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - MCP 서버 항목 (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- 프로젝트 `AGENTS.md`
+- `.omx/` 런타임 디렉토리 및 HUD 설정
+
+## 에이전트와 스킬
+
+- 프롬프트: `prompts/*.md` (`user`는 `~/.codex/prompts/`에, `project`는 `./.codex/prompts/`에 설치)
+- 스킬: `skills/*/SKILL.md` (`user`는 `~/.agents/skills/`에, `project`는 `./.agents/skills/`에 설치)
+
+예시:
+- 에이전트: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- 스킬: `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## 프로젝트 구조
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## 개발
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## 문서
+
+- **[전체 문서](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — 완전한 가이드
+- **[CLI 레퍼런스](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — 모든 `omx` 명령어, 플래그 및 도구
+- **[알림 가이드](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Discord, Telegram, Slack 및 webhook 설정
+- **[권장 워크플로우](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — 일반적인 작업을 위한 실전 검증된 스킬 체인
+- **[릴리스 노트](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — 각 버전의 새로운 기능
+
+## 참고
+
+- 전체 변경 로그: `CHANGELOG.md`
+- 마이그레이션 가이드 (v0.4.4 이후 mainline): `docs/migration-mainline-post-v0.4.4.md`
+- 커버리지 및 패리티 노트: `COVERAGE.md`
+- Hook 확장 워크플로우: `docs/hooks-extension.md`
+- 설정 및 기여 세부사항: `CONTRIBUTING.md`
+
+## 감사의 말
+
+[oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)에서 영감을 받아 Codex CLI용으로 적응하였습니다.
+
+## 라이선스
+
+MIT

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Multi-agent orchestration layer for [OpenAI Codex CLI](https://github.com/openai
 - [Español (Spanish)](./README.es.md)
 - [Português (Portuguese)](./README.pt.md)
 - [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
 
 
 OMX turns Codex from a single-session agent into a coordinated system with:

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,10 +1,59 @@
-# oh-my-codex (OMX) README em Português
+# oh-my-codex (OMX)
 
-> Para a documentação completa original, consulte [English README](./README.md).
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Seu codex não está sozinho.</em>
+</p>
 
-OMX é uma camada de orquestração multiagente para o OpenAI Codex CLI.
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-## Início rápido
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+Camada de orquestração multiagente para [OpenAI Codex CLI](https://github.com/openai/codex).
+
+## Idiomas
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX transforma o Codex de um agente de sessão única em um sistema coordenado com:
+- Role prompts (`/prompts:name`) para agentes especializados
+- Workflow skills (`$name`) para modos de execução repetíveis
+- Orquestração de equipes no tmux (`omx team`, `$team`)
+- Estado persistente e memória via servidores MCP
+
+## Por que OMX
+
+Codex CLI é forte para tarefas diretas. OMX adiciona estrutura para trabalhos maiores:
+- Decomposição e execução em etapas (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- Estado persistente do ciclo de vida dos modos (`.omx/state/`)
+- Superfícies de memória e bloco de notas para sessões longas
+- Controles operacionais para início, verificação e cancelamento
+
+OMX é um complemento, não um fork. Utiliza os pontos de extensão nativos do Codex.
+
+## Requisitos
+
+- macOS ou Linux (Windows via WSL2)
+- Node.js >= 20
+- Codex CLI instalado (`npm install -g @openai/codex`)
+- Autenticação do Codex configurada
+
+## Início rápido (3 minutos)
 
 ```bash
 npm install -g oh-my-codex
@@ -12,25 +61,254 @@ omx setup
 omx doctor
 ```
 
-## Recursos principais
+Perfil de inicialização recomendado para ambientes confiáveis:
 
-- Execução de agentes especializados com prompts de papel (`/prompts:name`)
-- Automação de fluxos repetitivos com skills (`$name`)
-- Orquestração em equipe com tmux (`omx team`, `$team`)
-- Estado e memória persistentes via servidores MCP
+```bash
+omx --xhigh --madmax
+```
+
+## Novidades na v0.5.0
+
+- **Configuração com escopo** via `omx setup --scope user|project` para modos de instalação flexíveis.
+- **Roteamento de Spark worker** via `--spark` / `--madmax-spark` — workers da equipe podem usar `gpt-5.3-codex-spark` sem forçar o modelo líder.
+- **Consolidação do catálogo** — removidos prompts obsoletos (`deep-executor`, `scientist`) e 9 skills obsoletas para uma superfície mais enxuta.
+- **Níveis de detalhamento de notificações** para controle granular da saída do CCNotifier.
+
+## Primeira sessão
+
+Dentro do Codex:
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+Do terminal:
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## Modelo central
+
+OMX instala e conecta estas camadas:
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (cérebro de orquestração)
+    -> ~/.codex/prompts/*.md (catálogo de prompts de agentes)
+    -> ~/.agents/skills/*/SKILL.md (catálogo de skills)
+    -> ~/.codex/config.toml (funcionalidades, notificações, MCP)
+    -> .omx/ (estado de execução, memória, planos, logs)
+```
 
 ## Comandos principais
 
 ```bash
-omx
-omx setup
-omx doctor
-omx team <args>
-omx status
-omx cancel
+omx                # Iniciar Codex (+ HUD no tmux quando disponível)
+omx setup          # Instalar prompts/skills/config por escopo + projeto AGENTS.md/.omx
+omx doctor         # Diagnósticos de instalação/execução
+omx doctor --team  # Diagnósticos de Team/swarm
+omx team ...       # Iniciar/status/retomar/encerrar workers tmux da equipe
+omx status         # Mostrar modos ativos
+omx cancel         # Cancelar modos de execução ativos
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (fluxo de trabalho de extensão de plugins)
+omx hud ...        # --watch|--json|--preset
+omx help
 ```
 
-## Saiba mais
+## Extensão de Hooks (Superfície adicional)
 
-- Documento principal: [README.md](./README.md)
-- Website: https://yeachan-heo.github.io/oh-my-codex-website/
+OMX agora inclui `omx hooks` para scaffolding e validação de plugins.
+
+- `omx tmux-hook` continua sendo suportado e não foi alterado.
+- `omx hooks` é aditivo e não substitui os fluxos de trabalho do tmux-hook.
+- Arquivos de plugins ficam em `.omx/hooks/*.mjs`.
+- Plugins estão desativados por padrão; ative com `OMX_HOOK_PLUGINS=1`.
+
+Consulte `docs/hooks-extension.md` para o fluxo de trabalho completo de extensões e modelo de eventos.
+
+## Flags de inicialização
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # apenas para setup
+```
+
+`--madmax` mapeia para Codex `--dangerously-bypass-approvals-and-sandbox`.
+Use apenas em ambientes sandbox confiáveis ou externos.
+
+### Política de workingDirectory MCP (endurecimento opcional)
+
+Por padrão, as ferramentas MCP de state/memory/trace aceitam o `workingDirectory` fornecido pelo chamador.
+Para restringir isso, defina uma lista de raízes permitidas:
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+Quando definido, valores de `workingDirectory` fora dessas raízes são rejeitados.
+
+## Controle de prompts Codex-First
+
+Por padrão, OMX injeta:
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+Isso adiciona as instruções do projeto `AGENTS.md` aos comandos de inicialização do Codex.
+Estende o comportamento do Codex, mas não substitui nem contorna as políticas centrais do sistema Codex.
+
+Controles:
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # desativar injeção de AGENTS.md
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## Modo equipe
+
+Use o modo equipe para trabalhos amplos que se beneficiam de workers paralelos.
+
+Ciclo de vida:
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+Comandos operacionais:
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+Regra importante: não encerre enquanto tarefas estiverem em estado `in_progress`, a menos que esteja abortando.
+
+### Política de limpeza Ralph
+
+Quando uma equipe roda em modo ralph (`omx team ralph ...`), a limpeza no encerramento
+aplica uma política dedicada diferente do caminho normal:
+
+| Comportamento | Equipe normal | Equipe Ralph |
+|---|---|---|
+| Encerramento forçado em caso de falha | Lança `shutdown_gate_blocked` | Ignora a porta, registra evento `ralph_cleanup_policy` |
+| Exclusão automática de branches | Exclui branches do worktree no rollback | Preserva branches (`skipBranchDeletion`) |
+| Log de conclusão | Evento padrão `shutdown_gate` | Evento adicional `ralph_cleanup_summary` com detalhamento de tarefas |
+
+A política Ralph é detectada automaticamente do estado do modo equipe (`linked_ralph`) ou
+pode ser passada explicitamente via `omx team shutdown <name> --ralph`.
+
+Seleção de Worker CLI para workers da equipe:
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # padrão; usa claude quando worker --model contém "claude"
+OMX_TEAM_WORKER_CLI=codex   # forçar workers Codex CLI
+OMX_TEAM_WORKER_CLI=claude  # forçar workers Claude CLI
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # mix de CLI por worker (comprimento=1 ou quantidade de workers)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # opcional: desativar fallback adaptativo queue->resend
+```
+
+Notas:
+- Argumentos de inicialização de workers são compartilhados via `OMX_TEAM_WORKER_LAUNCH_ARGS`.
+- `OMX_TEAM_WORKER_CLI_MAP` sobrescreve `OMX_TEAM_WORKER_CLI` para seleção por worker.
+- O envio de triggers usa retentativas adaptativas por padrão (queue/submit, depois fallback seguro clear-line+resend quando necessário).
+- No modo Claude worker, OMX inicia workers como `claude` simples (sem argumentos extras de inicialização) e ignora substituições explícitas de `--model` / `--config` / `--effort` para que o Claude use o `settings.json` padrão.
+
+## O que `omx setup` grava
+
+- `.omx/setup-scope.json` (escopo de instalação persistido)
+- Instalações dependentes do escopo:
+  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Comportamento de inicialização: se o escopo persistido for `project`, o lançamento do `omx` usa automaticamente `CODEX_HOME=./.codex` (a menos que `CODEX_HOME` já esteja definido).
+- O `AGENTS.md` existente é preservado por padrão. Em execuções TTY interativas, o setup pergunta antes de sobrescrever; `--force` sobrescreve sem perguntar (verificações de segurança de sessões ativas continuam aplicáveis).
+- Atualizações do `config.toml` (para ambos os escopos):
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - Entradas de servidores MCP (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- `AGENTS.md` do projeto
+- Diretórios `.omx/` de execução e configuração do HUD
+
+## Agentes e skills
+
+- Prompts: `prompts/*.md` (instalados em `~/.codex/prompts/` para `user`, `./.codex/prompts/` para `project`)
+- Skills: `skills/*/SKILL.md` (instalados em `~/.agents/skills/` para `user`, `./.agents/skills/` para `project`)
+
+Exemplos:
+- Agentes: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- Skills: `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## Estrutura do projeto
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## Desenvolvimento
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## Documentação
+
+- **[Documentação completa](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Guia completo
+- **[Referência CLI](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Todos os comandos `omx`, flags e ferramentas
+- **[Guia de notificações](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Configuração de Discord, Telegram, Slack e webhooks
+- **[Fluxos de trabalho recomendados](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Cadeias de skills testadas em batalha para tarefas comuns
+- **[Notas de versão](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Novidades em cada versão
+
+## Notas
+
+- Log de alterações completo: `CHANGELOG.md`
+- Guia de migração (pós-v0.4.4 mainline): `docs/migration-mainline-post-v0.4.4.md`
+- Notas de cobertura e paridade: `COVERAGE.md`
+- Fluxo de trabalho de extensão de hooks: `docs/hooks-extension.md`
+- Detalhes de instalação e contribuição: `CONTRIBUTING.md`
+
+## Agradecimentos
+
+Inspirado em [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), adaptado para Codex CLI.
+
+## Licença
+
+MIT

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,10 +1,59 @@
-# oh-my-codex (OMX) README на русском
+# oh-my-codex (OMX)
 
-> Полная оригинальная документация: [English README](./README.md).
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Ваш codex не одинок.</em>
+</p>
 
-OMX — это слой оркестрации мультиагентной работы для OpenAI Codex CLI.
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-## Быстрый старт
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+Слой мультиагентной оркестрации для [OpenAI Codex CLI](https://github.com/openai/codex).
+
+## Языки
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX превращает Codex из однопользовательского агента в координированную систему:
+- Role prompts (`/prompts:name`) для специализированных агентов
+- Workflow skills (`$name`) для повторяемых режимов выполнения
+- Командная оркестрация в tmux (`omx team`, `$team`)
+- Постоянное состояние и память через MCP-серверы
+
+## Почему OMX
+
+Codex CLI хорошо справляется с прямыми задачами. OMX добавляет структуру для более крупной работы:
+- Декомпозиция и поэтапное выполнение (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- Постоянное состояние жизненного цикла режимов (`.omx/state/`)
+- Поверхности памяти и блокнота для длительных сессий
+- Операционные элементы управления для запуска, проверки и отмены
+
+OMX — это дополнение, а не форк. Он использует нативные точки расширения Codex.
+
+## Требования
+
+- macOS или Linux (Windows через WSL2)
+- Node.js >= 20
+- Установленный Codex CLI (`npm install -g @openai/codex`)
+- Настроенная аутентификация Codex
+
+## Быстрый старт (3 минуты)
 
 ```bash
 npm install -g oh-my-codex
@@ -12,25 +61,254 @@ omx setup
 omx doctor
 ```
 
-## Ключевые возможности
+Рекомендуемый профиль запуска для доверенной среды:
 
-- Запуск специализированных агентов через role prompts (`/prompts:name`)
-- Автоматизация повторяемых процессов через skills (`$name`)
-- Командная оркестрация в tmux (`omx team`, `$team`)
-- Постоянное хранение состояния и памяти через MCP-серверы
+```bash
+omx --xhigh --madmax
+```
+
+## Новое в v0.5.0
+
+- **Настройка с учётом области** через `omx setup --scope user|project` для гибких режимов установки.
+- **Маршрутизация Spark worker** через `--spark` / `--madmax-spark` — рабочие команды могут использовать `gpt-5.3-codex-spark` без принудительной модели лидера.
+- **Консолидация каталога** — удалены устаревшие промпты (`deep-executor`, `scientist`) и 9 устаревших навыков для более компактной поверхности.
+- **Уровни подробности уведомлений** для детализированного управления выводом CCNotifier.
+
+## Первая сессия
+
+Внутри Codex:
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+Из терминала:
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## Базовая модель
+
+OMX устанавливает и связывает следующие слои:
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (мозг оркестрации)
+    -> ~/.codex/prompts/*.md (каталог промптов агентов)
+    -> ~/.agents/skills/*/SKILL.md (каталог навыков)
+    -> ~/.codex/config.toml (функции, уведомления, MCP)
+    -> .omx/ (состояние выполнения, память, планы, журналы)
+```
 
 ## Основные команды
 
 ```bash
-omx
-omx setup
-omx doctor
-omx team <args>
-omx status
-omx cancel
+omx                # Запустить Codex (+ HUD в tmux при наличии)
+omx setup          # Установить промпты/навыки/конфиг по области + проект AGENTS.md/.omx
+omx doctor         # Диагностика установки/среды выполнения
+omx doctor --team  # Диагностика Team/swarm
+omx team ...       # Запуск/статус/возобновление/завершение рабочих tmux
+omx status         # Показать активные режимы
+omx cancel         # Отменить активные режимы выполнения
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (рабочий процесс расширений плагинов)
+omx hud ...        # --watch|--json|--preset
+omx help
 ```
 
-## Подробнее
+## Расширение Hooks (Дополнительная поверхность)
 
-- Основной документ: [README.md](./README.md)
-- Сайт: https://yeachan-heo.github.io/oh-my-codex-website/
+OMX теперь включает `omx hooks` для создания шаблонов плагинов и валидации.
+
+- `omx tmux-hook` по-прежнему поддерживается и не изменён.
+- `omx hooks` является дополнительным и не заменяет рабочие процессы tmux-hook.
+- Файлы плагинов располагаются в `.omx/hooks/*.mjs`.
+- Плагины по умолчанию отключены; включите с помощью `OMX_HOOK_PLUGINS=1`.
+
+Полный рабочий процесс расширений и модель событий описаны в `docs/hooks-extension.md`.
+
+## Флаги запуска
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # только для setup
+```
+
+`--madmax` соответствует Codex `--dangerously-bypass-approvals-and-sandbox`.
+Используйте только в доверенных/внешних sandbox-окружениях.
+
+### Политика workingDirectory MCP (опциональное усиление)
+
+По умолчанию инструменты MCP state/memory/trace принимают `workingDirectory`, предоставленный вызывающей стороной.
+Чтобы ограничить это, задайте список разрешённых корней:
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+При установке значения `workingDirectory` за пределами этих корней будут отклонены.
+
+## Codex-First управление промптами
+
+По умолчанию OMX внедряет:
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+Это добавляет проектные инструкции `AGENTS.md` в команды запуска Codex.
+Расширяет поведение Codex, но не заменяет/обходит основные системные политики Codex.
+
+Управление:
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # отключить внедрение AGENTS.md
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## Командный режим
+
+Используйте командный режим для масштабной работы, которая выигрывает от параллельных исполнителей.
+
+Жизненный цикл:
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+Операционные команды:
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+Важное правило: не завершайте работу, пока задачи находятся в состоянии `in_progress`, если только не прерываете выполнение.
+
+### Политика очистки Ralph
+
+Когда команда работает в режиме ralph (`omx team ralph ...`), очистка при завершении
+применяет специальную политику, отличающуюся от обычного пути:
+
+| Поведение | Обычная команда | Команда Ralph |
+|---|---|---|
+| Принудительное завершение при сбое | Выбрасывает `shutdown_gate_blocked` | Обходит шлюз, логирует событие `ralph_cleanup_policy` |
+| Автоматическое удаление веток | Удаляет ветки worktree при откате | Сохраняет ветки (`skipBranchDeletion`) |
+| Логирование завершения | Стандартное событие `shutdown_gate` | Дополнительное событие `ralph_cleanup_summary` с разбивкой задач |
+
+Политика Ralph автоматически определяется из состояния командного режима (`linked_ralph`) или
+может быть указана явно через `omx team shutdown <name> --ralph`.
+
+Выбор Worker CLI для рабочих команды:
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # по умолчанию; использует claude, если worker --model содержит "claude"
+OMX_TEAM_WORKER_CLI=codex   # принудительно Codex CLI
+OMX_TEAM_WORKER_CLI=claude  # принудительно Claude CLI
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # CLI для каждого рабочего (длина=1 или количество рабочих)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # опционально: отключить адаптивный откат queue->resend
+```
+
+Примечания:
+- Аргументы запуска рабочих по-прежнему передаются через `OMX_TEAM_WORKER_LAUNCH_ARGS`.
+- `OMX_TEAM_WORKER_CLI_MAP` переопределяет `OMX_TEAM_WORKER_CLI` для выбора на уровне рабочего.
+- Отправка триггеров по умолчанию использует адаптивные повторные попытки (queue/submit, затем безопасный откат clear-line+resend при необходимости).
+- В режиме Claude worker OMX запускает рабочих как обычный `claude` (без дополнительных аргументов) и игнорирует явные переопределения `--model` / `--config` / `--effort`, чтобы Claude использовал стандартный `settings.json`.
+
+## Что записывает `omx setup`
+
+- `.omx/setup-scope.json` (сохранённая область установки)
+- Установки в зависимости от области:
+  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Поведение при запуске: если сохранённая область — `project`, `omx` автоматически использует `CODEX_HOME=./.codex` (если `CODEX_HOME` ещё не задан).
+- Существующий `AGENTS.md` сохраняется по умолчанию. В интерактивных TTY-запусках setup запрашивает подтверждение перед перезаписью; `--force` перезаписывает без запроса (проверки безопасности активных сессий остаются в силе).
+- Обновления `config.toml` (для обеих областей):
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - Записи MCP-серверов (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- Проектный `AGENTS.md`
+- Директории `.omx/` и конфигурация HUD
+
+## Агенты и навыки
+
+- Промпты: `prompts/*.md` (устанавливаются в `~/.codex/prompts/` для `user`, `./.codex/prompts/` для `project`)
+- Навыки: `skills/*/SKILL.md` (устанавливаются в `~/.agents/skills/` для `user`, `./.agents/skills/` для `project`)
+
+Примеры:
+- Агенты: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- Навыки: `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## Структура проекта
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## Разработка
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## Документация
+
+- **[Полная документация](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Полное руководство
+- **[Справочник CLI](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Все команды `omx`, флаги и инструменты
+- **[Руководство по уведомлениям](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Настройка Discord, Telegram, Slack и webhook
+- **[Рекомендуемые рабочие процессы](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Проверенные в бою цепочки навыков для типичных задач
+- **[Примечания к выпускам](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Что нового в каждой версии
+
+## Примечания
+
+- Полный журнал изменений: `CHANGELOG.md`
+- Руководство по миграции (после v0.4.4 mainline): `docs/migration-mainline-post-v0.4.4.md`
+- Заметки о покрытии и паритете: `COVERAGE.md`
+- Рабочий процесс расширений hook: `docs/hooks-extension.md`
+- Детали установки и участия: `CONTRIBUTING.md`
+
+## Благодарности
+
+Вдохновлено проектом [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), адаптировано для Codex CLI.
+
+## Лицензия
+
+MIT

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,0 +1,314 @@
+# oh-my-codex (OMX)
+
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Codex'iniz yalnız değil.</em>
+</p>
+
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
+
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+[OpenAI Codex CLI](https://github.com/openai/codex) için çok ajanlı orkestrasyon katmanı.
+
+## Diller
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX, Codex'i tek oturumlu bir ajandan koordineli bir sisteme dönüştürür:
+- Uzmanlaşmış ajanlar için role prompts (`/prompts:name`)
+- Tekrarlanabilir çalışma modları için workflow skills (`$name`)
+- tmux'ta takım orkestrasyonu (`omx team`, `$team`)
+- MCP sunucuları aracılığıyla kalıcı durum ve bellek
+
+## Neden OMX
+
+Codex CLI doğrudan görevler için güçlüdür. OMX daha büyük işler için yapı ekler:
+- Ayrıştırma ve aşamalı yürütme (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- Kalıcı mod yaşam döngüsü durumu (`.omx/state/`)
+- Uzun süreli oturumlar için bellek ve notepad yüzeyleri
+- Başlatma, doğrulama ve iptal için operasyonel kontroller
+
+OMX bir eklentidir, fork değil. Codex'in yerel uzantı noktalarını kullanır.
+
+## Gereksinimler
+
+- macOS veya Linux (Windows WSL2 ile)
+- Node.js >= 20
+- Codex CLI kurulu (`npm install -g @openai/codex`)
+- Codex kimlik doğrulaması yapılandırılmış
+
+## Hızlı Başlangıç (3 dakika)
+
+```bash
+npm install -g oh-my-codex
+omx setup
+omx doctor
+```
+
+Güvenilir ortam için önerilen başlatma profili:
+
+```bash
+omx --xhigh --madmax
+```
+
+## v0.5.0'daki Yenilikler
+
+- `omx setup --scope user|project` ile **kapsam duyarlı kurulum** — esnek kurulum modları.
+- `--spark` / `--madmax-spark` ile **Spark worker yönlendirmesi** — takım çalışanlarının lider modelini zorlamadan `gpt-5.3-codex-spark` kullanabilmesi.
+- **Katalog birleştirme** — kullanımdan kaldırılmış prompt'lar (`deep-executor`, `scientist`) ve 9 kullanımdan kaldırılmış skill kaldırıldı.
+- **Bildirim ayrıntı seviyeleri** — CCNotifier çıktısı için ince taneli kontrol.
+
+## İlk Oturum
+
+Codex içinde:
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+Terminalden:
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## Temel Model
+
+OMX şu katmanları kurar ve bağlar:
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (orkestrasyon beyni)
+    -> ~/.codex/prompts/*.md (ajan prompt kataloğu)
+    -> ~/.agents/skills/*/SKILL.md (skill kataloğu)
+    -> ~/.codex/config.toml (özellikler, bildirimler, MCP)
+    -> .omx/ (çalışma zamanı durumu, bellek, planlar, günlükler)
+```
+
+## Ana Komutlar
+
+```bash
+omx                # Codex'i başlat (tmux'ta HUD ile birlikte)
+omx setup          # Prompt/skill/config'i kapsama göre kur + proje AGENTS.md/.omx
+omx doctor         # Kurulum/çalışma zamanı tanılamaları
+omx doctor --team  # Team/swarm tanılamaları
+omx team ...       # tmux takım çalışanlarını başlat/durum/devam et/kapat
+omx status         # Aktif modları göster
+omx cancel         # Aktif çalışma modlarını iptal et
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (eklenti uzantı iş akışı)
+omx hud ...        # --watch|--json|--preset
+omx help
+```
+
+## Hooks Uzantısı (Ek Yüzey)
+
+OMX artık eklenti iskelesi ve doğrulaması için `omx hooks` içerir.
+
+- `omx tmux-hook` desteklenmeye devam eder ve değişmemiştir.
+- `omx hooks` ek niteliktedir ve tmux-hook iş akışlarını değiştirmez.
+- Eklenti dosyaları `.omx/hooks/*.mjs` konumunda bulunur.
+- Eklentiler varsayılan olarak kapalıdır; `OMX_HOOK_PLUGINS=1` ile etkinleştirin.
+
+Tam uzantı iş akışı ve olay modeli için `docs/hooks-extension.md` dosyasına bakın.
+
+## Başlatma Bayrakları
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # yalnızca setup
+```
+
+`--madmax`, Codex `--dangerously-bypass-approvals-and-sandbox` ile eşlenir.
+Yalnızca güvenilir/harici sandbox ortamlarında kullanın.
+
+### MCP workingDirectory politikası (isteğe bağlı sertleştirme)
+
+Varsayılan olarak, MCP durum/bellek/trace araçları çağıranın sağladığı `workingDirectory` değerini kabul eder.
+Bunu kısıtlamak için bir izin listesi belirleyin:
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+Ayarlandığında, bu kökler dışındaki `workingDirectory` değerleri reddedilir.
+
+## Codex-First Prompt Kontrolü
+
+Varsayılan olarak, OMX şunu enjekte eder:
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+Bu, proje `AGENTS.md` yönlendirmesini Codex başlatma talimatlarına katmanlar.
+Codex davranışını genişletir, ancak Codex çekirdek sistem politikalarını değiştirmez/atlamaz.
+
+Kontroller:
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # AGENTS.md enjeksiyonunu devre dışı bırak
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## Takım Modu
+
+Paralel çalışanlardan fayda sağlayan geniş kapsamlı işler için takım modunu kullanın.
+
+Yaşam döngüsü:
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+Operasyonel komutlar:
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+Önemli kural: İptal etmiyorsanız, görevler hâlâ `in_progress` durumundayken kapatmayın.
+
+### Ralph Temizlik Politikası
+
+Bir takım ralph modunda çalıştığında (`omx team ralph ...`), kapatma temizliği
+normal yoldan farklı özel bir politika uygular:
+
+| Davranış | Normal takım | Ralph takımı |
+|---|---|---|
+| Başarısızlıkta zorla kapatma | `shutdown_gate_blocked` hatası verir | Kapıyı atlar, `ralph_cleanup_policy` olayını günlükler |
+| Otomatik dal silme | Geri almada worktree dallarını siler | Dalları korur (`skipBranchDeletion`) |
+| Tamamlanma günlükleme | Standart `shutdown_gate` olayı | Görev dökümü ile ek `ralph_cleanup_summary` olayı |
+
+Ralph politikası takım modu durumundan (`linked_ralph`) otomatik algılanır veya
+`omx team shutdown <name> --ralph` ile açıkça belirtilebilir.
+
+Takım çalışanları için Worker CLI seçimi:
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # varsayılan; worker --model "claude" içeriyorsa claude kullanır
+OMX_TEAM_WORKER_CLI=codex   # Codex CLI çalışanlarını zorla
+OMX_TEAM_WORKER_CLI=claude  # Claude CLI çalışanlarını zorla
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # çalışan başına CLI karışımı (uzunluk=1 veya çalışan sayısı)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # isteğe bağlı: adaptif queue->resend geri dönüşünü devre dışı bırak
+```
+
+Notlar:
+- Worker başlatma argümanları hâlâ `OMX_TEAM_WORKER_LAUNCH_ARGS` aracılığıyla paylaşılır.
+- `OMX_TEAM_WORKER_CLI_MAP`, çalışan başına seçim için `OMX_TEAM_WORKER_CLI`'yi geçersiz kılar.
+- Tetikleyici gönderimi varsayılan olarak adaptif yeniden denemeler kullanır (queue/submit, ardından gerektiğinde güvenli clear-line+resend geri dönüşü).
+- Claude worker modunda, OMX çalışanları düz `claude` olarak başlatır (ekstra başlatma argümanı yok) ve açık `--model` / `--config` / `--effort` geçersiz kılmalarını yok sayar, böylece Claude varsayılan `settings.json` kullanır.
+
+## `omx setup` Ne Yazar
+
+- `.omx/setup-scope.json` (kalıcı kurulum kapsamı)
+- Kapsama bağlı kurulumlar:
+  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Başlatma davranışı: kalıcı kapsam `project` ise, `omx` başlatma otomatik olarak `CODEX_HOME=./.codex` kullanır (`CODEX_HOME` zaten ayarlanmadıysa).
+- Mevcut `AGENTS.md` varsayılan olarak korunur. Etkileşimli TTY çalıştırmalarında, üzerine yazmadan önce setup sorar; `--force` sormadan üzerine yazar (aktif oturum güvenlik kontrolleri hâlâ geçerlidir).
+- `config.toml` güncellemeleri (her iki kapsam için):
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - MCP sunucu girişleri (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- Proje `AGENTS.md`
+- `.omx/` çalışma zamanı dizinleri ve HUD yapılandırması
+
+## Ajanlar ve Skill'ler
+
+- Prompt'lar: `prompts/*.md` (`user` için `~/.codex/prompts/`'a, `project` için `./.codex/prompts/`'a kurulur)
+- Skill'ler: `skills/*/SKILL.md` (`user` için `~/.agents/skills/`'a, `project` için `./.agents/skills/`'a kurulur)
+
+Örnekler:
+- Ajanlar: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- Skill'ler: `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## Proje Yapısı
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## Geliştirme
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## Dokümantasyon
+
+- **[Tam Dokümantasyon](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Eksiksiz kılavuz
+- **[CLI Referansı](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Tüm `omx` komutları, bayraklar ve araçlar
+- **[Bildirim Kılavuzu](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Discord, Telegram, Slack ve webhook kurulumu
+- **[Önerilen İş Akışları](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Yaygın görevler için savaşta test edilmiş skill zincirleri
+- **[Sürüm Notları](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Her sürümdeki yenilikler
+
+## Notlar
+
+- Tam değişiklik günlüğü: `CHANGELOG.md`
+- Geçiş rehberi (v0.4.4 sonrası mainline): `docs/migration-mainline-post-v0.4.4.md`
+- Kapsam ve eşitlik notları: `COVERAGE.md`
+- Hook uzantı iş akışı: `docs/hooks-extension.md`
+- Kurulum ve katkı detayları: `CONTRIBUTING.md`
+
+## Teşekkürler
+
+[oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)'dan ilham alınmıştır, Codex CLI için uyarlanmıştır.
+
+## Lisans
+
+MIT

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,10 +1,59 @@
-# oh-my-codex (OMX) README tiếng Việt
+# oh-my-codex (OMX)
 
-> Tài liệu đầy đủ bằng tiếng Anh: [English README](./README.md).
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Codex của bạn không đơn độc.</em>
+</p>
 
-OMX là lớp điều phối đa tác nhân cho OpenAI Codex CLI.
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-## Bắt đầu nhanh
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+Lớp điều phối đa tác nhân cho [OpenAI Codex CLI](https://github.com/openai/codex).
+
+## Ngôn ngữ
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX biến Codex từ một tác nhân phiên đơn thành một hệ thống phối hợp với:
+- Role prompts (`/prompts:name`) cho các tác nhân chuyên biệt
+- Workflow skills (`$name`) cho các chế độ thực thi lặp lại
+- Điều phối đội ngũ trong tmux (`omx team`, `$team`)
+- Trạng thái bền vững và bộ nhớ qua máy chủ MCP
+
+## Tại sao chọn OMX
+
+Codex CLI mạnh mẽ cho các tác vụ trực tiếp. OMX thêm cấu trúc cho công việc lớn hơn:
+- Phân tách và thực thi theo giai đoạn (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- Trạng thái vòng đời chế độ bền vững (`.omx/state/`)
+- Bề mặt bộ nhớ và sổ ghi chú cho phiên làm việc dài
+- Điều khiển vận hành cho khởi chạy, xác minh và hủy bỏ
+
+OMX là một tiện ích bổ sung, không phải fork. Nó sử dụng các điểm mở rộng gốc của Codex.
+
+## Yêu cầu hệ thống
+
+- macOS hoặc Linux (Windows qua WSL2)
+- Node.js >= 20
+- Codex CLI đã cài đặt (`npm install -g @openai/codex`)
+- Xác thực Codex đã cấu hình
+
+## Bắt đầu nhanh (3 phút)
 
 ```bash
 npm install -g oh-my-codex
@@ -12,25 +61,254 @@ omx setup
 omx doctor
 ```
 
-## Tính năng chính
-
-- Chạy tác nhân chuyên biệt với role prompt (`/prompts:name`)
-- Tự động hóa workflow lặp lại bằng skill (`$name`)
-- Điều phối đội ngũ trong tmux (`omx team`, `$team`)
-- Lưu trạng thái + bộ nhớ lâu dài qua MCP servers
-
-## Lệnh thường dùng
+Cấu hình khởi chạy khuyến nghị cho môi trường tin cậy:
 
 ```bash
-omx
-omx setup
-omx doctor
-omx team <args>
-omx status
-omx cancel
+omx --xhigh --madmax
 ```
 
-## Tìm hiểu thêm
+## Mới trong v0.5.0
 
-- Tài liệu chính: [README.md](./README.md)
-- Website: https://yeachan-heo.github.io/oh-my-codex-website/
+- **Thiết lập nhận biết phạm vi** qua `omx setup --scope user|project` cho các chế độ cài đặt linh hoạt.
+- **Định tuyến Spark worker** qua `--spark` / `--madmax-spark` — worker của đội có thể sử dụng `gpt-5.3-codex-spark` mà không ép buộc model lãnh đạo.
+- **Hợp nhất danh mục** — loại bỏ các prompt không dùng nữa (`deep-executor`, `scientist`) và 9 skill không dùng nữa để có bề mặt gọn hơn.
+- **Mức độ chi tiết thông báo** cho kiểm soát chi tiết đầu ra CCNotifier.
+
+## Phiên đầu tiên
+
+Trong Codex:
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
+```
+
+Từ terminal:
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## Mô hình cốt lõi
+
+OMX cài đặt và kết nối các lớp sau:
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (bộ não điều phối)
+    -> ~/.codex/prompts/*.md (danh mục prompt tác nhân)
+    -> ~/.agents/skills/*/SKILL.md (danh mục skill)
+    -> ~/.codex/config.toml (tính năng, thông báo, MCP)
+    -> .omx/ (trạng thái runtime, bộ nhớ, kế hoạch, nhật ký)
+```
+
+## Các lệnh chính
+
+```bash
+omx                # Khởi chạy Codex (+ HUD trong tmux khi có sẵn)
+omx setup          # Cài đặt prompt/skill/config theo phạm vi + dự án AGENTS.md/.omx
+omx doctor         # Chẩn đoán cài đặt/runtime
+omx doctor --team  # Chẩn đoán Team/swarm
+omx team ...       # Khởi động/trạng thái/tiếp tục/tắt worker tmux của đội
+omx status         # Hiển thị các chế độ đang hoạt động
+omx cancel         # Hủy các chế độ thực thi đang hoạt động
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test (quy trình mở rộng plugin)
+omx hud ...        # --watch|--json|--preset
+omx help
+```
+
+## Mở rộng Hooks (Bề mặt bổ sung)
+
+OMX hiện bao gồm `omx hooks` cho scaffolding và xác thực plugin.
+
+- `omx tmux-hook` vẫn được hỗ trợ và không thay đổi.
+- `omx hooks` là bổ sung và không thay thế quy trình tmux-hook.
+- Tệp plugin nằm tại `.omx/hooks/*.mjs`.
+- Plugin tắt theo mặc định; kích hoạt bằng `OMX_HOOK_PLUGINS=1`.
+
+Xem `docs/hooks-extension.md` cho quy trình mở rộng đầy đủ và mô hình sự kiện.
+
+## Cờ khởi chạy
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # chỉ dành cho setup
+```
+
+`--madmax` ánh xạ đến Codex `--dangerously-bypass-approvals-and-sandbox`.
+Chỉ sử dụng trong môi trường sandbox tin cậy hoặc bên ngoài.
+
+### Chính sách workingDirectory MCP (tăng cường tùy chọn)
+
+Theo mặc định, các công cụ MCP state/memory/trace chấp nhận `workingDirectory` do người gọi cung cấp.
+Để hạn chế điều này, đặt danh sách gốc được phép:
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+Khi được đặt, các giá trị `workingDirectory` ngoài các gốc này sẽ bị từ chối.
+
+## Kiểm soát Prompt Codex-First
+
+Theo mặc định, OMX tiêm:
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+Điều này thêm hướng dẫn `AGENTS.md` của dự án vào lệnh khởi chạy Codex.
+Mở rộng hành vi Codex, nhưng không thay thế/bỏ qua các chính sách hệ thống cốt lõi của Codex.
+
+Điều khiển:
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # tắt tiêm AGENTS.md
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## Chế độ đội
+
+Sử dụng chế độ đội cho công việc lớn được hưởng lợi từ worker song song.
+
+Vòng đời:
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+Các lệnh vận hành:
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+Quy tắc quan trọng: không tắt khi các tác vụ vẫn đang ở trạng thái `in_progress` trừ khi đang hủy bỏ.
+
+### Chính sách dọn dẹp Ralph
+
+Khi đội chạy trong chế độ ralph (`omx team ralph ...`), việc dọn dẹp khi tắt
+áp dụng chính sách chuyên dụng khác với đường dẫn thông thường:
+
+| Hành vi | Đội thông thường | Đội Ralph |
+|---|---|---|
+| Tắt cưỡng bức khi lỗi | Ném `shutdown_gate_blocked` | Bỏ qua cổng, ghi nhật ký sự kiện `ralph_cleanup_policy` |
+| Xóa nhánh tự động | Xóa nhánh worktree khi rollback | Giữ lại nhánh (`skipBranchDeletion`) |
+| Ghi nhật ký hoàn thành | Sự kiện `shutdown_gate` tiêu chuẩn | Sự kiện `ralph_cleanup_summary` bổ sung với phân tích tác vụ |
+
+Chính sách Ralph được phát hiện tự động từ trạng thái chế độ đội (`linked_ralph`) hoặc
+có thể được truyền rõ ràng qua `omx team shutdown <name> --ralph`.
+
+Chọn Worker CLI cho worker của đội:
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # mặc định; sử dụng claude khi worker --model chứa "claude"
+OMX_TEAM_WORKER_CLI=codex   # ép buộc worker Codex CLI
+OMX_TEAM_WORKER_CLI=claude  # ép buộc worker Claude CLI
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # hỗn hợp CLI theo worker (độ dài=1 hoặc số worker)
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # tùy chọn: tắt fallback thích ứng queue->resend
+```
+
+Lưu ý:
+- Tham số khởi chạy worker vẫn được chia sẻ qua `OMX_TEAM_WORKER_LAUNCH_ARGS`.
+- `OMX_TEAM_WORKER_CLI_MAP` ghi đè `OMX_TEAM_WORKER_CLI` cho lựa chọn theo worker.
+- Gửi trigger sử dụng thử lại thích ứng theo mặc định (queue/submit, sau đó fallback an toàn clear-line+resend khi cần).
+- Trong chế độ Claude worker, OMX khởi chạy worker dưới dạng `claude` thuần túy (không có tham số khởi chạy thêm) và bỏ qua các ghi đè rõ ràng `--model` / `--config` / `--effort` để Claude sử dụng `settings.json` mặc định.
+
+## `omx setup` ghi những gì
+
+- `.omx/setup-scope.json` (phạm vi cài đặt được lưu trữ)
+- Cài đặt phụ thuộc phạm vi:
+  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
+  - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
+- Hành vi khởi chạy: nếu phạm vi được lưu trữ là `project`, khởi chạy `omx` tự động sử dụng `CODEX_HOME=./.codex` (trừ khi `CODEX_HOME` đã được đặt).
+- `AGENTS.md` hiện có được giữ nguyên theo mặc định. Trong các lần chạy TTY tương tác, setup hỏi trước khi ghi đè; `--force` ghi đè không hỏi (kiểm tra an toàn phiên hoạt động vẫn áp dụng).
+- Cập nhật `config.toml` (cho cả hai phạm vi):
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - Mục máy chủ MCP (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - `[tui] status_line`
+- `AGENTS.md` của dự án
+- Thư mục `.omx/` runtime và cấu hình HUD
+
+## Tác nhân và skill
+
+- Prompt: `prompts/*.md` (cài vào `~/.codex/prompts/` cho `user`, `./.codex/prompts/` cho `project`)
+- Skill: `skills/*/SKILL.md` (cài vào `~/.agents/skills/` cho `user`, `./.agents/skills/` cho `project`)
+
+Ví dụ:
+- Tác nhân: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
+- Skill: `autopilot`, `plan`, `team`, `ralph`, `ultrawork`, `cancel`
+
+## Cấu trúc dự án
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## Phát triển
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## Tài liệu
+
+- **[Tài liệu đầy đủ](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Hướng dẫn hoàn chỉnh
+- **[Tham chiếu CLI](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Tất cả lệnh `omx`, cờ và công cụ
+- **[Hướng dẫn thông báo](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Cài đặt Discord, Telegram, Slack và webhook
+- **[Quy trình công việc khuyến nghị](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Chuỗi skill đã thử nghiệm thực chiến cho các tác vụ phổ biến
+- **[Ghi chú phát hành](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Tính năng mới trong mỗi phiên bản
+
+## Ghi chú
+
+- Nhật ký thay đổi đầy đủ: `CHANGELOG.md`
+- Hướng dẫn di chuyển (sau v0.4.4 mainline): `docs/migration-mainline-post-v0.4.4.md`
+- Ghi chú về độ bao phủ và tương đương: `COVERAGE.md`
+- Quy trình mở rộng hook: `docs/hooks-extension.md`
+- Chi tiết cài đặt và đóng góp: `CONTRIBUTING.md`
+
+## Lời cảm ơn
+
+Lấy cảm hứng từ [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), được điều chỉnh cho Codex CLI.
+
+## Giấy phép
+
+MIT

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,10 +1,59 @@
-# oh-my-codex (OMX) — 简体中文
+# oh-my-codex (OMX)
 
-> 英文原版 README： [README.md](./README.md)
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>你的 codex 并不孤单。</em>
+</p>
 
-`oh-my-codex (OMX)` 是 [OpenAI Codex CLI](https://github.com/openai/codex) 的多智能体编排层。
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-## 快速开始
+> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+
+[OpenAI Codex CLI](https://github.com/openai/codex) 的多智能体编排层。
+
+## 语言
+
+- [English](./README.md)
+- [한국어 (Korean)](./README.ko.md)
+- [日本語 (Japanese)](./README.ja.md)
+- [简体中文 (Chinese)](./README.zh.md)
+- [Tiếng Việt (Vietnamese)](./README.vi.md)
+- [Español (Spanish)](./README.es.md)
+- [Português (Portuguese)](./README.pt.md)
+- [Русский (Russian)](./README.ru.md)
+- [Türkçe (Turkish)](./README.tr.md)
+- [Deutsch (German)](./README.de.md)
+- [Français (French)](./README.fr.md)
+- [Italiano (Italian)](./README.it.md)
+
+
+OMX 将 Codex 从单会话代理转变为协调系统：
+- 用于专业代理的 role prompts (`/prompts:name`)
+- 用于可重复执行模式的 workflow skills (`$name`)
+- 在 tmux 中的团队编排 (`omx team`, `$team`)
+- 通过 MCP 服务器实现持久状态和记忆
+
+## 为什么选择 OMX
+
+Codex CLI 擅长处理直接任务。OMX 为更大规模的工作添加结构：
+- 分解和分阶段执行 (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
+- 持久化的模式生命周期状态 (`.omx/state/`)
+- 长时间会话的记忆和记事本表面
+- 用于启动、验证和取消的操作控制
+
+OMX 是一个插件，而非 fork。它使用 Codex 的原生扩展点。
+
+## 系统要求
+
+- macOS 或 Linux（Windows 通过 WSL2）
+- Node.js >= 20
+- 已安装 Codex CLI (`npm install -g @openai/codex`)
+- 已配置 Codex 身份验证
+
+## 快速开始（3 分钟）
 
 ```bash
 npm install -g oh-my-codex
@@ -12,28 +61,254 @@ omx setup
 omx doctor
 ```
 
-推荐启动参数：
+推荐的可信环境启动配置：
 
 ```bash
 omx --xhigh --madmax
 ```
 
-## OMX 提供的能力
+## v0.5.0 新功能
 
-- 角色提示词（`/prompts:name`）
-- 工作流技能（`$name`）
-- 基于 tmux 的团队编排（`omx team`, `$team`）
-- 基于 `.omx/` 的状态与记忆持久化
+- 通过 `omx setup --scope user|project` 实现**作用域感知设置** — 灵活的安装模式。
+- 通过 `--spark` / `--madmax-spark` 实现 **Spark worker 路由** — 团队 worker 可以使用 `gpt-5.3-codex-spark` 而无需强制使用领导者模型。
+- **目录整合** — 移除已弃用的 prompt（`deep-executor`、`scientist`）和 9 个已弃用的 skill，使表面更精简。
+- **通知详细级别** — 对 CCNotifier 输出的精细控制。
 
-## 常用命令
+## 首次会话
 
-```bash
-omx
-omx setup
-omx doctor
-omx team <args>
-omx status
-omx cancel
+在 Codex 内部：
+
+```text
+/prompts:architect "analyze current auth boundaries"
+/prompts:executor "implement input validation in login"
+$plan "ship OAuth callback safely"
+$team 3:executor "fix all TypeScript errors"
 ```
 
-更多细节请参考英文文档 [README.md](./README.md)。
+从终端：
+
+```bash
+omx team 4:executor "parallelize a multi-module refactor"
+omx team status <team-name>
+omx team shutdown <team-name>
+```
+
+## 核心模型
+
+OMX 安装并连接以下层：
+
+```text
+User
+  -> Codex CLI
+    -> AGENTS.md (编排大脑)
+    -> ~/.codex/prompts/*.md (代理 prompt 目录)
+    -> ~/.agents/skills/*/SKILL.md (skill 目录)
+    -> ~/.codex/config.toml (功能、通知、MCP)
+    -> .omx/ (运行时状态、记忆、计划、日志)
+```
+
+## 主要命令
+
+```bash
+omx                # 启动 Codex（在 tmux 中附带 HUD）
+omx setup          # 按作用域安装 prompt/skill/config + 项目 AGENTS.md/.omx
+omx doctor         # 安装/运行时诊断
+omx doctor --team  # Team/swarm 诊断
+omx team ...       # 启动/状态/恢复/关闭 tmux 团队 worker
+omx status         # 显示活动模式
+omx cancel         # 取消活动执行模式
+omx reasoning <mode> # low|medium|high|xhigh
+omx tmux-hook ...  # init|status|validate|test
+omx hooks ...      # init|status|validate|test（插件扩展工作流）
+omx hud ...        # --watch|--json|--preset
+omx help
+```
+
+## Hooks 扩展（附加表面）
+
+OMX 现在包含用于插件脚手架和验证的 `omx hooks`。
+
+- `omx tmux-hook` 继续支持且未更改。
+- `omx hooks` 是附加的，不会替代 tmux-hook 工作流。
+- 插件文件位于 `.omx/hooks/*.mjs`。
+- 插件默认关闭；使用 `OMX_HOOK_PLUGINS=1` 启用。
+
+完整的扩展工作流和事件模型请参阅 `docs/hooks-extension.md`。
+
+## 启动标志
+
+```bash
+--yolo
+--high
+--xhigh
+--madmax
+--force
+--dry-run
+--verbose
+--scope <user|project>  # 仅用于 setup
+```
+
+`--madmax` 映射到 Codex `--dangerously-bypass-approvals-and-sandbox`。
+仅在可信/外部沙箱环境中使用。
+
+### MCP workingDirectory 策略（可选加固）
+
+默认情况下，MCP state/memory/trace 工具接受调用方提供的 `workingDirectory`。
+要限制此行为，请设置允许的根目录列表：
+
+```bash
+export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
+```
+
+设置后，超出这些根目录的 `workingDirectory` 值将被拒绝。
+
+## Codex-First Prompt 控制
+
+默认情况下，OMX 注入：
+
+```text
+-c model_instructions_file="<cwd>/AGENTS.md"
+```
+
+这将项目 `AGENTS.md` 指导添加到 Codex 启动指令中。
+扩展 Codex 行为，但不会替换/绕过 Codex 核心系统策略。
+
+控制：
+
+```bash
+OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # 禁用 AGENTS.md 注入
+OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
+```
+
+## 团队模式
+
+对于受益于并行 worker 的大规模工作，使用团队模式。
+
+生命周期：
+
+```text
+start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
+```
+
+操作命令：
+
+```bash
+omx team <args>
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+重要规则：除非中止，否则不要在任务仍处于 `in_progress` 状态时关闭。
+
+### Ralph 清理策略
+
+当团队在 ralph 模式下运行时（`omx team ralph ...`），关闭清理
+应用与常规路径不同的专用策略：
+
+| 行为 | 普通团队 | Ralph 团队 |
+|---|---|---|
+| 失败时强制关闭 | 抛出 `shutdown_gate_blocked` | 绕过闸门，记录 `ralph_cleanup_policy` 事件 |
+| 自动分支删除 | 回滚时删除 worktree 分支 | 保留分支 (`skipBranchDeletion`) |
+| 完成日志 | 标准 `shutdown_gate` 事件 | 附带任务分解的 `ralph_cleanup_summary` 事件 |
+
+Ralph 策略从团队模式状态（`linked_ralph`）自动检测，或
+可通过 `omx team shutdown <name> --ralph` 显式传递。
+
+团队 worker 的 Worker CLI 选择：
+
+```bash
+OMX_TEAM_WORKER_CLI=auto    # 默认；当 worker --model 包含 "claude" 时使用 claude
+OMX_TEAM_WORKER_CLI=codex   # 强制 Codex CLI worker
+OMX_TEAM_WORKER_CLI=claude  # 强制 Claude CLI worker
+OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # 每个 worker 的 CLI 混合（长度=1 或 worker 数量）
+OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # 可选：禁用自适应 queue->resend 回退
+```
+
+注意：
+- Worker 启动参数仍通过 `OMX_TEAM_WORKER_LAUNCH_ARGS` 共享。
+- `OMX_TEAM_WORKER_CLI_MAP` 覆盖 `OMX_TEAM_WORKER_CLI` 以实现每个 worker 的选择。
+- 触发器提交默认使用自适应重试（queue/submit，需要时使用安全的 clear-line+resend 回退）。
+- 在 Claude worker 模式下，OMX 以普通 `claude` 启动 worker（无额外启动参数），并忽略显式的 `--model` / `--config` / `--effort` 覆盖，使 Claude 使用默认 `settings.json`。
+
+## `omx setup` 写入的内容
+
+- `.omx/setup-scope.json`（持久化的设置作用域）
+- 依赖作用域的安装：
+  - `user`：`~/.codex/prompts/`、`~/.agents/skills/`、`~/.codex/config.toml`、`~/.omx/agents/`
+  - `project`：`./.codex/prompts/`、`./.agents/skills/`、`./.codex/config.toml`、`./.omx/agents/`
+- 启动行为：如果持久化的作用域是 `project`，`omx` 启动时自动使用 `CODEX_HOME=./.codex`（除非 `CODEX_HOME` 已设置）。
+- 现有 `AGENTS.md` 默认保留。在交互式 TTY 运行中，setup 会在覆盖前询问；`--force` 无需询问直接覆盖（活动会话安全检查仍然适用）。
+- `config.toml` 更新（两种作用域均适用）：
+  - `notify = ["node", "..."]`
+  - `model_reasoning_effort = "high"`
+  - `developer_instructions = "..."`
+  - `[features] multi_agent = true, child_agents_md = true`
+  - MCP 服务器条目（`omx_state`、`omx_memory`、`omx_code_intel`、`omx_trace`）
+  - `[tui] status_line`
+- 项目 `AGENTS.md`
+- `.omx/` 运行时目录和 HUD 配置
+
+## 代理和技能
+
+- Prompt：`prompts/*.md`（`user` 安装到 `~/.codex/prompts/`，`project` 安装到 `./.codex/prompts/`）
+- Skill：`skills/*/SKILL.md`（`user` 安装到 `~/.agents/skills/`，`project` 安装到 `./.agents/skills/`）
+
+示例：
+- 代理：`architect`、`planner`、`executor`、`debugger`、`verifier`、`security-reviewer`
+- 技能：`autopilot`、`plan`、`team`、`ralph`、`ultrawork`、`cancel`
+
+## 项目结构
+
+```text
+oh-my-codex/
+  bin/omx.js
+  src/
+    cli/
+    team/
+    mcp/
+    hooks/
+    hud/
+    config/
+    modes/
+    notifications/
+    verification/
+  prompts/
+  skills/
+  templates/
+  scripts/
+```
+
+## 开发
+
+```bash
+git clone https://github.com/Yeachan-Heo/oh-my-codex.git
+cd oh-my-codex
+npm install
+npm run build
+npm test
+```
+
+## 文档
+
+- **[完整文档](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — 完整指南
+- **[CLI 参考](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — 所有 `omx` 命令、标志和工具
+- **[通知指南](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Discord、Telegram、Slack 和 webhook 设置
+- **[推荐工作流](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — 用于常见任务的经过实战检验的 skill 链
+- **[发行说明](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — 每个版本的新功能
+
+## 备注
+
+- 完整变更日志：`CHANGELOG.md`
+- 迁移指南（v0.4.4 后的 mainline）：`docs/migration-mainline-post-v0.4.4.md`
+- 覆盖率和对等说明：`COVERAGE.md`
+- Hook 扩展工作流：`docs/hooks-extension.md`
+- 设置和贡献详情：`CONTRIBUTING.md`
+
+## 致谢
+
+受 [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) 启发，为 Codex CLI 适配。
+
+## 许可证
+
+MIT


### PR DESCRIPTION
Mission #12: OMX Multilingual README expansion

**New translations (5):**
- 🇩🇪 German (README.de.md)
- 🇫🇷 French (README.fr.md)
- 🇮🇹 Italian (README.it.md)
- 🇷🇺 Russian (README.ru.md)
- 🇹🇷 Turkish (README.tr.md)

**Updated:**
- Language navigation in all README files
- Synchronized ko, ja, es translations

**Total coverage:** 12 languages