### PR TITLE
feat(team): add Gemini CLI worker support

### DIFF
--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -88,6 +88,24 @@ function loadJobFromDisk(jobId: string): OmxTeamJob | undefined {
   }
 }
 
+function parseJsonFromStdout(rawStdout: string): { parsed?: Record<string, unknown>; text: string } {
+  const text = rawStdout.trim();
+  if (!text) return { text };
+  try {
+    return { parsed: JSON.parse(text) as Record<string, unknown>, text };
+  } catch {
+    const lines = text.split('\n').map((line) => line.trim()).filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        return { parsed: JSON.parse(lines[i]) as Record<string, unknown>, text: lines[i] };
+      } catch {
+        // continue
+      }
+    }
+    return { text };
+  }
+}
+
 async function loadPaneIds(jobId: string): Promise<{ paneIds: string[]; leaderPaneId: string } | null> {
   try {
     const parsed = JSON.parse(await readFile(join(OMX_JOBS_DIR, `${jobId}-panes.json`), 'utf-8')) as {
@@ -219,12 +237,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
       name: 'omx_run_team_start',
-      description: 'Spawn tmux CLI workers (codex/claude) in the background. Returns jobId immediately. Poll with omx_run_team_status.',
+      description: 'Spawn tmux CLI workers (codex/claude/gemini) in the background. Returns jobId immediately. Poll with omx_run_team_status.',
       inputSchema: {
         type: 'object',
         properties: {
           teamName: { type: 'string', description: 'Slug name for the team' },
-          agentTypes: { type: 'array', items: { type: 'string' }, description: '"codex" or "claude" per worker' },
+          agentTypes: { type: 'array', items: { type: 'string' }, description: '"codex", "claude", or "gemini" per worker' },
           tasks: {
             type: 'array',
             items: {
@@ -322,16 +340,17 @@ export async function handleTeamToolCall(request: {
           const stdout = Buffer.concat(outChunks).toString('utf-8').trim();
           const stderr = Buffer.concat(errChunks).toString('utf-8').trim();
           if (stdout) {
-            try {
-              const parsed = JSON.parse(stdout) as { status?: string };
-              const s = parsed.status;
+            const { parsed, text } = parseJsonFromStdout(stdout);
+            if (parsed) {
+              const s = typeof parsed.status === 'string' ? parsed.status : undefined;
               if (job.status === 'running') {
                 job.status = (s === 'completed' || s === 'failed') ? s : 'failed';
               }
-            } catch {
+              job.result = text;
+            } else {
               if (job.status === 'running') job.status = 'failed';
+              job.result = stdout;
             }
-            job.result = stdout;
           }
           if (job.status === 'running') {
             if (code === 0) job.status = 'completed';

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -12,6 +12,23 @@ async function loadRuntimeCliModule() {
 }
 
 describe('runtime-cli helpers', () => {
+  it('normalizes per-worker providers and validates supported values', async () => {
+    const runtimeCli = await loadRuntimeCliModule();
+
+    assert.deepEqual(
+      runtimeCli.normalizeAgentTypes(['codex', 'gemini'], 2),
+      ['codex', 'gemini'],
+    );
+    assert.deepEqual(
+      runtimeCli.normalizeAgentTypes(['gemini'], 3),
+      ['gemini'],
+    );
+    assert.throws(
+      () => runtimeCli.normalizeAgentTypes(['codex', 'invalid'], 2),
+      /Expected codex\\|claude\\|gemini/,
+    );
+  });
+
   it('refreshes pane targets from live team config after scale changes', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-live-'));
     try {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -180,6 +180,29 @@ describe('runtime', () => {
     assert.doesNotMatch(startupLog, /thinking_level=/);
   });
 
+  it('resolveWorkerLaunchArgsFromEnv logs model=gemini without thinking_level for gemini CLI', () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
+    try {
+      const args = resolveWorkerLaunchArgsFromEnv(
+        {
+          OMX_TEAM_WORKER_CLI: 'gemini',
+          OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gemini-2.0-pro',
+        },
+        'executor',
+      );
+      assert.deepEqual(args, ['--model', 'gemini-2.0-pro']);
+    } finally {
+      console.log = originalLog;
+    }
+    const startupLog = logs.find((line) => line.includes('worker startup resolution:'));
+    assert.ok(startupLog);
+    assert.match(startupLog, /model=gemini/);
+    assert.match(startupLog, /source=local-settings/);
+    assert.doesNotMatch(startupLog, /thinking_level=/);
+  });
+
   it('resolveWorkerLaunchArgsFromEnv keeps codex thinking_level logging for mixed CLI maps', () => {
     const logs: string[] = [];
     const originalLog = console.log;

--- a/src/team/__tests__/tmux-claude-workers-demo.test.ts
+++ b/src/team/__tests__/tmux-claude-workers-demo.test.ts
@@ -145,6 +145,12 @@ describe('tmux claude workers demo', () => {
       const result = translateWorkerLaunchArgsForCli('claude', args);
       assert.deepEqual(result, ['--dangerously-skip-permissions']);
     });
+
+    it('returns gemini approval-mode yolo with model passthrough', () => {
+      const args = ['--model', 'gemini-2.0-pro', '--json'];
+      const result = translateWorkerLaunchArgsForCli('gemini', args);
+      assert.deepEqual(result, ['--approval-mode', 'yolo', '--model', 'gemini-2.0-pro']);
+    });
   });
 
   describe('full demo scenario with 6 mixed workers', () => {
@@ -239,6 +245,17 @@ describe('tmux claude workers demo', () => {
       });
 
       assert.deepEqual(plan, ['codex']);
+    });
+
+    it('handles single worker with gemini', () => {
+      const plan = resolveTeamWorkerCliPlan(1, [], {
+        OMX_TEAM_WORKER_CLI_MAP: 'gemini',
+      });
+      assert.deepEqual(plan, ['gemini']);
+
+      const spec = buildWorkerProcessLaunchSpec('team', 1, ['--model', 'gemini-2.0-pro'], '/tmp', {}, 'gemini');
+      assert.equal(spec.workerCli, 'gemini');
+      assert.deepEqual(spec.args, ['--approval-mode', 'yolo', '--model', 'gemini-2.0-pro']);
     });
 
     it('rejects invalid CLI map with empty entries', () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -377,6 +377,31 @@ describe('paneLooksReady gate: status-only is not ready (#391)', () => {
 });
 
 describe('buildWorkerStartupCommand', () => {
+  it('auto-selects gemini worker CLI from gemini model', () => {
+    const prevShell = process.env.SHELL;
+    const prevCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.SHELL = '/bin/bash';
+    delete process.env.OMX_TEAM_WORKER_CLI; // auto
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const cmd = buildWorkerStartupCommand('alpha', 1, ['--model', 'gemini-2.0-pro']);
+      assert.match(cmd, /exec .*gemini/);
+      assert.match(cmd, /--approval-mode/);
+      assert.match(cmd, /yolo/);
+      assert.match(cmd, /--model/);
+      assert.match(cmd, /gemini-2.0-pro/);
+      assert.doesNotMatch(cmd, /\s-i(\s|$)/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
   it('auto-selects claude worker CLI from claude model', () => {
     const prevShell = process.env.SHELL;
     const prevCli = process.env.OMX_TEAM_WORKER_CLI;
@@ -721,8 +746,18 @@ describe('team worker CLI helpers', () => {
   it('resolveTeamWorkerCli auto-detects claude models', () => {
     assert.equal(resolveTeamWorkerCli(['--model', 'claude-3-7-sonnet'], {}), 'claude');
     assert.equal(resolveTeamWorkerCli(['--model=claude-sonnet-4-6'], {}), 'claude');
+    assert.equal(resolveTeamWorkerCli(['--model', 'gemini-2.0-pro'], {}), 'gemini');
     assert.equal(resolveTeamWorkerCli(['--model', 'gpt-5'], {}), 'codex');
     assert.equal(resolveTeamWorkerCli([], {}), 'codex');
+  });
+
+  it('resolveTeamWorkerCli accepts explicit gemini override', () => {
+    assert.equal(resolveTeamWorkerCli([], { OMX_TEAM_WORKER_CLI: 'gemini' }), 'gemini');
+  });
+
+  it('resolveTeamWorkerCliPlan accepts gemini in CLI map', () => {
+    const plan = resolveTeamWorkerCliPlan(3, [], { OMX_TEAM_WORKER_CLI_MAP: 'codex,gemini,claude' });
+    assert.deepEqual(plan, ['codex', 'gemini', 'claude']);
   });
 
   it('translateWorkerLaunchArgsForCli preserves args for codex', () => {
@@ -737,6 +772,17 @@ describe('team worker CLI helpers', () => {
     );
   });
 
+  it('translateWorkerLaunchArgsForCli emits approval-mode and optional model for gemini', () => {
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('gemini', ['--model', 'gemini-2.0-pro', '--json']),
+      ['--approval-mode', 'yolo', '--model', 'gemini-2.0-pro'],
+    );
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('gemini', ['--json']),
+      ['--approval-mode', 'yolo'],
+    );
+  });
+
   it('assertTeamWorkerCliBinaryAvailable throws clear error when binary missing', () => {
     assert.throws(
       () => assertTeamWorkerCliBinaryAvailable('claude', () => false),
@@ -748,9 +794,9 @@ describe('team worker CLI helpers', () => {
     const plan = resolveTeamWorkerCliPlan(
       4,
       [],
-      { OMX_TEAM_WORKER_CLI_MAP: 'codex,codex,claude,claude' },
+      { OMX_TEAM_WORKER_CLI_MAP: 'codex,codex,gemini,claude' },
     );
-    assert.deepEqual(plan, ['codex', 'codex', 'claude', 'claude']);
+    assert.deepEqual(plan, ['codex', 'codex', 'gemini', 'claude']);
   });
 
   it('resolveTeamWorkerCliPlan accepts single-value map and expands to all workers', () => {

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -22,6 +22,8 @@ interface CliInput {
   pollIntervalMs?: number;
 }
 
+type TeamWorkerProvider = 'codex' | 'claude' | 'gemini';
+
 interface TaskResult {
   taskId: string;
   status: string;
@@ -113,6 +115,18 @@ function collectTaskResults(stateRoot: string, teamName: string): TaskResult[] {
   } catch {
     return [];
   }
+}
+
+export function normalizeAgentTypes(raw: string[], workerCount: number): TeamWorkerProvider[] {
+  const providers = raw.map((entry) => String(entry || '').trim().toLowerCase());
+  const invalid = providers.filter((entry) => entry !== 'codex' && entry !== 'claude' && entry !== 'gemini');
+  if (invalid.length > 0) {
+    throw new Error(`Invalid agentTypes entries: ${invalid.join(', ')}. Expected codex|claude|gemini.`);
+  }
+  if (providers.length !== 1 && providers.length !== workerCount) {
+    throw new Error(`agentTypes length must be 1 or ${workerCount}; received ${providers.length}.`);
+  }
+  return providers as TeamWorkerProvider[];
 }
 
 async function main(): Promise<void> {
@@ -217,16 +231,24 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => handleShutdown('SIGTERM'));
 
   // Start the team — OMX's startTeam takes individual parameters
-  const agentType = agentTypes[0] ?? 'codex';
+  const agentType = 'executor';
   try {
-    runtime = await startTeam(
-      teamName,
-      tasks.map(t => t.subject).join('; '),
-      agentType,
-      workerCount,
-      tasks,
-      cwd,
-    );
+    const providers = normalizeAgentTypes(agentTypes, workerCount);
+    const previousCliMap = process.env.OMX_TEAM_WORKER_CLI_MAP;
+    try {
+      process.env.OMX_TEAM_WORKER_CLI_MAP = providers.join(',');
+      runtime = await startTeam(
+        teamName,
+        tasks.map(t => t.subject).join('; '),
+        agentType,
+        workerCount,
+        tasks,
+        cwd,
+      );
+    } finally {
+      if (typeof previousCliMap === 'string') process.env.OMX_TEAM_WORKER_CLI_MAP = previousCliMap;
+      else delete process.env.OMX_TEAM_WORKER_CLI_MAP;
+    }
   } catch (err) {
     process.stderr.write(`[runtime-cli] startTeam failed: ${err}\n`);
     process.exit(1);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -382,7 +382,7 @@ function spawnPromptWorker(
   workerCwd: string,
   launchArgs: string[],
   workerEnv: Record<string, string>,
-  workerCli: 'codex' | 'claude',
+  workerCli: 'codex' | 'claude' | 'gemini',
 ): ChildProcessByStdio<Writable, null, null> {
   const processSpec = buildWorkerProcessLaunchSpec(
     teamName,
@@ -437,6 +437,8 @@ export function resolveWorkerLaunchArgsFromEnv(
   const effectiveWorkerCli = resolveEffectiveWorkerCliForStartupLog(resolved, env);
   if (effectiveWorkerCli === 'claude') {
     console.log('[omx:team] worker startup resolution: model=claude source=local-settings');
+  } else if (effectiveWorkerCli === 'gemini') {
+    console.log('[omx:team] worker startup resolution: model=gemini source=local-settings');
   } else {
     console.log(`[omx:team] worker startup resolution: model=${resolvedModel} thinking_level=${thinkingLevel} source=${source}`);
   }
@@ -447,7 +449,7 @@ export function resolveWorkerLaunchArgsFromEnv(
 function resolveEffectiveWorkerCliForStartupLog(
   resolvedLaunchArgs: string[],
   env: NodeJS.ProcessEnv,
-): 'codex' | 'claude' {
+): 'codex' | 'claude' | 'gemini' {
   const rawCliMap = String(env.OMX_TEAM_WORKER_CLI_MAP ?? '').trim();
   if (rawCliMap !== '') {
     const entries = rawCliMap
@@ -459,12 +461,13 @@ function resolveEffectiveWorkerCliForStartupLog(
         ...env,
         OMX_TEAM_WORKER_CLI: 'auto',
       });
-      const resolvedMap = entries.map((entry): 'codex' | 'claude' | null => {
+      const resolvedMap = entries.map((entry): 'codex' | 'claude' | 'gemini' | null => {
         if (entry === 'auto') return autoCli;
-        if (entry === 'codex' || entry === 'claude') return entry;
+        if (entry === 'codex' || entry === 'claude' || entry === 'gemini') return entry;
         return null;
       });
       if (resolvedMap.every((entry) => entry === 'claude')) return 'claude';
+      if (resolvedMap.every((entry) => entry === 'gemini')) return 'gemini';
       if (resolvedMap.some((entry) => entry === 'codex')) return 'codex';
     }
   }

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -103,7 +103,7 @@ async function notifyWorkerPaneOutcome(
   workerIndex: number,
   message: string,
   paneId?: string,
-  workerCli?: 'codex' | 'claude',
+  workerCli?: 'codex' | 'claude' | 'gemini',
 ): Promise<DispatchOutcome> {
   try {
     await sendToWorker(sessionName, workerIndex, message, paneId, workerCli);

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -88,7 +88,7 @@ export interface WorkerInfo {
   name: string; // "worker-1"
   index: number; // tmux window index (1-based)
   role: string; // agent type
-  worker_cli?: 'codex' | 'claude';
+  worker_cli?: 'codex' | 'claude' | 'gemini';
   assigned_tasks: string[]; // task IDs
   pid?: number;
   pane_id?: string;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -26,7 +26,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude';
+  worker_cli?: 'codex' | 'claude' | 'gemini';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -38,10 +38,12 @@ const OMX_TEAM_WORKER_CLI_MAP_ENV = 'OMX_TEAM_WORKER_CLI_MAP';
 const OMX_TEAM_WORKER_LAUNCH_MODE_ENV = 'OMX_TEAM_WORKER_LAUNCH_MODE';
 const OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV = 'OMX_TEAM_AUTO_INTERRUPT_RETRY';
 const CLAUDE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
+const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
+const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
 const OMX_LEADER_NODE_PATH_ENV = 'OMX_LEADER_NODE_PATH';
 const OMX_LEADER_CLI_PATH_ENV = 'OMX_LEADER_CLI_PATH';
 
-export type TeamWorkerCli = 'codex' | 'claude';
+export type TeamWorkerCli = 'codex' | 'claude' | 'gemini';
 type TeamWorkerCliMode = 'auto' | TeamWorkerCli;
 export type TeamWorkerLaunchMode = 'interactive' | 'prompt';
 
@@ -418,8 +420,8 @@ function hasModelInstructionsOverride(args: string[]): boolean {
 function normalizeTeamWorkerCliMode(raw: string | undefined, sourceEnv: string = OMX_TEAM_WORKER_CLI_ENV): TeamWorkerCliMode {
   const normalized = String(raw ?? 'auto').trim().toLowerCase();
   if (normalized === '' || normalized === 'auto') return 'auto';
-  if (normalized === 'codex' || normalized === 'claude') return normalized;
-  throw new Error(`Invalid ${sourceEnv} value "${raw}". Expected: auto, codex, claude`);
+  if (normalized === 'codex' || normalized === 'claude' || normalized === 'gemini') return normalized;
+  throw new Error(`Invalid ${sourceEnv} value "${raw}". Expected: auto, codex, claude, gemini`);
 }
 
 export function resolveTeamWorkerLaunchMode(
@@ -459,7 +461,9 @@ export function resolveTeamWorkerCli(launchArgs: string[] = [], env: NodeJS.Proc
 
 function resolveTeamWorkerCliFromLaunchArgs(launchArgs: string[] = []): TeamWorkerCli {
   const model = extractModelOverride(launchArgs);
-  return model && /claude/i.test(model) ? 'claude' : 'codex';
+  if (model && /claude/i.test(model)) return 'claude';
+  if (model && /gemini/i.test(model)) return 'gemini';
+  return 'codex';
 }
 
 export function resolveTeamWorkerCliPlan(
@@ -487,7 +491,7 @@ export function resolveTeamWorkerCliPlan(
   if (entries.length === 0 || entries.every((part) => part.length === 0)) {
     throw new Error(
       `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} value "${env[OMX_TEAM_WORKER_CLI_MAP_ENV]}". `
-        + `Expected comma-separated values: auto|codex|claude.`,
+        + `Expected comma-separated values: auto|codex|claude|gemini.`,
     );
   }
   if (entries.some((part) => part.length === 0)) {
@@ -512,6 +516,12 @@ export function resolveTeamWorkerCliPlan(
 
 export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: string[]): string[] {
   if (workerCli === 'codex') return [...args];
+  if (workerCli === 'gemini') {
+    const model = extractModelOverride(args);
+    return model
+      ? [GEMINI_APPROVAL_MODE_FLAG, GEMINI_APPROVAL_MODE_YOLO, MODEL_FLAG, model]
+      : [GEMINI_APPROVAL_MODE_FLAG, GEMINI_APPROVAL_MODE_YOLO];
+  }
 
   // Claude workers must launch with exactly one permissions bypass flag.
   // All other launch args are dropped to avoid Codex-only flags and model/config overrides.
@@ -559,7 +569,7 @@ export function assertTeamWorkerCliBinaryAvailable(
   if (existsImpl(workerCli)) return;
   throw new Error(
     `Selected team worker CLI "${workerCli}" is not available on PATH. `
-      + `Install "${workerCli}" or set ${OMX_TEAM_WORKER_CLI_ENV}=codex|claude.`,
+      + `Install "${workerCli}" or set ${OMX_TEAM_WORKER_CLI_ENV}=codex|claude|gemini.`,
   );
 }
 


### PR DESCRIPTION
## Summary\n- add Gemini as a supported team worker CLI in team runtime/session resolution\n- support mixed CLI maps containing codex/claude/gemini workers\n- add/extend team runtime and tmux session coverage for Gemini worker launch behavior\n\n## Verification\n- npm run build\n- node --test dist/team/__tests__/runtime-cli.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/tmux-session.test.js dist/team/__tests__/tmux-claude-workers-demo.test.js