### PR TITLE
fix(team): make leader nudges actionable and visible

### DIFF
--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -55,8 +55,18 @@ export function resolveLeaderProgressStallThresholdMs() {
 
 function buildStatusCheckReminder(teamName, { keepPolling = false } = {}) {
   return keepPolling
-    ? `Next: omx team status ${teamName}; keep polling.`
-    : `Next: omx team status ${teamName}.`;
+    ? `Next: omx team status ${teamName}; check messages, assign next step; keep polling.`
+    : `Next: omx team status ${teamName}; check messages, assign next step.`;
+}
+
+function buildMailboxCheckReminder(teamName, { keepPolling = false } = {}) {
+  return keepPolling
+    ? `Next: omx team status ${teamName}; read mailbox messages; reply next step; keep polling.`
+    : `Next: omx team status ${teamName}; read mailbox messages; reply next step.`;
+}
+
+function buildWorkerStartEvidenceReminder(teamName, workerName) {
+  return `Next: check ${workerName} msg/output, confirm task in omx team status ${teamName}, then reassign/nudge.`;
 }
 
 function buildLeaderActionGuidance(teamName, {
@@ -72,7 +82,7 @@ function buildLeaderActionGuidance(teamName, {
 
   if (pendingFollowUpTasks) {
     return workerPanesAlive
-      ? 'Next: reuse this team with a follow-up task.'
+      ? 'Next: assign the next follow-up task to this idle team.'
       : 'Next: launch a new team for the next task set.';
   }
   if (allWorkersIdle && tasksComplete) {
@@ -594,24 +604,24 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
       nudgeReason = ACK_WITHOUT_START_EVIDENCE_REASON;
       text =
         `Team ${teamName}: ${ackWithoutStartEvidence.worker} said "${ackWithoutStartEvidence.body}" `
-        + `but has no work-start evidence yet (status: ${ackWithoutStartEvidence.statusState}, no owned in_progress task). `
-        + buildStatusCheckReminder(teamName);
+        + `but has no start evidence (status: ${ackWithoutStartEvidence.statusState}). `
+        + buildWorkerStartEvidenceReminder(teamName, ackWithoutStartEvidence.worker);
     } else if (stalledTeamNudge) {
       nudgeReason = stalledTeamReason;
       const { pending, in_progress, blocked } = progressSnapshot.taskCounts;
       const missingSignals = progressSnapshot.missingSignalWorkers > 0
-        ? `; ${progressSnapshot.missingSignalWorkers} worker signal${progressSnapshot.missingSignalWorkers === 1 ? '' : 's'} missing`
+        ? `; ${progressSnapshot.missingSignalWorkers} signal${progressSnapshot.missingSignalWorkers === 1 ? '' : 's'} missing`
         : '';
       const stallPrefix = leaderStale ? 'leader stale, ' : 'worker panes stalled, ';
       text =
-        `Team ${teamName}: ${stallPrefix}no team progress for ${formatDurationMs(stalledForMs)}. `
+        `Team ${teamName}: ${stallPrefix}no progress ${formatDurationMs(stalledForMs)}. `
         + `${leaderActionGuidance} `
-        + `(pending:${pending} in_progress:${in_progress} blocked:${blocked}${missingSignals})`;
+        + `(p:${pending} ip:${in_progress} b:${blocked}${missingSignals})`;
     } else if (stalePanesNudge && hasNewMessage) {
       nudgeReason = 'stale_leader_with_messages';
       text =
         `Team ${teamName}: leader stale, ${paneStatus.paneCount} pane(s) active, ${messages.length} msg(s) pending. `
-        + leaderActionGuidance;
+        + buildMailboxCheckReminder(teamName, { keepPolling: true });
     } else if (staleFollowupDue) {
       nudgeReason = 'stale_leader_panes_alive';
       text =
@@ -619,7 +629,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
         + leaderActionGuidance;
     } else if (hasNewMessage) {
       nudgeReason = 'new_mailbox_message';
-      text = `Team ${teamName}: ${messages.length} msg(s) for leader. ${leaderActionGuidance}`;
+      text = `Team ${teamName}: ${messages.length} msg(s) for leader. ${buildMailboxCheckReminder(teamName)}`;
     } else {
       continue;
     }

--- a/scripts/notify-hook/team-worker.js
+++ b/scripts/notify-hook/team-worker.js
@@ -386,7 +386,8 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   }
 
   const N = workers.length;
-  const message = `[OMX] All ${N} worker${N === 1 ? '' : 's'} idle. Ready for next instructions. ${DEFAULT_MARKER}`;
+  const nextAction = `Next: run omx team status ${teamName}, check unread worker messages, then assign the next concrete task or shut the team down.`;
+  const message = `[OMX] All ${N} worker${N === 1 ? '' : 's'} idle. ${nextAction} ${DEFAULT_MARKER}`;
   const tmuxTarget = leaderPaneId;
   const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
   if (!paneGuard.ok) {
@@ -591,6 +592,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
   if (prevState && prevState !== 'unknown') parts.push(`(was: ${prevState})`);
   if (currentTaskId) parts.push(`task: ${currentTaskId}`);
   if (currentReason) parts.push(`reason: ${currentReason}`);
+  parts.push(`Next: read ${workerName}'s latest message/output, then assign the next concrete step or mark the task complete.`);
   const message = `${parts.join('. ')}. ${DEFAULT_MARKER}`;
 
   try {

--- a/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
@@ -711,6 +711,7 @@ exit 0
       assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /\[OMX\] All 1 worker idle/, 'single worker uses singular form');
+      assert.match(tmuxLog, /Next: run omx team status solo-team, check unread worker messages, then assign the next concrete task or shut the team down/, 'all-workers-idle notification should include a next action');
       assert.doesNotMatch(tmuxLog, /All 1 workers idle/, 'should not use plural for single worker');
     });
   });

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -235,7 +235,7 @@ describe('notify-hook team dispatch consumer', () => {
         kind: 'mailbox',
         to_worker: 'leader-fixed',
         message_id: msg.message_id,
-        trigger_message: 'leader pane dispatch',
+        trigger_message: 'Read .omx/state/team/alpha/mailbox/leader-fixed.json; worker-1 sent a new message. Reply with the next concrete step.',
       }, cwd);
 
       const modulePath = new URL('../../../scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
@@ -245,6 +245,7 @@ describe('notify-hook team dispatch consumer', () => {
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8');
       assert.match(tmuxLog, /send-keys -t %99/);
+      assert.match(tmuxLog, /mailbox\/leader-fixed\.json; worker-1 sent a new message/);
       assert.doesNotMatch(tmuxLog, /send-keys -t .*devsess/);
     } finally {
       if (typeof prevPath === 'string') process.env.PATH = prevPath;

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -288,7 +288,7 @@ describe('notify-hook team leader nudge', () => {
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/);
-      assert.match(tmuxLog, /Next: reuse this team with a follow-up task/);
+      assert.match(tmuxLog, /Next: assign the next follow-up task to this idle team/);
       assert.doesNotMatch(tmuxLog, /launch a new team/);
       assert.doesNotMatch(tmuxLog, /omx team shutdown/);
     });
@@ -355,7 +355,7 @@ describe('notify-hook team leader nudge', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/);
       assert.match(tmuxLog, /Next: launch a new team for the next task set/);
-      assert.doesNotMatch(tmuxLog, /reuse this team with a follow-up task/);
+      assert.doesNotMatch(tmuxLog, /assign the next follow-up task to this idle team/);
     });
   });
 
@@ -524,8 +524,9 @@ describe('notify-hook team leader nudge', () => {
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /worker-1 said "on it"/);
-      assert.match(tmuxLog, /no work-start evidence yet/);
+      assert.match(tmuxLog, /no start evidence/);
       assert.match(tmuxLog, /status: unknown/);
+      assert.match(tmuxLog, /Next: check worker-1 msg\/output, confirm task in omx team status ack-missing-start/);
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
@@ -605,8 +606,9 @@ describe('notify-hook team leader nudge', () => {
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.doesNotMatch(tmuxLog, /no work-start evidence yet/);
+      assert.doesNotMatch(tmuxLog, /no start evidence/);
       assert.match(tmuxLog, /Team ack-with-start: 1 msg\(s\) for leader/);
+      assert.match(tmuxLog, /Next: omx team status ack-with-start; read mailbox messages; reply next step/);
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
@@ -793,7 +795,7 @@ exit 0
       assert.match(tmuxLog, /Team beta:/);
       assert.match(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /pane\(s\) still active/);
-      assert.match(tmuxLog, /Next: omx team status beta/);
+      assert.match(tmuxLog, /Next: omx team status beta; check messages, assign next step; keep polling/);
       assert.match(tmuxLog, /keep polling/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
     });
@@ -912,11 +914,11 @@ exit 0
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /Team stalled-progress: leader stale, no team progress for 3m/);
-      assert.match(tmuxLog, /Next: omx team status stalled-progress/);
+      assert.match(tmuxLog, /Team stalled-progress: leader stale, no progress 3m/);
+      assert.match(tmuxLog, /Next: omx team status stalled-progress; check messages, assign next step; keep polling/);
       assert.match(tmuxLog, /keep polling/);
-      assert.match(tmuxLog, /pending:1 in_progress:1 blocked:0/);
-      assert.match(tmuxLog, /1 worker signal missing/);
+      assert.match(tmuxLog, /p:1 ip:1 b:0/);
+      assert.match(tmuxLog, /1 signal missing/);
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
@@ -1039,11 +1041,11 @@ exit 0
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /Team stalled-before-stale: worker panes stalled, no team progress for 3m/);
-      assert.match(tmuxLog, /Next: omx team status stalled-before-stale/);
+      assert.match(tmuxLog, /Team stalled-before-stale: worker panes stalled, no progress 3m/);
+      assert.match(tmuxLog, /Next: omx team status stalled-before-stale; check messages, assign next step; keep polling/);
       assert.match(tmuxLog, /keep polling/);
       assert.doesNotMatch(tmuxLog, /leader stale/);
-      assert.match(tmuxLog, /pending:1 in_progress:1 blocked:0/);
+      assert.match(tmuxLog, /p:1 ip:1 b:0/);
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
@@ -1166,7 +1168,7 @@ exit 0
       assert.equal(second.status, 0, `notify-hook failed: ${second.stderr || second.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      const sends = tmuxLog.match(/send-keys -t %88 -l Team stalled-before-stale-bounded: worker panes stalled, no team progress/g) || [];
+      const sends = tmuxLog.match(/send-keys -t %88 -l Team stalled-before-stale-bounded: worker panes stalled, no progress/g) || [];
       assert.equal(sends.length, 1, 'cooldown should keep repeated stalled-team nudges bounded');
     });
   });
@@ -1610,7 +1612,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /leader stale/);
       assert.match(tmuxLog, /msg\(s\) pending/);
-      assert.match(tmuxLog, /Next: omx team status delta/);
+      assert.match(tmuxLog, /Next: omx team status delta; read mailbox messages; reply next step; keep polling/);
       assert.match(tmuxLog, /keep polling/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
 

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -707,6 +707,7 @@ exit 0
       assert.ok(existsSync(tmuxLogPath), 'tmux should have been called for unknown->idle');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /worker-1 idle/, 'should fire on unknown->idle transition');
+      assert.match(tmuxLog, /Next: read worker-1's latest message\/output, then assign the next concrete step or mark the task complete/, 'per-worker idle nudge should include a next action');
     });
   });
 
@@ -802,7 +803,9 @@ exit 0
       assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /worker-1 idle/, 'per-worker idle should fire');
+      assert.match(tmuxLog, /Next: read worker-1's latest message\/output, then assign the next concrete step or mark the task complete/, 'per-worker idle nudge should include a next action');
       assert.match(tmuxLog, /All 1 worker idle/, 'all-workers-idle should also fire');
+      assert.match(tmuxLog, /Next: run omx team status both-hooks, check unread worker messages, then assign the next concrete task or shut the team down/, 'all-workers-idle nudge should include a next action');
     });
   });
 });

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -283,7 +283,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           timeout_ms: { type: 'number', description: 'Maximum wait time in ms (default: 300000, max: 3600000)' },
           nudge_delay_ms: { type: 'number', description: 'Milliseconds a pane must be idle before nudging (default: 30000)' },
           nudge_max_count: { type: 'number', description: 'Maximum nudges per pane (default: 3)' },
-          nudge_message: { type: 'string', description: 'Message sent as nudge (default: "Continue working on your assigned task.")' },
+          nudge_message: { type: 'string', description: 'Message sent as nudge (default: "Next: read your inbox/mailbox, continue your assigned task now, and if blocked send the leader a concrete status update.")' },
           wake_on: { type: 'string', enum: ['terminal', 'event'], description: 'Wake on terminal completion (default) or the next team event.' },
           after_event_id: { type: 'string', description: 'Optional event cursor; in wake_on=event mode, wait for the next event after this id.' },
         },

--- a/src/team/__tests__/idle-nudge.test.ts
+++ b/src/team/__tests__/idle-nudge.test.ts
@@ -4,7 +4,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { NudgeTracker, capturePane, isPaneIdle } from '../idle-nudge.js';
+import { DEFAULT_NUDGE_CONFIG, NudgeTracker, capturePane, isPaneIdle } from '../idle-nudge.js';
 
 function buildFakeTmux(tmuxLogPath: string): string {
   return `#!/usr/bin/env bash
@@ -137,6 +137,15 @@ async function withMockedNow(
 }
 
 describe('idle-nudge', () => {
+  it('uses an explicit next-action default nudge message', () => {
+    assert.equal(
+      DEFAULT_NUDGE_CONFIG.message,
+      'Next: read your inbox/mailbox, continue your assigned task now, and if blocked send the leader a concrete status update.',
+    );
+    const tracker = new NudgeTracker();
+    assert.equal(tracker.totalNudges, 0);
+  });
+
   it('throttles scans that happen too soon after the previous scan', async () => {
     await withFakeTmux(async ({ tmuxLogPath }) => {
       await withMockedNow(10_000, async (setNow) => {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2385,6 +2385,62 @@ esac
     }
   });
 
+  it('sendWorkerMessage hook-preferred path injects leader mailbox read guidance when leader pane exists', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-inject-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-inject-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+    try {
+      await writeFile(
+        tmuxStubPath,
+        `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "\${1:-}" in
+  send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      );
+      await chmod(tmuxStubPath, 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+      await initTeamState('team-leader-inject', 'leader injection test', 'executor', 1, cwd);
+      const cfg = await readTeamConfig('team-leader-inject', cwd);
+      assert.ok(cfg);
+      if (!cfg) throw new Error('missing team config');
+      cfg.leader_pane_id = '%55';
+      await saveTeamConfig(cfg, cwd);
+
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-leader-inject', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+      manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 100 };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      await sendWorkerMessage('team-leader-inject', 'worker-1', 'leader-fixed', 'hello leader', cwd);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys -t %55 -l -- Read \.omx\/state\/team\/team-leader-inject\/mailbox\/leader-fixed\.json; worker-1 sent a new message\. Reply with the next concrete step\./);
+
+      const mailbox = await listMailboxMessages('team-leader-inject', 'leader-fixed', cwd);
+      assert.ok(mailbox.some((m: { notified_at?: string }) => typeof m.notified_at === 'string' && m.notified_at.length > 0));
+
+      const requests = await listDispatchRequests('team-leader-inject', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+      const latest = requests[requests.length - 1];
+      assert.equal(latest?.status, 'notified');
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
   it('sendWorkerMessage hook-preferred path for leader waits for receipt then falls back to direct notify', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-hook-'));
     try {

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -15,6 +15,7 @@ import {
   generateShutdownInbox,
   generateTriggerMessage,
   generateMailboxTriggerMessage,
+  generateLeaderMailboxTriggerMessage,
 } from '../worker-bootstrap.js';
 import type { TeamTask } from '../state.js';
 
@@ -331,7 +332,7 @@ describe('worker bootstrap', () => {
   it('generateMailboxTriggerMessage contains mailbox path and count', () => {
     const message = generateMailboxTriggerMessage('worker-2', 'team-mail', 3);
     assert.match(message, /3 new message/);
-    assert.match(message, /\.omx\/state\/team\/team-mail\/mailbox\/worker-2\.json/);
+    assert.match(message, /Read .*\.omx\/state\/team\/team-mail\/mailbox\/worker-2\.json/);
     assert.match(message, /act now/i);
     assert.match(message, /concrete progress/i);
     assert.match(message, /ACK-only/);
@@ -340,9 +341,29 @@ describe('worker bootstrap', () => {
   it('generateMailboxTriggerMessage uses provided state-root reference for worktree workers', () => {
     const message = generateMailboxTriggerMessage('worker-2', 'team-mail', 3, '$OMX_TEAM_STATE_ROOT');
     assert.match(message, /3 new msg/);
-    assert.match(message, /\$OMX_TEAM_STATE_ROOT\/team\/team-mail\/mailbox\/worker-2\.json/);
+    assert.match(message, /read .*\$OMX_TEAM_STATE_ROOT\/team\/team-mail\/mailbox\/worker-2\.json/i);
     assert.match(message, /act/i);
     assert.match(message, /report progress/i);
+    assert.ok(message.length < 200);
+  });
+
+  it('generateLeaderMailboxTriggerMessage is always < 200 characters', () => {
+    const message = generateLeaderMailboxTriggerMessage('team-with-long-name', 'worker-long-name');
+    assert.ok(message.length < 200);
+  });
+
+  it('generateLeaderMailboxTriggerMessage tells the leader to read the mailbox and reply', () => {
+    const message = generateLeaderMailboxTriggerMessage('team-mail', 'worker-2');
+    assert.match(message, /Read .*\.omx\/state\/team\/team-mail\/mailbox\/leader-fixed\.json/);
+    assert.match(message, /worker-2 sent a new message/);
+    assert.match(message, /Reply with the next concrete step/);
+  });
+
+  it('generateLeaderMailboxTriggerMessage uses provided state-root reference for worktree leaders', () => {
+    const message = generateLeaderMailboxTriggerMessage('team-mail', 'worker-2', '$OMX_TEAM_STATE_ROOT');
+    assert.match(message, /read .*\$OMX_TEAM_STATE_ROOT\/team\/team-mail\/mailbox\/leader-fixed\.json/i);
+    assert.match(message, /new msg from worker-2/i);
+    assert.match(message, /reply next step/i);
     assert.ok(message.length < 200);
   });
 

--- a/src/team/idle-nudge.ts
+++ b/src/team/idle-nudge.ts
@@ -30,7 +30,7 @@ export interface NudgeConfig {
 export const DEFAULT_NUDGE_CONFIG: NudgeConfig = {
   delayMs: 30_000,
   maxCount: 3,
-  message: 'Continue working on your assigned task.',
+  message: 'Next: read your inbox/mailbox, continue your assigned task now, and if blocked send the leader a concrete status update.',
 };
 
 // ---------------------------------------------------------------------------

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -87,6 +87,7 @@ import {
   generateShutdownInbox,
   generateTriggerMessage,
   generateMailboxTriggerMessage,
+  generateLeaderMailboxTriggerMessage,
   writeWorkerRoleInstructionsFile,
 } from './worker-bootstrap.js';
 import { loadRolePrompt } from './role-router.js';
@@ -2541,7 +2542,7 @@ export async function sendWorkerMessage(
   const manifest = await readTeamManifestV2(sanitized, cwd);
   const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
   if (toWorker === 'leader-fixed') {
-    const leaderTriggerMessage = `Team ${sanitized}: new worker message for leader from ${fromWorker}`;
+    const leaderTriggerMessage = generateLeaderMailboxTriggerMessage(sanitized, fromWorker);
     const leaderTransportPreference = dispatchPolicy.dispatch_mode === 'transport_direct'
       ? 'transport_direct'
       : 'hook_preferred_with_fallback';

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -470,7 +470,19 @@ export function generateMailboxTriggerMessage(
   const n = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
   const mailboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'mailbox', workerName + '.json');
   if (teamStateRoot !== '.omx/state') {
-    return `${n} new msg(s): check ${mailboxPath}, act and report progress.`;
+    return `${n} new msg(s): read ${mailboxPath}, act, report progress.`;
   }
-  return `You have ${n} new message(s). Check ${mailboxPath}, act now, and reply with concrete progress (not ACK-only).`;
+  return `You have ${n} new message(s). Read ${mailboxPath}, act now, and reply with concrete progress (not ACK-only).`;
+}
+
+export function generateLeaderMailboxTriggerMessage(
+  teamName: string,
+  fromWorker: string,
+  teamStateRoot: string = '.omx/state',
+): string {
+  const mailboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'mailbox', 'leader-fixed.json');
+  if (teamStateRoot !== '.omx/state') {
+    return `Read ${mailboxPath}; new msg from ${fromWorker}. Reply next step.`;
+  }
+  return `Read ${mailboxPath}; ${fromWorker} sent a new message. Reply with the next concrete step.`;
 }


### PR DESCRIPTION
## Summary
- make leader and worker nudges explicitly tell the user to read/check messages when relevant
- route new leader-directed worker messages through a dedicated leader mailbox injection prompt
- add focused regression coverage for message wording and leader-pane injection

## Testing
- npm run lint
- npm run check:no-unused
- npm run build
- node --test dist/team/__tests__/worker-bootstrap.test.js dist/team/__tests__/idle-nudge.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js
- node --test --test-name-pattern="sendWorkerMessage hook-preferred path injects leader mailbox read guidance when leader pane exists|sendWorkerMessage hook-preferred path for leader waits for receipt then falls back to direct notify|sendWorkerMessage transport_direct keeps leader-fixed request pending when leader_pane_id missing" dist/team/__tests__/runtime.test.js