### PR TITLE
fix(team): distribute generated aspect tasks across workers

### DIFF
--- a/src/cli/__tests__/team-decompose.test.ts
+++ b/src/cli/__tests__/team-decompose.test.ts
@@ -34,6 +34,13 @@ describe('decomposeTaskString', () => {
     assert.match(tasks[2].subject, /review|document/i);
   });
 
+  it('round-robins generated aspect subtasks when explicit same-role fanout is requested', () => {
+    const tasks = decomposeTaskString('implement user login', 3, 'executor', true, true);
+    assert.equal(tasks.length, 3);
+    assert.deepEqual(tasks.map((task) => task.owner), ['worker-1', 'worker-2', 'worker-3']);
+    assert.deepEqual(new Set(tasks.map((task) => task.role)), new Set(['executor']));
+  });
+
   it('assigns all workers the explicit agentType when explicitAgentType=true', () => {
     const tasks = decomposeTaskString('fix tests, build UI, and write docs', 3, 'executor', true);
     assert.equal(tasks.length, 3);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -418,6 +418,7 @@ export function buildTeamExecutionPlan(
   const fallbackRole = resolveImplicitTeamFallbackRole(agentType, explicitAgentType);
 
   let subtasks = plan.subtasks;
+  const usedAspectSubtasks = subtasks.length <= 1 && effectiveWorkerCount > 1;
   if (subtasks.length <= 1 && effectiveWorkerCount > 1) {
     subtasks = createAspectSubtasks(task, effectiveWorkerCount);
   }
@@ -430,9 +431,17 @@ export function buildTeamExecutionPlan(
     return { ...st, role: result.role };
   });
 
+  const normalizedRoles = new Set(tasksWithRoles.map((task) => (task.role ?? '').trim()));
+  const tasks = usedAspectSubtasks && tasksWithRoles.length > 1 && normalizedRoles.size <= 1
+    ? tasksWithRoles.map((task, index) => ({
+      ...task,
+      owner: `worker-${(index % effectiveWorkerCount) + 1}`,
+    }))
+    : distributeTasksToWorkers(tasksWithRoles, effectiveWorkerCount);
+
   return {
     workerCount: effectiveWorkerCount,
-    tasks: distributeTasksToWorkers(tasksWithRoles, effectiveWorkerCount),
+    tasks,
   };
 }
 


### PR DESCRIPTION
## Summary\n- distribute generated aspect subtasks across workers instead of assigning them all to worker-1\n- add regression coverage for explicit same-role aspect fanout\n\n## Verification\n- npm run build\n- node --test dist/cli/__tests__/team-decompose.test.js dist/cli/__tests__/team.test.js\n