### PR TITLE
fix: harden team workers under explicit launch args

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -483,6 +483,92 @@ sleep 5
     }
   });
 
+  it('startTeam preserves explicit codex launch args while forcing bypass in prompt mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-explicit-launch-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const capturePath = join(cwd, 'codex-argv.json');
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+const fs = require('fs');
+fs.writeFileSync(process.env.OMX_CODEX_ARGV_CAPTURE_PATH, JSON.stringify(process.argv.slice(2), null, 2));
+process.stdin.resume();
+setTimeout(() => process.exit(0), 5000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+      { mode: 0o755 },
+    );
+
+    const prevPath = process.env.PATH;
+    const prevTmux = process.env.TMUX;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    const prevCapture = process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
+
+    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
+    delete process.env.TMUX;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+    process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.3-codex-spark -c model_reasoning_effort="low"';
+    process.env.OMX_CODEX_ARGV_CAPTURE_PATH = capturePath;
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'team-codex-explicit-launch',
+          'codex prompt-mode team bootstrap',
+          'explore',
+          1,
+          [{ subject: 's', description: 'd', owner: 'worker-1' }],
+          cwd,
+        ));
+
+      assert.equal(runtime.config.worker_launch_mode, 'prompt');
+      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
+
+      let argv: string[] | null = null;
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        if (existsSync(capturePath)) {
+          argv = JSON.parse(await readFile(capturePath, 'utf-8')) as string[];
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      assert.ok(argv, 'codex argv capture file should be written');
+      assert.equal(argv.includes('--dangerously-bypass-approvals-and-sandbox'), true);
+      assert.equal(argv.filter((arg) => arg === '--dangerously-bypass-approvals-and-sandbox').length, 1);
+      assert.equal(argv.includes('--model'), true);
+      assert.equal(argv[argv.indexOf('--model') + 1], 'gpt-5.3-codex-spark');
+      assert.equal(argv.includes('-c'), true);
+      assert.equal(argv.includes('model_reasoning_effort="low"'), true);
+      assert.equal(argv.some((arg) => arg.includes('model_instructions_file=')), true);
+
+      await shutdownTeam(runtime.teamName, cwd, { force: true });
+      runtime = null;
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      if (typeof prevCapture === 'string') process.env.OMX_CODEX_ARGV_CAPTURE_PATH = prevCapture;
+      else delete process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
 
   it('startTeam preserves routed task roles into team state and worker launch args', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-role-routing-'));

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -663,6 +663,33 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('forces codex bypass under explicit launch-arg profiles', () => {
+    const prevShell = process.env.SHELL;
+    process.env.SHELL = '/bin/bash';
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const profiles = [
+        ['--model', 'gpt-5', '-c', 'model_reasoning_effort="high"'],
+        ['--model', 'gpt-5.3-codex-spark', '-c', 'model_reasoning_effort="low"'],
+      ];
+
+      for (const launchArgs of profiles) {
+        const cmd = buildWorkerStartupCommand('alpha', 1, launchArgs, process.cwd(), {}, 'codex');
+        assert.match(cmd, /exec .*codex/);
+        assert.equal((cmd.match(/--dangerously-bypass-approvals-and-sandbox/g) || []).length, 1);
+        assert.match(cmd, /--model/);
+        assert.match(cmd, new RegExp(launchArgs[1]!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+        assert.match(cmd, new RegExp(launchArgs[3]!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      }
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
   it('supports worker-specific reasoning overrides for codex and strips them for claude workers', () => {
     const prevShell = process.env.SHELL;
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
@@ -981,7 +1008,7 @@ describe('team worker launch mode helpers', () => {
       // command is now the resolved absolute path (or bare binary if which fails)
       assert.equal(spec.workerCli, 'codex');
       assert.ok(typeof spec.command === 'string' && spec.command.length > 0, 'command must be a non-empty string');
-      assert.deepEqual(spec.args, ['--model', 'gpt-5.3-codex']);
+      assert.deepEqual(spec.args, ['--model', 'gpt-5.3-codex', '--dangerously-bypass-approvals-and-sandbox']);
       assert.equal(spec.env.OMX_TEAM_WORKER, 'alpha-team/worker-2');
       assert.equal(spec.env.OMX_TEAM_STATE_ROOT, '/tmp/workspace/.omx/state');
     } finally {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -637,6 +637,9 @@ export function buildWorkerProcessLaunchSpec(
   const fullLaunchArgs = resolveWorkerLaunchArgs(launchArgs, cwd, effectiveEnv);
   const workerCli = workerCliOverride ?? resolveTeamWorkerCli(fullLaunchArgs, effectiveEnv);
   const cliLaunchArgs = translateWorkerLaunchArgsForCli(workerCli, fullLaunchArgs, initialPrompt);
+  const effectiveCliLaunchArgs = workerCli === 'codex' && !cliLaunchArgs.includes(CODEX_BYPASS_FLAG)
+    ? [...cliLaunchArgs, CODEX_BYPASS_FLAG]
+    : cliLaunchArgs;
 
   const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);
   const workerEnv: Record<string, string> = {
@@ -652,7 +655,7 @@ export function buildWorkerProcessLaunchSpec(
   return {
     workerCli,
     command: resolvedCliPath,
-    args: cliLaunchArgs,
+    args: effectiveCliLaunchArgs,
     env: workerEnv,
   };
 }


### PR DESCRIPTION
## Summary
- keep Codex team workers in unattended mode even when OMX_TEAM_WORKER_LAUNCH_ARGS explicitly sets model/reasoning
- inject the Codex bypass flag in the worker launch spec so explicit worker profiles do not fall back into approval prompts or derail startup automation
- add focused tmux-session/runtime regressions for explicit high and spark worker launch-arg profiles

## Testing
- npm run build
- node --test dist/team/__tests__/tmux-session.test.js dist/team/__tests__/runtime.test.js

Closes #706.