### PR TITLE
feat(setup): sync shared MCP registry into Codex config (issue #769 first slice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Notes:
   - `model_context_window = 1000000` and `model_auto_compact_token_limit = 900000` only when the effective root model is `gpt-5.4` and both context keys are absent
   - `[features] multi_agent = true, child_agents_md = true`
   - MCP server entries (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
+  - If a shared MCP registry exists at `~/.omx/mcp-registry.json` (fallback: `~/.omc/mcp-registry.json`), setup syncs those entries into a dedicated managed block in `config.toml` (skipping names already defined elsewhere to avoid duplicate TOML tables)
   - `[tui] status_line`
 - Project `AGENTS.md` (project scope only)
 - `.omx/` runtime directories and HUD config

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -203,4 +203,31 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("syncs shared MCP registry entries into config.toml during setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      const registryPath = join(wd, "mcp-registry.json");
+      await writeFile(
+        registryPath,
+        JSON.stringify({
+          eslint: { command: "npx", args: ["@eslint/mcp@latest"], timeout: 9 },
+        }),
+      );
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        mcpRegistryCandidates: [registryPath],
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(config, /oh-my-codex \(OMX\) Shared MCP Registry Sync/);
+      assert.match(config, /^\[mcp_servers\.eslint\]$/m);
+      assert.match(config, /^command = "npx"$/m);
+      assert.match(config, /^startup_timeout_sec = 9$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -28,6 +28,7 @@ import {
   omxAgentsConfigDir,
 } from "../utils/paths.js";
 import { buildMergedConfig, getRootModelName } from "../config/generator.js";
+import { loadUnifiedMcpRegistry } from "../config/mcp-registry.js";
 import { generateAgentToml } from "../agents/native-config.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { getPackageRoot } from "../utils/package.js";
@@ -45,6 +46,7 @@ interface SetupOptions {
     currentModel: string,
     targetModel: string,
   ) => Promise<boolean>;
+  mcpRegistryCandidates?: string[];
 }
 
 /**
@@ -472,7 +474,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     scopeDirs.nativeAgentsDir,
     summary.config,
     backupContext,
-    { dryRun, verbose, modelUpgradePrompt },
+    { dryRun, verbose, modelUpgradePrompt, mcpRegistryCandidates: options.mcpRegistryCandidates },
   );
   console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
 
@@ -959,7 +961,7 @@ async function updateManagedConfig(
   agentsConfigDir: string,
   summary: SetupCategorySummary,
   backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt">,
+  options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt" | "mcpRegistryCandidates">,
 ): Promise<void> {
   const existing = existsSync(configPath)
     ? await readFile(configPath, "utf-8")
@@ -981,9 +983,23 @@ async function updateManagedConfig(
     }
   }
 
+  const sharedMcpRegistry = await loadUnifiedMcpRegistry({
+    candidates: options.mcpRegistryCandidates,
+  });
+  if (options.verbose && sharedMcpRegistry.sourcePath) {
+    console.log(
+      `  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
+    );
+    for (const warning of sharedMcpRegistry.warnings) {
+      console.log(`  warning: ${warning}`);
+    }
+  }
+
   const finalConfig = buildMergedConfig(existing, pkgRoot, {
     agentsConfigDir,
     modelOverride,
+    sharedMcpServers: sharedMcpRegistry.servers,
+    sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
     verbose: options.verbose,
   });
   const changed = existing !== finalConfig;

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -471,4 +471,78 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
+  it("syncs shared MCP registry entries in a dedicated managed block", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const first = buildMergedConfig("", wd, {
+        sharedMcpServers: [
+          {
+            name: "eslint",
+            command: "npx",
+            args: ["@eslint/mcp@latest"],
+            enabled: true,
+            startupTimeoutSec: 12,
+          },
+        ],
+        sharedMcpRegistrySource: "/tmp/.omx/mcp-registry.json",
+      });
+      const second = buildMergedConfig(first, wd, {
+        sharedMcpServers: [
+          {
+            name: "eslint",
+            command: "npx",
+            args: ["@eslint/mcp@latest"],
+            enabled: true,
+            startupTimeoutSec: 12,
+          },
+        ],
+        sharedMcpRegistrySource: "/tmp/.omx/mcp-registry.json",
+      });
+
+      assert.equal(
+        count(second, /oh-my-codex \(OMX\) Shared MCP Registry Sync/g),
+        1,
+        "shared MCP sync block should appear once",
+      );
+      assert.equal(
+        count(second, /^\[mcp_servers\.eslint\]$/gm),
+        1,
+        "shared eslint MCP table should appear once",
+      );
+      assert.match(second, /# Source: \/tmp\/\.omx\/mcp-registry\.json/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips shared MCP entries that already exist in user config", () => {
+    const existing = [
+      "[mcp_servers.gitnexus]",
+      'command = "custom"',
+      'args = ["serve"]',
+      "",
+    ].join("\n");
+    const merged = buildMergedConfig(existing, "/tmp/omx", {
+      sharedMcpServers: [
+        {
+          name: "gitnexus",
+          command: "gitnexus",
+          args: ["mcp"],
+          enabled: true,
+        },
+        {
+          name: "eslint",
+          command: "npx",
+          args: ["@eslint/mcp@latest"],
+          enabled: true,
+        },
+      ],
+      sharedMcpRegistrySource: "/tmp/.omx/mcp-registry.json",
+    });
+
+    assert.equal(count(merged, /^\[mcp_servers\.gitnexus\]$/gm), 1);
+    assert.match(merged, /command = "custom"/);
+    assert.equal(count(merged, /^\[mcp_servers\.eslint\]$/gm), 1);
+  });
+
 });

--- a/src/config/__tests__/mcp-registry.test.ts
+++ b/src/config/__tests__/mcp-registry.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  getUnifiedMcpRegistryCandidates,
+  loadUnifiedMcpRegistry,
+} from "../mcp-registry.js";
+
+describe("unified MCP registry loader", () => {
+  it("prefers ~/.omx/mcp-registry.json over ~/.omc/mcp-registry.json", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-mcp-registry-"));
+    try {
+      const omxPath = join(wd, ".omx", "mcp-registry.json");
+      const omcPath = join(wd, ".omc", "mcp-registry.json");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await mkdir(join(wd, ".omc"), { recursive: true });
+
+      await writeFile(
+        omxPath,
+        JSON.stringify({
+          eslint: { command: "npx", args: ["@eslint/mcp@latest"], timeout: 11 },
+        }),
+      );
+      await writeFile(
+        omcPath,
+        JSON.stringify({
+          gitnexus: { command: "gitnexus", args: ["mcp"] },
+        }),
+      );
+
+      const result = await loadUnifiedMcpRegistry({ homeDir: wd });
+      assert.equal(result.sourcePath, omxPath);
+      assert.deepEqual(result.servers.map((server) => server.name), ["eslint"]);
+      assert.equal(result.servers[0].startupTimeoutSec, 11);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to ~/.omc/mcp-registry.json when ~/.omx registry is absent", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-mcp-registry-"));
+    try {
+      const omcPath = join(wd, ".omc", "mcp-registry.json");
+      await mkdir(join(wd, ".omc"), { recursive: true });
+      await writeFile(
+        omcPath,
+        JSON.stringify({
+          gitnexus: { command: "gitnexus", args: ["mcp"], enabled: false },
+        }),
+      );
+
+      const result = await loadUnifiedMcpRegistry({ homeDir: wd });
+      assert.equal(result.sourcePath, omcPath);
+      assert.equal(result.servers.length, 1);
+      assert.equal(result.servers[0].name, "gitnexus");
+      assert.equal(result.servers[0].enabled, false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips invalid entries but keeps valid entries from the same file", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-mcp-registry-"));
+    try {
+      const registryPath = join(wd, "registry.json");
+      await writeFile(
+        registryPath,
+        JSON.stringify({
+          bad_type: "not-an-object",
+          bad_args: { command: "npx", args: [1, 2, 3] },
+          good: { command: "npx", args: ["@eslint/mcp@latest"], timeout: 7 },
+        }),
+      );
+
+      const result = await loadUnifiedMcpRegistry({
+        candidates: [registryPath],
+      });
+      assert.equal(result.servers.length, 1);
+      assert.equal(result.servers[0].name, "good");
+      assert.equal(result.servers[0].startupTimeoutSec, 7);
+      assert.equal(result.warnings.length >= 2, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns canonical home-based registry candidates", () => {
+    const candidates = getUnifiedMcpRegistryCandidates("/tmp/home");
+    assert.deepEqual(candidates, [
+      "/tmp/home/.omx/mcp-registry.json",
+      "/tmp/home/.omc/mcp-registry.json",
+    ]);
+  });
+});

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -16,10 +16,13 @@ import { join } from "path";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { tryReadCatalogManifest } from "../catalog/reader.js";
 import { omxAgentsConfigDir } from "../utils/paths.js";
+import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 
 interface MergeOptions {
   agentsConfigDir?: string;
   modelOverride?: string;
+  sharedMcpServers?: UnifiedMcpRegistryServer[];
+  sharedMcpRegistrySource?: string;
   verbose?: boolean;
 }
 
@@ -41,6 +44,9 @@ const OMX_TOP_LEVEL_KEYS = [
 const DEFAULT_SETUP_MODEL = "gpt-5.4";
 const DEFAULT_SETUP_MODEL_CONTEXT_WINDOW = 1000000;
 const DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT = 900000;
+const SHARED_MCP_REGISTRY_MARKER = "oh-my-codex (OMX) Shared MCP Registry Sync";
+const SHARED_MCP_REGISTRY_END_MARKER =
+  "# End oh-my-codex shared MCP registry sync";
 
 function unwrapTomlString(value: string | undefined): string | undefined {
   return value?.match(/^"(.*)"$/)?.[1];
@@ -379,6 +385,100 @@ export function stripExistingOmxBlocks(config: string): {
   return { cleaned, removed };
 }
 
+export function stripExistingSharedMcpRegistryBlock(config: string): {
+  cleaned: string;
+  removed: number;
+} {
+  let cleaned = config;
+  let removed = 0;
+
+  while (true) {
+    const markerIdx = cleaned.indexOf(SHARED_MCP_REGISTRY_MARKER);
+    if (markerIdx < 0) break;
+
+    let blockStart = cleaned.lastIndexOf("\n", markerIdx);
+    blockStart = blockStart >= 0 ? blockStart + 1 : 0;
+
+    const previousLineEnd = blockStart - 1;
+    if (previousLineEnd >= 0) {
+      const previousLineStart = cleaned.lastIndexOf("\n", previousLineEnd - 1);
+      const previousLine = cleaned.slice(
+        previousLineStart + 1,
+        previousLineEnd,
+      );
+      if (/^# =+$/.test(previousLine.trim())) {
+        blockStart = previousLineStart >= 0 ? previousLineStart + 1 : 0;
+      }
+    }
+
+    let blockEnd = cleaned.length;
+    const endIdx = cleaned.indexOf(SHARED_MCP_REGISTRY_END_MARKER, markerIdx);
+    if (endIdx >= 0) {
+      const endLineBreak = cleaned.indexOf("\n", endIdx);
+      blockEnd = endLineBreak >= 0 ? endLineBreak + 1 : cleaned.length;
+    }
+
+    const before = cleaned.slice(0, blockStart).trimEnd();
+    const after = cleaned.slice(blockEnd).trimStart();
+    cleaned = [before, after].filter(Boolean).join("\n\n");
+    removed += 1;
+  }
+
+  return { cleaned, removed };
+}
+
+function toMcpServerTableKey(name: string): string {
+  if (/^[A-Za-z0-9_-]+$/.test(name)) {
+    return `mcp_servers.${name}`;
+  }
+  return `mcp_servers."${escapeTomlString(name)}"`;
+}
+
+function configHasMcpServer(config: string, name: string): boolean {
+  const tableName = toMcpServerTableKey(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^\\s*\\[${tableName}\\]\\s*$`, "m").test(config);
+}
+
+function getSharedMcpRegistryBlock(
+  servers: UnifiedMcpRegistryServer[],
+  sourcePath: string | undefined,
+  existingConfig: string,
+): string {
+  if (servers.length === 0) return "";
+  const deduped = servers.filter((server) => !configHasMcpServer(existingConfig, server.name));
+  if (deduped.length === 0) return "";
+
+  const lines = [
+    "# ============================================================",
+    `# ${SHARED_MCP_REGISTRY_MARKER}`,
+    "# Managed by omx setup - edit the registry file instead",
+  ];
+  if (sourcePath) {
+    lines.push(`# Source: ${sourcePath}`);
+  }
+  lines.push("# ============================================================", "");
+
+  for (const server of deduped) {
+    lines.push(`# Shared MCP Server: ${server.name}`);
+    lines.push(`[${toMcpServerTableKey(server.name)}]`);
+    lines.push(`command = "${escapeTomlString(server.command)}"`);
+    lines.push(
+      `args = [${server.args
+        .map((arg) => `"${escapeTomlString(arg)}"`)
+        .join(", ")}]`,
+    );
+    lines.push(`enabled = ${server.enabled ? "true" : "false"}`);
+    if (typeof server.startupTimeoutSec === "number") {
+      lines.push(`startup_timeout_sec = ${server.startupTimeoutSec}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("# ============================================================");
+  lines.push(SHARED_MCP_REGISTRY_END_MARKER);
+  return lines.join("\n");
+}
+
 /**
  * Generate [agents.<name>] entries for Codex native multi-agent support.
  * Each agent gets a description and config_file pointing to ~/.omx/agents/<name>.toml
@@ -518,6 +618,10 @@ export function buildMergedConfig(
     const stripped = stripExistingOmxBlocks(existing);
     existing = stripped.cleaned;
   }
+  if (existing.includes(SHARED_MCP_REGISTRY_MARKER)) {
+    const stripped = stripExistingSharedMcpRegistryBlock(existing);
+    existing = stripped.cleaned;
+  }
 
   existing = stripOmxTopLevelKeys(existing);
   if (options.modelOverride) {
@@ -535,8 +639,18 @@ export function buildMergedConfig(
     pkgRoot,
     options.agentsConfigDir || omxAgentsConfigDir(),
   );
+  const sharedRegistryBlock = getSharedMcpRegistryBlock(
+    options.sharedMcpServers ?? [],
+    options.sharedMcpRegistrySource,
+    existing,
+  );
 
-  return topLines.join("\n") + "\n\n" + existing.trimEnd() + "\n" + tablesBlock;
+  let body = existing.trimEnd();
+  if (sharedRegistryBlock) {
+    body = body ? `${body}\n\n${sharedRegistryBlock}` : sharedRegistryBlock;
+  }
+
+  return topLines.join("\n") + "\n\n" + body + "\n" + tablesBlock;
 }
 
 export async function mergeConfig(

--- a/src/config/mcp-registry.ts
+++ b/src/config/mcp-registry.ts
@@ -1,0 +1,124 @@
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+
+export interface UnifiedMcpRegistryServer {
+  name: string;
+  command: string;
+  args: string[];
+  enabled: boolean;
+  startupTimeoutSec?: number;
+}
+
+export interface UnifiedMcpRegistryLoadResult {
+  servers: UnifiedMcpRegistryServer[];
+  sourcePath?: string;
+  warnings: string[];
+}
+
+interface LoadUnifiedMcpRegistryOptions {
+  candidates?: string[];
+  homeDir?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeTimeout(
+  value: unknown,
+  name: string,
+  warnings: string[],
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    warnings.push(`registry entry "${name}" has invalid timeout; ignoring timeout`);
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function normalizeEntry(
+  name: string,
+  value: unknown,
+  warnings: string[],
+): UnifiedMcpRegistryServer | null {
+  if (!isRecord(value)) {
+    warnings.push(`registry entry "${name}" is not an object; skipping`);
+    return null;
+  }
+
+  const command = value.command;
+  if (typeof command !== "string" || command.trim().length === 0) {
+    warnings.push(`registry entry "${name}" is missing command; skipping`);
+    return null;
+  }
+
+  const argsValue = value.args;
+  if (
+    argsValue !== undefined &&
+    (!Array.isArray(argsValue) || argsValue.some((item) => typeof item !== "string"))
+  ) {
+    warnings.push(`registry entry "${name}" has non-string args; skipping`);
+    return null;
+  }
+
+  const enabledValue = value.enabled;
+  if (enabledValue !== undefined && typeof enabledValue !== "boolean") {
+    warnings.push(`registry entry "${name}" has non-boolean enabled; skipping`);
+    return null;
+  }
+
+  const timeoutCandidate =
+    value.timeout ?? value.startup_timeout_sec ?? value.startupTimeoutSec;
+
+  return {
+    name,
+    command,
+    args: (argsValue as string[] | undefined) ?? [],
+    enabled: enabledValue ?? true,
+    startupTimeoutSec: normalizeTimeout(timeoutCandidate, name, warnings),
+  };
+}
+
+export function getUnifiedMcpRegistryCandidates(homeDir = homedir()): string[] {
+  return [
+    join(homeDir, ".omx", "mcp-registry.json"),
+    join(homeDir, ".omc", "mcp-registry.json"),
+  ];
+}
+
+export async function loadUnifiedMcpRegistry(
+  options: LoadUnifiedMcpRegistryOptions = {},
+): Promise<UnifiedMcpRegistryLoadResult> {
+  const candidates =
+    options.candidates ?? getUnifiedMcpRegistryCandidates(options.homeDir);
+  const sourcePath = candidates.find((candidate) => existsSync(candidate));
+  if (!sourcePath) {
+    return { servers: [], warnings: [] };
+  }
+
+  const warnings: string[] = [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(sourcePath, "utf-8"));
+  } catch (error) {
+    warnings.push(`failed to parse shared MCP registry at ${sourcePath}: ${String(error)}`);
+    return { servers: [], sourcePath, warnings };
+  }
+
+  if (!isRecord(parsed)) {
+    warnings.push(`shared MCP registry at ${sourcePath} must be a JSON object`);
+    return { servers: [], sourcePath, warnings };
+  }
+
+  const servers: UnifiedMcpRegistryServer[] = [];
+  for (const [name, value] of Object.entries(parsed)) {
+    const normalized = normalizeEntry(name, value, warnings);
+    if (!normalized) continue;
+    servers.push(normalized);
+  }
+
+  return { servers, sourcePath, warnings };
+}


### PR DESCRIPTION
## Summary
- add a unified MCP registry loader that reads `~/.omx/mcp-registry.json` with fallback to `~/.omc/mcp-registry.json`
- wire `omx setup` config refresh to consume that registry and sync entries into a dedicated managed block in `config.toml`
- keep sync idempotent by replacing the managed sync block on rerun and skipping registry entries that already exist in user-defined `mcp_servers` tables
- add focused tests for loader behavior, config idempotency/duplication guards, and setup integration
- document the new setup behavior in README

## Scope note
This PR is the smallest OMX-first slice for #769: it implements shared-registry -> Codex config sync only, with no cross-repo OMC write path in this change.

## Verification
- `npm run lint`
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/config/__tests__/mcp-registry.test.js dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-refresh.test.js`
- `npm test`
