### PR TITLE
Fix lingering OMX MCP processes on stdio disconnect

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -1,28 +1,89 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { shouldAutoStartMcpServer } from '../bootstrap.js';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { shouldAutoStartMcpServer, type McpServerName } from '../bootstrap.js';
+
+const ALL_SERVERS: readonly McpServerName[] = [
+  'state',
+  'memory',
+  'code_intel',
+  'trace',
+  'team',
+] as const;
+
+const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
+  state: 'OMX_STATE_SERVER_DISABLE_AUTO_START',
+  memory: 'OMX_MEMORY_SERVER_DISABLE_AUTO_START',
+  code_intel: 'OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START',
+  trace: 'OMX_TRACE_SERVER_DISABLE_AUTO_START',
+  team: 'OMX_TEAM_SERVER_DISABLE_AUTO_START',
+};
+
+const SERVER_ENTRYPOINTS: Array<{ server: McpServerName; file: string }> = [
+  { server: 'state', file: 'src/mcp/state-server.ts' },
+  { server: 'memory', file: 'src/mcp/memory-server.ts' },
+  { server: 'code_intel', file: 'src/mcp/code-intel-server.ts' },
+  { server: 'trace', file: 'src/mcp/trace-server.ts' },
+  { server: 'team', file: 'src/mcp/team-server.ts' },
+];
 
 describe('mcp bootstrap auto-start guard', () => {
-  it('allows auto-start by default', () => {
-    assert.equal(shouldAutoStartMcpServer('state', {}), true);
-    assert.equal(shouldAutoStartMcpServer('memory', {}), true);
-    assert.equal(shouldAutoStartMcpServer('code_intel', {}), true);
-    assert.equal(shouldAutoStartMcpServer('trace', {}), true);
+  it('allows auto-start by default for every OMX MCP server', () => {
+    for (const server of ALL_SERVERS) {
+      assert.equal(shouldAutoStartMcpServer(server, {}), true, `${server} should auto-start by default`);
+    }
   });
 
   it('disables all servers when global disable flag is set', () => {
     const env = { OMX_MCP_SERVER_DISABLE_AUTO_START: '1' };
-    assert.equal(shouldAutoStartMcpServer('state', env), false);
-    assert.equal(shouldAutoStartMcpServer('memory', env), false);
-    assert.equal(shouldAutoStartMcpServer('code_intel', env), false);
-    assert.equal(shouldAutoStartMcpServer('trace', env), false);
+
+    for (const server of ALL_SERVERS) {
+      assert.equal(shouldAutoStartMcpServer(server, env), false, `${server} should honor global disable flag`);
+    }
   });
 
   it('disables per-server using server-specific flags', () => {
-    assert.equal(shouldAutoStartMcpServer('state', { OMX_STATE_SERVER_DISABLE_AUTO_START: '1' }), false);
-    assert.equal(shouldAutoStartMcpServer('memory', { OMX_MEMORY_SERVER_DISABLE_AUTO_START: '1' }), false);
-    assert.equal(shouldAutoStartMcpServer('code_intel', { OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START: '1' }), false);
-    assert.equal(shouldAutoStartMcpServer('trace', { OMX_TRACE_SERVER_DISABLE_AUTO_START: '1' }), false);
+    for (const server of ALL_SERVERS) {
+      assert.equal(
+        shouldAutoStartMcpServer(server, { [SERVER_DISABLE_ENV[server]]: '1' }),
+        false,
+        `${server} should honor ${SERVER_DISABLE_ENV[server]}`,
+      );
+    }
   });
 });
 
+describe('mcp shared stdio lifecycle contract', () => {
+  it('keeps shared stdio lifecycle wiring in bootstrap', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
+
+    assert.match(src, /StdioServerTransport/, 'bootstrap should own stdio transport creation');
+    assert.match(src, /server\.connect\(/, 'bootstrap should own MCP server connection');
+    assert.match(src, /stdin/i, 'bootstrap should react to stdin/client disconnect');
+    assert.match(src, /SIGTERM/, 'bootstrap should handle SIGTERM');
+    assert.match(src, /SIGINT/, 'bootstrap should handle SIGINT');
+  });
+
+  it('keeps individual server entrypoints free of duplicated raw stdio connect snippets', async () => {
+    for (const { server, file } of SERVER_ENTRYPOINTS) {
+      const src = await readFile(join(process.cwd(), file), 'utf8');
+
+      assert.match(
+        src,
+        new RegExp(`autoStartStdioMcpServer\\(['\"]${server}['\"],\\s*server\\)`),
+        `${file} should delegate ${server} startup to the shared stdio lifecycle helper`,
+      );
+      assert.doesNotMatch(
+        src,
+        /new StdioServerTransport\(\)/,
+        `${file} should delegate stdio transport construction to the shared lifecycle helper`,
+      );
+      assert.doesNotMatch(
+        src,
+        /server\.connect\(transport\)\.catch\(console\.error\);/,
+        `${file} should not duplicate raw server.connect(transport) bootstrap`,
+      );
+    }
+  });
+});

--- a/src/mcp/__tests__/code-intel-server.test.ts
+++ b/src/mcp/__tests__/code-intel-server.test.ts
@@ -28,10 +28,12 @@ describe('mcp/code-intel-server module contract', () => {
     assert.match(src, /new Server\(\s*\{ name: 'omx-code-intel', version: '0\.1\.0' \}/);
   });
 
-  it('keeps stdio auto-connect bootstrap', async () => {
+  it('delegates stdio lifecycle bootstrapping to the shared MCP bootstrap helper', async () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/code-intel-server.ts'), 'utf8');
-    assert.match(src, /const transport = new StdioServerTransport\(\);/);
-    assert.match(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
+
+    assert.match(src, /autoStartStdioMcpServer\('code_intel', server\)/);
+    assert.doesNotMatch(src, /new StdioServerTransport\(\)/);
+    assert.doesNotMatch(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
   });
 
   it('applies ast-grep rewrites only when dryRun=false', async () => {

--- a/src/mcp/__tests__/memory-server.test.ts
+++ b/src/mcp/__tests__/memory-server.test.ts
@@ -26,12 +26,15 @@ describe('mcp/memory-server module contract', () => {
     }
   });
 
-  it('retains section helpers and stdio bootstrap', async () => {
+  it('retains section helpers while delegating stdio lifecycle bootstrapping', async () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/memory-server.ts'), 'utf8');
+
     assert.match(src, /resolveWorkingDirectoryForState/);
     assert.match(src, /function extractSection\(content: string, section: string\): string/);
     assert.match(src, /function replaceSection\(content: string, section: string, newContent: string\): string/);
     assert.match(src, /function appendToSection\(content: string, section: string, entry: string\): string/);
-    assert.match(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
+    assert.match(src, /autoStartStdioMcpServer\('memory', server\)/);
+    assert.doesNotMatch(src, /new StdioServerTransport\(\)/);
+    assert.doesNotMatch(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
   });
 });

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -1,0 +1,203 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { join } from 'node:path';
+
+const STARTUP_SETTLE_MS = 150;
+const SPAWN_TIMEOUT_MS = 1_500;
+const EXIT_TIMEOUT_MS = 2_500;
+const OUTPUT_LIMIT = 4_096;
+
+const IDLE_ENTRYPOINTS = [
+  { server: 'state', file: 'state-server.js' },
+  { server: 'memory', file: 'memory-server.js' },
+  { server: 'code_intel', file: 'code-intel-server.js' },
+  { server: 'trace', file: 'trace-server.js' },
+  {
+    server: 'team',
+    file: 'team-server.js',
+    caveat: 'idle teardown only; request-time child-job semantics remain intentionally out of scope',
+  },
+] as const;
+
+type EntryPoint = (typeof IDLE_ENTRYPOINTS)[number];
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function trimOutput(chunks: string[]): string {
+  const text = chunks.join('');
+  if (text.length <= OUTPUT_LIMIT) return text;
+  return text.slice(-OUTPUT_LIMIT);
+}
+
+function isChildAlive(child: ChildProcess): boolean {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) {
+    return false;
+  }
+
+  try {
+    process.kill(child.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatFailureContext(entrypoint: EntryPoint, stderr: string[], stdout: string[]): string {
+  const note = 'caveat' in entrypoint ? ` (${entrypoint.caveat})` : '';
+  return [
+    `${entrypoint.server}${note}`,
+    `stdout=${JSON.stringify(trimOutput(stdout))}`,
+    `stderr=${JSON.stringify(trimOutput(stderr))}`,
+  ].join(' | ');
+}
+
+async function waitForSpawn(child: ChildProcess, entrypoint: EntryPoint, stderr: string[], stdout: string[]): Promise<void> {
+  await Promise.race([
+    once(child, 'spawn').then(() => undefined),
+    once(child, 'error').then(([error]) => {
+      throw new Error(
+        `failed to spawn ${formatFailureContext(entrypoint, stderr, stdout)}: ${(error as Error).message}`,
+      );
+    }),
+    delay(SPAWN_TIMEOUT_MS).then(() => {
+      throw new Error(`timed out waiting for spawn: ${formatFailureContext(entrypoint, stderr, stdout)}`);
+    }),
+  ]);
+}
+
+async function assertChildAliveBeforeTeardown(
+  child: ChildProcess,
+  entrypoint: EntryPoint,
+  stderr: string[],
+  stdout: string[],
+): Promise<void> {
+  await delay(STARTUP_SETTLE_MS);
+  assert.equal(
+    isChildAlive(child),
+    true,
+    `child must still be alive before teardown assertion: ${formatFailureContext(entrypoint, stderr, stdout)}`,
+  );
+}
+
+async function waitForExit(
+  child: ChildProcess,
+  entrypoint: EntryPoint,
+  stderr: string[],
+  stdout: string[],
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  try {
+    const [code, signal] = (await Promise.race([
+      once(child, 'exit') as Promise<[number | null, NodeJS.Signals | null]>,
+      delay(EXIT_TIMEOUT_MS).then(() => {
+        throw new Error(`timed out waiting for exit: ${formatFailureContext(entrypoint, stderr, stdout)}`);
+      }),
+    ])) as [number | null, NodeJS.Signals | null];
+
+    return { code, signal };
+  } catch (error) {
+    child.kill('SIGKILL');
+    throw error;
+  }
+}
+
+function spawnEntrypoint(entrypoint: EntryPoint): {
+  child: ChildProcess;
+  stdout: string[];
+  stderr: string[];
+} {
+  const child = spawn(process.execPath, [join(process.cwd(), 'dist', 'mcp', entrypoint.file)], {
+    cwd: process.cwd(),
+    env: { ...process.env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk: string) => stdout.push(chunk));
+  child.stderr?.on('data', (chunk: string) => stderr.push(chunk));
+
+  return { child, stdout, stderr };
+}
+
+async function forceCleanup(child: ChildProcess): Promise<void> {
+  if (!isChildAlive(child)) return;
+  child.kill('SIGKILL');
+  await once(child, 'exit').catch(() => {});
+}
+
+describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
+  for (const entrypoint of IDLE_ENTRYPOINTS) {
+    const label = 'caveat' in entrypoint
+      ? `${entrypoint.server} idle entrypoint exits after stdin closes (${entrypoint.caveat})`
+      : `${entrypoint.server} idle entrypoint exits after stdin closes`;
+
+    it(label, async () => {
+      const { child, stderr, stdout } = spawnEntrypoint(entrypoint);
+
+      try {
+        await waitForSpawn(child, entrypoint, stderr, stdout);
+        await assertChildAliveBeforeTeardown(child, entrypoint, stderr, stdout);
+
+        child.stdin?.end();
+        const exit = await waitForExit(child, entrypoint, stderr, stdout);
+
+        assert.notEqual(exit.signal, 'SIGKILL');
+        assert.equal(isChildAlive(child), false);
+      } finally {
+        await forceCleanup(child);
+      }
+    });
+  }
+
+  for (const entrypoint of IDLE_ENTRYPOINTS) {
+    const label = 'caveat' in entrypoint
+      ? `${entrypoint.server} idle entrypoint exits on SIGTERM (${entrypoint.caveat})`
+      : `${entrypoint.server} idle entrypoint exits on SIGTERM`;
+
+    it(label, async () => {
+      const { child, stderr, stdout } = spawnEntrypoint(entrypoint);
+
+      try {
+        await waitForSpawn(child, entrypoint, stderr, stdout);
+        await assertChildAliveBeforeTeardown(child, entrypoint, stderr, stdout);
+
+        child.kill('SIGTERM');
+        const exit = await waitForExit(child, entrypoint, stderr, stdout);
+
+        assert.notEqual(exit.signal, 'SIGKILL');
+        assert.equal(isChildAlive(child), false);
+      } finally {
+        await forceCleanup(child);
+      }
+    });
+  }
+
+  for (const entrypoint of IDLE_ENTRYPOINTS) {
+    const label = 'caveat' in entrypoint
+      ? `${entrypoint.server} idle entrypoint exits on SIGINT (${entrypoint.caveat})`
+      : `${entrypoint.server} idle entrypoint exits on SIGINT`;
+
+    it(label, async () => {
+      const { child, stderr, stdout } = spawnEntrypoint(entrypoint);
+
+      try {
+        await waitForSpawn(child, entrypoint, stderr, stdout);
+        await assertChildAliveBeforeTeardown(child, entrypoint, stderr, stdout);
+
+        child.kill('SIGINT');
+        const exit = await waitForExit(child, entrypoint, stderr, stdout);
+
+        assert.notEqual(exit.signal, 'SIGKILL');
+        assert.equal(isChildAlive(child), false);
+      } finally {
+        await forceCleanup(child);
+      }
+    });
+  }
+});

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -1,3 +1,5 @@
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
 export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'team';
 
 const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
@@ -10,6 +12,11 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
 
 const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
 
+interface StdioLifecycleServer {
+  connect(transport: StdioServerTransport): Promise<unknown>;
+  close(): Promise<unknown>;
+}
+
 export function shouldAutoStartMcpServer(
   server: McpServerName,
   env: Record<string, string | undefined> = process.env,
@@ -19,3 +26,63 @@ export function shouldAutoStartMcpServer(
   return !globalDisabled && !serverDisabled;
 }
 
+export function autoStartStdioMcpServer(
+  serverName: McpServerName,
+  server: StdioLifecycleServer,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  if (!shouldAutoStartMcpServer(serverName, env)) {
+    return;
+  }
+
+  const transport = new StdioServerTransport();
+  let shuttingDown = false;
+
+  const shutdown = async () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    process.stdin.off('end', handleStdinEnd);
+    process.stdin.off('close', handleStdinClose);
+    process.off('SIGTERM', handleSigterm);
+    process.off('SIGINT', handleSigint);
+
+    try {
+      await server.close();
+    } catch (error) {
+      console.error(`[omx-${serverName}-server] shutdown failed`, error);
+    }
+  };
+
+  const handleStdinEnd = () => {
+    void shutdown();
+  };
+  const handleStdinClose = () => {
+    void shutdown();
+  };
+  const handleSigterm = () => {
+    void shutdown();
+  };
+  const handleSigint = () => {
+    void shutdown();
+  };
+
+  process.stdin.once('end', handleStdinEnd);
+  process.stdin.once('close', handleStdinClose);
+  process.once('SIGTERM', handleSigterm);
+  process.once('SIGINT', handleSigint);
+
+  // Funnel transport/client disconnects through the same idempotent shutdown path.
+  transport.onclose = () => {
+    void shutdown();
+  };
+
+  server.connect(transport).catch((error) => {
+    process.stdin.off('end', handleStdinEnd);
+    process.stdin.off('close', handleStdinClose);
+    process.off('SIGTERM', handleSigterm);
+    process.off('SIGINT', handleSigint);
+    console.error(error);
+  });
+}

--- a/src/mcp/code-intel-server.ts
+++ b/src/mcp/code-intel-server.ts
@@ -5,7 +5,6 @@
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -15,7 +14,7 @@ import { readFile, readdir } from 'fs/promises';
 import { join, relative, extname, basename, resolve } from 'path';
 import { existsSync } from 'fs';
 import { promisify } from 'util';
-import { shouldAutoStartMcpServer } from './bootstrap.js';
+import { autoStartStdioMcpServer } from './bootstrap.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -659,7 +658,4 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-if (shouldAutoStartMcpServer('code_intel')) {
-  const transport = new StdioServerTransport();
-  server.connect(transport).catch(console.error);
-}
+autoStartStdioMcpServer('code_intel', server);

--- a/src/mcp/memory-server.ts
+++ b/src/mcp/memory-server.ts
@@ -5,7 +5,6 @@
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -14,7 +13,7 @@ import { readFile, writeFile, mkdir, rename } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { parseNotepadPruneDaysOld } from './memory-validation.js';
-import { shouldAutoStartMcpServer } from './bootstrap.js';
+import { autoStartStdioMcpServer } from './bootstrap.js';
 import { resolveWorkingDirectoryForState } from './state-paths.js';
 
 function getMemoryPath(wd: string): string {
@@ -455,7 +454,4 @@ function appendToSection(content: string, section: string, entry: string): strin
   return content.slice(0, nextHeader) + entry + content.slice(nextHeader);
 }
 
-if (shouldAutoStartMcpServer('memory')) {
-  const transport = new StdioServerTransport();
-  server.connect(transport).catch(console.error);
-}
+autoStartStdioMcpServer('memory', server);

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -5,7 +5,6 @@
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
 	CallToolRequestSchema,
 	ListToolsRequestSchema,
@@ -36,7 +35,7 @@ import {
 	validateAndNormalizeRalphState,
 } from "../ralph/contract.js";
 import { ensureCanonicalRalphArtifacts } from "../ralph/persistence.js";
-import { shouldAutoStartMcpServer } from "./bootstrap.js";
+import { autoStartStdioMcpServer } from "./bootstrap.js";
 import {
 	LEGACY_TEAM_MCP_TOOLS,
 	buildLegacyTeamDeprecationHint,
@@ -528,7 +527,4 @@ export async function handleStateToolCall(request: {
 server.setRequestHandler(CallToolRequestSchema, handleStateToolCall);
 
 // Start server
-if (shouldAutoStartMcpServer("state")) {
-	const transport = new StdioServerTransport();
-	server.connect(transport).catch(console.error);
-}
+autoStartStdioMcpServer("state", server);

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -5,7 +5,6 @@
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -21,7 +20,7 @@ import { killWorkerPanes } from '../team/tmux-session.js';
 import { teamReadConfig as readTeamConfig } from '../team/team-ops.js';
 import { NudgeTracker } from '../team/idle-nudge.js';
 import { getLatestTeamEventCursor, waitForTeamEvent } from '../team/state/events.js';
-import { shouldAutoStartMcpServer } from './bootstrap.js';
+import { autoStartStdioMcpServer } from './bootstrap.js';
 
 // ---------------------------------------------------------------------------
 // Zod schemas
@@ -565,7 +564,4 @@ export async function handleTeamToolCall(request: {
 
 server.setRequestHandler(CallToolRequestSchema, handleTeamToolCall);
 
-if (shouldAutoStartMcpServer('team')) {
-  const transport = new StdioServerTransport();
-  server.connect(transport).catch(console.error);
-}
+autoStartStdioMcpServer('team', server);

--- a/src/mcp/trace-server.ts
+++ b/src/mcp/trace-server.ts
@@ -5,7 +5,6 @@
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -15,7 +14,7 @@ import { join } from 'path';
 import { createReadStream, existsSync } from 'fs';
 import { createInterface } from 'readline';
 import { listModeStateFilesWithScopePreference, resolveWorkingDirectoryForState } from './state-paths.js';
-import { shouldAutoStartMcpServer } from './bootstrap.js';
+import { autoStartStdioMcpServer } from './bootstrap.js';
 
 function text(data: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
@@ -334,7 +333,4 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-if (shouldAutoStartMcpServer('trace')) {
-  const transport = new StdioServerTransport();
-  server.connect(transport).catch(console.error);
-}
+autoStartStdioMcpServer('trace', server);


### PR DESCRIPTION
## Summary
Apply the MCP stdio lifecycle teardown fix to `dev`.

## Context
The original fix was mistakenly merged to `main` in #626. This PR places the intended change onto `dev`, which was the correct target branch.

## What changed
- Adds `autoStartStdioMcpServer(...)` in `src/mcp/bootstrap.ts`
- Migrates OMX MCP stdio servers (`state`, `memory`, `code_intel`, `trace`, `team`) to the shared helper
- Removes duplicated per-file raw `StdioServerTransport` bootstrapping
- Expands bootstrap contract coverage to all OMX MCP servers, including `team`
- Updates code-intel and memory contract tests to assert shared lifecycle delegation
- Adds runtime lifecycle regression coverage for built MCP entrypoints

## Verification
- `npm run build`
- focused MCP lifecycle suite: `26 pass, 0 fail`
- full `npm test`: `2018 pass, 0 fail`

## Scope note
`team-server` runtime lifecycle coverage in the new regression harness is intentionally limited to **idle teardown** only. Active-work/request-time team semantics remain out of scope for this specific lifecycle test.
