### PR TITLE
feat: make omx explore default to sparkshell-backed read-only shell routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,9 +205,10 @@ Broad Request Detection:
 A request is broad when it uses vague verbs without targets, names no specific file or function, touches 3+ areas, or is a single sentence without a clear deliverable. For broad work: explore first, then plan if needed.
 
 Command Routing:
-- When `USE_OMX_EXPLORE_CMD` enables advisory routing, prefer `omx explore` for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
+- When `USE_OMX_EXPLORE_CMD` enables advisory routing, prefer `omx explore` as the default surface for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
 - Keep ambiguous, implementation-heavy, edit-heavy, or non-shell-only work on the normal Codex path.
 - If `omx explore` is unavailable or fails, gracefully fall back to the normal path.
+- Let `omx explore` keep direct inspection by default and use `omx sparkshell` only as an adaptive backend for qualifying read-only shell-native tasks.
 - For explicit tmux-pane / worker / leader / HUD inspection, prefer `omx sparkshell --tmux-pane ...` when a larger-tail read or bounded summary is useful. Sparkshell pane mode is explicit opt-in, not always-on.
 
 Parallelization:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ omx doctor         # Installation/runtime diagnostics
 omx doctor --team  # Team Mode diagnostics
 omx ask ...        # Ask local provider advisor (claude|gemini), writes .omx/artifacts/*
 omx resume         # Resume a previous interactive Codex session
-omx explore ...    # Run the low-cost read-only exploration harness
+omx explore ...    # Default read-only exploration entrypoint (may use sparkshell backend)
 omx ralph          # Launch Codex with ralph persistence mode active
 omx status         # Show active modes
 omx cancel         # Cancel active execution modes
@@ -245,7 +245,7 @@ omx explore --prompt-file prompts/explore-task.md
 USE_OMX_EXPLORE_CMD=1 omx   # advisory preference for simple read-only exploration prompts
 ```
 
-`omx explore` is intentionally read-only and shell-only. The routing flag only adds advisory steering in generated session instructions; ambiguous or implementation-heavy requests stay on the normal Codex path, and OMX falls back normally if the explore harness is unavailable. The harness constrains Codex through a temporary allowlisted shell/bin layer so only approved repository-inspection command families are available during the offloaded run.
+`omx explore` is the default OMX surface for simple read-only exploration. It stays intentionally read-only and shell-only, and qualifying shell-native read-only tasks may be routed through `omx sparkshell` as a backend when that is the cheaper/more direct fit. The routing flag only adds advisory steering in generated session instructions; ambiguous or implementation-heavy requests stay on the normal Codex path, and OMX falls back normally if the explore harness is unavailable. The harness constrains Codex through a temporary allowlisted shell/bin layer so only approved repository-inspection command families are available during the offloaded run.
 
 - Current shell allowlist: `rg`, `grep`, `ls`, `find`, `wc`, `cat`, `head`, `tail`, `pwd`, `printf`
 - Current shell restrictions: no pipes, redirection, `&&`, `||`, `;`, subshells, path-qualified binaries, non-allowlisted commands, stdin-fed inspection, or path escapes outside the target repository (including existing symlink-resolved escapes)
@@ -285,7 +285,9 @@ See `docs/hooks-extension.md` for the full extension workflow and event model.
 
 ## Sparkshell (preview)
 
-`omx sparkshell <command> [args...]` runs through a JS -> Rust sidecar bridge for fast command execution with adaptive summaries when output exceeds `OMX_SPARKSHELL_LINES`.
+`omx sparkshell <command> [args...]` runs through a JS -> Rust sidecar bridge for fast command execution with adaptive summaries when output exceeds `OMX_SPARKSHELL_LINES`. `omx explore` now treats it as a backend for qualifying read-only shell-native tasks; `omx sparkshell` remains the explicit specialist surface for direct operator use.
+
+It remains an explicit operator-facing command, but OMX may also use it as a backend for qualifying `omx explore` read-only shell-native tasks. That backend relationship does not relax read-only safety: non-read-only or unsupported shell execution should still stay blocked or on the normal path.
 
 Current preview contract:
 - Short output stays raw; long output is summarized into markdown sections limited to `summary:`, `failures:`, and `warnings:`.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "doctor": "node bin/omx.js doctor",
     "ask:claude": "./scripts/ask-claude.sh",
     "ask:gemini": "./scripts/ask-gemini.sh",
-    "test:explore": "cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js",
+    "test:explore": "cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js",
     "test:node": "node --test $(find dist -name '*.test.js')",
     "test": "npm run build && npm run test:node && node scripts/generate-catalog-docs.js --check",
     "coverage:team-critical": "npm run build && c8 --all --src dist/team --src dist/state --include 'dist/team/**/*.js' --include 'dist/state/**/*.js' --exclude '**/__tests__/**' --reporter=text-summary --reporter=lcov --reporter=json-summary --report-dir coverage/team --check-coverage --lines=78 --functions=90 --branches=70 --statements=78 node --test $(find dist/team/__tests__ dist/state/__tests__ -name '*.test.js')",

--- a/prompts/explore-harness.md
+++ b/prompts/explore-harness.md
@@ -14,6 +14,7 @@ Your job is to inspect the current repository and return a concise markdown summ
 - Treat unavailable tools as unavailable. Do not assume LSP, ast-grep, MCP, web search, images, or structured Read/Glob tools exist here.
 - Keep file/path arguments inside the current repository. Do not intentionally inspect `..` paths or unrelated absolute paths.
 - This harness is for simple read-only repository lookup tasks after `omx explore` has already been selected; it is not the richer normal path.
+- Prefer direct read-only inspection first; for qualifying read-only shell-native tasks where command-native execution or long output is the better fit, it is acceptable to use `omx sparkshell <allowlisted command...>` as a backend and then continue with a markdown answer.
 - If the user clearly needs non-shell-only tooling or the harness cannot answer safely, report the limitation so the caller can fall back to the richer normal path.
 - Return markdown only.
 </constraints>

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -15,6 +15,7 @@ import {
   parseExploreArgs,
   repoBuiltExploreHarnessCommand,
   resolveExploreHarnessCommand,
+  resolveExploreSparkShellRoute,
   resolvePackagedExploreHarnessCommand,
 } from '../explore.js';
 import { withPackagedExploreHarnessHidden, withPackagedExploreHarnessLock } from './packaged-explore-harness-lock.js';
@@ -88,7 +89,6 @@ async function runExploreCommandForTest(
   process.exitCode = originalExitCode;
   return { stdout: stdoutChunks.join(''), stderr: stderrChunks.join(''), exitCode };
 }
-
 
 async function createExploreTestPath(wd: string): Promise<string> {
   const binDir = join(wd, 'test-bin');
@@ -393,7 +393,62 @@ describe('buildExploreHarnessArgs', () => {
   });
 });
 
+describe('resolveExploreSparkShellRoute', () => {
+  it('keeps natural-language exploration prompts on the direct harness path', () => {
+    assert.equal(resolveExploreSparkShellRoute('which files define team routing'), undefined);
+    assert.equal(resolveExploreSparkShellRoute('map the relationship between hooks and tmux helpers'), undefined);
+  });
+
+  it('routes qualifying read-only git commands to sparkshell', () => {
+    assert.deepEqual(resolveExploreSparkShellRoute('git log --oneline'), {
+      argv: ['git', 'log', '--oneline'],
+      reason: 'long-output',
+    });
+    assert.deepEqual(resolveExploreSparkShellRoute('run git diff --stat'), {
+      argv: ['git', 'diff', '--stat'],
+      reason: 'long-output',
+    });
+  });
+
+  it('rejects non-read-only or shell-unsafe commands for sparkshell routing', () => {
+    assert.equal(resolveExploreSparkShellRoute('git commit -m test'), undefined);
+    assert.equal(resolveExploreSparkShellRoute('npm test'), undefined);
+    assert.equal(resolveExploreSparkShellRoute('git log | head'), undefined);
+    assert.equal(resolveExploreSparkShellRoute('find /tmp -maxdepth 1'), undefined);
+  });
+});
+
 describe('exploreCommand', () => {
+  it('routes qualifying read-only shell commands through sparkshell instead of the direct harness', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-sparkshell-route-'));
+    try {
+      const sparkshellStub = join(wd, 'sparkshell-stub.sh');
+      const harnessStub = join(wd, 'explore-stub.sh');
+      const capturePath = join(wd, 'sparkshell-capture.txt');
+      await writeFile(
+        sparkshellStub,
+        `#!/bin/sh\nprintf '%s\n' "$@" > ${JSON.stringify(capturePath)}\nprintf '# Answer\n- routed via sparkshell\n'\n`,
+      );
+      await writeFile(harnessStub, '#!/bin/sh\nprintf harness-should-not-run\n');
+      await chmod(sparkshellStub, 0o755);
+      await chmod(harnessStub, 0o755);
+
+      const result = runOmx(wd, ['explore', '--prompt', 'git log --oneline'], {
+        OMX_SPARKSHELL_BIN: sparkshellStub,
+        OMX_EXPLORE_BIN: harnessStub,
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stdout, '# Answer\n- routed via sparkshell\n');
+      assert.equal(result.stderr, '');
+      const captured = (await readFile(capturePath, 'utf-8')).trim().split('\n');
+      assert.deepEqual(captured, ['git', 'log', '--oneline']);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('passes prompt to harness and preserves markdown stdout', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-explore-cmd-'));
     try {

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -31,7 +31,7 @@ describe('package bin contract', () => {
       assert.equal(pkg.scripts?.['build:explore:release'], 'node scripts/build-explore-harness.js');
       assert.equal(pkg.scripts?.prepack, 'npm run build && npm run build:explore:release');
       assert.equal(pkg.scripts?.postpack, 'node scripts/cleanup-explore-harness.js');
-      assert.equal(pkg.scripts?.['test:explore'], 'cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js');
+      assert.equal(pkg.scripts?.['test:explore'], 'cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js');
       assert.ok(pkg.files?.includes('Cargo.toml'));
       assert.ok(pkg.files?.includes('Cargo.lock'));
       assert.ok(pkg.files?.includes('crates/'));

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -112,8 +112,10 @@ describe('omx sparkshell', () => {
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /omx explore\s+Default read-only exploration entrypoint \(may adaptively use sparkshell backend\)/);
       assert.match(result.stdout, /omx sparkshell <command> \[args\.\.\.\]/);
       assert.match(result.stdout, /omx sparkshell --tmux-pane <pane-id> \[--tail-lines <100-1000>\]/);
+      assert.match(result.stdout, /adaptive backend for qualifying read-only explore tasks/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { getPackageRoot } from '../utils/package.js';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
+import { resolveSparkShellBinaryPath, runSparkShellBinary } from './sparkshell.js';
 import { DEFAULT_FRONTIER_MODEL, getSparkDefaultModel } from '../config/models.js';
 
 export const EXPLORE_USAGE = [
@@ -30,6 +31,110 @@ interface ExploreHarnessMetadata {
   binaryName?: string;
   platform?: string;
   arch?: string;
+}
+
+
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
+  'log',
+  'diff',
+  'status',
+  'show',
+  'branch',
+  'rev-parse',
+]);
+
+const SHELL_ROUTE_DISALLOWED_PATTERN = /[|&;><`$()]/;
+const EXPLICIT_SHELL_PREFIX_PATTERN = /^run\s+/i;
+
+export interface ExploreSparkShellRoute {
+  argv: string[];
+  reason: 'shell-native' | 'long-output';
+}
+
+function tokenizeExploreShellCommand(commandText: string): string[] | undefined {
+  const trimmed = commandText.trim();
+  if (!trimmed || SHELL_ROUTE_DISALLOWED_PATTERN.test(trimmed) || trimmed.includes('\\')) return undefined;
+
+  const tokens = trimmed.match(/"[^"]*"|'[^']*'|\S+/g);
+  if (!tokens) return undefined;
+  return tokens.map((token) => {
+    if ((token.startsWith('\"') && token.endsWith('\"')) || (token.startsWith("'") && token.endsWith("'"))) {
+      return token.slice(1, -1);
+    }
+    return token;
+  });
+}
+
+function isReadOnlyGitArgs(args: readonly string[]): boolean {
+  const subcommand = args[1]?.toLowerCase();
+  if (!subcommand || !READ_ONLY_GIT_SUBCOMMANDS.has(subcommand)) return false;
+  if (subcommand === 'diff') {
+    return args.some((arg) => /^--(?:stat|name-only|name-status|numstat|shortstat)$/.test(arg));
+  }
+  if (subcommand === 'show') {
+    return args.some((arg) => /^--(?:stat|summary|name-only|name-status)$/.test(arg));
+  }
+  return true;
+}
+
+function classifyLongOutputShellCommand(args: readonly string[]): boolean {
+  const [command, subcommand] = args;
+  if (command === 'git') {
+    return ['log', 'diff', 'status', 'show'].includes((subcommand || '').toLowerCase());
+  }
+  return ['find', 'ls', 'rg', 'grep'].includes(command);
+}
+
+export function resolveExploreSparkShellRoute(prompt: string): ExploreSparkShellRoute | undefined {
+  const explicitShellPrefix = EXPLICIT_SHELL_PREFIX_PATTERN.test(prompt.trim());
+  const normalized = prompt.trim().replace(EXPLICIT_SHELL_PREFIX_PATTERN, '');
+  const argv = tokenizeExploreShellCommand(normalized);
+  if (!argv || argv.length === 0) return undefined;
+
+  const command = argv[0]?.toLowerCase();
+  if (!command) return undefined;
+
+  if (command === 'git' && isReadOnlyGitArgs(argv)) {
+    return {
+      argv,
+      reason: classifyLongOutputShellCommand(argv) ? 'long-output' : 'shell-native',
+    };
+  }
+
+  const shellNativeShape = explicitShellPrefix || argv.slice(1).some((arg) => (
+    arg.startsWith('-')
+    || arg.includes('/')
+    || arg === '.'
+    || arg.includes('*')
+  ));
+
+  if (
+    explicitShellPrefix
+    && shellNativeShape
+    && ['find', 'ls', 'rg', 'grep'].includes(command)
+    && argv.slice(1).every((arg) => !arg.startsWith('/') && !arg.startsWith('..'))
+  ) {
+    return {
+      argv,
+      reason: classifyLongOutputShellCommand(argv) ? 'long-output' : 'shell-native',
+    };
+  }
+
+  return undefined;
+}
+
+function runExploreViaSparkShell(route: ExploreSparkShellRoute, env: NodeJS.ProcessEnv = process.env): void {
+  const binaryPath = resolveSparkShellBinaryPath({ cwd: process.cwd(), env });
+  const result = runSparkShellBinary(binaryPath, route.argv, { cwd: process.cwd(), env });
+
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    throw new Error(`[explore] failed to launch sparkshell backend: ${errno.message}`);
+  }
+
+  if (result.status !== 0) {
+    process.exitCode = result.status ?? 1;
+  }
 }
 
 export function packagedExploreHarnessBinaryName(platform: NodeJS.Platform = process.platform): string {
@@ -200,6 +305,12 @@ export async function loadExplorePrompt(parsed: ParsedExploreArgs): Promise<stri
 export async function exploreCommand(args: string[]): Promise<void> {
   const parsed = parseExploreArgs(args);
   const prompt = await loadExplorePrompt(parsed);
+  const sparkShellRoute = resolveExploreSparkShellRoute(prompt);
+  if (sparkShellRoute) {
+    runExploreViaSparkShell(sparkShellRoute, process.env);
+    return;
+  }
+
   const packageRoot = getPackageRoot();
   const harness = resolveExploreHarnessCommand(packageRoot, process.env);
   const harnessArgs = [...harness.args, ...buildExploreHarnessArgs(prompt, process.cwd(), process.env, packageRoot)];

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -97,7 +97,7 @@ Usage:
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx resume    Resume a previous interactive Codex session
-  omx explore   Run the low-cost read-only exploration harness
+  omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree
@@ -112,6 +112,7 @@ Usage:
   omx sparkshell <command> [args...]
   omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]
                 Run native sparkshell sidecar for direct command execution or explicit tmux-pane summarization
+                (also used as an adaptive backend for qualifying read-only explore tasks)
   omx help      Show this help message
   omx status    Show active modes and state
   omx cancel    Cancel active execution modes

--- a/src/compat/fixtures/help.stdout.txt
+++ b/src/compat/fixtures/help.stdout.txt
@@ -8,7 +8,7 @@ Usage:
   omx doctor    Check installation health
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
-  omx explore   Run the low-cost read-only exploration harness
+  omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree
@@ -20,6 +20,10 @@ Usage:
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
   omx hooks     Manage hook plugins (init|status|validate|test)
   omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
+  omx sparkshell <command> [args...]
+  omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]
+                Run native sparkshell sidecar for direct command execution or explicit tmux-pane summarization
+                (also used as an adaptive backend for qualifying read-only explore tasks)
   omx help      Show this help message
   omx status    Show active modes and state
   omx cancel    Cancel active execution modes
@@ -52,4 +56,3 @@ Options:
   --verbose     Show detailed output
   --scope       Setup scope for "omx setup" only:
                 user | project
-

--- a/src/hooks/explore-routing.ts
+++ b/src/hooks/explore-routing.ts
@@ -35,8 +35,8 @@ export function buildExploreRoutingGuidance(env: NodeJS.ProcessEnv = process.env
   if (!isExploreCommandRoutingEnabled(env)) return '';
   return [
     `**Explore Command Preference:** enabled via \`${OMX_EXPLORE_CMD_ENV}\``,
-    '- When the user asks for a simple read-only exploration task (file/symbol/pattern/relationship lookup), strongly prefer `omx explore`.',
-    '- Treat this as advisory steering in current OMX sessions unless a true prompt interception surface is available.',
+    '- When the user asks for a simple read-only exploration task (file/symbol/pattern/relationship lookup), strongly prefer `omx explore` as the default surface.',
+    '- Treat this as advisory steering in current OMX sessions unless a true prompt interception surface is available; let `omx explore` handle direct inspection by default and reserve `omx sparkshell` as an adaptive backend for qualifying read-only shell-native tasks.',
     '- Keep implementation, refactor, test, or ambiguous broad requests on the normal Codex path.',
     '- If `omx explore` is unavailable or fails, gracefully fall back to the normal path.',
   ].join('\n');

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -205,9 +205,10 @@ Broad Request Detection:
 A request is broad when it uses vague verbs without targets, names no specific file or function, touches 3+ areas, or is a single sentence without a clear deliverable. For broad work: explore first, then plan if needed.
 
 Command Routing:
-- When `USE_OMX_EXPLORE_CMD` enables advisory routing, prefer `omx explore` for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
+- When `USE_OMX_EXPLORE_CMD` enables advisory routing, prefer `omx explore` as the default surface for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
 - Keep ambiguous, implementation-heavy, edit-heavy, or non-shell-only work on the normal Codex path.
 - If `omx explore` is unavailable or fails, gracefully fall back to the normal path.
+- Let `omx explore` keep direct inspection by default and use `omx sparkshell` only as an adaptive backend for qualifying read-only shell-native tasks.
 - For explicit tmux-pane / worker / leader / HUD inspection, prefer `omx sparkshell --tmux-pane ...` when a larger-tail read or bounded summary is useful. Sparkshell pane mode is explicit opt-in, not always-on.
 
 Parallelization:


### PR DESCRIPTION
## Summary
- make `omx explore` the default read-only exploration entrypoint and let it adaptively use `omx sparkshell` for qualifying read-only shell-native tasks
- keep natural-language exploration prompts on the direct explore harness path with conservative read-only routing heuristics
- update docs/help/guidance and add regression/package contract coverage for the explore+sparkshell relationship

## Verification
- npm run build
- npm run test:explore
- node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js dist/cli/__tests__/sparkshell-cli.test.js dist/cli/__tests__/package-bin-contract.test.js
- npx @biomejs/biome lint src/cli/explore.ts src/cli/index.ts src/hooks/explore-routing.ts src/cli/__tests__/explore.test.ts src/cli/__tests__/sparkshell-cli.test.ts src/cli/__tests__/package-bin-contract.test.ts
