### PR TITLE
refactor(team): split runtime governance from transport policy

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1658,6 +1658,34 @@ process.on('SIGTERM', () => {
     }
   });
 
+  it('shutdownTeam honors legacy policy cleanup override after governance hydration', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-legacy-'));
+    try {
+      await initTeamState('team-shutdown-gate-legacy', 'shutdown gate legacy policy test', 'executor', 1, cwd);
+      await createTask(
+        'team-shutdown-gate-legacy',
+        { subject: 'pending', description: 'd', status: 'pending' },
+        cwd,
+      );
+
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-legacy', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
+      manifest.policy = {
+        ...(manifest.policy || {}),
+        cleanup_requires_all_workers_inactive: false,
+      };
+      delete manifest.governance;
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      await shutdownTeam('team-shutdown-gate-legacy', cwd);
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-legacy');
+      assert.equal(existsSync(teamRoot), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('shutdownTeam blocks when failed tasks remain (completion gate)', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-failed-'));
     try {

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -120,6 +120,8 @@ describe('team state', () => {
       delete policy.dispatch_mode;
       policy.dispatch_ack_timeout_ms = 999_999;
       policy.delegation_only = true;
+      policy.nested_teams_allowed = true;
+      policy.cleanup_requires_all_workers_inactive = false;
       manifest.policy = policy;
       delete manifest.governance;
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
@@ -128,7 +130,11 @@ describe('team state', () => {
       assert.equal(loaded?.policy.dispatch_mode, 'hook_preferred_with_fallback');
       assert.equal(loaded?.policy.dispatch_ack_timeout_ms, 10_000);
       assert.equal(loaded?.governance.delegation_only, true);
+      assert.equal(loaded?.governance.nested_teams_allowed, true);
+      assert.equal(loaded?.governance.cleanup_requires_all_workers_inactive, false);
       assert.equal('delegation_only' in (loaded?.policy ?? {}), false);
+      assert.equal('nested_teams_allowed' in (loaded?.policy ?? {}), false);
+      assert.equal('cleanup_requires_all_workers_inactive' in (loaded?.policy ?? {}), false);
 
       const freshCwd = await mkdtemp(join(tmpdir(), 'omx-team-manifest-policy-default-'));
       try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -344,9 +344,8 @@ function resolveManifestLookupCwds(cwd: string): string[] {
 
 function resolveGovernancePolicy(
   governance: TeamGovernance | null | undefined,
-  legacyPolicy?: Partial<TeamGovernance> | null,
 ): TeamGovernance {
-  return normalizeTeamGovernance(governance, legacyPolicy);
+  return normalizeTeamGovernance(governance);
 }
 
 async function assertNestedTeamAllowed(cwd: string): Promise<void> {
@@ -355,7 +354,7 @@ async function assertNestedTeamAllowed(cwd: string): Promise<void> {
 
   for (const candidateCwd of resolveManifestLookupCwds(cwd)) {
     const manifest = await readTeamManifestV2(workerContext.teamName, candidateCwd);
-    const governance = resolveGovernancePolicy(manifest?.governance, manifest?.policy as Partial<TeamGovernance> | undefined);
+    const governance = resolveGovernancePolicy(manifest?.governance);
     if (governance.nested_teams_allowed) return;
     if (manifest) break;
   }
@@ -1467,10 +1466,7 @@ export async function assignTask(
   const task = await readTask(sanitized, taskId, cwd);
   if (!task) throw new Error(`Task ${taskId} not found`);
   const manifest = await readTeamManifestV2(sanitized, cwd);
-  const governance = resolveGovernancePolicy(
-    manifest?.governance,
-    manifest?.policy as Partial<TeamGovernance> | undefined,
-  );
+  const governance = resolveGovernancePolicy(manifest?.governance);
 
   if (governance.delegation_only && workerName === 'leader-fixed') {
     throw new Error('delegation_only_violation');
@@ -1593,10 +1589,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     return;
   }
   const manifest = await readTeamManifestV2(sanitized, cwd);
-  const governance = resolveGovernancePolicy(
-    manifest?.governance,
-    manifest?.policy as Partial<TeamGovernance> | undefined,
-  );
+  const governance = resolveGovernancePolicy(manifest?.governance);
 
   if (!force) {
     const allTasks = await listTasks(sanitized, cwd);
@@ -1903,10 +1896,7 @@ async function findActiveTeams(cwd: string, leaderSessionId: string): Promise<st
     const teamName = e.name;
     const cfg = await readTeamConfig(teamName, cwd);
     const manifest = await readTeamManifestV2(teamName, cwd);
-    const governance = resolveGovernancePolicy(
-      manifest?.governance,
-      manifest?.policy as Partial<TeamGovernance> | undefined,
-    );
+    const governance = resolveGovernancePolicy(manifest?.governance);
     if (governance.one_team_per_leader_session === false) continue;
     const workerLaunchMode = cfg?.worker_launch_mode
       ?? manifest?.policy?.worker_launch_mode

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -95,6 +95,10 @@ export interface TeamPolicy {
   dispatch_ack_timeout_ms: number;
 }
 
+/**
+ * Lifecycle/workflow guardrails persisted alongside the manifest, but kept
+ * separate from transport/runtime policy so each layer has a single owner.
+ */
 export interface TeamGovernance {
   delegation_only: boolean;
   plan_approval_required: boolean;


### PR DESCRIPTION
## Summary\n- remove runtime fallback that treated manifest.policy as a governance source\n- keep legacy manifest compatibility in the state layer by hydrating governance from older policy fields on read\n- add focused regressions for legacy governance hydration and shutdown cleanup gating\n\n## Testing\n- npm run build\n- npm run lint\n- npm run check:no-unused\n- node --test dist/team/__tests__/state.test.js dist/team/__tests__/runtime.test.js\n\nCloses #746