### PR TITLE
test: isolate tmux-related tests from active sessions

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -15,6 +15,34 @@ import {
   writeWorkerStatus,
 } from '../../team/state.js';
 
+
+function withoutTeamTestWorkerEnv<T>(fn: () => T): T {
+  const previousTeamWorker = process.env.OMX_TEAM_WORKER;
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+  delete process.env.OMX_TEAM_WORKER;
+  delete process.env.OMX_TEAM_STATE_ROOT;
+
+  let restoreImmediately = true;
+  const restore = () => {
+    if (typeof previousTeamWorker === 'string') process.env.OMX_TEAM_WORKER = previousTeamWorker;
+    else delete process.env.OMX_TEAM_WORKER;
+
+    if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+    else delete process.env.OMX_TEAM_STATE_ROOT;
+  };
+
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      restoreImmediately = false;
+      return result.finally(restore) as T;
+    }
+    return result;
+  } finally {
+    if (restoreImmediately) restore();
+  }
+}
+
 describe('parseTeamStartArgs', () => {
   it('parses default team start args without worktree', () => {
     const result = parseTeamStartArgs(['2:executor', 'build', 'feature']);
@@ -617,8 +645,8 @@ describe('teamCommand status', () => {
     const originalLog = console.log;
     try {
       process.chdir(wd);
-      const config = await initTeamState('pane-team', 'inspect worker panes', 'executor', 2, wd);
-      await createTask('pane-team', {
+      const config = await withoutTeamTestWorkerEnv(() => initTeamState('pane-team', 'inspect worker panes', 'executor', 2, wd));
+      await withoutTeamTestWorkerEnv(() => createTask('pane-team', {
         subject: 'Recover worker-1 progress',
         description: 'Inspect worker-1 pane',
         status: 'pending',
@@ -626,8 +654,8 @@ describe('teamCommand status', () => {
         requires_code_change: true,
         role: 'debugger',
         owner: 'worker-1',
-      }, wd);
-      await createTask('pane-team', {
+      }, wd));
+      await withoutTeamTestWorkerEnv(() => createTask('pane-team', {
         subject: 'Recover worker-2 progress',
         description: 'Inspect worker-2 pane',
         status: 'pending',
@@ -639,7 +667,7 @@ describe('teamCommand status', () => {
         owner: 'worker-2',
         result: 'waiting on worker-1',
         error: 'blocked by dependency',
-      }, wd);
+      }, wd));
       await writeFile(
         join(wd, '.omx', 'state', 'team', 'pane-team', 'tasks', 'task-1.json'),
         `${JSON.stringify({
@@ -738,7 +766,7 @@ describe('teamCommand status', () => {
       );
 
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['status', 'pane-team']);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-team']));
 
       const output = logs.join('\n');
       assert.match(output, /dead_workers: worker-1 worker-2/);
@@ -874,8 +902,8 @@ describe('teamCommand status', () => {
     const originalLog = console.log;
     try {
       process.chdir(wd);
-      const config = await initTeamState('pane-json-team', 'inspect worker panes', 'executor', 1, wd);
-      await createTask('pane-json-team', {
+      const config = await withoutTeamTestWorkerEnv(() => initTeamState('pane-json-team', 'inspect worker panes', 'executor', 1, wd));
+      await withoutTeamTestWorkerEnv(() => createTask('pane-json-team', {
         subject: 'Recover worker-1 progress',
         description: 'Inspect worker-1 pane',
         status: 'pending',
@@ -883,7 +911,7 @@ describe('teamCommand status', () => {
         requires_code_change: true,
         role: 'debugger',
         owner: 'worker-1',
-      }, wd);
+      }, wd));
       await writeFile(
         join(wd, '.omx', 'state', 'team', 'pane-json-team', 'tasks', 'task-1.json'),
         `${JSON.stringify({
@@ -951,7 +979,7 @@ describe('teamCommand status', () => {
       );
 
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['status', 'pane-json-team', '--json']);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-json-team', '--json']));
 
       const payload = JSON.parse(logs.at(-1) ?? '{}') as {
         schema_version?: string;
@@ -1269,7 +1297,7 @@ describe('teamCommand status', () => {
     try {
       process.chdir(wd);
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['status', 'missing-team', '--json']);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'missing-team', '--json']));
 
       const payload = JSON.parse(logs.at(-1) ?? '{}') as {
         schema_version?: string;
@@ -1297,7 +1325,7 @@ describe('teamCommand status', () => {
     const originalLog = console.log;
     try {
       process.chdir(wd);
-      const config = await initTeamState('pane-tail-team', 'inspect worker panes', 'executor', 1, wd);
+      const config = await withoutTeamTestWorkerEnv(() => initTeamState('pane-tail-team', 'inspect worker panes', 'executor', 1, wd));
       config.workers[0]!.pane_id = '%51';
       const manifestPath = join(wd, '.omx', 'state', 'team', 'pane-tail-team', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
@@ -1317,11 +1345,11 @@ describe('teamCommand status', () => {
       );
 
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['status', 'pane-tail-team', '--tail-lines', '600']);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-tail-team', '--tail-lines', '600']));
       assert.match(logs.join('\n'), /inspect_worker-1: omx sparkshell --tmux-pane %51 --tail-lines 600/);
 
       logs.length = 0;
-      await teamCommand(['status', 'pane-tail-team', '--json', '--tail-lines=550']);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-tail-team', '--json', '--tail-lines=550']));
       const payload = JSON.parse(logs.at(-1) ?? '{}') as {
         tail_lines?: number;
         panes?: { sparkshell_commands?: Record<string, string> };
@@ -1418,17 +1446,17 @@ process.on('SIGTERM', () => process.exit(0));
         return true;
       }) as typeof process.stderr.write;
 
-      await teamCommand(['1:executor', teamTask]);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       logs.length = 0;
       stderr.length = 0;
-      await teamCommand(['status', teamName]);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', teamName]));
       assert.match(logs.join('\n'), /phase=failed/);
       assert.doesNotMatch(stderr.join('\n'), /ESRCH/);
 
       logs.length = 0;
-      await teamCommand(['await', teamName, '--json', '--timeout-ms', '250']);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['await', teamName, '--json', '--timeout-ms', '250']));
       const payload = JSON.parse(logs.at(-1) ?? '{}') as {
         team_name?: string;
         status?: string;
@@ -1484,7 +1512,7 @@ process.on('SIGTERM', () => process.exit(0));
 
       const teamTask = 'issue 742 linked ralph launch';
       const teamName = parseTeamStartArgs(['ralph', '1:executor', teamTask]).parsed.teamName;
-      await teamCommand(['ralph', '1:executor', teamTask]);
+      await withoutTeamTestWorkerEnv(() => teamCommand(['ralph', '1:executor', teamTask]));
 
       const teamState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'team-state.json'), 'utf-8')) as Record<string, unknown>;
       const ralphState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'ralph-state.json'), 'utf-8')) as Record<string, unknown>;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -111,6 +111,68 @@ async function waitForFileText(
   throw new Error(`timed out waiting for ${filePath}`);
 }
 
+type MockBinarySpec = {
+  name: string;
+  content: string;
+};
+
+
+function teamStateTestPath(cwd: string, ...parts: string[]): string {
+  const stateRoot = process.env.OMX_TEAM_STATE_ROOT ?? join(cwd, '.omx', 'state');
+  return join(stateRoot, ...parts);
+}
+
+async function withMockTmuxFixture<T>(
+  options: {
+    dirPrefix: string;
+    tmuxScript: (tmuxLogPath: string) => string;
+    binaries?: MockBinarySpec[];
+    env?: Record<string, string | undefined>;
+  },
+  run: (ctx: { fakeBinDir: string; tmuxLogPath: string }) => Promise<T>,
+): Promise<T> {
+  const fakeBinDir = await mkdtemp(join(tmpdir(), options.dirPrefix));
+  const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+  const tmuxStubPath = join(fakeBinDir, 'tmux');
+  const previousPath = process.env.PATH;
+  const previousEnv = new Map<string, string | undefined>();
+  const envOverrides = {
+    OMX_TEAM_STATE_ROOT: undefined,
+    ...(options.env ?? {}),
+  };
+
+  try {
+    await writeFile(tmuxStubPath, options.tmuxScript(tmuxLogPath));
+    await chmod(tmuxStubPath, 0o755);
+
+    for (const binary of options.binaries ?? []) {
+      const binaryPath = join(fakeBinDir, binary.name);
+      await writeFile(binaryPath, binary.content);
+      await chmod(binaryPath, 0o755);
+    }
+
+    process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+    for (const [key, value] of Object.entries(envOverrides)) {
+      previousEnv.set(key, process.env[key]);
+      if (typeof value === 'string') process.env[key] = value;
+      else delete process.env[key];
+    }
+
+    return await run({ fakeBinDir, tmuxLogPath });
+  } finally {
+    if (typeof previousPath === 'string') process.env.PATH = previousPath;
+    else delete process.env.PATH;
+
+    for (const [key, value] of previousEnv) {
+      if (typeof value === 'string') process.env[key] = value;
+      else delete process.env[key];
+    }
+
+    await rm(fakeBinDir, { recursive: true, force: true });
+  }
+}
+
 describe('runtime', () => {
   it('resolveWorkerLaunchArgsFromEnv injects low-complexity default model when missing', () => {
     const args = resolveWorkerLaunchArgsFromEnv(
@@ -899,20 +961,16 @@ process.on('SIGTERM', () => process.exit(0));
 
   it('startTeam relaunch re-creates HUD pane and re-registers reconcile hooks after shutdown', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-relaunch-hud-'));
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-relaunch-hud-bin-'));
-    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
-    const geminiStubPath = join(fakeBinDir, 'gemini');
-    const previousPath = process.env.PATH;
     const previousTmux = process.env.TMUX;
     const previousTmuxPane = process.env.TMUX_PANE;
     const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     let runtime: TeamRuntime | null = null;
     try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-relaunch-hud-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
@@ -967,64 +1025,62 @@ case "\${1:-}" in
     ;;
 esac
 `,
-      );
-      await chmod(tmuxStubPath, 0o755);
-      await writeFile(
-        geminiStubPath,
-        `#!/bin/sh
+          binaries: [{
+            name: 'gemini',
+            content: `#!/bin/sh
 exit 0
 `,
+          }],
+        },
+        async ({ tmuxLogPath }) => {
+          process.env.TMUX = 'leader-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+          runtime = await withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-rerun-hud',
+              'rerun hud restore',
+              'explore',
+              1,
+              [{ subject: 'restore hud', description: 'restore hud', owner: 'worker-1' }],
+              cwd,
+            ));
+          assert.equal(runtime.config.hud_pane_id, '%3');
+          assert.ok(runtime.config.resize_hook_name);
+
+          await shutdownTeam(runtime.teamName, cwd, { force: true });
+          runtime = null;
+
+          runtime = await withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-rerun-hud',
+              'rerun hud restore',
+              'explore',
+              1,
+              [{ subject: 'restore hud again', description: 'restore hud again', owner: 'worker-1' }],
+              cwd,
+            ));
+          assert.equal(runtime.config.hud_pane_id, '%3');
+          assert.ok(runtime.config.resize_hook_name);
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          const hudSplitRe = new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
+          assert.equal(tmuxLog.match(hudSplitRe)?.length ?? 0, 3);
+          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
+          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
+          assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
+          assert.match(tmuxLog, /kill-pane -t %3/);
+        },
       );
-      await chmod(geminiStubPath, 0o755);
-
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
-      process.env.TMUX = 'leader-session,stub,0';
-      process.env.TMUX_PANE = '%1';
-      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
-      process.env.OMX_TEAM_WORKER_CLI = 'gemini';
-
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-rerun-hud',
-          'rerun hud restore',
-          'explore',
-          1,
-          [{ subject: 'restore hud', description: 'restore hud', owner: 'worker-1' }],
-          cwd,
-        ));
-      assert.equal(runtime.config.hud_pane_id, '%3');
-      assert.ok(runtime.config.resize_hook_name);
-
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
-
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-rerun-hud',
-          'rerun hud restore',
-          'explore',
-          1,
-          [{ subject: 'restore hud again', description: 'restore hud again', owner: 'worker-1' }],
-          cwd,
-        ));
-      assert.equal(runtime.config.hud_pane_id, '%3');
-      assert.ok(runtime.config.resize_hook_name);
-
-      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      const hudSplitRe = new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
-      assert.equal(tmuxLog.match(hudSplitRe)?.length ?? 0, 3);
-      assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
-      assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
-      assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
-      assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
-      assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
-      assert.match(tmuxLog, /kill-pane -t %3/);
     } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      const activeRuntime = runtime;
+      if (activeRuntime) {
+        await shutdownTeam((activeRuntime as TeamRuntime).teamName, cwd, { force: true }).catch(() => {});
       }
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
       if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
       else delete process.env.TMUX;
       if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
@@ -1034,7 +1090,6 @@ exit 0
       if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
       await rm(cwd, { recursive: true, force: true });
-      await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
 
@@ -1701,7 +1756,7 @@ process.on('SIGTERM', () => {
         /shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/,
       );
 
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-failed');
+      const teamRoot = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed');
       assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -1774,29 +1829,12 @@ process.on('SIGTERM', () => {
 
   it('shutdownTeam continues cleanup when resize hook unregister fails while session remains active', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-failed-'));
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-fake-tmux-'));
-    const previousPath = process.env.PATH;
-    const previousTmuxLog = process.env.TMUX_TEST_LOG;
-    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
     try {
-      await initTeamState('team-shutdown-gate-failed', 'shutdown resize hook failure test', 'executor', 1, cwd);
-      const configPath = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-failed', 'config.json');
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-failed', 'manifest.v2.json');
-      const config = JSON.parse(await readFile(configPath, 'utf-8')) as Record<string, unknown>;
-      config.tmux_session = 'omx-team-team-shutdown-gate-failed';
-      config.resize_hook_name = 'omx_resize_team_shutdown_gate_failed_test';
-      config.resize_hook_target = 'omx-team-team-shutdown-gate-failed:0';
-      await writeFile(configPath, JSON.stringify(config, null, 2));
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as Record<string, unknown>;
-      manifest.tmux_session = 'omx-team-team-shutdown-gate-failed';
-      manifest.resize_hook_name = 'omx_resize_team_shutdown_gate_failed_test';
-      manifest.resize_hook_target = 'omx-team-team-shutdown-gate-failed:0';
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-
-      const tmuxStubPath = join(fakeBinDir, 'tmux');
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-fake-tmux-',
+          env: { TMUX_TEST_LOG: undefined },
+          tmuxScript: () => `#!/bin/sh
 set -eu
 if [ -n "\${TMUX_TEST_LOG:-}" ]; then
   printf '%s\\n' "$*" >> "$TMUX_TEST_LOG"
@@ -1828,27 +1866,35 @@ case "$1" in
     ;;
 esac
 `,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState('team-shutdown-gate-failed', 'shutdown resize hook failure test', 'executor', 1, cwd);
+          const configPath = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed', 'config.json');
+          const manifestPath = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed', 'manifest.v2.json');
+          const config = JSON.parse(await readFile(configPath, 'utf-8')) as Record<string, unknown>;
+          config.tmux_session = 'omx-team-team-shutdown-gate-failed';
+          config.resize_hook_name = 'omx_resize_team_shutdown_gate_failed_test';
+          config.resize_hook_target = 'omx-team-team-shutdown-gate-failed:0';
+          await writeFile(configPath, JSON.stringify(config, null, 2));
+          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as Record<string, unknown>;
+          manifest.tmux_session = 'omx-team-team-shutdown-gate-failed';
+          manifest.resize_hook_name = 'omx_resize_team_shutdown_gate_failed_test';
+          manifest.resize_hook_target = 'omx-team-team-shutdown-gate-failed:0';
+          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+          process.env.TMUX_TEST_LOG = tmuxLogPath;
+
+          await shutdownTeam('team-shutdown-gate-failed', cwd);
+
+          const teamRoot = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed');
+          assert.equal(existsSync(teamRoot), false);
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/);
+          assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-gate-failed/);
+        },
       );
-      await chmod(tmuxStubPath, 0o755);
-
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
-      process.env.TMUX_TEST_LOG = tmuxLogPath;
-
-      await shutdownTeam('team-shutdown-gate-failed', cwd);
-
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-failed');
-      assert.equal(existsSync(teamRoot), false);
-
-      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/);
-      assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-gate-failed/);
     } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
-      if (typeof previousTmuxLog === 'string') process.env.TMUX_TEST_LOG = previousTmuxLog;
-      else delete process.env.TMUX_TEST_LOG;
       await rm(cwd, { recursive: true, force: true });
-      await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
 
@@ -2003,14 +2049,11 @@ esac
 
   it('shutdownTeam applies best-effort teardown even when worker pane is already dead', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-dead-pane-'));
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-dead-pane-bin-'));
-    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
-    const previousPath = process.env.PATH;
     try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-dead-pane-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
@@ -2036,46 +2079,40 @@ case "$1" in
     ;;
 esac
 `,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState('team-shutdown-dead-pane', 'shutdown dead pane test', 'executor', 2, cwd);
+          const config = await readTeamConfig('team-shutdown-dead-pane', cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'omx-team-team-shutdown-dead-pane';
+          config.workers[0]!.pane_id = '%404';
+          config.workers[1]!.pane_id = '%405';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam('team-shutdown-dead-pane', cwd, { force: true });
+          const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-dead-pane');
+          assert.equal(existsSync(teamRoot), false);
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /kill-pane -t %404/);
+          assert.match(tmuxLog, /kill-pane -t %405/);
+          assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-dead-pane/);
+        },
       );
-      await chmod(tmuxStubPath, 0o755);
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
-
-      await initTeamState('team-shutdown-dead-pane', 'shutdown dead pane test', 'executor', 2, cwd);
-      const config = await readTeamConfig('team-shutdown-dead-pane', cwd);
-      assert.ok(config);
-      if (!config) return;
-      config.tmux_session = 'omx-team-team-shutdown-dead-pane';
-      config.workers[0]!.pane_id = '%404';
-      config.workers[1]!.pane_id = '%405';
-      await saveTeamConfig(config, cwd);
-
-      await shutdownTeam('team-shutdown-dead-pane', cwd, { force: true });
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-dead-pane');
-      assert.equal(existsSync(teamRoot), false);
-
-      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /kill-pane -t %404/);
-      assert.match(tmuxLog, /kill-pane -t %405/);
-      assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-dead-pane/);
     } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
-      await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
 
 
   it('shutdownTeam restores a standalone HUD pane after tearing down the team HUD', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-restore-hud-'));
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-restore-hud-bin-'));
-    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
-    const previousPath = process.env.PATH;
     try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-restore-hud-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
@@ -2098,49 +2135,43 @@ case "$1" in
     ;;
 esac
 `,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState('team-shutdown-restore-hud', 'shutdown restore hud test', 'executor', 2, cwd);
+          const config = await readTeamConfig('team-shutdown-restore-hud', cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%12';
+          config.workers[1]!.pane_id = '%13';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam('team-shutdown-restore-hud', cwd, { force: true });
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
+          assert.match(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/);
+          assert.match(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
+          assert.match(tmuxLog, /hud --watch/);
+          assert.match(tmuxLog, /select-pane -t %11/);
+        },
       );
-      await chmod(tmuxStubPath, 0o755);
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
-
-      await initTeamState('team-shutdown-restore-hud', 'shutdown restore hud test', 'executor', 2, cwd);
-      const config = await readTeamConfig('team-shutdown-restore-hud', cwd);
-      assert.ok(config);
-      if (!config) return;
-      config.tmux_session = 'leader:0';
-      config.leader_pane_id = '%11';
-      config.hud_pane_id = '%12';
-      config.workers[0]!.pane_id = '%12';
-      config.workers[1]!.pane_id = '%13';
-      await saveTeamConfig(config, cwd);
-
-      await shutdownTeam('team-shutdown-restore-hud', cwd, { force: true });
-      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-      assert.match(tmuxLog, /kill-pane -t %12/);
-      assert.match(tmuxLog, /kill-pane -t %13/);
-      assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
-      assert.match(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/);
-      assert.match(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
-      assert.match(tmuxLog, /hud --watch/);
-      assert.match(tmuxLog, /select-pane -t %11/);
     } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
-      await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
 
   it('shutdownTeam preserves leader exclusion while tearing down the hud pane', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-exclusions-'));
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-exclusions-bin-'));
-    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
-    const previousPath = process.env.PATH;
     try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-exclusions-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
@@ -2159,32 +2190,29 @@ case "$1" in
     ;;
 esac
 `,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState('team-shutdown-exclusions', 'shutdown exclusions test', 'executor', 3, cwd);
+          const config = await readTeamConfig('team-shutdown-exclusions', cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'omx-team-team-shutdown-exclusions';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%11';
+          config.workers[1]!.pane_id = '%12';
+          config.workers[2]!.pane_id = '%13';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam('team-shutdown-exclusions', cwd, { force: true });
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+        },
       );
-      await chmod(tmuxStubPath, 0o755);
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
-
-      await initTeamState('team-shutdown-exclusions', 'shutdown exclusions test', 'executor', 3, cwd);
-      const config = await readTeamConfig('team-shutdown-exclusions', cwd);
-      assert.ok(config);
-      if (!config) return;
-      config.tmux_session = 'omx-team-team-shutdown-exclusions';
-      config.leader_pane_id = '%11';
-      config.hud_pane_id = '%12';
-      config.workers[0]!.pane_id = '%11';
-      config.workers[1]!.pane_id = '%12';
-      config.workers[2]!.pane_id = '%13';
-      await saveTeamConfig(config, cwd);
-
-      await shutdownTeam('team-shutdown-exclusions', cwd, { force: true });
-      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-      assert.match(tmuxLog, /kill-pane -t %12/);
-      assert.match(tmuxLog, /kill-pane -t %13/);
     } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
-      await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
 
@@ -2680,14 +2708,11 @@ esac
 
   it('sendWorkerMessage hook-preferred path injects leader mailbox read guidance when leader pane exists', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-inject-'));
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-inject-bin-'));
-    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
-    const previousPath = process.env.PATH;
     try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-leader-inject-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
@@ -2699,38 +2724,35 @@ case "\${1:-}" in
     ;;
 esac
 `,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState('team-leader-inject', 'leader injection test', 'executor', 1, cwd);
+          const cfg = await readTeamConfig('team-leader-inject', cwd);
+          assert.ok(cfg);
+          if (!cfg) throw new Error('missing team config');
+          cfg.leader_pane_id = '%55';
+          await saveTeamConfig(cfg, cwd);
+
+          const manifestPath = teamStateTestPath(cwd, 'team', 'team-leader-inject', 'manifest.v2.json');
+          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+          manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 100 };
+          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+          await sendWorkerMessage('team-leader-inject', 'worker-1', 'leader-fixed', 'hello leader', cwd);
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /send-keys -t %55 -l -- Read \.omx\/state\/team\/team-leader-inject\/mailbox\/leader-fixed\.json; worker-1 sent a new message\. Reply with the next concrete step\./);
+
+          const mailbox = await listMailboxMessages('team-leader-inject', 'leader-fixed', cwd);
+          assert.ok(mailbox.some((m: { notified_at?: string }) => typeof m.notified_at === 'string' && m.notified_at.length > 0));
+
+          const requests = await listDispatchRequests('team-leader-inject', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+          const latest = requests[requests.length - 1];
+          assert.equal(latest?.status, 'notified');
+        },
       );
-      await chmod(tmuxStubPath, 0o755);
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
-
-      await initTeamState('team-leader-inject', 'leader injection test', 'executor', 1, cwd);
-      const cfg = await readTeamConfig('team-leader-inject', cwd);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing team config');
-      cfg.leader_pane_id = '%55';
-      await saveTeamConfig(cfg, cwd);
-
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-leader-inject', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
-      manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 100 };
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-
-      await sendWorkerMessage('team-leader-inject', 'worker-1', 'leader-fixed', 'hello leader', cwd);
-
-      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %55 -l -- Read \.omx\/state\/team\/team-leader-inject\/mailbox\/leader-fixed\.json; worker-1 sent a new message\. Reply with the next concrete step\./);
-
-      const mailbox = await listMailboxMessages('team-leader-inject', 'leader-fixed', cwd);
-      assert.ok(mailbox.some((m: { notified_at?: string }) => typeof m.notified_at === 'string' && m.notified_at.length > 0));
-
-      const requests = await listDispatchRequests('team-leader-inject', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
-      const latest = requests[requests.length - 1];
-      assert.equal(latest?.status, 'notified');
     } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
-      await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -78,6 +78,28 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+async function withMockTmuxFixture<T>(
+  dirPrefix: string,
+  tmuxScript: (tmuxLogPath: string) => string,
+  run: (ctx: { logPath: string }) => Promise<T>,
+): Promise<T> {
+  const fakeBinDir = await mkdtemp(join(tmpdir(), dirPrefix));
+  const logPath = join(fakeBinDir, 'tmux.log');
+  const tmuxStubPath = join(fakeBinDir, 'tmux');
+  const previousPath = process.env.PATH;
+
+  try {
+    await writeFile(tmuxStubPath, tmuxScript(logPath));
+    await chmod(tmuxStubPath, 0o755);
+    process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+    return await run({ logPath });
+  } finally {
+    if (typeof previousPath === 'string') process.env.PATH = previousPath;
+    else delete process.env.PATH;
+    await rm(fakeBinDir, { recursive: true, force: true });
+  }
+}
+
 describe('sanitizeTeamName', () => {
   it('lowercases and strips invalid chars', () => {
     assert.equal(sanitizeTeamName('My Team!'), 'my-team');
@@ -1630,41 +1652,30 @@ describe('killWorker leader pane guard', () => {
 
 describe('teardownWorkerPanes shared primitive', () => {
   it('excludes leader and hud panes in shared pane-kill primitive', async () => {
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-tmux-teardown-'));
-    const logPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
-    const previousPath = process.env.PATH;
-    try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+    await withMockTmuxFixture(
+      'omx-tmux-teardown-',
+      (logPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${logPath}"
 exit 0
 `,
-      );
-      await chmod(tmuxStubPath, 0o755);
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+      async ({ logPath }) => {
+        const summary = await teardownWorkerPanes(['%1', '%2', '%3'], {
+          leaderPaneId: '%1',
+          hudPaneId: '%2',
+          graceMs: 1,
+        });
 
-      const summary = await teardownWorkerPanes(['%1', '%2', '%3'], {
-        leaderPaneId: '%1',
-        hudPaneId: '%2',
-        graceMs: 1,
-      });
-
-      assert.equal(summary.excluded.leader, 1);
-      assert.equal(summary.excluded.hud, 1);
-      assert.equal(summary.kill.attempted, 1);
-      assert.equal(summary.kill.succeeded, 1);
-      const log = await readFile(logPath, 'utf-8');
-      assert.match(log, /kill-pane -t %3/);
-      assert.doesNotMatch(log, /kill-pane -t %1/);
-      assert.doesNotMatch(log, /kill-pane -t %2/);
-    } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
-      await rm(fakeBinDir, { recursive: true, force: true });
-    }
+        assert.equal(summary.excluded.leader, 1);
+        assert.equal(summary.excluded.hud, 1);
+        assert.equal(summary.kill.attempted, 1);
+        assert.equal(summary.kill.succeeded, 1);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /kill-pane -t %3/);
+        assert.doesNotMatch(log, /kill-pane -t %1/);
+        assert.doesNotMatch(log, /kill-pane -t %2/);
+      },
+    );
   });
 
   it('uses pane-id-direct kill semantics without liveness-gated helper calls', async () => {
@@ -1675,14 +1686,9 @@ exit 0
   });
 
   it('continues best-effort when a pane target is missing', async () => {
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-tmux-teardown-missing-'));
-    const logPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
-    const previousPath = process.env.PATH;
-    try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+    await withMockTmuxFixture(
+      'omx-tmux-teardown-missing-',
+      (logPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${logPath}"
 if [ "$1" = "kill-pane" ] && [ "\${3:-}" = "%404" ]; then
@@ -1691,21 +1697,15 @@ if [ "$1" = "kill-pane" ] && [ "\${3:-}" = "%404" ]; then
 fi
 exit 0
 `,
-      );
-      await chmod(tmuxStubPath, 0o755);
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
-
-      const summary = await teardownWorkerPanes(['%404', '%405'], { graceMs: 1 });
-      assert.equal(summary.kill.attempted, 2);
-      assert.equal(summary.kill.succeeded, 1);
-      assert.equal(summary.kill.failed, 1);
-      const log = await readFile(logPath, 'utf-8');
-      assert.match(log, /kill-pane -t %404/);
-      assert.match(log, /kill-pane -t %405/);
-    } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
-      await rm(fakeBinDir, { recursive: true, force: true });
-    }
+      async ({ logPath }) => {
+        const summary = await teardownWorkerPanes(['%404', '%405'], { graceMs: 1 });
+        assert.equal(summary.kill.attempted, 2);
+        assert.equal(summary.kill.succeeded, 1);
+        assert.equal(summary.kill.failed, 1);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /kill-pane -t %404/);
+        assert.match(log, /kill-pane -t %405/);
+      },
+    );
   });
 });

--- a/src/team/__tests__/tmux-test-fixture.test.ts
+++ b/src/team/__tests__/tmux-test-fixture.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, type TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import { isRealTmuxAvailable, tmuxSessionExists, withTempTmuxSession } from './tmux-test-fixture.js';
+
+function skipUnlessTmux(t: TestContext): void {
+  if (!isRealTmuxAvailable()) {
+    t.skip('tmux is not available in this environment');
+  }
+}
+
+describe('withTempTmuxSession', () => {
+  it('provides isolated tmux env and cleans up on success', async (t) => {
+    skipUnlessTmux(t);
+    const ambientTmuxPane = process.env.TMUX_PANE;
+    let sessionName = '';
+
+    await withTempTmuxSession(async (fixture) => {
+      sessionName = fixture.sessionName;
+      assert.match(fixture.sessionName, /^omx-test-/);
+      assert.equal(process.env.TMUX, fixture.env.TMUX);
+      assert.equal(process.env.TMUX_PANE, fixture.leaderPaneId);
+      assert.equal(fixture.sessionExists(), true);
+      if (ambientTmuxPane) {
+        assert.notEqual(fixture.leaderPaneId, ambientTmuxPane);
+      }
+    });
+
+    assert.equal(tmuxSessionExists(sessionName), false);
+  });
+
+  it('cleans up when the callback throws', async (t) => {
+    skipUnlessTmux(t);
+    let sessionName = '';
+
+    await assert.rejects(
+      () => withTempTmuxSession(async (fixture) => {
+        sessionName = fixture.sessionName;
+        throw new Error('fixture boom');
+      }),
+      /fixture boom/,
+    );
+
+    assert.equal(tmuxSessionExists(sessionName), false);
+  });
+});

--- a/src/team/__tests__/tmux-test-fixture.ts
+++ b/src/team/__tests__/tmux-test-fixture.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface TempTmuxSessionFixture {
+  sessionName: string;
+  windowTarget: string;
+  leaderPaneId: string;
+  env: {
+    TMUX: string;
+    TMUX_PANE: string;
+  };
+  sessionExists: () => boolean;
+}
+
+function runTmux(args: string[], options: { ignoreTmuxEnv?: boolean } = {}): string {
+  const env = options.ignoreTmuxEnv ? { ...process.env, TMUX: undefined, TMUX_PANE: undefined } : process.env;
+  return execFileSync('tmux', args, { encoding: 'utf-8', env }).trim();
+}
+
+export function isRealTmuxAvailable(): boolean {
+  try {
+    runTmux(['-V'], { ignoreTmuxEnv: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function tmuxSessionExists(sessionName: string): boolean {
+  try {
+    runTmux(['has-session', '-t', sessionName], { ignoreTmuxEnv: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function uniqueSessionName(): string {
+  return `omx-test-${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export async function withTempTmuxSession<T>(fn: (fixture: TempTmuxSessionFixture) => Promise<T> | T): Promise<T> {
+  if (!isRealTmuxAvailable()) {
+    throw new Error('tmux is not available');
+  }
+
+  const fixtureCwd = await mkdtemp(join(tmpdir(), 'omx-tmux-fixture-'));
+  const sessionName = uniqueSessionName();
+  const created = runTmux([
+    'new-session',
+    '-d',
+    '-P',
+    '-F',
+    '#{session_name}:#{window_index} #{pane_id}',
+    '-s',
+    sessionName,
+    '-c',
+    fixtureCwd,
+    'sleep 300',
+  ], { ignoreTmuxEnv: true });
+  const [windowTarget = '', leaderPaneId = ''] = created.split(/\s+/, 2);
+  if (windowTarget === '' || leaderPaneId === '') {
+    try {
+      runTmux(['kill-session', '-t', sessionName], { ignoreTmuxEnv: true });
+    } catch {}
+    await rm(fixtureCwd, { recursive: true, force: true });
+    throw new Error(`failed to create temporary tmux fixture: ${created}`);
+  }
+
+  const socketPath = runTmux(['display-message', '-p', '-t', leaderPaneId, '#{socket_path}'], { ignoreTmuxEnv: true });
+  const previousTmux = process.env.TMUX;
+  const previousTmuxPane = process.env.TMUX_PANE;
+  process.env.TMUX = `${socketPath},${process.pid},0`;
+  process.env.TMUX_PANE = leaderPaneId;
+
+  const fixture: TempTmuxSessionFixture = {
+    sessionName,
+    windowTarget,
+    leaderPaneId,
+    env: {
+      TMUX: process.env.TMUX,
+      TMUX_PANE: leaderPaneId,
+    },
+    sessionExists: () => tmuxSessionExists(sessionName),
+  };
+
+  try {
+    return await fn(fixture);
+  } finally {
+    try {
+      runTmux(['kill-session', '-t', sessionName], { ignoreTmuxEnv: true });
+    } catch {}
+    if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+    else delete process.env.TMUX;
+    if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+    else delete process.env.TMUX_PANE;
+    await rm(fixtureCwd, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- add a disposable tmux test fixture for isolated session/pane setup and cleanup
- refactor tmux runtime/session tests to reuse shared tmux mock/setup helpers instead of ambient session state
- isolate CLI team tests from active worker env leakage while preserving non-tmux coverage

## Why
These tests may depend on tmux being available, but they should not target or pollute the maintainer's currently running tmux/OMX session.

## Verification
- npm run lint
- npm run build
- node --test dist/team/__tests__/tmux-test-fixture.test.js
- node --test dist/team/__tests__/tmux-session.test.js
- node --test dist/team/__tests__/runtime.test.js
- node --test dist/cli/__tests__/team.test.js
- tmux list-sessions -F '#{session_name}' | rg '^omx-test-' || true