### PR TITLE
fix: ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows during omx setup

### DIFF
--- a/bin/omx.js
+++ b/bin/omx.js
@@ -3,7 +3,7 @@
 // oh-my-codex CLI entry point
 // Requires compiled JavaScript output in dist/
 
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 
@@ -15,7 +15,7 @@ const root = join(__dirname, '..');
 const distEntry = join(root, 'dist', 'cli', 'index.js');
 
 if (existsSync(distEntry)) {
-  const { main } = await import(distEntry);
+  const { main } = await import(pathToFileURL(distEntry).href);
   await main(process.argv.slice(2));
   process.exit(process.exitCode ?? 0);
 } else {


### PR DESCRIPTION
Fixes #559

Converts absolute file paths to file:// URLs before dynamic import to fix ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows during omx setup.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*