### PR TITLE
fix(notifications): use valid tmux capture-pane history flag

### DIFF
--- a/src/notifications/__tests__/tmux.test.ts
+++ b/src/notifications/__tests__/tmux.test.ts
@@ -201,7 +201,7 @@ describe('captureTmuxPane', () => {
         'lines=""',
         'while [ "$#" -gt 0 ]; do',
         '  if [ "$1" = "-t" ]; then target="$2"; shift 2; continue; fi',
-        '  if [ "$1" = "-l" ]; then lines="$2"; shift 2; continue; fi',
+        '  if [ "$1" = "-S" ]; then lines="$2"; shift 2; continue; fi',
         '  shift',
         'done',
         'printf "capture:%s:%s\\n" "$target" "$lines"',
@@ -210,9 +210,9 @@ describe('captureTmuxPane', () => {
     chmodSync(tmuxPath, 0o755);
     process.env.PATH = `${fakeBinDir}:${originalPath ?? ''}`;
 
-    assert.equal(captureTmuxPane('%42', 7.8), 'capture:%42:7');
-    assert.equal(captureTmuxPane('%42', Number.NaN), 'capture:%42:12');
-    assert.equal(captureTmuxPane('%42', 0), 'capture:%42:1');
-    assert.equal(captureTmuxPane('%42', 999999), 'capture:%42:2000');
+    assert.equal(captureTmuxPane('%42', 7.8), 'capture:%42:-7');
+    assert.equal(captureTmuxPane('%42', Number.NaN), 'capture:%42:-12');
+    assert.equal(captureTmuxPane('%42', 0), 'capture:%42:-1');
+    assert.equal(captureTmuxPane('%42', 999999), 'capture:%42:-2000');
   });
 });

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -146,7 +146,7 @@ export function captureTmuxPane(paneId?: string | null, lines: number = 12): str
   const clampedLines = Math.max(1, Math.min(MAX_CAPTURE_LINES, safeLines));
 
   try {
-    const output = execFileSync("tmux", ["capture-pane", "-t", target, "-p", "-l", String(clampedLines)], {
+    const output = execFileSync("tmux", ["capture-pane", "-t", target, "-p", "-S", `-${clampedLines}`], {
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
- fix `captureTmuxPane()` to use tmux history-start capture syntax instead of invalid `-l`
- update the focused tmux notification unit test fixture and expectations
- keep the patch scoped to issue #591

Closes #591.

## Verification
- `npx tsc --noEmit --pretty false --project tsconfig.json` on touched files via diagnostics
- `node --test .tmp-verify/notifications/__tests__/tmux.test.js`
