### PR TITLE
feat(team): allocate reasoning effort per teammate

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,9 @@ OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # optional: disable adaptive queue->resend fall
 ```
 
 Notes:
-- Worker launch args are still shared via `OMX_TEAM_WORKER_LAUNCH_ARGS`.
+- Worker launch args are still shared via `OMX_TEAM_WORKER_LAUNCH_ARGS` for model/config inheritance.
 - `OMX_TEAM_WORKER_CLI_MAP` overrides `OMX_TEAM_WORKER_CLI` for per-worker selection.
+- Team mode now allocates `model_reasoning_effort` per teammate from the resolved worker role (`low` / `medium` / `high`) unless an explicit reasoning override already exists in `OMX_TEAM_WORKER_LAUNCH_ARGS`.
 - Trigger submission uses adaptive retries by default (queue/submit, then safe clear-line+resend fallback when needed).
 - In Claude worker mode, OMX spawns workers as plain `claude` (no extra launch args) and ignores explicit `--model` / `--config` / `--effort` overrides so Claude uses default `settings.json`.
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -147,15 +147,15 @@ Model precedence (highest to lowest):
 Thinking-level rule (critical):
 - **No model-name heuristic mapping.**
 - Team runtime must **not** infer `model_reasoning_effort` from model-name substrings (e.g., `spark`, `high-capability`, `mini`).
-- Worker thinking level is applied **only when explicitly provided** (leader/user launch args or explicit config).
-- If no explicit thinking value is provided, runtime leaves `model_reasoning_effort` unset.
+- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role (`low`, `medium`, `high`).
+- Explicit launch args still win: if `OMX_TEAM_WORKER_LAUNCH_ARGS` already includes `-c model_reasoning_effort=...`, that explicit value overrides dynamic allocation for every worker.
 
 Normalization requirements:
 - Parse both `--model <value>` and `--model=<value>`
 - Remove duplicate/conflicting model flags
 - Emit exactly one final canonical flag: `--model <value>`
 - Preserve unrelated args in worker launch config
-- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise do not inject one
+- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default reasoning level
 
 ## Required Lifecycle (Operator Contract)
 

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   collectInheritableTeamWorkerArgs,
   isLowComplexityAgentType,
+  resolveAgentReasoningEffort,
   resolveTeamWorkerLaunchArgs,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   resolveTeamLowComplexityDefaultModel,
@@ -101,10 +102,28 @@ describe('team model contract', () => {
     assert.equal(isLowComplexityAgentType('executor'), false);
     assert.equal(isLowComplexityAgentType('executor-low'), true);
   });
+
+  it('maps worker roles to default reasoning effort tiers', () => {
+    assert.equal(resolveAgentReasoningEffort('explore'), 'low');
+    assert.equal(resolveAgentReasoningEffort('executor'), 'medium');
+    assert.equal(resolveAgentReasoningEffort('architect'), 'high');
+    assert.equal(resolveAgentReasoningEffort('does-not-exist'), undefined);
+  });
 });
 
-describe('resolveTeamWorkerLaunchArgs - explicit thinking only', () => {
-  it('does not auto-inject thinking level for fallback model', () => {
+describe('resolveTeamWorkerLaunchArgs - teammate reasoning allocation', () => {
+  it('injects preferred reasoning when explicit reasoning is absent', () => {
+    const result = resolveTeamWorkerLaunchArgs({
+      fallbackModel: expectedLowComplexityModel(),
+      preferredReasoning: 'low',
+    });
+    assert.deepEqual(
+      result,
+      ['-c', 'model_reasoning_effort="low"', '--model', expectedLowComplexityModel()],
+    );
+  });
+
+  it('does not auto-inject thinking level for fallback model when no preference is provided', () => {
     const result = resolveTeamWorkerLaunchArgs({
       fallbackModel: expectedLowComplexityModel(),
     });
@@ -112,10 +131,11 @@ describe('resolveTeamWorkerLaunchArgs - explicit thinking only', () => {
     assert.ok(!joined.includes('model_reasoning_effort'), `Expected no auto-injected thinking level in: ${joined}`);
   });
 
-  it('preserves explicit reasoning override', () => {
+  it('preserves explicit reasoning override over teammate preference', () => {
     const result = resolveTeamWorkerLaunchArgs({
       existingRaw: '-c model_reasoning_effort="high"',
       fallbackModel: expectedLowComplexityModel(),
+      preferredReasoning: 'low',
     });
     const joined = result.join(' ');
     // Should contain the explicit high level

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -140,6 +140,34 @@ describe('runtime', () => {
     );
   });
 
+  it('resolveWorkerLaunchArgsFromEnv injects teammate reasoning and logs source=role-default', () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
+    try {
+      const lowArgs = resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+        'executor',
+        undefined,
+        'low',
+        'codex',
+      );
+      const highArgs = resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+        'executor',
+        undefined,
+        'high',
+        'codex',
+      );
+      assert.deepEqual(lowArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"']);
+      assert.deepEqual(highArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"']);
+    } finally {
+      console.log = originalLog;
+    }
+    assert.ok(logs.some((line) => line.includes('thinking_level=low') && line.includes('source=role-default')));
+    assert.ok(logs.some((line) => line.includes('thinking_level=high') && line.includes('source=role-default')));
+  });
+
   it('resolveWorkerLaunchArgsFromEnv preserves explicit reasoning and logs source=explicit', () => {
     const logs: string[] = [];
     const originalLog = console.log;
@@ -225,6 +253,48 @@ describe('runtime', () => {
       console.log = originalLog;
     }
     assert.ok(logs.some((line) => line.includes('thinking_level=high') && line.includes('source=explicit')));
+  });
+
+  it('resolveWorkerLaunchArgsFromEnv keeps claude and gemini startup logs free of thinking_level during teammate allocation', () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
+    try {
+      const codexArgs = resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
+        'executor',
+        undefined,
+        'high',
+        'codex',
+      );
+      const claudeArgs = resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen --model claude-3-7-sonnet' },
+        'executor',
+        undefined,
+        'low',
+        'claude',
+      );
+      const geminiArgs = resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gemini-2.0-pro' },
+        'executor',
+        undefined,
+        'low',
+        'gemini',
+      );
+      assert.deepEqual(codexArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"']);
+      assert.deepEqual(claudeArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"', '--model', 'claude-3-7-sonnet']);
+      assert.deepEqual(geminiArgs, ['-c', 'model_reasoning_effort="low"', '--model', 'gemini-2.0-pro']);
+    } finally {
+      console.log = originalLog;
+    }
+    const codexLog = logs.find((line) => line.includes('thinking_level=high'));
+    const claudeLog = logs.find((line) => line.includes('model=claude'));
+    const geminiLog = logs.find((line) => line.includes('model=gemini'));
+    assert.ok(codexLog);
+    assert.ok(claudeLog);
+    assert.ok(geminiLog);
+    assert.doesNotMatch(claudeLog ?? '', /thinking_level=/);
+    assert.doesNotMatch(geminiLog ?? '', /thinking_level=/);
   });
 
   it('resolveWorkerLaunchArgsFromEnv logs source=none/default-none when thinking is not explicit', () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -663,6 +663,27 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('supports worker-specific reasoning overrides for codex and strips them for claude workers', () => {
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.SHELL = '/bin/bash';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const codexCmd = buildWorkerStartupCommand('alpha', 1, ['-c', 'model_reasoning_effort="low"'], process.cwd(), {}, 'codex');
+      const claudeCmd = buildWorkerStartupCommand('alpha', 2, ['-c', 'model_reasoning_effort="high"'], process.cwd(), {}, 'claude');
+      assert.match(codexCmd, /exec .*codex/);
+      assert.match(codexCmd, /'model_reasoning_effort="low"'/);
+      assert.match(claudeCmd, /exec .*claude/);
+      assert.equal((claudeCmd.match(/--dangerously-skip-permissions/g) || []).length, 1);
+      assert.doesNotMatch(claudeCmd, /model_reasoning_effort/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
   it('injects model_instructions_file override by default', () => {
     const prevShell = process.env.SHELL;
     process.env.SHELL = '/bin/bash';

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,3 +1,4 @@
+import { getAgent } from '../agents/definitions.js';
 import { getTeamLowComplexityModel, HARDCODED_TEAM_LOW_COMPLEXITY_MODEL } from '../config/models.js';
 
 const MADMAX_FLAG = '--madmax';
@@ -14,6 +15,7 @@ const LOW_COMPLEXITY_AGENT_TYPES = new Set([
 ]);
 
 export const TEAM_LOW_COMPLEXITY_DEFAULT_MODEL = HARDCODED_TEAM_LOW_COMPLEXITY_MODEL;
+export type TeamReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface ParsedTeamWorkerLaunchArgs {
   passthrough: string[];
@@ -26,6 +28,7 @@ export interface ResolveTeamWorkerLaunchArgsOptions {
   existingRaw?: string;
   inheritedArgs?: string[];
   fallbackModel?: string;
+  preferredReasoning?: TeamReasoningEffort;
 }
 
 function isReasoningOverride(value: string): boolean {
@@ -40,6 +43,15 @@ function normalizeOptionalModel(model?: string | null): string | undefined {
   if (typeof model !== 'string') return undefined;
   const trimmed = model.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeOptionalReasoning(reasoning?: TeamReasoningEffort | string | null): TeamReasoningEffort | undefined {
+  if (typeof reasoning !== 'string') return undefined;
+  const normalized = reasoning.trim().toLowerCase();
+  if (normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh') {
+    return normalized;
+  }
+  return undefined;
 }
 
 export function splitWorkerLaunchArgs(raw: string | undefined): string[] {
@@ -112,12 +124,21 @@ export function collectInheritableTeamWorkerArgs(codexArgs: string[]): string[] 
   return inherited;
 }
 
-export function normalizeTeamWorkerLaunchArgs(args: string[], preferredModel?: string): string[] {
+export function normalizeTeamWorkerLaunchArgs(
+  args: string[],
+  preferredModel?: string,
+  preferredReasoning?: TeamReasoningEffort,
+): string[] {
   const parsed = parseTeamWorkerLaunchArgs(args);
   const normalized = [...parsed.passthrough];
 
   if (parsed.wantsBypass) normalized.push(CODEX_BYPASS_FLAG);
-  if (parsed.reasoningOverride) normalized.push(CONFIG_FLAG, parsed.reasoningOverride);
+
+  const selectedReasoning = parsed.reasoningOverride
+    ?? (normalizeOptionalReasoning(preferredReasoning)
+      ? `${REASONING_KEY}="${normalizeOptionalReasoning(preferredReasoning)}"`
+      : null);
+  if (selectedReasoning) normalized.push(CONFIG_FLAG, selectedReasoning);
 
   const selectedModel = normalizeOptionalModel(preferredModel) ?? normalizeOptionalModel(parsed.modelOverride);
   if (selectedModel) normalized.push(MODEL_FLAG, selectedModel);
@@ -134,7 +155,12 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
   const inheritedModel = normalizeOptionalModel(parseTeamWorkerLaunchArgs(inheritedArgs).modelOverride);
   const fallbackModel = normalizeOptionalModel(options.fallbackModel);
   const selectedModel = envModel ?? inheritedModel ?? fallbackModel;
-  return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel);
+  return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning);
+}
+
+export function resolveAgentReasoningEffort(agentType?: string): TeamReasoningEffort | undefined {
+  if (typeof agentType !== 'string' || agentType.trim() === '') return undefined;
+  return normalizeOptionalReasoning(getAgent(agentType)?.reasoningEffort);
 }
 
 export function isLowComplexityAgentType(agentType?: string): boolean {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -10,6 +10,7 @@ import {
   createTeamSession,
   buildWorkerProcessLaunchSpec,
   resolveTeamWorkerCli,
+  type TeamWorkerCli,
   resolveTeamWorkerCliPlan,
   resolveTeamWorkerLaunchMode,
   waitForWorkerReady,
@@ -95,6 +96,8 @@ import {
   resolveTeamLowComplexityDefaultModel,
   parseTeamWorkerLaunchArgs,
   splitWorkerLaunchArgs,
+  resolveAgentReasoningEffort,
+  type TeamReasoningEffort,
 } from './model-contract.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { inferPhaseTargetFromTaskCounts, reconcilePhaseStateForMonitor } from './phase-controller.js';
@@ -412,6 +415,8 @@ export function resolveWorkerLaunchArgsFromEnv(
   env: NodeJS.ProcessEnv,
   agentType: string,
   inheritedLeaderModel?: string,
+  preferredReasoning?: TeamReasoningEffort,
+  workerCliOverride?: TeamWorkerCli,
 ): string[] {
   const inheritedArgs = (typeof inheritedLeaderModel === 'string' && inheritedLeaderModel.trim() !== '')
     ? ['--model', inheritedLeaderModel.trim()]
@@ -429,6 +434,7 @@ export function resolveWorkerLaunchArgsFromEnv(
     existingRaw: env.OMX_TEAM_WORKER_LAUNCH_ARGS,
     inheritedArgs,
     fallbackModel,
+    preferredReasoning,
   });
 
   // Extract resolved model and thinking level from result args for startup log
@@ -436,8 +442,10 @@ export function resolveWorkerLaunchArgsFromEnv(
   const resolvedModel = resolvedParsed.modelOverride ?? fallbackModel ?? 'default';
   const reasoningMatch = resolvedParsed.reasoningOverride?.match(/model_reasoning_effort\s*=\s*"?(\w+)"?/);
   const thinkingLevel = reasoningMatch?.[1] ?? 'none';
-  const source = hasExplicitReasoning ? 'explicit' : 'none/default-none';
-  const effectiveWorkerCli = resolveEffectiveWorkerCliForStartupLog(resolved, env);
+  const source = hasExplicitReasoning
+    ? 'explicit'
+    : (preferredReasoning ? 'role-default' : 'none/default-none');
+  const effectiveWorkerCli = workerCliOverride ?? resolveEffectiveWorkerCliForStartupLog(resolved, env);
   if (effectiveWorkerCli === 'claude') {
     console.log('[omx:team] worker startup resolution: model=claude source=local-settings');
   } else if (effectiveWorkerCli === 'gemini') {
@@ -563,8 +571,13 @@ export async function startTeam(
   const createdWorkerPaneIds: string[] = [];
   let createdLeaderPaneId: string | undefined;
   let config: TeamConfig | null = null;
-  const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(process.env, agentType);
-  const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, workerLaunchArgs, process.env);
+  const sharedWorkerLaunchArgs = resolveTeamWorkerLaunchArgs({
+    existingRaw: process.env.OMX_TEAM_WORKER_LAUNCH_ARGS,
+    fallbackModel: isLowComplexityAgentType(agentType)
+      ? resolveTeamLowComplexityDefaultModel(process.env.CODEX_HOME)
+      : undefined,
+  });
+  const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, sharedWorkerLaunchArgs, process.env);
   const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(process.env);
   const skipWorkerReadyWait = shouldSkipWorkerReadyWait(process.env);
 
@@ -616,6 +629,8 @@ export async function startTeam(
       inbox: string;
       trigger: string;
       initialPrompt?: string;
+      workerLaunchArgs: string[];
+      workerCli: TeamWorkerCli;
     }>;
 
     for (let i = 1; i <= workerCount; i++) {
@@ -637,6 +652,14 @@ export async function startTeam(
         rolePromptContent: rolePromptContent ?? undefined,
       });
       const trigger = generateTriggerMessage(workerName, sanitized);
+      const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
+      const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
+        process.env,
+        agentType,
+        undefined,
+        preferredReasoning,
+        workerCliPlan[i - 1],
+      );
       const initialPrompt = workerCliPlan[i - 1] === 'gemini' ? trigger : undefined;
       if (initialPrompt) {
         await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
@@ -650,6 +673,8 @@ export async function startTeam(
         inbox,
         trigger,
         initialPrompt,
+        workerLaunchArgs,
+        workerCli: workerCliPlan[i - 1],
       });
     }
 
@@ -671,6 +696,8 @@ export async function startTeam(
         cwd: plan.workerWorkspace.cwd,
         env,
         initialPrompt: plan.initialPrompt,
+        launchArgs: plan.workerLaunchArgs,
+        workerCli: plan.workerCli,
       };
     });
 
@@ -678,7 +705,7 @@ export async function startTeam(
 
     // 6. Create worker runtime (interactive tmux panes or prompt-mode child processes)
     if (workerLaunchMode === 'interactive') {
-      const createdSession = createTeamSession(sanitized, workerCount, leaderCwd, workerLaunchArgs, workerStartups);
+      const createdSession = createTeamSession(sanitized, workerCount, leaderCwd, sharedWorkerLaunchArgs, workerStartups);
       sessionName = createdSession.name;
       sessionCreated = true;
       createdWorkerPaneIds.push(...createdSession.workerPaneIds);
@@ -705,9 +732,9 @@ export async function startTeam(
           workerName,
           i,
           startup.cwd || leaderCwd,
-          workerLaunchArgs,
+          startup.launchArgs || sharedWorkerLaunchArgs,
           startup.env || {},
-          workerCliPlan[i - 1],
+          startup.workerCli || workerCliPlan[i - 1],
           startup.initialPrompt,
         );
         if (config.workers[i - 1]) {

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -55,7 +55,9 @@ import { codexPromptsDir } from '../utils/paths.js';
 import {
   resolveTeamWorkerLaunchArgs,
   isLowComplexityAgentType,
-  TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+  resolveAgentReasoningEffort,
+  resolveTeamLowComplexityDefaultModel,
+  type TeamReasoningEffort,
 } from './model-contract.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 
@@ -200,9 +202,9 @@ export async function scaleUp(
       return { ok: false, error };
     };
 
-    // Resolve worker launch args
-    const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, agentType);
-    const workerCliPlan = resolveTeamWorkerCliPlan(count, workerLaunchArgs, env);
+    // Resolve shared worker launch args for CLI selection.
+    const sharedWorkerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, agentType);
+    const workerCliPlan = resolveTeamWorkerCliPlan(count, sharedWorkerLaunchArgs, env);
 
     for (let i = 0; i < count; i++) {
       const workerIndex = nextIndex;
@@ -213,11 +215,23 @@ export async function scaleUp(
       const workerDirPath = join(leaderCwd, '.omx', 'state', 'team', sanitized, 'workers', workerName);
       await mkdir(workerDirPath, { recursive: true });
 
+      // Resolve per-worker role from assigned task roles before launch so reasoning effort can vary by teammate.
+      const workerTaskRoles = tasks.filter(t => t.owner === workerName).map(t => t.role).filter(Boolean) as string[];
+      const uniqueTaskRoles = new Set(workerTaskRoles);
+      const workerRole = workerTaskRoles.length > 0 && uniqueTaskRoles.size === 1
+        ? workerTaskRoles[0]
+        : agentType;
+      if (uniqueTaskRoles.size > 1) {
+        console.log(`[omx:scaling] ${workerName}: mixed task roles [${[...uniqueTaskRoles].join(', ')}], falling back to ${agentType}`);
+      }
+
       // Build startup command and create tmux pane
       const extraEnv: Record<string, string> = {
         OMX_TEAM_STATE_ROOT: teamStateRoot,
         OMX_TEAM_LEADER_CWD: leaderCwd,
       };
+      const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
+      const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, agentType, preferredReasoning);
       const cmd = buildWorkerStartupCommand(
         sanitized,
         workerIndex,
@@ -253,16 +267,6 @@ export async function scaleUp(
 
       // Get PID
       const panePid = getWorkerPanePid(sessionName, workerIndex, paneId);
-
-      // Resolve per-worker role from assigned task roles
-      const workerTaskRoles = tasks.filter(t => t.owner === workerName).map(t => t.role).filter(Boolean) as string[];
-      const uniqueTaskRoles = new Set(workerTaskRoles);
-      const workerRole = workerTaskRoles.length > 0 && uniqueTaskRoles.size === 1
-        ? workerTaskRoles[0]
-        : agentType;
-      if (uniqueTaskRoles.size > 1) {
-        console.log(`[omx:scaling] ${workerName}: mixed task roles [${[...uniqueTaskRoles].join(', ')}], falling back to ${agentType}`);
-      }
 
       const workerInfo: WorkerInfo = {
         name: workerName,
@@ -610,15 +614,20 @@ function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
   return 45_000;
 }
 
-function resolveWorkerLaunchArgsForScaling(env: NodeJS.ProcessEnv, agentType: string): string[] {
+function resolveWorkerLaunchArgsForScaling(
+  env: NodeJS.ProcessEnv,
+  agentType: string,
+  preferredReasoning?: TeamReasoningEffort,
+): string[] {
   const inheritedArgs: string[] = [];
   const fallbackModel = isLowComplexityAgentType(agentType)
-    ? TEAM_LOW_COMPLEXITY_DEFAULT_MODEL
+    ? resolveTeamLowComplexityDefaultModel(env.CODEX_HOME)
     : undefined;
 
   return resolveTeamWorkerLaunchArgs({
     existingRaw: env.OMX_TEAM_WORKER_LAUNCH_ARGS,
     inheritedArgs,
     fallbackModel,
+    preferredReasoning,
   });
 }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -717,7 +717,13 @@ export function createTeamSession(
   workerCount: number,
   cwd: string,
   workerLaunchArgs: string[] = [],
-  workerStartups: Array<{ cwd?: string; env?: Record<string, string>; initialPrompt?: string }> = [],
+  workerStartups: Array<{
+    cwd?: string;
+    env?: Record<string, string>;
+    initialPrompt?: string;
+    launchArgs?: string[];
+    workerCli?: TeamWorkerCli;
+  }> = [],
 ): TeamSession {
   if (!isTmuxAvailable()) {
     throw new Error('tmux is not available');
@@ -729,7 +735,10 @@ export function createTeamSession(
     throw new Error('team mode requires running inside tmux leader pane');
   }
   const normalizedWorkerLaunchArgs = resolveWorkerLaunchArgs(workerLaunchArgs, cwd);
-  const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, normalizedWorkerLaunchArgs, process.env);
+  const defaultWorkerCliPlan = resolveTeamWorkerCliPlan(workerCount, normalizedWorkerLaunchArgs, process.env);
+  const workerCliPlan = workerStartups.length > 0
+    ? workerStartups.map((startup, index) => startup.workerCli ?? defaultWorkerCliPlan[index]!)
+    : defaultWorkerCliPlan;
   for (const workerCli of new Set(workerCliPlan)) {
     assertTeamWorkerCliBinaryAvailable(workerCli);
   }
@@ -769,10 +778,11 @@ export function createTeamSession(
       const workerCwd = startup.cwd || cwd;
       const tmuxWorkerCwd = translatePathForMsys(workerCwd);
       const workerEnv = startup.env || {};
+      const launchArgsForWorker = startup.launchArgs || workerLaunchArgs;
       const cmd = buildWorkerStartupCommand(
         safeTeamName,
         i,
-        workerLaunchArgs,
+        launchArgsForWorker,
         workerCwd,
         workerEnv,
         workerCliPlan[i - 1],


### PR DESCRIPTION
## Summary
- allocate worker reasoning effort dynamically from each teammate's resolved role when team panes are spawned
- preserve explicit `OMX_TEAM_WORKER_LAUNCH_ARGS` reasoning overrides, and thread per-worker launch args through prompt/tmux/scaling paths
- document the new contract and add regression coverage for model-contract, runtime, and tmux worker startup behavior

## Testing
- npm test
- npm run build && node --test dist/team/__tests__/model-contract.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/tmux-session.test.js

Closes #639