### PR TITLE
fix: force low reasoning for sparkshell summaries

### DIFF
--- a/native/omx-sparkshell/src/codex_bridge.rs
+++ b/native/omx-sparkshell/src/codex_bridge.rs
@@ -62,6 +62,8 @@ fn run_codex_exec(
         .arg(model)
         .arg("--sandbox")
         .arg("read-only")
+        .arg("-c")
+        .arg("model_reasoning_effort=\"low\"")
         .arg("--skip-git-repo-check")
         .arg("--color")
         .arg("never")
@@ -207,11 +209,16 @@ fn render_section(name: &str, entries: &[String]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_summary, read_summary_timeout_ms, resolve_model, DEFAULT_SPARK_MODEL};
+    use crate::test_support::env_lock;
+    use super::{
+        normalize_summary, read_summary_timeout_ms, resolve_model, DEFAULT_SPARK_MODEL,
+        DEFAULT_SUMMARY_TIMEOUT_MS,
+    };
     use std::env;
 
     #[test]
     fn model_resolution_prefers_sparkshell_override() {
+        let _guard = env_lock();
         unsafe {
             env::set_var("OMX_SPARKSHELL_MODEL", "spark-a");
             env::set_var("OMX_SPARK_MODEL", "spark-b");
@@ -225,6 +232,7 @@ mod tests {
 
     #[test]
     fn model_resolution_falls_back_to_default() {
+        let _guard = env_lock();
         unsafe {
             env::remove_var("OMX_SPARKSHELL_MODEL");
             env::remove_var("OMX_SPARK_MODEL");
@@ -234,10 +242,43 @@ mod tests {
 
     #[test]
     fn timeout_defaults_when_unset() {
+        let _guard = env_lock();
         unsafe {
             env::remove_var("OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS");
         }
         assert_eq!(read_summary_timeout_ms(), 60_000);
+    }
+
+    #[test]
+    fn model_resolution_ignores_blank_override_and_uses_secondary_env() {
+        let _guard = env_lock();
+        unsafe {
+            env::set_var("OMX_SPARKSHELL_MODEL", "   ");
+            env::set_var("OMX_SPARK_MODEL", "spark-b");
+        }
+        assert_eq!(resolve_model(), "spark-b");
+        unsafe {
+            env::remove_var("OMX_SPARKSHELL_MODEL");
+            env::remove_var("OMX_SPARK_MODEL");
+        }
+    }
+
+    #[test]
+    fn timeout_defaults_for_zero_and_invalid_values() {
+        let _guard = env_lock();
+        unsafe {
+            env::set_var("OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS", "0");
+        }
+        assert_eq!(read_summary_timeout_ms(), DEFAULT_SUMMARY_TIMEOUT_MS);
+
+        unsafe {
+            env::set_var("OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS", "bogus");
+        }
+        assert_eq!(read_summary_timeout_ms(), DEFAULT_SUMMARY_TIMEOUT_MS);
+
+        unsafe {
+            env::remove_var("OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS");
+        }
     }
 
     #[test]
@@ -250,5 +291,32 @@ mod tests {
         assert!(summary.contains("- failures: one test failed"));
         assert!(summary.contains("- warnings: cache miss"));
         assert!(!summary.contains("next step"));
+    }
+
+    #[test]
+    fn normalizes_indented_follow_up_bullets() {
+        let summary = normalize_summary(
+            "summary: command ran
+  second detail
+* failures: first failure
+  * nested detail
+warnings: caution
+",
+        )
+        .expect("normalized summary");
+        assert!(summary.contains("- summary: command ran"));
+        assert!(summary.contains("  - second detail"));
+        assert!(summary.contains("- failures: first failure"));
+        assert!(summary.contains("nested detail"));
+        assert!(summary.contains("- warnings: caution"));
+    }
+
+    #[test]
+    fn normalize_summary_returns_none_without_allowed_sections() {
+        assert!(normalize_summary(
+            "next steps: do a thing
+notes: nope"
+        )
+        .is_none());
     }
 }

--- a/native/omx-sparkshell/src/main.rs
+++ b/native/omx-sparkshell/src/main.rs
@@ -2,6 +2,8 @@ mod codex_bridge;
 mod error;
 mod exec;
 mod prompt;
+#[cfg(test)]
+mod test_support;
 mod threshold;
 
 use crate::codex_bridge::summarize_output;

--- a/native/omx-sparkshell/src/prompt.rs
+++ b/native/omx-sparkshell/src/prompt.rs
@@ -1,4 +1,5 @@
 use crate::exec::CommandOutput;
+use std::env;
 use std::borrow::Cow;
 use std::path::Path;
 
@@ -79,6 +80,9 @@ const SWIFT: CommandFamily = CommandFamily {
     what_it_does: "Builds, tests, or packages Swift and Apple-platform projects.",
 };
 
+const DEFAULT_SUMMARY_MAX_LINES: usize = 400;
+const DEFAULT_SUMMARY_MAX_BYTES: usize = 24_000;
+
 pub fn select_command_family(command: &str) -> &'static CommandFamily {
     let base = command_basename(command);
     match base.as_ref() {
@@ -107,6 +111,12 @@ fn command_basename(command: &str) -> Cow<'_, str> {
 pub fn build_summary_prompt(command: &[String], output: &CommandOutput) -> String {
     let executable = command.first().map(String::as_str).unwrap_or("unknown");
     let family = select_command_family(executable);
+    let stdout_text = output.stdout_text();
+    let stderr_text = output.stderr_text();
+    let stdout_lines = count_lines(&stdout_text);
+    let stderr_lines = count_lines(&stderr_text);
+    let stdout_excerpt = truncate_for_prompt(&stdout_text, "stdout");
+    let stderr_excerpt = truncate_for_prompt(&stderr_text, "stderr");
     format!(
         concat!(
             "You summarize shell command output.\\n",
@@ -119,6 +129,10 @@ pub fn build_summary_prompt(command: &[String], output: &CommandOutput) -> Strin
             "Family description: {family_description}\\n",
             "Family what_it_does: {family_what_it_does}\\n",
             "Exit code: {exit_code}\\n\\n",
+            "STDOUT total lines: {stdout_lines}\\n",
+            "STDOUT total bytes: {stdout_bytes}\\n",
+            "STDERR total lines: {stderr_lines}\\n",
+            "STDERR total bytes: {stderr_bytes}\\n\\n",
             "STDOUT:\\n<<<STDOUT\\n{stdout}\\n>>>STDOUT\\n\\n",
             "STDERR:\\n<<<STDERR\\n{stderr}\\n>>>STDERR\\n"
         ),
@@ -128,9 +142,108 @@ pub fn build_summary_prompt(command: &[String], output: &CommandOutput) -> Strin
         family_description = family.description,
         family_what_it_does = family.what_it_does,
         exit_code = output.exit_code(),
-        stdout = output.stdout_text(),
-        stderr = output.stderr_text(),
+        stdout_lines = stdout_lines,
+        stdout_bytes = stdout_text.len(),
+        stderr_lines = stderr_lines,
+        stderr_bytes = stderr_text.len(),
+        stdout = stdout_excerpt,
+        stderr = stderr_excerpt,
     )
+}
+
+fn count_lines(text: &str) -> usize {
+    if text.is_empty() {
+        0
+    } else {
+        text.lines().count()
+    }
+}
+
+fn read_positive_usize_env(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn truncate_for_prompt(text: &str, label: &str) -> String {
+    let max_lines = read_positive_usize_env(
+        "OMX_SPARKSHELL_SUMMARY_MAX_LINES",
+        DEFAULT_SUMMARY_MAX_LINES,
+    );
+    let max_bytes = read_positive_usize_env(
+        "OMX_SPARKSHELL_SUMMARY_MAX_BYTES",
+        DEFAULT_SUMMARY_MAX_BYTES,
+    );
+
+    let total_lines = count_lines(text);
+    let total_bytes = text.len();
+    let mut truncated = text.to_string();
+
+    if total_lines > max_lines {
+        let lines: Vec<&str> = text.lines().collect();
+        let head_count = max_lines / 2;
+        let tail_count = max_lines - head_count;
+        let mut excerpt: Vec<String> = Vec::with_capacity(max_lines + 1);
+        excerpt.extend(lines.iter().take(head_count).map(|line| (*line).to_string()));
+        excerpt.push(format!(
+            "[... truncated {label}: omitted {} of {total_lines} total lines ...]",
+            total_lines.saturating_sub(max_lines),
+        ));
+        excerpt.extend(
+            lines.iter()
+                .skip(total_lines - tail_count)
+                .map(|line| (*line).to_string()),
+        );
+        truncated = excerpt.join("\n");
+        if text.ends_with('\n') {
+            truncated.push('\n');
+        }
+    }
+
+    if truncated.len() > max_bytes {
+        let head_bytes = max_bytes / 2;
+        let tail_bytes = max_bytes.saturating_sub(head_bytes);
+        let prefix = safe_prefix(&truncated, head_bytes);
+        let suffix = safe_suffix(&truncated, tail_bytes);
+        let omitted_bytes = total_bytes.saturating_sub(prefix.len() + suffix.len());
+        truncated = format!(
+            "{prefix}\n[... truncated {label}: omitted approximately {omitted_bytes} of {total_bytes} total bytes ...]\n{suffix}"
+        );
+    }
+
+    truncated
+}
+
+fn safe_prefix(text: &str, max_bytes: usize) -> &str {
+    if text.len() <= max_bytes {
+        return text;
+    }
+    let mut end = 0;
+    for (index, ch) in text.char_indices() {
+        let next = index + ch.len_utf8();
+        if next > max_bytes {
+            break;
+        }
+        end = next;
+    }
+    &text[..end]
+}
+
+fn safe_suffix(text: &str, max_bytes: usize) -> &str {
+    if text.len() <= max_bytes {
+        return text;
+    }
+    let min_start = text.len().saturating_sub(max_bytes);
+    let mut start = text.len();
+    for (index, _) in text.char_indices() {
+        if index >= min_start {
+            start = index;
+            break;
+        }
+    }
+    &text[start..]
 }
 
 fn shell_join(command: &[String]) -> String {
@@ -152,8 +265,10 @@ fn shell_join(command: &[String]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::test_support::env_lock;
     use super::{build_summary_prompt, select_command_family};
     use crate::exec::CommandOutput;
+    use std::env;
     use std::process::Command;
 
     fn ok_status() -> std::process::ExitStatus {
@@ -184,5 +299,37 @@ mod tests {
         assert!(prompt.contains("Command family: git"));
         assert!(prompt.contains("<<<STDOUT"));
         assert!(prompt.contains("<<<STDERR"));
+    }
+
+    #[test]
+    fn prompt_truncates_large_streams_before_embedding_them() {
+        let _guard = env_lock();
+        unsafe {
+            env::set_var("OMX_SPARKSHELL_SUMMARY_MAX_LINES", "4");
+            env::set_var("OMX_SPARKSHELL_SUMMARY_MAX_BYTES", "120");
+        }
+
+        let output = CommandOutput {
+            status: ok_status(),
+            stdout: (1..=10)
+                .map(|value| format!("line-{value}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+                .into_bytes(),
+            stderr: b"warning-a\nwarning-b\nwarning-c\nwarning-d\nwarning-e\n".to_vec(),
+        };
+        let prompt = build_summary_prompt(&["find".into(), "src".into()], &output);
+
+        unsafe {
+            env::remove_var("OMX_SPARKSHELL_SUMMARY_MAX_LINES");
+            env::remove_var("OMX_SPARKSHELL_SUMMARY_MAX_BYTES");
+        }
+
+        assert!(prompt.contains("STDOUT total lines: 10"));
+        assert!(prompt.contains("truncated stdout"));
+        assert!(prompt.contains("line-1"));
+        assert!(prompt.contains("line-10"));
+        assert!(!prompt.contains("line-5"));
+        assert!(prompt.contains("truncated stderr"));
     }
 }

--- a/native/omx-sparkshell/src/test_support.rs
+++ b/native/omx-sparkshell/src/test_support.rs
@@ -1,0 +1,10 @@
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(test)]
+pub fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env lock")
+}

--- a/native/omx-sparkshell/src/threshold.rs
+++ b/native/omx-sparkshell/src/threshold.rs
@@ -23,7 +23,11 @@ pub fn combined_visible_lines(stdout: &[u8], stderr: &[u8]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{combined_visible_lines, count_visible_lines};
+    use crate::test_support::env_lock;
+    use super::{
+        combined_visible_lines, count_visible_lines, read_line_threshold, DEFAULT_MAX_VISIBLE_LINES,
+    };
+    use std::env;
 
     #[test]
     fn counts_trailing_partial_line() {
@@ -38,5 +42,33 @@ mod tests {
     #[test]
     fn combines_stdout_and_stderr() {
         assert_eq!(combined_visible_lines(b"one\ntwo\n", b"warn\n"), 3);
+    }
+
+    #[test]
+    fn threshold_defaults_for_zero_invalid_and_blank_values() {
+        let _guard = env_lock();
+        unsafe { env::set_var("OMX_SPARKSHELL_LINES", "0") };
+        assert_eq!(read_line_threshold(), DEFAULT_MAX_VISIBLE_LINES);
+
+        unsafe { env::set_var("OMX_SPARKSHELL_LINES", "not-a-number") };
+        assert_eq!(read_line_threshold(), DEFAULT_MAX_VISIBLE_LINES);
+
+        unsafe { env::set_var("OMX_SPARKSHELL_LINES", "   ") };
+        assert_eq!(read_line_threshold(), DEFAULT_MAX_VISIBLE_LINES);
+
+        unsafe { env::remove_var("OMX_SPARKSHELL_LINES") };
+    }
+
+    #[test]
+    fn threshold_accepts_trimmed_positive_values() {
+        let _guard = env_lock();
+        unsafe { env::set_var("OMX_SPARKSHELL_LINES", " 7 ") };
+        assert_eq!(read_line_threshold(), 7);
+        unsafe { env::remove_var("OMX_SPARKSHELL_LINES") };
+    }
+
+    #[test]
+    fn empty_output_counts_as_zero_lines() {
+        assert_eq!(count_visible_lines(b""), 0);
     }
 }

--- a/native/omx-sparkshell/tests/execution.rs
+++ b/native/omx-sparkshell/tests/execution.rs
@@ -87,6 +87,7 @@ fn summary_mode_uses_codex_exec_and_model_override() {
     assert!(args.contains("exec"));
     assert!(args.contains("--model"));
     assert!(args.contains("spark-test-model"));
+    assert!(args.contains("model_reasoning_effort=\"low\""));
 
     let prompt = fs::read_to_string(prompt_log).expect("prompt log");
     assert!(prompt.contains("Command family: generic-shell"));

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -13,6 +13,7 @@ import {
   loadExplorePrompt,
   packagedExploreHarnessBinaryName,
   parseExploreArgs,
+  repoBuiltExploreHarnessCommand,
   resolveExploreHarnessCommand,
   resolvePackagedExploreHarnessCommand,
 } from '../explore.js';
@@ -200,6 +201,27 @@ describe('resolveExploreHarnessCommand', () => {
     });
   });
 
+  it('uses an existing repo-built native harness before cargo fallback', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-target-'));
+    try {
+      const targetDir = join(wd, 'target', 'release');
+      await mkdir(targetDir, { recursive: true });
+      await writeFile(join(wd, 'package.json'), '{}\n');
+      await writeFile(join(targetDir, packagedExploreHarnessBinaryName()), '#!/bin/sh\nexit 0\n');
+      await chmod(join(targetDir, packagedExploreHarnessBinaryName()), 0o755);
+      await mkdir(join(wd, 'crates', 'omx-explore'), { recursive: true });
+      await writeFile(join(wd, 'crates', 'omx-explore', 'Cargo.toml'), '[package]\nname="omx-explore-harness"\nversion="0.0.0"\n');
+
+      const repoBuilt = repoBuiltExploreHarnessCommand(wd);
+      assert.deepEqual(repoBuilt, { command: join(targetDir, packagedExploreHarnessBinaryName()), args: [] });
+
+      const resolved = resolveExploreHarnessCommand(wd, {} as NodeJS.ProcessEnv);
+      assert.deepEqual(resolved, { command: join(targetDir, packagedExploreHarnessBinaryName()), args: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('builds cargo fallback command otherwise', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-explore-fallback-'));
     try {
@@ -333,6 +355,7 @@ describe('exploreCommand', () => {
         assert.match(captured.path, /omx-explore-allowlist-/);
         assert.match(captured.shell, /omx-explore-allowlist-.*\/bin\/bash$/);
         assert.equal(captured.allowed.status, 0, captured.allowed.stderr);
+        assert.ok(captured.argv.includes('model_reasoning_effort="low"'));
         assert.match(captured.allowed.stdout, /ripgrep/i);
         assert.notEqual(captured.blocked.status, 0);
         assert.match(captured.blocked.stderr, /not on the omx explore allowlist/);

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -58,6 +58,20 @@ export function resolvePackagedExploreHarnessCommand(
   }
 }
 
+export function repoBuiltExploreHarnessCommand(
+  packageRoot = getPackageRoot(),
+  platform: NodeJS.Platform = process.platform,
+): ExploreHarnessCommand | undefined {
+  const binaryName = packagedExploreHarnessBinaryName(platform);
+  for (const mode of ['release', 'debug'] as const) {
+    const binaryPath = join(packageRoot, 'target', mode, binaryName);
+    if (existsSync(binaryPath)) {
+      return { command: binaryPath, args: [] };
+    }
+  }
+  return undefined;
+}
+
 function exploreUsageError(reason: string): Error {
   return new Error(`${reason}\n${EXPLORE_USAGE}`);
 }
@@ -143,6 +157,9 @@ export function resolveExploreHarnessCommand(
 
   const packaged = resolvePackagedExploreHarnessCommand(packageRoot);
   if (packaged) return packaged;
+
+  const repoBuilt = repoBuiltExploreHarnessCommand(packageRoot);
+  if (repoBuilt) return repoBuilt;
 
   const manifestPath = join(packageRoot, 'crates', 'omx-explore', 'Cargo.toml');
   if (!existsSync(manifestPath)) {


### PR DESCRIPTION
## Summary
- force `omx sparkshell` summary-mode codex exec calls to use low reasoning
- truncate large sparkshell stdout/stderr before embedding them in summary prompts to reduce context blowups
- prefer a built explore harness binary before falling back to `cargo run`, while keeping `omx explore` low-reasoning coverage explicit

## Verification
- npm run build
- cargo test --manifest-path native/omx-sparkshell/Cargo.toml
- cargo test -p omx-explore-harness
- node --test dist/cli/__tests__/explore.test.js dist/cli/__tests__/sparkshell-cli.test.js