### PR TITLE
fix: reject malformed skills during setup/update

### DIFF
--- a/src/cli/__tests__/setup-skill-validation.test.ts
+++ b/src/cli/__tests__/setup-skill-validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { installSkills, parseSkillFrontmatter } from '../setup.js';
+
+describe('skill frontmatter validation', () => {
+  it('accepts valid SKILL.md frontmatter with quoted values and nested metadata', () => {
+    const content = `---\nname: help\ndescription: "Guide on using oh-my-codex plugin"\nmetadata:\n  short-description: Quick help\n---\n\n# Help\n`;
+
+    assert.deepEqual(parseSkillFrontmatter(content), {
+      name: 'help',
+      description: 'Guide on using oh-my-codex plugin',
+    });
+  });
+
+  it('rejects SKILL.md frontmatter without a description', () => {
+    const content = `---\nname: help\n---\n\n# Help\n`;
+
+    assert.throws(
+      () => parseSkillFrontmatter(content, '/tmp/help/SKILL.md'),
+      /missing a non-empty frontmatter "description"/i,
+    );
+  });
+
+  it('rejects SKILL.md frontmatter with unterminated quoted strings', () => {
+    const content = `---\nname: help\ndescription: "broken\n---\n\n# Help\n`;
+
+    assert.throws(
+      () => parseSkillFrontmatter(content, '/tmp/help/SKILL.md'),
+      /unterminated quoted string/i,
+    );
+  });
+});
+
+describe('omx setup skill validation', () => {
+  it('fails before installing a malformed shipped-style SKILL.md', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-setup-skill-validation-'));
+    const srcDir = join(root, 'src-skills');
+    const dstDir = join(root, 'dst-skills');
+    const skillDir = join(srcDir, 'help');
+
+    try {
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), `---\nname: help\ndescription: "broken\n---\n\n# Help\n`);
+      await writeFile(join(skillDir, 'notes.md'), 'extra file\n');
+
+      await assert.rejects(
+        () => installSkills(
+          srcDir,
+          dstDir,
+          { backupRoot: join(root, 'backups'), baseRoot: root },
+          { force: false, dryRun: false, verbose: false },
+        ),
+        /src-skills\/help\/SKILL\.md.*unterminated quoted string/i,
+      );
+
+      assert.equal(existsSync(join(dstDir, 'help', 'SKILL.md')), false);
+      assert.equal(existsSync(join(dstDir, 'help', 'notes.md')), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -104,6 +104,11 @@ interface SetupBackupContext {
   baseRoot: string;
 }
 
+export interface SkillFrontmatterMetadata {
+  name: string;
+  description: string;
+}
+
 const PROJECT_OMX_GITIGNORE_ENTRY = ".omx/";
 
 function applyScopePathRewritesToAgentsTemplate(
@@ -215,6 +220,89 @@ async function filesDiffer(src: string, dst: string): Promise<boolean> {
     readFile(dst, "utf-8"),
   ]);
   return srcContent !== dstContent;
+}
+
+function parseSkillFrontmatterScalar(
+  value: string,
+  key: string,
+  filePath: string,
+): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+  }
+  if (trimmed === "|" || trimmed === ">") {
+    throw new Error(`${filePath} frontmatter "${key}" must be a single-line string`);
+  }
+
+  const quote = trimmed[0];
+  if (quote === '"' || quote === "'") {
+    if (trimmed.length < 2 || trimmed.at(-1) !== quote) {
+      throw new Error(`${filePath} frontmatter "${key}" has an unterminated quoted string`);
+    }
+    const unquoted = trimmed.slice(1, -1).trim();
+    if (!unquoted) {
+      throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+    }
+    return unquoted;
+  }
+
+  const unquoted = trimmed.replace(/\s+#.*$/, "").trim();
+  if (!unquoted) {
+    throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+  }
+  return unquoted;
+}
+
+export function parseSkillFrontmatter(
+  content: string,
+  filePath = "SKILL.md",
+): SkillFrontmatterMetadata {
+  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!frontmatterMatch) {
+    throw new Error(
+      `${filePath} must start with YAML frontmatter containing non-empty name and description fields`,
+    );
+  }
+
+  let name: string | undefined;
+  let description: string | undefined;
+  const lines = frontmatterMatch[1].split(/\r?\n/);
+
+  for (const [index, rawLine] of lines.entries()) {
+    const line = rawLine.trimEnd();
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (/^\s/.test(rawLine)) continue;
+
+    const match = line.match(/^([A-Za-z0-9_-]+):(.*)$/);
+    if (!match) {
+      throw new Error(
+        `${filePath} has invalid YAML frontmatter on line ${index + 2}: ${trimmed}`,
+      );
+    }
+
+    const [, key, rawValue] = match;
+    if (!rawValue.trim()) continue;
+
+    const parsedValue = parseSkillFrontmatterScalar(rawValue, key, filePath);
+    if (key === "name") name = parsedValue;
+    if (key === "description") description = parsedValue;
+  }
+
+  if (!name) {
+    throw new Error(`${filePath} is missing a non-empty frontmatter "name"`);
+  }
+  if (!description) {
+    throw new Error(`${filePath} is missing a non-empty frontmatter "description"`);
+  }
+
+  return { name, description };
+}
+
+export async function validateSkillFile(skillMdPath: string): Promise<void> {
+  const content = await readFile(skillMdPath, "utf-8");
+  parseSkillFrontmatter(content, skillMdPath);
 }
 
 function logCategorySummary(name: string, summary: SetupCategorySummary): void {
@@ -1149,7 +1237,7 @@ async function refreshNativeAgentConfigs(
   return summary;
 }
 
-async function installSkills(
+export async function installSkills(
   srcDir: string,
   dstDir: string,
   backupContext: SetupBackupContext,
@@ -1157,6 +1245,11 @@ async function installSkills(
 ): Promise<SetupCategorySummary> {
   const summary = createEmptyCategorySummary();
   if (!existsSync(srcDir)) return summary;
+  const installableSkills: Array<{
+    name: string;
+    sourceDir: string;
+    destinationDir: string;
+  }> = [];
   const manifest = tryReadCatalogManifest();
   const skillStatusByName = manifest
     ? new Map(manifest.skills.map((skill) => [skill.name, skill.status]))
@@ -1185,6 +1278,22 @@ async function installSkills(
     const skillMd = join(skillSrc, "SKILL.md");
     if (!existsSync(skillMd)) continue;
 
+    installableSkills.push({
+      name: entry.name,
+      sourceDir: skillSrc,
+      destinationDir: skillDst,
+    });
+  }
+
+  for (const skill of installableSkills) {
+    await validateSkillFile(join(skill.sourceDir, "SKILL.md"));
+  }
+
+  for (const skill of installableSkills) {
+    const skillName = skill.name;
+    const skillSrc = skill.sourceDir;
+    const skillDst = skill.destinationDir;
+
     if (!options.dryRun) {
       await mkdir(skillDst, { recursive: true });
     }
@@ -1201,7 +1310,7 @@ async function installSkills(
         summary,
         backupContext,
         options,
-        `skill ${entry.name}/${sf}`,
+        `skill ${skillName}/${sf}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- validate shipped `SKILL.md` frontmatter before `omx setup` copies any skills
- reject malformed skill metadata early so update/setup no longer installs skills Codex will skip at runtime
- add focused parser/install tests covering malformed frontmatter and no-partial-install behavior

## Problem
Codex runtime skips malformed `SKILL.md` files, but our setup/update flow only checked for file existence and still installed them. That let malformed shipped skills land in installed skill directories even though the runtime loader would ignore them.

## Testing
- `npm run lint`
- `node --test dist/cli/__tests__/setup-skill-validation.test.js`
- `node --test dist/cli/__tests__/setup-skill-validation.test.js dist/cli/__tests__/setup-skills-overwrite.test.js dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/update.test.js`
- `npm test`
