### PR TITLE
fix(openclaw): prevent unresolved placeholder leakage in hook instruction templates

### DIFF
--- a/src/openclaw/__tests__/dispatcher.test.ts
+++ b/src/openclaw/__tests__/dispatcher.test.ts
@@ -71,14 +71,19 @@ describe('interpolateInstruction', () => {
     assert.equal(result, 'Session abc ended');
   });
 
-  it('leaves unknown variables as-is (not empty)', () => {
+  it('replaces unknown variables with empty string', () => {
     const result = interpolateInstruction('{{unknownVar}} text', {});
-    assert.equal(result, '{{unknownVar}} text');
+    assert.equal(result, ' text');
   });
 
-  it('leaves undefined variables as-is', () => {
+  it('replaces undefined variables with empty string', () => {
     const result = interpolateInstruction('{{sessionId}}', { sessionId: undefined });
-    assert.equal(result, '{{sessionId}}');
+    assert.equal(result, '');
+  });
+
+  it('replaces undefined tmuxSession with empty string', () => {
+    const result = interpolateInstruction('tmux:{{tmuxSession}}', { tmuxSession: undefined });
+    assert.equal(result, 'tmux:');
   });
 
   it('replaces multiple variables', () => {
@@ -106,12 +111,12 @@ describe('interpolateInstruction - reply context variables', () => {
     assert.equal(result, 'thread: thread-123');
   });
 
-  it('leaves reply variables as-is when undefined', () => {
+  it('replaces reply variables with empty string when undefined', () => {
     const result = interpolateInstruction(
       '{{replyChannel}} {{replyTarget}} {{replyThread}}',
       { replyChannel: undefined, replyTarget: undefined, replyThread: undefined },
     );
-    assert.equal(result, '{{replyChannel}} {{replyTarget}} {{replyThread}}');
+    assert.equal(result, '  ');
   });
 
   it('replaces all reply variables together', () => {

--- a/src/openclaw/dispatcher.ts
+++ b/src/openclaw/dispatcher.ts
@@ -76,14 +76,14 @@ export function validateGatewayUrl(url: string): boolean {
  * - {{replyTarget}} - reply target user/bot (from OPENCLAW_REPLY_TARGET env var)
  * - {{replyThread}} - reply thread ID (from OPENCLAW_REPLY_THREAD env var)
  *
- * Unresolved variables are left as-is (not replaced with empty string).
+ * Unresolved variables are replaced with empty string.
  */
 export function interpolateInstruction(
   template: string,
   variables: Record<string, string | undefined>,
 ): string {
-  return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
-    return variables[key] ?? match;
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, key: string) => {
+    return variables[key] ?? "";
   });
 }
 


### PR DESCRIPTION
## Summary
- replace unresolved instruction template placeholders with empty string fallback
- add regression tests for undefined tmuxSession and other undefined variables

## Testing
- npm test -- src/openclaw/__tests__/dispatcher.test.ts

Closes #578