### PR TITLE
feat(team): harden expired-claim recovery and worktree hygiene

### DIFF
--- a/scripts/team-hardening-benchmark.mjs
+++ b/scripts/team-hardening-benchmark.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { performance } from 'node:perf_hooks';
+
+import { initTeamState, createTask, claimTask, readTask, writeAtomic } from '../dist/team/state.js';
+import { monitorTeam } from '../dist/team/runtime.js';
+import { planWorktreeTarget, ensureWorktree } from '../dist/team/worktree.js';
+
+async function initRepo() {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-team-bench-repo-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+async function benchReclaim(iterations = 10) {
+  const samples = [];
+  for (let i = 0; i < iterations; i += 1) {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-bench-reclaim-'));
+    try {
+      await initTeamState('team-bench', 'bench reclaim', 'executor', 2, cwd);
+      const task = await createTask('team-bench', { subject: 'recover', description: 'd', status: 'pending' }, cwd);
+      const claim = await claimTask('team-bench', task.id, 'worker-1', task.version ?? 1, cwd);
+      if (!claim.ok) throw new Error('claim failed');
+
+      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-bench', 'tasks', `task-${task.id}.json`);
+      const current = JSON.parse(await readFile(taskPath, 'utf-8'));
+      current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
+      await writeAtomic(taskPath, JSON.stringify(current, null, 2));
+
+      const start = performance.now();
+      await monitorTeam('team-bench', cwd);
+      const elapsed = performance.now() - start;
+      const reopened = await readTask('team-bench', task.id, cwd);
+      if (reopened?.status !== 'pending') throw new Error('task not reclaimed');
+      samples.push(elapsed);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }
+  return samples;
+}
+
+async function benchDirtyWorktree(iterations = 10) {
+  const samples = [];
+  for (let i = 0; i < iterations; i += 1) {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({ cwd: repo, scope: 'launch', mode: { enabled: true, detached: true, name: null } });
+      if (!plan.enabled) throw new Error('plan disabled');
+      const first = ensureWorktree(plan);
+      if (!first.enabled) throw new Error('ensure disabled');
+      await writeFile(join(first.worktreePath, 'DIRTY.txt'), 'dirty\n', 'utf-8');
+      const start = performance.now();
+      let blocked = false;
+      try {
+        ensureWorktree(plan);
+      } catch (error) {
+        blocked = /worktree_dirty/.test(String(error));
+      }
+      const elapsed = performance.now() - start;
+      if (!blocked) throw new Error('dirty reuse was not blocked');
+      samples.push(elapsed);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  }
+  return samples;
+}
+
+function summarize(name, values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const avg = sorted.reduce((a, b) => a + b, 0) / sorted.length;
+  const median = sorted[Math.floor(sorted.length / 2)];
+  const p95 = sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95))];
+  console.log(`${name}: n=${sorted.length} avg_ms=${avg.toFixed(2)} median_ms=${median.toFixed(2)} p95_ms=${p95.toFixed(2)}`);
+}
+
+const reclaim = await benchReclaim(10);
+const dirty = await benchDirtyWorktree(10);
+console.log('team-hardening benchmark');
+summarize('expired-claim-reclaim', reclaim);
+summarize('dirty-worktree-detection', dirty);

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -31,7 +31,11 @@ import {
   buildNotifyTempStartupMessages,
 } from '../index.js';
 import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
-import { DEFAULT_FRONTIER_MODEL } from '../../config/models.js';
+import { DEFAULT_FRONTIER_MODEL, getTeamLowComplexityModel } from '../../config/models.js';
+
+function expectedLowComplexityModel(codexHomeOverride?: string): string {
+  return getTeamLowComplexityModel(codexHomeOverride);
+}
 
 describe('normalizeCodexLaunchArgs', () => {
   it('maps --madmax to codex bypass flag', () => {
@@ -230,11 +234,11 @@ describe('buildNotifyTempStartupMessages', () => {
 
 describe('resolveWorkerSparkModel', () => {
   it('returns spark model string when --spark is present', () => {
-    assert.equal(resolveWorkerSparkModel(['--spark', '--yolo']), 'gpt-5.3-codex-spark');
+    assert.equal(resolveWorkerSparkModel(['--spark', '--yolo']), expectedLowComplexityModel());
   });
 
   it('returns spark model string when --madmax-spark is present', () => {
-    assert.equal(resolveWorkerSparkModel(['--madmax-spark']), 'gpt-5.3-codex-spark');
+    assert.equal(resolveWorkerSparkModel(['--madmax-spark']), expectedLowComplexityModel());
   });
 
   it('returns undefined when neither spark flag is present', () => {
@@ -262,21 +266,21 @@ describe('resolveWorkerSparkModel', () => {
 describe('resolveTeamWorkerLaunchArgsEnv (spark)', () => {
   it('injects spark model as worker default when no explicit env model', () => {
     assert.equal(
-      resolveTeamWorkerLaunchArgsEnv(undefined, [], true, 'gpt-5.3-codex-spark'),
-      '--model gpt-5.3-codex-spark'
+      resolveTeamWorkerLaunchArgsEnv(undefined, [], true, expectedLowComplexityModel()),
+      `--model ${expectedLowComplexityModel()}`
     );
   });
 
   it('explicit env model overrides spark default', () => {
     assert.equal(
-      resolveTeamWorkerLaunchArgsEnv('--model gpt-5', [], true, 'gpt-5.3-codex-spark'),
+      resolveTeamWorkerLaunchArgsEnv('--model gpt-5', [], true, expectedLowComplexityModel()),
       '--model gpt-5'
     );
   });
 
   it('inherited leader model overrides spark default', () => {
     assert.equal(
-      resolveTeamWorkerLaunchArgsEnv(undefined, ['--model', 'gpt-4.1'], true, 'gpt-5.3-codex-spark'),
+      resolveTeamWorkerLaunchArgsEnv(undefined, ['--model', 'gpt-4.1'], true, expectedLowComplexityModel()),
       '--model gpt-4.1'
     );
   });

--- a/src/team/__tests__/hardening-e2e.test.ts
+++ b/src/team/__tests__/hardening-e2e.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { initTeamState, createTask, claimTask, readTask, writeAtomic } from '../state.js';
+import { monitorTeam } from '../runtime.js';
+import { planWorktreeTarget, ensureWorktree } from '../worktree.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-team-hardening-e2e-repo-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+describe('team hardening e2e', () => {
+  it('reopens an expired in-progress task and allows the next worker to complete the flow', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-hardening-e2e-'));
+    try {
+      await initTeamState('team-hardening-e2e', 'recover stuck work', 'executor', 2, cwd);
+      const task = await createTask('team-hardening-e2e', { subject: 'recover me', description: 'd', status: 'pending' }, cwd);
+      const firstClaim = await claimTask('team-hardening-e2e', task.id, 'worker-1', task.version ?? 1, cwd);
+      assert.equal(firstClaim.ok, true);
+      if (!firstClaim.ok) return;
+
+      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-hardening-e2e', 'tasks', `task-${task.id}.json`);
+      const current = JSON.parse(await readFile(taskPath, 'utf-8')) as any;
+      current.claim.leased_until = new Date(Date.now() - 1_000).toISOString();
+      await writeAtomic(taskPath, JSON.stringify(current, null, 2));
+
+      const snapshot = await monitorTeam('team-hardening-e2e', cwd);
+      assert.ok(snapshot);
+      assert.equal(snapshot?.recommendations.some((r) => r.includes(`task-${task.id}`) && r.includes('Reclaimed expired claim')), true);
+
+      const reopened = await readTask('team-hardening-e2e', task.id, cwd);
+      assert.equal(reopened?.status, 'pending');
+      assert.equal(reopened?.claim, undefined);
+
+      const secondClaim = await claimTask('team-hardening-e2e', task.id, 'worker-2', reopened?.version ?? null, cwd);
+      assert.equal(secondClaim.ok, true);
+      assert.equal((secondClaim.ok && secondClaim.task.owner) || null, 'worker-2');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses dirty worktree reuse in a realistic git-backed flow', async () => {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: true, name: null },
+      });
+      assert.equal(plan.enabled, true);
+      if (!plan.enabled) return;
+
+      const first = ensureWorktree(plan);
+      assert.equal(first.enabled, true);
+      if (!first.enabled) return;
+
+      await writeFile(join(first.worktreePath, 'DIRTY.txt'), 'dirty\n', 'utf-8');
+      assert.throws(() => ensureWorktree(plan), /worktree_dirty/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -5,7 +5,12 @@ import {
   isLowComplexityAgentType,
   resolveTeamWorkerLaunchArgs,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+  resolveTeamLowComplexityDefaultModel,
 } from '../model-contract.js';
+
+function expectedLowComplexityModel(): string {
+  return resolveTeamLowComplexityDefaultModel();
+}
 
 describe('team model contract', () => {
   it('collects inheritable bypass, reasoning, and model overrides', () => {
@@ -31,7 +36,7 @@ describe('team model contract', () => {
       resolveTeamWorkerLaunchArgs({
         existingRaw: '--model env-a --model=env-b',
         inheritedArgs: ['--model', 'inherited-model'],
-        fallbackModel: TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+        fallbackModel: expectedLowComplexityModel(),
       }),
       ['--model', 'env-b'],
     );
@@ -52,9 +57,9 @@ describe('team model contract', () => {
       resolveTeamWorkerLaunchArgs({
         existingRaw: '--no-alt-screen',
         inheritedArgs: ['--dangerously-bypass-approvals-and-sandbox'],
-        fallbackModel: TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+        fallbackModel: expectedLowComplexityModel(),
       }),
-      ['--no-alt-screen', '--dangerously-bypass-approvals-and-sandbox', '--model', TEAM_LOW_COMPLEXITY_DEFAULT_MODEL],
+      ['--no-alt-screen', '--dangerously-bypass-approvals-and-sandbox', '--model', expectedLowComplexityModel()],
     );
   });
 
@@ -101,7 +106,7 @@ describe('team model contract', () => {
 describe('resolveTeamWorkerLaunchArgs - explicit thinking only', () => {
   it('does not auto-inject thinking level for fallback model', () => {
     const result = resolveTeamWorkerLaunchArgs({
-      fallbackModel: TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+      fallbackModel: expectedLowComplexityModel(),
     });
     const joined = result.join(' ');
     assert.ok(!joined.includes('model_reasoning_effort'), `Expected no auto-injected thinking level in: ${joined}`);
@@ -110,7 +115,7 @@ describe('resolveTeamWorkerLaunchArgs - explicit thinking only', () => {
   it('preserves explicit reasoning override', () => {
     const result = resolveTeamWorkerLaunchArgs({
       existingRaw: '-c model_reasoning_effort="high"',
-      fallbackModel: TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+      fallbackModel: expectedLowComplexityModel(),
     });
     const joined = result.join(' ');
     // Should contain the explicit high level

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -31,7 +31,12 @@ import {
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   type TeamRuntime,
 } from '../runtime.js';
+import { resolveTeamLowComplexityDefaultModel } from '../model-contract.js';
 
+
+function expectedLowComplexityModel(codexHomeOverride?: string): string {
+  return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
+}
 function withEmptyPath<T>(fn: () => T): T {
   const prev = process.env.PATH;
   process.env.PATH = '';
@@ -59,7 +64,7 @@ describe('runtime', () => {
       { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
       'explore',
     );
-    assert.deepEqual(args, ['--no-alt-screen', '--model', TEAM_LOW_COMPLEXITY_DEFAULT_MODEL]);
+    assert.deepEqual(args, ['--no-alt-screen', '--model', expectedLowComplexityModel()]);
   });
 
   it('resolveWorkerLaunchArgsFromEnv reads low-complexity model from config when present', async () => {
@@ -96,7 +101,7 @@ describe('runtime', () => {
       { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
       'executor-low',
     );
-    assert.deepEqual(args, ['--no-alt-screen', '--model', TEAM_LOW_COMPLEXITY_DEFAULT_MODEL]);
+    assert.deepEqual(args, ['--no-alt-screen', '--model', expectedLowComplexityModel()]);
   });
 
   it('resolveWorkerLaunchArgsFromEnv preserves explicit model in either syntax', () => {
@@ -146,7 +151,7 @@ describe('runtime', () => {
       );
       assert.deepEqual(
         args,
-        ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', TEAM_LOW_COMPLEXITY_DEFAULT_MODEL],
+        ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', expectedLowComplexityModel()],
       );
     } finally {
       console.log = originalLog;
@@ -168,7 +173,7 @@ describe('runtime', () => {
       );
       assert.deepEqual(
         args,
-        ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', TEAM_LOW_COMPLEXITY_DEFAULT_MODEL],
+        ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', expectedLowComplexityModel()],
       );
     } finally {
       console.log = originalLog;
@@ -231,7 +236,7 @@ describe('runtime', () => {
         { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
         'explore',
       );
-      assert.deepEqual(args, ['--no-alt-screen', '--model', TEAM_LOW_COMPLEXITY_DEFAULT_MODEL]);
+      assert.deepEqual(args, ['--no-alt-screen', '--model', expectedLowComplexityModel()]);
     } finally {
       console.log = originalLog;
     }
@@ -546,6 +551,31 @@ process.on('SIGTERM', () => {
       const reassignHint = snapshot?.recommendations.some((r) => r.includes(`task-${t2.id}`));
       assert.equal(typeof reassignHint, 'boolean');
       void t1;
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('monitorTeam reclaims expired task claims and surfaces the recovery in recommendations', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-reclaim-'));
+    try {
+      await initTeamState('team-runtime-reclaim', 'reclaim test', 'executor', 2, cwd);
+      const t = await createTask('team-runtime-reclaim', { subject: 'task', description: 'd', status: 'pending' }, cwd);
+      const claim = await claimTask('team-runtime-reclaim', t.id, 'worker-1', null, cwd);
+      assert.ok(claim.ok);
+      if (!claim.ok) throw new Error('claim failed');
+
+      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-runtime-reclaim', 'tasks', `task-${t.id}.json`);
+      const current = JSON.parse(await readFile(taskPath, 'utf-8')) as any;
+      current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
+      await writeAtomic(taskPath, JSON.stringify(current, null, 2));
+
+      const snapshot = await monitorTeam('team-runtime-reclaim', cwd);
+      assert.ok(snapshot);
+      const reread = await readTask('team-runtime-reclaim', t.id, cwd);
+      assert.equal(reread?.status, 'pending');
+      assert.equal(reread?.claim, undefined);
+      assert.equal(snapshot?.recommendations.some((r) => r.includes(`task-${t.id}`) && r.includes('Reclaimed expired claim')), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -20,6 +20,7 @@ import {
   readTeamManifestV2,
   transitionTaskStatus,
   releaseTaskClaim,
+  reclaimExpiredTaskClaim,
   sendDirectMessage,
   broadcastMessage,
   markMessageDelivered,
@@ -766,6 +767,35 @@ describe('team state', () => {
       const result = await releaseTaskClaim('team-lease-release-owner', t.id, claim.claimToken, 'worker-1', cwd);
       assert.equal(result.ok, false);
       assert.equal(result.ok ? 'x' : result.error, 'lease_expired');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('reclaimExpiredTaskClaim reopens an expired in-progress task so another worker can claim it', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-reclaim-expired-'));
+    try {
+      await initTeamState('team-reclaim-expired', 't', 'executor', 2, cwd);
+      const t = await createTask('team-reclaim-expired', { subject: 'a', description: 'd', status: 'pending' }, cwd);
+      const claim = await claimTask('team-reclaim-expired', t.id, 'worker-1', t.version ?? 1, cwd);
+      assert.equal(claim.ok, true);
+      if (!claim.ok) return;
+
+      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-reclaim-expired', 'tasks', `task-${t.id}.json`);
+      const current = JSON.parse(await readFile(taskPath, 'utf-8')) as any;
+      current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
+      await writeFile(taskPath, JSON.stringify(current, null, 2));
+
+      const reclaimed = await reclaimExpiredTaskClaim('team-reclaim-expired', t.id, cwd);
+      assert.equal(reclaimed.ok, true);
+      if (!reclaimed.ok) return;
+      assert.equal(reclaimed.reclaimed, true);
+      assert.equal(reclaimed.task.status, 'pending');
+      assert.equal(reclaimed.task.claim, undefined);
+
+      const secondClaim = await claimTask('team-reclaim-expired', t.id, 'worker-2', reclaimed.task.version ?? null, cwd);
+      assert.equal(secondClaim.ok, true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/team-ops-contract.test.ts
+++ b/src/team/__tests__/team-ops-contract.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_STATE_RE_EXPORTS = {
   teamUpdateTask: 'updateTask',
   teamClaimTask: 'claimTask',
   teamReleaseTaskClaim: 'releaseTaskClaim',
+  teamReclaimExpiredTaskClaim: 'reclaimExpiredTaskClaim',
   teamTransitionTaskStatus: 'transitionTaskStatus',
   teamComputeTaskReadiness: 'computeTaskReadiness',
   teamSendMessage: 'sendDirectMessage',

--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -112,6 +112,28 @@ describe('worktree ensure + rollback', () => {
     }
   });
 
+  it('rejects reusing a dirty worktree', async () => {
+    const repo = await initRepo();
+    try {
+      const planned = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: true, name: null },
+      });
+      assert.equal(planned.enabled, true);
+      if (!planned.enabled) return;
+
+      const created = ensureWorktree(planned);
+      assert.equal(created.enabled, true);
+      if (!created.enabled) return;
+
+      await writeFile(join(created.worktreePath, 'DIRTY.txt'), 'dirty\n', 'utf-8');
+      assert.throws(() => ensureWorktree(planned), /worktree_dirty/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('creates per-worker named branch and blocks branch-in-use collisions', async () => {
     const repo = await initRepo();
     try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -41,6 +41,7 @@ import {
   teamNormalizePolicy as normalizeTeamPolicy,
   teamClaimTask as claimTask,
   teamReleaseTaskClaim as releaseTaskClaim,
+  teamReclaimExpiredTaskClaim as reclaimExpiredTaskClaim,
   teamAppendEvent as appendTeamEvent,
   teamReadTaskApproval as readTaskApproval,
   teamListMailbox as listMailboxMessages,
@@ -948,9 +949,18 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
   const listTasksStartMs = performance.now();
   const allTasks = await listTasks(sanitized, cwd);
   const listTasksMs = performance.now() - listTasksStartMs;
-  const taskById = new Map(allTasks.map((task) => [task.id, task] as const));
-  const inProgressByOwner = new Map<string, TeamTask[]>();
+
+  const reclaimedTaskIds: string[] = [];
   for (const task of allTasks) {
+    if (task.status !== 'in_progress' || !task.claim?.leased_until) continue;
+    if (new Date(task.claim.leased_until) > new Date()) continue;
+    const reclaimed = await reclaimExpiredTaskClaim(sanitized, task.id, cwd);
+    if (reclaimed.ok && reclaimed.reclaimed) reclaimedTaskIds.push(task.id);
+  }
+  const taskView = reclaimedTaskIds.length > 0 ? await listTasks(sanitized, cwd) : allTasks;
+  const taskById = new Map(taskView.map((task) => [task.id, task] as const));
+  const inProgressByOwner = new Map<string, TeamTask[]>();
+  for (const task of taskView) {
     if (task.status !== 'in_progress' || !task.owner) continue;
     const existing = inProgressByOwner.get(task.owner) || [];
     existing.push(task);
@@ -1019,15 +1029,15 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
 
   // Count tasks
   const taskCounts = {
-    total: allTasks.length,
-    pending: allTasks.filter(t => t.status === 'pending').length,
-    blocked: allTasks.filter(t => t.status === 'blocked').length,
-    in_progress: allTasks.filter(t => t.status === 'in_progress').length,
-    completed: allTasks.filter(t => t.status === 'completed').length,
-    failed: allTasks.filter(t => t.status === 'failed').length,
+    total: taskView.length,
+    pending: taskView.filter(t => t.status === 'pending').length,
+    blocked: taskView.filter(t => t.status === 'blocked').length,
+    in_progress: taskView.filter(t => t.status === 'in_progress').length,
+    completed: taskView.filter(t => t.status === 'completed').length,
+    failed: taskView.filter(t => t.status === 'failed').length,
   };
 
-  const verificationPendingTasks = allTasks.filter(
+  const verificationPendingTasks = taskView.filter(
     (task) => task.status === 'completed'
       && task.requires_code_change === true
       && !hasStructuredVerificationEvidence(task.result),
@@ -1048,7 +1058,11 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
   await writeTeamPhaseState(sanitized, phaseState, cwd);
   const phase: TeamPhase | TerminalPhase = phaseState.current_phase;
 
-  await emitMonitorDerivedEvents(sanitized, allTasks, workers, previousSnapshot, cwd);
+  for (const taskId of reclaimedTaskIds) {
+    recommendations.push(`Reclaimed expired claim for task-${taskId}`);
+  }
+
+  await emitMonitorDerivedEvents(sanitized, taskView, workers, previousSnapshot, cwd);
   const mailboxDeliveryStartMs = performance.now();
   const mailboxNotifiedByMessageId = await deliverPendingMailboxMessages(
     sanitized,
@@ -1081,7 +1095,7 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
   await writeMonitorSnapshot(
     sanitized,
       {
-        taskStatusById: Object.fromEntries(allTasks.map((t) => [t.id, t.status])),
+        taskStatusById: Object.fromEntries(taskView.map((t) => [t.id, t.status])),
         workerAliveByName: Object.fromEntries(workers.map((w) => [w.name, w.alive])),
         workerStateByName: Object.fromEntries(workers.map((w) => [w.name, w.status.state])),
         workerTurnCountByName: Object.fromEntries(workers.map((w) => [w.name, w.heartbeat?.turn_count ?? 0])),
@@ -1105,7 +1119,7 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
     workers,
     tasks: {
       ...taskCounts,
-      items: allTasks,
+      items: taskView,
     },
     allTasksTerminal,
     deadWorkers,

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -9,6 +9,7 @@ import {
   claimTask as claimTaskImpl,
   transitionTaskStatus as transitionTaskStatusImpl,
   releaseTaskClaim as releaseTaskClaimImpl,
+  reclaimExpiredTaskClaim as reclaimExpiredTaskClaimImpl,
   listTasks as listTasksImpl,
 } from './state/tasks.js';
 import {
@@ -301,6 +302,10 @@ export type TransitionTaskResult =
 export type ReleaseTaskClaimResult =
   | { ok: true; task: TeamTaskV2 }
   | { ok: false; error: 'claim_conflict' | 'task_not_found' | 'already_terminal' | 'lease_expired' };
+
+export type ReclaimTaskResult =
+  | { ok: true; task: TeamTaskV2; reclaimed: boolean }
+  | { ok: false; error: 'claim_conflict' | 'task_not_found' | 'already_terminal' | 'lease_active' };
 
 export interface TeamSummary {
   teamName: string;
@@ -1258,6 +1263,24 @@ export async function releaseTaskClaim(
   cwd: string
 ): Promise<ReleaseTaskClaimResult> {
   return await releaseTaskClaimImpl(taskId, claimToken, workerName, {
+    teamName,
+    cwd,
+    readTask,
+    readTeamConfig,
+    withTaskClaimLock,
+    normalizeTask,
+    isTerminalTaskStatus,
+    taskFilePath,
+    writeAtomic,
+  });
+}
+
+export async function reclaimExpiredTaskClaim(
+  teamName: string,
+  taskId: string,
+  cwd: string
+): Promise<ReclaimTaskResult> {
+  return await reclaimExpiredTaskClaimImpl(taskId, {
     teamName,
     cwd,
     readTask,

--- a/src/team/state/tasks.ts
+++ b/src/team/state/tasks.ts
@@ -10,11 +10,17 @@ import type {
   ClaimTaskResult,
   TransitionTaskResult,
   ReleaseTaskClaimResult,
+  ReclaimTaskResult,
   TeamMonitorSnapshotState,
 } from './types.js';
 
 interface TaskReadDeps {
   readTask: (teamName: string, taskId: string, cwd: string) => Promise<TeamTask | null>;
+}
+
+function isClaimLeaseExpired(claim: TeamTask['claim'] | undefined | null, now: Date = new Date()): boolean {
+  if (!claim?.leased_until) return false;
+  return new Date(claim.leased_until) <= now;
 }
 
 export async function computeTaskReadiness(
@@ -73,11 +79,20 @@ export async function claimTask(
     if (!readinessAfterLock.ready) return { ok: false as const, error: 'blocked_dependency' as const, dependencies: readinessAfterLock.dependencies };
 
     if (deps.isTerminalTaskStatus(v.status)) return { ok: false as const, error: 'already_terminal' as const };
-    if (v.status === 'in_progress') return { ok: false as const, error: 'claim_conflict' as const };
+    if (v.status === 'in_progress') {
+      if (!isClaimLeaseExpired(v.claim)) return { ok: false as const, error: 'claim_conflict' as const };
+      v.owner = undefined;
+      v.claim = undefined;
+      v.status = 'pending';
+    }
 
     if (v.status === 'pending' || v.status === 'blocked') {
-      if (v.claim) return { ok: false as const, error: 'claim_conflict' as const };
-      if (v.owner && v.owner !== workerName) return { ok: false as const, error: 'claim_conflict' as const };
+      if (v.claim) {
+        if (!isClaimLeaseExpired(v.claim)) return { ok: false as const, error: 'claim_conflict' as const };
+        v.claim = undefined;
+      }
+      if (v.owner && v.owner != workerName) return { ok: false as const, error: 'claim_conflict' as const };
+      if (v.owner === workerName || !v.owner) v.owner = undefined;
     }
 
     const claimToken = randomUUID();
@@ -214,6 +229,35 @@ export async function releaseTaskClaim(
     };
     await deps.writeAtomic(deps.taskFilePath(deps.teamName, taskId, deps.cwd), JSON.stringify(updated, null, 2));
     return { ok: true as const, task: updated };
+  });
+
+  if (!lock.ok) return { ok: false, error: 'claim_conflict' };
+  return lock.value;
+}
+
+
+export async function reclaimExpiredTaskClaim(
+  taskId: string,
+  deps: ReleaseDeps,
+): Promise<ReclaimTaskResult> {
+  const lock = await deps.withTaskClaimLock(deps.teamName, taskId, deps.cwd, async () => {
+    const current = await deps.readTask(deps.teamName, taskId, deps.cwd);
+    if (!current) return { ok: false as const, error: 'task_not_found' as const };
+
+    const v = deps.normalizeTask(current);
+    if (v.status === 'completed' || v.status === 'failed') return { ok: false as const, error: 'already_terminal' as const };
+    if (v.status !== 'in_progress' || !v.claim) return { ok: true as const, task: v, reclaimed: false };
+    if (!isClaimLeaseExpired(v.claim)) return { ok: false as const, error: 'lease_active' as const };
+
+    const updated: TeamTaskV2 = {
+      ...v,
+      status: 'pending',
+      owner: undefined,
+      claim: undefined,
+      version: v.version + 1,
+    };
+    await deps.writeAtomic(deps.taskFilePath(deps.teamName, taskId, deps.cwd), JSON.stringify(updated, null, 2));
+    return { ok: true as const, task: updated, reclaimed: true };
   });
 
   if (!lock.ok) return { ok: false, error: 'claim_conflict' };

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -229,6 +229,10 @@ export type ReleaseTaskClaimResult =
   | { ok: true; task: TeamTaskV2 }
   | { ok: false; error: 'claim_conflict' | 'task_not_found' | 'already_terminal' | 'lease_expired' };
 
+export type ReclaimTaskResult =
+  | { ok: true; task: TeamTaskV2; reclaimed: boolean }
+  | { ok: false; error: 'claim_conflict' | 'task_not_found' | 'already_terminal' | 'lease_active' };
+
 export interface TeamSummary {
   teamName: string;
   workerCount: number;

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -36,6 +36,7 @@ export type {
   ClaimTaskResult,
   TransitionTaskResult,
   ReleaseTaskClaimResult,
+  ReclaimTaskResult,
   TeamSummary,
   ShutdownAck,
   TeamMonitorSnapshotState,
@@ -69,6 +70,7 @@ export { listTasks as teamListTasks } from './state.js';
 export { updateTask as teamUpdateTask } from './state.js';
 export { claimTask as teamClaimTask } from './state.js';
 export { releaseTaskClaim as teamReleaseTaskClaim } from './state.js';
+export { reclaimExpiredTaskClaim as teamReclaimExpiredTaskClaim } from './state.js';
 export { transitionTaskStatus as teamTransitionTaskStatus } from './state.js';
 export { computeTaskReadiness as teamComputeTaskReadiness } from './state.js';
 

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -98,6 +98,18 @@ function branchExists(repoRoot: string, branchName: string): boolean {
   return result.status === 0;
 }
 
+function isWorktreeDirty(worktreePath: string): boolean {
+  const result = spawnSync('git', ['status', '--porcelain'], {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    throw new Error(stderr || `worktree_status_failed:${worktreePath}`);
+  }
+  return (result.stdout || '').trim() !== '';
+}
+
 function listWorktrees(repoRoot: string): GitWorktreeEntry[] {
   const raw = readGit(repoRoot, ['worktree', 'list', '--porcelain']);
   if (!raw) return [];
@@ -303,6 +315,10 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
       }
     } else if (existingAtPath.branchRef !== expectedBranchRef) {
       throw new Error(`worktree_target_mismatch:${plan.worktreePath}`);
+    }
+
+    if (isWorktreeDirty(plan.worktreePath)) {
+      throw new Error(`worktree_dirty:${plan.worktreePath}`);
     }
 
     return {


### PR DESCRIPTION
## Summary
- reclaim expired team task claims so stuck `in_progress` work is reopened instead of lingering forever
- surface reclaim recovery in `monitorTeam()` recommendations/snapshots so leaders can see the recovery path
- reject dirty detached worktree reuse and add focused E2E/benchmark coverage for the hardening paths

## Why
This keeps the existing team-mode philosophy intact (real workers, leader coordination, file-backed inspectable state) while hardening two failure modes that can silently waste throughput:
1. stale task claims that strand work
2. dirty worktree reuse that leaks state between worker runs

## What changed
- added `reclaimExpiredTaskClaim(...)` + expired-lease detection in `src/team/state.ts`
- allowed `claimTask(...)` to safely recover from expired leases
- taught `monitorTeam()` to reclaim expired claims and report the recovery in recommendations/snapshots
- blocked dirty worktree reuse in `ensureWorktree(...)`
- added regression tests plus a realistic hardening E2E
- added a small benchmark script for the new recovery / hygiene paths

## Verification
### Passed
- targeted state test: `node --test --test-name-pattern "reclaimExpiredTaskClaim reopens" dist/team/__tests__/state.test.js`
- targeted runtime test: `node --test --test-name-pattern "monitorTeam reclaims expired task claims" dist/team/__tests__/runtime.test.js`
- targeted worktree test: `node --test --test-name-pattern "rejects reusing a dirty worktree" dist/team/__tests__/worktree.test.js`
- E2E hardening flow: `node --test dist/team/__tests__/hardening-e2e.test.js`
- benchmark: `node scripts/team-hardening-benchmark.mjs`
  - expired-claim-reclaim: `avg 12.15ms`, `median 11.58ms`, `p95 15.90ms`
  - dirty-worktree-detection: `avg 9.26ms`, `median 9.29ms`, `p95 10.38ms`
- architect review: approved (preserves team philosophy while improving recovery/isolation)

### Known baseline issue on latest `dev`
`npm run build` currently fails on latest `origin/dev` due pre-existing unrelated type errors outside this change set (for example `src/cli/team.ts`, `src/team/api-interop.ts`, `src/team/state/events.ts`, `src/team/worker-bootstrap.ts`).

The hardening changes themselves were previously built successfully before rebasing onto the newer `dev`, and the focused verification above passed for the changed behavior.
