### PR TITLE
docs: add OpenClaw dev runbook for Korean tmux follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,13 @@ For OpenClaw with **clawdbot agent turns** (instead of direct message forwarding
 configure a command gateway using `clawdbot agent --deliver --reply-channel ... --reply-to ...`
 and map hook events (`session-start`, `session-idle`, `ask-user-question`, `session-stop`, `session-end`).
 
+For dev teams using `#omc-dev`, the OpenClaw guide includes a dedicated runbook for:
+- Korean-only hook responses
+- `sessionId` + `tmuxSession` tracing
+- `SOUL.md`-based follow-up workflow
+
+See: `docs/openclaw-integration.md` (Dev Guide section).
+
 Required env gates for OpenClaw command mode:
 
 ```bash

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -106,6 +106,8 @@ message/webhook forwarding), e.g. for `#omc-dev`.
 > Command gateway timeout precedence: `gateways.<name>.timeout` > `OMX_OPENCLAW_COMMAND_TIMEOUT_MS` > `5000`.
 > For `clawdbot agent` workflows, use `120000` (2 minutes) to avoid premature timeout.
 
+For Korean-first tmux follow-up operations in `#omc-dev`, see the dev guide section below.
+
 ```json
 {
   "notifications": {
@@ -131,32 +133,85 @@ message/webhook forwarding), e.g. for `#omc-dev`.
         "session-start": {
           "enabled": true,
           "gateway": "local",
-          "instruction": "OMX hook=session-start project={{projectName}} session={{sessionId}}. Send concise status update."
+          "instruction": "OMX hook=session-start project={{projectName}} session={{sessionId}} tmux={{tmuxSession}}. 한국어로 간단한 상태 업데이트를 #omc-dev에 전달하고, 필요한 후속조치는 SOUL.md를 참고해 진행하세요."
         },
         "session-idle": {
           "enabled": true,
           "gateway": "local",
-          "instruction": "OMX hook=session-idle project={{projectName}} session={{sessionId}}. Send brief idle update."
+          "instruction": "OMX hook=session-idle project={{projectName}} session={{sessionId}} tmux={{tmuxSession}}. 한국어로 idle 상태를 짧게 공유하고, 진행중이던 작업을 SOUL.md 기준으로 팔로업하세요."
         },
         "ask-user-question": {
           "enabled": true,
           "gateway": "local",
-          "instruction": "OMX hook=ask-user-question session={{sessionId}} question={{question}}. ACTION NEEDED: request user reply."
+          "instruction": "OMX hook=ask-user-question session={{sessionId}} tmux={{tmuxSession}} question={{question}}. 한국어로 사용자 응답이 필요함을 #omc-dev에 알리고 즉시 후속 요청을 남기세요."
         },
         "stop": {
           "enabled": true,
           "gateway": "local",
-          "instruction": "OMX hook=session-stop project={{projectName}} session={{sessionId}}. Send stop update."
+          "instruction": "OMX hook=session-stop project={{projectName}} session={{sessionId}} tmux={{tmuxSession}}. 한국어로 중단 상태를 공유하고 필요한 정리 액션을 SOUL.md 기준으로 수행하세요."
         },
         "session-end": {
           "enabled": true,
           "gateway": "local",
-          "instruction": "OMX hook=session-end project={{projectName}} session={{sessionId}} reason={{reason}}. Send completion summary in one line."
+          "instruction": "OMX hook=session-end project={{projectName}} session={{sessionId}} tmux={{tmuxSession}} reason={{reason}}. 한국어로 완료 요약 1줄을 #omc-dev에 남기고 필요한 후속조치를 SOUL.md 기준으로 이어가세요."
         }
       }
     }
   }
 }
+```
+
+## Dev Guide: OpenClaw + Clawdbot Agent (Korean follow-up mode)
+
+Use this profile when `#omc-dev` should receive OpenClaw notifications as
+**actual clawdbot agent turns**, with proactive follow-up behavior.
+
+### 1) Force Korean output in hook instructions
+
+- Write all hook instructions in Korean.
+- Explicitly require Korean in each instruction template.
+- Prefer Discord channel ID (`channel:<id>`) over channel alias for reliability.
+
+Example instruction style:
+
+```text
+OMX 훅={{event}} 프로젝트={{projectName}} 세션={{sessionId}}.
+반드시 한국어로 응답하세요.
+OMX tmux 세션: {{tmuxSession}}.
+SOUL.md 및 #omc-dev 맥락을 참고해 필요한 후속 액션이 있으면 즉시 안내하세요.
+```
+
+### 2) Track which OMX tmux session emitted the hook
+
+- Include both `{{sessionId}}` and `{{tmuxSession}}` in every hook message.
+- If `{{tmuxSession}}` is present, use that as the primary follow-up target.
+- If missing, derive candidate tmux sessions from `sessionId` and current project path.
+
+Quick checks:
+
+```bash
+tmux ls | grep '^omx-' || true
+tmux list-panes -a -F '#{session_name}\t#{pane_id}\t#{pane_current_path}' | grep "$(basename "$PWD")" || true
+```
+
+### 3) SOUL.md + #omc-dev follow-up runbook
+
+When a hook suggests active work or pending user action:
+
+1. Read `SOUL.md` and recent `#omc-dev` context.
+2. Follow up in Korean, citing `sessionId` + `tmuxSession`.
+3. If action is required, state concrete next step (for example, reply needed, retry needed, or session check needed).
+4. If delivery looks broken, inspect logs and retry without swallowed output.
+
+Troubleshooting commands:
+
+```bash
+tail -n 120 /tmp/omx-openclaw-agent.log
+
+clawdbot agent --session-id omx-hooks \
+  --message "OMX hook retry 점검: session={{sessionId}} tmux={{tmuxSession}}" \
+  --thinking minimal --deliver --reply-channel discord --reply-to 'channel:1468539002985644084' \
+  --timeout 120 --json
 ```
 
 ## Verification (required)

--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -152,6 +152,9 @@ Notes:
 - During troubleshooting, avoid swallowing command output; route it to a log file.
 - Timeout precedence: `gateways.<name>.timeout` > `OMX_OPENCLAW_COMMAND_TIMEOUT_MS` > `5000`.
 - For clawdbot agent workflows, set `gateways.<name>.timeout` to `120000` (recommended).
+- For dev operations, enforce Korean output in all hook instructions.
+- Include both `session={{sessionId}}` and `tmux={{tmuxSession}}` in hook text for traceability.
+- If follow-up is needed, explicitly instruct clawdbot to consult `SOUL.md` and continue in `#omc-dev`.
 
 Example (targeting `#omc-dev`):
 
@@ -179,27 +182,27 @@ jq \
    .notifications.openclaw.hooks["session-start"] = {
      enabled: true,
      gateway: "local",
-     instruction: "OMX hook=session-start project={{projectName}} session={{sessionId}}. Send concise status update."
+     instruction: "OMX hook=session-start project={{projectName}} session={{sessionId}} tmux={{tmuxSession}}. 한국어로 상태를 공유하고 SOUL.md를 참고해 필요한 후속 조치를 #omc-dev에 안내하세요."
    } |
    .notifications.openclaw.hooks["session-idle"] = {
      enabled: true,
      gateway: "local",
-     instruction: "OMX hook=session-idle project={{projectName}} session={{sessionId}}. Send brief idle update."
+     instruction: "OMX hook=session-idle project={{projectName}} session={{sessionId}} tmux={{tmuxSession}}. 한국어로 idle 상황을 간단히 공유하고 진행중인 작업 팔로업을 안내하세요."
    } |
    .notifications.openclaw.hooks["ask-user-question"] = {
      enabled: true,
      gateway: "local",
-     instruction: "OMX hook=ask-user-question session={{sessionId}} question={{question}}. ACTION NEEDED: request user reply."
+     instruction: "OMX hook=ask-user-question session={{sessionId}} tmux={{tmuxSession}} question={{question}}. 한국어로 사용자 응답 필요를 #omc-dev에 알리고 즉시 액션 아이템을 제시하세요."
    } |
    .notifications.openclaw.hooks["stop"] = {
      enabled: true,
      gateway: "local",
-     instruction: "OMX hook=session-stop project={{projectName}} session={{sessionId}}. Send stop update."
+     instruction: "OMX hook=session-stop project={{projectName}} session={{sessionId}} tmux={{tmuxSession}}. 한국어로 중단 상태와 정리 액션을 SOUL.md 기준으로 전달하세요."
    } |
    .notifications.openclaw.hooks["session-end"] = {
      enabled: true,
      gateway: "local",
-     instruction: "OMX hook=session-end project={{projectName}} session={{sessionId}} reason={{reason}}. Send completion summary in one line."
+     instruction: "OMX hook=session-end project={{projectName}} session={{sessionId}} tmux={{tmuxSession}} reason={{reason}}. 한국어로 완료 요약을 1줄로 남기고 필요한 후속 조치를 안내하세요."
    }' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
 ```
 
@@ -208,6 +211,19 @@ Verification for this mode:
 ```bash
 clawdbot agent --session-id omx-hooks --message "OMX hook test via clawdbot agent path" \
   --thinking minimal --deliver --reply-channel discord --reply-to '#omc-dev' --timeout 120 --json
+```
+
+Dev runbook (Korean + tmux follow-up):
+
+```bash
+# 1) identify active OMX tmux sessions
+tmux list-sessions -F '#{session_name}' | rg '^omx-' || true
+
+# 2) confirm hook templates include session/tmux context
+jq '.notifications.openclaw.hooks' "$CONFIG_FILE"
+
+# 3) inspect agent logs when delivery looks broken
+tail -n 120 /tmp/omx-openclaw-agent.log
 ```
 
 ### 4c) Compatibility + precedence contract

--- a/src/hooks/__tests__/openclaw-setup-contract.test.ts
+++ b/src/hooks/__tests__/openclaw-setup-contract.test.ts
@@ -126,4 +126,31 @@ describe("OpenClaw setup workflow contracts", () => {
       "openclaw integration doc should include #omc-dev target example",
     );
   });
+
+  it("documents dev runbook requirements: Korean output, tmux session tracing, and SOUL.md follow-up", () => {
+    assert.ok(
+      configureNotificationsSkill.includes("한국어"),
+      "configure-notifications should include Korean output guidance for clawdbot agent workflow",
+    );
+    assert.ok(
+      configureNotificationsSkill.includes("{{tmuxSession}}"),
+      "configure-notifications should include tmuxSession template guidance",
+    );
+    assert.ok(
+      configureNotificationsSkill.includes("SOUL.md"),
+      "configure-notifications should include SOUL.md follow-up guidance",
+    );
+    assert.ok(
+      openclawIntegrationDoc.includes("Dev Guide: OpenClaw + Clawdbot Agent"),
+      "openclaw integration doc should include dedicated dev guide section",
+    );
+    assert.ok(
+      openclawIntegrationDoc.includes("{{tmuxSession}}"),
+      "openclaw integration doc should include tmuxSession tracing guidance",
+    );
+    assert.ok(
+      openclawIntegrationDoc.includes("SOUL.md"),
+      "openclaw integration doc should include SOUL.md follow-up guidance",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Add a developer-focused OpenClaw/clawdbot notification runbook for `#omc-dev` so teams can operate agent-based hook delivery reliably.

## Changes

- `docs/openclaw-integration.md`
  - Added **Dev Guide: OpenClaw + Clawdbot Agent (Korean follow-up mode)**.
  - Added explicit guidance for:
    - Korean-only hook output policy
    - `sessionId` + `tmuxSession` tracing
    - `SOUL.md` + `#omc-dev` follow-up workflow
  - Updated command-gateway hook instruction examples to include `tmux={{tmuxSession}}` and Korean follow-up wording.
- `skills/configure-notifications/SKILL.md`
  - Added dev-runbook notes for Korean output, tmux traceability, and SOUL.md-driven follow-up.
  - Updated OpenClaw hook instruction examples accordingly.
- `README.md`
  - Added pointer to the new OpenClaw dev runbook section.
- `src/hooks/__tests__/openclaw-setup-contract.test.ts`
  - Added contract checks to ensure docs/skill continue to document:
    - Korean guidance
    - `{{tmuxSession}}` tracing
    - `SOUL.md` follow-up guidance.

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/hooks/__tests__/openclaw-setup-contract.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
