### PR TITLE
docs: refresh README positioning around Team Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[OpenClaw Integration Guide](./docs/openclaw-integration.md)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
 
-Multi-agent orchestration layer for [OpenAI Codex CLI](https://github.com/openai/codex).
+Operational runtime for [OpenAI Codex CLI](https://github.com/openai/codex).
 
 ## Featured Guides
 
@@ -34,39 +34,39 @@ Multi-agent orchestration layer for [OpenAI Codex CLI](https://github.com/openai
 - [Français (French)](./README.fr.md)
 - [Italiano (Italian)](./README.it.md)
 
-
-OMX turns Codex from a single-session agent into a coordinated system with:
-- Role prompts (`/prompts:name`) for specialized agents
-- Workflow skills (`$name`) for repeatable execution modes
-- Team orchestration (`omx team`, `$team`) with tmux interactive mode (default) or non-tmux prompt mode
-- Persistent state + memory via MCP servers
+OMX turns Codex into an operational runtime for real multi-step work:
+- **Team Mode first** — coordinated multi-agent execution with shared visibility, resume, recovery, and lifecycle control
+- **Role prompts + skills** — productized behaviors for planners, executors, reviewers, and reusable workflows
+- **Persistent runtime state** — MCP-backed state, memory, mailbox, plans, and diagnostics in `.omx/`
+- **Operator controls** — launch, inspect, verify, cancel, and resume long-running work without replacing Codex itself
 
 ## Why OMX
 
-Codex CLI is strong for direct tasks. OMX adds structure for larger work:
-- Decomposition and staged execution (`team-plan -> team-prd -> team-exec -> team-verify -> team-fix`)
-- Persistent mode lifecycle state (`.omx/state/`)
-- Memory + notepad surfaces for long-running sessions
-- Operational controls for launch, verification, and cancellation
+Codex CLI is unusually well suited to persistent orchestration: it is lightweight enough to stay alive across long sessions, tmux lanes, and repeated handoffs without burying coordination under a heavy shell stack.
 
-OMX is an add-on, not a fork. It uses Codex-native extension points.
+That matters because orchestration is not just fanout. It needs durable state, shared situational awareness, visible recovery paths, and tight operator control. Heavier shell-centric wrappers can be fine for one-shot launches, but they are a poor fit for always-on coordination where every extra layer adds latency, noise, and failure surface.
 
-## Positioning: CLI-first orchestration, MCP-backed state
+OMX keeps Codex as the execution engine and adds the runtime around it.
 
-OMX is best used as an **outer CLI orchestration layer**:
-- **Control plane (CLI/runtime):** `omx team`, tmux workers, lifecycle commands
-- **Capability/state plane (MCP):** task state, mailbox, memory, diagnostics tools
+## Runtime model
 
-Practical mode split:
-- **`$team` / `omx team`**: durable, inspectable, resumable multi-worker execution with live lanes, shared blockers, and visible handoff / rebalancing when one worker gets stuck
-- **`$ultrawork`**: lightweight parallel fanout for independent tasks (component mode)
+OMX is a small operational runtime layered around Codex:
+- **Execution plane:** Codex runs the actual agent work
+- **Control plane:** `omx` manages team workers, lifecycle commands, HUD/tmux integration, and recovery
+- **State plane:** MCP servers back state, mailbox, memory, diagnostics, and project context
 
-Why team mode exists even when ultrawork already exists:
-- Use **ultrawork** when tasks are mostly independent and the leader can merge results afterward.
-- Use **team mode** when the work benefits from shared situational awareness: workers can discover blockers early, hand work across lanes, and keep execution visible through tmux panes plus durable state.
-- Team mode is the better fit for orchestration-heavy or edge-case-heavy work where runtime control, recovery, and inspectability matter as much as raw fanout.
+This keeps the stack simple: Codex stays in the loop, while OMX makes the work inspectable, resumable, and repeatable.
 
-Low-token team profile example:
+## Team Mode vs. Ultrawork
+
+If you are deciding between the two, start with **Team Mode**.
+
+- **`$team` / `omx team`** — default for substantial work. Use it when tasks share context, blockers matter, handoffs are likely, or you want durable runtime control.
+- **`$ultrawork`** — use it for lightweight parallel fanout when subtasks are mostly independent and the leader can merge results afterward.
+
+In short: **Ultrawork is parallelism. Team Mode is orchestration.**
+
+Low-token Team Mode profile example:
 
 ```bash
 OMX_TEAM_WORKER_CLI=codex \
@@ -98,9 +98,10 @@ OMX features like `omx team` require **tmux**:
 ## Quickstart (3 minutes)
 
 ```bash
-npm install -g oh-my-codex
+npm install -g @openai/codex oh-my-codex
 omx setup
-omx doctor
+omx doctor --team
+omx team 3:executor "ship the scoped task with verification"
 ```
 
 Recommended trusted-environment launch profile:
@@ -121,10 +122,10 @@ omx --xhigh --madmax
 Inside Codex:
 
 ```text
-/prompts:architect "analyze current auth boundaries"
-/prompts:executor "implement input validation in login"
 $plan "ship OAuth callback safely"
-$team 3:executor "fix all TypeScript errors"
+$team 3:executor "implement safely with shared verification"
+/prompts:architect "review the boundary decisions"
+/prompts:executor "take the next scoped task"
 ```
 
 From terminal:
@@ -132,6 +133,7 @@ From terminal:
 ```bash
 omx team 4:executor "parallelize a multi-module refactor"
 omx team status <team-name>
+omx team resume <team-name>
 omx team shutdown <team-name>
 ```
 
@@ -140,8 +142,9 @@ omx team shutdown <team-name>
 OMX installs and wires these layers:
 
 ```text
-User
-  -> Codex CLI
+User / Operator
+  -> OMX runtime
+    -> Codex CLI (execution engine)
     -> AGENTS.md (orchestration brain)
     -> ~/.codex/prompts/*.md (installable active/internal agent prompt catalog)
     -> ~/.agents/skills/*/SKILL.md (skill catalog)
@@ -200,14 +203,14 @@ This experiment currently changes native prompt generation and metadata, not the
 ## Main Commands
 
 ```bash
-omx                # Launch Codex (+ HUD in tmux when available)
+omx                # Launch Codex inside the OMX runtime (+ HUD in tmux when available)
+omx team ...       # Start/status/resume/shutdown coordinated team workers (default orchestration surface)
 omx setup          # Install prompts/skills/config by scope + project .omx (AGENTS.md only for project scope)
 omx agents-init .  # Bootstrap lightweight AGENTS.md files for a repo/subtree
 omx doctor         # Installation/runtime diagnostics
-omx doctor --team  # Team/swarm diagnostics
+omx doctor --team  # Team Mode diagnostics
 omx ask ...        # Ask local provider advisor (claude|gemini), writes .omx/artifacts/*
 omx resume         # Resume a previous interactive Codex session
-omx team ...       # Start/status/resume/shutdown team workers (interactive tmux by default)
 omx ralph          # Launch Codex with ralph persistence mode active
 omx status         # Show active modes
 omx cancel         # Cancel active execution modes


### PR DESCRIPTION
## Summary
- reposition README copy to describe OMX as an operational runtime for Codex
- prioritize Team Mode in the intro, value framing, quickstart, and command overview
- clarify when to use Team Mode vs. Ultrawork and why Codex is a better fit for persistent orchestration than heavier shell stacks

## Validation
- npm run lint
- npm run build
- npm run check:no-unused
- npm test