### PR TITLE
fix: reduce fallback team delivery and stale-alert latency

### DIFF
--- a/scripts/notify-fallback-watcher.js
+++ b/scripts/notify-fallback-watcher.js
@@ -8,6 +8,11 @@ import { homedir } from 'os';
 import { drainPendingTeamDispatch } from './notify-hook/team-dispatch.js';
 import { resolveNudgePaneTarget } from './notify-hook/auto-nudge.js';
 import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
+import {
+  isLeaderStale,
+  maybeNudgeTeamLeader,
+  resolveLeaderStalenessThresholdMs,
+} from './notify-hook/team-leader-nudge.js';
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 
 function argValue(name, fallback = '') {
@@ -38,7 +43,10 @@ function isPidAlive(pid) {
 const cwd = resolve(argValue('--cwd', process.cwd()));
 const notifyScript = resolve(argValue('--notify-script', join(cwd, 'scripts', 'notify-hook.js')));
 const runOnce = process.argv.includes('--once');
-const pollMs = Math.max(50, asNumber(argValue('--poll-ms', '700'), 700));
+// Keep fallback control-plane ticks comfortably below the default dispatch
+// ack budget so leaderless team dispatch + stale-alert recovery do not feel
+// laggy between native notify-hook turns.
+const pollMs = Math.max(50, asNumber(argValue('--poll-ms', '250'), 250));
 const parentPid = Math.trunc(asNumber(argValue('--parent-pid', String(process.ppid || 0)), process.ppid || 0));
 const startedAt = Date.now();
 const fileWindowMs = runOnce ? 15000 : 30000;
@@ -73,6 +81,15 @@ let lastDispatchDrain = {
   leader_only: safeString(process.env.OMX_TEAM_WORKER || '').trim() === '',
   last_tick_at: null,
   last_result: null,
+  last_error: null,
+};
+let leaderNudgeRuns = 0;
+let lastLeaderNudge = {
+  enabled: true,
+  leader_only: safeString(process.env.OMX_TEAM_WORKER || '').trim() === '',
+  stale_threshold_ms: null,
+  precomputed_leader_stale: null,
+  last_tick_at: null,
   last_error: null,
 };
 let lastRalphContinueSteer = {
@@ -317,6 +334,11 @@ async function writeState(extra = {}) {
       run_count: dispatchDrainRuns,
       ...lastDispatchDrain,
     },
+    leader_nudge: {
+      enabled: true,
+      run_count: leaderNudgeRuns,
+      ...lastLeaderNudge,
+    },
     ralph_continue_steer: {
       ...lastRalphContinueSteer,
       enabled: true,
@@ -512,6 +534,72 @@ async function pollFiles() {
   }
 }
 
+async function runLeaderNudgeTick() {
+  const startedIso = new Date().toISOString();
+  const leaderOnly = safeString(process.env.OMX_TEAM_WORKER || '').trim() === '';
+  const staleThresholdMs = resolveLeaderStalenessThresholdMs();
+
+  if (!leaderOnly) {
+    leaderNudgeRuns += 1;
+    lastLeaderNudge = {
+      enabled: true,
+      leader_only: false,
+      stale_threshold_ms: staleThresholdMs,
+      precomputed_leader_stale: null,
+      last_tick_at: startedIso,
+      last_error: 'worker_context',
+    };
+    await eventLog({
+      type: 'leader_nudge_tick',
+      leader_only: false,
+      run_count: leaderNudgeRuns,
+      reason: 'worker_context',
+      stale_threshold_ms: staleThresholdMs,
+    });
+    return;
+  }
+
+  try {
+    const preComputedLeaderStale = await isLeaderStale(stateDir, staleThresholdMs, Date.now());
+    await maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderStale });
+    leaderNudgeRuns += 1;
+    lastLeaderNudge = {
+      enabled: true,
+      leader_only: true,
+      stale_threshold_ms: staleThresholdMs,
+      precomputed_leader_stale: preComputedLeaderStale,
+      last_tick_at: startedIso,
+      last_error: null,
+    };
+    await eventLog({
+      type: 'leader_nudge_tick',
+      leader_only: true,
+      run_count: leaderNudgeRuns,
+      stale_threshold_ms: staleThresholdMs,
+      precomputed_leader_stale: preComputedLeaderStale,
+      reason: 'leader_nudge_checked',
+    });
+  } catch (err) {
+    leaderNudgeRuns += 1;
+    lastLeaderNudge = {
+      enabled: true,
+      leader_only: true,
+      stale_threshold_ms: staleThresholdMs,
+      precomputed_leader_stale: null,
+      last_tick_at: startedIso,
+      last_error: err instanceof Error ? err.message : safeString(err),
+    };
+    await eventLog({
+      type: 'leader_nudge_tick',
+      leader_only: true,
+      run_count: leaderNudgeRuns,
+      stale_threshold_ms: staleThresholdMs,
+      reason: 'leader_nudge_failed',
+      error: lastLeaderNudge.last_error,
+    });
+  }
+}
+
 async function runDispatchDrainTick() {
   const startedIso = new Date().toISOString();
   try {
@@ -555,6 +643,7 @@ async function tick() {
   await ensureTrackedFiles();
   await pollFiles();
   await runDispatchDrainTick();
+  await runLeaderNudgeTick();
   await runRalphContinueSteerTick();
   await writeState();
   if (await enforceLifecycleGuards()) return;
@@ -597,6 +686,7 @@ async function main() {
     await ensureTrackedFiles();
     await pollFiles();
     await runDispatchDrainTick();
+    await runLeaderNudgeTick();
     await runRalphContinueSteerTick();
     await writeState();
     await eventLog({ type: 'watcher_once_complete', seen_turns: seenTurnKeys.size });

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -331,6 +331,69 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('runs leader nudge checks from the fallback watcher so stale alerts do not wait for a leader turn', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-leader-nudge-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state', 'team', 'dispatch-team'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      await writeFile(join(wd, '.omx', 'state', 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'dispatch-team',
+        current_phase: 'team-exec',
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+        last_turn_at: new Date(Date.now() - 300_000).toISOString(),
+        turn_count: 3,
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'config.json'), JSON.stringify({
+        name: 'dispatch-team',
+        tmux_session: 'omx-team-dispatch-team',
+        leader_pane_id: '%42',
+      }, null, 2));
+
+      const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook],
+        {
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          },
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(tmuxLog, /send-keys -t %42 -l Team dispatch-team: leader stale/);
+
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.poll_ms, 250);
+      assert.equal(watcherState.leader_nudge?.enabled, true);
+      assert.equal(watcherState.leader_nudge?.leader_only, true);
+      assert.equal(watcherState.leader_nudge?.run_count, 1);
+      assert.equal(watcherState.leader_nudge?.precomputed_leader_stale, true);
+
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const nudgeEvent = logEntries.find((entry: { type?: string }) => entry.type === 'leader_nudge_tick');
+      assert.ok(nudgeEvent, 'expected leader_nudge_tick log event');
+      assert.equal(nudgeEvent.leader_only, true);
+      assert.equal(nudgeEvent.precomputed_leader_stale, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('runs bounded non-turn team dispatch drain tick in leader context', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-dispatch-'));
     try {

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -125,6 +125,15 @@ describe('team state', () => {
       const loaded = await readTeamManifestV2('team-policy', cwd);
       assert.equal(loaded?.policy.dispatch_mode, 'hook_preferred_with_fallback');
       assert.equal(loaded?.policy.dispatch_ack_timeout_ms, 10_000);
+
+      const freshCwd = await mkdtemp(join(tmpdir(), 'omx-team-manifest-policy-default-'));
+      try {
+        await initTeamState('team-policy-default', 't', 'executor', 1, freshCwd);
+        const fresh = await readTeamManifestV2('team-policy-default', freshCwd);
+        assert.equal(fresh?.policy.dispatch_ack_timeout_ms, 2_000);
+      } finally {
+        await rm(freshCwd, { recursive: true, force: true });
+      }
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -336,7 +336,10 @@ export interface TeamSummaryPerformance {
 export const DEFAULT_MAX_WORKERS = 20;
 export const ABSOLUTE_MAX_WORKERS = 20;
 const LOCK_STALE_MS = 5 * 60 * 1000;
-const DEFAULT_DISPATCH_ACK_TIMEOUT_MS = 800;
+// Hook-preferred delivery can wait for the fallback watcher tick plus tmux
+// injection verification; keep the default ack budget above that steady-state
+// control-plane cadence to avoid spurious fallback/failed confirmations.
+const DEFAULT_DISPATCH_ACK_TIMEOUT_MS = 2_000;
 const MIN_DISPATCH_ACK_TIMEOUT_MS = 100;
 const MAX_DISPATCH_ACK_TIMEOUT_MS = 10_000;
 


### PR DESCRIPTION
## Summary
- lower the fallback watcher control-plane tick from 700ms to 250ms
- let the fallback watcher run leader nudge checks so stale/stalled alerts do not wait for a leader turn
- raise the default hook-preferred dispatch ack budget from 800ms to 2000ms so it better matches the real fallback drain + tmux verification path
- add focused regression coverage for the new fallback leader-nudge path and the new default dispatch timeout

## Findings
I instrumented/measured the path end-to-end in code/tests and the dominant latency bottleneck was the fallback control-plane cadence:
- fallback team dispatch drain only ran every 700ms by default
- hook-preferred dispatch waited only 800ms for an ack
- the dispatch drain itself can spend up to ~750ms in tmux injection verification
- stale/stalled leader nudges were not evaluated by the fallback watcher at all, so they could wait for a future leader turn instead of riding the fallback control plane

That combination made delivery/status propagation feel laggy and made stale alerts miss the fastest available path.

## What changed
- `scripts/notify-fallback-watcher.js`
  - default poll cadence: `700ms -> 250ms`
  - added `runLeaderNudgeTick()` so the fallback watcher now evaluates leader nudges on each tick in leader context
  - persisted/logged `leader_nudge` watcher state for timing visibility
- `src/team/state.ts`
  - default `dispatch_ack_timeout_ms`: `800 -> 2000`
- tests
  - added a fallback-watcher regression test proving stale leader nudges now fire without waiting for a leader turn
  - added a state-policy regression test pinning the new default ack timeout

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js dist/team/__tests__/state.test.js`
- `npx biome lint scripts/notify-fallback-watcher.js src/team/state.ts src/hooks/__tests__/notify-fallback-watcher.test.ts src/team/__tests__/state.test.ts`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

## Notes
- I confirmed worker bring-up is still serialized inside `startTeam()`; I treated that as a secondary concern and kept this PR scoped to the dominant control-plane latency bottleneck.
- Closes #738.
