### PR TITLE
fix(team): remove detached worker worktrees on shutdown

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1,10 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'child_process';
 import { mkdtemp, rm, writeFile, readFile, mkdir, chmod } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
-import { spawn } from 'child_process';
 import {
   initTeamState,
   createTask,
@@ -32,6 +32,17 @@ import {
   type TeamRuntime,
 } from '../runtime.js';
 import { resolveTeamLowComplexityDefaultModel } from '../model-contract.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-repo-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
 
 
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
@@ -598,6 +609,70 @@ process.on('SIGTERM', () => process.exit(0));
       if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam removes team-created detached worktrees on normal shutdown', async () => {
+    const repo = await initRepo();
+    const binDir = join(repo, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+process.stdin.resume();
+setTimeout(() => process.exit(0), 5000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+      { mode: 0o755 },
+    );
+
+    const prevPath = process.env.PATH;
+    const prevTmux = process.env.TMUX;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+
+    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
+    delete process.env.TMUX;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'team-detached-worktree-shutdown',
+          'detached worktree shutdown cleanup',
+          'executor',
+          1,
+          [],
+          repo,
+          { worktreeMode: { enabled: true, detached: true, name: null } },
+        ));
+
+      const worktreePath = runtime.config.workers[0]?.worktree_path;
+      assert.ok(worktreePath, 'worker worktree path should be persisted');
+      assert.equal(runtime.config.workers[0]?.worktree_created, true);
+      assert.equal(existsSync(worktreePath as string), true);
+
+      await shutdownTeam(runtime.teamName, repo);
+      runtime = null;
+
+      assert.equal(existsSync(worktreePath as string), false);
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'team', 'team-detached-worktree-shutdown')), false);
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, repo, { force: true }).catch(() => {});
+      }
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(repo, { recursive: true, force: true });
     }
   });
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -197,6 +197,35 @@ interface ShutdownOptions {
   ralph?: boolean;
 }
 
+function collectProvisionedShutdownWorktrees(config: TeamConfig): EnsureWorktreeResult[] {
+  const seenWorktreePaths = new Set<string>();
+  const worktrees: EnsureWorktreeResult[] = [];
+
+  for (const worker of config.workers) {
+    if (worker.worktree_created !== true) continue;
+    if (worker.worktree_detached !== true) continue;
+    if (!worker.worktree_repo_root || !worker.worktree_path) continue;
+    if (!existsSync(worker.worktree_path)) continue;
+
+    const worktreePath = resolve(worker.worktree_path);
+    if (seenWorktreePaths.has(worktreePath)) continue;
+    seenWorktreePaths.add(worktreePath);
+
+    worktrees.push({
+      enabled: true,
+      repoRoot: worker.worktree_repo_root,
+      worktreePath,
+      detached: true,
+      branchName: null,
+      created: true,
+      reused: false,
+      createdBranch: false,
+    });
+  }
+
+  return worktrees;
+}
+
 export interface TeamStartOptions {
   worktreeMode?: WorktreeMode;
   /** When true, applies ralph-specific cleanup policy during startup rollback (skip branch deletion). */
@@ -558,9 +587,11 @@ export async function startTeam(
   const workspaceMode: 'single' | 'worktree' = activeWorktreeMode ? 'worktree' : 'single';
   const workerWorkspaceByName = new Map<string, {
     cwd: string;
+    worktreeRepoRoot?: string;
     worktreePath?: string;
     worktreeBranch?: string;
     worktreeDetached?: boolean;
+    worktreeCreated?: boolean;
   }>();
   const provisionedWorktrees: Array<EnsureWorktreeResult | { enabled: false }> = [];
   for (let i = 1; i <= workerCount; i++) {
@@ -582,9 +613,11 @@ export async function startTeam(
       if (ensured.enabled) {
         workerWorkspaceByName.set(workerName, {
           cwd: ensured.worktreePath,
+          worktreeRepoRoot: ensured.repoRoot,
           worktreePath: ensured.worktreePath,
           worktreeBranch: ensured.branchName ?? undefined,
           worktreeDetached: ensured.detached,
+          worktreeCreated: ensured.created,
         });
       }
     }
@@ -658,7 +691,14 @@ export async function startTeam(
     const allTasks = await listTasks(sanitized, leaderCwd);
     const workerBootstrapPlans = [] as Array<{
       workerName: string;
-      workerWorkspace: { cwd: string; worktreePath?: string; worktreeBranch?: string; worktreeDetached?: boolean; };
+      workerWorkspace: {
+        cwd: string;
+        worktreeRepoRoot?: string;
+        worktreePath?: string;
+        worktreeBranch?: string;
+        worktreeDetached?: boolean;
+        worktreeCreated?: boolean;
+      };
       workerTasks: TeamTask[];
       workerRole: string;
       rolePromptContent: string | null;
@@ -816,9 +856,11 @@ export async function startTeam(
         worker_cli: workerCliPlan[i - 1],
         assigned_tasks: workerTasks.map(t => t.id),
         working_dir: workerWorkspace.cwd,
+        worktree_repo_root: workerWorkspace.worktreeRepoRoot,
         worktree_path: workerWorkspace.worktreePath,
         worktree_branch: workerWorkspace.worktreeBranch,
         worktree_detached: workerWorkspace.worktreeDetached,
+        worktree_created: workerWorkspace.worktreeCreated,
         team_state_root: teamStateRoot,
       };
 
@@ -835,9 +877,11 @@ export async function startTeam(
         config.workers[i - 1].role = workerRole;
         config.workers[i - 1].worker_cli = workerCliPlan[i - 1];
         config.workers[i - 1].working_dir = workerWorkspace.cwd;
+        config.workers[i - 1].worktree_repo_root = workerWorkspace.worktreeRepoRoot;
         config.workers[i - 1].worktree_path = workerWorkspace.worktreePath;
         config.workers[i - 1].worktree_branch = workerWorkspace.worktreeBranch;
         config.workers[i - 1].worktree_detached = workerWorkspace.worktreeDetached;
+        config.workers[i - 1].worktree_created = workerWorkspace.worktreeCreated;
         config.workers[i - 1].team_state_root = teamStateRoot;
       }
 
@@ -1555,8 +1599,28 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     ).catch(() => {});
   }
 
+  const cleanupErrors: string[] = [];
+  const provisionedWorktrees = collectProvisionedShutdownWorktrees(config);
+  if (provisionedWorktrees.length > 0) {
+    try {
+      await rollbackProvisionedWorktrees(provisionedWorktrees, {
+        skipBranchDeletion: options.ralph === true,
+      });
+    } catch (err) {
+      cleanupErrors.push(`rollbackProvisionedWorktrees: ${String(err)}`);
+    }
+  }
+
   // 7. Cleanup state
-  await cleanupTeamState(sanitized, cwd);
+  try {
+    await cleanupTeamState(sanitized, cwd);
+  } catch (err) {
+    cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+  }
+
+  if (cleanupErrors.length > 0) {
+    throw new Error(cleanupErrors.join(' | '));
+  }
 }
 
 /**

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -95,9 +95,11 @@ export interface WorkerInfo {
   pid?: number;
   pane_id?: string;
   working_dir?: string;
+  worktree_repo_root?: string;
   worktree_path?: string;
   worktree_branch?: string;
   worktree_detached?: boolean;
+  worktree_created?: boolean;
   team_state_root?: string;
 }
 

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -31,9 +31,11 @@ export interface WorkerInfo {
   pid?: number;
   pane_id?: string;
   working_dir?: string;
+  worktree_repo_root?: string;
   worktree_path?: string;
   worktree_branch?: string;
   worktree_detached?: boolean;
+  worktree_created?: boolean;
   team_state_root?: string;
 }
 


### PR DESCRIPTION
## Summary
- persist detached team worktree provenance needed for normal shutdown cleanup
- run existing worktree rollback helper from `shutdownTeam()` for team-created detached worker worktrees
- add a focused runtime regression test for successful normal shutdown cleanup

## Verification
- LSP diagnostics: `src/team/runtime.ts`, `src/team/__tests__/runtime.test.ts`
- `tsc --pretty false --noCheck --module nodenext --moduleResolution nodenext --target es2022 --outDir .tmp-verify src/team/runtime.ts src/team/state.ts src/team/state-root.ts src/team/team-ops.ts src/team/worktree.ts src/team/__tests__/runtime.test.ts`
- `node --test --test-name-pattern "shutdownTeam removes team-created detached worktrees on normal shutdown" .tmp-verify/team/__tests__/runtime.test.js`

Closes #695 (scope A only).