### PR TITLE
feat: add lightweight AGENTS bootstrap command

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -83,7 +83,7 @@
 | code-review | DONE | ~/.agents/skills/code-review/SKILL.md |
 | security-review | DONE | ~/.agents/skills/security-review/SKILL.md |
 | tdd | DONE | ~/.agents/skills/tdd/SKILL.md |
-| ~~deepinit~~ | REMOVED (v0.5.0) | — |
+| deepinit | DONE (lightweight CLI successor) | `omx agents-init [path]` (`omx deepinit [path]` alias) |
 | deepsearch | DONE | ~/.agents/skills/deepsearch/SKILL.md |
 | analyze | DONE | ~/.agents/skills/analyze/SKILL.md |
 | build-fix | DONE | ~/.agents/skills/build-fix/SKILL.md |

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ This experiment currently changes native prompt generation and metadata, not the
 ```bash
 omx                # Launch Codex (+ HUD in tmux when available)
 omx setup          # Install prompts/skills/config by scope + project .omx (AGENTS.md only for project scope)
+omx agents-init .  # Bootstrap lightweight AGENTS.md files for a repo/subtree
 omx doctor         # Installation/runtime diagnostics
 omx doctor --team  # Team/swarm diagnostics
 omx ask ...        # Ask local provider advisor (claude|gemini), writes .omx/artifacts/*
@@ -401,6 +402,24 @@ Notes:
 - Default setup output includes a compact per-category refresh summary; `--verbose` adds changed-file detail
 - `--force` is reserved for stronger maintenance behavior such as stale/deprecated skill cleanup; it is no longer required for ordinary refresh
 - The 1M GPT-5.4 context settings are experimental and can increase usage because requests beyond the standard context budget may count more heavily
+
+## Lightweight AGENTS bootstrap
+
+Use `omx agents-init [path]` when you only want a narrow AGENTS.md bootstrap helper instead of full OMX setup.
+
+- creates or refreshes `AGENTS.md` in the target directory plus its immediate child directories
+- skips generated/vendor/tooling directories such as `.git`, `.omx`, `.codex`, `.agents`, `node_modules`, `dist`, and `build`
+- preserves the `<!-- OMX:AGENTS-MANUAL:* -->` section on refresh
+- skips unmanaged existing `AGENTS.md` files unless you pass `--force`
+- does **not** install prompts, skills, config, or replace planning/execution workflows such as `team`, `ralph`, or `ralplan`
+
+Examples:
+
+```bash
+omx agents-init .
+omx agents-init ./src --dry-run
+omx agents-init . --force
+```
 
 ## Agents and Skills
 

--- a/docs/migration-mainline-post-v0.4.4.md
+++ b/docs/migration-mainline-post-v0.4.4.md
@@ -52,7 +52,7 @@ Use these replacements in docs, scripts, and personal shortcuts.
 | `$ultrapilot` | `$team` | Use team-based parallel orchestration. |
 | `$psm` / `$project-session-manager` | No in-repo replacement | Remove from automation or maintain out-of-tree tooling. |
 | `$release` | No in-repo replacement | Use your project release process directly. |
-| `$deepinit` | No in-repo replacement | Keep AGENTS/doc initialization manual or in custom local tooling. |
+| `$deepinit` | `omx agents-init [path]` | Lightweight CLI successor for AGENTS.md bootstrap only; immediate child directories only, unmanaged files preserved unless `--force`. |
 | `$learn-about-omx` / `$learner` / `$writer-memory` | No in-repo replacement | Remove stale references from workflows/docs. |
 
 ## Verification checklist after upgrade

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -49,6 +49,14 @@ If you haven't configured OMX yet:
 
 This is the **only command** you need to know. It downloads the configuration and you're done.
 
+If you only need lightweight directory guidance scaffolding for `AGENTS.md` files, use:
+
+```bash
+omx agents-init .
+```
+
+That command is intentionally narrower than full setup: it only bootstraps `AGENTS.md` files for the target directory and its immediate child directories.
+
 ## For 2.x Users
 
 Your old commands still work! `/ralph`, `/ultrawork`, `/plan`, etc. all function exactly as before.

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -13,6 +13,8 @@ Use this skill when users want to install or refresh oh-my-codex for the **curre
 omx setup [--force] [--dry-run] [--verbose] [--scope <user|project>]
 ```
 
+If you only want lightweight `AGENTS.md` scaffolding for an existing repo or subtree, use `omx agents-init [path]` instead of full setup.
+
 Supported setup flags (current implementation):
 - `--force`: overwrite/reinstall managed artifacts where applicable
 - `--dry-run`: print actions without mutating files

--- a/src/cli/__tests__/agents-init.test.ts
+++ b/src/cli/__tests__/agents-init.test.ts
@@ -1,0 +1,201 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { agentsInit } from '../agents-init.js';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+): { status: number | null; stdout: string; stderr: string; error?: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const result = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message,
+  };
+}
+
+function shouldSkipForSpawnPermissions(err?: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+async function withCwd<T>(cwd: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+async function readCurrentLinuxStartTicks(): Promise<number | undefined> {
+  if (process.platform !== 'linux') return undefined;
+  try {
+    const stat = await readFile('/proc/self/stat', 'utf-8');
+    const commandEnd = stat.lastIndexOf(')');
+    if (commandEnd === -1) return undefined;
+    const fields = stat.slice(commandEnd + 1).trim().split(/\s+/);
+    const ticks = Number(fields[19]);
+    return Number.isFinite(ticks) ? ticks : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+describe('omx agents-init', () => {
+  it('creates a managed root AGENTS.md plus direct-child AGENTS.md files while skipping ignored directories', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-init-'));
+    try {
+      await mkdir(join(wd, 'src'), { recursive: true });
+      await mkdir(join(wd, 'docs'), { recursive: true });
+      await mkdir(join(wd, 'node_modules', 'dep'), { recursive: true });
+      await mkdir(join(wd, 'dist'), { recursive: true });
+      await writeFile(join(wd, 'src', 'index.ts'), 'export const value = 1;\n');
+      await writeFile(join(wd, 'docs', 'guide.md'), '# guide\n');
+      await writeFile(join(wd, 'package.json'), '{"name":"fixture"}\n');
+
+      await withCwd(wd, async () => {
+        await agentsInit();
+      });
+
+      const rootAgents = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      const srcAgents = await readFile(join(wd, 'src', 'AGENTS.md'), 'utf-8');
+      const docsAgents = await readFile(join(wd, 'docs', 'AGENTS.md'), 'utf-8');
+
+      assert.match(rootAgents, /OMX:AGENTS-INIT:MANAGED/);
+      assert.match(rootAgents, /# oh-my-codex - Intelligent Multi-Agent Orchestration/);
+      assert.match(rootAgents, /\.\/\.codex/);
+      assert.match(srcAgents, /<!-- Parent: ..\/AGENTS\.md -->/);
+      assert.match(srcAgents, /`index\.ts`/);
+      assert.match(docsAgents, /`guide\.md`/);
+      assert.equal(existsSync(join(wd, 'node_modules', 'AGENTS.md')), false);
+      assert.equal(existsSync(join(wd, 'dist', 'AGENTS.md')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes managed subtree files while preserving the manual notes block', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-init-'));
+    try {
+      await mkdir(join(wd, 'src', 'lib'), { recursive: true });
+      await writeFile(join(wd, 'src', 'index.ts'), 'export const index = true;\n');
+
+      await withCwd(wd, async () => {
+        await agentsInit({ targetPath: 'src' });
+      });
+
+      const agentsPath = join(wd, 'src', 'AGENTS.md');
+      const initial = await readFile(agentsPath, 'utf-8');
+      const customized = initial.replace(
+        '- Add subtree-specific constraints, ownership notes, and test commands here.',
+        '- Preserve this custom manual note.',
+      );
+      await writeFile(agentsPath, customized);
+      await writeFile(join(wd, 'src', 'new-file.ts'), 'export const newer = true;\n');
+
+      await withCwd(wd, async () => {
+        await agentsInit({ targetPath: 'src' });
+      });
+
+      const refreshed = await readFile(agentsPath, 'utf-8');
+      assert.match(refreshed, /Preserve this custom manual note\./);
+      assert.match(refreshed, /`new-file\.ts`/);
+      assert.equal(existsSync(join(wd, 'src', 'lib', 'AGENTS.md')), true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips unmanaged AGENTS.md files by default but can adopt them with --force and a backup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-init-'));
+    const original = '# custom root guidance\n';
+    try {
+      await mkdir(join(wd, 'src'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), original);
+      await writeFile(join(wd, 'src', 'index.ts'), 'export const x = 1;\n');
+
+      await withCwd(wd, async () => {
+        await agentsInit();
+      });
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), original);
+      assert.equal(existsSync(join(wd, 'src', 'AGENTS.md')), true);
+
+      await withCwd(wd, async () => {
+        await agentsInit({ force: true });
+      });
+
+      const adopted = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      assert.match(adopted, /OMX:AGENTS-INIT:MANAGED/);
+      const backupRoot = join(wd, '.omx', 'backups', 'agents-init');
+      assert.equal(existsSync(backupRoot), true);
+      const timestamps = await readdir(backupRoot);
+      assert.equal(timestamps.length > 0, true);
+      const backupContent = await readFile(join(backupRoot, timestamps[0], 'AGENTS.md'), 'utf-8');
+      assert.equal(backupContent, original);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('protects project-root AGENTS.md during an active OMX session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-init-'));
+    try {
+      const pidStartTicks = await readCurrentLinuxStartTicks();
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(wd, 'src'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), '# unmanaged\n');
+      await writeFile(join(wd, 'src', 'index.ts'), 'export const x = 1;\n');
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({
+          session_id: 'session-1',
+          started_at: new Date().toISOString(),
+          cwd: wd,
+          pid: process.pid,
+          pid_start_ticks: pidStartTicks,
+        }, null, 2),
+      );
+
+      await withCwd(wd, async () => {
+        await agentsInit({ force: true });
+      });
+
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), '# unmanaged\n');
+      assert.equal(existsSync(join(wd, 'src', 'AGENTS.md')), true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('exposes help for agents-init and the deepinit alias', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-init-'));
+    try {
+      const helpRes = runOmx(wd, ['agents-init', '--help']);
+      if (shouldSkipForSpawnPermissions(helpRes.error)) return;
+      assert.equal(helpRes.status, 0, helpRes.stderr || helpRes.stdout);
+      assert.match(helpRes.stdout, /Usage: omx agents-init/);
+
+      const aliasRes = runOmx(wd, ['deepinit', '--help']);
+      if (shouldSkipForSpawnPermissions(aliasRes.error)) return;
+      assert.equal(aliasRes.status, 0, aliasRes.stderr || aliasRes.stdout);
+      assert.match(aliasRes.stdout, /Usage: omx agents-init/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -301,6 +301,20 @@ describe('resolveCliInvocation', () => {
     });
   });
 
+  it('resolves agents-init to agents-init command', () => {
+    assert.deepEqual(resolveCliInvocation(['agents-init', '.']), {
+      command: 'agents-init',
+      launchArgs: [],
+    });
+  });
+
+  it('resolves deepinit to deepinit alias command', () => {
+    assert.deepEqual(resolveCliInvocation(['deepinit', 'src']), {
+      command: 'deepinit',
+      launchArgs: [],
+    });
+  });
+
   it('resolves --help to the help command instead of launch', () => {
     assert.deepEqual(resolveCliInvocation(['--help']), {
       command: 'help',

--- a/src/cli/agents-init.ts
+++ b/src/cli/agents-init.ts
@@ -1,0 +1,341 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, stat, writeFile, copyFile } from 'node:fs/promises';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { getPackageRoot } from '../utils/package.js';
+import { readSessionState, isSessionStale } from '../hooks/session.js';
+
+export const AGENTS_INIT_USAGE = [
+  'Usage: omx agents-init [path] [--dry-run] [--force] [--verbose]',
+  '       omx deepinit [path] [--dry-run] [--force] [--verbose]',
+  '',
+  'Bootstrap lightweight AGENTS.md files for the target directory and its direct child directories.',
+  '',
+  'Options:',
+  '  --dry-run   Show planned file updates without writing files',
+  '  --force     Overwrite existing unmanaged AGENTS.md files after taking a backup',
+  '  --verbose   Print per-file actions and skip reasons',
+  '  --help      Show this message',
+].join('\n');
+
+const MANAGED_MARKER = '<!-- OMX:AGENTS-INIT:MANAGED -->';
+const MANUAL_START = '<!-- OMX:AGENTS-INIT:MANUAL:START -->';
+const MANUAL_END = '<!-- OMX:AGENTS-INIT:MANUAL:END -->';
+const DEFAULT_LIST_LIMIT = 12;
+const IGNORE_DIRECTORY_NAMES = new Set([
+  '.git',
+  '.omx',
+  '.codex',
+  '.agents',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  '.next',
+  '.nuxt',
+  '.turbo',
+  '.cache',
+  '__pycache__',
+  'vendor',
+  'target',
+  'tmp',
+  'temp',
+]);
+
+interface AgentsInitOptions {
+  dryRun?: boolean;
+  force?: boolean;
+  verbose?: boolean;
+  targetPath?: string;
+}
+
+interface AgentsInitSummary {
+  updated: number;
+  unchanged: number;
+  skipped: number;
+  backedUp: number;
+}
+
+interface ManagedFileDecision {
+  action: 'updated' | 'unchanged' | 'skipped';
+  reason?: string;
+  backedUp: boolean;
+}
+
+interface DirectorySnapshot {
+  files: string[];
+  directories: string[];
+}
+
+function createEmptySummary(): AgentsInitSummary {
+  return {
+    updated: 0,
+    unchanged: 0,
+    skipped: 0,
+    backedUp: 0,
+  };
+}
+
+function isManagedAgentsInitFile(content: string): boolean {
+  return content.includes(MANAGED_MARKER);
+}
+
+function extractManualSection(existingContent: string | undefined, fallbackBody: string): string {
+  if (!existingContent) return fallbackBody.trim();
+  const start = existingContent.indexOf(MANUAL_START);
+  const end = existingContent.indexOf(MANUAL_END);
+  if (start === -1 || end === -1 || end < start) return fallbackBody.trim();
+  return existingContent.slice(start + MANUAL_START.length, end).trim() || fallbackBody.trim();
+}
+
+function wrapManagedContent(body: string, manualBody: string): string {
+  return `${MANAGED_MARKER}\n${body.trimEnd()}\n\n${MANUAL_START}\n${manualBody.trim()}\n${MANUAL_END}\n`;
+}
+
+export function applyProjectScopePathRewritesToAgentsTemplate(content: string): string {
+  return content
+    .replaceAll('~/.codex', './.codex')
+    .replaceAll('~/.agents', './.agents');
+}
+
+async function readProjectRootTemplate(): Promise<string> {
+  const pkgRoot = getPackageRoot();
+  const templatePath = join(pkgRoot, 'templates', 'AGENTS.md');
+  return readFile(templatePath, 'utf-8');
+}
+
+export async function renderManagedProjectRootAgents(existingContent?: string): Promise<string> {
+  const template = applyProjectScopePathRewritesToAgentsTemplate(await readProjectRootTemplate());
+  const manual = extractManualSection(existingContent, `## Local Notes\n- Add repo-specific architecture notes, workflow conventions, and verification commands here.\n- This block is preserved by \`omx agents-init\` refreshes.`);
+  return wrapManagedContent(template, manual);
+}
+
+function formatList(items: string[], suffix = '', limit = DEFAULT_LIST_LIMIT): string[] {
+  if (items.length === 0) return ['- None'];
+  const visible = items.slice(0, limit).map((item) => `- \`${item}${suffix}\``);
+  if (items.length > limit) {
+    visible.push(`- ...and ${items.length - limit} more`);
+  }
+  return visible;
+}
+
+async function snapshotDirectory(dir: string): Promise<DirectorySnapshot> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  const directories: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name === 'AGENTS.md') continue;
+    if (entry.isDirectory()) {
+      if (IGNORE_DIRECTORY_NAMES.has(entry.name)) continue;
+      directories.push(entry.name);
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entry.name);
+    }
+  }
+
+  files.sort((a, b) => a.localeCompare(b));
+  directories.sort((a, b) => a.localeCompare(b));
+  return { files, directories };
+}
+
+function renderParentReference(dir: string, assumeParentAgents = false): string {
+  const parentAgentsPath = join(dirname(dir), 'AGENTS.md');
+  if (!assumeParentAgents && !existsSync(parentAgentsPath)) return '';
+  const relativePath = relative(dir, parentAgentsPath).replaceAll('\\', '/');
+  return `<!-- Parent: ${relativePath} -->\n`;
+}
+
+export async function renderManagedDirectoryAgents(
+  dir: string,
+  existingContent?: string,
+  assumeParentAgents = false,
+): Promise<string> {
+  const snapshot = await snapshotDirectory(dir);
+  const manual = extractManualSection(existingContent, `## Local Notes\n- Add subtree-specific constraints, ownership notes, and test commands here.\n- Keep notes scoped to this directory and its children.`);
+  const title = basename(dir);
+  const relativeDir = relative(process.cwd(), dir).replaceAll('\\', '/') || '.';
+  const parentReference = renderParentReference(dir, assumeParentAgents);
+  const body = `${parentReference}# ${title}\n\nThis AGENTS.md scopes guidance to \`${relativeDir}\`. Parent AGENTS guidance still applies unless this file narrows it for this subtree.\n\n## Bootstrap Guardrails\n- This is a lightweight scaffold generated by \`omx agents-init\`.\n- Refresh updates the layout summary below and preserves the manual notes block.\n- Keep only directory-specific guidance here; do not duplicate the root orchestration brain.\n\n## Current Layout\n\n### Files\n${formatList(snapshot.files).join('\n')}\n\n### Subdirectories\n${formatList(snapshot.directories, '/').join('\n')}`;
+  return wrapManagedContent(body, manual);
+}
+
+async function ensureBackup(destinationPath: string, backupRoot: string, dryRun: boolean): Promise<boolean> {
+  if (!existsSync(destinationPath)) return false;
+  const relativePath = relative(process.cwd(), destinationPath);
+  const safeRelativePath = relativePath.startsWith('..') || relativePath === ''
+    ? destinationPath.replace(/^[/]+/, '')
+    : relativePath;
+  const backupPath = join(backupRoot, safeRelativePath);
+  if (!dryRun) {
+    await mkdir(dirname(backupPath), { recursive: true });
+    await copyFile(destinationPath, backupPath);
+  }
+  return true;
+}
+
+function resolveTargetDirectories(targetDir: string): Promise<string[]> {
+  return readdir(targetDir, { withFileTypes: true }).then((entries) => {
+    const childDirs = entries
+      .filter((entry) => entry.isDirectory())
+      .filter((entry) => !IGNORE_DIRECTORY_NAMES.has(entry.name))
+      .map((entry) => join(targetDir, entry.name))
+      .sort((a, b) => a.localeCompare(b));
+    return [targetDir, ...childDirs];
+  });
+}
+
+async function syncManagedAgentsFile(
+  destinationPath: string,
+  content: string,
+  options: Required<Pick<AgentsInitOptions, 'dryRun' | 'force' | 'verbose'>>,
+  summary: AgentsInitSummary,
+  backupRoot: string,
+  skipReason?: string,
+): Promise<ManagedFileDecision> {
+  const destinationExists = existsSync(destinationPath);
+  const existingContent = destinationExists ? await readFile(destinationPath, 'utf-8') : undefined;
+
+  if (skipReason) {
+    summary.skipped += 1;
+    return { action: 'skipped', reason: skipReason, backedUp: false };
+  }
+
+  if (!destinationExists) {
+    if (!options.dryRun) {
+      await mkdir(dirname(destinationPath), { recursive: true });
+      await writeFile(destinationPath, content);
+    }
+    summary.updated += 1;
+    return { action: 'updated', backedUp: false };
+  }
+
+  if (existingContent === content) {
+    summary.unchanged += 1;
+    return { action: 'unchanged', backedUp: false };
+  }
+
+  if (!isManagedAgentsInitFile(existingContent ?? '') && !options.force) {
+    summary.skipped += 1;
+    return {
+      action: 'skipped',
+      reason: 'existing unmanaged AGENTS.md (re-run with --force to adopt it)',
+      backedUp: false,
+    };
+  }
+
+  const backedUp = await ensureBackup(destinationPath, backupRoot, options.dryRun);
+  if (backedUp) summary.backedUp += 1;
+
+  if (!options.dryRun) {
+    await mkdir(dirname(destinationPath), { recursive: true });
+    await writeFile(destinationPath, content);
+  }
+  summary.updated += 1;
+  return { action: 'updated', backedUp };
+}
+
+export async function agentsInit(options: AgentsInitOptions = {}): Promise<void> {
+  const dryRun = options.dryRun === true;
+  const force = options.force === true;
+  const verbose = options.verbose === true;
+  const cwd = process.cwd();
+  const requestedTarget = options.targetPath ?? '.';
+  const targetDir = resolve(cwd, requestedTarget);
+  const relativeTarget = relative(cwd, targetDir);
+
+  if (relativeTarget.startsWith('..')) {
+    throw new Error(`agents-init target must stay inside the current working directory: ${requestedTarget}`);
+  }
+
+  const targetStat = await stat(targetDir).catch(() => null);
+  if (!targetStat) throw new Error(`agents-init target not found: ${requestedTarget}`);
+  if (!targetStat.isDirectory()) throw new Error(`agents-init target must be a directory: ${requestedTarget}`);
+
+  const summary = createEmptySummary();
+  const plannedDirs = await resolveTargetDirectories(targetDir);
+  const backupRoot = join(cwd, '.omx', 'backups', 'agents-init', new Date().toISOString().replaceAll(':', '-'));
+  const activeSession = await readSessionState(cwd);
+  const rootSessionGuardActive = Boolean(activeSession && !isSessionStale(activeSession));
+
+  console.log('oh-my-codex AGENTS bootstrap');
+  console.log('===========================\n');
+  console.log(`Target: ${requestedTarget}`);
+  console.log(`Scope: target directory + ${Math.max(plannedDirs.length - 1, 0)} direct child director${plannedDirs.length === 2 ? 'y' : 'ies'}\n`);
+
+  for (let index = 0; index < plannedDirs.length; index += 1) {
+    const dir = plannedDirs[index];
+    const destinationPath = join(dir, 'AGENTS.md');
+    const existingContent = existsSync(destinationPath)
+      ? await readFile(destinationPath, 'utf-8')
+      : undefined;
+    const isRootTarget = index === 0;
+    const relativeDir = relative(cwd, dir).replaceAll('\\', '/') || '.';
+
+    const content = isRootTarget && targetDir === cwd
+      ? await renderManagedProjectRootAgents(existingContent)
+      : await renderManagedDirectoryAgents(dir, existingContent, dirname(dir) === targetDir);
+
+    const rootOverlayRisk = rootSessionGuardActive
+      && dir === cwd
+      && existsSync(destinationPath)
+      && existingContent !== content;
+
+    const decision = await syncManagedAgentsFile(
+      destinationPath,
+      content,
+      { dryRun, force, verbose },
+      summary,
+      backupRoot,
+      rootOverlayRisk ? 'active omx session detected for project root AGENTS.md' : undefined,
+    );
+
+    if (verbose || decision.action !== 'unchanged') {
+      const label = decision.action === 'updated'
+        ? (dryRun ? 'would update' : 'updated')
+        : decision.action === 'unchanged'
+          ? 'unchanged'
+          : 'skipped';
+      const reason = decision.reason ? ` (${decision.reason})` : '';
+      console.log(`  ${label} ${relativeDir}/AGENTS.md${reason}`);
+    }
+  }
+
+  console.log('\nGuardrails:');
+  console.log('- Generates the target directory and its direct child directories only.');
+  console.log('- Skips generated/vendor/build directories via a fixed exclusion list.');
+  console.log('- Preserves manual notes only for files already managed by omx agents-init.');
+  console.log('- Never overwrites unmanaged AGENTS.md files unless you pass --force.');
+  console.log('- Avoids rewriting project-root AGENTS.md while an active omx session is running.\n');
+
+  console.log('Summary:');
+  console.log(`  updated=${summary.updated}, unchanged=${summary.unchanged}, backed_up=${summary.backedUp}, skipped=${summary.skipped}`);
+}
+
+export async function agentsInitCommand(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(AGENTS_INIT_USAGE);
+    return;
+  }
+
+  const allowedFlags = new Set(['--dry-run', '--force', '--verbose']);
+  for (const arg of args) {
+    if (!arg.startsWith('-')) continue;
+    if (!allowedFlags.has(arg)) {
+      throw new Error(`Unknown agents-init option: ${arg}\n${AGENTS_INIT_USAGE}`);
+    }
+  }
+
+  const positionals = args.filter((arg) => !arg.startsWith('-'));
+  if (positionals.length > 1) {
+    throw new Error(`agents-init accepts at most one path argument.\n${AGENTS_INIT_USAGE}`);
+  }
+
+  await agentsInit({
+    targetPath: positionals[0],
+    dryRun: args.includes('--dry-run'),
+    force: args.includes('--force'),
+    verbose: args.includes('--verbose'),
+  });
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -470,7 +470,7 @@ function checkAgentsMd(scope: DoctorSetupScope): Check {
   if (scope === 'user') {
     return { name: 'AGENTS.md', status: 'pass', message: 'user scope leaves project AGENTS.md unchanged' };
   }
-  return { name: 'AGENTS.md', status: 'warn', message: 'not found in project root (run omx setup)' };
+  return { name: 'AGENTS.md', status: 'warn', message: 'not found in project root (run omx agents-init . or omx setup --scope project)' };
 }
 
 async function checkMcpServers(configPath: string): Promise<Check> {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { hudCommand } from '../hud/index.js';
 import { teamCommand } from './team.js';
 import { ralphCommand } from './ralph.js';
 import { askCommand } from './ask.js';
+import { agentsInitCommand } from './agents-init.js';
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -91,6 +92,10 @@ Usage:
   omx doctor    Check installation health
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx agents-init [path]
+                Bootstrap lightweight AGENTS.md files for a repo/subtree
+  omx deepinit [path]
+                Alias for agents-init (lightweight AGENTS bootstrap only)
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
   omx ralph     Launch Codex with ralph persistence mode active
   omx version   Show version information
@@ -147,7 +152,7 @@ const ALLOWED_SHELLS = new Set([
   '/usr/local/bin/bash', '/usr/local/bin/zsh', '/usr/local/bin/fish',
 ]);
 
-type CliCommand = 'launch' | 'setup' | 'uninstall' | 'doctor' | 'ask' | 'team' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
+type CliCommand = 'launch' | 'setup' | 'agents-init' | 'deepinit' | 'uninstall' | 'doctor' | 'ask' | 'team' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
 
 export interface ResolvedCliInvocation {
   command: CliCommand;
@@ -374,7 +379,7 @@ export function buildHudPaneCleanupTargets(existingPaneIds: string[], createdPan
 
 export async function main(args: string[]): Promise<void> {
   const knownCommands = new Set([
-    'launch', 'setup', 'uninstall', 'doctor', 'ask', 'team', 'ralph', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
+    'launch', 'setup', 'agents-init', 'deepinit', 'uninstall', 'doctor', 'ask', 'team', 'ralph', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
   ]);
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
@@ -387,7 +392,7 @@ export async function main(args: string[]): Promise<void> {
     team: flags.has('--team'),
   };
 
-  if (flags.has('--help') && !ralphHelpRequested && command !== 'team') {
+  if (flags.has('--help') && !ralphHelpRequested && !new Set(['team', 'agents-init', 'deepinit']).has(command)) {
     console.log(HELP);
     return;
   }
@@ -404,6 +409,12 @@ export async function main(args: string[]): Promise<void> {
           verbose: options.verbose,
           scope: resolveSetupScopeArg(args.slice(1)),
         });
+        break;
+      case 'agents-init':
+        await agentsInitCommand(args.slice(1));
+        break;
+      case 'deepinit':
+        await agentsInitCommand(args.slice(1));
         break;
       case 'uninstall':
         await uninstall({


### PR DESCRIPTION
## Summary
- add `omx agents-init [path]` plus `omx deepinit [path]` alias as a narrow AGENTS.md bootstrap utility
- generate/update the target directory and its immediate child `AGENTS.md` files with manual-note preservation, backups, and active-session/root-file guardrails
- document the new workflow in help/migration surfaces and cover it with focused CLI tests

## Guardrails
- immediate child directories only
- fixed ignore list for generated/vendor/tooling directories
- unmanaged `AGENTS.md` files are skipped unless `--force` is passed
- project-root `AGENTS.md` is not rewritten during an active OMX session

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/agents-init.test.js dist/cli/__tests__/index.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-agents-overwrite.test.js`
- `npm run lint`
- `npm run check:no-unused`

Closes #688.
