### PR TITLE
fix(team): harden leader follow-up and event-aware waiting

### DIFF
--- a/scripts/notify-fallback-watcher.js
+++ b/scripts/notify-fallback-watcher.js
@@ -30,6 +30,13 @@ const fileState = new Map();
 const seenTurnKeys = new Set();
 let stopping = false;
 const dispatchTickMax = Number(argValue('--dispatch-max-per-tick', '5')) || 5;
+let dispatchDrainRuns = 0;
+let lastDispatchDrain = {
+  leader_only: safeString(process.env.OMX_TEAM_WORKER || '').trim() === '',
+  last_tick_at: null,
+  last_result: null,
+  last_error: null,
+};
 
 function safeString(v) {
   return typeof v === 'string' ? v : '';
@@ -194,6 +201,43 @@ async function pollFiles() {
   }
 }
 
+async function runDispatchDrainTick() {
+  const startedIso = new Date().toISOString();
+  try {
+    const result = await drainPendingTeamDispatch({ cwd, stateDir, logsDir, maxPerTick: dispatchTickMax });
+    dispatchDrainRuns += 1;
+    lastDispatchDrain = {
+      leader_only: safeString(process.env.OMX_TEAM_WORKER || '').trim() === '',
+      last_tick_at: startedIso,
+      last_result: result,
+      last_error: null,
+    };
+    await eventLog({
+      type: 'dispatch_drain_tick',
+      leader_only: lastDispatchDrain.leader_only,
+      dispatch_max_per_tick: dispatchTickMax,
+      run_count: dispatchDrainRuns,
+      ...(result && typeof result === 'object' ? result : {}),
+    });
+  } catch (err) {
+    dispatchDrainRuns += 1;
+    lastDispatchDrain = {
+      leader_only: safeString(process.env.OMX_TEAM_WORKER || '').trim() === '',
+      last_tick_at: startedIso,
+      last_result: null,
+      last_error: err instanceof Error ? err.message : safeString(err),
+    };
+    await eventLog({
+      type: 'dispatch_drain_tick',
+      leader_only: lastDispatchDrain.leader_only,
+      dispatch_max_per_tick: dispatchTickMax,
+      run_count: dispatchDrainRuns,
+      reason: 'dispatch_drain_failed',
+      error: lastDispatchDrain.last_error,
+    });
+  }
+}
+
 async function writeState() {
   await mkdir(stateDir, { recursive: true }).catch(() => {});
   const state = {
@@ -204,6 +248,12 @@ async function writeState() {
     poll_ms: pollMs,
     tracked_files: fileState.size,
     seen_turns: seenTurnKeys.size,
+    dispatch_drain: {
+      enabled: true,
+      max_per_tick: dispatchTickMax,
+      run_count: dispatchDrainRuns,
+      ...lastDispatchDrain,
+    },
   };
   await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
 }
@@ -212,7 +262,7 @@ async function tick() {
   if (stopping) return;
   await ensureTrackedFiles();
   await pollFiles();
-  await drainPendingTeamDispatch({ cwd, stateDir, logsDir, maxPerTick: dispatchTickMax }).catch(() => {});
+  await runDispatchDrainTick();
   await writeState();
   setTimeout(tick, pollMs);
 }
@@ -244,7 +294,7 @@ async function main() {
   if (runOnce) {
     await ensureTrackedFiles();
     await pollFiles();
-    await drainPendingTeamDispatch({ cwd, stateDir, logsDir, maxPerTick: dispatchTickMax }).catch(() => {});
+    await runDispatchDrainTick();
     await writeState();
     await eventLog({ type: 'watcher_once_complete', seen_turns: seenTurnKeys.size });
     process.exit(0);

--- a/scripts/notify-hook/team-dispatch.js
+++ b/scripts/notify-hook/team-dispatch.js
@@ -209,6 +209,8 @@ async function appendLeaderNotificationDeferredEvent({
   request,
   reason,
   nowIso,
+  tmuxSession = '',
+  leaderPaneId = '',
 }) {
   const eventsDir = join(stateDir, 'team', teamName, 'events');
   const eventsPath = join(eventsDir, 'events.ndjson');
@@ -222,6 +224,9 @@ async function appendLeaderNotificationDeferredEvent({
     created_at: nowIso,
     request_id: request.request_id,
     ...(request.message_id ? { message_id: request.message_id } : {}),
+    tmux_session: tmuxSession || null,
+    leader_pane_id: leaderPaneId || null,
+    tmux_injection_attempted: false,
   };
   await mkdir(eventsDir, { recursive: true }).catch(() => {});
   await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(() => {});
@@ -433,6 +438,7 @@ async function updateMailboxNotified(stateDir, teamName, workerName, messageId) 
 
 async function appendDispatchLog(logsDir, event) {
   const path = join(logsDir, `team-dispatch-${new Date().toISOString().slice(0, 10)}.jsonl`);
+  await mkdir(logsDir, { recursive: true }).catch(() => {});
   await appendFile(path, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
 }
 
@@ -486,29 +492,38 @@ export async function drainPendingTeamDispatch({
 
         if (request.to_worker === 'leader-fixed' && !safeString(config?.leader_pane_id).trim()) {
           const nowIso = new Date().toISOString();
+          const alreadyDeferred = safeString(request.last_reason).trim() === LEADER_PANE_MISSING_DEFERRED_REASON;
           request.updated_at = nowIso;
           request.last_reason = LEADER_PANE_MISSING_DEFERRED_REASON;
           request.status = 'pending';
           skipped += 1;
           mutated = true;
-          await appendDispatchLog(logsDir, {
-            type: 'dispatch_deferred',
-            team: teamName,
-            request_id: request.request_id,
-            worker: request.to_worker,
-            to_worker: request.to_worker,
-            message_id: request.message_id || null,
-            reason: LEADER_PANE_MISSING_DEFERRED_REASON,
-            status: 'pending',
-            tmux_injection_attempted: false,
-          });
-          await appendLeaderNotificationDeferredEvent({
-            stateDir,
-            teamName,
-            request,
-            reason: LEADER_PANE_MISSING_DEFERRED_REASON,
-            nowIso,
-          });
+          if (!alreadyDeferred) {
+            await appendDispatchLog(logsDir, {
+              type: 'dispatch_deferred',
+              team: teamName,
+              request_id: request.request_id,
+              worker: request.to_worker,
+              to_worker: request.to_worker,
+              message_id: request.message_id || null,
+              reason: LEADER_PANE_MISSING_DEFERRED_REASON,
+              status: 'pending',
+              tmux_session: safeString(config?.tmux_session).trim() || null,
+              leader_pane_id: safeString(config?.leader_pane_id).trim() || null,
+              tmux_injection_attempted: false,
+            });
+            // Requests JSON is the canonical queue state; this event is a progress artifact
+            // for hook/watcher readers until shared readers normalize everything later.
+            await appendLeaderNotificationDeferredEvent({
+              stateDir,
+              teamName,
+              request,
+              reason: LEADER_PANE_MISSING_DEFERRED_REASON,
+              nowIso,
+              tmuxSession: safeString(config?.tmux_session).trim(),
+              leaderPaneId: safeString(config?.leader_pane_id).trim(),
+            });
+          }
           continue;
         }
 

--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -111,7 +111,7 @@ export async function emitTeamNudgeEvent(cwd, teamName, reason, nowIso) {
   }
 }
 
-async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso) {
+async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmuxSession = '', leaderPaneId = '' } = {}) {
   const eventsDir = join(cwd, '.omx', 'state', 'team', teamName, 'events');
   const eventsPath = join(eventsDir, 'events.ndjson');
   try {
@@ -124,6 +124,9 @@ async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso) {
       to_worker: 'leader-fixed',
       reason,
       created_at: nowIso,
+      tmux_session: tmuxSession || null,
+      leader_pane_id: leaderPaneId || null,
+      tmux_injection_attempted: false,
     };
     await appendFile(eventsPath, JSON.stringify(event) + '\n');
   } catch {
@@ -257,7 +260,14 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     const markedText = `${capped} ${DEFAULT_MARKER}`;
 
     if (!tmuxTarget) {
-      await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, nowIso);
+      nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '' };
+      if (shouldSendAllIdleNudge) {
+        nudgeState.last_idle_nudged_by_team[teamName] = { at: nowIso, worker_count: workerNames.length };
+      }
+      await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, nowIso, {
+        tmuxSession,
+        leaderPaneId,
+      });
       try {
         await logTmuxHookEvent(logsDir, {
           timestamp: nowIso,
@@ -266,7 +276,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
           worker: 'leader-fixed',
           to_worker: 'leader-fixed',
           reason: LEADER_PANE_MISSING_NO_INJECTION_REASON,
-          leader_pane_id: null,
+          leader_pane_id: leaderPaneId || null,
           tmux_session: tmuxSession || null,
           tmux_injection_attempted: false,
         });

--- a/scripts/notify-hook/team-worker.js
+++ b/scripts/notify-hook/team-worker.js
@@ -227,6 +227,9 @@ async function emitLeaderPaneMissingDeferred({
     to_worker: 'leader-fixed',
     reason,
     created_at: nowIso,
+    leader_pane_id: leaderPaneId || null,
+    tmux_session: tmuxSession || null,
+    tmux_injection_attempted: false,
   };
   await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(() => {});
 }
@@ -288,6 +291,14 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   if (!allIdle) return;
 
   if (!leaderPaneId) {
+    const nextIdleState = {
+      ...idleState,
+      last_notified_at_ms: nowMs,
+      last_notified_at: nowIso,
+      worker_count: workers.length,
+      delivery: 'deferred',
+    };
+    await writeFile(idleStatePath, JSON.stringify(nextIdleState, null, 2)).catch(() => {});
     await emitLeaderPaneMissingDeferred({
       stateDir,
       logsDir,

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { parseTeamStartArgs, teamCommand } from '../team.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
-import { initTeamState } from '../../team/state.js';
+import { initTeamState, appendTeamEvent } from '../../team/state.js';
 
 describe('parseTeamStartArgs', () => {
   it('parses default team start args without worktree', () => {
@@ -79,6 +79,8 @@ describe('teamCommand api', () => {
       assert.equal(logs.length, 1);
       assert.match(logs[0] ?? '', /Usage: omx team \[ralph\] \[N:agent-type\]/);
       assert.match(logs[0] ?? '', /omx team api <operation>/);
+      assert.match(logs[0] ?? '', /omx team await <team-name>/);
+      assert.match(logs[0] ?? '', /omx team await <team-name>/);
     } finally {
       console.log = originalLog;
     }
@@ -93,6 +95,7 @@ describe('teamCommand api', () => {
       assert.equal(logs.length, 1);
       assert.match(logs[0] ?? '', /Usage: omx team \[ralph\] \[N:agent-type\]/);
       assert.match(logs[0] ?? '', /omx team api <operation>/);
+      assert.match(logs[0] ?? '', /omx team await <team-name>/);
     } finally {
       console.log = originalLog;
     }
@@ -303,6 +306,91 @@ describe('teamCommand api', () => {
       assert.equal(transitioned.ok, true);
       assert.equal(transitioned.data?.ok, true);
       assert.equal(transitioned.data?.task?.status, 'completed');
+    } finally {
+      console.log = originalLog;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('accepts new canonical event types via CLI api append-event', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-event-'));
+    const previousCwd = process.cwd();
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      process.chdir(wd);
+      await initTeamState('event-team', 'event test', 'executor', 1, wd);
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+
+      await teamCommand([
+        'api',
+        'append-event',
+        '--input',
+        JSON.stringify({
+          team_name: 'event-team',
+          type: 'leader_notification_deferred',
+          worker: 'worker-1',
+          to_worker: 'leader-fixed',
+          reason: 'leader_pane_missing_no_injection',
+        }),
+        '--json',
+      ]);
+
+      const envelope = JSON.parse(logs.at(-1) ?? '{}') as {
+        ok?: boolean;
+        data?: { event?: { type?: string; to_worker?: string; reason?: string } };
+      };
+      assert.equal(envelope.ok, true);
+      assert.equal(envelope.data?.event?.type, 'leader_notification_deferred');
+      assert.equal(envelope.data?.event?.to_worker, 'leader-fixed');
+      assert.equal(envelope.data?.event?.reason, 'leader_pane_missing_no_injection');
+    } finally {
+      console.log = originalLog;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+
+describe('teamCommand await', () => {
+  it('returns next canonical event for a team in JSON mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-await-'));
+    const previousCwd = process.cwd();
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      process.chdir(wd);
+      await initTeamState('await-team', 'await test', 'executor', 1, wd);
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+
+      const waitPromise = teamCommand(['await', 'await-team', '--json', '--timeout-ms', '500']);
+      setTimeout(() => {
+        void appendTeamEvent('await-team', {
+          type: 'worker_state_changed',
+          worker: 'worker-1',
+          state: 'blocked',
+          prev_state: 'working',
+          reason: 'needs_follow_up',
+        }, wd);
+      }, 50);
+      await waitPromise;
+
+      const payload = JSON.parse(logs.at(-1) ?? '{}') as {
+        team_name?: string;
+        status?: string;
+        cursor?: string;
+        event?: { type?: string; state?: string; prev_state?: string; reason?: string } | null;
+      };
+      assert.equal(payload.team_name, 'await-team');
+      assert.equal(payload.status, 'event');
+      assert.equal(typeof payload.cursor, 'string');
+      assert.equal(payload.event?.type, 'worker_state_changed');
+      assert.equal(payload.event?.state, 'blocked');
+      assert.equal(payload.event?.prev_state, 'working');
+      assert.equal(payload.event?.reason, 'needs_follow_up');
     } finally {
       console.log = originalLog;
       process.chdir(previousCwd);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -2,6 +2,7 @@ import { updateModeState, startMode, readModeState } from '../modes/base.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime } from '../team/runtime.js';
 import { DEFAULT_MAX_WORKERS } from '../team/state.js';
 import { sanitizeTeamName } from '../team/tmux-session.js';
+import { waitForTeamEvent } from '../team/state/events.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import {
@@ -10,6 +11,7 @@ import {
   executeTeamApiOperation,
   type TeamApiOperation,
 } from '../team/api-interop.js';
+import { teamReadConfig as readTeamConfig } from '../team/team-ops.js';
 
 interface TeamCliOptions {
   verbose?: boolean;
@@ -28,6 +30,7 @@ const MIN_WORKER_COUNT = 1;
 const TEAM_HELP = `
 Usage: omx team [ralph] [N:agent-type] "<task description>"
        omx team status <team-name>
+       omx team await <team-name> [--timeout-ms <ms>] [--after-event-id <id>] [--json]
        omx team resume <team-name>
        omx team shutdown <team-name> [--force] [--ralph]
        omx team api <operation> [--input <json>] [--json]
@@ -527,6 +530,62 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
         `monitor_perf_ms: total=${snapshot.performance.total_ms} list=${snapshot.performance.list_tasks_ms} workers=${snapshot.performance.worker_scan_ms} mailbox=${snapshot.performance.mailbox_delivery_ms}`
       );
     }
+    return;
+  }
+
+  if (subcommand === 'await') {
+    const name = teamArgs[1];
+    if (!name) throw new Error('Usage: omx team await <team-name> [--timeout-ms <ms>] [--after-event-id <id>] [--json]');
+    const wantsJson = teamArgs.includes('--json');
+    const timeoutIdx = teamArgs.indexOf('--timeout-ms');
+    const afterIdx = teamArgs.indexOf('--after-event-id');
+    const timeoutMs = timeoutIdx >= 0 && teamArgs[timeoutIdx + 1]
+      ? Math.max(1, Number.parseInt(teamArgs[timeoutIdx + 1]!, 10) || 0)
+      : 30_000;
+    const afterEventId = afterIdx >= 0 ? (teamArgs[afterIdx + 1] || '') : '';
+    const config = await readTeamConfig(name, cwd);
+    if (!config) {
+      if (wantsJson) {
+        console.log(JSON.stringify({ team_name: name, status: 'missing', cursor: afterEventId || '', event: null }));
+      } else {
+        console.log(`No team state found for ${name}`);
+      }
+      return;
+    }
+
+    const result = await waitForTeamEvent(name, cwd, {
+      afterEventId: afterEventId || undefined,
+      timeoutMs,
+      pollMs: 100,
+      wakeableOnly: true,
+    });
+
+    if (wantsJson) {
+      console.log(JSON.stringify({
+        team_name: sanitizeTeamName(name),
+        status: result.status,
+        cursor: result.cursor,
+        event: result.event ?? null,
+      }));
+      return;
+    }
+
+    if (result.status === 'timeout') {
+      console.log(`No new event for ${name} before timeout (${timeoutMs}ms).`);
+      return;
+    }
+
+    const event = result.event!;
+    const context = [
+      `team=${name}`,
+      `event=${event.type}`,
+      `worker=${event.worker}`,
+      event.state ? `state=${event.state}` : '',
+      event.prev_state ? `prev=${event.prev_state}` : '',
+      event.task_id ? `task=${event.task_id}` : '',
+      `cursor=${result.cursor}`,
+    ].filter(Boolean).join(' ');
+    console.log(context);
     return;
   }
 

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -268,6 +268,45 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('records explicit leader-only dispatch drain state and log visibility in one-shot mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-dispatch-state-'));
+    try {
+      await initTeamState('dispatch-team', 'task', 'executor', 1, wd);
+      await enqueueDispatchRequest('dispatch-team', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: 'dispatch ping',
+      }, wd);
+
+      const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50', '--dispatch-max-per-tick', '1'],
+        { encoding: 'utf-8' },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.dispatch_drain?.enabled, true);
+      assert.equal(watcherState.dispatch_drain?.leader_only, true);
+      assert.equal(watcherState.dispatch_drain?.max_per_tick, 1);
+      assert.equal(watcherState.dispatch_drain?.run_count, 1);
+      assert.equal(watcherState.dispatch_drain?.last_result?.processed, 1);
+
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const drainEvent = logEntries.find((entry: { type?: string }) => entry.type === 'dispatch_drain_tick');
+      assert.ok(drainEvent, 'expected dispatch_drain_tick log event');
+      assert.equal(drainEvent.leader_only, true);
+      assert.equal(drainEvent.processed, 1);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('runs bounded non-turn team dispatch drain tick in leader context', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-dispatch-'));
     try {
@@ -314,6 +353,19 @@ describe('notify-fallback watcher', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
       const request = await readDispatchRequest('dispatch-team', queued.request.request_id, wd);
       assert.equal(request?.status, 'pending');
+
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.dispatch_drain?.leader_only, false);
+      assert.equal(watcherState.dispatch_drain?.last_result?.reason, 'worker_context');
+      assert.equal(watcherState.dispatch_drain?.last_result?.processed, 0);
+
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const drainEvent = logEntries.find((entry: { type?: string }) => entry.type === 'dispatch_drain_tick');
+      assert.ok(drainEvent, 'expected dispatch_drain_tick log event');
+      assert.equal(drainEvent.leader_only, false);
+      assert.equal(drainEvent.reason, 'worker_context');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
@@ -129,6 +129,16 @@ describe('notify-hook all-workers-idle notification', () => {
       const deferredEvent = events.find((e: { type: string; reason?: string }) =>
         e.type === 'leader_notification_deferred' && e.reason === 'leader_pane_missing_no_injection');
       assert.ok(deferredEvent, 'should emit leader_notification_deferred with missing-pane reason');
+      assert.equal(deferredEvent.to_worker, 'leader-fixed');
+      assert.equal(deferredEvent.tmux_session, 'devsess:0');
+      assert.equal(deferredEvent.leader_pane_id, null);
+      assert.equal(deferredEvent.tmux_injection_attempted, false);
+
+      const idleStatePath = join(teamDir, 'all-workers-idle.json');
+      assert.ok(existsSync(idleStatePath), 'cooldown state should be written even for deferred delivery');
+      const idleState = JSON.parse(await readFile(idleStatePath, 'utf-8'));
+      assert.equal(idleState.delivery, 'deferred');
+      assert.equal(idleState.worker_count, 2);
 
       const logPath = join(logsDir, `tmux-hook-${new Date().toISOString().split('T')[0]}.jsonl`);
       assert.ok(existsSync(logPath), 'tmux hook log should exist');
@@ -139,6 +149,55 @@ describe('notify-hook all-workers-idle notification', () => {
           entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_missing_no_injection');
       assert.ok(warn, 'should log leader_notification_deferred warning');
       assert.equal(warn.tmux_injection_attempted, false);
+    });
+  });
+
+  it('writes deferred visibility once per cooldown window when leader pane is missing', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'missing-pane-repeat';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(workersDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:11',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+          { name: 'worker-2', index: 2, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      for (const worker of ['worker-1', 'worker-2']) {
+        await mkdir(join(workersDir, worker), { recursive: true });
+        await writeJson(join(workersDir, worker, 'status.json'), {
+          state: 'idle',
+          updated_at: new Date().toISOString(),
+        });
+      }
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const first = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`, { OMX_TEAM_ALL_IDLE_COOLDOWN_MS: '600000' });
+      assert.equal(first.status, 0, `notify-hook failed: ${first.stderr || first.stdout}`);
+      const second = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`, { OMX_TEAM_ALL_IDLE_COOLDOWN_MS: '600000' });
+      assert.equal(second.status, 0, `notify-hook failed: ${second.stderr || second.stdout}`);
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const deferredEvents = events.filter((event: { type?: string; reason?: string }) =>
+        event.type === 'leader_notification_deferred' && event.reason === 'leader_pane_missing_no_injection');
+      assert.equal(deferredEvents.length, 1, 'cooldown should bound repeated deferred all-workers-idle artifacts');
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -159,6 +159,53 @@ describe('notify-hook team dispatch consumer', () => {
         && event.request_id === queued.request.request_id
         && event.to_worker === 'leader-fixed');
       assert.ok(deferred, 'expected leader_notification_deferred event for missing leader pane');
+      assert.equal(typeof deferred.tmux_session, 'string');
+      assert.ok(deferred.tmux_session.length > 0);
+      assert.equal(deferred.leader_pane_id, null);
+      assert.equal(deferred.tmux_injection_attempted, false);
+
+      const dispatchLogPath = join(cwd, '.omx', 'logs', `team-dispatch-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      const dispatchLogs = (await readFile(dispatchLogPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const deferredLog = dispatchLogs.find((entry: { type?: string; request_id?: string }) =>
+        entry.type === 'dispatch_deferred' && entry.request_id === queued.request.request_id);
+      assert.ok(deferredLog, 'expected dispatch_deferred log entry');
+      assert.equal(typeof deferredLog.tmux_session, 'string');
+      assert.ok(deferredLog.tmux_session.length > 0);
+      assert.equal(deferredLog.leader_pane_id, null);
+      assert.equal(deferredLog.tmux_injection_attempted, false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not duplicate deferred leader artifacts across repeated drain ticks', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    try {
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      const msg = await sendDirectMessage('alpha', 'worker-1', 'leader-fixed', 'hello leader', cwd);
+      const queued = await enqueueDispatchRequest('alpha', {
+        kind: 'mailbox',
+        to_worker: 'leader-fixed',
+        message_id: msg.message_id,
+        trigger_message: 'check leader mailbox',
+      }, cwd);
+
+      const modulePath = new URL('../../../scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      await mod.drainPendingTeamDispatch({ cwd, maxPerTick: 5, injector: async () => ({ ok: true, reason: 'injected_for_test' }) });
+      await mod.drainPendingTeamDispatch({ cwd, maxPerTick: 5, injector: async () => ({ ok: true, reason: 'injected_for_test' }) });
+
+      const eventsPath = join(cwd, '.omx', 'state', 'team', 'alpha', 'events', 'events.ndjson');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const deferredEvents = events.filter((event: { type?: string; request_id?: string }) =>
+        event.type === 'leader_notification_deferred' && event.request_id === queued.request.request_id);
+      assert.equal(deferredEvents.length, 1, 'should only write one deferred event per missing-pane request until state changes');
+
+      const dispatchLogPath = join(cwd, '.omx', 'logs', `team-dispatch-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      const dispatchLogs = (await readFile(dispatchLogPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const deferredLogs = dispatchLogs.filter((entry: { type?: string; request_id?: string }) =>
+        entry.type === 'dispatch_deferred' && entry.request_id === queued.request.request_id);
+      assert.equal(deferredLogs.length, 1, 'should only log one dispatch_deferred artifact per missing-pane request until state changes');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -361,6 +361,72 @@ describe('notify-hook team leader nudge', () => {
         e.type === 'leader_notification_deferred' && e.reason === 'leader_pane_missing_no_injection');
       assert.ok(deferred);
       assert.equal(deferred.type, 'leader_notification_deferred');
+      assert.equal(deferred.worker, 'leader-fixed');
+      assert.equal(deferred.to_worker, 'leader-fixed');
+      assert.equal(deferred.tmux_session, 'devsess:0');
+      assert.equal(deferred.leader_pane_id, null);
+      assert.equal(deferred.tmux_injection_attempted, false);
+
+      const nudgeStatePath = join(stateDir, 'team-leader-nudge.json');
+      assert.ok(existsSync(nudgeStatePath), 'nudge state should still advance on deferred leader visibility');
+      const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
+      assert.ok(nudgeState.last_nudged_by_team?.[teamName]?.at);
+    });
+  });
+
+  it('bounds repeated all-workers-idle nudges by cooldown', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'idle-bounded';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(workersDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'idle-bounded:0',
+        leader_pane_id: '%98',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+          { name: 'worker-2', index: 2, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: new Date().toISOString(),
+        turn_count: 1,
+      });
+      for (const worker of ['worker-1', 'worker-2']) {
+        await mkdir(join(workersDir, worker), { recursive: true });
+        await writeJson(join(workersDir, worker, 'status.json'), {
+          state: 'idle',
+          updated_at: new Date().toISOString(),
+        });
+      }
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const first = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_ALL_IDLE_COOLDOWN_MS: '600000' });
+      assert.equal(first.status, 0, `notify-hook failed: ${first.stderr || first.stdout}`);
+      const second = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_ALL_IDLE_COOLDOWN_MS: '600000' });
+      assert.equal(second.status, 0, `notify-hook failed: ${second.stderr || second.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      const sends = tmuxLog.match(/send-keys -t %98 -l \[OMX\] All 2 workers idle/g) || [];
+      assert.equal(sends.length, 1, 'cooldown should keep repeated all-workers-idle leader nudges bounded');
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -129,6 +129,10 @@ describe('notify-hook per-worker idle notification', () => {
       const event = events.find((entry: { type?: string; reason?: string }) =>
         entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_missing_no_injection');
       assert.ok(event, 'should emit deferred event with missing-pane reason');
+      assert.equal(event.to_worker, 'leader-fixed');
+      assert.equal(event.tmux_session, 'devsess:0');
+      assert.equal(event.leader_pane_id, null);
+      assert.equal(event.tmux_injection_attempted, false);
     });
   });
 

--- a/src/mcp/__tests__/team-server-wait.test.ts
+++ b/src/mcp/__tests__/team-server-wait.test.ts
@@ -1,0 +1,178 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { initTeamState, appendTeamEvent } from '../../team/state.js';
+
+const OMX_JOBS_DIR = join(homedir(), '.omx', 'team-jobs');
+
+async function writeJobFiles(
+  jobId: string,
+  job: Record<string, unknown>,
+  panes: { paneIds: string[]; leaderPaneId: string },
+): Promise<void> {
+  await mkdir(OMX_JOBS_DIR, { recursive: true });
+  await writeFile(join(OMX_JOBS_DIR, `${jobId}.json`), JSON.stringify(job));
+  await writeFile(join(OMX_JOBS_DIR, `${jobId}-panes.json`), JSON.stringify(panes));
+}
+
+async function cleanupJobFiles(jobId: string): Promise<void> {
+  await rm(join(OMX_JOBS_DIR, `${jobId}.json`), { force: true });
+  await rm(join(OMX_JOBS_DIR, `${jobId}-panes.json`), { force: true });
+}
+
+async function loadTeamServer() {
+  process.env.OMX_TEAM_SERVER_DISABLE_AUTO_START = '1';
+  return await import('../team-server.js');
+}
+
+describe('team-server wait semantics', () => {
+  it('keeps default terminal semantics unchanged when wake_on is omitted', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-wait-default-'));
+    const jobId = `omx-${Date.now().toString(36)}`;
+    try {
+      await initTeamState('wait-default', 'task', 'executor', 1, cwd);
+      await writeJobFiles(jobId, {
+        status: 'completed',
+        startedAt: Date.now() - 1000,
+        teamName: 'wait-default',
+        cwd,
+        result: JSON.stringify({ status: 'completed', ok: true }),
+      }, {
+        paneIds: ['%2'],
+        leaderPaneId: '%1',
+      });
+
+      const { handleTeamToolCall } = await loadTeamServer();
+      const response = await handleTeamToolCall({
+        params: {
+          name: 'omx_run_team_wait',
+          arguments: { job_id: jobId, timeout_ms: 50 },
+        },
+      });
+
+      const payload = JSON.parse(response.content[0]?.text ?? '{}') as { status?: string; result?: { ok?: boolean } };
+      assert.equal(payload.status, 'completed');
+      assert.equal(payload.result?.ok, true);
+    } finally {
+      await cleanupJobFiles(jobId);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns next event with cursor in wake_on=event mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-wait-event-'));
+    const jobId = `omx-${Date.now().toString(36)}`;
+    try {
+      await initTeamState('wait-event', 'task', 'executor', 1, cwd);
+      const baseline = await appendTeamEvent('wait-event', {
+        type: 'team_leader_nudge',
+        worker: 'leader-fixed',
+        reason: 'baseline',
+      }, cwd);
+      const next = await appendTeamEvent('wait-event', {
+        type: 'worker_state_changed',
+        worker: 'worker-1',
+        state: 'blocked',
+        prev_state: 'working',
+        reason: 'needs_follow_up',
+      }, cwd);
+
+      await writeJobFiles(jobId, {
+        status: 'running',
+        startedAt: Date.now() - 1000,
+        teamName: 'wait-event',
+        cwd,
+      }, {
+        paneIds: [],
+        leaderPaneId: '%1',
+      });
+
+      const { handleTeamToolCall } = await loadTeamServer();
+      const response = await handleTeamToolCall({
+        params: {
+          name: 'omx_run_team_wait',
+          arguments: {
+            job_id: jobId,
+            timeout_ms: 100,
+            wake_on: 'event',
+            after_event_id: baseline.event_id,
+          },
+        },
+      });
+
+      const payload = JSON.parse(response.content[0]?.text ?? '{}') as {
+        status?: string;
+        wake_on?: string;
+        cursor?: string;
+        event?: { event_id?: string; type?: string; state?: string; prev_state?: string };
+      };
+      assert.equal(payload.status, 'running');
+      assert.equal(payload.wake_on, 'event');
+      assert.equal(payload.cursor, next.event_id);
+      assert.equal(payload.event?.event_id, next.event_id);
+      assert.equal(payload.event?.type, 'worker_state_changed');
+      assert.equal(payload.event?.state, 'blocked');
+      assert.equal(payload.event?.prev_state, 'working');
+    } finally {
+      await cleanupJobFiles(jobId);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes legacy worker_idle events in wake_on=event mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-wait-legacy-'));
+    const jobId = `omx-${Date.now().toString(36)}`;
+    try {
+      await initTeamState('wait-legacy', 'task', 'executor', 1, cwd);
+      const baseline = await appendTeamEvent('wait-legacy', {
+        type: 'team_leader_nudge',
+        worker: 'leader-fixed',
+        reason: 'baseline',
+      }, cwd);
+      const idleEvent = await appendTeamEvent('wait-legacy', {
+        type: 'worker_idle',
+        worker: 'worker-1',
+        prev_state: 'working',
+        task_id: '1',
+      }, cwd);
+
+      await writeJobFiles(jobId, {
+        status: 'running',
+        startedAt: Date.now() - 1000,
+        teamName: 'wait-legacy',
+        cwd,
+      }, {
+        paneIds: [],
+        leaderPaneId: '%1',
+      });
+
+      const { handleTeamToolCall } = await loadTeamServer();
+      const response = await handleTeamToolCall({
+        params: {
+          name: 'omx_run_team_wait',
+          arguments: {
+            job_id: jobId,
+            timeout_ms: 100,
+            wake_on: 'event',
+            after_event_id: baseline.event_id,
+          },
+        },
+      });
+
+      const payload = JSON.parse(response.content[0]?.text ?? '{}') as {
+        event?: { event_id?: string; type?: string; source_type?: string; state?: string; prev_state?: string };
+        cursor?: string;
+      };
+      assert.equal(payload.cursor, idleEvent.event_id);
+      assert.equal(payload.event?.type, 'worker_state_changed');
+      assert.equal(payload.event?.source_type, 'worker_idle');
+      assert.equal(payload.event?.state, 'idle');
+      assert.equal(payload.event?.prev_state, 'working');
+    } finally {
+      await cleanupJobFiles(jobId);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -20,6 +20,7 @@ import { z } from 'zod';
 import { killWorkerPanes } from '../team/tmux-session.js';
 import { teamReadConfig as readTeamConfig } from '../team/team-ops.js';
 import { NudgeTracker } from '../team/idle-nudge.js';
+import { getLatestTeamEventCursor, waitForTeamEvent } from '../team/state/events.js';
 import { shouldAutoStartMcpServer } from './bootstrap.js';
 
 // ---------------------------------------------------------------------------
@@ -43,6 +44,8 @@ const waitSchema = z.object({
   nudge_delay_ms: z.number().optional(),
   nudge_max_count: z.number().optional(),
   nudge_message: z.string().optional(),
+  wake_on: z.enum(['terminal', 'event']).optional().default('terminal'),
+  after_event_id: z.string().optional(),
 });
 
 const cleanupSchema = z.object({
@@ -273,7 +276,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'omx_run_team_wait',
-      description: 'Block (poll internally) until a background omx_run_team job reaches a terminal state (completed or failed). Returns the result when done. One call instead of N polling calls. Uses exponential backoff (500ms to 2000ms). Auto-nudges idle teammate panes via tmux send-keys. If this wait call times out, workers are left running -- call omx_run_team_wait again to keep waiting, or omx_run_team_cleanup to stop them explicitly.',
+      description: 'Block (poll internally) until a background omx_run_team job reaches a terminal state (completed or failed) or, in wake_on=event mode, until the next team event arrives. Uses exponential backoff (500ms to 2000ms). Auto-nudges idle teammate panes via tmux send-keys. If this wait call times out, workers are left running -- call omx_run_team_wait again to keep waiting, or omx_run_team_cleanup to stop them explicitly.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -282,6 +285,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           nudge_delay_ms: { type: 'number', description: 'Milliseconds a pane must be idle before nudging (default: 30000)' },
           nudge_max_count: { type: 'number', description: 'Maximum nudges per pane (default: 3)' },
           nudge_message: { type: 'string', description: 'Message sent as nudge (default: "Continue working on your assigned task.")' },
+          wake_on: { type: 'string', enum: ['terminal', 'event'], description: 'Wake on terminal completion (default) or the next team event.' },
+          after_event_id: { type: 'string', description: 'Optional event cursor; in wake_on=event mode, wait for the next event after this id.' },
         },
         required: ['job_id'],
       },
@@ -385,10 +390,19 @@ export async function handleTeamToolCall(request: {
       }
 
       case 'omx_run_team_wait': {
-        const { job_id: jobId, timeout_ms: timeoutMs, nudge_delay_ms: nudgeDelayMs, nudge_max_count: nudgeMaxCount, nudge_message: nudgeMessage } = waitSchema.parse(a);
+        const {
+          job_id: jobId,
+          timeout_ms: timeoutMs,
+          nudge_delay_ms: nudgeDelayMs,
+          nudge_max_count: nudgeMaxCount,
+          nudge_message: nudgeMessage,
+          wake_on: wakeOn,
+          after_event_id: afterEventId,
+        } = waitSchema.parse(a);
 
         const deadline = Date.now() + Math.min(timeoutMs, 3_600_000);
         let pollDelay = 500;
+        let eventCursor = afterEventId;
 
         const nudgeTracker = new NudgeTracker({
           ...(nudgeDelayMs != null ? { delayMs: nudgeDelayMs } : {}),
@@ -424,8 +438,38 @@ export async function handleTeamToolCall(request: {
             if (nudgeTracker.totalNudges > 0) out.nudges = nudgeTracker.getSummary();
             return { content: [{ type: 'text' as const, text: JSON.stringify(out) }] };
           }
-          // Yield to Node.js event loop -- lets child.on('close', ...) fire between polls.
-          await new Promise<void>(r => setTimeout(r, pollDelay));
+
+          let waitedForEvent = false;
+          if (wakeOn === 'event' && job.teamName && job.cwd) {
+            if (!eventCursor) {
+              eventCursor = await getLatestTeamEventCursor(job.teamName, job.cwd);
+            }
+            const eventResult = await waitForTeamEvent(job.teamName, job.cwd, {
+              afterEventId: eventCursor,
+              timeoutMs: pollDelay,
+              pollMs: Math.min(pollDelay, 200),
+              wakeableOnly: true,
+            });
+            waitedForEvent = true;
+            if (eventResult.status === 'event' && eventResult.event) {
+              eventCursor = eventResult.cursor;
+              const elapsed = ((Date.now() - job.startedAt) / 1000).toFixed(1);
+              const out: Record<string, unknown> = {
+                jobId,
+                status: 'running',
+                elapsedSeconds: elapsed,
+                wake_on: 'event',
+                cursor: eventResult.cursor,
+                event: eventResult.event,
+              };
+              if (nudgeTracker.totalNudges > 0) out.nudges = nudgeTracker.getSummary();
+              return { content: [{ type: 'text' as const, text: JSON.stringify(out) }] };
+            }
+          }
+          if (!waitedForEvent) {
+            // Yield to Node.js event loop -- lets child.on('close', ...) fire between polls.
+            await new Promise<void>(r => setTimeout(r, pollDelay));
+          }
           pollDelay = Math.min(Math.floor(pollDelay * 1.5), 2000);
 
           // Auto-nudge idle panes
@@ -447,6 +491,7 @@ export async function handleTeamToolCall(request: {
           error: `Timed out waiting for job ${jobId} after ${(timeoutMs / 1000).toFixed(0)}s -- workers are still running; call omx_run_team_wait again to keep waiting or omx_run_team_cleanup to stop them`,
           jobId,
           status: 'running',
+          wake_on: wakeOn,
           elapsedSeconds: elapsed,
         };
         if (nudgeTracker.totalNudges > 0) timeoutOut.nudges = nudgeTracker.getSummary();

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -96,3 +96,12 @@ describe('runtime-cli helpers', () => {
     }
   });
 });
+
+
+  it('does not treat leader pane as a worker pane for dead-worker detection', async () => {
+    const runtimeCli = await loadRuntimeCliModule();
+
+    const result = runtimeCli.detectDeadWorkerFailure(1, 1, true, 'team-exec');
+    assert.equal(result.deadWorkerFailure, true);
+    assert.equal(result.fixingWithNoWorkers, false);
+  });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -597,7 +597,7 @@ process.on('SIGTERM', () => {
     }
   });
 
-  it('monitorTeam emits worker_idle and task_completed events based on transitions', async () => {
+  it('monitorTeam emits worker_state_changed, worker_idle, and task_completed events based on transitions', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     try {
       await initTeamState('team-events', 'monitor event test', 'executor', 1, cwd);
@@ -621,6 +621,7 @@ process.on('SIGTERM', () => {
       const eventsPath = join(cwd, '.omx', 'state', 'team', 'team-events', 'events', 'events.ndjson');
       const content = await readFile(eventsPath, 'utf-8');
       assert.match(content, /\"type\":\"task_completed\"/);
+      assert.match(content, /\"type\":\"worker_state_changed\"/);
       assert.match(content, /\"type\":\"worker_idle\"/);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -534,6 +534,10 @@ export async function executeTeamApiOperation(
           task_id: args.task_id as string | undefined,
           message_id: (args.message_id as string | undefined) ?? null,
           reason: args.reason as string | undefined,
+          state: args.state as string | undefined,
+          prev_state: args.prev_state as string | undefined,
+          to_worker: args.to_worker as string | undefined,
+          worker_count: typeof args.worker_count === 'number' ? args.worker_count : undefined,
         }, cwd);
         return { ok: true, operation, data: { event } };
       }

--- a/src/team/contracts.ts
+++ b/src/team/contracts.ts
@@ -25,12 +25,17 @@ export function canTransitionTeamTaskStatus(from: TeamTaskStatus, to: TeamTaskSt
 export const TEAM_EVENT_TYPES = [
   'task_completed',
   'task_failed',
+  'worker_state_changed',
   'worker_idle',
   'worker_stopped',
   'message_received',
+  'leader_notification_deferred',
+  'all_workers_idle',
   'shutdown_ack',
   'shutdown_gate',
   'shutdown_gate_forced',
+  'ralph_cleanup_policy',
+  'ralph_cleanup_summary',
   'approval_decision',
   'team_leader_nudge',
 ] as const;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1616,6 +1616,22 @@ async function emitMonitorDerivedEvents(
     }
 
     const prevState = previous.workerStateByName[worker.name];
+    if (prevState && prevState !== worker.status.state) {
+      await appendTeamEvent(
+        teamName,
+        {
+          type: 'worker_state_changed',
+          worker: worker.name,
+          task_id: worker.status.current_task_id,
+          message_id: null,
+          reason: worker.status.reason,
+          state: worker.status.state,
+          prev_state: prevState,
+        },
+        cwd
+      );
+    }
+
     if (prevState && prevState !== 'idle' && worker.status.state === 'idle') {
       await appendTeamEvent(
         teamName,
@@ -1625,6 +1641,9 @@ async function emitMonitorDerivedEvents(
           task_id: worker.status.current_task_id,
           message_id: null,
           reason: undefined,
+          prev_state: prevState,
+          state: 'idle',
+          source_type: 'worker_idle',
         },
         cwd
       );

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -56,6 +56,7 @@ import {
   canTransitionTeamTaskStatus,
   isTerminalTeamTaskStatus,
   type TeamTaskStatus,
+  type TeamEventType,
 } from './contracts.js';
 
 export interface TeamConfig {
@@ -237,24 +238,19 @@ export interface TeamWorkspaceMetadata {
 export interface TeamEvent {
   event_id: string;
   team: string;
-  type:
-    | 'task_completed'
-    | 'task_failed'
-    | 'worker_idle'
-    | 'worker_stopped'
-    | 'message_received'
-    | 'shutdown_ack'
-    | 'shutdown_gate'
-    | 'shutdown_gate_forced'
-    | 'ralph_cleanup_policy'
-    | 'ralph_cleanup_summary'
-    | 'approval_decision'
-    | 'team_leader_nudge';
+  type: TeamEventType;
   worker: string;
   task_id?: string;
   message_id?: string | null;
   reason?: string;
+  state?: WorkerStatus['state'];
+  prev_state?: WorkerStatus['state'];
+  worker_count?: number;
+  to_worker?: string;
+  source_type?: string;
+  metadata?: Record<string, unknown>;
   created_at: string;
+  [key: string]: unknown;
 }
 
 export interface TeamMailboxMessage {
@@ -542,7 +538,7 @@ function taskClaimLockDir(teamName: string, taskId: string, cwd: string): string
   return p;
 }
 
-function eventLogPath(teamName: string, cwd: string): string {
+export function teamEventLogPath(teamName: string, cwd: string): string {
   return join(teamDir(teamName, cwd), 'events', 'events.ndjson');
 }
 
@@ -1275,13 +1271,13 @@ export async function releaseTaskClaim(
 }
 
 export async function appendTeamEvent(teamName: string, event: Omit<TeamEvent, 'event_id' | 'created_at' | 'team'>, cwd: string): Promise<TeamEvent> {
-  const full: TeamEvent = {
+  const full = {
+    ...event,
     event_id: randomUUID(),
     team: teamName,
     created_at: new Date().toISOString(),
-    ...event,
-  };
-  const p = eventLogPath(teamName, cwd);
+  } as TeamEvent;
+  const p = teamEventLogPath(teamName, cwd);
   await mkdir(dirname(p), { recursive: true });
   await appendFile(p, `${JSON.stringify(full)}\n`, 'utf8');
   return full;

--- a/src/team/state/events.ts
+++ b/src/team/state/events.ts
@@ -1,1 +1,142 @@
-export { appendTeamEvent } from '../state.js';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import type { TeamEvent } from './types.js';
+import { teamEventLogPath, appendTeamEvent } from '../state.js';
+
+const CANONICAL_WAKE_EVENT_TYPES = new Set<TeamEvent['type']>([
+  'worker_state_changed',
+  'task_completed',
+  'task_failed',
+  'worker_stopped',
+  'message_received',
+  'leader_notification_deferred',
+  'all_workers_idle',
+  'team_leader_nudge',
+]);
+
+function asWorkerState(value: unknown): TeamEvent['state'] | undefined {
+  return typeof value === 'string'
+    && ['idle', 'working', 'blocked', 'done', 'failed', 'draining', 'unknown'].includes(value)
+    ? value as TeamEvent['state']
+    : undefined;
+}
+
+function normalizeRawTeamEvent(raw: unknown): TeamEvent | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = raw as Record<string, unknown>;
+  const eventId = typeof value.event_id === 'string' ? value.event_id.trim() : '';
+  const team = typeof value.team === 'string' ? value.team.trim() : '';
+  const type = typeof value.type === 'string' ? value.type.trim() : '';
+  const worker = typeof value.worker === 'string' ? value.worker.trim() : '';
+  const createdAt = typeof value.created_at === 'string' ? value.created_at.trim() : '';
+  if (!eventId || !team || !type || !worker || !createdAt) return null;
+
+  if (type === 'worker_idle') {
+    return {
+      ...(value as TeamEvent),
+      event_id: eventId,
+      team,
+      type: 'worker_state_changed',
+      source_type: 'worker_idle',
+      worker,
+      state: 'idle',
+      prev_state: asWorkerState(value.prev_state),
+      created_at: createdAt,
+    };
+  }
+
+  return {
+    ...(value as TeamEvent),
+    event_id: eventId,
+    team,
+    type: type as TeamEvent['type'],
+    worker,
+    task_id: typeof value.task_id === 'string' ? value.task_id : undefined,
+    message_id: typeof value.message_id === 'string' || value.message_id === null ? value.message_id as string | null : undefined,
+    reason: typeof value.reason === 'string' ? value.reason : undefined,
+    state: asWorkerState(value.state),
+    prev_state: asWorkerState(value.prev_state),
+    worker_count: typeof value.worker_count === 'number' ? value.worker_count : undefined,
+    to_worker: typeof value.to_worker === 'string' ? value.to_worker : undefined,
+    source_type: typeof value.source_type === 'string' ? value.source_type : undefined,
+    created_at: createdAt,
+  };
+}
+
+function isDuplicateNormalizedEvent(previous: TeamEvent | null, current: TeamEvent): boolean {
+  if (!previous) return false;
+  if (previous.type !== 'worker_state_changed' || current.type !== 'worker_state_changed') return false;
+  return previous.team === current.team
+    && previous.worker === current.worker
+    && previous.task_id === current.task_id
+    && previous.state === current.state
+    && previous.prev_state === current.prev_state
+    && current.source_type === 'worker_idle';
+}
+
+export async function readTeamEvents(
+  teamName: string,
+  cwd: string,
+  opts: { afterEventId?: string; wakeableOnly?: boolean } = {},
+): Promise<TeamEvent[]> {
+  const path = teamEventLogPath(teamName, cwd);
+  if (!existsSync(path)) return [];
+
+  const raw = await readFile(path, 'utf-8').catch(() => '');
+  if (!raw.trim()) return [];
+
+  const events: TeamEvent[] = [];
+  let started = !opts.afterEventId;
+  let previous: TeamEvent | null = null;
+
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const normalized = normalizeRawTeamEvent(parsed);
+    if (!normalized) continue;
+    if (!started) {
+      if (normalized.event_id === opts.afterEventId) started = true;
+      continue;
+    }
+    if (isDuplicateNormalizedEvent(previous, normalized)) continue;
+    previous = normalized;
+    if (opts.wakeableOnly && !CANONICAL_WAKE_EVENT_TYPES.has(normalized.type)) continue;
+    events.push(normalized);
+  }
+
+  return events;
+}
+
+export async function getLatestTeamEventCursor(teamName: string, cwd: string): Promise<string> {
+  const events = await readTeamEvents(teamName, cwd);
+  return events.at(-1)?.event_id ?? '';
+}
+
+export async function waitForTeamEvent(
+  teamName: string,
+  cwd: string,
+  opts: { afterEventId?: string; timeoutMs: number; pollMs?: number; wakeableOnly?: boolean },
+): Promise<{ status: 'event' | 'timeout'; event?: TeamEvent; cursor: string }> {
+  const deadline = Date.now() + Math.max(0, Math.floor(opts.timeoutMs));
+  let pollMs = Math.max(25, Math.floor(opts.pollMs ?? 100));
+  const baseline = opts.afterEventId ?? await getLatestTeamEventCursor(teamName, cwd);
+
+  while (Date.now() <= deadline) {
+    const events = await readTeamEvents(teamName, cwd, { afterEventId: baseline, wakeableOnly: opts.wakeableOnly !== false });
+    const event = events[0];
+    if (event) {
+      return { status: 'event', event, cursor: event.event_id };
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    pollMs = Math.min(Math.floor(pollMs * 1.5), 500);
+  }
+
+  return { status: 'timeout', cursor: baseline };
+}
+
+export { appendTeamEvent };

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -1,5 +1,5 @@
 import type { TeamPhase, TerminalPhase } from '../orchestrator.js';
-import type { TeamTaskStatus } from '../contracts.js';
+import type { TeamTaskStatus, TeamEventType } from '../contracts.js';
 
 export interface TeamConfig {
   name: string;
@@ -174,24 +174,19 @@ export interface TeamWorkspaceMetadata {
 export interface TeamEvent {
   event_id: string;
   team: string;
-  type:
-    | 'task_completed'
-    | 'task_failed'
-    | 'worker_idle'
-    | 'worker_stopped'
-    | 'message_received'
-    | 'shutdown_ack'
-    | 'shutdown_gate'
-    | 'shutdown_gate_forced'
-    | 'ralph_cleanup_policy'
-    | 'ralph_cleanup_summary'
-    | 'approval_decision'
-    | 'team_leader_nudge';
+  type: TeamEventType;
   worker: string;
   task_id?: string;
   message_id?: string | null;
   reason?: string;
+  state?: WorkerStatus['state'];
+  prev_state?: WorkerStatus['state'];
+  worker_count?: number;
+  to_worker?: string;
+  source_type?: string;
+  metadata?: Record<string, unknown>;
   created_at: string;
+  [key: string]: unknown;
 }
 
 export interface TeamMailboxMessage {

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -86,7 +86,7 @@ export { markDispatchRequestNotified as teamMarkDispatchRequestNotified } from '
 export { markDispatchRequestDelivered as teamMarkDispatchRequestDelivered } from './state.js';
 
 // === Events ===
-export { appendTeamEvent as teamAppendEvent } from './state.js';
+export { appendTeamEvent as teamAppendEvent, teamEventLogPath as teamEventLogPath } from './state.js';
 
 // === Approvals ===
 export { readTaskApproval as teamReadTaskApproval } from './state.js';


### PR DESCRIPTION
## Summary
- harden team leader follow-up without repurposing worker-only nudges
- add canonical team event normalization plus additive event-aware waiting
- make watcher/dispatch drain liveness explicit and strengthen deferred leader visibility/tests

## What changed
- expanded canonical team event types and synchronized event typing across `contracts.ts`, `state.ts`, `state/types.ts`, and API interop
- added shared event reading/normalization/cursor helpers in `src/team/state/events.ts`
- runtime now emits `worker_state_changed` while preserving legacy `worker_idle` compatibility
- added additive `wake_on=event` / `after_event_id` support to `omx_run_team_wait`
- added `omx team await <team-name>` CLI support
- made notify fallback watcher dispatch-drain progress visible in state/logs
- hardened deferred leader artifacts and bounded repeated missing-pane/all-idle nudge behavior
- added regression coverage for event-mode wait, CLI await, watcher liveness, all-workers-idle, dispatch dedupe, and leader notification paths

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/team-server-wait.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/runtime-cli.test.js`
- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js`
