### PR TITLE
Track delivered mailbox dispatches separately from notify receipts

### DIFF
--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -11,7 +11,13 @@ import {
   TEAM_API_OPERATIONS,
   type TeamApiOperation,
 } from '../api-interop.js';
-import { initTeamState, createTask } from '../state.js';
+import {
+  initTeamState,
+  createTask,
+  sendDirectMessage,
+  enqueueDispatchRequest,
+  readDispatchRequest,
+} from '../state.js';
 
 async function setupTeam(name: string): Promise<{ cwd: string; cleanup: () => Promise<void> }> {
   const cwd = await mkdtemp(join(tmpdir(), `omx-interop-${name}-`));
@@ -252,7 +258,7 @@ describe('executeTeamApiOperation: mailbox-list', () => {
 // ─── mailbox-mark-delivered ───────────────────────────────────────────────
 
 describe('executeTeamApiOperation: mailbox-mark-delivered', () => {
-  it('marks a message delivered after sending', async () => {
+  it('marks a message delivered after sending and promotes matching dispatch receipt', async () => {
     const { cwd, cleanup } = await setupTeam('mark-dlv');
     try {
       // Ensure the worker-2 mailbox directory exists so sendDirectMessage can write
@@ -260,16 +266,49 @@ describe('executeTeamApiOperation: mailbox-mark-delivered', () => {
       const sendResult = await executeTeamApiOperation('send-message', {
         team_name: 'mark-dlv', from_worker: 'worker-1', to_worker: 'worker-2', body: 'ack',
       }, cwd);
-      // Send must succeed to test mark-delivered
       assert.equal(sendResult.ok, true);
       const msg = sendResult.data.message as Record<string, unknown>;
       const msgId = String(msg?.message_id ?? '');
       assert.ok(msgId, 'message should have a message_id');
+
+      const dispatch = await enqueueDispatchRequest('mark-dlv', {
+        kind: 'mailbox',
+        to_worker: 'worker-2',
+        worker_index: 2,
+        message_id: msgId,
+        trigger_message: 'check mailbox',
+      }, cwd);
+
       const result = await executeTeamApiOperation('mailbox-mark-delivered', {
         team_name: 'mark-dlv', worker: 'worker-2', message_id: msgId,
       }, cwd);
-      // Mark operation returns a valid envelope (pass or fail based on state layer)
-      assert.ok(typeof result.ok === 'boolean');
+      assert.equal(result.ok, true);
+      if (!result.ok) throw new Error('expected successful mailbox-mark-delivered result');
+      assert.equal(result.data.dispatch_request_id, dispatch.request.request_id);
+      assert.equal(result.data.dispatch_updated, true);
+
+      const updatedDispatch = await readDispatchRequest('mark-dlv', dispatch.request.request_id, cwd);
+      assert.equal(updatedDispatch?.status, 'delivered');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('reports when no matching mailbox dispatch request exists', async () => {
+    const { cwd, cleanup } = await setupTeam('mark-dlv-no-dispatch');
+    try {
+      const message = await sendDirectMessage('mark-dlv-no-dispatch', 'worker-1', 'worker-2', 'ack', cwd);
+
+      const result = await executeTeamApiOperation('mailbox-mark-delivered', {
+        team_name: 'mark-dlv-no-dispatch',
+        worker: 'worker-2',
+        message_id: message.message_id,
+      }, cwd);
+
+      assert.equal(result.ok, true);
+      if (!result.ok) throw new Error('expected success envelope');
+      assert.equal(result.data.dispatch_request_id, null);
+      assert.equal(result.data.dispatch_updated, false);
     } finally {
       await cleanup();
     }

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -17,6 +17,9 @@ import {
   teamListMailbox as listMailboxMessages,
   teamMarkMessageDelivered as markMessageDelivered,
   teamMarkMessageNotified as markMessageNotified,
+  teamListDispatchRequests,
+  teamMarkDispatchRequestNotified,
+  teamMarkDispatchRequestDelivered,
   teamCreateTask,
   teamReadTask,
   teamListTasks,
@@ -113,6 +116,33 @@ export type TeamApiOperation = typeof TEAM_API_OPERATIONS[number];
 export type TeamApiEnvelope =
   | { ok: true; operation: TeamApiOperation; data: Record<string, unknown> }
   | { ok: false; operation: TeamApiOperation | 'unknown'; error: { code: string; message: string } };
+
+async function markLatestMailboxDispatchDelivered(
+  teamName: string,
+  worker: string,
+  messageId: string,
+  cwd: string,
+): Promise<{ matched_request_id: string | null; dispatch_updated: boolean }> {
+  const requests = await teamListDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: worker });
+  const matching = requests
+    .filter((request) => request.message_id === messageId)
+    .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at));
+
+  const latest = matching[0];
+  if (!latest) {
+    return { matched_request_id: null, dispatch_updated: false };
+  }
+
+  if (latest.status === 'pending') {
+    await teamMarkDispatchRequestNotified(teamName, latest.request_id, { message_id: messageId }, cwd);
+  }
+
+  const delivered = await teamMarkDispatchRequestDelivered(teamName, latest.request_id, { message_id: messageId }, cwd);
+  return {
+    matched_request_id: latest.request_id,
+    dispatch_updated: delivered?.status === 'delivered',
+  };
+}
 
 function isFiniteInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && Number.isFinite(value);
@@ -310,7 +340,18 @@ export async function executeTeamApiOperation(
           return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name, worker, message_id are required' } };
         }
         const updated = await markMessageDelivered(teamName, worker, messageId, cwd);
-        return { ok: true, operation, data: { worker, message_id: messageId, updated } };
+        const dispatch = await markLatestMailboxDispatchDelivered(teamName, worker, messageId, cwd);
+        return {
+          ok: true,
+          operation,
+          data: {
+            worker,
+            message_id: messageId,
+            updated,
+            dispatch_request_id: dispatch.matched_request_id,
+            dispatch_updated: dispatch.dispatch_updated,
+          },
+        };
       }
       case 'mailbox-mark-notified': {
         const teamName = String(args.team_name || '').trim();


### PR DESCRIPTION
## Summary
- keep mailbox dispatch requests distinct from pane-observed notification by promoting matching requests to `delivered` when workers call `mailbox-mark-delivered`
- return dispatch delivery telemetry from the team API so callers can tell whether a matching dispatch request was updated
- add focused regression coverage for matching and missing mailbox dispatch delivery cases

## Verification
- npm ci
- npm run build
- ./node_modules/.bin/biome lint src/team/api-interop.ts src/team/__tests__/api-interop.test.ts
- node --test dist/team/__tests__/api-interop.test.js