### PR TITLE
fix(keyword): explicit multi-skill order + /prompts guard hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,8 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "ralph", "don't stop", "must complete", "keep going" | `$ralph` | Read `~/.agents/skills/ralph/SKILL.md`, execute persistence loop |
 | "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
+| "ultraqa" | `$ultraqa` | Read `~/.agents/skills/ultraqa/SKILL.md`, run QA cycling workflow |
+| "analyze", "investigate" | `$analyze` | Read `~/.agents/skills/analyze/SKILL.md`, run deep analysis |
 | "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
 | "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
 | "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
@@ -157,14 +159,16 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "cancel", "stop", "abort" | `$cancel` | Read `~/.agents/skills/cancel/SKILL.md`, cancel active modes |
 | "tdd", "test first" | `$tdd` | Read `~/.agents/skills/tdd/SKILL.md`, start test-driven workflow |
 | "fix build", "type errors" | `$build-fix` | Read `~/.agents/skills/build-fix/SKILL.md`, fix build errors |
-| "review code" | `$code-review` | Read `~/.agents/skills/code-review/SKILL.md`, run code review |
+| "review code", "code review", "code-review" | `$code-review` | Read `~/.agents/skills/code-review/SKILL.md`, run code review |
 | "security review" | `$security-review` | Read `~/.agents/skills/security-review/SKILL.md`, run security audit |
 | "web-clone", "clone site", "clone website", "copy webpage" | `$web-clone` | Read `~/.agents/skills/web-clone/SKILL.md`, start website cloning pipeline |
 
 Detection rules:
 - Keywords are case-insensitive and match anywhere in the user's message
-- If multiple keywords match, use the most specific (longest match)
-- Conflict resolution: explicit `$name` invocation overrides keyword detection
+- If one or more explicit `$name` tokens are present, execute **all explicit skills left-to-right**.
+- If multiple non-explicit keywords match, use the most specific (longest match).
+- Conflict resolution: explicit `$name` invocation overrides keyword detection.
+- If user explicitly invokes `/prompts:<name>`, treat it as direct prompt execution and do not auto-activate keyword skills unless explicit `$name` tokens are also present.
 - The rest of the user's message (after keyword extraction) becomes the task description
 
 Ralph / Ralplan execution gate:

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -13,6 +13,53 @@ import { isUnderspecifiedForExecution, applyRalplanGate } from '../keyword-detec
 import { KEYWORD_TRIGGER_DEFINITIONS } from '../keyword-registry.js';
 
 describe('keyword detector swarm/team compatibility', () => {
+  it('keeps explicit $skill order in detectKeywords results (left-to-right)', () => {
+    const matches = detectKeywords('$analyze $ultraqa $code-review now');
+    assert.deepEqual(matches.map((m) => m.skill).slice(0, 3), ['analyze', 'ultraqa', 'code-review']);
+  });
+
+  it('de-duplicates repeated explicit skill tokens', () => {
+    const matches = detectKeywords('$analyze $analyze root cause');
+    assert.deepEqual(matches.map((m) => m.skill), ['analyze']);
+  });
+
+  it('does not auto-detect keywords for explicit /prompts invocation without $skills', () => {
+    const matches = detectKeywords('/prompts:architect analyze this issue');
+    assert.deepEqual(matches, []);
+    const primary = detectPrimaryKeyword('/prompts:architect analyze this issue');
+    assert.equal(primary, null);
+  });
+
+  it('treats /prompts invocation with trailing punctuation as explicit command', () => {
+    const matches = detectKeywords('/prompts:architect, analyze this issue');
+    assert.deepEqual(matches, []);
+    const primary = detectPrimaryKeyword('/prompts:architect, analyze this issue');
+    assert.equal(primary, null);
+  });
+
+  it('maps analyze keyword to analyze skill', () => {
+    const match = detectPrimaryKeyword('please analyze this workflow');
+    assert.ok(match);
+    assert.equal(match.skill, 'analyze');
+  });
+
+  it('maps code-review keyword variants to code-review skill', () => {
+    const hyphen = detectPrimaryKeyword('run code-review before merge');
+    assert.ok(hyphen);
+    assert.equal(hyphen.skill, 'code-review');
+
+    const spaced = detectPrimaryKeyword('please do a code review');
+    assert.ok(spaced);
+    assert.equal(spaced.skill, 'code-review');
+  });
+
+  it('supports explicit multi-skill invocation by prioritizing left-most $skill', () => {
+    const match = detectPrimaryKeyword('$ultraqa $analyze $code-review run now');
+    assert.ok(match);
+    assert.equal(match.skill, 'ultraqa');
+    assert.equal(match.keyword.toLowerCase(), '$ultraqa');
+  });
+
   it('maps "coordinated team" phrase to team orchestration skill', () => {
     const match = detectPrimaryKeyword('run a coordinated team for implementation');
 
@@ -61,10 +108,9 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match.skill, 'team');
   });
 
-  it('still triggers swarm for explicit /prompts:swarm invocation', () => {
+  it('does not trigger keyword detector for explicit /prompts:swarm invocation', () => {
     const match = detectPrimaryKeyword('use /prompts:swarm for this');
-    assert.ok(match);
-    assert.equal(match.skill, 'team');
+    assert.equal(match, null);
   });
 
   it('prefers ralplan over ralph when both keywords are present', () => {
@@ -134,6 +180,11 @@ describe('keyword detector swarm/team compatibility', () => {
 describe('keyword registry coverage', () => {
   it('includes key team/swarm aliases in runtime keyword registry', () => {
     const registryKeywords = new Set(KEYWORD_TRIGGER_DEFINITIONS.map((v) => v.keyword.toLowerCase()));
+    assert.ok(registryKeywords.has('ultraqa'));
+    assert.ok(registryKeywords.has('analyze'));
+    assert.ok(registryKeywords.has('investigate'));
+    assert.ok(registryKeywords.has('code review'));
+    assert.ok(registryKeywords.has('code-review'));
     assert.ok(registryKeywords.has('coordinated team'));
     assert.ok(registryKeywords.has('swarm'));
     assert.ok(registryKeywords.has('coordinated swarm'));

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -98,6 +98,34 @@ const TEAM_SWARM_INTENT_PATTERNS: Record<'team' | 'swarm', RegExp[]> = {
   ],
 };
 
+function hasExplicitPromptsInvocation(text: string): boolean {
+  return /(?:^|\s)\/prompts:[\w.-]+(?=[\s.,!?;:]|$)/i.test(text);
+}
+
+function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
+  const results: KeywordMatch[] = [];
+  const regex = /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    const token = (match[1] ?? '').toLowerCase();
+    if (!token) continue;
+
+    const normalizedSkill = token === 'swarm' ? 'team' : token;
+    const registryEntry = KEYWORD_TRIGGER_DEFINITIONS.find((entry) => entry.skill.toLowerCase() === normalizedSkill);
+    if (!registryEntry) continue;
+    if (results.some((item) => item.skill === normalizedSkill)) continue;
+
+    results.push({
+      keyword: `$${token}`,
+      skill: normalizedSkill,
+      priority: registryEntry.priority,
+    });
+  }
+
+  return results;
+}
+
 function hasIntentContextForKeyword(text: string, keyword: string): boolean {
   if (!KEYWORDS_REQUIRING_INTENT.has(keyword.toLowerCase())) return true;
   const k = keyword.toLowerCase() as 'team' | 'swarm';
@@ -106,16 +134,22 @@ function hasIntentContextForKeyword(text: string, keyword: string): boolean {
 
 /**
  * Detect keywords in user input text
- * Returns matching skills sorted by priority (highest first)
+ * Returns explicit `$skill` matches first (left-to-right),
+ * then appends implicit keyword matches sorted by priority.
  */
 export function detectKeywords(text: string): KeywordMatch[] {
-  const matches: KeywordMatch[] = [];
+  const explicit = extractExplicitSkillInvocations(text);
+  if (hasExplicitPromptsInvocation(text) && explicit.length === 0) {
+    return [];
+  }
+
+  const implicit: KeywordMatch[] = [];
 
   for (const { pattern, skill, priority } of KEYWORD_MAP) {
     const match = text.match(pattern);
     if (match) {
       if (!hasIntentContextForKeyword(text, match[0].toLowerCase())) continue;
-      matches.push({
+      implicit.push({
         keyword: match[0],
         skill,
         priority,
@@ -123,7 +157,14 @@ export function detectKeywords(text: string): KeywordMatch[] {
     }
   }
 
-  return matches.sort(compareKeywordMatches);
+  const merged: KeywordMatch[] = [...explicit];
+  const sortedImplicit = implicit.sort(compareKeywordMatches);
+  for (const item of sortedImplicit) {
+    if (merged.some((existing) => existing.skill === item.skill)) continue;
+    merged.push(item);
+  }
+
+  return merged;
 }
 
 /**

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -18,6 +18,9 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'ultrawork', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'ulw', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'parallel', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
+  { keyword: 'ultraqa', skill: 'ultraqa', priority: 8, guidance: 'Activate UltraQA cycling workflow' },
+  { keyword: 'analyze', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },
+  { keyword: 'investigate', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },
 
   { keyword: 'deep interview', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
   { keyword: 'gather requirements', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
@@ -48,6 +51,8 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'fix build', skill: 'build-fix', priority: 6, guidance: 'Activate build-fix workflow' },
   { keyword: 'type errors', skill: 'build-fix', priority: 6, guidance: 'Activate build-fix workflow' },
 
+  { keyword: 'code review', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
+  { keyword: 'code-review', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
   { keyword: 'review code', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
   { keyword: 'security review', skill: 'security-review', priority: 6, guidance: 'Activate security-review workflow' },
 ] as const;

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -149,6 +149,8 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "ralph", "don't stop", "must complete", "keep going" | `$ralph` | Read `~/.agents/skills/ralph/SKILL.md`, execute persistence loop |
 | "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
+| "ultraqa" | `$ultraqa` | Read `~/.agents/skills/ultraqa/SKILL.md`, run QA cycling workflow |
+| "analyze", "investigate" | `$analyze` | Read `~/.agents/skills/analyze/SKILL.md`, run deep analysis |
 | "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
 | "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
 | "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
@@ -157,14 +159,16 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "cancel", "stop", "abort" | `$cancel` | Read `~/.agents/skills/cancel/SKILL.md`, cancel active modes |
 | "tdd", "test first" | `$tdd` | Read `~/.agents/skills/tdd/SKILL.md`, start test-driven workflow |
 | "fix build", "type errors" | `$build-fix` | Read `~/.agents/skills/build-fix/SKILL.md`, fix build errors |
-| "review code" | `$code-review` | Read `~/.agents/skills/code-review/SKILL.md`, run code review |
+| "review code", "code review", "code-review" | `$code-review` | Read `~/.agents/skills/code-review/SKILL.md`, run code review |
 | "security review" | `$security-review` | Read `~/.agents/skills/security-review/SKILL.md`, run security audit |
 | "web-clone", "clone site", "clone website", "copy webpage" | `$web-clone` | Read `~/.agents/skills/web-clone/SKILL.md`, start website cloning pipeline |
 
 Detection rules:
 - Keywords are case-insensitive and match anywhere in the user's message
-- If multiple keywords match, use the most specific (longest match)
-- Conflict resolution: explicit `$name` invocation overrides keyword detection
+- If one or more explicit `$name` tokens are present, execute **all explicit skills left-to-right**.
+- If multiple non-explicit keywords match, use the most specific (longest match).
+- Conflict resolution: explicit `$name` invocation overrides keyword detection.
+- If user explicitly invokes `/prompts:<name>`, treat it as direct prompt execution and do not auto-activate keyword skills unless explicit `$name` tokens are also present.
 - The rest of the user's message (after keyword extraction) becomes the task description
 
 Ralph / Ralplan execution gate:


### PR DESCRIPTION
## Summary
- preserve explicit `` invocation order (left-to-right)
- add missing keyword aliases (`ultraqa`, `analyze`, `investigate`, `code review`, `code-review`)
- prevent implicit keyword auto-activation for direct `/prompts:<name>` invocations without explicit ``
- sync keyword-detection guidance in both `templates/AGENTS.md` and root `AGENTS.md`

## Validation
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js

Supersedes #577 (same fix retargeted to dev).
