### PR TITLE
fix: normalize nested CLI help routing

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -10,6 +10,7 @@ import {
   buildWindowsPromptCommand,
   buildTmuxSessionName,
   resolveCliInvocation,
+  commandOwnsLocalHelp,
   resolveCodexLaunchPolicy,
   classifyCodexExecFailure,
   resolveSignalExitCode,
@@ -284,6 +285,20 @@ describe('resolveTeamWorkerLaunchArgsEnv (spark)', () => {
       resolveTeamWorkerLaunchArgsEnv(undefined, ['--model', 'gpt-4.1'], true, expectedLowComplexityModel()),
       '--model gpt-4.1'
     );
+  });
+});
+
+describe('commandOwnsLocalHelp', () => {
+  it('returns true for nested commands that render their own help output', () => {
+    for (const command of ['agents-init', 'deepinit', 'hooks', 'ralph', 'resume', 'session', 'sparkshell', 'team', 'tmux-hook']) {
+      assert.equal(commandOwnsLocalHelp(command), true, `expected ${command} to own local help`);
+    }
+  });
+
+  it('returns false for top-level help-only commands', () => {
+    for (const command of ['help', 'launch', 'version']) {
+      assert.equal(commandOwnsLocalHelp(command), false, `expected ${command} to use top-level help`);
+    }
   });
 });
 

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(cwd: string, argv: string[]) {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  return spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+    },
+  });
+}
+
+describe('nested help routing', () => {
+  for (const [argv, expectedUsage] of [
+    [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
+    [['tmux-hook', '--help'], /Usage:\s*\n\s*omx tmux-hook init/i],
+    [['ralph', '--help'], /omx ralph - Launch Codex with ralph persistence mode active/i],
+  ] satisfies Array<[string[], RegExp]>) {
+    it(`routes ${argv.join(' ')} to command-local help`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-nested-help-'));
+      try {
+        const result = runOmx(cwd, argv);
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        assert.match(result.stdout, expectedUsage);
+        assert.doesNotMatch(result.stdout, /oh-my-codex \(omx\) - Multi-agent orchestration for Codex CLI/i);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -166,6 +166,18 @@ const WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS = 2500;
 
 type CliCommand = 'launch' | 'setup' | 'agents-init' | 'deepinit' | 'uninstall' | 'doctor' | 'ask' | 'explore' | 'sparkshell' | 'team' | 'session' | 'resume' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
 
+const NESTED_HELP_COMMANDS = new Set<CliCommand>([
+  'agents-init',
+  'deepinit',
+  'hooks',
+  'ralph',
+  'resume',
+  'session',
+  'sparkshell',
+  'team',
+  'tmux-hook',
+]);
+
 export interface ResolvedCliInvocation {
   command: CliCommand;
   launchArgs: string[];
@@ -254,6 +266,10 @@ export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
 
 export function resolveNotifyTempContract(args: string[], env: NodeJS.ProcessEnv = process.env): ParseNotifyTempContractResult {
   return parseNotifyTempContractFromArgs(args, env);
+}
+
+export function commandOwnsLocalHelp(command: CliCommand): boolean {
+  return NESTED_HELP_COMMANDS.has(command);
 }
 
 export type CodexLaunchPolicy = 'inside-tmux' | 'direct';
@@ -412,7 +428,6 @@ export async function main(args: string[]): Promise<void> {
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
   const flags = new Set(args.filter(a => a.startsWith('--')));
-  const ralphHelpRequested = firstArg === 'ralph' && (args[1] === '--help' || args[1] === '-h');
   const options = {
     force: flags.has('--force'),
     dryRun: flags.has('--dry-run'),
@@ -420,7 +435,7 @@ export async function main(args: string[]): Promise<void> {
     team: flags.has('--team'),
   };
 
-  if (flags.has('--help') && !ralphHelpRequested && !new Set(['team', 'session', 'agents-init', 'deepinit', 'resume', 'sparkshell']).has(command)) {
+  if (flags.has('--help') && !commandOwnsLocalHelp(command)) {
     console.log(HELP);
     return;
   }


### PR DESCRIPTION
## Summary
- normalize nested help routing through a shared local-help ownership helper in `src/cli/index.ts`
- add regression coverage for `hooks`, `tmux-hook`, and `ralph` command-local help
- preserve top-level help fallback for deferred commands like `ask`, `explore`, `hud`, and `reasoning`

## Verification
- npm run build
- biome lint src/cli/index.ts src/cli/__tests__/index.test.ts src/cli/__tests__/nested-help-routing.test.ts
- node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/nested-help-routing.test.js dist/cli/__tests__/sparkshell-cli.test.js dist/cli/__tests__/team.test.js dist/cli/__tests__/session-search-help.test.js dist/cli/__tests__/agents-init.test.js dist/cli/__tests__/resume.test.js
- direct `omx ... --help` smoke checks for nested-help owners and deferred fallback commands