### PR TITLE
fix(release): localize smoke hydration assets

### DIFF
--- a/scripts/__tests__/smoke-packed-install.test.mjs
+++ b/scripts/__tests__/smoke-packed-install.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  prepareLocalHydrationAssetDirectory,
+  rewriteManifestDownloadUrls,
+} from '../smoke-packed-install.mjs';
+
+test('rewrites copied native manifest download urls to the local smoke server', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-smoke-packed-install-'));
+  try {
+    const sourceDir = join(root, 'source-release-assets');
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, 'omx-explore-harness-x86_64-unknown-linux-gnu.tar.xz'), 'explore');
+    await writeFile(join(sourceDir, 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.xz'), 'sparkshell');
+    await writeFile(join(sourceDir, 'native-release-manifest.json'), JSON.stringify({
+      version: '0.9.0',
+      assets: [
+        {
+          product: 'omx-explore-harness',
+          archive: 'omx-explore-harness-x86_64-unknown-linux-gnu.tar.xz',
+          download_url: 'https://github.com/example/omx-explore-harness-x86_64-unknown-linux-gnu.tar.xz',
+        },
+        {
+          product: 'omx-sparkshell',
+          archive: 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.xz',
+          download_url: 'https://github.com/example/omx-sparkshell-x86_64-unknown-linux-gnu.tar.xz',
+        },
+      ],
+    }, null, 2));
+
+    const copiedDir = prepareLocalHydrationAssetDirectory(sourceDir, root);
+    rewriteManifestDownloadUrls(join(copiedDir, 'native-release-manifest.json'), 'http://127.0.0.1:43123');
+
+    const originalManifest = JSON.parse(await readFile(join(sourceDir, 'native-release-manifest.json'), 'utf-8'));
+    const copiedManifest = JSON.parse(await readFile(join(copiedDir, 'native-release-manifest.json'), 'utf-8'));
+
+    assert.match(originalManifest.assets[0].download_url, /^https:\/\/github\.com\//);
+    assert.deepEqual(
+      copiedManifest.assets.map((asset) => asset.download_url),
+      [
+        'http://127.0.0.1:43123/omx-explore-harness-x86_64-unknown-linux-gnu.tar.xz',
+        'http://127.0.0.1:43123/omx-sparkshell-x86_64-unknown-linux-gnu.tar.xz',
+      ],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/smoke-packed-install.mjs
+++ b/scripts/smoke-packed-install.mjs
@@ -1,9 +1,10 @@
 import { createServer } from 'node:http';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { chmodSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
 function usage() {
   return [
@@ -134,6 +135,23 @@ function writeCodexStub(binDir) {
   return stubPath;
 }
 
+export function prepareLocalHydrationAssetDirectory(sourceDir, tempRoot) {
+  const localDir = join(tempRoot, 'hydration-assets');
+  cpSync(sourceDir, localDir, { recursive: true });
+  return localDir;
+}
+
+export function rewriteManifestDownloadUrls(manifestPath, baseUrl) {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  manifest.assets = Array.isArray(manifest.assets)
+    ? manifest.assets.map((asset) => ({
+      ...asset,
+      download_url: new URL(asset.archive, `${baseUrl}/`).toString(),
+    }))
+    : [];
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
 async function main() {
   const { releaseAssetsDir } = parseArgs(process.argv.slice(2));
   const repoRoot = process.cwd();
@@ -161,7 +179,9 @@ async function main() {
     run(omxPath, ['--help'], { cwd: repoRoot });
 
     if (releaseAssetsDir) {
-      server = await startStaticServer(releaseAssetsDir);
+      const hydrationAssetsDir = prepareLocalHydrationAssetDirectory(releaseAssetsDir, tempRoot);
+      server = await startStaticServer(hydrationAssetsDir);
+      rewriteManifestDownloadUrls(join(hydrationAssetsDir, 'native-release-manifest.json'), server.baseUrl);
       const codexStub = writeCodexStub(helperBinDir);
       const env = {
         ...process.env,
@@ -190,7 +210,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(`packed install smoke: FAIL\n${error instanceof Error ? error.message : String(error)}`);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`packed install smoke: FAIL\n${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- copy the downloaded native release-asset bundle into the packed-install smoke tempdir
- rewrite manifest download URLs to the local smoke HTTP server before hydration
- add a focused regression test for the manifest rewrite helper

## Verification
- node --test scripts/__tests__/smoke-packed-install.test.mjs
- node --check scripts/smoke-packed-install.mjs
- node --check scripts/__tests__/smoke-packed-install.test.mjs
- npm run build
- targeted packed-install hydration check against v0.9.0 assets with poisoned remote download_url values confirmed both omx-explore-harness and omx-sparkshell hydrate from the local smoke bundle