### PR TITLE
Add additive event-query operations to omx team api

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -162,6 +162,76 @@ describe('teamCommand api', () => {
     }
   });
 
+  it('prints event query help for omx team api read-events help alias', async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+      await teamCommand(['api', 'read-events', 'help']);
+      assert.equal(logs.length, 1);
+      assert.match(logs[0] ?? '', /Usage: omx team api read-events --input <json> \[--json\]/);
+      assert.match(logs[0] ?? '', /after_event_id/);
+      assert.match(logs[0] ?? '', /wakeable_only/);
+      assert.match(logs[0] ?? '', /worker_idle/);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it('executes read-events via CLI api with canonical JSON results', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-read-events-'));
+    const previousCwd = process.cwd();
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      process.chdir(wd);
+      await initTeamState('api-read-events', 'api event test', 'executor', 1, wd);
+      await appendTeamEvent('api-read-events', {
+        type: 'worker_idle',
+        worker: 'worker-1',
+        task_id: '1',
+        prev_state: 'working',
+      }, wd);
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+
+      await teamCommand([
+        'api',
+        'read-events',
+        '--input',
+        JSON.stringify({
+          team_name: 'api-read-events',
+          type: 'worker_idle',
+          worker: 'worker-1',
+          task_id: '1',
+        }),
+        '--json',
+      ]);
+
+      assert.equal(logs.length, 1);
+      const envelope = JSON.parse(logs[0]) as {
+        command?: string;
+        ok?: boolean;
+        operation?: string;
+        data?: {
+          count?: number;
+          events?: Array<{ type?: string; source_type?: string; worker?: string; task_id?: string }>;
+        };
+      };
+      assert.equal(envelope.command, 'omx team api read-events');
+      assert.equal(envelope.ok, true);
+      assert.equal(envelope.operation, 'read-events');
+      assert.equal(envelope.data?.count, 1);
+      assert.equal(envelope.data?.events?.[0]?.type, 'worker_state_changed');
+      assert.equal(envelope.data?.events?.[0]?.source_type, 'worker_idle');
+      assert.equal(envelope.data?.events?.[0]?.worker, 'worker-1');
+      assert.equal(envelope.data?.events?.[0]?.task_id, '1');
+    } finally {
+      console.log = originalLog;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('executes CLI interop operation with stable JSON envelope', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-'));
     const previousCwd = process.cwd();

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -83,6 +83,8 @@ const TEAM_API_OPERATION_REQUIRED_FIELDS: Record<TeamApiOperation, string[]> = {
   'write-worker-inbox': ['team_name', 'worker', 'content'],
   'write-worker-identity': ['team_name', 'worker', 'index', 'role'],
   'append-event': ['team_name', 'type', 'worker'],
+  'read-events': ['team_name'],
+  'await-event': ['team_name'],
   'get-summary': ['team_name'],
   'cleanup': ['team_name'],
   'write-shutdown-request': ['team_name', 'worker', 'requested_by'],
@@ -103,6 +105,8 @@ const TEAM_API_OPERATION_OPTIONAL_FIELDS: Partial<Record<TeamApiOperation, strin
     'worktree_path', 'worktree_branch', 'worktree_detached', 'team_state_root',
   ],
   'append-event': ['task_id', 'message_id', 'reason'],
+  'read-events': ['after_event_id', 'wakeable_only', 'type', 'worker', 'task_id'],
+  'await-event': ['after_event_id', 'timeout_ms', 'poll_ms', 'wakeable_only', 'type', 'worker', 'task_id'],
   'write-task-approval': ['required'],
 };
 
@@ -110,6 +114,8 @@ const TEAM_API_OPERATION_NOTES: Partial<Record<TeamApiOperation, string>> = {
   'update-task': 'Only non-lifecycle task metadata can be updated.',
   'release-task-claim': 'Use this only for rollback/requeue to pending (not for completion).',
   'transition-task-status': 'Lifecycle flow is claim-safe and typically transitions in_progress -> completed|failed.',
+  'read-events': 'Events are returned in canonical form; worker_idle log entries normalize to type worker_state_changed with source_type worker_idle. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics.',
+  'await-event': 'Waits for the next matching event and returns status=timeout when no matching event arrives before timeout_ms. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics.',
 };
 
 function sampleValueForTeamApiField(field: string): unknown {
@@ -136,6 +142,10 @@ function sampleValueForTeamApiField(field: string): unknown {
     case 'assigned_tasks': return ['1', '2'];
     case 'type': return 'task_completed';
     case 'requested_by': return 'leader-fixed';
+    case 'after_event_id': return 'evt-123';
+    case 'wakeable_only': return true;
+    case 'timeout_ms': return 500;
+    case 'poll_ms': return 100;
     case 'min_updated_at': return '2026-03-04T00:00:00.000Z';
     case 'snapshot':
       return {

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -17,6 +17,7 @@ import {
   sendDirectMessage,
   enqueueDispatchRequest,
   readDispatchRequest,
+  appendTeamEvent,
 } from '../state.js';
 
 async function setupTeam(name: string): Promise<{ cwd: string; cleanup: () => Promise<void> }> {
@@ -52,7 +53,7 @@ describe('resolveTeamApiOperation', () => {
     assert.equal(resolveTeamApiOperation('  SEND_MESSAGE  '), 'send-message');
   });
 
-  it('resolves all 28 operations from the operation list', () => {
+  it('resolves all 30 operations from the operation list', () => {
     for (const op of TEAM_API_OPERATIONS) {
       assert.equal(resolveTeamApiOperation(op), op);
     }
@@ -94,8 +95,8 @@ describe('LEGACY_TEAM_MCP_TOOLS', () => {
 });
 
 describe('TEAM_API_OPERATIONS', () => {
-  it('contains 28 operations', () => {
-    assert.equal(TEAM_API_OPERATIONS.length, 28);
+  it('contains 30 operations', () => {
+    assert.equal(TEAM_API_OPERATIONS.length, 30);
   });
 
   it('all use kebab-case', () => {
@@ -891,6 +892,124 @@ describe('executeTeamApiOperation: append-event', () => {
       team_name: 'x',
     }, '/tmp');
     assert.equal(result.ok, false);
+  });
+});
+
+// ─── read-events ──────────────────────────────────────────────────────────
+
+describe('executeTeamApiOperation: read-events', () => {
+  it('returns canonical filtered events', async () => {
+    const { cwd, cleanup } = await setupTeam('evt-read');
+    try {
+      const first = await appendTeamEvent('evt-read', {
+        type: 'task_completed',
+        worker: 'worker-2',
+        task_id: '2',
+      }, cwd);
+      const second = await appendTeamEvent('evt-read', {
+        type: 'worker_idle',
+        worker: 'worker-1',
+        task_id: '1',
+        prev_state: 'working',
+      }, cwd);
+      await appendTeamEvent('evt-read', {
+        type: 'task_failed',
+        worker: 'worker-1',
+        task_id: '1',
+      }, cwd);
+
+      const result = await executeTeamApiOperation('read-events', {
+        team_name: 'evt-read',
+        after_event_id: first.event_id,
+        worker: 'worker-1',
+        task_id: '1',
+        type: 'worker_idle',
+      }, cwd);
+
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.data.count, 1);
+        assert.equal(result.data.cursor, second.event_id);
+        const events = result.data.events as Array<{ type?: string; source_type?: string; worker?: string; task_id?: string }>;
+        assert.equal(events.length, 1);
+        assert.equal(events[0]?.type, 'worker_state_changed');
+        assert.equal(events[0]?.source_type, 'worker_idle');
+        assert.equal(events[0]?.worker, 'worker-1');
+        assert.equal(events[0]?.task_id, '1');
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('rejects invalid event filters', async () => {
+    const result = await executeTeamApiOperation('read-events', {
+      team_name: 'evt-read-invalid',
+      type: 'not_an_event',
+    }, '/tmp');
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.error.message, /type must be one of/);
+    }
+  });
+});
+
+// ─── await-event ──────────────────────────────────────────────────────────
+
+describe('executeTeamApiOperation: await-event', () => {
+  it('waits for the next matching event', async () => {
+    const { cwd, cleanup } = await setupTeam('evt-await');
+    try {
+      const waitPromise = executeTeamApiOperation('await-event', {
+        team_name: 'evt-await',
+        worker: 'worker-1',
+        task_id: '1',
+        type: 'task_completed',
+        timeout_ms: 500,
+        poll_ms: 25,
+      }, cwd);
+
+      setTimeout(() => {
+        void appendTeamEvent('evt-await', {
+          type: 'worker_state_changed',
+          worker: 'worker-2',
+          task_id: '2',
+          state: 'working',
+        }, cwd);
+      }, 25);
+
+      setTimeout(() => {
+        void appendTeamEvent('evt-await', {
+          type: 'task_completed',
+          worker: 'worker-1',
+          task_id: '1',
+        }, cwd);
+      }, 60);
+
+      const result = await waitPromise;
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.data.status, 'event');
+        assert.equal(typeof result.data.cursor, 'string');
+        const event = result.data.event as { type?: string; worker?: string; task_id?: string } | null;
+        assert.equal(event?.type, 'task_completed');
+        assert.equal(event?.worker, 'worker-1');
+        assert.equal(event?.task_id, '1');
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('rejects invalid timeout values', async () => {
+    const result = await executeTeamApiOperation('await-event', {
+      team_name: 'evt-await-invalid',
+      timeout_ms: -1,
+    }, '/tmp');
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.error.message, /timeout_ms must be a non-negative integer/);
+    }
   });
 });
 

--- a/src/team/__tests__/events.test.ts
+++ b/src/team/__tests__/events.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { initTeamState, appendTeamEvent } from '../state.js';
+import { readTeamEvents, waitForTeamEvent } from '../state/events.js';
+
+async function setupTeam(name: string): Promise<{ cwd: string; cleanup: () => Promise<void> }> {
+  const cwd = await mkdtemp(join(tmpdir(), `omx-team-events-${name}-`));
+  await initTeamState(name, 'event test', 'executor', 2, cwd);
+  return { cwd, cleanup: () => rm(cwd, { recursive: true, force: true }) };
+}
+
+describe('team/state/events', () => {
+  it('reads canonical filtered events', async () => {
+    const { cwd, cleanup } = await setupTeam('canonical-filter');
+    try {
+      const baseline = await appendTeamEvent('canonical-filter', {
+        type: 'task_completed',
+        worker: 'worker-2',
+        task_id: '2',
+      }, cwd);
+      await appendTeamEvent('canonical-filter', {
+        type: 'worker_idle',
+        worker: 'worker-1',
+        task_id: '1',
+        prev_state: 'working',
+      }, cwd);
+
+      const events = await readTeamEvents('canonical-filter', cwd, {
+        afterEventId: baseline.event_id,
+        type: 'worker_idle',
+        worker: 'worker-1',
+        taskId: '1',
+      });
+
+      assert.equal(events.length, 1);
+      assert.equal(events[0]?.type, 'worker_state_changed');
+      assert.equal(events[0]?.source_type, 'worker_idle');
+      assert.equal(events[0]?.worker, 'worker-1');
+      assert.equal(events[0]?.task_id, '1');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('waits for the next matching filtered event', async () => {
+    const { cwd, cleanup } = await setupTeam('await-filter');
+    try {
+      const waitPromise = waitForTeamEvent('await-filter', cwd, {
+        timeoutMs: 500,
+        pollMs: 25,
+        wakeableOnly: false,
+        type: 'task_completed',
+        worker: 'worker-1',
+        taskId: '1',
+      });
+
+      setTimeout(() => {
+        void appendTeamEvent('await-filter', {
+          type: 'worker_state_changed',
+          worker: 'worker-2',
+          task_id: '2',
+          state: 'working',
+        }, cwd);
+      }, 25);
+
+      setTimeout(() => {
+        void appendTeamEvent('await-filter', {
+          type: 'task_completed',
+          worker: 'worker-1',
+          task_id: '1',
+        }, cwd);
+      }, 60);
+
+      const result = await waitPromise;
+      assert.equal(result.status, 'event');
+      assert.equal(result.event?.type, 'task_completed');
+      assert.equal(result.event?.worker, 'worker-1');
+      assert.equal(result.event?.task_id, '1');
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -11,6 +11,7 @@ import {
   type TeamEventType,
   type TeamTaskApprovalStatus,
 } from './contracts.js';
+import { readTeamEvents, waitForTeamEvent } from './state/events.js';
 import {
   teamSendMessage as sendDirectMessage,
   teamBroadcast as broadcastMessage,
@@ -101,6 +102,8 @@ export const TEAM_API_OPERATIONS = [
   'write-worker-inbox',
   'write-worker-identity',
   'append-event',
+  'read-events',
+  'await-event',
   'get-summary',
   'cleanup',
   'write-shutdown-request',
@@ -146,6 +149,37 @@ async function markLatestMailboxDispatchDelivered(
 
 function isFiniteInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && Number.isFinite(value);
+}
+
+function parseOptionalNonNegativeInteger(value: unknown, fieldName: string): number | null {
+  if (value === undefined) return null;
+  if (!isFiniteInteger(value) || value < 0) {
+    throw new Error(`${fieldName} must be a non-negative integer when provided`);
+  }
+  return value;
+}
+
+function parseOptionalBoolean(value: unknown, fieldName: string): boolean | null {
+  if (value === undefined) return null;
+  if (typeof value !== 'boolean') {
+    throw new Error(`${fieldName} must be a boolean when provided`);
+  }
+  return value;
+}
+
+function parseOptionalEventType(value: unknown): TeamEventType | 'worker_idle' | null {
+  if (value === undefined) return null;
+  if (typeof value !== 'string') {
+    throw new Error('type must be a string when provided');
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error('type cannot be empty when provided');
+  }
+  if (!TEAM_EVENT_TYPES.includes(normalized as TeamEventType)) {
+    throw new Error(`type must be one of: ${TEAM_EVENT_TYPES.join(', ')}`);
+  }
+  return normalized as TeamEventType | 'worker_idle';
 }
 
 function parseValidatedTaskIdArray(value: unknown, fieldName: string): string[] {
@@ -582,6 +616,62 @@ export async function executeTeamApiOperation(
           source_type: args.source_type as string | undefined,
         }, cwd);
         return { ok: true, operation, data: { event } };
+      }
+      case 'read-events': {
+        const teamName = String(args.team_name || '').trim();
+        if (!teamName) {
+          return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name is required' } };
+        }
+        const wakeableOnly = parseOptionalBoolean(args.wakeable_only, 'wakeable_only');
+        const eventType = parseOptionalEventType(args.type);
+        const worker = typeof args.worker === 'string' ? args.worker.trim() : '';
+        const taskId = typeof args.task_id === 'string' ? args.task_id.trim() : '';
+        const events = await readTeamEvents(teamName, cwd, {
+          afterEventId: typeof args.after_event_id === 'string' ? args.after_event_id.trim() || undefined : undefined,
+          wakeableOnly: wakeableOnly ?? false,
+          type: eventType ?? undefined,
+          worker: worker || undefined,
+          taskId: taskId || undefined,
+        });
+        return {
+          ok: true,
+          operation,
+          data: {
+            count: events.length,
+            cursor: events.at(-1)?.event_id ?? (typeof args.after_event_id === 'string' ? args.after_event_id.trim() : ''),
+            events,
+          },
+        };
+      }
+      case 'await-event': {
+        const teamName = String(args.team_name || '').trim();
+        if (!teamName) {
+          return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name is required' } };
+        }
+        const timeoutMs = parseOptionalNonNegativeInteger(args.timeout_ms, 'timeout_ms') ?? 30_000;
+        const pollMs = parseOptionalNonNegativeInteger(args.poll_ms, 'poll_ms');
+        const wakeableOnly = parseOptionalBoolean(args.wakeable_only, 'wakeable_only');
+        const eventType = parseOptionalEventType(args.type);
+        const worker = typeof args.worker === 'string' ? args.worker.trim() : '';
+        const taskId = typeof args.task_id === 'string' ? args.task_id.trim() : '';
+        const result = await waitForTeamEvent(teamName, cwd, {
+          afterEventId: typeof args.after_event_id === 'string' ? args.after_event_id.trim() || undefined : undefined,
+          timeoutMs,
+          pollMs: pollMs ?? undefined,
+          wakeableOnly: wakeableOnly ?? false,
+          type: eventType ?? undefined,
+          worker: worker || undefined,
+          taskId: taskId || undefined,
+        });
+        return {
+          ok: true,
+          operation,
+          data: {
+            status: result.status,
+            cursor: result.cursor,
+            event: result.event ?? null,
+          },
+        };
       }
       case 'get-summary': {
         const teamName = String(args.team_name || '').trim();

--- a/src/team/state/events.ts
+++ b/src/team/state/events.ts
@@ -14,6 +14,14 @@ const CANONICAL_WAKE_EVENT_TYPES = new Set<TeamEvent['type']>([
   'team_leader_nudge',
 ]);
 
+interface TeamEventReadOptions {
+  afterEventId?: string;
+  wakeableOnly?: boolean;
+  type?: TeamEvent['type'] | 'worker_idle';
+  worker?: string;
+  taskId?: string;
+}
+
 function asWorkerState(value: unknown): TeamEvent['state'] | undefined {
   return typeof value === 'string'
     && ['idle', 'working', 'blocked', 'done', 'failed', 'draining', 'unknown'].includes(value)
@@ -74,10 +82,23 @@ function isDuplicateNormalizedEvent(previous: TeamEvent | null, current: TeamEve
     && current.source_type === 'worker_idle';
 }
 
+function matchesEventType(event: TeamEvent, type: TeamEventReadOptions['type']): boolean {
+  if (!type) return true;
+  if (event.type === type) return true;
+  return type === 'worker_idle' && event.source_type === 'worker_idle';
+}
+
+function matchesEventQuery(event: TeamEvent, opts: TeamEventReadOptions): boolean {
+  if (!matchesEventType(event, opts.type)) return false;
+  if (opts.worker && event.worker !== opts.worker) return false;
+  if (opts.taskId && event.task_id !== opts.taskId) return false;
+  return true;
+}
+
 export async function readTeamEvents(
   teamName: string,
   cwd: string,
-  opts: { afterEventId?: string; wakeableOnly?: boolean } = {},
+  opts: TeamEventReadOptions = {},
 ): Promise<TeamEvent[]> {
   const path = teamEventLogPath(teamName, cwd);
   if (!existsSync(path)) return [];
@@ -106,6 +127,7 @@ export async function readTeamEvents(
     if (isDuplicateNormalizedEvent(previous, normalized)) continue;
     previous = normalized;
     if (opts.wakeableOnly && !CANONICAL_WAKE_EVENT_TYPES.has(normalized.type)) continue;
+    if (!matchesEventQuery(normalized, opts)) continue;
     events.push(normalized);
   }
 
@@ -120,14 +142,28 @@ export async function getLatestTeamEventCursor(teamName: string, cwd: string): P
 export async function waitForTeamEvent(
   teamName: string,
   cwd: string,
-  opts: { afterEventId?: string; timeoutMs: number; pollMs?: number; wakeableOnly?: boolean },
+  opts: {
+    afterEventId?: string;
+    timeoutMs: number;
+    pollMs?: number;
+    wakeableOnly?: boolean;
+    type?: TeamEvent['type'] | 'worker_idle';
+    worker?: string;
+    taskId?: string;
+  },
 ): Promise<{ status: 'event' | 'timeout'; event?: TeamEvent; cursor: string }> {
   const deadline = Date.now() + Math.max(0, Math.floor(opts.timeoutMs));
   let pollMs = Math.max(25, Math.floor(opts.pollMs ?? 100));
   const baseline = opts.afterEventId ?? await getLatestTeamEventCursor(teamName, cwd);
 
   while (Date.now() <= deadline) {
-    const events = await readTeamEvents(teamName, cwd, { afterEventId: baseline, wakeableOnly: opts.wakeableOnly !== false });
+    const events = await readTeamEvents(teamName, cwd, {
+      afterEventId: baseline,
+      wakeableOnly: opts.wakeableOnly !== false,
+      type: opts.type,
+      worker: opts.worker,
+      taskId: opts.taskId,
+    });
     const event = events[0];
     if (event) {
       return { status: 'event', event, cursor: event.event_id };


### PR DESCRIPTION
## Summary
- add additive `read-events` and `await-event` operations to `omx team api`
- keep existing mailbox/task primitives unchanged and layer event queries on top of current team event state
- add focused API, CLI, and event-state tests for canonical event filtering and waiting

## Why this first
This is the smallest coherent first patch for #709 because the event log/runtime surfaces already exist, so we can expose richer structured worker↔leader observability without replacing current primitives or inventing new lifecycle semantics in the same change.

## Scope notes
- additive only; existing `send-message`, mailbox, task, worker status, and monitor snapshot primitives remain unchanged
- this PR intentionally does **not** take on `report-progress`, `ack-inbox-read`, `worker-stalled`, `request-leader-action`, or worker runtime introspection yet
- `worker_idle` event filters return canonicalized events as `type=worker_state_changed` with `source_type=worker_idle`
- `wakeable_only` defaults to `false` for the new API operations; callers can set it to `true` to mirror `omx team await`

## Verification
- `npm run build && node --test dist/team/__tests__/api-interop.test.js dist/team/__tests__/events.test.js dist/cli/__tests__/team.test.js`
- `npm run lint`
- `npm run check:no-unused`

Refs #709