### PR TITLE
fix(team): resolve worktree worker inbox paths

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -70,6 +70,22 @@ function withoutTeamWorkerEnv<T>(fn: () => T): T {
   }
 }
 
+async function waitForFileText(
+  filePath: string,
+  matcher: (content: string) => boolean,
+  timeoutMs: number = 3_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(filePath)) {
+      const content = await readFile(filePath, 'utf-8');
+      if (matcher(content)) return content;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`timed out waiting for ${filePath}`);
+}
+
 describe('runtime', () => {
   it('resolveWorkerLaunchArgsFromEnv injects low-complexity default model when missing', () => {
     const args = resolveWorkerLaunchArgsFromEnv(
@@ -655,6 +671,117 @@ process.on('SIGTERM', () => process.exit(0));
       if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam routes detached worktree worker inbox and mailbox triggers through leader-root state references', async () => {
+    const repo = await initRepo();
+    const binDir = join(repo, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const logDir = join(repo, 'worker-logs');
+    const stdinLogPath = join(logDir, 'stdin.log');
+    const envLogPath = join(logDir, 'env.json');
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const logDir = process.env.OMX_TEST_LOG_DIR;
+fs.mkdirSync(logDir, { recursive: true });
+fs.writeFileSync(path.join(logDir, 'env.json'), JSON.stringify({
+  cwd: process.cwd(),
+  teamStateRoot: process.env.OMX_TEAM_STATE_ROOT || '',
+  worker: process.env.OMX_TEAM_WORKER || '',
+}));
+process.stdin.on('data', (chunk) => {
+  fs.appendFileSync(path.join(logDir, 'stdin.log'), chunk.toString());
+});
+process.stdin.resume();
+setInterval(() => {}, 1000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+      { mode: 0o755 },
+    );
+
+    const prevPath = process.env.PATH;
+    const prevTmux = process.env.TMUX;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevLogDir = process.env.OMX_TEST_LOG_DIR;
+
+    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
+    delete process.env.TMUX;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+    process.env.OMX_TEST_LOG_DIR = logDir;
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'team-detached-worktree-paths',
+          'detached worktree path resolution',
+          'executor',
+          1,
+          [{ subject: 's', description: 'd', owner: 'worker-1' }],
+          repo,
+          { worktreeMode: { enabled: true, detached: true, name: null } },
+        ));
+
+      const workerPath = runtime.config.workers[0]?.worktree_path;
+      assert.ok(workerPath, 'detached worker should have a worktree path');
+      assert.notEqual(workerPath, repo);
+
+      const startupLog = await waitForFileText(
+        stdinLogPath,
+        (content) => content.includes('/workers/worker-1/inbox.md'),
+      );
+      assert.match(
+        startupLog,
+        /\$OMX_TEAM_STATE_ROOT\/team\/team-detached-worktree-paths\/workers\/worker-1\/inbox\.md/,
+      );
+      assert.doesNotMatch(
+        startupLog,
+        /Read \.omx\/state\/team\/team-detached-worktree-paths\/workers\/worker-1\/inbox\.md/,
+      );
+
+      const envLog = JSON.parse(await waitForFileText(envLogPath, (content) => content.includes('teamStateRoot'))) as {
+        cwd: string;
+        teamStateRoot: string;
+        worker: string;
+      };
+      assert.equal(envLog.cwd, workerPath);
+      assert.equal(envLog.teamStateRoot, join(repo, '.omx', 'state'));
+      assert.equal(envLog.worker, 'team-detached-worktree-paths/worker-1');
+
+      await sendWorkerMessage(runtime.teamName, 'leader-fixed', 'worker-1', 'follow-up', repo);
+      const mailboxLog = await waitForFileText(
+        stdinLogPath,
+        (content) => content.includes('/mailbox/worker-1.json'),
+      );
+      assert.match(
+        mailboxLog,
+        /\$OMX_TEAM_STATE_ROOT\/team\/team-detached-worktree-paths\/mailbox\/worker-1\.json/,
+      );
+
+      await shutdownTeam(runtime.teamName, repo, { force: true });
+      runtime = null;
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, repo, { force: true }).catch(() => {});
+      }
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevLogDir === 'string') process.env.OMX_TEST_LOG_DIR = prevLogDir;
+      else delete process.env.OMX_TEST_LOG_DIR;
+      await rm(repo, { recursive: true, force: true });
     }
   });
 

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -315,6 +315,14 @@ describe('worker bootstrap', () => {
     assert.match(message, /ACK-only/);
   });
 
+  it('generateTriggerMessage uses provided state-root reference for worktree workers', () => {
+    const message = generateTriggerMessage('worker-9', 'team-path', '$OMX_TEAM_STATE_ROOT');
+    assert.match(message, /\$OMX_TEAM_STATE_ROOT\/team\/team-path\/workers\/worker-9\/inbox\.md/);
+    assert.match(message, /work now/i);
+    assert.match(message, /report progress/i);
+    assert.ok(message.length < 200);
+  });
+
   it('generateMailboxTriggerMessage is always < 200 characters', () => {
     const message = generateMailboxTriggerMessage('worker-long-name', 'team-with-long-name', 42);
     assert.ok(message.length < 200);
@@ -327,6 +335,15 @@ describe('worker bootstrap', () => {
     assert.match(message, /act now/i);
     assert.match(message, /concrete progress/i);
     assert.match(message, /ACK-only/);
+  });
+
+  it('generateMailboxTriggerMessage uses provided state-root reference for worktree workers', () => {
+    const message = generateMailboxTriggerMessage('worker-2', 'team-mail', 3, '$OMX_TEAM_STATE_ROOT');
+    assert.match(message, /3 new msg/);
+    assert.match(message, /\$OMX_TEAM_STATE_ROOT\/team\/team-mail\/mailbox\/worker-2\.json/);
+    assert.match(message, /act/i);
+    assert.match(message, /report progress/i);
+    assert.ok(message.length < 200);
   });
 
   it('writeTeamWorkerInstructionsFile composes base AGENTS.md with overlay', async () => {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -245,6 +245,7 @@ interface ShutdownGateCounts {
 const MODEL_INSTRUCTIONS_FILE_ENV = 'OMX_MODEL_INSTRUCTIONS_FILE';
 const TEAM_STATE_ROOT_ENV = 'OMX_TEAM_STATE_ROOT';
 const TEAM_LEADER_CWD_ENV = 'OMX_TEAM_LEADER_CWD';
+const WORKTREE_TRIGGER_STATE_ROOT = '$OMX_TEAM_STATE_ROOT';
 const CLAUDE_STARTUP_EVIDENCE_TIMEOUT_MS = 2_000;
 const CLAUDE_STARTUP_EVIDENCE_POLL_MS = 100;
 
@@ -258,6 +259,10 @@ const previousModelInstructionsFileByTeam = new Map<string, string | undefined>(
 const PROMPT_WORKER_SIGTERM_WAIT_MS = 3_000;
 const PROMPT_WORKER_SIGKILL_WAIT_MS = 2_000;
 const PROMPT_WORKER_EXIT_POLL_MS = 100;
+
+function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
+  return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
+}
 
 function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
   const raw = env.OMX_TEAM_READY_TIMEOUT_MS;
@@ -772,7 +777,11 @@ export async function startTeam(
         workerRole,
         rolePromptContent: rolePromptContent ?? undefined,
       });
-      const trigger = generateTriggerMessage(workerName, sanitized);
+      const trigger = generateTriggerMessage(
+        workerName,
+        sanitized,
+        resolveInstructionStateRoot(workerWorkspace.worktreePath),
+      );
       const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
       const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
         process.env,
@@ -1355,7 +1364,11 @@ export async function assignTask(
         workerIndex: workerInfo.index,
         paneId: workerInfo.pane_id,
         inbox,
-        triggerMessage: generateTriggerMessage(workerName, sanitized),
+        triggerMessage: generateTriggerMessage(
+          workerName,
+          sanitized,
+          resolveInstructionStateRoot(workerInfo.worktree_path),
+        ),
         cwd,
         dispatchPolicy,
         inboxCorrelationKey: `assign:${taskId}:${workerName}`,
@@ -1505,7 +1518,11 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         workerIndex: w.index,
         paneId: w.pane_id,
         inbox: generateShutdownInbox(sanitized, w.name),
-        triggerMessage: generateTriggerMessage(w.name, sanitized),
+        triggerMessage: generateTriggerMessage(
+          w.name,
+          sanitized,
+          resolveInstructionStateRoot(w.worktree_path),
+        ),
         cwd,
         dispatchPolicy,
         inboxCorrelationKey: `shutdown:${w.name}`,
@@ -2320,7 +2337,12 @@ async function deliverPendingMailboxMessages(
     if (!worker.alive) continue;
 
     for (const msg of unnotified) {
-      const triggerMessage = generateMailboxTriggerMessage(worker.name, teamName, 1);
+      const triggerMessage = generateMailboxTriggerMessage(
+        worker.name,
+        teamName,
+        1,
+        resolveInstructionStateRoot(workerInfo.worktree_path),
+      );
       const transportPreference = config.worker_launch_mode === 'prompt'
         ? 'prompt_stdin'
         : (dispatchPolicy.dispatch_mode === 'transport_direct' ? 'transport_direct' : 'hook_preferred_with_fallback');
@@ -2456,7 +2478,12 @@ export async function sendWorkerMessage(
   const recipient = config.workers.find((w) => w.name === toWorker);
   if (!recipient) throw new Error(`Worker ${toWorker} not found in team`);
 
-  const triggerMessage = generateMailboxTriggerMessage(toWorker, sanitized, 1);
+  const triggerMessage = generateMailboxTriggerMessage(
+    toWorker,
+    sanitized,
+    1,
+    resolveInstructionStateRoot(recipient.worktree_path),
+  );
   const transportPreference = config.worker_launch_mode === 'prompt'
     ? 'prompt_stdin'
     : (dispatchPolicy.dispatch_mode === 'transport_direct' ? 'transport_direct' : 'hook_preferred_with_fallback');
@@ -2519,7 +2546,12 @@ export async function broadcastWorkerMessage(
     recipients: config.workers.map((w) => ({ workerName: w.name, workerIndex: w.index, paneId: w.pane_id })),
     body,
     cwd,
-    triggerFor: (workerName) => generateMailboxTriggerMessage(workerName, sanitized, 1),
+    triggerFor: (workerName) => generateMailboxTriggerMessage(
+      workerName,
+      sanitized,
+      1,
+      resolveInstructionStateRoot(config.workers.find((worker) => worker.name === workerName)?.worktree_path),
+    ),
     transportPreference,
     fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
     notify: async (target, message) =>
@@ -2553,7 +2585,12 @@ export async function broadcastWorkerMessage(
       workerIndex: target.index,
       paneId: target.pane_id,
       messageId: outcome.message_id,
-      triggerMessage: generateMailboxTriggerMessage(target.name, sanitized, 1),
+      triggerMessage: generateMailboxTriggerMessage(
+        target.name,
+        sanitized,
+        1,
+        resolveInstructionStateRoot(target.worktree_path),
+      ),
       config,
       dispatchPolicy,
       cwd,

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -67,6 +67,7 @@ import { resolveCanonicalTeamStateRoot } from './state-root.js';
 // ── Environment gate ──────────────────────────────────────────────────────────
 
 const OMX_TEAM_SCALING_ENABLED_ENV = 'OMX_TEAM_SCALING_ENABLED';
+const WORKTREE_TRIGGER_STATE_ROOT = '$OMX_TEAM_STATE_ROOT';
 
 export function isScalingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[OMX_TEAM_SCALING_ENABLED_ENV];
@@ -101,6 +102,10 @@ export interface ScaleDownResult {
 export interface ScaleError {
   ok: false;
   error: string;
+}
+
+function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
+  return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
 }
 
 async function notifyWorkerPaneOutcome(
@@ -332,7 +337,11 @@ export async function scaleUp(
         rolePromptContent: rolePromptContent ?? undefined,
       });
 
-      const trigger = generateTriggerMessage(workerName, sanitized);
+      const trigger = generateTriggerMessage(
+        workerName,
+        sanitized,
+        resolveInstructionStateRoot(workerInfo.worktree_path),
+      );
       const queued = await queueInboxInstruction({
         teamName: sanitized,
         workerName,

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -437,19 +437,40 @@ Type \`exit\` or press Ctrl+C to end your Codex session.
 `;
 }
 
+function buildInstructionPath(...parts: string[]): string {
+  return join(...parts).replaceAll('\\', '/');
+}
+
 /**
  * Generate the SHORT send-keys trigger message.
  * Always < 200 characters, ASCII-safe.
  */
-export function generateTriggerMessage(workerName: string, teamName: string): string {
-  return `Read .omx/state/team/${teamName}/workers/${workerName}/inbox.md, start work now, then report concrete progress (not ACK-only).`;
+export function generateTriggerMessage(
+  workerName: string,
+  teamName: string,
+  teamStateRoot: string = '.omx/state',
+): string {
+  const inboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'workers', workerName, 'inbox.md');
+  if (teamStateRoot !== '.omx/state') {
+    return `Read ${inboxPath}, work now, report progress.`;
+  }
+  return `Read ${inboxPath}, start work now, then report concrete progress (not ACK-only).`;
 }
 
 /**
  * Generate a SHORT trigger for mailbox notifications.
  * Always < 200 characters, ASCII-safe.
  */
-export function generateMailboxTriggerMessage(workerName: string, teamName: string, count: number): string {
+export function generateMailboxTriggerMessage(
+  workerName: string,
+  teamName: string,
+  count: number,
+  teamStateRoot: string = '.omx/state',
+): string {
   const n = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
-  return `You have ${n} new message(s). Check .omx/state/team/${teamName}/mailbox/${workerName}.json, act now, and reply with concrete progress (not ACK-only).`;
+  const mailboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'mailbox', workerName + '.json');
+  if (teamStateRoot !== '.omx/state') {
+    return `${n} new msg(s): check ${mailboxPath}, act and report progress.`;
+  }
+  return `You have ${n} new message(s). Check ${mailboxPath}, act now, and reply with concrete progress (not ACK-only).`;
 }


### PR DESCRIPTION
## Summary

Detached/worktree workers were being told to read `.omx/state/...` relative to their own worktree cwd, which could miss the leader-owned team inbox/mailbox state. This switches worktree worker trigger text to use `$OMX_TEAM_STATE_ROOT/...` so startup and mailbox prompts resolve back to the leader root.

## Changes

- teach worker trigger generators to accept a state-root reference
- use `$OMX_TEAM_STATE_ROOT` for worktree worker startup/shutdown/assignment/mailbox triggers
- add focused regressions for trigger generation and detached-worktree prompt-mode runtime behavior

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused validation:
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node --test dist/team/__tests__/worker-bootstrap.test.js dist/team/__tests__/runtime.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #705
