### PR TITLE
fix(team-ralph): propagate linked terminal sync from runtime

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1223,6 +1223,52 @@ process.on('SIGTERM', () => {
     }
   });
 
+  it('monitorTeam propagates linked terminal state into Ralph without waiting for notify-hook', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-linked-ralph-monitor-'));
+    try {
+      await initTeamState('team-linked-ralph-monitor', 'linked runtime sync test', 'executor', 1, cwd);
+      await createTask(
+        'team-linked-ralph-monitor',
+        {
+          subject: 'code change',
+          description: 'implement feature',
+          status: 'completed',
+          owner: 'worker-1',
+          requires_code_change: false,
+        },
+        cwd,
+      );
+
+      await writeFile(join(cwd, '.omx', 'state', 'team-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'team-exec',
+        linked_ralph: true,
+        team_name: 'team-linked-ralph-monitor',
+      }, null, 2));
+      await writeFile(join(cwd, '.omx', 'state', 'ralph-state.json'), JSON.stringify({
+        active: true,
+        iteration: 1,
+        max_iterations: 10,
+        current_phase: 'executing',
+        started_at: '2026-03-11T00:00:00.000Z',
+        linked_team: true,
+      }, null, 2));
+
+      const snapshot = await monitorTeam('team-linked-ralph-monitor', cwd);
+      assert.ok(snapshot);
+      assert.equal(snapshot?.phase, 'complete');
+
+      const ralphState = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'ralph-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(ralphState.active, false);
+      assert.equal(ralphState.current_phase, 'complete');
+      assert.equal(ralphState.linked_team_terminal_phase, 'complete');
+      assert.ok(typeof ralphState.linked_team_terminal_at === 'string' && ralphState.linked_team_terminal_at);
+      assert.ok(typeof ralphState.completed_at === 'string' && ralphState.completed_at);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('monitorTeam emits worker_state_changed, worker_idle, and task_completed events based on transitions', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     try {
@@ -1802,6 +1848,44 @@ esac
       await shutdownTeam('team-ralph-summary', cwd, { ralph: true });
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-ralph-summary');
       assert.equal(existsSync(teamRoot), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam ralph=true propagates linked Ralph cancellation before cleanup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-linked-ralph-shutdown-'));
+    try {
+      await initTeamState('team-linked-ralph-shutdown', 'linked shutdown sync test', 'executor', 1, cwd);
+      await createTask(
+        'team-linked-ralph-shutdown',
+        { subject: 'done', description: 'd', status: 'completed' },
+        cwd,
+      );
+
+      await writeFile(join(cwd, '.omx', 'state', 'team-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'team-exec',
+        linked_ralph: true,
+        team_name: 'team-linked-ralph-shutdown',
+      }, null, 2));
+      await writeFile(join(cwd, '.omx', 'state', 'ralph-state.json'), JSON.stringify({
+        active: true,
+        iteration: 1,
+        max_iterations: 10,
+        current_phase: 'executing',
+        started_at: '2026-03-11T00:00:00.000Z',
+        linked_team: true,
+      }, null, 2));
+
+      await shutdownTeam('team-linked-ralph-shutdown', cwd, { ralph: true });
+
+      const ralphState = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'ralph-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(ralphState.active, false);
+      assert.equal(ralphState.current_phase, 'cancelled');
+      assert.equal(ralphState.linked_team_terminal_phase, 'cancelled');
+      assert.ok(typeof ralphState.linked_team_terminal_at === 'string' && ralphState.linked_team_terminal_at);
+      assert.ok(typeof ralphState.completed_at === 'string' && ralphState.completed_at);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -182,6 +182,50 @@ async function syncRootTeamModeStateOnTerminalPhase(
   }
 }
 
+async function syncLinkedRalphModeStateOnTerminalPhase(
+  teamName: string,
+  phase: TeamPhase | TerminalPhase,
+  cwd: string,
+  nowIso: string = new Date().toISOString(),
+): Promise<void> {
+  if (phase !== 'complete' && phase !== 'failed' && phase !== 'cancelled') return;
+
+  try {
+    const [teamState, ralphState] = await Promise.all([
+      readModeState('team', cwd),
+      readModeState('ralph', cwd),
+    ]);
+    if (!teamState || !ralphState) return;
+
+    const stateTeamName = typeof teamState.team_name === 'string' ? teamState.team_name.trim() : '';
+    if (stateTeamName && stateTeamName !== teamName) return;
+    if (teamState.linked_ralph !== true || ralphState.linked_team !== true) return;
+
+    const terminalAt = typeof teamState.completed_at === 'string' && teamState.completed_at
+      ? teamState.completed_at
+      : nowIso;
+    const alreadySynced = ralphState.active === false
+      && ralphState.current_phase === phase
+      && ralphState.linked_team_terminal_phase === phase
+      && ralphState.linked_team_terminal_at === terminalAt
+      && ralphState.completed_at === terminalAt;
+    if (alreadySynced) return;
+
+    await updateModeState('ralph', {
+      active: false,
+      current_phase: phase,
+      linked_mode: 'team',
+      linked_team: true,
+      linked_team_terminal_phase: phase,
+      linked_team_terminal_at: terminalAt,
+      completed_at: terminalAt,
+      last_turn_at: nowIso,
+    }, cwd);
+  } catch {
+    // Best-effort compatibility sync only.
+  }
+}
+
 /** Runtime handle returned by startTeam */
 export interface TeamRuntime {
   teamName: string;
@@ -1251,6 +1295,7 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
   await writeTeamPhaseState(sanitized, phaseState, cwd);
   const phase: TeamPhase | TerminalPhase = phaseState.current_phase;
   await syncRootTeamModeStateOnTerminalPhase(sanitized, phase, cwd);
+  await syncLinkedRalphModeStateOnTerminalPhase(sanitized, phase, cwd);
 
   for (const taskId of reclaimedTaskIds) {
     recommendations.push(`Reclaimed expired claim for task-${taskId}`);
@@ -1678,6 +1723,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       },
       cwd,
     ).catch(() => {});
+    await syncLinkedRalphModeStateOnTerminalPhase(sanitized, 'cancelled', cwd);
   }
 
   const cleanupErrors: string[] = [];


### PR DESCRIPTION
## Summary
- sync linked Ralph terminal state directly from runtime terminal transitions
- propagate linked Ralph cancellation during `shutdownTeam(..., { ralph: true })` before cleanup
- add runtime regression tests so terminal propagation no longer depends on a later notify-hook turn

## Testing
- node --test dist/team/__tests__/runtime.test.js

Closes #743