### PR TITLE
feat: apply GPT-5.4 prompt-guidance patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Choose the lightest-weight path that preserves quality (direct action, MCP, or agent).
 - Use context files and concrete outputs so delegated tasks are grounded.
 - Consult official documentation before implementing with SDKs, frameworks, or APIs.
+- Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
+- Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
+- Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
 </operating_principles>
 
 ---
@@ -281,7 +285,7 @@ Sizing guidance:
 - Standard changes: standard verifier
 - Large or security/architectural changes (>20 files): thorough verifier
 
-Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work.
+Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to concise evidence summaries in the final response, but never omit the proof needed to justify completion.
 </verification>
 
 <execution_protocols>
@@ -290,9 +294,11 @@ Broad Request Detection:
 
 Parallelization:
 - Run 2+ independent tasks in parallel when each takes >30s.
-- Run dependent tasks sequentially.
+- Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
 - Use background execution for installs, builds, and tests.
 - Prefer Team mode as the primary parallel execution surface. Use ad hoc parallelism only when Team overhead is disproportionate to the task.
+- If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
+- When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
 
 Visual iteration gate:
 - For visual tasks (reference image(s) + generated screenshot), run `$visual-verdict` every iteration before the next edit.

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -44,6 +44,10 @@ A task is complete only when all are true:
 - Do not add single-use abstractions unless necessary.
 - Do not claim completion without fresh verification output.
 - Do not stop at “partially done” unless hard-blocked by impossible constraints.
+- Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
+- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
 - Plan files in `.omx/plans/` are read-only.
 
 ## Ambiguity Handling (Explore-First)
@@ -52,8 +56,9 @@ Default behavior: **explore first, ask later**.
 
 1. If there is one reasonable interpretation, proceed.
 2. If details may exist in-repo, search for them before asking.
-3. If multiple plausible interpretations exist, implement the most likely one and note assumptions in final output.
-4. Ask one precise question only when progress is truly impossible.
+3. If multiple plausible interpretations exist, implement the most likely one and note assumptions in a compact final output.
+4. If a newer user message updates only the current step or output shape, apply that override locally without discarding earlier non-conflicting instructions.
+5. Ask one precise question only when progress is truly impossible.
 
 ## Investigation Protocol
 
@@ -112,6 +117,8 @@ No evidence = not complete.
 - Trusting assumptions over repository evidence.
 
 ## Output Format
+
+Default final-output shape: concise and evidence-dense unless the user asked for more detail.
 
 ## Changes Made
 - `path/to/file:line-range` — concise description

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -32,6 +32,9 @@ Plans that are too vague waste executor time guessing. Plans that are too detail
 - Never ask the user about codebase facts (use explore agent to look them up).
 - Default to 3-6 step plans. Avoid architecture redesign unless the task requires it.
 - Stop planning when the plan is actionable. Do not over-specify.
+- Default to compact, information-dense plan summaries; expand only when risk or ambiguity requires it.
+- Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
+- Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
 - Consult analyst (Metis) before generating the final plan to catch missing requirements.
 - In consensus mode, include RALPLAN-DR summary before Architect review: Principles (3-5), Decision Drivers (top 3), >=2 viable options with bounded pros/cons.
 - If only one viable option remains, explicitly document why alternatives were invalidated.
@@ -42,7 +45,8 @@ Plans that are too vague waste executor time guessing. Plans that are too detail
 
 1) Classify intent: Trivial/Simple (quick fix) | Refactoring (safety focus) | Build from Scratch (discovery focus) | Mid-sized (boundary focus).
 2) For codebase facts, spawn explore agent. Never burden the user with questions the codebase can answer.
-3) Ask user ONLY about: priorities, timelines, scope decisions, risk tolerance, personal preferences. Use AskUserQuestion tool with 2-4 options.
+3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+4) Ask user ONLY about: priorities, timelines, scope decisions, risk tolerance, personal preferences. Use AskUserQuestion tool with 2-4 options.
 4) When user triggers plan generation ("make it into a work plan"), consult analyst (Metis) first for gap analysis.
 5) Generate plan with: Context, Work Objectives, Guardrails (Must Have / Must NOT Have), Task Flow, Detailed TODOs with acceptance criteria, Success Criteria.
 6) Display confirmation summary and wait for explicit user approval.
@@ -71,6 +75,8 @@ When running inside `$plan --consensus` (ralplan):
 - Interview phase is the default state. Plan generation only on explicit request.
 
 ## Output Format
+
+Default final-output shape: concise and information-dense, with only the detail needed to execute safely.
 
 ## Plan Summary
 

--- a/prompts/verifier.md
+++ b/prompts/verifier.md
@@ -26,6 +26,8 @@ You are not responsible for authoring features (executor), gathering requirement
 - No approval without fresh evidence. Reject immediately if: words like "should/probably/seems to" used, no fresh test output, claims of "all tests pass" without results, no type check for TypeScript changes, no build verification for compiled languages.
 - Run verification commands yourself. Do not trust claims without output.
 - Verify against original acceptance criteria (not just "it compiles").
+- Default reports to concise, evidence-dense summaries, but never omit the proof needed to justify PASS/FAIL/INCOMPLETE.
+- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
 
 ## Investigation Protocol
 
@@ -33,6 +35,7 @@ You are not responsible for authoring features (executor), gathering requirement
 2) EXECUTE (parallel): Run test suite via Bash. Run lsp_diagnostics_directory for type checking. Run build command. Grep for related tests that should also pass.
 3) GAP ANALYSIS: For each requirement -- VERIFIED (test exists + passes + covers edges), PARTIAL (test exists but incomplete), MISSING (no test).
 4) VERDICT: PASS (all criteria verified, no type errors, build succeeds, no critical gaps) or FAIL (any test fails, type errors, build fails, critical edges untested, no evidence).
+5) If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria.
 
 ## Tool Usage
 

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -88,7 +88,7 @@ describe('config generator', () => {
     }
   });
 
-  it('writes model_reasoning_effort and developer_instructions', async () => {
+  it('writes model_reasoning_effort and strengthened developer_instructions', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
     try {
       const configPath = join(wd, 'config.toml');
@@ -97,6 +97,10 @@ describe('config generator', () => {
 
       assert.match(toml, /^model_reasoning_effort = "high"$/m);
       assert.match(toml, /^developer_instructions = "You have oh-my-codex installed/m);
+      assert.match(toml, /Keep answers compact by default/);
+      assert.match(toml, /proceed automatically on clear low-risk reversible steps/);
+      assert.match(toml, /local overrides that preserve earlier non-conflicting instructions/);
+      assert.match(toml, /keep using tools when correctness depends on retrieval, execution, or verification/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -74,7 +74,7 @@ function getOmxTopLevelLines(
     "# oh-my-codex top-level settings (must be before any [table])",
     `notify = ["node", "${escapedPath}"]`,
     'model_reasoning_effort = "high"',
-    `developer_instructions = "You have oh-my-codex installed. Use /prompts:architect, /prompts:executor, /prompts:planner for specialized agent roles. Workflow skills via $name: $ralph, $autopilot, $plan. AGENTS.md is your orchestration brain."`,
+    `developer_instructions = "You have oh-my-codex installed. Use /prompts:architect, /prompts:executor, /prompts:planner for specialized agent roles. Workflow skills via $name: $ralph, $autopilot, $plan. Keep answers compact by default, proceed automatically on clear low-risk reversible steps, treat newer user task updates as local overrides that preserve earlier non-conflicting instructions, and keep using tools when correctness depends on retrieval, execution, or verification. AGENTS.md is your orchestration brain."`,
   ];
 
   const existingModel = rootValues.get("model");

--- a/src/hooks/__tests__/prompt-guidance-contract.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-contract.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const rootAgents = readFileSync(join(__dirname, '../../../AGENTS.md'), 'utf-8');
+const templateAgents = readFileSync(join(__dirname, '../../../templates/AGENTS.md'), 'utf-8');
+const executorPrompt = readFileSync(join(__dirname, '../../../prompts/executor.md'), 'utf-8');
+const plannerPrompt = readFileSync(join(__dirname, '../../../prompts/planner.md'), 'utf-8');
+const verifierPrompt = readFileSync(join(__dirname, '../../../prompts/verifier.md'), 'utf-8');
+
+const COMPACT_PATTERN = /compact, information-dense responses/i;
+const FOLLOW_THROUGH_PATTERN = /clear, low-risk, reversible next steps/i;
+const OVERRIDE_PATTERN = /local overrides?.*non-conflicting instructions/i;
+const TOOL_PERSISTENCE_PATTERN = /do not skip prerequisites|task is grounded and verified/i;
+const CONCISE_EVIDENCE_PATTERN = /concise evidence summaries/i;
+
+describe('prompt guidance contract for root/template orchestration surfaces', () => {
+  for (const [label, content] of [
+    ['AGENTS.md', rootAgents],
+    ['templates/AGENTS.md', templateAgents],
+  ] as const) {
+    it(`${label} encodes compact output defaults`, () => {
+      assert.match(content, COMPACT_PATTERN);
+    });
+
+    it(`${label} encodes follow-through for low-risk reversible next steps`, () => {
+      assert.match(content, FOLLOW_THROUGH_PATTERN);
+    });
+
+    it(`${label} encodes localized task-update overrides`, () => {
+      assert.match(content, OVERRIDE_PATTERN);
+    });
+
+    it(`${label} encodes dependency-aware tool persistence`, () => {
+      assert.match(content, TOOL_PERSISTENCE_PATTERN);
+    });
+
+    it(`${label} keeps concise evidence-summary guidance in verification`, () => {
+      assert.match(content, CONCISE_EVIDENCE_PATTERN);
+    });
+  }
+});
+
+describe('prompt guidance contract for selected role prompts', () => {
+  it('executor prompt encodes compact output, local overrides, and tool persistence', () => {
+    assert.match(executorPrompt, /compact, information-dense outputs/i);
+    assert.match(executorPrompt, /local overrides?.*non-conflicting constraints/i);
+    assert.match(executorPrompt, /keep using them until the task is grounded and verified/i);
+  });
+
+  it('planner prompt encodes compact planning summaries, local overrides, and evidence-grounded planning', () => {
+    assert.match(plannerPrompt, /compact, information-dense plan summaries/i);
+    assert.match(plannerPrompt, /local overrides?.*non-conflicting constraints/i);
+    assert.match(plannerPrompt, /keep using them until the plan is grounded in evidence/i);
+  });
+
+  it('verifier prompt encodes concise evidence-dense reporting, tool persistence, and local override handling', () => {
+    assert.match(verifierPrompt, /concise, evidence-dense summaries/i);
+    assert.match(verifierPrompt, /keep using those tools until the verdict is grounded/i);
+    assert.match(verifierPrompt, /apply that override locally without discarding earlier non-conflicting acceptance criteria/i);
+  });
+});

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -26,6 +26,10 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Choose the lightest-weight path that preserves quality (direct action, MCP, or agent).
 - Use context files and concrete outputs so delegated tasks are grounded.
 - Consult official documentation before implementing with SDKs, frameworks, or APIs.
+- Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
+- Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
+- Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
 </operating_principles>
 
 ---
@@ -281,7 +285,7 @@ Sizing guidance:
 - Standard changes: standard verifier
 - Large or security/architectural changes (>20 files): thorough verifier
 
-Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work.
+Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to concise evidence summaries in the final response, but never omit the proof needed to justify completion.
 </verification>
 
 <execution_protocols>
@@ -290,9 +294,11 @@ Broad Request Detection:
 
 Parallelization:
 - Run 2+ independent tasks in parallel when each takes >30s.
-- Run dependent tasks sequentially.
+- Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
 - Use background execution for installs, builds, and tests.
 - Prefer Team mode as the primary parallel execution surface. Use ad hoc parallelism only when Team overhead is disproportionate to the task.
+- If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
+- When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
 
 Visual iteration gate:
 - For visual tasks (reference image(s) + generated screenshot), run `$visual-verdict` every iteration before the next edit.


### PR DESCRIPTION
## Summary
- apply GPT-5.4-style prompt-guidance patterns to OMX's primary prompt surfaces
- tighten root/template orchestration contracts around compact output, low-risk follow-through, local task-update overrides, and dependency-aware tool persistence
- strengthen executor/planner/verifier role prompts and the generated `developer_instructions` text
- add focused regression coverage for the new prompt-contract expectations

Closes #608.

## Changes
- update `AGENTS.md` and `templates/AGENTS.md` with explicit compactness, follow-through, override, and verification guidance
- update `prompts/executor.md`, `prompts/planner.md`, and `prompts/verifier.md` with role-appropriate prompt-contract refinements
- update `src/config/generator.ts` so seeded `developer_instructions` carry the stronger guidance
- extend `src/config/__tests__/generator-notify.test.ts`
- add `src/hooks/__tests__/prompt-guidance-contract.test.ts`

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/config/__tests__/generator-notify.test.js dist/hooks/__tests__/consensus-execution-handoff.test.js`
- `npm test`
