### PR TITLE
feat(notifications): temporary session-scoped notification override

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -27,6 +27,8 @@ import {
   buildDetachedSessionBootstrapSteps,
   buildDetachedSessionFinalizeSteps,
   buildDetachedSessionRollbackSteps,
+  resolveNotifyTempContract,
+  buildNotifyTempStartupMessages,
 } from '../index.js';
 import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
 
@@ -145,6 +147,83 @@ describe('normalizeCodexLaunchArgs', () => {
       normalizeCodexLaunchArgs(['--worktree=feature/demo', '--model', 'gpt-5']),
       ['--model', 'gpt-5'],
     );
+  });
+
+  it('does not forward notify-temp flags/selectors to leader codex args', () => {
+    const parsed = resolveNotifyTempContract(
+      ['--notify-temp', '--discord', '--custom', 'openclaw:ops', '--custom=my-hook', '--model', 'gpt-5'],
+      {},
+    );
+    assert.deepEqual(normalizeCodexLaunchArgs(parsed.passthroughArgs), ['--model', 'gpt-5']);
+  });
+});
+
+describe('resolveNotifyTempContract', () => {
+  it('activates from --notify-temp with no providers', () => {
+    const parsed = resolveNotifyTempContract(['--notify-temp', '--model', 'gpt-5'], {});
+    assert.equal(parsed.contract.active, true);
+    assert.equal(parsed.contract.source, 'cli');
+    assert.deepEqual(parsed.contract.canonicalSelectors, []);
+    assert.deepEqual(parsed.passthroughArgs, ['--model', 'gpt-5']);
+  });
+
+  it('auto-activates when provider selectors are present', () => {
+    const parsed = resolveNotifyTempContract(['--discord', '--slack'], {});
+    assert.equal(parsed.contract.active, true);
+    assert.equal(parsed.contract.source, 'providers');
+    assert.deepEqual(parsed.contract.canonicalSelectors, ['discord', 'slack']);
+    assert.equal(parsed.contract.warnings.some((line) => line.includes('imply temp mode')), true);
+  });
+
+  it('supports repeated --custom forms and canonicalizes selectors', () => {
+    const parsed = resolveNotifyTempContract(
+      ['--custom', 'OpenClaw:Ops', '--custom=my-hook', '--custom=', '--custom'],
+      {},
+    );
+    assert.deepEqual(parsed.contract.canonicalSelectors, ['openclaw:ops', 'custom:my-hook']);
+    assert.equal(parsed.contract.warnings.length >= 1, true);
+  });
+
+  it('activates from OMX_NOTIFY_TEMP=1 env parity', () => {
+    const parsed = resolveNotifyTempContract(['--model', 'gpt-5'], { OMX_NOTIFY_TEMP: '1' });
+    assert.equal(parsed.contract.active, true);
+    assert.equal(parsed.contract.source, 'env');
+    assert.deepEqual(parsed.passthroughArgs, ['--model', 'gpt-5']);
+  });
+});
+
+
+
+describe('buildNotifyTempStartupMessages', () => {
+  it('always emits summary when temp mode is active', () => {
+    const result = buildNotifyTempStartupMessages(
+      {
+        active: true,
+        selectors: ['discord'],
+        canonicalSelectors: ['discord'],
+        warnings: [],
+        source: 'cli',
+      },
+      true,
+    );
+    assert.deepEqual(result.infoLines, [
+      'notify temp: active | providers=discord | persistent-routing=bypassed',
+    ]);
+    assert.deepEqual(result.warningLines, []);
+  });
+
+  it('emits no-valid-provider warning when no provider is configured', () => {
+    const result = buildNotifyTempStartupMessages(
+      {
+        active: true,
+        selectors: [],
+        canonicalSelectors: [],
+        warnings: ['notify temp: provider selectors imply temp mode (auto-activated)'],
+        source: 'providers',
+      },
+      false,
+    );
+    assert.equal(result.warningLines.includes('notify temp: no valid providers resolved; notifications skipped'), true);
   });
 });
 
@@ -417,12 +496,34 @@ describe('detached tmux new-session sequencing', () => {
       "'node' '/tmp/omx.js' 'hud' '--watch'",
       '--model gpt-5',
       '/tmp/codex-home',
+      '{"active":true}',
     );
     assert.deepEqual(steps.map((step) => step.name), ['new-session', 'split-and-capture-hud-pane']);
     assert.equal(steps[1]?.args[3], String(HUD_TMUX_HEIGHT_LINES));
     assert.equal(steps[1]?.args[6], 'omx-demo');
     assert.equal(steps[1]?.args.includes('-P'), true);
     assert.equal(steps[1]?.args.includes('#{pane_id}'), true);
+    assert.equal(steps[0]?.args.includes('-e'), true);
+    assert.equal(steps[0]?.args.includes('OMX_NOTIFY_TEMP_CONTRACT={\"active\":true}'), true);
+  });
+
+  it('buildDetachedSessionBootstrapSteps forwards temp contract env to detached tmux session', () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      'omx-demo',
+      '/tmp/project',
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+      undefined,
+      '{"active":true,"canonicalSelectors":["discord"]}',
+    );
+    const newSession = steps.find((step) => step.name === 'new-session');
+    assert.ok(newSession);
+    assert.equal(
+      newSession!.args.includes('-e')
+      && newSession!.args.some((arg) => arg.startsWith('OMX_NOTIFY_TEMP_CONTRACT=')),
+      true,
+    );
   });
 
   it('buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach', () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -72,6 +72,13 @@ import {
   planWorktreeTarget,
   ensureWorktree,
 } from '../team/worktree.js';
+import {
+  OMX_NOTIFY_TEMP_CONTRACT_ENV,
+  parseNotifyTempContractFromArgs,
+  serializeNotifyTempContract,
+  type NotifyTempContract,
+  type ParseNotifyTempContractResult,
+} from '../notifications/temp-contract.js';
 
 const HELP = `
 oh-my-codex (omx) - Multi-agent orchestration for Codex CLI
@@ -106,6 +113,12 @@ Options:
                 Workers get the configured low-complexity team model; leader model unchanged
   --madmax-spark  spark model for workers + bypass approvals for leader and workers
                 (shorthand for: --spark --madmax)
+  --notify-temp  Enable temporary notification routing for this run/session only
+  --discord      Select Discord provider for temporary notification mode
+  --slack        Select Slack provider for temporary notification mode
+  --telegram     Select Telegram provider for temporary notification mode
+  --custom <name>
+                Select custom/OpenClaw gateway name for temporary notification mode
   -w, --worktree[=<name>]
                 Launch Codex in a git worktree (detached when no name is given)
   --force       Force reinstall (overwrite existing files)
@@ -216,6 +229,10 @@ export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
     return { command: 'launch', launchArgs: args.slice(1) };
   }
   return { command: firstArg, launchArgs: [] };
+}
+
+export function resolveNotifyTempContract(args: string[], env: NodeJS.ProcessEnv = process.env): ParseNotifyTempContractResult {
+  return parseNotifyTempContractFromArgs(args, env);
 }
 
 export type CodexLaunchPolicy = 'inside-tmux' | 'direct';
@@ -532,9 +549,10 @@ export async function launchWithHud(args: string[]): Promise<void> {
 
   const launchCwd = process.cwd();
   const parsedWorktree = parseWorktreeMode(args);
+  const notifyTempResult = resolveNotifyTempContract(parsedWorktree.remainingArgs, process.env);
   const codexHomeOverride = resolveCodexHomeForLaunch(launchCwd, process.env);
-  const workerSparkModel = resolveWorkerSparkModel(parsedWorktree.remainingArgs, codexHomeOverride);
-  const normalizedArgs = normalizeCodexLaunchArgs(parsedWorktree.remainingArgs);
+  const workerSparkModel = resolveWorkerSparkModel(notifyTempResult.passthroughArgs, codexHomeOverride);
+  const normalizedArgs = normalizeCodexLaunchArgs(notifyTempResult.passthroughArgs);
   let cwd = launchCwd;
   if (parsedWorktree.mode.enabled) {
     const planned = planWorktreeTarget({
@@ -565,7 +583,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
 
   // ── Phase 1: preLaunch ──────────────────────────────────────────────────
   try {
-    await preLaunch(cwd, sessionId);
+    await preLaunch(cwd, sessionId, notifyTempResult.contract);
   } catch (err) {
     // preLaunch errors must NOT prevent Codex from starting
     console.error(`[omx] preLaunch warning: ${err instanceof Error ? err.message : err}`);
@@ -573,7 +591,10 @@ export async function launchWithHud(args: string[]): Promise<void> {
 
   // ── Phase 2: run ────────────────────────────────────────────────────────
   try {
-    runCodex(cwd, normalizedArgs, sessionId, workerSparkModel, codexHomeOverride);
+    const notifyTempContractRaw = notifyTempResult.contract.active
+      ? serializeNotifyTempContract(notifyTempResult.contract)
+      : null;
+    runCodex(cwd, normalizedArgs, sessionId, workerSparkModel, codexHomeOverride, notifyTempContractRaw);
   } finally {
     // ── Phase 3: postLaunch ─────────────────────────────────────────────
     await postLaunch(cwd, sessionId);
@@ -849,11 +870,13 @@ export function buildDetachedSessionBootstrapSteps(
   hudCmd: string,
   workerLaunchArgs: string | null,
   codexHomeOverride?: string,
+  notifyTempContractRaw?: string | null,
 ): DetachedSessionTmuxStep[] {
   const newSessionArgs: string[] = [
     'new-session', '-d', '-s', sessionName, '-c', cwd,
     ...(workerLaunchArgs ? ['-e', `${TEAM_WORKER_LAUNCH_ARGS_ENV}=${workerLaunchArgs}`] : []),
     ...(codexHomeOverride ? ['-e', `CODEX_HOME=${codexHomeOverride}`] : []),
+    ...(notifyTempContractRaw ? ['-e', `${OMX_NOTIFY_TEMP_CONTRACT_ENV}=${notifyTempContractRaw}`] : []),
     codexCmd,
   ];
   const splitCaptureArgs: string[] = [
@@ -929,13 +952,31 @@ export function buildDetachedSessionRollbackSteps(
   return steps;
 }
 
+
+export function buildNotifyTempStartupMessages(
+  contract: NotifyTempContract,
+  hasValidProviders: boolean,
+): { infoLines: string[]; warningLines: string[] } {
+  const providers = contract.canonicalSelectors.length > 0
+    ? contract.canonicalSelectors.join(',')
+    : 'none';
+  const infoLines = [
+    `notify temp: active | providers=${providers} | persistent-routing=bypassed`,
+  ];
+  const warningLines = [...contract.warnings];
+  if (!hasValidProviders) {
+    warningLines.push('notify temp: no valid providers resolved; notifications skipped');
+  }
+  return { infoLines, warningLines };
+}
+
 /**
  * preLaunch: Prepare environment before Codex starts.
  * 1. Orphan cleanup (stale session from a crashed launch)
  * 2. Generate runtime overlay + write session-scoped model instructions file
  * 3. Write session.json
  */
-async function preLaunch(cwd: string, sessionId: string): Promise<void> {
+async function preLaunch(cwd: string, sessionId: string, notifyTempContract?: NotifyTempContract): Promise<void> {
   // 1. Orphan cleanup
   const existingSession = await readSessionState(cwd);
   if (existingSession && isSessionStale(existingSession)) {
@@ -976,8 +1017,22 @@ async function preLaunch(cwd: string, sessionId: string): Promise<void> {
     // Non-fatal
   }
 
-  // 6. Send session-start lifecycle notification (best effort)
+  // 6. Emit temp notification startup summary + warnings, then send session-start lifecycle notification (best effort)
   try {
+    if (notifyTempContract?.active) {
+      process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV] = serializeNotifyTempContract(notifyTempContract);
+      const { getNotificationConfig } = await import('../notifications/config.js');
+      const resolved = getNotificationConfig();
+      const startup = buildNotifyTempStartupMessages(notifyTempContract, Boolean(resolved?.enabled));
+      for (const info of startup.infoLines) {
+        console.log(`[omx] ${info}`);
+      }
+      for (const warning of startup.warningLines) {
+        console.warn(`[omx] ${warning}`);
+      }
+    } else {
+      delete process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV];
+    }
     const { notifyLifecycle } = await import('../notifications/index.js');
     await notifyLifecycle('session-start', {
       sessionId,
@@ -1014,6 +1069,7 @@ function runCodex(
   sessionId: string,
   workerDefaultModel?: string,
   codexHomeOverride?: string,
+  notifyTempContractRaw?: string | null,
 ): void {
   const launchArgs = injectModelInstructionsBypassArgs(
     cwd,
@@ -1036,6 +1092,9 @@ function runCodex(
   const codexEnv = workerLaunchArgs
     ? { ...codexBaseEnv, [TEAM_WORKER_LAUNCH_ARGS_ENV]: workerLaunchArgs }
     : codexBaseEnv;
+  const codexEnvWithNotify = notifyTempContractRaw
+    ? { ...codexEnv, [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw }
+    : codexEnv;
 
   if (resolveCodexLaunchPolicy(process.env) === 'inside-tmux') {
     // Already in tmux: launch codex in current pane, HUD in bottom split
@@ -1071,7 +1130,7 @@ function runCodex(
     }
 
     try {
-      runCodexBlocking(cwd, launchArgs, codexEnv);
+      runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
     } finally {
       const cleanupPaneIds = buildHudPaneCleanupTargets(
         listHudWatchPaneIdsInCurrentWindow(currentPaneId),
@@ -1099,6 +1158,7 @@ function runCodex(
         hudCmd,
         workerLaunchArgs,
         codexHomeOverride,
+        notifyTempContractRaw,
       );
       for (const step of bootstrapSteps) {
         const output = execFileSync('tmux', step.args, { stdio: step.name === 'new-session' ? 'ignore' : 'pipe', encoding: 'utf-8' });
@@ -1162,7 +1222,7 @@ function runCodex(
         }
       }
       // tmux not available or failed, just run codex directly
-      runCodexBlocking(cwd, launchArgs, codexEnv);
+      runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
     }
   }
 }

--- a/src/notifications/__tests__/temp-mode.test.ts
+++ b/src/notifications/__tests__/temp-mode.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getNotificationConfig } from '../config.js';
+import { shouldDispatchOpenClaw } from '../index.js';
+import { resetOpenClawConfigCache } from '../../openclaw/config.js';
+
+const ENV_KEYS = [
+  'CODEX_HOME',
+  'OMX_NOTIFY_TEMP',
+  'OMX_NOTIFY_TEMP_CONTRACT',
+  'OMX_NOTIFY_PROFILE',
+  'OMX_DISCORD_WEBHOOK_URL',
+  'OMX_DISCORD_NOTIFIER_BOT_TOKEN',
+  'OMX_DISCORD_NOTIFIER_CHANNEL',
+  'OMX_TELEGRAM_BOT_TOKEN',
+  'OMX_TELEGRAM_CHAT_ID',
+  'OMX_SLACK_WEBHOOK_URL',
+  'OMX_OPENCLAW',
+] as const;
+
+let tempCodexHome: string;
+
+async function writeCodexConfig(contents: unknown): Promise<void> {
+  await mkdir(tempCodexHome, { recursive: true });
+  await writeFile(join(tempCodexHome, '.omx-config.json'), JSON.stringify(contents, null, 2));
+}
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+describe('notification temp mode', () => {
+  beforeEach(async () => {
+    clearEnv();
+    resetOpenClawConfigCache();
+    tempCodexHome = await mkdtemp(join(tmpdir(), 'omx-notify-temp-'));
+    process.env.CODEX_HOME = tempCodexHome;
+  });
+
+  afterEach(async () => {
+    clearEnv();
+    resetOpenClawConfigCache();
+    if (tempCodexHome) {
+      await rm(tempCodexHome, { recursive: true, force: true });
+    }
+  });
+
+  it('temp contract bypasses persistent file/profile routing', async () => {
+    await writeCodexConfig({
+      notifications: {
+        enabled: true,
+        defaultProfile: 'file-profile',
+        profiles: {
+          'file-profile': {
+            enabled: true,
+            discord: { enabled: true, webhookUrl: 'https://discord.com/api/webhooks/file' },
+          },
+        },
+      },
+    });
+    process.env.OMX_NOTIFY_PROFILE = 'file-profile';
+    process.env.OMX_SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/temp-only';
+    process.env.OMX_NOTIFY_TEMP_CONTRACT = JSON.stringify({
+      active: true,
+      selectors: ['slack'],
+      canonicalSelectors: ['slack'],
+      warnings: [],
+      source: 'cli',
+    });
+
+    const config = getNotificationConfig();
+    assert.ok(config);
+    assert.equal(config.enabled, true);
+    assert.equal(config.slack?.enabled, true);
+    assert.equal(config.discord, undefined);
+  });
+
+  it('temp contract with no valid configured provider disables dispatch config', () => {
+    process.env.OMX_NOTIFY_TEMP_CONTRACT = JSON.stringify({
+      active: true,
+      selectors: ['telegram'],
+      canonicalSelectors: ['telegram'],
+      warnings: [],
+      source: 'cli',
+    });
+
+    const config = getNotificationConfig();
+    assert.ok(config);
+    assert.equal(config.enabled, false);
+  });
+
+  it('temp mode does not leak persistent openclaw/custom alias routing unless selected', async () => {
+    await writeCodexConfig({
+      notifications: {
+        enabled: true,
+        custom_cli_command: { enabled: true, command: 'echo test' },
+        openclaw: {
+          enabled: true,
+          gateways: { g: { type: 'command', command: 'echo hi' } },
+          hooks: { 'session-end': { enabled: true, gateway: 'g', instruction: 'i' } },
+        },
+      },
+    });
+    process.env.OMX_OPENCLAW = '1';
+    process.env.OMX_NOTIFY_TEMP_CONTRACT = JSON.stringify({
+      active: true,
+      selectors: ['discord'],
+      canonicalSelectors: ['discord'],
+      warnings: [],
+      source: 'cli',
+    });
+
+    const config = getNotificationConfig();
+    assert.ok(config);
+    assert.equal(config.openclaw, undefined);
+  });
+
+  it('temp mode enables openclaw config only when explicitly selected', () => {
+    process.env.OMX_OPENCLAW = '1';
+    process.env.OMX_NOTIFY_TEMP_CONTRACT = JSON.stringify({
+      active: true,
+      selectors: ['openclaw:gateway-main'],
+      canonicalSelectors: ['openclaw:gateway-main'],
+      warnings: [],
+      source: 'providers',
+    });
+
+    const config = getNotificationConfig();
+    assert.ok(config);
+    assert.equal(config.openclaw?.enabled, true);
+    assert.equal(config.enabled, true);
+  });
+
+  it('shouldDispatchOpenClaw enforces temp-mode explicit selection and gateway matching', async () => {
+    process.env.OMX_OPENCLAW = '1';
+    await writeCodexConfig({
+      notifications: {
+        enabled: true,
+        openclaw: {
+          enabled: true,
+          gateways: { g1: { type: 'command', command: 'echo hi' } },
+          hooks: { 'session-end': { enabled: true, gateway: 'g1', instruction: 'i' } },
+        },
+      },
+    });
+
+    const activeNoOpenClaw = {
+      active: true,
+      selectors: ['discord'],
+      canonicalSelectors: ['discord'],
+      warnings: [],
+      source: 'cli' as const,
+    };
+    const activeWithOpenClaw = {
+      active: true,
+      selectors: ['openclaw:g1'],
+      canonicalSelectors: ['openclaw:g1'],
+      warnings: [],
+      source: 'cli' as const,
+    };
+
+    const activeWithCustomGateway = {
+      active: true,
+      selectors: ['custom:g1'],
+      canonicalSelectors: ['custom:g1'],
+      warnings: [],
+      source: 'cli' as const,
+    };
+
+    const activeWithWrongGateway = {
+      active: true,
+      selectors: ['custom:other'],
+      canonicalSelectors: ['custom:other'],
+      warnings: [],
+      source: 'cli' as const,
+    };
+
+    assert.equal(
+      await shouldDispatchOpenClaw('session-end', activeNoOpenClaw, process.env),
+      false,
+    );
+    assert.equal(
+      await shouldDispatchOpenClaw('session-end', activeWithOpenClaw, process.env),
+      true,
+    );
+    assert.equal(
+      await shouldDispatchOpenClaw('session-end', activeWithCustomGateway, process.env),
+      true,
+    );
+    assert.equal(
+      await shouldDispatchOpenClaw('session-end', activeWithWrongGateway, process.env),
+      false,
+    );
+    assert.equal(
+      await shouldDispatchOpenClaw('session-end', null, process.env),
+      true,
+    );
+    assert.equal(
+      await shouldDispatchOpenClaw('session-end', activeWithOpenClaw, { OMX_OPENCLAW: '0', CODEX_HOME: tempCodexHome }),
+      false,
+    );
+  });
+});

--- a/src/notifications/config.ts
+++ b/src/notifications/config.ts
@@ -20,6 +20,12 @@ import type {
   VerbosityLevel,
 } from "./types.js";
 import { getHookConfig, mergeHookConfigIntoNotificationConfig } from "./hook-config.js";
+import {
+  getTempBuiltinSelectors,
+  isNotifyTempEnvActive,
+  isOpenClawSelectedInTempContract,
+  readNotifyTempContractFromEnv,
+} from "./temp-contract.js";
 
 const CONFIG_FILE = join(codexHome(), ".omx-config.json");
 
@@ -324,9 +330,46 @@ function normalizeCustomTransportGate(config: FullNotificationConfig): FullNotif
   };
 }
 
+function buildTempModeConfigFromContract(): FullNotificationConfig | null {
+  const contract = readNotifyTempContractFromEnv(process.env);
+  const envActive = isNotifyTempEnvActive(process.env);
+  if (!contract?.active && !envActive) return null;
+
+  const selectors = getTempBuiltinSelectors(contract);
+  const envConfig = buildConfigFromEnv();
+  const config: FullNotificationConfig = { enabled: false };
+
+  if (selectors.has("discord")) {
+    if (envConfig?.discord) config.discord = envConfig.discord;
+    if (envConfig?.["discord-bot"]) config["discord-bot"] = envConfig["discord-bot"];
+  }
+  if (selectors.has("telegram") && envConfig?.telegram) {
+    config.telegram = envConfig.telegram;
+  }
+  if (selectors.has("slack") && envConfig?.slack) {
+    config.slack = envConfig.slack;
+  }
+  if (isOpenClawSelectedInTempContract(contract)) {
+    config.openclaw = { enabled: true };
+  }
+
+  config.enabled = Boolean(
+    config.discord?.enabled
+    || config["discord-bot"]?.enabled
+    || config.telegram?.enabled
+    || config.slack?.enabled
+    || config.openclaw?.enabled,
+  );
+
+  return config;
+}
+
 export function getNotificationConfig(
   profileName?: string,
 ): FullNotificationConfig | null {
+  const tempModeConfig = buildTempModeConfigFromContract();
+  if (tempModeConfig) return tempModeConfig;
+
   const raw = readRawConfig();
 
   if (raw) {

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -128,6 +128,12 @@ import type {
   DispatchResult,
 } from "./types.js";
 import { getNotificationConfig, isEventEnabled, getVerbosity, shouldIncludeTmuxTail, getActiveProfileName } from "./config.js";
+import {
+  getSelectedOpenClawGatewayNames,
+  isOpenClawSelectedInTempContract,
+  readNotifyTempContractFromEnv,
+  type NotifyTempContract,
+} from "./temp-contract.js";
 import { formatNotification } from "./formatter.js";
 import { dispatchNotifications } from "./dispatcher.js";
 import { getCurrentTmuxSession, captureTmuxPane } from "./tmux.js";
@@ -149,6 +155,30 @@ function toOpenClawEvent(event: NotificationEvent): OpenClawHookEvent | null {
     case "ask-user-question": return "ask-user-question";
     case "session-stop": return "stop";
     default: return null;
+  }
+}
+
+export async function shouldDispatchOpenClaw(
+  event: OpenClawHookEvent,
+  tempContract: NotifyTempContract | null,
+  env: NodeJS.ProcessEnv = process.env,
+) : Promise<boolean> {
+  if (env.OMX_OPENCLAW !== "1") return false;
+  if (!tempContract?.active) return true;
+  if (!isOpenClawSelectedInTempContract(tempContract)) return false;
+
+  const selectedGatewayNames = getSelectedOpenClawGatewayNames(tempContract);
+  if (selectedGatewayNames.size === 0) return false;
+
+  try {
+    const { getOpenClawConfig, resolveGateway } = await import("../openclaw/config.js");
+    const config = getOpenClawConfig();
+    if (!config) return false;
+    const resolved = resolveGateway(config, event);
+    if (!resolved) return false;
+    return selectedGatewayNames.has(resolved.gatewayName.toLowerCase());
+  } catch {
+    return false;
   }
 }
 
@@ -211,11 +241,13 @@ export async function notifyLifecycle(
 
     const result = await dispatchNotifications(config, event, payload);
 
-    // Fire-and-forget OpenClaw gateway call (if OMX_OPENCLAW=1)
-    if (process.env.OMX_OPENCLAW === "1") {
-      try {
-        const openClawEvent = toOpenClawEvent(event);
-        if (openClawEvent !== null) {
+    // Fire-and-forget OpenClaw gateway call
+    const openClawEvent = toOpenClawEvent(event);
+    if (openClawEvent !== null) {
+      const tempContract = readNotifyTempContractFromEnv(process.env);
+      const openClawAllowed = await shouldDispatchOpenClaw(openClawEvent, tempContract, process.env);
+      if (openClawAllowed) {
+        try {
           const { wakeOpenClaw } = await import("../openclaw/index.js");
           // Non-blocking: do not await to avoid delaying notification return
           void wakeOpenClaw(openClawEvent, {
@@ -229,9 +261,9 @@ export async function notifyLifecycle(
             // Reply context env vars are read inside wakeOpenClaw;
             // callers do not need to pass them explicitly.
           });
+        } catch {
+          // OpenClaw failures must never affect notification dispatch
         }
-      } catch {
-        // OpenClaw failures must never affect notification dispatch
       }
     }
 

--- a/src/notifications/temp-contract.ts
+++ b/src/notifications/temp-contract.ts
@@ -1,0 +1,177 @@
+export const OMX_NOTIFY_TEMP_ENV = 'OMX_NOTIFY_TEMP';
+export const OMX_NOTIFY_TEMP_CONTRACT_ENV = 'OMX_NOTIFY_TEMP_CONTRACT';
+
+export type NotifyTempSource = 'none' | 'cli' | 'env' | 'providers';
+
+export interface NotifyTempContract {
+  active: boolean;
+  selectors: string[];
+  canonicalSelectors: string[];
+  warnings: string[];
+  source: NotifyTempSource;
+}
+
+export interface ParseNotifyTempContractResult {
+  contract: NotifyTempContract;
+  passthroughArgs: string[];
+}
+
+function normalizeCustomSelector(raw: string): string | null {
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized.startsWith('openclaw:')) {
+    const gateway = normalized.slice('openclaw:'.length).trim();
+    if (!gateway) return null;
+    return `openclaw:${gateway}`;
+  }
+  return `custom:${normalized}`;
+}
+
+function toUnique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+export function parseNotifyTempContractFromArgs(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): ParseNotifyTempContractResult {
+  const passthroughArgs: string[] = [];
+  const selectors: string[] = [];
+  const warnings: string[] = [];
+  let cliActivated = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--notify-temp') {
+      cliActivated = true;
+      continue;
+    }
+
+    if (arg === '--discord' || arg === '--slack' || arg === '--telegram') {
+      selectors.push(arg.slice(2));
+      continue;
+    }
+
+    if (arg === '--custom') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        warnings.push('notify temp: ignoring --custom without a provider name');
+        continue;
+      }
+      const normalized = normalizeCustomSelector(next);
+      if (!normalized) {
+        warnings.push(`notify temp: ignoring invalid --custom selector "${next}"`);
+      } else {
+        selectors.push(normalized);
+      }
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--custom=')) {
+      const raw = arg.slice('--custom='.length);
+      const normalized = normalizeCustomSelector(raw);
+      if (!normalized) {
+        warnings.push(`notify temp: ignoring invalid --custom selector "${raw}"`);
+      } else {
+        selectors.push(normalized);
+      }
+      continue;
+    }
+
+    passthroughArgs.push(arg);
+  }
+
+  const envActivated = env[OMX_NOTIFY_TEMP_ENV] === '1';
+  const canonicalSelectors = toUnique(selectors);
+  const providerActivated = canonicalSelectors.length > 0;
+  const active = cliActivated || envActivated || providerActivated;
+
+  if (providerActivated && !cliActivated && !envActivated) {
+    warnings.push('notify temp: provider selectors imply temp mode (auto-activated)');
+  }
+
+  let source: NotifyTempSource = 'none';
+  if (cliActivated) source = 'cli';
+  else if (envActivated) source = 'env';
+  else if (providerActivated) source = 'providers';
+
+  return {
+    contract: {
+      active,
+      selectors: [...selectors],
+      canonicalSelectors,
+      warnings,
+      source,
+    },
+    passthroughArgs,
+  };
+}
+
+export function serializeNotifyTempContract(contract: NotifyTempContract): string {
+  return JSON.stringify(contract);
+}
+
+
+export function isNotifyTempEnvActive(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[OMX_NOTIFY_TEMP_ENV] === '1';
+}
+
+export function readNotifyTempContractFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): NotifyTempContract | null {
+  const raw = env[OMX_NOTIFY_TEMP_CONTRACT_ENV];
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<NotifyTempContract>;
+    if (
+      typeof parsed.active !== 'boolean'
+      || !Array.isArray(parsed.selectors)
+      || !Array.isArray(parsed.canonicalSelectors)
+      || !Array.isArray(parsed.warnings)
+      || typeof parsed.source !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      active: parsed.active,
+      selectors: parsed.selectors.filter((entry): entry is string => typeof entry === 'string'),
+      canonicalSelectors: parsed.canonicalSelectors.filter((entry): entry is string => typeof entry === 'string'),
+      warnings: parsed.warnings.filter((entry): entry is string => typeof entry === 'string'),
+      source: parsed.source as NotifyTempSource,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isOpenClawSelectedInTempContract(contract: NotifyTempContract | null): boolean {
+  if (!contract?.active) return false;
+  return contract.canonicalSelectors.some((selector) =>
+    selector.startsWith('openclaw:') || selector.startsWith('custom:'));
+}
+
+export function getTempBuiltinSelectors(contract: NotifyTempContract | null): Set<string> {
+  if (!contract?.active) return new Set<string>();
+  return new Set(
+    contract.canonicalSelectors.filter((selector) =>
+      selector === 'discord' || selector === 'slack' || selector === 'telegram'),
+  );
+}
+
+export function getSelectedOpenClawGatewayNames(contract: NotifyTempContract | null): Set<string> {
+  if (!contract?.active) return new Set<string>();
+  const names: string[] = [];
+  for (const selector of contract.canonicalSelectors) {
+    if (selector.startsWith('openclaw:')) {
+      const name = selector.slice('openclaw:'.length).trim().toLowerCase();
+      if (name) names.push(name);
+      continue;
+    }
+    if (selector.startsWith('custom:')) {
+      const name = selector.slice('custom:'.length).trim().toLowerCase();
+      if (name) names.push(name);
+    }
+  }
+  return new Set(names);
+}


### PR DESCRIPTION
## Summary
- add a canonical temp notification contract parser for CLI flags/env (`--notify-temp`, provider selectors, repeated `--custom`)
- propagate the temp contract through direct + detached tmux launch paths via env
- add temp startup summary/warning UX and strip OMX-owned temp flags from Codex passthrough args
- add temp-mode config precedence so temp routing bypasses persistent profile/file config
- gate OpenClaw dispatch in temp mode so it only runs when explicitly selected and matches selected gateway
- add regression tests for parsing, propagation, precedence, and OpenClaw isolation

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/index.test.js dist/notifications/__tests__/temp-mode.test.js dist/notifications/__tests__/config.test.js dist/notifications/__tests__/profiles.test.js`

## Notes
- behavior is unchanged when temp mode is not active
- temp mode remains session/process scoped (no persistence writes)
