### PR TITLE
feat(deep-interview): add Ouroboros-inspired ambiguity-gated interview flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
 | "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
-| "interview", "deep interview", "gather requirements" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run structured requirements interview workflow |
+| "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
 | "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
 | "team", "swarm", "coordinated team", "coordinated swarm" | `$team` | Read `~/.agents/skills/team/SKILL.md`, start team orchestration (swarm compatibility alias) |
 | "ecomode", "eco", "budget" | `$ecomode` | Read `~/.agents/skills/ecomode/SKILL.md`, enable token-efficient mode |
@@ -189,7 +189,7 @@ Workflow Skills:
 - `swarm`: N coordinated agents on shared task list (compatibility facade over team)
 - `ultraqa`: QA cycling -- test, verify, fix, repeat
 - `plan`: Strategic planning with optional RALPLAN-DR consensus mode
-- `deep-interview`: Structured requirement interview workflow with quick/standard/deep depth
+- `deep-interview`: Socratic deep interview with Ouroboros-inspired mathematical ambiguity gating before execution
 - `ralplan`: Iterative consensus planning with RALPLAN-DR structured deliberation (planner + architect + critic); supports `--deliberate` for high-risk work
 
 Agent Shortcuts:

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -32,10 +32,14 @@ Most non-trivial software tasks require coordinated phases: understanding requir
 - QA cycles repeat up to 5 times; if the same error persists 3 times, stop and report the fundamental issue
 - Validation requires approval from all reviewers; rejected items get fixed and re-validated
 - Cancel with `/cancel` at any time; progress is preserved for resume
+- If a deep-interview spec exists, use it as high-clarity phase input instead of re-expanding from scratch
+- If input is too vague for reliable expansion, offer/trigger `$deep-interview` first
 </Execution_Policy>
 
 <Steps>
 1. **Phase 0 - Expansion**: Turn the user's idea into a detailed spec
+   - If `.omx/specs/deep-interview-*.md` exists for this task: reuse it and skip redundant expansion work
+   - If prompt is highly vague: route to `$deep-interview` for Socratic ambiguity-gated clarification
    - Analyst (Opus): Extract requirements
    - Architect (Opus): Create technical specification
    - Output: `.omx/plans/autopilot-spec.md`
@@ -121,7 +125,7 @@ Why bad: This is an exploration/brainstorming request. Respond conversationally 
 - Stop and report when the same QA error persists across 3 cycles (fundamental issue requiring human input)
 - Stop and report when validation keeps failing after 3 re-validation rounds
 - Stop when the user says "stop", "cancel", or "abort"
-- If requirements were too vague and expansion produces an unclear spec, pause and ask the user for clarification before proceeding
+- If requirements were too vague and expansion produces an unclear spec, pause and redirect to `$deep-interview` before proceeding
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
@@ -152,6 +156,18 @@ skipValidation = false
 ## Resume
 
 If autopilot was cancelled or failed, run `/autopilot` again to resume from where it stopped.
+
+## Recommended Clarity Pipeline
+
+For ambiguous requests, prefer:
+
+```
+deep-interview -> ralplan -> autopilot
+```
+
+- `deep-interview`: ambiguity-gated Socratic requirements
+- `ralplan`: consensus planning (planner/architect/critic)
+- `autopilot`: execution + QA + validation
 
 ## Best Practices for Input
 

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -1,71 +1,227 @@
 ---
 name: deep-interview
-description: Structured requirement interviews with depth control and transcript output
+description: Socratic deep interview with mathematical ambiguity gating before execution
+argument-hint: "<idea or vague description>"
 ---
 
 <Purpose>
-Deep Interview runs a structured requirements interview before planning or implementation. It clarifies goals, scope, constraints, and success criteria so downstream work is grounded in explicit requirements.
+Deep Interview implements an Ouroboros-inspired Socratic clarification loop before planning or implementation. It turns vague ideas into explicit specifications by asking targeted questions, scoring ambiguity across weighted dimensions, and gating execution until clarity reaches a configurable threshold.
 </Purpose>
 
-<Trigger_Keywords>
-- "interview"
-- "deep interview"
-- "gather requirements"
-</Trigger_Keywords>
-
 <Use_When>
-- Requirements are ambiguous or underspecified
-- Stakeholders need alignment before PRD/planning
-- You need explicit constraints, priorities, and validation criteria
+- The request is broad, ambiguous, or missing concrete acceptance criteria
+- The user says "deep interview", "interview me", "ask me everything", "don't assume", or "ouroboros"
+- The user wants to avoid misaligned implementation from underspecified requirements
+- You need a requirements artifact before handing off to `ralplan`, `autopilot`, `ralph`, or `team`
 </Use_When>
 
-<Depth_Levels>
-- **Quick**: 3-5 focused questions for rapid clarification (default for pre-PRD checks)
-- **Standard**: 6-10 questions covering full planning inputs
-- **Deep**: 12+ questions with scenario probing, edge cases, and risk exploration
-</Depth_Levels>
+<Do_Not_Use_When>
+- The request already has concrete file/symbol targets and clear acceptance criteria
+- The user explicitly asks to skip planning/interview and execute immediately
+- The user asks for lightweight brainstorming only (use `plan` instead)
+- A complete PRD/plan already exists and execution should start
+</Do_Not_Use_When>
 
-<Workflow_Stages>
-1. **Context gathering**: establish current system/task context and known facts
-2. **Goal clarification**: define desired outcomes and success signals
-3. **Scope**: identify in-scope/out-of-scope boundaries
-4. **Constraints**: capture technical, timeline, compliance, and resource limits
-5. **Validation**: confirm acceptance criteria, risks, and open questions
-</Workflow_Stages>
+<Why_This_Exists>
+Execution quality is usually bottlenecked by requirement clarity. A single expansion pass often misses hidden assumptions. This workflow applies Socratic pressure + quantitative ambiguity scoring so orchestration modes begin with an explicit, testable spec.
 
-<Cross_Platform_Tool_Abstraction>
-Interactive question collection varies by runtime:
-- **Codex CLI**: use `request_user_input` for structured multiple-choice questions
-- **Claude Code**: use `AskUserQuestion` for equivalent structured prompts
+Inspired by Ouroboros (https://github.com/Q00/ouroboros) and adapted for OMX conventions.
+</Why_This_Exists>
 
-When writing or maintaining this skill, preserve behavior parity across tools:
-- Ask equivalent questions in the same stage order
-- Keep option semantics aligned (recommended/default choices first)
-- Record responses in a normalized transcript format regardless of tool
-</Cross_Platform_Tool_Abstraction>
+<Depth_Profiles>
+- **Quick (`--quick`)**: fast pre-PRD pass; target threshold `<= 0.30`; max rounds 5
+- **Standard (`--standard`, default)**: full requirement interview; target threshold `<= 0.20`; max rounds 12
+- **Deep (`--deep`)**: high-rigor exploration; target threshold `<= 0.15`; max rounds 20
+
+If no flag is provided, use **Standard**.
+</Depth_Profiles>
 
 <Execution_Policy>
-- Pick depth level from user intent (`--quick`, `--standard`, `--deep`)
-- If no flag is provided, default to **Standard**
-- Keep questions atomic and non-leading
-- Summarize assumptions explicitly before closing
+- Ask ONE question per round (never batch)
+- Target the weakest clarity dimension each round
+- Gather codebase facts via `explore` before asking user about internals
+- Re-score ambiguity after each answer and show progress transparently
+- Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning
+- Persist mode state for resume safety (`state_write` / `state_read`)
 </Execution_Policy>
 
-<Output_Contract>
-After interview completion, write transcript/summary to:
+<Steps>
 
-`.omx/interviews/{slug}-{timestamp}.md`
+## Phase 1: Initialize
 
-Where:
-- `slug` = short task slug (kebab-case)
-- `timestamp` = UTC timestamp (e.g., `20260303T071500Z`)
+1. Parse `{{ARGUMENTS}}` and depth profile (`--quick|--standard|--deep`).
+2. Detect project context:
+   - Run `explore` to classify **brownfield** (existing codebase target) vs **greenfield**.
+   - For brownfield, collect relevant codebase context before questioning.
+3. Initialize state via `state_write(mode="deep-interview")`:
 
-Output must include:
-- Interview metadata (date, depth, participants/context)
-- Stage-by-stage Q&A summary
-- Confirmed requirements
-- Open questions / risks
-- Recommended next step (e.g., proceed to PRD)
-</Output_Contract>
+```json
+{
+  "active": true,
+  "current_phase": "deep-interview",
+  "state": {
+    "interview_id": "<uuid>",
+    "profile": "quick|standard|deep",
+    "type": "greenfield|brownfield",
+    "initial_idea": "<user input>",
+    "rounds": [],
+    "current_ambiguity": 1.0,
+    "threshold": 0.3,
+    "max_rounds": 5,
+    "challenge_modes_used": [],
+    "codebase_context": null
+  }
+}
+```
+
+4. Announce kickoff with profile, threshold, and current ambiguity.
+
+## Phase 2: Socratic Interview Loop
+
+Repeat until ambiguity `<= threshold`, user exits with warning, or max rounds reached.
+
+### 2a) Generate next question
+Use:
+- Original idea
+- Prior Q&A rounds
+- Current dimension scores
+- Brownfield context (if any)
+- Activated challenge mode injection (Phase 3)
+
+Target the lowest-scoring dimension:
+- Goal Clarity
+- Constraint Clarity
+- Success Criteria Clarity
+- Context Clarity (brownfield only)
+
+### 2b) Ask the question
+Use structured user-input tooling available in the runtime (`AskUserQuestion` / equivalent) and present:
+
+```
+Round {n} | Target: {weakest_dimension} | Ambiguity: {score}%
+
+{question}
+```
+
+### 2c) Score ambiguity
+Score each dimension in `[0.0, 1.0]` with justification + gap.
+
+Greenfield: `ambiguity = 1 - (goal × 0.40 + constraints × 0.30 + criteria × 0.30)`
+
+Brownfield: `ambiguity = 1 - (goal × 0.35 + constraints × 0.25 + criteria × 0.25 + context × 0.15)`
+
+### 2d) Report progress
+Show weighted breakdown table and next focus dimension.
+
+### 2e) Persist state
+Append round result and updated scores via `state_write`.
+
+### 2f) Round controls
+- Round 3+: allow explicit early exit with risk warning
+- Soft warning at profile midpoint (e.g., round 3/6/10 depending on profile)
+- Hard cap at profile `max_rounds`
+
+## Phase 3: Challenge Modes (assumption stress tests)
+
+Use each mode once when applicable:
+
+- **Contrarian** (round 4+): challenge core assumptions
+- **Simplifier** (round 6+): probe minimal viable scope
+- **Ontologist** (round 8+ and ambiguity > 0.30): ask for essence-level reframing
+
+Track used modes in state to prevent repetition.
+
+## Phase 4: Crystallize Artifacts
+
+When threshold is met (or user exits with warning / hard cap):
+
+1. Write interview transcript summary to:
+   - `.omx/interviews/{slug}-{timestamp}.md`  
+     (kept for ralph PRD compatibility)
+2. Write execution-ready spec to:
+   - `.omx/specs/deep-interview-{slug}.md`
+
+Spec should include:
+- Metadata (profile, rounds, final ambiguity, threshold, context type)
+- Clarity breakdown table
+- Goal / Constraints / Non-goals
+- Testable acceptance criteria
+- Assumptions exposed + resolutions
+- Technical context findings
+- Full or condensed transcript
+
+## Phase 5: Execution Bridge
+
+Present execution options after artifact generation:
+
+1. **`$ralplan` (Recommended)**
+   - Run consensus refinement on the spec:
+   - `$plan --consensus --direct <spec-path>`
+2. **`$autopilot`**
+   - Use spec as high-clarity execution input
+3. **`$ralph`**
+   - Sequential persistence loop using spec/criteria
+4. **`$team`**
+   - Parallel coordinated execution using shared spec
+5. **Refine further**
+   - Continue interview loop for lower ambiguity
+
+**IMPORTANT:** Deep-interview is a requirements mode. On handoff, invoke the selected skill. **Do NOT implement directly** inside deep-interview.
+
+</Steps>
+
+<Tool_Usage>
+- Use `explore` for codebase fact gathering
+- Use structured user-input tool for each interview round
+- Use `state_write` / `state_read` for resumable mode state
+- Save transcript/spec artifacts under `.omx/interviews/` and `.omx/specs/`
+</Tool_Usage>
+
+<Escalation_And_Stop_Conditions>
+- User says stop/cancel/abort -> persist state and stop
+- Ambiguity stalls for 3 rounds (+/- 0.05) -> force Ontologist mode once
+- Max rounds reached -> proceed with explicit residual-risk warning
+- All dimensions >= 0.9 -> allow early crystallization even before max rounds
+</Escalation_And_Stop_Conditions>
+
+<Final_Checklist>
+- [ ] Ambiguity score shown each round
+- [ ] Weakest-dimension targeting used
+- [ ] Challenge modes triggered at thresholds (when applicable)
+- [ ] Transcript written to `.omx/interviews/{slug}-{timestamp}.md`
+- [ ] Spec written to `.omx/specs/deep-interview-{slug}.md`
+- [ ] Handoff options provided (`$ralplan`, `$autopilot`, `$ralph`, `$team`)
+- [ ] No direct implementation performed in this mode
+</Final_Checklist>
+
+<Advanced>
+## Suggested Config (optional)
+
+```toml
+[omx.deepInterview]
+defaultProfile = "standard"
+quickThreshold = 0.30
+standardThreshold = 0.20
+deepThreshold = 0.15
+quickMaxRounds = 5
+standardMaxRounds = 12
+deepMaxRounds = 20
+enableChallengeModes = true
+```
+
+## Resume
+
+If interrupted, rerun `$deep-interview`. Resume from persisted mode state via `state_read(mode="deep-interview")`.
+
+## Recommended 3-Stage Pipeline
+
+```
+deep-interview -> ralplan -> autopilot
+```
+
+- Stage 1 (deep-interview): clarity gate
+- Stage 2 (ralplan): feasibility + architecture gate
+- Stage 3 (autopilot): execution + QA + validation gate
+</Advanced>
 
 Task: {{ARGUMENTS}}

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const deepInterviewSkill = readFileSync(
+  join(__dirname, '../../../skills/deep-interview/SKILL.md'),
+  'utf-8',
+);
+const autopilotSkill = readFileSync(
+  join(__dirname, '../../../skills/autopilot/SKILL.md'),
+  'utf-8',
+);
+const rootAgents = readFileSync(join(__dirname, '../../../AGENTS.md'), 'utf-8');
+const templateAgents = readFileSync(join(__dirname, '../../../templates/AGENTS.md'), 'utf-8');
+
+describe('deep-interview Ouroboros contract', () => {
+  it('includes Ouroboros framing and ambiguity gate math', () => {
+    assert.match(deepInterviewSkill, /Ouroboros/i);
+    assert.match(deepInterviewSkill, /ambiguity/i);
+    assert.match(deepInterviewSkill, /threshold/i);
+    assert.match(deepInterviewSkill, /Greenfield: `ambiguity =/);
+    assert.match(deepInterviewSkill, /Brownfield: `ambiguity =/);
+  });
+
+  it('includes challenge mode structure', () => {
+    assert.match(deepInterviewSkill, /Contrarian/i);
+    assert.match(deepInterviewSkill, /Simplifier/i);
+    assert.match(deepInterviewSkill, /Ontologist/i);
+  });
+
+  it('includes execution bridge and no-direct-implementation guard', () => {
+    assert.match(deepInterviewSkill, /Execution Bridge/i);
+    assert.match(deepInterviewSkill, /\$ralplan/i);
+    assert.match(deepInterviewSkill, /\$autopilot/i);
+    assert.match(deepInterviewSkill, /\$ralph/i);
+    assert.match(deepInterviewSkill, /\$team/i);
+    assert.match(deepInterviewSkill, /Do NOT implement directly/i);
+  });
+
+  it('uses OMX-native output paths', () => {
+    assert.match(deepInterviewSkill, /\.omx\/interviews\//);
+    assert.match(deepInterviewSkill, /\.omx\/specs\//);
+  });
+});
+
+describe('cross-skill and AGENTS coherence for deep-interview', () => {
+  it('autopilot references deep-interview handoff', () => {
+    assert.match(autopilotSkill, /deep-interview/i);
+    assert.match(autopilotSkill, /Socratic/i);
+  });
+
+  it('root and template AGENTS include ouroboros keyword and updated description', () => {
+    assert.match(rootAgents, /ouroboros/i);
+    assert.match(templateAgents, /ouroboros/i);
+    assert.match(rootAgents, /Socratic deep interview/i);
+    assert.match(templateAgents, /Socratic deep interview/i);
+  });
+});

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -98,6 +98,30 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match.keyword.toLowerCase(), 'gather requirements');
   });
 
+  it('maps "ouroboros" to deep-interview skill', () => {
+    const match = detectPrimaryKeyword('please run ouroboros before planning');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'deep-interview');
+    assert.equal(match.keyword.toLowerCase(), 'ouroboros');
+  });
+
+  it('maps "interview me" to deep-interview skill', () => {
+    const match = detectPrimaryKeyword('interview me before we start implementation');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'deep-interview');
+    assert.equal(match.keyword.toLowerCase(), 'interview me');
+  });
+
+  it('maps "don\'t assume" to deep-interview skill', () => {
+    const match = detectPrimaryKeyword("don't assume anything yet");
+
+    assert.ok(match);
+    assert.equal(match.skill, 'deep-interview');
+    assert.equal(match.keyword.toLowerCase(), "don't assume");
+  });
+
   it('prefers "deep interview" over "interview" for deterministic longest-match behavior', () => {
     const match = detectPrimaryKeyword('deep interview this request first');
 
@@ -113,6 +137,9 @@ describe('keyword registry coverage', () => {
     assert.ok(registryKeywords.has('coordinated team'));
     assert.ok(registryKeywords.has('swarm'));
     assert.ok(registryKeywords.has('coordinated swarm'));
+    assert.ok(registryKeywords.has('ouroboros'));
+    assert.ok(registryKeywords.has("don't assume"));
+    assert.ok(registryKeywords.has('interview me'));
   });
 });
 

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -19,9 +19,12 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'ulw', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'parallel', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
 
-  { keyword: 'deep interview', skill: 'deep-interview', priority: 8, guidance: 'Activate structured requirement interview workflow' },
-  { keyword: 'gather requirements', skill: 'deep-interview', priority: 8, guidance: 'Activate structured requirement interview workflow' },
-  { keyword: 'interview', skill: 'deep-interview', priority: 8, guidance: 'Activate structured requirement interview workflow' },
+  { keyword: 'deep interview', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
+  { keyword: 'gather requirements', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
+  { keyword: 'interview me', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
+  { keyword: "don't assume", skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
+  { keyword: 'ouroboros', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
+  { keyword: 'interview', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
 
   { keyword: 'plan this', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
   { keyword: 'plan the', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -150,7 +150,7 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
 | "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
-| "interview", "deep interview", "gather requirements" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run structured requirements interview workflow |
+| "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
 | "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
 | "team", "swarm", "coordinated team", "coordinated swarm" | `$team` | Read `~/.agents/skills/team/SKILL.md`, start team orchestration (swarm compatibility alias) |
 | "ecomode", "eco", "budget" | `$ecomode` | Read `~/.agents/skills/ecomode/SKILL.md`, enable token-efficient mode |
@@ -189,7 +189,7 @@ Workflow Skills:
 - `swarm`: N coordinated agents on shared task list (compatibility facade over team)
 - `ultraqa`: QA cycling -- test, verify, fix, repeat
 - `plan`: Strategic planning with optional RALPLAN-DR consensus mode
-- `deep-interview`: Structured requirement interview workflow with quick/standard/deep depth
+- `deep-interview`: Socratic deep interview with Ouroboros-inspired mathematical ambiguity gating before execution
 - `ralplan`: Iterative consensus planning with RALPLAN-DR structured deliberation (planner + architect + critic); supports `--deliberate` for high-risk work
 
 Agent Shortcuts:


### PR DESCRIPTION
## Summary
This PR upgrades OMX `deep-interview` to a v4.6.0-style Ouroboros-inspired workflow focused on requirement clarity before execution.

### What changed
- Reworked `skills/deep-interview/SKILL.md` to include:
  - Socratic interview loop
  - Mathematical ambiguity scoring
  - Threshold-based execution gate
  - Challenge modes (Contrarian, Simplifier, Ontologist)
  - Execution bridge (`$ralplan`, `$autopilot`, `$ralph`, `$team`)
  - OMX-native artifact paths (`.omx/interviews/*`, `.omx/specs/*`)
- Added new deep-interview keyword triggers:
  - `ouroboros`
  - `interview me`
  - `don't assume`
- Updated keyword tests for new triggers.
- Added regression contract test:
  - `src/hooks/__tests__/deep-interview-contract.test.ts`
- Updated deep-interview wording consistency in:
  - `AGENTS.md`
  - `templates/AGENTS.md`
  - `skills/autopilot/SKILL.md`

## Files changed
- `skills/deep-interview/SKILL.md`
- `skills/autopilot/SKILL.md`
- `src/hooks/keyword-registry.ts`
- `src/hooks/__tests__/keyword-detector.test.ts`
- `src/hooks/__tests__/deep-interview-contract.test.ts`
- `AGENTS.md`
- `templates/AGENTS.md`

## Verification
- `npm run build` ✅
- `node --test dist/hooks/__tests__/keyword-detector.test.js` ✅
- `node --test dist/hooks/__tests__/deep-interview-contract.test.js` ✅
- `node --test dist/cli/__tests__/ralph-prd-deep-interview.test.js` ✅
- `npm run lint` ✅
- `npm test` ✅ (full suite; 1733 passing)

## Commit
- `0839c82 feat(deep-interview): add ouroboros-inspired ambiguity-gated interview flow`
