### PR TITLE
fix(team): stop nudging completed teams and shell panes

### DIFF
--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -9,8 +9,10 @@ import { asNumber, safeString } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
+import { checkPaneReadyForTeamSendKeys } from './team-tmux-guard.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
+const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
 
 export function resolveLeaderNudgeIntervalMs() {
@@ -119,7 +121,7 @@ export async function emitTeamNudgeEvent(cwd, teamName, reason, nowIso) {
   }
 }
 
-async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmuxSession = '', leaderPaneId = '', sourceType = 'leader_nudge' } = {}) {
+async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmuxSession = '', leaderPaneId = '', paneCurrentCommand = '', sourceType = 'leader_nudge' } = {}) {
   const eventsDir = join(cwd, '.omx', 'state', 'team', teamName, 'events');
   const eventsPath = join(eventsDir, 'events.ndjson');
   try {
@@ -135,6 +137,7 @@ async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmu
       tmux_session: tmuxSession || null,
       leader_pane_id: leaderPaneId || null,
       tmux_injection_attempted: false,
+      pane_current_command: paneCurrentCommand || null,
       source_type: sourceType,
     };
     await appendFile(eventsPath, JSON.stringify(event) + '\n');
@@ -292,6 +295,36 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
           leader_pane_id: leaderPaneId || null,
           tmux_session: tmuxSession || null,
           tmux_injection_attempted: false,
+          source_type: 'leader_nudge',
+        });
+      } catch { /* ignore */ }
+      continue;
+    }
+
+    const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
+    if (!paneGuard.ok) {
+      nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '' };
+      if (shouldSendAllIdleNudge) {
+        nudgeState.last_idle_nudged_by_team[teamName] = { at: nowIso, worker_count: workerNames.length };
+      }
+      await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_SHELL_NO_INJECTION_REASON, nowIso, {
+        tmuxSession,
+        leaderPaneId,
+        paneCurrentCommand: paneGuard.paneCurrentCommand,
+        sourceType: 'leader_nudge',
+      });
+      try {
+        await logTmuxHookEvent(logsDir, {
+          timestamp: nowIso,
+          type: LEADER_NOTIFICATION_DEFERRED_TYPE,
+          team: teamName,
+          worker: 'leader-fixed',
+          to_worker: 'leader-fixed',
+          reason: LEADER_PANE_SHELL_NO_INJECTION_REASON,
+          leader_pane_id: leaderPaneId || null,
+          tmux_session: tmuxSession || null,
+          tmux_injection_attempted: false,
+          pane_current_command: paneGuard.paneCurrentCommand || null,
           source_type: 'leader_nudge',
         });
       } catch { /* ignore */ }

--- a/scripts/notify-hook/team-tmux-guard.js
+++ b/scripts/notify-hook/team-tmux-guard.js
@@ -1,0 +1,31 @@
+import { safeString } from './utils.js';
+import { runProcess } from './process-runner.js';
+import { buildPaneCurrentCommandArgv, isPaneRunningShell } from '../tmux-hook-engine.js';
+
+export async function checkPaneReadyForTeamSendKeys(paneTarget) {
+  const target = safeString(paneTarget).trim();
+  if (!target) {
+    return { ok: false, reason: 'missing_pane_target', paneCurrentCommand: '' };
+  }
+
+  try {
+    const result = await runProcess('tmux', buildPaneCurrentCommandArgv(target), 1000);
+    const paneCurrentCommand = safeString(result.stdout).trim();
+    if (isPaneRunningShell(paneCurrentCommand)) {
+      return {
+        ok: false,
+        reason: 'pane_running_shell',
+        paneCurrentCommand,
+      };
+    }
+    return {
+      ok: true,
+      paneCurrentCommand,
+    };
+  } catch {
+    return {
+      ok: true,
+      paneCurrentCommand: '',
+    };
+  }
+}

--- a/scripts/notify-hook/team-worker.js
+++ b/scripts/notify-hook/team-worker.js
@@ -9,7 +9,9 @@ import { asNumber, safeString } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
+import { checkPaneReadyForTeamSendKeys } from './team-tmux-guard.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
+const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 
 async function readTeamStateRootFromJson(path) {
   try {
@@ -202,6 +204,7 @@ async function emitLeaderPaneMissingDeferred({
   tmuxSession,
   leaderPaneId,
   reason = 'leader_pane_missing_no_injection',
+  paneCurrentCommand = '',
   sourceType = 'unknown',
 }) {
   const nowIso = new Date().toISOString();
@@ -215,6 +218,7 @@ async function emitLeaderPaneMissingDeferred({
     leader_pane_id: leaderPaneId || null,
     tmux_session: tmuxSession || null,
     tmux_injection_attempted: false,
+    pane_current_command: paneCurrentCommand || null,
     source_type: sourceType,
   }).catch(() => {});
 
@@ -232,6 +236,7 @@ async function emitLeaderPaneMissingDeferred({
     leader_pane_id: leaderPaneId || null,
     tmux_session: tmuxSession || null,
     tmux_injection_attempted: false,
+    pane_current_command: paneCurrentCommand || null,
     source_type: sourceType,
   };
   await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(() => {});
@@ -317,6 +322,29 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   const N = workers.length;
   const message = `[OMX] All ${N} worker${N === 1 ? '' : 's'} idle. Ready for next instructions. ${DEFAULT_MARKER}`;
   const tmuxTarget = leaderPaneId;
+  const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
+  if (!paneGuard.ok) {
+    const nextIdleState = {
+      ...idleState,
+      last_notified_at_ms: nowMs,
+      last_notified_at: nowIso,
+      worker_count: N,
+      delivery: 'deferred',
+    };
+    await writeFile(idleStatePath, JSON.stringify(nextIdleState, null, 2)).catch(() => {});
+    await emitLeaderPaneMissingDeferred({
+      stateDir,
+      logsDir,
+      teamName,
+      workerName,
+      reason: LEADER_PANE_SHELL_NO_INJECTION_REASON,
+      paneCurrentCommand: paneGuard.paneCurrentCommand,
+      sourceType: 'all_workers_idle',
+      tmuxSession,
+      leaderPaneId,
+    });
+    return;
+  }
 
   try {
     await runProcess('tmux', ['send-keys', '-t', tmuxTarget, '-l', message], 3000);
@@ -459,6 +487,31 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
     return;
   }
   const tmuxTarget = leaderPaneId;
+  const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
+  if (!paneGuard.ok) {
+    try {
+      const tmpPath = cooldownPath + '.tmp.' + process.pid;
+      await writeFile(tmpPath, JSON.stringify({
+        last_notified_at_ms: nowMs,
+        last_notified_at: nowIso,
+        prev_state: prevState,
+        delivery: 'deferred',
+      }, null, 2));
+      await rename(tmpPath, cooldownPath);
+    } catch { /* best effort */ }
+    await emitLeaderPaneMissingDeferred({
+      stateDir,
+      logsDir,
+      teamName,
+      workerName,
+      reason: LEADER_PANE_SHELL_NO_INJECTION_REASON,
+      paneCurrentCommand: paneGuard.paneCurrentCommand,
+      sourceType: 'worker_idle',
+      tmuxSession,
+      leaderPaneId,
+    });
+    return;
+  }
 
   // Build notification message with context
   const parts = [`[OMX] ${workerName} idle`];

--- a/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
@@ -203,6 +203,90 @@ describe('notify-hook all-workers-idle notification', () => {
     });
   });
 
+
+  it('does not inject all-workers-idle into a shell leader pane', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'shell-pane-all-idle';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(workersDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:81',
+        leader_pane_id: '%181',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+          { name: 'worker-2', index: 2, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      for (const worker of ['worker-1', 'worker-2']) {
+        await mkdir(join(workersDir, worker), { recursive: true });
+        await writeJson(join(workersDir, worker, 'status.json'), {
+          state: 'idle',
+          updated_at: new Date().toISOString(),
+        });
+      }
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%181" ]]; then
+    echo "zsh"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %181/, 'must not inject into shell pane');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      assert.ok(existsSync(eventsPath), 'events.ndjson should exist');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const deferred = events.find((event: { type?: string; reason?: string }) =>
+        event.type === 'leader_notification_deferred' && event.reason === 'leader_pane_shell_no_injection');
+      assert.ok(deferred, 'should defer shell-pane all-workers-idle notification');
+      assert.equal(deferred.pane_current_command, 'zsh');
+    });
+  });
+
   it('targets leader pane id when leader_pane_id is present', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -275,6 +275,93 @@ describe('notify-hook team leader nudge', () => {
     });
   });
 
+
+  it('does not inject leader nudge into a shell pane', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'shell-guard';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'shell-guard:0',
+        leader_pane_id: '%71',
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'm1',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'ACK',
+            created_at: '2026-02-14T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%71" ]]; then
+    echo "zsh"
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %71/, 'should not inject into a shell pane');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const deferred = events.find((entry: { type?: string; reason?: string }) =>
+        entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_shell_no_injection');
+      assert.ok(deferred, 'should emit deferred event for shell-pane leader');
+      assert.equal(deferred.pane_current_command, 'zsh');
+    });
+  });
+
   it('nudges when worker panes are alive and leader is stale (no recent HUD turn)', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -137,6 +137,88 @@ describe('notify-hook per-worker idle notification', () => {
     });
   });
 
+
+  it('does not inject worker-idle notification into a shell leader pane', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'shell-idle-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'devsess:21',
+        leader_pane_id: '%79',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        current_task_id: 'task-42',
+        reason: 'task complete',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%79" ]]; then
+    echo "zsh"
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %79/, 'should not inject worker-idle into a shell pane');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const deferred = events.find((entry: { type?: string; reason?: string }) =>
+        entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_shell_no_injection');
+      assert.ok(deferred, 'should emit deferred shell-pane event');
+      assert.equal(deferred.pane_current_command, 'zsh');
+    });
+  });
+
   it('does not fire when worker was already idle (idle->idle)', async () => {
     await withTempWorkingDir(async (cwd) => {
       const stateDir = join(cwd, '.omx', 'state');

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -813,6 +813,43 @@ process.on('SIGTERM', () => {
     }
   });
 
+
+
+  it('monitorTeam deactivates root team-state.json when the local phase becomes terminal', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-root-team-state-'));
+    try {
+      await initTeamState('team-root-sync', 'root sync test', 'executor', 1, cwd);
+      await createTask(
+        'team-root-sync',
+        {
+          subject: 'code change',
+          description: 'implement feature',
+          status: 'completed',
+          owner: 'worker-1',
+          requires_code_change: false,
+        },
+        cwd,
+      );
+      const rootStatePath = join(cwd, '.omx', 'state', 'team-state.json');
+      await writeFile(rootStatePath, JSON.stringify({
+        active: true,
+        current_phase: 'team-exec',
+        team_name: 'team-root-sync',
+      }, null, 2));
+
+      const snapshot = await monitorTeam('team-root-sync', cwd);
+      assert.ok(snapshot);
+      assert.equal(snapshot?.phase, 'complete');
+
+      const rootState = JSON.parse(await readFile(rootStatePath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(rootState.active, false);
+      assert.equal(rootState.current_phase, 'complete');
+      assert.ok(typeof rootState.completed_at === 'string' && rootState.completed_at.length > 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('monitorTeam emits worker_state_changed, worker_idle, and task_completed events based on transitions', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -104,6 +104,7 @@ import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { inferPhaseTargetFromTaskCounts, reconcilePhaseStateForMonitor } from './phase-controller.js';
 import { getTeamTmuxSessions } from '../notifications/tmux.js';
 import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
+import { readModeState, updateModeState } from '../modes/base.js';
 import {
   ensureWorktree,
   planWorktreeTarget,
@@ -144,6 +145,41 @@ export interface TeamSnapshot {
     total_ms: number;
     updated_at: string;
   };
+}
+
+async function syncRootTeamModeStateOnTerminalPhase(
+  teamName: string,
+  phase: TeamPhase | TerminalPhase,
+  cwd: string,
+): Promise<void> {
+  if (phase !== 'complete' && phase !== 'failed' && phase !== 'cancelled') return;
+
+  try {
+    const teamState = await readModeState('team', cwd);
+    if (!teamState) return;
+
+    const stateTeamName = typeof teamState.team_name === 'string' ? teamState.team_name.trim() : '';
+    if (stateTeamName && stateTeamName !== teamName) return;
+
+    const alreadySynced = teamState.active === false
+      && teamState.current_phase === phase
+      && typeof teamState.completed_at === 'string'
+      && teamState.completed_at.length > 0;
+    if (alreadySynced) return;
+
+    const updates: Record<string, unknown> = {
+      active: false,
+      current_phase: phase,
+      team_name: teamName,
+    };
+    if (typeof teamState.completed_at !== 'string' || !teamState.completed_at) {
+      updates.completed_at = new Date().toISOString();
+    }
+
+    await updateModeState('team', updates, cwd);
+  } catch {
+    // Best-effort compatibility sync only.
+  }
 }
 
 /** Runtime handle returned by startTeam */
@@ -1097,6 +1133,7 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
   const phaseState: TeamPhaseState = reconcilePhaseStateForMonitor(persistedPhase, targetPhase);
   await writeTeamPhaseState(sanitized, phaseState, cwd);
   const phase: TeamPhase | TerminalPhase = phaseState.current_phase;
+  await syncRootTeamModeStateOnTerminalPhase(sanitized, phase, cwd);
 
   for (const taskId of reclaimedTaskIds) {
     recommendations.push(`Reclaimed expired claim for task-${taskId}`);


### PR DESCRIPTION
## Summary
- sync root `.omx/state/team-state.json` to inactive terminal state when `monitorTeam` observes a terminal local phase
- defer leader nudge, all-workers-idle, and worker-idle tmux injections when the leader pane has already fallen back to an interactive shell
- add regressions for terminal team-state sync and the shell-pane guard paths while preserving the narrower stale-pane fix already merged in #686

## Context
- Replacement for #669 on top of current `dev`
- Keeps the still-needed parts from #669 and intentionally leaves out the #686 overlap that is already merged

## Testing
- `npm ci`
- `npx @biomejs/biome lint scripts/notify-hook/team-leader-nudge.js scripts/notify-hook/team-worker.js scripts/notify-hook/team-tmux-guard.js src/team/runtime.ts src/team/__tests__/runtime.test.ts src/hooks/__tests__/notify-hook-all-workers-idle.test.ts src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts src/hooks/__tests__/notify-hook-worker-idle.test.ts`
- `npm run build`
- `node --test dist/team/__tests__/runtime.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-hook-worker-idle.test.js`

Closes #667.
