### PR TITLE
Fix npm global omx bin contract for issue #630

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "omx": "bin/omx.js"
+    "omx": "./bin/omx.js"
   },
   "scripts": {
     "build": "tsc",

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+type PackageJson = {
+  bin?: string | Record<string, string>;
+};
+
+type NpmPackDryRunFile = {
+  path: string;
+  mode?: number;
+};
+
+type NpmPackDryRunResult = {
+  files?: NpmPackDryRunFile[];
+};
+
+describe('package bin contract', () => {
+  it('declares omx with an explicit relative bin path and ships an executable wrapper', () => {
+    const packageJsonPath = join(process.cwd(), 'package.json');
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+
+    assert.deepEqual(pkg.bin, { omx: './bin/omx.js' });
+
+    const binPath = join(process.cwd(), 'bin', 'omx.js');
+    assert.equal(existsSync(binPath), true, 'expected bin/omx.js to exist');
+
+    const binSource = readFileSync(binPath, 'utf-8');
+    assert.match(binSource, /^#!\/usr\/bin\/env node/);
+
+    const stat = statSync(binPath);
+    assert.notEqual(stat.mode & 0o111, 0, 'expected bin/omx.js to be executable');
+
+    const packed = spawnSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+    });
+
+    assert.equal(packed.status, 0, packed.stderr || packed.stdout);
+
+    const results = JSON.parse(packed.stdout) as NpmPackDryRunResult[];
+    assert.equal(Array.isArray(results), true, 'expected npm pack --json array output');
+
+    const binEntry = results[0]?.files?.find((file) => file.path === 'bin/omx.js');
+    assert.ok(binEntry, 'expected npm pack output to include bin/omx.js');
+    assert.notEqual((binEntry.mode ?? 0) & 0o111, 0, 'expected packed bin/omx.js to keep execute bits');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize the published npm bin path to `./bin/omx.js`
- add a packaging contract test that verifies the bin declaration, wrapper presence, shebang, execute bits, and `npm pack --dry-run --json` output
- keep the fix scoped to the npm/global-install bin contract reported in #630

## Verification
- `npx biome lint src/cli/__tests__/package-bin-contract.test.ts package.json`
- `npm run build`
- `node --test dist/cli/__tests__/package-bin-contract.test.js`
- `npm test`
- packed install smoke: `npm pack` + `npm install -g --prefix <tmp> ./oh-my-codex-0.8.6.tgz` → `<tmp>/prefix/bin/omx -> ../lib/node_modules/oh-my-codex/bin/omx.js`

Closes #630.
