### PR TITLE
fix(team): restore team-ops gateway contract

### DIFF
--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -86,7 +86,7 @@ export { markDispatchRequestNotified as teamMarkDispatchRequestNotified } from '
 export { markDispatchRequestDelivered as teamMarkDispatchRequestDelivered } from './state.js';
 
 // === Events ===
-export { appendTeamEvent as teamAppendEvent, teamEventLogPath as teamEventLogPath } from './state.js';
+export { appendTeamEvent as teamAppendEvent } from './state.js';
 
 // === Approvals ===
 export { readTaskApproval as teamReadTaskApproval } from './state.js';


### PR DESCRIPTION
## Summary
- restore the intended `team-ops` gateway public surface after #609
- remove the accidental `teamEventLogPath` re-export that broke the strict team-ops contract test

## Why
PR #609 merged the main team leader/event-aware wait changes into `dev`, but a post-merge CI investigation found one strict module-contract failure:
- `team/team-ops module contract`

This follow-up keeps the implementation intact and only restores the expected gateway export map.

## Verification
- `npm run build`
- `node --test dist/team/__tests__/team-ops-contract.test.js`
