### PR TITLE
fix(team): keep workers running after mailbox replies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64-apple-darwin
           - runner: macos-14
             target: aarch64-apple-darwin

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -95,7 +95,7 @@ describe('keyword detector swarm/team compatibility', () => {
   });
 
   it('does not trigger team keyword from filesystem/team-state path text', () => {
-    const match = detectPrimaryKeyword('You have 1 new message(s). Check .omx/state/team/execute-plan/mailbox/worker-3.json, act now, and reply with concrete progress (not ACK-only).');
+    const match = detectPrimaryKeyword('You have 1 new message(s). Read .omx/state/team/execute-plan/mailbox/worker-3.json, act now, reply with concrete progress, then continue assigned work or next feasible task.');
     assert.equal(match, null);
   });
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -673,7 +673,7 @@ sleep 5
         '--approval-mode',
         'yolo',
         '-i',
-        'Read .omx/state/team/team-gemini-prompt/workers/worker-1/inbox.md, start work now, then report concrete progress (not ACK-only).',
+        'Read .omx/state/team/team-gemini-prompt/workers/worker-1/inbox.md, start work now, report concrete progress, then continue assigned work or next feasible task.',
       ]);
 
       await shutdownTeam(runtime.teamName, cwd, { force: true });

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -220,6 +220,7 @@ describe('worker bootstrap', () => {
     assert.match(inbox, /ACK: worker-1 initialized/);
     assert.match(inbox, /Mailbox Delivery Protocol \(Required\)/);
     assert.match(inbox, /mailbox-mark-delivered/);
+    assert.match(inbox, /continue executing your assigned work or the next feasible task/i);
     assert.doesNotMatch(inbox, /Write `\{"status": "completed", "result": "brief summary"\}` to the task file/);
     assert.match(inbox, /Verification Requirements/);
     assert.match(inbox, /Fix-Verify Loop/);
@@ -322,7 +323,8 @@ describe('worker bootstrap', () => {
     assert.match(message, /\.omx\/state\/team\/team-path\/workers\/worker-9\/inbox\.md/);
     assert.match(message, /start work now/i);
     assert.match(message, /concrete progress/i);
-    assert.match(message, /ACK-only/);
+    assert.match(message, /continue assigned work/i);
+    assert.match(message, /next feasible task/i);
   });
 
   it('generateTriggerMessage uses provided state-root reference for worktree workers', () => {
@@ -330,6 +332,8 @@ describe('worker bootstrap', () => {
     assert.match(message, /\$OMX_TEAM_STATE_ROOT\/team\/team-path\/workers\/worker-9\/inbox\.md/);
     assert.match(message, /work now/i);
     assert.match(message, /report progress/i);
+    assert.match(message, /continue assigned work/i);
+    assert.match(message, /next feasible task/i);
     assert.ok(message.length < 200);
   });
 
@@ -344,7 +348,8 @@ describe('worker bootstrap', () => {
     assert.match(message, /Read .*\.omx\/state\/team\/team-mail\/mailbox\/worker-2\.json/);
     assert.match(message, /act now/i);
     assert.match(message, /concrete progress/i);
-    assert.match(message, /ACK-only/);
+    assert.match(message, /continue assigned work/i);
+    assert.match(message, /next feasible task/i);
   });
 
   it('generateMailboxTriggerMessage uses provided state-root reference for worktree workers', () => {
@@ -353,6 +358,8 @@ describe('worker bootstrap', () => {
     assert.match(message, /read .*\$OMX_TEAM_STATE_ROOT\/team\/team-mail\/mailbox\/worker-2\.json/i);
     assert.match(message, /act/i);
     assert.match(message, /report progress/i);
+    assert.match(message, /continue assigned work/i);
+    assert.match(message, /next feasible task/i);
     assert.ok(message.length < 200);
   });
 

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -83,6 +83,7 @@ CRITICAL: Never omit from_worker. The MCP server cannot auto-detect your identit
 When your mailbox receives a message, process delivery explicitly:
 1. Read: \`omx team api mailbox-list --input "{\"team_name\":\"${teamName}\",\"worker\":\"<your-worker-name>\"}" --json\`
 2. Mark delivered: \`omx team api mailbox-mark-delivered --input "{\"team_name\":\"${teamName}\",\"worker\":\"<your-worker-name>\",\"message_id\":\"<MESSAGE_ID>\"}" --json\`
+3. If you reply, include concrete progress and keep executing your assigned work or the next feasible task after replying.
 
 ## Rules
 - Do NOT edit files outside the paths listed in your task description
@@ -379,6 +380,7 @@ When you are notified about mailbox messages, always follow this exact flow:
    \`omx team api mailbox-mark-delivered --input "{\"team_name\":\"${teamName}\",\"worker\":\"${workerName}\",\"message_id\":\"<MESSAGE_ID>\"}" --json\`
 
 Use terse ACK bodies (single line) for consistent parsing across Codex and Claude workers.
+After any mailbox reply, continue executing your assigned work or the next feasible task; do not stop after sending the reply.
 
 ## Message Protocol
 When using \`omx team api send-message\`, ALWAYS include from_worker with YOUR worker name:
@@ -467,9 +469,9 @@ export function generateTriggerMessage(
 ): string {
   const inboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'workers', workerName, 'inbox.md');
   if (teamStateRoot !== '.omx/state') {
-    return `Read ${inboxPath}, work now, report progress.`;
+    return `Read ${inboxPath}, work now, report progress, continue assigned work or next feasible task.`;
   }
-  return `Read ${inboxPath}, start work now, then report concrete progress (not ACK-only).`;
+  return `Read ${inboxPath}, start work now, report concrete progress, then continue assigned work or next feasible task.`;
 }
 
 /**
@@ -485,9 +487,9 @@ export function generateMailboxTriggerMessage(
   const n = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
   const mailboxPath = buildInstructionPath(teamStateRoot, 'team', teamName, 'mailbox', workerName + '.json');
   if (teamStateRoot !== '.omx/state') {
-    return `${n} new msg(s): read ${mailboxPath}, act, report progress.`;
+    return `${n} new msg(s): read ${mailboxPath}, act, report progress, continue assigned work or next feasible task.`;
   }
-  return `You have ${n} new message(s). Read ${mailboxPath}, act now, and reply with concrete progress (not ACK-only).`;
+  return `You have ${n} new message(s). Read ${mailboxPath}, act now, reply with concrete progress, then continue assigned work or next feasible task.`;
 }
 
 export function generateLeaderMailboxTriggerMessage(

--- a/src/verification/__tests__/explore-harness-release-workflow.test.ts
+++ b/src/verification/__tests__/explore-harness-release-workflow.test.ts
@@ -15,7 +15,7 @@ describe('native release workflow', () => {
     assert.match(workflow, /id-token:\s*write/);
     assert.match(workflow, /ubuntu-24\.04/);
     assert.match(workflow, /ubuntu-24\.04-arm/);
-    assert.match(workflow, /macos-13/);
+    assert.match(workflow, /macos-15-intel/);
     assert.match(workflow, /macos-14/);
     assert.match(workflow, /windows-latest/);
     assert.match(workflow, /cargo install cargo-dist/);


### PR DESCRIPTION
## Summary
- update worker bootstrap mailbox guidance so replies include concrete progress and workers keep executing assigned or next feasible work
- refresh worker trigger wording for inbox/mailbox nudges so workers do not stop after replying
- update worker bootstrap, runtime, and keyword-detector assertions for the new wording

## Verification
- npm run build
- npx @biomejs/biome lint src/team/worker-bootstrap.ts src/team/__tests__/worker-bootstrap.test.ts src/team/__tests__/runtime.test.ts src/hooks/__tests__/keyword-detector.test.ts
- npm run check:no-unused
- node --test dist/team/__tests__/worker-bootstrap.test.js dist/team/__tests__/runtime.test.js dist/hooks/__tests__/keyword-detector.test.js
- node --test dist/team/__tests__/worker-bootstrap.test.js