### PR TITLE
fix: probe Windows codex cmd shims correctly

### DIFF
--- a/src/utils/__tests__/platform-command.test.ts
+++ b/src/utils/__tests__/platform-command.test.ts
@@ -29,8 +29,10 @@ describe('buildPlatformCommandSpec', () => {
 
       assert.equal(spec.command, 'C:\\Windows\\System32\\cmd.exe');
       assert.deepEqual(spec.args.slice(0, 3), ['/d', '/s', '/c']);
+      assert.match(spec.args[3] || '', /^""/);
       assert.match(spec.args[3] || '', /codex\.cmd/i);
       assert.match(spec.args[3] || '', /--version/i);
+      assert.match(spec.args[3] || '', /""$/);
       assert.equal(spec.resolvedPath, cmdPath);
     } finally {
       await rm(fakeBin, { recursive: true, force: true });
@@ -129,7 +131,11 @@ describe('spawnPlatformCommandSync', () => {
     try {
       const cmdPath = join(fakeBin, 'codex.cmd');
       await writeFile(cmdPath, '@echo off\r\n');
-      const calls: Array<{ command: string; args: readonly string[] }> = [];
+      const calls: Array<{
+        command: string;
+        args: readonly string[];
+        options?: { windowsVerbatimArguments?: boolean };
+      }> = [];
 
       const probed = spawnPlatformCommandSync(
         'codex',
@@ -142,8 +148,8 @@ describe('spawnPlatformCommandSync', () => {
           ComSpec: 'C:\\Windows\\System32\\cmd.exe',
         },
         undefined,
-        (((command: string, args: readonly string[]) => {
-          calls.push({ command, args });
+        (((command: string, args: readonly string[], options?: { windowsVerbatimArguments?: boolean }) => {
+          calls.push({ command, args, options });
           return {
             status: 0,
             stdout: 'ok',
@@ -159,6 +165,77 @@ describe('spawnPlatformCommandSync', () => {
       assert.equal(calls.length, 1);
       assert.equal(calls[0]?.command, 'C:\\Windows\\System32\\cmd.exe');
       assert.match((calls[0]?.args[3] || ''), /codex\.cmd/i);
+      assert.equal(calls[0]?.options?.windowsVerbatimArguments, true);
+    } finally {
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('does not force verbatim arguments for direct Windows executables', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-platform-spawn-exe-'));
+    try {
+      const exePath = join(fakeBin, 'tmux.exe');
+      await writeFile(exePath, '');
+      const calls: Array<{
+        command: string;
+        args: readonly string[];
+        options?: { windowsVerbatimArguments?: boolean };
+      }> = [];
+
+      spawnPlatformCommandSync(
+        'tmux',
+        ['-V'],
+        { encoding: 'utf-8' },
+        'win32',
+        {
+          PATH: fakeBin,
+          PATHEXT: '.EXE;.CMD',
+        },
+        undefined,
+        (((command: string, args: readonly string[], options?: { windowsVerbatimArguments?: boolean }) => {
+          calls.push({ command, args, options });
+          return {
+            status: 0,
+            stdout: 'ok',
+            stderr: '',
+            pid: 1,
+            output: [],
+            signal: null,
+          };
+        }) as unknown) as typeof import('child_process').spawnSync,
+      );
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0]?.command, exePath);
+      assert.equal(calls[0]?.options?.windowsVerbatimArguments, undefined);
+    } finally {
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('launches Windows cmd shims successfully with the real spawn implementation', async () => {
+    if (process.platform !== 'win32') return;
+
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-platform-spawn-real-'));
+    try {
+      const cmdPath = join(fakeBin, 'codex.cmd');
+      await writeFile(cmdPath, '@echo off\r\necho fake-codex 1.2.3\r\n');
+
+      const probed = spawnPlatformCommandSync(
+        'codex',
+        ['--version'],
+        { encoding: 'utf-8' },
+        'win32',
+        {
+          ...process.env,
+          PATH: [fakeBin, process.env.PATH || process.env.Path || ''].filter(Boolean).join(';'),
+          PATHEXT: '.CMD;.EXE',
+          ComSpec: process.env.ComSpec || 'C:\\Windows\\System32\\cmd.exe',
+        },
+      );
+
+      assert.equal(probed.result.status, 0, probed.result.stderr);
+      assert.equal((probed.result.stdout || '').trim(), 'fake-codex 1.2.3');
     } finally {
       await rm(fakeBin, { recursive: true, force: true });
     }

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -93,13 +93,21 @@ function buildCmdLaunch(commandPath: string, args: string[], env: NodeJS.Process
   const commandLine = [commandPath, ...args].map(quoteForCmd).join(' ');
   return {
     command: env.ComSpec || 'cmd.exe',
-    args: ['/d', '/s', '/c', commandLine],
+    args: ['/d', '/s', '/c', `"${commandLine}"`],
     resolvedPath: commandPath,
   };
 }
 
 function resolvePowerShellExecutable(env: NodeJS.ProcessEnv, existsImpl: ExistsSyncLike): string {
   return resolveWindowsCommandPath('powershell', env, existsImpl) || 'powershell.exe';
+}
+
+function shouldUseWindowsVerbatimArguments(platform: NodeJS.Platform, spec: PlatformCommandSpec): boolean {
+  return (
+    platform === 'win32' &&
+    typeof spec.resolvedPath === 'string' &&
+    classifyWindowsCommandPath(spec.resolvedPath) === 'cmd'
+  );
 }
 
 export function classifySpawnError(error: NodeJS.ErrnoException | undefined | null): SpawnErrorKind | null {
@@ -165,6 +173,9 @@ export function spawnPlatformCommandSync(
   spawnImpl: SpawnSyncLike = spawnSync,
 ): ProbedPlatformCommand {
   const spec = buildPlatformCommandSpec(command, args, platform, env, existsImpl);
-  const result = spawnImpl(spec.command, spec.args, options);
+  const spawnOptions = shouldUseWindowsVerbatimArguments(platform, spec)
+    ? { ...options, windowsVerbatimArguments: true }
+    : options;
+  const result = spawnImpl(spec.command, spec.args, spawnOptions);
   return { spec, result };
 }


### PR DESCRIPTION
## Summary

Fix a Windows false positive in `omx doctor` when Codex is installed via a `.cmd` shim.

On Windows, the doctor probe wraps `codex.cmd` with `cmd.exe /d /s /c`, but the generated command line was not wrapped in the form `cmd.exe` expects when launched from Node. That made `omx doctor` report Codex as missing/broken even though `codex --version` worked.

## Changes

- wrap Windows `.cmd` command lines with the extra outer quotes required by `cmd.exe /c`
- pass `windowsVerbatimArguments: true` only for resolved Windows `.cmd`/`.bat` launches so Node does not re-escape the prebuilt command line
- extend platform command tests to cover the new quoting shape, verbatim-argument behavior, and a real Windows `.cmd` spawn regression test

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `omx doctor` (via `node bin/omx.js doctor` on Windows)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #