### PR TITLE
fix(team): ignore leader-only panes in stale nudge detection

### DIFF
--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -37,7 +37,7 @@ export function resolveLeaderStalenessThresholdMs() {
   return 180_000;
 }
 
-export async function checkWorkerPanesAlive(tmuxTarget) {
+export async function checkWorkerPanesAlive(tmuxTarget, workerPaneIds = []) {
   const sessionName = tmuxTarget.split(':')[0];
   try {
     const result = await runProcess('tmux', ['list-panes', '-t', sessionName, '-F', '#{pane_id} #{pane_pid}'], 2000);
@@ -45,7 +45,15 @@ export async function checkWorkerPanesAlive(tmuxTarget) {
       .split('\n')
       .map(l => l.trim())
       .filter(Boolean);
-    return { alive: lines.length > 0, paneCount: lines.length };
+    const workerPaneIdSet = new Set(
+      Array.isArray(workerPaneIds)
+        ? workerPaneIds.map((paneId) => safeString(paneId).trim()).filter(Boolean)
+        : [],
+    );
+    const relevantLines = workerPaneIdSet.size > 0
+      ? lines.filter((line) => workerPaneIdSet.has(line.split(/\s+/, 1)[0] || ''))
+      : lines;
+    return { alive: relevantLines.length > 0, paneCount: relevantLines.length };
   } catch {
     return { alive: false, paneCount: 0 };
   }
@@ -190,13 +198,6 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     } catch {
       // ignore
     }
-    if (!tmuxSession && !leaderPaneId) continue;
-    const tmuxTarget = leaderPaneId;
-
-    const paneStatus = tmuxSession
-      ? await checkWorkerPanesAlive(tmuxSession)
-      : { alive: false, paneCount: 0 };
-
     let mailbox = null;
     try {
       const mailboxPath = join(omxDir, 'state', 'team', teamName, 'mailbox', 'leader-fixed.json');
@@ -211,6 +212,14 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     const workerNames = Array.isArray(workers)
       ? workers.map((w) => safeString(w && w.name ? w.name : '')).filter(Boolean)
       : [];
+    const workerPaneIds = Array.isArray(workers)
+      ? workers.map((w) => safeString(w && w.pane_id ? w.pane_id : '')).filter(Boolean)
+      : [];
+    if (!tmuxSession && !leaderPaneId) continue;
+    const tmuxTarget = leaderPaneId;
+    const paneStatus = tmuxSession
+      ? await checkWorkerPanesAlive(tmuxSession, workerPaneIds)
+      : { alive: false, paneCount: 0 };
     const workerStates = workerNames.length > 0
       ? await Promise.all(workerNames.map((workerName) => readWorkerStatusState(stateDir, teamName, workerName)))
       : [];

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -42,6 +42,29 @@ exit 0
 `;
 }
 
+function buildFakeTmuxWithListPanes(tmuxLogPath: string, listPaneLines: string[]): string {
+  const escapedLines = listPaneLines
+    .map((line) => line.replaceAll('\\', '\\\\').replaceAll('"', '\\"'))
+    .join('\\n');
+  return `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  printf "%b\\n" "${escapedLines}"
+  exit 0
+fi
+exit 0
+`;
+}
+
 function runNotifyHook(
   cwd: string,
   fakeBinDir: string,
@@ -297,6 +320,53 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /pane\(s\) still active/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
+    });
+  });
+
+  it('does not treat leader and HUD panes as active worker panes when worker pane ids are known', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'stale-no-workers';
+      const teamDir = join(stateDir, 'team', teamName);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(join(teamDir, 'mailbox'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'omx-team-stale-no-workers',
+        leader_pane_id: '%92',
+        hud_pane_id: '%93',
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10' },
+          { name: 'worker-2', index: 2, pane_id: '%11' },
+        ],
+      });
+
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: new Date(Date.now() - 300_000).toISOString(),
+        turn_count: 5,
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%92 12345', '%93 12346']));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %92 -l Team stale-no-workers: leader stale/);
     });
   });
 


### PR DESCRIPTION
## Summary
- narrow stale leader pane checks to known worker pane ids when the team manifest/config provides them
- prevent leader/HUD-only tmux sessions from being misclassified as active worker panes
- add regression coverage for the leader+HUD-only stale-session case

## Why
During the team runtime hardening audit, the most obvious remaining recoverable bug was in the leader nudge path: `scripts/notify-hook/team-leader-nudge.js` treated any live pane in the tmux session as evidence that worker panes were still active. In real sessions that can include only the leader pane and HUD pane after workers are gone, which causes noisy/stale follow-up nudges and muddies the audit signal between tmux behavior and OMX runtime logic.

## Verification
- `npm ci`
- `npm run build`
- `npx biome lint scripts/notify-hook/team-leader-nudge.js src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts`
- `node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`

## Audit context
This patch emerged from an audit of recent merged owner-authored team/tmux/leader/worker/runtime hardening PRs (#642, #643, #649, #661, #664, #674, #680). The broader diagnostic summary and next fix candidates will be reported separately.
