### PR TITLE
fix: keep worker role team-only in AGENTS template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ Work directly only for trivial operations where delegation adds disproportionate
 - Small clarifications, quick status checks, or single-command sequential operations.
 
 For substantive code changes, delegate to `executor` (default for both standard and complex implementation work).
+Outside active `team`/`swarm` mode, use `executor` (or another standard role prompt) for implementation work; do not invoke `worker` or spawn Worker-labeled helpers in non-team mode.
+Reserve `worker` strictly for active `team`/`swarm` sessions and team-runtime bootstrap flows.
 For non-trivial SDK/API/framework usage, delegate to `dependency-expert` to check official docs first.
 </delegation_rules>
 
@@ -80,6 +82,7 @@ Key constraints:
 - Each child has its own context window (not shared with parent)
 - Parent must read prompt file BEFORE calling spawn_agent
 - Child agents can access skills ($name) but should focus on their assigned role
+- `worker` is a team-runtime surface, not a general-purpose child role; outside active `team`/`swarm` mode, never substitute `worker` for `executor`
 - Child role prompts should report recommended handoffs upward instead of recursively orchestrating unless the parent explicitly authorizes recursion
 </child_agent_protocol>
 

--- a/src/hooks/__tests__/prompt-team-routing.test.ts
+++ b/src/hooks/__tests__/prompt-team-routing.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadSurface } from './prompt-guidance-test-helpers.js';
+
+for (const surface of ['AGENTS.md', 'templates/AGENTS.md']) {
+  describe(`${surface} team-vs-non-team routing guardrails`, () => {
+    it('routes non-team implementation work to executor instead of worker', () => {
+      assert.match(
+        loadSurface(surface),
+        /Outside active `team`\/`swarm` mode, use `executor`.*do not invoke `worker`/i,
+      );
+    });
+
+    it('reserves worker for active team sessions', () => {
+      assert.match(
+        loadSurface(surface),
+        /Reserve `worker` strictly for active `team`\/`swarm` sessions/i,
+      );
+      assert.match(
+        loadSurface(surface),
+        /`worker` is a team-runtime surface, not a general-purpose child role/i,
+      );
+    });
+  });
+}

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -12,6 +12,8 @@ const ROOT_TEMPLATE_PATTERNS = [
   rx('compact, information-dense responses'),
   rx('clear, low-risk, reversible next steps'),
   rx('local overrides?.*non-conflicting instructions'),
+  rx('Outside active `team`/`swarm` mode, use `executor`'),
+  rx('Reserve `worker` strictly for active `team`/`swarm` sessions'),
   rx('do not skip prerequisites|task is grounded and verified'),
   rx('concise evidence summaries'),
 ];

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -48,6 +48,8 @@ Work directly only for trivial operations where delegation adds disproportionate
 - Small clarifications, quick status checks, or single-command sequential operations.
 
 For substantive code changes, delegate to `executor` (default for both standard and complex implementation work).
+Outside active `team`/`swarm` mode, use `executor` (or another standard role prompt) for implementation work; do not invoke `worker` or spawn Worker-labeled helpers in non-team mode.
+Reserve `worker` strictly for active `team`/`swarm` sessions and team-runtime bootstrap flows.
 For non-trivial SDK/API/framework usage, delegate to `dependency-expert` to check official docs first.
 </delegation_rules>
 
@@ -80,6 +82,7 @@ Key constraints:
 - Each child has its own context window (not shared with parent)
 - Parent must read prompt file BEFORE calling spawn_agent
 - Child agents can access skills ($name) but should focus on their assigned role
+- `worker` is a team-runtime surface, not a general-purpose child role; outside active `team`/`swarm` mode, never substitute `worker` for `executor`
 - Child role prompts should report recommended handoffs upward instead of recursively orchestrating unless the parent explicitly authorizes recursion
 </child_agent_protocol>
 


### PR DESCRIPTION
## Summary
- add explicit AGENTS guardrails that non-team implementation work must use `executor`
- reserve `worker` for active `team`/`swarm` sessions and team runtime bootstrap flows only
- add regression coverage for both root AGENTS surfaces and extend the prompt guidance contract

## Testing
- `npm run build && node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js dist/hooks/__tests__/prompt-orchestration-boundary.test.js dist/hooks/__tests__/prompt-team-routing.test.js`
- `npm test`
