### PR TITLE
feat: add built-in anti-slop workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,16 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 <!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>
 
+## Working agreements
+- Write a cleanup plan before modifying code for cleanup/refactor/deslop work.
+- Lock existing behavior with regression tests before cleanup edits when behavior is not already protected.
+- Prefer deletion over addition.
+- Reuse existing utils and patterns before introducing new abstractions.
+- No new dependencies without explicit request.
+- Keep diffs small, reviewable, and reversible.
+- Run lint, typecheck, tests, and static analysis after changes.
+- Final reports must include changed files, simplifications made, and remaining risks.
+
 ---
 
 <delegation_rules>
@@ -160,6 +170,7 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
 | "ultraqa" | `$ultraqa` | Read `~/.agents/skills/ultraqa/SKILL.md`, run QA cycling workflow |
+| "anti-slop", "cleanup", "refactor", "deslop" | `$ai-slop-cleaner` | Read `~/.agents/skills/ai-slop-cleaner/SKILL.md`, run the tests-first anti-slop cleanup workflow |
 | "analyze", "investigate" | `$analyze` | Read `~/.agents/skills/analyze/SKILL.md`, run deep analysis |
 | "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
 | "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
@@ -202,6 +213,7 @@ Workflow Skills:
 - `team`: N coordinated agents on shared task list
 - `swarm`: N coordinated agents on shared task list (compatibility facade over team)
 - `ultraqa`: QA cycling -- test, verify, fix, repeat
+- `ai-slop-cleaner`: Tests-first anti-slop cleanup workflow with cleanup planning, smell-by-smell passes, and reviewer separation
 - `plan`: Strategic planning with optional RALPLAN-DR consensus mode
 - `deep-interview`: Socratic deep interview with Ouroboros-inspired mathematical ambiguity gating before execution
 - `ralplan`: Iterative consensus planning with RALPLAN-DR structured deliberation (planner + architect + critic); supports `--deliberate` for high-risk work
@@ -217,6 +229,7 @@ Agent Shortcuts:
 - `git-master` -> git-master: Git commit and history management
 
 Utilities:
+- `review`: Reviewer-only pass for existing plans or cleanup artifacts; use a separate reviewer context and never self-approve
 - `cancel`: Cancel active execution modes
 - `note`: Save notes for session persistence
 - `doctor`: Diagnose installation issues
@@ -311,6 +324,14 @@ Parallelization:
 - Prefer Team mode as the primary parallel execution surface. Use ad hoc parallelism only when Team overhead is disproportionate to the task.
 - If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
 - When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
+
+Anti-slop workflow:
+- For cleanup/refactor/deslop requests, route through `$ai-slop-cleaner` unless the user explicitly requests a different workflow.
+- Lock behavior with regression tests first, then write a cleanup plan before code changes.
+- Categorize issues (duplication, dead code, needless abstraction, boundary violations, missing tests) and execute one smell-focused pass at a time.
+- Prefer deletion, reuse, and boundary repair over new layers or dependencies.
+- Minimum cleanup quality gates: lint -> typecheck -> relevant unit/integration tests -> static/security scan when available.
+- Use writer/reviewer pass separation for plans, cleanup proposals, and approval: the context/agent that writes the change or plan must not be the final reviewer or approver.
 
 Visual iteration gate:
 - For visual tasks (reference image(s) + generated screenshot), run `$visual-verdict` every iteration before the next edit.

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ai-slop-cleaner
+description: Run an anti-slop cleanup/refactor/deslop workflow
+---
+
+# AI Slop Cleaner Skill
+
+Reduce AI-generated slop with a regression-tests-first, smell-by-smell cleanup workflow that preserves behavior and raises signal quality.
+
+## When to Use
+
+Use this skill when:
+- A code path works but feels bloated, noisy, repetitive, or over-abstracted
+- A user asks to “cleanup”, “refactor”, or “deslop” AI-generated output
+- Follow-up implementation left duplicate code, dead code, weak boundaries, missing tests, or unnecessary wrapper layers
+- You need a disciplined cleanup workflow without broad rewrites
+
+## GPT-5.4 Guidance Alignment
+
+- Keep outputs concise and evidence-dense unless risk or the user requests more detail.
+- Treat newer user instructions as local workflow updates without discarding earlier non-conflicting constraints.
+- Keep using inspection, tests, diagnostics, and verification until the cleanup is grounded.
+- Proceed automatically through clear, reversible cleanup steps; ask only when a choice materially changes scope or behavior.
+
+## Procedure
+
+1. **Lock behavior with regression tests first**
+   - Identify the behavior that must not change
+   - Add or run targeted regression tests before editing cleanup candidates
+   - If behavior is currently untested, create the narrowest test coverage needed first
+
+2. **Create a cleanup plan before code**
+   - List the specific smells to remove
+   - Bound the pass to the requested files/scope
+   - Order fixes from safest/highest-signal to riskiest
+   - Do not start coding until the cleanup plan is explicit
+
+3. **Categorize issues before editing**
+   - **Duplication** — repeated logic, copy-paste branches, redundant helpers
+   - **Dead code** — unused code, unreachable branches, stale flags, debug leftovers
+   - **Needless abstraction** — pass-through wrappers, speculative indirection, single-use helper layers
+   - **Boundary violations** — hidden coupling, leaky responsibilities, wrong-layer imports or side effects
+   - **Missing tests** — behavior not locked, weak regression coverage, gaps around edge cases
+
+4. **Execute passes one smell at a time**
+   - **Pass 1: Dead code deletion**
+   - **Pass 2: Duplicate removal**
+   - **Pass 3: Naming/error handling cleanup**
+   - **Pass 4: Test reinforcement**
+   - Re-run targeted verification after each pass
+   - Avoid bundling unrelated refactors into the same edit set
+
+5. **Run quality gates**
+   - Regression tests stay green
+   - Lint passes
+   - Typecheck passes
+   - Relevant unit/integration tests pass
+   - Static/security scan passes when available
+   - Diff stays minimal and scoped
+   - No new abstractions or dependencies unless explicitly required
+
+6. **Finish with an evidence-dense report**
+   - Changed files
+   - Simplifications made
+   - Tests/diagnostics/build checks run
+   - Remaining risks
+   - Residual follow-ups or consciously deferred cleanup
+
+## Output Format
+
+```text
+AI SLOP CLEANUP REPORT
+======================
+
+Scope: [files or feature area]
+Behavior Lock: [targeted regression tests added/run]
+Cleanup Plan: [bounded smells and order]
+
+Passes Completed:
+1. Pass 1: Dead code deletion - [concise fix]
+2. Pass 2: Duplicate removal - [concise fix]
+3. Pass 3: Naming/error handling cleanup - [concise fix]
+4. Pass 4: Test reinforcement - [concise fix]
+
+Quality Gates:
+- Regression tests: PASS/FAIL
+- Lint: PASS/FAIL
+- Typecheck: PASS/FAIL
+- Tests: PASS/FAIL
+- Static/security scan: PASS/FAIL or N/A
+
+Changed Files:
+- [path] - [simplification]
+
+Remaining Risks:
+- [none or short deferred item]
+```
+
+## Scenario Examples
+
+**Good:** The user says `continue` after tests already lock behavior and the next smell pass is clear. Continue with the next bounded cleanup pass.
+
+**Good:** The user narrows the scope to a specific file after planning. Keep the regression-tests-first workflow, but apply the new scope locally.
+
+**Bad:** Start rewriting architecture before protecting behavior with tests.
+
+**Bad:** Collapse multiple smell categories into one large refactor with no intermediate verification.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -108,9 +108,12 @@ Jumping into code without understanding requirements leads to rework, scope cree
 
 ### Review Mode (`--review`)
 
+0. Treat review as a reviewer-only pass. The context that wrote the plan, cleanup proposal, or diff MUST NOT be the context that approves it.
 1. Read plan file from `.omx/plans/`
 2. Evaluate via Critic using `ask_codex` with `agent_role: "critic"`
-3. Return verdict: APPROVED, REVISE (with specific feedback), or REJECT (replanning required)
+3. For cleanup/refactor/anti-slop work, verify that the artifact includes a cleanup plan, regression tests or an explicit test gap, smell-by-smell passes, and quality gates.
+4. Return verdict: APPROVED, REVISE (with specific feedback), or REJECT (replanning required)
+5. If the current context authored the artifact, hand the review to `/review`, `critic`, `quality-reviewer`, `security-reviewer`, or `verifier` as appropriate.
 
 ### Plan Output Format
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: review
-description: Alias for /plan --review
+description: Reviewer-only pass for /plan --review and cleanup artifact review
 ---
 
-# Review (Plan Review Alias)
+# Review (Reviewer-Only Pass)
 
-Review is a shorthand alias for `/plan --review`. It triggers Critic evaluation of an existing plan.
+Review is a shorthand alias for `/plan --review`. It triggers Critic evaluation of an existing plan and is intended to preserve writer/reviewer separation.
 
 ## Usage
 
@@ -23,8 +23,16 @@ This skill invokes the Plan skill in review mode:
 ```
 
 The review workflow:
-1. Read plan file from `.omx/plans/` (or specified path)
-2. Evaluate via Critic agent
-3. Return verdict: APPROVED, REVISE (with specific feedback), or REJECT (replanning required)
+1. Treat review as a reviewer-only pass. The authoring context may write the plan or cleanup proposal, but a separate reviewer context must issue the verdict.
+2. Read plan file from `.omx/plans/` (or specified path)
+3. Evaluate via Critic agent
+4. For cleanup/refactor/anti-slop work, confirm the artifact includes a cleanup plan, regression-test coverage or an explicit test gap, bounded smell-by-smell passes, and quality gates.
+5. Return verdict: APPROVED, REVISE (with specific feedback), or REJECT (replanning required)
+
+## Guardrails
+
+- Never write and approve in the same context.
+- If the current context authored the artifact, hand review to Critic or another reviewer role.
+- Approval must cite concrete evidence, not author claims.
 
 Follow the Plan skill's full documentation for review mode details.

--- a/src/catalog/__tests__/generator.test.ts
+++ b/src/catalog/__tests__/generator.test.ts
@@ -42,6 +42,7 @@ describe('catalog reader/contract', () => {
     assert.ok(contract.coreSkills.includes('autopilot'));
     assert.ok(contract.skills.some((s) => s.name === 'ask-claude' && s.status === 'active'));
     assert.ok(contract.skills.some((s) => s.name === 'ask-gemini' && s.status === 'active'));
+    assert.ok(contract.skills.some((s) => s.name === 'ai-slop-cleaner' && s.status === 'active'));
   });
 
   it('template manifest can be synced from source manifest', async () => {

--- a/src/catalog/__tests__/schema.test.ts
+++ b/src/catalog/__tests__/schema.test.ts
@@ -67,4 +67,12 @@ describe('catalog schema', () => {
     assert.equal(askClaude?.status, 'active');
     assert.equal(askGemini?.status, 'active');
   });
+
+  it('includes ai-slop-cleaner as an active built-in skill', () => {
+    const parsed = validateCatalogManifest(readSourceManifest());
+    const aiSlopCleaner = parsed.skills.find((skill) => skill.name === 'ai-slop-cleaner');
+
+    assert.equal(aiSlopCleaner?.category, 'shortcut');
+    assert.equal(aiSlopCleaner?.status, 'active');
+  });
 });

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-03-06T00:19:14.230Z",
+  "generatedAt": "2026-03-08T08:08:24.819Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 38,
+    "skillCount": 39,
     "promptCount": 29,
-    "activeSkillCount": 22,
+    "activeSkillCount": 23,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -118,6 +118,13 @@
       "category": "shortcut",
       "status": "alias",
       "canonical": "build-fixer",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "ai-slop-cleaner",
+      "category": "shortcut",
+      "status": "active",
       "core": false,
       "internalRequired": false
     },

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -86,6 +86,11 @@
       "canonical": "build-fixer"
     },
     {
+      "name": "ai-slop-cleaner",
+      "category": "shortcut",
+      "status": "active"
+    },
+    {
       "name": "code-review",
       "category": "shortcut",
       "status": "active",

--- a/src/hooks/__tests__/anti-slop-workflow.test.ts
+++ b/src/hooks/__tests__/anti-slop-workflow.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../../../');
+
+function read(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf-8');
+}
+
+describe('anti-slop workflow surfaces', () => {
+  it('adds anti-slop working agreements to root and template AGENTS', () => {
+    for (const file of ['AGENTS.md', 'templates/AGENTS.md']) {
+      const content = read(file);
+      assert.match(content, /## Working agreements/);
+      assert.match(content, /Write a cleanup plan before modifying code/i);
+      assert.match(content, /Lock existing behavior with regression tests/i);
+      assert.match(content, /Prefer deletion over addition/i);
+      assert.match(content, /No new dependencies without explicit request/i);
+      assert.match(content, /Run lint, typecheck, tests, and static analysis/i);
+      assert.match(content, /\$ai-slop-cleaner/);
+      assert.match(content, /writer\/reviewer pass separation/i);
+    }
+  });
+
+  it('documents reviewer-only separation in review and plan review mode', () => {
+    const reviewSkill = read('skills/review/SKILL.md');
+    const planSkill = read('skills/plan/SKILL.md');
+
+    assert.match(reviewSkill, /reviewer-only pass/i);
+    assert.match(reviewSkill, /Never write and approve in the same context/i);
+    assert.match(reviewSkill, /cleanup\/refactor\/anti-slop/i);
+
+    assert.match(planSkill, /### Review Mode \(`--review`\)/);
+    assert.match(planSkill, /reviewer-only pass/i);
+    assert.match(planSkill, /MUST NOT be the context that approves it/i);
+    assert.match(planSkill, /cleanup plan, regression tests/i);
+  });
+
+  it('defines the built-in ai-slop-cleaner workflow', () => {
+    const skill = read('skills/ai-slop-cleaner/SKILL.md');
+    assert.match(skill, /regression tests first/i);
+    assert.match(skill, /cleanup plan/i);
+    assert.match(skill, /duplication/i);
+    assert.match(skill, /dead code/i);
+    assert.match(skill, /needless abstraction/i);
+    assert.match(skill, /boundary violations/i);
+    assert.match(skill, /Pass 1: Dead code deletion/i);
+    assert.match(skill, /Pass 2: Duplicate removal/i);
+    assert.match(skill, /Pass 3: Naming\/error handling cleanup/i);
+    assert.match(skill, /Pass 4: Test reinforcement/i);
+    assert.match(skill, /quality gates/i);
+    assert.match(skill, /remaining risks/i);
+  });
+});

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -36,6 +36,16 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 <!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>
 
+## Working agreements
+- Write a cleanup plan before modifying code for cleanup/refactor/deslop work.
+- Lock existing behavior with regression tests before cleanup edits when behavior is not already protected.
+- Prefer deletion over addition.
+- Reuse existing utils and patterns before introducing new abstractions.
+- No new dependencies without explicit request.
+- Keep diffs small, reviewable, and reversible.
+- Run lint, typecheck, tests, and static analysis after changes.
+- Final reports must include changed files, simplifications made, and remaining risks.
+
 ---
 
 <delegation_rules>
@@ -160,6 +170,7 @@ Do not ask for confirmation — just read the skill file and follow its instruct
 | "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
 | "ultraqa" | `$ultraqa` | Read `~/.agents/skills/ultraqa/SKILL.md`, run QA cycling workflow |
+| "anti-slop", "cleanup", "refactor", "deslop" | `$ai-slop-cleaner` | Read `~/.agents/skills/ai-slop-cleaner/SKILL.md`, run the tests-first anti-slop cleanup workflow |
 | "analyze", "investigate" | `$analyze` | Read `~/.agents/skills/analyze/SKILL.md`, run deep analysis |
 | "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
 | "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
@@ -202,6 +213,7 @@ Workflow Skills:
 - `team`: N coordinated agents on shared task list
 - `swarm`: N coordinated agents on shared task list (compatibility facade over team)
 - `ultraqa`: QA cycling -- test, verify, fix, repeat
+- `ai-slop-cleaner`: Tests-first anti-slop cleanup workflow with cleanup planning, smell-by-smell passes, and reviewer separation
 - `plan`: Strategic planning with optional RALPLAN-DR consensus mode
 - `deep-interview`: Socratic deep interview with Ouroboros-inspired mathematical ambiguity gating before execution
 - `ralplan`: Iterative consensus planning with RALPLAN-DR structured deliberation (planner + architect + critic); supports `--deliberate` for high-risk work
@@ -217,6 +229,7 @@ Agent Shortcuts:
 - `git-master` -> git-master: Git commit and history management
 
 Utilities:
+- `review`: Reviewer-only pass for existing plans or cleanup artifacts; use a separate reviewer context and never self-approve
 - `cancel`: Cancel active execution modes
 - `note`: Save notes for session persistence
 - `doctor`: Diagnose installation issues
@@ -311,6 +324,14 @@ Parallelization:
 - Prefer Team mode as the primary parallel execution surface. Use ad hoc parallelism only when Team overhead is disproportionate to the task.
 - If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.
 - When correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
+
+Anti-slop workflow:
+- For cleanup/refactor/deslop requests, route through `$ai-slop-cleaner` unless the user explicitly requests a different workflow.
+- Lock behavior with regression tests first, then write a cleanup plan before code changes.
+- Categorize issues (duplication, dead code, needless abstraction, boundary violations, missing tests) and execute one smell-focused pass at a time.
+- Prefer deletion, reuse, and boundary repair over new layers or dependencies.
+- Minimum cleanup quality gates: lint -> typecheck -> relevant unit/integration tests -> static/security scan when available.
+- Use writer/reviewer pass separation for plans, cleanup proposals, and approval: the context/agent that writes the change or plan must not be the final reviewer or approver.
 
 Visual iteration gate:
 - For visual tasks (reference image(s) + generated screenshot), run `$visual-verdict` every iteration before the next edit.

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -109,6 +109,13 @@
       "internalRequired": false
     },
     {
+      "name": "ai-slop-cleaner",
+      "category": "shortcut",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "code-review",
       "category": "shortcut",
       "status": "active",


### PR DESCRIPTION
## Summary
- add anti-slop working agreements and cleanup routing to the root/template AGENTS surfaces
- add the built-in `$ai-slop-cleaner` skill and sync catalog manifests/public contract
- strengthen review mode with writer/reviewer separation for plan and cleanup review

## Changes
- AGENTS/template: added working agreements, cleanup/deslop keyword routing, anti-slop workflow guidance, and reviewer-only review guidance
- New skill: `skills/ai-slop-cleaner/SKILL.md`
- Review mode: updated `skills/review/SKILL.md` and `skills/plan/SKILL.md` to require separate reviewer context and anti-slop artifact checks
- Catalog sync: updated source/template manifests and generated public catalog
- Tests: added `src/hooks/__tests__/anti-slop-workflow.test.ts` and catalog assertions

## Verification
- `node --test dist/catalog/__tests__/schema.test.js dist/catalog/__tests__/generator.test.js dist/hooks/__tests__/anti-slop-workflow.test.js dist/hooks/__tests__/consensus-execution-handoff.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js dist/hooks/__tests__/deep-interview-contract.test.js`
- `node scripts/generate-catalog-docs.js --check`
- `npx tsc --noEmit --pretty false --project tsconfig.json` on changed test files via diagnostics MCP: 0 errors
- `npm run build` still fails due to pre-existing MCP dependency/type issues in `src/mcp/*` (`@modelcontextprotocol/sdk` / `zod`), unrelated to this change

Closes #632
