### PR TITLE
fix(tui): handle tmux send-keys Enter reliably in alternate screen

### DIFF
--- a/src/hooks/extensibility/sdk.ts
+++ b/src/hooks/extensibility/sdk.ts
@@ -192,6 +192,10 @@ async function sendTmuxKeys(
   }
 
   if (options.submit !== false) {
+    // Codex CLI's alternate-screen TUI can swallow an immediate C-m that lands
+    // in the same tmux send-keys burst as literal text. Give the raw-mode input
+    // buffer a brief moment to settle before the first submit.
+    sleepFractionalSeconds(0.12);
     const submitA = runTmux(['send-keys', '-t', targetResolution.target, 'C-m']);
     sleepFractionalSeconds(0.1);
     const submitB = runTmux(['send-keys', '-t', targetResolution.target, 'C-m']);

--- a/src/notifications/__tests__/tmux-detector.test.ts
+++ b/src/notifications/__tests__/tmux-detector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { analyzePaneContent, buildSendPaneArgvs, buildCapturePaneArgv } from '../tmux-detector.js';
+import { analyzePaneContent, buildSendPaneArgvs, buildCapturePaneArgv, sendToPane } from '../tmux-detector.js';
 import type { PaneAnalysis } from '../tmux-detector.js';
 
 describe('analyzePaneContent', () => {
@@ -167,6 +167,29 @@ describe('buildSendPaneArgvs', () => {
       ['send-keys', '-t', '%5', 'C-m'],
       ['send-keys', '-t', '%5', 'C-m'],
     ]);
+  });
+
+  it('delays the first C-m submit so tmux send-keys text is visible to the alternate-screen TUI', () => {
+    const calls: string[][] = [];
+    const sleeps: number[] = [];
+    const fakeSpawnSync = (command: string, argv: readonly string[]) => {
+      assert.equal(command, 'tmux');
+      calls.push([...argv]);
+      return { status: 0 };
+    };
+
+    const ok = sendToPane('%5', 'continue', true, {
+      spawnSyncImpl: fakeSpawnSync,
+      sleepImpl: (ms) => sleeps.push(ms),
+    });
+
+    assert.equal(ok, true);
+    assert.deepEqual(calls, [
+      ['send-keys', '-t', '%5', '-l', '--', 'continue'],
+      ['send-keys', '-t', '%5', 'C-m'],
+      ['send-keys', '-t', '%5', 'C-m'],
+    ]);
+    assert.deepEqual(sleeps, [120, 100]);
   });
 });
 

--- a/src/notifications/tmux-detector.ts
+++ b/src/notifications/tmux-detector.ts
@@ -6,6 +6,7 @@
  */
 
 import { execSync, execFileSync, spawnSync } from 'child_process';
+import { sleepSync } from '../utils/sleep.js';
 
 export function isTmuxAvailable(): boolean {
   try {
@@ -113,14 +114,46 @@ export function buildSendPaneArgvs(
   return argvs;
 }
 
-export function sendToPane(paneId: string, text: string, pressEnter: boolean = true): boolean {
-  for (const argv of buildSendPaneArgvs(paneId, text, pressEnter)) {
-    const result = spawnSync('tmux', argv, {
+const TMUX_TEXT_SETTLE_MS = 120;
+const TMUX_SUBMIT_REPEAT_DELAY_MS = 100;
+
+type SpawnSyncImpl = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options?: {
+    timeout?: number;
+    stdio?: ['pipe', 'pipe', 'pipe'];
+    encoding?: 'utf-8';
+  },
+) => { error?: Error; status: number | null };
+
+interface SendToPaneDeps {
+  spawnSyncImpl?: SpawnSyncImpl;
+  sleepImpl?: (ms: number) => void;
+}
+
+export function sendToPane(
+  paneId: string,
+  text: string,
+  pressEnter: boolean = true,
+  deps: SendToPaneDeps = {},
+): boolean {
+  const spawnSyncImpl = deps.spawnSyncImpl ?? spawnSync;
+  const sleepImpl = deps.sleepImpl ?? sleepSync;
+  const argvs = buildSendPaneArgvs(paneId, text, pressEnter);
+
+  for (const [index, argv] of argvs.entries()) {
+    const result = spawnSyncImpl('tmux', argv, {
       timeout: 3000,
       stdio: ['pipe', 'pipe', 'pipe'],
       encoding: 'utf-8',
     });
     if (result.error || result.status !== 0) return false;
+
+    const hasNextArgv = index < argvs.length - 1;
+    if (!hasNextArgv) continue;
+
+    sleepImpl(index === 0 ? TMUX_TEXT_SETTLE_MS : TMUX_SUBMIT_REPEAT_DELAY_MS);
   }
   return true;
 }


### PR DESCRIPTION
## Summary
- add a small settle delay between literal tmux text injection and the first C-m submit
- keep the follow-up submit retry delay and cover the alternate-screen timing regression with a test
- apply the same settle delay to hook extensibility tmux key submission

Closes #647