### PR TITLE
fix(team): tear down hud pane on shutdown

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1895,7 +1895,7 @@ esac
     }
   });
 
-  it('shutdownTeam preserves leader and hud exclusions in teardown', async () => {
+  it('shutdownTeam preserves leader exclusion while tearing down the hud pane', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-exclusions-'));
     const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-exclusions-bin-'));
     const tmuxLogPath = join(fakeBinDir, 'tmux.log');
@@ -1942,7 +1942,7 @@ esac
       await shutdownTeam('team-shutdown-exclusions', cwd, { force: true });
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-      assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
+      assert.match(tmuxLog, /kill-pane -t %12/);
       assert.match(tmuxLog, /kill-pane -t %13/);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1756,6 +1756,9 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       leaderPaneId,
       hudPaneId,
     });
+    if (hudPaneId) {
+      await killWorkerByPaneIdAsync(hudPaneId, leaderPaneId ?? undefined);
+    }
 
     // 4. Destroy tmux session
     if (!sessionName.includes(':')) {


### PR DESCRIPTION
## Summary
- kill the team HUD pane during interactive shutdown
- prevent stale HUD panes from leaking into rapid shutdown -> relaunch cycles
- update regression coverage for leader/HUD pane teardown behavior

## Testing
- npm run build
- npm run lint
- npm run check:no-unused
- node --test --test-name-pattern="shutdownTeam preserves leader exclusion while tearing down the hud pane" dist/team/__tests__/runtime.test.js
- node --test --test-name-pattern="buildRegisterClientAttachedReconcileArgs installs one-shot client-attached reconcile hook" dist/team/__tests__/tmux-session.test.js

Closes #764