### PR TITLE
fix(setup): skip non-installable skills and cleanup stale shipped dirs

### DIFF
--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -26,6 +26,8 @@ describe('omx setup skills overwrite behavior', () => {
       assert.equal(installed.has('ultraqa'), false);
       assert.equal(installed.has('ralph-init'), false);
       assert.equal(installed.has('frontend-ui-ux'), false);
+      assert.equal(installed.has('pipeline'), false);
+      assert.equal(installed.has('configure-notifications'), false);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -54,6 +56,31 @@ describe('omx setup skills overwrite behavior', () => {
       for (const staleSkill of staleSkills) {
         assert.equal(existsSync(join(wd, '.agents', 'skills', staleSkill)), false);
       }
+      assert.equal(existsSync(join(wd, '.agents', 'skills', 'team')), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes stale unlisted shipped skill directories on --force', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const staleSkill = 'pipeline';
+      const staleDir = join(wd, '.agents', 'skills', staleSkill);
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(staleDir, 'SKILL.md'), `# stale ${staleSkill}\n`);
+      assert.equal(existsSync(staleDir), true);
+
+      await setup({ scope: 'project', force: true });
+
+      assert.equal(existsSync(join(wd, '.agents', 'skills', staleSkill)), false);
       assert.equal(existsSync(join(wd, '.agents', 'skills', 'team')), true);
     } finally {
       process.chdir(previousCwd);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -464,9 +464,11 @@ async function installSkills(
     : null;
   const isInstallableStatus = (status: string | undefined): boolean => status === 'active' || status === 'internal';
   const entries = await readdir(srcDir, { withFileTypes: true });
+  const shippedSkillNames = new Set<string>();
   let count = 0;
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
+    shippedSkillNames.add(entry.name);
     const status = skillStatusByName?.get(entry.name);
     if (skillStatusByName && !isInstallableStatus(status)) {
       if (options.verbose) {
@@ -523,16 +525,20 @@ async function installSkills(
   }
 
   if (options.force && manifest && existsSync(dstDir)) {
-    for (const skill of manifest.skills) {
-      if (isInstallableStatus(skill.status)) continue;
-      const staleSkillDir = join(dstDir, skill.name);
+    for (const staleSkill of shippedSkillNames) {
+      const status = skillStatusByName?.get(staleSkill);
+      if (isInstallableStatus(status)) continue;
+
+      const staleSkillDir = join(dstDir, staleSkill);
       if (!existsSync(staleSkillDir)) continue;
+
       if (!options.dryRun) {
         await rm(staleSkillDir, { recursive: true, force: true });
       }
       if (options.verbose) {
         const prefix = options.dryRun ? 'would remove stale skill' : 'removed stale skill';
-        console.log(`  ${prefix} ${skill.name}/ (status: ${skill.status})`);
+        const label = status ?? 'unlisted';
+        console.log(`  ${prefix} ${staleSkill}/ (status: ${label})`);
       }
     }
   }


### PR DESCRIPTION
## Summary

Issue #574 requires setup skill installation to follow the catalog manifest and avoid installing deprecated/merged/alias entries, while also cleaning stale obsolete skill directories during `--force` runs.

## Changes

- Kept install behavior manifest-driven: only `active`/`internal` skills are installable.
- Updated `installSkills()` force-cleanup to scan actual shipped skill directories and remove stale destination dirs for any non-installable or unlisted shipped skill on `--force`.
- Added/updated setup tests to verify:
  - unlisted shipped skills are not installed,
  - stale unlisted shipped skill dirs are removed on `--force`.

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #574
