### PR TITLE
Surface ack-only worker replies as missing-start nudges

### DIFF
--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -2,7 +2,7 @@
  * Team leader nudge: remind the leader to check teammate/mailbox state.
  */
 
-import { readFile, writeFile, mkdir, appendFile } from 'fs/promises';
+import { readFile, writeFile, mkdir, appendFile, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { asNumber, safeString } from './utils.js';
@@ -14,6 +14,12 @@ import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
+const ACK_WITHOUT_START_EVIDENCE_REASON = 'ack_without_start_evidence';
+const ACK_LIKE_PATTERNS = [
+  /^ack(?::\s*[a-z0-9-]+(?:\s+initialized)?)?[.!]*$/i,
+  /^(?:ok|okay|k|roger|copy|received|got it|understood|sounds good)[.!]*$/i,
+  /^(?:on it|will do|i(?:'|’)ll do it|working on it)[.!]*$/i,
+];
 
 export function resolveLeaderNudgeIntervalMs() {
   const raw = safeString(process.env.OMX_TEAM_LEADER_NUDGE_MS || '');
@@ -72,16 +78,24 @@ export async function isLeaderStale(stateDir, thresholdMs, nowMs) {
   return (nowMs - lastMs) >= thresholdMs;
 }
 
-async function readWorkerStatusState(stateDir, teamName, workerName) {
-  if (!workerName) return 'unknown';
+async function readWorkerStatusSnapshot(stateDir, teamName, workerName) {
+  if (!workerName) return { state: 'unknown', current_task_id: '' };
   const path = join(stateDir, 'team', teamName, 'workers', workerName, 'status.json');
   try {
-    if (!existsSync(path)) return 'unknown';
+    if (!existsSync(path)) return { state: 'unknown', current_task_id: '' };
     const parsed = JSON.parse(await readFile(path, 'utf-8'));
-    return safeString(parsed && parsed.state ? parsed.state : 'unknown') || 'unknown';
+    return {
+      state: safeString(parsed && parsed.state ? parsed.state : 'unknown') || 'unknown',
+      current_task_id: safeString(parsed && parsed.current_task_id ? parsed.current_task_id : '').trim(),
+    };
   } catch {
-    return 'unknown';
+    return { state: 'unknown', current_task_id: '' };
   }
+}
+
+async function readWorkerStatusState(stateDir, teamName, workerName) {
+  const snapshot = await readWorkerStatusSnapshot(stateDir, teamName, workerName);
+  return snapshot.state;
 }
 
 function normalizeMailboxMessages(rawMailbox) {
@@ -100,6 +114,76 @@ function normalizeMessageIdentity(msg) {
   const from = safeString(msg.from_worker || msg.from || '').trim();
   const body = safeString(msg.body || '').trim();
   return [createdAt, from, body].filter(Boolean).join('|');
+}
+
+function normalizeMailboxBody(body) {
+  return safeString(body).replace(/\s+/g, ' ').trim();
+}
+
+function isAckLikeMailboxBody(body) {
+  const normalized = normalizeMailboxBody(body);
+  if (!normalized) return false;
+  return ACK_LIKE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function formatMailboxBodyForLeader(body, maxLength = 40) {
+  const normalized = normalizeMailboxBody(body);
+  if (!normalized) return 'ack-like update';
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+async function workerHasOwnedStartedTask(stateDir, teamName, workerName) {
+  const tasksDir = join(stateDir, 'team', teamName, 'tasks');
+  if (!existsSync(tasksDir)) return false;
+
+  try {
+    const taskFiles = (await readdir(tasksDir))
+      .filter((entry) => /^task-\d+\.json$/.test(entry))
+      .sort();
+    for (const entry of taskFiles) {
+      try {
+        const parsed = JSON.parse(await readFile(join(tasksDir, entry), 'utf-8'));
+        if (safeString(parsed?.owner).trim() !== workerName) continue;
+        const status = safeString(parsed?.status).trim();
+        if (status === 'in_progress' || status === 'completed' || status === 'failed') return true;
+      } catch {
+        // ignore malformed task files
+      }
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
+async function getAckWithoutStartEvidence(stateDir, teamName, msg) {
+  if (!msg || typeof msg !== 'object') return null;
+  const fromWorker = safeString(msg.from_worker || '').trim();
+  if (!fromWorker || fromWorker === 'leader-fixed') return null;
+  if (!isAckLikeMailboxBody(msg.body)) return null;
+
+  const status = await readWorkerStatusSnapshot(stateDir, teamName, fromWorker);
+  if (
+    status.current_task_id
+    || status.state === 'working'
+    || status.state === 'blocked'
+    || status.state === 'done'
+    || status.state === 'failed'
+  ) {
+    return null;
+  }
+
+  if (await workerHasOwnedStartedTask(stateDir, teamName, fromWorker)) {
+    return null;
+  }
+
+  return {
+    worker: fromWorker,
+    body: formatMailboxBodyForLeader(msg.body),
+    statusState: status.state,
+  };
 }
 
 export async function emitTeamNudgeEvent(cwd, teamName, reason, nowIso) {
@@ -237,6 +321,9 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
 
     const hasNewMessage = newestId && newestId !== prevMsgId;
     const dueByTime = !Number.isFinite(prevAtMs) || (nowMs - prevAtMs >= intervalMs);
+    const ackWithoutStartEvidence = hasNewMessage
+      ? await getAckWithoutStartEvidence(stateDir, teamName, newest)
+      : null;
 
     const prevIdle = nudgeState.last_idle_nudged_by_team[teamName] && typeof nudgeState.last_idle_nudged_by_team[teamName] === 'object'
       ? nudgeState.last_idle_nudged_by_team[teamName]
@@ -259,6 +346,12 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
       nudgeReason = 'all_workers_idle';
       const N = workerNames.length;
       text = `[OMX] All ${N} worker${N === 1 ? '' : 's'} idle. Ready for next instructions.`;
+    } else if (ackWithoutStartEvidence) {
+      nudgeReason = ACK_WITHOUT_START_EVIDENCE_REASON;
+      text =
+        `Team ${teamName}: ${ackWithoutStartEvidence.worker} said "${ackWithoutStartEvidence.body}" `
+        + `but has no work-start evidence yet (status: ${ackWithoutStartEvidence.statusState}, no owned in_progress task). `
+        + `Run: omx team status ${teamName}`;
     } else if (stalePanesNudge && hasNewMessage) {
       nudgeReason = 'stale_leader_with_messages';
       text = `Team ${teamName}: leader stale, ${paneStatus.paneCount} pane(s) active, ${messages.length} msg(s) pending. Run: omx team status ${teamName}`;

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -275,6 +275,149 @@ describe('notify-hook team leader nudge', () => {
     });
   });
 
+  it('surfaces ack-like mailbox replies without work-start evidence as missing-start nudges', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'ack-missing-start';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(join(workersDir, 'worker-1'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'ack-sess:0',
+        leader_pane_id: '%94',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: ['1'] },
+        ],
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'ack-1',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'on it',
+            created_at: '2026-02-14T00:00:00.000Z',
+          },
+        ],
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /worker-1 said "on it"/);
+      assert.match(tmuxLog, /no work-start evidence yet/);
+      assert.match(tmuxLog, /status: unknown/);
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
+      const nudgeEvent = events.find((e: { type?: string; reason?: string }) =>
+        e.type === 'team_leader_nudge' && e.reason === 'ack_without_start_evidence');
+      assert.ok(nudgeEvent, 'should emit an ack_without_start_evidence leader nudge');
+    });
+  });
+
+  it('does not classify ack-like replies as missing-start after a worker has claimed work', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'ack-with-start';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const workersDir = join(teamDir, 'workers');
+      const tasksDir = join(teamDir, 'tasks');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(join(workersDir, 'worker-1'), { recursive: true });
+      await mkdir(tasksDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'ack-started:0',
+        leader_pane_id: '%95',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: ['1'] },
+        ],
+      });
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: new Date().toISOString(),
+        turn_count: 1,
+      });
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'working',
+        current_task_id: '1',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(tasksDir, 'task-1.json'), {
+        id: '1',
+        subject: 'Investigate failure',
+        description: 'trace ack without start',
+        status: 'in_progress',
+        owner: 'worker-1',
+        created_at: new Date().toISOString(),
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'ack-2',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'on it',
+            created_at: '2026-02-14T00:00:00.000Z',
+          },
+        ],
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /no work-start evidence yet/);
+      assert.match(tmuxLog, /Team ack-with-start: 1 msg\(s\) for leader/);
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
+      const nudgeEvent = events.find((e: { type?: string }) => e.type === 'team_leader_nudge');
+      assert.equal(nudgeEvent?.reason, 'new_mailbox_message');
+    });
+  });
+
 
   it('does not inject leader nudge into a shell pane', async () => {
     await withTempWorkingDir(async (cwd) => {


### PR DESCRIPTION
## Summary
- classify narrow ack/promisework mailbox replies (for example: `ok`, `on it`, `will do`, startup ACKs) in leader nudges
- require real work-start evidence before treating those replies as normal progress, using worker status and claimed task ownership
- add regression coverage for both the missing-start case and the claimed-work case

## Verification
- npm run build
- ./node_modules/.bin/biome lint scripts/notify-hook/team-leader-nudge.js src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
- node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js
- npm run lint
- npm run check:no-unused
- npm test