### PR TITLE
docs(prompts): align explore and sparkshell guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,12 @@ Verification loop: identify what proves the claim, run the verification, read th
 Broad Request Detection:
 A request is broad when it uses vague verbs without targets, names no specific file or function, touches 3+ areas, or is a single sentence without a clear deliverable. For broad work: explore first, then plan if needed.
 
+Command Routing:
+- When `USE_OMX_EXPLORE_CMD` enables advisory routing, prefer `omx explore` for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
+- Keep ambiguous, implementation-heavy, edit-heavy, or non-shell-only work on the normal Codex path.
+- If `omx explore` is unavailable or fails, gracefully fall back to the normal path.
+- For explicit tmux-pane / worker / leader / HUD inspection, prefer `omx sparkshell --tmux-pane ...` when a larger-tail read or bounded summary is useful. Sparkshell pane mode is explicit opt-in, not always-on.
+
 Parallelization:
 - Run independent tasks in parallel.
 - Run dependent tasks sequentially.

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -30,6 +30,7 @@ Default: explore first, ask last.
 - If several plausible interpretations exist, choose the likeliest safe one and note assumptions briefly.
 - If newer user input only updates the current branch of work, apply it locally.
 - Ask one precise question only when progress is impossible.
+- When active session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups; keep edits, tests, ambiguous investigations, and other non-shell-only work on the richer normal path, with graceful fallback if `omx explore` is unavailable.
 </ask_gate>
 
 - Do not claim completion without fresh verification output.

--- a/prompts/explore-harness.md
+++ b/prompts/explore-harness.md
@@ -13,6 +13,8 @@ Your job is to inspect the current repository and return a concise markdown summ
 - Use shell inspection commands only.
 - Treat unavailable tools as unavailable. Do not assume LSP, ast-grep, MCP, web search, images, or structured Read/Glob tools exist here.
 - Keep file/path arguments inside the current repository. Do not intentionally inspect `..` paths or unrelated absolute paths.
+- This harness is for simple read-only repository lookup tasks after `omx explore` has already been selected; it is not the richer normal path.
+- If the user clearly needs non-shell-only tooling or the harness cannot answer safely, report the limitation so the caller can fall back to the richer normal path.
 - Return markdown only.
 </constraints>
 

--- a/prompts/explore.md
+++ b/prompts/explore.md
@@ -17,6 +17,8 @@ Search agents that return incomplete results or miss obvious matches force the c
 - Never store results in files; return them as message text.
 - For finding all usages of a symbol, use the best available local search tools first; if full reference tracing still requires a higher-capability surface, report that need upward to the leader.
 - This prompt is the richer explorer contract. `omx explore` uses a separate shell-only harness contract in `prompts/explore-harness.md`.
+- If session guidance enables `USE_OMX_EXPLORE_CMD`, treat `omx explore` as the preferred low-cost path for simple read-only file/symbol/pattern/relationship lookups; keep this richer prompt for ambiguous, relationship-heavy, or non-shell-only investigations.
+- If `omx explore` is unavailable or fails, continue on this richer normal path instead of dropping the search.
 </scope_guard>
 
 <ask_gate>

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -36,6 +36,7 @@ Interpret implementation requests as planning requests only when this role is ex
 <explore>
 1. Inspect the repository before asking the user about code facts.
 2. Classify the task: simple, refactor, new feature, or broad initiative.
+3. When active session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups; keep prompt-heavy or ambiguous planning work on the richer normal path and fall back normally if `omx explore` is unavailable.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->
 3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->

--- a/prompts/qa-tester.md
+++ b/prompts/qa-tester.md
@@ -55,6 +55,7 @@ Unit tests verify code logic; QA testing verifies real behavior. These rules exi
 - Use Bash for all tmux operations: `tmux new-session -d -s {name}`, `tmux send-keys`, `tmux capture-pane -t {name} -p`, `tmux kill-session -t {name}`.
 - Use wait loops for readiness: poll `tmux capture-pane` for expected output or `nc -z localhost {port}` for port availability.
 - Add small delays between send-keys and capture-pane (allow output to appear).
+- `omx sparkshell --tmux-pane <pane-id> --tail-lines <n>` is an optional operator aid for larger-tail inspection or summaries, but it does not replace raw `tmux capture-pane` evidence for PASS/FAIL assertions.
 </tool_persistence>
 </execution_loop>
 
@@ -62,6 +63,7 @@ Unit tests verify code logic; QA testing verifies real behavior. These rules exi
 - Use Bash for all tmux operations: `tmux new-session -d -s {name}`, `tmux send-keys`, `tmux capture-pane -t {name} -p`, `tmux kill-session -t {name}`.
 - Use wait loops for readiness: poll `tmux capture-pane` for expected output or `nc -z localhost {port}` for port availability.
 - Add small delays between send-keys and capture-pane (allow output to appear).
+- Use `omx sparkshell --tmux-pane ...` only when an explicit opt-in pane summary helps operator inspection; keep raw `tmux capture-pane` output as the canonical QA evidence path.
 </tools>
 
 <style>

--- a/prompts/sisyphus-lite.md
+++ b/prompts/sisyphus-lite.md
@@ -22,6 +22,7 @@ Default: explore first, ask last.
 - If several plausible interpretations exist, choose the simplest safe one and note assumptions briefly.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - Ask only when progress is truly impossible.
+- When active session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups; keep edits, ambiguous work, and non-shell-only tasks on the richer normal path and fall back normally if `omx explore` is unavailable.
 
 - Do not claim completion without fresh verification output.
 - Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -40,6 +40,7 @@ If no flag is provided, use **Standard**.
 - Ask ONE question per round (never batch)
 - Target the weakest clarity dimension each round
 - Gather codebase facts via `explore` before asking user about internals
+- When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only brownfield fact gathering; keep ambiguous or non-shell-only investigation on the richer normal path and fall back normally if `omx explore` is unavailable.
 - Always run a preflight context intake before the first interview question
 - In Codex CLI, prefer `request_user_input` when available; if unavailable, fall back to concise plain-text one-question turns
 - Re-score ambiguity after each answer and show progress transparently

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -30,6 +30,7 @@ Jumping into code without understanding requirements leads to rework, scope cree
 - Auto-detect interview vs direct mode based on request specificity
 - Ask one question at a time during interviews -- never batch multiple questions
 - Gather codebase facts via `explore` agent before asking the user about them
+- When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups during planning; keep prompt-heavy or ambiguous planning work on the richer normal path and fall back normally if `omx explore` is unavailable.
 - Plans must meet quality standards: 80%+ claims cite file/line, 90%+ criteria are testable
 - Consensus mode outputs the final plan by default; add `--interactive` to enable execution handoff
 - Consensus mode uses RALPLAN-DR short mode by default; switch to deliberate mode with `--deliberate` or when the request explicitly signals high risk (auth/security, data migration, destructive/irreversible changes, production incident, compliance/PII, public API breakage)

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -52,7 +52,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
      - unknowns/open questions
      - likely codebase touchpoints
    - If an existing relevant snapshot is available, reuse it and record the path in Ralph state.
-   - If request ambiguity is high, run `explore` first for brownfield facts, then run `$deep-interview --quick <task>` to close critical gaps.
+   - If request ambiguity is high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` to close critical gaps.
    - Do not begin Ralph execution work (delegation, implementation, or verification loops) until snapshot grounding exists. If forced to proceed quickly, note explicit risk tradeoffs.
 1. **Review progress**: Check TODO list and any prior iteration state
 2. **Continue from where you left off**: Pick up incomplete tasks

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -78,7 +78,7 @@ Before consensus planning or execution handoff, ensure a grounded context snapsh
    - constraints
    - unknowns/open questions
    - likely codebase touchpoints
-4. If ambiguity remains high, run `explore` first for brownfield facts, then run `$deep-interview --quick <task>` before continuing.
+4. If ambiguity remains high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` before continuing.
 
 Do not hand off to execution modes until this intake is complete; if urgency forces progress, explicitly document the risk tradeoffs.
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -110,6 +110,8 @@ Before launching `omx team`, require a grounded context snapshot:
 
 Do not start worker panes until this gate is satisfied; if forced to proceed quickly, state explicit scope/risk limitations in the launch report.
 
+For simple read-only brownfield lookups during intake, follow active session guidance: when `USE_OMX_EXPLORE_CMD` is enabled, prefer `omx explore`; otherwise use the richer normal explore path and fall back normally if `omx explore` is unavailable.
+
 ## Follow-up Staffing Contract
 
 When `$team` is used as a follow-up mode from ralplan, carry forward the approved plan's explicit **available-agent-types roster** and convert it into concrete staffing guidance before launch:
@@ -357,6 +359,7 @@ Use only after checking `omx team status <team>` and mailbox/state evidence:
 
 1. Capture pane tail to confirm current worker state:
    - `tmux capture-pane -t %<worker-pane> -p -S -120`
+   - If a larger-tail read or bounded summary would help, prefer explicit opt-in inspection via `omx sparkshell --tmux-pane %<worker-pane> --tail-lines 400` before improvising extra tmux commands.
 2. If the pane is stuck in an interactive state, safely return to idle prompt first:
    - optional interrupt `C-c` or escape flow (CLI-specific) once, then re-check pane capture
 3. Send one concise trigger (single line) and wait for evidence:
@@ -449,6 +452,7 @@ When operating this skill, provide concrete progress evidence:
 
 Do not claim success without file/pane evidence.
 Do not claim clean completion if shutdown occurred with `in_progress>0`.
+Use `omx sparkshell --tmux-pane ...` as an explicit opt-in operator aid for pane inspection and summaries; keep raw `tmux capture-pane` evidence available for manual intervention and proof.
 
 ## MCP Job Lifecycle Tools
 

--- a/src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts
+++ b/src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadSurface } from './prompt-guidance-test-helpers.js';
+
+function expectPatterns(path: string, patterns: RegExp[]): void {
+  const content = loadSurface(path);
+  for (const pattern of patterns) {
+    assert.match(content, pattern, `${path} missing required pattern: ${pattern}`);
+  }
+}
+
+describe('explore + sparkshell guidance contract', () => {
+  it('keeps AGENTS root and template aligned on conditional explore routing and opt-in sparkshell guidance', () => {
+    const patterns = [
+      /USE_OMX_EXPLORE_CMD/i,
+      /prefer `omx explore`/i,
+      /gracefully fall back to the normal path/i,
+      /omx sparkshell --tmux-pane/i,
+      /explicit opt-?in/i,
+    ];
+
+    for (const surface of ['AGENTS.md', 'templates/AGENTS.md']) {
+      expectPatterns(surface, patterns);
+    }
+  });
+
+  it('keeps explore surfaces explicit about richer-path fallback', () => {
+    expectPatterns('prompts/explore.md', [
+      /USE_OMX_EXPLORE_CMD/i,
+      /preferred low-cost path/i,
+      /continue on this richer normal path/i,
+    ]);
+
+    expectPatterns('prompts/explore-harness.md', [
+      /simple read-only repository lookup tasks/i,
+      /fall back to the richer normal path/i,
+    ]);
+  });
+
+  it('keeps execution and planning surfaces conditional on explore routing', () => {
+    for (const surface of [
+      'prompts/planner.md',
+      'prompts/executor.md',
+      'prompts/sisyphus-lite.md',
+      'skills/deep-interview/SKILL.md',
+      'skills/plan/SKILL.md',
+      'skills/ralplan/SKILL.md',
+      'skills/ralph/SKILL.md',
+      'skills/team/SKILL.md',
+    ]) {
+      expectPatterns(surface, [
+        /USE_OMX_EXPLORE_CMD/i,
+        /prefer `omx explore`/i,
+        /fall back normally|fallback normally|graceful fallback|richer normal explore path/i,
+      ]);
+    }
+  });
+
+  it('keeps sparkshell guidance explicit opt-in and preserves raw qa or tmux evidence', () => {
+    expectPatterns('prompts/qa-tester.md', [
+      /optional operator aid/i,
+      /does not replace raw `tmux capture-pane` evidence/i,
+      /explicit opt-?in/i,
+    ]);
+
+    expectPatterns('skills/team/SKILL.md', [
+      /omx sparkshell --tmux-pane/i,
+      /explicit opt-?in/i,
+      /raw `tmux capture-pane` evidence/i,
+    ]);
+  });
+});

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -204,6 +204,12 @@ Verification loop: identify what proves the claim, run the verification, read th
 Broad Request Detection:
 A request is broad when it uses vague verbs without targets, names no specific file or function, touches 3+ areas, or is a single sentence without a clear deliverable. For broad work: explore first, then plan if needed.
 
+Command Routing:
+- When `USE_OMX_EXPLORE_CMD` enables advisory routing, prefer `omx explore` for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
+- Keep ambiguous, implementation-heavy, edit-heavy, or non-shell-only work on the normal Codex path.
+- If `omx explore` is unavailable or fails, gracefully fall back to the normal path.
+- For explicit tmux-pane / worker / leader / HUD inspection, prefer `omx sparkshell --tmux-pane ...` when a larger-tail read or bounded summary is useful. Sparkshell pane mode is explicit opt-in, not always-on.
+
 Parallelization:
 - Run independent tasks in parallel.
 - Run dependent tasks sequentially.


### PR DESCRIPTION
## Summary

Adapt instruction surfaces so merged `omx explore` and `omx sparkshell` behavior is reflected in default AGENTS/prompt/skill guidance without overstating runtime behavior.

## Changes

- add conditional `USE_OMX_EXPLORE_CMD` routing guidance to root/template AGENTS and scoped prompt/skill surfaces
- keep `omx explore` fallback-to-normal-path wording explicit on richer prompt/skill surfaces
- add explicit opt-in `omx sparkshell --tmux-pane ...` guidance for tmux-pane/operator inspection while preserving raw `tmux capture-pane` evidence for QA/manual proof paths
- add a focused semantic contract test for explore/sparkshell guidance

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/prompt-guidance-catalog.test.js dist/hooks/__tests__/skill-guidance-contract.test.js dist/hooks/__tests__/agents-overlay.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js`
- [x] `node --test dist/cli/__tests__/explore.test.js dist/cli/__tests__/sparkshell-cli.test.js dist/cli/__tests__/team.test.js`
- [x] `npm run lint`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Target branch: `experimental/dev`
