### PR TITLE
Fix project-scope setup .omx gitignore handling

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -95,6 +95,34 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("creates .gitignore with a .omx/ entry during project-scoped setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      assert.equal(existsSync(join(wd, ".omx", "state")), true);
+      assert.equal(await readFile(join(wd, ".gitignore"), "utf-8"), ".omx/\n");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("appends .omx/ to an existing project .gitignore without duplicating it", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await writeFile(join(wd, ".gitignore"), "node_modules/\n");
+
+      await runSetupInTempDir(wd, { scope: "project" });
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
+      assert.equal(gitignore, "node_modules/\n.omx/\n");
+      assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 1);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("creates backup files under the scope-specific setup backup root when refreshing modified managed files", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -100,6 +100,8 @@ interface SetupBackupContext {
   baseRoot: string;
 }
 
+const PROJECT_OMX_GITIGNORE_ENTRY = ".omx/";
+
 function applyScopePathRewritesToAgentsTemplate(
   content: string,
   scope: SetupScope,
@@ -359,6 +361,47 @@ async function resolveSetupScope(
   return { scope: DEFAULT_SETUP_SCOPE, source: "default" };
 }
 
+function hasGitignoreEntry(content: string, entry: string): boolean {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .some((line) => line === entry);
+}
+
+async function ensureProjectOmxGitignore(
+  projectRoot: string,
+  backupContext: SetupBackupContext,
+  options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<"created" | "updated" | "unchanged"> {
+  const gitignorePath = join(projectRoot, ".gitignore");
+  const destinationExists = existsSync(gitignorePath);
+  const existing = destinationExists ? await readFile(gitignorePath, "utf-8") : "";
+
+  if (hasGitignoreEntry(existing, PROJECT_OMX_GITIGNORE_ENTRY)) {
+    return "unchanged";
+  }
+
+  const nextContent = destinationExists
+    ? `${existing}${existing.endsWith("\n") || existing.length === 0 ? "" : "\n"}${PROJECT_OMX_GITIGNORE_ENTRY}\n`
+    : `${PROJECT_OMX_GITIGNORE_ENTRY}\n`;
+
+  if (await ensureBackup(gitignorePath, destinationExists, backupContext, options)) {
+    // backup created when refreshing a pre-existing .gitignore
+  }
+
+  if (!options.dryRun) {
+    await writeFile(gitignorePath, nextContent);
+  }
+
+  if (options.verbose) {
+    console.log(
+      `  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore (${PROJECT_OMX_GITIGNORE_ENTRY})`,
+    );
+  }
+
+  return destinationExists ? "updated" : "created";
+}
+
 async function persistSetupScope(
   projectRoot: string,
   scope: SetupScope,
@@ -389,6 +432,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
   const scopeSourceMessage =
     resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
+  const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
 
   console.log("oh-my-codex setup");
   console.log("=================\n");
@@ -419,9 +463,25 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   });
   console.log("  Done.\n");
 
+  if (resolvedScope.scope === "project") {
+    const gitignoreResult = await ensureProjectOmxGitignore(
+      projectRoot,
+      backupContext,
+      { dryRun, verbose },
+    );
+    if (gitignoreResult === "created") {
+      console.log(
+        "  Created .gitignore with .omx/ so local OMX runtime state stays out of source control.\n",
+      );
+    } else if (gitignoreResult === "updated") {
+      console.log(
+        "  Added .omx/ to .gitignore so local OMX runtime state stays out of source control.\n",
+      );
+    }
+  }
+
   const catalogCounts = getCatalogHeadlineCounts();
   const summary = createEmptyRunSummary();
-  const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
 
   // Step 2: Install agent prompts
   console.log("[2/8] Installing agent prompts...");


### PR DESCRIPTION
## Summary
- add project-scope setup handling that ensures `.gitignore` contains `.omx/` when local OMX state is created
- create `.gitignore` when missing and avoid duplicate `.omx/` entries on reruns
- add targeted setup tests covering creation and append/idempotency behavior

## Verification
- npm ci
- npm run build
- npx biome lint src/cli/setup.ts src/cli/__tests__/setup-refresh.test.ts
- node --test dist/cli/__tests__/setup-refresh.test.js
- node --test dist/cli/__tests__/setup-scope.test.js
- manual check: `node bin/omx.js setup --scope project` in a temp repo created `.omx/state` and `.gitignore` containing `.omx/`

Closes #823