### PR TITLE
fix: skip tmux bootstrap when tmux is unavailable

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const result = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      ...envOverrides,
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message || '',
+  };
+}
+
+function shouldSkipForSpawnPermissions(err: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+describe('omx launch fallback when tmux is unavailable', () => {
+  it('launches codex directly without tmux ENOENT noise', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-fallback-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        '#!/bin/sh\nprintf \'fake-codex:%s\\n\' \"$*\"\n',
+      );
+      await chmod(fakeCodexPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        ['--xhigh', '--madmax'],
+        {
+          HOME: home,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
+      assert.match(result.stdout, /fake-codex:.*model_reasoning_effort="xhigh"/);
+      assert.doesNotMatch(result.stderr, /spawnSync tmux ENOENT/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1192,7 +1192,9 @@ function runCodex(
     ? { ...codexEnv, [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw }
     : codexEnv;
 
-  if (resolveCodexLaunchPolicy(process.env) === 'inside-tmux') {
+  const launchPolicy = resolveCodexLaunchPolicy(process.env);
+
+  if (launchPolicy === 'inside-tmux') {
     // Already in tmux: launch codex in current pane, HUD in bottom split
     const currentPaneId = process.env.TMUX_PANE;
     const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow(currentPaneId);
@@ -1237,6 +1239,10 @@ function runCodex(
         killTmuxPane(paneId);
       }
     }
+  } else if (!isTmuxAvailable()) {
+    // Detached HUD sessions require tmux. Skip the bootstrap entirely when the
+    // binary is unavailable so direct launches do not emit noisy ENOENT logs.
+    runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
   } else {
     // Not in tmux: create a new tmux session with codex + HUD pane
     const codexCmd = buildTmuxPaneCommand('codex', launchArgs);


### PR DESCRIPTION
## Summary
- skip detached tmux/HUD bootstrap when `omx` is launched outside tmux and the `tmux` binary is unavailable
- fall back directly to the existing direct Codex launch path instead of logging `spawnSync tmux ENOENT`
- add a regression test covering `omx --xhigh --madmax` with fake `codex` on a PATH that does not contain `tmux`

## Test Plan
- [x] `npm run build && node --test dist/cli/__tests__/launch-fallback.test.js`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js`

## Notes
- `npm test` still has unrelated pre-existing failures in this environment:
  - `dist/cli/__tests__/ask.test.js`
  - `dist/cli/__tests__/setup-scope.test.js`
