### PR TITLE
fix: align installable agent surface with catalog manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ OMX installs and wires these layers:
 User
   -> Codex CLI
     -> AGENTS.md (orchestration brain)
-    -> ~/.codex/prompts/*.md (agent prompt catalog)
+    -> ~/.codex/prompts/*.md (installable active/internal agent prompt catalog)
     -> ~/.agents/skills/*/SKILL.md (skill catalog)
     -> ~/.codex/config.toml (features, notify, MCP)
     -> .omx/ (runtime state, memory, plans, logs)

--- a/docs/agents.html
+++ b/docs/agents.html
@@ -88,7 +88,7 @@
     </main>
 
     <footer>
-      <div class="container"><span class="muted">All agents are installed by <code>omx setup</code>.</span></div>
+      <div class="container"><span class="muted">Installable agents follow the catalog manifest (active/internal roles only); merged roles stay documented for migration context.</span></div>
     </footer>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,7 +96,7 @@
       <pre><code>User
   -> Codex CLI
      -> AGENTS.md (orchestration brain)
-     -> ~/.codex/prompts/*.md (agent prompt catalog)
+     -> ~/.codex/prompts/*.md (installable active/internal agent prompt catalog)
      -> ~/.agents/skills/*/SKILL.md (skill catalog)
      -> ~/.codex/config.toml (features, notify, MCP)
      -> .omx/ (runtime state, memory, plans, logs)</code></pre>

--- a/src/cli/__tests__/setup-prompts-overwrite.test.ts
+++ b/src/cli/__tests__/setup-prompts-overwrite.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setup } from '../setup.js';
+
+describe('omx setup prompt/native-agent overwrite behavior', () => {
+  it('installs only active/internal catalog prompts and native agents', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const promptsDir = join(wd, '.codex', 'prompts');
+      const nativeAgentsDir = join(wd, '.omx', 'agents');
+      const installedPrompts = new Set(await readdir(promptsDir));
+      const installedNativeAgents = new Set(await readdir(nativeAgentsDir));
+
+      assert.equal(installedPrompts.has('executor.md'), true);
+      assert.equal(installedPrompts.has('code-reviewer.md'), true);
+      assert.equal(installedPrompts.has('style-reviewer.md'), false);
+      assert.equal(installedPrompts.has('quality-reviewer.md'), false);
+      assert.equal(installedPrompts.has('api-reviewer.md'), false);
+      assert.equal(installedPrompts.has('performance-reviewer.md'), false);
+      assert.equal(installedPrompts.has('product-manager.md'), false);
+      assert.equal(installedPrompts.has('ux-researcher.md'), false);
+      assert.equal(installedPrompts.has('information-architect.md'), false);
+      assert.equal(installedPrompts.has('product-analyst.md'), false);
+      assert.equal(installedPrompts.has('sisyphus-lite.md'), false);
+      assert.equal(installedPrompts.has('code-simplifier.md'), true);
+
+      assert.equal(installedNativeAgents.has('executor.toml'), true);
+      assert.equal(installedNativeAgents.has('code-reviewer.toml'), true);
+      assert.equal(installedNativeAgents.has('style-reviewer.toml'), false);
+      assert.equal(installedNativeAgents.has('quality-reviewer.toml'), false);
+      assert.equal(installedNativeAgents.has('api-reviewer.toml'), false);
+      assert.equal(installedNativeAgents.has('performance-reviewer.toml'), false);
+      assert.equal(installedNativeAgents.has('product-manager.toml'), false);
+      assert.equal(installedNativeAgents.has('ux-researcher.toml'), false);
+      assert.equal(installedNativeAgents.has('information-architect.toml'), false);
+      assert.equal(installedNativeAgents.has('product-analyst.toml'), false);
+      assert.equal(installedNativeAgents.has('code-simplifier.toml'), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes stale merged/unlisted prompts on --force', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const stalePrompts = ['style-reviewer.md', 'quality-reviewer.md', 'sisyphus-lite.md'];
+      for (const stalePrompt of stalePrompts) {
+        const stalePath = join(wd, '.codex', 'prompts', stalePrompt);
+        await writeFile(stalePath, `# stale ${stalePrompt}\n`);
+        assert.equal(existsSync(stalePath), true);
+      }
+
+      await setup({ scope: 'project', force: true });
+
+      for (const stalePrompt of stalePrompts) {
+        assert.equal(existsSync(join(wd, '.codex', 'prompts', stalePrompt)), false);
+      }
+      assert.equal(existsSync(join(wd, '.codex', 'prompts', 'executor.md')), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('removes stale merged native agents on --force', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const staleAgents = ['style-reviewer.toml', 'quality-reviewer.toml'];
+      for (const staleAgent of staleAgents) {
+        const stalePath = join(wd, '.omx', 'agents', staleAgent);
+        await writeFile(stalePath, '# stale native agent\n');
+        assert.equal(existsSync(stalePath), true);
+      }
+
+      await setup({ scope: 'project', force: true });
+
+      for (const staleAgent of staleAgents) {
+        assert.equal(existsSync(join(wd, '.omx', 'agents', staleAgent)), false);
+      }
+      assert.equal(existsSync(join(wd, '.omx', 'agents', 'executor.toml')), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+});

--- a/src/cli/catalog-contract.ts
+++ b/src/cli/catalog-contract.ts
@@ -1,4 +1,4 @@
-import { getCatalogCounts, tryReadCatalogManifest } from '../catalog/reader.js';
+import { tryReadCatalogManifest } from '../catalog/reader.js';
 
 export interface CatalogExpectations {
   promptMin: number;
@@ -7,18 +7,28 @@ export interface CatalogExpectations {
 
 const SAFETY_BUFFER = 2;
 
+function countInstallablePrompts(manifest: NonNullable<ReturnType<typeof tryReadCatalogManifest>>): number {
+  return manifest.agents
+    .filter((agent) => agent.status === 'active' || agent.status === 'internal')
+    .length;
+}
+
+function countInstallableSkills(manifest: NonNullable<ReturnType<typeof tryReadCatalogManifest>>): number {
+  return manifest.skills
+    .filter((skill) => skill.status === 'active' || skill.status === 'internal')
+    .length;
+}
+
 export function getCatalogExpectations(): CatalogExpectations {
   const manifest = tryReadCatalogManifest();
   if (!manifest) {
     return { promptMin: 25, skillMin: 30 };
   }
 
-  const counts = getCatalogCounts();
-  const installableSkillCount = manifest.skills
-    .filter((skill) => skill.status === 'active' || skill.status === 'internal')
-    .length;
+  const installablePromptCount = countInstallablePrompts(manifest);
+  const installableSkillCount = countInstallableSkills(manifest);
   return {
-    promptMin: Math.max(1, counts.promptCount - SAFETY_BUFFER),
+    promptMin: Math.max(1, installablePromptCount - SAFETY_BUFFER),
     skillMin: Math.max(1, installableSkillCount - SAFETY_BUFFER),
   };
 }
@@ -26,12 +36,8 @@ export function getCatalogExpectations(): CatalogExpectations {
 export function getCatalogHeadlineCounts(): { prompts: number; skills: number } | null {
   const manifest = tryReadCatalogManifest();
   if (!manifest) return null;
-  const counts = getCatalogCounts();
-  const installableSkillCount = manifest.skills
-    .filter((skill) => skill.status === 'active' || skill.status === 'internal')
-    .length;
   return {
-    prompts: counts.promptCount,
-    skills: installableSkillCount,
+    prompts: countInstallablePrompts(manifest),
+    skills: countInstallableSkills(manifest),
   };
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -710,35 +710,6 @@ async function syncManagedContent(
   }
 }
 
-async function installDirectory(
-  srcDir: string,
-  dstDir: string,
-  ext: string,
-  backupContext: SetupBackupContext,
-  options: SetupOptions,
-  kindLabel: string,
-): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
-  if (!existsSync(srcDir)) return summary;
-  const files = await readdir(srcDir);
-  for (const file of files) {
-    if (!file.endsWith(ext)) continue;
-    const src = join(srcDir, file);
-    const dst = join(dstDir, file);
-    const srcStat = await stat(src);
-    if (!srcStat.isFile()) continue;
-    await syncManagedFileFromDisk(
-      src,
-      dst,
-      summary,
-      backupContext,
-      options,
-      `${kindLabel} ${file}`,
-    );
-  }
-  return summary;
-}
-
 async function installPrompts(
   srcDir: string,
   dstDir: string,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -392,13 +392,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   {
     const promptsSrc = join(pkgRoot, "prompts");
     const promptsDst = scopeDirs.promptsDir;
-    summary.prompts = await installDirectory(
+    summary.prompts = await installPrompts(
       promptsSrc,
       promptsDst,
-      ".md",
       backupContext,
       { force, dryRun, verbose },
-      "prompt",
     );
     const cleanedLegacyPromptShims = await cleanupLegacySkillPromptShims(
       promptsSrc,
@@ -437,6 +435,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
       scopeDirs.nativeAgentsDir,
       backupContext,
       {
+        force,
         dryRun,
         verbose,
       },
@@ -740,11 +739,88 @@ async function installDirectory(
   return summary;
 }
 
+async function installPrompts(
+  srcDir: string,
+  dstDir: string,
+  backupContext: SetupBackupContext,
+  options: SetupOptions,
+): Promise<SetupCategorySummary> {
+  const summary = createEmptyCategorySummary();
+  if (!existsSync(srcDir)) return summary;
+
+  const manifest = tryReadCatalogManifest();
+  const agentStatusByName = manifest
+    ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
+    : null;
+  const isInstallableStatus = (status: string | undefined): boolean =>
+    status === "active" || status === "internal";
+
+  const files = await readdir(srcDir);
+  const staleCandidatePromptNames = new Set(
+    manifest?.agents.map((agent) => agent.name) ?? [],
+  );
+
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    const promptName = file.slice(0, -3);
+    staleCandidatePromptNames.add(promptName);
+
+    const status = agentStatusByName?.get(promptName);
+    if (agentStatusByName && !isInstallableStatus(status)) {
+      summary.skipped += 1;
+      if (options.verbose) {
+        const label = status ?? 'unlisted';
+        console.log(`  skipped ${file} (status: ${label})`);
+      }
+      continue;
+    }
+
+    const src = join(srcDir, file);
+    const dst = join(dstDir, file);
+    const srcStat = await stat(src);
+    if (!srcStat.isFile()) continue;
+    await syncManagedFileFromDisk(
+      src,
+      dst,
+      summary,
+      backupContext,
+      options,
+      `prompt ${file}`,
+    );
+  }
+
+  if (options.force && manifest && existsSync(dstDir)) {
+    const installedFiles = await readdir(dstDir);
+    for (const file of installedFiles) {
+      if (!file.endsWith('.md')) continue;
+      const promptName = file.slice(0, -3);
+      const status = agentStatusByName?.get(promptName);
+      if (isInstallableStatus(status)) continue;
+      if (!staleCandidatePromptNames.has(promptName) && status === undefined) continue;
+
+      const stalePromptPath = join(dstDir, file);
+      if (!existsSync(stalePromptPath)) continue;
+
+      if (!options.dryRun) {
+        await rm(stalePromptPath, { force: true });
+      }
+      summary.removed += 1;
+      if (options.verbose) {
+        const prefix = options.dryRun ? 'would remove stale prompt' : 'removed stale prompt';
+        const label = status ?? 'unlisted';
+        console.log(`  ${prefix} ${file} (status: ${label})`);
+      }
+    }
+  }
+
+  return summary;
+}
+
 async function refreshNativeAgentConfigs(
   pkgRoot: string,
   agentsDir: string,
   backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+  options: Pick<SetupOptions, "dryRun" | "verbose" | "force">,
 ): Promise<SetupCategorySummary> {
   const summary = createEmptyCategorySummary();
 
@@ -752,7 +828,28 @@ async function refreshNativeAgentConfigs(
     await mkdir(agentsDir, { recursive: true });
   }
 
+  const manifest = tryReadCatalogManifest();
+  const agentStatusByName = manifest
+    ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
+    : null;
+  const isInstallableStatus = (status: string | undefined): boolean =>
+    status === "active" || status === "internal";
+  const staleCandidateNativeAgentNames = new Set(
+    manifest?.agents.map((agent) => agent.name) ?? [],
+  );
+
   for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
+    staleCandidateNativeAgentNames.add(name);
+    const status = agentStatusByName?.get(name);
+    if (agentStatusByName && !isInstallableStatus(status)) {
+      if (options.verbose) {
+        const label = status ?? "unlisted";
+        console.log(`  skipped native agent ${name}.toml (status: ${label})`);
+      }
+      summary.skipped += 1;
+      continue;
+    }
+
     const promptPath = join(pkgRoot, "prompts", `${name}.md`);
     if (!existsSync(promptPath)) {
       continue;
@@ -769,6 +866,30 @@ async function refreshNativeAgentConfigs(
       options,
       `native agent ${name}.toml`,
     );
+  }
+
+  if (options.force && manifest && existsSync(agentsDir)) {
+    const installedFiles = await readdir(agentsDir);
+    for (const file of installedFiles) {
+      if (!file.endsWith('.toml')) continue;
+      const agentName = file.slice(0, -5);
+      const status = agentStatusByName?.get(agentName);
+      if (isInstallableStatus(status)) continue;
+      if (!staleCandidateNativeAgentNames.has(agentName) && status === undefined) continue;
+
+      const staleAgentPath = join(agentsDir, file);
+      if (!existsSync(staleAgentPath)) continue;
+
+      if (!options.dryRun) {
+        await rm(staleAgentPath, { force: true });
+      }
+      summary.removed += 1;
+      if (options.verbose) {
+        const prefix = options.dryRun ? 'would remove stale native agent' : 'removed stale native agent';
+        const label = status ?? 'unlisted';
+        console.log(`  ${prefix} ${file} (status: ${label})`);
+      }
+    }
   }
 
   return summary;

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -453,4 +453,22 @@ describe("config generator idempotency (#384)", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("writes only installable catalog agents into the OMX agent block", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, "utf-8");
+
+      assert.match(toml, /^\[agents\.executor\]$/m, "active agent kept");
+      assert.match(toml, /^\[agents\."code-simplifier"\]$/m, "internal agent kept");
+      assert.doesNotMatch(toml, /^\[agents\."style-reviewer"\]$/m, "merged agent omitted");
+      assert.doesNotMatch(toml, /^\[agents\."quality-reviewer"\]$/m, "merged agent omitted");
+      assert.doesNotMatch(toml, /^\[agents\."product-manager"\]$/m, "merged product agent omitted");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -14,6 +14,7 @@ import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
+import { tryReadCatalogManifest } from "../catalog/reader.js";
 import { omxAgentsConfigDir } from "../utils/paths.js";
 
 interface MergeOptions {
@@ -382,13 +383,29 @@ export function stripExistingOmxBlocks(config: string): {
  * Generate [agents.<name>] entries for Codex native multi-agent support.
  * Each agent gets a description and config_file pointing to ~/.omx/agents/<name>.toml
  */
+
+function getInstallableAgentEntries(): Array<[string, (typeof AGENT_DEFINITIONS)[string]]> {
+  const manifest = tryReadCatalogManifest();
+  if (!manifest) {
+    return Object.entries(AGENT_DEFINITIONS);
+  }
+
+  const installable = new Set(
+    manifest.agents
+      .filter((agent) => agent.status === "active" || agent.status === "internal")
+      .map((agent) => agent.name),
+  );
+
+  return Object.entries(AGENT_DEFINITIONS).filter(([name]) => installable.has(name));
+}
+
 function getAgentEntries(agentsConfigDir: string): string[] {
   const entries: string[] = [
     "",
     "# OMX Native Agent Roles (Codex multi-agent)",
   ];
 
-  for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
+  for (const [name, agent] of getInstallableAgentEntries()) {
     // TOML table headers with special chars need quoting
     const tableKey = name.includes("-") ? `agents."${name}"` : `agents.${name}`;
     const configFile = escapeTomlString(join(agentsConfigDir, `${name}.toml`));


### PR DESCRIPTION
## Summary
- make `omx setup` treat the catalog manifest as the installable source of truth for prompt installation
- skip merged/unlisted prompt/native-agent surfaces by default and remove stale ones on `--force`
- align installable prompt count messaging and add regression coverage for prompt/native-agent cleanup

Closes #652.

## Why
The repo had already consolidated many agent roles at the catalog level, but install/runtime exposure still drifted from that canonical surface. In practice that meant merged roles could keep showing up as installed prompts/native agents, which inflated the visible orchestration surface and made role selection noisier than the manifest intended.

## What changed
- added manifest-aware prompt installation + stale prompt cleanup in `src/cli/setup.ts`
- added manifest-aware native-agent refresh + stale native-agent cleanup in `src/cli/setup.ts`
- changed `src/cli/catalog-contract.ts` to report installable prompt counts from `active|internal` agents
- added `src/cli/__tests__/setup-prompts-overwrite.test.ts`
- clarified installable prompt wording in `README.md`, `docs/index.html`, and `docs/agents.html`

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/catalog-contract.test.js dist/cli/__tests__/setup-prompts-overwrite.test.js dist/cli/__tests__/setup-skills-overwrite.test.js`
- `npm test`
