### PR TITLE
fix(pkg): normalize npm bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "omx": "./bin/omx.js"
+    "omx": "bin/omx.js"
   },
   "scripts": {
     "build": "tsc",

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -22,7 +22,7 @@ describe('package bin contract', () => {
     const packageJsonPath = join(process.cwd(), 'package.json');
     const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
 
-    assert.deepEqual(pkg.bin, { omx: './bin/omx.js' });
+    assert.deepEqual(pkg.bin, { omx: 'bin/omx.js' });
 
     const binPath = join(process.cwd(), 'bin', 'omx.js');
     assert.equal(existsSync(binPath), true, 'expected bin/omx.js to exist');


### PR DESCRIPTION
## Summary
- change `package.json` bin entry from `./bin/omx.js` to `bin/omx.js`
- update the package-bin contract test to match the normalized npm bin path
- avoid npm publish auto-correcting and warning on release

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/package-bin-contract.test.js`
- `npm pack --dry-run`

## Context
`oh-my-codex@0.8.7` installs the `omx` CLI correctly after npm normalizes the bin path, but npm warned during publish that the local manifest entry was invalid and removed. This PR aligns the source manifest with the published shape so future releases are clean.