### PR TITLE
fix(hooks): auto-expand active Ralph max_iterations

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -56,6 +56,20 @@ import {
 } from './notify-hook/team-worker.js';
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 
+const RALPH_ACTIVE_PROGRESS_PHASES = new Set([
+  'start',
+  'started',
+  'starting',
+  'execute',
+  'execution',
+  'executing',
+  'verify',
+  'verification',
+  'verifying',
+  'fix',
+  'fixing',
+]);
+
 async function main() {
   const rawPayload = process.argv[process.argv.length - 1];
   if (!rawPayload || rawPayload.startsWith('-')) {
@@ -145,17 +159,33 @@ async function main() {
 
             const maxIterations = asNumber(state.max_iterations);
             if (maxIterations !== null && maxIterations > 0 && nextIteration >= maxIterations) {
-              state.active = false;
-              if (typeof state.current_phase !== 'string' || !state.current_phase.trim()) {
-                state.current_phase = 'complete';
-              } else if (!['cancelled', 'failed', 'complete'].includes(state.current_phase)) {
-                state.current_phase = 'complete';
-              }
-              if (typeof state.completed_at !== 'string' || !state.completed_at) {
-                state.completed_at = nowIso;
-              }
-              if (typeof state.stop_reason !== 'string' || !state.stop_reason) {
-                state.stop_reason = 'max_iterations_reached';
+              const currentPhase = typeof state.current_phase === 'string'
+                ? state.current_phase.trim().toLowerCase()
+                : '';
+              const isActiveRalphProgress = (
+                (f === 'ralph-state.json' || state.mode === 'ralph')
+                && RALPH_ACTIVE_PROGRESS_PHASES.has(currentPhase)
+              );
+
+              if (isActiveRalphProgress) {
+                state.max_iterations = maxIterations + 10;
+                state.max_iterations_auto_expand_count = (asNumber(state.max_iterations_auto_expand_count) || 0) + 1;
+                state.max_iterations_auto_expanded_at = nowIso;
+                delete state.completed_at;
+                delete state.stop_reason;
+              } else {
+                state.active = false;
+                if (typeof state.current_phase !== 'string' || !state.current_phase.trim()) {
+                  state.current_phase = 'complete';
+                } else if (!['cancelled', 'failed', 'complete'].includes(state.current_phase)) {
+                  state.current_phase = 'complete';
+                }
+                if (typeof state.completed_at !== 'string' || !state.completed_at) {
+                  state.completed_at = nowIso;
+                }
+                if (typeof state.stop_reason !== 'string' || !state.stop_reason) {
+                  state.stop_reason = 'max_iterations_reached';
+                }
               }
             }
 

--- a/src/hooks/__tests__/notify-hook-session-scope.test.ts
+++ b/src/hooks/__tests__/notify-hook-session-scope.test.ts
@@ -51,7 +51,7 @@ describe('notify-hook session-scoped iteration updates', () => {
     }
   });
 
-  it('marks active mode state complete when max_iterations is reached', async () => {
+  it('auto-expands active Ralph max_iterations by 10 when the run is still progressing', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-notify-test-'));
     try {
       const stateDir = join(wd, '.omx', 'state');
@@ -94,6 +94,63 @@ describe('notify-hook session-scoped iteration updates', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const updated = JSON.parse(await readFile(join(sessionScopedDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(updated.iteration, 2);
+      assert.equal(updated.active, true);
+      assert.equal(updated.current_phase, 'executing');
+      assert.equal(updated.max_iterations, 12);
+      assert.equal(updated.stop_reason, undefined);
+      assert.equal(updated.completed_at, undefined);
+      assert.equal(updated.max_iterations_auto_expand_count, 1);
+      assert.ok(typeof updated.max_iterations_auto_expanded_at === 'string' && updated.max_iterations_auto_expanded_at.length > 0);
+      assert.ok(typeof updated.last_turn_at === 'string' && updated.last_turn_at.length > 0);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('still marks non-Ralph modes complete when max_iterations is reached', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-test-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess1';
+      const sessionScopedDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionScopedDir, { recursive: true });
+
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(
+        join(sessionScopedDir, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          iteration: 1,
+          max_iterations: 2,
+          current_phase: 'executing',
+        })
+      );
+
+      const payload = {
+        cwd: wd,
+        type: 'agent-turn-complete',
+        thread_id: 'th2',
+        turn_id: 'tu2',
+        input_messages: [],
+        last_assistant_message: 'ok',
+      };
+
+      const testDir = dirname(fileURLToPath(import.meta.url));
+      const repoRoot = join(testDir, '..', '..', '..');
+      const result = spawnSync(process.execPath, ['scripts/notify-hook.js', JSON.stringify(payload)], {
+        cwd: repoRoot,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          OMX_TEAM_WORKER: '',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const updated = JSON.parse(await readFile(join(sessionScopedDir, 'team-state.json'), 'utf-8'));
       assert.equal(updated.iteration, 2);
       assert.equal(updated.active, false);
       assert.equal(updated.current_phase, 'complete');


### PR DESCRIPTION
## Summary
- auto-expand `ralph.max_iterations` by `+10` in the runtime notify-hook when an active Ralph run hits its cap while still in an active progress phase
- preserve the previous hard-stop behavior for non-Ralph modes and non-progress/terminal Ralph states
- cover both paths with focused notify-hook session-scope tests

## Investigation
- the current runtime stop condition lives in `scripts/notify-hook.js`, where each completed turn increments `iteration` and completes the mode when `iteration >= max_iterations`
- `src/modes/base.ts` and `src/ralph/contract.ts` only initialize/validate Ralph state; they do not enforce the runtime stop
- I also inspected the adjacent local `omc-main` runtime hook for relevant precedent; I did not find a matching `+10` auto-expansion behavior there, so this keeps the fix localized to OMX's current runtime enforcement path

## Implementation notes
- Ralph auto-expands only when the state file is Ralph and `current_phase` still indicates active progress (`starting` / `executing` / `verifying` / `fixing`, plus legacy aliases)
- the extension is persisted in state via updated `max_iterations`, `max_iterations_auto_expand_count`, and `max_iterations_auto_expanded_at`
- all other modes still stop with `stop_reason=max_iterations_reached`

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/hooks/__tests__/notify-hook-session-scope.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js`
- `npm test`

Closes #842.
