### PR TITLE
Tighten periodic team leader nudges

### DIFF
--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -16,9 +16,9 @@ const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
 export function resolveLeaderNudgeIntervalMs() {
   const raw = safeString(process.env.OMX_TEAM_LEADER_NUDGE_MS || '');
   const parsed = asNumber(raw);
-  // Default: 2 minutes. Guard against spam.
+  // Default: 30 seconds for stale-leader follow-up. Guard against spam.
   if (parsed !== null && parsed >= 10_000 && parsed <= 30 * 60_000) return parsed;
-  return 120_000;
+  return 30_000;
 }
 
 export function resolveLeaderAllIdleNudgeCooldownMs() {
@@ -233,10 +233,12 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     const dueByIdleCooldown = !Number.isFinite(prevIdleAtMs) || (nowMs - prevIdleAtMs >= idleCooldownMs);
     const shouldSendAllIdleNudge = allWorkersIdle && dueByIdleCooldown;
 
-    // stalePanesNudge must respect the same dueByTime rate limit (issue #116)
+    // Stale-leader follow-up is the only periodic visible nudge path.
+    // This keeps the leader pane quieter when the leader is not actually stale.
     const stalePanesNudge = paneStatus.alive && leaderStale;
+    const staleFollowupDue = stalePanesNudge && dueByTime;
 
-    if (!shouldSendAllIdleNudge && !hasNewMessage && !dueByTime) continue;
+    if (!shouldSendAllIdleNudge && !hasNewMessage && !staleFollowupDue) continue;
 
     let nudgeReason = '';
     let text = '';
@@ -247,15 +249,14 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     } else if (stalePanesNudge && hasNewMessage) {
       nudgeReason = 'stale_leader_with_messages';
       text = `Team ${teamName}: leader stale, ${paneStatus.paneCount} pane(s) active, ${messages.length} msg(s) pending. Run: omx team status ${teamName}`;
-    } else if (stalePanesNudge) {
+    } else if (staleFollowupDue) {
       nudgeReason = 'stale_leader_panes_alive';
       text = `Team ${teamName}: leader stale, ${paneStatus.paneCount} worker pane(s) still active. Run: omx team status ${teamName}`;
     } else if (hasNewMessage) {
       nudgeReason = 'new_mailbox_message';
       text = `Team ${teamName}: ${messages.length} msg(s) for leader. Run: omx team status ${teamName}`;
     } else {
-      nudgeReason = 'periodic_check';
-      text = `Team ${teamName} active. Run: omx team status ${teamName}`;
+      continue;
     }
     const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
     const markedText = `${capped} ${DEFAULT_MARKER}`;

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -300,6 +300,121 @@ describe('notify-hook team leader nudge', () => {
     });
   });
 
+  it('does not send a generic periodic leader nudge when the leader is not stale', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'fresh-leader';
+      const teamDir = join(stateDir, 'team', teamName);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(join(teamDir, 'mailbox'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'omx-team-fresh',
+        leader_pane_id: '%95',
+      });
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: new Date().toISOString(),
+        turn_count: 2,
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_NUDGE_MS: '30000' });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /Team fresh-leader/, 'non-stale leader should not receive generic periodic follow-up');
+      }
+    });
+  });
+
+  it('uses a 30s cadence for stale leader follow-up nudges', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'stale-cadence';
+      const teamDir = join(stateDir, 'team', teamName);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const now = Date.now();
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(join(teamDir, 'mailbox'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'omx-team-stale-cadence',
+        leader_pane_id: '%96',
+      });
+
+      const staleHud = {
+        last_turn_at: new Date(now - 300_000).toISOString(),
+        turn_count: 5,
+      };
+
+      await writeJson(join(stateDir, 'hud-state.json'), staleHud);
+      await writeJson(join(stateDir, 'team-leader-nudge.json'), {
+        last_nudged_by_team: {
+          [teamName]: {
+            at: new Date(now - 20_000).toISOString(),
+            last_message_id: '',
+          },
+        },
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const blocked = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_NUDGE_MS: '30000' });
+      assert.equal(blocked.status, 0, `notify-hook failed: ${blocked.stderr || blocked.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const firstLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(firstLog, /Team stale-cadence:/, 'stale follow-up should be blocked inside the 30s window');
+      }
+
+      await writeJson(join(stateDir, 'hud-state.json'), staleHud);
+      await writeJson(join(stateDir, 'team-leader-nudge.json'), {
+        last_nudged_by_team: {
+          [teamName]: {
+            at: new Date(now - 31_000).toISOString(),
+            last_message_id: '',
+          },
+        },
+      });
+
+      const allowed = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_NUDGE_MS: '30000' });
+      assert.equal(allowed.status, 0, `notify-hook failed: ${allowed.stderr || allowed.stdout}`);
+
+      const finalLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(finalLog, /Team stale-cadence:/);
+      assert.match(finalLog, /leader stale/);
+    });
+  });
+
   it('emits team_leader_nudge event to events.ndjson when nudge fires', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');


### PR DESCRIPTION
Summary
- tightens leader-pane follow-up nudges so periodic visible nudges only fire when the leader is already stale
- reduces context pollution by removing the broad generic periodic visible nudge path for non-stale leaders
- sets the default stale-follow-up cadence to 30 seconds and adds regression coverage

What changed
- updated `scripts/notify-hook/team-leader-nudge.js`
  - changed default `OMX_TEAM_LEADER_NUDGE_MS` fallback from 2m to 30s
  - made periodic visible follow-up depend on:
    - active team
    - existing `leader_pane_id`
    - existing stale-leader heuristic
    - elapsed cadence window
  - removed the fallback generic `periodic_check` injection branch
  - preserved higher-priority leader nudges:
    - `all_workers_idle`
    - `stale_leader_with_messages`
    - `stale_leader_panes_alive`
    - `new_mailbox_message`
    - deferred no-pane behavior
- updated `src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts`
  - added coverage that non-stale leaders do not receive generic periodic follow-up
  - added coverage that stale leader follow-up respects a 30s cadence
  - preserved existing regression coverage for mailbox / stale / all-idle / deferred paths

Why
- there was already a periodic leader nudge path, but it was too broad and could visibly inject follow-up text even when the leader was not stale
- this keeps the behavior in the existing leader-nudge subsystem while making it more targeted and less noisy

Verification
- `npm run lint -- scripts/notify-hook/team-leader-nudge.js src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts`
- `node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
- `node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/team/__tests__/idle-nudge.test.js`
- `npm test`

Risks / notes
- default leader follow-up cadence changes from 2 minutes to 30 seconds, but the visible periodic path is now stale-gated
- any downstream expectations tied specifically to the generic `periodic_check` visible injection path should now rely on the stale-gated reasons instead
