### PR TITLE
fix(packaging): exclude staged native binaries from npm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "files": [
     "Cargo.toml",
     "Cargo.lock",
-    "bin/",
+    "bin/omx.js",
     "dist/",
     "crates/",
     "agents/",


### PR DESCRIPTION
## Summary
- restrict npm package `files` from `bin/` to `bin/omx.js`
- prevent staged native binaries under `bin/native/` from being included in npm pack output
- preserve the published CLI entrypoint while keeping release packaging hermetic

## Root cause
CI run `23037200465` failed in job `Test (Node 20 / full)` / job id `66907844585` on `main` commit `23c6d8a86c4868eb75f41afe6eaa262be8012e48`.

The exact failing test was:
- `src/cli/__tests__/package-bin-contract.test.ts`
- assertion message: `did not expect staged sparkshell binaries in npm pack output`

The failure happened because `package.json` published the entire `bin/` directory. If a staged native binary existed at `bin/native/<platform>/omx-sparkshell`, `npm pack --dry-run --json` could include it in the package tarball. That made packaging sensitive to prior build state and caused the CI failure.

## Smallest coherent fix
Change `package.json`:
- from: `"bin/"`
- to: `"bin/omx.js"`

That keeps the intended executable in the package and excludes transient native build outputs.

## Repro + verification
### Inspect failing CI log
```bash
gh api repos/Yeachan-Heo/oh-my-codex/actions/jobs/66907844585/logs > /tmp/job66907844585.log
sed -n '1538,1575p' /tmp/job66907844585.log
```
Result:
- failing location: `dist/cli/__tests__/package-bin-contract.test.js:53:16`
- unexpected packed file: `bin/native/linux-x64/omx-sparkshell`

### Targeted packaging proof after the fix
```bash
~/.nvm/versions/node/v20.20.1/bin/npm run build >/dev/null
node scripts/build-sparkshell.mjs
~/.nvm/versions/node/v20.20.1/bin/npm pack --dry-run --json > /tmp/issue808-pack.json
node - <<'NODE'
const fs = require('fs');
const results = JSON.parse(fs.readFileSync('/tmp/issue808-pack.json', 'utf8'));
const files = results[0].files.map(f => f.path);
const native = files.filter(f => f.startsWith('bin/native/'));
console.log(JSON.stringify({native, hasBinOmx: files.includes('bin/omx.js')}, null, 2));
if (native.length) process.exit(1);
NODE
```
Result:
```json
{
  "native": [],
  "hasBinOmx": true
}
```

### Targeted tests
```bash
~/.nvm/versions/node/v20.20.1/bin/node --test \
  dist/cli/__tests__/package-bin-contract.test.js \
  dist/cli/__tests__/sparkshell-packaging.test.js
```
Result:
- `pass 2`
- `fail 0`

### CI-equivalent verification
```bash
~/.nvm/versions/node/v20.20.1/bin/npm test
~/.nvm/versions/node/v20.20.1/bin/npm run build:full
~/.nvm/versions/node/v20.20.1/bin/npm run clean:native-package-assets
```
Results:
- `npm test`: `pass 2397`, `fail 0`
- `npm run build:full`: passed
- cleanup run afterward to remove staged native artifacts from the worktree
