### PR TITLE
fix(team): seed gemini workers with prompt-interactive launch

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -269,6 +269,88 @@ describe('runtime', () => {
     }
   });
 
+  it('startTeam launches gemini workers with startup prompt and no default model passthrough', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-gemini-'));
+    const binDir = join(cwd, 'bin');
+    const fakeGeminiPath = join(binDir, 'gemini');
+    const capturePath = join(cwd, 'gemini-argv.json');
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeGeminiPath,
+      `#!/usr/bin/env bash
+printf '%s\n' "$@" > "$OMX_GEMINI_ARGV_CAPTURE_PATH"
+sleep 5
+`,
+      { mode: 0o755 },
+    );
+
+    const prevPath = process.env.PATH;
+    const prevTmux = process.env.TMUX;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    const prevCapture = process.env.OMX_GEMINI_ARGV_CAPTURE_PATH;
+
+    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
+    delete process.env.TMUX;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+    process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+    process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.3-codex-spark';
+    process.env.OMX_GEMINI_ARGV_CAPTURE_PATH = capturePath;
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'team-gemini-prompt',
+          'gemini prompt-mode team bootstrap',
+          'explore',
+          1,
+          [{ subject: 's', description: 'd', owner: 'worker-1' }],
+          cwd,
+        ));
+
+      assert.equal(runtime.config.worker_launch_mode, 'prompt');
+      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
+
+      let argv: string[] | null = null;
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        if (existsSync(capturePath)) {
+          argv = (await readFile(capturePath, 'utf-8')).trim().split('\n');
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      assert.ok(argv, 'gemini argv capture file should be written');
+      assert.deepEqual(argv, [
+        '--approval-mode',
+        'yolo',
+        '-i',
+        'Read and follow the instructions in .omx/state/team/team-gemini-prompt/workers/worker-1/inbox.md',
+      ]);
+
+      await shutdownTeam(runtime.teamName, cwd, { force: true });
+      runtime = null;
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      if (typeof prevCapture === 'string') process.env.OMX_GEMINI_ARGV_CAPTURE_PATH = prevCapture;
+      else delete process.env.OMX_GEMINI_ARGV_CAPTURE_PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam supports prompt launch mode without tmux and pipes trigger text via stdin', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-'));
     const binDir = join(cwd, 'bin');

--- a/src/team/__tests__/tmux-claude-workers-demo.test.ts
+++ b/src/team/__tests__/tmux-claude-workers-demo.test.ts
@@ -146,10 +146,14 @@ describe('tmux claude workers demo', () => {
       assert.deepEqual(result, ['--dangerously-skip-permissions']);
     });
 
-    it('returns gemini approval-mode yolo with model passthrough', () => {
+    it('returns gemini approval-mode yolo by default and adds -i when initial prompt is provided', () => {
       const args = ['--model', 'gemini-2.0-pro', '--json'];
       const result = translateWorkerLaunchArgsForCli('gemini', args);
       assert.deepEqual(result, ['--approval-mode', 'yolo', '--model', 'gemini-2.0-pro']);
+      assert.deepEqual(
+        translateWorkerLaunchArgsForCli('gemini', ['--json'], 'Read worker inbox'),
+        ['--approval-mode', 'yolo', '-i', 'Read worker inbox'],
+      );
     });
   });
 
@@ -253,9 +257,9 @@ describe('tmux claude workers demo', () => {
       });
       assert.deepEqual(plan, ['gemini']);
 
-      const spec = buildWorkerProcessLaunchSpec('team', 1, ['--model', 'gemini-2.0-pro'], '/tmp', {}, 'gemini');
+      const spec = buildWorkerProcessLaunchSpec('team', 1, ['--model', 'gemini-2.0-pro'], '/tmp', {}, 'gemini', 'Read worker inbox');
       assert.equal(spec.workerCli, 'gemini');
-      assert.deepEqual(spec.args, ['--approval-mode', 'yolo', '--model', 'gemini-2.0-pro']);
+      assert.deepEqual(spec.args, ['--approval-mode', 'yolo', '-i', 'Read worker inbox', '--model', 'gemini-2.0-pro']);
     });
 
     it('rejects invalid CLI map with empty entries', () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -385,13 +385,23 @@ describe('buildWorkerStartupCommand', () => {
     delete process.env.OMX_TEAM_WORKER_CLI; // auto
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
     try {
-      const cmd = buildWorkerStartupCommand('alpha', 1, ['--model', 'gemini-2.0-pro']);
+      const cmd = buildWorkerStartupCommand(
+        'alpha',
+        1,
+        ['--model', 'gemini-2.0-pro'],
+        process.cwd(),
+        {},
+        undefined,
+        'Read worker inbox',
+      );
       assert.match(cmd, /exec .*gemini/);
       assert.match(cmd, /--approval-mode/);
       assert.match(cmd, /yolo/);
       assert.match(cmd, /--model/);
       assert.match(cmd, /gemini-2.0-pro/);
-      assert.doesNotMatch(cmd, /\s-i(\s|$)/);
+      assert.match(cmd, /(?:^|\s|')-i(?:'|\s|$)/);
+      assert.match(cmd, /Read worker inbox/);
+      assert.match(cmd, /Read worker inbox/);
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;
       else delete process.env.SHELL;
@@ -772,14 +782,29 @@ describe('team worker CLI helpers', () => {
     );
   });
 
-  it('translateWorkerLaunchArgsForCli emits approval-mode and optional model for gemini', () => {
+  it('translateWorkerLaunchArgsForCli emits gemini approval-mode by default and adds -i when initial prompt is provided', () => {
     assert.deepEqual(
       translateWorkerLaunchArgsForCli('gemini', ['--model', 'gemini-2.0-pro', '--json']),
       ['--approval-mode', 'yolo', '--model', 'gemini-2.0-pro'],
     );
     assert.deepEqual(
+      translateWorkerLaunchArgsForCli('gemini', ['--model', 'gemini-2.0-pro', '--json'], 'Read worker inbox'),
+      ['--approval-mode', 'yolo', '-i', 'Read worker inbox', '--model', 'gemini-2.0-pro'],
+    );
+    assert.deepEqual(
       translateWorkerLaunchArgsForCli('gemini', ['--json']),
       ['--approval-mode', 'yolo'],
+    );
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('gemini', ['--json'], 'Read worker inbox'),
+      ['--approval-mode', 'yolo', '-i', 'Read worker inbox'],
+    );
+  });
+
+  it('translateWorkerLaunchArgsForCli omits non-gemini default models for gemini workers', () => {
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('gemini', ['--model', 'gpt-5.3-codex-spark'], 'Read worker inbox'),
+      ['--approval-mode', 'yolo', '-i', 'Read worker inbox'],
     );
   });
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -383,6 +383,7 @@ function spawnPromptWorker(
   launchArgs: string[],
   workerEnv: Record<string, string>,
   workerCli: 'codex' | 'claude' | 'gemini',
+  initialPrompt?: string,
 ): ChildProcessByStdio<Writable, null, null> {
   const processSpec = buildWorkerProcessLaunchSpec(
     teamName,
@@ -391,6 +392,7 @@ function spawnPromptWorker(
     workerCwd,
     workerEnv,
     workerCli,
+    initialPrompt,
   );
   const child = spawn(
     processSpec.command,
@@ -603,25 +605,71 @@ export async function startTeam(
     workerInstructionsPath = await writeTeamWorkerInstructionsFile(sanitized, leaderCwd, overlay);
     setTeamModelInstructionsFile(sanitized, workerInstructionsPath);
 
-    const workerStartups = Array.from({ length: workerCount }, (_, index) => {
-      const workerName = `worker-${index + 1}`;
+    const allTasks = await listTasks(sanitized, leaderCwd);
+    const workerBootstrapPlans = [] as Array<{
+      workerName: string;
+      workerWorkspace: { cwd: string; worktreePath?: string; worktreeBranch?: string; worktreeDetached?: boolean; };
+      workerTasks: TeamTask[];
+      workerRole: string;
+      rolePromptContent: string | null;
+      inbox: string;
+      trigger: string;
+      initialPrompt?: string;
+    }>;
+
+    for (let i = 1; i <= workerCount; i++) {
+      const workerName = `worker-${i}`;
       const workerWorkspace = workerWorkspaceByName.get(workerName) ?? { cwd: leaderCwd };
+      const workerTasks = allTasks.filter(t => t.owner === workerName);
+      const taskRoles = workerTasks.map(t => t.role).filter(Boolean) as string[];
+      const uniqueTaskRoles = new Set(taskRoles);
+      const workerRole = taskRoles.length > 0 && uniqueTaskRoles.size === 1
+        ? taskRoles[0]
+        : agentType;
+      const rolePromptContent = workerRole !== agentType
+        ? await loadRolePrompt(workerRole, codexPromptsDir())
+        : null;
+      const inbox = generateInitialInbox(workerName, sanitized, agentType, workerTasks, {
+        teamStateRoot,
+        leaderCwd,
+        workerRole,
+        rolePromptContent: rolePromptContent ?? undefined,
+      });
+      const trigger = generateTriggerMessage(workerName, sanitized);
+      const initialPrompt = workerCliPlan[i - 1] === 'gemini' ? trigger : undefined;
+      if (initialPrompt) {
+        await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
+      }
+      workerBootstrapPlans.push({
+        workerName,
+        workerWorkspace,
+        workerTasks,
+        workerRole,
+        rolePromptContent,
+        inbox,
+        trigger,
+        initialPrompt,
+      });
+    }
+
+    const workerStartups = workerBootstrapPlans.map((plan) => {
       const env: Record<string, string> = {
         [TEAM_STATE_ROOT_ENV]: teamStateRoot,
         [TEAM_LEADER_CWD_ENV]: leaderCwd,
       };
-      if (workerWorkspace.worktreePath) {
-        env.OMX_TEAM_WORKTREE_PATH = workerWorkspace.worktreePath;
+      if (plan.workerWorkspace.worktreePath) {
+        env.OMX_TEAM_WORKTREE_PATH = plan.workerWorkspace.worktreePath;
       }
-      if (workerWorkspace.worktreeBranch) {
-        env.OMX_TEAM_WORKTREE_BRANCH = workerWorkspace.worktreeBranch;
+      if (plan.workerWorkspace.worktreeBranch) {
+        env.OMX_TEAM_WORKTREE_BRANCH = plan.workerWorkspace.worktreeBranch;
       }
-      if (typeof workerWorkspace.worktreeDetached === 'boolean') {
-        env.OMX_TEAM_WORKTREE_DETACHED = workerWorkspace.worktreeDetached ? '1' : '0';
+      if (typeof plan.workerWorkspace.worktreeDetached === 'boolean') {
+        env.OMX_TEAM_WORKTREE_DETACHED = plan.workerWorkspace.worktreeDetached ? '1' : '0';
       }
       return {
-        cwd: workerWorkspace.cwd,
+        cwd: plan.workerWorkspace.cwd,
         env,
+        initialPrompt: plan.initialPrompt,
       };
     });
 
@@ -659,6 +707,7 @@ export async function startTeam(
           workerLaunchArgs,
           startup.env || {},
           workerCliPlan[i - 1],
+          startup.initialPrompt,
         );
         if (config.workers[i - 1]) {
           config.workers[i - 1].pid = child.pid;
@@ -668,31 +717,27 @@ export async function startTeam(
     await saveTeamConfig(config, leaderCwd);
 
     // 7. Wait for all workers to be ready (interactive mode), then bootstrap them
-    const allTasks = await listTasks(sanitized, leaderCwd);
     const manifest = await readTeamManifestV2(sanitized, leaderCwd);
     const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, workerLaunchMode);
     for (let i = 1; i <= workerCount; i++) {
-      const workerName = `worker-${i}`;
-      const paneId = workerPaneIds[i - 1];
-      const workerWorkspace = workerWorkspaceByName.get(workerName) ?? { cwd: leaderCwd };
-
-      // Get tasks assigned to this worker
-      const workerTasks = allTasks.filter(t => t.owner === workerName);
-
-      // Resolve per-worker role from assigned task roles
-      const taskRoles = workerTasks.map(t => t.role).filter(Boolean) as string[];
-      const uniqueTaskRoles = new Set(taskRoles);
-      const workerRole = taskRoles.length > 0 && uniqueTaskRoles.size === 1
-        ? taskRoles[0]
-        : agentType;
-      if (uniqueTaskRoles.size > 1) {
-        console.log(`[omx:team] ${workerName}: mixed task roles [${[...uniqueTaskRoles].join(', ')}], falling back to ${agentType}`);
+      const bootstrapPlan = workerBootstrapPlans[i - 1];
+      if (!bootstrapPlan) {
+        throw new Error(`missing bootstrap plan for worker-${i}`);
       }
+      const { workerName, paneId, workerTasks, workerRole, inbox, trigger, initialPrompt } = {
+        workerName: bootstrapPlan.workerName,
+        paneId: workerPaneIds[i - 1],
+        workerTasks: bootstrapPlan.workerTasks,
+        workerRole: bootstrapPlan.workerRole,
+        inbox: bootstrapPlan.inbox,
+        trigger: bootstrapPlan.trigger,
+        initialPrompt: bootstrapPlan.initialPrompt,
+      };
+      const workerWorkspace = bootstrapPlan.workerWorkspace;
 
-      // Load role-specific prompt content if role differs from default
-      const rolePromptContent = workerRole !== agentType
-        ? await loadRolePrompt(workerRole, codexPromptsDir())
-        : null;
+      if (workerTasks.map(t => t.role).filter(Boolean).length > 0 && new Set(workerTasks.map(t => t.role).filter(Boolean)).size > 1) {
+        console.log(`[omx:team] ${workerName}: mixed task roles [${[...new Set(workerTasks.map(t => t.role).filter(Boolean))].join(', ')}], falling back to ${agentType}`);
+      }
 
       // Write worker identity
       const identity: WorkerInfo = {
@@ -729,7 +774,7 @@ export async function startTeam(
       await writeWorkerIdentity(sanitized, workerName, identity, leaderCwd);
 
       // Wait for worker readiness
-      if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait) {
+      if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt) {
         const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);
         if (!ready) {
           throw new Error(`Worker ${workerName} did not become ready in tmux session ${sessionName}`);
@@ -739,40 +784,37 @@ export async function startTeam(
       // Queue inbox via MCP/state then notify worker via tmux transport.
       // Retry dispatch up to 3 times to handle Codex trust prompts that may
       // block the worker pane during startup (fixes #393).
-      const inbox = generateInitialInbox(workerName, sanitized, agentType, workerTasks, {
-        teamStateRoot,
-        leaderCwd,
-        workerRole,
-        rolePromptContent: rolePromptContent ?? undefined,
-      });
-      const trigger = generateTriggerMessage(workerName, sanitized);
       const maxStartupDispatchRetries = 3;
       const startupRetryDelayS = 3;
-      let dispatchOutcome: DispatchOutcome = { ok: false, transport: 'none', reason: 'not_attempted' };
-      for (let attempt = 1; attempt <= maxStartupDispatchRetries; attempt++) {
-        dispatchOutcome = await dispatchCriticalInboxInstruction({
-          teamName: sanitized,
-          config: config!,
-          workerName,
-          workerIndex: i,
-          paneId,
-          inbox,
-          triggerMessage: trigger,
-          cwd: leaderCwd,
-          dispatchPolicy,
-          inboxCorrelationKey: `startup:${workerName}`,
-        });
-        if (dispatchOutcome.ok) break;
-        if (attempt < maxStartupDispatchRetries) {
-          // Check for trust prompt blocking the worker and dismiss it before retry
-          if (workerLaunchMode === 'interactive') {
-            if (dismissTrustPromptIfPresent(sessionName, i, paneId)) {
-              waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);
+      let dispatchOutcome: DispatchOutcome = initialPrompt
+        ? { ok: true, transport: 'none', reason: 'startup_prompt_delivered_at_launch' }
+        : { ok: false, transport: 'none', reason: 'not_attempted' };
+      if (!initialPrompt) {
+        for (let attempt = 1; attempt <= maxStartupDispatchRetries; attempt++) {
+          dispatchOutcome = await dispatchCriticalInboxInstruction({
+            teamName: sanitized,
+            config: config!,
+            workerName,
+            workerIndex: i,
+            paneId,
+            inbox,
+            triggerMessage: trigger,
+            cwd: leaderCwd,
+            dispatchPolicy,
+            inboxCorrelationKey: `startup:${workerName}`,
+          });
+          if (dispatchOutcome.ok) break;
+          if (attempt < maxStartupDispatchRetries) {
+            // Check for trust prompt blocking the worker and dismiss it before retry
+            if (workerLaunchMode === 'interactive') {
+              if (dismissTrustPromptIfPresent(sessionName, i, paneId)) {
+                waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);
+              } else {
+                sleepFractionalSeconds(startupRetryDelayS);
+              }
             } else {
               sleepFractionalSeconds(startupRetryDelayS);
             }
-          } else {
-            sleepFractionalSeconds(startupRetryDelayS);
           }
         }
       }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -38,6 +38,7 @@ const OMX_TEAM_WORKER_CLI_MAP_ENV = 'OMX_TEAM_WORKER_CLI_MAP';
 const OMX_TEAM_WORKER_LAUNCH_MODE_ENV = 'OMX_TEAM_WORKER_LAUNCH_MODE';
 const OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV = 'OMX_TEAM_AUTO_INTERRUPT_RETRY';
 const CLAUDE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
+const GEMINI_PROMPT_INTERACTIVE_FLAG = '-i';
 const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
 const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
 const OMX_LEADER_NODE_PATH_ENV = 'OMX_LEADER_NODE_PATH';
@@ -514,13 +515,16 @@ export function resolveTeamWorkerCliPlan(
   });
 }
 
-export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: string[]): string[] {
+export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: string[], initialPrompt?: string): string[] {
   if (workerCli === 'codex') return [...args];
   if (workerCli === 'gemini') {
     const model = extractModelOverride(args);
-    return model
-      ? [GEMINI_APPROVAL_MODE_FLAG, GEMINI_APPROVAL_MODE_YOLO, MODEL_FLAG, model]
-      : [GEMINI_APPROVAL_MODE_FLAG, GEMINI_APPROVAL_MODE_YOLO];
+    const geminiModel = model && /gemini/i.test(model) ? model : null;
+    const translatedArgs = [GEMINI_APPROVAL_MODE_FLAG, GEMINI_APPROVAL_MODE_YOLO];
+    const trimmedPrompt = initialPrompt?.trim();
+    if (trimmedPrompt) translatedArgs.push(GEMINI_PROMPT_INTERACTIVE_FLAG, trimmedPrompt);
+    if (geminiModel) translatedArgs.push(MODEL_FLAG, geminiModel);
+    return translatedArgs;
   }
 
   // Claude workers must launch with exactly one permissions bypass flag.
@@ -601,6 +605,7 @@ export function buildWorkerStartupCommand(
   cwd: string = process.cwd(),
   extraEnv: Record<string, string> = {},
   workerCliOverride?: TeamWorkerCli,
+  initialPrompt?: string,
 ): string {
   const processSpec = buildWorkerProcessLaunchSpec(
     teamName,
@@ -609,6 +614,7 @@ export function buildWorkerStartupCommand(
     cwd,
     extraEnv,
     workerCliOverride,
+    initialPrompt,
   );
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
   const leaderNodeDir = resolveLeaderNodePath().replace(/\/[^/]+$/, ''); // dirname
@@ -629,10 +635,11 @@ export function buildWorkerProcessLaunchSpec(
   cwd: string = process.cwd(),
   extraEnv: Record<string, string> = {},
   workerCliOverride?: TeamWorkerCli,
+  initialPrompt?: string,
 ): WorkerProcessLaunchSpec {
   const fullLaunchArgs = resolveWorkerLaunchArgs(launchArgs, cwd);
   const workerCli = workerCliOverride ?? resolveTeamWorkerCli(fullLaunchArgs, process.env);
-  const cliLaunchArgs = translateWorkerLaunchArgsForCli(workerCli, fullLaunchArgs);
+  const cliLaunchArgs = translateWorkerLaunchArgsForCli(workerCli, fullLaunchArgs, initialPrompt);
 
   const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);
   const workerEnv: Record<string, string> = {
@@ -709,7 +716,7 @@ export function createTeamSession(
   workerCount: number,
   cwd: string,
   workerLaunchArgs: string[] = [],
-  workerStartups: Array<{ cwd?: string; env?: Record<string, string> }> = [],
+  workerStartups: Array<{ cwd?: string; env?: Record<string, string>; initialPrompt?: string }> = [],
 ): TeamSession {
   if (!isTmuxAvailable()) {
     throw new Error('tmux is not available');
@@ -768,6 +775,7 @@ export function createTeamSession(
         workerCwd,
         workerEnv,
         workerCliPlan[i - 1],
+        startup.initialPrompt,
       );
       // First split creates the right side from leader. Remaining splits stack on the right.
       const splitDirection = i === 1 ? '-h' : '-v';


### PR DESCRIPTION
## Summary
- launch Gemini team workers with `--approval-mode yolo -i "<initial prompt>"` instead of relying on stdin for the first instruction
- avoid passing non-Gemini default models through to Gemini workers unless the explicit model is actually a Gemini model
- add runtime and launcher test coverage for the new startup path

## Verification
- `node --test dist/team/__tests__/tmux-session.test.js --test-name-pattern='gemini|buildWorkerProcessLaunchSpec returns command/args/env for prompt process spawn'`
- `node --test dist/team/__tests__/tmux-claude-workers-demo.test.js --test-name-pattern='gemini'`
- live tmux verification: worker pane launched as `gemini --approval-mode yolo -i "Read and follow the instructions in .../inbox.md"`
