### PR TITLE
fix: unify planning-complete artifact checks

### DIFF
--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -43,7 +43,7 @@ return a `StageResult` with status, artifacts, and duration.
 
 ## Built-in Stages
 
-- **ralplan**: Consensus planning (planner + architect + critic). Skips if a `prd-*.md` plan already exists.
+- **ralplan**: Consensus planning (planner + architect + critic). Skips only when both `prd-*.md` and `test-spec-*.md` planning artifacts already exist, and carries any `deep-interview-*.md` spec paths forward for traceability.
 - **team-exec**: Team execution via Codex CLI workers. Always the OMX execution backend.
 - **ralph-verify**: Ralph verification loop with configurable iteration count.
 

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -14,7 +14,7 @@
  * - Session metadata
  */
 
-import { readFile, writeFile, mkdir, rm, readdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, rm } from 'fs/promises';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 import {
@@ -23,6 +23,7 @@ import {
   omxProjectMemoryPath,
   packageRoot,
 } from '../utils/paths.js';
+import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
 import { getReadScopedStateDirs, getStateDir, listModeStateFilesWithScopePreference } from '../mcp/state-paths.js';
 import { generateCodebaseMap } from './codebase-map.js';
 import { SKILL_ACTIVE_STATE_FILE } from './keyword-detector.js';
@@ -156,16 +157,13 @@ async function isRalphActive(cwd: string, sessionId?: string): Promise<boolean> 
   }
 }
 
-async function readRalphPlanningArtifacts(cwd: string): Promise<{ hasPrd: boolean; hasTestSpec: boolean }> {
-  const plansDir = join(cwd, '.omx', 'plans');
-  if (!existsSync(plansDir)) {
-    return { hasPrd: false, hasTestSpec: false };
-  }
-
-  const files = await readdir(plansDir).catch(() => [] as string[]);
-  const hasPrd = files.some((file) => /^prd-.*\.md$/i.test(file));
-  const hasTestSpec = files.some((file) => /^test-?spec-.*\.md$/i.test(file));
-  return { hasPrd, hasTestSpec };
+async function readRalphPlanningArtifacts(cwd: string): Promise<{ hasPrd: boolean; hasTestSpec: boolean; complete: boolean }> {
+  const artifacts = readPlanningArtifacts(cwd);
+  return {
+    hasPrd: artifacts.prdPaths.length > 0,
+    hasTestSpec: artifacts.testSpecPaths.length > 0,
+    complete: isPlanningComplete(artifacts),
+  };
 }
 
 async function readActiveModes(cwd: string, sessionId?: string): Promise<string> {
@@ -358,9 +356,7 @@ export async function generateOverlay(
   }
 
   if (ralphActive) {
-    const gateStatus = planningArtifacts.hasPrd && planningArtifacts.hasTestSpec
-      ? 'UNLOCKED'
-      : 'BLOCKED';
+    const gateStatus = planningArtifacts.complete ? 'UNLOCKED' : 'BLOCKED';
     const missing: string[] = [];
     if (!planningArtifacts.hasPrd) missing.push('`prd-*.md`');
     if (!planningArtifacts.hasTestSpec) missing.push('`test-spec-*.md`');

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -71,13 +71,36 @@ describe('RALPLAN Stage', () => {
     assert.equal(stage.canSkip!(makeCtx()), false);
   });
 
-  it('canSkip returns true when a prd- plan file exists', async () => {
+  it('canSkip returns false when only a prd- plan file exists', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });
     await writeFile(join(plansDir, 'prd-my-feature.md'), '# Plan\n');
 
     const stage = createRalplanStage();
+    assert.equal(stage.canSkip!(makeCtx()), false);
+  });
+
+  it('canSkip returns true when both prd and test spec plan files exist', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-my-feature.md'), '# Plan\n');
+    await writeFile(join(plansDir, 'test-spec-my-feature.md'), '# Test Spec\n');
+
+    const stage = createRalplanStage();
     assert.equal(stage.canSkip!(makeCtx()), true);
+  });
+
+  it('surfaces deep-interview specs in ralplan artifacts for downstream traceability', async () => {
+    const specsDir = join(tempDir, '.omx', 'specs');
+    await mkdir(specsDir, { recursive: true });
+    await writeFile(join(specsDir, 'deep-interview-my-feature.md'), '# Deep Interview Spec\n');
+
+    const stage = createRalplanStage();
+    const result = await stage.run(makeCtx());
+    const artifacts = result.artifacts as Record<string, unknown>;
+
+    assert.deepEqual(artifacts.deepInterviewSpecPaths, [join(specsDir, 'deep-interview-my-feature.md')]);
+    assert.equal(artifacts.planningComplete, false);
   });
 
   it('canSkip returns false for non-prd plan files', async () => {

--- a/src/pipeline/stages/ralplan.ts
+++ b/src/pipeline/stages/ralplan.ts
@@ -5,10 +5,8 @@
  * into a PipelineStage. Produces a plan artifact at `.omx/plans/`.
  */
 
-import { existsSync, readdirSync } from 'fs';
-import { readdir } from 'fs/promises';
-import { join } from 'path';
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
+import { isPlanningComplete, readPlanningArtifacts } from '../../planning/artifacts.js';
 
 /**
  * Create a RALPLAN pipeline stage.
@@ -26,33 +24,24 @@ export function createRalplanStage(): PipelineStage {
     name: 'ralplan',
 
     canSkip(ctx: StageContext): boolean {
-      // Skip if a plan artifact already exists
-      const plansDir = join(ctx.cwd, '.omx', 'plans');
-      if (!existsSync(plansDir)) return false;
-      try {
-        const files = readdirSync(plansDir) as string[];
-        return files.some(
-          (f: string) => f.startsWith('prd-') && f.endsWith('.md'),
-        );
-      } catch {
-        return false;
-      }
+      return isPlanningComplete(readPlanningArtifacts(ctx.cwd));
     },
 
     async run(ctx: StageContext): Promise<StageResult> {
       const startTime = Date.now();
-      const plansDir = join(ctx.cwd, '.omx', 'plans');
-
       try {
-        // Discover any existing plan files
-        const existingPlans = await discoverPlanFiles(plansDir);
+        const planningArtifacts = readPlanningArtifacts(ctx.cwd);
 
         return {
           status: 'completed',
           artifacts: {
-            plansDir,
+            plansDir: planningArtifacts.plansDir,
+            specsDir: planningArtifacts.specsDir,
             task: ctx.task,
-            existingPlans,
+            prdPaths: planningArtifacts.prdPaths,
+            testSpecPaths: planningArtifacts.testSpecPaths,
+            deepInterviewSpecPaths: planningArtifacts.deepInterviewSpecPaths,
+            planningComplete: isPlanningComplete(planningArtifacts),
             stage: 'ralplan',
             instruction: `Run RALPLAN consensus planning for: ${ctx.task}`,
           },
@@ -68,16 +57,4 @@ export function createRalplanStage(): PipelineStage {
       }
     },
   };
-}
-
-async function discoverPlanFiles(plansDir: string): Promise<string[]> {
-  if (!existsSync(plansDir)) return [];
-  try {
-    const files = await readdir(plansDir);
-    return files
-      .filter((f) => f.endsWith('.md'))
-      .map((f) => join(plansDir, f));
-  } catch {
-    return [];
-  }
 }

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isPlanningComplete, readPlanningArtifacts } from '../artifacts.js';
+
+let tempDir: string;
+
+async function setup(): Promise<void> {
+  tempDir = await mkdtemp(join(tmpdir(), 'omx-planning-artifacts-'));
+}
+
+async function cleanup(): Promise<void> {
+  if (tempDir && existsSync(tempDir)) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe('planning artifacts', () => {
+  beforeEach(async () => { await setup(); });
+  afterEach(async () => { await cleanup(); });
+
+  it('requires both PRD and test spec for planning completion', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-issue-827.md'), '# PRD\n');
+
+    const artifacts = readPlanningArtifacts(tempDir);
+    assert.equal(isPlanningComplete(artifacts), false);
+    assert.equal(artifacts.prdPaths.length, 1);
+    assert.equal(artifacts.testSpecPaths.length, 0);
+  });
+
+  it('surfaces deep-interview specs for downstream traceability', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const specsDir = join(tempDir, '.omx', 'specs');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(specsDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-issue-827.md'), '# PRD\n');
+    await writeFile(join(plansDir, 'test-spec-issue-827.md'), '# Test Spec\n');
+    await writeFile(join(specsDir, 'deep-interview-issue-827.md'), '# Deep Interview Spec\n');
+
+    const artifacts = readPlanningArtifacts(tempDir);
+    assert.equal(isPlanningComplete(artifacts), true);
+    assert.deepEqual(
+      artifacts.deepInterviewSpecPaths.map((file) => file.split('/').pop()),
+      ['deep-interview-issue-827.md'],
+    );
+  });
+});

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -1,0 +1,47 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { omxPlansDir } from '../utils/paths.js';
+
+const PRD_PATTERN = /^prd-.*\.md$/i;
+const TEST_SPEC_PATTERN = /^test-?spec-.*\.md$/i;
+const DEEP_INTERVIEW_SPEC_PATTERN = /^deep-interview-.*\.md$/i;
+
+export interface PlanningArtifacts {
+  plansDir: string;
+  specsDir: string;
+  prdPaths: string[];
+  testSpecPaths: string[];
+  deepInterviewSpecPaths: string[];
+}
+
+function readMatchingPaths(dir: string, pattern: RegExp): string[] {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  try {
+    return readdirSync(dir)
+      .filter((file) => pattern.test(file))
+      .sort((a, b) => a.localeCompare(b))
+      .map((file) => join(dir, file));
+  } catch {
+    return [];
+  }
+}
+
+export function readPlanningArtifacts(cwd: string): PlanningArtifacts {
+  const plansDir = omxPlansDir(cwd);
+  const specsDir = join(cwd, '.omx', 'specs');
+
+  return {
+    plansDir,
+    specsDir,
+    prdPaths: readMatchingPaths(plansDir, PRD_PATTERN),
+    testSpecPaths: readMatchingPaths(plansDir, TEST_SPEC_PATTERN),
+    deepInterviewSpecPaths: readMatchingPaths(specsDir, DEEP_INTERVIEW_SPEC_PATTERN),
+  };
+}
+
+export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
+  return artifacts.prdPaths.length > 0 && artifacts.testSpecPaths.length > 0;
+}


### PR DESCRIPTION
## Summary
- add a shared planning artifact helper that discovers PRD, test-spec, and deep-interview spec files
- unify ralplan skip logic and Ralph overlay gate semantics around the same planning-complete predicate
- preserve deep-interview -> planning traceability by carrying deep-interview spec paths in ralplan artifacts

## Verification
- `npm run build`
- `node --test dist/pipeline/__tests__/stages.test.js dist/hooks/__tests__/agents-overlay.test.js dist/planning/__tests__/artifacts.test.js`
- `npm run lint`
- `npm run check:no-unused`

## Scope landed for #827
This PR intentionally ships the first principled slice only:
- unified planning-complete helper/predicate
- aligned skip/gate logic with the actual required planning artifacts (`prd-*.md` + `test-spec-*.md`)
- preserved traceability from deep-interview spec discovery into ralplan stage artifacts

## Follow-up
Remaining work for #827:
- make downstream execution consume canonical plan bundle references instead of stage-summary JSON
- harden explicit deep-interview -> ralplan binding/materialization behavior end-to-end
- add broader contract tests across resume/re-entry and downstream execution handoffs
