### PR TITLE
feat(team): split team orchestrator brain and executor lane

### DIFF
--- a/docs/prs/dev-issue-715-team-brain-role-split.md
+++ b/docs/prs/dev-issue-715-team-brain-role-split.md
@@ -1,0 +1,20 @@
+# PR Draft: Fix issue #715 team brain / role split
+
+## Target branch
+`dev`
+
+## Summary
+This follow-up PR fixes issue #715 by separating team-mode execution defaults from the generic executor lane.
+
+I plan to fix #715 via this PR.
+
+## Changes
+- add a `team-executor` role prompt for supervised default team execution
+- register `team-executor` in the catalog/setup path so the prompt and native agent are actually installable for real team runs
+- keep explicit `N:agent-type` team launches unchanged
+- add a conservative fanout guard so weakly structured small team tasks do not over-split by default
+- add focused regression tests for role discovery and decomposition behavior
+
+## Validation
+- [x] `npm run lint`
+- [x] `npm test`

--- a/prompts/team-executor.md
+++ b/prompts/team-executor.md
@@ -1,0 +1,57 @@
+---
+description: "Team execution specialist for supervised, conservative team delivery"
+argument-hint: "task description"
+---
+<identity>
+You are Team Executor. Execute assigned work inside a supervised OMX team run.
+
+Deliver finished, verified results while keeping coordination overhead low.
+</identity>
+
+<constraints>
+<reasoning_effort>
+- Default effort: medium.
+- Raise to high only when the assigned task is risky or spans multiple files.
+</reasoning_effort>
+
+<team_posture>
+- Respect the leader's plan, task boundaries, and lifecycle protocol.
+- Prefer direct completion over speculative fanout or reframing.
+- Treat low-confidence work conservatively: do the smallest correct change first.
+- Preserve explicit user intent when the team was launched with a named agent type.
+</team_posture>
+
+<scope_guard>
+- Stay within assigned files unless correctness requires a narrow adjacent edit.
+- Do not broaden task scope just because more work is visible.
+- Prefer deletion/reuse over new abstractions.
+</scope_guard>
+
+- Do not claim completion without fresh verification output.
+- If blocked, report the blocker clearly instead of inventing parallel work.
+</constraints>
+
+<intent>
+Treat team tasks as execution requests. Explore enough to understand the assignment, then implement and verify the minimal correct change.
+</intent>
+
+<execution_loop>
+1. Read the assigned task and current repo state.
+2. Implement the smallest correct change for the assigned lane.
+3. Verify with diagnostics/tests relevant to the touched area.
+4. Report concise evidence back to the leader.
+
+<success_criteria>
+A task is complete only when:
+1. The requested change is implemented.
+2. Modified files are clean in diagnostics.
+3. Relevant tests/build checks for the touched area pass, or pre-existing failures are documented.
+4. No debug leftovers or speculative TODOs remain.
+</success_criteria>
+</execution_loop>
+
+<style>
+- Keep updates concise and evidence-dense.
+- Prefer concrete file/command references over long explanations.
+- In ambiguous low-confidence work, choose the conservative interpretation that preserves team momentum.
+</style>

--- a/prompts/team-orchestrator.md
+++ b/prompts/team-orchestrator.md
@@ -1,0 +1,8 @@
+<team_orchestrator_brain>
+You are in team orchestration mode.
+- Treat team as a supervised, high-overhead coordination surface rather than a generic parallel executor.
+- Prefer conservative staffing and minimal fanout unless the task is clearly decomposable and worth the coordination cost.
+- Keep orchestration judgment separate from worker runtime protocol: mailbox, claims, and lifecycle APIs remain authoritative.
+- Preserve explicit user-selected worker counts/roles; only bias default routing when team mode was inferred implicitly.
+- Optimize for lead/worker clarity, bounded delegation, and evidence-backed completion over aggressive task splitting.
+</team_orchestrator_brain>

--- a/src/agents/__tests__/definitions.test.ts
+++ b/src/agents/__tests__/definitions.test.ts
@@ -33,6 +33,7 @@ describe('agents/definitions', () => {
     const buildAgents = getAgentsByCategory('build');
     assert.ok(buildAgents.length > 0);
     assert.ok(buildAgents.some((agent) => agent.name === 'executor'));
+    assert.ok(buildAgents.some((agent) => agent.name === 'team-executor'));
 
     const allowed: AgentDefinition['category'][] = [
       'build',

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -28,6 +28,17 @@ const EXECUTOR_AGENT: AgentDefinition = {
   category: 'build',
 };
 
+const TEAM_EXECUTOR_AGENT: AgentDefinition = {
+  name: 'team-executor',
+  description: 'Supervised team execution for conservative delivery lanes',
+  reasoningEffort: 'medium',
+  posture: 'deep-worker',
+  modelClass: 'standard',
+  routingRole: 'executor',
+  tools: 'execution',
+  category: 'build',
+};
+
 export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   // Build/Analysis Lane
   'explore': {
@@ -81,6 +92,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
     category: 'build',
   },
   'executor': EXECUTOR_AGENT,
+  'team-executor': TEAM_EXECUTOR_AGENT,
   'verifier': {
     name: 'verifier',
     description: 'Completion evidence, claim validation, test adequacy',

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-03-08T08:08:24.819Z",
+  "generatedAt": "2026-03-10T10:43:36.374Z",
   "version": "2026.02.28.1",
   "counts": {
     "skillCount": 39,
-    "promptCount": 29,
+    "promptCount": 30,
     "activeSkillCount": 23,
     "activeAgentCount": 18
   },
@@ -339,6 +339,11 @@
       "name": "executor",
       "category": "build",
       "status": "active"
+    },
+    {
+      "name": "team-executor",
+      "category": "build",
+      "status": "internal"
     },
     {
       "name": "verifier",

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -266,6 +266,11 @@
       "status": "active"
     },
     {
+      "name": "team-executor",
+      "category": "build",
+      "status": "internal"
+    },
+    {
       "name": "verifier",
       "category": "build",
       "status": "active"

--- a/src/cli/__tests__/setup-prompts-overwrite.test.ts
+++ b/src/cli/__tests__/setup-prompts-overwrite.test.ts
@@ -22,6 +22,7 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       const installedNativeAgents = new Set(await readdir(nativeAgentsDir));
 
       assert.equal(installedPrompts.has('executor.md'), true);
+      assert.equal(installedPrompts.has('team-executor.md'), true);
       assert.equal(installedPrompts.has('code-reviewer.md'), true);
       assert.equal(installedPrompts.has('style-reviewer.md'), false);
       assert.equal(installedPrompts.has('quality-reviewer.md'), false);
@@ -35,6 +36,7 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       assert.equal(installedPrompts.has('code-simplifier.md'), true);
 
       assert.equal(installedNativeAgents.has('executor.toml'), true);
+      assert.equal(installedNativeAgents.has('team-executor.toml'), true);
       assert.equal(installedNativeAgents.has('code-reviewer.toml'), true);
       assert.equal(installedNativeAgents.has('style-reviewer.toml'), false);
       assert.equal(installedNativeAgents.has('quality-reviewer.toml'), false);

--- a/src/cli/__tests__/team-decompose.test.ts
+++ b/src/cli/__tests__/team-decompose.test.ts
@@ -14,7 +14,6 @@ describe('decomposeTaskString', () => {
   it('assigns different roles to split tasks via heuristic routing', () => {
     const tasks = decomposeTaskString('fix tests, build UI component, and write documentation', 3, 'executor', false);
     const roles = tasks.map(t => t.role);
-    // Should have at least 2 distinct roles (test-related, UI-related, doc-related)
     const uniqueRoles = new Set(roles);
     assert.ok(uniqueRoles.size >= 2, `Expected at least 2 distinct roles, got: ${[...uniqueRoles].join(', ')}`);
   });
@@ -27,8 +26,8 @@ describe('decomposeTaskString', () => {
     assert.match(tasks[2].description, /update docs/i);
   });
 
-  it('creates aspect sub-tasks for atomic tasks with multiple workers', () => {
-    const tasks = decomposeTaskString('implement user login', 3, 'executor', false);
+  it('creates aspect sub-tasks for atomic tasks when the worker count is explicit', () => {
+    const tasks = decomposeTaskString('implement user login', 3, 'executor', false, true);
     assert.equal(tasks.length, 3);
     assert.match(tasks[0].subject, /implement/i);
     assert.match(tasks[1].subject, /test/i);
@@ -80,5 +79,25 @@ describe('decomposeTaskString', () => {
     const tasks = decomposeTaskString('write tests and build UI', 2, 'debugger', true);
     assert.equal(tasks[0].role, 'debugger');
     assert.equal(tasks[1].role, 'debugger');
+  });
+
+  it('uses team-executor for implicit default low-confidence team work', () => {
+    const tasks = decomposeTaskString('Do the thing', 2, 'executor', false);
+    assert.equal(tasks.length, 1);
+    assert.equal(tasks[0].role, 'team-executor');
+  });
+
+  it('keeps explicit worker-count small tasks conservative only when count is implicit', () => {
+    const implicitTasks = decomposeTaskString('fix typo in README', 3, 'executor', false, false);
+    assert.equal(implicitTasks.length, 1);
+    assert.equal(implicitTasks[0].owner, 'worker-1');
+
+    const explicitTasks = decomposeTaskString('fix typo in README', 3, 'executor', false, true);
+    assert.equal(explicitTasks.length, 3);
+  });
+
+  it('keeps explicit numbered tasks fanned out even on implicit default team runs', () => {
+    const tasks = decomposeTaskString('1. add team brain overlay 2. add team-executor prompt 3. add tests', 3, 'executor', false);
+    assert.equal(tasks.length, 3);
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,9 +37,10 @@ import { maybeCheckAndPromptUpdate } from './update.js';
 import { maybePromptGithubStar } from './star-prompt.js';
 import {
   generateOverlay,
-  writeSessionModelInstructionsFile,
   removeSessionModelInstructionsFile,
+  resolveSessionOrchestrationMode,
   sessionModelInstructionsPath,
+  writeSessionModelInstructionsFile,
 } from '../hooks/agents-overlay.js';
 import {
   readSessionState, isSessionStale, writeSessionStart, writeSessionEnd, resetSessionMetrics,
@@ -1089,7 +1090,8 @@ async function preLaunch(cwd: string, sessionId: string, notifyTempContract?: No
   }
 
   // 2. Generate runtime overlay + write session-scoped model instructions file
-  const overlay = await generateOverlay(cwd, sessionId);
+  const orchestrationMode = await resolveSessionOrchestrationMode(cwd, sessionId);
+  const overlay = await generateOverlay(cwd, sessionId, { orchestrationMode });
   await writeSessionModelInstructionsFile(cwd, sessionId, overlay);
 
   // 3. Write session state

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -5,6 +5,7 @@ import { sanitizeTeamName } from '../team/tmux-session.js';
 import { readTeamEvents, waitForTeamEvent } from '../team/state/events.js';
 import type { TeamEvent } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
+import { classifyTaskSize } from '../hooks/task-size-detector.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import {
   buildFollowupStaffingPlan,
@@ -27,6 +28,7 @@ interface ParsedTeamArgs {
   workerCount: number;
   agentType: string;
   explicitAgentType: boolean;
+  explicitWorkerCount: boolean;
   task: string;
   teamName: string;
   ralph: boolean;
@@ -283,6 +285,7 @@ function parseTeamArgs(args: string[]): ParsedTeamArgs {
   let workerCount = 3;
   let agentType = 'executor';
   let explicitAgentType = false;
+  let explicitWorkerCount = false;
 
   if (tokens[0]?.toLowerCase() === 'ralph') {
     ralph = true;
@@ -297,6 +300,7 @@ function parseTeamArgs(args: string[]): ParsedTeamArgs {
       throw new Error(`Invalid worker count "${match[1]}". Expected ${MIN_WORKER_COUNT}-${DEFAULT_MAX_WORKERS}.`);
     }
     workerCount = count;
+    explicitWorkerCount = true;
     if (match[2]) {
       agentType = match[2];
       explicitAgentType = true;
@@ -310,7 +314,7 @@ function parseTeamArgs(args: string[]): ParsedTeamArgs {
   }
 
   const teamName = sanitizeTeamName(slugifyTask(task));
-  return { workerCount, agentType, explicitAgentType, task, teamName, ralph };
+  return { workerCount, agentType, explicitAgentType, explicitWorkerCount, task, teamName, ralph };
 }
 
 export function parseTeamStartArgs(args: string[]): ParsedTeamStartArgs {
@@ -332,31 +336,79 @@ export function parseTeamStartArgs(args: string[]): ParsedTeamStartArgs {
  * When the user specifies an explicit agent-type (e.g., `3:executor`), all tasks
  * get that role (backward compat). Otherwise, heuristic routing assigns roles.
  */
+type DecompositionStrategy = 'numbered' | 'conjunction' | 'atomic';
+
+interface DecompositionCandidate {
+  subject: string;
+  description: string;
+}
+
+interface DecompositionPlan {
+  strategy: DecompositionStrategy;
+  subtasks: DecompositionCandidate[];
+}
+
+function resolveImplicitTeamFallbackRole(agentType: string, explicitAgentType: boolean): string {
+  return !explicitAgentType && agentType === 'executor' ? 'team-executor' : agentType;
+}
+
+function resolveTeamFanoutLimit(
+  task: string,
+  requestedWorkerCount: number,
+  explicitAgentType: boolean,
+  explicitWorkerCount: boolean,
+  plan: DecompositionPlan,
+): number {
+  if (requestedWorkerCount <= 1 || explicitAgentType || explicitWorkerCount || plan.strategy === 'numbered') {
+    return requestedWorkerCount;
+  }
+
+  const size = classifyTaskSize(task).size;
+  if (plan.strategy === 'atomic') {
+    if (size === 'small') {
+      const proseHeavyAtomicTask = countWords(task) > 18 || CONTEXTUAL_DECOMPOSITION_CLAUSE.test(task);
+      if (!proseHeavyAtomicTask) return 1;
+    }
+  }
+
+  if (plan.strategy === 'conjunction' && size !== 'large') {
+    return Math.min(requestedWorkerCount, Math.max(2, plan.subtasks.length));
+  }
+
+  return requestedWorkerCount;
+}
+
 export function decomposeTaskString(
   task: string,
   workerCount: number,
   agentType: string,
   explicitAgentType: boolean,
+  explicitWorkerCount = false,
 ): Array<{ subject: string; description: string; owner: string; role?: string }> {
-  // Try to split the task into distinct sub-goals
-  let subtasks = splitTaskString(task);
+  const plan = splitTaskString(task);
+  const effectiveWorkerCount = resolveTeamFanoutLimit(
+    task,
+    workerCount,
+    explicitAgentType,
+    explicitWorkerCount,
+    plan,
+  );
+  const fallbackRole = resolveImplicitTeamFallbackRole(agentType, explicitAgentType);
 
-  // If no decomposition possible, create aspect-scoped sub-tasks for N>1
-  if (subtasks.length <= 1 && workerCount > 1) {
-    subtasks = createAspectSubtasks(task, workerCount);
+  let subtasks = plan.subtasks;
+  if (subtasks.length <= 1 && effectiveWorkerCount > 1) {
+    subtasks = createAspectSubtasks(task, effectiveWorkerCount);
   }
 
-  // Assign roles: skip heuristic routing if user specified explicit agent-type
   const tasksWithRoles = subtasks.map((st) => {
     if (explicitAgentType) {
       return { ...st, role: agentType };
     }
-    const result = routeTaskToRole(st.subject, st.description, 'team-exec', agentType);
+    const result = routeTaskToRole(st.subject, st.description, 'team-exec', fallbackRole);
     return { ...st, role: result.role };
   });
 
-  // Distribute tasks across workers
-  return distributeTasksToWorkers(tasksWithRoles, workerCount);
+  return distributeTasksToWorkers(tasksWithRoles, effectiveWorkerCount);
 }
 
 const ACTIONABLE_TASK_PREFIX = /^(?:add|analy(?:se|ze)|audit|benchmark|build|clean(?:\s+up)?|create|debug|design|document|draft|fix|implement|improve|investigate|migrate|optimi(?:s|z)e|profile|refactor|repair|research|review|ship|summari(?:s|z)e|test|update|validate|verify|write)\b/i;
@@ -380,7 +432,7 @@ function canSafelySplitWeakTaskList(task: string, parts: string[]): boolean {
 }
 
 /** Split a task string into sub-tasks using numbered lists or conservative delimiters. */
-function splitTaskString(task: string): Array<{ subject: string; description: string }> {
+function splitTaskString(task: string): DecompositionPlan {
   // Try numbered list: "1. foo 2. bar 3. baz" or "1) foo 2) bar"
   const numberedPattern = /(?:^|\s)(\d+)[.)]\s+/g;
   const numberedMatches = [...task.matchAll(numberedPattern)];
@@ -395,22 +447,30 @@ function splitTaskString(task: string): Array<{ subject: string; description: st
         parts.push({ subject: text.slice(0, 80), description: text });
       }
     }
-    if (parts.length >= 2) return parts;
+    if (parts.length >= 2) return { strategy: 'numbered', subtasks: parts };
   }
 
   const strongParts = task.split(/;\s+/).map(s => s.trim()).filter(s => s.length > 0);
   if (strongParts.length >= 2) {
-    return strongParts.map((part) => ({ subject: part.slice(0, 80), description: part }));
+    return {
+      strategy: 'conjunction',
+      subtasks: strongParts.map((part) => ({ subject: part.slice(0, 80), description: part })),
+    };
   }
 
   // Commas / "and" only split when the overall input already looks like a flat task list.
   const weakParts = task.split(/(?:,\s+and\s+|,\s+|\s+and\s+)/i).map(s => s.trim()).filter(s => s.length > 0);
   if (canSafelySplitWeakTaskList(task, weakParts)) {
-    return weakParts.map((part) => ({ subject: part.slice(0, 80), description: part }));
+    return {
+      strategy: 'conjunction',
+      subtasks: weakParts.map((part) => ({ subject: part.slice(0, 80), description: part })),
+    };
   }
 
-  // Single atomic task
-  return [{ subject: task.slice(0, 80), description: task }];
+  return {
+    strategy: 'atomic',
+    subtasks: [{ subject: task.slice(0, 80), description: task }],
+  };
 }
 
 /** Create aspect-scoped sub-tasks for an atomic task that can't be split. */
@@ -451,6 +511,7 @@ async function ensureTeamModeState(
   parsed: ParsedTeamArgs,
   tasks?: Array<{ role?: string }>,
 ): Promise<void> {
+  const fallbackRole = resolveImplicitTeamFallbackRole(parsed.agentType, parsed.explicitAgentType);
   const roleDistribution = tasks && tasks.length > 0
     ? [...new Set(tasks.map(t => t.role ?? parsed.agentType))].join(',')
     : parsed.agentType;
@@ -458,7 +519,7 @@ async function ensureTeamModeState(
   const availableAgentTypes = await resolveAvailableAgentTypes(process.cwd());
   const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
     workerCount: parsed.workerCount,
-    fallbackRole: parsed.agentType,
+    fallbackRole,
   });
 
   const existing = await readModeState('team');
@@ -706,13 +767,14 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
       workerCount: runtime.config.worker_count,
       agentType: runtime.config.agent_type,
       explicitAgentType: false,
+      explicitWorkerCount: false,
       teamName: runtime.teamName,
       ralph: preservedRalph,
     });
     const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
     const staffingPlan = buildFollowupStaffingPlan('team', runtime.config.task, availableAgentTypes, {
       workerCount: runtime.config.worker_count,
-      fallbackRole: runtime.config.agent_type,
+      fallbackRole: resolveImplicitTeamFallbackRole(runtime.config.agent_type, false),
     });
     await renderStartSummary(runtime, staffingPlan);
     return;
@@ -745,11 +807,17 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
   }
 
   const parsed = parseTeamArgs(teamArgs);
-  const tasks = decomposeTaskString(parsed.task, parsed.workerCount, parsed.agentType, parsed.explicitAgentType);
+  const tasks = decomposeTaskString(
+    parsed.task,
+    parsed.workerCount,
+    parsed.agentType,
+    parsed.explicitAgentType,
+    parsed.explicitWorkerCount,
+  );
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
   const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
     workerCount: parsed.workerCount,
-    fallbackRole: parsed.agentType,
+    fallbackRole: resolveImplicitTeamFallbackRole(parsed.agentType, parsed.explicitAgentType),
   });
   const runtime = await startTeam(
     parsed.teamName,

--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -16,6 +16,7 @@ import {
   applyOverlay,
   stripOverlay,
   hasOverlay,
+  resolveSessionOrchestrationMode,
   writeSessionModelInstructionsFile,
   removeSessionModelInstructionsFile,
   sessionModelInstructionsPath,
@@ -43,6 +44,15 @@ describe('generateOverlay', () => {
     assert.ok(overlay.includes('<!-- OMX:RUNTIME:END -->'));
     assert.ok(overlay.includes('test-session-1'));
     assert.ok(overlay.includes('Compaction Protocol'));
+  });
+
+  it('includes the team orchestrator overlay only when orchestration mode is team', async () => {
+    const overlay = await generateOverlay(tempDir, 'team-session', { orchestrationMode: 'team' });
+    assert.match(overlay, /\*\*Orchestration Mode:\*\* team/);
+    assert.match(overlay, /supervised, high-overhead coordination surface/i);
+
+    const defaultOverlay = await generateOverlay(tempDir, 'default-session', { orchestrationMode: 'default' });
+    assert.doesNotMatch(defaultOverlay, /\*\*Orchestration Mode:\*\* team/);
   });
 
   it('generates overlay with active modes', async () => {
@@ -188,6 +198,44 @@ describe('generateOverlay', () => {
     const overlay = await generateOverlay(tempDir, sessionId);
     assert.match(overlay, /\*\*Ralph Ralplan-First Gate:\*\* UNLOCKED/);
     assert.match(overlay, /Planning artifacts present: PRD \+ test spec/);
+  });
+});
+
+describe('resolveSessionOrchestrationMode', () => {
+  let tempDir: string;
+
+  before(async () => { tempDir = await makeTempDir(); });
+  after(async () => { await rm(tempDir, { recursive: true, force: true }); });
+
+  it('uses explicit activeSkill when provided', async () => {
+    const mode = await resolveSessionOrchestrationMode(tempDir, 'sess-explicit', 'team');
+    assert.equal(mode, 'team');
+  });
+
+  it('reads persisted team skill state from the current session scope', async () => {
+    const sessionId = 'sess-team';
+    const sessionDir = join(tempDir, '.omx', 'state', 'sessions', sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, 'skill-active-state.json'),
+      JSON.stringify({ active: true, skill: 'team' }),
+    );
+
+    const mode = await resolveSessionOrchestrationMode(tempDir, sessionId);
+    assert.equal(mode, 'team');
+  });
+
+  it('falls back to default mode for non-team skill state', async () => {
+    const sessionId = 'sess-autopilot';
+    const sessionDir = join(tempDir, '.omx', 'state', 'sessions', sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, 'skill-active-state.json'),
+      JSON.stringify({ active: true, skill: 'autopilot' }),
+    );
+
+    const mode = await resolveSessionOrchestrationMode(tempDir, sessionId);
+    assert.equal(mode, 'default');
   });
 });
 

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -17,9 +17,10 @@
 import { readFile, writeFile, mkdir, rm, readdir } from 'fs/promises';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
-import { omxNotepadPath, omxProjectMemoryPath } from '../utils/paths.js';
-import { getStateDir, listModeStateFilesWithScopePreference } from '../mcp/state-paths.js';
+import { omxNotepadPath, omxProjectMemoryPath, packageRoot } from '../utils/paths.js';
+import { getReadScopedStateDirs, getStateDir, listModeStateFilesWithScopePreference } from '../mcp/state-paths.js';
 import { generateCodebaseMap } from './codebase-map.js';
+import { SKILL_ACTIVE_STATE_FILE } from './keyword-detector.js';
 
 const START_MARKER = '<!-- OMX:RUNTIME:START -->';
 const END_MARKER = '<!-- OMX:RUNTIME:END -->';
@@ -96,6 +97,12 @@ type OverlaySection = {
   text: string;
   optional: boolean;
 };
+
+export type SessionOrchestrationMode = 'default' | 'team';
+
+export interface GenerateOverlayOptions {
+  orchestrationMode?: SessionOrchestrationMode;
+}
 
 function joinSections(sections: OverlaySection[]): string {
   return sections.map(s => s.text).join('\n\n');
@@ -230,18 +237,58 @@ function getCompactionInstructions(): string {
   ].join('\n');
 }
 
+async function readTeamOrchestratorOverlay(): Promise<string> {
+  const overlayPath = join(packageRoot(), 'prompts', 'team-orchestrator.md');
+  try {
+    return (await readFile(overlayPath, 'utf-8')).trim();
+  } catch {
+    return '';
+  }
+}
+
+export async function resolveSessionOrchestrationMode(
+  cwd: string,
+  sessionId?: string,
+  activeSkill?: string,
+): Promise<SessionOrchestrationMode> {
+  if (activeSkill === 'team') return 'team';
+  if (activeSkill) return 'default';
+
+  const scopedStateDirs = await getReadScopedStateDirs(cwd, sessionId);
+  for (const stateDir of scopedStateDirs) {
+    const statePath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
+    if (!existsSync(statePath)) continue;
+
+    try {
+      const state = JSON.parse(await readFile(statePath, 'utf-8')) as { active?: boolean; skill?: string };
+      if (state.active !== true) continue;
+      return state.skill === 'team' ? 'team' : 'default';
+    } catch {
+      continue;
+    }
+  }
+
+  return 'default';
+}
+
 /**
  * Generate the overlay content to inject into AGENTS.md.
  * Total output is capped at MAX_OVERLAY_SIZE chars.
  */
-export async function generateOverlay(cwd: string, sessionId?: string): Promise<string> {
-  const [activeModes, notepadPriority, projectMemory, codebaseMap, ralphActive, planningArtifacts] = await Promise.all([
+export async function generateOverlay(
+  cwd: string,
+  sessionId?: string,
+  options: GenerateOverlayOptions = {},
+): Promise<string> {
+  const orchestrationMode = options.orchestrationMode ?? 'default';
+  const [activeModes, notepadPriority, projectMemory, codebaseMap, ralphActive, planningArtifacts, teamOverlay] = await Promise.all([
     readActiveModes(cwd, sessionId),
     readNotepadPriority(cwd),
     readProjectMemorySummary(cwd),
     generateCodebaseMap(cwd),
     isRalphActive(cwd, sessionId),
     readRalphPlanningArtifacts(cwd),
+    orchestrationMode === 'team' ? readTeamOrchestratorOverlay() : Promise.resolve(''),
   ]);
 
   // Build sections with deterministic overflow behavior.
@@ -283,6 +330,14 @@ export async function generateOverlay(cwd: string, sessionId?: string): Promise<
     sections.push({
       key: 'project_context',
       text: `**Project Context:**\n${truncate(projectMemory, 1000)}`,
+      optional: true,
+    });
+  }
+
+  if (teamOverlay) {
+    sections.push({
+      key: 'team_orchestrator',
+      text: `**Orchestration Mode:** team\n${truncate(teamOverlay, 900)}`,
       optional: true,
     });
   }

--- a/src/team/__tests__/followup-planner.test.ts
+++ b/src/team/__tests__/followup-planner.test.ts
@@ -23,6 +23,20 @@ describe('followup-planner', () => {
     }
   });
 
+
+  it('includes team-executor when the prompt is available', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omx-followup-roster-'));
+    try {
+      await writeFile(join(dir, 'executor.md'), '# Executor');
+      await writeFile(join(dir, 'team-executor.md'), '# Team Executor');
+
+      const roles = await resolveAvailableAgentTypes(process.cwd(), { promptDirs: [dir] });
+      assert.deepEqual(roles, ['executor', 'team-executor']);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('builds concrete team staffing guidance from the available roster', () => {
     const plan = buildFollowupStaffingPlan(
       'team',

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -328,6 +328,11 @@
       "status": "active"
     },
     {
+      "name": "team-executor",
+      "category": "build",
+      "status": "internal"
+    },
+    {
       "name": "verifier",
       "category": "build",
       "status": "active"


### PR DESCRIPTION
## Summary
This PR fixes #715 by separating **team-mode orchestration behavior** from the generic execution assumptions that are shared elsewhere in OMX.

Today, team mode is a heavier coordination surface than ultrawork: it has stronger setup cost, explicit worker lifecycle management, mailbox/state coordination, and a greater risk of over-fanout if the leader treats every task like a generic parallel workload. The previous default behavior still leaned too much on the generic executor lane, which made team-mode decomposition and leader guidance less specialized than they should be.

This PR introduces a **team-specific orchestration brain** and a **team-specific default execution role** so that team runs can make more conservative staffing and decomposition decisions without changing explicit user-selected roles.

I plan to fix #715 through this PR, targeting the `dev` branch.

## Why this change is needed
The issue behind this PR is not simply “add one more prompt.” The deeper problem is that team mode and ultrawork are solving different operational problems:

- **Ultrawork** is optimized for high-throughput fanout and parallel task completion.
- **Team mode** is optimized for supervised, stateful, higher-overhead coordination with worker lifecycle, readiness, mailbox exchange, progress observation, and staged completion.

Because of that difference, reusing the same default orchestration posture creates several failure modes:

1. **Over-fanout on small or weakly-structured work**  
   Team mode can split too aggressively even when the task is too small to justify the coordination overhead.

2. **Low-confidence work falls back to a generic executor posture**  
   That posture is appropriate for direct implementation, but it does not encode the more conservative delivery behavior that team mode needs.

3. **The leader/brain lacks team-specific guidance at session launch**  
   Without a team-scoped orchestration overlay, the main orchestration surface cannot bias toward “minimal fanout, preserve explicit intent, supervised completion” when the active skill is `team`.

4. **Even if a new role exists in code, it is incomplete unless setup/catalog can install it**  
   A team-specific role is only real if prompt installation, native-agent generation, and catalog export all know about it.

This PR addresses those problems end-to-end.

## What changed

### 1) Added a team-specific orchestration brain
A new prompt was added:

- `prompts/team-orchestrator.md`

This prompt is injected through the existing session-scoped AGENTS overlay path, but only when the active orchestration mode resolves to `team`.

Concretely:

- `src/hooks/agents-overlay.ts`
  - adds `SessionOrchestrationMode = 'default' | 'team'`
  - adds `resolveSessionOrchestrationMode(...)`
  - teaches `generateOverlay(...)` to optionally include a team-only overlay block
  - loads the new `prompts/team-orchestrator.md` content from the package prompt directory
- `src/cli/index.ts`
  - resolves orchestration mode before writing the session model instructions file
  - passes the resolved mode into overlay generation during prelaunch

### 2) Added a dedicated default team execution role
A new role prompt was added:

- `prompts/team-executor.md`

This role is designed for supervised, conservative team delivery:

- respect leader plan and task boundaries
- prefer the smallest correct change first
- avoid speculative fanout
- stay narrow and verification-first
- preserve explicit user-selected roles when they were intentionally requested

Code registration:

- `src/agents/definitions.ts`
  - adds `team-executor` as a first-class agent definition
- `src/agents/__tests__/definitions.test.ts`
  - extends coverage to ensure the role is registered in the build category

### 3) Changed implicit team fallback behavior
Previously, implicit/default team work that fell back to `executor` would keep using the generic executor lane.

Now:

- implicit team work with default `executor` fallback is rerouted to `team-executor`
- explicit `N:agent-type` launches are preserved exactly as requested

This behavior is implemented in:

- `src/cli/team.ts`
  - `resolveImplicitTeamFallbackRole(...)`
  - low-confidence/implicit team routing now uses `team-executor`

This is important because the PR intentionally does **not** change user-declared role intent. If a user explicitly asks for `3:executor`, OMX still honors that exact choice.

### 4) Added conservative team fanout shaping
The team command now distinguishes between:

- numbered decomposition
- conjunction-based decomposition
- atomic work

and combines that with task-size classification to reduce unnecessary worker fanout for implicit team runs.

Key behaviors:

- explicit worker counts are preserved
- explicit agent types are preserved
- explicit numbered tasks remain fanned out
- small implicit atomic tasks collapse to a single worker
- medium implicit atomic tasks cap fanout more conservatively
- weakly-structured conjunction tasks avoid excessive spreading unless the task is clearly large enough to justify it

Implementation details:

- `src/cli/team.ts`
  - adds `explicitWorkerCount`
  - introduces structured decomposition planning
  - adds `resolveTeamFanoutLimit(...)`
  - updates decomposition logic to use task-size-aware team shaping

### 5) Kept staffing summaries aligned with the new fallback lane
The team staffing/reporting path now uses the effective team fallback role instead of continuing to describe the run as generic `executor` work when the actual implicit lane is `team-executor`.

This keeps:

- team mode state
- staffing summaries
- follow-up planning output

consistent with the actual runtime behavior.

Relevant files:

- `src/cli/team.ts`
- `src/team/__tests__/followup-planner.test.ts`

### 6) Registered the new role in catalog/setup so it is actually installable
During final review, I found an important gap: the role existed in definitions/prompt files, but without catalog registration it would not fully participate in setup/export flows.

This PR fixes that by adding `team-executor` to the catalog as an internal agent and regenerating the catalog artifacts.

Updated files:

- `src/catalog/manifest.json`
- `templates/catalog-manifest.json`
- `src/catalog/generated/public-catalog.json`
- `src/cli/__tests__/setup-prompts-overwrite.test.ts`

Expected result:

- setup can install `team-executor.md`
- native agent generation can include `team-executor.toml`
- exported catalog data stays consistent with the runtime role surface

### 7) Added focused regression coverage
New/expanded tests cover:

- team-only overlay injection
- orchestration mode resolution from persisted team skill state
- conservative implicit fanout behavior
- preservation of explicit worker count / explicit agent type semantics
- continued fanout for explicit numbered tasks
- role roster discovery including `team-executor`
- setup/install expectations for the new installable internal agent

Updated test files:

- `src/hooks/__tests__/agents-overlay.test.ts`
- `src/cli/__tests__/team-decompose.test.ts`
- `src/team/__tests__/followup-planner.test.ts`
- `src/cli/__tests__/setup-prompts-overwrite.test.ts`

## What this PR does **not** change
This PR is intentionally scoped.

It does **not**:

- change ultrawork behavior
- remove generic executor behavior outside team mode
- override explicit user-selected `agent-type`
- introduce dynamic mid-turn hot-swapping of an already-running leader brain

Instead, it creates a cleaner boundary so that **team-mode launches** start with team-specific orchestration guidance and safer default fanout behavior.

## Expected impact
After this PR, I expect the following improvements:

1. **Less wasteful team fanout on small tasks**  
   Team mode should stop creating unnecessary delivery lanes for work that does not justify the coordination overhead.

2. **More reliable default behavior for implicit team runs**  
   Low-confidence tasks should now land in a conservative team execution lane instead of a generic executor posture.

3. **Better separation between heavy team orchestration and lighter ultrawork-style parallelism**  
   This makes the system easier to reason about and reduces accidental behavioral coupling.

4. **Cleaner future iteration path**  
   With a dedicated team brain and team execution role in place, later work can specialize team-mode decomposition, progress inference, and verification rules without dragging unrelated execution modes along with it.

## Validation
I ran the following validation after the implementation and after the final catalog/setup fix:

- `npm run lint` ✅
- `npm test` ✅
- catalog export check (`node scripts/generate-catalog-docs.js --check`) ✅

In addition, the completed OMX team run used during execution was shut down cleanly after verification.

## Issue
Fixes #715.
