### PR TITLE
fix: lock deep-interview auto-approval injection (#636)

### DIFF
--- a/scripts/notify-hook/auto-nudge.js
+++ b/scripts/notify-hook/auto-nudge.js
@@ -13,11 +13,102 @@ import { logTmuxHookEvent } from './log.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 
 export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
+export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'];
+export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
+const DEEP_INTERVIEW_ERROR_PATTERNS = [' error', ' failed', ' failure', ' exception', 'unable to continue', 'cannot continue', 'could not continue'];
+const DEEP_INTERVIEW_ABORT_PATTERNS = ['aborted', 'cancelled', 'canceled'];
+const DEEP_INTERVIEW_ABORT_INPUTS = new Set(['abort', 'cancel', 'stop']);
 const SKILL_PHASES = new Set(['planning', 'executing', 'reviewing', 'completing']);
 
 function normalizeSkillPhase(phase) {
   const normalized = safeString(phase).toLowerCase().trim();
   return SKILL_PHASES.has(normalized) ? normalized : 'planning';
+}
+
+function normalizeInputLock(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    active: raw.active !== false,
+    scope: safeString(raw.scope),
+    acquired_at: safeString(raw.acquired_at),
+    released_at: safeString(raw.released_at),
+    blocked_inputs: Array.isArray(raw.blocked_inputs)
+      ? raw.blocked_inputs.map((value) => safeString(value).toLowerCase()).filter(Boolean)
+      : [...DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS],
+    message: safeString(raw.message) || DEEP_INTERVIEW_INPUT_LOCK_MESSAGE,
+    exit_reason: safeString(raw.exit_reason),
+  };
+}
+
+export function normalizeBlockedAutoApprovalInput(text) {
+  return safeString(text)
+    .toLowerCase()
+    .replace(/\[omx_tmux_inject\]/gi, '')
+    .replace(/[^a-z]+/g, ' ')
+    .trim();
+}
+
+export function isBlockedAutoApprovalInput(text, blockedInputs = DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS) {
+  const normalized = normalizeBlockedAutoApprovalInput(text);
+  if (!normalized) return false;
+  if (blockedInputs.some((entry) => normalizeBlockedAutoApprovalInput(entry) === normalized)) return true;
+
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return false;
+
+  const blockedTokenSet = new Set(
+    blockedInputs.flatMap((entry) => normalizeBlockedAutoApprovalInput(entry).split(/\s+/).filter(Boolean)),
+  );
+  return tokens.every((token) => blockedTokenSet.has(token));
+}
+
+function isDeepInterviewAbortInput(text) {
+  return DEEP_INTERVIEW_ABORT_INPUTS.has(normalizeBlockedAutoApprovalInput(text));
+}
+
+function hasAnySubstring(text, patterns) {
+  const lower = safeString(text).toLowerCase();
+  return patterns.some((pattern) => lower.includes(pattern));
+}
+
+export function isDeepInterviewAutoApprovalLocked(skillState) {
+  return Boolean(
+    skillState
+    && skillState.skill === 'deep-interview'
+    && skillState.input_lock
+    && (safeString(skillState.input_lock.scope) === '' || skillState.input_lock.scope === 'deep-interview-auto-approval')
+    && skillState.input_lock.active === true,
+  );
+}
+
+export function inferDeepInterviewReleaseReason({ skillState, latestUserInput = '', lastMessage = '' }) {
+  if (!isDeepInterviewAutoApprovalLocked(skillState)) {
+    return null;
+  }
+  if (isDeepInterviewAbortInput(latestUserInput) || hasAnySubstring(lastMessage, DEEP_INTERVIEW_ABORT_PATTERNS)) {
+    return 'abort';
+  }
+  if (hasAnySubstring(` ${safeString(lastMessage).toLowerCase()}`, DEEP_INTERVIEW_ERROR_PATTERNS)) {
+    return 'error';
+  }
+  if (skillState.phase === 'completing') {
+    return 'success';
+  }
+  return null;
+}
+
+function releaseDeepInterviewInputLock(skillState, reason, nowIso) {
+  if (!skillState?.input_lock) return skillState;
+  skillState.input_lock = {
+    ...skillState.input_lock,
+    active: false,
+    released_at: nowIso,
+    exit_reason: reason,
+  };
+  skillState.phase = 'completing';
+  skillState.active = false;
+  skillState.updated_at = nowIso;
+  return skillState;
 }
 
 export function normalizeSkillActiveState(raw) {
@@ -35,6 +126,7 @@ export function normalizeSkillActiveState(raw) {
     activated_at: safeString(raw.activated_at),
     updated_at: safeString(raw.updated_at),
     source: safeString(raw.source),
+    input_lock: normalizeInputLock(raw.input_lock),
   };
 }
 
@@ -66,6 +158,12 @@ async function loadSkillActiveState(stateDir) {
 
 async function persistSkillActiveState(stateDir, state) {
   await writeFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), JSON.stringify(state, null, 2)).catch(() => {});
+}
+
+function latestUserInputFromPayload(payload) {
+  const inputMessages = payload['input-messages'] || payload.input_messages || [];
+  if (!Array.isArray(inputMessages) || inputMessages.length === 0) return '';
+  return safeString(inputMessages[inputMessages.length - 1]);
 }
 
 export const DEFAULT_STALL_PATTERNS = [
@@ -134,15 +232,11 @@ export async function loadAutoNudgeConfig() {
 
 export function detectStallPattern(text, patterns) {
   if (!text || typeof text !== 'string') return false;
-  // Broader tail window (~800 chars / ~15-20 lines) for context
   const tail = text.slice(-800).toLowerCase();
   const lowerPatterns = patterns.map(p => p.toLowerCase());
-  // Focus on last few lines where stall prompts typically appear
   const lines = tail.split('\n').filter(l => l.trim());
   const hotZone = lines.slice(-3).join('\n');
-  // Primary: check last few lines (highest signal)
   if (lowerPatterns.some(p => hotZone.includes(p))) return true;
-  // Secondary: check broader tail window
   return lowerPatterns.some(p => tail.includes(p));
 }
 
@@ -158,11 +252,9 @@ export async function capturePane(paneId, lines = 10) {
 }
 
 export async function resolveNudgePaneTarget(stateDir) {
-  // 1. Try TMUX_PANE env var (inherited from the Codex process)
   const envPane = safeString(process.env.TMUX_PANE || '');
   if (envPane) return envPane;
 
-  // 2. Fallback: check active mode states for tmux_pane_id
   try {
     const scopedDirs = await getScopedStateDirsForCurrentSession(stateDir);
     for (const dir of scopedDirs) {
@@ -187,93 +279,111 @@ export async function resolveNudgePaneTarget(stateDir) {
   return '';
 }
 
+async function emitInjectionMessage(paneId, message) {
+  const markedResponse = `${message} ${DEFAULT_MARKER}`;
+  await runProcess('tmux', ['send-keys', '-t', paneId, '-l', markedResponse], 3000);
+  await new Promise(r => setTimeout(r, 100));
+  await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
+  await new Promise(r => setTimeout(r, 100));
+  await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
+}
+
 export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
   const config = await loadAutoNudgeConfig();
   if (!config.enabled) return;
 
-  const skillState = await loadSkillActiveState(stateDir);
   const lastMessage = safeString(payload['last-assistant-message'] || payload.last_assistant_message || '');
-  if (skillState) {
-    const inferredPhase = inferSkillPhaseFromText(lastMessage, skillState.phase);
-    if (inferredPhase !== skillState.phase || skillState.active !== (inferredPhase !== 'completing')) {
+  const latestUserInput = latestUserInputFromPayload(payload);
+  let skillState = await loadSkillActiveState(stateDir);
+  let releaseReason = null;
+
+  try {
+    if (skillState) {
+      const inferredPhase = inferSkillPhaseFromText(lastMessage, skillState.phase);
       skillState.phase = inferredPhase;
       skillState.active = inferredPhase !== 'completing';
       skillState.updated_at = new Date().toISOString();
-      await persistSkillActiveState(stateDir, skillState);
-    }
-  }
-
-  // Check nudge count against session limit
-  const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
-  let nudgeState = await readJsonIfExists(nudgeStatePath, null);
-  if (!nudgeState || typeof nudgeState !== 'object') {
-    nudgeState = { nudgeCount: 0, lastNudgeAt: '' };
-  }
-  const nudgeCount = asNumber(nudgeState.nudgeCount) ?? 0;
-  if (Number.isFinite(config.maxNudgesPerSession) && nudgeCount >= config.maxNudgesPerSession) return;
-
-  // Resolve pane target early (needed for both capture-pane check and sending)
-  const paneId = await resolveNudgePaneTarget(stateDir);
-
-  // Check last assistant message for stall patterns (fast path)
-  let detected = detectStallPattern(lastMessage, config.patterns);
-  let source = 'payload';
-
-  // Fallback: capture the last 10 lines of tmux pane output
-  if (!detected && paneId) {
-    const captured = await capturePane(paneId);
-    detected = detectStallPattern(captured, config.patterns);
-    source = 'capture-pane';
-  }
-
-  // Preserve completion quietness unless we explicitly see a stall phrase.
-  // This handles stale skill-state files that remain in "completing" while
-  // the assistant still asks for permission ("if you want", etc.).
-  if (skillState?.phase === 'completing' && !detected) return;
-
-  if (!detected || !paneId) return;
-
-  // Short delay to let the agent settle before nudging
-  if (config.delaySec > 0) {
-    await new Promise(r => setTimeout(r, config.delaySec * 1000));
-  }
-
-  const nowIso = new Date().toISOString();
-  try {
-    // Send the response text as literal bytes, then submit with double C-m
-    // Codex CLI needs C-m sent twice with a short delay for reliable prompt submission
-    const markedResponse = `${config.response} ${DEFAULT_MARKER}`;
-    await runProcess('tmux', ['send-keys', '-t', paneId, '-l', markedResponse], 3000);
-    await new Promise(r => setTimeout(r, 100));
-    await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
-    await new Promise(r => setTimeout(r, 100));
-    await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
-
-    nudgeState.nudgeCount = nudgeCount + 1;
-    nudgeState.lastNudgeAt = nowIso;
-    await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
-
-    if (skillState && skillState.phase === 'planning') {
-      skillState.phase = 'executing';
-      skillState.active = true;
-      skillState.updated_at = nowIso;
+      releaseReason = inferDeepInterviewReleaseReason({ skillState, latestUserInput, lastMessage });
       await persistSkillActiveState(stateDir, skillState);
     }
 
-    await logTmuxHookEvent(logsDir, {
-      timestamp: nowIso,
-      type: 'auto_nudge',
-      pane_id: paneId,
-      response: config.response,
-      source,
-      nudge_count: nudgeState.nudgeCount,
-    });
-  } catch (err) {
-    await logTmuxHookEvent(logsDir, {
-      timestamp: nowIso,
-      type: 'auto_nudge',
-      pane_id: paneId,
-      error: err instanceof Error ? err.message : safeString(err),
-    }).catch(() => {});
+    const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+    let nudgeState = await readJsonIfExists(nudgeStatePath, null);
+    if (!nudgeState || typeof nudgeState !== 'object') {
+      nudgeState = { nudgeCount: 0, lastNudgeAt: '' };
+    }
+    const nudgeCount = asNumber(nudgeState.nudgeCount) ?? 0;
+    if (Number.isFinite(config.maxNudgesPerSession) && nudgeCount >= config.maxNudgesPerSession) return;
+
+    const paneId = await resolveNudgePaneTarget(stateDir);
+
+    let detected = detectStallPattern(lastMessage, config.patterns);
+    let source = 'payload';
+
+    if (!detected && paneId) {
+      const captured = await capturePane(paneId);
+      detected = detectStallPattern(captured, config.patterns);
+      source = 'capture-pane';
+    }
+
+    if (skillState?.phase === 'completing' && !detected) return;
+    if (!detected || !paneId) return;
+
+    const deepInterviewLockActive = isDeepInterviewAutoApprovalLocked(skillState) && !releaseReason;
+    if (deepInterviewLockActive && isBlockedAutoApprovalInput(config.response, skillState.input_lock?.blocked_inputs)) {
+      const blockedMessage = skillState.input_lock?.message || DEEP_INTERVIEW_INPUT_LOCK_MESSAGE;
+      await emitInjectionMessage(paneId, blockedMessage);
+      await logTmuxHookEvent(logsDir, {
+        timestamp: new Date().toISOString(),
+        type: 'auto_nudge_blocked',
+        pane_id: paneId,
+        response: config.response,
+        source,
+        blocked_by: 'deep-interview-lock',
+        message: blockedMessage,
+      }).catch(() => {});
+      return;
+    }
+
+    if (config.delaySec > 0) {
+      await new Promise(r => setTimeout(r, config.delaySec * 1000));
+    }
+
+    const nowIso = new Date().toISOString();
+    try {
+      await emitInjectionMessage(paneId, config.response);
+
+      nudgeState.nudgeCount = nudgeCount + 1;
+      nudgeState.lastNudgeAt = nowIso;
+      await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
+
+      if (skillState && skillState.phase === 'planning') {
+        skillState.phase = 'executing';
+        skillState.active = true;
+        skillState.updated_at = nowIso;
+        await persistSkillActiveState(stateDir, skillState);
+      }
+
+      await logTmuxHookEvent(logsDir, {
+        timestamp: nowIso,
+        type: 'auto_nudge',
+        pane_id: paneId,
+        response: config.response,
+        source,
+        nudge_count: nudgeState.nudgeCount,
+      });
+    } catch (err) {
+      await logTmuxHookEvent(logsDir, {
+        timestamp: nowIso,
+        type: 'auto_nudge',
+        pane_id: paneId,
+        error: err instanceof Error ? err.message : safeString(err),
+      }).catch(() => {});
+    }
+  } finally {
+    if (releaseReason && skillState && isDeepInterviewAutoApprovalLocked(skillState)) {
+      releaseDeepInterviewInputLock(skillState, releaseReason, new Date().toISOString());
+      await persistSkillActiveState(stateDir, skillState).catch(() => {});
+    }
   }
 }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -8,6 +8,8 @@ import {
   detectPrimaryKeyword,
   recordSkillActivation,
   SKILL_ACTIVE_STATE_FILE,
+  DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS,
+  DEEP_INTERVIEW_INPUT_LOCK_MESSAGE,
 } from '../keyword-detector.js';
 import { isUnderspecifiedForExecution, applyRalplanGate } from '../keyword-detector.js';
 import { KEYWORD_TRIGGER_DEFINITIONS } from '../keyword-registry.js';
@@ -227,6 +229,55 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('acquires a deep-interview input lock immediately on activation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'please run a deep interview before planning',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'deep-interview');
+      assert.equal(result.input_lock?.active, true);
+      assert.deepEqual(result.input_lock?.blocked_inputs, [...DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS]);
+      assert.equal(result.input_lock?.message, DEEP_INTERVIEW_INPUT_LOCK_MESSAGE);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('releases the deep-interview input lock on abort via cancel keyword', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-abort-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await recordSkillActivation({
+        stateDir,
+        text: 'please run deep interview',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'abort now',
+        nowIso: '2026-02-25T00:05:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'deep-interview');
+      assert.equal(result.active, false);
+      assert.equal(result.phase, 'completing');
+      assert.equal(result.input_lock?.active, false);
+      assert.equal(result.input_lock?.released_at, '2026-02-25T00:05:00.000Z');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('does not write state when no keyword is present', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-none-'));
     const stateDir = join(cwd, '.omx', 'state');
@@ -362,7 +413,9 @@ describe('keyword detector skill-active-state lifecycle', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
 });
+
 
 describe('isUnderspecifiedForExecution', () => {
   it('flags vague prompt with no files or functions', () => {

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -21,6 +21,10 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+function escapeRegex(value: string): string {
+  return value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 /**
  * Build a fake tmux binary that logs all invocations and optionally returns
  * capture-pane content from OMX_TEST_CAPTURE_FILE.
@@ -370,14 +374,13 @@ describe('notify-hook auto-nudge', () => {
     });
   });
 
-  it('still auto-nudges stall phrases when skill-active state is stale completing', async () => {
+  it('acquires the deep-interview input lock when deep-interview activates', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
       const stateDir = join(omxDir, 'state');
       const logsDir = join(omxDir, 'logs');
       const codexHome = join(cwd, 'codex-home');
       const fakeBinDir = join(cwd, 'fake-bin');
-      const tmuxLogPath = join(cwd, 'tmux.log');
 
       await mkdir(logsDir, { recursive: true });
       await mkdir(stateDir, { recursive: true });
@@ -387,103 +390,29 @@ describe('notify-hook auto-nudge', () => {
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
-        version: 1,
-        active: false,
-        skill: 'autopilot',
-        keyword: 'autopilot',
-        phase: 'completing',
-        activated_at: '2026-02-25T00:00:00.000Z',
-        updated_at: '2026-02-25T00:00:00.000Z',
-        source: 'keyword-detector',
-      });
 
-      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'I can finish the cleanup too, if you want.',
+        'input-messages': ['please run a deep interview first'],
+        'last-assistant-message': 'Round 1 | Target: Goal Clarity',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should still nudge when completion phase is stale but message has a stall phrase');
+      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+        skill: string;
+        input_lock?: { active: boolean; blocked_inputs: string[]; message: string };
+      };
+      assert.equal(skillState.skill, 'deep-interview');
+      assert.equal(skillState.input_lock?.active, true);
+      assert.deepEqual(skillState.input_lock?.blocked_inputs, ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead']);
+      assert.match(skillState.input_lock?.message || '', /Deep interview is active/i);
     });
   });
 
-  it('does not auto-nudge for true completion text when skill-active state is completing', async () => {
-    await withTempWorkingDir(async (cwd) => {
-      const omxDir = join(cwd, '.omx');
-      const stateDir = join(omxDir, 'state');
-      const logsDir = join(omxDir, 'logs');
-      const codexHome = join(cwd, 'codex-home');
-      const fakeBinDir = join(cwd, 'fake-bin');
-      const tmuxLogPath = join(cwd, 'tmux.log');
-
-      await mkdir(logsDir, { recursive: true });
-      await mkdir(stateDir, { recursive: true });
-      await mkdir(codexHome, { recursive: true });
-      await mkdir(fakeBinDir, { recursive: true });
-
-      await writeJson(join(codexHome, '.omx-config.json'), {
-        autoNudge: { enabled: true, delaySec: 0 },
-      });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
-        version: 1,
-        active: false,
-        skill: 'autopilot',
-        keyword: 'autopilot',
-        phase: 'completing',
-        activated_at: '2026-02-25T00:00:00.000Z',
-        updated_at: '2026-02-25T00:00:00.000Z',
-        source: 'keyword-detector',
-      });
-
-      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
-      await chmod(join(fakeBinDir, 'tmux'), 0o755);
-
-      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'I completed the refactoring. All tests pass.',
-      });
-      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
-
-      if (existsSync(tmuxLogPath)) {
-        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-        assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l/, 'should remain quiet for true completion text');
-      }
-    });
-  });
-
-  it('detects all default stall patterns case-insensitively', async () => {
-    const patterns = [
-      'If You Want me to make changes',
-      'Would You Like me to continue?',
-      'Shall I proceed with the implementation?',
-      'Next I Can refactor the module for clarity.',
-      'Do You Want Me To apply this fix?',
-      'Let Me Know If you need anything else.',
-      'Want Me To make those changes?',
-      'Let Me Know what you think.',
-      'Just Let Me Know when ready.',
-      'I Can Also refactor the tests.',
-      'I Could Also add more tests if needed.',
-      'READY TO PROCEED with the next step.',
-      'Should I go ahead and deploy?',
-      'Whenever You are ready, I can start.',
-      'Say Go when you are ready.',
-      'Say Yes to confirm the changes.',
-      'Type Continue to proceed with the next step.',
-      "And I'll Continue once you confirm.",
-      "And I'll Proceed with the deployment.",
-      "I'll Keep Driving the implementation forward.",
-      "I'll Keep Pushing on the test coverage.",
-      "I'll Move Forward with the remaining items.",
-      "I'll Drive Forward from here.",
-      "I'll Proceed From Here with the next task.",
-      "I'll Continue From this point onward.",
-    ];
-
-    for (const message of patterns) {
+  for (const blockedResponse of ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead']) {
+    it(`blocks deep-interview auto-approval injection for "${blockedResponse}"`, async () => {
       await withTempWorkingDir(async (cwd) => {
         const omxDir = join(cwd, '.omx');
         const stateDir = join(omxDir, 'state');
@@ -498,23 +427,205 @@ describe('notify-hook auto-nudge', () => {
         await mkdir(fakeBinDir, { recursive: true });
 
         await writeJson(join(codexHome, '.omx-config.json'), {
-          autoNudge: { enabled: true, delaySec: 0 },
+          autoNudge: { enabled: true, delaySec: 0, response: blockedResponse },
+        });
+        await writeJson(join(stateDir, 'skill-active-state.json'), {
+          version: 1,
+          active: true,
+          skill: 'deep-interview',
+          keyword: 'deep interview',
+          phase: 'planning',
+          activated_at: '2026-02-25T00:00:00.000Z',
+          updated_at: '2026-02-25T00:00:00.000Z',
+          source: 'keyword-detector',
+          input_lock: {
+            active: true,
+            scope: 'deep-interview-auto-approval',
+            acquired_at: '2026-02-25T00:00:00.000Z',
+            blocked_inputs: ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'],
+            message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
+          },
         });
 
         await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
         await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
         const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-          'last-assistant-message': message,
+          'last-assistant-message': 'Would you like me to continue?',
         });
-        assert.equal(result.status, 0, `hook failed for pattern "${message}": ${result.stderr || result.stdout}`);
+        assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-        assert.ok(existsSync(tmuxLogPath), `tmux should be called for pattern: "${message}"`);
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-        assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, `should nudge with marker for: "${message}"`);
+        assert.match(tmuxLog, /Deep interview is active; auto-approval shortcuts are blocked until the interview finishes\. \[OMX_TMUX_INJECT\]/);
+        assert.equal(tmuxLog.includes(`send-keys -t %99 -l ${blockedResponse} [OMX_TMUX_INJECT]`), false);
       });
-    }
+    });
+  }
+
+  it('releases the deep-interview input lock on success', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+      await writeJson(join(stateDir, 'skill-active-state.json'), {
+        version: 1,
+        active: true,
+        skill: 'deep-interview',
+        keyword: 'deep interview',
+        phase: 'planning',
+        activated_at: '2026-02-25T00:00:00.000Z',
+        updated_at: '2026-02-25T00:00:00.000Z',
+        source: 'keyword-detector',
+        input_lock: {
+          active: true,
+          scope: 'deep-interview-auto-approval',
+          acquired_at: '2026-02-25T00:00:00.000Z',
+          blocked_inputs: ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'],
+          message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
+        },
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Interview completed. Final summary ready.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase: string;
+        input_lock?: { active: boolean; released_at?: string; exit_reason?: string };
+      };
+      assert.equal(skillState.active, false);
+      assert.equal(skillState.phase, 'completing');
+      assert.equal(skillState.input_lock?.active, false);
+      assert.ok(skillState.input_lock?.released_at);
+      assert.equal(skillState.input_lock?.exit_reason, 'success');
+    });
   });
+
+  it('releases the deep-interview input lock on error', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+      await writeJson(join(stateDir, 'skill-active-state.json'), {
+        version: 1,
+        active: true,
+        skill: 'deep-interview',
+        keyword: 'deep interview',
+        phase: 'planning',
+        activated_at: '2026-02-25T00:00:00.000Z',
+        updated_at: '2026-02-25T00:00:00.000Z',
+        source: 'keyword-detector',
+        input_lock: {
+          active: true,
+          scope: 'deep-interview-auto-approval',
+          acquired_at: '2026-02-25T00:00:00.000Z',
+          blocked_inputs: ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'],
+          message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
+        },
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Deep interview failed with error: unable to continue.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase: string;
+        input_lock?: { active: boolean; released_at?: string; exit_reason?: string };
+      };
+      assert.equal(skillState.active, false);
+      assert.equal(skillState.phase, 'completing');
+      assert.equal(skillState.input_lock?.active, false);
+      assert.ok(skillState.input_lock?.released_at);
+      assert.equal(skillState.input_lock?.exit_reason, 'error');
+    });
+  });
+
+  it('releases the deep-interview input lock on abort', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+      await writeJson(join(stateDir, 'skill-active-state.json'), {
+        version: 1,
+        active: true,
+        skill: 'deep-interview',
+        keyword: 'deep interview',
+        phase: 'planning',
+        activated_at: '2026-02-25T00:00:00.000Z',
+        updated_at: '2026-02-25T00:00:00.000Z',
+        source: 'keyword-detector',
+        input_lock: {
+          active: true,
+          scope: 'deep-interview-auto-approval',
+          acquired_at: '2026-02-25T00:00:00.000Z',
+          blocked_inputs: ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'],
+          message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
+        },
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(join(cwd, 'tmux.log')));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'input-messages': ['abort'],
+        'last-assistant-message': 'Stopping interview now.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+        skill: string;
+        active: boolean;
+        phase: string;
+        input_lock?: { active: boolean; released_at?: string };
+      };
+      assert.equal(skillState.skill, 'deep-interview');
+      assert.equal(skillState.active, false);
+      assert.equal(skillState.phase, 'completing');
+      assert.equal(skillState.input_lock?.active, false);
+      assert.ok(skillState.input_lock?.released_at);
+    });
+  });
+
 
   it('uses custom patterns from config', async () => {
     await withTempWorkingDir(async (cwd) => {

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -254,6 +254,56 @@ describe('notify-hook/auto-nudge – inferSkillPhaseFromText', () => {
   });
 });
 
+describe('notify-hook/auto-nudge – blocked deep-interview auto approvals', () => {
+  it('normalizes injected approval text before matching blocked inputs', async () => {
+    const { normalizeBlockedAutoApprovalInput } = await loadModule('notify-hook/auto-nudge.js');
+    assert.equal(normalizeBlockedAutoApprovalInput(' yes, proceed [OMX_TMUX_INJECT] '), 'yes proceed');
+  });
+
+  it('matches each blocked approval keyword or phrase', async () => {
+    const { isBlockedAutoApprovalInput, DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS } = await loadModule('notify-hook/auto-nudge.js');
+    for (const blocked of DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS) {
+      assert.equal(isBlockedAutoApprovalInput(blocked), true, `expected blocked input ${blocked} to match`);
+    }
+  });
+
+  it('blocks combined yes/proceed injection text', async () => {
+    const { isBlockedAutoApprovalInput } = await loadModule('notify-hook/auto-nudge.js');
+    assert.equal(isBlockedAutoApprovalInput('yes, proceed'), true);
+  });
+
+  it('does not block unrelated responses', async () => {
+    const { isBlockedAutoApprovalInput } = await loadModule('notify-hook/auto-nudge.js');
+    assert.equal(isBlockedAutoApprovalInput('deep interview is active; auto-approval shortcuts are blocked until the interview finishes.'), false);
+  });
+
+  it('infers success/error/abort lock release reasons', async () => {
+    const { inferDeepInterviewReleaseReason } = await loadModule('notify-hook/auto-nudge.js');
+    const baseState = {
+      skill: 'deep-interview',
+      phase: 'planning',
+      input_lock: { active: true },
+    };
+
+    assert.equal(inferDeepInterviewReleaseReason({
+      skillState: { ...baseState, phase: 'completing' },
+      latestUserInput: '',
+      lastMessage: 'Interview summary complete.',
+    }), 'success');
+    assert.equal(inferDeepInterviewReleaseReason({
+      skillState: baseState,
+      latestUserInput: '',
+      lastMessage: 'Interview failed with error: unable to continue.',
+    }), 'error');
+    assert.equal(inferDeepInterviewReleaseReason({
+      skillState: baseState,
+      latestUserInput: 'abort',
+      lastMessage: 'Stopping now.',
+    }), 'abort');
+  });
+});
+
+
 // ---------------------------------------------------------------------------
 // team-worker.js – parseTeamWorkerEnv
 // ---------------------------------------------------------------------------

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -24,6 +24,16 @@ export interface KeywordMatch {
 
 export type SkillActivePhase = 'planning' | 'executing' | 'reviewing' | 'completing';
 
+export interface DeepInterviewInputLock {
+  active: boolean;
+  scope: 'deep-interview-auto-approval';
+  acquired_at: string;
+  released_at?: string;
+  exit_reason?: 'success' | 'error' | 'abort' | 'handoff';
+  blocked_inputs: string[];
+  message: string;
+}
+
 export interface SkillActiveState {
   version: 1;
   active: boolean;
@@ -36,6 +46,7 @@ export interface SkillActiveState {
   session_id?: string;
   thread_id?: string;
   turn_id?: string;
+  input_lock?: DeepInterviewInputLock;
 }
 
 export interface RecordSkillActivationInput {
@@ -48,6 +59,32 @@ export interface RecordSkillActivationInput {
 }
 
 export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
+export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'] as const;
+export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
+
+function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {
+  return {
+    active: true,
+    scope: 'deep-interview-auto-approval',
+    acquired_at: previous?.active ? previous.acquired_at : nowIso,
+    blocked_inputs: [...DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS],
+    message: DEEP_INTERVIEW_INPUT_LOCK_MESSAGE,
+  };
+}
+
+function releaseDeepInterviewInputLock(
+  previous: DeepInterviewInputLock | undefined,
+  nowIso: string,
+  reason: DeepInterviewInputLock['exit_reason'] = 'handoff',
+): DeepInterviewInputLock | undefined {
+  if (!previous) return undefined;
+  return {
+    ...previous,
+    active: false,
+    released_at: nowIso,
+    exit_reason: reason,
+  };
+}
 
 async function readExistingSkillState(statePath: string): Promise<SkillActiveState | null> {
   try {
@@ -182,8 +219,41 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const nowIso = input.nowIso ?? new Date().toISOString();
   const statePath = join(input.stateDir, SKILL_ACTIVE_STATE_FILE);
   const previous = await readExistingSkillState(statePath);
+  const hadDeepInterviewLock = previous?.skill === 'deep-interview' && previous?.input_lock?.active === true;
+  const matches = detectKeywords(input.text);
+  const hasCancelIntent = matches.some((entry) => entry.skill === 'cancel');
+
+  if (hasCancelIntent && hadDeepInterviewLock) {
+    const state: SkillActiveState = {
+      version: 1,
+      active: false,
+      skill: 'deep-interview',
+      keyword: previous?.keyword || 'deep interview',
+      phase: 'completing',
+      activated_at: previous?.activated_at || nowIso,
+      updated_at: nowIso,
+      source: 'keyword-detector',
+      session_id: input.sessionId ?? previous?.session_id,
+      thread_id: input.threadId ?? previous?.thread_id,
+      turn_id: input.turnId ?? previous?.turn_id,
+      ...(previous?.input_lock ? { input_lock: releaseDeepInterviewInputLock(previous.input_lock, nowIso, 'abort') } : {}),
+    };
+
+    try {
+      await writeFile(statePath, JSON.stringify(state, null, 2));
+    } catch (error) {
+      console.warn('[omx] warning: failed to persist keyword activation state', error);
+    }
+
+    return state;
+  }
+
   const sameSkill = previous?.active === true && previous.skill === match.skill;
   const sameKeyword = previous?.keyword?.toLowerCase() === match.keyword.toLowerCase();
+
+  const deepInterviewInputLock = match.skill === 'deep-interview'
+    ? createDeepInterviewInputLock(nowIso, previous?.input_lock)
+    : releaseDeepInterviewInputLock(previous?.input_lock, nowIso);
 
   const state: SkillActiveState = {
     version: 1,
@@ -197,6 +267,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     session_id: input.sessionId,
     thread_id: input.threadId,
     turn_id: input.turnId,
+    ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
   };
 
   try {


### PR DESCRIPTION
## Summary
- acquire a deep-interview input lock immediately via the existing skill-active-state mechanism
- block auto-approval injections while the lock is active and emit a user-facing blocked message instead
- release the lock on success, error, and abort, with terminal cleanup guarded by try/finally

## Testing
- targeted TypeScript diagnostics on modified files
- targeted compiled tests for keyword-detector, notify-hook auto-nudge integration, and notify-hook module helpers

Closes #636