### PR TITLE
fix(team): route raw API cleanup through shutdown

### DIFF
--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -1214,6 +1214,64 @@ describe('executeTeamApiOperation: cleanup', () => {
     const result = await executeTeamApiOperation('cleanup', {}, '/tmp');
     assert.equal(result.ok, false);
   });
+
+  it('routes cleanup through the shutdown gate for failed tasks on normal teams', async () => {
+    const { cwd, cleanup } = await setupTeam('cleanup-gate');
+    try {
+      await createTask('cleanup-gate', {
+        subject: 'failed task',
+        description: 'must keep team state when gate blocks cleanup',
+        status: 'failed',
+      }, cwd);
+
+      const result = await executeTeamApiOperation('cleanup', {
+        team_name: 'cleanup-gate',
+      }, cwd);
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.match(result.error.message, /shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/);
+      }
+
+      const summary = await executeTeamApiOperation('get-summary', {
+        team_name: 'cleanup-gate',
+      }, cwd);
+      assert.equal(summary.ok, true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('honors linked Ralph cleanup policy for failure-only cleanup', async () => {
+    const { cwd, cleanup } = await setupTeam('cleanup-linked-ralph');
+    try {
+      await createTask('cleanup-linked-ralph', {
+        subject: 'failed task',
+        description: 'linked Ralph cleanup should bypass failure-only shutdown gate',
+        status: 'failed',
+      }, cwd);
+      await writeFile(join(cwd, '.omx', 'state', 'team-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'team-exec',
+        linked_ralph: true,
+        team_name: 'cleanup-linked-ralph',
+      }, null, 2));
+
+      const result = await executeTeamApiOperation('cleanup', {
+        team_name: 'cleanup-linked-ralph',
+      }, cwd);
+      assert.equal(result.ok, true);
+
+      const summary = await executeTeamApiOperation('get-summary', {
+        team_name: 'cleanup-linked-ralph',
+      }, cwd);
+      assert.equal(summary.ok, false);
+      if (!summary.ok) {
+        assert.equal(summary.error.code, 'team_not_found');
+      }
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 // ─── write-shutdown-request ───────────────────────────────────────────────

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -1,5 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve as resolvePath } from 'node:path';
+import { readModeState } from '../modes/base.js';
+import { shutdownTeam } from './runtime.js';
 import {
   TEAM_NAME_SAFE_PATTERN,
   WORKER_NAME_SAFE_PATTERN,
@@ -37,7 +39,6 @@ import {
   teamWriteWorkerIdentity,
   teamAppendEvent,
   teamGetSummary,
-  teamCleanup,
   teamWriteShutdownRequest,
   teamReadShutdownAck,
   teamReadMonitorSnapshot,
@@ -868,7 +869,11 @@ export async function executeTeamApiOperation(
       case 'cleanup': {
         const teamName = String(args.team_name || '').trim();
         if (!teamName) return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name is required' } };
-        await teamCleanup(teamName, cwd);
+        const ralphFromState = await readModeState('team', cwd).then(
+          (state) => state?.active === true && state?.linked_ralph === true && state?.team_name === teamName,
+          () => false,
+        );
+        await shutdownTeam(teamName, cwd, { ralph: ralphFromState });
         return { ok: true, operation, data: { team_name: teamName } };
       }
       case 'write-shutdown-request': {


### PR DESCRIPTION
## Summary

Fixes the team API `cleanup` path so normal operator cleanup follows the runtime shutdown contract instead of deleting team state directly.

## Changes

- route `executeTeamApiOperation('cleanup')` through `shutdownTeam(...)` instead of raw `cleanupTeamState(...)`
- mirror CLI behavior by auto-detecting linked Ralph state before cleanup so failure-only Ralph cleanup still bypasses the shutdown gate
- add focused regression coverage proving normal teams now respect `shutdown_gate_blocked` and linked Ralph cleanup still succeeds

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #745
