### PR TITLE
refactor(team): split TeamPolicy transport from governance

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -53,21 +53,44 @@ function expectedLowComplexityModel(codexHomeOverride?: string): string {
 function withEmptyPath<T>(fn: () => T): T {
   const prev = process.env.PATH;
   process.env.PATH = '';
+  let restoreImmediately = true;
   try {
-    return fn();
+    const result = fn();
+    if (result instanceof Promise) {
+      restoreImmediately = false;
+      return result.finally(() => {
+        if (typeof prev === 'string') process.env.PATH = prev;
+        else delete process.env.PATH;
+      }) as T;
+    }
+    return result;
   } finally {
-    if (typeof prev === 'string') process.env.PATH = prev;
-    else delete process.env.PATH;
+    if (restoreImmediately) {
+      if (typeof prev === 'string') process.env.PATH = prev;
+      else delete process.env.PATH;
+    }
   }
 }
 
 function withoutTeamWorkerEnv<T>(fn: () => T): T {
   const prev = process.env.OMX_TEAM_WORKER;
   delete process.env.OMX_TEAM_WORKER;
+  let restoreImmediately = true;
   try {
-    return fn();
+    const result = fn();
+    if (result instanceof Promise) {
+      restoreImmediately = false;
+      return result.finally(() => {
+        if (typeof prev === 'string') process.env.OMX_TEAM_WORKER = prev;
+        else delete process.env.OMX_TEAM_WORKER;
+      }) as T;
+    }
+    return result;
   } finally {
-    if (typeof prev === 'string') process.env.OMX_TEAM_WORKER = prev;
+    if (restoreImmediately) {
+      if (typeof prev === 'string') process.env.OMX_TEAM_WORKER = prev;
+      else delete process.env.OMX_TEAM_WORKER;
+    }
   }
 }
 
@@ -441,9 +464,81 @@ describe('runtime', () => {
     }
   });
 
+  it('startTeam allows nested team invocation when parent governance enables it', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-nested-allow-'));
+    const binDir = join(cwd, 'bin');
+    const fakeGeminiPath = join(binDir, 'gemini');
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeGeminiPath,
+      `#!/usr/bin/env bash
+sleep 5
+`,
+      { mode: 0o755 },
+    );
+
+    await initTeamState('parent-team', 'parent', 'executor', 1, cwd);
+    const parentManifestPath = join(cwd, '.omx', 'state', 'team', 'parent-team', 'manifest.v2.json');
+    const parentManifest = JSON.parse(await readFile(parentManifestPath, 'utf-8')) as any;
+    parentManifest.governance = { ...(parentManifest.governance || {}), nested_teams_allowed: true };
+    await writeFile(parentManifestPath, JSON.stringify(parentManifest, null, 2));
+
+    const prevPath = process.env.PATH;
+    const prevTmux = process.env.TMUX;
+    const prevWorker = process.env.OMX_TEAM_WORKER;
+    const prevStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const prevLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+
+    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
+    delete process.env.TMUX;
+    process.env.OMX_TEAM_WORKER = 'parent-team/worker-1';
+    process.env.OMX_TEAM_STATE_ROOT = join(cwd, '.omx', 'state');
+    process.env.OMX_TEAM_LEADER_CWD = cwd;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+    process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await startTeam(
+        'nested-allowed',
+        'nested task',
+        'explore',
+        1,
+        [{ subject: 's', description: 'd', owner: 'worker-1' }],
+        cwd,
+      );
+      assert.equal(runtime.teamName, 'nested-allowed');
+      await shutdownTeam(runtime.teamName, cwd, { force: true });
+      runtime = null;
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevWorker === 'string') process.env.OMX_TEAM_WORKER = prevWorker;
+      else delete process.env.OMX_TEAM_WORKER;
+      if (typeof prevStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof prevLeaderCwd === 'string') process.env.OMX_TEAM_LEADER_CWD = prevLeaderCwd;
+      else delete process.env.OMX_TEAM_LEADER_CWD;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam throws when tmux is not available', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     try {
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
       await assert.rejects(
         () => withoutTeamWorkerEnv(() =>
           withEmptyPath(() =>
@@ -452,6 +547,8 @@ describe('runtime', () => {
         /requires tmux/i,
       );
     } finally {
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -1335,6 +1432,33 @@ process.on('SIGTERM', () => {
     }
   });
 
+  it('shutdownTeam honors governance cleanup override when active tasks remain', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-override-'));
+    try {
+      await initTeamState('team-shutdown-gate-override', 'shutdown gate override test', 'executor', 1, cwd);
+      await createTask(
+        'team-shutdown-gate-override',
+        { subject: 'pending', description: 'd', status: 'pending' },
+        cwd,
+      );
+
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-override', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
+      manifest.governance = {
+        ...(manifest.governance || {}),
+        cleanup_requires_all_workers_inactive: false,
+      };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      await shutdownTeam('team-shutdown-gate-override', cwd);
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-override');
+      assert.equal(existsSync(teamRoot), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('shutdownTeam blocks when failed tasks remain (completion gate)', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-failed-'));
     try {
@@ -1977,7 +2101,7 @@ esac
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-delegation', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
-      manifest.policy.delegation_only = true;
+      manifest.governance = { ...(manifest.governance || {}), delegation_only: true };
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
       await assert.rejects(
@@ -2077,7 +2201,7 @@ esac
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-approval', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
-      manifest.policy.plan_approval_required = true;
+      manifest.governance = { ...(manifest.governance || {}), plan_approval_required: true };
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
       await assert.rejects(

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -110,7 +110,7 @@ describe('team state', () => {
     }
   });
 
-  it('normalizes legacy manifest policy with dispatch defaults and timeout bounds', async () => {
+  it('normalizes legacy manifest policy with dispatch defaults, timeout bounds, and governance split', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-manifest-policy-'));
     try {
       await initTeamState('team-policy', 't', 'executor', 1, cwd);
@@ -119,18 +119,31 @@ describe('team state', () => {
       const policy = (manifest.policy ?? {}) as Record<string, unknown>;
       delete policy.dispatch_mode;
       policy.dispatch_ack_timeout_ms = 999_999;
+      policy.delegation_only = true;
       manifest.policy = policy;
+      delete manifest.governance;
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
       const loaded = await readTeamManifestV2('team-policy', cwd);
       assert.equal(loaded?.policy.dispatch_mode, 'hook_preferred_with_fallback');
       assert.equal(loaded?.policy.dispatch_ack_timeout_ms, 10_000);
+      assert.equal(loaded?.governance.delegation_only, true);
+      assert.equal('delegation_only' in (loaded?.policy ?? {}), false);
 
       const freshCwd = await mkdtemp(join(tmpdir(), 'omx-team-manifest-policy-default-'));
       try {
         await initTeamState('team-policy-default', 't', 'executor', 1, freshCwd);
         const fresh = await readTeamManifestV2('team-policy-default', freshCwd);
         assert.equal(fresh?.policy.dispatch_ack_timeout_ms, 2_000);
+        assert.equal(fresh?.governance.cleanup_requires_all_workers_inactive, true);
+
+        const freshManifestPath = join(freshCwd, '.omx', 'state', 'team', 'team-policy-default', 'manifest.v2.json');
+        const persisted = JSON.parse(await readFile(freshManifestPath, 'utf8')) as {
+          policy?: Record<string, unknown>;
+          governance?: Record<string, unknown>;
+        };
+        assert.equal('delegation_only' in (persisted.policy ?? {}), false);
+        assert.equal(persisted.governance?.delegation_only, false);
       } finally {
         await rm(freshCwd, { recursive: true, force: true });
       }
@@ -1444,6 +1457,7 @@ describe('team state', () => {
       assert.ok(config);
       assert.equal(manifest?.policy.display_mode, 'split_pane');
       assert.equal(manifest?.policy.worker_launch_mode, 'prompt');
+      assert.equal(manifest?.governance.cleanup_requires_all_workers_inactive, true);
       assert.equal(config?.worker_launch_mode, 'prompt');
       assert.equal(manifest?.permissions_snapshot.approval_mode, 'on-request');
       assert.equal(manifest?.permissions_snapshot.sandbox_mode, 'workspace-write');

--- a/src/team/__tests__/team-ops-contract.test.ts
+++ b/src/team/__tests__/team-ops-contract.test.ts
@@ -16,6 +16,7 @@ const EXPECTED_STATE_RE_EXPORTS = {
   teamCleanup: 'cleanupTeamState',
   teamMigrateV1ToV2: 'migrateV1ToV2',
   teamNormalizePolicy: 'normalizeTeamPolicy',
+  teamNormalizeGovernance: 'normalizeTeamGovernance',
   teamWriteWorkerIdentity: 'writeWorkerIdentity',
   teamReadWorkerHeartbeat: 'readWorkerHeartbeat',
   teamUpdateWorkerHeartbeat: 'updateWorkerHeartbeat',

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -39,6 +39,7 @@ import {
   teamReadTask as readTask,
   teamListTasks as listTasks,
   teamReadManifest as readTeamManifestV2,
+  teamNormalizeGovernance as normalizeTeamGovernance,
   teamNormalizePolicy as normalizeTeamPolicy,
   teamClaimTask as claimTask,
   teamReleaseTaskClaim as releaseTaskClaim,
@@ -67,6 +68,7 @@ import {
   type TeamTask,
   type TeamMonitorSnapshotState,
   type TeamPhaseState,
+  type TeamGovernance,
   type TeamPolicy,
 } from './team-ops.js';
 import {
@@ -313,6 +315,49 @@ function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
   const parsed = Number.parseInt(String(raw ?? ''), 10);
   if (Number.isFinite(parsed) && parsed >= 5_000) return parsed;
   return 45_000;
+}
+
+function parseTeamWorkerContext(raw: string | undefined): { teamName: string; workerName: string } | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+  const [teamName, workerName] = raw.trim().split('/');
+  if (!teamName || !workerName) return null;
+  return { teamName, workerName };
+}
+
+function resolveManifestLookupCwds(cwd: string): string[] {
+  const candidates = new Set<string>([resolve(cwd)]);
+  const leaderCwd = process.env[TEAM_LEADER_CWD_ENV];
+  if (typeof leaderCwd === 'string' && leaderCwd.trim() !== '') {
+    candidates.add(resolve(leaderCwd));
+  }
+
+  const teamStateRoot = process.env[TEAM_STATE_ROOT_ENV];
+  if (typeof teamStateRoot === 'string' && teamStateRoot.trim() !== '') {
+    candidates.add(resolve(teamStateRoot, '..', '..'));
+  }
+
+  return [...candidates];
+}
+
+function resolveGovernancePolicy(
+  governance: TeamGovernance | null | undefined,
+  legacyPolicy?: Partial<TeamGovernance> | null,
+): TeamGovernance {
+  return normalizeTeamGovernance(governance, legacyPolicy);
+}
+
+async function assertNestedTeamAllowed(cwd: string): Promise<void> {
+  const workerContext = parseTeamWorkerContext(process.env.OMX_TEAM_WORKER);
+  if (!workerContext) return;
+
+  for (const candidateCwd of resolveManifestLookupCwds(cwd)) {
+    const manifest = await readTeamManifestV2(workerContext.teamName, candidateCwd);
+    const governance = resolveGovernancePolicy(manifest?.governance, manifest?.policy as Partial<TeamGovernance> | undefined);
+    if (governance.nested_teams_allowed) return;
+    if (manifest) break;
+  }
+
+  throw new Error('nested_team_disallowed');
 }
 
 type WorkerStartupEvidence = 'task_claim' | 'worker_progress' | 'leader_ack' | 'none';
@@ -673,9 +718,8 @@ export async function startTeam(
   cwd: string,
   options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
-  if (process.env.OMX_TEAM_WORKER) {
-    throw new Error('nested_team_disallowed');
-  }
+  const leaderCwd = resolve(cwd);
+  await assertNestedTeamAllowed(leaderCwd);
 
   const workerLaunchMode = resolveTeamWorkerLaunchMode(process.env);
   const displayMode = workerLaunchMode === 'interactive' ? 'split_pane' : 'auto';
@@ -688,7 +732,6 @@ export async function startTeam(
     }
   }
 
-  const leaderCwd = resolve(cwd);
   const sanitized = sanitizeTeamName(teamName);
   const teamStateRoot = resolveCanonicalTeamStateRoot(leaderCwd);
   const activeWorktreeMode: 'detached' | 'named' | null =
@@ -1390,12 +1433,16 @@ export async function assignTask(
   const task = await readTask(sanitized, taskId, cwd);
   if (!task) throw new Error(`Task ${taskId} not found`);
   const manifest = await readTeamManifestV2(sanitized, cwd);
+  const governance = resolveGovernancePolicy(
+    manifest?.governance,
+    manifest?.policy as Partial<TeamGovernance> | undefined,
+  );
 
-  if (manifest?.policy?.delegation_only && workerName === 'leader-fixed') {
+  if (governance.delegation_only && workerName === 'leader-fixed') {
     throw new Error('delegation_only_violation');
   }
 
-  if (manifest?.policy?.plan_approval_required && task.requires_code_change === true) {
+  if (governance.plan_approval_required && task.requires_code_change === true) {
     const approved = await isTaskApprovedForExecution(sanitized, taskId, cwd);
     if (!approved) {
       throw new Error('plan_approval_required');
@@ -1511,6 +1558,11 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     restoreTeamModelInstructionsFile(sanitized);
     return;
   }
+  const manifest = await readTeamManifestV2(sanitized, cwd);
+  const governance = resolveGovernancePolicy(
+    manifest?.governance,
+    manifest?.policy as Partial<TeamGovernance> | undefined,
+  );
 
   if (!force) {
     const allTasks = await listTasks(sanitized, cwd);
@@ -1523,14 +1575,15 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       failed: allTasks.filter((t) => t.status === 'failed').length,
       allowed: false,
     };
-    gate.allowed = gate.pending === 0 && gate.blocked === 0 && gate.in_progress === 0 && gate.failed === 0;
+    gate.allowed = governance.cleanup_requires_all_workers_inactive !== true
+      || (gate.pending === 0 && gate.blocked === 0 && gate.in_progress === 0 && gate.failed === 0);
 
     await appendTeamEvent(
       sanitized,
       {
         type: 'shutdown_gate',
         worker: 'leader-fixed',
-        reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed}${ralph ? ' policy=ralph' : ''}`,
+        reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed} cleanup_requires_all_workers_inactive=${governance.cleanup_requires_all_workers_inactive}${ralph ? ' policy=ralph' : ''}`,
       },
       cwd,
     ).catch(() => {});
@@ -1566,7 +1619,6 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   }
 
   const sessionName = config.tmux_session;
-  const manifest = await readTeamManifestV2(sanitized, cwd);
   const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
   const shutdownRequestTimes = new Map<string, string>();
 
@@ -1808,7 +1860,11 @@ async function findActiveTeams(cwd: string, leaderSessionId: string): Promise<st
     const teamName = e.name;
     const cfg = await readTeamConfig(teamName, cwd);
     const manifest = await readTeamManifestV2(teamName, cwd);
-    if (manifest?.policy?.one_team_per_leader_session === false) continue;
+    const governance = resolveGovernancePolicy(
+      manifest?.governance,
+      manifest?.policy as Partial<TeamGovernance> | undefined,
+    );
+    if (governance.one_team_per_leader_session === false) continue;
     const workerLaunchMode = cfg?.worker_launch_mode
       ?? manifest?.policy?.worker_launch_mode
       ?? 'interactive';

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -157,6 +157,13 @@ export interface TeamPolicy {
   worker_launch_mode: 'interactive' | 'prompt';
   dispatch_mode: 'hook_preferred_with_fallback' | 'transport_direct';
   dispatch_ack_timeout_ms: number;
+}
+
+/**
+ * Lifecycle/workflow guardrails persisted alongside the manifest, but kept
+ * separate from transport/runtime policy so each layer has a single owner.
+ */
+export interface TeamGovernance {
   delegation_only: boolean;
   plan_approval_required: boolean;
   nested_teams_allowed: boolean;
@@ -215,6 +222,7 @@ export interface TeamManifestV2 {
   task: string;
   leader: TeamLeader;
   policy: TeamPolicy;
+  governance: TeamGovernance;
   permissions_snapshot: PermissionsSnapshot;
   tmux_session: string;
   worker_count: number;
@@ -392,6 +400,11 @@ function defaultPolicy(
     worker_launch_mode: workerLaunchMode,
     dispatch_mode: 'hook_preferred_with_fallback',
     dispatch_ack_timeout_ms: DEFAULT_DISPATCH_ACK_TIMEOUT_MS,
+  };
+}
+
+function defaultGovernance(): TeamGovernance {
+  return {
     delegation_only: false,
     plan_approval_required: false,
     nested_teams_allowed: false,
@@ -417,17 +430,24 @@ export function normalizeTeamPolicy(
     : 'hook_preferred_with_fallback';
 
   return {
-    ...base,
-    ...(policy ?? {}),
     worker_launch_mode: policy?.worker_launch_mode === 'prompt' ? 'prompt' : base.worker_launch_mode,
     display_mode: policy?.display_mode === 'split_pane' ? 'split_pane' : base.display_mode,
     dispatch_mode: dispatchMode,
     dispatch_ack_timeout_ms: clampDispatchAckTimeoutMs(policy?.dispatch_ack_timeout_ms),
-    delegation_only: policy?.delegation_only === true,
-    plan_approval_required: policy?.plan_approval_required === true,
-    nested_teams_allowed: policy?.nested_teams_allowed === true,
-    one_team_per_leader_session: policy?.one_team_per_leader_session !== false,
-    cleanup_requires_all_workers_inactive: policy?.cleanup_requires_all_workers_inactive !== false,
+  };
+}
+
+export function normalizeTeamGovernance(
+  governance: Partial<TeamGovernance> | null | undefined,
+  legacyPolicy: Partial<TeamGovernance> | null | undefined = null,
+): TeamGovernance {
+  const source = governance ?? legacyPolicy ?? {};
+  return {
+    delegation_only: source?.delegation_only === true,
+    plan_approval_required: source?.plan_approval_required === true,
+    nested_teams_allowed: source?.nested_teams_allowed === true,
+    one_team_per_leader_session: source?.one_team_per_leader_session !== false,
+    cleanup_requires_all_workers_inactive: source?.cleanup_requires_all_workers_inactive !== false,
   };
 }
 
@@ -769,6 +789,7 @@ export async function initTeamState(
         worker_id: leaderWorkerId,
       },
       policy: defaultPolicy(displayMode, workerLaunchMode),
+      governance: defaultGovernance(),
       permissions_snapshot: permissionsSnapshot,
       tmux_session: config.tmux_session,
       worker_count: workerCount,
@@ -874,6 +895,7 @@ function teamManifestFromConfig(config: TeamConfig): TeamManifestV2 {
     task: normalized.task,
     leader: defaultLeader(),
     policy,
+    governance: defaultGovernance(),
     permissions_snapshot: defaultPermissionsSnapshot(),
     tmux_session: normalized.tmux_session,
     worker_count: normalized.worker_count,
@@ -896,6 +918,10 @@ export async function writeTeamManifestV2(manifest: TeamManifestV2, cwd: string)
     display_mode: manifest.policy?.display_mode === 'split_pane' ? 'split_pane' : 'auto',
     worker_launch_mode: manifest.policy?.worker_launch_mode === 'prompt' ? 'prompt' : 'interactive',
   });
+  const normalizedGovernance = normalizeTeamGovernance(
+    manifest.governance,
+    manifest.policy as Partial<TeamGovernance>,
+  );
   const p = teamManifestV2Path(manifest.name, cwd);
   await writeAtomic(
     p,
@@ -903,6 +929,7 @@ export async function writeTeamManifestV2(manifest: TeamManifestV2, cwd: string)
       {
         ...manifest,
         policy: normalizedPolicy,
+        governance: normalizedGovernance,
       },
       null,
       2,
@@ -917,12 +944,17 @@ export async function readTeamManifestV2(teamName: string, cwd: string): Promise
     const raw = await readFile(p, 'utf8');
     const parsed = JSON.parse(raw) as unknown;
     if (!isTeamManifestV2(parsed)) return null;
+    const parsedManifest = parsed as TeamManifestV2 & {
+      policy?: Partial<TeamPolicy> & Partial<TeamGovernance>;
+      governance?: Partial<TeamGovernance>;
+    };
     return {
-      ...parsed,
-      policy: normalizeTeamPolicy(parsed.policy, {
-        display_mode: parsed.policy?.display_mode === 'split_pane' ? 'split_pane' : 'auto',
-        worker_launch_mode: parsed.policy?.worker_launch_mode === 'prompt' ? 'prompt' : 'interactive',
+      ...parsedManifest,
+      policy: normalizeTeamPolicy(parsedManifest.policy, {
+        display_mode: parsedManifest.policy?.display_mode === 'split_pane' ? 'split_pane' : 'auto',
+        worker_launch_mode: parsedManifest.policy?.worker_launch_mode === 'prompt' ? 'prompt' : 'interactive',
       }),
+      governance: normalizeTeamGovernance(parsedManifest.governance, parsedManifest.policy),
     };
   } catch {
     return null;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -93,6 +93,9 @@ export interface TeamPolicy {
   worker_launch_mode: 'interactive' | 'prompt';
   dispatch_mode: 'hook_preferred_with_fallback' | 'transport_direct';
   dispatch_ack_timeout_ms: number;
+}
+
+export interface TeamGovernance {
   delegation_only: boolean;
   plan_approval_required: boolean;
   nested_teams_allowed: boolean;
@@ -151,6 +154,7 @@ export interface TeamManifestV2 {
   task: string;
   leader: TeamLeader;
   policy: TeamPolicy;
+  governance: TeamGovernance;
   permissions_snapshot: PermissionsSnapshot;
   tmux_session: string;
   worker_count: number;

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -22,6 +22,7 @@ export type {
   TeamManifestV2,
   TeamLeader,
   TeamPolicy,
+  TeamGovernance,
   PermissionsSnapshot,
   TeamEvent,
   TeamMailboxMessage,
@@ -55,6 +56,7 @@ export { saveTeamConfig as teamSaveConfig } from './state.js';
 export { cleanupTeamState as teamCleanup } from './state.js';
 export { migrateV1ToV2 as teamMigrateV1ToV2 } from './state.js';
 export { normalizeTeamPolicy as teamNormalizePolicy } from './state.js';
+export { normalizeTeamGovernance as teamNormalizeGovernance } from './state.js';
 
 // === Worker operations ===
 export { writeWorkerIdentity as teamWriteWorkerIdentity } from './state.js';


### PR DESCRIPTION
## Summary
- split persisted team transport/runtime policy from lifecycle governance in the manifest contract
- make runtime governance checks authoritative for nested teams, delegation/approval gates, and shutdown cleanup gating
- add regression coverage for legacy manifest migration, nested-team allowance, shutdown cleanup override, and team-ops exports

## Testing
- npm run build
- node --test dist/team/__tests__/state.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/scaling.test.js dist/team/__tests__/team-ops-contract.test.js
- npx biome lint src/team/state.ts src/team/runtime.ts src/team/state/types.ts src/team/team-ops.ts src/team/__tests__/state.test.ts src/team/__tests__/runtime.test.ts src/team/__tests__/team-ops-contract.test.ts

Closes #746