### PR TITLE
fix(team): restore HUD rehydrate hooks on rerun

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -5,6 +5,7 @@ import { mkdtemp, rm, writeFile, readFile, mkdir, chmod } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
+import { HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import {
   initTeamState,
   createTask,
@@ -893,6 +894,147 @@ process.on('SIGTERM', () => process.exit(0));
       if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam relaunch re-creates HUD pane and re-registers reconcile hooks after shutdown', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-relaunch-hud-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-relaunch-hud-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const geminiStubPath = join(fakeBinDir, 'gemini');
+    const previousPath = process.env.PATH;
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    let runtime: TeamRuntime | null = null;
+    try {
+      await writeFile(
+        tmuxStubPath,
+        `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"* )
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "1 999999"
+        ;;
+      *"#{pane_pid}"*)
+        echo "999999"
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      );
+      await chmod(tmuxStubPath, 0o755);
+      await writeFile(
+        geminiStubPath,
+        `#!/bin/sh
+exit 0
+`,
+      );
+      await chmod(geminiStubPath, 0o755);
+
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+      process.env.TMUX = 'leader-session,stub,0';
+      process.env.TMUX_PANE = '%1';
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+      process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'team-rerun-hud',
+          'rerun hud restore',
+          'explore',
+          1,
+          [{ subject: 'restore hud', description: 'restore hud', owner: 'worker-1' }],
+          cwd,
+        ));
+      assert.equal(runtime.config.hud_pane_id, '%3');
+      assert.ok(runtime.config.resize_hook_name);
+
+      await shutdownTeam(runtime.teamName, cwd, { force: true });
+      runtime = null;
+
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'team-rerun-hud',
+          'rerun hud restore',
+          'explore',
+          1,
+          [{ subject: 'restore hud again', description: 'restore hud again', owner: 'worker-1' }],
+          cwd,
+        ));
+      assert.equal(runtime.config.hud_pane_id, '%3');
+      assert.ok(runtime.config.resize_hook_name);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      const hudSplitRe = new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
+      assert.equal(tmuxLog.match(hudSplitRe)?.length ?? 0, 2);
+      assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
+      assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
+      assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
+      assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
+      assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
+      assert.match(tmuxLog, /kill-pane -t %3/);
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -750,6 +750,7 @@ export function createTeamSession(
 
   const safeTeamName = sanitizeTeamName(teamName);
   let registeredResizeHook: { name: string; target: string } | null = null;
+  let registeredClientAttachedHook: { name: string; target: string } | null = null;
   const rollbackPaneIds: string[] = [];
   try {
     const tmuxPaneTarget = process.env.TMUX_PANE;
@@ -862,6 +863,22 @@ export function createTeamSession(
           }
           registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
 
+          const clientAttachedHookName = buildClientAttachedReconcileHookName(
+            safeTeamName,
+            sessionName,
+            windowIndex,
+            hudPaneId,
+          );
+          const registerClientAttachedHook = runTmux(
+            buildRegisterClientAttachedReconcileArgs(resizeHookTarget, clientAttachedHookName, hudPaneId),
+          );
+          if (!registerClientAttachedHook.ok) {
+            throw new Error(
+              `failed to register client-attached reconcile hook ${clientAttachedHookName}: ${registerClientAttachedHook.stderr}`,
+            );
+          }
+          registeredClientAttachedHook = { name: clientAttachedHookName, target: resizeHookTarget };
+
           const delayed = runTmux(buildScheduleDelayedHudResizeArgs(hudPaneId));
           if (!delayed.ok) {
             throw new Error(`failed to schedule delayed HUD resize: ${delayed.stderr}`);
@@ -896,6 +913,14 @@ export function createTeamSession(
       resizeHookTarget,
     };
   } catch (error) {
+    if (registeredClientAttachedHook) {
+      runTmux(
+        buildUnregisterClientAttachedReconcileArgs(
+          registeredClientAttachedHook.target,
+          registeredClientAttachedHook.name,
+        ),
+      );
+    }
     if (registeredResizeHook) {
       runTmux(buildUnregisterResizeHookArgs(registeredResizeHook.target, registeredResizeHook.name));
     }


### PR DESCRIPTION
## Summary
- re-register the team HUD client-attached reconcile hook when recreating the HUD pane during team startup
- keep rollback symmetric by unregistering the one-shot reconcile hook if team startup fails
- add a narrow regression covering shutdown -> immediate relaunch restoring HUD pane creation, layout placement, and resize reconcile registration

## Verification
- npm run build
- node --test dist/team/__tests__/runtime.test.js --test-name-pattern="relaunch re-creates HUD pane and re-registers reconcile hooks after shutdown"
- npx biome lint src/team/tmux-session.ts src/team/__tests__/runtime.test.ts

## Hotfix note
This is a release-blocker hotfix for the rerun path after #764: shutdown already tears down stale HUD panes, and this restores the missing relaunch-side HUD recreate/re-register path.