### PR TITLE
feat: add roster-aware ralplan follow-up staffing guidance

### DIFF
--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -54,6 +54,7 @@ Interpret implementation requests as planning requests only when this role is ex
 - The plan is saved to `.omx/plans/{name}.md`.
 - User confirmation is obtained before handoff.
 - In consensus mode, the RALPLAN-DR and ADR requirements are complete.
+- In consensus handoff mode, include an explicit available-agent-types roster plus concrete staffing / role-allocation guidance for both team and ralph follow-up paths.
 </success_criteria>
 
 <verification_loop>

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -95,6 +95,7 @@ Jumping into code without understanding requirements leads to rework, scope cree
    b. Deduplicate and categorize the suggestions
    c. Update the plan file in `.omx/plans/` with the accepted improvements (add missing details, refine steps, strengthen acceptance criteria, ADR updates, etc.)
    d. Note which improvements were applied in a brief changelog section at the end of the plan
+   e. Before any execution handoff, derive an explicit **available-agent-types roster** from the known prompt catalog and add concrete **follow-up staffing guidance** for both `$ralph` and `$team` (recommended roles, counts, and why each lane exists)
 7. On Critic approval (with improvements applied): *(--interactive only)* If running with `--interactive`, use `AskUserQuestion` to present the plan with these options:
    - **Approve and execute** — proceed to implementation via ralph+ultrawork
    - **Approve and implement via team** — proceed to implementation via coordinated parallel team agents
@@ -103,8 +104,8 @@ Jumping into code without understanding requirements leads to rework, scope cree
    If NOT running with `--interactive`, output the final approved plan and stop. Do NOT auto-execute.
 8. *(--interactive only)* User chooses via the structured `AskUserQuestion` UI (never ask for approval in plain text)
 9. On user approval (--interactive only):
-   - **Approve and execute**: **MUST** invoke `$ralph` with the approved plan path from `.omx/plans/` as context. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
-   - **Approve and implement via team**: **MUST** invoke `$team` with the approved plan path from `.omx/plans/` as context. Do NOT implement directly. The team skill coordinates parallel agents across the staged pipeline for faster execution on large tasks.
+   - **Approve and execute**: **MUST** invoke `$ralph` with the approved plan path from `.omx/plans/` as context **plus the explicit available-agent-types roster and concrete role allocation guidance for Ralph follow-up work**. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
+   - **Approve and implement via team**: **MUST** invoke `$team` with the approved plan path from `.omx/plans/` as context **plus the explicit available-agent-types roster and concrete staffing / worker-role allocation guidance for team follow-up work**. Do NOT implement directly. The team skill coordinates parallel agents across the staged pipeline for faster execution on large tasks.
 
 ### Review Mode (`--review`)
 
@@ -125,6 +126,7 @@ Every plan includes:
 - Verification Steps
 - For consensus/ralplan: **RALPLAN-DR summary** (Principles, Decision Drivers, Options)
 - For consensus/ralplan final output: **ADR** (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups)
+- For consensus/ralplan execution handoff: **Available-Agent-Types Roster** and **Follow-up Staffing Guidance** for both `$ralph` and `$team`
 - For deliberate consensus mode: **Pre-mortem (3 scenarios)** and **Expanded Test Plan** (unit/integration/e2e/observability)
 
 Plans are saved to `.omx/plans/`. Drafts go to `.omx/drafts/`.
@@ -143,6 +145,7 @@ Plans are saved to `.omx/plans/`. Drafts go to `.omx/drafts/`.
 - In consensus mode, default to RALPLAN-DR short mode; enable deliberate mode on `--deliberate` or explicit high-risk signals (auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage)
 - In consensus mode with `--interactive`: use `AskUserQuestion` for the user feedback step (step 2) and the final approval step (step 7) -- never ask for approval in plain text. Without `--interactive`, auto-proceed through planning steps without pausing. Output the final plan without execution.
 - In consensus mode with `--interactive`, on user approval **MUST** invoke `$ralph` for execution (step 9) -- never implement directly in the planning agent
+- In consensus mode, execution follow-up handoff **MUST** include an explicit available-agent-types roster plus concrete staffing / role-allocation guidance grounded in that roster
 </Tool_Usage>
 
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -60,6 +60,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
    - Simple lookups: LOW tier -- "What does this function return?"
    - Standard work: STANDARD tier -- "Add error handling to this module"
    - Complex analysis: THOROUGH tier -- "Debug this race condition"
+   - When Ralph is entered as a ralplan follow-up, start from the approved **available-agent-types roster** and make the delegation plan explicit: implementation lane, evidence/regression lane, and final sign-off lane using only known agent types
 4. **Run long operations in background**: Builds, installs, test suites use `run_in_background: true`
 5. **Visual task gate (when screenshot/reference images are present)**:
    - Run `$visual-verdict` **before every next edit**.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -57,9 +57,9 @@ The consensus workflow:
    d. Return to Critic evaluation
    e. Repeat this loop until Critic returns `APPROVE` or 5 iterations are reached
    f. If 5 iterations are reached without `APPROVE`, present the best version to the user
-6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and execute via ralph / Approve and implement via team / Request changes / Reject). Final plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups). Otherwise, output the final plan and stop.
+6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and execute via ralph / Approve and implement via team / Request changes / Reject). Final plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups), an explicit available-agent-types roster, and concrete follow-up staffing guidance for both `ralph` and `team`. Otherwise, output the final plan and stop.
 7. *(--interactive only)* User chooses: Approve (ralph or team), Request changes, or Reject
-8. *(--interactive only)* On approval: invoke `$ralph` for sequential execution or `$team` for parallel team execution -- never implement directly
+8. *(--interactive only)* On approval: invoke `$ralph` for sequential execution or `$team` for parallel team execution with the explicit available-agent-types roster and role/staffing allocation guidance from the approved plan -- never implement directly
 
 > **Important:** Steps 3 and 4 MUST run sequentially. Do NOT issue both agent calls in the same parallel batch. Always await the Architect result before invoking Critic.
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -94,6 +94,15 @@ Before launching `omx team`, require a grounded context snapshot:
 
 Do not start worker panes until this gate is satisfied; if forced to proceed quickly, state explicit scope/risk limitations in the launch report.
 
+## Follow-up Staffing Contract
+
+When `$team` is used as a follow-up mode from ralplan, carry forward the approved plan's explicit **available-agent-types roster** and convert it into concrete staffing guidance before launch:
+
+- keep worker-role choices inside the known roster
+- state the recommended headcount and role counts
+- explain why each lane exists (delivery, verification, specialist support)
+- if the ideal role is unavailable, choose the closest role from the roster and say so
+
 ## Current Runtime Behavior (As Implemented)
 
 `omx team` currently performs:

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -1,5 +1,9 @@
 import { startMode, updateModeState } from '../modes/base.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
+import {
+  buildFollowupStaffingPlan,
+  resolveAvailableAgentTypes,
+} from '../team/followup-planner.js';
 
 export const RALPH_HELP = `omx ralph - Launch Codex with ralph persistence mode active
 
@@ -91,10 +95,15 @@ export async function ralphCommand(args: string[]): Promise<void> {
   }
   const artifacts = await ensureCanonicalRalphArtifacts(cwd);
   const task = extractRalphTaskDescription(normalizedArgs);
+  const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
+  const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes);
   await startMode('ralph', task, 50);
   await updateModeState('ralph', {
     current_phase: 'starting',
     canonical_progress_path: artifacts.canonicalProgressPath,
+    available_agent_types: availableAgentTypes,
+    staffing_summary: staffingPlan.staffingSummary,
+    staffing_allocations: staffingPlan.allocations,
     ...(artifacts.canonicalPrdPath ? { canonical_prd_path: artifacts.canonicalPrdPath } : {}),
   });
   if (artifacts.migratedPrd) {
@@ -104,6 +113,8 @@ export async function ralphCommand(args: string[]): Promise<void> {
     console.log('[ralph] Migrated legacy progress -> ' + artifacts.canonicalProgressPath);
   }
   console.log('[ralph] Ralph persistence mode active. Launching Codex...');
+  console.log(`[ralph] available_agent_types: ${staffingPlan.rosterSummary}`);
+  console.log(`[ralph] staffing_plan: ${staffingPlan.staffingSummary}`);
   const { launchWithHud } = await import('./index.js');
   const codexArgs = filterRalphCodexArgs(normalizedArgs);
   await launchWithHud(codexArgs);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -7,6 +7,11 @@ import type { TeamEvent } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import {
+  buildFollowupStaffingPlan,
+  resolveAvailableAgentTypes,
+  type FollowupStaffingPlan,
+} from '../team/followup-planner.js';
+import {
   TEAM_API_OPERATIONS,
   resolveTeamApiOperation,
   executeTeamApiOperation,
@@ -417,6 +422,12 @@ async function ensureTeamModeState(
     ? [...new Set(tasks.map(t => t.role ?? parsed.agentType))].join(',')
     : parsed.agentType;
 
+  const availableAgentTypes = await resolveAvailableAgentTypes(process.cwd());
+  const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
+    workerCount: parsed.workerCount,
+    fallbackRole: parsed.agentType,
+  });
+
   const existing = await readModeState('team');
   if (existing?.active) {
     await updateModeState('team', {
@@ -426,6 +437,9 @@ async function ensureTeamModeState(
       team_name: parsed.teamName,
       agent_count: parsed.workerCount,
       agent_types: roleDistribution,
+      available_agent_types: availableAgentTypes,
+      staffing_summary: staffingPlan.staffingSummary,
+      staffing_allocations: staffingPlan.allocations,
     });
     return;
   }
@@ -437,14 +451,21 @@ async function ensureTeamModeState(
     team_name: parsed.teamName,
     agent_count: parsed.workerCount,
     agent_types: roleDistribution,
+    available_agent_types: availableAgentTypes,
+    staffing_summary: staffingPlan.staffingSummary,
+    staffing_allocations: staffingPlan.allocations,
   });
 }
 
-async function renderStartSummary(runtime: TeamRuntime): Promise<void> {
+async function renderStartSummary(runtime: TeamRuntime, staffingPlan?: FollowupStaffingPlan): Promise<void> {
   console.log(`Team started: ${runtime.teamName}`);
   console.log(`tmux target: ${runtime.sessionName}`);
   console.log(`workers: ${runtime.config.worker_count}`);
   console.log(`agent_type: ${runtime.config.agent_type}`);
+  if (staffingPlan) {
+    console.log(`available_agent_types: ${staffingPlan.rosterSummary}`);
+    console.log(`staffing_plan: ${staffingPlan.staffingSummary}`);
+  }
 
   const snapshot = await monitorTeam(runtime.teamName, runtime.cwd);
   if (!snapshot) {
@@ -655,7 +676,12 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
       teamName: runtime.teamName,
       ralph: preservedRalph,
     });
-    await renderStartSummary(runtime);
+    const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
+    const staffingPlan = buildFollowupStaffingPlan('team', runtime.config.task, availableAgentTypes, {
+      workerCount: runtime.config.worker_count,
+      fallbackRole: runtime.config.agent_type,
+    });
+    await renderStartSummary(runtime, staffingPlan);
     return;
   }
 
@@ -687,6 +713,11 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
 
   const parsed = parseTeamArgs(teamArgs);
   const tasks = decomposeTaskString(parsed.task, parsed.workerCount, parsed.agentType, parsed.explicitAgentType);
+  const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
+  const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
+    workerCount: parsed.workerCount,
+    fallbackRole: parsed.agentType,
+  });
   const runtime = await startTeam(
     parsed.teamName,
     parsed.task,
@@ -701,5 +732,5 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
   if (options.verbose) {
     console.log(`linked_ralph=${parsed.ralph}`);
   }
-  await renderStartSummary(runtime);
+  await renderStartSummary(runtime, staffingPlan);
 }

--- a/src/hooks/__tests__/consensus-execution-handoff.test.ts
+++ b/src/hooks/__tests__/consensus-execution-handoff.test.ts
@@ -136,6 +136,13 @@ describe('Consensus mode execution handoff (plan/SKILL.md)', () => {
     assert.ok(consensusSection.includes('**Follow-ups**'), 'ADR should include Follow-ups');
   });
 
+  it('should require available-agent-types roster and staffing guidance in handoff output', () => {
+    const consensusSection = extractSection(planSkill, 'Consensus Mode');
+    assert.ok(consensusSection, 'Consensus Mode section should exist');
+    assert.match(consensusSection, /available-agent-types roster/i);
+    assert.match(consensusSection, /staffing guidance|role allocation/i);
+  });
+
   it('should mention deliberate mode requirements in consensus mode', () => {
     const consensusSection = extractSection(planSkill, 'Consensus Mode');
     assert.ok(consensusSection, 'Consensus Mode section should exist');
@@ -262,6 +269,11 @@ describe('RALPLAN-DR in ralplan/SKILL.md', () => {
       'ralplan/SKILL.md should reference ADR requirement'
     );
   });
+
+  it('should document roster-aware team and ralph follow-up guidance', () => {
+    assert.match(ralplanSkill, /available-agent-types roster/i);
+    assert.match(ralplanSkill, /staffing guidance|role\/staffing allocation/i);
+  });
 });
 
 describe('Architect prompt RALPLAN-DR sections', () => {
@@ -291,6 +303,13 @@ describe('Architect prompt RALPLAN-DR sections', () => {
       architectPrompt.includes('ralplan'),
       'architect.md should reference ralplan consensus reviews'
     );
+  });
+});
+
+describe('Planner prompt follow-up staffing guidance', () => {
+  it('should require roster-aware staffing guidance for team and ralph handoff', () => {
+    assert.match(plannerPrompt, /available-agent-types roster/i);
+    assert.match(plannerPrompt, /team and ralph follow-up paths/i);
   });
 });
 

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -8,6 +8,7 @@ import type { StageContext } from '../types.js';
 import { createRalplanStage } from '../stages/ralplan.js';
 import { createTeamExecStage, buildTeamInstruction } from '../stages/team-exec.js';
 import { createRalphVerifyStage, buildRalphInstruction } from '../stages/ralph-verify.js';
+import { buildFollowupStaffingPlan } from '../../team/followup-planner.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -132,6 +133,9 @@ describe('Team Exec Stage', () => {
 
     const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
     assert.ok((descriptor.task as string).includes('plan-content'));
+    assert.ok(Array.isArray(descriptor.availableAgentTypes));
+    assert.ok((descriptor.availableAgentTypes as unknown[]).length > 0);
+    assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
   });
 
   it('falls back to raw task when no ralplan artifacts exist', async () => {
@@ -140,28 +144,40 @@ describe('Team Exec Stage', () => {
 
     const descriptor = (result.artifacts as Record<string, unknown>).teamDescriptor as Record<string, unknown>;
     assert.equal(descriptor.task, 'raw task description');
+    assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
   });
 
   describe('buildTeamInstruction', () => {
     it('builds correct CLI instruction', () => {
+      const staffingPlan = buildFollowupStaffingPlan('team', 'implement feature', ['executor', 'test-engineer'], {
+        workerCount: 3,
+      });
       const instruction = buildTeamInstruction({
         task: 'implement feature',
         workerCount: 3,
         agentType: 'executor',
+        availableAgentTypes: ['executor', 'test-engineer'],
+        staffingPlan,
         useWorktrees: false,
         cwd: '/tmp/test',
       });
 
       assert.match(instruction, /^omx team 3:executor/);
       assert.match(instruction, /implement feature/);
+      assert.match(instruction, /staffing=/);
     });
 
     it('truncates long task descriptions', () => {
       const longTask = 'a'.repeat(1000);
+      const staffingPlan = buildFollowupStaffingPlan('team', longTask, ['executor', 'test-engineer'], {
+        workerCount: 1,
+      });
       const instruction = buildTeamInstruction({
         task: longTask,
         workerCount: 1,
         agentType: 'executor',
+        availableAgentTypes: ['executor', 'test-engineer'],
+        staffingPlan,
         useWorktrees: false,
         cwd: '/tmp',
       });
@@ -214,27 +230,36 @@ describe('Ralph Verify Stage', () => {
     const descriptor = (result.artifacts as Record<string, unknown>).verifyDescriptor as Record<string, unknown>;
     const execArtifacts = descriptor.executionArtifacts as Record<string, unknown>;
     assert.ok(execArtifacts.teamDescriptor);
+    assert.ok(Array.isArray(descriptor.availableAgentTypes));
+    assert.equal(typeof (descriptor.staffingPlan as Record<string, unknown>).staffingSummary, 'string');
   });
 
   describe('buildRalphInstruction', () => {
     it('includes max iterations in instruction', () => {
+      const staffingPlan = buildFollowupStaffingPlan('ralph', 'verify feature', ['architect', 'executor', 'test-engineer']);
       const instruction = buildRalphInstruction({
         task: 'verify feature',
         maxIterations: 15,
         cwd: '/tmp',
+        availableAgentTypes: ['architect', 'executor', 'test-engineer'],
+        staffingPlan,
         executionArtifacts: {},
       });
 
       assert.match(instruction, /max 15 iterations/);
       assert.match(instruction, /verify feature/);
+      assert.match(instruction, /staffing=/);
     });
 
     it('truncates long task descriptions', () => {
       const longTask = 'b'.repeat(500);
+      const staffingPlan = buildFollowupStaffingPlan('ralph', longTask, ['architect', 'executor', 'test-engineer']);
       const instruction = buildRalphInstruction({
         task: longTask,
         maxIterations: 10,
         cwd: '/tmp',
+        availableAgentTypes: ['architect', 'executor', 'test-engineer'],
+        staffingPlan,
         executionArtifacts: {},
       });
 

--- a/src/pipeline/stages/ralph-verify.ts
+++ b/src/pipeline/stages/ralph-verify.ts
@@ -6,6 +6,10 @@
  */
 
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
+import {
+  buildFollowupStaffingPlan,
+  resolveAvailableAgentTypes,
+} from '../../team/followup-planner.js';
 
 export interface RalphVerifyStageOptions {
   /**
@@ -37,6 +41,10 @@ export function createRalphVerifyStage(options: RalphVerifyStageOptions = {}): P
       try {
         // Extract execution context from previous stage
         const teamArtifacts = ctx.artifacts['team-exec'] as Record<string, unknown> | undefined;
+        const availableAgentTypes = await resolveAvailableAgentTypes(ctx.cwd);
+        const staffingPlan = buildFollowupStaffingPlan('ralph', ctx.task, availableAgentTypes, {
+          workerCount: Math.min(maxIterations, 3),
+        });
 
         // Build ralph verification descriptor
         const verifyDescriptor: RalphVerifyDescriptor = {
@@ -44,6 +52,8 @@ export function createRalphVerifyStage(options: RalphVerifyStageOptions = {}): P
           maxIterations,
           cwd: ctx.cwd,
           sessionId: ctx.sessionId,
+          availableAgentTypes,
+          staffingPlan,
           executionArtifacts: teamArtifacts ?? {},
         };
 
@@ -52,6 +62,8 @@ export function createRalphVerifyStage(options: RalphVerifyStageOptions = {}): P
           artifacts: {
             verifyDescriptor,
             maxIterations,
+            availableAgentTypes,
+            staffingPlan,
             stage: 'ralph-verify',
             instruction: buildRalphInstruction(verifyDescriptor),
           },
@@ -81,6 +93,8 @@ export interface RalphVerifyDescriptor {
   maxIterations: number;
   cwd: string;
   sessionId?: string;
+  availableAgentTypes: string[];
+  staffingPlan: ReturnType<typeof buildFollowupStaffingPlan>;
   executionArtifacts: Record<string, unknown>;
 }
 
@@ -88,5 +102,5 @@ export interface RalphVerifyDescriptor {
  * Build the ralph CLI instruction from a descriptor.
  */
 export function buildRalphInstruction(descriptor: RalphVerifyDescriptor): string {
-  return `ralph verify (max ${descriptor.maxIterations} iterations): ${descriptor.task.slice(0, 200)}`;
+  return `ralph verify (max ${descriptor.maxIterations} iterations): ${descriptor.task.slice(0, 200)} | staffing=${descriptor.staffingPlan.staffingSummary}`;
 }

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -7,6 +7,10 @@
  */
 
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
+import {
+  buildFollowupStaffingPlan,
+  resolveAvailableAgentTypes,
+} from '../../team/followup-planner.js';
 
 export interface TeamExecStageOptions {
   /** Number of Codex CLI workers to launch. Defaults to 2. */
@@ -46,12 +50,19 @@ export function createTeamExecStage(options: TeamExecStageOptions = {}): Pipelin
         const planContext = ralplanArtifacts
           ? `Plan from RALPLAN stage:\n${JSON.stringify(ralplanArtifacts, null, 2)}\n\nTask: ${ctx.task}`
           : ctx.task;
+        const availableAgentTypes = await resolveAvailableAgentTypes(ctx.cwd);
+        const staffingPlan = buildFollowupStaffingPlan('team', ctx.task, availableAgentTypes, {
+          workerCount,
+          fallbackRole: agentType,
+        });
 
         // Build team execution descriptor
         const teamDescriptor: TeamExecDescriptor = {
           task: planContext,
           workerCount,
           agentType,
+          availableAgentTypes,
+          staffingPlan,
           useWorktrees: options.useWorktrees ?? false,
           cwd: ctx.cwd,
           extraEnv: options.extraEnv,
@@ -63,6 +74,8 @@ export function createTeamExecStage(options: TeamExecStageOptions = {}): Pipelin
             teamDescriptor,
             workerCount,
             agentType,
+            availableAgentTypes,
+            staffingPlan,
             stage: 'team-exec',
             instruction: buildTeamInstruction(teamDescriptor),
           },
@@ -91,6 +104,8 @@ export interface TeamExecDescriptor {
   task: string;
   workerCount: number;
   agentType: string;
+  availableAgentTypes: string[];
+  staffingPlan: ReturnType<typeof buildFollowupStaffingPlan>;
   useWorktrees: boolean;
   cwd: string;
   extraEnv?: Record<string, string>;
@@ -103,5 +118,6 @@ export function buildTeamInstruction(descriptor: TeamExecDescriptor): string {
   const parts = ['omx', 'team'];
   parts.push(`${descriptor.workerCount}:${descriptor.agentType}`);
   parts.push(JSON.stringify(descriptor.task.slice(0, 500)));
+  parts.push(`# staffing=${descriptor.staffingPlan.staffingSummary}`);
   return parts.join(' ');
 }

--- a/src/team/__tests__/followup-planner.test.ts
+++ b/src/team/__tests__/followup-planner.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  buildFollowupStaffingPlan,
+  resolveAvailableAgentTypes,
+} from '../followup-planner.js';
+
+describe('followup-planner', () => {
+  it('resolves available agent types from explicit prompt directories', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omx-followup-roster-'));
+    try {
+      await writeFile(join(dir, 'executor.md'), '# Executor');
+      await writeFile(join(dir, 'architect.md'), '# Architect');
+      await writeFile(join(dir, 'test-engineer.md'), '# Test Engineer');
+
+      const roles = await resolveAvailableAgentTypes(process.cwd(), { promptDirs: [dir] });
+      assert.deepEqual(roles, ['architect', 'executor', 'test-engineer']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('builds concrete team staffing guidance from the available roster', () => {
+    const plan = buildFollowupStaffingPlan(
+      'team',
+      'Fix flaky integration tests and update README',
+      ['executor', 'test-engineer', 'writer'],
+      { workerCount: 3, fallbackRole: 'executor' },
+    );
+
+    assert.equal(plan.mode, 'team');
+    assert.equal(plan.recommendedHeadcount, 3);
+    assert.match(plan.staffingSummary, /test-engineer x1/);
+    assert.ok(plan.allocations.every((allocation) => ['executor', 'test-engineer', 'writer'].includes(allocation.role)));
+    assert.ok(
+      plan.allocations.some((allocation) => allocation.reason.includes('specialist') || allocation.reason.includes('verification')),
+    );
+  });
+
+  it('builds concrete ralph staffing guidance from the available roster', () => {
+    const plan = buildFollowupStaffingPlan(
+      'ralph',
+      'Investigate auth regression and verify the fix',
+      ['architect', 'debugger', 'executor', 'test-engineer'],
+    );
+
+    assert.equal(plan.mode, 'ralph');
+    assert.equal(plan.recommendedHeadcount, 3);
+    assert.match(plan.staffingSummary, /architect x1/);
+    assert.match(plan.staffingSummary, /test-engineer x1/);
+    assert.ok(plan.allocations.some((allocation) => allocation.reason.includes('sign-off')));
+  });
+});

--- a/src/team/followup-planner.ts
+++ b/src/team/followup-planner.ts
@@ -1,0 +1,172 @@
+import { join } from 'path';
+import { codexPromptsDir, packageRoot } from '../utils/paths.js';
+import { listAvailableRoles, routeTaskToRole } from './role-router.js';
+
+export type FollowupMode = 'team' | 'ralph';
+
+export interface FollowupAllocation {
+  role: string;
+  count: number;
+  reason: string;
+}
+
+export interface FollowupStaffingPlan {
+  mode: FollowupMode;
+  availableAgentTypes: string[];
+  recommendedHeadcount: number;
+  allocations: FollowupAllocation[];
+  rosterSummary: string;
+  staffingSummary: string;
+}
+
+export interface ResolveAvailableAgentTypesOptions {
+  promptDirs?: string[];
+}
+
+export interface BuildFollowupStaffingPlanOptions {
+  workerCount?: number;
+  fallbackRole?: string;
+}
+
+function defaultPromptDirs(projectRoot: string): string[] {
+  return [
+    join(projectRoot, 'prompts'),
+    join(projectRoot, '.codex', 'prompts'),
+    join(packageRoot(), 'prompts'),
+    codexPromptsDir(),
+  ];
+}
+
+export async function resolveAvailableAgentTypes(
+  projectRoot: string,
+  options: ResolveAvailableAgentTypesOptions = {},
+): Promise<string[]> {
+  const dirs = options.promptDirs ?? defaultPromptDirs(projectRoot);
+  const roles = new Set<string>();
+
+  for (const dir of dirs) {
+    const dirRoles = await listAvailableRoles(dir);
+    for (const role of dirRoles) roles.add(role);
+  }
+
+  return [...roles].sort();
+}
+
+function chooseAvailableRole(
+  availableRoles: readonly string[],
+  preferredRoles: readonly string[],
+  fallbackRole: string,
+): string {
+  for (const role of preferredRoles) {
+    if (availableRoles.includes(role)) return role;
+  }
+  if (availableRoles.includes(fallbackRole)) return fallbackRole;
+  return availableRoles[0] ?? fallbackRole;
+}
+
+function mergeAllocation(
+  allocations: FollowupAllocation[],
+  role: string,
+  count: number,
+  reason: string,
+): void {
+  if (count <= 0) return;
+  const existing = allocations.find((item) => item.role === role && item.reason === reason);
+  if (existing) {
+    existing.count += count;
+    return;
+  }
+  allocations.push({ role, count, reason });
+}
+
+function summarizeAllocations(allocations: readonly FollowupAllocation[]): string {
+  return allocations
+    .map((allocation) => `${allocation.role} x${allocation.count} (${allocation.reason})`)
+    .join('; ');
+}
+
+function pickSpecialistRole(
+  task: string,
+  availableRoles: readonly string[],
+  fallbackRole: string,
+): string {
+  const normalizedTask = task.toLowerCase();
+
+  if (/(security|auth|authorization|authentication|xss|injection|cve|vulnerability)/.test(normalizedTask)) {
+    return chooseAvailableRole(availableRoles, ['security-reviewer', 'architect'], fallbackRole);
+  }
+  if (/(debug|regression|root cause|stack trace|incident|flaky)/.test(normalizedTask)) {
+    return chooseAvailableRole(availableRoles, ['debugger', 'architect'], fallbackRole);
+  }
+  if (/(build|compile|tsc|type error|lint)/.test(normalizedTask)) {
+    return chooseAvailableRole(availableRoles, ['build-fixer', 'debugger'], fallbackRole);
+  }
+  if (/(ui|ux|layout|css|responsive|design|frontend)/.test(normalizedTask)) {
+    return chooseAvailableRole(availableRoles, ['designer'], fallbackRole);
+  }
+  if (/(readme|docs|documentation|changelog|migration)/.test(normalizedTask)) {
+    return chooseAvailableRole(availableRoles, ['writer'], fallbackRole);
+  }
+
+  return chooseAvailableRole(availableRoles, ['architect', 'researcher'], fallbackRole);
+}
+
+export function buildFollowupStaffingPlan(
+  mode: FollowupMode,
+  task: string,
+  availableAgentTypes: readonly string[],
+  options: BuildFollowupStaffingPlanOptions = {},
+): FollowupStaffingPlan {
+  const fallbackRole = options.fallbackRole ?? 'executor';
+  const workerCount = Math.max(1, options.workerCount ?? (mode === 'team' ? 2 : 3));
+  const primaryRoute = routeTaskToRole(
+    task,
+    task,
+    mode === 'team' ? 'team-exec' : 'team-verify',
+    fallbackRole,
+  );
+  const primaryRole = chooseAvailableRole(availableAgentTypes, [primaryRoute.role], fallbackRole);
+  const qualityRole = chooseAvailableRole(
+    availableAgentTypes,
+    ['test-engineer', 'verifier', 'quality-reviewer'],
+    primaryRole,
+  );
+  const allocations: FollowupAllocation[] = [];
+
+  mergeAllocation(allocations, primaryRole, 1, mode === 'team' ? 'primary delivery lane' : 'primary implementation lane');
+
+  if (mode === 'team') {
+    if (workerCount >= 2) {
+      mergeAllocation(allocations, qualityRole, 1, 'verification + regression lane');
+    }
+    if (workerCount >= 3) {
+      const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole);
+      mergeAllocation(allocations, specialistRole, 1, 'specialist support lane');
+    }
+    if (workerCount >= 4) {
+      mergeAllocation(allocations, primaryRole, workerCount - 3, 'extra implementation capacity');
+    }
+  } else {
+    mergeAllocation(allocations, qualityRole, 1, 'evidence + regression checks');
+    const architectRole = chooseAvailableRole(
+      availableAgentTypes,
+      ['architect', 'critic', 'verifier'],
+      qualityRole,
+    );
+    mergeAllocation(allocations, architectRole, 1, 'final architecture / completion sign-off');
+
+    if (workerCount >= 4) {
+      const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole);
+      mergeAllocation(allocations, specialistRole, workerCount - 3, 'parallel specialist follow-up capacity');
+    }
+  }
+
+  return {
+    mode,
+    availableAgentTypes: [...availableAgentTypes],
+    recommendedHeadcount: workerCount,
+    allocations,
+    rosterSummary: availableAgentTypes.join(', '),
+    staffingSummary: summarizeAllocations(allocations),
+  };
+}


### PR DESCRIPTION
## Summary
- add a small follow-up staffing planner that resolves the explicit available-agent-types roster and produces roster-aware allocations for `team` and `ralph`
- thread the new roster/staffing artifacts into team/ralph CLI state plus pipeline stage descriptors/instructions
- tighten ralplan/planner/team/ralph contracts and regression tests around roster-aware execution handoff guidance

## Testing
- npm run build
- npx biome lint src/team/followup-planner.ts src/team/__tests__/followup-planner.test.ts src/pipeline/stages/team-exec.ts src/pipeline/stages/ralph-verify.ts src/pipeline/__tests__/stages.test.ts src/cli/team.ts src/cli/ralph.ts src/hooks/__tests__/consensus-execution-handoff.test.ts
- npm run check:no-unused
- npm test

Closes #678
