### PR TITLE
refactor(team): consolidate shared tmux stall heuristics

### DIFF
--- a/scripts/notify-hook/auto-nudge.js
+++ b/scripts/notify-hook/auto-nudge.js
@@ -10,7 +10,8 @@ import { asNumber, safeString } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession, readdir } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
-import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
+import { checkPaneReadyForTeamSendKeys } from './team-tmux-guard.js';
+import { buildCapturePaneArgv, DEFAULT_MARKER } from '../tmux-hook-engine.js';
 
 export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
 export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'];
@@ -254,9 +255,7 @@ export function detectStallPattern(text, patterns) {
 
 export async function capturePane(paneId, lines = 10) {
   try {
-    const result = await runProcess('tmux', [
-      'capture-pane', '-t', paneId, '-p', '-l', String(lines),
-    ], 3000);
+    const result = await runProcess('tmux', buildCapturePaneArgv(paneId, lines), 3000);
     return result.stdout || '';
   } catch {
     return '';
@@ -340,6 +339,18 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
 
     if (skillState?.phase === 'completing' && !detected) return;
     if (!detected || !paneId) return;
+
+    const paneGuard = await checkPaneReadyForTeamSendKeys(paneId);
+    if (!paneGuard.ok) {
+      await logTmuxHookEvent(logsDir, {
+        timestamp: new Date().toISOString(),
+        type: 'auto_nudge_skipped',
+        pane_id: paneId,
+        reason: paneGuard.reason,
+        source,
+      }).catch(() => {});
+      return;
+    }
 
     const deepInterviewLockActive = isDeepInterviewAutoApprovalLocked(skillState) && !releaseReason;
     if (deepInterviewLockActive && isBlockedAutoApprovalInput(config.response, skillState.input_lock?.blocked_inputs)) {

--- a/scripts/notify-hook/team-dispatch.js
+++ b/scripts/notify-hook/team-dispatch.js
@@ -4,7 +4,14 @@ import { dirname, join, resolve } from 'path';
 import { safeString } from './utils.js';
 import { runProcess } from './process-runner.js';
 import { resolvePaneTarget } from './tmux-injection.js';
-import { buildCapturePaneArgv, buildPaneInModeArgv, buildSendKeysArgv } from '../tmux-hook-engine.js';
+import {
+  buildCapturePaneArgv,
+  buildPaneInModeArgv,
+  buildSendKeysArgv,
+  normalizeTmuxCapture,
+  paneHasActiveTask,
+  paneLooksReady,
+} from '../tmux-hook-engine.js';
 
 function readJson(path, fallback) {
   return readFile(path, 'utf8')
@@ -260,18 +267,14 @@ function resolveWorkerCliForRequest(request, config) {
   return 'codex';
 }
 
-function normalizeCaptureText(value) {
-  return safeString(value).replace(/\r/g, '').replace(/\s+/g, ' ').trim();
-}
-
 function capturedPaneContainsTrigger(captured, trigger) {
   if (!captured || !trigger) return false;
-  return normalizeCaptureText(captured).includes(normalizeCaptureText(trigger));
+  return normalizeTmuxCapture(captured).includes(normalizeTmuxCapture(trigger));
 }
 
 function capturedPaneContainsTriggerNearTail(captured, trigger, nonEmptyTailLines = 24) {
   if (!captured || !trigger) return false;
-  const normalizedTrigger = normalizeCaptureText(trigger);
+  const normalizedTrigger = normalizeTmuxCapture(trigger);
   if (!normalizedTrigger) return false;
   const lines = safeString(captured)
     .split('\n')
@@ -279,57 +282,7 @@ function capturedPaneContainsTriggerNearTail(captured, trigger, nonEmptyTailLine
     .filter((line) => line.length > 0);
   if (lines.length === 0) return false;
   const tail = lines.slice(-Math.max(1, nonEmptyTailLines)).join(' ');
-  return normalizeCaptureText(tail).includes(normalizedTrigger);
-}
-
-// Ported from src/team/tmux-session.ts:949-963 — detects active CLI task indicators.
-function paneHasActiveTask(captured) {
-  const lines = safeString(captured)
-    .split('\n')
-    .map((line) => line.replace(/\r/g, '').trim())
-    .filter((line) => line.length > 0);
-  const tail = lines.slice(-40);
-  if (tail.some((line) => /\b\d+\s+background terminal running\b/i.test(line))) return true;
-  if (tail.some((line) => /esc to interrupt/i.test(line))) return true;
-  if (tail.some((line) => /\bbackground terminal running\b/i.test(line))) return true;
-  if (tail.some((line) => /^•\s.+\(.+•\s*esc to interrupt\)$/i.test(line))) return true;
-  // Claude active generation lines
-  if (tail.some((line) => /^[·✻]\s+[A-Za-z][A-Za-z0-9''-]*(?:\s+[A-Za-z][A-Za-z0-9''-]*){0,3}(?:…|\.{3})$/u.test(line))) return true;
-  return false;
-}
-
-function paneIsBootstrapping(captured) {
-  const lines = safeString(captured)
-    .split('\n')
-    .map((line) => line.replace(/\r/g, '').trim())
-    .filter((line) => line.length > 0);
-  return lines.some((line) =>
-    /\b(loading|initializing|starting up)\b/i.test(line)
-    || /\bmodel:\s*loading\b/i.test(line)
-    || /\bconnecting\s+to\b/i.test(line),
-  );
-}
-
-function paneLooksReady(captured) {
-  const content = safeString(captured).trimEnd();
-  if (content === '') return false;
-
-  const lines = content
-    .split('\n')
-    .map((line) => line.replace(/\r/g, ''))
-    .map((line) => line.trimEnd())
-    .filter((line) => line.trim() !== '');
-
-  if (paneIsBootstrapping(content)) return false;
-
-  const lastLine = lines.length > 0 ? lines[lines.length - 1] : '';
-  if (/^\s*[›>❯]\s*/u.test(lastLine)) return true;
-
-  const hasCodexPromptLine = lines.some((line) => /^\s*›\s*/u.test(line));
-  const hasClaudePromptLine = lines.some((line) => /^\s*❯\s*/u.test(line));
-  if (hasCodexPromptLine || hasClaudePromptLine) return true;
-
-  return false;
+  return normalizeTmuxCapture(tail).includes(normalizedTrigger);
 }
 
 const INJECT_VERIFY_DELAY_MS = 250;

--- a/scripts/notify-hook/team-tmux-guard.js
+++ b/scripts/notify-hook/team-tmux-guard.js
@@ -1,31 +1,48 @@
 import { safeString } from './utils.js';
 import { runProcess } from './process-runner.js';
-import { buildPaneCurrentCommandArgv, isPaneRunningShell } from '../tmux-hook-engine.js';
+import {
+  buildCapturePaneArgv,
+  buildPaneCurrentCommandArgv,
+  isPaneRunningShell,
+  paneHasActiveTask,
+  paneLooksReady,
+} from '../tmux-hook-engine.js';
 
 export async function checkPaneReadyForTeamSendKeys(paneTarget) {
   const target = safeString(paneTarget).trim();
   if (!target) {
-    return { ok: false, reason: 'missing_pane_target', paneCurrentCommand: '' };
+    return { ok: false, reason: 'missing_pane_target', paneCurrentCommand: '', paneCapture: '' };
   }
 
+  let paneCurrentCommand = '';
   try {
     const result = await runProcess('tmux', buildPaneCurrentCommandArgv(target), 1000);
-    const paneCurrentCommand = safeString(result.stdout).trim();
+    paneCurrentCommand = safeString(result.stdout).trim();
     if (isPaneRunningShell(paneCurrentCommand)) {
       return {
         ok: false,
         reason: 'pane_running_shell',
         paneCurrentCommand,
+        paneCapture: '',
       };
     }
-    return {
-      ok: true,
-      paneCurrentCommand,
-    };
   } catch {
-    return {
-      ok: true,
-      paneCurrentCommand: '',
-    };
+    paneCurrentCommand = '';
+  }
+
+  try {
+    const capture = await runProcess('tmux', buildCapturePaneArgv(target), 1000);
+    const paneCapture = safeString(capture.stdout);
+    if (paneCapture.trim() !== '') {
+      if (paneHasActiveTask(paneCapture)) {
+        return { ok: false, reason: 'pane_has_active_task', paneCurrentCommand, paneCapture };
+      }
+      if (!paneLooksReady(paneCapture)) {
+        return { ok: false, reason: 'pane_not_ready', paneCurrentCommand, paneCapture };
+      }
+    }
+    return { ok: true, paneCurrentCommand, paneCapture };
+  } catch {
+    return { ok: true, paneCurrentCommand, paneCapture: '' };
   }
 }

--- a/scripts/notify-hook/tmux-injection.js
+++ b/scripts/notify-hook/tmux-injection.js
@@ -16,14 +16,13 @@ import {
 } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
+import { checkPaneReadyForTeamSendKeys } from './team-tmux-guard.js';
 import {
   normalizeTmuxHookConfig,
   pickActiveMode,
   evaluateInjectionGuards,
   buildSendKeysArgv,
   buildPaneInModeArgv,
-  buildPaneCurrentCommandArgv,
-  isPaneRunningShell,
 } from '../tmux-hook-engine.js';
 
 export async function resolveSessionToPane(sessionName) {
@@ -373,28 +372,28 @@ export async function handleTmuxInjection({
     }
   }
 
-  // Shell-detection guard: skip injection when the agent process has exited
-  // and the pane has returned to an interactive shell (zsh, bash, etc.).
-  // Sending the inject marker to a shell causes glob errors like
-  // "zsh: no matches found: [OMX_TMUX_INJECT]".  See #441.
+  // Shared pane-state guard: skip injection when the target pane has returned
+  // to a shell, is still bootstrapping, or is visibly busy with active work.
   try {
-    const cmdResult = await runProcess('tmux', buildPaneCurrentCommandArgv(paneTarget), 1000);
-    const currentCmd = safeString(cmdResult.stdout).trim();
-    if (isPaneRunningShell(currentCmd)) {
-      state.last_reason = 'agent_not_running';
+    const paneGuard = await checkPaneReadyForTeamSendKeys(paneTarget);
+    if (!paneGuard.ok) {
+      const reason = paneGuard.reason === 'pane_running_shell'
+        ? 'agent_not_running'
+        : paneGuard.reason;
+      state.last_reason = reason;
       state.last_event_at = nowIso;
       await writeFile(hookStatePath, JSON.stringify(state, null, 2)).catch(() => {});
       await logTmuxHookEvent(logsDir, {
         ...baseLog,
         event: 'injection_skipped',
-        reason: 'agent_not_running',
+        reason,
         pane_target: paneTarget,
-        pane_current_command: currentCmd,
+        pane_current_command: paneGuard.paneCurrentCommand || undefined,
       });
       return;
     }
   } catch {
-    // Non-fatal: if querying pane command fails, proceed with injection.
+    // Non-fatal: if querying pane state fails, proceed with injection.
   }
 
   if (config.dry_run) {

--- a/scripts/tmux-hook-engine.js
+++ b/scripts/tmux-hook-engine.js
@@ -178,6 +178,62 @@ export function isPaneRunningShell(paneCurrentCommand) {
   return SHELL_COMMANDS.has(base);
 }
 
+export function normalizeTmuxCapture(value) {
+  return String(value ?? '')
+    .replace(/\r/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizePaneLines(capturedOrLines) {
+  if (Array.isArray(capturedOrLines)) {
+    return capturedOrLines
+      .map((line) => String(line ?? '').replace(/\r/g, '').trimEnd())
+      .filter((line) => line.trim() !== '');
+  }
+
+  return String(capturedOrLines ?? '')
+    .split('\n')
+    .map((line) => line.replace(/\r/g, '').trimEnd())
+    .filter((line) => line.trim() !== '');
+}
+
+export function paneIsBootstrapping(capturedOrLines) {
+  const lines = normalizePaneLines(capturedOrLines);
+  return lines.some((line) =>
+    /\b(loading|initializing|starting up)\b/i.test(line)
+    || /\bmodel:\s*loading\b/i.test(line)
+    || /\bconnecting\s+to\b/i.test(line)
+  );
+}
+
+export function paneLooksReady(captured) {
+  const content = String(captured ?? '').trimEnd();
+  if (content === '') return false;
+
+  const lines = normalizePaneLines(content);
+
+  if (paneIsBootstrapping(lines)) return false;
+
+  const lastLine = lines.length > 0 ? lines[lines.length - 1] : '';
+  if (/^\s*[›>❯]\s*/u.test(lastLine)) return true;
+
+  const hasCodexPromptLine = lines.some((line) => /^\s*›\s*/u.test(line));
+  const hasClaudePromptLine = lines.some((line) => /^\s*❯\s*/u.test(line));
+  if (hasCodexPromptLine || hasClaudePromptLine) return true;
+
+  return lines.some((line) => /^\s*(?:[›>❯]\s*)?[A-Z][A-Z0-9]+-\d+\s+only(?:\s*(?:…|\.{3}))?\s*$/iu.test(line));
+}
+
+export function paneHasActiveTask(captured) {
+  const tail = normalizePaneLines(captured).map((line) => line.trim()).slice(-40);
+  if (tail.some((line) => /\b\d+\s+background terminal running\b/i.test(line))) return true;
+  if (tail.some((line) => /esc to interrupt/i.test(line))) return true;
+  if (tail.some((line) => /\bbackground terminal running\b/i.test(line))) return true;
+  if (tail.some((line) => /^•\s.+\(.+•\s*esc to interrupt\)$/i.test(line))) return true;
+  return tail.some((line) => /^[·✻]\s+[A-Za-z][A-Za-z0-9'’-]*(?:\s+[A-Za-z][A-Za-z0-9'’-]*){0,3}(?:…|\.{3})$/u.test(line));
+}
+
 export function buildCapturePaneArgv(paneTarget, tailLines = 80) {
   return ['capture-pane', '-t', paneTarget, '-p', '-S', `-${tailLines}`];
 }

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -148,7 +148,7 @@ describe('notify-hook auto-nudge', () => {
       });
 
       // capture-pane will return content with a stall pattern
-      await writeFile(captureFile, 'Here are the results.\nWould you like me to continue with the implementation?\n');
+      await writeFile(captureFile, 'Here are the results.\nWould you like me to continue with the implementation?\n› ');
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -232,6 +232,50 @@ describe('notify-hook auto-nudge', () => {
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
         assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should NOT send nudge');
       }
+    });
+  });
+
+  it('does not nudge when pane capture shows an active task despite stall-like assistant text', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const captureFile = join(cwd, 'capture-output.txt');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      await writeFile(
+        captureFile,
+        [
+          'Working...',
+          '• Running tests (3m 12s • esc to interrupt)',
+          '',
+        ].join('\n'),
+      );
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Would you like me to continue with the next step?',
+      }, {
+        OMX_TEST_CAPTURE_FILE: captureFile,
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /capture-pane/, 'should inspect pane state before nudging');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should not inject while pane is busy');
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -684,4 +684,106 @@ exit 1
       assert.equal(healedConfig.target.value, '%99');
     });
   });
+
+  it('skips injection when the resolved pane is still busy', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-busy-pane';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'session.json'), { session_id: sessionId });
+      await writeJson(join(sessionStateDir, 'ralph-state.json'), { active: true, iteration: 0, tmux_pane_id: '%42' });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%42' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && "$target" == "%42" ]]; then
+    echo "%42"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%42" ]]; then
+    echo "0"
+    exit 0
+  fi
+  echo "bad display target: $target / $format" >&2
+  exit 1
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  cat <<'EOF'
+Working...
+• Running tests (3m 12s • esc to interrupt)
+EOF
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  echo "unexpected send-keys" >&2
+  exit 1
+fi
+echo "unsupported cmd: $cmd" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-test-busy-pane',
+        'turn-id': 'turn-test-busy-pane',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_WORKER: '',
+        },
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'pane_has_active_task');
+      assert.equal(hookState.total_injections ?? 0, 0);
+    });
+  });
 });

--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -3,8 +3,12 @@ import assert from 'node:assert/strict';
 import {
   DEFAULT_ALLOWED_MODES,
   DEFAULT_MARKER,
+  normalizeTmuxCapture,
   normalizeTmuxHookConfig,
   pickActiveMode,
+  paneHasActiveTask,
+  paneIsBootstrapping,
+  paneLooksReady,
   evaluateInjectionGuards,
   buildSendKeysArgv,
   buildPaneCurrentCommandArgv,
@@ -295,5 +299,51 @@ describe('buildSendKeysArgv', () => {
       prompt: 'continue',
       dryRun: true,
     }), null);
+  });
+});
+
+describe('normalizeTmuxCapture', () => {
+  it('collapses whitespace and trims tmux capture text', () => {
+    assert.equal(normalizeTmuxCapture('  hello\r\n  world  \n'), 'hello world');
+  });
+});
+
+describe('paneIsBootstrapping', () => {
+  it('detects startup/loading markers', () => {
+    assert.equal(paneIsBootstrapping(['model: loading']), true);
+    assert.equal(paneIsBootstrapping(['Initializing workspace']), true);
+    assert.equal(paneIsBootstrapping(['connecting to agent']), true);
+  });
+
+  it('returns false for ready prompt content', () => {
+    assert.equal(paneIsBootstrapping(['› ready']), false);
+  });
+});
+
+describe('paneLooksReady', () => {
+  it('accepts explicit prompt lines', () => {
+    assert.equal(paneLooksReady('some output\n› '), true);
+    assert.equal(paneLooksReady('some output\n❯ '), true);
+  });
+
+  it('rejects status-only and bootstrapping captures', () => {
+    assert.equal(paneLooksReady('gpt-5 50% left'), false);
+    assert.equal(paneLooksReady('model: loading\n› '), false);
+  });
+
+  it('accepts issue-only prompts without a glyph', () => {
+    assert.equal(paneLooksReady('IND-123 only...'), true);
+  });
+});
+
+describe('paneHasActiveTask', () => {
+  it('detects Codex and Claude activity markers', () => {
+    assert.equal(paneHasActiveTask('• Running tests (3m 12s • esc to interrupt)'), true);
+    assert.equal(paneHasActiveTask('· Pollinating…'), true);
+    assert.equal(paneHasActiveTask('2 background terminal running'), true);
+  });
+
+  it('returns false for idle prompts', () => {
+    assert.equal(paneHasActiveTask('› ready for input'), false);
   });
 });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -9,6 +9,12 @@ import {
   LONG_CONFIG_FLAG,
   MODEL_FLAG,
 } from '../cli/constants.js';
+import {
+  normalizeTmuxCapture as sharedNormalizeTmuxCapture,
+  paneHasActiveTask as sharedPaneHasActiveTask,
+  paneIsBootstrapping as sharedPaneIsBootstrapping,
+  paneLooksReady as sharedPaneLooksReady,
+} from '../../scripts/tmux-hook-engine.js';
 import { sleep, sleepSync } from '../utils/sleep.js';
 import { classifySpawnError, resolveCommandPathForPlatform, spawnPlatformCommandSync } from '../utils/platform-command.js';
 
@@ -985,49 +991,8 @@ function paneTarget(sessionName: string, workerIndex: number, workerPaneId?: str
   return `${sessionName}:${workerIndex}`;
 }
 
-export function paneIsBootstrapping(lines: string[]): boolean {
-  return lines.some((line) =>
-    /\b(loading|initializing|starting up)\b/i.test(line) ||
-    /\bmodel:\s*loading\b/i.test(line) ||
-    /\bconnecting\s+to\b/i.test(line),
-  );
-}
-
-export function paneLooksReady(captured: string): boolean {
-  const content = captured.trimEnd();
-  if (content === '') return false;
-
-  const lines = content
-    .split('\n')
-    .map(l => l.replace(/\r/g, ''))
-    .map(l => l.trimEnd())
-    .filter(l => l.trim() !== '');
-
-  // Negative gate: loading/startup states override all positive signals.
-  // Fixes #391: status bar markers (gpt-*, % left) can appear before the CLI
-  // is truly input-ready, causing typed triggers to sit as unsent drafts.
-  if (paneIsBootstrapping(lines)) return false;
-
-  const lastLine = lines.length > 0 ? lines[lines.length - 1] : '';
-  // Strong positive: prompt character on last line means input-ready.
-  if (/^\s*[›>❯]\s*/u.test(lastLine)) return true;
-
-  // Prompt character anywhere in the captured output (e.g. Codex TUI renders
-  // the prompt line above a status footer).
-  const hasCodexPromptLine = lines.some((line) => /^\s*›\s*/u.test(line));
-  const hasClaudePromptLine = lines.some((line) => /^\s*❯\s*/u.test(line));
-  if (hasCodexPromptLine || hasClaudePromptLine) return true;
-
-  // Custom per-issue prompts (e.g. "› IND-123 only..."). Capture output can
-  // occasionally omit the glyph, so accept both with/without leading prompt char.
-  const hasIssuePromptLine = lines.some((line) => /^\s*(?:[›>❯]\s*)?[A-Z][A-Z0-9]+-\d+\s+only(?:\s*(?:…|\.{3}))?\s*$/iu.test(line));
-  if (hasIssuePromptLine) return true;
-
-  // Status-only markers (model name in status bar, token budget) are NOT
-  // sufficient on their own — they can appear during bootstrap before the CLI
-  // accepts input.  Require an actual prompt character (checked above).
-  return false;
-}
+export const paneIsBootstrapping = sharedPaneIsBootstrapping;
+export const paneLooksReady = sharedPaneLooksReady;
 
 function paneHasTrustPrompt(captured: string): boolean {
   const lines = captured
@@ -1040,24 +1005,7 @@ function paneHasTrustPrompt(captured: string): boolean {
   return hasQuestion && hasActiveChoices;
 }
 
-export function paneHasActiveTask(captured: string): boolean {
-  const lines = captured
-    .split('\n')
-    .map((line) => line.replace(/\r/g, '').trim())
-    .filter((line) => line.length > 0);
-
-  const tail = lines.slice(-40);
-  // Codex v5 status line can appear without "esc to interrupt"; treat as busy first.
-  if (tail.some((line) => /\b\d+\s+background terminal running\b/i.test(line))) return true;
-  if (tail.some((line) => /esc to interrupt/i.test(line))) return true;
-  if (tail.some((line) => /\bbackground terminal running\b/i.test(line))) return true;
-  // Typical Codex activity line: "• Doing X (3m 12s • esc to interrupt)"
-  if (tail.some((line) => /^•\s.+\(.+•\s*esc to interrupt\)$/i.test(line))) return true;
-  // Claude active generation lines (observed): "· Caramelizing…", "· Beboppin'…", "✻ Pollinating…"
-  // Keep this fairly narrow to minimize false positives in regular bullet content.
-  if (tail.some((line) => /^[·✻]\s+[A-Za-z][A-Za-z0-9'’-]*(?:\s+[A-Za-z][A-Za-z0-9'’-]*){0,3}(?:…|\.{3})$/u.test(line))) return true;
-  return false;
-}
+export const paneHasActiveTask = sharedPaneHasActiveTask;
 
 function resolveSendStrategyFromEnv(): 'auto' | 'queue' | 'interrupt' {
   const raw = String(process.env.OMX_TEAM_SEND_STRATEGY || '')
@@ -1264,12 +1212,7 @@ export function dismissTrustPromptIfPresent(
   return true;
 }
 
-export function normalizeTmuxCapture(value: string): string {
-  return value
-    .replace(/\r/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
+export const normalizeTmuxCapture = sharedNormalizeTmuxCapture;
 
 function assertWorkerTriggerText(text: string): void {
   if (text.length >= 200) {

--- a/src/types/tmux-hook-engine.d.ts
+++ b/src/types/tmux-hook-engine.d.ts
@@ -44,6 +44,10 @@ declare module '*tmux-hook-engine.js' {
     state: Record<string, unknown>;
   }): { allow: boolean; reason: string; dedupeKey?: string };
   export function buildCapturePaneArgv(paneTarget: string, tailLines?: number): string[];
+  export function normalizeTmuxCapture(value: unknown): string;
+  export function paneIsBootstrapping(lines: string[] | string): boolean;
+  export function paneLooksReady(captured: string): boolean;
+  export function paneHasActiveTask(captured: string): boolean;
   export function buildPaneInModeArgv(paneTarget: string): string[];
   export function buildPaneCurrentCommandArgv(paneTarget: string): string[];
   export function isPaneRunningShell(paneCurrentCommand: string): boolean;


### PR DESCRIPTION
## Summary
- extract shared tmux capture normalization, bootstrapping, ready, and active-task heuristics into `scripts/tmux-hook-engine.js`
- reuse the shared heuristics from notify-hook dispatch/guard paths and the team tmux session runtime
- harden auto-nudge/tmux injection with focused regression coverage for busy-pane skips

## Testing
- npm run build
- npx biome lint scripts/notify-hook/auto-nudge.js scripts/notify-hook/team-dispatch.js scripts/notify-hook/team-tmux-guard.js scripts/notify-hook/tmux-injection.js scripts/tmux-hook-engine.js src/hooks/__tests__/notify-hook-auto-nudge.test.ts src/hooks/__tests__/notify-hook-tmux-heal.test.ts src/hooks/__tests__/tmux-hook-engine.test.ts src/team/tmux-session.ts src/types/tmux-hook-engine.d.ts
- node --test dist/hooks/__tests__/tmux-hook-engine.test.js dist/hooks/__tests__/tmux-hook-engine-types-sync.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/notify-hook-tmux-heal.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/team/__tests__/tmux-session.test.js

Closes #732.