### PR TITLE
Improve leader team status nudges while team is running

### DIFF
--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -53,6 +53,12 @@ export function resolveLeaderProgressStallThresholdMs() {
   return 120_000;
 }
 
+function buildStatusCheckReminder(teamName, { keepPolling = false } = {}) {
+  return keepPolling
+    ? `Check: omx team status ${teamName}; keep polling.`
+    : `Check: omx team status ${teamName}.`;
+}
+
 export async function checkWorkerPanesAlive(tmuxTarget, workerPaneIds = []) {
   const sessionName = tmuxTarget.split(':')[0];
   try {
@@ -562,7 +568,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
       text =
         `Team ${teamName}: ${ackWithoutStartEvidence.worker} said "${ackWithoutStartEvidence.body}" `
         + `but has no work-start evidence yet (status: ${ackWithoutStartEvidence.statusState}, no owned in_progress task). `
-        + `Run: omx team status ${teamName}`;
+        + buildStatusCheckReminder(teamName);
     } else if (stalledTeamNudge) {
       nudgeReason = stalledTeamReason;
       const { pending, in_progress, blocked } = progressSnapshot.taskCounts;
@@ -571,18 +577,22 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
         : '';
       const stallPrefix = leaderStale ? 'leader stale, ' : 'worker panes stalled, ';
       text =
-        `Team ${teamName}: ${stallPrefix}no team progress for ${formatDurationMs(stalledForMs)} `
-        + `(pending:${pending} in_progress:${in_progress} blocked:${blocked}${missingSignals}). `
-        + `Run: omx team status ${teamName}`;
+        `Team ${teamName}: ${stallPrefix}no team progress for ${formatDurationMs(stalledForMs)}. `
+        + `${buildStatusCheckReminder(teamName, { keepPolling: true })} `
+        + `(pending:${pending} in_progress:${in_progress} blocked:${blocked}${missingSignals})`;
     } else if (stalePanesNudge && hasNewMessage) {
       nudgeReason = 'stale_leader_with_messages';
-      text = `Team ${teamName}: leader stale, ${paneStatus.paneCount} pane(s) active, ${messages.length} msg(s) pending. Run: omx team status ${teamName}`;
+      text =
+        `Team ${teamName}: leader stale, ${paneStatus.paneCount} pane(s) active, ${messages.length} msg(s) pending. `
+        + buildStatusCheckReminder(teamName, { keepPolling: true });
     } else if (staleFollowupDue) {
       nudgeReason = 'stale_leader_panes_alive';
-      text = `Team ${teamName}: leader stale, ${paneStatus.paneCount} worker pane(s) still active. Run: omx team status ${teamName}`;
+      text =
+        `Team ${teamName}: leader stale, ${paneStatus.paneCount} worker pane(s) still active. `
+        + buildStatusCheckReminder(teamName, { keepPolling: true });
     } else if (hasNewMessage) {
       nudgeReason = 'new_mailbox_message';
-      text = `Team ${teamName}: ${messages.length} msg(s) for leader. Run: omx team status ${teamName}`;
+      text = `Team ${teamName}: ${messages.length} msg(s) for leader. ${buildStatusCheckReminder(teamName)}`;
     } else {
       continue;
     }

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -200,6 +200,20 @@ Follow this exact lifecycle when running `$team`:
 Do not run `shutdown` while workers are actively writing updates unless user explicitly requested abort/cancel.
 Do not treat ad-hoc pane typing as primary control flow when runtime/state evidence is available.
 
+### Active leader monitoring rule
+
+While a team is **ON/running**, the leader must not go blind. Keep checking live team state until terminal completion.
+
+Minimum acceptable loop:
+
+```bash
+sleep 30 && omx team status <team-name>
+```
+
+Repeat that check while the team stays active, or use `omx team await <team-name> --timeout-ms 30000 --json` when event-driven waiting is a better fit.
+
+If the leader gets a stale/team-stalled nudge, immediately run `omx team status <team-name>` before taking any manual intervention.
+
 ## Message Dispatch Policy (CLI-first, state-first)
 
 To avoid brittle behavior, **message/task delivery must not be driven by ad-hoc tmux typing**.

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { parseTeamStartArgs, teamCommand } from '../team.js';
+import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
 import {
   appendTeamEvent,
@@ -77,6 +77,13 @@ describe('teamCommand shutdown --force parsing', () => {
 });
 
 describe('teamCommand api', () => {
+  it('builds leader monitoring hints that keep team status visible while ON', () => {
+    const hints = buildLeaderMonitoringHints('My Team');
+    assert.equal(hints[0], 'leader_check: omx team status my-team');
+    assert.match(hints[1] ?? '', /while ON, keep checking state/);
+    assert.match(hints[1] ?? '', /sleep 30 && omx team status my-team/);
+  });
+
   it('prints team-specific help for omx team --help', async () => {
     const logs: string[] = [];
     const originalLog = console.log;

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -587,6 +587,14 @@ async function ensureTeamModeState(
   });
 }
 
+export function buildLeaderMonitoringHints(teamName: string): string[] {
+  const sanitized = sanitizeTeamName(teamName);
+  return [
+    `leader_check: omx team status ${sanitized}`,
+    `leader_loop_hint: while ON, keep checking state (example: sleep 30 && omx team status ${sanitized})`,
+  ];
+}
+
 async function renderStartSummary(runtime: TeamRuntime, staffingPlan?: FollowupStaffingPlan): Promise<void> {
   console.log(`Team started: ${runtime.teamName}`);
   console.log(`tmux target: ${runtime.sessionName}`);
@@ -607,6 +615,9 @@ async function renderStartSummary(runtime: TeamRuntime, staffingPlan?: FollowupS
     console.log(
       `monitor_perf_ms: total=${snapshot.performance.total_ms} list=${snapshot.performance.list_tasks_ms} workers=${snapshot.performance.worker_scan_ms} mailbox=${snapshot.performance.mailbox_delivery_ms}`
     );
+  }
+  for (const hint of buildLeaderMonitoringHints(runtime.teamName)) {
+    console.log(hint);
   }
 }
 

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -596,6 +596,8 @@ exit 0
       assert.match(tmuxLog, /Team beta:/);
       assert.match(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /pane\(s\) still active/);
+      assert.match(tmuxLog, /Check: omx team status beta/);
+      assert.match(tmuxLog, /keep polling/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
     });
   });
@@ -714,6 +716,8 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /Team stalled-progress: leader stale, no team progress for 3m/);
+      assert.match(tmuxLog, /Check: omx team status stalled-progress/);
+      assert.match(tmuxLog, /keep polling/);
       assert.match(tmuxLog, /pending:1 in_progress:1 blocked:0/);
       assert.match(tmuxLog, /1 worker signal missing/);
 
@@ -839,6 +843,8 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /Team stalled-before-stale: worker panes stalled, no team progress for 3m/);
+      assert.match(tmuxLog, /Check: omx team status stalled-before-stale/);
+      assert.match(tmuxLog, /keep polling/);
       assert.doesNotMatch(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /pending:1 in_progress:1 blocked:0/);
 
@@ -1407,6 +1413,8 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /msg\(s\) pending/);
+      assert.match(tmuxLog, /Check: omx team status delta/);
+      assert.match(tmuxLog, /keep polling/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
 
       // Verify event reason


### PR DESCRIPTION
## Summary
- add leader-facing monitoring hints after team start/resume so the operator keeps checking `omx team status` while a team is on
- tighten stale/stalled leader notify-hook messages so they explicitly tell the leader to check team status and keep polling
- document the active leader monitoring rule in the team skill and cover the new behavior with focused tests

## Testing
- npm run lint
- npm run build
- npm run check:no-unused
- node --test dist/cli/__tests__/team.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js
