### PR TITLE
fix(openclaw): configurable command timeout for long-running agent hooks

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -16,6 +16,10 @@ export OMX_OPENCLAW=1
 
 # Required in addition for command gateways
 export OMX_OPENCLAW_COMMAND=1
+
+# Optional global default for command gateway timeout (ms)
+# Precedence: gateway timeout > env override > 5000 default
+export OMX_OPENCLAW_COMMAND_TIMEOUT_MS=120000
 ```
 
 ## Canonical precedence contract
@@ -98,6 +102,9 @@ message/webhook forwarding), e.g. for `#omc-dev`.
 > Shell safety: template variables (for example `{{instruction}}`) are interpolated into the
 > command string. Keep templates simple and avoid shell metacharacters in user-derived content.
 > For troubleshooting, temporarily remove output redirection and inspect command output.
+>
+> Command gateway timeout precedence: `gateways.<name>.timeout` > `OMX_OPENCLAW_COMMAND_TIMEOUT_MS` > `5000`.
+> For `clawdbot agent` workflows, use `120000` (2 minutes) to avoid premature timeout.
 
 ```json
 {
@@ -116,7 +123,8 @@ message/webhook forwarding), e.g. for `#omc-dev`.
       "gateways": {
         "local": {
           "type": "command",
-          "command": "(clawdbot agent --session-id omx-hooks --message {{instruction}} --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json >/tmp/omx-openclaw-agent.log 2>&1)"
+          "command": "(clawdbot agent --session-id omx-hooks --message {{instruction}} --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json >/tmp/omx-openclaw-agent.log 2>&1)",
+          "timeout": 120000
         }
       },
       "hooks": {
@@ -197,3 +205,4 @@ test "$OMX_OPENCLAW_COMMAND" = "1" && echo "OMX_OPENCLAW_COMMAND=1" || echo "mis
 - **5xx**: gateway runtime issue; inspect logs.
 - **Timeout/connection refused**: host/port/firewall issue.
 - **Command gateway disabled**: set both `OMX_OPENCLAW=1` and `OMX_OPENCLAW_COMMAND=1`.
+- **Command killed by `SIGTERM`**: increase `gateways.<name>.timeout` (recommend `120000` for clawdbot agent) or set `OMX_OPENCLAW_COMMAND_TIMEOUT_MS`.

--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -137,6 +137,7 @@ jq \
 
 > Activation gate: OpenClaw-backed dispatch is active only when `OMX_OPENCLAW=1`.
 > For command gateways, also require `OMX_OPENCLAW_COMMAND=1`.
+> Optional timeout env override: `OMX_OPENCLAW_COMMAND_TIMEOUT_MS` (ms).
 
 ### 4b-1) OpenClaw + Clawdbot Agent Workflow (recommended for dev)
 
@@ -149,6 +150,8 @@ Notes:
 - OMX shell-escapes template substitutions for command gateways (including `{{instruction}}`).
 - Keep `instruction` templates concise and avoid untrusted shell metacharacters.
 - During troubleshooting, avoid swallowing command output; route it to a log file.
+- Timeout precedence: `gateways.<name>.timeout` > `OMX_OPENCLAW_COMMAND_TIMEOUT_MS` > `5000`.
+- For clawdbot agent workflows, set `gateways.<name>.timeout` to `120000` (recommended).
 
 Example (targeting `#omc-dev`):
 
@@ -169,7 +172,8 @@ jq \
    .notifications.openclaw.gateways = (.notifications.openclaw.gateways // {}) |
    .notifications.openclaw.gateways["local"] = {
      type: "command",
-     command: $command
+     command: $command,
+     timeout: 120000
    } |
    .notifications.openclaw.hooks = (.notifications.openclaw.hooks // {}) |
    .notifications.openclaw.hooks["session-start"] = {

--- a/src/openclaw/__tests__/dispatcher.test.ts
+++ b/src/openclaw/__tests__/dispatcher.test.ts
@@ -2,7 +2,7 @@
  * Tests for OpenClaw gateway dispatcher.
  */
 
-import { describe, it, beforeEach, afterEach } from 'node:test';
+import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
@@ -10,6 +10,7 @@ import {
   shellEscapeArg,
   interpolateInstruction,
   isCommandGateway,
+  resolveCommandTimeoutMs,
 } from '../dispatcher.js';
 
 describe('validateGatewayUrl', () => {
@@ -136,9 +137,40 @@ describe('isCommandGateway', () => {
   });
 });
 
+describe('resolveCommandTimeoutMs', () => {
+  afterEach(() => {
+    delete process.env.OMX_OPENCLAW_COMMAND_TIMEOUT_MS;
+  });
+
+  it('uses default timeout when gateway and env timeouts are absent', () => {
+    assert.equal(resolveCommandTimeoutMs(undefined, undefined), 5000);
+  });
+
+  it('uses env timeout when gateway timeout is absent', () => {
+    assert.equal(resolveCommandTimeoutMs(undefined, '120000'), 120000);
+  });
+
+  it('uses gateway timeout over env timeout', () => {
+    assert.equal(resolveCommandTimeoutMs(45000, '120000'), 45000);
+  });
+
+  it('clamps timeout to minimum bound', () => {
+    assert.equal(resolveCommandTimeoutMs(10, undefined), 100);
+  });
+
+  it('clamps timeout to maximum bound', () => {
+    assert.equal(resolveCommandTimeoutMs(999999, undefined), 300000);
+  });
+
+  it('ignores invalid env timeout and falls back to default', () => {
+    assert.equal(resolveCommandTimeoutMs(undefined, 'not-a-number'), 5000);
+  });
+});
+
 describe('wakeCommandGateway - command gate', () => {
   afterEach(() => {
     delete process.env.OMX_OPENCLAW_COMMAND;
+    delete process.env.OMX_OPENCLAW_COMMAND_TIMEOUT_MS;
   });
 
   it('returns error when OMX_OPENCLAW_COMMAND is not set', async () => {
@@ -161,5 +193,30 @@ describe('wakeCommandGateway - command gate', () => {
     process.env.OMX_OPENCLAW_COMMAND = '1';
     const result = await wakeCommandGateway('test', { type: 'command', command: 'false' }, {});
     assert.equal(result.success, false);
+  });
+
+  it('uses env timeout when gateway timeout is not set', async () => {
+    const { wakeCommandGateway } = await import('../dispatcher.js');
+    process.env.OMX_OPENCLAW_COMMAND = '1';
+    process.env.OMX_OPENCLAW_COMMAND_TIMEOUT_MS = '100';
+    const result = await wakeCommandGateway(
+      'test',
+      { type: 'command', command: "node -e \"setTimeout(() => {}, 250)\"" },
+      {},
+    );
+    assert.equal(result.success, false);
+    assert.ok(result.error?.includes('SIGTERM'));
+  });
+
+  it('uses gateway timeout over env timeout', async () => {
+    const { wakeCommandGateway } = await import('../dispatcher.js');
+    process.env.OMX_OPENCLAW_COMMAND = '1';
+    process.env.OMX_OPENCLAW_COMMAND_TIMEOUT_MS = '100';
+    const result = await wakeCommandGateway(
+      'test',
+      { type: 'command', command: "node -e \"setTimeout(() => {}, 250)\"", timeout: 500 },
+      {},
+    );
+    assert.equal(result.success, true);
   });
 });

--- a/src/openclaw/dispatcher.ts
+++ b/src/openclaw/dispatcher.ts
@@ -6,8 +6,8 @@
  * to avoid blocking hooks.
  *
  * SECURITY: Command gateway requires OMX_OPENCLAW_COMMAND=1 opt-in.
- * Hard 5-second timeout (non-configurable). Prefers execFile for
- * simple commands; falls back to sh -c only for shell metacharacters.
+ * Command timeout is configurable with safe bounds.
+ * Prefers execFile for simple commands; falls back to sh -c only for shell metacharacters.
  */
 
 import type {
@@ -21,8 +21,16 @@ import type {
 /** Default per-request timeout for HTTP gateways */
 const DEFAULT_HTTP_TIMEOUT_MS = 10_000;
 
-/** Hard non-configurable timeout for command gateways */
-const COMMAND_TIMEOUT_MS = 5_000;
+/** Default command gateway timeout (backward-compatible default) */
+const DEFAULT_COMMAND_TIMEOUT_MS = 5_000;
+
+/**
+ * Command timeout safety bounds.
+ * - Minimum 100ms: avoids immediate/near-zero timeout misconfiguration.
+ * - Maximum 300000ms (5 minutes): prevents runaway long-lived command processes.
+ */
+const MIN_COMMAND_TIMEOUT_MS = 100;
+const MAX_COMMAND_TIMEOUT_MS = 300_000;
 
 /** Shell metacharacters that require sh -c instead of execFile */
 const SHELL_METACHAR_RE = /[|&;><`$()]/;
@@ -97,6 +105,33 @@ export function shellEscapeArg(value: string): string {
 }
 
 /**
+ * Resolve command gateway timeout with precedence:
+ * gateway timeout > OMX_OPENCLAW_COMMAND_TIMEOUT_MS > default.
+ */
+export function resolveCommandTimeoutMs(
+  gatewayTimeout?: number,
+  envTimeoutRaw: string | undefined = process.env.OMX_OPENCLAW_COMMAND_TIMEOUT_MS,
+): number {
+  const parseFinite = (value: unknown): number | undefined => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+    return value;
+  };
+
+  const parseEnv = (value: string | undefined): number | undefined => {
+    if (!value) return undefined;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  };
+
+  const rawTimeout =
+    parseFinite(gatewayTimeout) ??
+    parseEnv(envTimeoutRaw) ??
+    DEFAULT_COMMAND_TIMEOUT_MS;
+
+  return Math.min(MAX_COMMAND_TIMEOUT_MS, Math.max(MIN_COMMAND_TIMEOUT_MS, Math.trunc(rawTimeout)));
+}
+
+/**
  * Wake an HTTP-type OpenClaw gateway with the given payload.
  */
 export async function wakeGateway(
@@ -151,7 +186,8 @@ export async function wakeGateway(
  *
  * SECURITY REQUIREMENTS:
  * - Requires OMX_OPENCLAW_COMMAND=1 opt-in (separate gate from OMX_OPENCLAW)
- * - Hard 5-second timeout (non-configurable)
+ * - Timeout is configurable via gateway.timeout or OMX_OPENCLAW_COMMAND_TIMEOUT_MS
+ *   with safe clamping bounds and backward-compatible default 5000ms
  * - Prefers execFile for simple commands (no metacharacters)
  * - Falls back to sh -c only when metacharacters detected
  * - detached: false to prevent orphan processes
@@ -179,6 +215,7 @@ export async function wakeCommandGateway(
 
   try {
     const { execFile, exec } = await import("child_process");
+    const timeout = resolveCommandTimeoutMs(gatewayConfig.timeout);
 
     // Interpolate variables with shell escaping
     const interpolated = gatewayConfig.command.replace(
@@ -236,7 +273,7 @@ export async function wakeCommandGateway(
       if (hasMetachars) {
         // Fall back to sh -c for complex commands with metacharacters
         child = exec(interpolated, {
-          timeout: COMMAND_TIMEOUT_MS,
+          timeout,
           env: { ...process.env },
         });
       } else {
@@ -245,7 +282,7 @@ export async function wakeCommandGateway(
         const cmd = parts[0];
         const args = parts.slice(1);
         child = execFile(cmd, args, {
-          timeout: COMMAND_TIMEOUT_MS,
+          timeout,
           env: { ...process.env },
         });
       }

--- a/src/openclaw/types.ts
+++ b/src/openclaw/types.ts
@@ -38,7 +38,11 @@ export interface OpenClawCommandGatewayConfig {
   /** Command template with {{variable}} placeholders.
    *  Variables are shell-escaped automatically before interpolation. */
   command: string;
-  /** Per-command timeout in ms (non-configurable hard limit: 5000ms for security) */
+  /**
+   * Per-command timeout in ms.
+   * Precedence: gateway timeout > OMX_OPENCLAW_COMMAND_TIMEOUT_MS > default (5000ms).
+   * Runtime clamps to safe bounds.
+   */
   timeout?: number;
 }
 


### PR DESCRIPTION
## Summary
Make OpenClaw command gateway timeout configurable to support longer-running agent commands (e.g., `clawdbot agent`) while preserving safe defaults and bounds.

## Problem
Command gateways used a hard 5s timeout in the dispatcher, causing real hook runs to fail with:
- `Command killed by signal SIGTERM`

This breaks conversational/agent-style integrations that require >5s.

## Changes
### Runtime
- Added timeout resolver in `src/openclaw/dispatcher.ts`:
  - Precedence: `gateway.timeout` > `OMX_OPENCLAW_COMMAND_TIMEOUT_MS` > default `5000`
  - Clamps to safe bounds: `100ms`..`300000ms`
- Updated command execution paths (`exec` + `execFile`) to use resolved timeout.
- Updated comments to remove “hard non-configurable timeout” wording.

### Types
- Updated `OpenClawCommandGatewayConfig.timeout` docs in `src/openclaw/types.ts` to reflect precedence and clamping.

### Tests
- Extended `src/openclaw/__tests__/dispatcher.test.ts`:
  - Unit tests for timeout resolution precedence/clamping
  - Behavior tests proving env override and gateway override are used

### Docs/Skill
- `docs/openclaw-integration.md`
- `skills/configure-notifications/SKILL.md`

Added guidance for:
- optional `OMX_OPENCLAW_COMMAND_TIMEOUT_MS`
- precedence rules
- recommended `120000` timeout for clawdbot-agent workflows

## Verification
- `npm run build`
- `node --test dist/openclaw/__tests__/dispatcher.test.js`
- `node --test dist/hooks/__tests__/openclaw-setup-contract.test.js`

## Live smoke evidence
Manually validated in this environment:
- no override (default 5000) => 6s command SIGTERM
- env override (`OMX_OPENCLAW_COMMAND_TIMEOUT_MS=12000`) => success
- gateway override (`timeout: 13000`) => success

Also set local user config to use:
- `notifications.openclaw.gateways.local.timeout = 120000`
for stable clawdbot agent hook delivery.
