### PR TITLE
fix: preserve post-ralplan team follow-up context

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -90,6 +90,77 @@ describe('parseTeamStartArgs', () => {
       new RegExp(`Expected 1-${DEFAULT_MAX_WORKERS}`),
     );
   });
+
+  it('reuses the approved team launch hint for a short English follow-up', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-en-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-831.md'),
+        '# Approved plan\n\nLaunch via omx team ralph 3:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831.md'), '# Test spec\n');
+
+      const result = parseTeamStartArgs(['team']);
+      assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.agentType, 'executor');
+      assert.equal(result.parsed.explicitWorkerCount, true);
+      assert.equal(result.parsed.ralph, true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses the approved team launch hint for a short Korean follow-up', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-ko-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-831.md'),
+        '# Approved plan\n\nLaunch via omx team ralph 3:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831.md'), '# Test spec\n');
+
+      const result = parseTeamStartArgs(['team으로', '해줘']);
+      assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
+      assert.equal(result.parsed.workerCount, 3);
+      assert.equal(result.parsed.ralph, true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves explicit team staffing overrides while reusing the approved plan task', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-override-'));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'plans', 'prd-issue-831.md'),
+        '# Approved plan\n\nLaunch via omx team ralph 3:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831.md'), '# Test spec\n');
+
+      const result = parseTeamStartArgs(['2:debugger', 'team']);
+      assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
+      assert.equal(result.parsed.workerCount, 2);
+      assert.equal(result.parsed.agentType, 'debugger');
+      assert.equal(result.parsed.explicitWorkerCount, true);
+      assert.equal(result.parsed.explicitAgentType, true);
+      assert.equal(result.parsed.ralph, true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('teamCommand shutdown --force parsing', () => {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { updateModeState, startMode, readModeState } from '../modes/base.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
@@ -7,6 +8,7 @@ import { readTeamEvents, waitForTeamEvent } from '../team/state/events.js';
 import type { TeamEvent, TeamTask, WorkerInfo, WorkerStatus } from '../team/state.js';
 import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
 import { classifyTaskSize } from '../hooks/task-size-detector.js';
+import { readApprovedExecutionLaunchHint } from '../planning/artifacts.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import { allocateTasksToWorkers } from '../team/allocation-policy.js';
 import {
@@ -37,6 +39,85 @@ interface ParsedTeamArgs {
   task: string;
   teamName: string;
   ralph: boolean;
+}
+
+
+interface TeamFollowupContext {
+  task: string;
+  workerCount: number;
+  explicitWorkerCount: boolean;
+  agentType?: string;
+  explicitAgentType?: boolean;
+  ralph: boolean;
+}
+
+function readPersistedTeamFollowupState(cwd: string): {
+  task?: string;
+  task_description?: string;
+  workerCount?: number;
+  agent_count?: number;
+  agentType?: string;
+  agent_types?: string;
+  linkedRalph?: boolean;
+  linked_ralph?: boolean;
+} | null {
+  const path = join(cwd, '.omx', 'state', 'team-state.json');
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as {
+      task?: string;
+      workerCount?: number;
+      agentType?: string;
+      linkedRalph?: boolean;
+      task_description?: string;
+      agent_count?: number;
+      agent_types?: string;
+    };
+  } catch {
+    return null;
+  }
+}
+
+function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFollowupContext | null {
+  const normalizedTask = task.trim();
+  if (!normalizedTask) return null;
+
+  const existingTeamState = readPersistedTeamFollowupState(cwd);
+  const shortFollowup = ['team', 'team으로 해줘', 'team으로 해주세요'].includes(normalizedTask);
+  if (!shortFollowup) return null;
+
+  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'team');
+  if (!approvedHint) return null;
+
+  const persistedTask = typeof existingTeamState?.task_description === 'string'
+    ? existingTeamState.task_description
+    : typeof existingTeamState?.task === 'string'
+      ? existingTeamState.task
+      : null;
+  const persistedWorkerCount = typeof existingTeamState?.agent_count === 'number'
+    ? existingTeamState.agent_count
+    : typeof existingTeamState?.workerCount === 'number'
+      ? existingTeamState.workerCount
+      : null;
+  if (persistedTask && persistedWorkerCount && persistedTask.trim() === approvedHint.task.trim()) {
+    return {
+      task: persistedTask,
+      workerCount: persistedWorkerCount,
+      explicitWorkerCount: true,
+      agentType: approvedHint.agentType,
+      explicitAgentType: approvedHint.agentType != null,
+      ralph: existingTeamState?.linked_ralph === true || existingTeamState?.linkedRalph === true || approvedHint.linkedRalph === true,
+    };
+  }
+
+  return {
+    task: approvedHint.task,
+    workerCount: approvedHint.workerCount ?? 3,
+    explicitWorkerCount: approvedHint.workerCount != null,
+    agentType: approvedHint.agentType,
+    explicitAgentType: approvedHint.agentType != null,
+    ralph: approvedHint.linkedRalph === true,
+  };
 }
 
 const MIN_WORKER_COUNT = 1;
@@ -1686,7 +1767,7 @@ function renderTeamPaneStatus(
   }
 }
 
-function parseTeamArgs(args: string[]): ParsedTeamArgs {
+function parseTeamArgs(args: string[], cwd: string = process.cwd()): ParsedTeamArgs {
   const tokens = [...args];
   let ralph = false;
   let workerCount = 3;
@@ -1720,8 +1801,22 @@ function parseTeamArgs(args: string[]): ParsedTeamArgs {
     throw new Error('Usage: omx team [ralph] [N:agent-type] "<task description>"');
   }
 
-  const teamName = sanitizeTeamName(slugifyTask(task));
-  return { workerCount, agentType, explicitAgentType, explicitWorkerCount, task, teamName, ralph };
+  const followupContext = resolveApprovedTeamFollowupContext(cwd, task);
+  const effectiveTask = followupContext?.task ?? task;
+  if (followupContext) {
+    if (!explicitWorkerCount) {
+      workerCount = followupContext.workerCount;
+      explicitWorkerCount = followupContext.explicitWorkerCount;
+    }
+    if (!explicitAgentType && followupContext.agentType) {
+      agentType = followupContext.agentType;
+      explicitAgentType = followupContext.explicitAgentType === true;
+    }
+    ralph = ralph || followupContext.ralph;
+  }
+
+  const teamName = sanitizeTeamName(slugifyTask(effectiveTask));
+  return { workerCount, agentType, explicitAgentType, explicitWorkerCount, task: effectiveTask, teamName, ralph };
 }
 
 export function parseTeamStartArgs(args: string[]): ParsedTeamStartArgs {
@@ -2407,7 +2502,7 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
     return;
   }
 
-  const parsed = parseTeamArgs(teamArgs);
+  const parsed = parseTeamArgs(teamArgs, cwd);
   const executionPlan = buildTeamExecutionPlan(
     parsed.task,
     parsed.workerCount,

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -503,6 +503,44 @@ describe('isUnderspecifiedForExecution', () => {
 });
 
 describe('applyRalplanGate', () => {
+  it('does not re-enter ralplan for a short approved team follow-up', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-gate-followup-'));
+    try {
+      const plansDir = join(cwd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-issue-831.md'),
+        '# Approved plan\n\nLaunch hint: omx team ralph 3:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-831.md'), '# Test spec\n');
+
+      const result = applyRalplanGate(['team'], 'team', { cwd });
+      assert.equal(result.gateApplied, false);
+      assert.deepEqual(result.keywords, ['team']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not re-enter ralplan for a short approved Korean team follow-up', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-gate-followup-ko-'));
+    try {
+      const plansDir = join(cwd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-issue-831.md'),
+        '# Approved plan\n\nLaunch hint: omx team ralph 3:executor "Execute approved issue 831 plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-831.md'), '# Test spec\n');
+
+      const result = applyRalplanGate(['team'], 'team으로 해줘', { cwd });
+      assert.equal(result.gateApplied, false);
+      assert.deepEqual(result.keywords, ['team']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('redirects underspecified execution keywords to ralplan', () => {
     const result = applyRalplanGate(['ralph'], 'ralph fix this');
     assert.equal(result.gateApplied, true);

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -14,6 +14,8 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { classifyTaskSize, isHeavyMode, type TaskSizeResult, type TaskSizeThresholds } from './task-size-detector.js';
+import { isApprovedExecutionFollowupShortcut, type FollowupMode } from '../team/followup-planner.js';
+import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
 import { KEYWORD_TRIGGER_DEFINITIONS, compareKeywordMatches } from './keyword-registry.js';
 
 export interface KeywordMatch {
@@ -374,9 +376,15 @@ export function isUnderspecifiedForExecution(text: string): boolean {
  *
  * Returns the modified keyword list and gate metadata.
  */
+export interface ApplyRalplanGateOptions {
+  cwd?: string;
+  priorSkill?: string | null;
+}
+
 export function applyRalplanGate(
   keywords: string[],
   text: string,
+  options: ApplyRalplanGateOptions = {},
 ): { keywords: string[]; gateApplied: boolean; gatedKeywords: string[] } {
   if (keywords.length === 0) {
     return { keywords, gateApplied: false, gatedKeywords: [] };
@@ -400,6 +408,23 @@ export function applyRalplanGate(
 
   // Check if prompt is underspecified
   if (!isUnderspecifiedForExecution(text)) {
+    return { keywords, gateApplied: false, gatedKeywords: [] };
+  }
+
+  const planningComplete = isPlanningComplete(readPlanningArtifacts(options.cwd ?? process.cwd()));
+  const shortFollowupBypasses = executionKeywords.filter((keyword) => {
+    const normalizedKeyword = keyword === 'swarm' ? 'team' : keyword;
+    if (normalizedKeyword !== 'team' && normalizedKeyword !== 'ralph') return false;
+    return isApprovedExecutionFollowupShortcut(
+      normalizedKeyword as FollowupMode,
+      text,
+      {
+        planningComplete,
+        priorSkill: options.priorSkill,
+      },
+    );
+  });
+  if (shortFollowupBypasses.length > 0) {
     return { keywords, gateApplied: false, gatedKeywords: [] };
   }
 

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { omxPlansDir } from '../utils/paths.js';
 
@@ -44,4 +44,86 @@ export function readPlanningArtifacts(cwd: string): PlanningArtifacts {
 
 export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
   return artifacts.prdPaths.length > 0 && artifacts.testSpecPaths.length > 0;
+}
+
+export interface ApprovedExecutionLaunchHint {
+  mode: 'team' | 'ralph';
+  command: string;
+  task: string;
+  workerCount?: number;
+  agentType?: string;
+  linkedRalph?: boolean;
+  sourcePath: string;
+}
+
+function decodeQuotedValue(raw: string): string | null {
+  const normalized = raw.trim();
+  if (!normalized) return null;
+  try {
+    return JSON.parse(normalized) as string;
+  } catch {
+    if (
+      (normalized.startsWith('"') && normalized.endsWith('"'))
+      || (normalized.startsWith("'") && normalized.endsWith("'"))
+    ) {
+      return normalized.slice(1, -1);
+    }
+    return null;
+  }
+}
+
+function readApprovedPlanText(cwd: string): { path: string; content: string } | null {
+  const artifacts = readPlanningArtifacts(cwd);
+  if (!isPlanningComplete(artifacts)) return null;
+
+  const latestPrdPath = artifacts.prdPaths.at(-1);
+  if (!latestPrdPath || !existsSync(latestPrdPath)) return null;
+
+  try {
+    return {
+      path: latestPrdPath,
+      content: readFileSync(latestPrdPath, 'utf-8'),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function readApprovedExecutionLaunchHint(
+  cwd: string,
+  mode: 'team' | 'ralph',
+): ApprovedExecutionLaunchHint | null {
+  const planText = readApprovedPlanText(cwd);
+  if (!planText) return null;
+
+  if (mode === 'team') {
+    const teamPattern = /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
+    const matches = [...planText.content.matchAll(teamPattern)];
+    const last = matches.at(-1);
+    if (!last?.groups) return null;
+    const task = decodeQuotedValue(last.groups.task);
+    if (!task) return null;
+    return {
+      mode,
+      command: last.groups.command,
+      task,
+      workerCount: Number.parseInt(last.groups.count, 10),
+      agentType: last.groups.role || undefined,
+      linkedRalph: Boolean(last.groups.ralph?.trim()),
+      sourcePath: planText.path,
+    };
+  }
+
+  const ralphPattern = /(?<command>(?:omx\s+ralph|\$ralph)\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
+  const matches = [...planText.content.matchAll(ralphPattern)];
+  const last = matches.at(-1);
+  if (!last?.groups) return null;
+  const task = decodeQuotedValue(last.groups.task);
+  if (!task) return null;
+  return {
+    mode,
+    command: last.groups.command,
+    task,
+    sourcePath: planText.path,
+  };
 }

--- a/src/team/__tests__/followup-planner.test.ts
+++ b/src/team/__tests__/followup-planner.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   buildFollowupStaffingPlan,
+  isApprovedExecutionFollowupShortcut,
   resolveAvailableAgentTypes,
 } from '../followup-planner.js';
 
@@ -75,5 +76,26 @@ describe('followup-planner', () => {
     assert.equal(plan.launchHints.skillCommand, '$ralph "Investigate auth regression and verify the fix"');
     assert.match(plan.verificationPlan.summary, /persistent execution and verification owner/i);
     assert.equal(plan.verificationPlan.checkpoints.length, 3);
+  });
+
+  it('recognizes short approved team follow-up shortcuts in English and Korean', () => {
+    assert.equal(
+      isApprovedExecutionFollowupShortcut('team', 'team', { planningComplete: true }),
+      true,
+    );
+    assert.equal(
+      isApprovedExecutionFollowupShortcut('team', 'team으로 해줘', { planningComplete: true }),
+      true,
+    );
+  });
+
+  it('rejects short follow-up shortcuts when the prior execution context conflicts', () => {
+    assert.equal(
+      isApprovedExecutionFollowupShortcut('team', 'team', {
+        planningComplete: true,
+        priorSkill: 'autopilot',
+      }),
+      false,
+    );
   });
 });

--- a/src/team/followup-planner.ts
+++ b/src/team/followup-planner.ts
@@ -43,6 +43,49 @@ export interface BuildFollowupStaffingPlanOptions {
   fallbackRole?: string;
 }
 
+export interface ApprovedExecutionFollowupContext {
+  planningComplete?: boolean;
+  priorSkill?: string | null;
+}
+
+const SHORT_TEAM_FOLLOWUP_PATTERNS: RegExp[] = [
+  /^team$/i,
+  /^team\s+please$/i,
+  /^team(?:으로)?\s+해줘$/i,
+  /^team(?:으로)?\s+해주세요$/i,
+];
+
+const SHORT_RALPH_FOLLOWUP_PATTERNS: RegExp[] = [
+  /^ralph$/i,
+  /^ralph\s+please$/i,
+];
+
+function normalizeFollowupShortcutText(text: string): string {
+  return text.trim().replace(/\s+/g, ' ');
+}
+
+export function isShortTeamFollowupRequest(text: string): boolean {
+  const normalized = normalizeFollowupShortcutText(text);
+  return SHORT_TEAM_FOLLOWUP_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function isShortRalphFollowupRequest(text: string): boolean {
+  const normalized = normalizeFollowupShortcutText(text);
+  return SHORT_RALPH_FOLLOWUP_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function isApprovedExecutionFollowupShortcut(
+  mode: FollowupMode,
+  text: string,
+  context: ApprovedExecutionFollowupContext = {},
+): boolean {
+  if (context.planningComplete !== true) return false;
+  if (context.priorSkill && context.priorSkill.toLowerCase() !== 'ralplan') return false;
+  return mode === 'team'
+    ? isShortTeamFollowupRequest(text)
+    : isShortRalphFollowupRequest(text);
+}
+
 function defaultPromptDirs(projectRoot: string): string[] {
   return [
     join(projectRoot, 'prompts'),


### PR DESCRIPTION
## Summary
- preserve approved team launch hints for short post-ralplan follow-up execution requests
- bypass ralplan re-gating for approved short English/Korean team follow-ups
- keep explicit worker/role overrides while reusing the approved plan task and linked Ralph path

## Testing
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/followup-planner.test.js
- npm run lint
- npm run check:no-unused
