### PR TITLE
refactor: extract shared prompt guidance fragments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,12 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Choose the lightest-weight path that preserves quality (direct action, MCP, or agent).
 - Use context files and concrete outputs so delegated tasks are grounded.
 - Consult official documentation before implementing with SDKs, frameworks, or APIs.
+<!-- OMX:GUIDANCE:OPERATING:START -->
 - Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
 - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
+<!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>
 
 ---
@@ -285,7 +287,13 @@ Sizing guidance:
 - Standard changes: standard verifier
 - Large or security/architectural changes (>20 files): thorough verifier
 
+<!-- OMX:GUIDANCE:VERIFYSEQ:START -->
 Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to concise evidence summaries in the final response, but never omit the proof needed to justify completion.
+
+- Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
+- If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
+- When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
+<!-- OMX:GUIDANCE:VERIFYSEQ:END -->
 </verification>
 
 <execution_protocols>

--- a/docs/prompt-guidance-fragments/core-operating-principles.md
+++ b/docs/prompt-guidance-fragments/core-operating-principles.md
@@ -1,0 +1,4 @@
+- Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
+- Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
+- Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.

--- a/docs/prompt-guidance-fragments/core-verification-and-sequencing.md
+++ b/docs/prompt-guidance-fragments/core-verification-and-sequencing.md
@@ -1,0 +1,5 @@
+Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to concise evidence summaries in the final response, but never omit the proof needed to justify completion.
+
+- Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
+- If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
+- When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.

--- a/docs/prompt-guidance-fragments/executor-constraints.md
+++ b/docs/prompt-guidance-fragments/executor-constraints.md
@@ -1,0 +1,4 @@
+- Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
+- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.

--- a/docs/prompt-guidance-fragments/executor-output.md
+++ b/docs/prompt-guidance-fragments/executor-output.md
@@ -1,0 +1,1 @@
+Default final-output shape: concise and evidence-dense unless the user asked for more detail.

--- a/docs/prompt-guidance-fragments/executor-shared.md
+++ b/docs/prompt-guidance-fragments/executor-shared.md
@@ -1,0 +1,6 @@
+- Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
+- If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
+
+Default final-output shape: concise and evidence-dense unless the user asked for more detail.

--- a/docs/prompt-guidance-fragments/planner-constraints.md
+++ b/docs/prompt-guidance-fragments/planner-constraints.md
@@ -1,0 +1,3 @@
+- Default to compact, information-dense plan summaries; expand only when risk or ambiguity requires it.
+- Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
+- Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.

--- a/docs/prompt-guidance-fragments/planner-investigation.md
+++ b/docs/prompt-guidance-fragments/planner-investigation.md
@@ -1,0 +1,1 @@
+3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.

--- a/docs/prompt-guidance-fragments/planner-output.md
+++ b/docs/prompt-guidance-fragments/planner-output.md
@@ -1,0 +1,1 @@
+Default final-output shape: concise and information-dense, with only the detail needed to execute safely.

--- a/docs/prompt-guidance-fragments/planner-shared.md
+++ b/docs/prompt-guidance-fragments/planner-shared.md
@@ -1,0 +1,6 @@
+- Default to compact, information-dense plan summaries; expand only when risk or ambiguity requires it.
+- Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
+- Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
+- If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+
+Default final-output shape: concise and information-dense, with only the detail needed to execute safely.

--- a/docs/prompt-guidance-fragments/verifier-constraints.md
+++ b/docs/prompt-guidance-fragments/verifier-constraints.md
@@ -1,0 +1,2 @@
+- Default reports to concise, evidence-dense summaries, but never omit the proof needed to justify PASS/FAIL/INCOMPLETE.
+- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.

--- a/docs/prompt-guidance-fragments/verifier-investigation.md
+++ b/docs/prompt-guidance-fragments/verifier-investigation.md
@@ -1,0 +1,1 @@
+5) If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria.

--- a/docs/prompt-guidance-fragments/verifier-shared.md
+++ b/docs/prompt-guidance-fragments/verifier-shared.md
@@ -1,0 +1,3 @@
+- Default reports to concise, evidence-dense summaries, but never omit the proof needed to justify PASS/FAIL/INCOMPLETE.
+- If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
+- If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria.

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -44,10 +44,12 @@ A task is complete only when all are true:
 - Do not add single-use abstractions unless necessary.
 - Do not claim completion without fresh verification output.
 - Do not stop at “partially done” unless hard-blocked by impossible constraints.
+<!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:START -->
 - Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
+<!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:END -->
 - Plan files in `.omx/plans/` are read-only.
 
 ## Ambiguity Handling (Explore-First)
@@ -118,7 +120,9 @@ No evidence = not complete.
 
 ## Output Format
 
+<!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:START -->
 Default final-output shape: concise and evidence-dense unless the user asked for more detail.
+<!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:END -->
 
 ## Changes Made
 - `path/to/file:line-range` — concise description

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -32,9 +32,11 @@ Plans that are too vague waste executor time guessing. Plans that are too detail
 - Never ask the user about codebase facts (use explore agent to look them up).
 - Default to 3-6 step plans. Avoid architecture redesign unless the task requires it.
 - Stop planning when the plan is actionable. Do not over-specify.
+<!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:START -->
 - Default to compact, information-dense plan summaries; expand only when risk or ambiguity requires it.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
+<!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->
 - Consult analyst (Metis) before generating the final plan to catch missing requirements.
 - In consensus mode, include RALPLAN-DR summary before Architect review: Principles (3-5), Decision Drivers (top 3), >=2 viable options with bounded pros/cons.
 - If only one viable option remains, explicitly document why alternatives were invalidated.
@@ -45,7 +47,9 @@ Plans that are too vague waste executor time guessing. Plans that are too detail
 
 1) Classify intent: Trivial/Simple (quick fix) | Refactoring (safety focus) | Build from Scratch (discovery focus) | Mid-sized (boundary focus).
 2) For codebase facts, spawn explore agent. Never burden the user with questions the codebase can answer.
+<!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->
 3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+<!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->
 4) Ask user ONLY about: priorities, timelines, scope decisions, risk tolerance, personal preferences. Use AskUserQuestion tool with 2-4 options.
 4) When user triggers plan generation ("make it into a work plan"), consult analyst (Metis) first for gap analysis.
 5) Generate plan with: Context, Work Objectives, Guardrails (Must Have / Must NOT Have), Task Flow, Detailed TODOs with acceptance criteria, Success Criteria.
@@ -76,7 +80,9 @@ When running inside `$plan --consensus` (ralplan):
 
 ## Output Format
 
+<!-- OMX:GUIDANCE:PLANNER:OUTPUT:START -->
 Default final-output shape: concise and information-dense, with only the detail needed to execute safely.
+<!-- OMX:GUIDANCE:PLANNER:OUTPUT:END -->
 
 ## Plan Summary
 

--- a/prompts/verifier.md
+++ b/prompts/verifier.md
@@ -26,8 +26,10 @@ You are not responsible for authoring features (executor), gathering requirement
 - No approval without fresh evidence. Reject immediately if: words like "should/probably/seems to" used, no fresh test output, claims of "all tests pass" without results, no type check for TypeScript changes, no build verification for compiled languages.
 - Run verification commands yourself. Do not trust claims without output.
 - Verify against original acceptance criteria (not just "it compiles").
+<!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:START -->
 - Default reports to concise, evidence-dense summaries, but never omit the proof needed to justify PASS/FAIL/INCOMPLETE.
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
+<!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:END -->
 
 ## Investigation Protocol
 
@@ -35,7 +37,9 @@ You are not responsible for authoring features (executor), gathering requirement
 2) EXECUTE (parallel): Run test suite via Bash. Run lsp_diagnostics_directory for type checking. Run build command. Grep for related tests that should also pass.
 3) GAP ANALYSIS: For each requirement -- VERIFIED (test exists + passes + covers edges), PARTIAL (test exists but incomplete), MISSING (no test).
 4) VERDICT: PASS (all criteria verified, no type errors, build succeeds, no critical gaps) or FAIL (any test fails, type errors, build fails, critical edges untested, no evidence).
+<!-- OMX:GUIDANCE:VERIFIER:INVESTIGATION:START -->
 5) If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria.
+<!-- OMX:GUIDANCE:VERIFIER:INVESTIGATION:END -->
 
 ## Tool Usage
 

--- a/scripts/sync-prompt-guidance-fragments.js
+++ b/scripts/sync-prompt-guidance-fragments.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+
+async function read(path) { return await readFile(path, 'utf-8'); }
+
+function replaceBetween(text, startMarker, endMarker, replacement) {
+  const start = text.indexOf(startMarker);
+  const end = text.indexOf(endMarker, start + startMarker.length);
+  if (start === -1 || end === -1) throw new Error(`Markers not found: ${startMarker} .. ${endMarker}`);
+  return text.slice(0, start + startMarker.length) + '\n' + replacement.trimEnd() + '\n' + text.slice(end);
+}
+
+async function main() {
+  const op = (await read('docs/prompt-guidance-fragments/core-operating-principles.md')).trim();
+  const vs = (await read('docs/prompt-guidance-fragments/core-verification-and-sequencing.md')).trim();
+  const exC = (await read('docs/prompt-guidance-fragments/executor-constraints.md')).trim();
+  const exO = (await read('docs/prompt-guidance-fragments/executor-output.md')).trim();
+  const plC = (await read('docs/prompt-guidance-fragments/planner-constraints.md')).trim();
+  const plI = (await read('docs/prompt-guidance-fragments/planner-investigation.md')).trim();
+  const plO = (await read('docs/prompt-guidance-fragments/planner-output.md')).trim();
+  const vfC = (await read('docs/prompt-guidance-fragments/verifier-constraints.md')).trim();
+  const vfI = (await read('docs/prompt-guidance-fragments/verifier-investigation.md')).trim();
+
+  for (const file of ['AGENTS.md', 'templates/AGENTS.md']) {
+    let text = await read(file);
+    text = replaceBetween(text, '<!-- OMX:GUIDANCE:OPERATING:START -->', '<!-- OMX:GUIDANCE:OPERATING:END -->', op);
+    text = replaceBetween(text, '<!-- OMX:GUIDANCE:VERIFYSEQ:START -->', '<!-- OMX:GUIDANCE:VERIFYSEQ:END -->', vs);
+    await writeFile(file, text);
+  }
+
+  let text = await read('prompts/executor.md');
+  text = replaceBetween(text, '<!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:START -->', '<!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:END -->', exC);
+  text = replaceBetween(text, '<!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:START -->', '<!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:END -->', exO);
+  await writeFile('prompts/executor.md', text);
+
+  text = await read('prompts/planner.md');
+  text = replaceBetween(text, '<!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:START -->', '<!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->', plC);
+  text = replaceBetween(text, '<!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->', '<!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->', plI);
+  text = replaceBetween(text, '<!-- OMX:GUIDANCE:PLANNER:OUTPUT:START -->', '<!-- OMX:GUIDANCE:PLANNER:OUTPUT:END -->', plO);
+  await writeFile('prompts/planner.md', text);
+
+  text = await read('prompts/verifier.md');
+  text = replaceBetween(text, '<!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:START -->', '<!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:END -->', vfC);
+  text = replaceBetween(text, '<!-- OMX:GUIDANCE:VERIFIER:INVESTIGATION:START -->', '<!-- OMX:GUIDANCE:VERIFIER:INVESTIGATION:END -->', vfI);
+  await writeFile('prompts/verifier.md', text);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/hooks/__tests__/prompt-guidance-fragments.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-fragments.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../../../');
+
+function read(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf-8');
+}
+
+function extract(text: string, startMarker: string, endMarker: string): string {
+  const start = text.indexOf(startMarker);
+  const end = text.indexOf(endMarker, start + startMarker.length);
+  assert.notEqual(start, -1, `missing start marker ${startMarker}`);
+  assert.notEqual(end, -1, `missing end marker ${endMarker}`);
+  return text.slice(start + startMarker.length, end).trim();
+}
+
+describe('prompt-guidance fragments stay synced with generated surfaces', () => {
+  it('syncs root/template AGENTS shared guidance blocks', () => {
+    const operating = read('docs/prompt-guidance-fragments/core-operating-principles.md').trim();
+    const verifySeq = read('docs/prompt-guidance-fragments/core-verification-and-sequencing.md').trim();
+
+    for (const file of ['AGENTS.md', 'templates/AGENTS.md']) {
+      const content = read(file);
+      assert.equal(
+        extract(content, '<!-- OMX:GUIDANCE:OPERATING:START -->', '<!-- OMX:GUIDANCE:OPERATING:END -->'),
+        operating,
+      );
+      assert.equal(
+        extract(content, '<!-- OMX:GUIDANCE:VERIFYSEQ:START -->', '<!-- OMX:GUIDANCE:VERIFYSEQ:END -->'),
+        verifySeq,
+      );
+    }
+  });
+
+  it('syncs executor guidance fragments', () => {
+    const content = read('prompts/executor.md');
+    assert.equal(
+      extract(content, '<!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:START -->', '<!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:END -->'),
+      read('docs/prompt-guidance-fragments/executor-constraints.md').trim(),
+    );
+    assert.equal(
+      extract(content, '<!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:START -->', '<!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:END -->'),
+      read('docs/prompt-guidance-fragments/executor-output.md').trim(),
+    );
+  });
+
+  it('syncs planner guidance fragments', () => {
+    const content = read('prompts/planner.md');
+    assert.equal(
+      extract(content, '<!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:START -->', '<!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->'),
+      read('docs/prompt-guidance-fragments/planner-constraints.md').trim(),
+    );
+    assert.equal(
+      extract(content, '<!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->', '<!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->'),
+      read('docs/prompt-guidance-fragments/planner-investigation.md').trim(),
+    );
+    assert.equal(
+      extract(content, '<!-- OMX:GUIDANCE:PLANNER:OUTPUT:START -->', '<!-- OMX:GUIDANCE:PLANNER:OUTPUT:END -->'),
+      read('docs/prompt-guidance-fragments/planner-output.md').trim(),
+    );
+  });
+
+  it('syncs verifier guidance fragments', () => {
+    const content = read('prompts/verifier.md');
+    assert.equal(
+      extract(content, '<!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:START -->', '<!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:END -->'),
+      read('docs/prompt-guidance-fragments/verifier-constraints.md').trim(),
+    );
+    assert.equal(
+      extract(content, '<!-- OMX:GUIDANCE:VERIFIER:INVESTIGATION:START -->', '<!-- OMX:GUIDANCE:VERIFIER:INVESTIGATION:END -->'),
+      read('docs/prompt-guidance-fragments/verifier-investigation.md').trim(),
+    );
+  });
+});

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -26,10 +26,12 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Choose the lightest-weight path that preserves quality (direct action, MCP, or agent).
 - Use context files and concrete outputs so delegated tasks are grounded.
 - Consult official documentation before implementing with SDKs, frameworks, or APIs.
+<!-- OMX:GUIDANCE:OPERATING:START -->
 - Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
 - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
+<!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>
 
 ---
@@ -285,7 +287,13 @@ Sizing guidance:
 - Standard changes: standard verifier
 - Large or security/architectural changes (>20 files): thorough verifier
 
+<!-- OMX:GUIDANCE:VERIFYSEQ:START -->
 Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to concise evidence summaries in the final response, but never omit the proof needed to justify completion.
+
+- Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
+- If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
+- When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
+<!-- OMX:GUIDANCE:VERIFYSEQ:END -->
 </verification>
 
 <execution_protocols>


### PR DESCRIPTION
## Summary
- extract the most duplicated GPT-5.4-style guidance blocks into shared fragment files
- add a sync script that composes those fragments back into the checked-in prompt surfaces
- apply the fragment-backed markers to the highest-duplication surfaces first: `AGENTS.md`, `templates/AGENTS.md`, `prompts/executor.md`, `prompts/planner.md`, and `prompts/verifier.md`
- add a sync-integrity test that verifies the marker-bounded sections exactly match the fragment sources

Follow-up to #613 (Phase 2A of the prompt-guidance dedup work).

## What this changes
### New fragment sources
Under `docs/prompt-guidance-fragments/`:
- `core-operating-principles.md`
- `core-verification-and-sequencing.md`
- `executor-constraints.md`
- `executor-output.md`
- `planner-constraints.md`
- `planner-investigation.md`
- `planner-output.md`
- `verifier-constraints.md`
- `verifier-investigation.md`

### New sync tooling
- `scripts/sync-prompt-guidance-fragments.js`

### Initial fragment-backed surfaces
- `AGENTS.md`
- `templates/AGENTS.md`
- `prompts/executor.md`
- `prompts/planner.md`
- `prompts/verifier.md`

### New sync-integrity test
- `src/hooks/__tests__/prompt-guidance-fragments.test.ts`

## Why this matters
After #611 and #612, guidance coverage was broad. After #613, validation was centralized. This PR is the first step that actually deduplicates the repeated guidance text itself while keeping runtime-consumed markdown files intact.

## Non-goals
- no runtime orchestration logic changes
- no broader fragment migration across the entire prompt catalog yet
- no skill fragment generation yet

## Verification
- `npm run build && node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-scenarios.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/prompt-guidance-catalog.test.js dist/hooks/__tests__/skill-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js`
- `npm test`
