### PR TITLE
Fix user-scope setup preserving project AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ This experiment currently changes native prompt generation and metadata, not the
 
 ```bash
 omx                # Launch Codex (+ HUD in tmux when available)
-omx setup          # Install prompts/skills/config by scope + project AGENTS.md/.omx
+omx setup          # Install prompts/skills/config by scope + project .omx (AGENTS.md only for project scope)
 omx doctor         # Installation/runtime diagnostics
 omx doctor --team  # Team/swarm diagnostics
 omx ask ...        # Ask local provider advisor (claude|gemini), writes .omx/artifacts/*
@@ -353,7 +353,8 @@ Notes:
   - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`
   - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`
 - Launch behavior: if persisted scope is `project`, `omx` launch auto-uses `CODEX_HOME=./.codex` (unless `CODEX_HOME` is already set).
-- Managed OMX artifacts refresh by default in both interactive and non-interactive runs: prompts, skills, native agent configs, project `AGENTS.md`, and the managed OMX portion of `config.toml`
+- Managed OMX artifacts refresh by default in both interactive and non-interactive runs: prompts, skills, native agent configs, and the managed OMX portion of `config.toml`
+- Project `AGENTS.md` is only generated/refreshed for `project` scope; `user` scope leaves any existing project `AGENTS.md` unchanged
 - If a managed file differs and will be overwritten, setup creates a backup first under `.omx/backups/setup/<timestamp>/...` (project scope) or `~/.omx/backups/setup/<timestamp>/...` (user scope)
 - Active-session safety still blocks `AGENTS.md` overwrite while an OMX session is running
 - `config.toml` updates (for both scopes):
@@ -366,7 +367,7 @@ Notes:
   - `[features] multi_agent = true, child_agents_md = true`
   - MCP server entries (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
   - `[tui] status_line`
-- Project `AGENTS.md`
+- Project `AGENTS.md` (project scope only)
 - `.omx/` runtime directories and HUD config
 - Default setup output includes a compact per-category refresh summary; `--verbose` adds changed-file detail
 - `--force` is reserved for stronger maintenance behavior such as stale/deprecated skill cleanup; it is no longer required for ordinary refresh

--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -56,6 +56,28 @@ async function readCurrentLinuxStartTicks(): Promise<number | undefined> {
 }
 
 describe('omx setup AGENTS refresh behavior', () => {
+  it('leaves project AGENTS.md untouched for user scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(true);
+    const existing = '# project-owned agents file\n';
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+      });
+
+      assert.match(output, /User scope leaves project AGENTS\.md unchanged\./);
+      assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
+      assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);
+    } finally {
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('refreshes existing AGENTS.md by default in TTY and creates a backup first', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
     const restoreTty = setMockTty(true);

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -158,11 +158,14 @@ describe('omx setup scope behavior', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-scope-'));
     try {
       const home = join(wd, 'home');
+      const existingAgents = '# keep my project agents instructions\n';
       await mkdir(home, { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existingAgents);
       const res = runOmx(wd, ['setup'], { HOME: home });
       if (shouldSkipForSpawnPermissions(res.error)) return;
       assert.equal(res.status, 0, res.stderr || res.stdout);
       assert.match(res.stdout, /Using setup scope: user/);
+      assert.match(res.stdout, /User scope leaves project AGENTS\.md unchanged\./);
 
       assert.equal(existsSync(join(home, '.codex', 'prompts')), true);
       assert.equal(existsSync(join(home, '.agents', 'skills')), true);
@@ -170,6 +173,31 @@ describe('omx setup scope behavior', () => {
       assert.equal(existsSync(join(wd, '.omx', 'setup-scope.json')), true);
       const persistedScope = JSON.parse(await readFile(join(wd, '.omx', 'setup-scope.json'), 'utf-8')) as { scope: string };
       assert.equal(persistedScope.scope, 'user');
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existingAgents);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('doctor does not warn about missing project AGENTS.md for user scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-user-scope-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(join(home, '.codex', 'prompts'), { recursive: true });
+      await mkdir(join(home, '.agents', 'skills', 'sample-skill'), { recursive: true });
+      await mkdir(join(home, '.omx', 'agents'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'user' }));
+      await writeFile(join(home, '.codex', 'prompts', 'executor.md'), '# executor\n');
+      await writeFile(join(home, '.agents', 'skills', 'sample-skill', 'SKILL.md'), '# skill\n');
+      await writeFile(join(home, '.codex', 'config.toml'), 'omx_enabled = true\n[mcp_servers.omx_state]\ncommand = "node"\n');
+
+      const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: join(home, '.codex') });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /Resolved setup scope: user \(from \.omx\/setup-scope\.json\)/);
+      assert.match(res.stdout, /\[OK\] AGENTS\.md: user scope leaves project AGENTS\.md unchanged/);
+      assert.doesNotMatch(res.stdout, /AGENTS\.md: not found in project root/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -128,7 +128,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
   checks.push(await checkSkills(paths.skillsDir));
 
   // Check 7: AGENTS.md in project
-  checks.push(checkAgentsMd());
+  checks.push(checkAgentsMd(scopeResolution.scope));
 
   // Check 8: State directory
   checks.push(checkDirectory('State dir', paths.stateDir));
@@ -462,10 +462,13 @@ async function checkSkills(dir: string): Promise<Check> {
   }
 }
 
-function checkAgentsMd(): Check {
+function checkAgentsMd(scope: DoctorSetupScope): Check {
   const agentsMd = join(process.cwd(), 'AGENTS.md');
   if (existsSync(agentsMd)) {
     return { name: 'AGENTS.md', status: 'pass', message: 'found in project root' };
+  }
+  if (scope === 'user') {
+    return { name: 'AGENTS.md', status: 'pass', message: 'user scope leaves project AGENTS.md unchanged' };
   }
   return { name: 'AGENTS.md', status: 'warn', message: 'not found in project root (run omx setup)' };
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -489,55 +489,60 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
   // Step 6: Generate AGENTS.md
   console.log("[6/8] Generating AGENTS.md...");
-  const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
-  const agentsMdDst = join(projectRoot, "AGENTS.md");
-  const agentsMdExists = existsSync(agentsMdDst);
-
-  // Guard: refuse to overwrite AGENTS.md during active session
-  const activeSession = await readSessionState(projectRoot);
-  const sessionIsActive = activeSession && !isSessionStale(activeSession);
-
-  if (existsSync(agentsMdSrc)) {
-    const content = await readFile(agentsMdSrc, "utf-8");
-    const rewritten = applyScopePathRewritesToAgentsTemplate(
-      content,
-      resolvedScope.scope,
-    );
-    let changed = true;
-    if (agentsMdExists) {
-      const existing = await readFile(agentsMdDst, "utf-8");
-      changed = existing !== rewritten;
-    }
-
-    if (sessionIsActive && agentsMdExists && changed) {
-      summary.agentsMd.skipped += 1;
-      console.log(
-        "  WARNING: Active omx session detected (pid " +
-          activeSession?.pid +
-          ").",
-      );
-      console.log(
-        "  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
-      );
-      console.log("  Stop the active session first, then re-run setup.");
-    } else {
-      await syncManagedContent(
-        rewritten,
-        agentsMdDst,
-        summary.agentsMd,
-        backupContext,
-        { dryRun, verbose },
-        "AGENTS.md",
-      );
-      if (summary.agentsMd.updated > 0) {
-        console.log("  Generated AGENTS.md in project root.");
-      } else if (summary.agentsMd.unchanged > 0) {
-        console.log("  AGENTS.md already up to date.");
-      }
-    }
-  } else {
+  if (resolvedScope.scope !== "project") {
     summary.agentsMd.skipped += 1;
-    console.log("  AGENTS.md template not found, skipping.");
+    console.log("  User scope leaves project AGENTS.md unchanged.");
+  } else {
+    const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
+    const agentsMdDst = join(projectRoot, "AGENTS.md");
+    const agentsMdExists = existsSync(agentsMdDst);
+
+    // Guard: refuse to overwrite AGENTS.md during active session
+    const activeSession = await readSessionState(projectRoot);
+    const sessionIsActive = activeSession && !isSessionStale(activeSession);
+
+    if (existsSync(agentsMdSrc)) {
+      const content = await readFile(agentsMdSrc, "utf-8");
+      const rewritten = applyScopePathRewritesToAgentsTemplate(
+        content,
+        resolvedScope.scope,
+      );
+      let changed = true;
+      if (agentsMdExists) {
+        const existing = await readFile(agentsMdDst, "utf-8");
+        changed = existing !== rewritten;
+      }
+
+      if (sessionIsActive && agentsMdExists && changed) {
+        summary.agentsMd.skipped += 1;
+        console.log(
+          "  WARNING: Active omx session detected (pid " +
+            activeSession?.pid +
+            ").",
+        );
+        console.log(
+          "  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
+        );
+        console.log("  Stop the active session first, then re-run setup.");
+      } else {
+        await syncManagedContent(
+          rewritten,
+          agentsMdDst,
+          summary.agentsMd,
+          backupContext,
+          { dryRun, verbose },
+          "AGENTS.md",
+        );
+        if (summary.agentsMd.updated > 0) {
+          console.log("  Generated AGENTS.md in project root.");
+        } else if (summary.agentsMd.unchanged > 0) {
+          console.log("  AGENTS.md already up to date.");
+        }
+      }
+    } else {
+      summary.agentsMd.skipped += 1;
+      console.log("  AGENTS.md template not found, skipping.");
+    }
   }
   console.log();
 


### PR DESCRIPTION
## Summary
- stop `omx setup` from generating or overwriting project `AGENTS.md` when setup scope is `user`
- make `omx doctor` treat a missing project `AGENTS.md` as expected for user-scope installs
- cover the scoped behavior with focused setup/doctor tests and clarify the README

## Testing
- `npm run lint`
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-agents-overwrite.test.js dist/cli/__tests__/doctor-warning-copy.test.js`
- `npm test`

Closes #676