### PR TITLE
perf(team): prototype tmux stream inspector scaffold

### DIFF
--- a/docs/tmux-stream-inspector.md
+++ b/docs/tmux-stream-inspector.md
@@ -1,0 +1,76 @@
+# tmux stream inspector proposal
+
+## Why
+
+OMX currently issues a large number of tmux CLI calls in hot paths:
+- capture-pane
+- list-panes
+- display-message
+- send-keys guard checks around those reads
+
+The expensive part is not only tmux itself, but the repeated Node child-process spawn + pane capture + string parsing loop.
+
+## Current hot paths
+
+### Team runtime
+- src/team/tmux-session.ts
+  - waitForWorkerReady() repeatedly polls capture-pane
+  - capturePaneAsync()
+  - multiple list-panes / display-message helpers
+
+### Team idle / nudge
+- src/team/idle-nudge.ts
+  - capturePane() on each scan
+  - isPaneIdle() = capture + parse loop
+
+### Notifications / reply injection
+- src/notifications/tmux-detector.ts
+- src/notifications/tmux.ts
+- scripts/tmux-hook-engine.js
+- scripts/notify-hook/tmux-injection.js
+- scripts/notify-hook/auto-nudge.js
+- scripts/notify-hook/team-leader-nudge.js
+
+## Proposal
+
+Introduce a Rust helper / sidecar, tentatively omx-tmux-inspect.
+
+### Mode A: snapshot
+Return cached pane/session state as JSON.
+
+Example:
+- omx-tmux-inspect snapshot --session omx-team-foo
+- omx-tmux-inspect pane --id %3
+
+### Mode B: watch
+Run one long-lived inspector loop that watches tmux sessions and maintains:
+- pane current command
+- pane dead/alive state
+- recent tail buffer
+- shell detection
+- ready/idle heuristics
+- marker presence / injection guard signals
+
+Node should query this cached state rather than directly calling tmux capture-pane in every hot path.
+
+## Expected wins
+
+- fewer tmux child-process spawns
+- lower latency in worker readiness polling
+- cheaper multi-pane idle detection
+- centralized shell/idle heuristics
+- easier perf instrumentation
+
+## Incremental adoption plan
+
+1. add Rust helper binary + simple JSON snapshot output
+2. switch waitForWorkerReady() to inspector-backed reads
+3. switch idle-nudge.ts to inspector state
+4. switch notify/reply helpers to inspector state
+5. consider deeper event-driven integration later
+
+## Non-goals
+
+- replacing all tmux writes immediately
+- changing team runtime semantics in the same PR
+- full tmux control-mode migration in the first iteration


### PR DESCRIPTION
## Summary
- add an opt-in first prototype for the tmux stream inspector idea on the hottest current path: `waitForWorkerReady()`
- benchmark the prototype against the current polling path instead of assuming the stream approach is a win
- keep the work exploratory and draft-only because the first prototype does **not** show an end-to-end perf win yet

## Prototype scope
This PR stays intentionally narrow.

Included:
- a small `tmux-stream-inspector` scaffold behind `OMX_TMUX_STREAM_INSPECTOR=1`
- integration only at `src/team/tmux-session.ts -> waitForWorkerReady()`
- tests covering inspector setup/teardown and fallback behavior

Not included:
- idle-nudge migration
- notification/reply helper migration
- any larger tmux runtime rewrite

## Benchmark verdict
Real tmux timing comparison, 5 runs each, using a pane that becomes ready after ~650ms:

- baseline (`OMX_TMUX_STREAM_INSPECTOR=0`): **920.8ms avg**
- prototype (`OMX_TMUX_STREAM_INSPECTOR=1`): **932.4ms avg**
- delta: **+11.5ms** for the prototype (**~1.3% slower**)

Conclusion: the first per-call stream scaffold reduces repeated `capture-pane` reads, but the one-shot `pipe-pane` setup/teardown cost cancels out the benefit. This is a coherent prototype, but **not a performance win** in its current form.

## Why this stays draft
The result de-risks the idea by showing that a per-call inspector is not enough. The likely useful direction is narrower now:

**next step: build only a persistent session-level inspector reused across multiple readiness checks/panes**

That is the smallest next experiment still worth pursuing. Anything broader should wait until that persistent version proves an actual win.

## Follow-up
- either stop here and close as exploratory
- or implement a persistent session-level inspector only, then re-benchmark before expanding adoption