### PR TITLE
fix(tmux): stop leaking server-global mouse state

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -613,7 +613,7 @@ describe('detached tmux new-session sequencing', () => {
   });
 
   it('buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach', () => {
-    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', true, false);
+    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', true);
     const names = steps.map((step) => step.name);
     const attachedIndex = names.indexOf('register-client-attached-reconcile');
     const scheduleIndex = names.indexOf('schedule-delayed-resize');
@@ -627,7 +627,7 @@ describe('detached tmux new-session sequencing', () => {
   });
 
   it('buildDetachedSessionFinalizeSteps uses quiet best-effort tmux resize commands', () => {
-    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', false, false);
+    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', false);
     const registerHook = steps.find((step) => step.name === 'register-resize-hook');
     const schedule = steps.find((step) => step.name === 'schedule-delayed-resize');
     const reconcile = steps.find((step) => step.name === 'reconcile-hud-resize');
@@ -641,11 +641,17 @@ describe('detached tmux new-session sequencing', () => {
   });
 
   it('buildDetachedSessionFinalizeSteps skips detached resize hooks on native Windows', () => {
-    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', true, false, true);
+    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', true, true);
     assert.deepEqual(
       steps.map((step) => step.name),
       ['set-mouse', 'attach-session'],
     );
+  });
+
+  it('buildDetachedSessionFinalizeSteps never appends server-global terminal-overrides', () => {
+    const steps = buildDetachedSessionFinalizeSteps('omx-demo', '%12', '3', true);
+    assert.equal(steps.some((step) => step.name === 'set-wsl-xt'), false);
+    assert.equal(steps.some((step) => step.args.includes('terminal-overrides')), false);
   });
 
   it('buildDetachedSessionRollbackSteps unregisters hooks before killing session', () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -60,7 +60,6 @@ import {
   enableMouseScrolling,
   isNativeWindows,
   isTmuxAvailable,
-  isWsl2,
 } from '../team/tmux-session.js';
 import { getPackageRoot } from '../utils/package.js';
 import { codexConfigPath } from '../utils/paths.js';
@@ -1035,7 +1034,6 @@ export function buildDetachedSessionFinalizeSteps(
   hudPaneId: string | null,
   hookWindowIndex: string | null,
   enableMouse: boolean,
-  wsl2: boolean,
   nativeWindows = false,
 ): DetachedSessionTmuxStep[] {
   const steps: DetachedSessionTmuxStep[] = [];
@@ -1063,9 +1061,6 @@ export function buildDetachedSessionFinalizeSteps(
 
   if (enableMouse) {
     steps.push({ name: 'set-mouse', args: ['set-option', '-t', sessionName, 'mouse', 'on'] });
-    if (wsl2) {
-      steps.push({ name: 'set-wsl-xt', args: ['set-option', '-ga', 'terminal-overrides', ',xterm*:XT'] });
-    }
   }
   steps.push({ name: 'attach-session', args: ['attach-session', '-t', sessionName] });
   return steps;
@@ -1337,7 +1332,6 @@ function runCodex(
             hudPaneId,
             hookWindowIndex,
             process.env.OMX_MOUSE !== '0',
-            isWsl2(),
             nativeWindows,
           );
           if (nativeWindows && detachedWindowsCodexCmd) {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -18,7 +18,6 @@ import {
   buildScheduleDelayedHudResizeArgs,
   buildUnregisterClientAttachedReconcileArgs,
   buildUnregisterResizeHookArgs,
-  buildScrollCopyBindings,
   buildWorkerStartupCommand,
   buildHudPaneTarget,
   chooseTeamLeaderPaneId,
@@ -1559,52 +1558,6 @@ describe('sleepFractionalSeconds', () => {
   });
 });
 
-describe('buildScrollCopyBindings (issue #206)', () => {
-  it('returns a non-empty array of tmux command arg arrays', () => {
-    const bindings = buildScrollCopyBindings();
-    assert.ok(Array.isArray(bindings));
-    assert.ok(bindings.length > 0);
-    for (const b of bindings) {
-      assert.ok(Array.isArray(b), 'each binding must be an array');
-      assert.ok(b.length > 0, 'each binding must have at least one element');
-      assert.equal(typeof b[0], 'string', 'first element must be a string');
-    }
-  });
-
-  it('includes WheelUpPane binding that enters copy-mode (fixes viewport scroll)', () => {
-    const bindings = buildScrollCopyBindings();
-    const wheelUp = bindings.find((b) => b.includes('WheelUpPane'));
-    assert.ok(wheelUp, 'WheelUpPane binding must be present');
-    assert.ok(wheelUp.some((tok) => tok.includes('copy-mode')), 'WheelUpPane binding must activate copy-mode');
-    assert.ok(wheelUp.some((tok) => tok.includes('pane_in_mode')), 'WheelUpPane must check pane_in_mode to avoid double-entry');
-  });
-
-  it('WheelUpPane binding is in the root key table (-n flag)', () => {
-    const bindings = buildScrollCopyBindings();
-    const wheelUp = bindings.find((b) => b.includes('WheelUpPane'));
-    assert.ok(wheelUp, 'WheelUpPane binding must be present');
-    const nIdx = wheelUp.indexOf('-n');
-    assert.ok(nIdx !== -1, 'WheelUpPane binding must use -n (root table) flag');
-    assert.equal(wheelUp[nIdx + 1], 'WheelUpPane');
-  });
-
-  it('includes MouseDragEnd1Pane binding that copies selection to clipboard (fixes copy)', () => {
-    const bindings = buildScrollCopyBindings();
-    const dragEnd = bindings.find((b) => b.includes('MouseDragEnd1Pane'));
-    assert.ok(dragEnd, 'MouseDragEnd1Pane binding must be present');
-    assert.ok(dragEnd.includes('copy-selection-and-cancel'), 'drag-end binding must copy the selection');
-  });
-
-  it('MouseDragEnd1Pane binding is in copy-mode key table (-T copy-mode)', () => {
-    const bindings = buildScrollCopyBindings();
-    const dragEnd = bindings.find((b) => b.includes('MouseDragEnd1Pane'));
-    assert.ok(dragEnd, 'MouseDragEnd1Pane binding must be present');
-    const tIdx = dragEnd.indexOf('-T');
-    assert.ok(tIdx !== -1, 'drag-end binding must specify a key table with -T');
-    assert.equal(dragEnd[tIdx + 1], 'copy-mode', 'drag-end binding must be in copy-mode table');
-  });
-});
-
 describe('enableMouseScrolling scroll and copy setup (issue #206)', () => {
   it('returns false gracefully when scroll-copy setup fails because tmux is unavailable', () => {
     // With empty PATH the initial "mouse on" call fails, so the function returns
@@ -1625,6 +1578,37 @@ describe('enableMouseScrolling scroll and copy setup (issue #206)', () => {
       if (typeof prev === 'string') process.env.WSL_DISTRO_NAME = prev;
       else delete process.env.WSL_DISTRO_NAME;
     }
+  });
+});
+
+
+describe('enableMouseScrolling session scoping (issue #817)', () => {
+  it('only applies session-scoped tmux options and does not mutate global bindings or terminal-overrides', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-enable-mouse-scope-',
+      (tmuxLogPath) => `#!/bin/sh
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  set-option)
+    if [ "$2" = "-t" ]; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        assert.equal(enableMouseScrolling('omx-team-x'), true);
+        const tmuxLog = await readFile(logPath, 'utf-8');
+        assert.match(tmuxLog, /set-option -t omx-team-x mouse on/);
+        assert.match(tmuxLog, /set-option -t omx-team-x set-clipboard on/);
+        assert.doesNotMatch(tmuxLog, /bind-key/);
+        assert.doesNotMatch(tmuxLog, /terminal-overrides/);
+      },
+    );
   });
 });
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -996,58 +996,13 @@ export function restoreStandaloneHudPane(
 }
 
 /**
- * Returns the tmux argv arrays for the scroll-and-copy key bindings applied
- * by enableMouseScrolling. Exported as a pure function so tests can verify
- * the binding configuration without requiring a live tmux session.
- *
- * The bindings fix two issues that appear in --xhigh and --madmax modes
- * (closes #206):
- *
- *  1. Scroll: Codex CLI TUI claims mouse input, causing tmux to forward wheel
- *     events to the application where they are interpreted as up/down arrow
- *     keys (history navigation). The WheelUpPane binding in the root table
- *     intercepts scroll events before they reach the app and enters tmux
- *     copy-mode so the user sees viewport scrolling instead.
- *
- *  2. Copy: with only "mouse on" set, selecting text with the mouse does not
- *     reach the system clipboard. The MouseDragEnd1Pane binding in copy-mode
- *     copies the selection via copy-selection-and-cancel; OSC 52
- *     (set-clipboard on) then propagates it to the terminal's clipboard.
- */
-export function buildScrollCopyBindings(): Array<string[]> {
-  return [
-    // On scroll-up: if already in copy-mode forward the event; otherwise
-    // enter copy-mode first so the user gets viewport scroll, not history nav.
-    [
-      'bind-key', '-n', 'WheelUpPane',
-      'if-shell', '-Ft=', '#{pane_in_mode}',
-      'send-keys -M',
-      'select-pane -t=; copy-mode -e; send-keys -M',
-    ],
-    // Copy mouse-selected text to clipboard when the drag ends in copy-mode.
-    [
-      'bind-key', '-T', 'copy-mode', 'MouseDragEnd1Pane',
-      'send-keys', '-X', 'copy-selection-and-cancel',
-    ],
-  ];
-}
-
-/**
  * Enable tmux mouse mode for a session so users can scroll pane content
  * (e.g. long agent output) with the mouse wheel instead of arrow keys.
- * Arrow keys remain reserved for Codex CLI input-history navigation.
  *
- * Also configures viewport scrolling via copy-mode on wheel-up and clipboard
- * copy on mouse selection, fixing scroll and copy issues in --xhigh and
- * --madmax modes. (closes #206)
- *
- * In WSL2, Windows Terminal uses the SGR mouse protocol but tmux will not
- * activate it unless the terminal advertises the XT capability. Without XT,
- * scroll wheel events are silently dropped. When a WSL2 environment is
- * detected the global terminal-overrides are extended with xterm*:XT so
- * that tmux negotiates the correct protocol with the host terminal. (closes #113)
- *
- * Returns true if the option was set successfully, false otherwise.
+ * This helper is intentionally limited to session-scoped options so OMX
+ * does not overwrite server-global tmux bindings/options owned by users,
+ * oh-my-tmux, or other sessions. Returns true if the session mouse option
+ * was set successfully, false otherwise.
  */
 export function enableMouseScrolling(sessionTarget: string): boolean {
   const result = runTmux(['set-option', '-t', sessionTarget, 'mouse', 'on']);
@@ -1056,18 +1011,6 @@ export function enableMouseScrolling(sessionTarget: string): boolean {
   // Enable OSC 52 so copy-selection-and-cancel propagates selected text to
   // the terminal's clipboard without requiring xclip or pbcopy. (closes #206)
   runTmux(['set-option', '-t', sessionTarget, 'set-clipboard', 'on']);
-
-  // Apply the scroll-into-copy-mode and mouse-copy bindings. (closes #206)
-  for (const binding of buildScrollCopyBindings()) {
-    runTmux(binding);
-  }
-
-  if (isWsl2()) {
-    // Append the XT capability override globally (terminal-overrides is a
-    // global-only option). -ga appends rather than replacing, preserving any
-    // overrides the user may already have configured.
-    runTmux(['set-option', '-ga', 'terminal-overrides', ',xterm*:XT']);
-  }
 
   return true;
 }


### PR DESCRIPTION
## Summary
- stop `enableMouseScrolling()` from installing server-global tmux bindings/options
- remove detached-session WSL `terminal-overrides` mutation so OMX only changes session-scoped tmux options
- add regression coverage for both the live tmux command path and detached-session finalize steps

## Root cause
Issue #817 was reproducible on current `dev` because OMX still mutated tmux server-global state in two places:
- `src/team/tmux-session.ts` `enableMouseScrolling()` overwrote `WheelUpPane` and `MouseDragEnd1Pane` via `bind-key ...` with no session target
- `src/cli/index.ts` `buildDetachedSessionFinalizeSteps()` appended `set-option -ga terminal-overrides ,xterm*:XT`, which is tmux-server global

That leaked outside OMX-owned sessions and conflicted with existing oh-my-tmux/user bindings.

## Verification
- `npm run build`
- `node --test dist/team/__tests__/tmux-session.test.js dist/cli/__tests__/index.test.js`
- `npx biome lint src/team/tmux-session.ts src/cli/index.ts src/team/__tests__/tmux-session.test.ts src/cli/__tests__/index.test.ts`
- manual isolated tmux repro before fix: existing `WheelUpPane`/`MouseDragEnd1Pane` bindings were overwritten; WSL path appended `terminal-overrides[1] xterm*:XT`
- manual isolated tmux repro after fix: existing bindings remained unchanged while session `mouse on` and `set-clipboard on` were still applied; global `terminal-overrides` remained unchanged

Fixes #817.
