### PR TITLE
docs(team-ralph): align linked launch path docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,15 +411,19 @@ omx team 3:executor "execute the approved ralplan with shared runtime coordinati
 
 Planned documentation/product direction: make `ralplan` produce stronger team follow-up guidance by default, including worker placement hints and an explicit follow-up path such as `--followup team`.
 
-### Why `omx team ralph` is a distinct launch mode
+### Why `omx team ralph` is a linked launch path
 
 Use `omx team ralph ...` when the team run and Ralph follow-up should behave as
 one linked lifecycle, not as two unrelated commands.
 
-- **Linked lifecycle/state:** team starts with `linked_ralph=true`, Ralph tracks
-  `linked_team=true`, and terminal team phases propagate into Ralph state. That
-  gives one operator-visible chain for resume/cancel/final verification instead
-  of a manual handoff after the fact.
+It does **not** spin up a separate team runtime. OMX uses the normal
+`omx team` startup path, then seeds linked team/Ralph state from launch time so
+later status, shutdown, and cancel flows can observe one connected run.
+
+- **Linked lifecycle/state:** launch records `linked_ralph=true` in team state,
+  creates/updates Ralph state with `linked_team=true`, and later terminal team
+  phases propagate into Ralph state. That gives one operator-visible chain for
+  resume/cancel/final verification instead of a manual handoff after the fact.
 - **Cleanup/shutdown:** linked shutdown uses the Ralph-aware cleanup policy.
   Team cleanup happens first, Ralph is terminalized from the linked team result,
   branch rollback preserves worktree branches, and the run records linked

--- a/docs/contracts/ralph-cancel-contract.md
+++ b/docs/contracts/ralph-cancel-contract.md
@@ -1,6 +1,8 @@
 # Ralph Cancellation Contract (Normative)
 
-This contract defines required post-conditions for Ralph cancellation.
+This contract defines required post-conditions for Ralph cancellation, whether
+Ralph was started directly or linked from the real `omx team ralph ...` launch
+path.
 
 ## Required post-conditions
 

--- a/docs/contracts/ralph-state-contract.md
+++ b/docs/contracts/ralph-state-contract.md
@@ -12,6 +12,20 @@ Ralph runtime state is stored at `.omx/state/{scope}/ralph-state.json` and MUST 
 - `completed_at?: ISO8601 string`
 - Optional linkage fields: `linked_ultrawork`, `linked_ecomode`, `linked_team`, `linked_mode`, `linked_team_terminal_phase`, `linked_team_terminal_at`
 
+## Team-linked launch path guarantees
+
+When Ralph is launched through `omx team ralph ...`, the authoritative scope
+MUST reflect that linked launch from the start:
+
+- team state records `linked_ralph=true` and the resolved `team_name`
+- Ralph state records `active=true`, `linked_team=true`, `linked_mode='team'`,
+  and the same `team_name`
+- `linked_team_terminal_phase` and `linked_team_terminal_at` stay unset until
+  the linked team reaches a terminal phase
+
+This is a linked launch path over the shared team runtime, not a separate team
+state schema.
+
 Legacy phase aliases may be normalized for compatibility, but persisted values MUST end in the frozen enum below.
 
 ## Frozen Ralph phase vocabulary

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -42,13 +42,15 @@ omx team "debug flaky integration tests"
 omx team ralph "ship end-to-end fix with verification"
 ```
 
-### Why `team ralph` exists as a separate launch form
+### Why `team ralph` exists as a linked launch path
 
 `omx team ralph ...` is not just shorthand for "run team now, decide on Ralph
-later." It creates a linked team+Ralph lifecycle from launch time.
+later." It creates a linked team+Ralph lifecycle from launch time while still
+using the normal `omx team` runtime startup path.
 
-- **Linked lifecycle/state:** the team run is marked `linked_ralph`, Ralph is
-  marked `linked_team`, and team terminal phases can propagate into Ralph state.
+- **Linked lifecycle/state:** launch marks team state with `linked_ralph`,
+  creates/updates Ralph state with `linked_team`, and team terminal phases can
+  propagate into Ralph state.
 - **Cleanup/shutdown:** linked cancellation and shutdown happen in order: team
   cleanup first, then Ralph terminalization/cleanup metadata.
 - **Operator choice:**

--- a/src/hooks/__tests__/notify-hook-linked-sync.test.ts
+++ b/src/hooks/__tests__/notify-hook-linked-sync.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { parseTeamStartArgs, teamCommand } from '../../cli/team.js';
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../scripts/notify-hook.js', import.meta.url);
 
@@ -50,6 +51,82 @@ async function readJson<T>(path: string): Promise<T> {
 }
 
 describe('notify-hook linked team -> ralph terminal sync', () => {
+  it('syncs linked terminal state starting from a real omx team ralph launch', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const binDir = join(cwd, 'bin');
+      const fakeCodexPath = join(binDir, 'codex');
+      const previousCwd = process.cwd();
+      const previousPath = process.env.PATH;
+      const previousTmux = process.env.TMUX;
+      const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+
+      await mkdir(binDir, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        `#!/usr/bin/env node
+setTimeout(() => process.exit(0), 150);
+process.stdin.resume();
+process.on('SIGTERM', () => process.exit(0));
+`,
+      );
+      await chmod(fakeCodexPath, 0o755);
+
+      try {
+        process.chdir(cwd);
+        process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+        delete process.env.TMUX;
+        process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+        process.env.OMX_TEAM_WORKER_CLI = 'codex';
+
+        const teamTask = 'real launch linked notify sync';
+        const teamName = parseTeamStartArgs(['ralph', '1:executor', teamTask]).parsed.teamName;
+        await teamCommand(['ralph', '1:executor', teamTask]);
+
+        const stateDir = join(cwd, '.omx', 'state');
+        const teamStatePath = join(stateDir, 'team-state.json');
+        const ralphStatePath = join(stateDir, 'ralph-state.json');
+        const launchedTeamState = await readJson<Record<string, unknown>>(teamStatePath);
+        const launchedRalphState = await readJson<Record<string, unknown>>(ralphStatePath);
+
+        assert.equal(launchedTeamState.linked_ralph, true);
+        assert.equal(launchedTeamState.team_name, teamName);
+        assert.equal(launchedRalphState.active, true);
+        assert.equal(launchedRalphState.linked_team, true);
+        assert.equal(launchedRalphState.linked_mode, 'team');
+        assert.equal(launchedRalphState.team_name, teamName);
+        assert.equal(launchedRalphState.linked_team_terminal_phase, undefined);
+        assert.equal(launchedRalphState.linked_team_terminal_at, undefined);
+
+        await writeJson(teamStatePath, {
+          ...launchedTeamState,
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-02-10T00:00:00.000Z',
+        });
+
+        runNotifyHook(cwd);
+
+        const ralphState = await readJson<Record<string, unknown>>(ralphStatePath);
+        assert.equal(ralphState.active, false);
+        assert.equal(ralphState.current_phase, 'complete');
+        assert.equal(ralphState.linked_team_terminal_phase, 'complete');
+        assert.equal(ralphState.linked_team_terminal_at, '2026-02-10T00:00:00.000Z');
+        assert.equal(ralphState.completed_at, '2026-02-10T00:00:00.000Z');
+      } finally {
+        process.chdir(previousCwd);
+        if (typeof previousPath === 'string') process.env.PATH = previousPath;
+        else delete process.env.PATH;
+        if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+        else delete process.env.TMUX;
+        if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+        else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+        if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+        else delete process.env.OMX_TEAM_WORKER_CLI;
+      }
+    });
+  });
+
   it('updates root ralph state when linked team enters terminal phase', async () => {
     await withTempWorkingDir(async (cwd) => {
       const stateDir = join(cwd, '.omx', 'state');


### PR DESCRIPTION
## Summary
- reword README and team skill docs so `omx team ralph` is described as a linked launch path over the shared team runtime
- extend Ralph contracts to spell out the launch-seeded linked state and tie cancel semantics back to the real launch path
- add a notify-hook regression that starts from a real `omx team ralph` launch before asserting linked terminal sync

## Verification
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/hooks/__tests__/notify-hook-linked-sync.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/runtime.test.js

Closes #748