### PR TITLE
Add team idle and stall read APIs

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -5,7 +5,14 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { parseTeamStartArgs, teamCommand } from '../team.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
-import { initTeamState, appendTeamEvent } from '../../team/state.js';
+import {
+  appendTeamEvent,
+  createTask,
+  initTeamState,
+  updateWorkerHeartbeat,
+  writeMonitorSnapshot,
+  writeWorkerStatus,
+} from '../../team/state.js';
 
 describe('parseTeamStartArgs', () => {
   it('parses default team start args without worktree', () => {
@@ -111,6 +118,8 @@ describe('teamCommand api', () => {
       assert.match(logs[0] ?? '', /Usage: omx team api <operation>/);
       assert.match(logs[0] ?? '', /send-message/);
       assert.match(logs[0] ?? '', /transition-task-status/);
+      assert.match(logs[0] ?? '', /read-idle-state/);
+      assert.match(logs[0] ?? '', /read-stall-state/);
     } finally {
       console.log = originalLog;
     }
@@ -225,6 +234,171 @@ describe('teamCommand api', () => {
       assert.equal(envelope.data?.events?.[0]?.source_type, 'worker_idle');
       assert.equal(envelope.data?.events?.[0]?.worker, 'worker-1');
       assert.equal(envelope.data?.events?.[0]?.task_id, '1');
+    } finally {
+      console.log = originalLog;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('executes read-idle-state via CLI api with structured JSON results', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-read-idle-state-'));
+    const previousCwd = process.cwd();
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      process.chdir(wd);
+      await initTeamState('api-read-idle', 'api idle state test', 'executor', 2, wd);
+      await writeMonitorSnapshot('api-read-idle', {
+        taskStatusById: {},
+        workerAliveByName: { 'worker-1': true, 'worker-2': true },
+        workerStateByName: { 'worker-1': 'idle', 'worker-2': 'working' },
+        workerTurnCountByName: { 'worker-1': 2, 'worker-2': 4 },
+        workerTaskIdByName: { 'worker-1': '', 'worker-2': '1' },
+        mailboxNotifiedByMessageId: {},
+        completedEventTaskIds: {},
+      }, wd);
+      await appendTeamEvent('api-read-idle', {
+        type: 'worker_idle',
+        worker: 'worker-1',
+        task_id: '1',
+        prev_state: 'working',
+      }, wd);
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+
+      await teamCommand([
+        'api',
+        'read-idle-state',
+        '--input',
+        JSON.stringify({ team_name: 'api-read-idle' }),
+        '--json',
+      ]);
+
+      assert.equal(logs.length, 1);
+      const envelope = JSON.parse(logs[0]) as {
+        command?: string;
+        ok?: boolean;
+        operation?: string;
+        data?: {
+          all_workers_idle?: boolean;
+          idle_worker_count?: number;
+          idle_workers?: string[];
+          non_idle_workers?: string[];
+          last_idle_transition_by_worker?: Record<string, { source_type?: string } | null>;
+        };
+      };
+      assert.equal(envelope.command, 'omx team api read-idle-state');
+      assert.equal(envelope.ok, true);
+      assert.equal(envelope.operation, 'read-idle-state');
+      assert.equal(envelope.data?.all_workers_idle, false);
+      assert.equal(envelope.data?.idle_worker_count, 1);
+      assert.deepEqual(envelope.data?.idle_workers, ['worker-1']);
+      assert.deepEqual(envelope.data?.non_idle_workers, ['worker-2']);
+      assert.equal(envelope.data?.last_idle_transition_by_worker?.['worker-1']?.source_type, 'worker_idle');
+    } finally {
+      console.log = originalLog;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('executes read-stall-state via CLI api with structured JSON results', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-read-stall-state-'));
+    const previousCwd = process.cwd();
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      process.chdir(wd);
+      await initTeamState('api-read-stall', 'api stall state test', 'executor', 2, wd);
+      const task = await createTask('api-read-stall', {
+        subject: 'Pending work',
+        description: 'Needs leader attention',
+        status: 'pending',
+      }, wd);
+      await writeWorkerStatus('api-read-stall', 'worker-1', {
+        state: 'working',
+        current_task_id: task.id,
+        updated_at: '2026-03-10T10:00:00.000Z',
+      }, wd);
+      await writeWorkerStatus('api-read-stall', 'worker-2', {
+        state: 'idle',
+        updated_at: '2026-03-10T10:00:00.000Z',
+      }, wd);
+      await updateWorkerHeartbeat('api-read-stall', 'worker-1', {
+        alive: true,
+        pid: 201,
+        turn_count: 1,
+        last_turn_at: '2026-03-10T10:00:00.000Z',
+      }, wd);
+      await updateWorkerHeartbeat('api-read-stall', 'worker-2', {
+        alive: true,
+        pid: 202,
+        turn_count: 1,
+        last_turn_at: '2026-03-10T10:00:00.000Z',
+      }, wd);
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+      await teamCommand([
+        'api',
+        'get-summary',
+        '--input',
+        JSON.stringify({ team_name: 'api-read-stall' }),
+        '--json',
+      ]);
+      logs.length = 0;
+
+      await updateWorkerHeartbeat('api-read-stall', 'worker-1', {
+        alive: true,
+        pid: 201,
+        turn_count: 8,
+        last_turn_at: '2026-03-10T10:05:00.000Z',
+      }, wd);
+      await writeMonitorSnapshot('api-read-stall', {
+        taskStatusById: { [task.id]: 'pending' },
+        workerAliveByName: { 'worker-1': true, 'worker-2': true },
+        workerStateByName: { 'worker-1': 'idle', 'worker-2': 'idle' },
+        workerTurnCountByName: { 'worker-1': 8, 'worker-2': 1 },
+        workerTaskIdByName: { 'worker-1': task.id, 'worker-2': '' },
+        mailboxNotifiedByMessageId: {},
+        completedEventTaskIds: {},
+      }, wd);
+      await appendTeamEvent('api-read-stall', {
+        type: 'all_workers_idle',
+        worker: 'worker-2',
+        worker_count: 2,
+      }, wd);
+      await appendTeamEvent('api-read-stall', {
+        type: 'team_leader_nudge',
+        worker: 'leader-fixed',
+        reason: 'all_workers_idle',
+      }, wd);
+
+      await teamCommand([
+        'api',
+        'read-stall-state',
+        '--input',
+        JSON.stringify({ team_name: 'api-read-stall' }),
+        '--json',
+      ]);
+
+      assert.equal(logs.length, 1);
+      const envelope = JSON.parse(logs[0]) as {
+        command?: string;
+        ok?: boolean;
+        operation?: string;
+        data?: {
+          team_stalled?: boolean;
+          leader_stale?: boolean;
+          stalled_workers?: string[];
+          reasons?: string[];
+        };
+      };
+      assert.equal(envelope.command, 'omx team api read-stall-state');
+      assert.equal(envelope.ok, true);
+      assert.equal(envelope.operation, 'read-stall-state');
+      assert.equal(envelope.data?.team_stalled, true);
+      assert.equal(envelope.data?.leader_stale, true);
+      assert.deepEqual(envelope.data?.stalled_workers, ['worker-1']);
+      assert.match((envelope.data?.reasons ?? []).join(' '), /leader_attention_pending:team_leader_nudge/);
     } finally {
       console.log = originalLog;
       process.chdir(previousCwd);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -87,6 +87,8 @@ const TEAM_API_OPERATION_REQUIRED_FIELDS: Record<TeamApiOperation, string[]> = {
   'append-event': ['team_name', 'type', 'worker'],
   'read-events': ['team_name'],
   'await-event': ['team_name'],
+  'read-idle-state': ['team_name'],
+  'read-stall-state': ['team_name'],
   'get-summary': ['team_name'],
   'cleanup': ['team_name'],
   'write-shutdown-request': ['team_name', 'worker', 'requested_by'],
@@ -118,6 +120,8 @@ const TEAM_API_OPERATION_NOTES: Partial<Record<TeamApiOperation, string>> = {
   'transition-task-status': 'Lifecycle flow is claim-safe and typically transitions in_progress -> completed|failed.',
   'read-events': 'Events are returned in canonical form; worker_idle log entries normalize to type worker_state_changed with source_type worker_idle. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics.',
   'await-event': 'Waits for the next matching event and returns status=timeout when no matching event arrives before timeout_ms. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics.',
+  'read-idle-state': 'Builds a structured idle summary from the existing monitor snapshot, team summary, and recent events.',
+  'read-stall-state': 'Builds a structured stall summary from the existing monitor snapshot, team summary, and recent events.',
 };
 
 function sampleValueForTeamApiField(field: string): unknown {

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -18,6 +18,9 @@ import {
   enqueueDispatchRequest,
   readDispatchRequest,
   appendTeamEvent,
+  updateWorkerHeartbeat,
+  writeMonitorSnapshot,
+  writeWorkerStatus,
 } from '../state.js';
 
 async function setupTeam(name: string): Promise<{ cwd: string; cleanup: () => Promise<void> }> {
@@ -53,7 +56,7 @@ describe('resolveTeamApiOperation', () => {
     assert.equal(resolveTeamApiOperation('  SEND_MESSAGE  '), 'send-message');
   });
 
-  it('resolves all 30 operations from the operation list', () => {
+  it('resolves all 32 operations from the operation list', () => {
     for (const op of TEAM_API_OPERATIONS) {
       assert.equal(resolveTeamApiOperation(op), op);
     }
@@ -95,8 +98,8 @@ describe('LEGACY_TEAM_MCP_TOOLS', () => {
 });
 
 describe('TEAM_API_OPERATIONS', () => {
-  it('contains 30 operations', () => {
-    assert.equal(TEAM_API_OPERATIONS.length, 30);
+  it('contains 32 operations', () => {
+    assert.equal(TEAM_API_OPERATIONS.length, 32);
   });
 
   it('all use kebab-case', () => {
@@ -1009,6 +1012,150 @@ describe('executeTeamApiOperation: await-event', () => {
     assert.equal(result.ok, false);
     if (!result.ok) {
       assert.match(result.error.message, /timeout_ms must be a non-negative integer/);
+    }
+  });
+});
+
+// ─── read-idle-state ────────────────────────────────────────────────────────
+
+describe('executeTeamApiOperation: read-idle-state', () => {
+  it('returns structured idle state from summary, snapshot, and recent events', async () => {
+    const { cwd, cleanup } = await setupTeam('idle-state-team');
+    try {
+      await writeMonitorSnapshot('idle-state-team', {
+        taskStatusById: { '1': 'pending' },
+        workerAliveByName: { 'worker-1': true, 'worker-2': true },
+        workerStateByName: { 'worker-1': 'idle', 'worker-2': 'working' },
+        workerTurnCountByName: { 'worker-1': 3, 'worker-2': 5 },
+        workerTaskIdByName: { 'worker-1': '1', 'worker-2': '1' },
+        mailboxNotifiedByMessageId: {},
+        completedEventTaskIds: {},
+      }, cwd);
+      await appendTeamEvent('idle-state-team', {
+        type: 'worker_idle',
+        worker: 'worker-1',
+        task_id: '1',
+        prev_state: 'working',
+      }, cwd);
+      const allIdleEvent = await appendTeamEvent('idle-state-team', {
+        type: 'all_workers_idle',
+        worker: 'worker-1',
+        worker_count: 2,
+      }, cwd);
+
+      const result = await executeTeamApiOperation('read-idle-state', {
+        team_name: 'idle-state-team',
+      }, cwd);
+
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.data.team_name, 'idle-state-team');
+        assert.equal(result.data.worker_count, 2);
+        assert.equal(result.data.idle_worker_count, 1);
+        assert.deepEqual(result.data.idle_workers, ['worker-1']);
+        assert.deepEqual(result.data.non_idle_workers, ['worker-2']);
+        assert.equal(result.data.all_workers_idle, false);
+        const byWorker = result.data.last_idle_transition_by_worker as Record<string, { event_id?: string; source_type?: string } | null>;
+        assert.equal(byWorker['worker-1']?.source_type, 'worker_idle');
+        assert.equal(byWorker['worker-2'], null);
+        const lastAllIdle = result.data.last_all_workers_idle_event as { event_id?: string; type?: string; worker_count?: number } | null;
+        assert.equal(lastAllIdle?.event_id, allIdleEvent.event_id);
+        assert.equal(lastAllIdle?.type, 'all_workers_idle');
+        assert.equal(lastAllIdle?.worker_count, 2);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+// ─── read-stall-state ───────────────────────────────────────────────────────
+
+describe('executeTeamApiOperation: read-stall-state', () => {
+  it('returns structured stall state from summary, snapshot, and recent events', async () => {
+    const { cwd, cleanup } = await setupTeam('stall-state-team');
+    try {
+      const task = await createTask('stall-state-team', {
+        subject: 'Pending work',
+        description: 'Needs attention',
+        status: 'pending',
+      }, cwd);
+
+      await writeWorkerStatus('stall-state-team', 'worker-1', {
+        state: 'working',
+        current_task_id: task.id,
+        updated_at: '2026-03-10T10:00:00.000Z',
+      }, cwd);
+      await writeWorkerStatus('stall-state-team', 'worker-2', {
+        state: 'idle',
+        updated_at: '2026-03-10T10:00:00.000Z',
+      }, cwd);
+      await updateWorkerHeartbeat('stall-state-team', 'worker-1', {
+        alive: true,
+        pid: 101,
+        turn_count: 1,
+        last_turn_at: '2026-03-10T10:00:00.000Z',
+      }, cwd);
+      await updateWorkerHeartbeat('stall-state-team', 'worker-2', {
+        alive: true,
+        pid: 102,
+        turn_count: 1,
+        last_turn_at: '2026-03-10T10:00:00.000Z',
+      }, cwd);
+      const primed = await executeTeamApiOperation('get-summary', {
+        team_name: 'stall-state-team',
+      }, cwd);
+      assert.equal(primed.ok, true);
+
+      await updateWorkerHeartbeat('stall-state-team', 'worker-1', {
+        alive: true,
+        pid: 101,
+        turn_count: 8,
+        last_turn_at: '2026-03-10T10:05:00.000Z',
+      }, cwd);
+      await writeMonitorSnapshot('stall-state-team', {
+        taskStatusById: { [task.id]: 'pending' },
+        workerAliveByName: { 'worker-1': true, 'worker-2': true },
+        workerStateByName: { 'worker-1': 'idle', 'worker-2': 'idle' },
+        workerTurnCountByName: { 'worker-1': 8, 'worker-2': 1 },
+        workerTaskIdByName: { 'worker-1': task.id, 'worker-2': '' },
+        mailboxNotifiedByMessageId: {},
+        completedEventTaskIds: {},
+      }, cwd);
+      const idleEvent = await appendTeamEvent('stall-state-team', {
+        type: 'all_workers_idle',
+        worker: 'worker-2',
+        worker_count: 2,
+      }, cwd);
+      const nudgeEvent = await appendTeamEvent('stall-state-team', {
+        type: 'team_leader_nudge',
+        worker: 'leader-fixed',
+        reason: 'all_workers_idle',
+      }, cwd);
+
+      const result = await executeTeamApiOperation('read-stall-state', {
+        team_name: 'stall-state-team',
+      }, cwd);
+
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.data.team_name, 'stall-state-team');
+        assert.equal(result.data.team_stalled, true);
+        assert.equal(result.data.leader_stale, true);
+        assert.deepEqual(result.data.stalled_workers, ['worker-1']);
+        assert.deepEqual(result.data.dead_workers, []);
+        assert.equal(result.data.pending_task_count, 1);
+        assert.equal(result.data.all_workers_idle, true);
+        assert.match((result.data.reasons as string[]).join(' '), /workers_non_reporting:worker-1/);
+        assert.match((result.data.reasons as string[]).join(' '), /leader_attention_pending:team_leader_nudge/);
+        const lastAllIdle = result.data.last_all_workers_idle_event as { event_id?: string } | null;
+        const lastNudge = result.data.last_team_leader_nudge_event as { event_id?: string; reason?: string } | null;
+        assert.equal(lastAllIdle?.event_id, idleEvent.event_id);
+        assert.equal(lastNudge?.event_id, nudgeEvent.event_id);
+        assert.equal(lastNudge?.reason, 'all_workers_idle');
+      }
+    } finally {
+      await cleanup();
     }
   });
 });

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -44,7 +44,9 @@ import {
   teamWriteMonitorSnapshot,
   teamReadTaskApproval,
   teamWriteTaskApproval,
+  type TeamEvent,
   type TeamMonitorSnapshotState,
+  type TeamSummary,
 } from './team-ops.js';
 
 const TEAM_UPDATE_TASK_MUTABLE_FIELDS = new Set(['subject', 'description', 'blocked_by', 'requires_code_change']);
@@ -104,6 +106,8 @@ export const TEAM_API_OPERATIONS = [
   'append-event',
   'read-events',
   'await-event',
+  'read-idle-state',
+  'read-stall-state',
   'get-summary',
   'cleanup',
   'write-shutdown-request',
@@ -119,6 +123,8 @@ export type TeamApiOperation = typeof TEAM_API_OPERATIONS[number];
 export type TeamApiEnvelope =
   | { ok: true; operation: TeamApiOperation; data: Record<string, unknown> }
   | { ok: false; operation: TeamApiOperation | 'unknown'; error: { code: string; message: string } };
+
+const TEAM_STATE_EVENT_WINDOW = 50;
 
 async function markLatestMailboxDispatchDelivered(
   teamName: string,
@@ -180,6 +186,144 @@ function parseOptionalEventType(value: unknown): TeamEventType | 'worker_idle' |
     throw new Error(`type must be one of: ${TEAM_EVENT_TYPES.join(', ')}`);
   }
   return normalized as TeamEventType | 'worker_idle';
+}
+
+function selectRecentEvents(events: TeamEvent[]): TeamEvent[] {
+  return events.slice(Math.max(0, events.length - TEAM_STATE_EVENT_WINDOW));
+}
+
+function listTeamWorkerNames(summary: TeamSummary | null, snapshot: TeamMonitorSnapshotState | null): string[] {
+  const names = new Set<string>();
+  for (const worker of summary?.workers ?? []) {
+    names.add(worker.name);
+  }
+  for (const workerName of Object.keys(snapshot?.workerStateByName ?? {})) {
+    names.add(workerName);
+  }
+  return [...names].sort();
+}
+
+function findLatestEventByType(events: TeamEvent[], types: TeamEvent['type'][]): TeamEvent | null {
+  const allowed = new Set(types);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event && allowed.has(event.type)) {
+      return event;
+    }
+  }
+  return null;
+}
+
+function findLatestWorkerIdleEvent(events: TeamEvent[], workerName: string): TeamEvent | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!event || event.worker !== workerName) continue;
+    if (event.type === 'worker_state_changed' && event.state === 'idle') {
+      return event;
+    }
+  }
+  return null;
+}
+
+function summarizeEvent(event: TeamEvent | null): Record<string, unknown> | null {
+  if (!event) return null;
+  return {
+    event_id: event.event_id,
+    type: event.type,
+    worker: event.worker,
+    task_id: event.task_id ?? null,
+    created_at: event.created_at,
+    reason: event.reason ?? null,
+    state: event.state ?? null,
+    prev_state: event.prev_state ?? null,
+    source_type: event.source_type ?? null,
+    worker_count: event.worker_count ?? null,
+  };
+}
+
+function buildIdleState(
+  teamName: string,
+  summary: TeamSummary | null,
+  snapshot: TeamMonitorSnapshotState | null,
+  recentEvents: TeamEvent[],
+): Record<string, unknown> {
+  const workerNames = listTeamWorkerNames(summary, snapshot);
+  const idleWorkers = workerNames.filter((workerName) => snapshot?.workerStateByName[workerName] === 'idle');
+  const nonIdleWorkers = workerNames.filter((workerName) => !idleWorkers.includes(workerName));
+  const lastIdleTransitionByWorker = Object.fromEntries(
+    workerNames.map((workerName) => [workerName, summarizeEvent(findLatestWorkerIdleEvent(recentEvents, workerName))]),
+  );
+  const lastAllWorkersIdleEvent = findLatestEventByType(recentEvents, ['all_workers_idle']);
+
+  return {
+    team_name: teamName,
+    worker_count: summary?.workerCount ?? workerNames.length,
+    idle_worker_count: idleWorkers.length,
+    idle_workers: idleWorkers,
+    non_idle_workers: nonIdleWorkers,
+    all_workers_idle: workerNames.length > 0 && idleWorkers.length === workerNames.length,
+    last_idle_transition_by_worker: lastIdleTransitionByWorker,
+    last_all_workers_idle_event: summarizeEvent(lastAllWorkersIdleEvent),
+    source: {
+      summary_available: summary !== null,
+      snapshot_available: snapshot !== null,
+      recent_event_count: recentEvents.length,
+    },
+  };
+}
+
+function buildStallState(
+  teamName: string,
+  summary: TeamSummary | null,
+  snapshot: TeamMonitorSnapshotState | null,
+  recentEvents: TeamEvent[],
+): Record<string, unknown> {
+  const idleState = buildIdleState(teamName, summary, snapshot, recentEvents);
+  const workerNames = listTeamWorkerNames(summary, snapshot);
+  const deadWorkers = workerNames.filter((workerName) => summary?.workers.find((worker) => worker.name === workerName)?.alive === false);
+  const stalledWorkers = [...(summary?.nonReportingWorkers ?? [])].sort();
+  const latestAllWorkersIdleEvent = findLatestEventByType(recentEvents, ['all_workers_idle']);
+  const latestLeaderNudgeEvent = findLatestEventByType(recentEvents, ['team_leader_nudge']);
+  const latestDeferredEvent = findLatestEventByType(recentEvents, ['leader_notification_deferred']);
+  const pendingTaskCount = (summary?.tasks.pending ?? 0) + (summary?.tasks.blocked ?? 0) + (summary?.tasks.in_progress ?? 0);
+  const leaderStale = pendingTaskCount > 0 && idleState.all_workers_idle === true && (
+    latestLeaderNudgeEvent !== null
+    || latestDeferredEvent !== null
+    || latestAllWorkersIdleEvent !== null
+  );
+  const teamStalled = stalledWorkers.length > 0 || leaderStale || (deadWorkers.length > 0 && pendingTaskCount > 0);
+  const reasons: string[] = [];
+
+  if (stalledWorkers.length > 0) {
+    reasons.push(`workers_non_reporting:${stalledWorkers.join(',')}`);
+  }
+  if (deadWorkers.length > 0 && pendingTaskCount > 0) {
+    reasons.push(`dead_workers_with_pending_work:${deadWorkers.join(',')}`);
+  }
+  if (leaderStale) {
+    const leaderSignal = latestLeaderNudgeEvent ?? latestDeferredEvent ?? latestAllWorkersIdleEvent;
+    reasons.push(`leader_attention_pending:${leaderSignal?.type ?? 'all_workers_idle'}`);
+  }
+
+  return {
+    team_name: teamName,
+    team_stalled: teamStalled,
+    leader_stale: leaderStale,
+    stalled_workers: stalledWorkers,
+    dead_workers: deadWorkers,
+    pending_task_count: pendingTaskCount,
+    all_workers_idle: idleState.all_workers_idle,
+    idle_workers: idleState.idle_workers,
+    reasons,
+    last_all_workers_idle_event: summarizeEvent(latestAllWorkersIdleEvent),
+    last_team_leader_nudge_event: summarizeEvent(latestLeaderNudgeEvent),
+    last_leader_notification_deferred_event: summarizeEvent(latestDeferredEvent),
+    source: {
+      summary_available: summary !== null,
+      snapshot_available: snapshot !== null,
+      recent_event_count: recentEvents.length,
+    },
+  };
 }
 
 function parseValidatedTaskIdArray(value: unknown, fieldName: string): string[] {
@@ -671,6 +815,46 @@ export async function executeTeamApiOperation(
             cursor: result.cursor,
             event: result.event ?? null,
           },
+        };
+      }
+      case 'read-idle-state': {
+        const teamName = String(args.team_name || '').trim();
+        if (!teamName) {
+          return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name is required' } };
+        }
+        const [summary, snapshot, events] = await Promise.all([
+          teamGetSummary(teamName, cwd),
+          teamReadMonitorSnapshot(teamName, cwd),
+          readTeamEvents(teamName, cwd),
+        ]);
+        if (!summary) {
+          return { ok: false, operation, error: { code: 'team_not_found', message: 'team_not_found' } };
+        }
+        const recentEvents = selectRecentEvents(events);
+        return {
+          ok: true,
+          operation,
+          data: buildIdleState(teamName, summary, snapshot, recentEvents),
+        };
+      }
+      case 'read-stall-state': {
+        const teamName = String(args.team_name || '').trim();
+        if (!teamName) {
+          return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name is required' } };
+        }
+        const [summary, snapshot, events] = await Promise.all([
+          teamGetSummary(teamName, cwd),
+          teamReadMonitorSnapshot(teamName, cwd),
+          readTeamEvents(teamName, cwd),
+        ]);
+        if (!summary) {
+          return { ok: false, operation, error: { code: 'team_not_found', message: 'team_not_found' } };
+        }
+        const recentEvents = selectRecentEvents(events);
+        return {
+          ok: true,
+          operation,
+          data: buildStallState(teamName, summary, snapshot, recentEvents),
         };
       }
       case 'get-summary': {


### PR DESCRIPTION
## Summary
- add `read-idle-state` and `read-stall-state` team API operations
- wire both operations through `omx team api` help/input plumbing
- add focused interop + CLI tests for the new idle/stall reads

## Verification
- npm run build
- node --test dist/team/__tests__/api-interop.test.js
- node --test dist/cli/__tests__/team.test.js
- npx biome lint src/team/api-interop.ts src/cli/team.ts src/team/__tests__/api-interop.test.ts src/cli/__tests__/team.test.ts

Refs #716