### PR TITLE
fix(setup): skip [tui] section for codex >= 0.107.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -866,6 +866,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1179,6 +1180,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2330,6 +2332,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/cli/__tests__/setup-codex-version.test.ts
+++ b/src/cli/__tests__/setup-codex-version.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parseCodexVersion, setup } from '../setup.js';
+
+async function writeFakeCodex(binDir: string): Promise<void> {
+  const codexPath = join(binDir, 'codex');
+  const script = [
+    '#!/usr/bin/env node',
+    'if (process.argv.includes("--version")) {',
+    '  process.stdout.write(process.env.OMX_TEST_CODEX_VERSION_OUTPUT ?? "0.106.0");',
+    '  process.exit(0);',
+    '}',
+    'process.exit(1);',
+    '',
+  ].join('\n');
+  await writeFile(codexPath, script, { mode: 0o755 });
+  await chmod(codexPath, 0o755);
+}
+
+async function runSetupWithCapturedLogs(cwd: string, env: Record<string, string>): Promise<string> {
+  const previousCwd = process.cwd();
+  const previousEnv = {
+    HOME: process.env.HOME,
+    PATH: process.env.PATH,
+    OMX_TEST_CODEX_VERSION_OUTPUT: process.env.OMX_TEST_CODEX_VERSION_OUTPUT,
+  };
+  const logs: string[] = [];
+  const originalLog = console.log;
+  process.chdir(cwd);
+  process.env.HOME = env.HOME;
+  process.env.PATH = env.PATH;
+  process.env.OMX_TEST_CODEX_VERSION_OUTPUT = env.OMX_TEST_CODEX_VERSION_OUTPUT;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((arg) => String(arg)).join(' '));
+  };
+
+  try {
+    await setup({ scope: 'project' });
+    return logs.join('\n');
+  } finally {
+    console.log = originalLog;
+    process.chdir(previousCwd);
+    process.env.HOME = previousEnv.HOME;
+    process.env.PATH = previousEnv.PATH;
+    process.env.OMX_TEST_CODEX_VERSION_OUTPUT = previousEnv.OMX_TEST_CODEX_VERSION_OUTPUT;
+  }
+}
+
+describe('omx setup codex version handling', () => {
+  it('parses codex versions from common --version outputs', () => {
+    assert.equal(parseCodexVersion('0.107.0'), '0.107.0');
+    assert.equal(parseCodexVersion('codex 0.107.1'), '0.107.1');
+    assert.equal(parseCodexVersion('v0.106.2'), '0.106.2');
+    assert.equal(parseCodexVersion('codex version: unknown'), undefined);
+  });
+
+  it('skips [tui] for codex >= 0.107.0', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-codex-version-'));
+    try {
+      const home = join(wd, 'home');
+      const binDir = join(wd, 'bin');
+      await mkdir(home, { recursive: true });
+      await mkdir(binDir, { recursive: true });
+      await writeFakeCodex(binDir);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+        OMX_TEST_CODEX_VERSION_OUTPUT: 'codex 0.107.1',
+      });
+
+      const config = await readFile(join(wd, '.codex', 'config.toml'), 'utf-8');
+      assert.doesNotMatch(config, /^\[tui\]$/m);
+      assert.match(output, /StatusLine \[tui\] skipped \(detected codex 0\.107\.1 >= 0\.107\.0\)\./);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps [tui] when codex version is unparseable (compatibility default)', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-codex-version-'));
+    try {
+      const home = join(wd, 'home');
+      const binDir = join(wd, 'bin');
+      await mkdir(home, { recursive: true });
+      await mkdir(binDir, { recursive: true });
+      await writeFakeCodex(binDir);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+        OMX_TEST_CODEX_VERSION_OUTPUT: 'codex version: unknown',
+      });
+
+      const config = await readFile(join(wd, '.codex', 'config.toml'), 'utf-8');
+      assert.match(config, /^\[tui\]$/m);
+      assert.match(output, /StatusLine configured in config\.toml via \[tui\] section \(codex version unparseable; compatibility mode\)\./);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -27,6 +27,14 @@ interface SetupOptions {
   agentsOverwritePrompt?: () => Promise<boolean>;
 }
 
+const CODEX_TUI_REMOVED_VERSION = [0, 107, 0] as const;
+
+interface CodexVersionDetection {
+  includeTuiSection: boolean;
+  version?: string;
+  reason: 'detected' | 'unavailable' | 'unparseable';
+}
+
 /**
  * Legacy scope values that may appear in persisted setup-scope.json files.
  * Both 'project-local' (renamed) and old 'project' (minimal, removed) are
@@ -77,6 +85,51 @@ function isSetupScope(value: string): value is SetupScope {
 
 function getScopeFilePath(projectRoot: string): string {
   return join(projectRoot, '.omx', 'setup-scope.json');
+}
+
+export function parseCodexVersion(output: string): string | undefined {
+  const match = output.match(/(?:^|\s|\b)v?(\d+)\.(\d+)\.(\d+)(?=\b|\s|$)/i);
+  if (!match) return undefined;
+  return `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`;
+}
+
+function parseSemverTriplet(version: string): [number, number, number] | undefined {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemverTriplet(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number]
+): number {
+  if (left[0] !== right[0]) return left[0] - right[0];
+  if (left[1] !== right[1]) return left[1] - right[1];
+  return left[2] - right[2];
+}
+
+export function shouldIncludeTuiSection(version: string): boolean {
+  const parsed = parseSemverTriplet(version);
+  if (!parsed) return true;
+  return compareSemverTriplet(parsed, CODEX_TUI_REMOVED_VERSION) < 0;
+}
+
+function detectCodexVersion(): CodexVersionDetection {
+  const result = spawnSync('codex', ['--version'], { encoding: 'utf-8' });
+  if (result.status !== 0) {
+    return { includeTuiSection: true, reason: 'unavailable' };
+  }
+
+  const versionText = parseCodexVersion(`${result.stdout || ''}\n${result.stderr || ''}`);
+  if (!versionText) {
+    return { includeTuiSection: true, reason: 'unparseable' };
+  }
+
+  return {
+    includeTuiSection: shouldIncludeTuiSection(versionText),
+    version: versionText,
+    reason: 'detected',
+  };
 }
 
 export function resolveScopeDirectories(scope: SetupScope, projectRoot: string): ScopeDirectories {
@@ -206,6 +259,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   const resolvedScope = await resolveSetupScope(projectRoot, requestedScope);
   const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
   const scopeSourceMessage = resolvedScope.source === 'persisted' ? ' (from .omx/setup-scope.json)' : '';
+  const codexVersion = detectCodexVersion();
 
   console.log('oh-my-codex setup');
   console.log('=================\n');
@@ -287,6 +341,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     await mergeConfig(scopeDirs.codexConfigFile, pkgRoot, {
       verbose,
       agentsConfigDir: scopeDirs.nativeAgentsDir,
+      includeTuiSection: codexVersion.includeTuiSection,
     });
   }
   console.log(`  Done (${scopeDirs.codexConfigFile}).\n`);
@@ -361,7 +416,17 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   } else {
     console.log('  HUD config already exists (use --force to overwrite).');
   }
-  console.log('  StatusLine configured in config.toml via [tui] section.');
+  if (codexVersion.includeTuiSection) {
+    if (codexVersion.reason === 'detected' && codexVersion.version) {
+      console.log(`  StatusLine configured in config.toml via [tui] section (codex ${codexVersion.version}).`);
+    } else if (codexVersion.reason === 'unavailable') {
+      console.log('  StatusLine configured in config.toml via [tui] section (codex version unavailable; compatibility mode).');
+    } else {
+      console.log('  StatusLine configured in config.toml via [tui] section (codex version unparseable; compatibility mode).');
+    }
+  } else {
+    console.log(`  StatusLine [tui] skipped (detected codex ${codexVersion.version} >= 0.107.0).`);
+  }
   console.log();
 
   console.log('Setup complete! Run "omx doctor" to verify installation.');

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -282,4 +282,34 @@ describe('config generator', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('skips [tui] section when includeTuiSection is false', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd, { includeTuiSection: false });
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.doesNotMatch(toml, /^\[tui\]$/m);
+      assert.doesNotMatch(toml, /^status_line = \[/m);
+      assert.match(toml, /^\[mcp_servers\.omx_state\]$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes prior OMX [tui] section when rerun with includeTuiSection false', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd);
+      await mergeConfig(configPath, wd, { includeTuiSection: false });
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.doesNotMatch(toml, /^\[tui\]$/m);
+      assert.doesNotMatch(toml, /^status_line = \[/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -18,6 +18,7 @@ import { omxAgentsConfigDir } from '../utils/paths.js';
 
 interface MergeOptions {
   agentsConfigDir?: string;
+  includeTuiSection?: boolean;
   verbose?: boolean;
 }
 
@@ -327,14 +328,14 @@ function getAgentEntries(agentsConfigDir: string): string[] {
  * OMX table-section block (MCP servers, TUI).
  * Contains ONLY [table] sections — no bare keys.
  */
-function getOmxTablesBlock(pkgRoot: string, agentsConfigDir: string): string {
+function getOmxTablesBlock(pkgRoot: string, agentsConfigDir: string, includeTuiSection = true): string {
   const stateServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'state-server.js'));
   const memoryServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'memory-server.js'));
   const codeIntelServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'code-intel-server.js'));
   const traceServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'trace-server.js'));
   const teamServerPath = escapeTomlString(join(pkgRoot, 'dist', 'mcp', 'team-server.js'));
 
-  return [
+  const lines = [
     '',
     '# ============================================================',
     '# oh-my-codex (OMX) Configuration',
@@ -376,15 +377,25 @@ function getOmxTablesBlock(pkgRoot: string, agentsConfigDir: string): string {
     'enabled = true',
     'startup_timeout_sec = 5',
     ...getAgentEntries(agentsConfigDir),
-    '',
-    '# OMX TUI StatusLine (Codex CLI v0.101.0+)',
-    '[tui]',
-    'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit"]',
+  ];
+
+  if (includeTuiSection) {
+    lines.push(
+      '',
+      '# OMX TUI StatusLine (Codex CLI v0.101.0+)',
+      '[tui]',
+      'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit"]',
+    );
+  }
+
+  lines.push(
     '',
     '# ============================================================',
     '# End oh-my-codex',
     '',
-  ].join('\n');
+  );
+
+  return lines.join('\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -434,7 +445,11 @@ export async function mergeConfig(
   // Build final config:
   //   top-level keys → existing content (with [features]) → OMX tables block
   const topLines = getOmxTopLevelLines(pkgRoot);
-  const tablesBlock = getOmxTablesBlock(pkgRoot, options.agentsConfigDir || omxAgentsConfigDir());
+  const tablesBlock = getOmxTablesBlock(
+    pkgRoot,
+    options.agentsConfigDir || omxAgentsConfigDir(),
+    options.includeTuiSection ?? true,
+  );
 
   const finalConfig = topLines.join('\n') + '\n\n' + existing.trimEnd() + '\n' + tablesBlock;
 


### PR DESCRIPTION
## Summary
Fixes #564

Codex 0.107+ removed `[tui]` section support from `config.toml`. The OMX setup generator was unconditionally writing this section, causing config issues on newer codex versions.

## Changes
- **`src/config/generator.ts`**: Added `includeTuiSection` option to `MergeOptions`; conditionally generates `[tui]` block
- **`src/cli/setup.ts`**: Added codex version detection via `codex --version`; passes `includeTuiSection` to `mergeConfig`; updated setup output messaging
- **`src/config/__tests__/generator-notify.test.ts`**: Added tests for `includeTuiSection: false` behavior
- **`src/cli/__tests__/setup-codex-version.test.ts`**: New test file with version parsing tests and integration tests using fake codex binary

## Behavior
- codex < 0.107.0 → `[tui]` section included (existing behavior)
- codex >= 0.107.0 → `[tui]` section skipped
- codex unavailable/unparseable → `[tui]` included (compatibility fallback)

## Test plan
- [x] `npm test` — 1909 tests, 0 failures
- [x] Targeted tests: 15/15 pass (generator + version handling)