### PR TITLE
fix: restore documented ecomode/web-clone keyword aliases

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -85,6 +85,34 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.match(match.keyword.toLowerCase(), /swarm/);
   });
 
+  it('maps ecomode keyword aliases to ecomode skill', () => {
+    const direct = detectPrimaryKeyword('please enable ecomode for this task');
+    assert.ok(direct);
+    assert.equal(direct.skill, 'ecomode');
+
+    const short = detectPrimaryKeyword('eco mode would help here');
+    assert.ok(short);
+    assert.equal(short.skill, 'ecomode');
+
+    const budget = detectPrimaryKeyword('we are on a budget today');
+    assert.ok(budget);
+    assert.equal(budget.skill, 'ecomode');
+  });
+
+  it('maps web-clone keyword aliases to web-clone skill', () => {
+    const direct = detectPrimaryKeyword('please run web-clone on this landing page');
+    assert.ok(direct);
+    assert.equal(direct.skill, 'web-clone');
+
+    const cloneSite = detectPrimaryKeyword('clone site example.com');
+    assert.ok(cloneSite);
+    assert.equal(cloneSite.skill, 'web-clone');
+
+    const copyWebpage = detectPrimaryKeyword('copy webpage https://example.com');
+    assert.ok(copyWebpage);
+    assert.equal(copyWebpage.skill, 'web-clone');
+  });
+
   it('keeps swarm trigger priority aligned with team trigger', () => {
     const teamMatch = detectKeywords('use team agents for this').find((entry) => entry.skill === 'team');
     const swarmMatch = detectKeywords('use swarm for this').find((entry) => entry.skill === 'team');
@@ -190,9 +218,16 @@ describe('keyword registry coverage', () => {
     assert.ok(registryKeywords.has('coordinated team'));
     assert.ok(registryKeywords.has('swarm'));
     assert.ok(registryKeywords.has('coordinated swarm'));
+    assert.ok(registryKeywords.has('ecomode'));
+    assert.ok(registryKeywords.has('eco'));
+    assert.ok(registryKeywords.has('budget'));
     assert.ok(registryKeywords.has('ouroboros'));
     assert.ok(registryKeywords.has("don't assume"));
     assert.ok(registryKeywords.has('interview me'));
+    assert.ok(registryKeywords.has('web-clone'));
+    assert.ok(registryKeywords.has('clone site'));
+    assert.ok(registryKeywords.has('clone website'));
+    assert.ok(registryKeywords.has('copy webpage'));
   });
 });
 

--- a/src/hooks/__tests__/keyword-guidance-contract.test.ts
+++ b/src/hooks/__tests__/keyword-guidance-contract.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { KEYWORD_TRIGGER_DEFINITIONS } from "../keyword-registry.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const rootAgents = readFileSync(join(__dirname, "../../../AGENTS.md"), "utf-8");
+const templateAgents = readFileSync(
+	join(__dirname, "../../../templates/AGENTS.md"),
+	"utf-8",
+);
+
+function extractKeywordTable(content: string): string {
+	const match = content.match(
+		/\| Keyword\(s\) \| Skill \| Action \|([\s\S]*?)\n\nDetection rules:/,
+	);
+	assert.ok(match, "Expected keyword table before Detection rules");
+	return match[1] ?? "";
+}
+
+function parseKeywordSkillPairs(content: string): Set<string> {
+	const table = extractKeywordTable(content);
+	const pairs = new Set<string>();
+
+	for (const line of table.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith('| "')) continue;
+
+		const cells = trimmed
+			.split("|")
+			.map((cell) => cell.trim())
+			.filter(Boolean);
+		assert.ok(
+			cells.length >= 3,
+			`Expected keyword table row with 3 cells: ${line}`,
+		);
+
+		const keywordsCell = cells[0] ?? "";
+		const skillCell = cells[1] ?? "";
+		const skillMatch = skillCell.match(/\$([a-z-]+)/i);
+		assert.ok(skillMatch, `Expected skill token in row: ${line}`);
+		const skill = skillMatch[1].toLowerCase();
+
+		for (const keywordMatch of keywordsCell.matchAll(/"([^"]+)"/g)) {
+			pairs.add(`${keywordMatch[1].toLowerCase()}=>${skill}`);
+		}
+	}
+
+	return pairs;
+}
+
+function buildRegistryPairs(): Set<string> {
+	return new Set(
+		KEYWORD_TRIGGER_DEFINITIONS.map(
+			({ keyword, skill }) =>
+				`${keyword.toLowerCase()}=>${skill.toLowerCase()}`,
+		),
+	);
+}
+
+describe("keyword guidance contract", () => {
+	const registryPairs = buildRegistryPairs();
+
+	for (const [label, content] of [
+		["root AGENTS", rootAgents],
+		["template AGENTS", templateAgents],
+	] as const) {
+		it(`${label} enumerates every runtime keyword/skill pair`, () => {
+			const documentedPairs = parseKeywordSkillPairs(content);
+			assert.deepEqual(documentedPairs, registryPairs);
+		});
+	}
+});

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -41,6 +41,10 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'coordinated team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
   { keyword: 'coordinated swarm', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode (swarm is a compatibility alias for team)' },
 
+  { keyword: 'ecomode', skill: 'ecomode', priority: 7, guidance: 'Activate token-efficient mode' },
+  { keyword: 'eco', skill: 'ecomode', priority: 7, guidance: 'Activate token-efficient mode' },
+  { keyword: 'budget', skill: 'ecomode', priority: 7, guidance: 'Activate token-efficient mode' },
+
   { keyword: 'cancel', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
   { keyword: 'stop', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
   { keyword: 'abort', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
@@ -55,6 +59,11 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'code-review', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
   { keyword: 'review code', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
   { keyword: 'security review', skill: 'security-review', priority: 6, guidance: 'Activate security-review workflow' },
+
+  { keyword: 'web-clone', skill: 'web-clone', priority: 8, guidance: 'Activate website cloning pipeline' },
+  { keyword: 'clone site', skill: 'web-clone', priority: 8, guidance: 'Activate website cloning pipeline' },
+  { keyword: 'clone website', skill: 'web-clone', priority: 8, guidance: 'Activate website cloning pipeline' },
+  { keyword: 'copy webpage', skill: 'web-clone', priority: 8, guidance: 'Activate website cloning pipeline' },
 ] as const;
 
 export function compareKeywordMatches(a: { priority: number; keyword: string }, b: { priority: number; keyword: string }): number {


### PR DESCRIPTION
## Summary
Restore runtime keyword support for the `ecomode` and `web-clone` aliases that were already documented in `AGENTS.md` and `templates/AGENTS.md`.

This keeps the hooks keyword router aligned with the published guidance and adds a contract test so future AGENTS/runtime drift fails in test instead of shipping silently.

## Changes
- add the missing `ecomode` aliases (`ecomode`, `eco`, `budget`) to `src/hooks/keyword-registry.ts`
- add the missing `web-clone` aliases (`web-clone`, `clone site`, `clone website`, `copy webpage`) to `src/hooks/keyword-registry.ts`
- extend `src/hooks/__tests__/keyword-detector.test.ts` with direct alias-detection coverage plus registry presence assertions
- add `src/hooks/__tests__/keyword-guidance-contract.test.ts` to require exact keyword/skill parity between AGENTS keyword tables and `KEYWORD_TRIGGER_DEFINITIONS`

## Validation
- [x] `npm run build`
- [x] `npm run lint`
- [x] `node --test dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/keyword-guidance-contract.test.js`
- [x] affected-file diagnostics clean
- [x] smoke check for restored aliases
- [ ] `npm test` *(currently red on pre-existing unrelated suites outside this PR scope)*

## Notes
`npm test` currently reports unrelated failures outside the keyword-trigger drift scope, including existing failures in `omx ask`, `resolveExploreHarnessCommand`, `exploreCommand`, launch fallback, notify-hook, and team runtime suites. The targeted keyword build/tests for this PR pass.