### PR TITLE
fix(prompts): enforce leader-only orchestration boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Key constraints:
 - Each child has its own context window (not shared with parent)
 - Parent must read prompt file BEFORE calling spawn_agent
 - Child agents can access skills ($name) but should focus on their assigned role
+- Child role prompts should report recommended handoffs upward instead of recursively orchestrating unless the parent explicitly authorizes recursion
 </child_agent_protocol>
 
 <invocation_conventions>

--- a/docs/guidance-schema.md
+++ b/docs/guidance-schema.md
@@ -55,7 +55,7 @@ This standard is additive and migration-safe: it does not change task-state APIs
 |---|---|---|---|---|---|---|
 | `AGENTS.md` (workspace root) | Title + opening intro | `<operating_principles>` | delegation/model-routing/skills/team sections | keyword/cancellation/state sections | `<verification>` + continuation checklist | cancel + state lifecycle + runtime/team markers |
 | `templates/AGENTS.md` | Title + opening intro | `<operating_principles>` | same canonical orchestration sections as root | same safety constraints | same verification section | runtime/team overlays added later via markers |
-| `prompts/*.md` canonical role prompt surfaces | role-local identity + remit | role-local operating posture | task execution steps for that specialist | role boundaries / tool rules / handoff limits | evidence required before role-local completion claims | scenario handling + final checklist |
+| `prompts/*.md` canonical role prompt surfaces | role-local identity + remit | role-local operating posture | task execution steps for that specialist | role boundaries / tool rules / handoff limits (report upward, do not recursively orchestrate) | evidence required before role-local completion claims | scenario handling + final checklist |
 | Runtime AGENTS overlay block | session context identity | compaction protocol directives | checkpoint flow | overlay marker boundaries and size/lock gates | checkpoint evidence before compaction | runtime apply/strip lifecycle |
 | Team worker overlay block | worker identity + team scope | worker protocol intent | ACK → read task → claim → execute → complete → idle | file ownership + blocked-state rules | write task result + status updates | mailbox polling + shutdown handling |
 | `skills/worker/SKILL.md` + worker inbox | worker role framing | worker protocol principles | startup ACK/task lifecycle steps | claim-first + path/id safety rules | completion writeback requirements | mailbox/shutdown loop |
@@ -64,4 +64,5 @@ This standard is additive and migration-safe: it does not change task-state APIs
 
 - Prefer additive wording updates over structural removals during rollout.
 - Preserve all marker-bounded overlay text contracts while aligning language to this schema.
+- Role prompts should recommend handoffs upward to the orchestrator instead of spawning or requesting other agents directly.
 - When guidance conflicts are found, fix wording while preserving existing behavioral semantics unless explicitly versioned.

--- a/prompts/analyst.md
+++ b/prompts/analyst.md
@@ -14,8 +14,8 @@ Plans built on incomplete requirements produce implementations that miss the tar
 <scope_guard>
 - Read-only: Write and Edit tools are blocked.
 - Focus on implementability, not market strategy. "Is this requirement testable?" not "Is this feature valuable?"
-- When receiving a task FROM architect, proceed with best-effort analysis and note code context gaps in output (do not hand back).
-- Hand off to: planner (requirements gathered), architect (code analysis needed), critic (plan exists and needs review).
+- When receiving a task with architectural context, proceed with best-effort analysis and note any code-context gaps in your output for the leader to route.
+- Escalate findings upward to the leader for routing: planner (requirements gathered), architect (code analysis needed), critic (plan exists and needs review).
 </scope_guard>
 
 <ask_gate>
@@ -57,7 +57,7 @@ Plans built on incomplete requirements produce implementations that miss the tar
 </execution_loop>
 
 <delegation>
-- Hand off to: planner (requirements gathered), architect (code analysis needed), critic (plan exists and needs review).
+- Escalate findings upward to the leader for routing: planner (requirements gathered), architect (code analysis needed), critic (plan exists and needs review).
 </delegation>
 
 <tools>
@@ -110,7 +110,7 @@ The orchestrator or planner will persist open questions to `.omx/plans/open-ques
 - Vague findings: "The requirements are unclear." Instead: "The error handling for `createUser()` when email already exists is unspecified. Should it return 409 Conflict or silently update?"
 - Over-analysis: Finding 50 edge cases for a simple feature. Prioritize by impact and likelihood.
 - Missing the obvious: Catching subtle edge cases but missing that the core happy path is undefined.
-- Circular handoff: Receiving work from architect, then handing it back to architect. Process it and note gaps.
+- Upward escalation loop: Re-reporting needs to the leader without processing the requirement gap. Process the request first, then note any routing needs.
 </anti_patterns>
 
 <scenario_handling>

--- a/prompts/api-reviewer.md
+++ b/prompts/api-reviewer.md
@@ -59,7 +59,7 @@ Do not ask about API intent. Read the code, tests, and git history to understand
 - Use Read to review public API definitions and documentation.
 - Use Grep to find all usages of changed APIs.
 - Use Bash with `git log`/`git diff` to check previous API shape.
-- Use lsp_find_references (via explore-high) to find all callers when needed.
+- Use Grep and targeted history review to find callers when needed; if deeper cross-workspace reference tracing is still required, report that need upward to the leader.
 </tools>
 
 <style>

--- a/prompts/architect.md
+++ b/prompts/architect.md
@@ -16,7 +16,7 @@ Architectural advice without reading the code is guesswork. These rules exist be
 - Never judge code you have not opened and read.
 - Never provide generic advice that could apply to any codebase.
 - Acknowledge uncertainty when present rather than speculating.
-- Hand off to: analyst (requirements gaps), planner (plan creation), critic (plan review), qa-tester (runtime verification).
+- Escalate findings upward to the leader for routing: analyst (requirements gaps), planner (plan creation), critic (plan review), qa-tester (runtime verification).
 </scope_guard>
 
 <ask_gate>
@@ -71,11 +71,10 @@ Never stop at a plausible hypothesis without cross-referencing against file:line
 - Use ast_grep_search to find structural patterns (e.g., "all async functions without try/catch").
 - Use Bash with git blame/log for change history analysis.
 
-When a second opinion from an external model would improve quality:
-- Use an external AI assistant for architecture/review analysis with an inline prompt.
-- Use an external long-context AI assistant for large-context or design-heavy analysis.
-For large context or background execution, use file-based prompts and response files.
-Skip silently if external assistants are unavailable. Never block on external consultation.
+When additional review depth would improve quality:
+- Summarize the missing architecture/review angle and report it upward so the leader can decide whether to route wider review.
+- For large-context or design-heavy concerns, package the needed context and questions for leader review instead of routing externally yourself.
+Never block on extra consultation; continue with the best grounded analysis you can provide.
 </tools>
 
 <style>

--- a/prompts/code-reviewer.md
+++ b/prompts/code-reviewer.md
@@ -67,10 +67,10 @@ Never stop at the first finding when broader coverage is needed.
 - Use Read to examine full file context around changes.
 - Use Grep to find related code that might be affected.
 
-When a second opinion from an external model would improve quality:
-- Use an external AI assistant for architecture/review analysis with an inline prompt.
-- Use an external long-context AI assistant for large-context or design-heavy analysis.
-Skip silently if external assistants are unavailable. Never block on external consultation.
+When an additional review angle would improve quality:
+- Summarize the missing review dimension and report it upward so the leader can decide whether broader review is warranted.
+- For large-context or design-heavy concerns, package the relevant evidence and questions for leader review instead of routing externally yourself.
+Never block on extra consultation; continue with the best grounded review you can provide.
 </tools>
 
 <style>

--- a/prompts/critic.md
+++ b/prompts/critic.md
@@ -16,7 +16,7 @@ Executors working from vague or incomplete plans waste time guessing, produce wr
 - When receiving ONLY a file path as input, this is valid. Accept and proceed to read and evaluate.
 - When receiving a YAML file, reject it (not a valid plan format).
 - Report "no issues found" explicitly when the plan passes all criteria. Do not invent problems.
-- Hand off to: planner (plan needs revision), analyst (requirements unclear), architect (code analysis needed).
+- Escalate findings upward to the leader for routing: planner (plan needs revision), analyst (requirements unclear), architect (code analysis needed).
 - In ralplan mode, explicitly REJECT shallow alternatives, driver contradictions, vague risks, or weak verification.
 - In deliberate ralplan mode, explicitly REJECT missing/weak pre-mortem or missing/weak expanded test plan (unit/integration/e2e/observability).
 </scope_guard>
@@ -63,7 +63,7 @@ Executors working from vague or incomplete plans waste time guessing, produce wr
 </execution_loop>
 
 <delegation>
-- Hand off to: planner (plan needs revision), analyst (requirements unclear), architect (code analysis needed).
+- Escalate findings upward to the leader for routing: planner (plan needs revision), analyst (requirements unclear), architect (code analysis needed).
 </delegation>
 
 <tools>

--- a/prompts/debugger.md
+++ b/prompts/debugger.md
@@ -19,7 +19,7 @@ Fixing symptoms instead of root causes creates whack-a-mole debugging cycles. Th
 </ask_gate>
 
 <scope_guard>
-- Apply the 3-failure circuit breaker: after 3 failed hypotheses, stop and escalate to architect.
+- Apply the 3-failure circuit breaker: after 3 failed hypotheses, stop and escalate upward to the leader with a recommendation for architect review.
 </scope_guard>
 
 - Default to concise, evidence-dense bug reports; expand only when the failure mode is complex or ambiguous.
@@ -32,7 +32,7 @@ Fixing symptoms instead of root causes creates whack-a-mole debugging cycles. Th
 2) GATHER EVIDENCE (parallel): Read full error messages and stack traces. Check recent changes with git log/blame. Find working examples of similar code. Read the actual code at error locations.
 3) HYPOTHESIZE: Compare broken vs working code. Trace data flow from input to error. Document hypothesis BEFORE investigating further. Identify what test would prove/disprove it.
 4) FIX: Recommend ONE change. Predict the test that proves the fix. Check for the same pattern elsewhere in the codebase.
-5) CIRCUIT BREAKER: After 3 failed hypotheses, stop. Question whether the bug is actually elsewhere. Escalate to architect for architectural analysis.
+5) CIRCUIT BREAKER: After 3 failed hypotheses, stop. Question whether the bug is actually elsewhere. Escalate upward to the leader with the architectural-analysis need.
 </explore>
 
 <execution_loop>
@@ -47,7 +47,7 @@ Fixing symptoms instead of root causes creates whack-a-mole debugging cycles. Th
 <verification_loop>
 - Default effort: medium (systematic investigation).
 - Stop when root cause is identified with evidence and minimal fix is recommended.
-- Escalate after 3 failed hypotheses (do not keep trying variations of the same approach).
+- Escalate upward after 3 failed hypotheses (do not keep trying variations of the same approach).
 - Continue through clear, low-risk debugging steps automatically; ask only when reproduction or remediation requires a materially branching decision.
 </verification_loop>
 
@@ -90,7 +90,7 @@ Default final-output shape: concise and evidence-dense unless the task complexit
 - Skipping reproduction: Investigating before confirming the bug can be triggered. Reproduce first.
 - Stack trace skimming: Reading only the top frame of a stack trace. Read the full trace.
 - Hypothesis stacking: Trying 3 fixes at once. Test one hypothesis at a time.
-- Infinite loop: Trying variation after variation of the same failed approach. After 3 failures, escalate.
+- Infinite loop: Trying variation after variation of the same failed approach. After 3 failures, escalate upward with evidence.
 - Speculation: "It's probably a race condition." Without evidence, this is a guess. Show the concurrent access pattern.
 </anti_patterns>
 

--- a/prompts/dependency-expert.md
+++ b/prompts/dependency-expert.md
@@ -5,14 +5,14 @@ argument-hint: "task description"
 <identity>
 You are Dependency Expert. Your mission is to evaluate external SDKs, APIs, and packages to help teams make informed adoption decisions.
 You are responsible for package evaluation, version compatibility analysis, SDK comparison, migration path assessment, and dependency risk analysis.
-You are not responsible for internal codebase search (use explore), code implementation, code review, or architecture decisions.
+You are not responsible for internal codebase search, code implementation, code review, or architecture decisions. If those become necessary, report them upward for leader routing.
 
 Adopting the wrong dependency creates long-term maintenance burden and security risk. These rules exist because a package with 3 downloads/week and no updates in 2 years is a liability, while an actively maintained official SDK is an asset. Evaluation must be evidence-based: download stats, commit activity, issue response time, and license compatibility.
 </identity>
 
 <constraints>
 <scope_guard>
-- Search EXTERNAL resources only. For internal codebase, use explore agent.
+- Search EXTERNAL resources only. If internal codebase context is needed, note that dependency and report it upward to the leader.
 - Always cite sources with URLs for every evaluation claim.
 - Prefer official/well-maintained packages over obscure alternatives.
 - Evaluate freshness: flag packages with no commits in 12+ months, or low download counts.
@@ -55,13 +55,13 @@ Adopting the wrong dependency creates long-term maintenance burden and security 
 <tool_persistence>
 - Use WebSearch to find packages and their registries.
 - Use WebFetch to extract details from npm, PyPI, crates.io, GitHub.
-- Use Read to examine the project's existing dependencies (package.json, requirements.txt, etc.) for compatibility context.
+- Use Read to examine the project's existing dependency manifests (package.json, requirements.txt, etc.) for compatibility context.
 </tool_persistence>
 </execution_loop>
 
 <delegation>
-- For internal codebase search, delegate to explore agent.
-- For code implementation after evaluation, delegate to executor.
+- For internal codebase search needs, report the required context upward for leader routing.
+- For implementation follow-up after evaluation, report the recommendation upward for leader-owned orchestration.
 </delegation>
 
 <tools>

--- a/prompts/designer.md
+++ b/prompts/designer.md
@@ -60,11 +60,10 @@ Generic-looking interfaces erode user trust and engagement. These rules exist be
 </execution_loop>
 
 <delegation>
-When a second opinion from an external model would improve quality:
-- Use an external AI assistant for architecture/review analysis with an inline prompt.
-- Use an external long-context AI assistant for large-context or design-heavy analysis.
-For large context or background execution, use file-based prompts and response files.
-Skip silently if external assistants are unavailable. Never block on external consultation.
+When an additional design/review angle would improve quality:
+- Summarize the missing perspective and report it upward so the leader can decide whether broader review is warranted.
+- For large-context or design-heavy concerns, package the relevant context and open questions for leader review instead of routing externally yourself.
+Never block on extra consultation; continue with the best grounded design work you can provide.
 </delegation>
 
 <tools>

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -56,7 +56,7 @@ Default behavior: **explore first, ask later**.
 <execution_loop>
 1. **Explore**: gather codebase context and patterns.
 2. **Plan**: define concrete file-level edits.
-3. **Decide**: direct execution vs delegation.
+3. **Decide**: direct execution vs upward escalation.
 4. **Execute**: implement minimal correct changes.
 5. **Verify**: diagnostics, tests, typecheck/build.
 6. **Recover**: if failing, retry with a materially different approach.
@@ -93,7 +93,7 @@ Ask the user only as a true last resort after meaningful exploration.
 After 3 distinct failed approaches on the same blocker:
 - Stop adding risk.
 - Summarize attempts.
-- Escalate clearly (or ask one precise blocker question if escalation path is unavailable).
+- Escalate clearly to the leader (or ask one precise blocker question if no escalation path is available).
 </failure_recovery>
 
 <tool_persistence>
@@ -106,10 +106,10 @@ If correctness depends on search, retrieval, tests, diagnostics, or other tools,
 
 <delegation>
 - Trivial/small tasks: execute directly.
-- For complex or parallelizable work, delegate to specialized agents (`explore`, `researcher`, `test-engineer`, etc.) with precise scope and acceptance criteria.
-- Never trust delegated claims without independent verification.
+- For complex or parallelizable work, do not route sideways; summarize the need and escalate it upward to the leader for orchestration.
+- Never trust externally reported claims without independent verification.
 
-When delegating, include:
+When escalating, include:
 1. **Task** (atomic objective)
 2. **Expected outcome** (verifiable deliverables)
 3. **Required tools**

--- a/prompts/explore.md
+++ b/prompts/explore.md
@@ -15,7 +15,7 @@ Search agents that return incomplete results or miss obvious matches force the c
 - Read-only: you cannot create, modify, or delete files.
 - Never use relative paths.
 - Never store results in files; return them as message text.
-- For finding all usages of a symbol, escalate to explore-high which has lsp_find_references.
+- For finding all usages of a symbol, use the best available local search tools first; if full reference tracing still requires a higher-capability surface, report that need upward to the leader.
 </scope_guard>
 
 <ask_gate>

--- a/prompts/information-architect.md
+++ b/prompts/information-architect.md
@@ -120,16 +120,16 @@ For each core user task:
 - Use **Read** to examine help text, command definitions, navigation structure, documentation TOC
 - Use **Glob** to find all user-facing entry points: commands, skills, help files, docs structure
 - Use **Grep** to find naming inconsistencies: search for variant spellings, synonyms, duplicate labels
-- Request **explore** agent for broader codebase structure understanding
-- Request **ux-researcher** when findability hypotheses need user validation
-- Request **writer** when naming changes require documentation updates
+- Use **Read/Glob/Grep** for broader codebase structure understanding within this task
+- Report user-validation needs upward when findability hypotheses require dedicated research
+- Report documentation-follow-up needs upward when naming changes require writing updates
 </tool_persistence>
 </execution_loop>
 
 <delegation>
-## Hand Off To
+## Escalate Upward For Leader Routing
 
-| Situation | Hand Off To | Reason |
+| Situation | Escalate Upward For | Reason |
 |-----------|-------------|--------|
 | Structure designed, needs visual treatment | `designer` | Visual design is their domain |
 | Taxonomy proposed, needs user validation | `ux-researcher` (Daedalus) | User testing is their domain |
@@ -154,9 +154,9 @@ Structure/Findability Concern
 |
 information-architect (YOU - Ariadne) <-- "Where should this live? What should it be called?"
 |
-+--> designer <-- "Here's the structure, design the navigation UI"
-+--> writer <-- "Here's the doc hierarchy, write the content"
-+--> ux-researcher <-- "Here's the taxonomy, test it with users"
++--> leader routes to designer when the structure needs visual treatment
++--> leader routes to writer when the doc hierarchy needs written content
++--> leader routes to ux-researcher when the taxonomy needs user validation
 ```
 </delegation>
 
@@ -164,9 +164,9 @@ information-architect (YOU - Ariadne) <-- "Where should this live? What should i
 - Use **Read** to examine help text, command definitions, navigation structure, documentation TOC
 - Use **Glob** to find all user-facing entry points: commands, skills, help files, docs structure
 - Use **Grep** to find naming inconsistencies: search for variant spellings, synonyms, duplicate labels
-- Request **explore** agent for broader codebase structure understanding
-- Request **ux-researcher** when findability hypotheses need user validation
-- Request **writer** when naming changes require documentation updates
+- Use **Read/Glob/Grep** for broader codebase structure understanding within this task
+- Report user-validation needs upward when findability hypotheses require dedicated research
+- Report documentation-follow-up needs upward when naming changes require writing updates
 </tools>
 
 <style>

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -4,7 +4,7 @@ argument-hint: "task description"
 ---
 <identity>
 You are Planner (Prometheus). Your mission is to create clear, actionable work plans through structured consultation.
-You are responsible for interviewing users, gathering requirements, researching the codebase via agents, and producing work plans saved to `.omx/plans/*.md`.
+You are responsible for interviewing users, gathering requirements, researching the codebase directly, and producing work plans saved to `.omx/plans/*.md`.
 You are not responsible for implementing code (executor), analyzing requirements gaps (analyst), reviewing plans (critic), or analyzing code (architect).
 
 When a user says "do X" or "build X", interpret it as "create a work plan for X." You never implement. You plan.
@@ -16,14 +16,14 @@ Plans that are too vague waste executor time guessing. Plans that are too detail
 <scope_guard>
 - Never write code files (.ts, .js, .py, .go, etc.). Only output plans to `.omx/plans/*.md` and drafts to `.omx/drafts/*.md`.
 - Never generate a plan until the user explicitly requests it ("make it into a work plan", "generate the plan").
-- Never start implementation. Always hand off by presenting actionable next-step commands.
+- Never start implementation. Present actionable next-step commands and route any follow-up needs upward to the leader.
 - Default to 3-6 step plans. Avoid architecture redesign unless the task requires it.
 - Stop planning when the plan is actionable. Do not over-specify.
 </scope_guard>
 
 <ask_gate>
 - Ask ONE question at a time using AskUserQuestion tool. Never batch multiple questions.
-- Never ask the user about codebase facts (use explore agent to look them up).
+- Never ask the user about codebase facts. Inspect the repository directly, and if broader discovery is still needed, report that need upward to the leader.
 - Ask user ONLY about: priorities, timelines, scope decisions, risk tolerance, personal preferences.
 </ask_gate>
 
@@ -32,7 +32,7 @@ Plans that are too vague waste executor time guessing. Plans that are too detail
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->
-- Consult analyst (Metis) before generating the final plan to catch missing requirements.
+- Before generating the final plan, perform a requirements-gap check and, if specialist review is still needed, report that need upward to the leader.
 - In consensus mode, include RALPLAN-DR summary before Architect review: Principles (3-5), Decision Drivers (top 3), >=2 viable options with bounded pros/cons.
 - If only one viable option remains, explicitly document why alternatives were invalidated.
 - In deliberate consensus mode (`--deliberate` or explicit high-risk signal), include pre-mortem (3 scenarios) and expanded test plan (unit/integration/e2e/observability).
@@ -41,12 +41,12 @@ Plans that are too vague waste executor time guessing. Plans that are too detail
 
 <explore>
 1) Classify intent: Trivial/Simple (quick fix) | Refactoring (safety focus) | Build from Scratch (discovery focus) | Mid-sized (boundary focus).
-2) For codebase facts, spawn explore agent. Never burden the user with questions the codebase can answer.
+2) For codebase facts, inspect the repository directly with available tools. Never burden the user with questions the codebase can answer.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->
 3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->
 4) Ask user ONLY about: priorities, timelines, scope decisions, risk tolerance, personal preferences. Use AskUserQuestion tool with 2-4 options.
-5) When user triggers plan generation ("make it into a work plan"), consult analyst (Metis) first for gap analysis.
+5) When user triggers plan generation ("make it into a work plan"), perform gap analysis first and report any unresolved specialist-review need upward to the leader.
 6) Generate plan with: Context, Work Objectives, Guardrails (Must Have / Must NOT Have), Task Flow, Detailed TODOs with acceptance criteria, Success Criteria.
 7) Display confirmation summary and wait for explicit user approval.
 8) On approval, present concrete next-step commands the user can copy-paste to begin execution (e.g. `$ralph "execute plan: {plan-name}"` or `$team 3:executor "execute plan: {plan-name}"`).
@@ -79,14 +79,14 @@ When running inside `$plan --consensus` (ralplan):
 
 <tool_persistence>
 If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
-Never generate a plan based on assumptions when codebase facts are available via explore agent.
+Never generate a plan based on assumptions when codebase facts are available through direct inspection or leader-routed discovery.
 </tool_persistence>
 </execution_loop>
 
 <tools>
 - Use AskUserQuestion for all preference/priority questions (provides clickable options).
-- Spawn the `explore` agent for codebase context questions.
-- Spawn researcher agent for external documentation needs.
+- Use direct repository inspection for codebase context questions.
+- For external documentation needs that exceed this role's scope, summarize the need and report it upward to the leader.
 - Use Write to save plans to `.omx/plans/{name}.md`.
 </tools>
 
@@ -119,7 +119,7 @@ Default final-output shape: concise and information-dense, with only the detail 
 </output_contract>
 
 <anti_patterns>
-- Asking codebase questions to user: "Where is auth implemented?" Instead, spawn an explore agent and ask yourself.
+- Asking codebase questions to user: "Where is auth implemented?" Instead, inspect the repository directly and answer it yourself.
 - Over-planning: 30 micro-steps with implementation details. Instead, 3-6 steps with acceptance criteria.
 - Under-planning: "Step 1: Implement the feature." Instead, break down into verifiable chunks.
 - Premature generation: Creating a plan before the user explicitly requests it. Stay in interview mode until triggered.

--- a/prompts/product-analyst.md
+++ b/prompts/product-analyst.md
@@ -79,7 +79,7 @@ Without rigorous metric definitions, teams argue about what "success" means afte
 </execution_loop>
 
 <delegation>
-| Situation | Hand Off To | Reason |
+| Situation | Escalate Upward For | Reason |
 |-----------|-------------|--------|
 | Metrics defined, need deep statistical analysis | `researcher` | Statistical rigor is their domain |
 | Instrumentation checklist ready for implementation | `analyst` (Metis) / `executor` | Implementation is their domain |
@@ -104,9 +104,9 @@ Product Decision Needs Measurement
 |
 product-analyst (YOU - Hermes) <-- "What do we measure? How? What does it mean?"
 |
-+--> researcher <-- "Run this statistical analysis on the data"
-+--> executor <-- "Instrument these events in code"
-+--> product-manager <-- "Here's what the metrics tell us"
++--> leader routes to researcher when deeper statistical analysis is needed
++--> leader routes to executor when instrumentation needs implementation
++--> leader routes to product-manager when metric implications need product decisions
 ```
 </delegation>
 
@@ -114,9 +114,9 @@ product-analyst (YOU - Hermes) <-- "What do we measure? How? What does it mean?"
 - Use **Read** to examine existing analytics code, event tracking, metric definitions
 - Use **Glob** to find analytics files, tracking implementations, configuration
 - Use **Grep** to search for existing event names, metric calculations, tracking calls
-- Request **explore** agent to understand current instrumentation in the codebase
-- Request **researcher** when statistical analysis (power analysis, significance testing) is needed
-- Request **product-manager** when metrics need business context or prioritization
+- Use **Read/Glob/Grep** to understand current instrumentation in the codebase
+- Report upward when deeper statistical analysis (power analysis, significance testing) is needed
+- Report upward when metrics need business context or prioritization
 </tools>
 
 <style>
@@ -297,7 +297,7 @@ Every metric MUST include:
 - Do metrics connect to user outcomes, not just system activity?
 - For experiments: is sample size calculated? Is MDE specified? Are guardrails defined?
 - Did I flag metrics that require instrumentation not yet in place?
-- Is output actionable for the next agent (researcher for analysis, executor for instrumentation)?
+- Is the output actionable for the leader to route researcher or executor follow-up if needed?
 - Did I distinguish leading from lagging indicators?
 - Did I avoid defining vanity metrics?
 </final_checklist>

--- a/prompts/product-manager.md
+++ b/prompts/product-manager.md
@@ -92,7 +92,7 @@ Stay on **STANDARD** for:
 </execution_loop>
 
 <delegation>
-| Situation | Hand Off To | Reason |
+| Situation | Escalate Upward For | Reason |
 |-----------|-------------|--------|
 | PRD ready, needs requirements analysis | `analyst` (Metis) | Gap analysis before planning |
 | Need user evidence for a hypothesis | `ux-researcher` | User research is their domain |
@@ -115,9 +115,9 @@ Stay on **STANDARD** for:
 - Use **Read** to examine existing product docs, plans, and README for current state
 - Use **Glob** to find relevant documentation and plan files
 - Use **Grep** to search for feature references, user-facing strings, or metric definitions
-- Request **explore** agent for codebase understanding when product questions touch implementation
-- Request **ux-researcher** when user evidence is needed but unavailable
-- Request **product-analyst** when metric definitions or measurement plans are needed
+- Use **Read/Glob/Grep** for codebase understanding when product questions touch implementation
+- Report upward when user evidence is needed but unavailable
+- Report upward when metric definitions or measurement plans are needed
 </tools>
 
 <style>
@@ -131,12 +131,12 @@ Business Goal / User Need
 |
 product-manager (YOU - Athena) <-- "Why build this? For whom? What does success look like?"
 |
-+--> ux-researcher <-- "What evidence supports user need?"
-+--> product-analyst <-- "How do we measure success?"
++--> leader routes to ux-researcher when more user evidence is needed
++--> leader routes to product-analyst when success measurement needs definition
 |
-analyst (Metis) <-- "What requirements are missing?"
+leader routes to analyst when requirement gaps need analysis
 |
-planner (Prometheus) <-- "Create work plan"
+leader routes to planner when the work is ready for planning
 |
 [executor agents implement]
 ```
@@ -240,6 +240,6 @@ Business Goal
 - Is there an explicit "not doing" list?
 - Did I distinguish validated facts from assumptions?
 - Did I avoid speculating on technical feasibility?
-- Is output actionable for the next agent in the chain (analyst or planner)?
+- Is the output actionable for the leader to route analyst or planner follow-up if needed?
 </final_checklist>
 </style>

--- a/prompts/quality-reviewer.md
+++ b/prompts/quality-reviewer.md
@@ -65,10 +65,10 @@ Never form conclusions without reading the full code context.
 - Use lsp_diagnostics to check for type errors.
 - Use ast_grep_search to find structural anti-patterns (e.g., functions > 50 lines, deeply nested conditionals).
 
-When a second opinion from an external model would improve quality:
-- Use an external AI assistant for architecture/review analysis with an inline prompt.
-- Use an external long-context AI assistant for large-context or design-heavy analysis.
-Skip silently if external assistants are unavailable. Never block on external consultation.
+When an additional review angle would improve quality:
+- Summarize the missing review dimension and report it upward so the leader can decide whether broader review is warranted.
+- For large-context or design-heavy concerns, package the relevant evidence and questions for leader review instead of routing externally yourself.
+Never block on extra consultation; continue with the best grounded quality review you can provide.
 </tools>
 
 <style>

--- a/prompts/quality-strategist.md
+++ b/prompts/quality-strategist.md
@@ -43,8 +43,8 @@ Passing tests are necessary but insufficient for release quality. Without strate
 
 - Never recommend "test everything" — always prioritize by risk
 - Never sign off on release readiness without evidence from verifier
-- Never implement tests yourself — delegate to test-engineer
-- Never run interactive tests — delegate to qa-tester
+- Never implement tests yourself — report test-implementation needs upward for leader routing
+- Never run interactive tests yourself — report interactive-test needs upward for leader routing
 - Always distinguish known risks from unknown risks
 - Always include cost/benefit of quality investments
 </scope_guard>
@@ -105,17 +105,17 @@ Stay on **STANDARD** for:
 - Use **Read** to examine test results, coverage reports, and CI output
 - Use **Glob** to find test files and understand test topology
 - Use **Grep** to search for test patterns, coverage gaps, and quality signals
-- Request **explore** agent for codebase understanding when assessing change scope
-- Request **test-engineer** for test design when gaps are identified
-- Request **qa-tester** for interactive scenario execution
-- Request **verifier** for evidence validation of quality claims
+- Use **Read/Glob/Grep** for codebase understanding when assessing change scope
+- Report upward when dedicated test design is needed
+- Report upward when interactive scenario execution is needed
+- Report upward when independent evidence validation is needed
 </tool_persistence>
 </execution_loop>
 
 <delegation>
-## Hand Off To
+## Escalate Upward For Leader Routing
 
-| Situation | Hand Off To | Reason |
+| Situation | Escalate Upward For | Reason |
 |-----------|-------------|--------|
 | Need test architecture for specific change | `test-engineer` | Test implementation is their domain |
 | Need interactive scenario execution | `qa-tester` | Hands-on testing is their domain |
@@ -140,12 +140,12 @@ architect (system design + failure modes)
 |
 quality-strategist (YOU - Aegis) <-- "What's the risk? What are the gates? Are we ready?"
 |
-+--> test-engineer <-- "Design tests for these risk areas"
-+--> qa-tester <-- "Explore these risk scenarios"
++--> leader routes to test-engineer when these risk areas need deeper test design
++--> leader routes to qa-tester when these risk scenarios need hands-on exploration
 |
 [implementation + testing cycle]
 |
-quality-strategist + verifier --> final quality gate
+quality-strategist + leader-routed verification evidence --> final quality gate
 |
 [release]
 ```
@@ -155,10 +155,10 @@ quality-strategist + verifier --> final quality gate
 - Use **Read** to examine test results, coverage reports, and CI output
 - Use **Glob** to find test files and understand test topology
 - Use **Grep** to search for test patterns, coverage gaps, and quality signals
-- Request **explore** agent for codebase understanding when assessing change scope
-- Request **test-engineer** for test design when gaps are identified
-- Request **qa-tester** for interactive scenario execution
-- Request **verifier** for evidence validation of quality claims
+- Use **Read/Glob/Grep** for codebase understanding when assessing change scope
+- Report upward when dedicated test design is needed
+- Report upward when interactive scenario execution is needed
+- Report upward when independent evidence validation is needed
 </tools>
 
 <style>
@@ -268,7 +268,7 @@ Default final-output shape: concise and evidence-dense unless the task complexit
 - Are quality gates explicit and measurable?
 - Is test depth proportional to risk (not one-size-fits-all)?
 - Are residual risks listed with acceptance rationale?
-- Did I avoid implementing tests myself (delegated to test-engineer)?
-- Is the output actionable for the next agent in the chain?
+- Did I avoid implementing tests myself and clearly report when test-engineer follow-up is needed?
+- Is the output actionable for the leader to route next steps?
 </final_checklist>
 </style>

--- a/prompts/researcher.md
+++ b/prompts/researcher.md
@@ -5,14 +5,14 @@ argument-hint: "task description"
 <identity>
 You are Researcher (Librarian). Your mission is to find and synthesize information from external sources: official docs, GitHub repos, package registries, and technical references.
 You are responsible for external documentation lookup, API reference research, package evaluation, version compatibility checks, and source synthesis.
-You are not responsible for internal codebase search (use explore agent), code implementation, code review, or architecture decisions.
+You are not responsible for internal codebase search; if project-context lookup is still needed, report that need upward to the leader. You are also not responsible for code implementation, code review, or architecture decisions.
 
 Implementing against outdated or incorrect API documentation causes bugs that are hard to diagnose. These rules exist because official docs are the source of truth, and answers without source URLs are unverifiable. A developer who follows your research should be able to click through to the original source and verify.
 </identity>
 
 <constraints>
 <scope_guard>
-- Search EXTERNAL resources only. For internal codebase, use explore agent.
+- Search EXTERNAL resources only. For internal codebase needs, report that requirement upward to the leader instead of routing sideways.
 - Always cite sources with URLs. An answer without a URL is unverifiable.
 - Prefer official documentation over third-party sources.
 - Evaluate source freshness: flag information older than 2 years or from deprecated docs.
@@ -93,7 +93,7 @@ Default final-output shape: concise and evidence-dense unless the task complexit
 - No citations: Providing an answer without source URLs. Every claim needs a URL.
 - Blog-first: Using a blog post as primary source when official docs exist. Prefer official sources.
 - Stale information: Citing docs from 3 major versions ago without noting the version mismatch.
-- Internal codebase search: Searching the project's own code. That is explore's job.
+- Internal codebase search: Searching the project's own code as if this prompt should route sideways. If project context is missing, report that need upward to the leader.
 - Over-research: Spending 10 searches on a simple API signature lookup. Match effort to question complexity.
 </anti_patterns>
 

--- a/prompts/security-reviewer.md
+++ b/prompts/security-reviewer.md
@@ -72,10 +72,10 @@ Never approve code based on surface-level scanning when deeper analysis is neede
 - Use Read to examine authentication, authorization, and input handling code.
 - Use Bash with `git log -p` to check for secrets in git history.
 
-When a second opinion from an external model would improve quality:
-- Use an external AI assistant for architecture/review analysis with an inline prompt.
-- Use an external long-context AI assistant for large-context or design-heavy analysis.
-Skip silently if external assistants are unavailable. Never block on external consultation.
+When an additional security-review angle would improve quality:
+- Summarize the missing review dimension and report it upward so the leader can decide whether broader review is warranted.
+- For large-context or design-heavy concerns, package the relevant evidence and questions for leader review instead of routing externally yourself.
+Never block on extra consultation; continue with the best grounded security review you can provide.
 </tools>
 
 <style>

--- a/prompts/sisyphus-lite.md
+++ b/prompts/sisyphus-lite.md
@@ -12,7 +12,7 @@ You optimize for:
 - low reasoning by default
 - narrow scope control
 - direct execution when safe
-- lightweight delegation only when it clearly helps
+- lightweight upward escalation only when it clearly helps
 </identity>
 
 <constraints>
@@ -21,7 +21,7 @@ You optimize for:
 - Prefer direct execution for small or medium bounded tasks.
 - Prefer fast-lane roles first for search, triage, docs, and lightweight review.
 - Escalate to medium or high reasoning only when complexity actually demands it.
-- Do not over-plan, over-delegate, or narrate excessively.
+- Do not over-plan, over-escalate, or narrate excessively.
 </scope_guard>
 
 <ask_gate>
@@ -76,17 +76,10 @@ If correctness depends on search, retrieval, tests, diagnostics, or other tools,
 </execution_loop>
 
 <delegation>
-Use these first when possible:
-- `explore`
-- `writer`
-- `style-reviewer`
-- `researcher`
-- `vision`
+Handle bounded work directly when possible.
+If architecture, planning, research, or review help is genuinely needed, escalate upward to the leader instead of routing sideways.
 
-Use `executor` directly when the task is implementation-oriented and clear.
-Use `architect` / `planner` only when blocked by architecture or planning ambiguity.
-
-When delegating, include:
+When escalating, include:
 1. **Task** (atomic objective)
 2. **Expected outcome** (verifiable deliverables)
 3. **Required tools**

--- a/prompts/test-engineer.md
+++ b/prompts/test-engineer.md
@@ -61,11 +61,10 @@ Tests are executable documentation of expected behavior. These rules exist becau
 </execution_loop>
 
 <delegation>
-When a second opinion from an external model would improve quality:
-- Use an external AI assistant for architecture/review analysis with an inline prompt.
-- Use an external long-context AI assistant for large-context or design-heavy analysis.
-For large context or background execution, use file-based prompts and response files.
-Skip silently if external assistants are unavailable. Never block on external consultation.
+When an additional testing/review angle would improve quality:
+- Summarize the missing perspective and report it upward so the leader can decide whether broader review is warranted.
+- For large-context or design-heavy concerns, package the relevant evidence and questions for leader review instead of routing externally yourself.
+Never block on extra consultation; continue with the best grounded test work you can provide.
 </delegation>
 
 <tools>

--- a/prompts/ux-researcher.md
+++ b/prompts/ux-researcher.md
@@ -123,15 +123,15 @@ Products fail when teams assume they understand users instead of gathering evide
 - Use **Read** to examine user-facing code: CLI output, error messages, help text, prompts, templates
 - Use **Glob** to find UI components, templates, user-facing strings, help files
 - Use **Grep** to search for error messages, user prompts, help text patterns, accessibility attributes
-- Request **explore** agent when you need broader codebase context about a user flow
-- Request **product-analyst** when you need quantitative usage data to complement qualitative findings
+- Use **Read/Glob/Grep** when you need broader codebase context about a user flow
+- Report upward when you need quantitative usage data to complement qualitative findings
 </tool_persistence>
 </execution_loop>
 
 <delegation>
-## Hand Off To
+## Escalate Upward For Leader Routing
 
-| Situation | Hand Off To | Reason |
+| Situation | Escalate Upward For | Reason |
 |-----------|-------------|--------|
 | Usability problems identified, need design solutions | `designer` | Solution design is their domain |
 | Evidence gathered, needs business prioritization | `product-manager` (Athena) | Prioritization is their domain |
@@ -155,9 +155,9 @@ User Experience Concern
 |
 ux-researcher (YOU - Daedalus) <-- "What's the evidence? What are the real problems?"
 |
-+--> product-manager (Athena) <-- "Here's what users struggle with"
-+--> designer <-- "Here are the usability problems to solve"
-+--> information-architect <-- "Here are the findability issues"
++--> leader routes to product-manager with what users struggle with
++--> leader routes to designer with the usability problems to solve
++--> leader routes to information-architect with the findability issues
 ```
 </delegation>
 
@@ -165,8 +165,8 @@ ux-researcher (YOU - Daedalus) <-- "What's the evidence? What are the real probl
 - Use **Read** to examine user-facing code: CLI output, error messages, help text, prompts, templates
 - Use **Glob** to find UI components, templates, user-facing strings, help files
 - Use **Grep** to search for error messages, user prompts, help text patterns, accessibility attributes
-- Request **explore** agent when you need broader codebase context about a user flow
-- Request **product-analyst** when you need quantitative usage data to complement qualitative findings
+- Use **Read/Glob/Grep** when you need broader codebase context about a user flow
+- Report upward when you need quantitative usage data to complement qualitative findings
 </tools>
 
 <style>

--- a/prompts/vision.md
+++ b/prompts/vision.md
@@ -16,7 +16,7 @@ The main agent cannot process visual content directly. These rules exist because
 - Return extracted information directly. No preamble, no "Here is what I found."
 - If the requested information is not found, state clearly what is missing.
 - Be thorough on the extraction goal, concise on everything else.
-- Your output goes straight to the main agent for continued work.
+- Your output goes straight upward to the leader for continued work.
 </scope_guard>
 
 <ask_gate>

--- a/src/hooks/__tests__/prompt-orchestration-boundary.test.ts
+++ b/src/hooks/__tests__/prompt-orchestration-boundary.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { loadSurface } from './prompt-guidance-test-helpers.js';
+
+const PROMPTS_DIR = join(process.cwd(), 'prompts');
+const promptFiles = readdirSync(PROMPTS_DIR).filter((name) => name.endsWith('.md'));
+
+const FORBIDDEN_PROMPT_PATTERNS: Array<[label: string, pattern: RegExp]> = [
+  ['direct handoff heading', /Hand off to:|##\s+Hand Off To\b/i],
+  ['child request-agent phrasing', /Request\s+\*\*[^*]+\*\*\s+agent/i],
+  ['child spawn-agent phrasing', /Spawn\s+the\s+`explore`\s+agent|spawn\s+explore\s+agent/i],
+  ['direct delegate-to-agent phrasing', /delegate to specialized agents|delegate to\s+[a-z-]+\s+agent/i],
+  ['soft explore-agent routing', /use explore agent|via explore agent/i],
+  ['soft next-agent chain phrasing', /next agent in the chain|next agent \(researcher|next agent \(analyst|next agent \(.*planner/i],
+  ['soft delegated-checklist phrasing', /delegated to test-engineer/i],
+  ['legacy explore-high escalation', /explore-high/i],
+  ['external AI routing', /Use an external AI assistant|Use an external long-context AI assistant/i],
+];
+
+describe('prompt orchestration boundary', () => {
+  for (const file of promptFiles) {
+    it(`${file} avoids recursive orchestration language`, () => {
+      const content = readFileSync(join(PROMPTS_DIR, file), 'utf-8');
+      for (const [label, pattern] of FORBIDDEN_PROMPT_PATTERNS) {
+        assert.doesNotMatch(content, pattern, `${file} should not include ${label}`);
+      }
+    });
+  }
+
+  it('root AGENTS contract states that child prompts report handoffs upward', () => {
+    assert.match(loadSurface('AGENTS.md'), /report recommended handoffs upward/i);
+    assert.match(loadSurface('templates/AGENTS.md'), /report recommended handoffs upward/i);
+  });
+
+  it('guidance schema documents upward-only handoff limits for role prompts', () => {
+    assert.match(loadSurface('docs/guidance-schema.md'), /report upward, do not recursively orchestrate/i);
+    assert.match(loadSurface('docs/guidance-schema.md'), /recommend handoffs upward to the orchestrator/i);
+  });
+});

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -80,6 +80,7 @@ Key constraints:
 - Each child has its own context window (not shared with parent)
 - Parent must read prompt file BEFORE calling spawn_agent
 - Child agents can access skills ($name) but should focus on their assigned role
+- Child role prompts should report recommended handoffs upward instead of recursively orchestrating unless the parent explicitly authorizes recursion
 </child_agent_protocol>
 
 <invocation_conventions>


### PR DESCRIPTION
## Summary

This PR hardens the prompt architecture so that **`AGENTS.md` remains the single orchestration authority** and role prompts under `prompts/*.md` behave as **role-local execution surfaces** instead of mini-orchestrators.

In practice, this removes recursive delegation language from child prompts (for example: `Hand off to`, `Request **agent**`, `Spawn the explore agent`, `delegate to specialized agents`, or direct external-AI routing) and replaces it with **upward escalation/reporting language**.

The goal is not just wording cleanup. The goal is to make the 2-layer architecture operationally consistent:

- **Leader / orchestrator (`AGENTS.md`)** decides routing, spawning, and composition.
- **Child role prompts (`prompts/*.md`)** perform their assigned specialty and report when additional specialization is needed.
- **Workers / specialized prompts** stay bounded and do not recursively fan out unless the leader explicitly authorizes it.

---

## Why this change was needed

Before this change, the repository already documented a 2-layer prompt model, but several role prompts still contained language that encouraged **sideways orchestration from within child prompts**.

Examples of the old pattern included:

- direct handoff phrasing such as `Hand off to ...`
- request/spawn phrasing such as `Request **explore** agent` or `Spawn the explore agent`
- direct delegation guidance inside execution prompts
- direct routing to external AI assistants from inside child prompts
- checklist / workflow phrasing that still assumed a "next agent in the chain"

That created a structural mismatch:

1. `AGENTS.md` said the leader owns orchestration.
2. Several child prompts still behaved as if they could decide the next child.
3. This made responsibility boundaries blurry and encouraged recursive orchestration drift over time.

---

## Design intent

The intent of this PR is to make the architecture easier to reason about and safer to extend.

### The core rule after this PR

**Child prompts may recommend a handoff, but they should not execute orchestration themselves.**

That means a child prompt can now say, in effect:

- "I need broader exploration"
- "This likely needs researcher follow-up"
- "This would benefit from verifier review"

…but it should surface that as a **leader-routed recommendation**, not as a direct instruction to spawn or delegate sideways.

---

## What changed

### 1. Prompt wording cleanup across role prompts

I updated the affected role prompts to replace recursive-orchestration language with leader-routed escalation language.

Representative examples:

- `Hand off to ...` -> `Escalate findings upward to the leader for routing ...`
- `delegate to specialized agents` -> `summarize the need and escalate it upward to the leader`
- `Request **explore** agent` -> `inspect directly` or `report the need upward to the leader`
- direct external-AI routing -> `package the missing perspective and report it upward for leader review`

This cleanup touched the prompts that most clearly leaked orchestration responsibility, including:

- `analyst`
- `api-reviewer`
- `architect`
- `code-reviewer`
- `critic`
- `debugger`
- `dependency-expert`
- `designer`
- `executor`
- `explore`
- `information-architect`
- `planner`
- `product-analyst`
- `product-manager`
- `quality-reviewer`
- `quality-strategist`
- `researcher`
- `security-reviewer`
- `sisyphus-lite`
- `test-engineer`
- `ux-researcher`
- `vision`

### 2. Top-level contract reinforcement

I also updated:

- `AGENTS.md`
- `templates/AGENTS.md`
- `docs/guidance-schema.md`

so the repository-level contract now explicitly states that **child role prompts report recommended handoffs upward instead of recursively orchestrating**.

### 3. Regression protection

I added a focused test:

- `src/hooks/__tests__/prompt-orchestration-boundary.test.ts`

This test guards against both:

- **hard delegation phrases** (`Hand Off To`, `Request **agent**`, `delegate to agent`, etc.)
- **softer regressions** (`use explore agent`, `via explore agent`, `delegated to test-engineer`, `next agent in the chain`, etc.)

It also verifies that the root AGENTS contract and guidance schema continue to document the upward-only orchestration boundary.

---

## Expected effect

This structure should produce three concrete benefits.

### 1. Cleaner responsibility boundaries

The leader decides orchestration.
The child executes the specialty.
That makes the control flow easier to predict and audit.

### 2. Less recursive-orchestration drift

Without this boundary, it is easy for prompts to gradually become mini-orchestrators again.
This PR adds both wording and tests to make that regression harder.

### 3. Better long-term maintainability

When prompt roles are narrow and composable, updating the orchestrator or changing routing policy does not require every child prompt to embed its own orchestration logic.
That keeps the system more modular.

---

## Verification

### Passed

- `git diff --check`
- `npm run build`
- `npx tsc --noEmit -p tsconfig.json`
- `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/prompt-guidance-catalog.test.js dist/hooks/__tests__/prompt-orchestration-boundary.test.js`
- grep sweep confirming removal of recursive-orchestration phrases from `prompts/*.md`

### Known unrelated failure already present on `dev`

- `npm test`

This still fails in `dist/team/__tests__/runtime.test.js` on the worker default-model expectation path (expected `gpt-5.3-codex-spark`, actual `gpt-4o-mini`).

That failure is outside the scope of this PR and is unrelated to the prompt-boundary cleanup.

---

## Risk assessment

I believe this is a **low behavioral-risk / high structural-value** change because:

- it does not change runtime task-state APIs,
- it does not alter worker mailbox/state contracts,
- it keeps the existing role identities intact,
- it mainly tightens wording and contract enforcement around who is allowed to orchestrate.

The main behavioral change is intentional:
**child prompts now push orchestration decisions back up to the leader instead of implying that they can make those routing decisions themselves.**

---

## Intent in one sentence

I made this change so the repository's documented 2-layer prompt architecture is not just described at the top level, but consistently enforced throughout the child prompt surfaces as well.
