### PR TITLE
feat(session-search): add first-class session history search CLI

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -294,6 +294,13 @@ describe('resolveCliInvocation', () => {
     });
   });
 
+  it('resolves session to session command', () => {
+    assert.deepEqual(resolveCliInvocation(['session', 'search', 'startup evidence']), {
+      command: 'session',
+      launchArgs: [],
+    });
+  });
+
   it('resolves hooks to hooks command', () => {
     assert.deepEqual(resolveCliInvocation(['hooks']), {
       command: 'hooks',

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(cwd: string, argv: string[]) {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  return spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: process.env,
+  });
+}
+
+describe('omx session help', () => {
+  it('documents the session search command in help output', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-help-'));
+    try {
+      const mainHelp = runOmx(cwd, ['--help']);
+      assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
+      assert.match(mainHelp.stdout, /omx session\s+Search prior local session transcripts/i);
+
+      const sessionHelp = runOmx(cwd, ['session', '--help']);
+      assert.equal(sessionHelp.status, 0, sessionHelp.stderr || sessionHelp.stdout);
+      assert.match(sessionHelp.stdout, /omx session search <query>/i);
+      assert.match(sessionHelp.stdout, /--since <spec>/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { parseSessionSearchArgs } from '../session-search.js';
+
+async function writeRollout(
+  codexHomeDir: string,
+  isoDate: string,
+  fileName: string,
+  lines: Array<Record<string, unknown>>,
+): Promise<void> {
+  const [year, month, day] = isoDate.slice(0, 10).split('-');
+  const dir = join(codexHomeDir, 'sessions', year, month, day);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, fileName), `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`, 'utf-8');
+}
+
+function runOmx(cwd: string, argv: string[], envOverrides: Record<string, string> = {}) {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const result = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+describe('parseSessionSearchArgs', () => {
+  it('parses query tokens and flags', () => {
+    const parsed = parseSessionSearchArgs(['team', 'api', '--limit', '5', '--project=current', '--json']);
+    assert.equal(parsed.options.query, 'team api');
+    assert.equal(parsed.options.limit, 5);
+    assert.equal(parsed.options.project, 'current');
+    assert.equal(parsed.json, true);
+  });
+});
+
+describe('omx session search', () => {
+  it('prints structured JSON results for matching transcripts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-cli-'));
+    const codexHomeDir = join(cwd, '.codex-home');
+    try {
+      await writeRollout(codexHomeDir, '2026-03-10T12:00:00.000Z', 'rollout-2026-03-10T12-00-00-session-a.jsonl', [
+        {
+          type: 'session_meta',
+          payload: {
+            id: 'session-a',
+            timestamp: '2026-03-10T12:00:00.000Z',
+            cwd,
+          },
+        },
+        {
+          type: 'event_msg',
+          payload: {
+            type: 'user_message',
+            message: 'Show previous discussions of team api in recent runs.',
+          },
+        },
+      ]);
+
+      const result = runOmx(cwd, ['session', 'search', 'team api', '--project', 'current', '--json'], {
+        CODEX_HOME: codexHomeDir,
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const parsed = JSON.parse(result.stdout) as {
+        query: string;
+        results: Array<{ session_id: string; snippet: string; cwd: string }>;
+      };
+      assert.equal(parsed.query, 'team api');
+      assert.equal(parsed.results.length, 1);
+      assert.equal(parsed.results[0].session_id, 'session-a');
+      assert.equal(parsed.results[0].cwd, cwd);
+      assert.match(parsed.results[0].snippet, /team api/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import { teamCommand } from './team.js';
 import { ralphCommand } from './ralph.js';
 import { askCommand } from './ask.js';
 import { agentsInitCommand } from './agents-init.js';
+import { sessionCommand } from './session-search.js';
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -94,6 +95,7 @@ Usage:
   omx doctor    Check installation health
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree
   omx deepinit [path]
@@ -154,7 +156,7 @@ const ALLOWED_SHELLS = new Set([
   '/usr/local/bin/bash', '/usr/local/bin/zsh', '/usr/local/bin/fish',
 ]);
 
-type CliCommand = 'launch' | 'setup' | 'agents-init' | 'deepinit' | 'uninstall' | 'doctor' | 'ask' | 'team' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
+type CliCommand = 'launch' | 'setup' | 'agents-init' | 'deepinit' | 'uninstall' | 'doctor' | 'ask' | 'team' | 'session' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
 
 export interface ResolvedCliInvocation {
   command: CliCommand;
@@ -394,7 +396,7 @@ export function buildHudPaneCleanupTargets(existingPaneIds: string[], createdPan
 
 export async function main(args: string[]): Promise<void> {
   const knownCommands = new Set([
-    'launch', 'setup', 'agents-init', 'deepinit', 'uninstall', 'doctor', 'ask', 'team', 'ralph', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
+    'launch', 'setup', 'agents-init', 'deepinit', 'uninstall', 'doctor', 'ask', 'team', 'ralph', 'session', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
   ]);
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
@@ -407,7 +409,7 @@ export async function main(args: string[]): Promise<void> {
     team: flags.has('--team'),
   };
 
-  if (flags.has('--help') && !ralphHelpRequested && !new Set(['team', 'agents-init', 'deepinit']).has(command)) {
+  if (flags.has('--help') && !ralphHelpRequested && !new Set(['team', 'session', 'agents-init', 'deepinit']).has(command)) {
     console.log(HELP);
     return;
   }
@@ -448,6 +450,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case 'team':
         await teamCommand(args.slice(1), options);
+        break;
+      case 'session':
+        await sessionCommand(args.slice(1));
         break;
       case 'ralph':
         await ralphCommand(args.slice(1));

--- a/src/cli/session-search.ts
+++ b/src/cli/session-search.ts
@@ -1,0 +1,147 @@
+import { searchSessionHistory, type SessionSearchReport, type SessionSearchOptions } from '../session-history/search.js';
+
+const HELP = `omx session - Search prior local session history
+
+Usage:
+  omx session search <query> [options]
+
+Options:
+  --limit <n>          Maximum results to return (default: 10)
+  --session <id>       Restrict to a specific session id or id fragment
+  --since <spec>       Restrict by recency (examples: 7d, 24h, 2026-03-10)
+  --project <scope>    Filter by project context: current | all | <cwd-fragment>
+  --context <n>        Snippet context characters (default: 80)
+  --case-sensitive     Match query using exact case
+  --json               Emit structured JSON
+  -h, --help           Show this help
+
+Examples:
+  omx session search "worker inbox path"
+  omx session search all_workers_idle --since 7d --limit 5
+  omx session search "team api" --project current --json
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+export interface ParsedSessionSearchArgs {
+  options: SessionSearchOptions;
+  json: boolean;
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${flag} value "${value}". Expected a non-negative integer.`);
+  }
+  return parsed;
+}
+
+export function parseSessionSearchArgs(args: string[]): ParsedSessionSearchArgs {
+  const options: SessionSearchOptions = {
+    query: '',
+  };
+  let json = false;
+  const queryTokens: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    if (token === '--case-sensitive') {
+      options.caseSensitive = true;
+      continue;
+    }
+    if (token === '--limit' || token === '--session' || token === '--since' || token === '--project' || token === '--context') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value after ${token}.`);
+      }
+      if (token === '--limit') options.limit = parsePositiveInteger(next, token);
+      if (token === '--session') options.session = next;
+      if (token === '--since') options.since = next;
+      if (token === '--project') options.project = next;
+      if (token === '--context') options.context = parsePositiveInteger(next, token);
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--limit=')) {
+      options.limit = parsePositiveInteger(token.slice('--limit='.length), '--limit');
+      continue;
+    }
+    if (token.startsWith('--session=')) {
+      options.session = token.slice('--session='.length);
+      continue;
+    }
+    if (token.startsWith('--since=')) {
+      options.since = token.slice('--since='.length);
+      continue;
+    }
+    if (token.startsWith('--project=')) {
+      options.project = token.slice('--project='.length);
+      continue;
+    }
+    if (token.startsWith('--context=')) {
+      options.context = parsePositiveInteger(token.slice('--context='.length), '--context');
+      continue;
+    }
+    if (token.startsWith('-')) {
+      throw new Error(`Unknown option: ${token}`);
+    }
+    queryTokens.push(token);
+  }
+
+  options.query = queryTokens.join(' ').trim();
+  if (options.query === '') {
+    throw new Error(`Missing search query.\n${HELP}`);
+  }
+
+  return { options, json };
+}
+
+function formatReport(report: SessionSearchReport): string {
+  if (report.results.length === 0) {
+    return `No session history matches for "${report.query}". Searched ${report.searched_files} transcript(s).`;
+  }
+
+  const lines = [
+    `Found ${report.results.length} match(es) across ${report.matched_sessions} session(s) in ${report.searched_files} transcript(s).`,
+  ];
+
+  for (const result of report.results) {
+    lines.push('');
+    lines.push(`session: ${result.session_id}`);
+    lines.push(`time: ${result.timestamp ?? 'unknown'}`);
+    lines.push(`cwd: ${result.cwd ?? 'unknown'}`);
+    lines.push(`source: ${result.transcript_path}:${result.line_number} (${result.record_type})`);
+    lines.push(`snippet: ${result.snippet}`);
+  }
+
+  return lines.join('\n');
+}
+
+export async function sessionCommand(args: string[]): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || HELP_TOKENS.has(subcommand)) {
+    console.log(HELP.trim());
+    return;
+  }
+
+  if (subcommand !== 'search') {
+    throw new Error(`Unknown session subcommand: ${subcommand}\n${HELP}`);
+  }
+
+  if (args.slice(1).some((token) => HELP_TOKENS.has(token))) {
+    console.log(HELP.trim());
+    return;
+  }
+
+  const parsed = parseSessionSearchArgs(args.slice(1));
+  const report = await searchSessionHistory(parsed.options);
+  if (parsed.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  console.log(formatReport(report));
+}

--- a/src/session-history/__tests__/search.test.ts
+++ b/src/session-history/__tests__/search.test.ts
@@ -1,0 +1,162 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseSinceSpec, searchSessionHistory } from '../search.js';
+
+async function writeRollout(
+  codexHomeDir: string,
+  isoDate: string,
+  fileName: string,
+  lines: Array<Record<string, unknown>>,
+): Promise<string> {
+  const [year, month, day] = isoDate.slice(0, 10).split('-');
+  const dir = join(codexHomeDir, 'sessions', year, month, day);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, fileName);
+  await writeFile(path, `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`, 'utf-8');
+  return path;
+}
+
+describe('parseSinceSpec', () => {
+  it('parses duration and date forms', () => {
+    const now = Date.parse('2026-03-10T12:00:00.000Z');
+    assert.equal(parseSinceSpec('24h', now), now - 24 * 3_600_000);
+    assert.equal(parseSinceSpec('2026-03-09', now), Date.parse('2026-03-09'));
+  });
+});
+
+describe('searchSessionHistory', () => {
+  it('returns structured matches with snippets from rollout transcripts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-'));
+    const codexHomeDir = join(cwd, '.codex-home');
+    try {
+      await writeRollout(codexHomeDir, '2026-03-10T12:00:00.000Z', 'rollout-2026-03-10T12-00-00-session-a.jsonl', [
+        {
+          type: 'session_meta',
+          payload: {
+            id: 'session-a',
+            timestamp: '2026-03-10T12:00:00.000Z',
+            cwd: '/tmp/project-a',
+          },
+        },
+        {
+          type: 'event_msg',
+          payload: {
+            type: 'user_message',
+            message: 'Please investigate the worker inbox path issue in team mode.',
+          },
+        },
+      ]);
+
+      const report = await searchSessionHistory({
+        query: 'worker inbox path',
+        codexHomeDir,
+        cwd,
+      });
+
+      assert.equal(report.results.length, 1);
+      assert.equal(report.matched_sessions, 1);
+      assert.equal(report.results[0].session_id, 'session-a');
+      assert.equal(report.results[0].record_type, 'event_msg:user_message');
+      assert.match(report.results[0].snippet, /worker inbox path issue/i);
+      assert.equal(report.results[0].transcript_path_relative, 'sessions/2026/03/10/rollout-2026-03-10T12-00-00-session-a.jsonl');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('supports session, project, and limit filters', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-'));
+    const codexHomeDir = join(cwd, '.codex-home');
+    try {
+      await writeRollout(codexHomeDir, '2026-03-10T12:00:00.000Z', 'rollout-2026-03-10T12-00-00-session-a.jsonl', [
+        {
+          type: 'session_meta',
+          payload: {
+            id: 'session-a',
+            timestamp: '2026-03-10T12:00:00.000Z',
+            cwd: '/repo/current',
+          },
+        },
+        {
+          type: 'response_item',
+          payload: {
+            type: 'function_call_output',
+            output: 'all_workers_idle fired after startup evidence was missing',
+          },
+        },
+      ]);
+      await writeRollout(codexHomeDir, '2026-03-09T12:00:00.000Z', 'rollout-2026-03-09T12-00-00-session-b.jsonl', [
+        {
+          type: 'session_meta',
+          payload: {
+            id: 'session-b',
+            timestamp: '2026-03-09T12:00:00.000Z',
+            cwd: '/repo/other',
+          },
+        },
+        {
+          type: 'event_msg',
+          payload: {
+            type: 'agent_message',
+            message: 'all_workers_idle should remain searchable in older sessions too',
+          },
+        },
+      ]);
+
+      const projectReport = await searchSessionHistory({
+        query: 'all_workers_idle',
+        project: '/repo/current',
+        session: 'session-a',
+        limit: 1,
+        codexHomeDir,
+        cwd,
+      });
+      assert.equal(projectReport.results.length, 1);
+      assert.equal(projectReport.results[0].session_id, 'session-a');
+
+      const sinceReport = await searchSessionHistory({
+        query: 'all_workers_idle',
+        since: '12h',
+        now: Date.parse('2026-03-10T18:00:00.000Z'),
+        codexHomeDir,
+        cwd,
+      });
+      assert.equal(sinceReport.results.length, 1);
+      assert.equal(sinceReport.results[0].session_id, 'session-a');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns no results cleanly when nothing matches', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-'));
+    const codexHomeDir = join(cwd, '.codex-home');
+    try {
+      await writeRollout(codexHomeDir, '2026-03-10T12:00:00.000Z', 'rollout-2026-03-10T12-00-00-session-a.jsonl', [
+        {
+          type: 'session_meta',
+          payload: {
+            id: 'session-a',
+            timestamp: '2026-03-10T12:00:00.000Z',
+            cwd: '/tmp/project-a',
+          },
+        },
+      ]);
+
+      const report = await searchSessionHistory({
+        query: 'startup evidence',
+        codexHomeDir,
+        cwd,
+      });
+
+      assert.deepEqual(report.results, []);
+      assert.equal(report.matched_sessions, 0);
+      assert.equal(report.searched_files, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/session-history/search.ts
+++ b/src/session-history/search.ts
@@ -1,0 +1,381 @@
+import { createReadStream, existsSync } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { createInterface } from 'node:readline';
+import { codexHome } from '../utils/paths.js';
+
+type JsonRecord = Record<string, unknown>;
+
+export interface SessionSearchOptions {
+  query: string;
+  limit?: number;
+  session?: string;
+  since?: string;
+  project?: string;
+  context?: number;
+  caseSensitive?: boolean;
+  cwd?: string;
+  now?: number;
+  codexHomeDir?: string;
+}
+
+export interface SessionSearchResult {
+  session_id: string;
+  timestamp: string | null;
+  cwd: string | null;
+  transcript_path: string;
+  transcript_path_relative: string;
+  record_type: string;
+  line_number: number;
+  snippet: string;
+}
+
+export interface SessionSearchReport {
+  query: string;
+  searched_files: number;
+  matched_sessions: number;
+  results: SessionSearchResult[];
+}
+
+interface SessionMeta {
+  sessionId: string;
+  timestamp: string | null;
+  cwd: string | null;
+}
+
+interface SearchableText {
+  text: string;
+  recordType: string;
+}
+
+const DEFAULT_LIMIT = 10;
+const DEFAULT_CONTEXT = 80;
+const MAX_LIMIT = 100;
+const MAX_CONTEXT = 400;
+const DURATION_RE = /^(\d+)([smhdw])$/i;
+
+function clampInteger(value: number, fallback: number, max: number): number {
+  if (!Number.isInteger(value) || value < 0) return fallback;
+  return Math.min(value, max);
+}
+
+function normalizeProjectFilter(project: string | undefined, cwd: string): string | undefined {
+  if (!project) return undefined;
+  const trimmed = project.trim();
+  if (trimmed === '') return undefined;
+  if (trimmed === 'current') return cwd;
+  if (trimmed === 'all') return undefined;
+  return trimmed;
+}
+
+export function parseSinceSpec(value: string | undefined, now = Date.now()): number | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+
+  const durationMatch = DURATION_RE.exec(trimmed);
+  if (durationMatch) {
+    const amount = Number(durationMatch[1]);
+    const unit = durationMatch[2].toLowerCase();
+    const multipliers: Record<string, number> = {
+      s: 1000,
+      m: 60_000,
+      h: 3_600_000,
+      d: 86_400_000,
+      w: 604_800_000,
+    };
+    return now - amount * multipliers[unit];
+  }
+
+  const timestamp = Date.parse(trimmed);
+  if (!Number.isNaN(timestamp)) return timestamp;
+  throw new Error(`Invalid --since value "${value}". Use formats like 7d, 24h, or 2026-03-10.`);
+}
+
+async function listRolloutFiles(root: string): Promise<string[]> {
+  if (!existsSync(root)) return [];
+
+  const files: string[] = [];
+  const queue = [root];
+
+  while (queue.length > 0) {
+    const dir = queue.pop();
+    if (!dir) continue;
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(path);
+        continue;
+      }
+      if (entry.isFile() && entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) {
+        files.push(path);
+      }
+    }
+  }
+
+  return files.sort((a, b) => b.localeCompare(a));
+}
+
+function safeParseJson(line: string): JsonRecord | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    return parsed && typeof parsed === 'object' ? parsed as JsonRecord : null;
+  } catch {
+    return null;
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+function collectTextFragments(value: unknown, fragments: string[]): void {
+  if (typeof value === 'string') {
+    if (value.trim() !== '') fragments.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectTextFragments(item, fragments);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+
+  for (const [key, child] of Object.entries(value as JsonRecord)) {
+    if (key === 'base_instructions' || key === 'developer_instructions') continue;
+    collectTextFragments(child, fragments);
+  }
+}
+
+function extractSessionMeta(parsed: JsonRecord | null): SessionMeta | null {
+  if (!parsed || parsed.type !== 'session_meta') return null;
+  const payload = parsed.payload;
+  if (!payload || typeof payload !== 'object') return null;
+  const typedPayload = payload as JsonRecord;
+  const sessionId = asString(typedPayload.id);
+  if (!sessionId) return null;
+  return {
+    sessionId,
+    timestamp: asString(typedPayload.timestamp),
+    cwd: asString(typedPayload.cwd),
+  };
+}
+
+function extractSearchableTexts(parsed: JsonRecord | null, rawLine: string): SearchableText[] {
+  if (!parsed) {
+    return [{ text: rawLine, recordType: 'raw' }];
+  }
+
+  const topType = asString(parsed.type) ?? 'unknown';
+  const texts: SearchableText[] = [];
+
+  if (topType === 'session_meta') {
+    const payload = parsed.payload;
+    if (payload && typeof payload === 'object') {
+      const meta = payload as JsonRecord;
+      const summary = [meta.id, meta.cwd, meta.agent_role, meta.agent_nickname]
+        .flatMap((value) => (typeof value === 'string' && value.trim() !== '') ? [value] : [])
+        .join(' ')
+        .trim();
+      if (summary) texts.push({ text: summary, recordType: 'session_meta' });
+    }
+    return texts;
+  }
+
+  if (topType === 'event_msg') {
+    const payload = parsed.payload;
+    const payloadType = payload && typeof payload === 'object'
+      ? asString((payload as JsonRecord).type) ?? 'unknown'
+      : 'unknown';
+    const fragments: string[] = [];
+    collectTextFragments(payload, fragments);
+    const text = fragments.join(' \n ').trim();
+    if (text) {
+      texts.push({ text, recordType: `event_msg:${payloadType}` });
+    }
+    return texts;
+  }
+
+  if (topType === 'response_item') {
+    const payload = parsed.payload;
+    if (!payload || typeof payload !== 'object') return texts;
+
+    const typedPayload = payload as JsonRecord;
+    const payloadType = asString(typedPayload.type) ?? 'unknown';
+    if (payloadType === 'message') {
+      const role = asString(typedPayload.role) ?? 'unknown';
+      if (role !== 'assistant' && role !== 'user') return texts;
+      const fragments: string[] = [];
+      collectTextFragments(typedPayload.content, fragments);
+      const text = fragments.join(' \n ').trim();
+      if (text) texts.push({ text, recordType: `response_item:${payloadType}:${role}` });
+      return texts;
+    }
+
+    const fragments: string[] = [];
+    if (payloadType === 'function_call') {
+      const name = asString(typedPayload.name);
+      if (name) fragments.push(name);
+      const argumentsText = asString(typedPayload.arguments);
+      if (argumentsText) fragments.push(argumentsText);
+    } else if (payloadType === 'function_call_output') {
+      const outputText = typedPayload.output;
+      collectTextFragments(outputText, fragments);
+    } else {
+      collectTextFragments(typedPayload, fragments);
+    }
+
+    const text = fragments.join(' \n ').trim();
+    if (text) texts.push({ text, recordType: `response_item:${payloadType}` });
+    return texts;
+  }
+
+  return [{ text: rawLine, recordType: topType }];
+}
+
+function buildSnippet(text: string, query: string, context: number, caseSensitive: boolean): string | null {
+  if (text === '') return null;
+  const haystack = caseSensitive ? text : text.toLowerCase();
+  const needle = caseSensitive ? query : query.toLowerCase();
+  const index = haystack.indexOf(needle);
+  if (index < 0) return null;
+
+  const start = Math.max(0, index - context);
+  const end = Math.min(text.length, index + query.length + context);
+  const prefix = start > 0 ? '…' : '';
+  const suffix = end < text.length ? '…' : '';
+  return `${prefix}${text.slice(start, end).replace(/\s+/g, ' ').trim()}${suffix}`;
+}
+
+function matchesFilter(value: string | null, filter: string | undefined, caseSensitive: boolean): boolean {
+  if (!filter) return true;
+  if (!value) return false;
+  if (caseSensitive) return value.includes(filter);
+  return value.toLowerCase().includes(filter.toLowerCase());
+}
+
+async function searchRolloutFile(
+  filePath: string,
+  options: Required<Pick<SessionSearchOptions, 'query' | 'context' | 'caseSensitive'>> & {
+    limit: number;
+    session?: string;
+    sinceCutoff: number | null;
+    projectFilter?: string;
+    cwd: string;
+    codexHomeDir: string;
+  },
+): Promise<{ meta: SessionMeta | null; results: SessionSearchResult[] }> {
+  const stream = createReadStream(filePath, 'utf-8');
+  const reader = createInterface({ input: stream, crlfDelay: Infinity });
+  const results: SessionSearchResult[] = [];
+  let meta: SessionMeta | null = null;
+  let lineNumber = 0;
+  let skipFile = false;
+
+  try {
+    for await (const line of reader) {
+      lineNumber += 1;
+      const parsed = safeParseJson(line);
+      if (lineNumber === 1) {
+        meta = extractSessionMeta(parsed);
+        const fallbackSessionId = filePath.split('rollout-')[1]?.replace(/\.jsonl$/, '') ?? filePath;
+        if (!meta) {
+          meta = { sessionId: fallbackSessionId, timestamp: null, cwd: null };
+        }
+        const sessionTimestamp = meta.timestamp ? Date.parse(meta.timestamp) : Number.NaN;
+        if (options.sinceCutoff != null && !Number.isNaN(sessionTimestamp) && sessionTimestamp < options.sinceCutoff) {
+          skipFile = true;
+          break;
+        }
+        if (!matchesFilter(meta.sessionId, options.session, options.caseSensitive)) {
+          skipFile = true;
+          break;
+        }
+        if (!matchesFilter(meta.cwd, options.projectFilter, options.caseSensitive)) {
+          skipFile = true;
+          break;
+        }
+      }
+
+      for (const candidate of extractSearchableTexts(parsed, line)) {
+        const snippet = buildSnippet(candidate.text, options.query, options.context, options.caseSensitive);
+        if (!snippet || !meta) continue;
+        results.push({
+          session_id: meta.sessionId,
+          timestamp: meta.timestamp,
+          cwd: meta.cwd,
+          transcript_path: filePath,
+          transcript_path_relative: relative(options.codexHomeDir, filePath),
+          record_type: candidate.recordType,
+          line_number: lineNumber,
+          snippet,
+        });
+        if (results.length >= options.limit) {
+          return { meta, results };
+        }
+      }
+    }
+  } finally {
+    reader.close();
+    stream.destroy();
+  }
+
+  return skipFile ? { meta, results: [] } : { meta, results };
+}
+
+export async function searchSessionHistory(options: SessionSearchOptions): Promise<SessionSearchReport> {
+  const query = options.query.trim();
+  if (query === '') {
+    throw new Error('Search query must not be empty.');
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const codexHomeDir = options.codexHomeDir ?? codexHome();
+  const limit = clampInteger(options.limit ?? DEFAULT_LIMIT, DEFAULT_LIMIT, MAX_LIMIT) || DEFAULT_LIMIT;
+  const context = clampInteger(options.context ?? DEFAULT_CONTEXT, DEFAULT_CONTEXT, MAX_CONTEXT) || DEFAULT_CONTEXT;
+  const caseSensitive = options.caseSensitive === true;
+  const sinceCutoff = parseSinceSpec(options.since, options.now ?? Date.now());
+  const projectFilter = normalizeProjectFilter(options.project, cwd);
+  const rolloutRoot = join(codexHomeDir, 'sessions');
+  const files = await listRolloutFiles(rolloutRoot);
+
+  const results: SessionSearchResult[] = [];
+  let searchedFiles = 0;
+  const matchedSessions = new Set<string>();
+
+  for (const filePath of files) {
+    if (results.length >= limit) break;
+
+    const fileStat = await stat(filePath).catch(() => null);
+    if (!fileStat) continue;
+    if (sinceCutoff != null && fileStat.mtimeMs < sinceCutoff) {
+      continue;
+    }
+
+    searchedFiles += 1;
+    const fileSearch = await searchRolloutFile(filePath, {
+      query,
+      context,
+      caseSensitive,
+      limit: limit - results.length,
+      session: options.session,
+      sinceCutoff,
+      projectFilter,
+      cwd,
+      codexHomeDir,
+    });
+
+    for (const result of fileSearch.results) {
+      results.push(result);
+      matchedSessions.add(result.session_id);
+      if (results.length >= limit) break;
+    }
+  }
+
+  return {
+    query,
+    searched_files: searchedFiles,
+    matched_sessions: matchedSessions.size,
+    results,
+  };
+}


### PR DESCRIPTION
## Summary
- add `omx session search <query>` as a first-class CLI surface over local Codex rollout transcripts
- return structured session search results with session id, cwd/path metadata, line number, and snippet text
- add focused parser/help/search coverage for the new CLI slice

## Verification
- npm run build
- ./node_modules/.bin/biome lint src/cli/index.ts src/cli/session-search.ts src/session-history/search.ts src/cli/__tests__/session-search.test.ts src/cli/__tests__/session-search-help.test.ts src/session-history/__tests__/search.test.ts src/cli/__tests__/index.test.ts
- npm run check:no-unused
- node --test dist/session-history/__tests__/search.test.js dist/cli/__tests__/session-search.test.js dist/cli/__tests__/session-search-help.test.js dist/cli/__tests__/index.test.js
- node bin/omx.js session search "worker inbox path" --limit 1 --json

Closes #721