### PR TITLE
feat(setup): default user-scope skills to $CODEX_HOME/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ User / Operator
     -> Codex CLI (execution engine)
     -> AGENTS.md (orchestration brain)
     -> ~/.codex/prompts/*.md (installable active/internal agent prompt catalog)
-    -> ~/.agents/skills/*/SKILL.md (skill catalog)
+    -> ~/.codex/skills/*/SKILL.md (skill catalog)
     -> ~/.codex/config.toml (features, notify, MCP)
     -> .omx/ (runtime state, memory, plans, logs)
 ```
@@ -545,7 +545,7 @@ Notes:
 
 - `.omx/setup-scope.json` (persisted setup scope)
 - Scope-dependent installs:
-  - `user`: `~/.codex/prompts/`, `~/.agents/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`, `~/.codex/AGENTS.md`
+  - `user`: `~/.codex/prompts/`, `~/.codex/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`, `~/.codex/AGENTS.md`
   - `project`: `./.codex/prompts/`, `./.agents/skills/`, `./.codex/config.toml`, `./.omx/agents/`, `./AGENTS.md`
 - Launch behavior: if persisted scope is `project`, `omx` launch auto-uses `CODEX_HOME=./.codex` (unless `CODEX_HOME` is already set).
 - Launch instructions merge `~/.codex/AGENTS.md` (or `CODEX_HOME/AGENTS.md` when overridden) with project `./AGENTS.md`, then append the runtime overlay
@@ -592,7 +592,7 @@ omx agents-init . --force
 ## Agents and Skills
 
 - Prompts: `prompts/*.md` (installed to `~/.codex/prompts/` for `user`, `./.codex/prompts/` for `project`)
-- Skills: `skills/*/SKILL.md` (installed to `~/.agents/skills/` for `user`, `./.agents/skills/` for `project`)
+- Skills: `skills/*/SKILL.md` (installed to `~/.codex/skills/` for `user`, `./.agents/skills/` for `project`)
 
 Examples:
 - Agents: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -42,7 +42,7 @@ Supported setup flags (current implementation):
 - Local project orchestration file is `./AGENTS.md` (project root).
 - If `AGENTS.md` exists and `--force` is not used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
 - Scope targets:
-  - `user`: user directories (`~/.codex`, `~/.agents/skills`, `~/.omx/agents`)
+  - `user`: user directories (`~/.codex`, `~/.codex/skills`, `~/.omx/agents`)
   - `project`: local directories (`./.codex`, `./.agents/skills`, `./.omx/agents`)
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - With `--force`, AGENTS overwrite may still be skipped if an active OMX session is detected (safety guard).

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -15,13 +15,13 @@ Meta-skill for managing oh-my-codex skills via CLI-like commands.
 Show all local skills organized by scope.
 
 **Behavior:**
-1. Scan user skills at `~/.agents/skills/`
+1. Scan user skills at `~/.codex/skills/`
 2. Scan project skills at `.agents/skills/`
 3. Parse YAML frontmatter for metadata
 4. Display in organized table format:
 
 ```
-USER SKILLS (~/.agents/skills/):
+USER SKILLS (~/.codex/skills/):
 | Name              | Triggers           | Quality | Usage | Scope |
 |-------------------|--------------------|---------|-------|-------|
 | error-handler     | fix, error         | 95%     | 42    | user  |
@@ -51,7 +51,7 @@ Interactive wizard for creating a new skill.
 4. **Ask for argument hint** (optional)
    - Example: "<file> [options]"
 5. **Ask for scope:**
-   - `user` → `~/.agents/skills/<name>/SKILL.md`
+   - `user` → `~/.codex/skills/<name>/SKILL.md`
    - `project` → `.agents/skills/<name>/SKILL.md`
 6. **Create skill file** with template:
 
@@ -105,7 +105,7 @@ Triggers (comma-separated): log, logger, logging
 Argument hint (optional): <level> [message]
 Scope (user/project): user
 
-✓ Created skill at ~/.agents/skills/custom-logger/SKILL.md
+✓ Created skill at ~/.codex/skills/custom-logger/SKILL.md
 → Edit with: /skill edit custom-logger
 ```
 
@@ -117,13 +117,13 @@ Remove a skill by name.
 
 **Behavior:**
 1. **Search for skill** in both scopes:
-   - `~/.agents/skills/<name>/SKILL.md`
+   - `~/.codex/skills/<name>/SKILL.md`
    - `.agents/skills/<name>/SKILL.md`
 2. **If found:**
    - Display skill info (name, description, scope)
    - **Ask for confirmation:** "Delete '<name>' skill from <scope>? (yes/no)"
 3. **If confirmed:**
-   - Delete entire skill directory (e.g., `~/.agents/skills/<name>/`)
+   - Delete entire skill directory (e.g., `~/.codex/skills/<name>/`)
    - Report: "✓ Removed skill '<name>' from <scope>"
 4. **If not found:**
    - Report: "✗ Skill '<name>' not found in user or project scope"
@@ -135,7 +135,7 @@ Remove a skill by name.
 User: /skill remove old-logger
 Assistant: Found skill 'old-logger' in user scope:
   Description: Legacy logging utility
-  Scope: user (~/.agents/skills/)
+  Scope: user (~/.codex/skills/)
 
 Delete 'old-logger' skill? (yes/no)
 
@@ -251,13 +251,13 @@ Show detailed information about a skill.
 
 ```
 Skill: custom-logger
-Scope: user (~/.agents/skills/custom-logger/)
+Scope: user (~/.codex/skills/custom-logger/)
 Description: Enhanced logging with structured output
 Triggers: log, logger, logging
 Argument Hint: <level> [message]
 Quality: 95% (if available)
 Usage Count: 42 times (if available)
-File Path: /home/user/.agents/skills/custom-logger/SKILL.md
+File Path: /home/user/.codex/skills/custom-logger/SKILL.md
 
 --- FULL CONTENT ---
 [entire markdown content]
@@ -272,7 +272,7 @@ Assistant: Skill: custom-logger
 Scope: user
 Description: Enhanced logging with structured output
 Triggers: log, logger, logging
-File: ~/.agents/skills/custom-logger/SKILL.md
+File: ~/.codex/skills/custom-logger/SKILL.md
 
 --- CONTENT ---
 # Custom Logger Skill
@@ -290,7 +290,7 @@ Sync skills between user and project scopes.
 
 **Behavior:**
 1. **Scan both scopes:**
-   - User skills: `~/.agents/skills/`
+   - User skills: `~/.codex/skills/`
    - Project skills: `.agents/skills/`
 2. **Compare and categorize:**
    - User-only skills (not in project)
@@ -360,7 +360,7 @@ First, check if skill directories exist and create them if needed:
 
 ```bash
 # Check and create user-level skills directory
-USER_SKILLS_DIR="$HOME/.agents/skills"
+USER_SKILLS_DIR="$HOME/.codex/skills"
 if [ -d "$USER_SKILLS_DIR" ]; then
   echo "User skills directory exists: $USER_SKILLS_DIR"
 else
@@ -384,15 +384,15 @@ Scan both directories and show a comprehensive inventory:
 
 ```bash
 # Scan user-level skills
-echo "=== USER-LEVEL SKILLS (~/.agents/skills/) ==="
-if [ -d "$HOME/.agents/skills" ]; then
-  USER_COUNT=$(find "$HOME/.agents/skills" -name "*.md" 2>/dev/null | wc -l)
+echo "=== USER-LEVEL SKILLS (~/.codex/skills/) ==="
+if [ -d "$HOME/.codex/skills" ]; then
+  USER_COUNT=$(find "$HOME/.codex/skills" -name "*.md" 2>/dev/null | wc -l)
   echo "Total skills: $USER_COUNT"
 
   if [ $USER_COUNT -gt 0 ]; then
     echo ""
     echo "Skills found:"
-    find "$HOME/.agents/skills" -name "*.md" -type f -exec sh -c '
+    find "$HOME/.codex/skills" -name "*.md" -type f -exec sh -c '
       FILE="$1"
       NAME=$(grep -m1 "^name:" "$FILE" 2>/dev/null | sed "s/name: //")
       DESC=$(grep -m1 "^description:" "$FILE" 2>/dev/null | sed "s/description: //")
@@ -467,7 +467,7 @@ Ask user to provide either:
 - **Paste content**: Paste skill markdown content directly
 
 Then ask for scope:
-- **User-level** (~/.agents/skills/) - Available across all projects
+- **User-level** (~/.codex/skills/) - Available across all projects
 - **Project-level** (.agents/skills/) - Only for this project
 
 Validate the skill format and save to the chosen location.
@@ -760,7 +760,7 @@ Good skills are:
 > /skill list
 
 Checking skill directories...
-✓ User skills directory exists: ~/.agents/skills/
+✓ User skills directory exists: ~/.codex/skills/
 ✓ Project skills directory exists: .agents/skills/
 
 Scanning for skills...

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -171,7 +171,7 @@ describe('omx setup scope behavior', () => {
       assert.match(res.stdout, /User scope leaves project AGENTS\.md unchanged\./);
 
       assert.equal(existsSync(join(home, '.codex', 'prompts')), true);
-      assert.equal(existsSync(join(home, '.agents', 'skills')), true);
+      assert.equal(existsSync(join(home, '.codex', 'skills')), true);
       assert.equal(existsSync(join(home, '.omx', 'agents')), true);
       assert.equal(existsSync(join(home, '.codex', 'AGENTS.md')), true);
       assert.equal(existsSync(join(wd, '.omx', 'setup-scope.json')), true);
@@ -188,13 +188,13 @@ describe('omx setup scope behavior', () => {
     try {
       const home = join(wd, 'home');
       await mkdir(join(home, '.codex', 'prompts'), { recursive: true });
-      await mkdir(join(home, '.agents', 'skills', 'sample-skill'), { recursive: true });
+      await mkdir(join(home, '.codex', 'skills', 'sample-skill'), { recursive: true });
       await mkdir(join(home, '.omx', 'agents'), { recursive: true });
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'user' }));
       await writeFile(join(home, '.codex', 'AGENTS.md'), '# user agents\n');
       await writeFile(join(home, '.codex', 'prompts', 'executor.md'), '# executor\n');
-      await writeFile(join(home, '.agents', 'skills', 'sample-skill', 'SKILL.md'), '# skill\n');
+      await writeFile(join(home, '.codex', 'skills', 'sample-skill', 'SKILL.md'), '# skill\n');
       await writeFile(join(home, '.codex', 'config.toml'), 'omx_enabled = true\n[mcp_servers.omx_state]\ncommand = "node"\n');
 
       const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: join(home, '.codex') });
@@ -263,6 +263,49 @@ describe('omx setup scope behavior', () => {
       assert.match(overwritten, /# oh-my-codex - Intelligent Multi-Agent Orchestration/);
       assert.doesNotMatch(overwritten, /# old custom file/);
       assert.match(res.stdout, /Force mode: enabled additional destructive maintenance/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('--skill-target agents installs skills to ~/.agents/skills', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skill-target-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+      const res = runOmx(wd, ['setup', '--scope', 'user', '--skill-target', 'agents'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      // Skills should be in legacy location
+      assert.equal(existsSync(join(home, '.agents', 'skills')), true);
+      assert.equal(existsSync(join(home, '.agents', 'skills', 'omx-setup', 'SKILL.md')), true);
+      // Should NOT be in new location
+      assert.equal(existsSync(join(home, '.codex', 'skills')), false);
+
+      // Persisted scope should include skillTarget
+      const persisted = JSON.parse(await readFile(join(wd, '.omx', 'setup-scope.json'), 'utf-8')) as { scope: string; skillTarget?: string };
+      assert.equal(persisted.scope, 'user');
+      assert.equal(persisted.skillTarget, 'agents');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('defaults to ~/.codex/skills for user scope without --skill-target', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-default-skills-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+      const res = runOmx(wd, ['setup', '--scope', 'user'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      // Skills should be in new location
+      assert.equal(existsSync(join(home, '.codex', 'skills')), true);
+      assert.equal(existsSync(join(home, '.codex', 'skills', 'omx-setup', 'SKILL.md')), true);
+      // Should NOT be in legacy location
+      assert.equal(existsSync(join(home, '.agents', 'skills')), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -7,7 +7,7 @@ import { readdir, readFile } from 'fs/promises';
 import { join } from 'path';
 import {
   codexHome, codexConfigPath, codexPromptsDir,
-  userSkillsDir, omxStateDir,
+  userSkillsDir, legacyUserSkillsDir, omxStateDir,
 } from '../utils/paths.js';
 import { classifySpawnError, spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { getCatalogExpectations } from './catalog-contract.js';
@@ -132,6 +132,12 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
   // Check 6: Skills installed
   checks.push(await checkSkills(paths.skillsDir));
+
+  // Check 6.5: Legacy skills detection (migration warning)
+  const legacyCheck = await checkLegacySkills(paths.skillsDir, scopeResolution.scope);
+  if (legacyCheck) {
+    checks.push(legacyCheck);
+  }
 
   // Check 7: AGENTS.md in project
   checks.push(checkAgentsMd(scopeResolution.scope, paths.codexHomeDir));
@@ -596,6 +602,56 @@ async function checkSkills(dir: string): Promise<Check> {
     return { name: 'Skills', status: 'warn', message: `${skillDirs.length} skills (expected >= ${expectations.skillMin})` };
   } catch {
     return { name: 'Skills', status: 'fail', message: 'cannot read skills directory' };
+  }
+}
+
+async function checkLegacySkills(currentSkillsDir: string, scope: DoctorSetupScope): Promise<Check | null> {
+  // Only check for legacy skills in user scope when not using legacy path
+  if (scope !== 'user' || currentSkillsDir === legacyUserSkillsDir()) {
+    return null;
+  }
+  
+  const legacyDir = legacyUserSkillsDir();
+  if (!existsSync(legacyDir)) {
+    return null;
+  }
+  
+  try {
+    const entries = await readdir(legacyDir, { withFileTypes: true });
+    const legacySkillDirs = entries.filter(e => e.isDirectory());
+    
+    if (legacySkillDirs.length === 0) {
+      return null;
+    }
+    
+    // Check if current location also has skills (duplicate situation)
+    let currentCount = 0;
+    if (existsSync(currentSkillsDir)) {
+      const currentEntries = await readdir(currentSkillsDir, { withFileTypes: true });
+      currentCount = currentEntries.filter(e => e.isDirectory()).length;
+    }
+    
+    const legacyCount = legacySkillDirs.length;
+    
+    if (currentCount > 0) {
+      // Both locations have skills - this is a duplicate/warning situation
+      return {
+        name: 'Legacy Skills',
+        status: 'warn',
+        message: `${legacyCount} skills in legacy ~/.agents/skills (also ${currentCount} in ~/.codex/skills). ` +
+          `Run with --skill-target agents to use legacy, or remove ~/.agents/skills to avoid duplicates.`,
+      };
+    }
+    
+    // Only legacy has skills - informational
+    return {
+      name: 'Legacy Skills',
+      status: 'warn',
+      message: `${legacyCount} skills in legacy ~/.agents/skills. ` +
+        `New default is ~/.codex/skills. Run with --skill-target agents to use legacy path.`,
+    };
+  } catch {
+    return null;
   }
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -246,6 +246,30 @@ export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {
   throw new Error(`Invalid setup scope: ${value}. Expected one of: ${SETUP_SCOPES.join(', ')}`);
 }
 
+export function resolveSkillTargetArg(args: string[]): 'codex-home' | 'agents' | undefined {
+  let value: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--skill-target') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing skill target value after --skill-target. Expected: agents`);
+      }
+      value = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--skill-target=')) {
+      value = arg.slice('--skill-target='.length);
+    }
+  }
+  if (!value) return undefined;
+  if (value === 'agents') {
+    return 'agents';
+  }
+  throw new Error(`Invalid skill target: ${value}. Expected: agents`);
+}
+
 export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
   const firstArg = args[0];
   if (firstArg === '--help' || firstArg === '-h') {
@@ -456,6 +480,7 @@ export async function main(args: string[]): Promise<void> {
           dryRun: options.dryRun,
           verbose: options.verbose,
           scope: resolveSetupScopeArg(args.slice(1)),
+          skillTarget: resolveSkillTargetArg(args.slice(1)),
         });
         break;
       case 'agents-init':

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -22,6 +22,7 @@ import {
   codexConfigPath,
   codexPromptsDir,
   userSkillsDir,
+  legacyUserSkillsDir,
   omxStateDir,
   omxPlansDir,
   omxLogsDir,
@@ -50,6 +51,7 @@ interface SetupOptions {
   force?: boolean;
   dryRun?: boolean;
   scope?: SetupScope;
+  skillTarget?: 'codex-home' | 'agents';
   verbose?: boolean;
   agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
   modelUpgradePrompt?: (
@@ -107,15 +109,18 @@ function applyScopePathRewritesToAgentsTemplate(
   if (scope !== "project") return content;
   return content
     .replaceAll("~/.codex", "./.codex")
-    .replaceAll("~/.agents", "./.agents");
+    .replaceAll("~/.agents", "./.agents")
+    .replaceAll("./.codex/skills", "./.agents/skills");
 }
 
 interface PersistedSetupScope {
   scope: SetupScope;
+  skillTarget?: 'codex-home' | 'agents';
 }
 
 interface ResolvedSetupScope {
   scope: SetupScope;
+  skillTarget?: 'codex-home' | 'agents';
   source: "cli" | "persisted" | "prompt" | "default";
 }
 
@@ -219,6 +224,7 @@ function getScopeFilePath(projectRoot: string): string {
 export function resolveScopeDirectories(
   scope: SetupScope,
   projectRoot: string,
+  skillTarget?: 'codex-home' | 'agents',
 ): ScopeDirectories {
   if (scope === "project") {
     const codexHomeDir = join(projectRoot, ".codex");
@@ -235,13 +241,13 @@ export function resolveScopeDirectories(
     codexHomeDir: codexHome(),
     nativeAgentsDir: omxAgentsConfigDir(),
     promptsDir: codexPromptsDir(),
-    skillsDir: userSkillsDir(),
+    skillsDir: skillTarget === 'agents' ? legacyUserSkillsDir() : userSkillsDir(),
   };
 }
 
 async function readPersistedSetupScope(
   projectRoot: string,
-): Promise<SetupScope | undefined> {
+): Promise<{ scope: SetupScope; skillTarget?: 'codex-home' | 'agents' } | undefined> {
   const scopePath = getScopeFilePath(projectRoot);
   if (!existsSync(scopePath)) return undefined;
   try {
@@ -249,7 +255,12 @@ async function readPersistedSetupScope(
     const parsed = JSON.parse(raw) as Partial<PersistedSetupScope>;
     if (parsed && typeof parsed.scope === "string") {
       // Direct match to current scopes
-      if (isSetupScope(parsed.scope)) return parsed.scope;
+      if (isSetupScope(parsed.scope)) {
+        return {
+          scope: parsed.scope,
+          skillTarget: parsed.skillTarget,
+        };
+      }
       // Migrate legacy scope values (project-local → project)
       const migrated = LEGACY_SCOPE_MIGRATION[parsed.scope];
       if (migrated) {
@@ -257,7 +268,7 @@ async function readPersistedSetupScope(
           `[omx] Migrating persisted setup scope "${parsed.scope}" → "${migrated}" ` +
             `(see issue #243: simplified to user/project).`,
         );
-        return migrated;
+        return { scope: migrated, skillTarget: parsed.skillTarget };
       }
     }
   } catch {
@@ -278,7 +289,7 @@ async function promptForSetupScope(
   });
   try {
     console.log("Select setup scope:");
-    console.log(`  1) user (default) — installs to ~/.codex, ~/.agents`);
+    console.log(`  1) user (default) — installs to ~/.codex (skills, prompts, config)`);
     console.log(
       "  2) project — installs to ./.codex, ./.agents (local to project)",
     );
@@ -344,13 +355,18 @@ async function promptForAgentsOverwrite(
 async function resolveSetupScope(
   projectRoot: string,
   requestedScope?: SetupScope,
+  requestedSkillTarget?: 'codex-home' | 'agents',
 ): Promise<ResolvedSetupScope> {
   if (requestedScope) {
-    return { scope: requestedScope, source: "cli" };
+    return { scope: requestedScope, skillTarget: requestedSkillTarget, source: "cli" };
   }
   const persisted = await readPersistedSetupScope(projectRoot);
   if (persisted) {
-    return { scope: persisted, source: "persisted" };
+    return {
+      scope: persisted.scope,
+      skillTarget: persisted.skillTarget,
+      source: "persisted",
+    };
   }
   if (process.stdin.isTTY && process.stdout.isTTY) {
     const scope = await promptForSetupScope(DEFAULT_SETUP_SCOPE);
@@ -363,6 +379,7 @@ async function persistSetupScope(
   projectRoot: string,
   scope: SetupScope,
   options: Pick<SetupOptions, "dryRun" | "verbose">,
+  skillTarget?: 'codex-home' | 'agents',
 ): Promise<void> {
   const scopePath = getScopeFilePath(projectRoot);
   if (options.dryRun) {
@@ -371,6 +388,9 @@ async function persistSetupScope(
   }
   await mkdir(dirname(scopePath), { recursive: true });
   const payload: PersistedSetupScope = { scope };
+  if (skillTarget) {
+    payload.skillTarget = skillTarget;
+  }
   await writeFile(scopePath, JSON.stringify(payload, null, 2) + "\n");
   if (options.verbose) console.log(`  Wrote ${scopePath}`);
 }
@@ -380,13 +400,14 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     force = false,
     dryRun = false,
     scope: requestedScope,
+    skillTarget: requestedSkillTarget,
     verbose = false,
     modelUpgradePrompt,
   } = options;
   const pkgRoot = getPackageRoot();
   const projectRoot = process.cwd();
-  const resolvedScope = await resolveSetupScope(projectRoot, requestedScope);
-  const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
+  const resolvedScope = await resolveSetupScope(projectRoot, requestedScope, requestedSkillTarget);
+  const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot, resolvedScope.skillTarget);
   const scopeSourceMessage =
     resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
 
@@ -416,7 +437,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   await persistSetupScope(projectRoot, resolvedScope.scope, {
     dryRun,
     verbose,
-  });
+  }, resolvedScope.skillTarget);
   console.log("  Done.\n");
 
   const catalogCounts = getCatalogHeadlineCounts();

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -8,6 +8,7 @@ import {
   codexConfigPath,
   codexPromptsDir,
   userSkillsDir,
+  legacyUserSkillsDir,
   projectSkillsDir,
   omxStateDir,
   omxProjectMemoryPath,
@@ -86,8 +87,14 @@ describe('codexPromptsDir', () => {
 });
 
 describe('userSkillsDir', () => {
+  it('returns ~/.codex/skills', () => {
+    assert.equal(userSkillsDir(), join(codexHome(), 'skills'));
+  });
+});
+
+describe('legacyUserSkillsDir', () => {
   it('returns ~/.agents/skills', () => {
-    assert.equal(userSkillsDir(), join(homedir(), '.agents', 'skills'));
+    assert.equal(legacyUserSkillsDir(), join(homedir(), '.agents', 'skills'));
   });
 });
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -23,8 +23,13 @@ export function codexPromptsDir(): string {
   return join(codexHome(), 'prompts');
 }
 
-/** User-level skills directory (~/.agents/skills/) */
+/** User-level skills directory (~/.codex/skills/) */
 export function userSkillsDir(): string {
+  return join(codexHome(), 'skills');
+}
+
+/** Legacy user-level skills directory (~/.agents/skills/) - for backward compatibility */
+export function legacyUserSkillsDir(): string {
   return join(homedir(), '.agents', 'skills');
 }
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -114,22 +114,22 @@ The `deep-interview` skill is the Socratic deep interview workflow and includes 
 
 | Keyword(s) | Skill | Action |
 |-------------|-------|--------|
-| "ralph", "don't stop", "must complete", "keep going" | `$ralph` | Read `~/.agents/skills/ralph/SKILL.md`, execute persistence loop |
-| "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
-| "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
-| "ultraqa" | `$ultraqa` | Read `~/.agents/skills/ultraqa/SKILL.md`, run QA cycling workflow |
-| "analyze", "investigate" | `$analyze` | Read `~/.agents/skills/analyze/SKILL.md`, run deep analysis |
-| "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
-| "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
-| "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
-| "team", "swarm", "coordinated team", "coordinated swarm" | `$team` | Read `~/.agents/skills/team/SKILL.md`, start team orchestration (swarm compatibility alias) |
-| "ecomode", "eco", "budget" | `$ecomode` | Read `~/.agents/skills/ecomode/SKILL.md`, enable token-efficient mode |
-| "cancel", "stop", "abort" | `$cancel` | Read `~/.agents/skills/cancel/SKILL.md`, cancel active modes |
-| "tdd", "test first" | `$tdd` | Read `~/.agents/skills/tdd/SKILL.md`, start test-driven workflow |
-| "fix build", "type errors" | `$build-fix` | Read `~/.agents/skills/build-fix/SKILL.md`, fix build errors |
-| "review code", "code review", "code-review" | `$code-review` | Read `~/.agents/skills/code-review/SKILL.md`, run code review |
-| "security review" | `$security-review` | Read `~/.agents/skills/security-review/SKILL.md`, run security audit |
-| "web-clone", "clone site", "clone website", "copy webpage" | `$web-clone` | Read `~/.agents/skills/web-clone/SKILL.md`, start website cloning pipeline |
+| "ralph", "don't stop", "must complete", "keep going" | `$ralph` | Read `~/.codex/skills/ralph/SKILL.md`, execute persistence loop |
+| "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.codex/skills/autopilot/SKILL.md`, execute autonomous pipeline |
+| "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.codex/skills/ultrawork/SKILL.md`, execute parallel agents |
+| "ultraqa" | `$ultraqa` | Read `~/.codex/skills/ultraqa/SKILL.md`, run QA cycling workflow |
+| "analyze", "investigate" | `$analyze` | Read `~/.codex/skills/analyze/SKILL.md`, run deep analysis |
+| "plan this", "plan the", "let's plan" | `$plan` | Read `~/.codex/skills/plan/SKILL.md`, start planning workflow |
+| "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.codex/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
+| "ralplan", "consensus plan" | `$ralplan` | Read `~/.codex/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
+| "team", "swarm", "coordinated team", "coordinated swarm" | `$team` | Read `~/.codex/skills/team/SKILL.md`, start team orchestration (swarm compatibility alias) |
+| "ecomode", "eco", "budget" | `$ecomode` | Read `~/.codex/skills/ecomode/SKILL.md`, enable token-efficient mode |
+| "cancel", "stop", "abort" | `$cancel` | Read `~/.codex/skills/cancel/SKILL.md`, cancel active modes |
+| "tdd", "test first" | `$tdd` | Read `~/.codex/skills/tdd/SKILL.md`, start test-driven workflow |
+| "fix build", "type errors" | `$build-fix` | Read `~/.codex/skills/build-fix/SKILL.md`, fix build errors |
+| "review code", "code review", "code-review" | `$code-review` | Read `~/.codex/skills/code-review/SKILL.md`, run code review |
+| "security review" | `$security-review` | Read `~/.codex/skills/security-review/SKILL.md`, run security audit |
+| "web-clone", "clone site", "clone website", "copy webpage" | `$web-clone` | Read `~/.codex/skills/web-clone/SKILL.md`, start website cloning pipeline |
 
 Detection rules:
 - Keywords are case-insensitive and match anywhere in the user message.


### PR DESCRIPTION
Closes #836

## Summary

Changes user-scope skill installation from `~/.agents/skills/` to `$CODEX_HOME/skills` (typically `~/.codex/skills/`), preventing Codex-specific skills from polluting the shared `~/.agents/` directory read by other AI tools.

## Key changes

| File | Change |
|------|--------|
| `src/utils/paths.ts` | `userSkillsDir()` returns `$CODEX_HOME/skills`; add `legacyUserSkillsDir()` |
| `src/cli/setup.ts` | `skillTarget` option; persist to `setup-scope.json`; pass to `resolveScopeDirectories()` |
| `src/cli/index.ts` | Parse `--skill-target agents` flag |
| `src/cli/doctor.ts` | `checkLegacySkills()` warns when `~/.agents/skills` has OMX skills |
| `templates/AGENTS.md` | Update skills paths in keyword table |
| `README.md` | Update scope target documentation |
| `skills/omx-setup/SKILL.md` | Update user scope path |
| `skills/skill/SKILL.md` | Update all user-scope skills paths |
| `src/utils/__tests__/paths.test.ts` | Update `userSkillsDir` test; add `legacyUserSkillsDir` test |
| `src/cli/__tests__/setup-scope.test.ts` | Update expectations; add `--skill-target agents` test |

## Behavior

```
# New default: installs to ~/.codex/skills
omx setup --scope user

# Legacy opt-in: installs to ~/.agents/skills (persisted in setup-scope.json)
omx setup --scope user --skill-target agents

# Doctor warns if ~/.agents/skills has skills while target is the new default
omx doctor
# [!!] Legacy Skills: 34 skills in legacy ~/.agents/skills (also 3 in ~/.codex/skills).
#      Run with --skill-target agents to use legacy, or remove ~/.agents/skills to avoid duplicates.
```

## Backward compatibility

- Project scope is unchanged — still uses `./.agents/skills/`
- Existing users with skills in `~/.agents/skills` get a doctor warning, not a forced migration
- `--skill-target agents` preserves the old behavior indefinitely
- Non-destructive: nothing is auto-deleted from `~/.agents/skills`

## Tests

All existing tests pass. New tests added:
- `userSkillsDir()` returns `~/.codex/skills`
- `legacyUserSkillsDir()` returns `~/.agents/skills`
- `--skill-target agents` installs to `~/.agents/skills` and persists `skillTarget` in JSON
- Default (no flag) installs to `~/.codex/skills` and does not create `~/.agents/skills`