### PR TITLE
docs(openclaw): harden token/command guidance after review

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -8,6 +8,9 @@ This guide covers two supported setup paths:
 ## Activation gates
 
 ```bash
+# Prefer exporting a token env var in your shell profile (avoid hardcoding secrets in JSON):
+export HOOKS_TOKEN="your-openclaw-hooks-token"
+
 # Required for OpenClaw dispatch pipeline
 export OMX_OPENCLAW=1
 
@@ -38,7 +41,7 @@ This keeps behavior deterministic and backward compatible.
           "type": "http",
           "url": "http://127.0.0.1:18789/hooks/agent",
           "headers": {
-            "Authorization": "Bearer YOUR_HOOKS_TOKEN"
+            "Authorization": "Bearer ${HOOKS_TOKEN}"
           }
         }
       },
@@ -70,7 +73,7 @@ This keeps behavior deterministic and backward compatible.
       "url": "http://127.0.0.1:18789/hooks/agent",
       "method": "POST",
       "headers": {
-        "Authorization": "Bearer YOUR_HOOKS_TOKEN"
+        "Authorization": "Bearer ${HOOKS_TOKEN}"
       },
       "events": ["session-end", "ask-user-question"],
       "instruction": "OMX event {{event}} for {{projectPath}}"
@@ -92,6 +95,10 @@ These aliases are normalized by OMX into internal OpenClaw gateway mappings.
 Use this when you want OMX hook events to trigger **agent turns** (not plain
 message/webhook forwarding), e.g. for `#omc-dev`.
 
+> Shell safety: template variables (for example `{{instruction}}`) are interpolated into the
+> command string. Keep templates simple and avoid shell metacharacters in user-derived content.
+> For troubleshooting, temporarily remove output redirection and inspect command output.
+
 ```json
 {
   "notifications": {
@@ -109,7 +116,7 @@ message/webhook forwarding), e.g. for `#omc-dev`.
       "gateways": {
         "local": {
           "type": "command",
-          "command": "(clawdbot agent --session-id omx-hooks --message {{instruction}} --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json >/dev/null 2>&1 || true)"
+          "command": "(clawdbot agent --session-id omx-hooks --message {{instruction}} --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json >/tmp/omx-openclaw-agent.log 2>&1)"
         }
       },
       "hooks": {
@@ -150,7 +157,7 @@ message/webhook forwarding), e.g. for `#omc-dev`.
 
 ```bash
 curl -sS -X POST http://127.0.0.1:18789/hooks/wake \
-  -H "Authorization: Bearer YOUR_HOOKS_TOKEN" \
+  -H "Authorization: Bearer ${HOOKS_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{"text":"OMX wake smoke test","mode":"now"}'
 ```
@@ -162,9 +169,9 @@ Expected pass signal: JSON includes `"ok":true`.
 ```bash
 curl -sS -o /tmp/omx-openclaw-agent-check.json -w "HTTP %{http_code}\n" \
   -X POST http://127.0.0.1:18789/hooks/agent \
-  -H "Authorization: Bearer YOUR_HOOKS_TOKEN" \
+  -H "Authorization: Bearer ${HOOKS_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d '{"instruction":"OMX delivery verification","event":"session-end","sessionId":"manual-check"}'
+  -d '{"message":"OMX delivery verification","instruction":"OMX delivery verification","event":"session-end","sessionId":"manual-check"}'
 ```
 
 Expected pass signal: HTTP 2xx + accepted response body.
@@ -173,7 +180,7 @@ Expected pass signal: HTTP 2xx + accepted response body.
 
 ```bash
 # token present
-test -n "$YOUR_HOOKS_TOKEN" && echo "token ok" || echo "token missing"
+test -n "$HOOKS_TOKEN" && echo "token ok" || echo "token missing"
 
 # reachability
 curl -sS -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:18789 || echo "gateway unreachable"

--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -135,17 +135,26 @@ jq \
    }' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
 ```
 
+> Activation gate: OpenClaw-backed dispatch is active only when `OMX_OPENCLAW=1`.
+> For command gateways, also require `OMX_OPENCLAW_COMMAND=1`.
+
 ### 4b-1) OpenClaw + Clawdbot Agent Workflow (recommended for dev)
 
 If the user explicitly asks to route hook notifications through **clawdbot agent turns**
 (not direct message/webhook forwarding), use a command gateway that invokes
 `clawdbot agent` and delivers back to Discord.
 
+Notes:
+- Hook name mapping is intentional: notifications `session-stop` -> OpenClaw hook `stop`.
+- OMX shell-escapes template substitutions for command gateways (including `{{instruction}}`).
+- Keep `instruction` templates concise and avoid untrusted shell metacharacters.
+- During troubleshooting, avoid swallowing command output; route it to a log file.
+
 Example (targeting `#omc-dev`):
 
 ```bash
 jq \
-  --arg command "(clawdbot agent --session-id omx-hooks --message {{instruction}} --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json >/dev/null 2>&1 || true)" \
+  --arg command "(clawdbot agent --session-id omx-hooks --message {{instruction}} --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json >/tmp/omx-openclaw-agent.log 2>&1)" \
   '.notifications = (.notifications // {enabled: true}) |
    .notifications.enabled = true |
    .notifications.verbosity = "verbose" |


### PR DESCRIPTION
## Summary
Follow-up hardening pass after external review (`$ask-claude`) for notification/OpenClaw docs.

## What changed
- `docs/openclaw-integration.md`
  - Use env-style token examples (`HOOKS_TOKEN`) instead of inline literal placeholders.
  - Add shell-safety and troubleshooting notes for command gateway templates.
  - Update clawdbot agent example to log to `/tmp/omx-openclaw-agent.log` instead of swallowing all output.
  - Expand `/hooks/agent` delivery probe payload to include `message` + `instruction` for compatibility.
- `skills/configure-notifications/SKILL.md`
  - Add explicit OpenClaw activation gate reminder (`OMX_OPENCLAW=1`, `OMX_OPENCLAW_COMMAND=1`).
  - Document `session-stop -> stop` mapping for OpenClaw hooks.
  - Add shell-safety/debug notes for command templates.

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/openclaw-setup-contract.test.js`

## Notes
Code-path verification was done before changes:
- OpenClaw env gates and alias normalization are implemented in `src/openclaw/*`.
- This PR is docs hardening/clarification only.
