### PR TITLE
fix(hooks): reduce clawhip lifecycle event noise

### DIFF
--- a/docs/clawhip-event-contract.md
+++ b/docs/clawhip-event-contract.md
@@ -52,10 +52,17 @@ When available, OMX includes these fields in `context`:
 | `test-failed` | `test-failed` | derived | Derived from failed test command completion. |
 | `handoff-needed` | `handoff-needed` | native/derived | Human or orchestrator follow-up is needed. |
 
+## Lifecycle ownership
+
+- native session lifecycle events are the canonical source for `started`, `blocked`, `finished`, and `failed`
+- derived operational events add follow-up detail for `retry-needed`, `pr-created`, `test-*`, and `handoff-needed`
+- operational contexts resolve `session_name` from the OMX session id + worktree so session metadata stays stable across native and derived events
+
 ## Noise and duplicate controls
 
 - `notify-hook` turn dedupe suppresses duplicate `agent-turn-complete` processing by `thread_id + turn_id + type`.
 - `session-idle` emission still uses the idle cooldown gate.
+- assistant-text heuristics emit follow-up signals (`retry-needed`, `handoff-needed`) but do not duplicate session completion/failure lifecycle events.
 - team dispatch retry and failure events emit only on explicit queue transition branches.
 - rollout-derived command events are correlated by `call_id` and only emit once per matching command lifecycle.
 

--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -41,7 +41,12 @@ import { drainPendingTeamDispatch } from './notify-hook/team-dispatch.js';
 import { syncLinkedRalphOnTeamTerminal } from './notify-hook/linked-sync.js';
 import { handleTmuxInjection } from './notify-hook/tmux-injection.js';
 import { maybeAutoNudge, resolveNudgePaneTarget } from './notify-hook/auto-nudge.js';
-import { buildOperationalContext, deriveAssistantSignalEvents, readRepositoryMetadata } from './notify-hook/operational-events.js';
+import {
+  buildOperationalContext,
+  deriveAssistantSignalEvents,
+  readRepositoryMetadata,
+  resolveOperationalSessionName,
+} from './notify-hook/operational-events.js';
 import {
   parseTeamWorkerEnv,
   resolveTeamStateDirForWorker,
@@ -332,7 +337,7 @@ async function main() {
       input_messages: normalizeInputMessages(payload),
       output_preview: outputPreview,
       ...readRepositoryMetadata(cwd),
-      session_name: sessionIdForHooks || undefined,
+      session_name: resolveOperationalSessionName(cwd, sessionIdForHooks),
       project_path: cwd,
       project_name: safeString(payload.project_name || ''),
     }, {

--- a/scripts/notify-hook/operational-events.js
+++ b/scripts/notify-hook/operational-events.js
@@ -1,7 +1,6 @@
 import { execFileSync } from 'child_process';
-import { basename } from 'path';
+import { basename, dirname } from 'path';
 import { safeString } from './utils.js';
-import { detectStallPattern, DEFAULT_STALL_PATTERNS, inferSkillPhaseFromText } from './auto-nudge.js';
 
 const TEST_SEGMENT_PATTERNS = [
   /^npm\s+(?:run\s+)?test\b/i,
@@ -18,13 +17,6 @@ const TEST_SEGMENT_PATTERNS = [
 
 const PR_CREATE_SEGMENT_RE = /^gh\s+pr\s+create\b/i;
 const SEARCH_SEGMENT_RE = /^(?:rg|grep|ag|ack|find|sed|awk|cat|printf|echo)\b/i;
-const BLOCKED_PATTERNS = [
-  /\bawaiting (?:approval|input|review|response)\b/i,
-  /\bwaiting for input\b/i,
-  /\bneed(?:s)? user input\b/i,
-  /\bcannot proceed without\b/i,
-  /\brequires user input\b/i,
-];
 const HANDOFF_PATTERNS = [
   /\bhandoff\b/i,
   /\bhand off\b/i,
@@ -38,15 +30,6 @@ const RETRY_PATTERNS = [
   /\brerun\b/i,
   /\bre-run\b/i,
   /\btry again\b/i,
-];
-const FAILURE_PATTERNS = [
-  /\bfailed with error\b/i,
-  /\boperation failed\b/i,
-  /\bbuild failed\b/i,
-  /\bverification failed\b/i,
-  /\bunable to continue\b/i,
-  /\bcannot continue\b/i,
-  /\berror:\s*\S/i,
 ];
 
 function gitValue(cwd, args) {
@@ -67,6 +50,49 @@ function shellSegments(command) {
     .split(/(?:&&|\|\||;|\n)/)
     .map((segment) => segment.trim())
     .filter(Boolean);
+}
+
+function sanitizeTmuxToken(value) {
+  const cleaned = safeString(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return cleaned || 'unknown';
+}
+
+function buildTmuxSessionName(cwd, sessionId) {
+  const parentDir = basename(dirname(cwd));
+  const dirName = basename(cwd);
+  const dirToken = parentDir.endsWith('.omx-worktrees')
+    ? sanitizeTmuxToken(`${parentDir.slice(0, -'.omx-worktrees'.length)}-${dirName}`)
+    : sanitizeTmuxToken(dirName);
+  const branch = gitValue(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  const branchToken = branch ? sanitizeTmuxToken(branch) : 'detached';
+  const sessionToken = sanitizeTmuxToken(safeString(sessionId).replace(/^omx-/, ''));
+  const name = `omx-${dirToken}-${branchToken}-${sessionToken}`;
+  return name.length > 120 ? name.slice(0, 120) : name;
+}
+
+export function resolveOperationalSessionName(cwd, sessionId = '', sessionName = '') {
+  const explicit = safeString(sessionName).trim();
+  if (explicit) return explicit;
+
+  if (process.env.TMUX) {
+    try {
+      const tmuxSession = execFileSync('tmux', ['display-message', '-p', '#S'], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 2000,
+      }).trim();
+      if (tmuxSession) return tmuxSession;
+    } catch {
+      // best effort only
+    }
+  }
+
+  const normalizedSessionId = safeString(sessionId).trim();
+  if (!normalizedSessionId) return undefined;
+  return buildTmuxSessionName(cwd, normalizedSessionId);
 }
 
 export function readRepositoryMetadata(cwd) {
@@ -182,10 +208,11 @@ export function buildOperationalContext({
     ...(prNumber !== undefined ? { pr_number: prNumber } : {}),
     ...(prUrl !== undefined ? { pr_url: prUrl } : {}),
   };
+  const resolvedSessionName = resolveOperationalSessionName(cwd, sessionId, sessionName);
 
   return {
     normalized_event: normalizedEvent,
-    session_name: sessionName || sessionId || undefined,
+    ...(resolvedSessionName ? { session_name: resolvedSessionName } : {}),
     ...repoMeta,
     ...(detectedIssue !== undefined ? { issue_number: detectedIssue } : {}),
     ...(detectedPrInfo.pr_number !== undefined ? { pr_number: detectedPrInfo.pr_number } : {}),
@@ -203,11 +230,8 @@ export function deriveAssistantSignalEvents(message) {
   if (!text) return [];
 
   const signals = [];
-  const phase = inferSkillPhaseFromText(text);
-  const blocked = BLOCKED_PATTERNS.some((pattern) => pattern.test(text)) || detectStallPattern(text, DEFAULT_STALL_PATTERNS);
   const handoff = HANDOFF_PATTERNS.some((pattern) => pattern.test(text));
   const retryNeeded = RETRY_PATTERNS.some((pattern) => pattern.test(text));
-  const failed = FAILURE_PATTERNS.some((pattern) => pattern.test(text));
 
   if (handoff) {
     signals.push({
@@ -224,23 +248,6 @@ export function deriveAssistantSignalEvents(message) {
       normalized_event: 'retry-needed',
       parser_reason: 'assistant_message_retry',
       confidence: 0.78,
-    });
-  }
-
-  if (failed) {
-    signals.push({
-      event: 'failed',
-      normalized_event: 'failed',
-      parser_reason: 'assistant_message_failure',
-      confidence: 0.72,
-      error_summary: extractErrorSummary(text),
-    });
-  } else if (!blocked && !handoff && phase === 'completing') {
-    signals.push({
-      event: 'finished',
-      normalized_event: 'finished',
-      parser_reason: 'assistant_message_completion',
-      confidence: 0.65,
     });
   }
 

--- a/src/hooks/__tests__/clawhip-event-contract.test.ts
+++ b/src/hooks/__tests__/clawhip-event-contract.test.ts
@@ -23,4 +23,10 @@ describe('clawhip event contract doc', () => {
       assert.match(contractDoc, new RegExp(eventName.replace('-', '\\-')));
     }
   });
+
+  it('documents lifecycle ownership and reduced assistant-signal noise', () => {
+    assert.match(contractDoc, /native session lifecycle events are the canonical source/i);
+    assert.match(contractDoc, /session_name.*stable across native and derived events/i);
+    assert.match(contractDoc, /do not duplicate session completion\/failure lifecycle events/i);
+  });
 });

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -149,6 +149,31 @@ describe('notify-hook/operational-events – parseCommandResult', () => {
   });
 });
 
+describe('notify-hook/operational-events – buildOperationalContext', () => {
+  it('resolves a stable session_name from cwd + session id', async () => {
+    const { buildOperationalContext } = await loadModule('notify-hook/operational-events.js');
+    const sessionId = 'omx-issue-663-session';
+    const originalTmux = process.env.TMUX;
+    delete process.env.TMUX;
+    try {
+      const context = buildOperationalContext({
+        cwd: process.cwd(),
+        normalizedEvent: 'pr-created',
+        sessionId,
+        status: 'finished',
+      });
+
+      assert.equal(typeof context.session_name, 'string');
+      assert.notEqual(context.session_name, sessionId);
+      assert.match(context.session_name || '', /^omx-/);
+      assert.match(context.session_name || '', /issue-663-session/);
+    } finally {
+      if (originalTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = originalTmux;
+    }
+  });
+});
+
 describe('notify-hook/operational-events – deriveAssistantSignalEvents', () => {
   it('detects handoff-needed and retry-needed from assistant text', async () => {
     const { deriveAssistantSignalEvents } = await loadModule('notify-hook/operational-events.js');
@@ -157,15 +182,15 @@ describe('notify-hook/operational-events – deriveAssistantSignalEvents', () =>
     assert.equal(signals.some((signal: { event?: string }) => signal.event === 'retry-needed'), true);
   });
 
-  it('detects completion and failure conservatively', async () => {
+  it('avoids duplicate finished/failed assistant lifecycle signals', async () => {
     const { deriveAssistantSignalEvents } = await loadModule('notify-hook/operational-events.js');
     assert.equal(
       deriveAssistantSignalEvents('Implementation completed. Final summary ready.').some((signal: { event?: string }) => signal.event === 'finished'),
-      true,
+      false,
     );
     assert.equal(
       deriveAssistantSignalEvents('The operation failed with error: unable to continue.').some((signal: { event?: string }) => signal.event === 'failed'),
-      true,
+      false,
     );
   });
 });


### PR DESCRIPTION
## Summary

Tightens the clawhip event surface without changing the broader contract shape.
This patch keeps native session lifecycle events as the canonical source for started/blocked/finished/failed, removes duplicate assistant-text finished/failed signals, and aligns derived event `context.session_name` with the native session naming path so clawhip sees one stable session identity across lifecycle, PR, test, and handoff events.

## Changes

- resolve derived operational `session_name` through the same tmux/worktree-based naming path used by native lifecycle events
- use that shared session-name resolution in the notify hook's native `turn-complete` payload as well
- stop emitting derived assistant-text `finished` / `failed` lifecycle signals and keep only follow-up `retry-needed` / `handoff-needed` heuristics
- document lifecycle ownership + lower-noise behavior in the clawhip event contract
- add focused tests for stable `session_name` resolution and non-duplication of assistant lifecycle signals

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #663
