### PR TITLE
fix(team): use fish-compatible PATH syntax in worker startup command

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -824,6 +824,43 @@ describe('buildWorkerStartupCommand', () => {
       else delete process.env.MSYSTEM;
     }
   });
+
+  it('uses fish-compatible PATH syntax when SHELL is fish', () => {
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.SHELL = '/opt/homebrew/bin/fish';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const cmd = buildWorkerStartupCommand('alpha', 1, [], '/tmp/project');
+      // Fish uses 'set -x PATH ... $PATH' instead of 'export PATH=...:$PATH'
+      assert.doesNotMatch(cmd, /export PATH=/);
+      assert.match(cmd, /set -x PATH/);
+      // Shell should still be fish
+      assert.match(cmd, /fish/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('does not use colon-separated PATH concatenation for fish shell', () => {
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.SHELL = '/usr/bin/fish';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const cmd = buildWorkerStartupCommand('alpha', 1, [], '/tmp/project');
+      // Fish PATH is space-separated, not colon-separated
+      assert.doesNotMatch(cmd, /':[$]PATH/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
 });
 
 describe('team worker CLI helpers', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -620,7 +620,10 @@ export function buildWorkerStartupCommand(
   );
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
   const leaderNodeDir = resolveLeaderNodePath().replace(/\/[^/]+$/, ''); // dirname
-  const pathPrefix = leaderNodeDir ? `export PATH='${leaderNodeDir}':$PATH; ` : '';
+  const isFish = /\/fish$/i.test(launchSpec.shell);
+  const pathPrefix = leaderNodeDir
+    ? (isFish ? `set -x PATH '${leaderNodeDir}' $PATH; ` : `export PATH='${leaderNodeDir}':$PATH; `)
+    : '';
   const quotedArgs = processSpec.args.map(shellQuoteSingle).join(' ');
   const cliInvocation = quotedArgs.length > 0 ? `exec ${processSpec.command} ${quotedArgs}` : `exec ${processSpec.command}`;
   const rcPrefix = launchSpec.rcFile ? `if [ -f ${launchSpec.rcFile} ]; then source ${launchSpec.rcFile}; fi; ` : '';


### PR DESCRIPTION
## Summary

- Fix fish shell compatibility in team worker startup: `buildWorkerStartupCommand` now emits `set -x PATH '...' $PATH` (fish-native) instead of POSIX `export PATH='...':$PATH` when `SHELL` is fish
- The POSIX syntax corrupts fish's space-separated PATH list, causing `env: node: No such file or directory` → worker timeout (`Worker worker-N did not become ready`)

## Root Cause

Fish shell's `PATH` is a **space-separated list** (not colon-separated). When `buildWorkerStartupCommand` runs `export PATH='/path':$PATH` inside `fish -lc '...'`, it collapses the entire PATH into a single broken entry. All binary lookups fail, including `node` (needed by codex's shebang `#!/usr/bin/env node`).

## Changes

| File | Change |
|------|--------|
| `src/team/tmux-session.ts` | Detect fish shell via `/\/fish$/i` regex, emit `set -x PATH` instead of `export PATH` |
| `src/team/__tests__/tmux-session.test.ts` | 2 TDD tests: verify fish-compatible syntax + no colon-separated PATH for fish |

## Validation

- [x] TDD: wrote failing tests first, then fixed code
- [x] 132/132 tmux-session tests pass (0 regressions)
- [x] 2248 total project tests: 2243 pass, 5 fail (all 5 pre-existing on `main`)
- [x] Manual QA: verified generated command strings for both fish and bash shells
- [x] Build passes (`tsc` clean)