### PR TITLE
feat: use DEFAULT_FRONTIER_MODEL for default model fallback

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -31,6 +31,7 @@ import {
   buildNotifyTempStartupMessages,
 } from '../index.js';
 import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
+import { DEFAULT_FRONTIER_MODEL } from '../../config/models.js';
 
 describe('normalizeCodexLaunchArgs', () => {
   it('maps --madmax to codex bypass flag', () => {
@@ -689,15 +690,15 @@ describe('team worker launch arg inheritance helpers', () => {
     );
   });
 
-  it('resolveTeamWorkerLaunchArgsEnv uses default model when env and inherited models are absent', () => {
+  it('resolveTeamWorkerLaunchArgsEnv uses frontier default model when env and inherited models are absent', () => {
     assert.equal(
       resolveTeamWorkerLaunchArgsEnv(
         '--no-alt-screen',
         ['--dangerously-bypass-approvals-and-sandbox'],
         true,
-        'gpt-5.3-codex'
+        DEFAULT_FRONTIER_MODEL
       ),
-      '--no-alt-screen --dangerously-bypass-approvals-and-sandbox --model gpt-5.3-codex'
+      `--no-alt-screen --dangerously-bypass-approvals-and-sandbox --model ${DEFAULT_FRONTIER_MODEL}`
     );
   });
 

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { getModelForMode, getTeamLowComplexityModel } from '../models.js';
+import { DEFAULT_FRONTIER_MODEL, getModelForMode, getTeamLowComplexityModel } from '../models.js';
 
 describe('getModelForMode', () => {
   let tempDir: string;
@@ -28,13 +28,13 @@ describe('getModelForMode', () => {
     await writeFile(join(tempDir, '.omx-config.json'), JSON.stringify(config));
   }
 
-  it('returns hardcoded default when config file does not exist', () => {
-    assert.equal(getModelForMode('team'), 'gpt-5.3-codex');
+  it('returns frontier default when config file does not exist', () => {
+    assert.equal(getModelForMode('team'), DEFAULT_FRONTIER_MODEL);
   });
 
-  it('returns hardcoded default when config has no models section', async () => {
+  it('returns frontier default when config has no models section', async () => {
     await writeConfig({ notifications: { enabled: false } });
-    assert.equal(getModelForMode('team'), 'gpt-5.3-codex');
+    assert.equal(getModelForMode('team'), DEFAULT_FRONTIER_MODEL);
   });
 
   it('returns mode-specific model when configured', async () => {
@@ -47,9 +47,9 @@ describe('getModelForMode', () => {
     assert.equal(getModelForMode('team'), 'o4-mini');
   });
 
-  it('returns hardcoded default when models section is empty', async () => {
+  it('returns frontier default when models section is empty', async () => {
     await writeConfig({ models: {} });
-    assert.equal(getModelForMode('team'), 'gpt-5.3-codex');
+    assert.equal(getModelForMode('team'), DEFAULT_FRONTIER_MODEL);
   });
 
   it('ignores empty string values and falls back to default', async () => {
@@ -69,14 +69,14 @@ describe('getModelForMode', () => {
     assert.equal(getModelForMode('ralph'), 'gpt-5');
   });
 
-  it('returns hardcoded default for invalid models section (array)', async () => {
+  it('returns frontier default for invalid models section (array)', async () => {
     await writeConfig({ models: ['not', 'valid'] });
-    assert.equal(getModelForMode('team'), 'gpt-5.3-codex');
+    assert.equal(getModelForMode('team'), DEFAULT_FRONTIER_MODEL);
   });
 
-  it('returns hardcoded default for malformed JSON', async () => {
+  it('returns frontier default for malformed JSON', async () => {
     await writeFile(join(tempDir, '.omx-config.json'), 'not-json');
-    assert.equal(getModelForMode('team'), 'gpt-5.3-codex');
+    assert.equal(getModelForMode('team'), DEFAULT_FRONTIER_MODEL);
   });
 
   it('returns low-complexity team model when configured', async () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -11,7 +11,7 @@
  *   }
  * }
  *
- * Resolution: mode-specific > "default" key > 'gpt-5.3-codex' (hardcoded fallback)
+ * Resolution: mode-specific > "default" key > DEFAULT_FRONTIER_MODEL (hardcoded fallback)
  */
 
 import { readFileSync, existsSync } from 'fs';
@@ -36,16 +36,17 @@ function readModelsBlock(codexHomeOverride?: string): ModelsConfig | null {
   }
 }
 
-export const HARDCODED_DEFAULT_MODEL = 'gpt-5.3-codex';
+export const DEFAULT_FRONTIER_MODEL = 'gpt-5.4';
+export const HARDCODED_DEFAULT_MODEL = DEFAULT_FRONTIER_MODEL;
 export const HARDCODED_TEAM_LOW_COMPLEXITY_MODEL = 'gpt-5.3-codex-spark';
 
 /**
  * Get the configured model for a specific mode.
- * Resolution: mode-specific override > "default" key > 'gpt-5.3-codex'
+ * Resolution: mode-specific override > "default" key > DEFAULT_FRONTIER_MODEL
  */
 export function getModelForMode(mode: string, codexHomeOverride?: string): string {
   const models = readModelsBlock(codexHomeOverride);
-  if (!models) return HARDCODED_DEFAULT_MODEL;
+  if (!models) return DEFAULT_FRONTIER_MODEL;
 
   const modeValue = models[mode];
   if (typeof modeValue === 'string' && modeValue.trim() !== '') {
@@ -57,7 +58,7 @@ export function getModelForMode(mode: string, codexHomeOverride?: string): strin
     return defaultValue.trim();
   }
 
-  return HARDCODED_DEFAULT_MODEL;
+  return DEFAULT_FRONTIER_MODEL;
 }
 
 const TEAM_LOW_COMPLEXITY_MODEL_KEYS = [


### PR DESCRIPTION
## Summary

Replace hardcoded default frontier-model fallback references to `gpt-5.3-codex` with `DEFAULT_FRONTIER_MODEL`.

## Changes

- add `DEFAULT_FRONTIER_MODEL = 'gpt-5.4'` in `src/config/models.ts`
- route `getModelForMode()` fallback logic through `DEFAULT_FRONTIER_MODEL`
- keep low-complexity spark default unchanged as `gpt-5.3-codex-spark`
- update affected tests to assert against `DEFAULT_FRONTIER_MODEL` instead of hardcoded `gpt-5.3-codex`

## Files changed

- `src/config/models.ts`
- `src/config/__tests__/models.test.ts`
- `src/cli/__tests__/index.test.ts`

## Verification

- `npm ci`
- `npm run build`
- `node --test dist/config/__tests__/models.test.js dist/cli/__tests__/index.test.js`

Result:
- 102 passing
- 0 failing

## Notes

- only true default-frontier fallback references were updated
- passthrough/example `gpt-5.3-codex` usages not tied to default-model semantics were left unchanged
- spark default remains `gpt-5.3-codex-spark`
