### PR TITLE
feat(ralplan): emit explicit team follow-up guidance

### DIFF
--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -54,7 +54,7 @@ Interpret implementation requests as planning requests only when this role is ex
 - The plan is saved to `.omx/plans/{name}.md`.
 - User confirmation is obtained before handoff.
 - In consensus mode, the RALPLAN-DR and ADR requirements are complete.
-- In consensus handoff mode, include an explicit available-agent-types roster plus concrete staffing / role-allocation guidance for both team and ralph follow-up paths.
+- In consensus handoff mode, include an explicit available-agent-types roster plus concrete staffing / role-allocation guidance, suggested reasoning levels by lane, explicit launch hints, and a team -> ralph verification path for team and ralph follow-up paths.
 </success_criteria>
 
 <verification_loop>

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -95,7 +95,8 @@ Jumping into code without understanding requirements leads to rework, scope cree
    b. Deduplicate and categorize the suggestions
    c. Update the plan file in `.omx/plans/` with the accepted improvements (add missing details, refine steps, strengthen acceptance criteria, ADR updates, etc.)
    d. Note which improvements were applied in a brief changelog section at the end of the plan
-   e. Before any execution handoff, derive an explicit **available-agent-types roster** from the known prompt catalog and add concrete **follow-up staffing guidance** for both `$ralph` and `$team` (recommended roles, counts, and why each lane exists)
+   e. Before any execution handoff, derive an explicit **available-agent-types roster** from the known prompt catalog and add concrete **follow-up staffing guidance** for both `$ralph` and `$team` (recommended roles, counts, suggested reasoning levels by lane, and why each lane exists)
+   f. For the `$team` path, add an explicit launch-hint block with concrete `omx team` / `$team` commands and a **team -> ralph verification path** (what team proves before shutdown, what Ralph verifies after handoff)
 7. On Critic approval (with improvements applied): *(--interactive only)* If running with `--interactive`, use `AskUserQuestion` to present the plan with these options:
    - **Approve and execute** — proceed to implementation via ralph+ultrawork
    - **Approve and implement via team** — proceed to implementation via coordinated parallel team agents
@@ -104,8 +105,8 @@ Jumping into code without understanding requirements leads to rework, scope cree
    If NOT running with `--interactive`, output the final approved plan and stop. Do NOT auto-execute.
 8. *(--interactive only)* User chooses via the structured `AskUserQuestion` UI (never ask for approval in plain text)
 9. On user approval (--interactive only):
-   - **Approve and execute**: **MUST** invoke `$ralph` with the approved plan path from `.omx/plans/` as context **plus the explicit available-agent-types roster and concrete role allocation guidance for Ralph follow-up work**. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
-   - **Approve and implement via team**: **MUST** invoke `$team` with the approved plan path from `.omx/plans/` as context **plus the explicit available-agent-types roster and concrete staffing / worker-role allocation guidance for team follow-up work**. Do NOT implement directly. The team skill coordinates parallel agents across the staged pipeline for faster execution on large tasks.
+   - **Approve and execute**: **MUST** invoke `$ralph` with the approved plan path from `.omx/plans/` as context **plus the explicit available-agent-types roster, suggested reasoning levels, concrete role allocation guidance, and direct launch hints for Ralph follow-up work**. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
+   - **Approve and implement via team**: **MUST** invoke `$team` with the approved plan path from `.omx/plans/` as context **plus the explicit available-agent-types roster, suggested reasoning levels, concrete staffing / worker-role allocation guidance, explicit `omx team` / `$team` launch hints, and the team -> ralph verification path**. Do NOT implement directly. The team skill coordinates parallel agents across the staged pipeline for faster execution on large tasks.
 
 ### Review Mode (`--review`)
 
@@ -126,7 +127,7 @@ Every plan includes:
 - Verification Steps
 - For consensus/ralplan: **RALPLAN-DR summary** (Principles, Decision Drivers, Options)
 - For consensus/ralplan final output: **ADR** (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups)
-- For consensus/ralplan execution handoff: **Available-Agent-Types Roster** and **Follow-up Staffing Guidance** for both `$ralph` and `$team`
+- For consensus/ralplan execution handoff: **Available-Agent-Types Roster**, **Follow-up Staffing Guidance** (including suggested reasoning levels by lane), explicit `omx team` / `$team` **Launch Hints**, and **team -> ralph Verification Path**
 - For deliberate consensus mode: **Pre-mortem (3 scenarios)** and **Expanded Test Plan** (unit/integration/e2e/observability)
 
 Plans are saved to `.omx/plans/`. Drafts go to `.omx/drafts/`.
@@ -145,7 +146,7 @@ Plans are saved to `.omx/plans/`. Drafts go to `.omx/drafts/`.
 - In consensus mode, default to RALPLAN-DR short mode; enable deliberate mode on `--deliberate` or explicit high-risk signals (auth/security, migrations, destructive changes, production incidents, compliance/PII, public API breakage)
 - In consensus mode with `--interactive`: use `AskUserQuestion` for the user feedback step (step 2) and the final approval step (step 7) -- never ask for approval in plain text. Without `--interactive`, auto-proceed through planning steps without pausing. Output the final plan without execution.
 - In consensus mode with `--interactive`, on user approval **MUST** invoke `$ralph` for execution (step 9) -- never implement directly in the planning agent
-- In consensus mode, execution follow-up handoff **MUST** include an explicit available-agent-types roster plus concrete staffing / role-allocation guidance grounded in that roster
+- In consensus mode, execution follow-up handoff **MUST** include an explicit available-agent-types roster plus concrete staffing / role-allocation guidance grounded in that roster, suggested reasoning levels by lane, explicit `omx team` / `$team` launch hints, and a team -> ralph verification path
 </Tool_Usage>
 
 

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -57,9 +57,9 @@ The consensus workflow:
    d. Return to Critic evaluation
    e. Repeat this loop until Critic returns `APPROVE` or 5 iterations are reached
    f. If 5 iterations are reached without `APPROVE`, present the best version to the user
-6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and execute via ralph / Approve and implement via team / Request changes / Reject). Final plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups), an explicit available-agent-types roster, and concrete follow-up staffing guidance for both `ralph` and `team`. Otherwise, output the final plan and stop.
+6. On Critic approval *(--interactive only)*: If `--interactive` is set, use `AskUserQuestion` to present the plan with approval options (Approve and execute via ralph / Approve and implement via team / Request changes / Reject). Final plan must include ADR (Decision, Drivers, Alternatives considered, Why chosen, Consequences, Follow-ups), an explicit available-agent-types roster, concrete follow-up staffing guidance for both `ralph` and `team`, suggested reasoning levels by lane, explicit `omx team` / `$team` launch hints, and a concrete **team -> ralph** verification path. Otherwise, output the final plan and stop.
 7. *(--interactive only)* User chooses: Approve (ralph or team), Request changes, or Reject
-8. *(--interactive only)* On approval: invoke `$ralph` for sequential execution or `$team` for parallel team execution with the explicit available-agent-types roster and role/staffing allocation guidance from the approved plan -- never implement directly
+8. *(--interactive only)* On approval: invoke `$ralph` for sequential execution or `$team` for parallel team execution with the explicit available-agent-types roster, reasoning-by-lane guidance, role/staffing allocation guidance, launch hints, and verification-path guidance from the approved plan -- never implement directly
 
 > **Important:** Steps 3 and 4 MUST run sequentially. Do NOT issue both agent calls in the same parallel batch. Always await the Architect result before invoking Critic.
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -100,7 +100,9 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 
 - keep worker-role choices inside the known roster
 - state the recommended headcount and role counts
+- state the suggested reasoning level for each lane when available
 - explain why each lane exists (delivery, verification, specialist support)
+- include an explicit launch hint (`omx team ralph N "<task>"` / `$team ralph N "<task>"`) when the plan expects Ralph to verify after team delivery
 - if the ideal role is unavailable, choose the closest role from the roster and say so
 
 ## Current Runtime Behavior (As Implemented)

--- a/src/hooks/__tests__/consensus-execution-handoff.test.ts
+++ b/src/hooks/__tests__/consensus-execution-handoff.test.ts
@@ -141,6 +141,9 @@ describe('Consensus mode execution handoff (plan/SKILL.md)', () => {
     assert.ok(consensusSection, 'Consensus Mode section should exist');
     assert.match(consensusSection, /available-agent-types roster/i);
     assert.match(consensusSection, /staffing guidance|role allocation/i);
+    assert.match(consensusSection, /reasoning levels? by lane|suggested reasoning/i);
+    assert.match(consensusSection, /omx team|launch hint/i);
+    assert.match(consensusSection, /team -> ralph verification path|team -> ralph/i);
   });
 
   it('should mention deliberate mode requirements in consensus mode', () => {
@@ -273,6 +276,9 @@ describe('RALPLAN-DR in ralplan/SKILL.md', () => {
   it('should document roster-aware team and ralph follow-up guidance', () => {
     assert.match(ralplanSkill, /available-agent-types roster/i);
     assert.match(ralplanSkill, /staffing guidance|role\/staffing allocation/i);
+    assert.match(ralplanSkill, /reasoning levels? by lane|reasoning-by-lane/i);
+    assert.match(ralplanSkill, /omx team|launch hints?/i);
+    assert.match(ralplanSkill, /team -> ralph/i);
   });
 });
 
@@ -310,6 +316,9 @@ describe('Planner prompt follow-up staffing guidance', () => {
   it('should require roster-aware staffing guidance for team and ralph handoff', () => {
     assert.match(plannerPrompt, /available-agent-types roster/i);
     assert.match(plannerPrompt, /team and ralph follow-up paths/i);
+    assert.match(plannerPrompt, /reasoning levels? by lane|suggested reasoning/i);
+    assert.match(plannerPrompt, /launch hints?/i);
+    assert.match(plannerPrompt, /team -> ralph/i);
   });
 });
 

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -162,12 +162,13 @@ describe('Team Exec Stage', () => {
         cwd: '/tmp/test',
       });
 
-      assert.match(instruction, /^omx team 3:executor/);
+      assert.match(instruction, /^omx team ralph 3:executor /);
       assert.match(instruction, /implement feature/);
       assert.match(instruction, /staffing=/);
+      assert.match(instruction, /verify=/);
     });
 
-    it('truncates long task descriptions', () => {
+    it('still emits a launch instruction for long task descriptions', () => {
       const longTask = 'a'.repeat(1000);
       const staffingPlan = buildFollowupStaffingPlan('team', longTask, ['executor', 'test-engineer'], {
         workerCount: 1,
@@ -182,8 +183,8 @@ describe('Team Exec Stage', () => {
         cwd: '/tmp',
       });
 
-      // The instruction should contain a truncated version (500 chars max)
-      assert.ok(instruction.length < longTask.length);
+      assert.match(instruction, /^omx team ralph 1:executor /);
+      assert.match(instruction, /staffing=/);
     });
   });
 });
@@ -246,12 +247,14 @@ describe('Ralph Verify Stage', () => {
         executionArtifacts: {},
       });
 
-      assert.match(instruction, /max 15 iterations/);
+      assert.match(instruction, /max_iterations=15/);
+      assert.match(instruction, /^omx ralph /);
       assert.match(instruction, /verify feature/);
       assert.match(instruction, /staffing=/);
+      assert.match(instruction, /verify=/);
     });
 
-    it('truncates long task descriptions', () => {
+    it('still emits a launch instruction for long task descriptions', () => {
       const longTask = 'b'.repeat(500);
       const staffingPlan = buildFollowupStaffingPlan('ralph', longTask, ['architect', 'executor', 'test-engineer']);
       const instruction = buildRalphInstruction({
@@ -263,7 +266,8 @@ describe('Ralph Verify Stage', () => {
         executionArtifacts: {},
       });
 
-      assert.ok(instruction.length < longTask.length);
+      assert.match(instruction, /^omx ralph /);
+      assert.match(instruction, /staffing=/);
     });
   });
 });

--- a/src/pipeline/stages/ralph-verify.ts
+++ b/src/pipeline/stages/ralph-verify.ts
@@ -102,5 +102,5 @@ export interface RalphVerifyDescriptor {
  * Build the ralph CLI instruction from a descriptor.
  */
 export function buildRalphInstruction(descriptor: RalphVerifyDescriptor): string {
-  return `ralph verify (max ${descriptor.maxIterations} iterations): ${descriptor.task.slice(0, 200)} | staffing=${descriptor.staffingPlan.staffingSummary}`;
+  return `${descriptor.staffingPlan.launchHints.shellCommand} # max_iterations=${descriptor.maxIterations} # staffing=${descriptor.staffingPlan.staffingSummary} # verify=${descriptor.staffingPlan.verificationPlan.summary}`;
 }

--- a/src/pipeline/stages/team-exec.ts
+++ b/src/pipeline/stages/team-exec.ts
@@ -115,9 +115,6 @@ export interface TeamExecDescriptor {
  * Build the `omx team` CLI instruction from a descriptor.
  */
 export function buildTeamInstruction(descriptor: TeamExecDescriptor): string {
-  const parts = ['omx', 'team'];
-  parts.push(`${descriptor.workerCount}:${descriptor.agentType}`);
-  parts.push(JSON.stringify(descriptor.task.slice(0, 500)));
-  parts.push(`# staffing=${descriptor.staffingPlan.staffingSummary}`);
-  return parts.join(' ');
+  const launchCommand = `omx team ralph ${descriptor.workerCount}:${descriptor.agentType} ${JSON.stringify(descriptor.task)}`;
+  return `${launchCommand} # staffing=${descriptor.staffingPlan.staffingSummary} # verify=${descriptor.staffingPlan.verificationPlan.summary}`;
 }

--- a/src/team/__tests__/followup-planner.test.ts
+++ b/src/team/__tests__/followup-planner.test.ts
@@ -34,10 +34,15 @@ describe('followup-planner', () => {
     assert.equal(plan.mode, 'team');
     assert.equal(plan.recommendedHeadcount, 3);
     assert.match(plan.staffingSummary, /test-engineer x1/);
+    assert.match(plan.staffingSummary, /reasoning/);
     assert.ok(plan.allocations.every((allocation) => ['executor', 'test-engineer', 'writer'].includes(allocation.role)));
     assert.ok(
       plan.allocations.some((allocation) => allocation.reason.includes('specialist') || allocation.reason.includes('verification')),
     );
+    assert.equal(plan.launchHints.shellCommand, 'omx team ralph 3:executor "Fix flaky integration tests and update README"');
+    assert.equal(plan.launchHints.skillCommand, '$team ralph 3:executor "Fix flaky integration tests and update README"');
+    assert.match(plan.verificationPlan.summary, /team -> ralph/i);
+    assert.equal(plan.verificationPlan.checkpoints.length, 3);
   });
 
   it('builds concrete ralph staffing guidance from the available roster', () => {
@@ -52,5 +57,9 @@ describe('followup-planner', () => {
     assert.match(plan.staffingSummary, /architect x1/);
     assert.match(plan.staffingSummary, /test-engineer x1/);
     assert.ok(plan.allocations.some((allocation) => allocation.reason.includes('sign-off')));
+    assert.equal(plan.launchHints.shellCommand, 'omx ralph "Investigate auth regression and verify the fix"');
+    assert.equal(plan.launchHints.skillCommand, '$ralph "Investigate auth regression and verify the fix"');
+    assert.match(plan.verificationPlan.summary, /persistent execution and verification owner/i);
+    assert.equal(plan.verificationPlan.checkpoints.length, 3);
   });
 });

--- a/src/team/followup-planner.ts
+++ b/src/team/followup-planner.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { codexPromptsDir, packageRoot } from '../utils/paths.js';
+import { resolveAgentReasoningEffort, type TeamReasoningEffort } from './model-contract.js';
 import { listAvailableRoles, routeTaskToRole } from './role-router.js';
 
 export type FollowupMode = 'team' | 'ralph';
@@ -8,6 +9,18 @@ export interface FollowupAllocation {
   role: string;
   count: number;
   reason: string;
+  reasoningEffort?: TeamReasoningEffort;
+}
+
+export interface FollowupLaunchHints {
+  shellCommand: string;
+  skillCommand: string;
+  rationale: string;
+}
+
+export interface FollowupVerificationPlan {
+  summary: string;
+  checkpoints: string[];
 }
 
 export interface FollowupStaffingPlan {
@@ -17,6 +30,8 @@ export interface FollowupStaffingPlan {
   allocations: FollowupAllocation[];
   rosterSummary: string;
   staffingSummary: string;
+  launchHints: FollowupLaunchHints;
+  verificationPlan: FollowupVerificationPlan;
 }
 
 export interface ResolveAvailableAgentTypesOptions {
@@ -71,18 +86,75 @@ function mergeAllocation(
   reason: string,
 ): void {
   if (count <= 0) return;
-  const existing = allocations.find((item) => item.role === role && item.reason === reason);
+  const reasoningEffort = resolveAgentReasoningEffort(role);
+  const existing = allocations.find(
+    (item) => item.role === role && item.reason === reason && item.reasoningEffort === reasoningEffort,
+  );
   if (existing) {
     existing.count += count;
     return;
   }
-  allocations.push({ role, count, reason });
+  allocations.push({ role, count, reason, reasoningEffort });
 }
 
 function summarizeAllocations(allocations: readonly FollowupAllocation[]): string {
   return allocations
-    .map((allocation) => `${allocation.role} x${allocation.count} (${allocation.reason})`)
+    .map((allocation) => {
+      const reasoning = allocation.reasoningEffort ? `, ${allocation.reasoningEffort} reasoning` : '';
+      return `${allocation.role} x${allocation.count} (${allocation.reason}${reasoning})`;
+    })
     .join('; ');
+}
+
+function toQuotedCliArg(value: string): string {
+  return JSON.stringify(value);
+}
+
+function buildLaunchHints(
+  mode: FollowupMode,
+  task: string,
+  recommendedHeadcount: number,
+  fallbackRole: string,
+): FollowupLaunchHints {
+  if (mode === 'team') {
+    return {
+      shellCommand: `omx team ralph ${recommendedHeadcount}:${fallbackRole} ${toQuotedCliArg(task)}`,
+      skillCommand: `$team ralph ${recommendedHeadcount}:${fallbackRole} ${toQuotedCliArg(task)}`,
+      rationale: 'Launch team with linked Ralph follow-up so delivery lanes stay parallel but final verification remains persistent and evidence-backed.',
+    };
+  }
+
+  return {
+    shellCommand: `omx ralph ${toQuotedCliArg(task)}`,
+    skillCommand: `$ralph ${toQuotedCliArg(task)}`,
+    rationale: 'Launch Ralph directly when one persistent implementation + verification loop is sufficient without team coordination overhead.',
+  };
+}
+
+function buildVerificationPlan(
+  mode: FollowupMode,
+  allocations: readonly FollowupAllocation[],
+): FollowupVerificationPlan {
+  if (mode === 'team') {
+    const qualityLane = allocations.find((allocation) => allocation.reason.includes('verification'));
+    return {
+      summary: 'Use a linked team -> ralph path: team workers deliver in parallel, then Ralph closes with fresh evidence, regression checks, and final sign-off.',
+      checkpoints: [
+        'Launch via `omx team ralph ...` (or `$team ralph ...`) so Ralph stays linked to the team run.',
+        `Keep ${qualityLane?.role ?? 'the verification lane'} focused on tests, regression coverage, and evidence capture before team shutdown.`,
+        'Reserve Ralph for post-team completion review, acceptance-criteria validation, and final architecture/completion sign-off.',
+      ],
+    };
+  }
+
+  return {
+    summary: 'Use Ralph as the persistent execution and verification owner: implementation happens first, then evidence/regression checks, then final sign-off.',
+    checkpoints: [
+      'Run fresh verification commands before claiming completion.',
+      'Keep the evidence/regression lane current with test/build output.',
+      'Finish with the final sign-off lane reviewing completion evidence against acceptance criteria.',
+    ],
+  };
 }
 
 function pickSpecialistRole(
@@ -168,5 +240,7 @@ export function buildFollowupStaffingPlan(
     allocations,
     rosterSummary: availableAgentTypes.join(', '),
     staffingSummary: summarizeAllocations(allocations),
+    launchHints: buildLaunchHints(mode, task, workerCount, fallbackRole),
+    verificationPlan: buildVerificationPlan(mode, allocations),
   };
 }


### PR DESCRIPTION
## Summary
- extend ralplan follow-up guidance to include explicit team launch hints, reasoning-by-lane notes, and a concrete team -> ralph verification path
- enrich follow-up planner artifacts with launch/verification metadata while keeping executable team pipeline instructions grounded in the real runtime payload and role
- add regression coverage for the new guidance contract across planner docs and pipeline/followup planner tests

## Testing
- npm run build
- npx biome lint src/team/followup-planner.ts src/team/__tests__/followup-planner.test.ts src/pipeline/stages/team-exec.ts src/pipeline/stages/ralph-verify.ts src/pipeline/__tests__/stages.test.ts src/hooks/__tests__/consensus-execution-handoff.test.ts
- npm run check:no-unused
- node --test dist/team/__tests__/followup-planner.test.js dist/pipeline/__tests__/stages.test.js dist/hooks/__tests__/consensus-execution-handoff.test.js
- npm test

Closes #682