### PR TITLE
fix(team): avoid dead-worker ESRCH stall in prompt launch smoke (closes #662)

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { parseTeamStartArgs, teamCommand } from '../team.js';
@@ -394,6 +394,81 @@ describe('teamCommand await', () => {
     } finally {
       console.log = originalLog;
       process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a dead-worker event for the prompt-launch smoke path instead of timing out', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-await-prompt-dead-'));
+    const binDir = join(wd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const previousCwd = process.cwd();
+    const previousPath = process.env.PATH;
+    const previousTmux = process.env.TMUX;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const logs: string[] = [];
+    const stderr: string[] = [];
+    const originalLog = console.log;
+    const originalStderrWrite = process.stderr.write.bind(process.stderr);
+    const teamTask = 'issue 662 prompt dead worker smoke';
+    const teamName = parseTeamStartArgs(['1:executor', teamTask]).parsed.teamName;
+
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+setTimeout(() => process.exit(0), 150);
+process.stdin.resume();
+process.on('SIGTERM', () => process.exit(0));
+`,
+    );
+    await chmod(fakeCodexPath, 0o755);
+
+    try {
+      process.chdir(wd);
+      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+      delete process.env.TMUX;
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_TEAM_WORKER_CLI = 'codex';
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        stderr.push(String(chunk));
+        return true;
+      }) as typeof process.stderr.write;
+
+      await teamCommand(['1:executor', teamTask]);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      logs.length = 0;
+      stderr.length = 0;
+      await teamCommand(['status', teamName]);
+      assert.match(logs.join('\n'), /phase=failed/);
+      assert.doesNotMatch(stderr.join('\n'), /ESRCH/);
+
+      logs.length = 0;
+      await teamCommand(['await', teamName, '--json', '--timeout-ms', '250']);
+      const payload = JSON.parse(logs.at(-1) ?? '{}') as {
+        team_name?: string;
+        status?: string;
+        event?: { type?: string; worker?: string; reason?: string | null } | null;
+      };
+      assert.equal(payload.team_name, teamName);
+      assert.equal(payload.status, 'event');
+      assert.equal(payload.event?.type, 'worker_stopped');
+      assert.equal(payload.event?.worker, 'worker-1');
+    } finally {
+      console.log = originalLog;
+      process.stderr.write = originalStderrWrite;
+      process.chdir(previousCwd);
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
       await rm(wd, { recursive: true, force: true });
     }
   });

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,8 +1,9 @@
 import { updateModeState, startMode, readModeState } from '../modes/base.js';
-import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime } from '../team/runtime.js';
+import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
 import { DEFAULT_MAX_WORKERS } from '../team/state.js';
 import { sanitizeTeamName } from '../team/tmux-session.js';
-import { waitForTeamEvent } from '../team/state/events.js';
+import { readTeamEvents, waitForTeamEvent } from '../team/state/events.js';
+import type { TeamEvent } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import {
@@ -239,6 +240,26 @@ function slugifyTask(task: string): string {
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
     .slice(0, 30) || 'team-task';
+}
+
+function snapshotHasDeadWorkerStall(snapshot: TeamSnapshot): boolean {
+  return snapshot.deadWorkers.length > 0 && (snapshot.tasks.pending + snapshot.tasks.in_progress) > 0;
+}
+
+function buildDeadWorkerAwaitEvent(teamName: string, snapshot: TeamSnapshot): TeamEvent | null {
+  const deadWorker = snapshot.workers.find((worker) => worker.alive === false);
+  if (!deadWorker) return null;
+  return {
+    event_id: `snapshot-${Date.now()}`,
+    team: sanitizeTeamName(teamName),
+    type: 'worker_stopped',
+    worker: deadWorker.name,
+    task_id: deadWorker.status.current_task_id,
+    message_id: null,
+    reason: deadWorker.status.reason ?? 'dead_worker_detected_during_await',
+    created_at: deadWorker.status.updated_at || new Date().toISOString(),
+    source_type: 'await_snapshot',
+  };
 }
 
 function parseTeamArgs(args: string[]): ParsedTeamArgs {
@@ -553,12 +574,37 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
       return;
     }
 
-    const result = await waitForTeamEvent(name, cwd, {
-      afterEventId: afterEventId || undefined,
-      timeoutMs,
-      pollMs: 100,
+    const baselineCursor = afterEventId || (await readTeamEvents(name, cwd, { wakeableOnly: true }).then((events) => events.at(-1)?.event_id ?? ''));
+    const snapshot = await monitorTeam(name, cwd);
+    const immediateEvent = await readTeamEvents(name, cwd, {
+      afterEventId: baselineCursor || undefined,
       wakeableOnly: true,
-    });
+    }).then((events) => events[0]);
+
+    const result =
+      immediateEvent
+        ? { status: 'event' as const, cursor: immediateEvent.event_id, event: immediateEvent }
+        : snapshot && snapshotHasDeadWorkerStall(snapshot)
+          ? await readTeamEvents(name, cwd, { wakeableOnly: true }).then((events) => {
+            const latestWakeableEvent = events.at(-1);
+            if (latestWakeableEvent) {
+              return {
+                status: 'event' as const,
+                cursor: latestWakeableEvent.event_id,
+                event: latestWakeableEvent,
+              };
+            }
+            const fallbackEvent = buildDeadWorkerAwaitEvent(name, snapshot);
+            return fallbackEvent
+              ? { status: 'event' as const, cursor: baselineCursor, event: fallbackEvent }
+              : { status: 'timeout' as const, cursor: baselineCursor };
+          })
+          : await waitForTeamEvent(name, cwd, {
+            afterEventId: baselineCursor || undefined,
+            timeoutMs,
+            pollMs: 100,
+            wakeableOnly: true,
+          });
 
     if (wantsJson) {
       console.log(JSON.stringify({

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -262,6 +262,7 @@ function isPidAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
     process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
     return false;
   }
@@ -309,7 +310,9 @@ async function teardownPromptWorker(
       process.kill(pid, 'SIGTERM');
     }
   } catch (err) {
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+    if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
+      process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+    }
     // Best effort.
   }
 
@@ -336,7 +339,9 @@ async function teardownPromptWorker(
       process.kill(pid, 'SIGKILL');
     }
   } catch (err) {
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+    if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
+      process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+    }
     // Best effort.
   }
 
@@ -366,14 +371,7 @@ async function teardownPromptWorker(
 function isPromptWorkerAlive(config: TeamConfig, worker: WorkerInfo): boolean {
   const handle = getPromptWorkerHandle(config.name, worker.name);
   if (handle?.child.exitCode === null && !handle.child.killed) return true;
-  if (!Number.isFinite(worker.pid) || (worker.pid ?? 0) <= 0) return false;
-  try {
-    process.kill(worker.pid as number, 0);
-    return true;
-  } catch (err) {
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    return false;
-  }
+  return isPidAlive(worker.pid as number);
 }
 
 export { TEAM_LOW_COMPLEXITY_DEFAULT_MODEL };
@@ -1084,11 +1082,18 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
   }
 
   const allTasksTerminal = taskCounts.pending === 0 && taskCounts.blocked === 0 && taskCounts.in_progress === 0;
+  const deadWorkerStall =
+    config.worker_launch_mode === 'prompt'
+    && config.workers.length > 0
+    && deadWorkers.length >= config.workers.length
+    && !allTasksTerminal;
 
   const persistedPhase = await readTeamPhaseState(sanitized, cwd);
-  const targetPhase = inferPhaseTargetFromTaskCounts(taskCounts, {
-    verificationPending: verificationPendingTasks.length > 0,
-  });
+  const targetPhase = deadWorkerStall
+    ? 'failed'
+    : inferPhaseTargetFromTaskCounts(taskCounts, {
+      verificationPending: verificationPendingTasks.length > 0,
+    });
   const phaseState: TeamPhaseState = reconcilePhaseStateForMonitor(persistedPhase, targetPhase);
   await writeTeamPhaseState(sanitized, phaseState, cwd);
   const phase: TeamPhase | TerminalPhase = phaseState.current_phase;
@@ -1096,8 +1101,11 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
   for (const taskId of reclaimedTaskIds) {
     recommendations.push(`Reclaimed expired claim for task-${taskId}`);
   }
+  if (deadWorkerStall) {
+    recommendations.push('All workers are dead while work remains; mark the team failed or restart with fresh workers.');
+  }
 
-  await emitMonitorDerivedEvents(sanitized, taskView, workers, previousSnapshot, cwd);
+  await emitMonitorDerivedEvents(sanitized, taskView, workers, previousSnapshot, config.worker_launch_mode, cwd);
   const mailboxDeliveryStartMs = performance.now();
   const mailboxNotifiedByMessageId = await deliverPendingMailboxMessages(
     sanitized,
@@ -1529,13 +1537,7 @@ export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRun
     const missingHandles = config.workers
       .filter((worker) => {
         if (!Number.isFinite(worker.pid) || (worker.pid ?? 0) <= 0) return false;
-        try {
-          process.kill(worker.pid as number, 0);
-          return true;
-        } catch (err) {
-          process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-          return false;
-        }
+        return isPidAlive(worker.pid as number);
       })
       .filter((worker) => !getPromptWorkerHandle(sanitized, worker.name));
     if (missingHandles.length > 0) {
@@ -1625,15 +1627,14 @@ async function emitMonitorDerivedEvents(
   tasks: TeamTask[],
   workers: TeamSnapshot['workers'],
   previous: TeamMonitorSnapshotState | null,
+  workerLaunchMode: TeamConfig['worker_launch_mode'],
   cwd: string,
 ): Promise<void> {
-  if (!previous) return;
-
   for (const task of tasks) {
-    const prevStatus = previous.taskStatusById[task.id];
+    const prevStatus = previous?.taskStatusById[task.id];
     if (prevStatus && prevStatus !== 'completed' && task.status === 'completed') {
       // Skip if a task_completed event was already emitted by transitionTaskStatus (issue #161).
-      if (previous.completedEventTaskIds?.[task.id]) continue;
+      if (previous?.completedEventTaskIds?.[task.id]) continue;
       await appendTeamEvent(
         teamName,
         {
@@ -1649,8 +1650,9 @@ async function emitMonitorDerivedEvents(
   }
 
   for (const worker of workers) {
-    const prevAlive = previous.workerAliveByName[worker.name];
-    if (prevAlive === true && worker.alive === false) {
+    const prevAlive = previous?.workerAliveByName[worker.name];
+    const shouldEmitInitialPromptWorkerStop = workerLaunchMode === 'prompt' && prevAlive === undefined;
+    if ((prevAlive === true || shouldEmitInitialPromptWorkerStop) && worker.alive === false) {
       await appendTeamEvent(
         teamName,
         {
@@ -1664,7 +1666,7 @@ async function emitMonitorDerivedEvents(
       );
     }
 
-    const prevState = previous.workerStateByName[worker.name];
+    const prevState = previous?.workerStateByName[worker.name];
     if (prevState && prevState !== worker.status.state) {
       await appendTeamEvent(
         teamName,


### PR DESCRIPTION
## Summary
- treat prompt-launch teams with no live workers and outstanding work as failed instead of leaving them in team-exec
- suppress expected ESRCH noise for dead prompt worker PID probes/teardown and emit a first-pass worker_stopped wake event
- make `omx team await` surface the dead-worker wake event in the local prompt smoke flow and lock it with regression coverage

## Verification
- npm run build
- npm run check:no-unused
- npx biome lint src/cli/team.ts src/team/runtime.ts src/cli/__tests__/team.test.ts src/team/__tests__/runtime.test.ts
- node --test dist/cli/__tests__/team.test.js dist/team/__tests__/runtime.test.js
- node --test dist/team/__tests__/runtime-cli.test.js
- manual prompt smoke: `OMX_TEAM_WORKER_LAUNCH_MODE=prompt` + 1-worker executor fake-codex flow (`status` => phase=failed, `await` => worker_stopped)
- manual runtime-cli smoke: prompt-mode 1-worker fake-codex flow exits failed quickly instead of stalling