### PR TITLE
chore: rebalance reasoning effort tiers for planning and fast-path agents

### DIFF
--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -218,7 +218,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'qa-tester': {
     name: 'qa-tester',
     description: 'Interactive CLI/service runtime validation',
-    reasoningEffort: 'medium',
+    reasoningEffort: 'low',
     posture: 'deep-worker',
     modelClass: 'standard',
     routingRole: 'executor',
@@ -248,7 +248,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'researcher': {
     name: 'researcher',
     description: 'External documentation and reference research',
-    reasoningEffort: 'medium',
+    reasoningEffort: 'low',
     posture: 'fast-lane',
     modelClass: 'standard',
     routingRole: 'specialist',
@@ -280,7 +280,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'information-architect': {
     name: 'information-architect',
     description: 'Taxonomy, navigation, findability',
-    reasoningEffort: 'medium',
+    reasoningEffort: 'low',
     posture: 'frontier-orchestrator',
     modelClass: 'standard',
     routingRole: 'specialist',
@@ -290,7 +290,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'product-analyst': {
     name: 'product-analyst',
     description: 'Product metrics, funnel analysis, experiments',
-    reasoningEffort: 'medium',
+    reasoningEffort: 'low',
     posture: 'frontier-orchestrator',
     modelClass: 'standard',
     routingRole: 'specialist',
@@ -312,7 +312,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'vision': {
     name: 'vision',
     description: 'Image/screenshot/diagram analysis',
-    reasoningEffort: 'medium',
+    reasoningEffort: 'low',
     posture: 'fast-lane',
     modelClass: 'standard',
     routingRole: 'specialist',


### PR DESCRIPTION
## Summary

This PR rebalances default `reasoningEffort` assignments for planning-oriented and fast-path agents.

### Changed to `medium`
- `analyst`: `high` -> `medium`
- `planner`: `high` -> `medium`

### Changed to `low`
- `qa-tester`: `medium` -> `low`
- `researcher`: `medium` -> `low`
- `information-architect`: `medium` -> `low`
- `product-analyst`: `medium` -> `low`
- `vision`: `medium` -> `low`

## Motivation

We want the tiering model to map more cleanly to actual task shape:

- **low**: fast-path tasks, lightweight exploration, first-pass inspection, and routine validation
- **medium**: reasoning-heavy but routine planning, implementation, and analysis
- **high**: deep, concrete, high-stakes review and architectural judgment

Under that model:
- `analyst` and `planner` are better defaulted to `medium`
- several fast-path agents are better defaulted to `low` so they can run on cheaper/faster settings without over-allocating reasoning budget

## Scope

Changed only:

- `src/agents/definitions.ts`

No changes were made to prompts, routing roles, categories, tool permissions, or model class assignments.
