### PR TITLE
fix(team): harden Codex startup ACK-without-claim stalls (#698)

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -28,6 +28,7 @@ import {
   assignTask,
   sendWorkerMessage,
   resolveWorkerLaunchArgsFromEnv,
+  waitForWorkerStartupEvidence,
   waitForClaudeStartupEvidence,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   type TeamRuntime,
@@ -360,6 +361,44 @@ describe('runtime', () => {
       const taskClaim = await waitForClaudeStartupEvidence({
         teamName: 'claude-startup',
         workerName: 'worker-1',
+        cwd,
+        timeoutMs: 25,
+        pollMs: 5,
+      });
+      assert.equal(taskClaim, 'task_claim');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('waitForWorkerStartupEvidence ignores Codex ACK-only startup replies until work is claimed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-startup-'));
+    try {
+      await initTeamState('codex-startup', 'startup evidence test', 'executor', 1, cwd);
+
+      await sendWorkerMessage('codex-startup', 'worker-1', 'leader-fixed', 'ACK', cwd);
+      const ackOnly = await waitForWorkerStartupEvidence({
+        teamName: 'codex-startup',
+        workerName: 'worker-1',
+        workerCli: 'codex',
+        cwd,
+        timeoutMs: 25,
+        pollMs: 5,
+      });
+      assert.equal(ackOnly, 'none');
+
+      await writeAtomic(
+        join(cwd, '.omx', 'state', 'team', 'codex-startup', 'workers', 'worker-1', 'status.json'),
+        JSON.stringify({
+          state: 'working',
+          current_task_id: 'task-1',
+          updated_at: new Date().toISOString(),
+        }, null, 2),
+      );
+      const taskClaim = await waitForWorkerStartupEvidence({
+        teamName: 'codex-startup',
+        workerName: 'worker-1',
+        workerCli: 'codex',
         cwd,
         timeoutMs: 25,
         pollMs: 5,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -246,8 +246,8 @@ const MODEL_INSTRUCTIONS_FILE_ENV = 'OMX_MODEL_INSTRUCTIONS_FILE';
 const TEAM_STATE_ROOT_ENV = 'OMX_TEAM_STATE_ROOT';
 const TEAM_LEADER_CWD_ENV = 'OMX_TEAM_LEADER_CWD';
 const WORKTREE_TRIGGER_STATE_ROOT = '$OMX_TEAM_STATE_ROOT';
-const CLAUDE_STARTUP_EVIDENCE_TIMEOUT_MS = 2_000;
-const CLAUDE_STARTUP_EVIDENCE_POLL_MS = 100;
+const STARTUP_EVIDENCE_TIMEOUT_MS = 2_000;
+const STARTUP_EVIDENCE_POLL_MS = 100;
 
 interface PromptWorkerHandle {
   child: ChildProcessByStdio<Writable, null, null>;
@@ -271,13 +271,13 @@ function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
   return 45_000;
 }
 
-type ClaudeStartupEvidence = 'task_claim' | 'worker_progress' | 'leader_ack' | 'none';
+type WorkerStartupEvidence = 'task_claim' | 'worker_progress' | 'leader_ack' | 'none';
 
-async function readClaudeStartupEvidence(
+async function readWorkerStartupEvidence(
   teamName: string,
   workerName: string,
   cwd: string,
-): Promise<ClaudeStartupEvidence> {
+): Promise<WorkerStartupEvidence> {
   const status = await readWorkerStatus(teamName, workerName, cwd);
   if (typeof status.current_task_id === 'string' && status.current_task_id.trim() !== '') {
     return 'task_claim';
@@ -292,23 +292,43 @@ async function readClaudeStartupEvidence(
   return 'none';
 }
 
+function doesStartupEvidenceSettle(
+  workerCli: TeamWorkerCli,
+  evidence: WorkerStartupEvidence,
+): boolean {
+  if (evidence === 'none') return false;
+  if (workerCli === 'codex' && evidence === 'leader_ack') return false;
+  return true;
+}
+
+export async function waitForWorkerStartupEvidence(params: {
+  teamName: string;
+  workerName: string;
+  workerCli: TeamWorkerCli;
+  cwd: string;
+  timeoutMs?: number;
+  pollMs?: number;
+}): Promise<WorkerStartupEvidence> {
+  const timeoutMs = Math.max(0, Math.floor(params.timeoutMs ?? STARTUP_EVIDENCE_TIMEOUT_MS));
+  const pollMs = Math.max(25, Math.floor(params.pollMs ?? STARTUP_EVIDENCE_POLL_MS));
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const evidence = await readWorkerStartupEvidence(params.teamName, params.workerName, params.cwd);
+    if (doesStartupEvidenceSettle(params.workerCli, evidence)) return evidence;
+    if (Date.now() >= deadline) return 'none';
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+}
+
 export async function waitForClaudeStartupEvidence(params: {
   teamName: string;
   workerName: string;
   cwd: string;
   timeoutMs?: number;
   pollMs?: number;
-}): Promise<ClaudeStartupEvidence> {
-  const timeoutMs = Math.max(0, Math.floor(params.timeoutMs ?? CLAUDE_STARTUP_EVIDENCE_TIMEOUT_MS));
-  const pollMs = Math.max(25, Math.floor(params.pollMs ?? CLAUDE_STARTUP_EVIDENCE_POLL_MS));
-  const deadline = Date.now() + timeoutMs;
-
-  while (true) {
-    const evidence = await readClaudeStartupEvidence(params.teamName, params.workerName, params.cwd);
-    if (evidence !== 'none') return evidence;
-    if (Date.now() >= deadline) return 'none';
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
+}): Promise<WorkerStartupEvidence> {
+  return await waitForWorkerStartupEvidence({ ...params, workerCli: 'claude' });
 }
 
 function shouldSkipWorkerReadyWait(env: NodeJS.ProcessEnv): boolean {
@@ -968,7 +988,7 @@ export async function startTeam(
             cwd: leaderCwd,
             dispatchPolicy,
             inboxCorrelationKey: `startup:${workerName}`,
-            requireClaudeStartupEvidence: true,
+            requireWorkerStartupEvidence: true,
           });
           if (dispatchOutcome.ok) break;
           if (attempt < maxStartupDispatchRetries) {
@@ -1956,7 +1976,7 @@ async function dispatchCriticalInboxInstruction(params: {
   cwd: string;
   dispatchPolicy: TeamPolicy;
   inboxCorrelationKey: string;
-  requireClaudeStartupEvidence?: boolean;
+  requireWorkerStartupEvidence?: boolean;
 }): Promise<DispatchOutcome> {
   const {
     teamName,
@@ -1970,7 +1990,7 @@ async function dispatchCriticalInboxInstruction(params: {
     cwd,
     dispatchPolicy,
     inboxCorrelationKey,
-    requireClaudeStartupEvidence,
+    requireWorkerStartupEvidence,
   } = params;
 
   if (config.worker_launch_mode === 'prompt') {
@@ -2028,21 +2048,24 @@ async function dispatchCriticalInboxInstruction(params: {
   if (receipt?.status === 'delivered') {
     return { ok: true, transport: 'hook', reason: 'hook_receipt_delivered', request_id: queued.request_id };
   }
-  let claudeStartupEvidence: ClaudeStartupEvidence = 'none';
+  const requiresObservedStartupEvidence = requireWorkerStartupEvidence === true
+    && (workerCli === 'claude' || workerCli === 'codex');
+  let startupEvidence: WorkerStartupEvidence = 'none';
   if (receipt?.status === 'notified') {
-    if (!(requireClaudeStartupEvidence && workerCli === 'claude')) {
+    if (!requiresObservedStartupEvidence) {
       return { ok: true, transport: 'hook', reason: 'hook_receipt_notified', request_id: queued.request_id };
     }
-    claudeStartupEvidence = await waitForClaudeStartupEvidence({
+    startupEvidence = await waitForWorkerStartupEvidence({
       teamName,
       workerName,
+      workerCli,
       cwd,
     });
-    if (claudeStartupEvidence !== 'none') {
+    if (startupEvidence !== 'none') {
       return {
         ok: true,
         transport: 'hook',
-        reason: `hook_receipt_notified_with_${claudeStartupEvidence}`,
+        reason: `hook_receipt_notified_with_${startupEvidence}`,
         request_id: queued.request_id,
       };
     }
@@ -2082,11 +2105,11 @@ async function dispatchCriticalInboxInstruction(params: {
   }
 
   const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
-  const claudeStartupFallbackLabel = receipt?.status === 'notified' && requireClaudeStartupEvidence && workerCli === 'claude'
-    ? 'claude_startup_no_evidence'
+  const startupFallbackLabel = receipt?.status === 'notified' && requiresObservedStartupEvidence
+    ? `${workerCli}_startup_no_evidence`
     : null;
-  const fallbackFailureReason = claudeStartupFallbackLabel
-    ? `${claudeStartupFallbackLabel}_fallback_failed:${fallback.reason}`
+  const fallbackFailureReason = startupFallbackLabel
+    ? `${startupFallbackLabel}_fallback_failed:${fallback.reason}`
     : `fallback_attempted_but_unconfirmed:${fallback.reason}`;
   if (fallback.ok) {
     const marked = await markDispatchRequestNotified(
@@ -2108,8 +2131,8 @@ async function dispatchCriticalInboxInstruction(params: {
     return {
       ok: true,
       transport: fallback.transport,
-      reason: claudeStartupFallbackLabel
-        ? `${claudeStartupFallbackLabel}_fallback_confirmed:${fallback.reason}`
+      reason: startupFallbackLabel
+        ? `${startupFallbackLabel}_fallback_confirmed:${fallback.reason}`
         : `hook_timeout_fallback_confirmed:${fallback.reason}`,
       request_id: queued.request_id,
     };


### PR DESCRIPTION
## Summary
- harden startup dispatch evidence handling so Codex ACK-only replies no longer settle hook-preferred startup delivery
- keep Claude startup behavior intact while reusing a generic worker startup evidence helper
- add a focused runtime regression covering Codex ACK-without-claim startup behavior

## Verification
- npm run build
- node --test dist/team/__tests__/runtime.test.js
- npm run lint
- npm run check:no-unused
