### PR TITLE
fix: make the team HUD a full-width bottom strip

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1066,8 +1066,10 @@ exit 0
           assert.ok(runtime.config.resize_hook_name);
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          const hudSplitRe = new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
-          assert.equal(tmuxLog.match(hudSplitRe)?.length ?? 0, 3);
+          const teamHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`, 'g');
+          const standaloneHudSplitRe = new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
+          assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 1);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -862,8 +862,9 @@ export function createTeamSession(
       }
     }
 
-    // Re-create a single HUD pane under the leader column for team visibility.
-    // Keep this after layout sizing so HUD does not get mixed into worker stack.
+    // Re-create a single team HUD as a full-width bottom strip spanning both
+    // leader + worker columns. Keep this after layout sizing so the main
+    // leader/worker topology stays readable and the HUD remains compact.
     // Capture the HUD pane ID so it can be tracked and excluded from worker cleanup.
     let hudPaneId: string | null = null;
     let resizeHookName: string | null = null;
@@ -873,7 +874,7 @@ export function createTeamSession(
       const hudCmd = `node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
       const hudResult = runTmux([
-        'split-window', '-v', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', leaderPaneId, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
+        'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', teamTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
       ]);
       if (hudResult.ok) {
         const id = hudResult.stdout.split('\n')[0]?.trim() ?? '';


### PR DESCRIPTION
## Summary
- change team-mode HUD creation to use a full-width tmux bottom split across the whole team window
- keep the HUD compact at the existing team height while preserving leader/worker readability above it
- update the runtime regression to distinguish team full-width HUD creation from standalone HUD restoration

## Verification
- `npm run build`
- `npx biome lint src/team/tmux-session.ts src/team/__tests__/runtime.test.ts`
- `node --test dist/team/__tests__/tmux-session.test.js`
- `node --test --test-name-pattern "startTeam relaunch re-creates HUD pane and re-registers reconcile hooks after shutdown|startTeam routes detached worktree worker inbox and mailbox triggers through leader-root state references" dist/team/__tests__/runtime.test.js`
- real tmux geometry check: after `split-window -v -f -l 3 -t <session>:0`, HUD pane spans the full width (`width=74`) while leader/worker panes remain above it