### PR TITLE
fix(update): run setup refresh after auto-update

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { isNewerVersion, shouldCheckForUpdates } from '../update.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  isNewerVersion,
+  maybeCheckAndPromptUpdate,
+  shouldCheckForUpdates,
+} from '../update.js';
 
 describe('isNewerVersion', () => {
   it('returns true when latest has higher major', () => {
@@ -78,5 +85,54 @@ describe('shouldCheckForUpdates', () => {
     const customInterval = 60 * 1000; // 1 min
     const recentCheck = new Date(now - 30 * 1000).toISOString(); // 30s ago
     assert.equal(shouldCheckForUpdates(now, { last_checked_at: recentCheck }, customInterval), false);
+  });
+});
+
+describe('maybeCheckAndPromptUpdate', () => {
+  it('runs setup refresh after a successful auto-update', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
+    const originalStdinTty = process.stdin.isTTY;
+    const originalStdoutTty = process.stdout.isTTY;
+    const originalLog = console.log;
+    const prompts: string[] = [];
+    const setupCalls: Array<{ force?: boolean }> = [];
+
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+    console.log = (...args: unknown[]) => {
+      prompts.push(args.map((arg) => String(arg)).join(' '));
+    };
+
+    try {
+      await maybeCheckAndPromptUpdate(cwd, {
+        getCurrentVersion: async () => '0.8.9',
+        fetchLatestVersion: async () => '0.9.0',
+        askYesNo: async () => true,
+        runGlobalUpdate: () => ({ ok: true, stderr: '' }),
+        setup: async (options) => {
+          setupCalls.push(options ?? {});
+        },
+      });
+
+      assert.deepEqual(setupCalls, [{ force: true }]);
+      assert.match(prompts.join('\n'), /Updated to v0\.9\.0/);
+    } finally {
+      console.log = originalLog;
+      Object.defineProperty(process.stdin, 'isTTY', {
+        configurable: true,
+        value: originalStdinTty,
+      });
+      Object.defineProperty(process.stdout, 'isTTY', {
+        configurable: true,
+        value: originalStdoutTty,
+      });
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import { spawnSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { getPackageRoot } from '../utils/package.js';
+import { setup } from './setup.js';
 
 interface UpdateState {
   last_checked_at: string;
@@ -123,7 +124,27 @@ async function askYesNo(question: string): Promise<boolean> {
   }
 }
 
-export async function maybeCheckAndPromptUpdate(cwd: string): Promise<void> {
+interface UpdateDependencies {
+  askYesNo: typeof askYesNo;
+  fetchLatestVersion: typeof fetchLatestVersion;
+  getCurrentVersion: typeof getCurrentVersion;
+  runGlobalUpdate: typeof runGlobalUpdate;
+  setup: typeof setup;
+}
+
+const defaultUpdateDependencies: UpdateDependencies = {
+  askYesNo,
+  fetchLatestVersion,
+  getCurrentVersion,
+  runGlobalUpdate,
+  setup,
+};
+
+export async function maybeCheckAndPromptUpdate(
+  cwd: string,
+  dependencies: Partial<UpdateDependencies> = {},
+): Promise<void> {
+  const updateDependencies = { ...defaultUpdateDependencies, ...dependencies };
   if (process.env.OMX_AUTO_UPDATE === '0') return;
   if (!process.stdin.isTTY || !process.stdout.isTTY) return;
 
@@ -132,8 +153,8 @@ export async function maybeCheckAndPromptUpdate(cwd: string): Promise<void> {
   if (!shouldCheckForUpdates(now, state)) return;
 
   const [current, latest] = await Promise.all([
-    getCurrentVersion(),
-    fetchLatestVersion(),
+    updateDependencies.getCurrentVersion(),
+    updateDependencies.fetchLatestVersion(),
   ]);
 
   await writeUpdateState(cwd, {
@@ -143,13 +164,16 @@ export async function maybeCheckAndPromptUpdate(cwd: string): Promise<void> {
 
   if (!current || !latest || !isNewerVersion(current, latest)) return;
 
-  const approved = await askYesNo(`[omx] Update available: v${current} → v${latest}. Update now? [Y/n] `);
+  const approved = await updateDependencies.askYesNo(
+    `[omx] Update available: v${current} → v${latest}. Update now? [Y/n] `,
+  );
   if (!approved) return;
 
   console.log(`[omx] Running: npm install -g ${PACKAGE_NAME}@latest`);
-  const result = runGlobalUpdate();
+  const result = updateDependencies.runGlobalUpdate();
 
   if (result.ok) {
+    await updateDependencies.setup({ force: true });
     console.log(`[omx] Updated to v${latest}. Restart to use new code.`);
   } else {
     console.log('[omx] Update failed. Run manually: npm install -g oh-my-codex@latest');


### PR DESCRIPTION
## Summary
- call `setup({ force: true })` after a successful global auto-update so prompts, skills, and AGENTS.md refresh immediately
- keep the update flow testable by allowing the update helpers to be dependency-injected in the regression test
- add a regression test covering the post-update setup refresh

## Testing
- npm test
- npx biome lint src/cli/update.ts src/cli/__tests__/update.test.ts