### PR TITLE
feat(team): tag deferred leader notifications with source metadata

### DIFF
--- a/scripts/notify-hook/team-dispatch.js
+++ b/scripts/notify-hook/team-dispatch.js
@@ -226,6 +226,7 @@ async function appendLeaderNotificationDeferredEvent({
   nowIso,
   tmuxSession = '',
   leaderPaneId = '',
+  sourceType = 'team_dispatch',
 }) {
   const eventsDir = join(stateDir, 'team', teamName, 'events');
   const eventsPath = join(eventsDir, 'events.ndjson');
@@ -242,6 +243,7 @@ async function appendLeaderNotificationDeferredEvent({
     tmux_session: tmuxSession || null,
     leader_pane_id: leaderPaneId || null,
     tmux_injection_attempted: false,
+    source_type: sourceType,
   };
   await mkdir(eventsDir, { recursive: true }).catch(() => {});
   await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(() => {});
@@ -537,6 +539,7 @@ export async function drainPendingTeamDispatch({
               nowIso,
               tmuxSession: safeString(config?.tmux_session).trim(),
               leaderPaneId: safeString(config?.leader_pane_id).trim(),
+              sourceType: 'team_dispatch',
             });
           }
           continue;

--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -111,7 +111,7 @@ export async function emitTeamNudgeEvent(cwd, teamName, reason, nowIso) {
   }
 }
 
-async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmuxSession = '', leaderPaneId = '' } = {}) {
+async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmuxSession = '', leaderPaneId = '', sourceType = 'leader_nudge' } = {}) {
   const eventsDir = join(cwd, '.omx', 'state', 'team', teamName, 'events');
   const eventsPath = join(eventsDir, 'events.ndjson');
   try {
@@ -127,6 +127,7 @@ async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmu
       tmux_session: tmuxSession || null,
       leader_pane_id: leaderPaneId || null,
       tmux_injection_attempted: false,
+      source_type: sourceType,
     };
     await appendFile(eventsPath, JSON.stringify(event) + '\n');
   } catch {
@@ -269,6 +270,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
       await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, nowIso, {
         tmuxSession,
         leaderPaneId,
+        sourceType: 'leader_nudge',
       });
       try {
         await logTmuxHookEvent(logsDir, {
@@ -281,6 +283,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
           leader_pane_id: leaderPaneId || null,
           tmux_session: tmuxSession || null,
           tmux_injection_attempted: false,
+          source_type: 'leader_nudge',
         });
       } catch { /* ignore */ }
       continue;

--- a/scripts/notify-hook/team-worker.js
+++ b/scripts/notify-hook/team-worker.js
@@ -202,6 +202,7 @@ async function emitLeaderPaneMissingDeferred({
   tmuxSession,
   leaderPaneId,
   reason = 'leader_pane_missing_no_injection',
+  sourceType = 'unknown',
 }) {
   const nowIso = new Date().toISOString();
   await logTmuxHookEvent(logsDir, {
@@ -214,6 +215,7 @@ async function emitLeaderPaneMissingDeferred({
     leader_pane_id: leaderPaneId || null,
     tmux_session: tmuxSession || null,
     tmux_injection_attempted: false,
+    source_type: sourceType,
   }).catch(() => {});
 
   const eventsDir = join(stateDir, 'team', teamName, 'events');
@@ -230,6 +232,7 @@ async function emitLeaderPaneMissingDeferred({
     leader_pane_id: leaderPaneId || null,
     tmux_session: tmuxSession || null,
     tmux_injection_attempted: false,
+    source_type: sourceType,
   };
   await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(() => {});
 }
@@ -304,6 +307,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       logsDir,
       teamName,
       workerName,
+      sourceType: 'all_workers_idle',
       tmuxSession,
       leaderPaneId,
     });
@@ -448,6 +452,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       logsDir,
       teamName,
       workerName,
+      sourceType: 'worker_idle',
       tmuxSession,
       leaderPaneId,
     });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -333,6 +333,7 @@ describe('teamCommand api', () => {
           type: 'leader_notification_deferred',
           worker: 'worker-1',
           to_worker: 'leader-fixed',
+          source_type: 'worker_idle',
           reason: 'leader_pane_missing_no_injection',
         }),
         '--json',
@@ -340,11 +341,12 @@ describe('teamCommand api', () => {
 
       const envelope = JSON.parse(logs.at(-1) ?? '{}') as {
         ok?: boolean;
-        data?: { event?: { type?: string; to_worker?: string; reason?: string } };
+        data?: { event?: { type?: string; to_worker?: string; reason?: string; source_type?: string } };
       };
       assert.equal(envelope.ok, true);
       assert.equal(envelope.data?.event?.type, 'leader_notification_deferred');
       assert.equal(envelope.data?.event?.to_worker, 'leader-fixed');
+      assert.equal(envelope.data?.event?.source_type, 'worker_idle');
       assert.equal(envelope.data?.event?.reason, 'leader_pane_missing_no_injection');
     } finally {
       console.log = originalLog;

--- a/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
@@ -130,6 +130,7 @@ describe('notify-hook all-workers-idle notification', () => {
         e.type === 'leader_notification_deferred' && e.reason === 'leader_pane_missing_no_injection');
       assert.ok(deferredEvent, 'should emit leader_notification_deferred with missing-pane reason');
       assert.equal(deferredEvent.to_worker, 'leader-fixed');
+      assert.equal(deferredEvent.source_type, 'all_workers_idle');
       assert.equal(deferredEvent.tmux_session, 'devsess:0');
       assert.equal(deferredEvent.leader_pane_id, null);
       assert.equal(deferredEvent.tmux_injection_attempted, false);
@@ -148,6 +149,7 @@ describe('notify-hook all-workers-idle notification', () => {
         .find((entry: { type?: string; reason?: string }) =>
           entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_missing_no_injection');
       assert.ok(warn, 'should log leader_notification_deferred warning');
+      assert.equal(warn.source_type, 'all_workers_idle');
       assert.equal(warn.tmux_injection_attempted, false);
     });
   });

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -159,6 +159,7 @@ describe('notify-hook team dispatch consumer', () => {
         && event.request_id === queued.request.request_id
         && event.to_worker === 'leader-fixed');
       assert.ok(deferred, 'expected leader_notification_deferred event for missing leader pane');
+      assert.equal(deferred.source_type, 'team_dispatch');
       assert.equal(typeof deferred.tmux_session, 'string');
       assert.ok(deferred.tmux_session.length > 0);
       assert.equal(deferred.leader_pane_id, null);

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -537,6 +537,7 @@ describe('notify-hook team leader nudge', () => {
       assert.equal(deferred.type, 'leader_notification_deferred');
       assert.equal(deferred.worker, 'leader-fixed');
       assert.equal(deferred.to_worker, 'leader-fixed');
+      assert.equal(deferred.source_type, 'leader_nudge');
       assert.equal(deferred.tmux_session, 'devsess:0');
       assert.equal(deferred.leader_pane_id, null);
       assert.equal(deferred.tmux_injection_attempted, false);

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -130,6 +130,7 @@ describe('notify-hook per-worker idle notification', () => {
         entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_missing_no_injection');
       assert.ok(event, 'should emit deferred event with missing-pane reason');
       assert.equal(event.to_worker, 'leader-fixed');
+      assert.equal(event.source_type, 'worker_idle');
       assert.equal(event.tmux_session, 'devsess:0');
       assert.equal(event.leader_pane_id, null);
       assert.equal(event.tmux_injection_attempted, false);

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -538,6 +538,7 @@ export async function executeTeamApiOperation(
           prev_state: args.prev_state as string | undefined,
           to_worker: args.to_worker as string | undefined,
           worker_count: typeof args.worker_count === 'number' ? args.worker_count : undefined,
+          source_type: args.source_type as string | undefined,
         }, cwd);
         return { ok: true, operation, data: { event } };
       }


### PR DESCRIPTION
## Summary
- add `source_type` to deferred leader-notification artifacts so different emitters are distinguishable
- preserve existing `type=leader_notification_deferred` and transport-level `reason`
- extend API/test coverage for the new metadata field

## What changed
- updated deferred leader notification emitters to attach `source_type`
  - `leader_nudge`
  - `worker_idle`
  - `all_workers_idle`
  - `team_dispatch`
- updated `omx team api append-event` passthrough to preserve `source_type`
- updated regression tests across leader nudge, worker idle, all-workers-idle, dispatch, and CLI append-event paths

## Why
- different hook paths currently reuse the same deferred event type/reason, which makes distinct causes look like accidental duplicates in logs/events
- adding source metadata improves observability without changing existing event compatibility

## Verification
- `npm run lint`
- `npm run build`
- `node --test dist/cli/__tests__/team.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js`

## Risks / notes
- no deduplication behavior changed; this is observability-only
- existing consumers that ignore unknown fields remain compatible
