### PR TITLE
fix(pkg): declare zod runtime dependency for team MCP server (closes #657)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.8.10",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0"
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "zod": "^4.3.6"
       },
       "bin": {
         "omx": "bin/omx.js"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0"
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",

--- a/src/mcp/__tests__/team-server-runtime-deps.test.ts
+++ b/src/mcp/__tests__/team-server-runtime-deps.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+};
+
+describe('team MCP runtime dependency contract', () => {
+  it('declares zod as a top-level runtime dependency because team-server imports it directly', () => {
+    const teamServerSource = readFileSync(join(process.cwd(), 'src', 'mcp', 'team-server.ts'), 'utf8');
+    assert.match(teamServerSource, /from ['\"]zod['\"]/);
+
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as PackageJson;
+    assert.equal(
+      typeof pkg.dependencies?.zod,
+      'string',
+      'package.json must declare zod in top-level runtime dependencies when shipped JS imports it directly',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The published package ships `dist/mcp/team-server.js`, and that entrypoint imports `zod` directly. Because `package.json` only declared `@modelcontextprotocol/sdk`, npm consumers could install a package tree where `zod` was not available at runtime, causing `omx_team_run` MCP startup to crash.

## Changes

- add `zod` to top-level runtime `dependencies`
- keep `package-lock.json` in sync with the package manifest
- add a regression test that requires a direct `team-server` import to be backed by a top-level runtime dependency declaration

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/server-lifecycle.test.js dist/mcp/__tests__/team-server-runtime-deps.test.js`
- [x] Verified `dist/mcp/team-server.js` still imports `zod`
- [x] Verified the MCP startup path still points `omx_team_run` at `dist/mcp/team-server.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #657
