### PR TITLE
fix: setup skips deprecated/merged/alias catalog skills

### DIFF
--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -1,12 +1,66 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { setup } from '../setup.js';
 
 describe('omx setup skills overwrite behavior', () => {
+  it('installs only active/internal catalog skills (skips alias/merged)', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const skillsDir = join(wd, '.agents', 'skills');
+      const installed = new Set(await readdir(skillsDir));
+
+      assert.equal(installed.has('team'), true);
+      assert.equal(installed.has('worker'), true);
+      assert.equal(installed.has('swarm'), false);
+      assert.equal(installed.has('ecomode'), false);
+      assert.equal(installed.has('ultraqa'), false);
+      assert.equal(installed.has('ralph-init'), false);
+      assert.equal(installed.has('frontend-ui-ux'), false);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes stale alias/merged skill directories on --force', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const staleSkills = ['swarm', 'ecomode', 'ultraqa'];
+      for (const staleSkill of staleSkills) {
+        const staleDir = join(wd, '.agents', 'skills', staleSkill);
+        await mkdir(staleDir, { recursive: true });
+        await writeFile(join(staleDir, 'SKILL.md'), `# stale ${staleSkill}\n`);
+        assert.equal(existsSync(staleDir), true);
+      }
+
+      await setup({ scope: 'project', force: true });
+
+      for (const staleSkill of staleSkills) {
+        assert.equal(existsSync(join(wd, '.agents', 'skills', staleSkill)), false);
+      }
+      assert.equal(existsSync(join(wd, '.agents', 'skills', 'team')), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves existing skill files unless --force is set', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
     const previousCwd = process.cwd();
@@ -29,6 +83,33 @@ describe('omx setup skills overwrite behavior', () => {
       await setup({ scope: 'project', force: true });
       assert.equal(await readFile(skillPath, 'utf-8'), installed);
     } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('logs skip/remove decisions in verbose mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map((arg) => String(arg)).join(' '));
+      };
+
+      await setup({ scope: 'project', verbose: true });
+      await mkdir(join(wd, '.agents', 'skills', 'swarm'), { recursive: true });
+      await writeFile(join(wd, '.agents', 'skills', 'swarm', 'SKILL.md'), '# stale swarm\n');
+      await setup({ scope: 'project', force: true, verbose: true });
+
+      const output = logs.join('\n');
+      assert.match(output, /skipped swarm\/ \(status: alias\)/);
+      assert.match(output, /removed stale skill swarm\/ \(status: alias\)/);
+    } finally {
+      console.log = originalLog;
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/catalog-contract.ts
+++ b/src/cli/catalog-contract.ts
@@ -14,9 +14,12 @@ export function getCatalogExpectations(): CatalogExpectations {
   }
 
   const counts = getCatalogCounts();
+  const installableSkillCount = manifest.skills
+    .filter((skill) => skill.status === 'active' || skill.status === 'internal')
+    .length;
   return {
     promptMin: Math.max(1, counts.promptCount - SAFETY_BUFFER),
-    skillMin: Math.max(1, counts.skillCount - SAFETY_BUFFER),
+    skillMin: Math.max(1, installableSkillCount - SAFETY_BUFFER),
   };
 }
 
@@ -24,8 +27,11 @@ export function getCatalogHeadlineCounts(): { prompts: number; skills: number } 
   const manifest = tryReadCatalogManifest();
   if (!manifest) return null;
   const counts = getCatalogCounts();
+  const installableSkillCount = manifest.skills
+    .filter((skill) => skill.status === 'active' || skill.status === 'internal')
+    .length;
   return {
     prompts: counts.promptCount,
-    skills: counts.skillCount,
+    skills: installableSkillCount,
   };
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -18,6 +18,7 @@ import { installNativeAgentConfigs } from '../agents/native-config.js';
 import { getPackageRoot } from '../utils/package.js';
 import { readSessionState, isSessionStale } from '../hooks/session.js';
 import { getCatalogHeadlineCounts } from './catalog-contract.js';
+import { tryReadCatalogManifest } from '../catalog/reader.js';
 
 interface SetupOptions {
   force?: boolean;
@@ -457,10 +458,24 @@ async function installSkills(
   options: SetupOptions
 ): Promise<number> {
   if (!existsSync(srcDir)) return 0;
+  const manifest = tryReadCatalogManifest();
+  const skillStatusByName = manifest
+    ? new Map(manifest.skills.map((skill) => [skill.name, skill.status]))
+    : null;
+  const isInstallableStatus = (status: string | undefined): boolean => status === 'active' || status === 'internal';
   const entries = await readdir(srcDir, { withFileTypes: true });
   let count = 0;
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
+    const status = skillStatusByName?.get(entry.name);
+    if (skillStatusByName && !isInstallableStatus(status)) {
+      if (options.verbose) {
+        const label = status ?? 'unlisted';
+        console.log(`  skipped ${entry.name}/ (status: ${label})`);
+      }
+      continue;
+    }
+
     const skillSrc = join(srcDir, entry.name);
     const skillDst = join(dstDir, entry.name);
     const skillMd = join(skillSrc, 'SKILL.md');
@@ -506,6 +521,22 @@ async function installSkills(
       );
     }
   }
+
+  if (options.force && manifest && existsSync(dstDir)) {
+    for (const skill of manifest.skills) {
+      if (isInstallableStatus(skill.status)) continue;
+      const staleSkillDir = join(dstDir, skill.name);
+      if (!existsSync(staleSkillDir)) continue;
+      if (!options.dryRun) {
+        await rm(staleSkillDir, { recursive: true, force: true });
+      }
+      if (options.verbose) {
+        const prefix = options.dryRun ? 'would remove stale skill' : 'removed stale skill';
+        console.log(`  ${prefix} ${skill.name}/ (status: ${skill.status})`);
+      }
+    }
+  }
+
   return count;
 }
 


### PR DESCRIPTION
## Summary
- make setup skill install manifest-aware by loading catalog manifest in `installSkills()`
- install only `active`/`internal` skills and skip `deprecated`/`merged`/`alias` (with `--verbose` skip logs)
- when `--force` is used, remove stale installed skill directories for non-installable manifest entries
- align catalog headline/doctor skill expectations to installable skills to avoid false warnings after setup
- add setup tests for skip behavior, `--force` cleanup, and verbose skip/remove logging

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/setup-skills-overwrite.test.js dist/cli/__tests__/catalog-contract.test.js dist/cli/__tests__/setup-scope.test.js`

Closes #574.
