### PR TITLE
fix(worktree): reuse existing valid launch worktree path

### DIFF
--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -141,6 +141,63 @@ describe('worktree ensure + rollback', () => {
       if (!conflictingLaunchPlan.enabled) return;
 
       assert.throws(() => ensureWorktree(conflictingLaunchPlan), /branch_in_use/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses existing worktree when target path already exists as a valid alias', async () => {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: false, name: 'feature/reuse-alias' },
+      });
+      assert.equal(plan.enabled, true);
+      if (!plan.enabled) return;
+
+      const created = ensureWorktree(plan);
+      assert.equal(created.enabled, true);
+      if (!created.enabled) return;
+      assert.equal(created.created, true);
+
+      const aliasPath = `${created.worktreePath}-alias`;
+      await symlink(created.worktreePath, aliasPath);
+
+      const reused = ensureWorktree({ ...plan, worktreePath: aliasPath });
+      assert.equal(reused.enabled, true);
+      if (!reused.enabled) return;
+      assert.equal(reused.reused, true);
+      assert.equal(reused.created, false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves mismatch safety when existing alias points to a different branch', async () => {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: false, name: 'feature/mismatch-source' },
+      });
+      assert.equal(plan.enabled, true);
+      if (!plan.enabled) return;
+
+      const created = ensureWorktree(plan);
+      assert.equal(created.enabled, true);
+      if (!created.enabled) return;
+      assert.equal(created.created, true);
+
+      const aliasPath = `${created.worktreePath}-alias`;
+      await symlink(created.worktreePath, aliasPath);
+
+      assert.throws(
+        () => ensureWorktree({ ...plan, worktreePath: aliasPath, branchName: 'feature/other-branch' }),
+        /worktree_target_mismatch/,
+      );
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -171,6 +171,48 @@ function hasBranchInUse(entries: GitWorktreeEntry[], branchName: string, worktre
   return entries.some((entry) => entry.branchRef === expectedRef && resolve(entry.path) !== resolvedPath);
 }
 
+function resolveGitCommonDir(cwd: string): string | null {
+  const result = spawnSync('git', ['rev-parse', '--git-common-dir'], {
+    cwd,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) return null;
+  const value = (result.stdout || '').trim();
+  if (!value) return null;
+  return resolve(cwd, value);
+}
+
+function readWorktreeEntryFromPath(repoRoot: string, worktreePath: string): GitWorktreeEntry | null {
+  if (!existsSync(worktreePath)) return null;
+
+  const repoCommonDir = resolveGitCommonDir(repoRoot);
+  const worktreeCommonDir = resolveGitCommonDir(worktreePath);
+  if (!repoCommonDir || !worktreeCommonDir || repoCommonDir !== worktreeCommonDir) {
+    return null;
+  }
+
+  const headResult = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  if (headResult.status !== 0) return null;
+  const head = (headResult.stdout || '').trim();
+  if (!head) return null;
+
+  const branchResult = spawnSync('git', ['symbolic-ref', '-q', 'HEAD'], {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  const branchRef = branchResult.status === 0 ? (branchResult.stdout || '').trim() : null;
+
+  return {
+    path: resolve(worktreePath),
+    head,
+    branchRef: branchRef || null,
+    detached: !branchRef,
+  };
+}
+
 export function parseWorktreeMode(args: string[]): ParsedWorktreeMode {
   let mode: WorktreeMode = { enabled: false };
   const remaining: string[] = [];
@@ -250,7 +292,8 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
   if (!plan.enabled) return { enabled: false };
 
   const allWorktrees = listWorktrees(plan.repoRoot);
-  const existingAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath);
+  const existingAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath)
+    ?? readWorktreeEntryFromPath(plan.repoRoot, plan.worktreePath);
   const expectedBranchRef = plan.branchName ? `refs/heads/${plan.branchName}` : null;
 
   if (existingAtPath) {


### PR DESCRIPTION
## Summary
- avoid throwing `worktree_path_conflict` when the target launch worktree path already exists but points to the corresponding valid git worktree
- fall back to reading worktree metadata from the existing path and reuse it when compatible
- preserve mismatch protections by keeping `worktree_target_mismatch` behavior for branch/detached mismatches

## Tests
- `npx tsc --module nodenext --target es2022 --outDir /tmp/omx-worktree-test-build src/team/worktree.ts src/team/__tests__/worktree.test.ts`
- `node --test /tmp/omx-worktree-test-build/__tests__/worktree.test.js`
- `npx @biomejs/biome lint src/team/worktree.ts src/team/__tests__/worktree.test.ts`