### PR TITLE
fix(hud): harden repo/branch display and config loading

### DIFF
--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -40,9 +40,9 @@ describe('runWatchMode', () => {
     const promise = runWatchMode('/tmp', WATCH_FLAGS, {
       isTTY: true,
       env: {},
-      readAllStateFn: async () => emptyCtx(),
-      readHudConfigFn: async () => ({ preset: 'focused' }),
-      renderHudFn: () => 'frame',
+      readAllStateFn: async (_cwd, config) => ({ ...emptyCtx(), gitBranch: config?.git.display ?? null }),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' } }),
+      renderHudFn: (ctx) => `frame:${ctx.gitBranch}`,
       writeStdout: (text) => { writes.push(text); },
       writeStderr: () => {},
       registerSigint: (handler) => { sigintHandler = handler; },
@@ -59,6 +59,7 @@ describe('runWatchMode', () => {
     assert.equal(clearCount, 1);
     assert.ok(writes.some((chunk) => chunk.includes('\x1b[?25l')), 'cursor should be hidden in watch mode');
     assert.ok(writes.some((chunk) => chunk.includes('\x1b[?25h\x1b[2J\x1b[H')), 'cursor should be restored on SIGINT');
+    assert.ok(writes.some((chunk) => chunk.includes('frame:repo-branch')));
   });
 
   it('coalesces ticks so slow renders do not overlap', async () => {
@@ -77,7 +78,7 @@ describe('runWatchMode', () => {
     const promise = runWatchMode('/tmp', WATCH_FLAGS, {
       isTTY: true,
       env: {},
-      readAllStateFn: async () => {
+      readAllStateFn: async (_cwd, config) => {
         callCount += 1;
         inFlight += 1;
         maxInFlight = Math.max(maxInFlight, inFlight);
@@ -90,7 +91,7 @@ describe('runWatchMode', () => {
           inFlight -= 1;
         }
       },
-      readHudConfigFn: async () => ({ preset: 'focused' }),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' } }),
       renderHudFn: () => 'frame',
       writeStdout: (text) => { writes.push(text); },
       writeStderr: () => {},
@@ -128,10 +129,10 @@ describe('runWatchMode', () => {
     await runWatchMode('/tmp', WATCH_FLAGS, {
       isTTY: true,
       env: {},
-      readAllStateFn: async () => {
+      readAllStateFn: async (_cwd, config) => {
         throw new Error('boom');
       },
-      readHudConfigFn: async () => ({ preset: 'focused' }),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' } }),
       renderHudFn: () => 'frame',
       writeStdout: (text) => { writes.push(text); },
       writeStderr: (text) => { errors.push(text); },

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -3,7 +3,17 @@ import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readGitBranch, readRalphState } from '../state.js';
+import { buildGitBranchLabel, readGitBranch, readRalphState } from '../state.js';
+
+function gitRunnerFromMap(map: Record<string, string | Error>) {
+  return (_cwd: string, args: string[]) => {
+    const command = `git ${args.join(' ')}`;
+    const value = map[command];
+    if (value instanceof Error) return null;
+    if (value === undefined) throw new Error(`Unexpected command: ${command}`);
+    return value;
+  };
+}
 
 describe('readGitBranch', () => {
   it('returns null in a non-git directory without printing git fatal noise', async () => {
@@ -29,6 +39,86 @@ describe('readGitBranch', () => {
     }
 
     assert.equal(stderrChunks.join('').includes('not a git repository'), false);
+  });
+});
+
+describe('buildGitBranchLabel', () => {
+  it('keeps the branch when origin lookup fails', () => {
+    const gitRunner = gitRunnerFromMap({
+      'git rev-parse --abbrev-ref HEAD': 'fix/hud-regression',
+      'git remote get-url origin': new Error('missing origin'),
+      'git remote': '',
+      'git rev-parse --show-toplevel': new Error('no top-level'),
+    });
+
+    assert.equal(buildGitBranchLabel('/repo', undefined, gitRunner), 'fix/hud-regression');
+  });
+
+  it('prefers configured remoteName over origin', () => {
+    const gitRunner = gitRunnerFromMap({
+      'git rev-parse --abbrev-ref HEAD': 'feature/test',
+      'git remote get-url upstream': 'git@github.com:acme/upstream-repo.git',
+      'git remote get-url origin': 'git@github.com:acme/origin-repo.git',
+    });
+
+    assert.equal(buildGitBranchLabel('/repo', {
+      preset: 'focused',
+      git: { display: 'repo-branch', remoteName: 'upstream' },
+    }, gitRunner), 'upstream-repo/feature/test');
+  });
+
+  it('prefers origin over first-remote fallback', () => {
+    const gitRunner = gitRunnerFromMap({
+      'git rev-parse --abbrev-ref HEAD': 'feature/test',
+      'git remote get-url origin': 'https://github.com/acme/origin-repo.git',
+    });
+
+    assert.equal(buildGitBranchLabel('/repo', undefined, gitRunner), 'origin-repo/feature/test');
+  });
+
+  it('falls back to the first resolvable remote when origin is absent', () => {
+    const gitRunner = gitRunnerFromMap({
+      'git rev-parse --abbrev-ref HEAD': 'feature/test',
+      'git remote get-url origin': new Error('missing origin'),
+      'git remote': 'upstream\nbackup',
+      'git remote get-url upstream': 'https://github.com/acme/upstream-repo.git',
+    });
+
+    assert.equal(buildGitBranchLabel('/repo', undefined, gitRunner), 'upstream-repo/feature/test');
+  });
+
+  it('falls back to repo basename when no remote resolves', () => {
+    const gitRunner = gitRunnerFromMap({
+      'git rev-parse --abbrev-ref HEAD': 'feature/test',
+      'git remote get-url origin': new Error('missing origin'),
+      'git remote': 'upstream',
+      'git remote get-url upstream': new Error('missing upstream'),
+      'git rev-parse --show-toplevel': '/tmp/project-repo',
+    });
+
+    assert.equal(buildGitBranchLabel('/repo', undefined, gitRunner), 'project-repo/feature/test');
+  });
+
+  it('omits repo prefix in branch display mode', () => {
+    const gitRunner = gitRunnerFromMap({
+      'git rev-parse --abbrev-ref HEAD': 'feature/test',
+    });
+
+    assert.equal(buildGitBranchLabel('/repo', {
+      preset: 'focused',
+      git: { display: 'branch' },
+    }, gitRunner), 'feature/test');
+  });
+
+  it('uses explicit repoLabel before any git remote lookup', () => {
+    const gitRunner = gitRunnerFromMap({
+      'git rev-parse --abbrev-ref HEAD': 'feature/test',
+    });
+
+    assert.equal(buildGitBranchLabel('/repo', {
+      preset: 'focused',
+      git: { display: 'repo-branch', repoLabel: 'manual' },
+    }, gitRunner), 'manual/feature/test');
   });
 });
 

--- a/src/hud/__tests__/types.test.ts
+++ b/src/hud/__tests__/types.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { normalizeHudConfig } from '../state.js';
 import { DEFAULT_HUD_CONFIG } from '../types.js';
 
 describe('DEFAULT_HUD_CONFIG', () => {
@@ -7,13 +8,50 @@ describe('DEFAULT_HUD_CONFIG', () => {
     assert.equal(DEFAULT_HUD_CONFIG.preset, 'focused');
   });
 
-  it('is an object with a preset property', () => {
-    assert.equal(typeof DEFAULT_HUD_CONFIG, 'object');
-    assert.ok('preset' in DEFAULT_HUD_CONFIG);
+  it('defaults git display to repo-branch', () => {
+    assert.deepEqual(DEFAULT_HUD_CONFIG.git, { display: 'repo-branch' });
+  });
+});
+
+describe('normalizeHudConfig', () => {
+  it('returns resolved defaults for nullish config', () => {
+    assert.deepEqual(normalizeHudConfig(undefined), DEFAULT_HUD_CONFIG);
+    assert.deepEqual(normalizeHudConfig(null), DEFAULT_HUD_CONFIG);
   });
 
-  it('preset is a valid HudPreset value', () => {
-    const validPresets = ['minimal', 'focused', 'full'];
-    assert.ok(validPresets.includes(DEFAULT_HUD_CONFIG.preset));
+  it('keeps legacy preset-only configs backward compatible', () => {
+    assert.deepEqual(normalizeHudConfig({ preset: 'minimal' }), {
+      preset: 'minimal',
+      git: { display: 'repo-branch' },
+    });
+  });
+
+  it('deep-merges bounded git config', () => {
+    assert.deepEqual(normalizeHudConfig({
+      preset: 'full',
+      git: {
+        display: 'branch',
+        remoteName: 'upstream',
+        repoLabel: 'manual-repo',
+      },
+    }), {
+      preset: 'full',
+      git: {
+        display: 'branch',
+        remoteName: 'upstream',
+        repoLabel: 'manual-repo',
+      },
+    });
+  });
+
+  it('ignores invalid nested values quietly', () => {
+    assert.deepEqual(normalizeHudConfig({
+      preset: 'focused',
+      git: {
+        display: 'bogus' as never,
+        remoteName: '   ',
+        repoLabel: 123 as never,
+      },
+    }), DEFAULT_HUD_CONFIG);
   });
 });

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -12,7 +12,7 @@
 import { execFileSync } from 'child_process';
 import { readAllState, readHudConfig } from './state.js';
 import { renderHud } from './render.js';
-import type { HudFlags, HudPreset, HudRenderContext } from './types.js';
+import type { HudFlags, HudPreset, HudRenderContext, ResolvedHudConfig } from './types.js';
 import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { sleep } from '../utils/sleep.js';
 
@@ -57,8 +57,8 @@ export async function watchRenderLoop(
 interface RunWatchModeDependencies {
   isTTY: boolean;
   env: NodeJS.ProcessEnv;
-  readAllStateFn: (cwd: string) => Promise<HudRenderContext>;
-  readHudConfigFn: (cwd: string) => Promise<{ preset: HudPreset }>;
+  readAllStateFn: (cwd: string, config?: ResolvedHudConfig) => Promise<HudRenderContext>;
+  readHudConfigFn: (cwd: string) => Promise<ResolvedHudConfig>;
   renderHudFn: (ctx: HudRenderContext, preset: HudPreset) => string;
   writeStdout: (text: string) => void;
   writeStderr: (text: string) => void;
@@ -130,10 +130,8 @@ export async function runWatchMode(
       } else {
         dependencies.writeStdout('\x1b[H');
       }
-      const [ctx, config] = await Promise.all([
-        dependencies.readAllStateFn(cwd),
-        dependencies.readHudConfigFn(cwd),
-      ]);
+      const config = await dependencies.readHudConfigFn(cwd);
+      const ctx = await dependencies.readAllStateFn(cwd, config);
       const preset = flags.preset ?? config.preset;
       const line = dependencies.renderHudFn(ctx, preset);
       dependencies.writeStdout(line + '\x1b[K\n\x1b[J');
@@ -193,10 +191,8 @@ function parseFlags(args: string[]): HudFlags {
 }
 
 async function renderOnce(cwd: string, flags: HudFlags): Promise<void> {
-  const [ctx, config] = await Promise.all([
-    readAllState(cwd),
-    readHudConfig(cwd),
-  ]);
+  const config = await readHudConfig(cwd);
+  const ctx = await readAllState(cwd, config);
 
   const preset = flags.preset ?? config.preset;
 
@@ -236,10 +232,8 @@ export async function hudCommand(args: string[]): Promise<void> {
     } else {
       process.stdout.write('\x1b[H'); // Move cursor to top-left (no clear)
     }
-    const [ctx, config] = await Promise.all([
-      readAllState(cwd),
-      readHudConfig(cwd),
-    ]);
+    const config = await readHudConfig(cwd);
+    const ctx = await readAllState(cwd, config);
     const preset = flags.preset ?? config.preset;
     const line = renderHud(ctx, preset);
     process.stdout.write(line + '\x1b[K\n\x1b[J'); // Write line, clear rest of line + below

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -7,7 +7,7 @@
 import { readFile } from 'fs/promises';
 import { readFileSync } from 'fs';
 import { execSync } from 'child_process';
-import { join, dirname } from 'path';
+import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { omxStateDir } from '../utils/paths.js';
 import { getReadScopedStatePaths } from '../mcp/state-paths.js';
@@ -21,6 +21,8 @@ import type {
   HudConfig,
   HudRenderContext,
   SessionStateForHud,
+  ResolvedHudConfig,
+  HudGitDisplay,
 } from './types.js';
 import { DEFAULT_HUD_CONFIG } from './types.js';
 
@@ -40,6 +42,49 @@ async function readScopedModeState<T>(cwd: string, mode: string): Promise<T | nu
     if (state) return state;
   }
   return null;
+}
+
+function isValidPreset(value: unknown): value is ResolvedHudConfig['preset'] {
+  return value === 'minimal' || value === 'focused' || value === 'full';
+}
+
+function isValidGitDisplay(value: unknown): value is HudGitDisplay {
+  return value === 'branch' || value === 'repo-branch';
+}
+
+function sanitizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedHudConfig {
+  const normalized: ResolvedHudConfig = {
+    preset: DEFAULT_HUD_CONFIG.preset,
+    git: {
+      ...DEFAULT_HUD_CONFIG.git,
+    },
+  };
+
+  if (!raw || typeof raw !== 'object') return normalized;
+
+  if (isValidPreset(raw.preset)) {
+    normalized.preset = raw.preset;
+  }
+
+  if (raw.git && typeof raw.git === 'object') {
+    if (isValidGitDisplay(raw.git.display)) {
+      normalized.git.display = raw.git.display;
+    }
+
+    const remoteName = sanitizeOptionalString(raw.git.remoteName);
+    if (remoteName) normalized.git.remoteName = remoteName;
+
+    const repoLabel = sanitizeOptionalString(raw.git.repoLabel);
+    if (repoLabel) normalized.git.repoLabel = repoLabel;
+  }
+
+  return normalized;
 }
 
 export async function readRalphState(cwd: string): Promise<RalphStateForHud | null> {
@@ -75,9 +120,9 @@ export async function readSessionState(cwd: string): Promise<SessionStateForHud 
   return state?.session_id ? state : null;
 }
 
-export async function readHudConfig(cwd: string): Promise<HudConfig> {
+export async function readHudConfig(cwd: string): Promise<ResolvedHudConfig> {
   const config = await readJsonFile<HudConfig>(join(cwd, '.omx', 'hud-config.json'));
-  return config ?? DEFAULT_HUD_CONFIG;
+  return normalizeHudConfig(config);
 }
 
 export function readVersion(): string | null {
@@ -91,28 +136,96 @@ export function readVersion(): string | null {
   }
 }
 
-export function readGitBranch(cwd: string): string | null {
+export type GitRunner = (cwd: string, args: string[]) => string | null;
+
+function runGit(cwd: string, args: string[]): string | null {
   try {
-    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+    return execSync(`git ${args.join(' ')}`, {
       cwd,
       encoding: 'utf-8',
       timeout: 2000,
       stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    const remote = execSync('git remote get-url origin', { cwd, encoding: 'utf-8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-    // Extract repo name from URL: https://github.com/user/repo.git -> repo
-    const repoMatch = remote.match(/\/([^/]+?)(?:\.git)?$/);
-    const repo = repoMatch ? repoMatch[1] : null;
-    return repo ? `${repo}/${branch}` : branch;
+    }).trim() || null;
   } catch {
     return null;
   }
 }
 
+function extractRepoName(remoteUrl: string | null): string | null {
+  if (!remoteUrl) return null;
+  const repoMatch = remoteUrl.match(/[:/]([^/]+?)(?:\.git)?$/);
+  return repoMatch?.[1] ?? null;
+}
+
+function readGitBranchName(cwd: string, gitRunner: GitRunner): string | null {
+  return gitRunner(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
+}
+
+function readGitRemoteUrl(cwd: string, remoteName: string, gitRunner: GitRunner): string | null {
+  return gitRunner(cwd, ['remote', 'get-url', remoteName]);
+}
+
+function readFirstRemoteName(cwd: string, gitRunner: GitRunner): string | null {
+  const remotes = gitRunner(cwd, ['remote']);
+  if (!remotes) return null;
+
+  for (const remote of remotes.split(/\r?\n/)) {
+    const trimmed = remote.trim();
+    if (trimmed) return trimmed;
+  }
+
+  return null;
+}
+
+function readRepoBasename(cwd: string, gitRunner: GitRunner): string | null {
+  const topLevel = gitRunner(cwd, ['rev-parse', '--show-toplevel']);
+  return topLevel ? basename(topLevel) : null;
+}
+
+function resolveRepoLabel(cwd: string, config: ResolvedHudConfig, gitRunner: GitRunner): string | null {
+  if (config.git.repoLabel) return config.git.repoLabel;
+
+  if (config.git.remoteName) {
+    const repoFromConfiguredRemote = extractRepoName(readGitRemoteUrl(cwd, config.git.remoteName, gitRunner));
+    if (repoFromConfiguredRemote) return repoFromConfiguredRemote;
+  }
+
+  const repoFromOrigin = extractRepoName(readGitRemoteUrl(cwd, 'origin', gitRunner));
+  if (repoFromOrigin) return repoFromOrigin;
+
+  const firstRemoteName = readFirstRemoteName(cwd, gitRunner);
+  if (firstRemoteName) {
+    const repoFromFirstRemote = extractRepoName(readGitRemoteUrl(cwd, firstRemoteName, gitRunner));
+    if (repoFromFirstRemote) return repoFromFirstRemote;
+  }
+
+  return readRepoBasename(cwd, gitRunner);
+}
+
+export function readGitBranch(cwd: string): string | null {
+  return readGitBranchName(cwd, runGit);
+}
+
+export function buildGitBranchLabel(
+  cwd: string,
+  config: ResolvedHudConfig = DEFAULT_HUD_CONFIG,
+  gitRunner: GitRunner = runGit,
+): string | null {
+  const branch = readGitBranchName(cwd, gitRunner);
+  if (!branch) return null;
+
+  if (config.git.display === 'branch') {
+    return branch;
+  }
+
+  const repoLabel = resolveRepoLabel(cwd, config, gitRunner);
+  return repoLabel ? `${repoLabel}/${branch}` : branch;
+}
+
 /** Read all state files and build the full render context */
-export async function readAllState(cwd: string): Promise<HudRenderContext> {
+export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFAULT_HUD_CONFIG): Promise<HudRenderContext> {
   const version = readVersion();
-  const gitBranch = readGitBranch(cwd);
+  const gitBranch = buildGitBranchLabel(cwd, config);
 
   const [ralph, ultrawork, autopilot, team, metrics, hudNotify, session] =
     await Promise.all([

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -70,14 +70,37 @@ export interface HudRenderContext {
 /** HUD preset names */
 export type HudPreset = 'minimal' | 'focused' | 'full';
 
+export type HudGitDisplay = 'branch' | 'repo-branch';
+
+export interface HudGitConfig {
+  display?: HudGitDisplay;
+  remoteName?: string;
+  repoLabel?: string;
+}
+
 /** HUD configuration stored in .omx/hud-config.json */
 export interface HudConfig {
+  preset?: HudPreset;
+  git?: HudGitConfig;
+}
+
+export interface ResolvedHudGitConfig {
+  display: HudGitDisplay;
+  remoteName?: string;
+  repoLabel?: string;
+}
+
+export interface ResolvedHudConfig {
   preset: HudPreset;
+  git: ResolvedHudGitConfig;
 }
 
 /** Default HUD configuration */
-export const DEFAULT_HUD_CONFIG: HudConfig = {
+export const DEFAULT_HUD_CONFIG: ResolvedHudConfig = {
   preset: 'focused',
+  git: {
+    display: 'repo-branch',
+  },
 };
 
 /** CLI flags for omx hud */


### PR DESCRIPTION
## Summary
- decouple HUD branch rendering from `origin`-only lookup failures
- add bounded normalized HUD config with git display defaults
- thread normalized config through HUD state/watch paths while preserving `flags.preset ?? config.preset`
- add regression coverage for missing-origin and fallback-order behavior

## Why
This hardens the HUD for worktrees/repos where the GitHub remote is not named `origin`. Previously the HUD could hide repo/branch entirely even when branch lookup succeeded.

## Verification
- `npm run build`
- `node --test dist/hud/__tests__/state.test.js dist/hud/__tests__/types.test.js dist/hud/__tests__/render.test.js dist/hud/__tests__/index.test.js dist/hud/__tests__/hud-tmux-injection.test.js`
- `npx biome lint src/hud/types.ts src/hud/state.ts src/hud/index.ts src/hud/__tests__/state.test.ts src/hud/__tests__/types.test.ts src/hud/__tests__/index.test.ts`
- `node bin/omx.js hud --preset=focused` shows repo/branch again in this no-`origin` worktree

## Notes
- keeps `gitBranch` string-based in phase 1
- defers broader HUD layout/ordering work