### PR TITLE
fix(team): harden worker trigger wording (#692)

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -95,7 +95,7 @@ describe('keyword detector swarm/team compatibility', () => {
   });
 
   it('does not trigger team keyword from filesystem/team-state path text', () => {
-    const match = detectPrimaryKeyword('You have 1 new message(s). Check .omx/state/team/execute-plan/mailbox/worker-3.json');
+    const match = detectPrimaryKeyword('You have 1 new message(s). Check .omx/state/team/execute-plan/mailbox/worker-3.json, act now, and reply with concrete progress (not ACK-only).');
     assert.equal(match, null);
   });
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -401,7 +401,7 @@ sleep 5
         '--approval-mode',
         'yolo',
         '-i',
-        'Read and follow the instructions in .omx/state/team/team-gemini-prompt/workers/worker-1/inbox.md',
+        'Read .omx/state/team/team-gemini-prompt/workers/worker-1/inbox.md, start work now, then report concrete progress (not ACK-only).',
       ]);
 
       await shutdownTeam(runtime.teamName, cwd, { force: true });

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -310,6 +310,9 @@ describe('worker bootstrap', () => {
   it('generateTriggerMessage contains the inbox path', () => {
     const message = generateTriggerMessage('worker-9', 'team-path');
     assert.match(message, /\.omx\/state\/team\/team-path\/workers\/worker-9\/inbox\.md/);
+    assert.match(message, /start work now/i);
+    assert.match(message, /concrete progress/i);
+    assert.match(message, /ACK-only/);
   });
 
   it('generateMailboxTriggerMessage is always < 200 characters', () => {
@@ -321,6 +324,9 @@ describe('worker bootstrap', () => {
     const message = generateMailboxTriggerMessage('worker-2', 'team-mail', 3);
     assert.match(message, /3 new message/);
     assert.match(message, /\.omx\/state\/team\/team-mail\/mailbox\/worker-2\.json/);
+    assert.match(message, /act now/i);
+    assert.match(message, /concrete progress/i);
+    assert.match(message, /ACK-only/);
   });
 
   it('writeTeamWorkerInstructionsFile composes base AGENTS.md with overlay', async () => {

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -442,7 +442,7 @@ Type \`exit\` or press Ctrl+C to end your Codex session.
  * Always < 200 characters, ASCII-safe.
  */
 export function generateTriggerMessage(workerName: string, teamName: string): string {
-  return `Read and follow the instructions in .omx/state/team/${teamName}/workers/${workerName}/inbox.md`;
+  return `Read .omx/state/team/${teamName}/workers/${workerName}/inbox.md, start work now, then report concrete progress (not ACK-only).`;
 }
 
 /**
@@ -451,5 +451,5 @@ export function generateTriggerMessage(workerName: string, teamName: string): st
  */
 export function generateMailboxTriggerMessage(workerName: string, teamName: string, count: number): string {
   const n = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
-  return `You have ${n} new message(s). Check .omx/state/team/${teamName}/mailbox/${workerName}.json`;
+  return `You have ${n} new message(s). Check .omx/state/team/${teamName}/mailbox/${workerName}.json, act now, and reply with concrete progress (not ACK-only).`;
 }


### PR DESCRIPTION
## Summary
- harden the short worker inbox trigger so fresh inbox dispatches explicitly require immediate work start and concrete progress instead of ack-only replies
- harden the mailbox/send-message trigger with the same concrete-progress wording
- update focused wording contract tests and the prompt-mode runtime expectation

## Testing
- npx biome lint src/team/worker-bootstrap.ts src/team/__tests__/worker-bootstrap.test.ts src/team/__tests__/runtime.test.ts src/hooks/__tests__/keyword-detector.test.ts
- npm run build
- node --test dist/team/__tests__/worker-bootstrap.test.js dist/team/__tests__/runtime.test.js dist/hooks/__tests__/keyword-detector.test.js