### PR TITLE
fix: fall back when sparkshell hits glibc mismatch

### DIFF
--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -592,6 +592,38 @@ describe('exploreCommand', () => {
     }
   });
 
+  it('falls back to the explore harness when sparkshell is GLIBC-incompatible', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-explore-sparkshell-glibc-'));
+    try {
+      const sparkshellStub = join(wd, 'sparkshell-stub.sh');
+      const harnessStub = join(wd, 'explore-stub.sh');
+      await writeFile(
+        sparkshellStub,
+        "#!/bin/sh\necho \"omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.39' not found\" 1>&2\nexit 1\n",
+      );
+      await writeFile(
+        harnessStub,
+        '#!/bin/sh\nprintf "%s\\n" "# Answer" "- fallback harness recovered the lookup"\n',
+      );
+      await chmod(sparkshellStub, 0o755);
+      await chmod(harnessStub, 0o755);
+
+      const result = runOmx(wd, ['explore', '--prompt', 'git log --oneline'], {
+        OMX_SPARKSHELL_BIN: sparkshellStub,
+        OMX_EXPLORE_BIN: harnessStub,
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /GLIBC symbols/i);
+      assert.match(result.stderr, /Falling back to the explore harness/);
+      assert.match(result.stdout, /fallback harness recovered the lookup/);
+      assert.doesNotMatch(result.stderr, /version `GLIBC_2\.39' not found/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('passes prompt to harness and preserves markdown stdout', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-explore-cmd-'));
     try {

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import {
+  isSparkShellNativeCompatibilityFailure,
   nestedRepoLocalSparkShellBinaryPath,
   parseSparkShellFallbackInvocation,
   repoLocalSparkShellBinaryPath,
@@ -250,7 +251,7 @@ describe('runSparkShellBinary', () => {
     assert.deepEqual(invoked, {
       binaryPath: '/fake/omx-sparkshell',
       args: ['git', 'diff --stat', 'a|b'],
-      stdio: 'inherit',
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
   });
 
@@ -289,6 +290,36 @@ describe('runSparkShellBinary', () => {
     } finally {
       await rm(codexHome, { recursive: true, force: true });
     }
+  });
+});
+
+describe('isSparkShellNativeCompatibilityFailure', () => {
+  it('detects GLIBC symbol version failures from the native loader', () => {
+    assert.equal(
+      isSparkShellNativeCompatibilityFailure({
+        pid: 1,
+        output: [],
+        stdout: '',
+        stderr: "omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found\n",
+        status: 1,
+        signal: null,
+      }),
+      true,
+    );
+  });
+
+  it('ignores non-compatibility stderr failures', () => {
+    assert.equal(
+      isSparkShellNativeCompatibilityFailure({
+        pid: 1,
+        output: [],
+        stdout: '',
+        stderr: 'omx sparkshell: summary unavailable (tmux failed)\n',
+        status: 1,
+        signal: null,
+      }),
+      false,
+    );
   });
 });
 
@@ -366,6 +397,38 @@ describe('omx sparkshell', () => {
       assert.equal(result.status, 7, result.stderr || result.stdout);
       assert.equal(result.stdout, 'spark-stdout\n');
       assert.equal(result.stderr, 'spark-stderr\n');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to raw execution when the packaged native binary is GLIBC-incompatible', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-sparkshell-glibc-fallback-'));
+    try {
+      const testDir = dirname(fileURLToPath(import.meta.url));
+      const repoRoot = join(testDir, '..', '..', '..');
+      const packageJson = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf-8')) as { version: string };
+      const cacheDir = join(cwd, 'cache');
+      const binDir = join(cacheDir, packageJson.version, `${process.platform}-${process.arch}`, 'omx-sparkshell');
+      await mkdir(binDir, { recursive: true });
+      const stubPath = join(binDir, process.platform === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell');
+      await writeFile(
+        stubPath,
+        process.platform === 'win32'
+          ? '@echo off\r\n>&2 echo omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39\' not found\r\nexit /b 1\r\n'
+          : "#!/bin/sh\necho \"omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.39' not found\" 1>&2\nexit 1\n",
+      );
+      if (process.platform !== 'win32') await chmod(stubPath, 0o755);
+
+      const result = runOmx(cwd, ['sparkshell', 'node', '-e', 'process.stdout.write("raw-fallback\\n")'], {
+        OMX_NATIVE_CACHE_DIR: cacheDir,
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stdout, 'raw-fallback\n');
+      assert.match(result.stderr, /GLIBC-incompatible/i);
+      assert.doesNotMatch(result.stderr, /version `GLIBC_2\.39' not found/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -3,7 +3,11 @@ import { isAbsolute, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { getPackageRoot } from '../utils/package.js';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
-import { resolveSparkShellBinaryPathWithHydration, runSparkShellBinary } from './sparkshell.js';
+import {
+  isSparkShellNativeCompatibilityFailure,
+  resolveSparkShellBinaryPathWithHydration,
+  runSparkShellBinary,
+} from './sparkshell.js';
 import { getMainDefaultModel, getSparkDefaultModel } from '../config/models.js';
 import {
   EXPLORE_BIN_ENV as EXPLORE_BIN_ENV_SHARED,
@@ -138,6 +142,13 @@ async function runExploreViaSparkShell(route: ExploreSparkShellRoute, env: NodeJ
     const errno = result.error as NodeJS.ErrnoException;
     throw new Error(`[explore] failed to launch sparkshell backend: ${errno.message}`);
   }
+
+  if (isSparkShellNativeCompatibilityFailure(result)) {
+    throw new Error('[explore] sparkshell backend is incompatible with this Linux runtime (missing GLIBC symbols)');
+  }
+
+  if (result.stdout && result.stdout.length > 0) process.stdout.write(result.stdout);
+  if (result.stderr && result.stderr.length > 0) process.stderr.write(result.stderr);
 
   if (result.status !== 0) {
     process.exitCode = result.status ?? 1;

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -160,16 +160,32 @@ export function runSparkShellBinary(
   const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
     cwd,
     env: { ...configEnvOverrides, ...env },
-    stdio: 'inherit',
+    stdio: ['ignore', 'pipe', 'pipe'],
     encoding: 'utf-8',
   };
 
   return spawnImpl(binaryPath, [...args], spawnOptions);
 }
 
+function writeSparkShellResultOutput(result: SpawnSyncReturns<string>): void {
+  if (typeof result.stdout === 'string' && result.stdout.length > 0) process.stdout.write(result.stdout);
+  if (typeof result.stderr === 'string' && result.stderr.length > 0) process.stderr.write(result.stderr);
+}
+
+const SPARKSHELL_GLIBC_INCOMPATIBLE_PATTERN = /GLIBC(?:XX)?_[0-9.]+['` ]+not found/i;
+
+export function isSparkShellNativeCompatibilityFailure(result: SpawnSyncReturns<string>): boolean {
+  if ((result.status ?? 0) === 0) return false;
+  return SPARKSHELL_GLIBC_INCOMPATIBLE_PATTERN.test(result.stderr || '');
+}
+
 interface SparkShellFallbackInvocation {
   argv: string[];
   kind: 'command' | 'tmux-pane';
+}
+
+interface RunSparkShellFallbackOptions {
+  announce?: boolean;
 }
 
 export function parseSparkShellFallbackInvocation(args: readonly string[]): SparkShellFallbackInvocation {
@@ -241,9 +257,12 @@ export function parseSparkShellFallbackInvocation(args: readonly string[]): Spar
   };
 }
 
-function runSparkShellFallback(args: readonly string[]): void {
+function runSparkShellFallback(args: readonly string[], options: RunSparkShellFallbackOptions = {}): void {
+  const { announce = true } = options;
   const invocation = parseSparkShellFallbackInvocation(args);
-  process.stderr.write('[sparkshell] native sidecar unavailable; falling back to raw command execution without summary support.\n');
+  if (announce) {
+    process.stderr.write('[sparkshell] native sidecar unavailable; falling back to raw command execution without summary support.\n');
+  }
   const result = spawnSync(invocation.argv[0], invocation.argv.slice(1), {
     cwd: process.cwd(),
     env: process.env,
@@ -307,6 +326,14 @@ export async function sparkshellCommand(args: string[]): Promise<void> {
     }
     throw new Error(`[sparkshell] failed to launch native binary: ${errno.message}`);
   }
+
+  if (!hasExplicitOverride && isSparkShellNativeCompatibilityFailure(result)) {
+    process.stderr.write('[sparkshell] GLIBC-incompatible native sidecar detected; falling back to raw command execution without summary support.\n');
+    runSparkShellFallback(args, { announce: false });
+    return;
+  }
+
+  writeSparkShellResultOutput(result);
 
   if (result.status !== 0) {
     process.exitCode = typeof result.status === 'number'


### PR DESCRIPTION
## Summary
- detect Linux GLIBC symbol-version loader failures from the hydrated/packaged `omx-sparkshell` binary
- fall back to raw command execution for `omx sparkshell` and to the explore harness for `omx explore`
- add regression tests covering the GLIBC-incompatible native path for both entrypoints

## Root cause
Release assets for `omx-sparkshell` are currently published from the `*-unknown-linux-gnu` target on `ubuntu-24.04`. The resulting binary imports newer glibc symbols than older/stable Linux hosts provide. I reproduced this against the released `v0.9.0` asset with:

```bash
objdump -T omx-sparkshell | grep GLIBC | sort -u | tail
```

That showed imports including:
- `GLIBC_2.34` (`pthread_*`, `dlsym`)
- `GLIBC_2.39` (`pidfd_getpid`, `pidfd_spawnp`)

On older hosts, the loader fails before the sidecar can run, so the previous code path surfaced an immediate native launch failure with no fallback.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/sparkshell-cli.test.js dist/cli/__tests__/explore.test.js`
- `npm run lint -- src/cli/sparkshell.ts src/cli/explore.ts src/cli/__tests__/sparkshell-cli.test.ts src/cli/__tests__/explore.test.ts`

## Notes
This is the smallest coherent fix on `dev`: preserve current release packaging, but recover automatically when the native sidecar is ABI-incompatible. A later release/packaging follow-up can lower the Linux glibc baseline or add an alternate asset.
