### PR TITLE
chore: lower analyst and planner reasoning effort to medium

### DIFF
--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -43,7 +43,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'analyst': {
     name: 'analyst',
     description: 'Requirements clarity, acceptance criteria, hidden constraints',
-    reasoningEffort: 'high',
+    reasoningEffort: 'medium',
     posture: 'frontier-orchestrator',
     modelClass: 'frontier',
     routingRole: 'leader',
@@ -53,7 +53,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'planner': {
     name: 'planner',
     description: 'Task sequencing, execution plans, risk flags',
-    reasoningEffort: 'high',
+    reasoningEffort: 'medium',
     posture: 'frontier-orchestrator',
     modelClass: 'frontier',
     routingRole: 'leader',


### PR DESCRIPTION
## Summary

This PR lowers the default `reasoningEffort` for two planning-oriented agents:

- `analyst`: `high` -> `medium`
- `planner`: `high` -> `medium`

## Motivation

We want the tiering model to reflect three clear buckets:

- **low**: fast-path tasks that can benefit from a quicker GPT-5.4 low configuration
- **medium**: tasks that require reasoning and structured judgment
- **high**: tasks that require deep, concrete, high-stakes review

Under that model, `analyst` and `planner` fit better in the **medium** tier than the **high** tier.

## Scope

Changed only:

- `src/agents/definitions.ts`

No changes were made to prompts, routing roles, categories, or tool permissions.
