### PR TITLE
docs: position ralplan team ralph workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,13 @@ OMX is best used as an **outer CLI orchestration layer**:
 - **Capability/state plane (MCP):** task state, mailbox, memory, diagnostics tools
 
 Practical mode split:
-- **`$team` / `omx team`**: durable, inspectable, resumable multi-worker execution
+- **`$team` / `omx team`**: durable, inspectable, resumable multi-worker execution with live lanes, shared blockers, and visible handoff / rebalancing when one worker gets stuck
 - **`$ultrawork`**: lightweight parallel fanout for independent tasks (component mode)
+
+Why team mode exists even when ultrawork already exists:
+- Use **ultrawork** when tasks are mostly independent and the leader can merge results afterward.
+- Use **team mode** when the work benefits from shared situational awareness: workers can discover blockers early, hand work across lanes, and keep execution visible through tmux panes plus durable state.
+- Team mode is the better fit for orchestration-heavy or edge-case-heavy work where runtime control, recovery, and inspectability matter as much as raw fanout.
 
 Low-token team profile example:
 
@@ -313,6 +318,30 @@ omx team shutdown <team-name>
 ```
 
 Important rule: do not shutdown while tasks are still `in_progress` unless aborting.
+
+### Recommended high-control workflow: `ralplan -> team -> ralph`
+
+For contributors who want tighter control than `autopilot` but more coordination than `$ultrawork`, the strongest workflow is:
+
+```text
+ralplan -> team -> ralph
+```
+
+Why this combination works well:
+- **`ralplan`** turns a rough request into a spec, acceptance checks, and a lane-ready breakdown before workers start.
+- **`$team`** executes that plan with durable worker coordination, visible runtime state, and better handling of blockers than simple fanout.
+- **`$ralph`** keeps the loop alive until verification is real, evidence is fresh, and cleanup is explicit.
+
+In practice, this is the right workflow when you want to stay in control of planning and orchestration while still getting parallel execution. `autopilot` can chain these modes for you, but advanced users will often prefer running the sequence directly so they can tune worker roles, follow-up stages, and verification thresholds themselves.
+
+Example:
+
+```bash
+omx ask --agent-prompt planner "ralplan: break this feature into worker lanes and acceptance checks"
+omx team 3:executor "execute the approved ralplan with shared runtime coordination"
+```
+
+Planned documentation/product direction: make `ralplan` produce stronger team follow-up guidance by default, including worker placement hints and an explicit follow-up path such as `--followup team`.
 
 ### Ralph Cleanup Policy
 

--- a/docs/issues/team-ralph-followup-team.md
+++ b/docs/issues/team-ralph-followup-team.md
@@ -1,0 +1,38 @@
+# Issue Draft: Make `ralplan` first-class for `team` follow-up planning
+
+## Title
+[Feature] Make `ralplan` emit explicit `team` follow-up guidance (for example `--followup team`)
+
+## Problem
+OMX already has the ingredients for a strong high-control workflow: `ralplan` for scoped planning, `team` for durable multi-worker execution, and `ralph` for persistence plus verification. What is still under-explained and under-productized is the handoff between planning and team execution.
+
+Today, experienced users can manually infer the pattern: run `ralplan`, then launch `team`, then keep the work alive with `ralph`. But the workflow's biggest advantage is not just parallelism. It is coordinated execution: teammates can surface blockers early, redistribute work, and stay inspectable through panes plus runtime state. That benefit should be reflected directly in planning output.
+
+## Proposed solution
+Teach `ralplan` to support an explicit team-oriented follow-up mode, such as `--followup team`, that produces:
+
+1. a normal implementation plan and acceptance criteria
+2. recommended worker lanes / role allocation
+3. suggested reasoning levels by lane
+4. explicit follow-up commands or launch hints for `omx team` / `$team`
+5. verification expectations that fit a `team -> ralph` execution path
+
+This would make the intended workflow clearer:
+
+```text
+ralplan -> team -> ralph
+```
+
+## Why this is good
+- Clarifies why `team` exists alongside `ultrawork`: team mode is about coordination and runtime control, not only fanout.
+- Reduces the gap between planning output and actual orchestration.
+- Makes one of OMX's strongest workflows more discoverable for advanced users.
+- Improves execution quality on runtime-edge-case and orchestration-edge-case work, where durable coordination matters more than raw task splitting.
+- Fits OMX's architecture well because the runtime already supports worker roles, mixed CLIs, runtime state, and inspectable team lifecycle commands.
+
+## Alternatives considered
+- Keep the pattern implicit in docs only. This helps discovery, but still leaves users to translate plans into worker lanes manually.
+- Fold everything into `autopilot`. Useful for default automation, but weaker for users who want direct control over planning, staffing, and verification.
+
+## Additional context
+Expected user outcome: a user runs `ralplan`, sees a plan that is already shaped for team execution, launches `team` with less guesswork, and uses `ralph` to keep the workflow honest until evidence-backed completion.

--- a/docs/prs/dev-team-ralph-workflow-positioning.md
+++ b/docs/prs/dev-team-ralph-workflow-positioning.md
@@ -1,0 +1,36 @@
+# PR Draft: Document the `ralplan -> team -> ralph` workflow
+
+## Target branch
+`dev`
+
+## Summary
+This PR documents one of OMX's strongest high-control workflows: `ralplan -> team -> ralph`. The goal is to make the README explain not only that team mode exists, but why it matters even when `$ultrawork` already provides parallel execution.
+
+The key point is that team mode is not just fanout. It is coordinated, inspectable, runtime-aware execution. Workers can share blocker awareness, execution stays visible through tmux panes plus durable state, and the leader retains stronger control over recovery and lifecycle commands. Pairing that with `ralplan` up front and `ralph` at the back creates a workflow that is both fast and operationally disciplined.
+
+## Changes
+- clarify the positioning difference between `$team` and `$ultrawork`
+- add README guidance for the recommended high-control workflow: `ralplan -> team -> ralph`
+- add an issue draft proposing stronger `ralplan` support for team follow-up planning, such as `--followup team`
+
+## Why this is good
+- Explains a real product strength more clearly to contributors and users.
+- Helps advanced users understand when to choose team mode over simpler parallel fanout.
+- Frames a credible design direction: planning output that already anticipates team staffing and follow-up execution.
+- Makes `autopilot` easier to explain too, because it can be described as an automatic chaining layer over the same underlying workflow.
+
+## Design direction
+The docs position `ralplan` as the place where team follow-up should become more explicit. In future work, `ralplan` can emit lane recommendations, role placement hints, and launch guidance for a direct `team` handoff, while `ralph` remains the persistence and verification layer.
+
+## Expected outcomes
+- Better onboarding for users evaluating OMX's orchestration model
+- Easier explanation of why team mode is distinct from ultrawork
+- Clearer path from planning to execution for future feature work
+- Better support for mixed-CLI teams and runtime-heavy edge-case work
+
+## Validation
+- [ ] `npm run build`
+- [ ] `npm test`
+
+## Related
+- Proposed issue: `docs/issues/team-ralph-followup-team.md`


### PR DESCRIPTION
## Summary
This PR documents one of OMX's strongest high-control workflows: `ralplan -> team -> ralph`. The goal is to make the README explain not only that team mode exists, but why it matters even when `$ultrawork` already provides parallel execution.

The key point is that team mode is not just fanout. It is coordinated, inspectable, runtime-aware execution. Workers can share blocker awareness, execution stays visible through tmux panes plus durable state, and the leader retains stronger control over recovery and lifecycle commands. Pairing that with `ralplan` up front and `ralph` at the back creates a workflow that is both fast and operationally disciplined.

## Changes
- clarify the positioning difference between `$team` and `$ultrawork`
- add README guidance for the recommended high-control workflow: `ralplan -> team -> ralph`
- add a concrete command example for the workflow handoff
- add an issue draft proposing stronger `ralplan` support for team follow-up planning, such as `--followup team`

## Validation
- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist
- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related
Closes #682
