### PR TITLE
fix(team): resolve POSIX worker startup paths

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -60,6 +60,10 @@ function withEmptyPath<T>(fn: () => T): T {
   }
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 describe('sanitizeTeamName', () => {
   it('lowercases and strips invalid chars', () => {
     assert.equal(sanitizeTeamName('My Team!'), 'my-team');
@@ -602,6 +606,48 @@ describe('buildWorkerStartupCommand', () => {
       else delete process.env.SHELL;
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('resolves POSIX leader paths before building fish worker startup commands', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-worker-startup-posix-'));
+    const prevPath = process.env.PATH;
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.PATH = fakeBin;
+    process.env.SHELL = '/bin/fish';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const nodePath = join(fakeBin, 'node');
+      const codexPath = join(fakeBin, 'codex');
+      await writeFile(nodePath, '#!/bin/sh\n');
+      await writeFile(codexPath, '#!/bin/sh\n');
+      await chmod(nodePath, 0o755);
+      await chmod(codexPath, 0o755);
+
+      const { buildWorkerStartupCommand: buildFreshWorkerStartupCommand } = await import(`../tmux-session.js?posix-path=${Date.now()}`);
+      const cmd = buildFreshWorkerStartupCommand(
+        'alpha',
+        1,
+        ['-c', 'model_reasoning_effort="low"'],
+        process.cwd(),
+        {},
+        'codex',
+      );
+
+      assert.match(cmd, new RegExp(escapeRegExp(`OMX_LEADER_NODE_PATH=${nodePath}`)));
+      assert.match(cmd, new RegExp(escapeRegExp(`OMX_LEADER_CLI_PATH=${codexPath}`)));
+      assert.match(cmd, new RegExp(escapeRegExp(`export PATH='\\''${fakeBin}'\\'':$PATH; exec ${codexPath}`)));
+      assert.doesNotMatch(cmd, /export PATH='\\''node'\\'':\$PATH/);
+      assert.doesNotMatch(cmd, / exec codex(?:\s|')/);
+    } finally {
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      await rm(fakeBin, { recursive: true, force: true });
     }
   });
 

--- a/src/utils/__tests__/platform-command.test.ts
+++ b/src/utils/__tests__/platform-command.test.ts
@@ -107,6 +107,35 @@ describe('resolveCommandPathForPlatform', () => {
       await rm(fakeBin, { recursive: true, force: true });
     }
   });
+
+  it('resolves PATH entries to absolute paths on POSIX', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-platform-posix-'));
+    try {
+      const nodePath = join(fakeBin, 'node');
+      await writeFile(nodePath, '');
+      assert.equal(
+        resolveCommandPathForPlatform(
+          'node',
+          'linux',
+          { PATH: fakeBin },
+        ),
+        nodePath,
+      );
+    } finally {
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null on POSIX when the command is not present on PATH', () => {
+    assert.equal(
+      resolveCommandPathForPlatform(
+        'missing-binary',
+        'linux',
+        { PATH: '/tmp/does-not-exist' },
+      ),
+      null,
+    );
+  });
 });
 
 describe('classifySpawnError', () => {

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { spawnSync, type SpawnSyncOptionsWithStringEncoding, type SpawnSyncReturns } from 'child_process';
-import { delimiter, extname, join } from 'path';
+import { delimiter, extname, join, resolve } from 'path';
 
 type ExistsSyncLike = (path: string) => boolean;
 type SpawnSyncLike = typeof spawnSync;
@@ -86,6 +86,32 @@ function resolveWindowsCommandPath(
   return null;
 }
 
+function resolvePosixCommandPath(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  existsImpl: ExistsSyncLike,
+): string | null {
+  const trimmed = command.trim();
+  if (trimmed === '') return null;
+
+  if (trimmed.includes('/')) {
+    const candidate = resolve(trimmed);
+    return existsImpl(candidate) ? candidate : null;
+  }
+
+  const pathEntries = String(env.PATH ?? env.Path ?? '')
+    .split(delimiter)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  for (const entry of pathEntries) {
+    const candidate = resolve(entry, trimmed);
+    if (existsImpl(candidate)) return candidate;
+  }
+
+  return null;
+}
+
 function quoteForCmd(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
@@ -119,7 +145,7 @@ export function resolveCommandPathForPlatform(
   if (platform === 'win32') {
     return resolveWindowsCommandPath(command, env, existsImpl);
   }
-  return command;
+  return resolvePosixCommandPath(command, env, existsImpl);
 }
 
 export function buildPlatformCommandSpec(


### PR DESCRIPTION
## Summary
- resolve POSIX command names to absolute paths instead of returning bare names
- prevent fish/tmux worker startup from exporting `PATH='node':$PATH` and `exec codex` bare when leader binaries are on PATH
- add focused regressions for POSIX path resolution and fish worker startup command generation

Fixes #774.

## Verification
- `npx @biomejs/biome lint src/utils/platform-command.ts src/utils/__tests__/platform-command.test.ts src/team/__tests__/tmux-session.test.ts`
- `node --test /tmp/omx-774-tests/utils/__tests__/platform-command.test.js /tmp/omx-774-tests/team/__tests__/tmux-session.test.js`
- transpiled smoke reproduction now emits absolute `OMX_LEADER_NODE_PATH`, absolute `OMX_LEADER_CLI_PATH`, and `export PATH='<abs-dir>':$PATH; exec <abs-codex>`

## Notes
- `npm run build` is currently blocked by unrelated pre-existing syntax errors in `src/cli/__tests__/explore.test.ts` in this worktree.
