### PR TITLE
Improve deep-interview intent and boundary capture

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "<idea or vague description>"
 ---
 
 <Purpose>
-Deep Interview implements an Ouroboros-inspired Socratic clarification loop before planning or implementation. It turns vague ideas into explicit specifications by asking targeted questions, scoring ambiguity across weighted dimensions, and gating execution until clarity reaches a configurable threshold.
+Deep Interview is an intent-first Socratic clarification loop before planning or implementation. It turns vague ideas into execution-ready specifications by asking targeted questions about why the user wants a change, how far it should go, what should stay out of scope, and what OMX may decide without confirmation.
 </Purpose>
 
 <Use_When>
@@ -23,9 +23,7 @@ Deep Interview implements an Ouroboros-inspired Socratic clarification loop befo
 </Do_Not_Use_When>
 
 <Why_This_Exists>
-Execution quality is usually bottlenecked by requirement clarity. A single expansion pass often misses hidden assumptions. This workflow applies Socratic pressure + quantitative ambiguity scoring so orchestration modes begin with an explicit, testable spec.
-
-Inspired by Ouroboros (https://github.com/Q00/ouroboros) and adapted for OMX conventions.
+Execution quality is usually bottlenecked by intent clarity, not just missing implementation detail. A single expansion pass often misses why the user wants a change, where the scope should stop, which tradeoffs are unacceptable, and which decisions still require user approval. This workflow applies Socratic pressure + quantitative ambiguity scoring so orchestration modes begin with an explicit, testable, intent-aligned spec.
 </Why_This_Exists>
 
 <Depth_Profiles>
@@ -38,13 +36,17 @@ If no flag is provided, use **Standard**.
 
 <Execution_Policy>
 - Ask ONE question per round (never batch)
-- Target the weakest clarity dimension each round
+- Ask about intent and boundaries before implementation detail
+- Target the weakest clarity dimension each round after applying the stage-priority rules below
 - Gather codebase facts via `explore` before asking user about internals
 - When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only brownfield fact gathering; keep prompts narrow and concrete, and keep ambiguous or non-shell-only investigation on the richer normal path and fall back normally if `omx explore` is unavailable.
 - Always run a preflight context intake before the first interview question
+- Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
+- For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
 - In Codex CLI, prefer `request_user_input` when available; if unavailable, fall back to concise plain-text one-question turns
 - Re-score ambiguity after each answer and show progress transparently
 - Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning
+- Do not crystallize or hand off while `Non-goals` or `Decision Boundaries` remain unresolved, even if the weighted ambiguity threshold is met
 - Persist mode state for resume safety (`state_write` / `state_read`)
 </Execution_Policy>
 
@@ -57,9 +59,12 @@ If no flag is provided, use **Standard**.
 3. If no snapshot exists, create a minimum context snapshot with:
    - Task statement
    - Desired outcome
+   - Stated solution (what the user asked for)
+   - Probable intent hypothesis (why they likely want it)
    - Known facts/evidence
    - Constraints
    - Unknowns/open questions
+   - Decision-boundary unknowns
    - Likely codebase touchpoints
 4. Save snapshot to `.omx/context/{slug}-{timestamp}.md` (UTC `YYYYMMDDTHHMMSSZ`) and reference it in mode state.
 
@@ -86,6 +91,8 @@ If no flag is provided, use **Standard**.
     "max_rounds": 5,
     "challenge_modes_used": [],
     "codebase_context": null,
+    "current_stage": "intent-first",
+    "current_focus": "intent",
     "context_snapshot_path": ".omx/context/<slug>-<timestamp>.md"
   }
 }
@@ -105,11 +112,20 @@ Use:
 - Brownfield context (if any)
 - Activated challenge mode injection (Phase 3)
 
-Target the lowest-scoring dimension:
-- Goal Clarity
-- Constraint Clarity
-- Success Criteria Clarity
-- Context Clarity (brownfield only)
+Target the lowest-scoring dimension, but respect stage priority:
+- **Stage 1 — Intent-first:** Intent, Outcome, Scope, Non-goals, Decision Boundaries
+- **Stage 2 — Feasibility:** Constraints, Success Criteria
+- **Stage 3 — Brownfield grounding:** Context Clarity (brownfield only)
+
+Detailed dimensions:
+- Intent Clarity — why the user wants this
+- Outcome Clarity — what end state they want
+- Scope Clarity — how far the change should go
+- Constraint Clarity — technical or business limits that must hold
+- Success Criteria Clarity — how completion will be judged
+- Context Clarity — existing codebase understanding (brownfield only)
+
+`Non-goals` and `Decision Boundaries` are mandatory readiness gates. Ask about them early and keep revisiting them until they are explicit.
 
 ### 2b) Ask the question
 Use structured user-input tooling available in the runtime (`AskUserQuestion` / equivalent) and present:
@@ -121,14 +137,19 @@ Round {n} | Target: {weakest_dimension} | Ambiguity: {score}%
 ```
 
 ### 2c) Score ambiguity
-Score each dimension in `[0.0, 1.0]` with justification + gap.
+Score each weighted dimension in `[0.0, 1.0]` with justification + gap.
 
-Greenfield: `ambiguity = 1 - (goal × 0.40 + constraints × 0.30 + criteria × 0.30)`
+Greenfield: `ambiguity = 1 - (intent × 0.30 + outcome × 0.25 + scope × 0.20 + constraints × 0.15 + success × 0.10)`
 
-Brownfield: `ambiguity = 1 - (goal × 0.35 + constraints × 0.25 + criteria × 0.25 + context × 0.15)`
+Brownfield: `ambiguity = 1 - (intent × 0.25 + outcome × 0.20 + scope × 0.20 + constraints × 0.15 + success × 0.10 + context × 0.10)`
+
+Readiness gate:
+- `Non-goals` must be explicit
+- `Decision Boundaries` must be explicit
+- If either gate is unresolved, continue interviewing even when weighted ambiguity is below threshold
 
 ### 2d) Report progress
-Show weighted breakdown table and next focus dimension.
+Show weighted breakdown table, readiness-gate status (`Non-goals`, `Decision Boundaries`), and the next focus dimension.
 
 ### 2e) Persist state
 Append round result and updated scores via `state_write`.
@@ -162,7 +183,12 @@ Spec should include:
 - Metadata (profile, rounds, final ambiguity, threshold, context type)
 - Context snapshot reference/path (for ralplan/team reuse)
 - Clarity breakdown table
-- Goal / Constraints / Non-goals
+- Intent (why the user wants this)
+- Desired Outcome
+- In-Scope
+- Out-of-Scope / Non-goals
+- Decision Boundaries (what OMX may decide without confirmation)
+- Constraints
 - Testable acceptance criteria
 - Assumptions exposed + resolutions
 - Technical context findings
@@ -207,7 +233,8 @@ Present execution options after artifact generation:
 <Final_Checklist>
 - [ ] Preflight context snapshot exists under `.omx/context/{slug}-{timestamp}.md`
 - [ ] Ambiguity score shown each round
-- [ ] Weakest-dimension targeting used
+- [ ] Intent-first stage priority used before implementation detail
+- [ ] Weakest-dimension targeting used within the active stage
 - [ ] Challenge modes triggered at thresholds (when applicable)
 - [ ] Transcript written to `.omx/interviews/{slug}-{timestamp}.md`
 - [ ] Spec written to `.omx/specs/deep-interview-{slug}.md`

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -18,14 +18,36 @@ const rootAgents = readFileSync(join(__dirname, '../../../AGENTS.md'), 'utf-8');
 const templateAgents = readFileSync(join(__dirname, '../../../templates/AGENTS.md'), 'utf-8');
 
 describe('deep-interview Ouroboros contract', () => {
-  it('includes Ouroboros framing and ambiguity gate math', () => {
-    assert.match(deepInterviewSkill, /Ouroboros/i);
+  it('includes ambiguity gate math and intent-first scoring', () => {
     assert.match(deepInterviewSkill, /ambiguity/i);
     assert.match(deepInterviewSkill, /threshold/i);
     assert.match(deepInterviewSkill, /Greenfield: `ambiguity =/);
     assert.match(deepInterviewSkill, /Brownfield: `ambiguity =/);
+    assert.match(deepInterviewSkill, /intent × 0\.30/i);
+    assert.match(deepInterviewSkill, /Decision Boundaries/i);
   });
 
+
+  it('adds intent-first concepts and readiness gates', () => {
+    assert.match(deepInterviewSkill, /Intent \(why the user wants this\)/i);
+    assert.match(deepInterviewSkill, /Desired Outcome/i);
+    assert.match(deepInterviewSkill, /Out-of-Scope \/ Non-goals/i);
+    assert.match(deepInterviewSkill, /Decision Boundaries/i);
+    assert.match(deepInterviewSkill, /Reduce user effort/i);
+    assert.match(deepInterviewSkill, /must be explicit/i);
+  });
+
+  it('prioritizes intent-boundary questioning before implementation detail', () => {
+    const intentFirstIndex = deepInterviewSkill.indexOf('Ask about intent and boundaries before implementation detail');
+    const weakDimIndex = deepInterviewSkill.indexOf('Target the lowest-scoring dimension, but respect stage priority');
+    const artifactIndex = deepInterviewSkill.indexOf('Spec should include:');
+
+    assert.notEqual(intentFirstIndex, -1);
+    assert.notEqual(weakDimIndex, -1);
+    assert.notEqual(artifactIndex, -1);
+    assert.ok(intentFirstIndex < artifactIndex);
+    assert.ok(weakDimIndex < artifactIndex);
+  });
   it('includes challenge mode structure', () => {
     assert.match(deepInterviewSkill, /Contrarian/i);
     assert.match(deepInterviewSkill, /Simplifier/i);


### PR DESCRIPTION
## Summary
This PR reworks `deep-interview` into an intent-first requirements skill.

The main change is a shift from a generic “goal / constraints / success criteria” interview shape toward a contract that first clarifies:
- why the user wants the change,
- how far the change should go,
- what must stay out of scope,
- and what OMX may decide without asking again.

The implementation stays intentionally small and reviewable:
- update `skills/deep-interview/SKILL.md`
- extend `src/hooks/__tests__/deep-interview-contract.test.ts`
- preserve the existing `.omx` artifact flow and the same execution bridges (`$ralplan`, `$autopilot`, `$ralph`, `$team`)

## Why this direction
The previous deep-interview contract was good at collecting specification detail, but it was weaker at pinning down user intent boundaries early.

That gap matters because downstream execution quality is usually not limited by “missing implementation detail” first. It is more often limited by ambiguity around:
- the actual outcome the user wants,
- the acceptable scope of the change,
- the tradeoffs that are not acceptable,
- and the decisions that still require user confirmation.

When those boundaries are unclear, later stages can still produce technically plausible work while drifting from the user’s real intent.

This PR improves that by making intent and boundaries first-class in three places at once:
1. **question ordering** — ask about intent and boundaries before implementation detail,
2. **readiness logic** — do not treat the interview as execution-ready until non-goals and decision boundaries are explicit,
3. **artifact output** — produce a richer handoff spec for later planning/execution modes.

## What changed
### 1. Intent-first interview contract
`skills/deep-interview/SKILL.md` now explicitly prioritizes:
- **Intent** — why the user wants this
- **Outcome** — what end state they want
- **Scope** — how far the change should go
- **Non-goals** — what should remain out of scope
- **Decision Boundaries** — what OMX may decide without confirmation

This moves the skill away from a purely spec-centric interview and toward an intent-alignment interview.

### 2. Lower user effort by design
The updated execution policy now makes two expectations explicit:
- ask only the highest-leverage unresolved question each round,
- do not ask the user for facts that can be discovered from codebase context.

For brownfield cases, the guidance now prefers evidence-backed confirmation questions instead of open-ended discovery questions.

That should reduce repetitive questioning and lower decision fatigue.

### 3. Revised ambiguity model
The ambiguity section now uses an intent-first weighting model.

Instead of centering only on goal/constraints/success, the weighted dimensions now emphasize:
- intent,
- outcome,
- scope,
- constraints,
- success,
- and context for brownfield work.

In addition, two explicit readiness gates were added:
- **Non-goals must be explicit**
- **Decision Boundaries must be explicit**

That means a low numeric ambiguity score is no longer enough on its own if critical scope/authority boundaries are still missing.

### 4. Richer handoff artifacts
The crystallized spec requirements now include:
- Intent
- Desired Outcome
- In-Scope
- Out-of-Scope / Non-goals
- Decision Boundaries
- Constraints
- Acceptance Criteria
- Assumptions Resolved

This is important because later execution modes need more than a thin “goal + constraints” summary if they are going to act with less guesswork.

### 5. Contract tests now lock the new behavior in place
`src/hooks/__tests__/deep-interview-contract.test.ts` was expanded to verify:
- intent-first scoring language,
- the new readiness-gate concepts,
- richer artifact expectations,
- and ordering/focus expectations that intent-boundary guidance appears before implementation-detail guidance.

This keeps the change from regressing back into a generic spec-expansion prompt later.

## What we expect to improve
### Better intent alignment
Later stages should get a clearer picture of what the user actually wants, not just the first solution wording they typed.

### Fewer wasted questions
The updated contract should avoid asking the user for information that the repo or current context already provides.

### Stronger scope control
By requiring non-goals and decision boundaries to be explicit, the skill should reduce both scope creep and over-eager autonomy.

### Better downstream execution quality
The richer spec output should help later modes make fewer guesses and produce changes that are closer to what the user intended.

## Compatibility / non-goals
This PR intentionally does **not**:
- rewrite deep-interview into a runtime engine,
- redesign keyword routing,
- change the existing execution bridge options,
- or change the `.omx/context`, `.omx/interviews`, `.omx/specs` artifact paths.

The goal here is a bounded contract improvement, not an architecture rewrite.

## Verification
Ran from the feature worktree rooted at `/home/yun/.worktrees/oh-my-codex-deep-interview-intent-first`:

- `npm run build`
- `npm run lint -- skills/deep-interview/SKILL.md src/hooks/__tests__/deep-interview-contract.test.ts`
- `node --test dist/hooks/__tests__/deep-interview-contract.test.js dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/pre-context-gate-skills.test.js`
- `npm run check:no-unused`
- `npm test`

Additionally, architect review approved the implementation after verification.

## Risks / follow-up
This remains a prompt-contract-driven feature, so a later follow-up may still be useful to persist readiness-gate state more explicitly if we want even tighter resume semantics.

For now, this PR focuses on the highest-leverage bounded improvement: better intent capture, lower user effort, and richer downstream handoff quality.
