### PR TITLE
fix(team): persist routed roles into startup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Team task-role startup injection now matches runtime role reasoning** — routed/scaled worker roles now persist into team state, compose per-worker startup instructions from the matching role prompt, and continue to use role-based default reasoning unless an explicit launch override is provided.
+
 ## [0.8.8] - 2026-03-08
 
 5 non-merge commits from `main..dev`. Contributor: [@Yeachan-Heo](https://github.com/Yeachan-Heo).

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Notes:
 - Worker launch args are still shared via `OMX_TEAM_WORKER_LAUNCH_ARGS` for model/config inheritance.
 - `OMX_TEAM_WORKER_CLI_MAP` overrides `OMX_TEAM_WORKER_CLI` for per-worker selection.
 - Team mode now allocates `model_reasoning_effort` per teammate from the resolved worker role (`low` / `medium` / `high`) unless an explicit reasoning override already exists in `OMX_TEAM_WORKER_LAUNCH_ARGS`.
+- When a worker resolves to a concrete task role, OMX composes a per-worker startup instructions file that layers the corresponding role prompt on top of the shared team worker protocol; explicit `model_instructions_file` launch overrides still win.
 - Trigger submission uses adaptive retries by default (queue/submit, then safe clear-line+resend fallback when needed).
 - In Claude worker mode, OMX spawns workers as plain `claude` (no extra launch args) and ignores explicit `--model` / `--config` / `--effort` overrides so Claude uses default `settings.json`.
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -426,6 +426,122 @@ sleep 5
     }
   });
 
+
+  it('startTeam preserves routed task roles into team state and worker launch args', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-role-routing-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const captureDir = join(cwd, 'captures');
+    const promptsDir = join(cwd, '.codex', 'prompts');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(captureDir, { recursive: true });
+    await mkdir(promptsDir, { recursive: true });
+    await writeFile(join(promptsDir, 'test-engineer.md'), '<identity>Test Engineer</identity>');
+    await writeFile(join(promptsDir, 'writer.md'), '<identity>You are Writer.</identity>');
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const worker = String(process.env.OMX_TEAM_WORKER || 'unknown').replace(/[^a-zA-Z0-9_-]+/g, '__');
+const out = path.join(process.env.OMX_ARGV_CAPTURE_DIR, worker + '.json');
+fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), worker }, null, 2));
+process.stdin.resume();
+setTimeout(() => process.exit(0), 5000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+      { mode: 0o755 },
+    );
+
+    const prevPath = process.env.PATH;
+    const prevTmux = process.env.TMUX;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
+
+    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
+    delete process.env.TMUX;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+    process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'team-role-routing',
+          'heuristic routing handoff',
+          'executor',
+          2,
+          [
+            { subject: 'test routing report only', description: 'test routing report only', owner: 'worker-1', role: 'test-engineer' },
+            { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
+          ],
+          cwd,
+        ));
+
+      assert.equal(runtime.config.worker_launch_mode, 'prompt');
+      assert.equal(runtime.config.workers[0]?.role, 'test-engineer');
+      assert.equal(runtime.config.workers[1]?.role, 'writer');
+
+      const config = await readTeamConfig(runtime.teamName, cwd);
+      assert.equal(config?.workers[0]?.role, 'test-engineer');
+      assert.equal(config?.workers[1]?.role, 'writer');
+
+      const task1 = await readTask(runtime.teamName, '1', cwd);
+      const task2 = await readTask(runtime.teamName, '2', cwd);
+      assert.equal(task1?.role, 'test-engineer');
+      assert.equal(task2?.role, 'writer');
+
+      const worker1Instructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'AGENTS.md'), 'utf-8');
+      const worker2Instructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-2', 'AGENTS.md'), 'utf-8');
+      assert.match(worker1Instructions, /You are operating as the \*\*test-engineer\*\* role/);
+      assert.match(worker1Instructions, /Test Engineer/);
+      assert.match(worker2Instructions, /You are operating as the \*\*writer\*\* role/);
+      assert.match(worker2Instructions, /You are Writer\./);
+
+      let worker1Args: string[] | null = null;
+      let worker2Args: string[] | null = null;
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        const worker1Path = join(captureDir, 'team-role-routing__worker-1.json');
+        const worker2Path = join(captureDir, 'team-role-routing__worker-2.json');
+        if (existsSync(worker1Path) && existsSync(worker2Path)) {
+          worker1Args = JSON.parse(await readFile(worker1Path, 'utf-8')).argv;
+          worker2Args = JSON.parse(await readFile(worker2Path, 'utf-8')).argv;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      assert.ok(worker1Args, 'worker-1 argv capture file should be written');
+      assert.ok(worker2Args, 'worker-2 argv capture file should be written');
+      const worker1Joined = worker1Args!.join(' ');
+      const worker2Joined = worker2Args!.join(' ');
+      assert.match(worker1Joined, /model_reasoning_effort="medium"/);
+      assert.match(worker1Joined, /model_instructions_file=.*worker-1\/AGENTS\.md/);
+      assert.match(worker2Joined, /model_reasoning_effort="low"/);
+      assert.match(worker2Joined, /model_instructions_file=.*worker-2\/AGENTS\.md/);
+
+      await shutdownTeam(runtime.teamName, cwd, { force: true });
+      runtime = null;
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
+      else delete process.env.OMX_ARGV_CAPTURE_DIR;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam supports prompt launch mode without tmux and pipes trigger text via stdin', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-'));
     const binDir = join(cwd, 'bin');

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -706,6 +706,32 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+
+  it('uses per-worker OMX_MODEL_INSTRUCTIONS_FILE from extraEnv when building process launch spec', () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevInstr = process.env.OMX_MODEL_INSTRUCTIONS_FILE;
+    delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    delete process.env.OMX_MODEL_INSTRUCTIONS_FILE;
+    try {
+      const spec = buildWorkerProcessLaunchSpec(
+        'alpha',
+        1,
+        ['-c', 'model_reasoning_effort="low"'],
+        '/tmp/project',
+        { OMX_MODEL_INSTRUCTIONS_FILE: '/tmp/project/.omx/state/team/alpha/workers/worker-1/AGENTS.md' },
+        'codex',
+      );
+      const joined = spec.args.join(' ');
+      assert.match(joined, /model_reasoning_effort="low"/);
+      assert.match(joined, /model_instructions_file="\/tmp\/project\/.omx\/state\/team\/alpha\/workers\/worker-1\/AGENTS\.md"/);
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevInstr === 'string') process.env.OMX_MODEL_INSTRUCTIONS_FILE = prevInstr;
+      else delete process.env.OMX_MODEL_INSTRUCTIONS_FILE;
+    }
+  });
+
   it('does not inject model_instructions_file override when disabled', () => {
     const prevShell = process.env.SHELL;
     process.env.SHELL = '/bin/bash';

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -8,6 +8,7 @@ import {
   applyWorkerOverlay,
   stripWorkerOverlay,
   writeTeamWorkerInstructionsFile,
+  writeWorkerRoleInstructionsFile,
   removeTeamWorkerInstructionsFile,
   generateInitialInbox,
   generateTaskAssignmentInbox,
@@ -339,6 +340,31 @@ describe('worker bootstrap', () => {
       // Verify project AGENTS.md was NOT modified
       const projectContent = await readFile(join(cwd, 'AGENTS.md'), 'utf8');
       assert.doesNotMatch(projectContent, /<!-- OMX:TEAM:WORKER:START -->/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('writeWorkerRoleInstructionsFile layers role prompt on top of team worker instructions', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-worker-bootstrap-'));
+    try {
+      const overlay = generateWorkerOverlay('role-team');
+      const basePath = await writeTeamWorkerInstructionsFile('role-team', cwd, overlay);
+      const outPath = await writeWorkerRoleInstructionsFile(
+        'role-team',
+        'worker-2',
+        cwd,
+        basePath,
+        'writer',
+        '<identity>Writer role prompt</identity>',
+      );
+
+      const content = await readFile(outPath, 'utf8');
+      assert.match(content, /team "role-team"/);
+      assert.match(content, /<!-- OMX:TEAM:ROLE:START -->/);
+      assert.match(content, /\*\*writer\*\* role/);
+      assert.match(content, /<identity>Writer role prompt<\/identity>/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -85,6 +85,7 @@ import {
   generateShutdownInbox,
   generateTriggerMessage,
   generateMailboxTriggerMessage,
+  writeWorkerRoleInstructionsFile,
 } from './worker-bootstrap.js';
 import { loadRolePrompt } from './role-router.js';
 import { codexPromptsDir } from '../utils/paths.js';
@@ -494,7 +495,7 @@ export async function startTeam(
   task: string,
   agentType: string,
   workerCount: number,
-  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[] }>,
+  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; role?: string }>,
   cwd: string,
   options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
@@ -612,6 +613,7 @@ export async function startTeam(
         status: 'pending',
         owner: t.owner,
         blocked_by: t.blocked_by,
+        role: t.role,
       }, leaderCwd);
     }
 
@@ -626,6 +628,7 @@ export async function startTeam(
       workerTasks: TeamTask[];
       workerRole: string;
       rolePromptContent: string | null;
+      instructionsFilePath: string;
       inbox: string;
       trigger: string;
       initialPrompt?: string;
@@ -642,9 +645,11 @@ export async function startTeam(
       const workerRole = taskRoles.length > 0 && uniqueTaskRoles.size === 1
         ? taskRoles[0]
         : agentType;
-      const rolePromptContent = workerRole !== agentType
-        ? await loadRolePrompt(workerRole, codexPromptsDir())
-        : null;
+      const rolePromptContent = await loadRolePrompt(workerRole, join(leaderCwd, '.codex', 'prompts'))
+        ?? await loadRolePrompt(workerRole, codexPromptsDir());
+      const instructionsFilePath = rolePromptContent
+        ? await writeWorkerRoleInstructionsFile(sanitized, workerName, leaderCwd, workerInstructionsPath, workerRole, rolePromptContent)
+        : workerInstructionsPath;
       const inbox = generateInitialInbox(workerName, sanitized, agentType, workerTasks, {
         teamStateRoot,
         leaderCwd,
@@ -670,6 +675,7 @@ export async function startTeam(
         workerTasks,
         workerRole,
         rolePromptContent,
+        instructionsFilePath,
         inbox,
         trigger,
         initialPrompt,
@@ -682,6 +688,7 @@ export async function startTeam(
       const env: Record<string, string> = {
         [TEAM_STATE_ROOT_ENV]: teamStateRoot,
         [TEAM_LEADER_CWD_ENV]: leaderCwd,
+        [MODEL_INSTRUCTIONS_FILE_ENV]: plan.instructionsFilePath,
       };
       if (plan.workerWorkspace.worktreePath) {
         env.OMX_TEAM_WORKTREE_PATH = plan.workerWorkspace.worktreePath;
@@ -791,6 +798,7 @@ export async function startTeam(
       if (paneId) identity.pane_id = paneId;
       if (config.workers[i - 1]) {
         config.workers[i - 1].pane_id = paneId;
+        config.workers[i - 1].role = workerRole;
         config.workers[i - 1].worker_cli = workerCliPlan[i - 1];
         config.workers[i - 1].working_dir = workerWorkspace.cwd;
         config.workers[i - 1].worktree_path = workerWorkspace.worktreePath;

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -49,6 +49,7 @@ import {
 import {
   generateInitialInbox,
   generateTriggerMessage,
+  writeWorkerRoleInstructionsFile,
 } from './worker-bootstrap.js';
 import { loadRolePrompt } from './role-router.js';
 import { codexPromptsDir } from '../utils/paths.js';
@@ -226,9 +227,16 @@ export async function scaleUp(
       }
 
       // Build startup command and create tmux pane
+      const rolePromptContent = await loadRolePrompt(workerRole, join(leaderCwd, '.codex', 'prompts'))
+        ?? await loadRolePrompt(workerRole, codexPromptsDir());
+      const teamInstructionsPath = join(leaderCwd, '.omx', 'state', 'team', sanitized, 'worker-agents.md');
+      const instructionsFilePath = rolePromptContent
+        ? await writeWorkerRoleInstructionsFile(sanitized, workerName, leaderCwd, teamInstructionsPath, workerRole, rolePromptContent)
+        : teamInstructionsPath;
       const extraEnv: Record<string, string> = {
         OMX_TEAM_STATE_ROOT: teamStateRoot,
         OMX_TEAM_LEADER_CWD: leaderCwd,
+        OMX_MODEL_INSTRUCTIONS_FILE: instructionsFilePath,
       };
       const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
       const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, agentType, preferredReasoning);
@@ -294,11 +302,6 @@ export async function scaleUp(
 
       // Get assigned tasks for this worker
       const workerTasks = tasks.filter(t => t.owner === workerName);
-
-      // Load role-specific prompt content if role differs from default
-      const rolePromptContent = workerRole !== agentType
-        ? await loadRolePrompt(workerRole, codexPromptsDir())
-        : null;
 
       const inbox = generateInitialInbox(workerName, sanitized, agentType, workerTasks.map((t, idx) => ({
         id: String(idx + 1),

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -638,8 +638,9 @@ export function buildWorkerProcessLaunchSpec(
   workerCliOverride?: TeamWorkerCli,
   initialPrompt?: string,
 ): WorkerProcessLaunchSpec {
-  const fullLaunchArgs = resolveWorkerLaunchArgs(launchArgs, cwd);
-  const workerCli = workerCliOverride ?? resolveTeamWorkerCli(fullLaunchArgs, process.env);
+  const effectiveEnv: NodeJS.ProcessEnv = { ...process.env, ...extraEnv };
+  const fullLaunchArgs = resolveWorkerLaunchArgs(launchArgs, cwd, effectiveEnv);
+  const workerCli = workerCliOverride ?? resolveTeamWorkerCli(fullLaunchArgs, effectiveEnv);
   const cliLaunchArgs = translateWorkerLaunchArgsForCli(workerCli, fullLaunchArgs, initialPrompt);
 
   const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -176,6 +176,39 @@ export async function writeTeamWorkerInstructionsFile(
 }
 
 /**
+ * Compose a per-worker startup instructions file by layering the team worker
+ * instructions with the resolved role prompt content.
+ */
+export async function writeWorkerRoleInstructionsFile(
+  teamName: string,
+  workerName: string,
+  cwd: string,
+  baseInstructionsPath: string,
+  workerRole: string,
+  rolePromptContent: string,
+): Promise<string> {
+  const base = await readFile(baseInstructionsPath, 'utf-8').catch(() => '');
+  const roleOverlay = `
+<!-- OMX:TEAM:ROLE:START -->
+<team_worker_role>
+You are operating as the **${workerRole}** role for this team run. Apply the following role-local guidance in addition to the team worker protocol.
+
+${rolePromptContent.trim()}
+</team_worker_role>
+<!-- OMX:TEAM:ROLE:END -->
+`;
+  const composed = base.trim().length > 0
+    ? `${base.trimEnd()}
+
+${roleOverlay}`
+    : roleOverlay.trimStart();
+  const outPath = join(cwd, '.omx', 'state', 'team', teamName, 'workers', workerName, 'AGENTS.md');
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, composed);
+  return outPath;
+}
+
+/**
  * Remove the team-scoped model instructions file.
  */
 export async function removeTeamWorkerInstructionsFile(


### PR DESCRIPTION
## Summary
- persist routed task `role` into team task state and live worker config/identity
- compose per-worker startup instructions from the resolved role prompt instead of limiting role guidance to inbox text
- keep role-based default reasoning behavior while preserving explicit launch overrides
- add runtime, tmux-session, and worker-bootstrap regression coverage plus README/changelog updates

## Why
Team decomposition was correctly assigning task roles, but `startTeam()` dropped the `role` field before task state creation. That meant live workers fell back to the top-level agent type, so routed roles did not affect startup prompt injection or reasoning defaults at runtime.

## Verification
- `npm run build && node --test dist/team/__tests__/model-contract.test.js dist/team/__tests__/worker-bootstrap.test.js dist/team/__tests__/tmux-session.test.js dist/team/__tests__/runtime.test.js`
  - `227 pass, 0 fail`
- `lsp_diagnostics` on modified team/runtime/test files
  - `0 errors`
