### PR TITLE
fix(team): keep low-confidence analysis prompts single-lane

### DIFF
--- a/src/cli/__tests__/team-decompose.test.ts
+++ b/src/cli/__tests__/team-decompose.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { decomposeTaskString } from '../team.js';
+import { buildTeamExecutionPlan, decomposeTaskString } from '../team.js';
 
 describe('decomposeTaskString', () => {
   it('splits conjunction-separated tasks', () => {
@@ -66,13 +66,13 @@ describe('decomposeTaskString', () => {
     assert.match(tasks[2].description, /write benchmark/);
   });
 
-  it('keeps long prose prompts intact instead of shattering them into sentence fragments', () => {
+  it('keeps long analytic prose prompts in a single-worker lane by default', () => {
     const task = 'Analyze OMX team mode reliability/efficiency weaknesses, focusing on orchestration progress detection, heartbeat/task-state coupling, tmux/state-plane brittleness, and verification gaps. Produce concrete findings with root cause, user impact, evidence pointers, and actionable recommendations suitable for a GitHub issue.';
-    const tasks = decomposeTaskString(task, 3, 'executor', false);
-    assert.equal(tasks.length, 3);
-    assert.match(tasks[0].subject, /^Implement:/i);
-    assert.match(tasks[1].subject, /^Test:/i);
-    assert.match(tasks[2].subject, /^Review and document:/i);
+    const plan = buildTeamExecutionPlan(task, 3, 'executor', false);
+    assert.equal(plan.workerCount, 1);
+    assert.equal(plan.tasks.length, 1);
+    assert.equal(plan.tasks[0].owner, 'worker-1');
+    assert.match(plan.tasks[0].description, /Analyze OMX team mode reliability\/efficiency weaknesses/i);
   });
 
   it('preserves backward compat: explicit agentType overrides routing', () => {
@@ -94,6 +94,14 @@ describe('decomposeTaskString', () => {
 
     const explicitTasks = decomposeTaskString('fix typo in README', 3, 'executor', false, true);
     assert.equal(explicitTasks.length, 3);
+  });
+
+  it('preserves explicit worker-count fanout for analytic prompts', () => {
+    const task = 'Analyze OMX team mode reliability/efficiency weaknesses, focusing on orchestration progress detection, heartbeat/task-state coupling, tmux/state-plane brittleness, and verification gaps. Produce concrete findings with root cause, user impact, evidence pointers, and actionable recommendations suitable for a GitHub issue.';
+    const plan = buildTeamExecutionPlan(task, 3, 'executor', false, true);
+    assert.equal(plan.workerCount, 3);
+    assert.equal(plan.tasks.length, 3);
+    assert.match(plan.tasks[0].subject, /^Implement:/i);
   });
 
   it('keeps explicit numbered tasks fanned out even on implicit default team runs', () => {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -352,8 +352,21 @@ interface DecompositionPlan {
   subtasks: DecompositionCandidate[];
 }
 
+export interface TeamExecutionPlan {
+  workerCount: number;
+  tasks: Array<{ subject: string; description: string; owner: string; role?: string }>;
+}
+
 function resolveImplicitTeamFallbackRole(agentType: string, explicitAgentType: boolean): string {
   return !explicitAgentType && agentType === 'executor' ? 'team-executor' : agentType;
+}
+
+function looksLikeLowConfidenceAnalysisTask(task: string): boolean {
+  const normalized = task.trim();
+  return ANALYSIS_TASK_PREFIX.test(normalized)
+    && (ANALYSIS_DELIVERABLE_SIGNAL.test(normalized)
+      || countWords(normalized) > 18
+      || CONTEXTUAL_DECOMPOSITION_CLAUSE.test(normalized));
 }
 
 function resolveTeamFanoutLimit(
@@ -369,6 +382,10 @@ function resolveTeamFanoutLimit(
 
   const size = classifyTaskSize(task).size;
   if (plan.strategy === 'atomic') {
+    if (looksLikeLowConfidenceAnalysisTask(task)) {
+      return 1;
+    }
+
     if (size === 'small') {
       const proseHeavyAtomicTask = countWords(task) > 18 || CONTEXTUAL_DECOMPOSITION_CLAUSE.test(task);
       if (!proseHeavyAtomicTask) return 1;
@@ -382,13 +399,13 @@ function resolveTeamFanoutLimit(
   return requestedWorkerCount;
 }
 
-export function decomposeTaskString(
+export function buildTeamExecutionPlan(
   task: string,
   workerCount: number,
   agentType: string,
   explicitAgentType: boolean,
   explicitWorkerCount = false,
-): Array<{ subject: string; description: string; owner: string; role?: string }> {
+): TeamExecutionPlan {
   const plan = splitTaskString(task);
   const effectiveWorkerCount = resolveTeamFanoutLimit(
     task,
@@ -412,11 +429,26 @@ export function decomposeTaskString(
     return { ...st, role: result.role };
   });
 
-  return distributeTasksToWorkers(tasksWithRoles, effectiveWorkerCount);
+  return {
+    workerCount: effectiveWorkerCount,
+    tasks: distributeTasksToWorkers(tasksWithRoles, effectiveWorkerCount),
+  };
+}
+
+export function decomposeTaskString(
+  task: string,
+  workerCount: number,
+  agentType: string,
+  explicitAgentType: boolean,
+  explicitWorkerCount = false,
+): Array<{ subject: string; description: string; owner: string; role?: string }> {
+  return buildTeamExecutionPlan(task, workerCount, agentType, explicitAgentType, explicitWorkerCount).tasks;
 }
 
 const ACTIONABLE_TASK_PREFIX = /^(?:add|analy(?:se|ze)|audit|benchmark|build|clean(?:\s+up)?|create|debug|design|document|draft|fix|implement|improve|investigate|migrate|optimi(?:s|z)e|profile|refactor|repair|research|review|ship|summari(?:s|z)e|test|update|validate|verify|write)\b/i;
 const TASK_LABEL_PREFIX = /^(?:task|step|phase|part)\s+[\w-]+(?:\s+[\w-]+)?$/i;
+const ANALYSIS_TASK_PREFIX = /^(?:analy(?:se|ze)|audit|assess|evaluate|explore|investigate|research|review|study|summari(?:s|z)e)\b/i;
+const ANALYSIS_DELIVERABLE_SIGNAL = /\b(?:actionable recommendations?|evidence(?: pointers?)?|findings?|issue|operator|report|root cause|summary|user impact|write-?up)\b/i;
 const CONTEXTUAL_DECOMPOSITION_CLAUSE = /\b(?:focusing on|focus on|including|covers?|covering|with|while|without|ensuring|suitable for|root cause|user impact|evidence pointers|actionable recommendations)\b/i;
 
 function countWords(text: string): number {
@@ -811,29 +843,33 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
   }
 
   const parsed = parseTeamArgs(teamArgs);
-  const tasks = decomposeTaskString(
+  const executionPlan = buildTeamExecutionPlan(
     parsed.task,
     parsed.workerCount,
     parsed.agentType,
     parsed.explicitAgentType,
     parsed.explicitWorkerCount,
   );
+  const tasks = executionPlan.tasks;
+  const effectiveParsed = executionPlan.workerCount === parsed.workerCount
+    ? parsed
+    : { ...parsed, workerCount: executionPlan.workerCount };
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
   const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
-    workerCount: parsed.workerCount,
+    workerCount: executionPlan.workerCount,
     fallbackRole: resolveImplicitTeamFallbackRole(parsed.agentType, parsed.explicitAgentType),
   });
   const runtime = await startTeam(
     parsed.teamName,
     parsed.task,
     parsed.agentType,
-    parsed.workerCount,
+    executionPlan.workerCount,
     tasks,
     cwd,
     { worktreeMode: parsedWorktree.mode, ralph: parsed.ralph },
   );
 
-  await ensureTeamModeState(parsed, tasks);
+  await ensureTeamModeState(effectiveParsed, tasks);
   if (options.verbose) {
     console.log(`linked_ralph=${parsed.ralph}`);
   }


### PR DESCRIPTION
## Summary
- keep low-confidence analytic team prompts in a single-worker lane by default instead of auto-fanning out aspect tasks
- preserve explicit worker-count fanout as an operator override for users who intentionally want parallelism
- thread the effective worker count through team startup and staffing summaries so runtime orchestration matches the inferred lane

## Testing
- npm run build
- ./node_modules/.bin/biome lint src/cli/team.ts src/cli/__tests__/team-decompose.test.ts
- node --test dist/cli/__tests__/team-decompose.test.js
- node --test dist/cli/__tests__/team.test.js

Refs #710