### PR TITLE
fix(hooks): treat 'Next I should' as continuation input

### DIFF
--- a/scripts/notify-hook/auto-nudge.js
+++ b/scripts/notify-hook/auto-nudge.js
@@ -13,11 +13,12 @@ import { logTmuxHookEvent } from './log.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 
 export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
-export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'];
+export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'];
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
 const DEEP_INTERVIEW_ERROR_PATTERNS = [' error', ' failed', ' failure', ' exception', 'unable to continue', 'cannot continue', 'could not continue'];
 const DEEP_INTERVIEW_ABORT_PATTERNS = ['aborted', 'cancelled', 'canceled'];
 const DEEP_INTERVIEW_ABORT_INPUTS = new Set(['abort', 'cancel', 'stop']);
+const DEEP_INTERVIEW_BLOCKED_APPROVAL_PREFIXES = new Set(['next i should']);
 const SKILL_PHASES = new Set(['planning', 'executing', 'reviewing', 'completing']);
 
 function normalizeSkillPhase(phase) {
@@ -52,6 +53,12 @@ export function isBlockedAutoApprovalInput(text, blockedInputs = DEEP_INTERVIEW_
   const normalized = normalizeBlockedAutoApprovalInput(text);
   if (!normalized) return false;
   if (blockedInputs.some((entry) => normalizeBlockedAutoApprovalInput(entry) === normalized)) return true;
+  if (
+    blockedInputs
+      .map((entry) => normalizeBlockedAutoApprovalInput(entry))
+      .filter((entry) => DEEP_INTERVIEW_BLOCKED_APPROVAL_PREFIXES.has(entry))
+      .some((prefix) => normalized.startsWith(`${prefix} `))
+  ) return true;
 
   const tokens = normalized.split(/\s+/).filter(Boolean);
   if (tokens.length === 0) return false;

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -244,6 +244,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(result.skill, 'deep-interview');
       assert.equal(result.input_lock?.active, true);
       assert.deepEqual(result.input_lock?.blocked_inputs, [...DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS]);
+      assert.equal(result.input_lock?.blocked_inputs.includes('next i should'), true);
       assert.equal(result.input_lock?.message, DEEP_INTERVIEW_INPUT_LOCK_MESSAGE);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -7,6 +7,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../scripts/notify-hook.js', import.meta.url);
+const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'];
+const NEXT_I_SHOULD_RESPONSE = 'Next I should update the focused tests.';
 
 async function withTempWorkingDir(run: (cwd: string) => Promise<void>): Promise<void> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-auto-nudge-'));
@@ -406,7 +408,7 @@ describe('notify-hook auto-nudge', () => {
       };
       assert.equal(skillState.skill, 'deep-interview');
       assert.equal(skillState.input_lock?.active, true);
-      assert.deepEqual(skillState.input_lock?.blocked_inputs, ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead']);
+      assert.deepEqual(skillState.input_lock?.blocked_inputs, DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS);
       assert.match(skillState.input_lock?.message || '', /Deep interview is active/i);
     });
   });
@@ -442,7 +444,7 @@ describe('notify-hook auto-nudge', () => {
             active: true,
             scope: 'deep-interview-auto-approval',
             acquired_at: '2026-02-25T00:00:00.000Z',
-            blocked_inputs: ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'],
+            blocked_inputs: DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS,
             message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
           },
         });
@@ -461,6 +463,55 @@ describe('notify-hook auto-nudge', () => {
       });
     });
   }
+
+  it('blocks deep-interview auto-approval injection for actionable "Next I should ..." replies', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, response: NEXT_I_SHOULD_RESPONSE },
+      });
+      await writeJson(join(stateDir, 'skill-active-state.json'), {
+        version: 1,
+        active: true,
+        skill: 'deep-interview',
+        keyword: 'deep interview',
+        phase: 'planning',
+        activated_at: '2026-02-25T00:00:00.000Z',
+        updated_at: '2026-02-25T00:00:00.000Z',
+        source: 'keyword-detector',
+        input_lock: {
+          active: true,
+          scope: 'deep-interview-auto-approval',
+          acquired_at: '2026-02-25T00:00:00.000Z',
+          blocked_inputs: DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS,
+          message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
+        },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Would you like me to continue?',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /Deep interview is active; auto-approval shortcuts are blocked until the interview finishes\. \[OMX_TMUX_INJECT\]/);
+      assert.equal(tmuxLog.includes(`send-keys -t %99 -l ${NEXT_I_SHOULD_RESPONSE} [OMX_TMUX_INJECT]`), false);
+    });
+  });
 
   it('releases the deep-interview input lock on success', async () => {
     await withTempWorkingDir(async (cwd) => {
@@ -491,7 +542,7 @@ describe('notify-hook auto-nudge', () => {
           active: true,
           scope: 'deep-interview-auto-approval',
           acquired_at: '2026-02-25T00:00:00.000Z',
-          blocked_inputs: ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'],
+          blocked_inputs: DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS,
           message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
         },
       });
@@ -545,7 +596,7 @@ describe('notify-hook auto-nudge', () => {
           active: true,
           scope: 'deep-interview-auto-approval',
           acquired_at: '2026-02-25T00:00:00.000Z',
-          blocked_inputs: ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'],
+          blocked_inputs: DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS,
           message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
         },
       });
@@ -599,7 +650,7 @@ describe('notify-hook auto-nudge', () => {
           active: true,
           scope: 'deep-interview-auto-approval',
           acquired_at: '2026-02-25T00:00:00.000Z',
-          blocked_inputs: ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'],
+          blocked_inputs: DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS,
           message: 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.',
         },
       });

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -331,6 +331,12 @@ describe('notify-hook/auto-nudge – blocked deep-interview auto approvals', () 
     assert.equal(isBlockedAutoApprovalInput('yes, proceed'), true);
   });
 
+  it('treats actionable "Next I should ..." replies like continuation approval', async () => {
+    const { isBlockedAutoApprovalInput } = await loadModule('notify-hook/auto-nudge.js');
+    assert.equal(isBlockedAutoApprovalInput('Next I should update the focused tests.'), true);
+    assert.equal(isBlockedAutoApprovalInput('Maybe next I should update the focused tests.'), false);
+  });
+
   it('does not block unrelated responses', async () => {
     const { isBlockedAutoApprovalInput } = await loadModule('notify-hook/auto-nudge.js');
     assert.equal(isBlockedAutoApprovalInput('deep interview is active; auto-approval shortcuts are blocked until the interview finishes.'), false);

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -59,7 +59,7 @@ export interface RecordSkillActivationInput {
 }
 
 export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
-export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead'] as const;
+export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'] as const;
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
 
 function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {


### PR DESCRIPTION
## Summary
- treat short `Next I should ...` replies as deep-interview auto-approval continuation input in the notify-hook inject path
- persist the new blocked continuation phrase in deep-interview keyword state
- add focused regression coverage for the matcher and notify-hook integration

## Verification
- ./node_modules/.bin/biome lint scripts/notify-hook/auto-nudge.js src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts src/hooks/__tests__/notify-hook-modules.test.ts src/hooks/__tests__/notify-hook-auto-nudge.test.ts
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/notify-hook-modules.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js

Closes #702