### PR TITLE
fix(cli): ignore stale notify fallback ESRCH

### DIFF
--- a/src/cli/__tests__/error-handling-warnings.test.ts
+++ b/src/cli/__tests__/error-handling-warnings.test.ts
@@ -20,6 +20,8 @@ describe('error-handling warning guards', () => {
     assert.ok(!source.includes("await mkdir(join(cwd, '.omx', 'state'), { recursive: true }).catch(() => {});"));
     assert.ok(!source.includes('await unlink(pidPath).catch(() => {});'));
 
+    const esrchGuardCount = source.match(/if \(!hasErrnoCode\(error, 'ESRCH'\)\)/g)?.length ?? 0;
+    assert.equal(esrchGuardCount, 2);
     assert.match(source, /failed to write notify fallback watcher pid file/);
     assert.match(source, /failed to write hook-derived watcher pid file/);
     assert.match(source, /failed to remove notify fallback watcher pid file/);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -246,6 +246,10 @@ type ExecFileSyncFailure = NodeJS.ErrnoException & {
   signal?: NodeJS.Signals | null;
 };
 
+function hasErrnoCode(error: unknown, code: string): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === code);
+}
+
 export interface CodexExecFailureClassification {
   kind: 'exit' | 'launch-error';
   code?: string;
@@ -1458,10 +1462,12 @@ async function startNotifyFallbackWatcher(cwd: string): Promise<void> {
         process.kill(prev.pid, 'SIGTERM');
       }
     } catch (error: unknown) {
-      console.warn('[omx] warning: failed to stop stale notify fallback watcher', {
-        path: pidPath,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      if (!hasErrnoCode(error, 'ESRCH')) {
+        console.warn('[omx] warning: failed to stop stale notify fallback watcher', {
+          path: pidPath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 
@@ -1556,10 +1562,12 @@ async function stopNotifyFallbackWatcher(cwd: string): Promise<void> {
       process.kill(parsed.pid, 'SIGTERM');
     }
   } catch (error: unknown) {
-    console.warn('[omx] warning: failed to stop notify fallback watcher process', {
-      path: pidPath,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    if (!hasErrnoCode(error, 'ESRCH')) {
+      console.warn('[omx] warning: failed to stop notify fallback watcher process', {
+        path: pidPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   await unlink(pidPath).catch((error: unknown) => {


### PR DESCRIPTION
## Summary
- suppress stale notify fallback watcher warnings when the recorded PID is already gone (`ESRCH`)
- keep warning logs for real stop failures in both startup cleanup and normal shutdown paths
- tighten the warning-guard test so both notify-fallback guard sites are covered

## Testing
- npm run build
- node --test dist/cli/__tests__/error-handling-warnings.test.js
- timeout 3 node bin/omx.js --madmax (with a fake stale notify-fallback PID file)