### PR TITLE
Refactor notify-hook pane injection paths

### DIFF
--- a/scripts/notify-hook/auto-nudge.js
+++ b/scripts/notify-hook/auto-nudge.js
@@ -10,7 +10,7 @@ import { asNumber, safeString } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession, readdir } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
-import { checkPaneReadyForTeamSendKeys } from './team-tmux-guard.js';
+import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
 import { buildCapturePaneArgv, DEFAULT_MARKER } from '../tmux-hook-engine.js';
 
 export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
@@ -304,15 +304,6 @@ export async function resolveNudgePaneTarget(stateDir) {
   return '';
 }
 
-async function emitInjectionMessage(paneId, message) {
-  const markedResponse = `${message} ${DEFAULT_MARKER}`;
-  await runProcess('tmux', ['send-keys', '-t', paneId, '-l', markedResponse], 3000);
-  await new Promise(r => setTimeout(r, 100));
-  await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
-  await new Promise(r => setTimeout(r, 100));
-  await runProcess('tmux', ['send-keys', '-t', paneId, 'C-m'], 3000);
-}
-
 export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
   const config = await loadAutoNudgeConfig();
   if (!config.enabled) return;
@@ -354,14 +345,15 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     if (skillState?.phase === 'completing' && !detected) return;
     if (!detected || !paneId) return;
 
-    const paneGuard = await checkPaneReadyForTeamSendKeys(paneId);
+    const paneGuard = await evaluatePaneInjectionReadiness(paneId, { skipIfScrolling: true });
     if (!paneGuard.ok) {
       await logTmuxHookEvent(logsDir, {
         timestamp: new Date().toISOString(),
         type: 'auto_nudge_skipped',
         pane_id: paneId,
-        reason: paneGuard.reason,
+        reason: mapPaneInjectionReadinessReason(paneGuard.reason),
         source,
+        pane_current_command: paneGuard.paneCurrentCommand || undefined,
       }).catch(() => {});
       return;
     }
@@ -369,7 +361,15 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     const deepInterviewLockActive = isDeepInterviewAutoApprovalLocked(skillState) && !releaseReason;
     if (deepInterviewLockActive && isBlockedAutoApprovalInput(config.response, skillState.input_lock?.blocked_inputs)) {
       const blockedMessage = skillState.input_lock?.message || DEEP_INTERVIEW_INPUT_LOCK_MESSAGE;
-      await emitInjectionMessage(paneId, blockedMessage);
+      const blockedSend = await sendPaneInput({
+        paneTarget: paneId,
+        prompt: `${blockedMessage} ${DEFAULT_MARKER}`,
+        submitKeyPresses: 2,
+        submitDelayMs: 100,
+      });
+      if (!blockedSend.ok) {
+        throw new Error(blockedSend.error || blockedSend.reason);
+      }
       await logTmuxHookEvent(logsDir, {
         timestamp: new Date().toISOString(),
         type: 'auto_nudge_blocked',
@@ -388,7 +388,15 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
 
     const nowIso = new Date().toISOString();
     try {
-      await emitInjectionMessage(paneId, config.response);
+      const sendResult = await sendPaneInput({
+        paneTarget: paneId,
+        prompt: `${config.response} ${DEFAULT_MARKER}`,
+        submitKeyPresses: 2,
+        submitDelayMs: 100,
+      });
+      if (!sendResult.ok) {
+        throw new Error(sendResult.error || sendResult.reason);
+      }
 
       nudgeState.nudgeCount = nudgeCount + 1;
       nudgeState.lastNudgeAt = nowIso;

--- a/scripts/notify-hook/team-dispatch.js
+++ b/scripts/notify-hook/team-dispatch.js
@@ -4,9 +4,9 @@ import { dirname, join, resolve } from 'path';
 import { safeString } from './utils.js';
 import { runProcess } from './process-runner.js';
 import { resolvePaneTarget } from './tmux-injection.js';
+import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import {
   buildCapturePaneArgv,
-  buildPaneInModeArgv,
   buildSendKeysArgv,
   normalizeTmuxCapture,
   paneHasActiveTask,
@@ -297,13 +297,14 @@ async function injectDispatchRequest(request, config, cwd) {
   if (!resolution.paneTarget) {
     return { ok: false, reason: `target_resolution_failed:${resolution.reason}` };
   }
-  try {
-    const inMode = await runProcess('tmux', buildPaneInModeArgv(resolution.paneTarget), 1000);
-    if (safeString(inMode.stdout).trim() === '1') {
-      return { ok: false, reason: 'scroll_active' };
-    }
-  } catch {
-    // best effort
+  const paneGuard = await evaluatePaneInjectionReadiness(resolution.paneTarget, {
+    skipIfScrolling: true,
+    requireRunningAgent: false,
+    requireReady: false,
+    requireIdle: false,
+  });
+  if (!paneGuard.ok) {
+    return { ok: false, reason: paneGuard.reason };
   }
 
   const argv = buildSendKeysArgv({
@@ -336,7 +337,14 @@ async function injectDispatchRequest(request, config, cwd) {
       await runProcess('tmux', ['send-keys', '-t', resolution.paneTarget, 'C-u'], 1000).catch(() => {});
       await new Promise((r) => setTimeout(r, 50));
     }
-    await runProcess('tmux', argv.typeArgv, 3000);
+    const typeResult = await sendPaneInput({
+      paneTarget: resolution.paneTarget,
+      prompt: request.trigger_message,
+      submitKeyPresses: 0,
+    });
+    if (!typeResult.ok) {
+      return { ok: false, reason: typeResult.reason };
+    }
   }
 
   for (const submit of argv.submitArgv) {
@@ -389,7 +397,8 @@ async function injectDispatchRequest(request, config, cwd) {
 
 function shouldSkipRequest(request) {
   if (request.status !== 'pending') return true;
-  return request.transport_preference !== 'hook_preferred_with_fallback';
+  const preference = safeString(request.transport_preference).trim();
+  return preference !== '' && preference !== 'hook_preferred_with_fallback';
 }
 
 async function updateMailboxNotified(stateDir, teamName, workerName, messageId) {

--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -9,7 +9,7 @@ import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
-import { checkPaneReadyForTeamSendKeys } from './team-tmux-guard.js';
+import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
@@ -659,13 +659,16 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
       continue;
     }
 
-    const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
+    const paneGuard = await evaluatePaneInjectionReadiness(tmuxTarget, { skipIfScrolling: true });
     if (!paneGuard.ok) {
+      const deferredReason = paneGuard.reason === 'pane_running_shell'
+        ? LEADER_PANE_SHELL_NO_INJECTION_REASON
+        : paneGuard.reason;
       nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '', reason: nudgeReason };
       if (shouldSendAllIdleNudge) {
         nudgeState.last_idle_nudged_by_team[teamName] = { at: nowIso, worker_count: workerNames.length };
       }
-      await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_SHELL_NO_INJECTION_REASON, nowIso, {
+      await emitLeaderNudgeDeferredEvent(cwd, teamName, deferredReason, nowIso, {
         tmuxSession,
         leaderPaneId,
         paneCurrentCommand: paneGuard.paneCurrentCommand,
@@ -678,11 +681,12 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
           team: teamName,
           worker: 'leader-fixed',
           to_worker: 'leader-fixed',
-          reason: LEADER_PANE_SHELL_NO_INJECTION_REASON,
+          reason: deferredReason,
           leader_pane_id: leaderPaneId || null,
           tmux_session: tmuxSession || null,
           tmux_injection_attempted: false,
           pane_current_command: paneGuard.paneCurrentCommand || null,
+          injection_skip_reason: paneGuard.reason,
           source_type: 'leader_nudge',
         });
       } catch { /* ignore */ }
@@ -690,11 +694,15 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     }
 
     try {
-      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, '-l', markedText], 3000);
-      await new Promise(r => setTimeout(r, 100));
-      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'C-m'], 3000);
-      await new Promise(r => setTimeout(r, 100));
-      await runProcess('tmux', ['send-keys', '-t', tmuxTarget, 'C-m'], 3000);
+      const sendResult = await sendPaneInput({
+        paneTarget: tmuxTarget,
+        prompt: markedText,
+        submitKeyPresses: 2,
+        submitDelayMs: 100,
+      });
+      if (!sendResult.ok) {
+        throw new Error(sendResult.error || sendResult.reason);
+      }
       nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '', reason: nudgeReason };
       if (shouldSendAllIdleNudge) {
         nudgeState.last_idle_nudged_by_team[teamName] = { at: nowIso, worker_count: workerNames.length };

--- a/scripts/notify-hook/team-tmux-guard.js
+++ b/scripts/notify-hook/team-tmux-guard.js
@@ -2,26 +2,65 @@ import { safeString } from './utils.js';
 import { runProcess } from './process-runner.js';
 import {
   buildCapturePaneArgv,
+  buildPaneInModeArgv,
   buildPaneCurrentCommandArgv,
+  buildSendKeysArgv,
   isPaneRunningShell,
   paneHasActiveTask,
   paneLooksReady,
 } from '../tmux-hook-engine.js';
 
-export async function checkPaneReadyForTeamSendKeys(paneTarget) {
+export function mapPaneInjectionReadinessReason(reason) {
+  return reason === 'pane_running_shell' ? 'agent_not_running' : reason;
+}
+
+export async function evaluatePaneInjectionReadiness(paneTarget, {
+  skipIfScrolling = false,
+  captureLines = 80,
+  requireRunningAgent = true,
+  requireReady = true,
+  requireIdle = true,
+} = {}) {
   const target = safeString(paneTarget).trim();
   if (!target) {
-    return { ok: false, reason: 'missing_pane_target', paneCurrentCommand: '', paneCapture: '' };
+    return {
+      ok: false,
+      sent: false,
+      reason: 'missing_pane_target',
+      paneTarget: '',
+      paneCurrentCommand: '',
+      paneCapture: '',
+    };
+  }
+
+  if (skipIfScrolling) {
+    try {
+      const modeResult = await runProcess('tmux', buildPaneInModeArgv(target), 1000);
+      if (safeString(modeResult.stdout).trim() === '1') {
+        return {
+          ok: false,
+          sent: false,
+          reason: 'scroll_active',
+          paneTarget: target,
+          paneCurrentCommand: '',
+          paneCapture: '',
+        };
+      }
+    } catch {
+      // Non-fatal: continue with remaining preflight checks.
+    }
   }
 
   let paneCurrentCommand = '';
   try {
     const result = await runProcess('tmux', buildPaneCurrentCommandArgv(target), 1000);
     paneCurrentCommand = safeString(result.stdout).trim();
-    if (isPaneRunningShell(paneCurrentCommand)) {
+    if (requireRunningAgent && isPaneRunningShell(paneCurrentCommand)) {
       return {
         ok: false,
+        sent: false,
         reason: 'pane_running_shell',
+        paneTarget: target,
         paneCurrentCommand,
         paneCapture: '',
       };
@@ -31,18 +70,100 @@ export async function checkPaneReadyForTeamSendKeys(paneTarget) {
   }
 
   try {
-    const capture = await runProcess('tmux', buildCapturePaneArgv(target), 1000);
+    const capture = await runProcess('tmux', buildCapturePaneArgv(target, captureLines), 1000);
     const paneCapture = safeString(capture.stdout);
     if (paneCapture.trim() !== '') {
-      if (paneHasActiveTask(paneCapture)) {
-        return { ok: false, reason: 'pane_has_active_task', paneCurrentCommand, paneCapture };
+      if (requireIdle && paneHasActiveTask(paneCapture)) {
+        return {
+          ok: false,
+          sent: false,
+          reason: 'pane_has_active_task',
+          paneTarget: target,
+          paneCurrentCommand,
+          paneCapture,
+        };
       }
-      if (!paneLooksReady(paneCapture)) {
-        return { ok: false, reason: 'pane_not_ready', paneCurrentCommand, paneCapture };
+      if (requireReady && !paneLooksReady(paneCapture)) {
+        return {
+          ok: false,
+          sent: false,
+          reason: 'pane_not_ready',
+          paneTarget: target,
+          paneCurrentCommand,
+          paneCapture,
+        };
       }
     }
-    return { ok: true, paneCurrentCommand, paneCapture };
+    return {
+      ok: true,
+      sent: false,
+      reason: 'ok',
+      paneTarget: target,
+      paneCurrentCommand,
+      paneCapture,
+    };
   } catch {
-    return { ok: true, paneCurrentCommand, paneCapture: '' };
+    return {
+      ok: true,
+      sent: false,
+      reason: 'ok',
+      paneTarget: target,
+      paneCurrentCommand,
+      paneCapture: '',
+    };
   }
+}
+
+export async function sendPaneInput({
+  paneTarget,
+  prompt,
+  submitKeyPresses = 2,
+  submitDelayMs = 0,
+}) {
+  const target = safeString(paneTarget).trim();
+  if (!target) {
+    return { ok: false, sent: false, reason: 'missing_pane_target', paneTarget: '' };
+  }
+
+  const normalizedSubmitKeyPresses = Number.isFinite(submitKeyPresses)
+    ? Math.max(0, Math.floor(submitKeyPresses))
+    : 2;
+  const argv = normalizedSubmitKeyPresses === 0
+    ? {
+      typeArgv: ['send-keys', '-t', target, '-l', prompt],
+      submitArgv: [],
+    }
+    : buildSendKeysArgv({
+      paneTarget: target,
+      prompt,
+      dryRun: false,
+      submitKeyPresses: normalizedSubmitKeyPresses,
+    });
+  if (!argv) {
+    return { ok: false, sent: false, reason: 'send_failed', paneTarget: target };
+  }
+
+  try {
+    await runProcess('tmux', argv.typeArgv, 3000);
+    for (const submit of argv.submitArgv) {
+      if (submitDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, submitDelayMs));
+      }
+      await runProcess('tmux', submit, 3000);
+    }
+    return { ok: true, sent: true, reason: 'sent', paneTarget: target, argv };
+  } catch (error) {
+    return {
+      ok: false,
+      sent: false,
+      reason: 'send_failed',
+      paneTarget: target,
+      argv,
+      error: error instanceof Error ? error.message : safeString(error),
+    };
+  }
+}
+
+export async function checkPaneReadyForTeamSendKeys(paneTarget) {
+  return evaluatePaneInjectionReadiness(paneTarget);
 }

--- a/scripts/notify-hook/tmux-injection.js
+++ b/scripts/notify-hook/tmux-injection.js
@@ -16,13 +16,12 @@ import {
 } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
-import { checkPaneReadyForTeamSendKeys } from './team-tmux-guard.js';
+import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
 import {
   normalizeTmuxHookConfig,
   pickActiveMode,
   evaluateInjectionGuards,
   buildSendKeysArgv,
-  buildPaneInModeArgv,
 } from '../tmux-hook-engine.js';
 
 export async function resolveSessionToPane(sessionName) {
@@ -346,40 +345,14 @@ export async function handleTmuxInjection({
     }
   };
 
-  // Scroll-safety guard: skip injection when the user is actively scrolling
-  // (pane is in copy-mode / tmux's scrollback view).  Sending keys to a pane
-  // in copy-mode would exit scrollback and disrupt the user's review session.
-  // We do NOT record the dedupe key here so the injection can be retried on
-  // the next agent-turn event once the pane is no longer in scroll mode.
-  if (config.skip_if_scrolling) {
-    try {
-      const modeResult = await runProcess('tmux', buildPaneInModeArgv(paneTarget), 1000);
-      const paneInMode = safeString(modeResult.stdout).trim();
-      if (paneInMode === '1') {
-        state.last_reason = 'scroll_active';
-        state.last_event_at = nowIso;
-        await writeFile(hookStatePath, JSON.stringify(state, null, 2)).catch(() => {});
-        await logTmuxHookEvent(logsDir, {
-          ...baseLog,
-          event: 'injection_skipped',
-          reason: 'scroll_active',
-          pane_target: paneTarget,
-        });
-        return;
-      }
-    } catch {
-      // Non-fatal: if querying copy-mode state fails, proceed with injection.
-    }
-  }
-
-  // Shared pane-state guard: skip injection when the target pane has returned
-  // to a shell, is still bootstrapping, or is visibly busy with active work.
+  // Shared pane-state guard: skip injection when the target pane is scrolling,
+  // has returned to a shell, is still bootstrapping, or is visibly busy.
   try {
-    const paneGuard = await checkPaneReadyForTeamSendKeys(paneTarget);
+    const paneGuard = await evaluatePaneInjectionReadiness(paneTarget, {
+      skipIfScrolling: config.skip_if_scrolling,
+    });
     if (!paneGuard.ok) {
-      const reason = paneGuard.reason === 'pane_running_shell'
-        ? 'agent_not_running'
-        : paneGuard.reason;
+      const reason = mapPaneInjectionReadinessReason(paneGuard.reason);
       state.last_reason = reason;
       state.last_event_at = nowIso;
       await writeFile(hookStatePath, JSON.stringify(state, null, 2)).catch(() => {});
@@ -389,6 +362,7 @@ export async function handleTmuxInjection({
         reason,
         pane_target: paneTarget,
         pane_current_command: paneGuard.paneCurrentCommand || undefined,
+        pane_capture_excerpt: paneGuard.paneCapture ? paneGuard.paneCapture.slice(-200) : undefined,
       });
       return;
     }
@@ -410,11 +384,14 @@ export async function handleTmuxInjection({
   }
 
   try {
-    await runProcess('tmux', argv.typeArgv, 3000);
-    for (const submit of argv.submitArgv) {
-      await runProcess('tmux', submit, 3000);
-      // Give the pane a moment to process the keypress; avoids occasional missed submits.
-      await new Promise(r => setTimeout(r, 25));
+    const sendResult = await sendPaneInput({
+      paneTarget,
+      prompt,
+      submitKeyPresses: argv.submitArgv.length,
+      submitDelayMs: 25,
+    });
+    if (!sendResult.ok) {
+      throw new Error(sendResult.error || sendResult.reason);
     }
     updateStateForAttempt(true, 'injection_sent');
     await writeFile(hookStatePath, JSON.stringify(state, null, 2)).catch(() => {});

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -724,15 +724,16 @@ describe('notify-fallback watcher', () => {
       await mkdir(fakeBinDir, { recursive: true });
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
-      // Verify loop uses 2 captures/round (narrow+wide) × 3 rounds = 6 per attempt.
-      // Pre-capture on retries adds 1 more. "ready" = no trigger in narrow area → retype.
+      // Shared preflight now adds one 80-line capture per tick before the
+      // narrow retry check. Pre-capture on retries still returns "ready"
+      // (no trigger) so the request is retyped on every retry.
       await writeFile(captureSeqFile, [
-        // Run 1 (attempt 0): no pre-capture, type, 6 verify captures
-        'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping',
-        // Run 2 (attempt 1): 1 pre-capture ("ready" → retype), 6 verify captures
+        // Run 1 (attempt 0): 1 shared preflight + 3 verify rounds × 2 captures = 7
         'ready', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping',
-        // Run 3 (attempt 2): 1 pre-capture ("ready" → retype), 6 verify captures
-        'ready', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping',
+        // Run 2 (attempt 1): 1 shared preflight + 1 pre-capture + 3 verify rounds × 2 captures = 8
+        'ready', 'ready', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping',
+        // Run 3 (attempt 2): 1 shared preflight + 1 pre-capture + 3 verify rounds × 2 captures = 8
+        'ready', 'ready', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping', 'dispatch ping',
       ].join('\n'));
 
       await initTeamState('dispatch-team', 'task', 'executor', 1, wd);

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -235,6 +235,151 @@ describe('notify-hook auto-nudge', () => {
     });
   });
 
+  it('logs agent_not_running with pane_current_command when the target pane is a shell', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%99" ]]; then
+    echo "zsh"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  printf "Would you like me to continue?\\n"
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(join(fakeBinDir, 'tmux'), fakeTmux);
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Would you like me to continue?',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /display-message -p -t %99 #\{pane_current_command\}/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99/, 'should not inject when pane is running a shell');
+
+      const logPath = join(logsDir, `tmux-hook-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      const entries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const skipped = entries.find((entry: { type?: string; reason?: string }) =>
+        entry.type === 'auto_nudge_skipped' && entry.reason === 'agent_not_running');
+      assert.ok(skipped, 'should log mapped skip reason for shell pane');
+      assert.equal(skipped.pane_current_command, 'zsh');
+    });
+  });
+
+  it('logs scroll_active and avoids send-keys when auto-nudge target pane is in copy-mode', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%99" ]]; then
+    echo "1"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  printf "Would you like me to continue?\\n"
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(join(fakeBinDir, 'tmux'), fakeTmux);
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Would you like me to continue?',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /display-message -p -t %99 #\{pane_in_mode\}/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99/, 'should not inject while pane is scrolling');
+
+      const logPath = join(logsDir, `tmux-hook-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      const entries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const skipped = entries.find((entry: { type?: string; reason?: string }) =>
+        entry.type === 'auto_nudge_skipped' && entry.reason === 'scroll_active');
+      assert.ok(skipped, 'should log scroll_active skip for copy-mode pane');
+    });
+  });
+
   it('does not nudge when pane capture shows an active task despite stall-like assistant text', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/__tests__/notify-hook-regression-205.test.ts
+++ b/src/hooks/__tests__/notify-hook-regression-205.test.ts
@@ -4,21 +4,93 @@
  * - resolveTeamStateDirForWorker must be exported from team-worker.js
  * - DEFAULT_STALL_PATTERNS must contain 'if you want'
  * - detectStallPattern must match 'if you want'
+ * - notify-hook end-to-end auto-nudge must still inject for 'if you want'
  */
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS_DIR = join(__dirname, '..', '..', '..', 'scripts');
+const NOTIFY_HOOK_SCRIPT = new URL('../../../scripts/notify-hook.js', import.meta.url);
 
 async function loadModule(rel: string) {
   return import(pathToFileURL(join(SCRIPTS_DIR, rel)).href);
+}
+
+async function withTempWorkingDir(run: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-regression-205-'));
+  try {
+    await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+function buildFakeTmux(tmuxLogPath: string): string {
+  return `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "capture-pane" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "display-message" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+}
+
+function runNotifyHook(
+  cwd: string,
+  fakeBinDir: string,
+  codexHome: string,
+  payloadOverrides: Record<string, unknown> = {},
+) {
+  const payload = {
+    cwd,
+    type: 'agent-turn-complete',
+    'thread-id': 'thread-test',
+    'turn-id': `turn-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+    'input-messages': ['test'],
+    'last-assistant-message': 'done',
+    ...payloadOverrides,
+  };
+
+  return spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+    encoding: 'utf8',
+    timeout: 15_000,
+    env: {
+      ...process.env,
+      PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      CODEX_HOME: codexHome,
+      TMUX_PANE: '%99',
+      TMUX: '1',
+      OMX_TEAM_WORKER: '',
+      OMX_TEAM_LEADER_NUDGE_MS: '9999999',
+      OMX_TEAM_LEADER_STALE_MS: '9999999',
+    },
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -74,6 +146,65 @@ describe('regression-205: detectStallPattern matches "if you want"', () => {
       detectStallPattern('Build succeeded. All tests pass.', DEFAULT_STALL_PATTERNS),
       false,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// notify-hook.js – "if you want" still triggers the injection path end-to-end
+// ---------------------------------------------------------------------------
+describe('regression-205: notify-hook still injects on "if you want"', () => {
+  let originalTeamWorker: string | undefined;
+  let originalTeamStateRoot: string | undefined;
+
+  before(() => {
+    originalTeamWorker = process.env.OMX_TEAM_WORKER;
+    originalTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_WORKER;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+  });
+
+  after(() => {
+    if (originalTeamWorker === undefined) delete process.env.OMX_TEAM_WORKER;
+    else process.env.OMX_TEAM_WORKER = originalTeamWorker;
+    if (originalTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+    else process.env.OMX_TEAM_STATE_ROOT = originalTeamStateRoot;
+  });
+
+  it('sends the default auto-nudge response with marker and submit keys', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'I checked the files. If you want, I can keep going and apply the fix.',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+      assert.ok(existsSync(tmuxLogPath), 'expected tmux to be called');
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(
+        tmuxLog,
+        /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/,
+        'expected default auto-nudge response to be injected',
+      );
+      const submitMatches = tmuxLog.match(/send-keys -t %99 C-m/g);
+      assert.ok(submitMatches && submitMatches.length >= 2, `expected at least 2 submit keys, got ${submitMatches?.length ?? 0}`);
+    });
   });
 });
 

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -84,6 +84,28 @@ exit 0
 }
 
 describe('notify-hook team dispatch consumer', () => {
+  const originalTeamWorker = process.env.OMX_TEAM_WORKER;
+  const originalTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+
+  before(() => {
+    delete process.env.OMX_TEAM_WORKER;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+  });
+
+  after(() => {
+    if (originalTeamWorker === undefined) {
+      delete process.env.OMX_TEAM_WORKER;
+    } else {
+      process.env.OMX_TEAM_WORKER = originalTeamWorker;
+    }
+
+    if (originalTeamStateRoot === undefined) {
+      delete process.env.OMX_TEAM_STATE_ROOT;
+    } else {
+      process.env.OMX_TEAM_STATE_ROOT = originalTeamStateRoot;
+    }
+  });
+
   it('marks pending request as notified and preserves mailbox notified_at semantics', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
     try {
@@ -497,15 +519,16 @@ describe('notify-hook team dispatch consumer', () => {
       await mkdir(fakeBinDir, { recursive: true });
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
-      // Each verify round now does narrow + wide capture (2 calls per round).
-      // Pre-capture on retries returns 'ready' (no trigger) to allow retype.
+      // Shared preflight now adds one 80-line capture per tick before the
+      // narrow retry check. Pre-capture on retries still returns "ready"
+      // (no trigger) so the request is retyped on every retry.
       await writeFile(captureSeqFile, [
-        // tick1: 3 verify rounds × 2 captures = 6
-        'ping', 'ping', 'ping', 'ping', 'ping', 'ping',
-        // tick2: 1 pre-capture + 3 verify rounds × 2 captures = 7
+        // tick1: 1 shared preflight + 3 verify rounds × 2 captures = 7
         'ready', 'ping', 'ping', 'ping', 'ping', 'ping', 'ping',
-        // tick3: 1 pre-capture + 3 verify rounds × 2 captures = 7
-        'ready', 'ping', 'ping', 'ping', 'ping', 'ping', 'ping',
+        // tick2: 1 shared preflight + 1 pre-capture + 3 verify rounds × 2 captures = 8
+        'ready', 'ready', 'ping', 'ping', 'ping', 'ping', 'ping', 'ping',
+        // tick3: 1 shared preflight + 1 pre-capture + 3 verify rounds × 2 captures = 8
+        'ready', 'ready', 'ping', 'ping', 'ping', 'ping', 'ping', 'ping',
       ].join('\n'));
       process.env.PATH = `${fakeBinDir}:${previousPath || ''}`;
       process.env.OMX_TEST_CAPTURE_SEQUENCE_FILE = captureSeqFile;

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -151,6 +151,9 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /-t %99/, 'should target leader pane when present');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'should emit all-workers-idle nudge');
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
+      const submitMatches = tmuxLog.match(/send-keys -t %99 C-m/g) || [];
+      assert.equal(submitMatches.length, 2, 'leader nudge should submit with isolated double C-m');
+      assert.ok(!/send-keys[^\n]*-l[^\n]*C-m/.test(tmuxLog), 'must not mix literal payload with submit keypresses');
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       assert.ok(existsSync(eventsPath), 'events.ndjson should exist');
@@ -702,6 +705,97 @@ exit 0
         entry.type === 'leader_notification_deferred' && entry.reason === 'leader_pane_shell_no_injection');
       assert.ok(deferred, 'should emit deferred event for shell-pane leader');
       assert.equal(deferred.pane_current_command, 'zsh');
+    });
+  });
+
+  it('does not inject leader nudge while leader pane is in copy-mode', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'scroll-guard';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'scroll-guard:0',
+        leader_pane_id: '%72',
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'm1',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'follow up',
+            created_at: '2026-03-12T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%72" ]]; then
+    echo "1"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%72" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /display-message -p -t %72 #\{pane_in_mode\}/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %72/, 'should not inject into a scrolling leader pane');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const deferred = events.find((entry: { type?: string; reason?: string }) =>
+        entry.type === 'leader_notification_deferred' && entry.reason === 'scroll_active');
+      assert.ok(deferred, 'should emit deferred event for scrolling leader pane');
     });
   });
 


### PR DESCRIPTION
## Summary

Refactor the notify-hook pane injection paths around a shared preflight/send contract and lock in the regression coverage for the injection semantics.

## Changes

- extract shared pane injection helpers in `team-tmux-guard.js`
- route `auto-nudge`, `team-leader-nudge`, `tmux-injection`, and `team-dispatch` through the shared helper surfaces
- preserve producer-specific orchestration/state behavior while de-duplicating guard/send logic
- expand targeted hook regressions for copy-mode, shell-pane skips, dispatch retry semantics, and the `"if you want"` auto-nudge path
- fix team-worker env contamination in the team-dispatch regression harness and align fallback-watcher expectations with shared-preflight capture behavior

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] targeted notify-hook matrix (`auto-nudge`, `team-leader-nudge`, `regression-205`, `tmux-scrollback`, `team-dispatch`)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Refs #205
