### PR TITLE
fix: harden auto-nudge guards and ignore legacy MCP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ Notes:
   - `model_context_window = 1000000` and `model_auto_compact_token_limit = 900000` only when the effective root model matches `OMX_DEFAULT_FRONTIER_MODEL` and both context keys are absent
   - `[features] multi_agent = true, child_agents_md = true`
   - MCP server entries (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
-  - If a shared MCP registry exists at `~/.omx/mcp-registry.json` (fallback: `~/.omc/mcp-registry.json`), setup syncs those entries into a dedicated managed block in `config.toml` (skipping names already defined elsewhere to avoid duplicate TOML tables)
+  - If a shared MCP registry exists at `~/.omx/mcp-registry.json`, setup syncs those entries into a dedicated managed block in `config.toml` (skipping names already defined elsewhere to avoid duplicate TOML tables)
   - User-scoped setup also syncs missing shared MCP entries into `~/.claude/settings.json` without overwriting existing Claude Code MCP server definitions
   - `[tui] status_line`
 - Scope-specific `AGENTS.md`

--- a/scripts/notify-hook/auto-nudge.js
+++ b/scripts/notify-hook/auto-nudge.js
@@ -220,6 +220,16 @@ function normalizeStallDetectionText(text) {
     .replace(/[’‘`]/g, '\'');
 }
 
+function summarizePaneCaptureForLog(captured, maxLines = 6) {
+  const lines = safeString(captured)
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim() !== '');
+  if (lines.length === 0) return '';
+  return lines.slice(-maxLines).join('\n').slice(0, 600);
+}
+
 export function normalizeAutoNudgeConfig(raw) {
   if (!raw || typeof raw !== 'object') {
     return {
@@ -354,6 +364,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
         reason: mapPaneInjectionReadinessReason(paneGuard.reason),
         source,
         pane_current_command: paneGuard.paneCurrentCommand || undefined,
+        pane_excerpt: summarizePaneCaptureForLog(paneGuard.paneCapture),
       }).catch(() => {});
       return;
     }

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -328,4 +328,39 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("ignores legacy ~/.omc/mcp-registry.json during setup unless candidates are passed explicitly", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      process.env.HOME = wd;
+      delete process.env.CODEX_HOME;
+
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".omc"), { recursive: true });
+      await writeFile(
+        join(wd, ".omc", "mcp-registry.json"),
+        JSON.stringify({
+          gitnexus: { command: "gitnexus", args: ["mcp"] },
+        }),
+      );
+
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.doesNotMatch(config, /^\[mcp_servers\.gitnexus\]$/m);
+      assert.doesNotMatch(config, /Shared MCP Server: gitnexus/);
+
+      const output = await runSetupWithCapturedLogs(wd, { scope: "project" });
+      assert.match(output, /legacy shared MCP registry detected at .*\.omc\/mcp-registry\.json but ignored by default/i);
+      assert.match(output, /move it to .*\.omx\/mcp-registry\.json/i);
+    } finally {
+      if (typeof previousHome === "string") process.env.HOME = previousHome;
+      else delete process.env.HOME;
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -29,6 +29,7 @@ import {
 } from "../utils/paths.js";
 import { buildMergedConfig, getRootModelName } from "../config/generator.js";
 import {
+  getUnifiedMcpRegistryCandidates,
   loadUnifiedMcpRegistry,
   planClaudeCodeMcpSettingsSync,
   type UnifiedMcpRegistryLoadResult,
@@ -501,9 +502,22 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
   // Step 5: Update config.toml
   console.log("[5/8] Updating config.toml...");
+  const registryCandidates = getUnifiedMcpRegistryCandidates();
+  const defaultRegistryCandidates = registryCandidates.slice(0, 1);
   const sharedMcpRegistry = await loadUnifiedMcpRegistry({
-    candidates: options.mcpRegistryCandidates,
+    candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
   });
+  if (
+    !options.mcpRegistryCandidates &&
+    !sharedMcpRegistry.sourcePath &&
+    registryCandidates.length > 1 &&
+    existsSync(registryCandidates[1]) &&
+    !existsSync(registryCandidates[0])
+  ) {
+    console.log(
+      `  warning: legacy shared MCP registry detected at ${registryCandidates[1]} but ignored by default; move it to ${registryCandidates[0]} if you still want setup to sync those servers`,
+    );
+  }
   if (verbose && sharedMcpRegistry.sourcePath) {
     console.log(
       `  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -31,7 +31,7 @@ function escapeRegex(value: string): string {
  * Build a fake tmux binary that logs all invocations and optionally returns
  * capture-pane content from OMX_TEST_CAPTURE_FILE.
  */
-function buildFakeTmux(tmuxLogPath: string): string {
+function buildFakeTmux(tmuxLogPath: string, paneInMode: '0' | '1' = '0'): string {
   return `#!/usr/bin/env bash
 set -eu
 echo "$@" >> "${tmuxLogPath}"
@@ -47,6 +47,18 @@ if [[ "\$cmd" == "send-keys" ]]; then
   exit 0
 fi
 if [[ "\$cmd" == "display-message" ]]; then
+  format=""
+  while [[ "\$#" -gt 0 ]]; do
+    case "\$1" in
+      -p) shift ;;
+      -t) shift 2 ;;
+      *) format="\$1"; shift ;;
+    esac
+  done
+  if [[ "\$format" == "#{pane_in_mode}" ]]; then
+    echo "${paneInMode}"
+    exit 0
+  fi
   exit 0
 fi
 if [[ "\$cmd" == "list-panes" ]]; then
@@ -326,51 +338,17 @@ exit 0
         autoNudge: { enabled: true, delaySec: 0 },
       });
 
-      const fakeTmux = `#!/usr/bin/env bash
-set -eu
-echo "$@" >> "${tmuxLogPath}"
-cmd="$1"
-shift || true
-if [[ "$cmd" == "display-message" ]]; then
-  target=""
-  format=""
-  while (($#)); do
-    case "$1" in
-      -p) shift ;;
-      -t) target="$2"; shift 2 ;;
-      *) format="$1"; shift ;;
-    esac
-  done
-  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%99" ]]; then
-    echo "1"
-    exit 0
-  fi
-  exit 0
-fi
-if [[ "$cmd" == "capture-pane" ]]; then
-  printf "Would you like me to continue?\\n"
-  exit 0
-fi
-if [[ "$cmd" == "send-keys" ]]; then
-  exit 0
-fi
-if [[ "$cmd" == "list-panes" ]]; then
-  echo "%1 12345"
-  exit 0
-fi
-exit 0
-`;
-      await writeFile(join(fakeBinDir, 'tmux'), fakeTmux);
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath, '1'));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'Would you like me to continue?',
+        'last-assistant-message': 'If you want, I can keep going from here.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p -t %99 #\{pane_in_mode\}/);
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99/, 'should not inject while pane is scrolling');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should not inject while pane is in copy-mode');
 
       const logPath = join(logsDir, `tmux-hook-${new Date().toISOString().slice(0, 10)}.jsonl`);
       const entries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));


### PR DESCRIPTION
## Summary
- resolve the auto-nudge stash-pop conflict by keeping the shared pane readiness helper, mapped skip reasons, and richer skipped-pane logging
- stop `omx setup` from implicitly importing the legacy `~/.omc/mcp-registry.json` fallback
- warn when a legacy `.omc` MCP registry is detected but ignored, and document the `~/.omx/mcp-registry.json` path

## Testing
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/cli/__tests__/setup-refresh.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js
