### PR TITLE
feat(setup): sync shared MCP registry to Claude settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ Notes:
   - `[features] multi_agent = true, child_agents_md = true`
   - MCP server entries (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
   - If a shared MCP registry exists at `~/.omx/mcp-registry.json` (fallback: `~/.omc/mcp-registry.json`), setup syncs those entries into a dedicated managed block in `config.toml` (skipping names already defined elsewhere to avoid duplicate TOML tables)
+  - User-scoped setup also syncs missing shared MCP entries into `~/.claude/settings.json` without overwriting existing Claude Code MCP server definitions
   - `[tui] status_line`
 - Project `AGENTS.md` (project scope only)
 - `.omx/` runtime directories and HUD config

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -230,4 +230,103 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("syncs shared MCP registry entries into ~/.claude/settings.json for user scope", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      process.env.HOME = wd;
+      delete process.env.CODEX_HOME;
+
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".claude"), { recursive: true });
+      await writeFile(
+        join(wd, ".claude", "settings.json"),
+        JSON.stringify(
+          {
+            uiTheme: "dark",
+            mcpServers: {
+              gitnexus: {
+                command: "custom-gitnexus",
+                args: ["serve"],
+                enabled: true,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      const registryPath = join(wd, "mcp-registry.json");
+      await writeFile(
+        registryPath,
+        JSON.stringify({
+          gitnexus: { command: "gitnexus", args: ["mcp"] },
+          eslint: { command: "npx", args: ["@eslint/mcp@latest"], enabled: false },
+        }),
+      );
+
+      await runSetupInTempDir(wd, {
+        scope: "user",
+        mcpRegistryCandidates: [registryPath],
+      });
+
+      const settings = JSON.parse(
+        await readFile(join(wd, ".claude", "settings.json"), "utf-8"),
+      ) as {
+        uiTheme?: string;
+        mcpServers?: Record<string, { command: string; args: string[]; enabled: boolean }>;
+      };
+      assert.equal(settings.uiTheme, "dark");
+      assert.deepEqual(settings.mcpServers?.gitnexus, {
+        command: "custom-gitnexus",
+        args: ["serve"],
+        enabled: true,
+      });
+      assert.deepEqual(settings.mcpServers?.eslint, {
+        command: "npx",
+        args: ["@eslint/mcp@latest"],
+        enabled: false,
+      });
+    } finally {
+      if (typeof previousHome === "string") process.env.HOME = previousHome;
+      else delete process.env.HOME;
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not write ~/.claude/settings.json during project-scoped setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      process.env.HOME = wd;
+      delete process.env.CODEX_HOME;
+
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      const registryPath = join(wd, "mcp-registry.json");
+      await writeFile(
+        registryPath,
+        JSON.stringify({
+          eslint: { command: "npx", args: ["@eslint/mcp@latest"] },
+        }),
+      );
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        mcpRegistryCandidates: [registryPath],
+      });
+
+      assert.equal(existsSync(join(wd, ".claude", "settings.json")), false);
+    } finally {
+      if (typeof previousHome === "string") process.env.HOME = previousHome;
+      else delete process.env.HOME;
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -28,7 +28,11 @@ import {
   omxAgentsConfigDir,
 } from "../utils/paths.js";
 import { buildMergedConfig, getRootModelName } from "../config/generator.js";
-import { loadUnifiedMcpRegistry } from "../config/mcp-registry.js";
+import {
+  loadUnifiedMcpRegistry,
+  planClaudeCodeMcpSettingsSync,
+  type UnifiedMcpRegistryLoadResult,
+} from "../config/mcp-registry.js";
 import { generateAgentToml } from "../agents/native-config.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { getPackageRoot } from "../utils/package.js";
@@ -468,14 +472,34 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
   // Step 5: Update config.toml
   console.log("[5/8] Updating config.toml...");
+  const sharedMcpRegistry = await loadUnifiedMcpRegistry({
+    candidates: options.mcpRegistryCandidates,
+  });
+  if (verbose && sharedMcpRegistry.sourcePath) {
+    console.log(
+      `  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
+    );
+  }
+  for (const warning of sharedMcpRegistry.warnings) {
+    console.log(`  warning: ${warning}`);
+  }
   await updateManagedConfig(
     scopeDirs.codexConfigFile,
     pkgRoot,
     scopeDirs.nativeAgentsDir,
+    sharedMcpRegistry,
     summary.config,
     backupContext,
-    { dryRun, verbose, modelUpgradePrompt, mcpRegistryCandidates: options.mcpRegistryCandidates },
+    { dryRun, verbose, modelUpgradePrompt },
   );
+  if (resolvedScope.scope === "user") {
+    await syncClaudeCodeMcpSettings(
+      sharedMcpRegistry,
+      summary.config,
+      backupContext,
+      { dryRun, verbose },
+    );
+  }
   console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
 
   // Step 5.5: Verify team CLI interop surface is available.
@@ -960,9 +984,10 @@ async function updateManagedConfig(
   configPath: string,
   pkgRoot: string,
   agentsConfigDir: string,
+  sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
   summary: SetupCategorySummary,
   backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt" | "mcpRegistryCandidates">,
+  options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt">,
 ): Promise<void> {
   const existing = existsSync(configPath)
     ? await readFile(configPath, "utf-8")
@@ -981,18 +1006,6 @@ async function updateManagedConfig(
       if (shouldUpgrade) {
         modelOverride = DEFAULT_SETUP_MODEL;
       }
-    }
-  }
-
-  const sharedMcpRegistry = await loadUnifiedMcpRegistry({
-    candidates: options.mcpRegistryCandidates,
-  });
-  if (options.verbose && sharedMcpRegistry.sourcePath) {
-    console.log(
-      `  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
-    );
-    for (const warning of sharedMcpRegistry.warnings) {
-      console.log(`  warning: ${warning}`);
     }
   }
 
@@ -1042,6 +1055,54 @@ async function updateManagedConfig(
       `  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
     );
   }
+}
+
+function getClaudeCodeSettingsPath(homeDir = homedir()): string {
+  return join(homeDir, ".claude", "settings.json");
+}
+
+async function syncClaudeCodeMcpSettings(
+  sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
+  summary: SetupCategorySummary,
+  backupContext: SetupBackupContext,
+  options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<void> {
+  if (sharedMcpRegistry.servers.length === 0) return;
+
+  const settingsPath = getClaudeCodeSettingsPath();
+  const existing = existsSync(settingsPath)
+    ? await readFile(settingsPath, "utf-8")
+    : "";
+  const syncPlan = planClaudeCodeMcpSettingsSync(
+    existing,
+    sharedMcpRegistry.servers,
+  );
+
+  for (const warning of syncPlan.warnings) {
+    console.log(`  warning: ${warning}`);
+  }
+  if (syncPlan.warnings.length > 0) {
+    summary.skipped += 1;
+    return;
+  }
+  if (!syncPlan.content) {
+    summary.unchanged += 1;
+    if (options.verbose && syncPlan.unchanged.length > 0) {
+      console.log(
+        `  shared MCP servers already present in Claude Code settings (${settingsPath})`,
+      );
+    }
+    return;
+  }
+
+  await syncManagedContent(
+    syncPlan.content,
+    settingsPath,
+    summary,
+    backupContext,
+    options,
+    `Claude Code MCP settings ${settingsPath} (+${syncPlan.added.join(", ")})`,
+  );
 }
 
 async function setupNotifyHook(

--- a/src/config/__tests__/mcp-registry.test.ts
+++ b/src/config/__tests__/mcp-registry.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import {
   getUnifiedMcpRegistryCandidates,
   loadUnifiedMcpRegistry,
+  planClaudeCodeMcpSettingsSync,
 } from "../mcp-registry.js";
 
 describe("unified MCP registry loader", () => {
@@ -92,5 +93,78 @@ describe("unified MCP registry loader", () => {
       "/tmp/home/.omx/mcp-registry.json",
       "/tmp/home/.omc/mcp-registry.json",
     ]);
+  });
+
+  it("plans Claude settings sync by adding only missing shared servers", () => {
+    const plan = planClaudeCodeMcpSettingsSync(
+      JSON.stringify(
+        {
+          theme: "dark",
+          mcpServers: {
+            gitnexus: {
+              command: "custom-gitnexus",
+              args: ["serve"],
+              enabled: true,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      [
+        {
+          name: "gitnexus",
+          command: "gitnexus",
+          args: ["mcp"],
+          enabled: true,
+        },
+        {
+          name: "eslint",
+          command: "npx",
+          args: ["@eslint/mcp@latest"],
+          enabled: false,
+          startupTimeoutSec: 9,
+        },
+      ],
+    );
+
+    assert.deepEqual(plan.added, ["eslint"]);
+    assert.deepEqual(plan.unchanged, ["gitnexus"]);
+    assert.deepEqual(plan.warnings, []);
+
+    const parsed = JSON.parse(plan.content ?? "{}") as {
+      theme?: string;
+      mcpServers?: Record<string, { command: string; args: string[]; enabled: boolean }>;
+    };
+    assert.equal(parsed.theme, "dark");
+    assert.deepEqual(parsed.mcpServers?.gitnexus, {
+      command: "custom-gitnexus",
+      args: ["serve"],
+      enabled: true,
+    });
+    assert.deepEqual(parsed.mcpServers?.eslint, {
+      command: "npx",
+      args: ["@eslint/mcp@latest"],
+      enabled: false,
+    });
+  });
+
+  it('warns when Claude settings.json has a non-object "mcpServers" field', () => {
+    const plan = planClaudeCodeMcpSettingsSync(
+      JSON.stringify({ mcpServers: [] }),
+      [
+        {
+          name: "eslint",
+          command: "npx",
+          args: ["@eslint/mcp@latest"],
+          enabled: true,
+        },
+      ],
+    );
+
+    assert.equal(plan.content, undefined);
+    assert.deepEqual(plan.added, []);
+    assert.deepEqual(plan.unchanged, []);
+    assert.match(plan.warnings[0] ?? "", /mcpServers/);
   });
 });

--- a/src/config/mcp-registry.ts
+++ b/src/config/mcp-registry.ts
@@ -17,6 +17,19 @@ export interface UnifiedMcpRegistryLoadResult {
   warnings: string[];
 }
 
+export interface ClaudeCodeMcpServerConfig {
+  command: string;
+  args: string[];
+  enabled: boolean;
+}
+
+export interface ClaudeCodeSettingsSyncPlan {
+  content?: string;
+  added: string[];
+  unchanged: string[];
+  warnings: string[];
+}
+
 interface LoadUnifiedMcpRegistryOptions {
   candidates?: string[];
   homeDir?: string;
@@ -24,6 +37,16 @@ interface LoadUnifiedMcpRegistryOptions {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toClaudeCodeMcpServerConfig(
+  server: UnifiedMcpRegistryServer,
+): ClaudeCodeMcpServerConfig {
+  return {
+    command: server.command,
+    args: [...server.args],
+    enabled: server.enabled,
+  };
 }
 
 function normalizeTimeout(
@@ -121,4 +144,77 @@ export async function loadUnifiedMcpRegistry(
   }
 
   return { servers, sourcePath, warnings };
+}
+
+export function planClaudeCodeMcpSettingsSync(
+  existingContent: string,
+  servers: UnifiedMcpRegistryServer[],
+): ClaudeCodeSettingsSyncPlan {
+  if (servers.length === 0) {
+    return { added: [], unchanged: [], warnings: [] };
+  }
+
+  let parsed: unknown = {};
+  const trimmed = existingContent.trim();
+  if (trimmed.length > 0) {
+    try {
+      parsed = JSON.parse(existingContent);
+    } catch (error) {
+      return {
+        added: [],
+        unchanged: [],
+        warnings: [`failed to parse Claude settings.json: ${String(error)}`],
+      };
+    }
+  }
+
+  if (!isRecord(parsed)) {
+    return {
+      added: [],
+      unchanged: [],
+      warnings: ["Claude settings.json must contain a JSON object"],
+    };
+  }
+
+  const currentMcpServers = parsed.mcpServers;
+  if (currentMcpServers !== undefined && !isRecord(currentMcpServers)) {
+    return {
+      added: [],
+      unchanged: [],
+      warnings: ['Claude settings.json field "mcpServers" must be an object'],
+    };
+  }
+
+  const nextMcpServers: Record<string, unknown> = {
+    ...(currentMcpServers ?? {}),
+  };
+  const added: string[] = [];
+  const unchanged: string[] = [];
+
+  for (const server of servers) {
+    if (Object.hasOwn(nextMcpServers, server.name)) {
+      unchanged.push(server.name);
+      continue;
+    }
+    nextMcpServers[server.name] = toClaudeCodeMcpServerConfig(server);
+    added.push(server.name);
+  }
+
+  if (added.length === 0) {
+    return { added, unchanged, warnings: [] };
+  }
+
+  return {
+    content: `${JSON.stringify(
+      {
+        ...parsed,
+        mcpServers: nextMcpServers,
+      },
+      null,
+      2,
+    )}\n`,
+    added,
+    unchanged,
+    warnings: [],
+  };
 }


### PR DESCRIPTION
## Summary
- load the shared MCP registry once during `omx setup` and keep the existing Codex TOML sync path intact
- add a small Claude settings sync plan that appends only missing shared MCP entries to `~/.claude/settings.json` for user-scoped setup
- preserve existing Claude Code MCP definitions, skip global Claude writes for project scope, and cover the behavior with focused tests

Closes #769.

## Testing
- `npm run build`
- `npx biome lint src/config/mcp-registry.ts src/config/__tests__/mcp-registry.test.ts src/cli/setup.ts src/cli/__tests__/setup-refresh.test.ts`
- `node --test dist/config/__tests__/mcp-registry.test.js dist/cli/__tests__/setup-refresh.test.js`
- `node --test dist/mcp/__tests__/team-server-wait.test.js`
- `npm test`
- `node scripts/generate-catalog-docs.js --check`
