### PR TITLE
fix(platform): replace win32 hard-block with tmux capability check; add psmux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,24 @@ omx team 2:explore "short scoped analysis task"
 
 ## Requirements
 
-- macOS or Linux (Windows via WSL2)
 - Node.js >= 20 (CI validates Node 20 and current LTS, currently Node 22)
 - Codex CLI installed (`npm install -g @openai/codex`)
 - Codex auth configured
+
+### Platform & tmux
+
+OMX features like `omx team` require **tmux**:
+
+| Platform       | tmux provider                                            | Install                |
+| -------------- | -------------------------------------------------------- | ---------------------- |
+| macOS          | [tmux](https://github.com/tmux/tmux)                    | `brew install tmux`    |
+| Ubuntu/Debian  | tmux                                                     | `sudo apt install tmux`|
+| Fedora         | tmux                                                     | `sudo dnf install tmux`|
+| Arch           | tmux                                                     | `sudo pacman -S tmux`  |
+| Windows        | [psmux](https://github.com/marlocarlo/psmux) (native)   | `winget install psmux` |
+| Windows (WSL2) | tmux (inside WSL)                                        | `sudo apt install tmux`|
+
+> **Windows users:** [psmux](https://github.com/marlocarlo/psmux) provides a native `tmux` binary for Windows with 76 tmux-compatible commands. No WSL required.
 
 ## Quickstart (3 minutes)
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -55,6 +55,7 @@ import {
   buildUnregisterResizeHookArgs,
   enableMouseScrolling,
   isNativeWindows,
+  isTmuxAvailable,
   isWsl2,
 } from '../team/tmux-session.js';
 import { getPackageRoot } from '../utils/package.js';
@@ -534,14 +535,15 @@ async function reasoningCommand(args: string[]): Promise<void> {
 
 export async function launchWithHud(args: string[]): Promise<void> {
   // ── Win32 guard ──────────────────────────────────────────────────────
-  if (isNativeWindows()) {
+  if (isNativeWindows() && !isTmuxAvailable()) {
     console.error(
-      '[omx] OMX requires tmux, which is not available on native Windows.\n' +
-      '[omx] Please use one of the following supported environments:\n' +
-      '[omx]   - WSL2 (Windows Subsystem for Linux 2)\n' +
-      '[omx]   - macOS\n' +
-      '[omx]   - Linux\n' +
-      '[omx] See: https://docs.microsoft.com/en-us/windows/wsl/install',
+      '[omx] OMX requires tmux, which was not found on this system.\n' +
+      '[omx] Install a tmux provider for your platform:\n' +
+      '[omx]   - Windows: winget install psmux  (native tmux for Windows)\n' +
+      '[omx]   - WSL2: sudo apt install tmux\n' +
+      '[omx]   - macOS: brew install tmux\n' +
+      '[omx]   - Linux: sudo apt install tmux\n' +
+      '[omx] See: https://github.com/marlocarlo/psmux',
     );
     process.exitCode = 1;
     return;

--- a/src/mcp/code-intel-server.ts
+++ b/src/mcp/code-intel-server.ts
@@ -176,7 +176,8 @@ function extractSymbols(content: string): DocumentSymbol[] {
 async function findSgBinary(): Promise<string | null> {
   for (const bin of ['sg', 'ast-grep']) {
     try {
-      await execFileAsync('which', [bin]);
+      const finder = process.platform === 'win32' ? 'where' : 'which';
+      await execFileAsync(finder, [bin]);
       return bin;
     } catch (err) {
       process.stderr.write(`[code-intel-server] operation failed: ${err}\n`);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -547,9 +547,10 @@ function commandExists(binary: string): boolean {
  * Returns the absolute path or the bare command name as fallback.
  */
 function resolveAbsoluteBinaryPath(binary: string): string {
-  const result = spawnSync('which', [binary], { encoding: 'utf-8', timeout: 5000 });
+  const finder = process.platform === 'win32' ? 'where' : 'which';
+  const result = spawnSync(finder, [binary], { encoding: 'utf-8', timeout: 5000 });
   if (result.status === 0 && result.stdout.trim()) {
-    return result.stdout.trim();
+    return result.stdout.trim().split('\n')[0];
   }
   return binary;
 }


### PR DESCRIPTION
## Summary

Enables OMX to run on native Windows when [psmux](https://github.com/marlocarlo/psmux) is installed, without requiring WSL2.

**psmux** provides a native `tmux` binary for Windows with 76 tmux-compatible commands (send-keys, capture-pane, list-panes, split-window, etc.). When psmux is installed, `tmux -V` succeeds and OMX should work normally.

Related: Yeachan-Heo/oh-my-claudecode#1390, Yeachan-Heo/oh-my-claudecode#1423

## Changes

### 1. `src/cli/index.ts`
- The win32 guard now checks `isNativeWindows() && !isTmuxAvailable()` instead of just `isNativeWindows()`
- When psmux is installed on Windows, the guard passes through — no block
- Updated error message to recommend `winget install psmux` as the primary Windows option

### 2. `src/team/tmux-session.ts`
- `resolveAbsoluteBinaryPath()` now uses `where` instead of `which` on win32
- Handles multi-line `where` output (takes first match)

### 3. `src/mcp/code-intel-server.ts`
- `findSgBinary()` now uses `where` instead of `which` on win32

### 4. `README.md`
- Added **Platform & tmux** section with install instructions for all platforms
- Windows: `winget install psmux` (native), WSL2: `sudo apt install tmux`

## Design

**Capability detection over platform detection**: instead of assuming win32 cannot have tmux, we check if `tmux -V` succeeds via the existing `isTmuxAvailable()` function. This works transparently with native tmux on Unix and with psmux on Windows.

No new dependencies. All changes are backward-compatible — Unix/WSL2/MSYS behavior is unchanged.
