### PR TITLE
fix: clean up notify fallback watchers

### DIFF
--- a/scripts/notify-fallback-watcher.js
+++ b/scripts/notify-fallback-watcher.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync } from 'fs';
-import { appendFile, mkdir, readFile, readdir, stat, writeFile } from 'fs/promises';
+import { appendFile, mkdir, readFile, readdir, stat, unlink, writeFile } from 'fs/promises';
 import { spawnSync } from 'child_process';
 import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
@@ -13,23 +13,55 @@ function argValue(name, fallback = '') {
   return process.argv[idx + 1];
 }
 
+function asNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function safeString(v) {
+  return typeof v === 'string' ? v : '';
+}
+
+function isPidAlive(pid) {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && typeof error === 'object' && error.code === 'EPERM';
+  }
+}
+
 const cwd = resolve(argValue('--cwd', process.cwd()));
 const notifyScript = resolve(argValue('--notify-script', join(cwd, 'scripts', 'notify-hook.js')));
-const pollMs = Number(argValue('--poll-ms', '700')) || 700;
 const runOnce = process.argv.includes('--once');
+const pollMs = Math.max(50, asNumber(argValue('--poll-ms', '700'), 700));
+const parentPid = Math.trunc(asNumber(argValue('--parent-pid', String(process.ppid || 0)), process.ppid || 0));
 const startedAt = Date.now();
 const fileWindowMs = runOnce ? 15000 : 30000;
+const defaultMaxLifetimeMs = 6 * 60 * 60 * 1000;
+const maxLifetimeMs = runOnce
+  ? 0
+  : Math.max(
+    pollMs,
+    asNumber(
+      argValue('--max-lifetime-ms', process.env.OMX_NOTIFY_FALLBACK_MAX_LIFETIME_MS || String(defaultMaxLifetimeMs)),
+      defaultMaxLifetimeMs
+    )
+  );
 
 const omxDir = join(cwd, '.omx');
 const logsDir = join(omxDir, 'logs');
 const stateDir = join(omxDir, 'state');
 const statePath = join(stateDir, 'notify-fallback-state.json');
+const pidFilePath = resolve(argValue('--pid-file', join(stateDir, 'notify-fallback.pid')));
 const logPath = join(logsDir, `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
 
 const fileState = new Map();
 const seenTurnKeys = new Set();
 let stopping = false;
-const dispatchTickMax = Number(argValue('--dispatch-max-per-tick', '5')) || 5;
+let shutdownPromise = null;
+const dispatchTickMax = Math.max(1, asNumber(argValue('--dispatch-max-per-tick', '5'), 5));
 let dispatchDrainRuns = 0;
 let lastDispatchDrain = {
   leader_only: safeString(process.env.OMX_TEAM_WORKER || '').trim() === '',
@@ -38,12 +70,121 @@ let lastDispatchDrain = {
   last_error: null,
 };
 
-function safeString(v) {
-  return typeof v === 'string' ? v : '';
-}
-
 function eventLog(event) {
   return appendFile(logPath, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
+}
+
+async function readPidFilePid(path) {
+  const raw = await readFile(path, 'utf-8');
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return Number.isFinite(parsed.pid) && parsed.pid > 0 ? parsed.pid : null;
+  } catch {
+    const pid = Number.parseInt(trimmed, 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  }
+}
+
+async function registerPidFile() {
+  if (runOnce) return;
+  await mkdir(dirname(pidFilePath), { recursive: true }).catch(() => {});
+
+  const existingPid = await readPidFilePid(pidFilePath).catch(() => null);
+  if (existingPid && existingPid !== process.pid && isPidAlive(existingPid)) {
+    try {
+      process.kill(existingPid, 'SIGTERM');
+      await eventLog({
+        type: 'watcher_stale_pid_reaped',
+        stale_pid: existingPid,
+        pid_file: pidFilePath,
+      });
+    } catch (error) {
+      await eventLog({
+        type: 'watcher_stale_pid_reap_failed',
+        stale_pid: existingPid,
+        pid_file: pidFilePath,
+        error: error instanceof Error ? error.message : safeString(error),
+      });
+    }
+  }
+
+  await writeFile(pidFilePath, JSON.stringify({
+    pid: process.pid,
+    parent_pid: parentPid,
+    cwd,
+    started_at: new Date(startedAt).toISOString(),
+    max_lifetime_ms: maxLifetimeMs,
+  }, null, 2)).catch(() => {});
+}
+
+async function removePidFileIfOwned() {
+  if (runOnce) return;
+  const existingPid = await readPidFilePid(pidFilePath).catch(() => null);
+  if (existingPid !== process.pid) return;
+  await unlink(pidFilePath).catch(() => {});
+}
+
+function parentIsGone() {
+  if (!Number.isFinite(parentPid) || parentPid <= 0) return false;
+  if (parentPid === process.pid) return false;
+  return !isPidAlive(parentPid);
+}
+
+async function writeState(extra = {}) {
+  await mkdir(stateDir, { recursive: true }).catch(() => {});
+  const state = {
+    pid: process.pid,
+    parent_pid: parentPid,
+    started_at: new Date(startedAt).toISOString(),
+    cwd,
+    notify_script: notifyScript,
+    poll_ms: pollMs,
+    pid_file: runOnce ? null : pidFilePath,
+    max_lifetime_ms: maxLifetimeMs,
+    tracked_files: fileState.size,
+    seen_turns: seenTurnKeys.size,
+    dispatch_drain: {
+      enabled: true,
+      max_per_tick: dispatchTickMax,
+      run_count: dispatchDrainRuns,
+      ...lastDispatchDrain,
+    },
+    ...extra,
+  };
+  await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
+}
+
+async function requestShutdown(reason, signal = null) {
+  if (shutdownPromise) return shutdownPromise;
+  stopping = true;
+  shutdownPromise = (async () => {
+    await writeState({ stop_reason: reason, stop_signal: signal, stopping: true });
+    await eventLog({
+      type: 'watcher_stop',
+      signal,
+      reason,
+      parent_pid: parentPid,
+      pid_file: runOnce ? null : pidFilePath,
+    });
+    await removePidFileIfOwned();
+    process.exit(0);
+  })();
+  return shutdownPromise;
+}
+
+async function enforceLifecycleGuards() {
+  if (runOnce) return false;
+  if (parentIsGone()) {
+    await requestShutdown('parent_gone');
+    return true;
+  }
+  if (maxLifetimeMs > 0 && Date.now() - startedAt >= maxLifetimeMs) {
+    await requestShutdown('max_lifetime_exceeded');
+    return true;
+  }
+  return false;
 }
 
 function sessionDirs() {
@@ -176,8 +317,6 @@ async function ensureTrackedFiles() {
     const threadId = shouldTrackSessionMeta(line);
     if (!threadId) continue;
     const size = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
-    // In streaming mode, tail from current EOF to avoid replaying old events.
-    // In one-shot mode, read from start to catch just-finished turns.
     const offset = runOnce ? 0 : size;
     fileState.set(path, { threadId, offset, size, partial: '' });
   }
@@ -238,38 +377,21 @@ async function runDispatchDrainTick() {
   }
 }
 
-async function writeState() {
-  await mkdir(stateDir, { recursive: true }).catch(() => {});
-  const state = {
-    pid: process.pid,
-    started_at: new Date(startedAt).toISOString(),
-    cwd,
-    notify_script: notifyScript,
-    poll_ms: pollMs,
-    tracked_files: fileState.size,
-    seen_turns: seenTurnKeys.size,
-    dispatch_drain: {
-      enabled: true,
-      max_per_tick: dispatchTickMax,
-      run_count: dispatchDrainRuns,
-      ...lastDispatchDrain,
-    },
-  };
-  await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
-}
-
 async function tick() {
   if (stopping) return;
+  if (await enforceLifecycleGuards()) return;
   await ensureTrackedFiles();
   await pollFiles();
   await runDispatchDrainTick();
   await writeState();
-  setTimeout(tick, pollMs);
+  if (await enforceLifecycleGuards()) return;
+  setTimeout(() => {
+    void tick();
+  }, pollMs);
 }
 
 function shutdown(signal) {
-  stopping = true;
-  eventLog({ type: 'watcher_stop', signal }).finally(() => process.exit(0));
+  void requestShutdown('signal', signal);
 }
 
 async function main() {
@@ -280,16 +402,22 @@ async function main() {
     process.exit(1);
   }
 
+  await registerPidFile();
   await eventLog({
     type: 'watcher_start',
     cwd,
     notify_script: notifyScript,
     poll_ms: pollMs,
     once: runOnce,
+    parent_pid: parentPid,
+    pid_file: runOnce ? null : pidFilePath,
+    max_lifetime_ms: maxLifetimeMs,
   });
   process.on('SIGINT', () => shutdown('SIGINT'));
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGHUP', () => shutdown('SIGHUP'));
+
+  if (await enforceLifecycleGuards()) return;
 
   if (runOnce) {
     await ensureTrackedFiles();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1442,6 +1442,29 @@ function hookDerivedWatcherPidPath(cwd: string): string {
   return join(cwd, '.omx', 'state', 'hook-derived-watcher.pid');
 }
 
+function parseWatcherPidFile(content: string): number | null {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as { pid?: unknown };
+    return typeof parsed.pid === 'number' && Number.isFinite(parsed.pid) && parsed.pid > 0 ? parsed.pid : null;
+  } catch {
+    const pid = Number.parseInt(trimmed, 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  }
+}
+
+function tryKillPid(pid: number, signal: NodeJS.Signals = 'SIGTERM'): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
 async function startNotifyFallbackWatcher(cwd: string): Promise<void> {
   if (process.env.OMX_NOTIFY_FALLBACK === '0') return;
 
@@ -1455,9 +1478,9 @@ async function startNotifyFallbackWatcher(cwd: string): Promise<void> {
   // Stop stale watcher from a previous run.
   if (existsSync(pidPath)) {
     try {
-      const prev = JSON.parse(await readFile(pidPath, 'utf-8')) as { pid?: number };
-      if (prev && typeof prev.pid === 'number') {
-        process.kill(prev.pid, 'SIGTERM');
+      const prevPid = parseWatcherPidFile(await readFile(pidPath, 'utf-8'));
+      if (prevPid) {
+        tryKillPid(prevPid, 'SIGTERM');
       }
     } catch (error: unknown) {
       console.warn('[omx] warning: failed to stop stale notify fallback watcher', {
@@ -1475,7 +1498,20 @@ async function startNotifyFallbackWatcher(cwd: string): Promise<void> {
   });
   const child = spawn(
     process.execPath,
-    [watcherScript, '--cwd', cwd, '--notify-script', notifyScript],
+    [
+      watcherScript,
+      '--cwd',
+      cwd,
+      '--notify-script',
+      notifyScript,
+      '--pid-file',
+      pidPath,
+      '--parent-pid',
+      String(process.pid),
+      ...(process.env.OMX_NOTIFY_FALLBACK_MAX_LIFETIME_MS
+        ? ['--max-lifetime-ms', process.env.OMX_NOTIFY_FALLBACK_MAX_LIFETIME_MS]
+        : []),
+    ],
     {
       cwd,
       detached: true,
@@ -1553,9 +1589,9 @@ async function stopNotifyFallbackWatcher(cwd: string): Promise<void> {
   if (!existsSync(pidPath)) return;
 
   try {
-    const parsed = JSON.parse(await readFile(pidPath, 'utf-8')) as { pid?: number };
-    if (parsed && typeof parsed.pid === 'number') {
-      process.kill(parsed.pid, 'SIGTERM');
+    const pid = parseWatcherPidFile(await readFile(pidPath, 'utf-8'));
+    if (pid) {
+      tryKillPid(pid, 'SIGTERM');
     }
   } catch (error: unknown) {
     console.warn('[omx] warning: failed to stop notify fallback watcher process', {

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -44,6 +44,26 @@ async function waitFor(predicate: () => Promise<boolean>, timeoutMs: number = 30
   throw new Error(`waitFor timed out after ${timeoutMs}ms`);
 }
 
+function isPidAlive(pid: number | undefined): boolean {
+  if (!pid || !Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number = 4000): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await Promise.race([
+    once(child, 'exit'),
+    sleep(timeoutMs).then(() => {
+      throw new Error(`process ${child.pid ?? 'unknown'} did not exit within ${timeoutMs}ms`);
+    }),
+  ]);
+}
+
 function buildFakeTmux(tmuxLogPath: string): string {
   return `#!/usr/bin/env bash
 set -eu
@@ -483,6 +503,201 @@ describe('notify-fallback watcher', () => {
       assert.equal(request?.last_reason, 'unconfirmed_after_max_retries');
     } finally {
       await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('exits when the tracked parent pid is gone', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-exit-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-home-'));
+    const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+    const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: { ...process.env, HOME: tempHome },
+        }
+      );
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
+      )));
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('replaces a stale watcher from the per-cwd pid file', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-stale-pid-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-stale-home-'));
+    const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+    const pidPath = join(wd, '.omx', 'state', 'notify-fallback.pid');
+    let first: ReturnType<typeof spawn> | undefined;
+    let second: ReturnType<typeof spawn> | undefined;
+
+    try {
+      first = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(process.pid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: { ...process.env, HOME: tempHome },
+        }
+      );
+      assert.ok(first.pid, 'expected first watcher pid');
+
+      await waitFor(async () => {
+        try {
+          const pidFile = JSON.parse(await readFile(pidPath, 'utf-8')) as { pid?: number };
+          return pidFile.pid === first?.pid;
+        } catch {
+          return false;
+        }
+      }, 4000, 50);
+
+      second = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(process.pid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: { ...process.env, HOME: tempHome },
+        }
+      );
+      assert.ok(second.pid, 'expected second watcher pid');
+
+      await waitForExit(first, 4000);
+      assert.equal(first.exitCode, 0);
+
+      await waitFor(async () => {
+        try {
+          const pidFile = JSON.parse(await readFile(pidPath, 'utf-8')) as { pid?: number };
+          return pidFile.pid === second?.pid;
+        } catch {
+          return false;
+        }
+      }, 4000, 50);
+
+      assert.ok(isPidAlive(second.pid), 'expected replacement watcher to remain alive');
+    } finally {
+      if (second && isPidAlive(second.pid)) {
+        second.kill('SIGTERM');
+        await waitForExit(second, 4000).catch(() => {});
+      }
+      if (first && isPidAlive(first.pid)) {
+        first.kill('SIGTERM');
+        await waitForExit(first, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('exits after the configured max lifetime', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-max-life-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-max-home-'));
+    const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+    const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(process.pid),
+          '--max-lifetime-ms',
+          '200',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: { ...process.env, HOME: tempHome },
+        }
+      );
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'max_lifetime_exceeded'
+      )));
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
- add notify fallback watcher parent PID/lifetime cleanup guards and per-cwd pid-file ownership
- pass parent/pid-file metadata from the CLI launcher and ignore already-dead watcher pids
- cover parent exit, stale watcher replacement, and max lifetime with watcher regression tests

## Testing
- npm run lint
- npm run check:no-unused
- npm test