### PR TITLE
fix(team-ralph): establish Ralph linked state on launch

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
@@ -713,6 +713,64 @@ process.on('SIGTERM', () => process.exit(0));
     } finally {
       console.log = originalLog;
       process.stderr.write = originalStderrWrite;
+      process.chdir(previousCwd);
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('establishes Ralph-side linked state for real omx team ralph launches', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-ralph-link-'));
+    const binDir = join(wd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const previousCwd = process.cwd();
+    const previousPath = process.env.PATH;
+    const previousTmux = process.env.TMUX;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+setTimeout(() => process.exit(0), 150);
+process.stdin.resume();
+process.on('SIGTERM', () => process.exit(0));
+`,
+    );
+    await chmod(fakeCodexPath, 0o755);
+
+    try {
+      process.chdir(wd);
+      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+      delete process.env.TMUX;
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_TEAM_WORKER_CLI = 'codex';
+
+      const teamTask = 'issue 742 linked ralph launch';
+      const teamName = parseTeamStartArgs(['ralph', '1:executor', teamTask]).parsed.teamName;
+      await teamCommand(['ralph', '1:executor', teamTask]);
+
+      const teamState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'team-state.json'), 'utf-8')) as Record<string, unknown>;
+      const ralphState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'ralph-state.json'), 'utf-8')) as Record<string, unknown>;
+
+      assert.equal(teamState.linked_ralph, true);
+      assert.equal(teamState.team_name, teamName);
+      assert.equal(ralphState.active, true);
+      assert.equal(ralphState.current_phase, 'executing');
+      assert.equal(ralphState.linked_team, true);
+      assert.equal(ralphState.linked_mode, 'team');
+      assert.equal(ralphState.team_name, teamName);
+      assert.equal(ralphState.linked_team_terminal_phase, undefined);
+      assert.equal(ralphState.linked_team_terminal_at, undefined);
+    } finally {
       process.chdir(previousCwd);
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -571,6 +571,9 @@ async function ensureTeamModeState(
       staffing_summary: staffingPlan.staffingSummary,
       staffing_allocations: staffingPlan.allocations,
     });
+    if (parsed.ralph) {
+      await ensureLinkedRalphModeState(parsed);
+    }
     return;
   }
 
@@ -584,6 +587,35 @@ async function ensureTeamModeState(
     available_agent_types: availableAgentTypes,
     staffing_summary: staffingPlan.staffingSummary,
     staffing_allocations: staffingPlan.allocations,
+  });
+
+  if (parsed.ralph) {
+    await ensureLinkedRalphModeState(parsed);
+  }
+}
+
+async function ensureLinkedRalphModeState(parsed: ParsedTeamArgs): Promise<void> {
+  const existing = await readModeState('ralph').catch(() => null);
+  const nextPhase = existing?.active === true
+    && typeof existing.current_phase === 'string'
+    && !['complete', 'failed', 'cancelled'].includes(existing.current_phase)
+    ? existing.current_phase
+    : 'executing';
+
+  if (!existing?.active) {
+    await startMode('ralph', parsed.task, 50);
+  }
+
+  await updateModeState('ralph', {
+    active: true,
+    task_description: parsed.task,
+    current_phase: nextPhase,
+    completed_at: undefined,
+    linked_team: true,
+    linked_mode: 'team',
+    team_name: parsed.teamName,
+    linked_team_terminal_phase: undefined,
+    linked_team_terminal_at: undefined,
   });
 }
 


### PR DESCRIPTION
## Summary
- create/update Ralph mode state during real `omx team ralph` launches
- mark the Ralph side as linked to team so cancel/linked-sync paths see the real launch contract
- cover the real prompt-mode launch path with a regression test

## Testing
- node --test dist/cli/__tests__/team.test.js

Closes #742