### PR TITLE
docs(notifications): document OpenClaw clawdbot-agent workflow

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -87,6 +87,63 @@ This keeps behavior deterministic and backward compatible.
 
 These aliases are normalized by OMX into internal OpenClaw gateway mappings.
 
+## Option C: Clawdbot agent-command workflow (recommended for dev)
+
+Use this when you want OMX hook events to trigger **agent turns** (not plain
+message/webhook forwarding), e.g. for `#omc-dev`.
+
+```json
+{
+  "notifications": {
+    "enabled": true,
+    "verbosity": "verbose",
+    "events": {
+      "session-start": { "enabled": true },
+      "session-idle": { "enabled": true },
+      "ask-user-question": { "enabled": true },
+      "session-stop": { "enabled": true },
+      "session-end": { "enabled": true }
+    },
+    "openclaw": {
+      "enabled": true,
+      "gateways": {
+        "local": {
+          "type": "command",
+          "command": "(clawdbot agent --session-id omx-hooks --message {{instruction}} --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json >/dev/null 2>&1 || true)"
+        }
+      },
+      "hooks": {
+        "session-start": {
+          "enabled": true,
+          "gateway": "local",
+          "instruction": "OMX hook=session-start project={{projectName}} session={{sessionId}}. Send concise status update."
+        },
+        "session-idle": {
+          "enabled": true,
+          "gateway": "local",
+          "instruction": "OMX hook=session-idle project={{projectName}} session={{sessionId}}. Send brief idle update."
+        },
+        "ask-user-question": {
+          "enabled": true,
+          "gateway": "local",
+          "instruction": "OMX hook=ask-user-question session={{sessionId}} question={{question}}. ACTION NEEDED: request user reply."
+        },
+        "stop": {
+          "enabled": true,
+          "gateway": "local",
+          "instruction": "OMX hook=session-stop project={{projectName}} session={{sessionId}}. Send stop update."
+        },
+        "session-end": {
+          "enabled": true,
+          "gateway": "local",
+          "instruction": "OMX hook=session-end project={{projectName}} session={{sessionId}} reason={{reason}}. Send completion summary in one line."
+        }
+      }
+    }
+  }
+}
+```
+
 ## Verification (required)
 
 ### A) Wake smoke test (`/hooks/wake`)

--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -135,6 +135,68 @@ jq \
    }' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
 ```
 
+### 4b-1) OpenClaw + Clawdbot Agent Workflow (recommended for dev)
+
+If the user explicitly asks to route hook notifications through **clawdbot agent turns**
+(not direct message/webhook forwarding), use a command gateway that invokes
+`clawdbot agent` and delivers back to Discord.
+
+Example (targeting `#omc-dev`):
+
+```bash
+jq \
+  --arg command "(clawdbot agent --session-id omx-hooks --message {{instruction}} --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json >/dev/null 2>&1 || true)" \
+  '.notifications = (.notifications // {enabled: true}) |
+   .notifications.enabled = true |
+   .notifications.verbosity = "verbose" |
+   .notifications.events = (.notifications.events // {}) |
+   .notifications.events["session-start"] = {enabled: true} |
+   .notifications.events["session-idle"] = {enabled: true} |
+   .notifications.events["ask-user-question"] = {enabled: true} |
+   .notifications.events["session-stop"] = {enabled: true} |
+   .notifications.events["session-end"] = {enabled: true} |
+   .notifications.openclaw = (.notifications.openclaw // {}) |
+   .notifications.openclaw.enabled = true |
+   .notifications.openclaw.gateways = (.notifications.openclaw.gateways // {}) |
+   .notifications.openclaw.gateways["local"] = {
+     type: "command",
+     command: $command
+   } |
+   .notifications.openclaw.hooks = (.notifications.openclaw.hooks // {}) |
+   .notifications.openclaw.hooks["session-start"] = {
+     enabled: true,
+     gateway: "local",
+     instruction: "OMX hook=session-start project={{projectName}} session={{sessionId}}. Send concise status update."
+   } |
+   .notifications.openclaw.hooks["session-idle"] = {
+     enabled: true,
+     gateway: "local",
+     instruction: "OMX hook=session-idle project={{projectName}} session={{sessionId}}. Send brief idle update."
+   } |
+   .notifications.openclaw.hooks["ask-user-question"] = {
+     enabled: true,
+     gateway: "local",
+     instruction: "OMX hook=ask-user-question session={{sessionId}} question={{question}}. ACTION NEEDED: request user reply."
+   } |
+   .notifications.openclaw.hooks["stop"] = {
+     enabled: true,
+     gateway: "local",
+     instruction: "OMX hook=session-stop project={{projectName}} session={{sessionId}}. Send stop update."
+   } |
+   .notifications.openclaw.hooks["session-end"] = {
+     enabled: true,
+     gateway: "local",
+     instruction: "OMX hook=session-end project={{projectName}} session={{sessionId}} reason={{reason}}. Send completion summary in one line."
+   }' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+```
+
+Verification for this mode:
+
+```bash
+clawdbot agent --session-id omx-hooks --message "OMX hook test via clawdbot agent path" \
+  --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json
+```
+
 ### 4c) Compatibility + precedence contract
 
 OMX accepts both:

--- a/src/hooks/__tests__/openclaw-setup-contract.test.ts
+++ b/src/hooks/__tests__/openclaw-setup-contract.test.ts
@@ -111,4 +111,19 @@ describe("OpenClaw setup workflow contracts", () => {
       "openclaw integration doc should document explicit openclaw precedence",
     );
   });
+
+  it("documents clawdbot agent command workflow for OpenClaw command gateways", () => {
+    assert.ok(
+      configureNotificationsSkill.includes("clawdbot agent"),
+      "configure-notifications should document clawdbot agent workflow",
+    );
+    assert.ok(
+      openclawIntegrationDoc.includes("clawdbot agent"),
+      "openclaw integration doc should document clawdbot agent workflow",
+    );
+    assert.ok(
+      openclawIntegrationDoc.includes("#omc-dev"),
+      "openclaw integration doc should include #omc-dev target example",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
This PR updates the notifications setup docs/skill to explicitly support a **clawdbot agent-based OpenClaw workflow** (instead of direct message send), targeting `dev` behavior.

## What changed
- **skills/configure-notifications/SKILL.md**
  - Added an OpenClaw + clawdbot section that documents using a command gateway with:
    - `clawdbot agent --deliver --reply-channel discord --reply-to '#omc-dev'`
  - Added command-template guidance and event instruction templates.
  - Added verification guidance for agent-path delivery and notes about gateway fallback behavior.
- **docs/openclaw-integration.md**
  - Added a dedicated "Clawdbot agent command workflow (recommended for conversational routing)" section.
  - Included canonical config examples for `notifications.openclaw.gateways.<name>.type = command` using `clawdbot agent`.
  - Added preflight and verification commands tailored for agent delivery.
- **src/hooks/__tests__/openclaw-setup-contract.test.ts**
  - Added contract coverage ensuring docs/skill keep the clawdbot agent workflow present.

## Why
Users running clawdbot want OMX hooks to trigger **agent turns** (with channel-aware conversational responses), not low-level direct sends.

## Validation
- `npm run build`
- `node --test dist/hooks/__tests__/openclaw-setup-contract.test.js`
