### PR TITLE
feat(team): add allocation and rebalance policy seams

### DIFF
--- a/docs/reference/team-allocation-rebalance-policy.md
+++ b/docs/reference/team-allocation-rebalance-policy.md
@@ -1,0 +1,50 @@
+# Team Allocation and Rebalance Policy Notes
+
+This note documents the current team-mode allocation/rebalance seam and the constraints that the phased allocation/rebalance upgrade must preserve.
+
+## Current baseline
+
+### Startup allocation
+- `buildTeamExecutionPlan()` splits the top-level request, routes each subtask to a role, then assigns owners via `distributeTasksToWorkers()`.
+- Ownership is still strict round-robin today (`src/cli/team.ts:402-435`, `src/cli/team.ts:535-543`).
+- Atomic tasks fan out into the fixed aspect trio: implement, test, review/document (`src/cli/team.ts:512-533`).
+
+### Runtime monitoring
+- `monitorTeam()` already gathers the signals needed for rebalance decisions: task inventory, lease expiry, worker liveness, worker status, heartbeat turn counts, and verification evidence gaps (`src/team/runtime.ts:1212-1420`).
+- The runtime currently turns those signals into recommendations such as:
+  - reassign work from dead workers (`src/team/runtime.ts:1288-1294`)
+  - remind non-reporting workers (`src/team/runtime.ts:1297-1300`)
+  - surface missing PASS/FAIL verification evidence (`src/team/runtime.ts:1313-1321`)
+  - note reclaimed expired claims (`src/team/runtime.ts:1343-1345`)
+- `assignTask()` remains the claim + dispatch gateway, including approval checks and post-claim rollback when worker notification fails (`src/team/runtime.ts:1426-1527`).
+
+### Claim-safety invariants
+- `claimTask()` can only move work into `in_progress` after dependency readiness succeeds and no active claim is held by another worker (`src/team/state/tasks.ts:56-113`).
+- `transitionTaskStatus()` requires the active claim token before terminal completion/failure (`src/team/state/tasks.ts:132-200`).
+- `releaseTaskClaim()` and `reclaimExpiredTaskClaim()` are the safe rollback/requeue paths; both clear owner + claim and return the task to `pending` (`src/team/state/tasks.ts:204-265`).
+
+## Recommended policy seam
+
+To keep the upgrade incremental and reversible, separate **signal collection** from **decision policy**:
+
+1. **Allocation policy**
+   - Input: decomposed tasks, routed roles, worker roster, dependency readiness, and current load.
+   - Output: chosen owner, ranked fallbacks, and a short reason string.
+   - Integration point: replace the round-robin-only decision inside `buildTeamExecutionPlan()` without changing task decomposition or role routing.
+
+2. **Rebalance policy**
+   - Input: the runtime snapshot inputs already assembled by `monitorTeam()`.
+   - Output: structured actions (`noop`, `recommend`, `requeue`, `reassign`) plus rationale.
+   - Integration point: let `monitorTeam()` compute richer actions, but keep `assignTask()` as the only real dispatch path.
+
+## Safety rules for v1
+- Do not steal active work that still has a valid claim lease.
+- Only auto-reassign when work is pending, explicitly released, reclaimed after lease expiry, or attached to a dead/non-recoverable worker.
+- Keep tmux layout and scale-up behavior unchanged for the first milestone.
+- Preserve `.omx/state/team/...` storage and `omx team api` contracts.
+- Make every allocation/rebalance decision explainable with a reason string suitable for logs, snapshots, and tests.
+
+## Review notes
+- The code already has good low-level claim primitives; the main gap is decision logic, not transport.
+- The clearest review risk is letting new heuristics bypass `assignTask()`/claim safety. Any rebalance helper should return a decision, not perform ad-hoc mutation.
+- Startup assignment and runtime rebalance should stay small, explicit policy seams so `src/cli/team.ts` and `src/team/runtime.ts` do not absorb another large block of inline heuristics.

--- a/src/cli/__tests__/team-decompose.test.ts
+++ b/src/cli/__tests__/team-decompose.test.ts
@@ -42,13 +42,18 @@ describe('decomposeTaskString', () => {
     }
   });
 
-  it('distributes tasks across workers round-robin', () => {
+  it('keeps explicit same-role tasks on a single specialization lane', () => {
     const tasks = decomposeTaskString('task A, task B, task C, task D', 2, 'executor', true);
     assert.equal(tasks.length, 4);
-    assert.equal(tasks[0].owner, 'worker-1');
-    assert.equal(tasks[1].owner, 'worker-2');
-    assert.equal(tasks[2].owner, 'worker-1');
-    assert.equal(tasks[3].owner, 'worker-2');
+    assert.deepEqual(tasks.map((task) => task.owner), ['worker-1', 'worker-1', 'worker-1', 'worker-1']);
+  });
+
+  it('clusters same-role work to preserve specialization when routing is mixed', () => {
+    const tasks = decomposeTaskString('write docs, build UI component, update docs, and fix tests', 3, 'executor', false);
+    assert.equal(tasks.length, 4);
+    const docOwners = tasks.filter((task) => task.role === 'writer').map((task) => task.owner);
+    assert.ok(docOwners.length >= 2);
+    assert.equal(new Set(docOwners).size, 1);
   });
 
   it('handles single worker with single task', () => {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -7,6 +7,7 @@ import type { TeamEvent } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { classifyTaskSize } from '../hooks/task-size-detector.js';
 import { routeTaskToRole } from '../team/role-router.js';
+import { allocateTasksToWorkers } from '../team/allocation-policy.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
@@ -532,15 +533,13 @@ function createAspectSubtasks(
   return result;
 }
 
-/** Distribute tasks across workers, assigning owners round-robin. */
+/** Distribute tasks across workers using an inspectable allocation policy. */
 function distributeTasksToWorkers(
-  tasks: Array<{ subject: string; description: string; role?: string }>,
+  tasks: Array<{ subject: string; description: string; role?: string; blocked_by?: string[] }>,
   workerCount: number,
 ): Array<{ subject: string; description: string; owner: string; role?: string }> {
-  return tasks.map((t, i) => ({
-    ...t,
-    owner: `worker-${(i % workerCount) + 1}`,
-  }));
+  const workers = Array.from({ length: workerCount }, (_, index) => ({ name: `worker-${index + 1}` }));
+  return allocateTasksToWorkers(tasks, workers).map(({ allocation_reason: _allocationReason, ...task }) => task);
 }
 
 async function ensureTeamModeState(

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { allocateTasksToWorkers, chooseTaskOwner } from '../allocation-policy.js';
+
+describe('allocation-policy', () => {
+  it('prefers matching worker role when no prior assignments exist', () => {
+    const decision = chooseTaskOwner(
+      { subject: 'write docs', description: 'document the feature', role: 'writer' },
+      [
+        { name: 'worker-1', role: 'executor' },
+        { name: 'worker-2', role: 'writer' },
+      ],
+      [],
+    );
+
+    assert.equal(decision.owner, 'worker-2');
+    assert.match(decision.reason, /matches worker role writer/);
+  });
+
+  it('clusters same-role tasks on a specialized lane before spilling over', () => {
+    const assignments = allocateTasksToWorkers(
+      [
+        { subject: 'write docs 1', description: 'd1', role: 'writer' },
+        { subject: 'write docs 2', description: 'd2', role: 'writer' },
+        { subject: 'implement feature', description: 'd3', role: 'executor' },
+      ],
+      [
+        { name: 'worker-1', role: 'executor' },
+        { name: 'worker-2', role: 'writer' },
+        { name: 'worker-3', role: 'test-engineer' },
+      ],
+    );
+
+    assert.equal(assignments[0].owner, 'worker-2');
+    assert.equal(assignments[1].owner, 'worker-2');
+    assert.equal(assignments[2].owner, 'worker-1');
+  });
+
+  it('falls back to load balancing when roles do not differentiate the work', () => {
+    const assignments = allocateTasksToWorkers(
+      [
+        { subject: 'task a', description: 'a' },
+        { subject: 'task b', description: 'b' },
+        { subject: 'task c', description: 'c' },
+      ],
+      [
+        { name: 'worker-1' },
+        { name: 'worker-2' },
+      ],
+    );
+
+    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2', 'worker-1']);
+  });
+});

--- a/src/team/__tests__/rebalance-policy.test.ts
+++ b/src/team/__tests__/rebalance-policy.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildRebalanceDecisions } from '../rebalance-policy.js';
+
+describe('rebalance-policy', () => {
+  it('prioritizes reclaimed pending work and emits explicit assign actions with reasons', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: ['2'],
+      tasks: [
+        {
+          id: '1',
+          subject: 'Existing UI work',
+          description: 'continue designer lane',
+          status: 'in_progress',
+          owner: 'worker-1',
+          role: 'designer',
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '2',
+          subject: 'Recovered test task',
+          description: 'reclaimed after lease expiry',
+          status: 'pending',
+          role: 'test-engineer',
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+        {
+          id: '3',
+          subject: 'Unowned UI polish',
+          description: 'idle pickup candidate',
+          status: 'pending',
+          role: 'designer',
+          created_at: '2026-03-11T00:00:02.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'working', current_task_id: '1', updated_at: '2026-03-11T00:00:00.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:00.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions, [
+      {
+        type: 'assign',
+        taskId: '2',
+        workerName: 'worker-2',
+        reason: 'reclaimed work is ready; balances current load',
+      },
+      {
+        type: 'assign',
+        taskId: '3',
+        workerName: 'worker-2',
+        reason: 'idle worker pickup; balances current load',
+      },
+    ]);
+  });
+
+  it('skips pending work whose dependencies are not yet completed', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: [
+        {
+          id: '1',
+          subject: 'Blocked follow-up',
+          description: 'waits for task 9',
+          status: 'pending',
+          role: 'executor',
+          depends_on: ['9'],
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '9',
+          subject: 'Prerequisite',
+          description: 'still running',
+          status: 'in_progress',
+          owner: 'worker-1',
+          role: 'executor',
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:00.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions, []);
+  });
+
+  it('does not assign work when no live idle worker is available', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: ['4'],
+      tasks: [
+        {
+          id: '4',
+          subject: 'Recovered task',
+          description: 'should wait for a worker',
+          status: 'pending',
+          role: 'executor',
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: false,
+          status: { state: 'unknown', updated_at: '2026-03-11T00:00:00.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'working', current_task_id: '1', updated_at: '2026-03-11T00:00:00.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions, []);
+  });
+});

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1212,8 +1212,63 @@ process.on('SIGTERM', () => {
     }
   });
 
+  it('monitorTeam surfaces reclaimed work pickup attempts when an idle worker is available', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-reassign-reclaimed-'));
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+    let sleeper1: ReturnType<typeof spawn> | null = null;
+    let sleeper2: ReturnType<typeof spawn> | null = null;
+    try {
+      await initTeamState('team-runtime-reassign', 'reassign reclaimed test', 'executor', 2, cwd);
+      const task = await createTask('team-runtime-reassign', { subject: 'write docs', description: 'document feature', status: 'pending', role: 'writer' }, cwd);
+      const claim = await claimTask('team-runtime-reassign', task.id, 'worker-1', null, cwd);
+      assert.ok(claim.ok);
+      if (!claim.ok) throw new Error('claim failed');
+
+      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-runtime-reassign', 'tasks', `task-${task.id}.json`);
+      const current = JSON.parse(await readFile(taskPath, 'utf-8')) as any;
+      current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
+      await writeAtomic(taskPath, JSON.stringify(current, null, 2));
+
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-runtime-reassign', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
+      sleeper1 = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore', detached: false });
+      sleeper2 = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore', detached: false });
+      manifest.policy = { ...(manifest.policy || {}), worker_launch_mode: 'prompt' };
+      manifest.workers[0].role = 'executor';
+      manifest.workers[1].role = 'writer';
+      manifest.workers[0].pid = sleeper1.pid;
+      manifest.workers[1].pid = sleeper2.pid;
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      await writeAtomic(
+        join(cwd, '.omx', 'state', 'team', 'team-runtime-reassign', 'workers', 'worker-1', 'status.json'),
+        JSON.stringify({ state: 'working', current_task_id: task.id, updated_at: new Date().toISOString() }, null, 2),
+      );
+      await writeAtomic(
+        join(cwd, '.omx', 'state', 'team', 'team-runtime-reassign', 'workers', 'worker-2', 'status.json'),
+        JSON.stringify({ state: 'idle', updated_at: new Date().toISOString() }, null, 2),
+      );
+
+      const snapshot = await monitorTeam('team-runtime-reassign', cwd);
+      assert.ok(snapshot);
+      const reread = await readTask('team-runtime-reassign', task.id, cwd);
+      assert.equal(reread?.status, 'pending');
+      assert.equal(reread?.owner, undefined);
+      assert.equal(snapshot?.recommendations.some((r) => r.includes(`Unable to assign task-${task.id} to worker-2: worker_notify_failed`)), true);
+    } finally {
+      try { if (sleeper1?.pid) process.kill(sleeper1.pid, 'SIGKILL'); } catch {}
+      try { if (sleeper2?.pid) process.kill(sleeper2.pid, 'SIGKILL'); } catch {}
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('monitorTeam reclaims expired task claims and surfaces the recovery in recommendations', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-reclaim-'));
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
     try {
       await initTeamState('team-runtime-reclaim', 'reclaim test', 'executor', 2, cwd);
       const t = await createTask('team-runtime-reclaim', { subject: 'task', description: 'd', status: 'pending' }, cwd);
@@ -1233,6 +1288,8 @@ process.on('SIGTERM', () => {
       assert.equal(reread?.claim, undefined);
       assert.equal(snapshot?.recommendations.some((r) => r.includes(`task-${t.id}`) && r.includes('Reclaimed expired claim')), true);
     } finally {
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -1,0 +1,102 @@
+export interface AllocationTaskInput {
+  subject: string;
+  description: string;
+  role?: string;
+  blocked_by?: string[];
+}
+
+export interface AllocationWorkerInput {
+  name: string;
+  role?: string;
+}
+
+export interface AllocationDecision {
+  owner: string;
+  reason: string;
+}
+
+interface WorkerAllocationState extends AllocationWorkerInput {
+  assignedCount: number;
+  primaryRole?: string;
+}
+
+function scoreWorker(task: AllocationTaskInput, worker: WorkerAllocationState): number {
+  let score = 0;
+  const taskRole = task.role?.trim();
+  const workerRole = worker.role?.trim();
+
+  if (taskRole && worker.primaryRole === taskRole) score += 18;
+  if (taskRole && workerRole === taskRole) score += 12;
+  if (taskRole && !worker.primaryRole && worker.assignedCount === 0) score += 5;
+
+  score -= worker.assignedCount * 4;
+
+  if ((task.blocked_by?.length ?? 0) > 0) {
+    score -= worker.assignedCount;
+  }
+
+  return score;
+}
+
+export function chooseTaskOwner(
+  task: AllocationTaskInput,
+  workers: AllocationWorkerInput[],
+  currentAssignments: Array<{ owner: string; role?: string }>,
+): AllocationDecision {
+  if (workers.length === 0) {
+    throw new Error('at least one worker is required for allocation');
+  }
+
+  const workerState = workers.map<WorkerAllocationState>((worker) => {
+    const assigned = currentAssignments.filter((item) => item.owner === worker.name);
+    const primaryRole = assigned.find((item) => item.role)?.role;
+    return {
+      ...worker,
+      assignedCount: assigned.length,
+      primaryRole,
+    };
+  });
+
+  const ranked = workerState
+    .map((worker, index) => ({
+      worker,
+      index,
+      score: scoreWorker(task, worker),
+    }))
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      if (left.worker.assignedCount !== right.worker.assignedCount) {
+        return left.worker.assignedCount - right.worker.assignedCount;
+      }
+      return left.index - right.index;
+    });
+
+  const selected = ranked[0]?.worker ?? workerState[0];
+  const reasons: string[] = [];
+  if (task.role && selected.primaryRole === task.role) reasons.push(`keeps ${task.role} work grouped`);
+  else if (task.role && selected.role === task.role) reasons.push(`matches worker role ${selected.role}`);
+  else reasons.push('balances current load');
+
+  if ((task.blocked_by?.length ?? 0) > 0) reasons.push('keeps blocked work on a lighter lane');
+
+  return {
+    owner: selected.name,
+    reason: reasons.join('; '),
+  };
+}
+
+export function allocateTasksToWorkers<T extends AllocationTaskInput>(
+  tasks: T[],
+  workers: AllocationWorkerInput[],
+): Array<T & { owner: string; allocation_reason: string }> {
+  const assignments: Array<T & { owner: string; allocation_reason: string }> = [];
+  for (const task of tasks) {
+    const decision = chooseTaskOwner(task, workers, assignments);
+    assignments.push({
+      ...task,
+      owner: decision.owner,
+      allocation_reason: decision.reason,
+    });
+  }
+  return assignments;
+}

--- a/src/team/rebalance-policy.ts
+++ b/src/team/rebalance-policy.ts
@@ -1,0 +1,70 @@
+import type { TeamTask, WorkerStatus } from './state/types.js';
+import { chooseTaskOwner, type AllocationWorkerInput } from './allocation-policy.js';
+
+export interface RebalanceWorkerInput extends AllocationWorkerInput {
+  alive: boolean;
+  status: WorkerStatus;
+}
+
+export interface RebalanceDecision {
+  type: 'assign' | 'recommend';
+  taskId?: string;
+  workerName?: string;
+  reason: string;
+}
+
+export interface RebalancePolicyInput {
+  tasks: TeamTask[];
+  workers: RebalanceWorkerInput[];
+  reclaimedTaskIds: string[];
+}
+
+function hasCompletedDependencies(task: TeamTask, taskById: Map<string, TeamTask>): boolean {
+  const dependencyIds = task.depends_on ?? task.blocked_by ?? [];
+  if (dependencyIds.length === 0) return true;
+  return dependencyIds.every((id) => taskById.get(id)?.status === 'completed');
+}
+
+function isWorkerAvailable(worker: RebalanceWorkerInput): boolean {
+  return worker.alive && (worker.status.state === 'idle' || worker.status.state === 'done' || worker.status.state === 'unknown');
+}
+
+export function buildRebalanceDecisions(input: RebalancePolicyInput): RebalanceDecision[] {
+  const taskById = new Map(input.tasks.map((task) => [task.id, task] as const));
+  const liveWorkers = input.workers.filter(isWorkerAvailable);
+  if (liveWorkers.length === 0) return [];
+
+  const unownedPendingTasks = input.tasks
+    .filter((task) => task.status === 'pending' && !task.owner)
+    .filter((task) => hasCompletedDependencies(task, taskById))
+    .sort((left, right) => {
+      const leftReclaimed = input.reclaimedTaskIds.includes(left.id) ? 0 : 1;
+      const rightReclaimed = input.reclaimedTaskIds.includes(right.id) ? 0 : 1;
+      if (leftReclaimed !== rightReclaimed) return leftReclaimed - rightReclaimed;
+      return Number(left.id) - Number(right.id);
+    });
+
+  const inFlightAssignments = input.tasks
+    .filter((task) => task.owner && task.status === 'in_progress')
+    .map((task) => ({ owner: task.owner as string, role: task.role }));
+
+  const decisions: RebalanceDecision[] = [];
+  const claimedTaskIds = new Set<string>();
+
+  for (const task of unownedPendingTasks) {
+    if (claimedTaskIds.has(task.id)) continue;
+    const decision = chooseTaskOwner(task, liveWorkers, inFlightAssignments);
+    decisions.push({
+      type: 'assign',
+      taskId: task.id,
+      workerName: decision.owner,
+      reason: input.reclaimedTaskIds.includes(task.id)
+        ? `reclaimed work is ready; ${decision.reason}`
+        : `idle worker pickup; ${decision.reason}`,
+    });
+    inFlightAssignments.push({ owner: decision.owner, role: task.role });
+    claimedTaskIds.add(task.id);
+  }
+
+  return decisions;
+}

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -106,6 +106,7 @@ import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { inferPhaseTargetFromTaskCounts, reconcilePhaseStateForMonitor } from './phase-controller.js';
 import { getTeamTmuxSessions } from '../notifications/tmux.js';
 import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
+import { buildRebalanceDecisions } from './rebalance-policy.js';
 import { readModeState, updateModeState } from '../modes/base.js';
 import {
   ensureWorktree,
@@ -1230,7 +1231,7 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
     const reclaimed = await reclaimExpiredTaskClaim(sanitized, task.id, cwd);
     if (reclaimed.ok && reclaimed.reclaimed) reclaimedTaskIds.push(task.id);
   }
-  const taskView = reclaimedTaskIds.length > 0 ? await listTasks(sanitized, cwd) : allTasks;
+  let taskView = reclaimedTaskIds.length > 0 ? await listTasks(sanitized, cwd) : allTasks;
   const taskById = new Map(taskView.map((task) => [task.id, task] as const));
   const inProgressByOwner = new Map<string, TeamTask[]>();
   for (const task of taskView) {
@@ -1300,6 +1301,40 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
     }
   }
 
+  for (const taskId of reclaimedTaskIds) {
+    recommendations.push(`Reclaimed expired claim for task-${taskId}`);
+  }
+  const rebalanceDecisions = buildRebalanceDecisions({
+    tasks: taskView,
+    workers: workers.map((worker) => ({
+      name: worker.name,
+      role: config.workers.find((entry) => entry.name === worker.name)?.role,
+      alive: worker.alive,
+      status: worker.status,
+    })),
+    reclaimedTaskIds,
+  });
+
+  let assignedDuringMonitor = false;
+  for (const decision of rebalanceDecisions) {
+    if (decision.type === 'assign' && decision.taskId && decision.workerName) {
+      try {
+        await assignTask(sanitized, decision.workerName, decision.taskId, cwd);
+        recommendations.push(`Assigned task-${decision.taskId} to ${decision.workerName}: ${decision.reason}`);
+        assignedDuringMonitor = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        recommendations.push(`Unable to assign task-${decision.taskId} to ${decision.workerName}: ${message}`);
+      }
+    } else {
+      recommendations.push(decision.reason);
+    }
+  }
+
+  if (assignedDuringMonitor) {
+    taskView = await listTasks(sanitized, cwd);
+  }
+
   // Count tasks
   const taskCounts = {
     total: taskView.length,
@@ -1340,9 +1375,6 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
   await syncRootTeamModeStateOnTerminalPhase(sanitized, phase, cwd);
   await syncLinkedRalphModeStateOnTerminalPhase(sanitized, phase, cwd);
 
-  for (const taskId of reclaimedTaskIds) {
-    recommendations.push(`Reclaimed expired claim for task-${taskId}`);
-  }
   if (deadWorkerStall) {
     recommendations.push('All workers are dead while work remains; mark the team failed or restart with fresh workers.');
   }


### PR DESCRIPTION
## Summary

This PR upgrades team-mode work distribution from a mostly static startup assignment model into an explicit **allocation + conservative rebalance policy** model.

At a high level, the change does three things:

1. **Improves startup task allocation** so work is no longer distributed purely round-robin.
2. **Introduces a narrow rebalance policy seam** that can react to reclaimed pending work and idle workers.
3. **Keeps the existing team architecture intact**: tmux runtime, task claim lifecycle, state storage, and CLI/API contracts all remain the same.

This is intentionally an incremental policy-layer change, not a runtime rewrite.

---

## Why this work was needed

Before this PR, the team runtime already had useful observability and safety signals:

- worker heartbeats
- worker status transitions
- expired-claim reclaim
- dead-worker / non-reporting detection
- mailbox and event-driven monitoring

However, the actual task distribution policy was much simpler than the runtime around it.

### Previous behavior

- Startup task ownership was effectively assigned by **round-robin** after decomposition.
- Role routing existed, but owner selection did not meaningfully use that role information to preserve specialization lanes.
- The monitor could detect reclaimed work, stalled work, or dead-worker fallout, but it primarily surfaced **recommendations**, not actionable reassignment decisions.

That combination created a gap:

- the runtime knew *when* work was in trouble,
- but the allocation layer was still too simplistic to make the best use of worker roles and recovered work.

---

## Why this was implemented this way

I deliberately chose a **policy seam** approach instead of embedding more heuristics directly into the existing orchestration functions or rewriting the runtime.

### Why not a broader rewrite?

A full scheduler/coordinator rewrite would be much higher risk because team mode already has a large contract surface:

- tmux pane/session lifecycle
- team state files under `.omx/state/team/...`
- task claim / release / reclaim semantics
- runtime monitor snapshots
- worker mailbox flows
- CLI and API interop

Those systems are already exercised by a meaningful test surface. Replacing them would create regression risk far beyond the actual problem we were trying to solve.

### Why not just inline a few heuristics?

That would have made `src/cli/team.ts` and `src/team/runtime.ts` even more responsibility-heavy.

Instead, this PR isolates the decision logic into dedicated modules so that:

- startup allocation policy is easier to reason about,
- runtime rebalance decisions are explicit and testable,
- orchestration code remains the adapter layer,
- future tuning can happen in one place without scattering more logic across the runtime.

### Design principle used here

This PR follows a narrow rule:

> **Keep the current team runtime and safety model, but make ownership decisions smarter.**

That means:

- no new control plane,
- no new storage model,
- no aggressive work-stealing,
- no hidden/opaque scheduling logic.

The new policy stays inspectable and conservative.

---

## What changed

### 1. Added startup allocation policy

New file:
- `src/team/allocation-policy.ts`

This module introduces explicit allocation decisions for startup ownership.

Instead of assigning owners with a simple `worker-(i % n)` round-robin pattern, allocation now considers:

- worker role affinity
- already-assigned lane specialization
- current assignment count / load
- whether blocked work should land on a lighter lane

This allows the runtime to preserve specialization more effectively.

#### Practical effect

If several tasks are clearly the same kind of work (for example documentation-heavy tasks), they can be clustered onto the same lane instead of being fragmented across workers just because they appeared next in sequence.

That matters because it preserves:

- clearer worker specialization,
- more coherent prompts/instructions,
- less cross-lane fragmentation,
- fewer unnecessary context switches.

---

### 2. Added conservative rebalance policy

New file:
- `src/team/rebalance-policy.ts`

This module turns runtime signals into explicit rebalance decisions.

The current scope is intentionally conservative:

- prioritize **reclaimed pending work** after lease expiry
- allow **idle-worker pickup** only for safe pending work
- respect dependency gating
- avoid assigning work when no live/eligible idle worker exists

This is important because it improves recovery without violating the existing claim-safety model.

#### What it does **not** do

This PR does **not** introduce aggressive live work-stealing.

It does **not** silently move claimed in-progress work between workers just because another worker is idle.

That is deliberate.

The current task lifecycle and claim model are one of the strongest correctness/safety features in team mode. This PR improves responsiveness while preserving that safety boundary.

---

### 3. Wired rebalance decisions into monitor flow

Updated:
- `src/team/runtime.ts`

The monitor path now does more than just reclaim expired claims and emit recommendations.

When reclaimed pending work exists and a safe assignment is possible, the runtime can now:

- build rebalance decisions,
- attempt assignment through the existing safe assignment path,
- surface the result in recommendations.

This preserves the current transport and lifecycle rules because real execution still goes through the same assignment gateway rather than inventing a second path.

---

### 4. Replaced round-robin owner distribution with policy-backed allocation

Updated:
- `src/cli/team.ts`

The execution-plan builder now delegates worker ownership distribution to the allocation policy rather than hard-coding round-robin assignment.

This means team startup now benefits from lane-aware ownership without changing the higher-level CLI contract.

---

### 5. Added focused tests for new behavior

New tests:
- `src/team/__tests__/allocation-policy.test.ts`
- `src/team/__tests__/rebalance-policy.test.ts`

Expanded tests:
- `src/cli/__tests__/team-decompose.test.ts`
- `src/team/__tests__/runtime.test.ts`

Coverage added for:

- role-based startup clustering
- specialization-lane preservation
- conservative load balancing fallback
- reclaimed pending work reassignment decisions
- dependency-aware skip behavior
- safe no-op behavior when no eligible idle worker exists
- runtime reclaim + reassignment visibility

---

### 6. Added documentation

New file:
- `docs/reference/team-allocation-rebalance-policy.md`

This documents:

- previous behavior
- new allocation/rebalance behavior
- safety boundaries
- v1 conservative scope

---

## Duplicate / overlap check

I checked for obvious duplication before preparing this PR:

- `gh pr list --state open` returned **no open PRs** overlapping this change set.
- Searching PR history for allocation/rebalance title overlap returned **no matching PRs**.
- `origin/dev` does **not** already contain these new files:
  - `src/team/allocation-policy.ts`
  - `src/team/rebalance-policy.ts`
  - `src/team/__tests__/allocation-policy.test.ts`
  - `src/team/__tests__/rebalance-policy.test.ts`
  - `docs/reference/team-allocation-rebalance-policy.md`

There are nearby team-runtime changes in history, but this PR is not a duplicate of them. It extends the existing runtime with explicit policy seams rather than redoing earlier work.

---

## What we should expect after this PR

### Functional expectations

After this PR, team mode should behave better in two important areas:

#### A. Better startup ownership

We should expect improved initial work placement because same-kind work is more likely to be grouped onto an appropriate lane instead of being distributed mechanically.

That should reduce:

- worker prompt mismatch,
- unnecessary cross-lane fragmentation,
- wasted context switching,
- “mixed lane” confusion for startup assignments.

#### B. Better recovery from reclaimed work

When work becomes unowned again after claim expiry, the runtime can now make a **safe, explainable attempt** to reassign that work to an eligible idle worker.

That should reduce:

- manual operator intervention after reclaimed work,
- time spent with recoverable work sitting idle,
- avoidable stalls after a worker drops out or fails to keep a claim alive.

---

## Performance impact

I want to be precise here.

This PR does **not** introduce a benchmarked raw CPU/runtime optimization.
It is not claiming a lower Big-O complexity or a microbenchmark win.

The performance improvement here is **operational throughput and utilization**, not raw compute speed.

### What should improve

This PR should improve:

- **effective lane utilization**
- **time-to-pickup for recovered work**
- **startup allocation quality**
- **reduction in avoidable idle time after reclaim**
- **reduction in fragmentation across specialized workers**

In practice, that means team mode should be more likely to:

- start workers on the kind of work they are best aligned to do,
- keep related work on the same lane,
- recover pending work faster after a claim expires,
- finish complex multi-lane runs with less operator nudging.

### What is intentionally unchanged

This PR does **not** attempt to optimize:

- tmux pane creation speed
- process startup time
- mailbox file I/O performance
- low-level event-loop overhead

So the improvement is best described as:

> **better scheduling quality and better runtime recovery behavior**, which should improve real-world team execution efficiency.

That is the correct claim for this change.

---

## Safety and scope boundaries

This PR intentionally keeps several boundaries conservative:

- no aggressive reassignment of still-claimed in-progress work
- no rewrite of team lifecycle/state ownership
- no new persistent scheduler state
- no change to tmux layout contract
- no hidden heuristic model that cannot be tested or explained

This is important because team mode reliability depends heavily on the predictability of:

- claim ownership,
- monitor behavior,
- shutdown behavior,
- worker lifecycle recovery.

This PR improves those paths without destabilizing them.

---

## Verification

### Build
- `npm run build` ✅

### Focused tests
- `node --test dist/team/__tests__/allocation-policy.test.js dist/team/__tests__/rebalance-policy.test.js dist/cli/__tests__/team-decompose.test.js` ✅
- `node --test --test-name-pattern='monitorTeam surfaces reclaimed work pickup attempts when an idle worker is available|monitorTeam reclaims expired task claims and surfaces the recovery in recommendations' dist/team/__tests__/runtime.test.js` ✅

### Lint
- `npx biome lint src/team/allocation-policy.ts src/team/rebalance-policy.ts src/team/__tests__/allocation-policy.test.ts src/team/__tests__/rebalance-policy.test.ts src/cli/team.ts src/cli/__tests__/team-decompose.test.ts src/team/runtime.ts src/team/__tests__/runtime.test.ts docs/reference/team-allocation-rebalance-policy.md` ✅

### Notes
There are broader unrelated test failures in the repository outside this change area, but the changed-area verification for allocation/rebalance behavior is green.

---

## Changed files

- `src/cli/team.ts`
- `src/team/runtime.ts`
- `src/team/allocation-policy.ts`
- `src/team/rebalance-policy.ts`
- `src/cli/__tests__/team-decompose.test.ts`
- `src/team/__tests__/runtime.test.ts`
- `src/team/__tests__/allocation-policy.test.ts`
- `src/team/__tests__/rebalance-policy.test.ts`
- `docs/reference/team-allocation-rebalance-policy.md`

---

## PR target

- **Base branch:** `dev`
