### PR TITLE
fix(ralph): send periodic continue steer while Ralph stays active

### DIFF
--- a/scripts/notify-fallback-watcher.js
+++ b/scripts/notify-fallback-watcher.js
@@ -6,6 +6,9 @@ import { spawnSync } from 'child_process';
 import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { drainPendingTeamDispatch } from './notify-hook/team-dispatch.js';
+import { resolveNudgePaneTarget } from './notify-hook/auto-nudge.js';
+import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
+import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 
 function argValue(name, fallback = '') {
   const idx = process.argv.indexOf(name);
@@ -56,6 +59,9 @@ const stateDir = join(omxDir, 'state');
 const statePath = join(stateDir, 'notify-fallback-state.json');
 const pidFilePath = resolve(argValue('--pid-file', join(stateDir, 'notify-fallback.pid')));
 const logPath = join(logsDir, `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+const RALPH_CONTINUE_TEXT = 'Ralph loop active continue';
+const RALPH_CONTINUE_CADENCE_MS = 60_000;
+const RALPH_TERMINAL_PHASES = new Set(['complete', 'failed', 'cancelled']);
 
 const fileState = new Map();
 const seenTurnKeys = new Set();
@@ -69,9 +75,169 @@ let lastDispatchDrain = {
   last_result: null,
   last_error: null,
 };
+let lastRalphContinueSteer = {
+  enabled: true,
+  cadence_ms: RALPH_CONTINUE_CADENCE_MS,
+  message: RALPH_CONTINUE_TEXT,
+  active: false,
+  last_state_check_at: null,
+  last_sent_at: '',
+  last_reason: 'init',
+  state_path: '',
+  pane_id: '',
+  pane_current_command: '',
+  current_phase: '',
+};
 
 function eventLog(event) {
   return appendFile(logPath, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
+}
+
+function normalizeRalphContinueSteerState(raw) {
+  if (!raw || typeof raw !== 'object') return { ...lastRalphContinueSteer };
+  return {
+    enabled: raw.enabled !== false,
+    cadence_ms: Number.isFinite(raw.cadence_ms) && raw.cadence_ms > 0 ? raw.cadence_ms : RALPH_CONTINUE_CADENCE_MS,
+    message: safeString(raw.message) || RALPH_CONTINUE_TEXT,
+    active: raw.active === true,
+    last_state_check_at: safeString(raw.last_state_check_at) || null,
+    last_sent_at: safeString(raw.last_sent_at),
+    last_reason: safeString(raw.last_reason) || 'init',
+    state_path: safeString(raw.state_path),
+    pane_id: safeString(raw.pane_id),
+    pane_current_command: safeString(raw.pane_current_command),
+    current_phase: safeString(raw.current_phase),
+  };
+}
+
+function hasRalphTerminalState(raw) {
+  if (!raw || typeof raw !== 'object') return true;
+  if (raw.active !== true) return true;
+  const phase = safeString(raw.current_phase).trim().toLowerCase();
+  if (phase && RALPH_TERMINAL_PHASES.has(phase)) return true;
+  if (safeString(raw.completed_at).trim()) return true;
+  return false;
+}
+
+async function loadPersistedWatcherState() {
+  const persisted = await readFile(statePath, 'utf-8')
+    .then((content) => JSON.parse(content))
+    .catch(() => null);
+  lastRalphContinueSteer = normalizeRalphContinueSteerState(persisted?.ralph_continue_steer);
+}
+
+async function resolveActiveRalphState() {
+  const candidateDirs = [];
+  const sessionPath = join(stateDir, 'session.json');
+  try {
+    const session = JSON.parse(await readFile(sessionPath, 'utf-8'));
+    const sessionId = safeString(session?.session_id).trim();
+    if (sessionId) {
+      candidateDirs.push(join(stateDir, 'sessions', sessionId));
+    }
+  } catch {
+    // No active session file; fall back to root state only.
+  }
+  if (!candidateDirs.includes(stateDir)) candidateDirs.push(stateDir);
+
+  for (const dir of candidateDirs) {
+    const path = join(dir, 'ralph-state.json');
+    if (!existsSync(path)) continue;
+    const parsed = await readFile(path, 'utf-8')
+      .then((content) => JSON.parse(content))
+      .catch(() => null);
+    if (!parsed || typeof parsed !== 'object') continue;
+    if (hasRalphTerminalState(parsed)) {
+      return {
+        active: false,
+        reason: 'terminal',
+        path,
+        state: parsed,
+      };
+    }
+    return {
+      active: true,
+      reason: 'active',
+      path,
+      state: parsed,
+    };
+  }
+
+  return {
+    active: false,
+    reason: 'cleared',
+    path: '',
+    state: null,
+  };
+}
+
+async function emitRalphContinueSteer(paneId, message) {
+  const markedText = `${message} ${DEFAULT_MARKER}`;
+  await new Promise((resolve) => {
+    const typed = spawnSync('tmux', ['send-keys', '-t', paneId, '-l', markedText], { encoding: 'utf-8' });
+    if (typed.status !== 0) throw new Error((typed.stderr || typed.stdout || '').trim() || 'tmux send-keys failed');
+    setTimeout(resolve, 100);
+  });
+  await new Promise((resolve) => {
+    const submitA = spawnSync('tmux', ['send-keys', '-t', paneId, 'C-m'], { encoding: 'utf-8' });
+    if (submitA.status !== 0) throw new Error((submitA.stderr || submitA.stdout || '').trim() || 'tmux send-keys C-m failed');
+    setTimeout(resolve, 100);
+  });
+  const submitB = spawnSync('tmux', ['send-keys', '-t', paneId, 'C-m'], { encoding: 'utf-8' });
+  if (submitB.status !== 0) {
+    throw new Error((submitB.stderr || submitB.stdout || '').trim() || 'tmux send-keys C-m failed');
+  }
+}
+
+async function runRalphContinueSteerTick() {
+  const now = Date.now();
+  const nowIso = new Date(now).toISOString();
+  const activeRalph = await resolveActiveRalphState();
+  lastRalphContinueSteer = {
+    ...lastRalphContinueSteer,
+    active: activeRalph.active,
+    current_phase: safeString(activeRalph.state?.current_phase),
+    last_state_check_at: nowIso,
+    last_reason: activeRalph.reason,
+    state_path: activeRalph.path,
+    pane_current_command: '',
+  };
+
+  if (!activeRalph.active) return;
+
+  const lastSentMs = Date.parse(lastRalphContinueSteer.last_sent_at);
+  if (Number.isFinite(lastSentMs) && now - lastSentMs < RALPH_CONTINUE_CADENCE_MS) {
+    lastRalphContinueSteer.last_reason = 'cooldown';
+    return;
+  }
+
+  const paneId = safeString(activeRalph.state?.tmux_pane_id).trim() || await resolveNudgePaneTarget(stateDir);
+  if (!paneId) {
+    lastRalphContinueSteer.last_reason = 'pane_missing';
+    lastRalphContinueSteer.pane_id = '';
+    return;
+  }
+
+  const paneGuard = await checkPaneReadyForTeamSendKeys(paneId);
+  lastRalphContinueSteer.pane_id = paneId;
+  lastRalphContinueSteer.pane_current_command = paneGuard.paneCurrentCommand || '';
+  if (!paneGuard.ok) {
+    lastRalphContinueSteer.last_reason = paneGuard.reason || 'pane_guard_blocked';
+    return;
+  }
+
+  await emitRalphContinueSteer(paneId, RALPH_CONTINUE_TEXT);
+  lastRalphContinueSteer.last_sent_at = nowIso;
+  lastRalphContinueSteer.last_reason = 'sent';
+  await eventLog({
+    type: 'ralph_continue_steer',
+    reason: 'sent',
+    pane_id: paneId,
+    state_path: activeRalph.path,
+    current_phase: safeString(activeRalph.state?.current_phase) || null,
+    cadence_ms: RALPH_CONTINUE_CADENCE_MS,
+    message: RALPH_CONTINUE_TEXT,
+  });
 }
 
 async function readPidFilePid(path) {
@@ -150,6 +316,12 @@ async function writeState(extra = {}) {
       max_per_tick: dispatchTickMax,
       run_count: dispatchDrainRuns,
       ...lastDispatchDrain,
+    },
+    ralph_continue_steer: {
+      ...lastRalphContinueSteer,
+      enabled: true,
+      cadence_ms: RALPH_CONTINUE_CADENCE_MS,
+      message: RALPH_CONTINUE_TEXT,
     },
     ...extra,
   };
@@ -383,6 +555,7 @@ async function tick() {
   await ensureTrackedFiles();
   await pollFiles();
   await runDispatchDrainTick();
+  await runRalphContinueSteerTick();
   await writeState();
   if (await enforceLifecycleGuards()) return;
   setTimeout(() => {
@@ -403,6 +576,7 @@ async function main() {
   }
 
   await registerPidFile();
+  await loadPersistedWatcherState();
   await eventLog({
     type: 'watcher_start',
     cwd,
@@ -423,6 +597,7 @@ async function main() {
     await ensureTrackedFiles();
     await pollFiles();
     await runDispatchDrainTick();
+    await runRalphContinueSteerTick();
     await writeState();
     await eventLog({ type: 'watcher_once_complete', seen_turns: seenTurnKeys.size });
     process.exit(0);

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -116,6 +116,10 @@ if [[ "$cmd" == "display-message" ]]; then
     pwd
     exit 0
   fi
+  if [[ "$fmt" == "#{pane_current_command}" ]]; then
+    echo "codex"
+    exit 0
+  fi
   if [[ "$fmt" == "#S" ]]; then
     echo "session-test"
     exit 0
@@ -441,6 +445,131 @@ describe('notify-fallback watcher', () => {
       const request = await readDispatchRequest('dispatch-team', queued.request.request_id, wd);
       assert.equal(request?.status, 'pending');
       assert.equal(request?.last_reason, 'tmux_send_keys_unconfirmed');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('sends bounded periodic Ralph continue steer while Ralph state stays active', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-active-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const statePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(wd, '.omx', 'state', 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        tmux_pane_id: '%42',
+      }, null, 2));
+
+      const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...process.env,
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      };
+
+      const first = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+
+      const second = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+
+      const boundedLog = await readFile(tmuxLogPath, 'utf8');
+      let sends = boundedLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 1, 'cadence should suppress a second Ralph steer inside 60s');
+
+      const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
+      watcherState.ralph_continue_steer.last_sent_at = new Date(Date.now() - 61_000).toISOString();
+      await writeFile(statePath, JSON.stringify(watcherState, null, 2));
+
+      const third = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(third.status, 0, third.stderr || third.stdout);
+
+      const finalLog = await readFile(tmuxLogPath, 'utf8');
+      sends = finalLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 2, 'Ralph steer should fire again once the 60s cadence elapses');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('stops Ralph continue steer immediately once Ralph state is terminal or cleared', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-terminal-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    const watcherStatePath = join(stateDir, 'notify-fallback-state.json');
+    const ralphStatePath = join(stateDir, 'ralph-state.json');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(ralphStatePath, JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        tmux_pane_id: '%42',
+      }, null, 2));
+
+      const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...process.env,
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      };
+
+      const first = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      watcherState.ralph_continue_steer.last_sent_at = new Date(Date.now() - 61_000).toISOString();
+      await writeFile(watcherStatePath, JSON.stringify(watcherState, null, 2));
+      await writeFile(ralphStatePath, JSON.stringify({
+        active: false,
+        current_phase: 'complete',
+        completed_at: new Date().toISOString(),
+        tmux_pane_id: '%42',
+      }, null, 2));
+
+      const terminalRun = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(terminalRun.status, 0, terminalRun.stderr || terminalRun.stdout);
+
+      await rm(ralphStatePath, { force: true });
+      const clearedRun = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(clearedRun.status, 0, clearedRun.stderr || clearedRun.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 1, 'terminal/cleared Ralph state must stop additional periodic steer sends');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add a Ralph-specific fallback in the notify fallback watcher that sends `Ralph loop active continue` every 60s while Ralph state remains active and non-terminal
- stop the steer immediately once Ralph state is cleared or terminal
- add focused watcher tests for the bounded cadence and terminal/cleared stop behavior

Closes #731