### PR TITLE
Fix team notify injection into shell panes after completion

### DIFF
--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -5,7 +5,7 @@
 import { readFile, writeFile, mkdir, appendFile, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { asNumber, safeString } from './utils.js';
+import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
@@ -84,6 +84,66 @@ export async function isLeaderStale(stateDir, thresholdMs, nowMs) {
   const lastMs = Date.parse(lastTurnAt);
   if (!Number.isFinite(lastMs)) return true;
   return (nowMs - lastMs) >= thresholdMs;
+}
+
+function resolveTerminalAtFromPhaseDoc(parsed, fallbackIso) {
+  const transitions = Array.isArray(parsed && parsed.transitions) ? parsed.transitions : [];
+  for (let idx = transitions.length - 1; idx >= 0; idx -= 1) {
+    const at = safeString(transitions[idx] && transitions[idx].at).trim();
+    if (at) return at;
+  }
+  const updatedAt = safeString(parsed && parsed.updated_at).trim();
+  return updatedAt || fallbackIso;
+}
+
+async function readTeamPhaseSnapshot(stateDir, teamName, nowIso) {
+  const phasePath = join(stateDir, 'team', teamName, 'phase.json');
+  try {
+    if (!existsSync(phasePath)) return { currentPhase: '', terminal: false, completedAt: '' };
+    const parsed = JSON.parse(await readFile(phasePath, 'utf-8'));
+    const currentPhase = safeString(parsed && parsed.current_phase).trim();
+    return {
+      currentPhase,
+      terminal: isTerminalPhase(currentPhase),
+      completedAt: resolveTerminalAtFromPhaseDoc(parsed, nowIso),
+    };
+  } catch {
+    return { currentPhase: '', terminal: false, completedAt: '' };
+  }
+}
+
+async function syncScopedTeamStateFromPhase(teamStatePath, teamName, phaseSnapshot, nowIso) {
+  if (!phaseSnapshot || !phaseSnapshot.terminal) return false;
+  try {
+    if (!existsSync(teamStatePath)) return false;
+    const parsed = JSON.parse(await readFile(teamStatePath, 'utf-8'));
+    if (!parsed || safeString(parsed.team_name).trim() !== teamName) return false;
+
+    let changed = false;
+    if (parsed.active !== false) {
+      parsed.active = false;
+      changed = true;
+    }
+    if (safeString(parsed.current_phase).trim() !== phaseSnapshot.currentPhase) {
+      parsed.current_phase = phaseSnapshot.currentPhase;
+      changed = true;
+    }
+    if (safeString(parsed.completed_at).trim() !== phaseSnapshot.completedAt && phaseSnapshot.completedAt) {
+      parsed.completed_at = phaseSnapshot.completedAt;
+      changed = true;
+    }
+    if (safeString(parsed.last_turn_at).trim() !== nowIso) {
+      parsed.last_turn_at = nowIso;
+      changed = true;
+    }
+
+    if (changed) {
+      await writeFile(teamStatePath, JSON.stringify(parsed, null, 2));
+    }
+    return changed;
+  } catch {
+    return false;
+  }
 }
 
 async function readWorkerStatusSnapshot(stateDir, teamName, workerName) {
@@ -371,7 +431,15 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
       const parsed = JSON.parse(await readFile(teamStatePath, 'utf-8'));
       if (!parsed || parsed.active !== true) continue;
       const teamName = safeString(parsed.team_name || '').trim();
-      if (teamName) activeTeamNames.add(teamName);
+      if (!teamName) continue;
+
+      const phaseSnapshot = await readTeamPhaseSnapshot(stateDir, teamName, nowIso);
+      if (phaseSnapshot.terminal) {
+        await syncScopedTeamStateFromPhase(teamStatePath, teamName, phaseSnapshot, nowIso);
+        continue;
+      }
+
+      activeTeamNames.add(teamName);
     }
   } catch {
     // Non-critical

--- a/scripts/notify-hook/team-worker.js
+++ b/scripts/notify-hook/team-worker.js
@@ -5,7 +5,7 @@
 import { readFile, writeFile, mkdir, appendFile, rename, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, resolve as resolvePath } from 'path';
-import { asNumber, safeString } from './utils.js';
+import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
@@ -119,6 +119,67 @@ function isFreshIso(value, maxAgeMs, nowMs) {
   const ts = parseIsoMs(value);
   if (!Number.isFinite(ts)) return false;
   return (nowMs - ts) <= maxAgeMs;
+}
+
+function resolveTerminalAtFromPhaseDoc(parsed, fallbackIso) {
+  const transitions = Array.isArray(parsed && parsed.transitions) ? parsed.transitions : [];
+  for (let idx = transitions.length - 1; idx >= 0; idx -= 1) {
+    const at = safeString(transitions[idx] && transitions[idx].at).trim();
+    if (at) return at;
+  }
+  const updatedAt = safeString(parsed && parsed.updated_at).trim();
+  return updatedAt || fallbackIso;
+}
+
+async function readTeamPhaseSnapshot(stateDir, teamName, nowIso = new Date().toISOString()) {
+  const phasePath = join(stateDir, 'team', teamName, 'phase.json');
+  try {
+    if (!existsSync(phasePath)) return { currentPhase: '', terminal: false, completedAt: '' };
+    const parsed = JSON.parse(await readFile(phasePath, 'utf-8'));
+    const currentPhase = safeString(parsed && parsed.current_phase).trim();
+    return {
+      currentPhase,
+      terminal: isTerminalPhase(currentPhase),
+      completedAt: resolveTerminalAtFromPhaseDoc(parsed, nowIso),
+    };
+  } catch {
+    return { currentPhase: '', terminal: false, completedAt: '' };
+  }
+}
+
+async function syncScopedTeamStateFromPhase(stateDir, teamName, phaseSnapshot, nowIso = new Date().toISOString()) {
+  if (!phaseSnapshot || !phaseSnapshot.terminal) return false;
+  const teamStatePath = join(stateDir, 'team-state.json');
+  try {
+    if (!existsSync(teamStatePath)) return false;
+    const parsed = JSON.parse(await readFile(teamStatePath, 'utf-8'));
+    if (!parsed || safeString(parsed.team_name).trim() !== teamName) return false;
+
+    let changed = false;
+    if (parsed.active !== false) {
+      parsed.active = false;
+      changed = true;
+    }
+    if (safeString(parsed.current_phase).trim() !== phaseSnapshot.currentPhase) {
+      parsed.current_phase = phaseSnapshot.currentPhase;
+      changed = true;
+    }
+    if (safeString(parsed.completed_at).trim() !== phaseSnapshot.completedAt && phaseSnapshot.completedAt) {
+      parsed.completed_at = phaseSnapshot.completedAt;
+      changed = true;
+    }
+    if (safeString(parsed.last_turn_at).trim() !== nowIso) {
+      parsed.last_turn_at = nowIso;
+      changed = true;
+    }
+
+    if (changed) {
+      await writeFile(teamStatePath, JSON.stringify(parsed, null, 2));
+    }
+    return changed;
+  } catch {
+    return false;
+  }
 }
 
 async function readWorkerStatusSnapshot(stateDir, teamName, workerName, nowMs = Date.now()) {
@@ -265,6 +326,11 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   const { teamName, workerName } = parsedTeamWorker;
   const nowMs = Date.now();
   const nowIso = new Date(nowMs).toISOString();
+  const phaseSnapshot = await readTeamPhaseSnapshot(stateDir, teamName, nowIso);
+  if (phaseSnapshot.terminal) {
+    await syncScopedTeamStateFromPhase(stateDir, teamName, phaseSnapshot, nowIso);
+    return;
+  }
 
   // Only trigger check when this worker is idle
   const mySnapshot = await readWorkerStatusSnapshot(stateDir, teamName, workerName, nowMs);
@@ -329,7 +395,8 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       last_notified_at_ms: nowMs,
       last_notified_at: nowIso,
       worker_count: N,
-      delivery: 'deferred',
+      delivery: 'deferred_shell',
+      pane_current_command: paneGuard.paneCurrentCommand || null,
     };
     await writeFile(idleStatePath, JSON.stringify(nextIdleState, null, 2)).catch(() => {});
     await emitLeaderPaneMissingDeferred({
@@ -402,6 +469,11 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
   const { teamName, workerName } = parsedTeamWorker;
   const nowMs = Date.now();
   const nowIso = new Date(nowMs).toISOString();
+  const phaseSnapshot = await readTeamPhaseSnapshot(stateDir, teamName, nowIso);
+  if (phaseSnapshot.terminal) {
+    await syncScopedTeamStateFromPhase(stateDir, teamName, phaseSnapshot, nowIso);
+    return;
+  }
 
   // Read current worker status (full object for task context)
   const workerDir = join(stateDir, 'team', teamName, 'workers', workerName);
@@ -495,7 +567,8 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
         last_notified_at_ms: nowMs,
         last_notified_at: nowIso,
         prev_state: prevState,
-        delivery: 'deferred',
+        delivery: 'deferred_shell',
+        pane_current_command: paneGuard.paneCurrentCommand || null,
       }, null, 2));
       await rename(tmpPath, cooldownPath);
     } catch { /* best effort */ }

--- a/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
@@ -275,6 +275,7 @@ exit 0
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /display-message -p -t %181 #\{pane_current_command\}/);
       assert.doesNotMatch(tmuxLog, /send-keys -t %181/, 'must not inject into shell pane');
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
@@ -284,6 +285,10 @@ exit 0
         event.type === 'leader_notification_deferred' && event.reason === 'leader_pane_shell_no_injection');
       assert.ok(deferred, 'should defer shell-pane all-workers-idle notification');
       assert.equal(deferred.pane_current_command, 'zsh');
+
+      const idleState = JSON.parse(await readFile(join(teamDir, 'all-workers-idle.json'), 'utf-8'));
+      assert.equal(idleState.delivery, 'deferred_shell');
+      assert.equal(idleState.pane_current_command, 'zsh');
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -494,6 +494,7 @@ exit 0
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /display-message -p -t %71 #\{pane_current_command\}/);
       assert.doesNotMatch(tmuxLog, /send-keys -t %71/, 'should not inject into a shell pane');
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
@@ -502,6 +503,52 @@ exit 0
         entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_shell_no_injection');
       assert.ok(deferred, 'should emit deferred event for shell-pane leader');
       assert.equal(deferred.pane_current_command, 'zsh');
+    });
+  });
+
+  it('syncs stale root team-state to inactive when team-local phase is already terminal', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'terminal-sync';
+      const teamDir = join(stateDir, 'team', teamName);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(teamDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'phase.json'), {
+        current_phase: 'complete',
+        transitions: [
+          { from: 'team-verify', to: 'complete', at: '2026-03-09T19:20:19.088Z' },
+        ],
+        updated_at: '2026-03-09T19:20:19.088Z',
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const syncedState = JSON.parse(await readFile(join(stateDir, 'team-state.json'), 'utf-8'));
+      assert.equal(syncedState.active, false);
+      assert.equal(syncedState.current_phase, 'complete');
+      assert.equal(syncedState.completed_at, '2026-03-09T19:20:19.088Z');
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys/, 'must not nudge a terminal team');
+      }
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -208,6 +208,7 @@ exit 0
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /display-message -p -t %79 #\{pane_current_command\}/);
       assert.doesNotMatch(tmuxLog, /send-keys -t %79/, 'should not inject worker-idle into a shell pane');
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
@@ -216,6 +217,10 @@ exit 0
         entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_shell_no_injection');
       assert.ok(deferred, 'should emit deferred shell-pane event');
       assert.equal(deferred.pane_current_command, 'zsh');
+
+      const cooldown = JSON.parse(await readFile(join(workersDir, 'worker-1', 'worker-idle-notify.json'), 'utf-8'));
+      assert.equal(cooldown.delivery, 'deferred_shell');
+      assert.equal(cooldown.pane_current_command, 'zsh');
     });
   });
 


### PR DESCRIPTION
## Summary
- guard team worker/leader notify paths against injecting into shell panes
- stop nudging teams whose local `phase.json` is already terminal by syncing stale root `team-state.json`
- add regression coverage for worker-idle, all-workers-idle, and leader nudge paths

Closes #667.

## Testing
- `npx biome lint scripts/notify-hook/team-worker.js scripts/notify-hook/team-leader-nudge.js src/hooks/__tests__/notify-hook-worker-idle.test.ts src/hooks/__tests__/notify-hook-all-workers-idle.test.ts src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts`
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
- `node --test --test-concurrency=1 dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-hook-worker-idle.test.js`
