### PR TITLE
feat: improve native Windows support with WezTerm runtime parity

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -10,6 +10,33 @@ const PROVIDER_BINARIES = {
 };
 const ASK_ORIGINAL_TASK_ENV = 'OMX_ASK_ORIGINAL_TASK';
 
+function resolveBinaryOnWindows(binary) {
+  const probe = spawnSync('where.exe', [binary], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (probe.status !== 0 || !probe.stdout) return binary;
+  const resolved = probe.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  return resolved || binary;
+}
+
+function buildLaunchSpec(binary, args) {
+  if (process.platform === 'win32') {
+    const resolvedBinary = resolveBinaryOnWindows(binary);
+    const psCommand = [`& '${resolvedBinary.replace(/'/g, "''")}'`]
+      .concat(args.map((part) => `'${String(part).replace(/'/g, "''")}'`))
+      .join(' ');
+    return {
+      command: 'powershell.exe',
+      args: ['-NoProfile', '-Command', psCommand],
+    };
+  }
+  return { command: binary, args };
+}
+
 function usage() {
   console.error('Usage: omx ask <claude|gemini> "<prompt>"');
   console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini> <prompt...>');
@@ -56,7 +83,8 @@ function parseArgs(argv) {
 }
 
 function ensureBinary(binary) {
-  const probe = spawnSync(binary, ['--version'], {
+  const launch = buildLaunchSpec(binary, ['--version']);
+  const probe = spawnSync(launch.command, launch.args, {
     stdio: 'ignore',
     encoding: 'utf8',
   });
@@ -144,7 +172,8 @@ async function main() {
 
   ensureBinary(binary);
 
-  const run = spawnSync(binary, ['-p', prompt], {
+  const launch = buildLaunchSpec(binary, ['-p', prompt]);
+  const run = spawnSync(launch.command, launch.args, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
   });

--- a/scripts/wezterm-worker-launch.js
+++ b/scripts/wezterm-worker-launch.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { spawn } from 'child_process';
+
+const configPath = process.argv[2];
+
+if (!configPath) {
+  console.error('[wezterm-worker-launch] missing config path');
+  process.exit(1);
+}
+
+const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+const child = spawn(config.command, config.args || [], {
+  cwd: config.cwd || process.cwd(),
+  env: { ...process.env, ...(config.env || {}) },
+  stdio: 'inherit',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error(`[wezterm-worker-launch] ${error.message}`);
+  process.exit(1);
+});

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -44,7 +44,7 @@ Use CLI interop:
 Copy/paste template:
 
 ```bash
-omx team api send-message --input "{\"team_name\":\"<teamName>\",\"from_worker\":\"<workerName>\",\"to_worker\":\"leader-fixed\",\"body\":\"ACK: <workerName> initialized\"}" --json
+omx team api send-message --input '{"team_name":"<teamName>","from_worker":"<workerName>","to_worker":"leader-fixed","body":"ACK: <workerName> initialized"}' --json
 ```
 
 ## Inbox + Tasks
@@ -63,12 +63,20 @@ omx team api send-message --input "{\"team_name\":\"<teamName>\",\"from_worker\"
    - The MCP/state API uses the numeric id (`"1"`), not `"task-1"`.
    - Never use legacy `tasks/{id}.json` wording.
 6. Claim the task (do NOT start work without a claim) using claim-safe lifecycle CLI interop (`omx team api claim-task --json`).
+   Copy/paste template:
+   `omx team api claim-task --input '{"team_name":"<teamName>","task_id":"<id>","worker":"<workerName>","expected_version":1}' --json`
 7. Do the work.
 8. Complete/fail the task via lifecycle transition CLI interop (`omx team api transition-task-status --json`) from `in_progress` to `completed` or `failed`.
    - Do NOT directly write lifecycle fields (`status`, `owner`, `result`, `error`) in task files.
+   Completion template:
+   `omx team api transition-task-status --input '{"team_name":"<teamName>","task_id":"<id>","from":"in_progress","to":"completed","claim_token":"<claim-token>","result":"<summary with verification evidence>"}' --json`
+   Failure template:
+   `omx team api transition-task-status --input '{"team_name":"<teamName>","task_id":"<id>","from":"in_progress","to":"failed","claim_token":"<claim-token>","error":"<failure summary>"}' --json`
 9. Use `omx team api release-task-claim --json` only for rollback/requeue to `pending` (not for completion).
 10. Update your worker status:
    `<team_state_root>/team/<teamName>/workers/<workerName>/status.json` with `{"state":"idle", ...}`
+   PowerShell template:
+   `Set-Content -Path '<team_state_root>/team/<teamName>/workers/<workerName>/status.json' -Value '{"state":"idle","updated_at":"<ISO>"}'`
 
 ## Mailbox
 
@@ -89,9 +97,17 @@ Use CLI interop:
 Copy/paste templates:
 
 ```bash
-omx team api mailbox-list --input "{\"team_name\":\"<teamName>\",\"worker\":\"<workerName>\"}" --json
-omx team api mailbox-mark-delivered --input "{\"team_name\":\"<teamName>\",\"worker\":\"<workerName>\",\"message_id\":\"<MESSAGE_ID>\"}" --json
+omx team api mailbox-list --input '{"team_name":"<teamName>","worker":"<workerName>"}' --json
+omx team api mailbox-mark-delivered --input '{"team_name":"<teamName>","worker":"<workerName>","message_id":"<MESSAGE_ID>"}' --json
 ```
+
+## Completion Gate
+
+Task work is not finished until all of the following are true:
+
+1. The task has been transitioned via `omx team api transition-task-status`
+2. Your worker status file says `idle`
+3. You have stopped making changes for that task
 
 ## Dispatch Discipline (state-first)
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -5,11 +5,12 @@
 import { existsSync } from 'fs';
 import { readdir, readFile } from 'fs/promises';
 import { join } from 'path';
-import { execFileSync, spawnSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import {
   codexHome, codexConfigPath, codexPromptsDir,
   userSkillsDir, omxStateDir,
 } from '../utils/paths.js';
+import { spawnBinarySync } from '../utils/cli-launch.js';
 import { getCatalogExpectations } from './catalog-contract.js';
 
 interface DoctorOptions {
@@ -382,12 +383,16 @@ function listTeamTmuxSessions(): Set<string> | null {
 }
 
 function checkCodexCli(): Check {
-  try {
-    const version = execFileSync('codex', ['--version'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  const result = spawnBinarySync('codex', ['--version'], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: process.env,
+  });
+  if (!result.error && result.status === 0) {
+    const version = String(result.stdout || '').trim();
     return { name: 'Codex CLI', status: 'pass', message: `installed (${version})` };
-  } catch {
-    return { name: 'Codex CLI', status: 'fail', message: 'not found - install from https://github.com/openai/codex' };
   }
+  return { name: 'Codex CLI', status: 'fail', message: 'not found - install from https://github.com/openai/codex' };
 }
 
 function checkNodeVersion(): Check {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -56,6 +56,8 @@ import {
   enableMouseScrolling,
   isNativeWindows,
   isWsl2,
+  listWezTermPanes,
+  resolveWezTermBinary,
 } from '../team/tmux-session.js';
 import { getPackageRoot } from '../utils/package.js';
 import { codexConfigPath } from '../utils/paths.js';
@@ -79,6 +81,7 @@ import {
   type NotifyTempContract,
   type ParseNotifyTempContractResult,
 } from '../notifications/temp-contract.js';
+import { buildCliLaunchSpec } from '../utils/cli-launch.js';
 
 const HELP = `
 oh-my-codex (omx) - Multi-agent orchestration for Codex CLI
@@ -238,7 +241,9 @@ export function resolveNotifyTempContract(args: string[], env: NodeJS.ProcessEnv
 export type CodexLaunchPolicy = 'inside-tmux' | 'direct';
 
 export function resolveCodexLaunchPolicy(env: NodeJS.ProcessEnv = process.env): CodexLaunchPolicy {
-  return env.TMUX ? 'inside-tmux' : 'direct';
+  if (env.TMUX) return 'inside-tmux';
+  if (isNativeWindows() && String(env.WEZTERM_PANE ?? '').trim() !== '') return 'inside-tmux';
+  return 'direct';
 }
 
 type ExecFileSyncFailure = NodeJS.ErrnoException & {
@@ -297,8 +302,9 @@ export function classifyCodexExecFailure(error: unknown): CodexExecFailureClassi
 }
 
 function runCodexBlocking(cwd: string, launchArgs: string[], codexEnv: NodeJS.ProcessEnv): void {
+  const codexLaunch = buildCliLaunchSpec('codex', launchArgs, codexEnv);
   try {
-    execFileSync('codex', launchArgs, { cwd, stdio: 'inherit', env: codexEnv });
+    execFileSync(codexLaunch.command, codexLaunch.args, { cwd, stdio: 'inherit', env: codexEnv });
   } catch (error) {
     const classified = classifyCodexExecFailure(error);
     if (classified.kind === 'exit') {
@@ -533,20 +539,6 @@ async function reasoningCommand(args: string[]): Promise<void> {
 }
 
 export async function launchWithHud(args: string[]): Promise<void> {
-  // ── Win32 guard ──────────────────────────────────────────────────────
-  if (isNativeWindows()) {
-    console.error(
-      '[omx] OMX requires tmux, which is not available on native Windows.\n' +
-      '[omx] Please use one of the following supported environments:\n' +
-      '[omx]   - WSL2 (Windows Subsystem for Linux 2)\n' +
-      '[omx]   - macOS\n' +
-      '[omx]   - Linux\n' +
-      '[omx] See: https://docs.microsoft.com/en-us/windows/wsl/install',
-    );
-    process.exitCode = 1;
-    return;
-  }
-
   const launchCwd = process.cwd();
   const parsedWorktree = parseWorktreeMode(args);
   const notifyTempResult = resolveNotifyTempContract(parsedWorktree.remainingArgs, process.env);
@@ -1096,6 +1088,12 @@ function runCodex(
     ? { ...codexEnv, [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw }
     : codexEnv;
 
+  if (isNativeWindows()) {
+    // Native Windows skips tmux/HUD orchestration and launches Codex directly.
+    runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+    return;
+  }
+
   if (resolveCodexLaunchPolicy(process.env) === 'inside-tmux') {
     // Already in tmux: launch codex in current pane, HUD in bottom split
     const currentPaneId = process.env.TMUX_PANE;
@@ -1228,6 +1226,16 @@ function runCodex(
 }
 
 function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): string[] {
+  if (isNativeWindows()) {
+    const activePaneId = String(currentPaneId ?? process.env.WEZTERM_PANE ?? '').trim();
+    if (!activePaneId) return [];
+    const activePane = listWezTermPanes().find((pane) => String(pane.pane_id) === activePaneId);
+    if (!activePane) return [];
+    return listWezTermPanes()
+      .filter((pane) => pane.workspace === activePane.workspace && pane.title?.toLowerCase() === 'node.exe')
+      .map((pane) => String(pane.pane_id))
+      .filter((paneId) => paneId !== activePaneId);
+  }
   try {
     const output = execFileSync(
       'tmux',
@@ -1242,6 +1250,18 @@ function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): string[] {
 }
 
 function createHudWatchPane(cwd: string, hudCmd: string): string | null {
+  if (isNativeWindows()) {
+    const currentPaneId = String(process.env.WEZTERM_PANE ?? '').trim()
+      || String(listWezTermPanes().find((pane) => pane.is_active)?.pane_id ?? '').trim();
+    if (!currentPaneId) return null;
+    const omxBin = process.argv[1];
+    const output = execFileSync(
+      resolveWezTermBinary(),
+      ['cli', '--prefer-mux', 'split-pane', '--pane-id', currentPaneId, '--bottom', '--cells', String(HUD_TMUX_HEIGHT_LINES), '--cwd', cwd, process.execPath, omxBin, 'hud', '--watch'],
+      { encoding: 'utf-8' }
+    );
+    return output.trim().split('\n')[0]?.trim() ?? null;
+  }
   const output = execFileSync(
     'tmux',
     ['split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES), '-d', '-c', cwd, '-P', '-F', '#{pane_id}', hudCmd],
@@ -1251,6 +1271,15 @@ function createHudWatchPane(cwd: string, hudCmd: string): string | null {
 }
 
 function killTmuxPane(paneId: string): void {
+  if (isNativeWindows()) {
+    if (!/^\d+$/.test(paneId)) return;
+    try {
+      execFileSync(resolveWezTermBinary(), ['cli', '--prefer-mux', 'kill-pane', '--pane-id', paneId], { stdio: 'ignore' });
+    } catch (err) {
+      process.stderr.write(`[cli/index] operation failed: ${err}\n`);
+    }
+    return;
+  }
   if (!paneId.startsWith('%')) return;
   try {
     execFileSync('tmux', ['kill-pane', '-t', paneId], { stdio: 'ignore' });

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -3,6 +3,8 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { getPackageRoot } from '../utils/package.js';
+import { isNativeWindows } from '../team/tmux-session.js';
+import { resolveBinaryOnPath } from '../utils/cli-launch.js';
 
 type TmuxTargetType = 'session' | 'pane';
 
@@ -53,6 +55,8 @@ const DEFAULT_CONFIG: TmuxHookConfig = {
   log_level: 'info',
   skip_if_scrolling: true,
 };
+
+const WEZTERM_PATH_ENV = 'OMX_WEZTERM_PATH';
 
 const HELP = `
 Usage:
@@ -216,7 +220,73 @@ function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; st
   return { ok: true, stdout: (result.stdout || '').trim() };
 }
 
+function resolveWezTermBinary(): string {
+  const envOverride = String(process.env[WEZTERM_PATH_ENV] ?? '').trim();
+  if (envOverride) return envOverride;
+
+  const resolved = resolveBinaryOnPath('wezterm');
+  if (resolved !== 'wezterm') return resolved;
+
+  const candidates = [
+    'C:\\Program Files\\WezTerm\\wezterm.exe',
+    join(process.env.LOCALAPPDATA || '', 'Programs', 'WezTerm', 'wezterm.exe'),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (candidate && existsSync(candidate)) return candidate;
+  }
+
+  return 'wezterm';
+}
+
+function runWezTerm(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
+  const result = spawnSync(resolveWezTermBinary(), ['cli', '--prefer-mux', ...args], { encoding: 'utf-8' });
+  if (result.error) {
+    return { ok: false, stderr: result.error.message };
+  }
+  if (result.status !== 0) {
+    return { ok: false, stderr: (result.stderr || '').trim() || `wezterm exited ${result.status}` };
+  }
+  return { ok: true, stdout: (result.stdout || '').trim() };
+}
+
+interface WezTermPaneInfo {
+  pane_id: number;
+  workspace: string;
+  is_active?: boolean;
+}
+
+function listWezTermPanes(): WezTermPaneInfo[] {
+  const result = runWezTerm(['list', '--format', 'json']);
+  if (!result.ok) return [];
+  try {
+    const parsed = JSON.parse(result.stdout) as WezTermPaneInfo[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 function resolveValidateTarget(config: TmuxHookConfig): { ok: true; target: string } | { ok: false; reason: string } {
+  if (isNativeWindows()) {
+    const panes = listWezTermPanes();
+    if (panes.length === 0) {
+      return { ok: false, reason: 'no WezTerm panes found' };
+    }
+
+    if (config.target.type === 'pane') {
+      const pane = panes.find((entry) => String(entry.pane_id) === config.target.value.trim());
+      if (!pane) return { ok: false, reason: 'WezTerm pane not found' };
+      return { ok: true, target: String(pane.pane_id) };
+    }
+
+    const workspace = config.target.value.trim();
+    const pane = panes.find((entry) => entry.workspace === workspace && entry.is_active)
+      || panes.find((entry) => entry.workspace === workspace);
+    if (!pane) return { ok: false, reason: 'WezTerm workspace has no panes' };
+    return { ok: true, target: String(pane.pane_id) };
+  }
+
   if (config.target.type === 'pane') {
     const paneCheck = runTmux(['display-message', '-p', '-t', config.target.value, '#{pane_id}']);
     if (!paneCheck.ok || paneCheck.stdout === '') {
@@ -242,6 +312,17 @@ function resolveValidateTarget(config: TmuxHookConfig): { ok: true; target: stri
 }
 
 function detectActivePaneFromList(): InitialTargetDetection | null {
+  if (isNativeWindows()) {
+    const panes = listWezTermPanes();
+    if (panes.length === 0) return null;
+    const active = panes.find((entry) => entry.is_active) || panes[0];
+    if (!active) return null;
+    return {
+      target: { type: 'pane', value: String(active.pane_id) },
+      sessionName: active.workspace || undefined,
+    };
+  }
+
   const paneList = runTmux(['list-panes', '-a', '-F', '#{pane_id}\t#{pane_active}\t#{session_name}']);
   if (!paneList.ok || paneList.stdout.trim() === '') return null;
 
@@ -265,6 +346,10 @@ function detectActivePaneFromList(): InitialTargetDetection | null {
 }
 
 function detectInitialTarget(): InitialTargetDetection | null {
+  if (isNativeWindows()) {
+    return detectActivePaneFromList();
+  }
+
   const tmuxPaneEnv = process.env.TMUX_PANE;
   if (tmuxPaneEnv) {
     const pane = runTmux(['display-message', '-p', '-t', tmuxPaneEnv, '#{pane_id}']);
@@ -408,10 +493,10 @@ async function validateTmuxHookConfig(): Promise<void> {
   const resolved = resolveValidateTarget(config);
 
   if (!resolved.ok) {
-    throw new Error(`tmux target validation failed: ${resolved.reason}`);
+    throw new Error(`hook target validation failed: ${resolved.reason}`);
   }
 
-  console.log('tmux-hook config is valid.');
+  console.log('hook config is valid.');
   console.log(`Resolved target pane: ${resolved.target}`);
   console.log(`Mode gating: ${config.allowed_modes.join(', ')}`);
   if (!config.enabled) {

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -15,6 +15,12 @@ import { renderHud } from './render.js';
 import type { HudFlags, HudPreset, HudRenderContext } from './types.js';
 import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { sleep } from '../utils/sleep.js';
+import {
+  isNativeWindows,
+  isWezTermAvailable,
+  listWezTermPanes,
+  resolveWezTermBinary,
+} from '../team/tmux-session.js';
 
 type SleepFn = (ms: number, signal?: AbortSignal) => Promise<void>;
 
@@ -278,6 +284,49 @@ export function buildTmuxSplitArgs(
 }
 
 async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
+  if (isNativeWindows()) {
+    if (!isWezTermAvailable()) {
+      console.error('WezTerm is not available. Start WezTerm first, then run: omx hud --tmux');
+      process.exit(1);
+    }
+    const currentPaneId = String(process.env.WEZTERM_PANE ?? '').trim();
+    const fallbackPaneId = listWezTermPanes().find((pane) => pane.is_active)?.pane_id;
+    const targetPaneId = currentPaneId || (fallbackPaneId != null ? String(fallbackPaneId) : '');
+    if (!targetPaneId) {
+      console.error('No active WezTerm pane detected. Focus a WezTerm pane, then run: omx hud --tmux');
+      process.exit(1);
+    }
+
+    const omxBin = process.argv[1];
+    const safePreset = parseHudPreset(flags.preset);
+    const args = [
+      'cli',
+      '--prefer-mux',
+      'split-pane',
+      '--pane-id',
+      targetPaneId,
+      '--bottom',
+      '--cells',
+      String(HUD_TMUX_HEIGHT_LINES),
+      '--cwd',
+      cwd,
+      process.execPath,
+      omxBin,
+      'hud',
+      '--watch',
+      ...(safePreset ? [`--preset=${safePreset}`] : []),
+    ];
+
+    try {
+      execFileSync(resolveWezTermBinary(), args, { stdio: 'inherit' });
+      console.log('HUD launched in WezTerm pane below.');
+      return;
+    } catch {
+      console.error('Failed to create WezTerm split. Ensure WezTerm mux is available.');
+      process.exit(1);
+    }
+  }
+
   // Check if we're inside tmux
   if (!process.env.TMUX) {
     console.error('Not inside a tmux session. Start tmux first, then run: omx hud --tmux');

--- a/src/notifications/config.ts
+++ b/src/notifications/config.ts
@@ -330,52 +330,12 @@ function normalizeCustomTransportGate(config: FullNotificationConfig): FullNotif
   };
 }
 
-function buildTempModeConfigFromContract(): FullNotificationConfig | null {
-  const contract = readNotifyTempContractFromEnv(process.env);
-  const envActive = isNotifyTempEnvActive(process.env);
-  if (!contract?.active && !envActive) return null;
-
-  const selectors = getTempBuiltinSelectors(contract);
-  const envConfig = buildConfigFromEnv();
-  const config: FullNotificationConfig = { enabled: false };
-
-  if (selectors.has("discord")) {
-    if (envConfig?.discord) config.discord = envConfig.discord;
-    if (envConfig?.["discord-bot"]) config["discord-bot"] = envConfig["discord-bot"];
-  }
-  if (selectors.has("telegram") && envConfig?.telegram) {
-    config.telegram = envConfig.telegram;
-  }
-  if (selectors.has("slack") && envConfig?.slack) {
-    config.slack = envConfig.slack;
-  }
-  if (isOpenClawSelectedInTempContract(contract)) {
-    config.openclaw = { enabled: true };
-  }
-
-  config.enabled = Boolean(
-    config.discord?.enabled
-    || config["discord-bot"]?.enabled
-    || config.telegram?.enabled
-    || config.slack?.enabled
-    || config.openclaw?.enabled,
-  );
-
-  return config;
-}
-
-export function getNotificationConfig(
-  profileName?: string,
-): FullNotificationConfig | null {
-  const tempModeConfig = buildTempModeConfigFromContract();
-  if (tempModeConfig) return tempModeConfig;
-
+function buildConfiguredNotificationConfig(profileName?: string): FullNotificationConfig | null {
   const raw = readRawConfig();
 
   if (raw) {
     const notifications = raw.notifications as NotificationsBlock | undefined;
     if (notifications) {
-      // Try profile resolution first
       const profileConfig = resolveProfileConfig(notifications, profileName);
       if (profileConfig) {
         if (typeof profileConfig.enabled !== "boolean") {
@@ -388,7 +348,6 @@ export function getNotificationConfig(
         return applyHookConfigIfPresent(normalizeCustomTransportGate(merged));
       }
 
-      // Fall back to flat config (backward compatible)
       if (typeof notifications.enabled !== "boolean") {
         return null;
       }
@@ -423,6 +382,48 @@ export function getNotificationConfig(
   }
 
   return null;
+}
+
+function buildTempModeConfigFromContract(profileName?: string): FullNotificationConfig | null {
+  const contract = readNotifyTempContractFromEnv(process.env);
+  const envActive = isNotifyTempEnvActive(process.env);
+  if (!contract?.active && !envActive) return null;
+
+  const selectors = getTempBuiltinSelectors(contract);
+  const baseConfig = buildConfiguredNotificationConfig(profileName);
+  const config: FullNotificationConfig = { enabled: false };
+
+  if (selectors.has("discord")) {
+    if (baseConfig?.discord) config.discord = baseConfig.discord;
+    if (baseConfig?.["discord-bot"]) config["discord-bot"] = baseConfig["discord-bot"];
+  }
+  if (selectors.has("telegram") && baseConfig?.telegram) {
+    config.telegram = baseConfig.telegram;
+  }
+  if (selectors.has("slack") && baseConfig?.slack) {
+    config.slack = baseConfig.slack;
+  }
+  if (isOpenClawSelectedInTempContract(contract)) {
+    config.openclaw = { enabled: true };
+  }
+
+  config.enabled = Boolean(
+    config.discord?.enabled
+    || config["discord-bot"]?.enabled
+    || config.telegram?.enabled
+    || config.slack?.enabled
+    || config.openclaw?.enabled,
+  );
+
+  return config;
+}
+
+export function getNotificationConfig(
+  profileName?: string,
+): FullNotificationConfig | null {
+  const tempModeConfig = buildTempModeConfigFromContract(profileName);
+  if (tempModeConfig) return tempModeConfig;
+  return buildConfiguredNotificationConfig(profileName);
 }
 
 const VALID_VERBOSITY_LEVELS: VerbosityLevel[] = ["verbose", "agent", "session", "minimal"];

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1,11 +1,12 @@
 import { join, resolve } from 'path';
 import { existsSync } from 'fs';
-import { readdir, readFile } from 'fs/promises';
+import { readdir, readFile, mkdir, writeFile } from 'fs/promises';
 import { performance } from 'perf_hooks';
 import { spawn, type ChildProcessByStdio } from 'child_process';
 import type { Writable } from 'stream';
 import {
   sanitizeTeamName,
+  isNativeWindows,
   isTmuxAvailable,
   createTeamSession,
   buildWorkerProcessLaunchSpec,
@@ -85,7 +86,7 @@ import {
   generateMailboxTriggerMessage,
 } from './worker-bootstrap.js';
 import { loadRolePrompt } from './role-router.js';
-import { codexPromptsDir } from '../utils/paths.js';
+import { codexPromptsDir, packageRoot as getPackageRoot } from '../utils/paths.js';
 import { type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
   isLowComplexityAgentType,
@@ -371,6 +372,53 @@ function isPromptWorkerAlive(config: TeamConfig, worker: WorkerInfo): boolean {
   }
 }
 
+const TEAM_START_RETRY_ATTEMPTS = 6;
+const TEAM_START_RETRY_DELAY_MS = 2000;
+const TEAM_SHUTDOWN_SETTLE_TIMEOUT_MS = 15000;
+const TEAM_SHUTDOWN_SETTLE_POLL_MS = 500;
+
+async function sleepMs(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForInteractiveSessionCleanup(
+  sessionName: string,
+  timeoutMs: number = TEAM_SHUTDOWN_SETTLE_TIMEOUT_MS,
+): Promise<boolean> {
+  const baseSession = sessionName.split(':')[0];
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  while (Date.now() < deadline) {
+    if (!listTeamSessions().includes(baseSession)) {
+      return true;
+    }
+    await sleepMs(TEAM_SHUTDOWN_SETTLE_POLL_MS);
+  }
+  return !listTeamSessions().includes(baseSession);
+}
+
+async function ensureWorkerOmxShim(
+  teamName: string,
+  workerName: string,
+  teamStateRoot: string,
+): Promise<string> {
+  const shimDir = join(teamStateRoot, 'team', teamName, 'workers', workerName, 'bin');
+  const omxEntry = resolve(getPackageRoot(), 'bin', 'omx.js');
+  const normalizedOmxEntry = omxEntry.replace(/'/g, "''");
+  await mkdir(shimDir, { recursive: true });
+  await writeFile(
+    join(shimDir, 'omx.cmd'),
+    `@echo off\r\n"%OMX_LEADER_NODE_PATH%" "${omxEntry}" %*\r\n`,
+    'utf8',
+  );
+  await writeFile(
+    join(shimDir, 'omx.ps1'),
+    `$node = if ($env:OMX_LEADER_NODE_PATH) { $env:OMX_LEADER_NODE_PATH } else { 'node' }\r\n`
+      + `& $node '${normalizedOmxEntry}' @args\r\n`,
+    'utf8',
+  );
+  return shimDir;
+}
+
 export { TEAM_LOW_COMPLEXITY_DEFAULT_MODEL };
 
 export { resolveCanonicalTeamStateRoot };
@@ -496,10 +544,10 @@ export async function startTeam(
   const workerLaunchMode = resolveTeamWorkerLaunchMode(process.env);
   const displayMode = workerLaunchMode === 'interactive' ? 'split_pane' : 'auto';
   if (workerLaunchMode === 'interactive') {
-    if (!isTmuxAvailable()) {
+    if (!isNativeWindows() && !isTmuxAvailable()) {
       throw new Error('Team mode requires tmux. Install with: apt install tmux / brew install tmux');
     }
-    if (!process.env.TMUX) {
+    if (!isNativeWindows() && !process.env.TMUX) {
       throw new Error('Team mode requires running inside tmux current leader pane');
     }
   }
@@ -549,7 +597,14 @@ export async function startTeam(
   const leaderSessionId = await resolveLeaderSessionId(leaderCwd);
 
   // Topology guard: one active team per leader session/process context.
-  const activeTeams = await findActiveTeams(leaderCwd, leaderSessionId);
+  let activeTeams: string[] = [];
+  for (let attempt = 0; attempt < TEAM_START_RETRY_ATTEMPTS; attempt++) {
+    activeTeams = await findActiveTeams(leaderCwd, leaderSessionId);
+    if (activeTeams.length === 0) break;
+    if (attempt < TEAM_START_RETRY_ATTEMPTS - 1) {
+      await sleepMs(TEAM_START_RETRY_DELAY_MS);
+    }
+  }
   if (activeTeams.length > 0) {
     throw new Error(`leader_session_conflict: active team exists (${activeTeams.join(', ')})`);
   }
@@ -672,6 +727,14 @@ export async function startTeam(
         initialPrompt: plan.initialPrompt,
       };
     });
+
+    for (let i = 0; i < workerBootstrapPlans.length; i++) {
+      const plan = workerBootstrapPlans[i];
+      if (!plan) continue;
+      const shimDir = await ensureWorkerOmxShim(sanitized, plan.workerName, teamStateRoot);
+      const inheritedPath = workerStartups[i]?.env.PATH || process.env.PATH || '';
+      workerStartups[i]!.env.PATH = `${shimDir};${inheritedPath}`;
+    }
 
     const workerPaneIds = Array.from({ length: workerCount }, () => undefined as string | undefined);
 
@@ -819,7 +882,7 @@ export async function startTeam(
         }
       }
       if (!dispatchOutcome.ok) {
-        throw new Error(`worker_notify_failed:${workerName}`);
+        throw new Error(`worker_notify_failed:${workerName}:${dispatchOutcome.reason}`);
       }
     }
     await saveTeamConfig(config, leaderCwd);
@@ -1417,6 +1480,10 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
       }
     }
+    const settled = await waitForInteractiveSessionCleanup(sessionName);
+    if (!settled) {
+      console.warn(`[team shutdown] ${sanitized}: session cleanup still pending after ${TEAM_SHUTDOWN_SETTLE_TIMEOUT_MS}ms`);
+    }
   } else {
     const promptTeardownFailures: string[] = [];
     for (const w of config.workers) {
@@ -1505,7 +1572,9 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
   } else {
     // Check if tmux session still exists
     const baseSession = config.tmux_session.split(':')[0];
-    const teamSessions = getTeamTmuxSessions(sanitized);
+    const teamSessions = isNativeWindows()
+      ? listTeamSessions()
+      : getTeamTmuxSessions(sanitized);
     if (!teamSessions.includes(baseSession)) return null;
   }
 
@@ -1651,7 +1720,7 @@ async function notifyWorkerOutcome(config: TeamConfig, workerIndex: number, mess
     }
   }
 
-  if (!config.tmux_session || !isTmuxAvailable()) {
+  if (!config.tmux_session || (!isNativeWindows() && !isTmuxAvailable())) {
     return { ok: false, transport: 'tmux_send_keys', reason: 'tmux_unavailable' };
   }
   try {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1,6 +1,6 @@
 import { spawnSync, execFile } from 'child_process';
 import { promisify } from 'util';
-import { readFileSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import {
   CODEX_BYPASS_FLAG,
@@ -9,6 +9,14 @@ import {
   LONG_CONFIG_FLAG,
   MODEL_FLAG,
 } from '../cli/constants.js';
+import {
+  buildCliLaunchSpec,
+  isWslEnvironment,
+  isWindowsShellWrapped,
+  resolveBinaryOnPath,
+  spawnBinarySync,
+} from '../utils/cli-launch.js';
+import { getPackageRoot } from '../utils/package.js';
 import { sleep, sleepSync } from '../utils/sleep.js';
 
 const execFileAsync = promisify(execFile);
@@ -43,6 +51,7 @@ const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
 const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
 const OMX_LEADER_NODE_PATH_ENV = 'OMX_LEADER_NODE_PATH';
 const OMX_LEADER_CLI_PATH_ENV = 'OMX_LEADER_CLI_PATH';
+const WEZTERM_PATH_ENV = 'OMX_WEZTERM_PATH';
 
 export type TeamWorkerCli = 'codex' | 'claude' | 'gemini';
 type TeamWorkerCliMode = 'auto' | TeamWorkerCli;
@@ -85,6 +94,95 @@ function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; st
     return { ok: false, stderr: (result.stderr || '').trim() || `tmux exited ${result.status}` };
   }
   return { ok: true, stdout: (result.stdout || '').trim() };
+}
+
+export function resolveWezTermBinary(): string {
+  const envOverride = String(process.env[WEZTERM_PATH_ENV] ?? '').trim();
+  if (envOverride) return envOverride;
+
+  const resolved = resolveBinaryOnPath('wezterm');
+  if (resolved !== 'wezterm') return resolved;
+
+  const candidates = [
+    'C:\\Program Files\\WezTerm\\wezterm.exe',
+    join(process.env.LOCALAPPDATA || '', 'Programs', 'WezTerm', 'wezterm.exe'),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (candidate && existsSync(candidate)) return candidate;
+  }
+
+  return 'wezterm';
+}
+
+export function runWezTermCli(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
+  const result = spawnSync(resolveWezTermBinary(), ['cli', '--prefer-mux', ...args], { encoding: 'utf-8' });
+  if (result.error) {
+    return { ok: false, stderr: result.error.message };
+  }
+  if (result.status !== 0) {
+    return { ok: false, stderr: (result.stderr || '').trim() || `wezterm exited ${result.status}` };
+  }
+  return { ok: true, stdout: (result.stdout || '').trim() };
+}
+
+async function runWezTermCliAsync(args: string[]): Promise<{ok: true; stdout: string} | {ok: false; stderr: string}> {
+  try {
+    const { stdout } = await execFileAsync(resolveWezTermBinary(), ['cli', '--prefer-mux', ...args], { encoding: 'utf-8' });
+    return { ok: true, stdout: (stdout || '').trim() };
+  } catch (error: unknown) {
+    const err = error as { stderr?: string; message?: string };
+    return { ok: false, stderr: (err.stderr || err.message || '').trim() || 'wezterm cli command failed' };
+  }
+}
+
+export interface WezTermPaneInfo {
+  window_id: number;
+  tab_id: number;
+  pane_id: number;
+  workspace: string;
+  title?: string;
+  cwd?: string;
+  is_active?: boolean;
+}
+
+export function listWezTermPanes(): WezTermPaneInfo[] {
+  const result = runWezTermCli(['list', '--format', 'json']);
+  if (!result.ok) return [];
+  try {
+    const parsed = JSON.parse(result.stdout) as WezTermPaneInfo[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isWezTermAvailable(): boolean {
+  const binary = resolveWezTermBinary();
+  const result = spawnSync(binary, ['--version'], { encoding: 'utf-8' });
+  return !result.error && result.status === 0;
+}
+
+function isWezTermPaneId(value: string | null | undefined): boolean {
+  return typeof value === 'string' && /^\d+$/.test(value.trim());
+}
+
+function writeWezTermLaunchConfig(
+  teamName: string,
+  workerName: string,
+  workerCwd: string,
+  processSpec: WorkerProcessLaunchSpec,
+): string {
+  const workerDir = join(workerCwd, '.omx', 'state', 'team', teamName, 'workers', workerName);
+  mkdirSync(workerDir, { recursive: true });
+  const configPath = join(workerDir, 'wezterm-launch.json');
+  writeFileSync(configPath, JSON.stringify({
+    command: processSpec.command,
+    args: processSpec.args,
+    env: processSpec.env,
+    cwd: workerCwd,
+  }, null, 2));
+  return configPath;
 }
 
 export function isMsysOrGitBash(env: NodeJS.ProcessEnv = process.env, platform: NodeJS.Platform = process.platform): boolean {
@@ -199,6 +297,24 @@ async function runTmuxAsync(args: string[]): Promise<{ok: true; stdout: string} 
 }
 
 async function sendKeyAsync(target: string, key: string): Promise<void> {
+  if (isNativeWindows() && isWezTermPaneId(target)) {
+    const keyMap: Record<string, string> = {
+      'C-m': '\r',
+      'C-c': '\u0003',
+      'C-d': '\u0004',
+      'C-u': '\u0015',
+      Tab: '\t',
+    };
+    const mapped = keyMap[key];
+    if (!mapped) {
+      throw new Error(`sendKeyAsync: unsupported key ${key} for wezterm transport`);
+    }
+    const result = await runWezTermCliAsync(['send-text', '--pane-id', target, '--no-paste', mapped]);
+    if (!result.ok) {
+      throw new Error(`sendKeyAsync: failed to send ${key}: ${result.stderr}`);
+    }
+    return;
+  }
   const result = await runTmuxAsync(['send-keys', '-t', target, key]);
   if (!result.ok) {
     throw new Error(`sendKeyAsync: failed to send ${key}: ${result.stderr}`);
@@ -206,12 +322,22 @@ async function sendKeyAsync(target: string, key: string): Promise<void> {
 }
 
 async function capturePaneAsync(target: string): Promise<string> {
+  if (isNativeWindows() && isWezTermPaneId(target)) {
+    const result = await runWezTermCliAsync(['get-text', '--pane-id', target, '--start-line', '-80']);
+    if (!result.ok) return '';
+    return result.stdout;
+  }
   const result = await runTmuxAsync(['capture-pane', '-t', target, '-p', '-S', '-80']);
   if (!result.ok) return '';
   return result.stdout;
 }
 
 async function isWorkerAliveAsync(sessionName: string, workerIndex: number, workerPaneId?: string): Promise<boolean> {
+  if (isNativeWindows() && isWezTermPaneId(workerPaneId)) {
+    void sessionName;
+    void workerIndex;
+    return listWezTermPanes().some((pane) => String(pane.pane_id) === workerPaneId);
+  }
   const result = await runTmuxAsync([
     'list-panes',
     '-t', paneTarget(sessionName, workerIndex, workerPaneId),
@@ -534,7 +660,7 @@ export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: 
 }
 
 function commandExists(binary: string): boolean {
-  const result = spawnSync(binary, ['--version'], { encoding: 'utf-8' });
+  const result = spawnBinarySync(binary, ['--version'], { encoding: 'utf-8', env: process.env });
   if (result.error) {
     const code = (result.error as NodeJS.ErrnoException).code;
     if (code === 'ENOENT') return false;
@@ -547,11 +673,7 @@ function commandExists(binary: string): boolean {
  * Returns the absolute path or the bare command name as fallback.
  */
 function resolveAbsoluteBinaryPath(binary: string): string {
-  const result = spawnSync('which', [binary], { encoding: 'utf-8', timeout: 5000 });
-  if (result.status === 0 && result.stdout.trim()) {
-    return result.stdout.trim();
-  }
-  return binary;
+  return resolveBinaryOnPath(binary);
 }
 
 /**
@@ -561,7 +683,9 @@ function resolveAbsoluteBinaryPath(binary: string): string {
 let _leaderPaths: { node: string; } | null = null;
 function resolveLeaderNodePath(): string {
   if (!_leaderPaths) {
-    _leaderPaths = { node: resolveAbsoluteBinaryPath('node') };
+    _leaderPaths = {
+      node: isWindowsShellWrapped() ? process.execPath : resolveAbsoluteBinaryPath('node'),
+    };
   }
   return _leaderPaths.node;
 }
@@ -640,12 +764,11 @@ export function buildWorkerProcessLaunchSpec(
   const fullLaunchArgs = resolveWorkerLaunchArgs(launchArgs, cwd);
   const workerCli = workerCliOverride ?? resolveTeamWorkerCli(fullLaunchArgs, process.env);
   const cliLaunchArgs = translateWorkerLaunchArgsForCli(workerCli, fullLaunchArgs, initialPrompt);
-
-  const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);
+  const workerLaunch = buildCliLaunchSpec(workerCli, cliLaunchArgs, process.env);
   const workerEnv: Record<string, string> = {
     OMX_TEAM_WORKER: `${teamName}/worker-${workerIndex}`,
     [OMX_LEADER_NODE_PATH_ENV]: resolveLeaderNodePath(),
-    [OMX_LEADER_CLI_PATH_ENV]: resolvedCliPath,
+    [OMX_LEADER_CLI_PATH_ENV]: workerCli,
   };
   for (const [key, value] of Object.entries(extraEnv)) {
     if (typeof value !== 'string' || value.trim() === '') continue;
@@ -654,8 +777,8 @@ export function buildWorkerProcessLaunchSpec(
 
   return {
     workerCli,
-    command: resolvedCliPath,
-    args: cliLaunchArgs,
+    command: workerLaunch.command,
+    args: workerLaunch.args,
     env: workerEnv,
   };
 }
@@ -682,15 +805,7 @@ export function sanitizeTeamName(name: string): string {
  * Fallback: check /proc/version for the Microsoft kernel string.
  */
 export function isWsl2(): boolean {
-  if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) {
-    return true;
-  }
-  try {
-    const version = readFileSync('/proc/version', 'utf-8');
-    return /microsoft/i.test(version);
-  } catch {
-    return false;
-  }
+  return isWslEnvironment();
 }
 
 /**
@@ -698,11 +813,12 @@ export function isWsl2(): boolean {
  * OMX requires tmux, which is unavailable on native Windows.
  */
 export function isNativeWindows(): boolean {
-  return process.platform === 'win32' && !isWsl2() && !isMsysOrGitBash();
+  return isWindowsShellWrapped() && !isMsysOrGitBash();
 }
 
 // Check if tmux is available
 export function isTmuxAvailable(): boolean {
+  if (isNativeWindows()) return false;
   const result = spawnSync('tmux', ['-V'], { encoding: 'utf-8' });
   if (result.error) return false;
   return result.status === 0;
@@ -718,6 +834,115 @@ export function createTeamSession(
   workerLaunchArgs: string[] = [],
   workerStartups: Array<{ cwd?: string; env?: Record<string, string>; initialPrompt?: string }> = [],
 ): TeamSession {
+  if (isNativeWindows()) {
+    if (!isWezTermAvailable()) {
+      throw new Error('wezterm is not available');
+    }
+    if (!Number.isInteger(workerCount) || workerCount < 1) {
+      throw new Error(`workerCount must be >= 1 (got ${workerCount})`);
+    }
+
+    const normalizedWorkerLaunchArgs = resolveWorkerLaunchArgs(workerLaunchArgs, cwd);
+    const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, normalizedWorkerLaunchArgs, process.env);
+    for (const workerCli of new Set(workerCliPlan)) {
+      assertTeamWorkerCliBinaryAvailable(workerCli);
+    }
+
+    const safeTeamName = sanitizeTeamName(teamName);
+    const workspaceName = `omx-team-${safeTeamName}`;
+    const leaderSpawn = runWezTermCli([
+      'spawn',
+      '--new-window',
+      '--workspace',
+      workspaceName,
+      '--cwd',
+      cwd,
+      'cmd.exe',
+      '/d',
+      '/k',
+      `title OMX Leader ${safeTeamName}`,
+    ]);
+    if (!leaderSpawn.ok) {
+      throw new Error(`failed to create wezterm leader pane: ${leaderSpawn.stderr}`);
+    }
+    const leaderPaneId = leaderSpawn.stdout.split('\n')[0]?.trim() ?? '';
+    if (!isWezTermPaneId(leaderPaneId)) {
+      throw new Error(`failed to capture wezterm leader pane id: ${leaderSpawn.stdout}`);
+    }
+
+    const workerPaneIds: string[] = [];
+    for (let i = 1; i <= workerCount; i++) {
+      const startup = workerStartups[i - 1] || {};
+      const workerCwd = startup.cwd || cwd;
+      const workerEnv = startup.env || {};
+      const processSpec = buildWorkerProcessLaunchSpec(
+        safeTeamName,
+        i,
+        workerLaunchArgs,
+        workerCwd,
+        workerEnv,
+        workerCliPlan[i - 1],
+        startup.initialPrompt,
+      );
+      const launchConfigPath = writeWezTermLaunchConfig(safeTeamName, `worker-${i}`, workerCwd, processSpec);
+      const split = runWezTermCli([
+        'split-pane',
+        '--pane-id',
+        leaderPaneId,
+        i === 1 ? '--right' : '--bottom',
+        '--cwd',
+        workerCwd,
+        process.execPath,
+        join(getPackageRoot(), 'scripts', 'wezterm-worker-launch.js'),
+        launchConfigPath,
+      ]);
+      if (!split.ok) {
+        throw new Error(`failed to create wezterm worker pane ${i}: ${split.stderr}`);
+      }
+      const paneId = split.stdout.split('\n')[0]?.trim() ?? '';
+      if (!isWezTermPaneId(paneId)) {
+        throw new Error(`failed to capture wezterm worker pane id for worker ${i}`);
+      }
+      workerPaneIds.push(paneId);
+    }
+
+    let hudPaneId: string | null = null;
+    const omxEntry = process.argv[1];
+    if (omxEntry && omxEntry.trim() !== '') {
+      const hudSplit = runWezTermCli([
+        'split-pane',
+        '--pane-id',
+        leaderPaneId,
+        '--bottom',
+        '--cells',
+        String(HUD_TMUX_TEAM_HEIGHT_LINES),
+        '--cwd',
+        cwd,
+        process.execPath,
+        omxEntry,
+        'hud',
+        '--watch',
+      ]);
+      if (hudSplit.ok) {
+        const paneId = hudSplit.stdout.split('\n')[0]?.trim() ?? '';
+        if (isWezTermPaneId(paneId)) {
+          hudPaneId = paneId;
+        }
+      }
+    }
+
+    return {
+      name: workspaceName,
+      workerCount,
+      cwd,
+      workerPaneIds,
+      leaderPaneId,
+      hudPaneId,
+      resizeHookName: null,
+      resizeHookTarget: null,
+    };
+  }
+
   if (!isTmuxAvailable()) {
     throw new Error('tmux is not available');
   }
@@ -969,6 +1194,7 @@ export function enableMouseScrolling(sessionTarget: string): boolean {
 
 function paneTarget(sessionName: string, workerIndex: number, workerPaneId?: string): string {
   if (workerPaneId && workerPaneId.startsWith('%')) return workerPaneId;
+  if (isNativeWindows() && isWezTermPaneId(workerPaneId)) return workerPaneId as string;
   if (sessionName.includes(':')) {
     return `${sessionName}.${workerIndex}`;
   }
@@ -1135,6 +1361,13 @@ export function shouldAttemptAdaptiveRetry(
 }
 
 function sendLiteralTextOrThrow(target: string, text: string): void {
+  if (isNativeWindows() && isWezTermPaneId(target)) {
+    const send = runWezTermCli(['send-text', '--pane-id', target, '--no-paste', text]);
+    if (!send.ok) {
+      throw new Error(`sendToWorker: failed to send text: ${send.stderr}`);
+    }
+    return;
+  }
   const send = runTmux(['send-keys', '-t', target, '-l', '--', text]);
   if (!send.ok) {
     throw new Error(`sendToWorker: failed to send text: ${send.stderr}`);
@@ -1180,6 +1413,20 @@ export function waitForWorkerReady(
   timeoutMs: number = 15000,
   workerPaneId?: string,
 ): boolean {
+  if (isNativeWindows() && isWezTermPaneId(workerPaneId)) {
+    const paneId = workerPaneId as string;
+    void sessionName;
+    void workerIndex;
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      const captured = runWezTermCli(['get-text', '--pane-id', paneId, '--start-line', '-40']);
+      if (captured.ok && paneLooksReady(captured.stdout)) {
+        return true;
+      }
+      sleepSeconds(0.5);
+    }
+    return true;
+  }
   const initialBackoffMs = 300;
   const maxBackoffMs = 8000;
   const startedAt = Date.now();
@@ -1241,6 +1488,11 @@ export function dismissTrustPromptIfPresent(
   workerIndex: number,
   workerPaneId?: string,
 ): boolean {
+  if (isNativeWindows() && isWezTermPaneId(workerPaneId)) {
+    void sessionName;
+    void workerIndex;
+    return false;
+  }
   if (process.env.OMX_TEAM_AUTO_TRUST === '0') return false;
   if (!isTmuxAvailable()) return false;
   const target = paneTarget(sessionName, workerIndex, workerPaneId);
@@ -1374,6 +1626,7 @@ export async function sendToWorker(
 }
 
 export function notifyLeaderStatus(sessionName: string, message: string): boolean {
+  if (isNativeWindows()) return false;
   if (!isTmuxAvailable()) return false;
   const trimmed = message.trim();
   if (!trimmed) return false;
@@ -1384,6 +1637,11 @@ export function notifyLeaderStatus(sessionName: string, message: string): boolea
 
 // Get PID of the shell process in a worker's tmux pane
 export function getWorkerPanePid(sessionName: string, workerIndex: number, workerPaneId?: string): number | null {
+  if (isNativeWindows() && isWezTermPaneId(workerPaneId)) {
+    void sessionName;
+    void workerIndex;
+    return null;
+  }
   const result = runTmux(['list-panes', '-t', paneTarget(sessionName, workerIndex, workerPaneId), '-F', '#{pane_pid}']);
   if (!result.ok) return null;
 
@@ -1397,6 +1655,11 @@ export function getWorkerPanePid(sessionName: string, workerIndex: number, worke
 
 // Check if worker's tmux pane has a running process
 export function isWorkerAlive(sessionName: string, workerIndex: number, workerPaneId?: string): boolean {
+  if (isNativeWindows() && isWezTermPaneId(workerPaneId)) {
+    void sessionName;
+    void workerIndex;
+    return listWezTermPanes().some((pane) => String(pane.pane_id) === workerPaneId);
+  }
   const result = runTmux([
     'list-panes',
     '-t', paneTarget(sessionName, workerIndex, workerPaneId),
@@ -1446,6 +1709,11 @@ export async function killWorker(sessionName: string, workerIndex: number, worke
 
 // leaderPaneId: when provided, the kill is skipped if workerPaneId matches it.
 export function killWorkerByPaneId(workerPaneId: string, leaderPaneId?: string): void {
+  if (isNativeWindows() && isWezTermPaneId(workerPaneId)) {
+    if (leaderPaneId && workerPaneId === leaderPaneId) return;
+    runWezTermCli(['kill-pane', '--pane-id', workerPaneId]);
+    return;
+  }
   if (!workerPaneId.startsWith('%')) return;
   // Guard: never kill the leader's own pane.
   if (leaderPaneId && workerPaneId === leaderPaneId) return;
@@ -1453,6 +1721,11 @@ export function killWorkerByPaneId(workerPaneId: string, leaderPaneId?: string):
 }
 
 export async function killWorkerByPaneIdAsync(workerPaneId: string, leaderPaneId?: string): Promise<void> {
+  if (isNativeWindows() && isWezTermPaneId(workerPaneId)) {
+    if (leaderPaneId && workerPaneId === leaderPaneId) return;
+    await runWezTermCliAsync(['kill-pane', '--pane-id', workerPaneId]);
+    return;
+  }
   if (!workerPaneId.startsWith('%')) return;
   // Guard: never kill the leader's own pane.
   if (leaderPaneId && workerPaneId === leaderPaneId) return;
@@ -1482,6 +1755,7 @@ export interface PaneTeardownOptions {
 function normalizePaneTarget(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
+  if (isNativeWindows() && /^\d+$/.test(trimmed)) return trimmed;
   if (!trimmed.startsWith('%')) return null;
   return trimmed;
 }
@@ -1543,7 +1817,9 @@ export async function teardownWorkerPanes(
   };
 
   for (const paneId of killablePaneIds) {
-    const result = await runTmuxAsync(['kill-pane', '-t', paneId]);
+    const result = isNativeWindows()
+      ? await runWezTermCliAsync(['kill-pane', '--pane-id', paneId])
+      : await runTmuxAsync(['kill-pane', '-t', paneId]);
     if (result.ok) summary.kill.succeeded += 1;
     else summary.kill.failed += 1;
     await sleep(perPaneGrace);
@@ -1563,6 +1839,15 @@ export async function killWorkerPanes(
 
 // Kill entire tmux session. Tolerates already-dead sessions.
 export function destroyTeamSession(sessionName: string): void {
+  if (isNativeWindows()) {
+    const paneIds = listWezTermPanes()
+      .filter((pane) => pane.workspace === sessionName)
+      .map((pane) => String(pane.pane_id));
+    for (const paneId of paneIds) {
+      runWezTermCli(['kill-pane', '--pane-id', paneId]);
+    }
+    return;
+  }
   try {
     runTmux(['kill-session', '-t', sessionName]);
   } catch {
@@ -1572,6 +1857,13 @@ export function destroyTeamSession(sessionName: string): void {
 
 // List all tmux sessions matching omx-team-* pattern
 export function listTeamSessions(): string[] {
+  if (isNativeWindows()) {
+    return [...new Set(
+      listWezTermPanes()
+        .map((pane) => pane.workspace)
+        .filter((workspace) => workspace.startsWith('omx-team-')),
+    )];
+  }
   const result = runTmux(['list-sessions', '-F', '#{session_name}']);
   if (!result.ok) return [];
 
@@ -1593,6 +1885,15 @@ export async function sendToLeaderPane(
   leaderPaneId: string,
   text: string,
 ): Promise<void> {
+  if (isNativeWindows() && isWezTermPaneId(leaderPaneId)) {
+    const send = await runWezTermCliAsync(['send-text', '--pane-id', leaderPaneId, '--no-paste', text]);
+    if (!send.ok) {
+      throw new Error(`sendToLeaderPane: failed to send text: ${send.stderr}`);
+    }
+    await sleep(150);
+    await runWezTermCliAsync(['send-text', '--pane-id', leaderPaneId, '--no-paste', '\r']);
+    return;
+  }
   const send = runTmux(['send-keys', '-t', leaderPaneId, '-l', '--', text]);
   if (!send.ok) {
     throw new Error(`sendToLeaderPane: failed to send text: ${send.stderr}`);

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -75,13 +75,13 @@ Before doing any task work, send exactly one startup ACK to the leader.
 Keep the body short and deterministic so all worker CLIs (Codex/Claude) behave consistently.
 
 Example:
-omx team api send-message --input "{\"team_name\":\"${teamName}\",\"from_worker\":\"<your-worker-name>\",\"to_worker\":\"leader-fixed\",\"body\":\"ACK: <your-worker-name> initialized\"}" --json
+omx team api send-message --input '{"team_name":"${teamName}","from_worker":"<your-worker-name>","to_worker":"leader-fixed","body":"ACK: <your-worker-name> initialized"}' --json
 
 CRITICAL: Never omit from_worker. The MCP server cannot auto-detect your identity.
 
 When your mailbox receives a message, process delivery explicitly:
-1. Read: \`omx team api mailbox-list --input "{\"team_name\":\"${teamName}\",\"worker\":\"<your-worker-name>\"}" --json\`
-2. Mark delivered: \`omx team api mailbox-mark-delivered --input "{\"team_name\":\"${teamName}\",\"worker\":\"<your-worker-name>\",\"message_id\":\"<MESSAGE_ID>\"}" --json\`
+1. Read: \`omx team api mailbox-list --input '{"team_name":"${teamName}","worker":"<your-worker-name>"}' --json\`
+2. Mark delivered: \`omx team api mailbox-mark-delivered --input '{"team_name":"${teamName}","worker":"<your-worker-name>","message_id":"<MESSAGE_ID>"}' --json\`
 
 ## Rules
 - Do NOT edit files outside the paths listed in your task description
@@ -307,7 +307,7 @@ ${taskList}
    - \`${leaderCwd}/skills/worker/SKILL.md\` (repo fallback)
 2. Send startup ACK to the lead mailbox BEFORE any task work (run this exact command):
 
-   \`omx team api send-message --input "{\"team_name\":\"${teamName}\",\"from_worker\":\"${workerName}\",\"to_worker\":\"leader-fixed\",\"body\":\"ACK: ${workerName} initialized\"}" --json\`
+   \`omx team api send-message --input '{"team_name":"${teamName}","from_worker":"${workerName}","to_worker":"leader-fixed","body":"ACK: ${workerName} initialized"}' --json\`
 
 3. Start with the first non-blocked task
 4. Resolve canonical team state root in this order: \`OMX_TEAM_STATE_ROOT\` env -> worker identity \`team_state_root\` -> config/manifest \`team_state_root\` -> local cwd fallback.
@@ -315,20 +315,37 @@ ${taskList}
 6. Task id format:
    - State/MCP APIs use \`task_id: "<id>"\` (example: \`"1"\`), not \`"task-1"\`.
 7. Request a claim via CLI interop (\`omx team api claim-task --json\`) to claim it
+   - Claim template:
+     \`omx team api claim-task --input '{"team_name":"${teamName}","task_id":"<id>","worker":"${workerName}","expected_version":1}' --json\`
 8. Complete the work described in the task
 9. Complete/fail it via lifecycle transition API (\`omx team api transition-task-status --json\`) from \`"in_progress"\` to \`"completed"\` or \`"failed"\` (include \`result\`/\`error\`)
+   - Completion template:
+     \`omx team api transition-task-status --input '{"team_name":"${teamName}","task_id":"<id>","from":"in_progress","to":"completed","claim_token":"<claim-token>","result":"<summary with verification evidence>"}' --json\`
+   - Failure template:
+     \`omx team api transition-task-status --input '{"team_name":"${teamName}","task_id":"<id>","from":"in_progress","to":"failed","claim_token":"<claim-token>","error":"<failure summary>"}' --json\`
 10. Use \`omx team api release-task-claim --json\` only for rollback to \`pending\`
 11. Write \`{"state": "idle", "updated_at": "<current ISO timestamp>"}\` to \`${teamStateRoot}/team/${teamName}/workers/${workerName}/status.json\`
+    - PowerShell template:
+      \`Set-Content -Path '${teamStateRoot}/team/${teamName}/workers/${workerName}/status.json' -Value '{"state":"idle","updated_at":"<ISO>"}'\`
 12. Wait for the next instruction from the lead
 13. For legacy team_* MCP tools (hard-deprecated), use \`omx team api\`; do not pass \`workingDirectory\` unless the lead explicitly asks (if resolution fails, use leader cwd: \`${leaderCwd}\`)
+
+## Completion Gate
+
+You are NOT done when the code change or verification finishes.
+You are done only after ALL of these are true:
+
+1. The task file has been transitioned with \`omx team api transition-task-status\`
+2. Your status file says \`"state":"idle"\`
+3. You have stopped making further edits for this task
 
 ## Mailbox Delivery Protocol (Required)
 When you are notified about mailbox messages, always follow this exact flow:
 
 1. List mailbox:
-   \`omx team api mailbox-list --input "{\"team_name\":\"${teamName}\",\"worker\":\"${workerName}\"}" --json\`
+   \`omx team api mailbox-list --input '{"team_name":"${teamName}","worker":"${workerName}"}' --json\`
 2. For each undelivered message, mark delivery:
-   \`omx team api mailbox-mark-delivered --input "{\"team_name\":\"${teamName}\",\"worker\":\"${workerName}\",\"message_id\":\"<MESSAGE_ID>\"}" --json\`
+   \`omx team api mailbox-mark-delivered --input '{"team_name":"${teamName}","worker":"${workerName}","message_id":"<MESSAGE_ID>"}' --json\`
 
 Use terse ACK bodies (single line) for consistent parsing across Codex and Claude workers.
 
@@ -337,7 +354,7 @@ When using \`omx team api send-message\`, ALWAYS include from_worker with YOUR w
 - from_worker: "${workerName}"
 - to_worker: "leader-fixed" (for leader) or "worker-N" (for peers)
 
-Example: omx team api send-message --input "{\"team_name\":\"${teamName}\",\"from_worker\":\"${workerName}\",\"to_worker\":\"leader-fixed\",\"body\":\"ACK: initialized\"}" --json
+Example: omx team api send-message --input '{"team_name":"${teamName}","from_worker":"${workerName}","to_worker":"leader-fixed","body":"ACK: initialized"}' --json
 
 ${buildVerificationSection('each assigned task')}
 

--- a/src/utils/cli-launch.ts
+++ b/src/utils/cli-launch.ts
@@ -1,0 +1,71 @@
+import { spawnSync, type SpawnSyncOptions } from 'child_process';
+import { readFileSync } from 'fs';
+
+export interface CliLaunchSpec {
+  command: string;
+  args: string[];
+}
+
+export function isWslEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.WSL_DISTRO_NAME || env.WSL_INTEROP) {
+    return true;
+  }
+  try {
+    const version = readFileSync('/proc/version', 'utf-8');
+    return /microsoft/i.test(version);
+  } catch {
+    return false;
+  }
+}
+
+export function isWindowsShellWrapped(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === 'win32' && !isWslEnvironment(env);
+}
+
+export function buildCliLaunchSpec(
+  binary: string,
+  args: string[] = [],
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): CliLaunchSpec {
+  if (isWindowsShellWrapped(env, platform)) {
+    return {
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', binary, ...args],
+    };
+  }
+  return { command: binary, args };
+}
+
+export function spawnBinarySync(
+  binary: string,
+  args: string[] = [],
+  options: SpawnSyncOptions = {},
+) {
+  const spec = buildCliLaunchSpec(binary, args, options.env);
+  return spawnSync(spec.command, spec.args, options);
+}
+
+export function resolveBinaryOnPath(
+  binary: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const locator = platform === 'win32' ? 'where.exe' : 'which';
+  const result = spawnSync(locator, [binary], {
+    encoding: 'utf-8',
+    timeout: 5000,
+    env,
+  });
+  if (result.status === 0) {
+    const resolved = (result.stdout || '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (resolved) return resolved;
+  }
+  return binary;
+}


### PR DESCRIPTION
## Summary

This draft improves native Windows usability by replacing several tmux-only runtime paths with WezTerm-backed equivalents and by fixing Windows-specific process launching issues.

The main goal is to make the existing team/runtime workflow usable on native Windows without requiring WSL2, while preserving the current tmux behavior on other platforms.

## Changes

- add Windows-safe CLI launching helpers and use them for Codex/provider detection and execution
- add WezTerm-backed team session support for native Windows workers
- add WezTerm-backed HUD pane creation for team sessions and `omx hud --tmux`
- make `team resume` and `tmux-hook validate` work against WezTerm sessions on native Windows
- harden worker completion prompts so Windows interactive workers reliably ACK/claim/complete/return idle
- make `notify-temp` resolve providers from configured notification settings instead of env-only temp config
- fix Windows provider advisor launching for `omx ask gemini` / `omx ask claude`

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [x] `omx doctor` (setup/config/runtime smoke)

Additional manual verification on native Windows + PowerShell + WezTerm:

- `omx team start/status/shutdown` completed successfully in smoke workspaces
- `omx team resume` restored an active WezTerm-backed team
- `omx tmux-hook init` and `omx tmux-hook validate` passed in repeated loops
- `omx ask gemini --prompt "say OK in one word"` succeeded after Windows launch fixes
- `omx --notify-temp --discord --version` resolved configured notification providers correctly
- Discord webhook dispatch succeeded through the notification subsystem

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

Notes:

- tmux-specific resize hook / client-attached reconcile semantics are still tmux-native concepts. On Windows, this PR targets practical WezTerm parity for runtime/HUD behavior rather than strict hook-model equivalence.
- The Windows validation here was done on native Windows with WezTerm, not WSL2.
- This is one of my first GitHub contributions, so I may have missed some project-specific conventions.

## Related

Closes #
