### PR TITLE
refactor: centralize prompt guidance contract validation

### DIFF
--- a/src/hooks/__tests__/prompt-guidance-catalog.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-catalog.test.ts
@@ -1,48 +1,11 @@
 import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function loadPrompt(name: string): string {
-  return readFileSync(join(__dirname, `../../../prompts/${name}.md`), 'utf-8');
-}
+import { CATALOG_CONTRACTS, LEGACY_PROMPT_CONTRACTS } from '../prompt-guidance-contract.js';
+import { assertContractSurface } from './prompt-guidance-test-helpers.js';
 
 describe('prompt guidance catalog coverage', () => {
-  const markdownPrompts = [
-    'analyst',
-    'api-reviewer',
-    'build-fixer',
-    'dependency-expert',
-    'designer',
-    'git-master',
-    'information-architect',
-    'performance-reviewer',
-    'product-analyst',
-    'product-manager',
-    'qa-tester',
-    'quality-strategist',
-    'style-reviewer',
-    'ux-researcher',
-    'vision',
-    'writer',
-  ] as const;
-
-  for (const name of markdownPrompts) {
-    const content = loadPrompt(name);
-    it(`${name} includes concise output, local overrides, and scenario examples`, () => {
-      assert.match(content, /Default final-output shape: concise and evidence-dense/i);
-      assert.match(content, /Treat newer user task updates as local overrides/i);
-      assert.match(content, /user says `continue`/i);
+  for (const contract of [...CATALOG_CONTRACTS, ...LEGACY_PROMPT_CONTRACTS]) {
+    it(`${contract.id} satisfies catalog prompt-guidance coverage`, () => {
+      assertContractSurface(contract);
     });
   }
-
-  it('code-simplifier legacy prompt includes local overrides and grounded simplification guidance', () => {
-    const content = loadPrompt('code-simplifier');
-    assert.match(content, /local overrides for the active simplification scope/i);
-    assert.match(content, /until the simplification result is grounded/i);
-    assert.match(content, /<Scenario_Examples>/i);
-  });
 });

--- a/src/hooks/__tests__/prompt-guidance-contract.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-contract.test.ts
@@ -1,66 +1,11 @@
 import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { CORE_ROLE_CONTRACTS, ROOT_TEMPLATE_CONTRACTS } from '../prompt-guidance-contract.js';
+import { assertContractSurface } from './prompt-guidance-test-helpers.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-const rootAgents = readFileSync(join(__dirname, '../../../AGENTS.md'), 'utf-8');
-const templateAgents = readFileSync(join(__dirname, '../../../templates/AGENTS.md'), 'utf-8');
-const executorPrompt = readFileSync(join(__dirname, '../../../prompts/executor.md'), 'utf-8');
-const plannerPrompt = readFileSync(join(__dirname, '../../../prompts/planner.md'), 'utf-8');
-const verifierPrompt = readFileSync(join(__dirname, '../../../prompts/verifier.md'), 'utf-8');
-
-const COMPACT_PATTERN = /compact, information-dense responses/i;
-const FOLLOW_THROUGH_PATTERN = /clear, low-risk, reversible next steps/i;
-const OVERRIDE_PATTERN = /local overrides?.*non-conflicting instructions/i;
-const TOOL_PERSISTENCE_PATTERN = /do not skip prerequisites|task is grounded and verified/i;
-const CONCISE_EVIDENCE_PATTERN = /concise evidence summaries/i;
-
-describe('prompt guidance contract for root/template orchestration surfaces', () => {
-  for (const [label, content] of [
-    ['AGENTS.md', rootAgents],
-    ['templates/AGENTS.md', templateAgents],
-  ] as const) {
-    it(`${label} encodes compact output defaults`, () => {
-      assert.match(content, COMPACT_PATTERN);
-    });
-
-    it(`${label} encodes follow-through for low-risk reversible next steps`, () => {
-      assert.match(content, FOLLOW_THROUGH_PATTERN);
-    });
-
-    it(`${label} encodes localized task-update overrides`, () => {
-      assert.match(content, OVERRIDE_PATTERN);
-    });
-
-    it(`${label} encodes dependency-aware tool persistence`, () => {
-      assert.match(content, TOOL_PERSISTENCE_PATTERN);
-    });
-
-    it(`${label} keeps concise evidence-summary guidance in verification`, () => {
-      assert.match(content, CONCISE_EVIDENCE_PATTERN);
+describe('prompt guidance contract', () => {
+  for (const contract of [...ROOT_TEMPLATE_CONTRACTS, ...CORE_ROLE_CONTRACTS]) {
+    it(`${contract.id} satisfies the core prompt-guidance contract`, () => {
+      assertContractSurface(contract);
     });
   }
-});
-
-describe('prompt guidance contract for selected role prompts', () => {
-  it('executor prompt encodes compact output, local overrides, and tool persistence', () => {
-    assert.match(executorPrompt, /compact, information-dense outputs/i);
-    assert.match(executorPrompt, /local overrides?.*non-conflicting constraints/i);
-    assert.match(executorPrompt, /keep using them until the task is grounded and verified/i);
-  });
-
-  it('planner prompt encodes compact planning summaries, local overrides, and evidence-grounded planning', () => {
-    assert.match(plannerPrompt, /compact, information-dense plan summaries/i);
-    assert.match(plannerPrompt, /local overrides?.*non-conflicting constraints/i);
-    assert.match(plannerPrompt, /keep using them until the plan is grounded in evidence/i);
-  });
-
-  it('verifier prompt encodes concise evidence-dense reporting, tool persistence, and local override handling', () => {
-    assert.match(verifierPrompt, /concise, evidence-dense summaries/i);
-    assert.match(verifierPrompt, /keep using those tools until the verdict is grounded/i);
-    assert.match(verifierPrompt, /apply that override locally without discarding earlier non-conflicting acceptance criteria/i);
-  });
 });

--- a/src/hooks/__tests__/prompt-guidance-scenarios.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-scenarios.test.ts
@@ -1,34 +1,11 @@
 import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-const executorPrompt = readFileSync(join(__dirname, '../../../prompts/executor.md'), 'utf-8');
-const plannerPrompt = readFileSync(join(__dirname, '../../../prompts/planner.md'), 'utf-8');
-const verifierPrompt = readFileSync(join(__dirname, '../../../prompts/verifier.md'), 'utf-8');
+import { SCENARIO_ROLE_CONTRACTS } from '../prompt-guidance-contract.js';
+import { assertContractSurface } from './prompt-guidance-test-helpers.js';
 
 describe('prompt guidance scenario examples', () => {
-  it('executor prompt documents scoped updates for continue / PR / merge-if-green flows', () => {
-    assert.match(executorPrompt, /user says `continue`/i);
-    assert.match(executorPrompt, /make a PR targeting dev/i);
-    assert.match(executorPrompt, /merge to dev if CI green/i);
-    assert.match(executorPrompt, /Check the PR checks, confirm CI is green, then merge/i);
-  });
-
-  it('planner prompt documents scoped planning updates for continue / PR / merge-if-green flows', () => {
-    assert.match(plannerPrompt, /user says `continue`/i);
-    assert.match(plannerPrompt, /user says `make a PR`/i);
-    assert.match(plannerPrompt, /user says `merge if CI green`/i);
-    assert.match(plannerPrompt, /scoped condition on the next operational step/i);
-  });
-
-  it('verifier prompt documents evidence-first handling of merge-if-green and continue flows', () => {
-    assert.match(verifierPrompt, /user says `merge if CI green`/i);
-    assert.match(verifierPrompt, /confirm they are green/i);
-    assert.match(verifierPrompt, /user says `continue`/i);
-    assert.match(verifierPrompt, /keep gathering the required evidence/i);
-  });
+  for (const contract of SCENARIO_ROLE_CONTRACTS) {
+    it(`${contract.id} documents the expected scenario examples`, () => {
+      assertContractSurface(contract);
+    });
+  }
 });

--- a/src/hooks/__tests__/prompt-guidance-test-helpers.ts
+++ b/src/hooks/__tests__/prompt-guidance-test-helpers.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { GuidanceSurfaceContract } from '../prompt-guidance-contract.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../../../');
+
+export function loadSurface(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf-8');
+}
+
+export function assertContractSurface(contract: GuidanceSurfaceContract): void {
+  const content = loadSurface(contract.path);
+  for (const pattern of contract.requiredPatterns) {
+    assert.match(content, pattern, `${contract.id} missing required pattern: ${pattern}`);
+  }
+}

--- a/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
@@ -1,62 +1,30 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function loadPrompt(name: string): string {
-  return readFileSync(join(__dirname, `../../../prompts/${name}.md`), 'utf-8');
-}
+import { WAVE_TWO_CONTRACTS } from '../prompt-guidance-contract.js';
+import { assertContractSurface, loadSurface } from './prompt-guidance-test-helpers.js';
 
 describe('prompt guidance wave two contract', () => {
-  const prompts = {
-    architect: loadPrompt('architect'),
-    critic: loadPrompt('critic'),
-    debugger: loadPrompt('debugger'),
-    testEngineer: loadPrompt('test-engineer'),
-    codeReviewer: loadPrompt('code-reviewer'),
-    qualityReviewer: loadPrompt('quality-reviewer'),
-    securityReviewer: loadPrompt('security-reviewer'),
-    researcher: loadPrompt('researcher'),
-    explore: loadPrompt('explore'),
-  };
-
-  for (const [label, content] of Object.entries(prompts)) {
-    it(`${label} defaults to concise output and localized task-update handling`, () => {
-      assert.match(content, /Default final-output shape: concise and evidence-dense/i);
-      assert.match(content, /Treat newer user task updates as local overrides/i);
+  for (const contract of WAVE_TWO_CONTRACTS) {
+    it(`${contract.id} satisfies the wave-two contract`, () => {
+      assertContractSurface(contract);
     });
   }
 
-  it('wave two prompts encode persistent evidence gathering with role-appropriate wording', () => {
-    assert.match(prompts.architect, /keep using those tools until the analysis is grounded/i);
-    assert.match(prompts.critic, /keep doing so until the verdict is grounded/i);
-    assert.match(prompts.debugger, /keep using those tools until the diagnosis is grounded/i);
-    assert.match(prompts.testEngineer, /keep using those tools until the recommendation is grounded/i);
-    assert.match(prompts.codeReviewer, /keep using those tools until the review is grounded/i);
-    assert.match(prompts.qualityReviewer, /keep using those tools until the review is grounded/i);
-    assert.match(prompts.securityReviewer, /keep using those tools until the security verdict is grounded/i);
-    assert.match(prompts.researcher, /keep researching until the answer is grounded/i);
-    assert.match(prompts.explore, /keep using those tools until the answer is grounded/i);
+  it('wave-two prompts encode role-appropriate grounded-evidence wording', () => {
+    assert.match(loadSurface('prompts/architect.md'), /analysis is grounded/i);
+    assert.match(loadSurface('prompts/critic.md'), /verdict is grounded/i);
+    assert.match(loadSurface('prompts/debugger.md'), /diagnosis is grounded/i);
+    assert.match(loadSurface('prompts/test-engineer.md'), /recommendation is grounded/i);
+    assert.match(loadSurface('prompts/code-reviewer.md'), /review is grounded/i);
+    assert.match(loadSurface('prompts/quality-reviewer.md'), /review is grounded/i);
+    assert.match(loadSurface('prompts/security-reviewer.md'), /security verdict is grounded/i);
+    assert.match(loadSurface('prompts/researcher.md'), /answer is grounded/i);
+    assert.match(loadSurface('prompts/explore.md'), /answer is grounded/i);
   });
 
-  it('wave two prompts contain scenario examples for continue and scoped update handling', () => {
-    assert.match(prompts.architect, /user says `continue`/i);
-    assert.match(prompts.critic, /user says `continue`/i);
-    assert.match(prompts.debugger, /user says `continue`/i);
-    assert.match(prompts.testEngineer, /user says `continue`/i);
-    assert.match(prompts.codeReviewer, /user says `continue`/i);
-    assert.match(prompts.qualityReviewer, /user says `continue`/i);
-    assert.match(prompts.securityReviewer, /user says `continue`/i);
-    assert.match(prompts.researcher, /user says `continue`/i);
-    assert.match(prompts.explore, /user says `continue`/i);
-  });
-
-  it('security and verifier-adjacent prompts preserve merge-if-green as downstream context, not replacement evidence', () => {
-    assert.match(prompts.securityReviewer, /merge if CI green/i);
-    assert.match(prompts.critic, /later workflow condition|downstream context/i);
-    assert.match(prompts.testEngineer, /merge if CI green/i);
+  it('security and verifier-adjacent prompts preserve merge-if-green as downstream context', () => {
+    assert.match(loadSurface('prompts/security-reviewer.md'), /merge if CI green/i);
+    assert.match(loadSurface('prompts/critic.md'), /later workflow condition|downstream context/i);
+    assert.match(loadSurface('prompts/test-engineer.md'), /merge if CI green/i);
   });
 });

--- a/src/hooks/__tests__/skill-guidance-contract.test.ts
+++ b/src/hooks/__tests__/skill-guidance-contract.test.ts
@@ -1,34 +1,11 @@
 import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function loadSkill(name: string): string {
-  return readFileSync(join(__dirname, `../../../skills/${name}/SKILL.md`), 'utf-8');
-}
+import { SKILL_CONTRACTS } from '../prompt-guidance-contract.js';
+import { assertContractSurface } from './prompt-guidance-test-helpers.js';
 
 describe('execution-heavy skill guidance contract', () => {
-  const skills = {
-    analyze: loadSkill('analyze'),
-    autopilot: loadSkill('autopilot'),
-    buildFix: loadSkill('build-fix'),
-    codeReview: loadSkill('code-review'),
-    securityReview: loadSkill('security-review'),
-    plan: loadSkill('plan'),
-    ralph: loadSkill('ralph'),
-    ralplan: loadSkill('ralplan'),
-    team: loadSkill('team'),
-    ultraqa: loadSkill('ultraqa'),
-  };
-
-  for (const [label, content] of Object.entries(skills)) {
-    it(`${label} includes guidance for concise reporting, local overrides, and continue scenarios`, () => {
-      assert.match(content, /concise, evidence-dense progress and completion reporting|concise, evidence-dense progress and completion reporting/i);
-      assert.match(content, /local overrides for the active workflow branch|local overrides for the active workflow branch while preserving/i);
-      assert.match(content, /user says `continue`/i);
+  for (const contract of SKILL_CONTRACTS) {
+    it(`${contract.id} satisfies the execution-heavy skill guidance contract`, () => {
+      assertContractSurface(contract);
     });
   }
 });

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -1,0 +1,165 @@
+export interface GuidanceSurfaceContract {
+  id: string;
+  path: string;
+  requiredPatterns: RegExp[];
+}
+
+function rx(pattern: string): RegExp {
+  return new RegExp(pattern, 'i');
+}
+
+const ROOT_TEMPLATE_PATTERNS = [
+  rx('compact, information-dense responses'),
+  rx('clear, low-risk, reversible next steps'),
+  rx('local overrides?.*non-conflicting instructions'),
+  rx('do not skip prerequisites|task is grounded and verified'),
+  rx('concise evidence summaries'),
+];
+
+const CORE_ROLE_PATTERNS = {
+  executor: [
+    rx('compact, information-dense outputs'),
+    rx('local overrides?.*non-conflicting constraints'),
+    rx('task is grounded and verified'),
+  ],
+  planner: [
+    rx('compact, information-dense plan summaries'),
+    rx('local overrides?.*non-conflicting constraints'),
+    rx('plan is grounded in evidence'),
+  ],
+  verifier: [
+    rx('concise, evidence-dense summaries'),
+    rx('verdict is grounded'),
+    rx('non-conflicting acceptance criteria'),
+  ],
+};
+
+const WAVE_TWO_PATTERNS = [
+  rx('Default final-output shape: concise and evidence-dense'),
+  rx('Treat newer user task updates as local overrides'),
+  rx('user says `continue`'),
+];
+
+const CATALOG_PATTERNS = [
+  rx('Default final-output shape: concise and evidence-dense'),
+  rx('Treat newer user task updates as local overrides'),
+  rx('user says `continue`'),
+];
+
+const SKILL_PATTERNS = [
+  rx('concise, evidence-dense progress and completion reporting'),
+  rx('local overrides for the active workflow branch'),
+  rx('user says `continue`'),
+];
+
+export const ROOT_TEMPLATE_CONTRACTS: GuidanceSurfaceContract[] = [
+  { id: 'agents-root', path: 'AGENTS.md', requiredPatterns: ROOT_TEMPLATE_PATTERNS },
+  { id: 'agents-template', path: 'templates/AGENTS.md', requiredPatterns: ROOT_TEMPLATE_PATTERNS },
+];
+
+export const CORE_ROLE_CONTRACTS: GuidanceSurfaceContract[] = [
+  { id: 'executor', path: 'prompts/executor.md', requiredPatterns: CORE_ROLE_PATTERNS.executor },
+  { id: 'planner', path: 'prompts/planner.md', requiredPatterns: CORE_ROLE_PATTERNS.planner },
+  { id: 'verifier', path: 'prompts/verifier.md', requiredPatterns: CORE_ROLE_PATTERNS.verifier },
+];
+
+export const SCENARIO_ROLE_CONTRACTS: GuidanceSurfaceContract[] = [
+  {
+    id: 'executor-scenarios',
+    path: 'prompts/executor.md',
+    requiredPatterns: [
+      rx('user says `continue`'),
+      rx('make a PR targeting dev'),
+      rx('merge to dev if CI green'),
+      rx('confirm CI is green, then merge'),
+    ],
+  },
+  {
+    id: 'planner-scenarios',
+    path: 'prompts/planner.md',
+    requiredPatterns: [
+      rx('user says `continue`'),
+      rx('user says `make a PR`'),
+      rx('user says `merge if CI green`'),
+      rx('scoped condition on the next operational step'),
+    ],
+  },
+  {
+    id: 'verifier-scenarios',
+    path: 'prompts/verifier.md',
+    requiredPatterns: [
+      rx('user says `merge if CI green`'),
+      rx('confirm they are green'),
+      rx('user says `continue`'),
+      rx('keep gathering the required evidence'),
+    ],
+  },
+];
+
+export const WAVE_TWO_CONTRACTS: GuidanceSurfaceContract[] = [
+  'architect',
+  'critic',
+  'debugger',
+  'test-engineer',
+  'code-reviewer',
+  'quality-reviewer',
+  'security-reviewer',
+  'researcher',
+  'explore',
+].map((name) => ({
+  id: name,
+  path: `prompts/${name}.md`,
+  requiredPatterns: WAVE_TWO_PATTERNS,
+}));
+
+export const CATALOG_CONTRACTS: GuidanceSurfaceContract[] = [
+  'analyst',
+  'api-reviewer',
+  'build-fixer',
+  'dependency-expert',
+  'designer',
+  'git-master',
+  'information-architect',
+  'performance-reviewer',
+  'product-analyst',
+  'product-manager',
+  'qa-tester',
+  'quality-strategist',
+  'style-reviewer',
+  'ux-researcher',
+  'vision',
+  'writer',
+].map((name) => ({
+  id: name,
+  path: `prompts/${name}.md`,
+  requiredPatterns: CATALOG_PATTERNS,
+}));
+
+export const LEGACY_PROMPT_CONTRACTS: GuidanceSurfaceContract[] = [
+  {
+    id: 'code-simplifier',
+    path: 'prompts/code-simplifier.md',
+    requiredPatterns: [
+      rx('local overrides for the active simplification scope'),
+      rx('simplification result is grounded'),
+      rx('<Scenario_Examples>'),
+    ],
+  },
+];
+
+export const SKILL_CONTRACTS: GuidanceSurfaceContract[] = [
+  'analyze',
+  'autopilot',
+  'build-fix',
+  'code-review',
+  'plan',
+  'ralph',
+  'ralplan',
+  'security-review',
+  'team',
+  'ultraqa',
+].map((name) => ({
+  id: name,
+  path: `skills/${name}/SKILL.md`,
+  requiredPatterns: SKILL_PATTERNS,
+}));


### PR DESCRIPTION
## Summary
- introduce a shared prompt-guidance contract registry for the GPT-5.4-style prompt/skill guidance themes
- add reusable test helpers so prompt-guidance validation is defined once instead of duplicated across multiple test files
- refactor the existing prompt/skill guidance test suite to validate against the registry while preserving behavior and coverage

Follow-up to #611 and #612.

## What this changes
### New shared validation layer
- `src/hooks/prompt-guidance-contract.ts`
- `src/hooks/__tests__/prompt-guidance-test-helpers.ts`

### Refactored tests to use the shared registry
- `src/hooks/__tests__/prompt-guidance-contract.test.ts`
- `src/hooks/__tests__/prompt-guidance-scenarios.test.ts`
- `src/hooks/__tests__/prompt-guidance-wave-two.test.ts`
- `src/hooks/__tests__/prompt-guidance-catalog.test.ts`
- `src/hooks/__tests__/skill-guidance-contract.test.ts`

## Why this matters
After #611 and #612, the guidance coverage was broad, but the validation layer itself had started to duplicate the same path-loading and regex-assertion logic across several files.

This PR is the safer first step for the architecture/dedup follow-up:
- centralize the contract definitions
- centralize the assertion helper
- keep prompt/skill content unchanged
- reduce drift in the validation layer before attempting any fragment/generation refactor

## Non-goals
- no runtime orchestration logic changes
- no prompt content rewrite
- no shared prompt-fragment generation yet

## Verification
- `npm run build && node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-scenarios.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/prompt-guidance-catalog.test.js dist/hooks/__tests__/skill-guidance-contract.test.js`
- `npm test`
