### PR TITLE
fix(notify-hook): extend case-agnostic stall phrase detection

### DIFF
--- a/scripts/notify-hook/auto-nudge.js
+++ b/scripts/notify-hook/auto-nudge.js
@@ -193,6 +193,8 @@ export const DEFAULT_STALL_PATTERNS = [
   'next step',
   'next steps',
   'ready to proceed',
+  'i\'m ready to',
+  'keep going',
   'should i',
   'whenever you',
   'say go',
@@ -207,6 +209,16 @@ export const DEFAULT_STALL_PATTERNS = [
   'proceed from here',
   'i\'ll continue from',
 ];
+
+function normalizeStallDetectionText(text) {
+  return safeString(text)
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .filter((line) => !line.includes(DEFAULT_MARKER))
+    .join('\n')
+    .toLowerCase()
+    .replace(/[’‘`]/g, '\'');
+}
 
 export function normalizeAutoNudgeConfig(raw) {
   if (!raw || typeof raw !== 'object') {
@@ -245,12 +257,14 @@ export async function loadAutoNudgeConfig() {
 
 export function detectStallPattern(text, patterns) {
   if (!text || typeof text !== 'string') return false;
-  const tail = text.slice(-800).toLowerCase();
-  const lowerPatterns = patterns.map(p => p.toLowerCase());
-  const lines = tail.split('\n').filter(l => l.trim());
+  const normalized = normalizeStallDetectionText(text);
+  if (!normalized) return false;
+  const tail = normalized.slice(-800);
+  const normalizedPatterns = patterns.map((pattern) => normalizeStallDetectionText(pattern)).filter(Boolean);
+  const lines = tail.split('\n').filter((line) => line.trim());
   const hotZone = lines.slice(-3).join('\n');
-  if (lowerPatterns.some(p => hotZone.includes(p))) return true;
-  return lowerPatterns.some(p => tail.includes(p));
+  if (normalizedPatterns.some((pattern) => hotZone.includes(pattern))) return true;
+  return normalizedPatterns.some((pattern) => tail.includes(pattern));
 }
 
 export async function capturePane(paneId, lines = 10) {

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -207,6 +207,8 @@ describe('notify-hook/auto-nudge – detectStallPattern', () => {
     assert.equal(detectStallPattern('If you want, I can refactor.', DEFAULT_STALL_PATTERNS), true);
     assert.equal(detectStallPattern('Let me know if you need more help.', DEFAULT_STALL_PATTERNS), true);
     assert.equal(detectStallPattern('Ready to proceed whenever you are.', DEFAULT_STALL_PATTERNS), true);
+    assert.equal(detectStallPattern('I’M READY TO take the next step.', DEFAULT_STALL_PATTERNS), true);
+    assert.equal(detectStallPattern('KEEP GOING and I will finish the patch.', DEFAULT_STALL_PATTERNS), true);
   });
 
   it('detects team-worker follow-up phrases like continue with and next step', async () => {
@@ -229,6 +231,12 @@ describe('notify-hook/auto-nudge – detectStallPattern', () => {
     const custom = ['awaiting approval'];
     assert.equal(detectStallPattern('Changes staged. Awaiting approval.', custom), true);
     assert.equal(detectStallPattern('Would you like me to proceed?', custom), false);
+  });
+
+  it('ignores prior OMX injection lines so injected text cannot self-trigger detection', async () => {
+    const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
+    const text = 'Completed the change.\nyes, proceed [OMX_TMUX_INJECT]\nkeep going [OMX_TMUX_INJECT]';
+    assert.equal(detectStallPattern(text, DEFAULT_STALL_PATTERNS), false);
   });
 
   it('focuses detection on the last few lines (hotZone)', async () => {

--- a/src/hooks/__tests__/notify-hook-regression-205.test.ts
+++ b/src/hooks/__tests__/notify-hook-regression-205.test.ts
@@ -35,6 +35,8 @@ describe('regression-205: DEFAULT_STALL_PATTERNS contains "if you want"', () => 
       DEFAULT_STALL_PATTERNS.includes('if you want'),
       `Expected DEFAULT_STALL_PATTERNS to contain "if you want", got: ${JSON.stringify(DEFAULT_STALL_PATTERNS)}`,
     );
+    assert.ok(DEFAULT_STALL_PATTERNS.includes('i\'m ready to'));
+    assert.ok(DEFAULT_STALL_PATTERNS.includes('keep going'));
   });
 });
 
@@ -55,6 +57,14 @@ describe('regression-205: detectStallPattern matches "if you want"', () => {
     assert.equal(
       detectStallPattern('IF YOU WANT I can do more.', DEFAULT_STALL_PATTERNS),
       true,
+    );
+  });
+
+  it('ignores OMX injection-marker lines when matching patterns', async () => {
+    const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
+    assert.equal(
+      detectStallPattern('keep going [OMX_TMUX_INJECT]', DEFAULT_STALL_PATTERNS),
+      false,
     );
   });
 


### PR DESCRIPTION
## Summary
- extend auto-nudge stall detection with owner-approved phrases: `I'm ready to` and `keep going`
- keep matching case-agnostic, including curly-apostrophe variants
- ignore prior `[OMX_TMUX_INJECT]` lines during detection so injected text cannot self-trigger loops

## Testing
- `npm run lint`
- `npm run build`
- `node --test --test-name-pattern "notify-hook/auto-nudge – detectStallPattern|regression-205" dist/hooks/__tests__/notify-hook-modules.test.js dist/hooks/__tests__/notify-hook-regression-205.test.js`
- `node --test --test-name-pattern "notify-hook auto-nudge" dist/hooks/__tests__/notify-hook-auto-nudge.test.js`