### PR TITLE
fix(deps): add zod as direct dependency (#657)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0"
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",


### PR DESCRIPTION
## Summary

Adds `zod` (`^3.23.0`) as a direct dependency in `package.json`.

## Problem

`dist/mcp/team-server.js` imports `zod` at line 14:
```js
import { z } from 'zod';
```

But `zod` is not declared in `package.json` dependencies. On fresh installs where npm doesn't hoist `zod` from transitive deps, this causes:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod'
MCP startup failed: omx_team_run
```

## Fix

Add `"zod": "^3.23.0"` to `dependencies`.

Closes #657