### PR TITLE
feat(autoresearch): stop after repeated noops

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ omx ask ...        # Ask local provider advisor (claude|gemini), writes .omx/art
 omx resume         # Resume a previous interactive Codex session
 omx explore ...    # Default read-only exploration entrypoint (may use sparkshell backend)
 omx ralph          # Launch Codex with ralph persistence mode active
+omx autoresearch <mission-dir> # Launch thin-supervisor autoresearch with keep/discard/reset parity
 omx status         # Show active modes
 omx cancel         # Cancel active execution modes
 omx reasoning <mode> # low|medium|high|xhigh
@@ -299,11 +300,33 @@ omx explore --prompt-file prompts/explore-task.md
 USE_OMX_EXPLORE_CMD=1 omx   # advisory preference for simple read-only exploration prompts
 ```
 
+Autoresearch command example:
+
+```bash
+mkdir -p missions/demo
+cat > missions/demo/mission.md <<'EOF'
+# Mission
+Solve the scoped task in this repository.
+EOF
+cat > missions/demo/sandbox.md <<'EOF'
+---
+evaluator:
+  command: node scripts/eval.js
+  format: json
+---
+Stay inside the mission boundary and stop when the evaluator passes.
+EOF
+omx autoresearch missions/demo
+```
+
+`omx autoresearch` now runs as a thin supervisor around one Codex experiment session at a time. A fresh launch creates a run-tagged `autoresearch/<slug>/<run-tag>` worktree lane, seeds the baseline evaluator row, writes authoritative per-run artifacts under `.omx/logs/autoresearch/<run-id>/`, and expects the session to hand back a repo-root `candidate.json` artifact. Each iteration's bootstrap instructions include the current baseline/last-kept state plus a bounded recent ledger summary, and `status=candidate` artifacts must point at the current worktree `HEAD` and last-kept base commit. After each session exit, OMX evaluates the candidate, records keep/discard/reset state, hard-resets discarded or ambiguous experiments back to the last kept commit, and relaunches the next iteration unless the run aborts. Use `omx autoresearch --resume <run-id>` to continue an existing run from its manifest/worktree.
+
 `omx explore` is the default OMX surface for simple read-only exploration. It stays intentionally read-only and shell-only, and qualifying shell-native read-only tasks may be routed through `omx sparkshell` as a backend when that is the cheaper/more direct fit. The routing flag only adds advisory steering in generated session instructions; ambiguous or implementation-heavy requests stay on the normal Codex path, and OMX falls back normally if the explore harness is unavailable. The harness constrains Codex through a temporary allowlisted shell/bin layer so only approved repository-inspection command families are available during the offloaded run.
 
 - Current shell allowlist: `rg`, `grep`, `ls`, `find`, `wc`, `cat`, `head`, `tail`, `pwd`, `printf`
 - Current shell restrictions: no pipes, redirection, `&&`, `||`, `;`, subshells, path-qualified binaries, non-allowlisted commands, stdin-fed inspection, or path escapes outside the target repository (including existing symlink-resolved escapes)
 - `omx explore` is **not** a full parity surface for modern Codex read-only mode: it does not promise web search, MCP, images, or general-purpose tool access
+
 
 Packaging / install notes:
 

--- a/docs/contracts/autoresearch-command-contract.md
+++ b/docs/contracts/autoresearch-command-contract.md
@@ -1,0 +1,106 @@
+# `omx autoresearch` parity contract
+
+`omx autoresearch` is a thin supervisor that drives one Codex experiment session per iteration while OMX owns the durable keep/discard/reset loop.
+
+## CLI
+
+```bash
+omx autoresearch <mission-dir> [codex-args...]
+omx autoresearch --resume <run-id> [codex-args...]
+omx autoresearch --help
+```
+
+- Fresh launch always creates a new run-tagged lane.
+- `--resume <run-id>` loads `.omx/logs/autoresearch/<run-id>/manifest.json`.
+- A second launch is rejected while repo-root `.omx/state/autoresearch-state.json` points at an active run.
+
+## Mission / sandbox contract
+
+`<mission-dir>` must be inside a git repo and contain `mission.md` plus `sandbox.md`.
+
+`sandbox.md` YAML frontmatter must define:
+- `evaluator.command`
+- `evaluator.format: json`
+- optional `evaluator.keep_policy: score_improvement | pass_only`
+
+Evaluator stdout must be JSON with required boolean `pass` and optional numeric `score`.
+
+## Runtime model
+
+Fresh launch creates:
+- branch `autoresearch/<mission-slug>/<run-tag>`
+- worktree `<repo>.omx-worktrees/autoresearch-<mission-slug>-<run-tag>`
+- repo-root run artifacts under `.omx/logs/autoresearch/<run-id>/`
+
+Repo-root state responsibilities:
+- `.omx/state/autoresearch-state.json` = active-run pointer/lock only
+- `.omx/logs/autoresearch/<run-id>/manifest.json` = authoritative per-run state
+- `.omx/logs/autoresearch/<run-id>/candidate.json` = candidate handoff from the just-finished Codex session
+- `.omx/logs/autoresearch/<run-id>/iteration-ledger.json` = durable iteration history
+- `.omx/logs/autoresearch/<run-id>/latest-evaluator-result.json` = latest evaluator output
+
+Worktree-local state responsibilities:
+- `results.tsv`
+- optional evaluator logs such as `run.log`
+- these runtime-generated files must be excluded via worktree-local `.git/info/exclude`
+
+## Candidate artifact
+
+The launched session must write repo-root `candidate.json` with:
+- `status`: `candidate | noop | abort | interrupted`
+- `candidate_commit`: string or `null`
+- `base_commit`: string
+- `description`: string
+- `notes`: string[]
+- `created_at`: ISO timestamp
+
+Integrity rules:
+- `status=candidate` requires a non-null `candidate_commit`
+- `candidate_commit` must resolve in git and match the worktree `HEAD` commit on exit
+- `base_commit` must resolve in git and match the supervisor-provided `last_kept_commit`
+
+Supervisor behavior:
+- `candidate` → run evaluator, classify keep/discard/ambiguous/error, update manifest/ledger/results, reset if discarded
+- `noop` → log noop iteration and continue by default
+- `abort` → stop run without reset
+- `interrupted` → if dirty, stop for operator intervention; if clean, log interrupted/noop style outcome
+
+## Decision policy
+
+- Baseline row is always recorded.
+- `pass=false` => discard.
+- evaluator error/crash => discard.
+- `keep_policy=score_improvement` => keep only when `pass=true` and score improves over last kept score; pass without comparable score is `ambiguous` and discarded.
+- `keep_policy=pass_only` => any `pass=true` candidate is kept.
+- Discard / ambiguous / error paths must reset to the last kept commit.
+
+## Resume
+
+`--resume <run-id>` must fail with actionable errors when:
+- manifest is missing
+- referenced worktree is missing
+- worktree is dirty outside allowlisted runtime artifacts
+- manifest is terminal
+
+Successful resume continues from the last kept commit and existing results history.
+
+## Iteration handoff context
+
+Each launched worker session receives a supervisor-written instruction snapshot including:
+- current iteration number
+- baseline commit
+- last kept commit
+- last kept score when known
+- previous iteration outcome
+- bounded recent ledger summary
+- keep policy
+
+## Verification targets
+
+Parity-aligned implementation should prove:
+1. fresh launches create distinct run-tagged lanes
+2. repo-root active-run lock rejects concurrent launches
+3. candidate handoff artifact drives keep/discard/reset decisions
+4. discarded candidates reset to `last_kept_commit`
+5. `--resume <run-id>` reloads authoritative manifest/worktree state
+6. README/help/contracts describe the thin-supervisor parity loop

--- a/docs/contracts/autoresearch-command-review.md
+++ b/docs/contracts/autoresearch-command-review.md
@@ -1,0 +1,97 @@
+# `omx autoresearch` Full-Parity Review Notes
+
+Date: 2026-03-14  
+Reviewer lane: worker-3
+
+## Scope reviewed
+
+Compared the implementation and operator-facing docs against:
+
+- `.omx/plans/prd-autoresearch-full-parity.md`
+- `.omx/plans/test-spec-autoresearch-full-parity.md`
+
+Reviewed code and docs:
+
+- `src/cli/autoresearch.ts`
+- `src/autoresearch/contracts.ts`
+- `src/autoresearch/runtime.ts`
+- `src/team/worktree.ts`
+- `src/modes/base.ts`
+- `README.md`
+- `docs/contracts/autoresearch-command-contract.md`
+- focused autoresearch tests under `src/**/__tests__`
+
+## Current status
+
+**Status:** parity-critical behavior appears implemented and the previously noted shared help/test wording mismatch is now resolved.
+
+The branch now matches the PRD/test-spec shape much more closely than the earlier scaffold review:
+
+- `omx autoresearch` exposes both fresh launch and `--resume <run-id>` flows.
+- the runtime owns a thin-supervisor loop boundary via repo-root candidate handoff + post-session evaluator decisions.
+- repo-root active-run locking and authoritative per-run manifests are present.
+- fresh launches create run-tagged autoresearch lanes instead of silently reusing one long-lived lane.
+- docs/help/contracts describe keep/discard/reset semantics instead of the earlier v1 scaffold.
+
+## Verified evidence
+
+### Build
+- `npm run build` → PASS
+
+### Focused tests
+- `node --test dist/autoresearch/__tests__/runtime.test.js dist/cli/__tests__/autoresearch.test.js dist/cli/__tests__/index.test.js dist/cli/__tests__/nested-help-routing.test.js dist/team/__tests__/worktree.test.js dist/modes/__tests__/base-autoresearch-contract.test.js` → PASS
+- `node --test dist/cli/__tests__/session-search-help.test.js` → PASS
+
+### Code/doc alignment observed
+- CLI help documents fresh launch + `--resume <run-id>`: `src/cli/autoresearch.ts`
+- top-level help advertises thin-supervisor parity semantics: `src/cli/index.ts`, `src/compat/fixtures/help.stdout.txt`
+- README now explains baseline seeding, repo-root per-run artifacts, candidate handoff, keep/discard/reset, relaunch loop, and resume behavior: `README.md`
+- contract doc now defines run-tagged lanes, repo-root authority split, candidate artifact schema, decision policy, and resume failure conditions: `docs/contracts/autoresearch-command-contract.md`
+- runtime implements active-run lock, per-run manifest files, allowlisted runtime excludes, candidate parsing, evaluator-backed decisions, reset-to-last-kept behavior, and resume validation: `src/autoresearch/runtime.ts`
+- worktree planning test locks run-tagged autoresearch branch/path naming: `src/team/__tests__/worktree.test.ts`
+
+## Parity checklist
+
+### 1. Thin-supervisor iteration model
+**Pass.**
+- `buildAutoresearchInstructions()` tells the launched Codex session to perform exactly one experiment cycle and write the candidate artifact before exit.
+- `runAutoresearchLoop()` relaunches Codex after `processAutoresearchCandidate()` unless the run aborts/errors.
+
+### 2. Repo-root state authority
+**Pass.**
+- repo-root active-run lock lives at `.omx/state/autoresearch-state.json`.
+- per-run manifest, candidate, ledger, and latest evaluator files live under `.omx/logs/autoresearch/<run-id>/`.
+- worktree-local runtime artifacts are limited to `results.tsv` and allowlisted logs.
+
+### 3. Fresh-run semantics
+**Pass.**
+- fresh launches compute a run tag and plan `autoresearch/<mission-slug>/<run-tag>` plus `autoresearch-<mission-slug>-<run-tag>`.
+- focused worktree coverage now asserts run-tagged branch/path naming.
+
+### 4. Resume contract
+**Pass.**
+- CLI parses `--resume <run-id>`.
+- runtime rejects missing manifest, missing worktree, dirty worktree, and terminal runs.
+
+### 5. Keep/discard/reset decision policy
+**Pass.**
+- baseline row is seeded.
+- evaluator failure/error discards.
+- `pass_only` keeps any pass.
+- `score_improvement` requires comparable numeric scores and improvement; otherwise ambiguous/discard.
+- discard paths reset to `last_kept_commit`.
+
+### 6. Docs/help/contracts alignment
+**Pass.**
+- README, command help, top-level help, fixture help text, and the contract doc now describe the parity loop rather than a one-shot bootstrap scaffold.
+- Shared help/test wording now matches the thin-supervisor parity wording.
+
+## Remaining review notes / risks
+
+1. `runAutoresearchLoop()` currently reads the run id back from the manifest file via `execFileSync('cat', ...)` + `JSON.parse(...)` on each iteration. That works, but it is a slightly awkward implementation detail and could be simplified to avoid shelling out to `cat`.
+2. Focused tests cover the main parity surfaces, but there is still room for broader runtime coverage around `noop`, `abort`, `interrupted`, and explicit `pass_only` policy branches if the lead wants even tighter semantic locking.
+3. I verified focused parity coverage and build status, not the entire repository-wide test suite/lint suite.
+
+## Reviewer conclusion
+
+This lane no longer looks like the earlier v1 scaffold. The reviewed implementation and docs now appear largely consistent with the requested thin-supervisor autoresearch parity model; the previously noted shared top-level help/test wording mismatch is resolved; remaining follow-ups are optional cleanup/coverage improvements.

--- a/missions/README.md
+++ b/missions/README.md
@@ -1,0 +1,20 @@
+# Autoresearch pilot missions
+
+These mission bundles are **autoresearch-ready pilots** for this repo snapshot.
+
+Each mission directory contains:
+- `mission.md` — objective, scope, and expected deliverable
+- `sandbox.md` — evaluator contract plus safety/operating rules
+
+Current pilots:
+- `cli-discoverability-pilot/`
+- `security-path-traversal-pilot/`
+
+You can run the evaluators directly today:
+
+```bash
+node scripts/eval-cli-discoverability.js
+node scripts/eval-security-path-traversal.js
+```
+
+These bundles are designed to become first-class `omx autoresearch` missions once the runtime is present in-tree.

--- a/missions/candidate-handoff/mission.md
+++ b/missions/candidate-handoff/mission.md
@@ -1,0 +1,11 @@
+# Mission
+Implement and validate repo-root `candidate.json` handoff for the thin-supervisor autoresearch cycle.
+
+Primary target:
+- per-run candidate artifact contract
+- keep/discard/reset decision entrypoint
+
+Success means:
+1. candidate handoff artifact is explicit and test-covered
+2. runtime can distinguish candidate / noop / abort / interrupted states
+3. parity runtime tests pass

--- a/missions/candidate-handoff/sandbox.md
+++ b/missions/candidate-handoff/sandbox.md
@@ -1,0 +1,7 @@
+---
+evaluator:
+  command: node scripts/eval-candidate-handoff.js
+  format: json
+---
+Focus only on candidate handoff contract, supervisor decision boundaries, and targeted parity tests.
+Do not broaden into unrelated docs cleanup unless tests require it.

--- a/missions/cli-discoverability-pilot/mission.md
+++ b/missions/cli-discoverability-pilot/mission.md
@@ -1,0 +1,29 @@
+# Mission: CLI discoverability hardening
+
+Improve command discoverability across the OMX CLI, with emphasis on:
+- top-level help
+- nested help routing
+- sparkshell discoverability
+- session-search discoverability
+
+## Goal
+Find the smallest changes that improve operator success when trying to discover the right CLI surface from help text alone.
+
+## Focus areas
+- `README.md`
+- `src/cli/index.ts`
+- `src/cli/__tests__/index.test.ts`
+- `src/cli/__tests__/nested-help-routing.test.ts`
+- `src/cli/__tests__/sparkshell-cli.test.ts`
+- `src/cli/__tests__/session-search-help.test.ts`
+
+## Desired output
+Produce a compact improvement set that:
+1. preserves existing command routing semantics
+2. improves help clarity/discoverability
+3. keeps targeted CLI discoverability tests green
+
+## Success hints
+- prefer small help-text or routing-clarity changes
+- avoid widening scope into unrelated command behavior
+- preserve existing docs/contracts unless a discoverability improvement requires aligned edits

--- a/missions/cli-discoverability-pilot/sandbox.md
+++ b/missions/cli-discoverability-pilot/sandbox.md
@@ -1,0 +1,20 @@
+---
+evaluator:
+  command: node scripts/eval-cli-discoverability.js
+  format: json
+  keep_policy: score_improvement
+---
+
+# Sandbox rules
+
+- Keep changes focused on CLI discoverability only.
+- Prefer the smallest reviewable diff.
+- Do not add dependencies.
+- Preserve command semantics; this mission is about discoverability, not feature redesign.
+- The evaluator rewards passing the targeted build + CLI discoverability test slice.
+
+# Evaluation policy
+
+- `pass=true` means the targeted build and discoverability tests all passed.
+- `score` is the fraction of targeted checks passing, from `0.00` to `1.00`.
+- Higher scores are better.

--- a/missions/fresh-run-tagging/mission.md
+++ b/missions/fresh-run-tagging/mission.md
@@ -1,0 +1,10 @@
+# Mission
+Guarantee fresh autoresearch launches always create distinct run-tagged branches and worktree paths instead of silently reusing prior clean lanes.
+
+Primary target:
+- autoresearch worktree planning and associated tests
+
+Success means:
+1. repeated fresh launches produce distinct run identities by default
+2. tests prove prior clean lanes are not silently reused for fresh runs
+3. related help/contracts remain consistent

--- a/missions/fresh-run-tagging/sandbox.md
+++ b/missions/fresh-run-tagging/sandbox.md
@@ -1,0 +1,8 @@
+---
+evaluator:
+  command: node scripts/eval-fresh-run-tagging.js
+  format: json
+  keep_policy: pass_only
+---
+Stay focused on fresh-run lane creation semantics, worktree naming, and targeted tests.
+Avoid changing resume semantics unless strictly required by the lane naming contract.

--- a/missions/help-consistency/mission.md
+++ b/missions/help-consistency/mission.md
@@ -1,0 +1,15 @@
+# Mission
+Fix the failing help-consistency regression so the CLI help text, compatibility fixture, and tests all describe the same `omx autoresearch` wording.
+
+Primary target:
+- `src/cli/__tests__/session-search-help.test.ts`
+
+Supporting surfaces that may need alignment:
+- `src/cli/index.ts`
+- `src/compat/fixtures/help.stdout.txt`
+- any related help-routing/help-contract tests if needed
+
+Success means:
+1. `node --test dist/cli/__tests__/session-search-help.test.js` passes
+2. top-level help wording for `omx autoresearch` is internally consistent across source, built output expectations, and fixtures
+3. no unrelated CLI help behavior regresses

--- a/missions/help-consistency/sandbox.md
+++ b/missions/help-consistency/sandbox.md
@@ -1,0 +1,19 @@
+---
+evaluator:
+  command: node scripts/eval-help-consistency.js
+  format: json
+  keep_policy: pass_only
+---
+Stay tightly scoped to help/test/fixture consistency for `omx autoresearch`.
+
+Allowed changes:
+- CLI help text
+- help fixtures
+- targeted tests that assert help output
+
+Avoid:
+- runtime behavior changes
+- worktree/runtime/autoresearch loop changes
+- unrelated documentation churn
+
+A passing outcome is one where the focused help-consistency test passes and nearby help assertions remain coherent.

--- a/missions/parity-smoke/mission.md
+++ b/missions/parity-smoke/mission.md
@@ -1,0 +1,10 @@
+# Mission
+Run a very small autoresearch smoke task against the current parity surfaces.
+
+Goal:
+Validate that the core autoresearch contract still holds after edits without running the entire parity sweep.
+
+Success means:
+1. the project builds
+2. autoresearch runtime/contracts smoke tests pass
+3. CLI help routing for autoresearch still works

--- a/missions/parity-smoke/sandbox.md
+++ b/missions/parity-smoke/sandbox.md
@@ -1,0 +1,8 @@
+---
+evaluator:
+  command: node scripts/eval-parity-smoke.js
+  format: json
+  keep_policy: pass_only
+---
+Keep this mission lightweight and fast.
+Prefer minimal changes only if needed to restore the smoke path.

--- a/missions/parity-sweep/mission.md
+++ b/missions/parity-sweep/mission.md
@@ -1,0 +1,18 @@
+# Mission
+Bring `omx autoresearch` to parity with the currently approved full-parity plan in one bounded sweep.
+
+Primary targets:
+- fresh run-tagged lanes
+- explicit `--resume <run-id>` behavior
+- repo-root active-run pointer/lock
+- authoritative per-run manifest state
+- repo-root `candidate.json` handoff
+- keep / discard / ambiguous / error handling
+- reset-safe worktree-local runtime files
+- aligned docs/help/contracts/tests
+
+Success means:
+1. build passes
+2. focused parity tests pass
+3. help/docs/contracts describe the same behavior
+4. no remaining known parity blocker from the current PRD/test-spec remains unimplemented

--- a/missions/parity-sweep/sandbox.md
+++ b/missions/parity-sweep/sandbox.md
@@ -1,0 +1,18 @@
+---
+evaluator:
+  command: node scripts/eval-parity-sweep.js
+  format: json
+---
+Stay within autoresearch runtime/CLI/worktree/docs/tests.
+
+Allowed files:
+- src/cli/autoresearch.ts
+- src/autoresearch/*
+- src/team/worktree.ts
+- src/modes/base.ts
+- relevant autoresearch/worktree/mode/CLI tests
+- README.md
+- docs/contracts/autoresearch-command-contract.md
+- related help fixtures
+
+Avoid unrelated refactors or broad documentation churn.

--- a/missions/resume-dirty-guard/mission.md
+++ b/missions/resume-dirty-guard/mission.md
@@ -1,0 +1,10 @@
+# Mission
+Ensure `omx autoresearch --resume <run-id>` fails cleanly when the referenced worktree is dirty.
+
+Primary target:
+- resume validation / guard behavior in autoresearch CLI/runtime
+
+Success means:
+1. resume rejects dirty worktrees with an actionable error
+2. no silent reset or unsafe continuation occurs
+3. focused resume-guard tests pass

--- a/missions/resume-dirty-guard/sandbox.md
+++ b/missions/resume-dirty-guard/sandbox.md
@@ -1,0 +1,8 @@
+---
+evaluator:
+  command: node scripts/eval-resume-dirty-guard.js
+  format: json
+  keep_policy: pass_only
+---
+Only change autoresearch resume validation, related runtime helpers, and targeted tests.
+Do not broaden scope into full loop behavior.

--- a/missions/security-path-traversal-pilot/mission.md
+++ b/missions/security-path-traversal-pilot/mission.md
@@ -1,0 +1,22 @@
+# Mission: MCP path-traversal hardening
+
+Strengthen path-validation and traversal defenses around MCP/state-facing surfaces without expanding scope into unrelated security work.
+
+## Goal
+Improve confidence that unsafe paths and traversal attempts are rejected deterministically with actionable errors.
+
+## Focus areas
+- `src/mcp/__tests__/path-traversal.test.ts`
+- `src/mcp/__tests__/state-paths.test.ts`
+- adjacent MCP/state validation code touched by those tests
+
+## Desired output
+Produce the smallest safe hardening diff that:
+1. preserves existing allowed-path behavior
+2. tightens traversal rejection where needed
+3. keeps the targeted security regression slice green
+
+## Success hints
+- prefer boundary checks and validation tightening over broad refactors
+- preserve current CLI/MCP contracts unless the change is necessary to block unsafe input
+- document any intentionally unsupported path patterns if surfaced by the work

--- a/missions/security-path-traversal-pilot/sandbox.md
+++ b/missions/security-path-traversal-pilot/sandbox.md
@@ -1,0 +1,19 @@
+---
+evaluator:
+  command: node scripts/eval-security-path-traversal.js
+  format: json
+  keep_policy: score_improvement
+---
+
+# Sandbox rules
+
+- Keep changes focused on path validation and traversal rejection.
+- No new dependencies.
+- Prefer explicit validation and regression tests over architectural churn.
+- Do not weaken existing guardrails to make tests pass.
+
+# Evaluation policy
+
+- `pass=true` means the targeted build and MCP path-safety test slice all passed.
+- `score` is the fraction of targeted checks passing, from `0.00` to `1.00`.
+- Higher scores are better.

--- a/scripts/eval-candidate-handoff.js
+++ b/scripts/eval-candidate-handoff.js
@@ -1,0 +1,8 @@
+import { spawnSync } from 'node:child_process';
+const result = spawnSync('node', ['--test', 'dist/autoresearch/__tests__/runtime.test.js', 'dist/autoresearch/__tests__/contracts.test.js'], {
+  encoding: 'utf-8',
+});
+process.stdout.write(JSON.stringify({ pass: result.status === 0 }));
+if (result.stdout) process.stderr.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+process.exit(result.status ?? 1);

--- a/scripts/eval-cli-discoverability.js
+++ b/scripts/eval-cli-discoverability.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const checks = [
+  ['node', ['--test', 'dist/cli/__tests__/index.test.js']],
+  ['node', ['--test', 'dist/cli/__tests__/nested-help-routing.test.js']],
+  ['node', ['--test', 'dist/cli/__tests__/sparkshell-cli.test.js']],
+  ['node', ['--test', 'dist/cli/__tests__/session-search-help.test.js']],
+];
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    command: [command, ...args].join(' '),
+    status: result.status ?? 1,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+const build = run('npm', ['run', 'build']);
+const results = [build, ...checks.map(([command, args]) => run(command, args))];
+const passed = results.filter((result) => result.status === 0).length;
+const score = Number((passed / results.length).toFixed(2));
+const pass = results.every((result) => result.status === 0);
+
+console.log(JSON.stringify({
+  pass,
+  score,
+  summary: 'CLI discoverability pilot evaluator',
+  details: results.map(({ command, status, stderr }) => ({
+    command,
+    ok: status === 0,
+    status,
+    stderr: stderr || undefined,
+  })),
+}));

--- a/scripts/eval-fresh-run-tagging.js
+++ b/scripts/eval-fresh-run-tagging.js
@@ -1,0 +1,8 @@
+import { spawnSync } from 'node:child_process';
+const result = spawnSync('node', ['--test', 'dist/team/__tests__/worktree.test.js', 'dist/cli/__tests__/autoresearch.test.js'], {
+  encoding: 'utf-8',
+});
+process.stdout.write(JSON.stringify({ pass: result.status === 0 }));
+if (result.stdout) process.stderr.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+process.exit(result.status ?? 1);

--- a/scripts/eval-help-consistency.js
+++ b/scripts/eval-help-consistency.js
@@ -1,0 +1,11 @@
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync('node', ['--test', 'dist/cli/__tests__/session-search-help.test.js'], {
+  encoding: 'utf-8',
+});
+
+const pass = result.status === 0;
+process.stdout.write(JSON.stringify({ pass }));
+if (result.stdout) process.stderr.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+process.exit(result.status ?? 1);

--- a/scripts/eval-parity-smoke.js
+++ b/scripts/eval-parity-smoke.js
@@ -1,0 +1,20 @@
+import { spawnSync } from 'node:child_process';
+
+const build = spawnSync('npm', ['run', 'build'], { encoding: 'utf-8' });
+if (build.stdout) process.stderr.write(build.stdout);
+if (build.stderr) process.stderr.write(build.stderr);
+if (build.status !== 0) {
+  process.stdout.write(JSON.stringify({ pass: false }));
+  process.exit(build.status ?? 1);
+}
+
+const test = spawnSync('node', [
+  '--test',
+  'dist/autoresearch/__tests__/contracts.test.js',
+  'dist/autoresearch/__tests__/runtime.test.js',
+  'dist/cli/__tests__/autoresearch.test.js',
+], { encoding: 'utf-8' });
+if (test.stdout) process.stderr.write(test.stdout);
+if (test.stderr) process.stderr.write(test.stderr);
+process.stdout.write(JSON.stringify({ pass: test.status === 0 }));
+process.exit(test.status ?? 1);

--- a/scripts/eval-parity-sweep.js
+++ b/scripts/eval-parity-sweep.js
@@ -1,0 +1,26 @@
+import { spawnSync } from 'node:child_process';
+
+const build = spawnSync('npm', ['run', 'build'], { encoding: 'utf-8' });
+if (build.stdout) process.stderr.write(build.stdout);
+if (build.stderr) process.stderr.write(build.stderr);
+if (build.status !== 0) {
+  process.stdout.write(JSON.stringify({ pass: false }));
+  process.exit(build.status ?? 1);
+}
+
+const testArgs = [
+  '--test',
+  'dist/cli/__tests__/autoresearch.test.js',
+  'dist/cli/__tests__/index.test.js',
+  'dist/cli/__tests__/nested-help-routing.test.js',
+  'dist/cli/__tests__/session-search-help.test.js',
+  'dist/autoresearch/__tests__/contracts.test.js',
+  'dist/autoresearch/__tests__/runtime.test.js',
+  'dist/team/__tests__/worktree.test.js',
+  'dist/modes/__tests__/base-autoresearch-contract.test.js',
+];
+const test = spawnSync('node', testArgs, { encoding: 'utf-8' });
+if (test.stdout) process.stderr.write(test.stdout);
+if (test.stderr) process.stderr.write(test.stderr);
+process.stdout.write(JSON.stringify({ pass: test.status === 0 }));
+process.exit(test.status ?? 1);

--- a/scripts/eval-resume-dirty-guard.js
+++ b/scripts/eval-resume-dirty-guard.js
@@ -1,0 +1,8 @@
+import { spawnSync } from 'node:child_process';
+const result = spawnSync('node', ['--test', 'dist/cli/__tests__/autoresearch.test.js', 'dist/autoresearch/__tests__/runtime.test.js'], {
+  encoding: 'utf-8',
+});
+process.stdout.write(JSON.stringify({ pass: result.status === 0 }));
+if (result.stdout) process.stderr.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+process.exit(result.status ?? 1);

--- a/scripts/eval-security-path-traversal.js
+++ b/scripts/eval-security-path-traversal.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const checks = [
+  ['node', ['--test', 'dist/mcp/__tests__/path-traversal.test.js']],
+  ['node', ['--test', 'dist/mcp/__tests__/state-paths.test.js']],
+];
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    command: [command, ...args].join(' '),
+    status: result.status ?? 1,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+const build = run('npm', ['run', 'build']);
+const results = [build, ...checks.map(([command, args]) => run(command, args))];
+const passed = results.filter((result) => result.status === 0).length;
+const score = Number((passed / results.length).toFixed(2));
+const pass = results.every((result) => result.status === 0);
+
+console.log(JSON.stringify({
+  pass,
+  score,
+  summary: 'Security path-traversal pilot evaluator',
+  details: results.map(({ command, status, stderr }) => ({
+    command,
+    ok: status === 0,
+    status,
+    stderr: stderr || undefined,
+  })),
+}));

--- a/src/autoresearch/__tests__/contracts.test.ts
+++ b/src/autoresearch/__tests__/contracts.test.ts
@@ -1,0 +1,134 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  loadAutoresearchMissionContract,
+  parseEvaluatorResult,
+  parseSandboxContract,
+  slugifyMissionName,
+} from '../contracts.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-contracts-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+describe('autoresearch contracts', () => {
+  it('slugifies mission names deterministically', () => {
+    assert.equal(slugifyMissionName('Missions/My Demo Mission'), 'missions-my-demo-mission');
+  });
+
+  it('parses sandbox contract with evaluator command and json format', () => {
+    const parsed = parseSandboxContract(`---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n---\nStay in bounds.\n`);
+    assert.equal(parsed.evaluator.command, 'node scripts/eval.js');
+    assert.equal(parsed.evaluator.format, 'json');
+    assert.equal(parsed.body, 'Stay in bounds.');
+  });
+
+  it('rejects sandbox contract without frontmatter', () => {
+    assert.throws(
+      () => parseSandboxContract('No frontmatter here'),
+      /sandbox\.md must start with YAML frontmatter/i,
+    );
+  });
+
+  it('rejects sandbox contract without evaluator command', () => {
+    assert.throws(
+      () => parseSandboxContract(`---\nevaluator:\n  format: json\n---\nPolicy\n`),
+      /evaluator\.command is required/i,
+    );
+  });
+
+  it('rejects sandbox contract without evaluator format', () => {
+    assert.throws(
+      () => parseSandboxContract(`---\nevaluator:\n  command: node eval.js\n---\nPolicy\n`),
+      /evaluator\.format is required/i,
+    );
+  });
+
+  it('rejects sandbox contract with non-json evaluator format', () => {
+    assert.throws(
+      () => parseSandboxContract(`---\nevaluator:\n  command: node eval.js\n  format: text\n---\nPolicy\n`),
+      /evaluator\.format must be json/i,
+    );
+  });
+
+  it('parses optional evaluator keep_policy', () => {
+    const parsed = parseSandboxContract(`---
+evaluator:
+  command: node scripts/eval.js
+  format: json
+  keep_policy: pass_only
+---
+Stay in bounds.
+`);
+    assert.equal(parsed.evaluator.keep_policy, 'pass_only');
+  });
+
+  it('rejects unsupported evaluator keep_policy', () => {
+    assert.throws(
+      () => parseSandboxContract(`---
+evaluator:
+  command: node scripts/eval.js
+  format: json
+  keep_policy: maybe
+---
+Stay in bounds.
+`),
+      /keep_policy must be one of/i,
+    );
+  });
+
+  it('accepts evaluator result with pass only', () => {
+    assert.deepEqual(parseEvaluatorResult('{"pass":true}'), { pass: true });
+  });
+
+  it('accepts evaluator result with pass and score', () => {
+    assert.deepEqual(parseEvaluatorResult('{"pass":false,"score":61}'), { pass: false, score: 61 });
+  });
+
+  it('rejects evaluator result without pass', () => {
+    assert.throws(
+      () => parseEvaluatorResult('{"score":61}'),
+      /must include boolean pass/i,
+    );
+  });
+
+  it('rejects evaluator result with non-numeric score', () => {
+    assert.throws(
+      () => parseEvaluatorResult('{"pass":true,"score":"high"}'),
+      /score must be numeric/i,
+    );
+  });
+
+  it('loads mission contract from in-repo mission directory', async () => {
+    const repo = await initRepo();
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\nShip it\n', 'utf-8');
+      await writeFile(
+        join(missionDir, 'sandbox.md'),
+        `---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n---\nStay in bounds.\n`,
+        'utf-8',
+      );
+
+      const contract = await loadAutoresearchMissionContract(missionDir);
+      assert.equal(contract.repoRoot, repo);
+      assert.equal(contract.missionRelativeDir.replace(/\\/g, '/'), 'missions/demo');
+      assert.equal(contract.missionSlug, 'missions-demo');
+      assert.equal(contract.sandbox.evaluator.command, 'node scripts/eval.js');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/autoresearch/__tests__/runtime-parity-extra.test.ts
+++ b/src/autoresearch/__tests__/runtime-parity-extra.test.ts
@@ -1,0 +1,406 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AutoresearchMissionContract } from '../contracts.js';
+import {
+  assertResetSafeWorktree,
+  decideAutoresearchOutcome,
+  loadAutoresearchRunManifest,
+  materializeAutoresearchMissionToWorktree,
+  prepareAutoresearchRuntime,
+  processAutoresearchCandidate,
+  resumeAutoresearchRuntime,
+} from '../runtime.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-parity-extra-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+async function makeContract(repo: string, keepPolicy?: 'score_improvement' | 'pass_only'): Promise<AutoresearchMissionContract> {
+  const missionDir = join(repo, 'missions', 'demo');
+  await mkdir(missionDir, { recursive: true });
+  await mkdir(join(repo, 'scripts'), { recursive: true });
+  const missionFile = join(missionDir, 'mission.md');
+  const sandboxFile = join(missionDir, 'sandbox.md');
+  const missionContent = '# Mission\nSolve the task.\n';
+  const keepPolicyLine = keepPolicy ? `  keep_policy: ${keepPolicy}\n` : '';
+  const sandboxContent = `---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n${keepPolicyLine}---\nStay inside the mission boundary.\n`;
+  await writeFile(missionFile, missionContent, 'utf-8');
+  await writeFile(sandboxFile, sandboxContent, 'utf-8');
+  await writeFile(join(repo, 'score.txt'), '1\n', 'utf-8');
+  await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true, score: 1 }));\n", 'utf-8');
+  execFileSync('git', ['add', 'missions/demo/mission.md', 'missions/demo/sandbox.md', 'scripts/eval.js', 'score.txt'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'add autoresearch fixtures'], { cwd: repo, stdio: 'ignore' });
+  return {
+    missionDir,
+    repoRoot: repo,
+    missionFile,
+    sandboxFile,
+    missionRelativeDir: 'missions/demo',
+    missionContent,
+    sandboxContent,
+    sandbox: {
+      frontmatter: { evaluator: { command: 'node scripts/eval.js', format: 'json', ...(keepPolicy ? { keep_policy: keepPolicy } : {}) } },
+      evaluator: { command: 'node scripts/eval.js', format: 'json', ...(keepPolicy ? { keep_policy: keepPolicy } : {}) },
+      body: 'Stay inside the mission boundary.',
+    },
+    missionSlug: 'missions-demo',
+  };
+}
+
+describe('autoresearch runtime parity extras', () => {
+  it('treats allowed runtime files as reset-safe and blocks unrelated dirt', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t020000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t020000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T020000Z' });
+
+      await writeFile(join(worktreePath, 'results.tsv'), 'iteration\tcommit\tpass\tscore\tstatus\tdescription\n', 'utf-8');
+      await writeFile(join(worktreePath, 'run.log'), 'ok\n', 'utf-8');
+      assert.doesNotThrow(() => assertResetSafeWorktree(worktreePath));
+
+      await writeFile(join(worktreePath, 'scratch.tmp'), 'nope\n', 'utf-8');
+      assert.throws(() => assertResetSafeWorktree(worktreePath), /autoresearch_reset_requires_clean_worktree/i);
+
+      const manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      assert.equal(manifest.results_file, join(worktreePath, 'results.tsv'));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects concurrent fresh runs via the repo-root active-run lock', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePathA = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t030000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t030000z', worktreePathA, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContractA = await materializeAutoresearchMissionToWorktree(contract, worktreePathA);
+      const runtimeA = await prepareAutoresearchRuntime(worktreeContractA, repo, worktreePathA, { runTag: '20260314T030000Z' });
+
+      const worktreePathB = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t030500z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t030500z', worktreePathB, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContractB = await materializeAutoresearchMissionToWorktree(contract, worktreePathB);
+
+      await assert.rejects(
+        () => prepareAutoresearchRuntime(worktreeContractB, repo, worktreePathB, { runTag: '20260314T030500Z' }),
+        /autoresearch_active_run_exists/i,
+      );
+      assert.equal(existsSync(runtimeA.manifestFile), true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes a running manifest and rejects missing worktrees', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t040000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t040000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T040000Z' });
+      const statePath = join(repo, '.omx', 'state', 'autoresearch-state.json');
+      const idleState = {
+        schema_version: 1,
+        active: false,
+        run_id: runtime.runId,
+        mission_slug: contract.missionSlug,
+        repo_root: repo,
+        worktree_path: worktreePath,
+        status: 'idle',
+        updated_at: '2026-03-14T04:05:00.000Z',
+      };
+      await writeFile(statePath, `${JSON.stringify(idleState, null, 2)}\n`, 'utf-8');
+
+      const resumed = await resumeAutoresearchRuntime(repo, runtime.runId);
+      assert.equal(resumed.runId, runtime.runId);
+      assert.equal(resumed.worktreePath, worktreePath);
+
+      await writeFile(statePath, `${JSON.stringify(idleState, null, 2)}\n`, 'utf-8');
+      await rm(worktreePath, { recursive: true, force: true });
+      await assert.rejects(
+        () => resumeAutoresearchRuntime(repo, runtime.runId),
+        /autoresearch_resume_missing_worktree/i,
+      );
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('decides ambiguous vs keep based on keep_policy semantics', () => {
+    const candidate = {
+      status: 'candidate' as const,
+      candidate_commit: 'abc1234',
+      base_commit: 'base1234',
+      description: 'candidate',
+      notes: [],
+      created_at: '2026-03-14T05:00:00.000Z',
+    };
+
+    const ambiguous = decideAutoresearchOutcome(
+      { keep_policy: 'score_improvement', last_kept_score: null },
+      candidate,
+      { command: 'node eval.js', ran_at: '2026-03-14T05:00:01.000Z', status: 'pass', pass: true, exit_code: 0 },
+    );
+    assert.equal(ambiguous.decision, 'ambiguous');
+    assert.equal(ambiguous.keep, false);
+
+    const kept = decideAutoresearchOutcome(
+      { keep_policy: 'pass_only', last_kept_score: null },
+      candidate,
+      { command: 'node eval.js', ran_at: '2026-03-14T05:00:01.000Z', status: 'pass', pass: true, exit_code: 0 },
+    );
+    assert.equal(kept.decision, 'keep');
+    assert.equal(kept.keep, true);
+  });
+
+  it('resume rejects terminal manifests', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t050000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t050000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T050000Z' });
+      const manifest = JSON.parse(await readFile(runtime.manifestFile, 'utf-8')) as Record<string, unknown>;
+      manifest.status = 'completed';
+      await writeFile(runtime.manifestFile, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+      await writeFile(join(repo, '.omx', 'state', 'autoresearch-state.json'), `${JSON.stringify({
+        schema_version: 1,
+        active: false,
+        run_id: runtime.runId,
+        mission_slug: contract.missionSlug,
+        repo_root: repo,
+        worktree_path: worktreePath,
+        status: 'completed',
+        updated_at: '2026-03-14T05:05:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+
+      await assert.rejects(
+        () => resumeAutoresearchRuntime(repo, runtime.runId),
+        /autoresearch_resume_terminal_run/i,
+      );
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('records noop and abort candidate branches explicitly', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t060000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t060000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T060000Z' });
+
+      let manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'noop',
+        candidate_commit: null,
+        base_commit: manifest.last_kept_commit,
+        description: 'no useful change',
+        notes: ['noop branch'],
+        created_at: '2026-03-14T06:01:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      assert.equal(await processAutoresearchCandidate(worktreeContract, manifest, repo), 'noop');
+
+      manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'abort',
+        candidate_commit: null,
+        base_commit: manifest.last_kept_commit,
+        description: 'operator stop',
+        notes: ['abort branch'],
+        created_at: '2026-03-14T06:02:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      assert.equal(await processAutoresearchCandidate(worktreeContract, manifest, repo), 'abort');
+
+      const results = await readFile(runtime.resultsFile, 'utf-8');
+      assert.match(results, /^1\t.+\t\t\tnoop\tno useful change$/m);
+      assert.match(results, /^2\t.+\t\t\tabort\toperator stop$/m);
+
+      const finalManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      assert.equal(finalManifest.status, 'stopped');
+      assert.equal(finalManifest.stop_reason, 'candidate abort');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects candidate integrity mismatches and missing candidate artifacts with actionable failure state', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t070000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t070000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T070000Z' });
+
+      let manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'candidate',
+        candidate_commit: null,
+        base_commit: manifest.last_kept_commit,
+        description: 'invalid candidate',
+        notes: ['missing commit'],
+        created_at: '2026-03-14T07:01:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      assert.equal(await processAutoresearchCandidate(worktreeContract, manifest, repo), 'error');
+
+      let failedManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      assert.equal(failedManifest.status, 'failed');
+      assert.match(failedManifest.stop_reason || '', /non-null candidate_commit/i);
+
+      const failureResults = await readFile(runtime.resultsFile, 'utf-8');
+      assert.match(failureResults, /^1\t.+\t\t\terror\tinvalid candidate$/m);
+
+      const secondWorktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t071000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t071000z', secondWorktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const secondContract = await materializeAutoresearchMissionToWorktree(contract, secondWorktreePath);
+      const secondRuntime = await prepareAutoresearchRuntime(secondContract, repo, secondWorktreePath, { runTag: '20260314T071000Z' });
+
+      manifest = await loadAutoresearchRunManifest(repo, secondRuntime.runId);
+      await writeFile(secondRuntime.candidateFile, `${JSON.stringify({
+        status: 'candidate',
+        candidate_commit: manifest.last_kept_commit,
+        base_commit: 'deadbeef',
+        description: 'mismatched base',
+        notes: ['bad base'],
+        created_at: '2026-03-14T07:02:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      assert.equal(await processAutoresearchCandidate(secondContract, manifest, repo), 'error');
+
+      failedManifest = await loadAutoresearchRunManifest(repo, secondRuntime.runId);
+      assert.equal(failedManifest.status, 'failed');
+      assert.match(failedManifest.stop_reason || '', /base_commit/i);
+
+      const thirdWorktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t072000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t072000z', thirdWorktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const thirdContract = await materializeAutoresearchMissionToWorktree(contract, thirdWorktreePath);
+      const thirdRuntime = await prepareAutoresearchRuntime(thirdContract, repo, thirdWorktreePath, { runTag: '20260314T072000Z' });
+
+      manifest = await loadAutoresearchRunManifest(repo, thirdRuntime.runId);
+      await rm(thirdRuntime.candidateFile, { force: true });
+      assert.equal(await processAutoresearchCandidate(thirdContract, manifest, repo), 'error');
+      failedManifest = await loadAutoresearchRunManifest(repo, thirdRuntime.runId);
+      assert.equal(failedManifest.status, 'failed');
+      assert.match(failedManifest.stop_reason || '', /autoresearch_candidate_missing/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('handles interrupted, evaluator failure, and evaluator parse-error branches', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t080000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t080000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T080000Z' });
+
+      let manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'interrupted',
+        candidate_commit: null,
+        base_commit: manifest.last_kept_commit,
+        description: 'clean interrupt',
+        notes: ['ctrl-c'],
+        created_at: '2026-03-14T08:01:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      assert.equal(await processAutoresearchCandidate(worktreeContract, manifest, repo), 'interrupted');
+
+      manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(join(worktreePath, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: false, score: 0 }));\n", 'utf-8');
+      await writeFile(join(worktreePath, 'score.txt'), '0\n', 'utf-8');
+      execFileSync('git', ['add', 'scripts/eval.js', 'score.txt'], { cwd: worktreePath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'make evaluator fail'], { cwd: worktreePath, stdio: 'ignore' });
+      const failingCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktreePath, encoding: 'utf-8' }).trim();
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'candidate',
+        candidate_commit: failingCommit,
+        base_commit: manifest.last_kept_commit,
+        description: 'failing evaluator branch',
+        notes: ['pass false'],
+        created_at: '2026-03-14T08:02:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      assert.equal(await processAutoresearchCandidate(worktreeContract, manifest, repo), 'discard');
+
+      manifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(join(worktreePath, 'scripts', 'eval.js'), "process.stdout.write('not json');\n", 'utf-8');
+      execFileSync('git', ['add', 'scripts/eval.js'], { cwd: worktreePath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'break evaluator json'], { cwd: worktreePath, stdio: 'ignore' });
+      const parseErrorCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktreePath, encoding: 'utf-8' }).trim();
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'candidate',
+        candidate_commit: parseErrorCommit,
+        base_commit: manifest.last_kept_commit,
+        description: 'parse error branch',
+        notes: ['invalid json'],
+        created_at: '2026-03-14T08:03:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+      assert.equal(await processAutoresearchCandidate(worktreeContract, manifest, repo), 'discard');
+
+      const results = await readFile(runtime.resultsFile, 'utf-8');
+      assert.match(results, /^1\t.+\t\t\tinterrupted\tclean interrupt$/m);
+      assert.match(results, /^2\t.+\tfalse\t0\tdiscard\tfailing evaluator branch$/m);
+      assert.match(results, /^3\t.+\t\t\tdiscard\tparse error branch$/m);
+
+      const ledger = JSON.parse(await readFile(runtime.ledgerFile, 'utf-8')) as {
+        entries: Array<{ decision: string; decision_reason: string }>;
+      };
+      assert.equal(ledger.entries[1]?.decision, 'interrupted');
+      assert.equal(ledger.entries[2]?.decision, 'discard');
+      assert.equal(ledger.entries[3]?.decision, 'discard');
+      assert.match(ledger.entries[3]?.decision_reason || '', /evaluator error/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/autoresearch/__tests__/runtime.test.ts
+++ b/src/autoresearch/__tests__/runtime.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { AutoresearchMissionContract } from '../contracts.js';
 import {
+  assertResetSafeWorktree,
   buildAutoresearchInstructions,
   loadAutoresearchRunManifest,
   materializeAutoresearchMissionToWorktree,
@@ -78,6 +79,8 @@ describe('autoresearch runtime', () => {
     const repo = await initRepo();
     try {
       const contract = await makeContract(repo);
+      await mkdir(join(repo, 'node_modules', 'fixture-dep'), { recursive: true });
+      await writeFile(join(repo, 'node_modules', 'fixture-dep', 'index.js'), 'export default 1;\n', 'utf-8');
       const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t000000z');
       execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t000000z', worktreePath, 'HEAD'], {
         cwd: repo,
@@ -93,6 +96,8 @@ describe('autoresearch runtime', () => {
       assert.equal(existsSync(runtime.ledgerFile), true);
       assert.equal(existsSync(runtime.latestEvaluatorFile), true);
       assert.equal(existsSync(runtime.resultsFile), true);
+      assert.equal(existsSync(join(worktreePath, 'node_modules')), true);
+      assert.doesNotThrow(() => assertResetSafeWorktree(worktreePath));
 
       const manifest = JSON.parse(await readFile(runtime.manifestFile, 'utf-8')) as Record<string, unknown>;
       assert.equal(manifest.mission_slug, 'missions-demo');

--- a/src/autoresearch/__tests__/runtime.test.ts
+++ b/src/autoresearch/__tests__/runtime.test.ts
@@ -1,0 +1,222 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AutoresearchMissionContract } from '../contracts.js';
+import {
+  buildAutoresearchInstructions,
+  loadAutoresearchRunManifest,
+  materializeAutoresearchMissionToWorktree,
+  prepareAutoresearchRuntime,
+  processAutoresearchCandidate,
+} from '../runtime.js';
+import { readModeState } from '../../modes/base.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-runtime-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+async function makeContract(repo: string): Promise<AutoresearchMissionContract> {
+  const missionDir = join(repo, 'missions', 'demo');
+  await mkdir(missionDir, { recursive: true });
+  await mkdir(join(repo, 'scripts'), { recursive: true });
+  const missionFile = join(missionDir, 'mission.md');
+  const sandboxFile = join(missionDir, 'sandbox.md');
+  const missionContent = '# Mission\nSolve the task.\n';
+  const sandboxContent = `---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n---\nStay inside the mission boundary.\n`;
+  await writeFile(missionFile, missionContent, 'utf-8');
+  await writeFile(sandboxFile, sandboxContent, 'utf-8');
+  await writeFile(join(repo, 'score.txt'), '1\n', 'utf-8');
+  await writeFile(join(repo, 'scripts', 'eval.js'), "import { readFileSync } from 'node:fs';\nconst score = Number(readFileSync('score.txt', 'utf-8').trim());\nprocess.stdout.write(JSON.stringify({ pass: true, score }));\n", 'utf-8');
+  execFileSync('git', ['add', 'missions/demo/mission.md', 'missions/demo/sandbox.md', 'scripts/eval.js', 'score.txt'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'add autoresearch fixtures'], { cwd: repo, stdio: 'ignore' });
+  return {
+    missionDir,
+    repoRoot: repo,
+    missionFile,
+    sandboxFile,
+    missionRelativeDir: 'missions/demo',
+    missionContent,
+    sandboxContent,
+    sandbox: {
+      frontmatter: { evaluator: { command: 'node scripts/eval.js', format: 'json' } },
+      evaluator: { command: 'node scripts/eval.js', format: 'json' },
+      body: 'Stay inside the mission boundary.',
+    },
+    missionSlug: 'missions-demo',
+  };
+}
+
+describe('autoresearch runtime', () => {
+  it('builds bootstrap instructions with mission, sandbox, and evaluator contract', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const instructions = buildAutoresearchInstructions(contract, { runId: 'missions-demo-20260314t000000z', iteration: 1, baselineCommit: 'abc1234', lastKeptCommit: 'abc1234', resultsFile: 'results.tsv', candidateFile: '.omx/logs/autoresearch/missions-demo-20260314t000000z/candidate.json', keepPolicy: 'score_improvement' });
+      assert.match(instructions, /exactly one experiment cycle/i);
+      assert.match(instructions, /required output field: pass/i);
+      assert.match(instructions, /optional output field: score/i);
+      assert.match(instructions, /Iteration state snapshot:/i);
+      assert.match(instructions, /Mission file:/i);
+      assert.match(instructions, /Sandbox policy:/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('prepares runtime artifacts and persists autoresearch mode state', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t000000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t000000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T000000Z' });
+
+      assert.equal(existsSync(worktreeContract.missionFile), true);
+      assert.equal(existsSync(worktreeContract.sandboxFile), true);
+      assert.equal(existsSync(runtime.instructionsFile), true);
+      assert.equal(existsSync(runtime.manifestFile), true);
+      assert.equal(existsSync(runtime.ledgerFile), true);
+      assert.equal(existsSync(runtime.latestEvaluatorFile), true);
+      assert.equal(existsSync(runtime.resultsFile), true);
+
+      const manifest = JSON.parse(await readFile(runtime.manifestFile, 'utf-8')) as Record<string, unknown>;
+      assert.equal(manifest.mission_slug, 'missions-demo');
+      assert.equal(manifest.branch_name, 'autoresearch/missions-demo/20260314t000000z');
+      assert.equal(manifest.mission_dir, join(worktreePath, 'missions', 'demo'));
+      assert.equal(manifest.worktree_path, worktreePath);
+      assert.equal(manifest.results_file, runtime.resultsFile);
+      assert.equal(typeof manifest.baseline_commit, 'string');
+
+      const ledger = JSON.parse(await readFile(runtime.ledgerFile, 'utf-8')) as Record<string, unknown>;
+      assert.equal(Array.isArray(ledger.entries), true);
+      assert.equal((ledger.entries as unknown[]).length, 1);
+
+      const latestEvaluator = JSON.parse(await readFile(runtime.latestEvaluatorFile, 'utf-8')) as Record<string, unknown>;
+      assert.equal(latestEvaluator.status, 'pass');
+      assert.equal(latestEvaluator.pass, true);
+      assert.equal(latestEvaluator.score, 1);
+
+      const results = await readFile(runtime.resultsFile, 'utf-8');
+      assert.match(results, /^iteration	commit	pass	score	status	description$/m);
+      assert.match(results, /^0	.+	true	1	baseline	initial baseline evaluation$/m);
+
+      const state = await readModeState('autoresearch', repo);
+      assert.ok(state);
+
+      const worktreeState = await readModeState('autoresearch', worktreePath);
+      assert.equal(worktreeState, null);
+      assert.equal(state?.active, true);
+      assert.equal(state?.current_phase, 'running');
+      assert.equal(state?.mission_slug, 'missions-demo');
+      assert.equal(state?.mission_dir, join(worktreePath, 'missions', 'demo'));
+      assert.equal(state?.worktree_path, worktreePath);
+      assert.equal(state?.bootstrap_instructions_path, runtime.instructionsFile);
+      assert.equal(state?.latest_evaluator_status, 'pass');
+      assert.equal(state?.results_file, runtime.resultsFile);
+      assert.equal(state?.baseline_commit, manifest.baseline_commit);
+
+      const instructions = await readFile(runtime.instructionsFile, 'utf-8');
+      assert.match(instructions, /Last kept score:\s+1/i);
+      assert.match(instructions, /previous_iteration_outcome/i);
+      assert.match(instructions, /baseline established/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+
+describe('autoresearch parity decisions', () => {
+  it('keeps improved candidates and resets discarded candidates back to the last kept commit', async () => {
+    const repo = await initRepo();
+    try {
+      const contract = await makeContract(repo);
+      const worktreePath = join(repo, '..', `${repo.split('/').pop()}.omx-worktrees`, 'autoresearch-missions-demo-20260314t010000z');
+      execFileSync('git', ['worktree', 'add', '-b', 'autoresearch/missions-demo/20260314t010000z', worktreePath, 'HEAD'], {
+        cwd: repo,
+        stdio: 'ignore',
+      });
+      const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, worktreePath);
+      const runtime = await prepareAutoresearchRuntime(worktreeContract, repo, worktreePath, { runTag: '20260314T010000Z' });
+
+      await writeFile(join(worktreePath, 'score.txt'), '2\n', 'utf-8');
+      execFileSync('git', ['add', 'score.txt'], { cwd: worktreePath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'improve score'], { cwd: worktreePath, stdio: 'ignore' });
+      const improvedCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktreePath, encoding: 'utf-8' }).trim();
+      const initialManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'candidate',
+        candidate_commit: improvedCommit,
+        base_commit: initialManifest.last_kept_commit,
+        description: 'improved score',
+        notes: ['score raised to 2'],
+        created_at: '2026-03-14T01:00:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+
+      const keepDecision = await processAutoresearchCandidate(worktreeContract, initialManifest, repo);
+      assert.equal(keepDecision, 'keep');
+      const keptManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      assert.equal(keptManifest.last_kept_commit, improvedCommit);
+
+      await writeFile(join(worktreePath, 'score.txt'), '1\n', 'utf-8');
+      execFileSync('git', ['add', 'score.txt'], { cwd: worktreePath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'worse score'], { cwd: worktreePath, stdio: 'ignore' });
+      const worseCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktreePath, encoding: 'utf-8' }).trim();
+      const beforeDiscardManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      await writeFile(runtime.candidateFile, `${JSON.stringify({
+        status: 'candidate',
+        candidate_commit: worseCommit,
+        base_commit: beforeDiscardManifest.last_kept_commit,
+        description: 'worse score',
+        notes: ['score dropped back to 1'],
+        created_at: '2026-03-14T01:05:00.000Z',
+      }, null, 2)}\n`, 'utf-8');
+
+      const discardDecision = await processAutoresearchCandidate(worktreeContract, beforeDiscardManifest, repo);
+      assert.equal(discardDecision, 'discard');
+      const headAfterDiscard = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktreePath, encoding: 'utf-8' }).trim();
+      assert.equal(headAfterDiscard, improvedCommit);
+
+      const finalManifest = await loadAutoresearchRunManifest(repo, runtime.runId);
+      const results = await readFile(runtime.resultsFile, 'utf-8');
+      assert.match(results, /^1\t.+\ttrue\t2\tkeep\timproved score$/m);
+      assert.match(results, /^2\t.+\ttrue\t1\tdiscard\tworse score$/m);
+
+      const ledger = JSON.parse(await readFile(runtime.ledgerFile, 'utf-8')) as {
+        entries: Array<{ decision: string; description: string }>;
+      };
+      assert.equal(ledger.entries.length, 3);
+      assert.deepEqual(
+        ledger.entries.map((entry) => [entry.decision, entry.description]),
+        [
+          ['baseline', 'initial baseline evaluation'],
+          ['keep', 'improved score'],
+          ['discard', 'worse score'],
+        ],
+      );
+
+      const instructions = await readFile(runtime.instructionsFile, 'utf-8');
+      assert.match(instructions, /"previous_iteration_outcome": "discard:score did not improve"/);
+      assert.match(instructions, /"decision": "keep"/);
+      assert.match(instructions, /"decision": "discard"/);
+      assert.equal(finalManifest.last_kept_commit, improvedCommit);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/autoresearch/contracts.ts
+++ b/src/autoresearch/contracts.ts
@@ -1,0 +1,238 @@
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { basename, join, relative, resolve } from 'path';
+
+export type AutoresearchKeepPolicy = 'score_improvement' | 'pass_only';
+
+export interface AutoresearchEvaluatorContract {
+  command: string;
+  format: 'json';
+  keep_policy?: AutoresearchKeepPolicy;
+}
+
+export interface ParsedSandboxContract {
+  frontmatter: Record<string, unknown>;
+  evaluator: AutoresearchEvaluatorContract;
+  body: string;
+}
+
+export interface AutoresearchEvaluatorResult {
+  pass: boolean;
+  score?: number;
+}
+
+export interface AutoresearchMissionContract {
+  missionDir: string;
+  repoRoot: string;
+  missionFile: string;
+  sandboxFile: string;
+  missionRelativeDir: string;
+  missionContent: string;
+  sandboxContent: string;
+  sandbox: ParsedSandboxContract;
+  missionSlug: string;
+}
+
+function contractError(message: string): Error {
+  return new Error(message);
+}
+
+function readGit(repoPath: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };
+    const stderr = typeof err.stderr === 'string'
+      ? err.stderr.trim()
+      : err.stderr instanceof Buffer
+        ? err.stderr.toString('utf-8').trim()
+        : '';
+    throw contractError(stderr || 'mission-dir must be inside a git repository.');
+  }
+}
+
+export function slugifyMissionName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48) || 'mission';
+}
+
+function ensurePathInside(parentPath: string, childPath: string): void {
+  const rel = relative(parentPath, childPath);
+  if (rel === '' || (!rel.startsWith('..') && rel !== '..')) return;
+  throw contractError('mission-dir must be inside a git repository.');
+}
+
+function extractFrontmatter(content: string): { frontmatter: string; body: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) {
+    throw contractError('sandbox.md must start with YAML frontmatter containing evaluator.command and evaluator.format=json.');
+  }
+  return {
+    frontmatter: match[1] || '',
+    body: (match[2] || '').trim(),
+  };
+}
+
+function parseSimpleYamlFrontmatter(frontmatter: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let currentSection: string | null = null;
+
+  for (const rawLine of frontmatter.split(/\r?\n/)) {
+    const line = rawLine.replace(/\t/g, '  ');
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const sectionMatch = /^([A-Za-z0-9_-]+):\s*$/.exec(trimmed);
+    if (sectionMatch) {
+      currentSection = sectionMatch[1];
+      result[currentSection] = {};
+      continue;
+    }
+
+    const nestedMatch = /^([A-Za-z0-9_-]+):\s*(.+)\s*$/.exec(trimmed);
+    if (!nestedMatch) {
+      throw contractError(`Unsupported sandbox.md frontmatter line: ${trimmed}`);
+    }
+
+    const [, key, rawValue] = nestedMatch;
+    const value = rawValue.replace(/^['"]|['"]$/g, '');
+    if (line.startsWith(' ') || line.startsWith('\t')) {
+      if (!currentSection) {
+        throw contractError(`Nested sandbox.md frontmatter key requires a parent section: ${trimmed}`);
+      }
+      const section = result[currentSection];
+      if (!section || typeof section !== 'object' || Array.isArray(section)) {
+        throw contractError(`Invalid sandbox.md frontmatter section: ${currentSection}`);
+      }
+      (section as Record<string, unknown>)[key] = value;
+      continue;
+    }
+
+    result[key] = value;
+    currentSection = null;
+  }
+
+  return result;
+}
+
+function parseKeepPolicy(raw: unknown): AutoresearchKeepPolicy | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'string') {
+    throw contractError('sandbox.md frontmatter evaluator.keep_policy must be a string when provided.');
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === 'pass_only') return 'pass_only';
+  if (normalized === 'score_improvement') return 'score_improvement';
+  throw contractError('sandbox.md frontmatter evaluator.keep_policy must be one of: score_improvement, pass_only.');
+}
+
+export function parseSandboxContract(content: string): ParsedSandboxContract {
+  const { frontmatter, body } = extractFrontmatter(content);
+  const parsedFrontmatter = parseSimpleYamlFrontmatter(frontmatter);
+  const evaluatorRaw = parsedFrontmatter.evaluator;
+
+  if (!evaluatorRaw || typeof evaluatorRaw !== 'object' || Array.isArray(evaluatorRaw)) {
+    throw contractError('sandbox.md frontmatter must define an evaluator block.');
+  }
+
+  const evaluator = evaluatorRaw as { command?: unknown; format?: unknown; keep_policy?: unknown };
+  const command = typeof evaluator.command === 'string'
+    ? evaluator.command.trim()
+    : '';
+  const format = typeof evaluator.format === 'string'
+    ? evaluator.format.trim().toLowerCase()
+    : '';
+  const keepPolicy = parseKeepPolicy(evaluator.keep_policy);
+
+  if (!command) {
+    throw contractError('sandbox.md frontmatter evaluator.command is required.');
+  }
+  if (!format) {
+    throw contractError('sandbox.md frontmatter evaluator.format is required and must be json in autoresearch v1.');
+  }
+  if (format !== 'json') {
+    throw contractError('sandbox.md frontmatter evaluator.format must be json in autoresearch v1.');
+  }
+
+  return {
+    frontmatter: parsedFrontmatter,
+    evaluator: {
+      command,
+      format: 'json',
+      ...(keepPolicy ? { keep_policy: keepPolicy } : {}),
+    },
+    body,
+  };
+}
+
+export function parseEvaluatorResult(raw: string): AutoresearchEvaluatorResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw contractError('Evaluator output must be valid JSON with required boolean pass and optional numeric score.');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw contractError('Evaluator output must be a JSON object.');
+  }
+
+  const result = parsed as Record<string, unknown>;
+  if (typeof result.pass !== 'boolean') {
+    throw contractError('Evaluator output must include boolean pass.');
+  }
+  if (result.score !== undefined && typeof result.score !== 'number') {
+    throw contractError('Evaluator output score must be numeric when provided.');
+  }
+
+  return result.score === undefined
+    ? { pass: result.pass }
+    : { pass: result.pass, score: result.score };
+}
+
+export async function loadAutoresearchMissionContract(missionDirArg: string): Promise<AutoresearchMissionContract> {
+  const missionDir = resolve(missionDirArg);
+  if (!existsSync(missionDir)) {
+    throw contractError(`mission-dir does not exist: ${missionDir}`);
+  }
+
+  const repoRoot = readGit(missionDir, ['rev-parse', '--show-toplevel']);
+  ensurePathInside(repoRoot, missionDir);
+
+  const missionFile = join(missionDir, 'mission.md');
+  const sandboxFile = join(missionDir, 'sandbox.md');
+  if (!existsSync(missionFile)) {
+    throw contractError(`mission.md is required inside mission-dir: ${missionFile}`);
+  }
+  if (!existsSync(sandboxFile)) {
+    throw contractError(`sandbox.md is required inside mission-dir: ${sandboxFile}`);
+  }
+
+  const missionContent = await readFile(missionFile, 'utf-8');
+  const sandboxContent = await readFile(sandboxFile, 'utf-8');
+  const sandbox = parseSandboxContract(sandboxContent);
+  const missionRelativeDir = relative(repoRoot, missionDir) || basename(missionDir);
+  const missionSlug = slugifyMissionName(missionRelativeDir);
+
+  return {
+    missionDir,
+    repoRoot,
+    missionFile,
+    sandboxFile,
+    missionRelativeDir,
+    missionContent,
+    sandboxContent,
+    sandbox,
+    missionSlug,
+  };
+}

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from 'child_process';
 import { existsSync } from 'fs';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile, symlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { cancelMode, readModeState, startMode, updateModeState } from '../modes/base.js';
 import {
@@ -129,7 +129,7 @@ interface AutoresearchInstructionLedgerSummary {
 }
 
 const AUTORESEARCH_RESULTS_HEADER = 'iteration\tcommit\tpass\tscore\tstatus\tdescription\n';
-const ALLOWED_RUNTIME_UNTRACKED_FILES = ['results.tsv', 'run.log'];
+const AUTORESEARCH_WORKTREE_EXCLUDES = ['results.tsv', 'run.log', 'node_modules'];
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -185,8 +185,7 @@ function tryResolveGitCommit(worktreePath: string, ref: string): string | null {
 }
 
 async function writeGitInfoExclude(worktreePath: string, pattern: string): Promise<void> {
-  const gitDir = readGit(worktreePath, ['rev-parse', '--git-dir']);
-  const excludePath = join(worktreePath, gitDir, 'info', 'exclude');
+  const excludePath = readGit(worktreePath, ['rev-parse', '--git-path', 'info/exclude']);
   const existing = existsSync(excludePath)
     ? await readFile(excludePath, 'utf-8')
     : '';
@@ -198,9 +197,18 @@ async function writeGitInfoExclude(worktreePath: string, pattern: string): Promi
 }
 
 async function ensureRuntimeExcludes(worktreePath: string): Promise<void> {
-  for (const file of ALLOWED_RUNTIME_UNTRACKED_FILES) {
+  for (const file of AUTORESEARCH_WORKTREE_EXCLUDES) {
     await writeGitInfoExclude(worktreePath, file);
   }
+}
+
+async function ensureAutoresearchWorktreeDependencies(repoRoot: string, worktreePath: string): Promise<void> {
+  const sourceNodeModules = join(repoRoot, 'node_modules');
+  const targetNodeModules = join(worktreePath, 'node_modules');
+  if (!existsSync(sourceNodeModules) || existsSync(targetNodeModules)) {
+    return;
+  }
+  await symlink(sourceNodeModules, targetNodeModules, process.platform === 'win32' ? 'junction' : 'dir');
 }
 
 function readGitShortHead(worktreePath: string): string {
@@ -238,7 +246,7 @@ function isAllowedRuntimeDirtyLine(line: string): boolean {
   const trimmed = line.trim();
   if (trimmed.length < 4) return false;
   const path = trimmed.slice(3).trim();
-  return trimmed.startsWith('?? ') && ALLOWED_RUNTIME_UNTRACKED_FILES.includes(path);
+  return trimmed.startsWith('?? ') && AUTORESEARCH_WORKTREE_EXCLUDES.includes(path);
 }
 
 export function assertResetSafeWorktree(worktreePath: string): void {
@@ -366,6 +374,17 @@ async function readAutoresearchLedgerEntries(ledgerFile: string): Promise<Autore
   if (!existsSync(ledgerFile)) return [];
   const parsed = await readJsonFile<{ entries?: AutoresearchLedgerEntry[] }>(ledgerFile);
   return Array.isArray(parsed.entries) ? parsed.entries : [];
+}
+
+export async function countTrailingAutoresearchNoops(ledgerFile: string): Promise<number> {
+  const entries = await readAutoresearchLedgerEntries(ledgerFile);
+  let count = 0;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (!entry || entry.kind !== 'iteration' || entry.decision !== 'noop') break;
+    count += 1;
+  }
+  return count;
 }
 
 function formatAutoresearchInstructionSummary(
@@ -743,6 +762,7 @@ export async function prepareAutoresearchRuntime(
 ): Promise<PreparedAutoresearchRuntime> {
   await assertAutoresearchLockAvailable(projectRoot);
   await ensureRuntimeExcludes(worktreePath);
+  await ensureAutoresearchWorktreeDependencies(projectRoot, worktreePath);
   assertResetSafeWorktree(worktreePath);
 
   const runTag = options.runTag || buildAutoresearchRunTag();
@@ -883,6 +903,7 @@ export async function resumeAutoresearchRuntime(projectRoot: string, runId: stri
     throw new Error(`autoresearch_resume_missing_worktree:${manifest.worktree_path}`);
   }
   await ensureRuntimeExcludes(manifest.worktree_path);
+  await ensureAutoresearchWorktreeDependencies(projectRoot, manifest.worktree_path);
   assertResetSafeWorktree(manifest.worktree_path);
   await startMode('autoresearch', `autoresearch resume ${runId}`, 1, projectRoot);
   await activateAutoresearchRun(manifest);

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -1,0 +1,1252 @@
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { cancelMode, readModeState, startMode, updateModeState } from '../modes/base.js';
+import {
+  parseEvaluatorResult,
+  type AutoresearchKeepPolicy,
+  type AutoresearchMissionContract,
+} from './contracts.js';
+
+export type AutoresearchCandidateStatus = 'candidate' | 'noop' | 'abort' | 'interrupted';
+export type AutoresearchDecisionStatus = 'baseline' | 'keep' | 'discard' | 'ambiguous' | 'noop' | 'abort' | 'interrupted' | 'error';
+export type AutoresearchRunStatus = 'running' | 'stopped' | 'completed' | 'failed';
+
+export interface PreparedAutoresearchRuntime {
+  runId: string;
+  runTag: string;
+  runDir: string;
+  instructionsFile: string;
+  manifestFile: string;
+  ledgerFile: string;
+  latestEvaluatorFile: string;
+  resultsFile: string;
+  stateFile: string;
+  candidateFile: string;
+  repoRoot: string;
+  worktreePath: string;
+  taskDescription: string;
+}
+
+export interface AutoresearchEvaluationRecord {
+  command: string;
+  ran_at: string;
+  status: 'pass' | 'fail' | 'error';
+  pass?: boolean;
+  score?: number;
+  exit_code?: number | null;
+  stdout?: string;
+  stderr?: string;
+  parse_error?: string;
+}
+
+export interface AutoresearchCandidateArtifact {
+  status: AutoresearchCandidateStatus;
+  candidate_commit: string | null;
+  base_commit: string;
+  description: string;
+  notes: string[];
+  created_at: string;
+}
+
+export interface AutoresearchLedgerEntry {
+  iteration: number;
+  kind: 'baseline' | 'iteration';
+  decision: AutoresearchDecisionStatus;
+  decision_reason: string;
+  candidate_status: AutoresearchCandidateStatus | 'baseline';
+  base_commit: string;
+  candidate_commit: string | null;
+  kept_commit: string;
+  keep_policy: AutoresearchKeepPolicy;
+  evaluator: AutoresearchEvaluationRecord | null;
+  created_at: string;
+  notes: string[];
+  description: string;
+}
+
+export interface AutoresearchRunManifest {
+  schema_version: 1;
+  run_id: string;
+  run_tag: string;
+  mission_dir: string;
+  mission_file: string;
+  sandbox_file: string;
+  repo_root: string;
+  worktree_path: string;
+  mission_slug: string;
+  branch_name: string;
+  baseline_commit: string;
+  last_kept_commit: string;
+  last_kept_score: number | null;
+  latest_candidate_commit: string | null;
+  results_file: string;
+  instructions_file: string;
+  manifest_file: string;
+  ledger_file: string;
+  latest_evaluator_file: string;
+  candidate_file: string;
+  evaluator: AutoresearchMissionContract['sandbox']['evaluator'];
+  keep_policy: AutoresearchKeepPolicy;
+  status: AutoresearchRunStatus;
+  stop_reason: string | null;
+  iteration: number;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+interface AutoresearchActiveRunState {
+  schema_version: 1;
+  active: boolean;
+  run_id: string | null;
+  mission_slug: string | null;
+  repo_root: string;
+  worktree_path: string | null;
+  status: AutoresearchRunStatus | 'idle';
+  updated_at: string;
+  completed_at?: string;
+}
+
+interface AutoresearchDecision {
+  decision: AutoresearchDecisionStatus;
+  decisionReason: string;
+  keep: boolean;
+  evaluator: AutoresearchEvaluationRecord | null;
+  notes: string[];
+}
+
+interface AutoresearchInstructionLedgerSummary {
+  iteration: number;
+  decision: AutoresearchDecisionStatus;
+  reason: string;
+  kept_commit: string;
+  candidate_commit: string | null;
+  evaluator_status: AutoresearchEvaluationRecord['status'] | null;
+  evaluator_score: number | null;
+  description: string;
+}
+
+const AUTORESEARCH_RESULTS_HEADER = 'iteration\tcommit\tpass\tscore\tstatus\tdescription\n';
+const ALLOWED_RUNTIME_UNTRACKED_FILES = ['results.tsv', 'run.log'];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function buildAutoresearchRunTag(date = new Date()): string {
+  const iso = date.toISOString();
+  return iso
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z')
+    .replace('T', 'T');
+}
+
+function buildRunId(missionSlug: string, runTag: string): string {
+  return `${missionSlug}-${runTag.toLowerCase()}`;
+}
+
+function activeRunStateFile(projectRoot: string): string {
+  return join(projectRoot, '.omx', 'state', 'autoresearch-state.json');
+}
+
+function trimContent(value: string, max = 4000): string {
+  const trimmed = value.trim();
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max)}\n...`;
+}
+
+function readGit(repoPath: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };
+    const stderr = typeof err.stderr === 'string'
+      ? err.stderr.trim()
+      : err.stderr instanceof Buffer
+        ? err.stderr.toString('utf-8').trim()
+        : '';
+    throw new Error(stderr || `git ${args.join(' ')} failed`);
+  }
+}
+
+function tryResolveGitCommit(worktreePath: string, ref: string): string | null {
+  const result = spawnSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) return null;
+  const resolved = (result.stdout || '').trim();
+  return resolved || null;
+}
+
+async function writeGitInfoExclude(worktreePath: string, pattern: string): Promise<void> {
+  const gitDir = readGit(worktreePath, ['rev-parse', '--git-dir']);
+  const excludePath = join(worktreePath, gitDir, 'info', 'exclude');
+  const existing = existsSync(excludePath)
+    ? await readFile(excludePath, 'utf-8')
+    : '';
+  const lines = new Set(existing.split(/\r?\n/).filter(Boolean));
+  if (lines.has(pattern)) return;
+  const next = `${existing}${existing.endsWith('\n') || existing.length === 0 ? '' : '\n'}${pattern}\n`;
+  await ensureParentDir(excludePath);
+  await writeFile(excludePath, next, 'utf-8');
+}
+
+async function ensureRuntimeExcludes(worktreePath: string): Promise<void> {
+  for (const file of ALLOWED_RUNTIME_UNTRACKED_FILES) {
+    await writeGitInfoExclude(worktreePath, file);
+  }
+}
+
+function readGitShortHead(worktreePath: string): string {
+  return readGit(worktreePath, ['rev-parse', '--short=7', 'HEAD']);
+}
+
+function readGitFullHead(worktreePath: string): string {
+  return readGit(worktreePath, ['rev-parse', 'HEAD']);
+}
+
+function requireGitSuccess(worktreePath: string, args: string[]): void {
+  const result = spawnSync('git', args, {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  if (result.status === 0) return;
+  throw new Error((result.stderr || '').trim() || `git ${args.join(' ')} failed`);
+}
+
+function gitStatusLines(worktreePath: string): string[] {
+  const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    throw new Error((result.stderr || '').trim() || `git status failed for ${worktreePath}`);
+  }
+  return (result.stdout || '')
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean);
+}
+
+function isAllowedRuntimeDirtyLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length < 4) return false;
+  const path = trimmed.slice(3).trim();
+  return trimmed.startsWith('?? ') && ALLOWED_RUNTIME_UNTRACKED_FILES.includes(path);
+}
+
+export function assertResetSafeWorktree(worktreePath: string): void {
+  const lines = gitStatusLines(worktreePath);
+  const blocking = lines.filter((line) => !isAllowedRuntimeDirtyLine(line));
+  if (blocking.length === 0) return;
+  throw new Error(`autoresearch_reset_requires_clean_worktree:${worktreePath}:${blocking.join(' | ')}`);
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await ensureParentDir(filePath);
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, 'utf-8')) as T;
+}
+
+async function readActiveRunState(projectRoot: string): Promise<AutoresearchActiveRunState | null> {
+  const file = activeRunStateFile(projectRoot);
+  if (!existsSync(file)) return null;
+  return readJsonFile<AutoresearchActiveRunState>(file);
+}
+
+async function writeActiveRunState(projectRoot: string, value: AutoresearchActiveRunState): Promise<void> {
+  await writeJsonFile(activeRunStateFile(projectRoot), value);
+}
+
+async function assertAutoresearchLockAvailable(projectRoot: string): Promise<void> {
+  const state = await readActiveRunState(projectRoot);
+  if (state?.active && state.run_id) {
+    throw new Error(`autoresearch_active_run_exists:${state.run_id}`);
+  }
+}
+
+async function activateAutoresearchRun(manifest: AutoresearchRunManifest): Promise<void> {
+  await writeActiveRunState(manifest.repo_root, {
+    schema_version: 1,
+    active: true,
+    run_id: manifest.run_id,
+    mission_slug: manifest.mission_slug,
+    repo_root: manifest.repo_root,
+    worktree_path: manifest.worktree_path,
+    status: manifest.status,
+    updated_at: nowIso(),
+  });
+}
+
+async function deactivateAutoresearchRun(manifest: AutoresearchRunManifest): Promise<void> {
+  const previous = await readActiveRunState(manifest.repo_root);
+  await writeActiveRunState(manifest.repo_root, {
+    schema_version: 1,
+    active: false,
+    run_id: previous?.run_id ?? manifest.run_id,
+    mission_slug: previous?.mission_slug ?? manifest.mission_slug,
+    repo_root: manifest.repo_root,
+    worktree_path: previous?.worktree_path ?? manifest.worktree_path,
+    status: manifest.status,
+    updated_at: nowIso(),
+    completed_at: nowIso(),
+  });
+}
+
+function resultPassValue(value: boolean | undefined): string {
+  return value === undefined ? '' : String(value);
+}
+
+function resultScoreValue(value: number | undefined | null): string {
+  return typeof value === 'number' ? String(value) : '';
+}
+
+async function initializeAutoresearchResultsFile(resultsFile: string): Promise<void> {
+  if (existsSync(resultsFile)) return;
+  await ensureParentDir(resultsFile);
+  await writeFile(resultsFile, AUTORESEARCH_RESULTS_HEADER, 'utf-8');
+}
+
+async function appendAutoresearchResultsRow(
+  resultsFile: string,
+  row: {
+    iteration: number;
+    commit: string;
+    pass?: boolean;
+    score?: number | null;
+    status: AutoresearchDecisionStatus;
+    description: string;
+  },
+): Promise<void> {
+  const existing = existsSync(resultsFile)
+    ? await readFile(resultsFile, 'utf-8')
+    : AUTORESEARCH_RESULTS_HEADER;
+  await writeFile(
+    resultsFile,
+    `${existing}${row.iteration}\t${row.commit}\t${resultPassValue(row.pass)}\t${resultScoreValue(row.score)}\t${row.status}\t${row.description}\n`,
+    'utf-8',
+  );
+}
+
+async function appendAutoresearchLedgerEntry(ledgerFile: string, entry: AutoresearchLedgerEntry): Promise<void> {
+  const parsed = existsSync(ledgerFile)
+    ? await readJsonFile<{
+      schema_version?: number;
+      run_id?: string;
+      created_at?: string;
+      updated_at?: string;
+      entries?: AutoresearchLedgerEntry[];
+    }>(ledgerFile)
+    : { schema_version: 1, entries: [] };
+  const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+  entries.push(entry);
+  await writeJsonFile(ledgerFile, {
+    schema_version: typeof parsed.schema_version === 'number' ? parsed.schema_version : 1,
+    run_id: parsed.run_id,
+    created_at: parsed.created_at || nowIso(),
+    updated_at: nowIso(),
+    entries,
+  });
+}
+
+async function readAutoresearchLedgerEntries(ledgerFile: string): Promise<AutoresearchLedgerEntry[]> {
+  if (!existsSync(ledgerFile)) return [];
+  const parsed = await readJsonFile<{ entries?: AutoresearchLedgerEntry[] }>(ledgerFile);
+  return Array.isArray(parsed.entries) ? parsed.entries : [];
+}
+
+function formatAutoresearchInstructionSummary(
+  entries: AutoresearchLedgerEntry[],
+  maxEntries = 3,
+): AutoresearchInstructionLedgerSummary[] {
+  return entries
+    .slice(-maxEntries)
+    .map((entry) => ({
+      iteration: entry.iteration,
+      decision: entry.decision,
+      reason: trimContent(entry.decision_reason, 160),
+      kept_commit: entry.kept_commit,
+      candidate_commit: entry.candidate_commit,
+      evaluator_status: entry.evaluator?.status ?? null,
+      evaluator_score: typeof entry.evaluator?.score === 'number' ? entry.evaluator.score : null,
+      description: trimContent(entry.description, 120),
+    }));
+}
+
+async function buildAutoresearchInstructionContext(manifest: AutoresearchRunManifest): Promise<{
+  previousIterationOutcome: string | null;
+  recentLedgerSummary: AutoresearchInstructionLedgerSummary[];
+}> {
+  const entries = await readAutoresearchLedgerEntries(manifest.ledger_file);
+  const previous = entries.at(-1);
+  return {
+    previousIterationOutcome: previous
+      ? `${previous.decision}:${trimContent(previous.decision_reason, 160)}`
+      : null,
+    recentLedgerSummary: formatAutoresearchInstructionSummary(entries),
+  };
+}
+
+export async function runAutoresearchEvaluator(
+  contract: AutoresearchMissionContract,
+  worktreePath: string,
+  ledgerFile?: string,
+  latestEvaluatorFile?: string,
+): Promise<AutoresearchEvaluationRecord> {
+  const ran_at = nowIso();
+  const result = spawnSync(contract.sandbox.evaluator.command, {
+    cwd: worktreePath,
+    encoding: 'utf-8',
+    shell: true,
+    maxBuffer: 1024 * 1024,
+  });
+  const stdout = result.stdout?.trim() || '';
+  const stderr = result.stderr?.trim() || '';
+
+  let record: AutoresearchEvaluationRecord;
+  if (result.error || result.status !== 0) {
+    record = {
+      command: contract.sandbox.evaluator.command,
+      ran_at,
+      status: 'error',
+      exit_code: result.status,
+      stdout,
+      stderr: result.error ? [stderr, result.error.message].filter(Boolean).join('\n') : stderr,
+    };
+  } else {
+    try {
+      const parsed = parseEvaluatorResult(stdout);
+      record = {
+        command: contract.sandbox.evaluator.command,
+        ran_at,
+        status: parsed.pass ? 'pass' : 'fail',
+        pass: parsed.pass,
+        ...(parsed.score !== undefined ? { score: parsed.score } : {}),
+        exit_code: result.status,
+        stdout,
+        stderr,
+      };
+    } catch (error) {
+      record = {
+        command: contract.sandbox.evaluator.command,
+        ran_at,
+        status: 'error',
+        exit_code: result.status,
+        stdout,
+        stderr,
+        parse_error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  if (latestEvaluatorFile) {
+    await writeJsonFile(latestEvaluatorFile, record);
+  }
+  if (ledgerFile) {
+    await appendAutoresearchLedgerEntry(ledgerFile, {
+      iteration: -1,
+      kind: 'iteration',
+      decision: record.status === 'error' ? 'error' : record.status === 'pass' ? 'keep' : 'discard',
+      decision_reason: 'raw evaluator record',
+      candidate_status: 'candidate',
+      base_commit: readGitShortHead(worktreePath),
+      candidate_commit: null,
+      kept_commit: readGitShortHead(worktreePath),
+      keep_policy: contract.sandbox.evaluator.keep_policy ?? 'score_improvement',
+      evaluator: record,
+      created_at: nowIso(),
+      notes: ['raw evaluator invocation'],
+      description: 'raw evaluator record',
+    });
+  }
+  return record;
+}
+
+function comparableScore(previousScore: number | null, nextScore: number | undefined): boolean {
+  return typeof previousScore === 'number' && typeof nextScore === 'number';
+}
+
+export function decideAutoresearchOutcome(
+  manifest: Pick<AutoresearchRunManifest, 'keep_policy' | 'last_kept_score'>,
+  candidate: AutoresearchCandidateArtifact,
+  evaluation: AutoresearchEvaluationRecord | null,
+): AutoresearchDecision {
+  if (candidate.status === 'abort') {
+    return {
+      decision: 'abort',
+      decisionReason: 'candidate requested abort',
+      keep: false,
+      evaluator: null,
+      notes: ['run stopped by candidate artifact'],
+    };
+  }
+  if (candidate.status === 'noop') {
+    return {
+      decision: 'noop',
+      decisionReason: 'candidate reported noop',
+      keep: false,
+      evaluator: null,
+      notes: ['no code change was proposed'],
+    };
+  }
+  if (candidate.status === 'interrupted') {
+    return {
+      decision: 'interrupted',
+      decisionReason: 'candidate session was interrupted',
+      keep: false,
+      evaluator: null,
+      notes: ['supervisor should inspect worktree cleanliness before continuing'],
+    };
+  }
+  if (!evaluation || evaluation.status === 'error') {
+    return {
+      decision: 'discard',
+      decisionReason: 'evaluator error',
+      keep: false,
+      evaluator: evaluation,
+      notes: ['candidate discarded because evaluator errored or crashed'],
+    };
+  }
+  if (!evaluation.pass) {
+    return {
+      decision: 'discard',
+      decisionReason: 'evaluator reported failure',
+      keep: false,
+      evaluator: evaluation,
+      notes: ['candidate discarded because evaluator pass=false'],
+    };
+  }
+  if (manifest.keep_policy === 'pass_only') {
+    return {
+      decision: 'keep',
+      decisionReason: 'pass_only keep policy accepted evaluator pass=true',
+      keep: true,
+      evaluator: evaluation,
+      notes: ['candidate kept because sandbox opted into pass_only policy'],
+    };
+  }
+  if (!comparableScore(manifest.last_kept_score, evaluation.score)) {
+    return {
+      decision: 'ambiguous',
+      decisionReason: 'evaluator pass without comparable score',
+      keep: false,
+      evaluator: evaluation,
+      notes: ['candidate discarded because score_improvement policy requires comparable numeric scores'],
+    };
+  }
+  if ((evaluation.score as number) > (manifest.last_kept_score as number)) {
+    return {
+      decision: 'keep',
+      decisionReason: 'score improved over last kept score',
+      keep: true,
+      evaluator: evaluation,
+      notes: ['candidate kept because evaluator score increased'],
+    };
+  }
+  return {
+    decision: 'discard',
+    decisionReason: 'score did not improve',
+    keep: false,
+    evaluator: evaluation,
+    notes: ['candidate discarded because evaluator score was not better than the kept baseline'],
+  };
+}
+
+export function buildAutoresearchInstructions(
+  contract: AutoresearchMissionContract,
+  context: {
+    runId: string;
+    iteration: number;
+    baselineCommit: string;
+    lastKeptCommit: string;
+    lastKeptScore?: number | null;
+    resultsFile: string;
+    candidateFile: string;
+    keepPolicy: AutoresearchKeepPolicy;
+    previousIterationOutcome?: string | null;
+    recentLedgerSummary?: AutoresearchInstructionLedgerSummary[];
+  },
+): string {
+  return [
+    '# OMX Autoresearch Supervisor Instructions',
+    '',
+    `Run ID: ${context.runId}`,
+    `Mission directory: ${contract.missionDir}`,
+    `Mission file: ${contract.missionFile}`,
+    `Sandbox file: ${contract.sandboxFile}`,
+    `Mission slug: ${contract.missionSlug}`,
+    `Iteration: ${context.iteration}`,
+    `Baseline commit: ${context.baselineCommit}`,
+    `Last kept commit: ${context.lastKeptCommit}`,
+    `Last kept score: ${typeof context.lastKeptScore === 'number' ? context.lastKeptScore : 'n/a'}`,
+    `Results file: ${context.resultsFile}`,
+    `Candidate artifact: ${context.candidateFile}`,
+    `Keep policy: ${context.keepPolicy}`,
+    '',
+    'Iteration state snapshot:',
+    '```json',
+    JSON.stringify({
+      iteration: context.iteration,
+      baseline_commit: context.baselineCommit,
+      last_kept_commit: context.lastKeptCommit,
+      last_kept_score: context.lastKeptScore ?? null,
+      previous_iteration_outcome: context.previousIterationOutcome ?? 'none yet',
+      recent_ledger_summary: context.recentLedgerSummary ?? [],
+      keep_policy: context.keepPolicy,
+    }, null, 2),
+    '```',
+    '',
+    'Operate as a thin autoresearch experiment worker for exactly one experiment cycle.',
+    'Do not loop forever inside this session. Make at most one candidate commit, then write the candidate artifact JSON and exit.',
+    '',
+    'Candidate artifact contract:',
+    '- Write JSON to the exact candidate artifact path above.',
+    '- status: candidate | noop | abort | interrupted',
+    '- candidate_commit: string | null',
+    '- base_commit: current base commit before your edits',
+    '- for status=candidate, candidate_commit must resolve in git and match the worktree HEAD commit when you exit',
+    '- base_commit must still match the last kept commit provided above',
+    '- description: short one-line summary',
+    '- notes: array of short strings',
+    '- created_at: ISO timestamp',
+    '',
+    'Supervisor semantics after you exit:',
+    '- status=candidate => evaluator runs, then supervisor keeps or discards and may reset the worktree',
+    '- status=noop => supervisor logs a noop iteration and relaunches',
+    '- status=abort => supervisor stops the run',
+    '- status=interrupted => supervisor inspects worktree safety before deciding how to proceed',
+    '',
+    'Evaluator contract:',
+    `- command: ${contract.sandbox.evaluator.command}`,
+    '- format: json',
+    '- required output field: pass (boolean)',
+    '- optional output field: score (number)',
+    '',
+    'Mission content:',
+    '```md',
+    trimContent(contract.missionContent),
+    '```',
+    '',
+    'Sandbox policy:',
+    '```md',
+    trimContent(contract.sandbox.body || contract.sandboxContent),
+    '```',
+  ].join('\n');
+}
+
+export async function materializeAutoresearchMissionToWorktree(
+  contract: AutoresearchMissionContract,
+  worktreePath: string,
+): Promise<AutoresearchMissionContract> {
+  const missionDir = join(worktreePath, contract.missionRelativeDir);
+  const missionFile = join(missionDir, 'mission.md');
+  const sandboxFile = join(missionDir, 'sandbox.md');
+
+  await mkdir(missionDir, { recursive: true });
+  await writeFile(missionFile, contract.missionContent, 'utf-8');
+  await writeFile(sandboxFile, contract.sandboxContent, 'utf-8');
+
+  return {
+    ...contract,
+    missionDir,
+    missionFile,
+    sandboxFile,
+  };
+}
+
+export async function loadAutoresearchRunManifest(projectRoot: string, runId: string): Promise<AutoresearchRunManifest> {
+  const manifestFile = join(projectRoot, '.omx', 'logs', 'autoresearch', runId, 'manifest.json');
+  if (!existsSync(manifestFile)) {
+    throw new Error(`autoresearch_resume_manifest_missing:${runId}`);
+  }
+  return readJsonFile<AutoresearchRunManifest>(manifestFile);
+}
+
+async function writeRunManifest(manifest: AutoresearchRunManifest): Promise<void> {
+  manifest.updated_at = nowIso();
+  await writeJsonFile(manifest.manifest_file, manifest);
+}
+
+async function writeInstructionsFile(contract: AutoresearchMissionContract, manifest: AutoresearchRunManifest): Promise<void> {
+  const instructionContext = await buildAutoresearchInstructionContext(manifest);
+  await writeFile(
+    manifest.instructions_file,
+    `${buildAutoresearchInstructions(contract, {
+      runId: manifest.run_id,
+      iteration: manifest.iteration + 1,
+      baselineCommit: manifest.baseline_commit,
+      lastKeptCommit: manifest.last_kept_commit,
+      lastKeptScore: manifest.last_kept_score,
+      resultsFile: manifest.results_file,
+      candidateFile: manifest.candidate_file,
+      keepPolicy: manifest.keep_policy,
+      previousIterationOutcome: instructionContext.previousIterationOutcome,
+      recentLedgerSummary: instructionContext.recentLedgerSummary,
+    })}\n`,
+    'utf-8',
+  );
+}
+
+async function seedBaseline(
+  contract: AutoresearchMissionContract,
+  manifest: AutoresearchRunManifest,
+): Promise<AutoresearchEvaluationRecord> {
+  const evaluation = await runAutoresearchEvaluator(contract, manifest.worktree_path);
+  await writeJsonFile(manifest.latest_evaluator_file, evaluation);
+  await appendAutoresearchResultsRow(manifest.results_file, {
+    iteration: 0,
+    commit: readGitShortHead(manifest.worktree_path),
+    pass: evaluation.pass,
+    score: evaluation.score,
+    status: evaluation.status === 'error' ? 'error' : 'baseline',
+    description: 'initial baseline evaluation',
+  });
+  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+    iteration: 0,
+    kind: 'baseline',
+    decision: evaluation.status === 'error' ? 'error' : 'baseline',
+    decision_reason: evaluation.status === 'error' ? 'baseline evaluator error' : 'baseline established',
+    candidate_status: 'baseline',
+    base_commit: manifest.baseline_commit,
+    candidate_commit: null,
+    kept_commit: manifest.last_kept_commit,
+    keep_policy: manifest.keep_policy,
+    evaluator: evaluation,
+    created_at: nowIso(),
+    notes: ['baseline row is always recorded'],
+    description: 'initial baseline evaluation',
+  });
+  manifest.last_kept_score = evaluation.pass && typeof evaluation.score === 'number' ? evaluation.score : null;
+  await writeRunManifest(manifest);
+  await writeInstructionsFile(contract, manifest);
+  return evaluation;
+}
+
+export async function prepareAutoresearchRuntime(
+  contract: AutoresearchMissionContract,
+  projectRoot: string,
+  worktreePath: string,
+  options: { runTag?: string } = {},
+): Promise<PreparedAutoresearchRuntime> {
+  await assertAutoresearchLockAvailable(projectRoot);
+  await ensureRuntimeExcludes(worktreePath);
+  assertResetSafeWorktree(worktreePath);
+
+  const runTag = options.runTag || buildAutoresearchRunTag();
+  const runId = buildRunId(contract.missionSlug, runTag);
+  const baselineCommit = readGitShortHead(worktreePath);
+  const branchName = readGit(worktreePath, ['symbolic-ref', '--quiet', '--short', 'HEAD']);
+  const runDir = join(projectRoot, '.omx', 'logs', 'autoresearch', runId);
+  const stateFile = activeRunStateFile(projectRoot);
+  const instructionsFile = join(runDir, 'bootstrap-instructions.md');
+  const manifestFile = join(runDir, 'manifest.json');
+  const ledgerFile = join(runDir, 'iteration-ledger.json');
+  const latestEvaluatorFile = join(runDir, 'latest-evaluator-result.json');
+  const candidateFile = join(runDir, 'candidate.json');
+  const resultsFile = join(worktreePath, 'results.tsv');
+  const taskDescription = `autoresearch ${contract.missionRelativeDir} (${runId})`;
+  const keepPolicy = contract.sandbox.evaluator.keep_policy ?? 'score_improvement';
+
+  await mkdir(runDir, { recursive: true });
+  await initializeAutoresearchResultsFile(resultsFile);
+  await writeJsonFile(candidateFile, {
+    status: 'noop',
+    candidate_commit: null,
+    base_commit: baselineCommit,
+    description: 'not-yet-written',
+    notes: ['candidate artifact will be overwritten by the launched session'],
+    created_at: nowIso(),
+  } satisfies AutoresearchCandidateArtifact);
+
+  const manifest: AutoresearchRunManifest = {
+    schema_version: 1,
+    run_id: runId,
+    run_tag: runTag,
+    mission_dir: contract.missionDir,
+    mission_file: contract.missionFile,
+    sandbox_file: contract.sandboxFile,
+    repo_root: projectRoot,
+    worktree_path: worktreePath,
+    mission_slug: contract.missionSlug,
+    branch_name: branchName,
+    baseline_commit: baselineCommit,
+    last_kept_commit: readGitFullHead(worktreePath),
+    last_kept_score: null,
+    latest_candidate_commit: null,
+    results_file: resultsFile,
+    instructions_file: instructionsFile,
+    manifest_file: manifestFile,
+    ledger_file: ledgerFile,
+    latest_evaluator_file: latestEvaluatorFile,
+    candidate_file: candidateFile,
+    evaluator: contract.sandbox.evaluator,
+    keep_policy: keepPolicy,
+    status: 'running',
+    stop_reason: null,
+    iteration: 0,
+    created_at: nowIso(),
+    updated_at: nowIso(),
+    completed_at: null,
+  };
+
+  await writeInstructionsFile(contract, manifest);
+  await writeRunManifest(manifest);
+  await writeJsonFile(ledgerFile, {
+    schema_version: 1,
+    run_id: runId,
+    created_at: nowIso(),
+    updated_at: nowIso(),
+    entries: [],
+  });
+  await writeJsonFile(latestEvaluatorFile, {
+    run_id: runId,
+    status: 'not-yet-run',
+    updated_at: nowIso(),
+  });
+
+  const existingModeState = await readModeState('autoresearch', projectRoot);
+  if (existingModeState?.active) {
+    throw new Error(`autoresearch_active_mode_exists:${String(existingModeState.run_id || 'unknown')}`);
+  }
+  await startMode('autoresearch', taskDescription, 1, projectRoot);
+  await activateAutoresearchRun(manifest);
+  await updateModeState('autoresearch', {
+    current_phase: 'evaluating-baseline',
+    run_id: runId,
+    run_tag: runTag,
+    mission_dir: contract.missionDir,
+    mission_file: contract.missionFile,
+    sandbox_file: contract.sandboxFile,
+    mission_slug: contract.missionSlug,
+    repo_root: projectRoot,
+    worktree_path: worktreePath,
+    baseline_commit: baselineCommit,
+    last_kept_commit: manifest.last_kept_commit,
+    results_file: resultsFile,
+    manifest_path: manifestFile,
+    iteration_ledger_path: ledgerFile,
+    latest_evaluator_result_path: latestEvaluatorFile,
+    bootstrap_instructions_path: instructionsFile,
+    candidate_path: candidateFile,
+    keep_policy: keepPolicy,
+    state_file: stateFile,
+  }, projectRoot);
+
+  const evaluation = await seedBaseline(contract, manifest);
+  await updateModeState('autoresearch', {
+    current_phase: 'running',
+    latest_evaluator_status: evaluation.status,
+    latest_evaluator_pass: evaluation.pass,
+    latest_evaluator_score: evaluation.score,
+    latest_evaluator_ran_at: evaluation.ran_at,
+    last_kept_commit: manifest.last_kept_commit,
+    last_kept_score: manifest.last_kept_score,
+  }, projectRoot);
+
+  return {
+    runId,
+    runTag,
+    runDir,
+    instructionsFile,
+    manifestFile,
+    ledgerFile,
+    latestEvaluatorFile,
+    resultsFile,
+    stateFile,
+    candidateFile,
+    repoRoot: projectRoot,
+    worktreePath,
+    taskDescription,
+  };
+}
+
+export async function resumeAutoresearchRuntime(projectRoot: string, runId: string): Promise<PreparedAutoresearchRuntime> {
+  await assertAutoresearchLockAvailable(projectRoot);
+  const manifest = await loadAutoresearchRunManifest(projectRoot, runId);
+  if (manifest.status !== 'running') {
+    throw new Error(`autoresearch_resume_terminal_run:${runId}`);
+  }
+  if (!existsSync(manifest.worktree_path)) {
+    throw new Error(`autoresearch_resume_missing_worktree:${manifest.worktree_path}`);
+  }
+  await ensureRuntimeExcludes(manifest.worktree_path);
+  assertResetSafeWorktree(manifest.worktree_path);
+  await startMode('autoresearch', `autoresearch resume ${runId}`, 1, projectRoot);
+  await activateAutoresearchRun(manifest);
+  await updateModeState('autoresearch', {
+    current_phase: 'running',
+    run_id: manifest.run_id,
+    run_tag: manifest.run_tag,
+    mission_dir: manifest.mission_dir,
+    mission_file: manifest.mission_file,
+    sandbox_file: manifest.sandbox_file,
+    mission_slug: manifest.mission_slug,
+    repo_root: manifest.repo_root,
+    worktree_path: manifest.worktree_path,
+    baseline_commit: manifest.baseline_commit,
+    last_kept_commit: manifest.last_kept_commit,
+    last_kept_score: manifest.last_kept_score,
+    results_file: manifest.results_file,
+    manifest_path: manifest.manifest_file,
+    iteration_ledger_path: manifest.ledger_file,
+    latest_evaluator_result_path: manifest.latest_evaluator_file,
+    bootstrap_instructions_path: manifest.instructions_file,
+    candidate_path: manifest.candidate_file,
+    keep_policy: manifest.keep_policy,
+    state_file: activeRunStateFile(projectRoot),
+  }, projectRoot);
+  return {
+    runId: manifest.run_id,
+    runTag: manifest.run_tag,
+    runDir: dirname(manifest.manifest_file),
+    instructionsFile: manifest.instructions_file,
+    manifestFile: manifest.manifest_file,
+    ledgerFile: manifest.ledger_file,
+    latestEvaluatorFile: manifest.latest_evaluator_file,
+    resultsFile: manifest.results_file,
+    stateFile: activeRunStateFile(projectRoot),
+    candidateFile: manifest.candidate_file,
+    repoRoot: manifest.repo_root,
+    worktreePath: manifest.worktree_path,
+    taskDescription: `autoresearch resume ${runId}`,
+  };
+}
+
+export function parseAutoresearchCandidateArtifact(raw: string): AutoresearchCandidateArtifact {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('autoresearch candidate artifact must be valid JSON');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('autoresearch candidate artifact must be a JSON object');
+  }
+  const record = parsed as Record<string, unknown>;
+  const status = record.status;
+  if (status !== 'candidate' && status !== 'noop' && status !== 'abort' && status !== 'interrupted') {
+    throw new Error('autoresearch candidate artifact status must be candidate|noop|abort|interrupted');
+  }
+  if (record.candidate_commit !== null && typeof record.candidate_commit !== 'string') {
+    throw new Error('autoresearch candidate artifact candidate_commit must be string|null');
+  }
+  if (typeof record.base_commit !== 'string' || !record.base_commit.trim()) {
+    throw new Error('autoresearch candidate artifact base_commit is required');
+  }
+  if (typeof record.description !== 'string') {
+    throw new Error('autoresearch candidate artifact description is required');
+  }
+  if (!Array.isArray(record.notes) || record.notes.some((note) => typeof note !== 'string')) {
+    throw new Error('autoresearch candidate artifact notes must be a string array');
+  }
+  if (typeof record.created_at !== 'string' || !record.created_at.trim()) {
+    throw new Error('autoresearch candidate artifact created_at is required');
+  }
+  return {
+    status,
+    candidate_commit: record.candidate_commit,
+    base_commit: record.base_commit,
+    description: record.description,
+    notes: record.notes,
+    created_at: record.created_at,
+  };
+}
+
+async function readCandidateArtifact(candidateFile: string): Promise<AutoresearchCandidateArtifact> {
+  if (!existsSync(candidateFile)) {
+    throw new Error(`autoresearch_candidate_missing:${candidateFile}`);
+  }
+  return parseAutoresearchCandidateArtifact(await readFile(candidateFile, 'utf-8'));
+}
+
+async function finalizeRun(
+  manifest: AutoresearchRunManifest,
+  projectRoot: string,
+  updates: { status: AutoresearchRunStatus; stopReason: string },
+): Promise<void> {
+  manifest.status = updates.status;
+  manifest.stop_reason = updates.stopReason;
+  manifest.completed_at = nowIso();
+  await writeRunManifest(manifest);
+  await updateModeState('autoresearch', {
+    active: false,
+    current_phase: updates.status,
+    completed_at: manifest.completed_at,
+    stop_reason: updates.stopReason,
+  }, projectRoot);
+  await deactivateAutoresearchRun(manifest);
+}
+
+function resetToLastKeptCommit(manifest: AutoresearchRunManifest): void {
+  assertResetSafeWorktree(manifest.worktree_path);
+  requireGitSuccess(manifest.worktree_path, ['reset', '--hard', manifest.last_kept_commit]);
+}
+
+function validateAutoresearchCandidate(
+  manifest: Pick<AutoresearchRunManifest, 'last_kept_commit' | 'worktree_path'>,
+  candidate: AutoresearchCandidateArtifact,
+): { candidate: AutoresearchCandidateArtifact } | { reason: string } {
+  const resolvedBaseCommit = tryResolveGitCommit(manifest.worktree_path, candidate.base_commit);
+  if (!resolvedBaseCommit) {
+    return {
+      reason: `candidate base_commit does not resolve in git: ${candidate.base_commit}`,
+    };
+  }
+  if (resolvedBaseCommit !== manifest.last_kept_commit) {
+    return {
+      reason: `candidate base_commit ${resolvedBaseCommit} does not match last kept commit ${manifest.last_kept_commit}`,
+    };
+  }
+
+  if (candidate.status !== 'candidate') {
+    return {
+      candidate: {
+        ...candidate,
+        base_commit: resolvedBaseCommit,
+      },
+    };
+  }
+
+  if (!candidate.candidate_commit) {
+    return {
+      reason: 'candidate status requires a non-null candidate_commit',
+    };
+  }
+  const resolvedCandidateCommit = tryResolveGitCommit(manifest.worktree_path, candidate.candidate_commit);
+  if (!resolvedCandidateCommit) {
+    return {
+      reason: `candidate_commit does not resolve in git: ${candidate.candidate_commit}`,
+    };
+  }
+  const headCommit = readGitFullHead(manifest.worktree_path);
+  if (resolvedCandidateCommit !== headCommit) {
+    return {
+      reason: `candidate_commit ${resolvedCandidateCommit} does not match worktree HEAD ${headCommit}`,
+    };
+  }
+
+  return {
+    candidate: {
+      ...candidate,
+      base_commit: resolvedBaseCommit,
+      candidate_commit: resolvedCandidateCommit,
+    },
+  };
+}
+
+async function failAutoresearchIteration(
+  manifest: AutoresearchRunManifest,
+  projectRoot: string,
+  reason: string,
+  candidate?: AutoresearchCandidateArtifact,
+): Promise<'error'> {
+  const headCommit = (() => {
+    try {
+      return readGitShortHead(manifest.worktree_path);
+    } catch {
+      return manifest.baseline_commit;
+    }
+  })();
+
+  await appendAutoresearchResultsRow(manifest.results_file, {
+    iteration: manifest.iteration,
+    commit: headCommit,
+    status: 'error',
+    description: candidate?.description || 'candidate validation failed',
+  });
+  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+    iteration: manifest.iteration,
+    kind: 'iteration',
+    decision: 'error',
+    decision_reason: reason,
+    candidate_status: candidate?.status ?? 'candidate',
+    base_commit: candidate?.base_commit ?? manifest.last_kept_commit,
+    candidate_commit: candidate?.candidate_commit ?? null,
+    kept_commit: manifest.last_kept_commit,
+    keep_policy: manifest.keep_policy,
+    evaluator: null,
+    created_at: nowIso(),
+    notes: [...(candidate?.notes ?? []), `validation_error:${reason}`],
+    description: candidate?.description || 'candidate validation failed',
+  });
+  await finalizeRun(manifest, projectRoot, { status: 'failed', stopReason: reason });
+  return 'error';
+}
+
+export async function processAutoresearchCandidate(
+  contract: AutoresearchMissionContract,
+  manifest: AutoresearchRunManifest,
+  projectRoot: string,
+): Promise<AutoresearchDecisionStatus> {
+  manifest.iteration += 1;
+  let candidate: AutoresearchCandidateArtifact;
+  try {
+    candidate = await readCandidateArtifact(manifest.candidate_file);
+  } catch (error) {
+    return failAutoresearchIteration(
+      manifest,
+      projectRoot,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  const validation = validateAutoresearchCandidate(manifest, candidate);
+  if ('reason' in validation) {
+    return failAutoresearchIteration(manifest, projectRoot, validation.reason, candidate);
+  }
+  candidate = validation.candidate;
+  manifest.latest_candidate_commit = candidate.candidate_commit;
+
+  if (candidate.status === 'abort') {
+    await appendAutoresearchResultsRow(manifest.results_file, {
+      iteration: manifest.iteration,
+      commit: readGitShortHead(manifest.worktree_path),
+      status: 'abort',
+      description: candidate.description,
+    });
+    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+      iteration: manifest.iteration,
+      kind: 'iteration',
+      decision: 'abort',
+      decision_reason: 'candidate requested abort',
+      candidate_status: candidate.status,
+      base_commit: candidate.base_commit,
+      candidate_commit: candidate.candidate_commit,
+      kept_commit: manifest.last_kept_commit,
+      keep_policy: manifest.keep_policy,
+      evaluator: null,
+      created_at: nowIso(),
+      notes: candidate.notes,
+      description: candidate.description,
+    });
+    await finalizeRun(manifest, projectRoot, { status: 'stopped', stopReason: 'candidate abort' });
+    return 'abort';
+  }
+
+  if (candidate.status === 'interrupted') {
+    try {
+      assertResetSafeWorktree(manifest.worktree_path);
+    } catch {
+      await finalizeRun(manifest, projectRoot, { status: 'failed', stopReason: 'interrupted dirty worktree requires operator intervention' });
+      return 'error';
+    }
+    await appendAutoresearchResultsRow(manifest.results_file, {
+      iteration: manifest.iteration,
+      commit: readGitShortHead(manifest.worktree_path),
+      status: 'interrupted',
+      description: candidate.description,
+    });
+    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+      iteration: manifest.iteration,
+      kind: 'iteration',
+      decision: 'interrupted',
+      decision_reason: 'candidate session interrupted cleanly',
+      candidate_status: candidate.status,
+      base_commit: candidate.base_commit,
+      candidate_commit: candidate.candidate_commit,
+      kept_commit: manifest.last_kept_commit,
+      keep_policy: manifest.keep_policy,
+      evaluator: null,
+      created_at: nowIso(),
+      notes: candidate.notes,
+      description: candidate.description,
+    });
+    await writeRunManifest(manifest);
+    await writeInstructionsFile(contract, manifest);
+    return 'interrupted';
+  }
+
+  if (candidate.status === 'noop') {
+    await appendAutoresearchResultsRow(manifest.results_file, {
+      iteration: manifest.iteration,
+      commit: readGitShortHead(manifest.worktree_path),
+      status: 'noop',
+      description: candidate.description,
+    });
+    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+      iteration: manifest.iteration,
+      kind: 'iteration',
+      decision: 'noop',
+      decision_reason: 'candidate reported noop',
+      candidate_status: candidate.status,
+      base_commit: candidate.base_commit,
+      candidate_commit: candidate.candidate_commit,
+      kept_commit: manifest.last_kept_commit,
+      keep_policy: manifest.keep_policy,
+      evaluator: null,
+      created_at: nowIso(),
+      notes: candidate.notes,
+      description: candidate.description,
+    });
+    await writeRunManifest(manifest);
+    await writeInstructionsFile(contract, manifest);
+    return 'noop';
+  }
+
+  const evaluation = await runAutoresearchEvaluator(contract, manifest.worktree_path);
+  await writeJsonFile(manifest.latest_evaluator_file, evaluation);
+  const decision = decideAutoresearchOutcome(manifest, candidate, evaluation);
+  if (decision.keep) {
+    manifest.last_kept_commit = readGitFullHead(manifest.worktree_path);
+    manifest.last_kept_score = typeof evaluation.score === 'number' ? evaluation.score : manifest.last_kept_score;
+  } else {
+    resetToLastKeptCommit(manifest);
+  }
+
+  await appendAutoresearchResultsRow(manifest.results_file, {
+    iteration: manifest.iteration,
+    commit: decision.keep ? readGitShortHead(manifest.worktree_path) : readGitShortHead(manifest.worktree_path),
+    pass: evaluation.pass,
+    score: evaluation.score,
+    status: decision.decision,
+    description: candidate.description,
+  });
+  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+    iteration: manifest.iteration,
+    kind: 'iteration',
+    decision: decision.decision,
+    decision_reason: decision.decisionReason,
+    candidate_status: candidate.status,
+    base_commit: candidate.base_commit,
+    candidate_commit: candidate.candidate_commit,
+    kept_commit: manifest.last_kept_commit,
+    keep_policy: manifest.keep_policy,
+    evaluator: evaluation,
+    created_at: nowIso(),
+    notes: [...candidate.notes, ...decision.notes],
+    description: candidate.description,
+  });
+  await writeRunManifest(manifest);
+  await writeInstructionsFile(contract, manifest);
+  await updateModeState('autoresearch', {
+    current_phase: 'running',
+    iteration: manifest.iteration,
+    last_kept_commit: manifest.last_kept_commit,
+    last_kept_score: manifest.last_kept_score,
+    latest_evaluator_status: evaluation.status,
+    latest_evaluator_pass: evaluation.pass,
+    latest_evaluator_score: evaluation.score,
+    latest_evaluator_ran_at: evaluation.ran_at,
+  }, projectRoot);
+  return decision.decision;
+}
+
+export async function stopAutoresearchRuntime(projectRoot: string): Promise<void> {
+  const state = await readModeState('autoresearch', projectRoot);
+  if (state?.active) {
+    await cancelMode('autoresearch', projectRoot);
+  }
+}

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -1265,9 +1265,32 @@ export async function processAutoresearchCandidate(
   return decision.decision;
 }
 
+export async function finalizeAutoresearchRunState(
+  projectRoot: string,
+  runId: string,
+  updates: { status: AutoresearchRunStatus; stopReason: string },
+): Promise<void> {
+  const manifest = await loadAutoresearchRunManifest(projectRoot, runId);
+  if (manifest.status !== 'running') {
+    return;
+  }
+  await finalizeRun(manifest, projectRoot, updates);
+}
+
 export async function stopAutoresearchRuntime(projectRoot: string): Promise<void> {
   const state = await readModeState('autoresearch', projectRoot);
-  if (state?.active) {
-    await cancelMode('autoresearch', projectRoot);
+  if (!state?.active) {
+    return;
   }
+
+  const runId = typeof state.run_id === 'string' ? state.run_id : null;
+  if (runId) {
+    await finalizeAutoresearchRunState(projectRoot, runId, {
+      status: 'stopped',
+      stopReason: 'operator stop',
+    });
+    return;
+  }
+
+  await cancelMode('autoresearch', projectRoot);
 }

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -181,6 +181,130 @@ describe('omx autoresearch', () => {
       assert.equal(existsSync(worktreePath), false, 'expected launch to abort before creating autoresearch worktree');
     } finally {
       await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('launches codex exec for autoresearch turns', async () => {
+    const repo = await initRepo();
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-fake-bin-'));
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await mkdir(join(repo, 'scripts'), { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\nWrite a noop candidate artifact.\n', 'utf-8');
+      await writeFile(
+        join(missionDir, 'sandbox.md'),
+        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
+        'utf-8',
+      );
+      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
+      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'add autoresearch mission'], { cwd: repo, stdio: 'ignore' });
+
+      const fakeCodexPath = join(fakeBin, 'codex');
+      await writeFile(
+        fakeCodexPath,
+        `#!/bin/sh
+printf 'fake-codex:%s\\n' "$*" >&2
+cat >/dev/null
+candidate_file=$(find /tmp -path '*/.omx/logs/autoresearch/*/candidate.json' | head -n 1)
+candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
+head_commit=$(git rev-parse HEAD)
+cat >"$candidate_file" <<EOF
+{
+  "status": "abort",
+  "candidate_commit": null,
+  "base_commit": "$head_commit",
+  "description": "stop after first exec",
+  "notes": ["fake codex exec"],
+  "created_at": "2026-03-15T00:00:00.000Z"
+}
+EOF
+`,
+        'utf-8',
+      );
+      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+
+      const result = runOmx(
+        repo,
+        ['autoresearch', missionDir, '--dangerously-bypass-approvals-and-sandbox'],
+        { PATH: `${fakeBin}:${process.env.PATH || ''}`, OMX_TEST_REPO_ROOT: repo },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /fake-codex:exec --dangerously-bypass-approvals-and-sandbox -/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('stops after repeated noop turns', async () => {
+    const repo = await initRepo();
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-noop-bin-'));
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await mkdir(join(repo, 'scripts'), { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\nKeep returning noop.\n', 'utf-8');
+      await writeFile(
+        join(missionDir, 'sandbox.md'),
+        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
+        'utf-8',
+      );
+      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
+      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'add autoresearch noop mission'], { cwd: repo, stdio: 'ignore' });
+
+      const fakeCodexPath = join(fakeBin, 'codex');
+      await writeFile(
+        fakeCodexPath,
+        `#!/bin/sh
+cat >/dev/null
+candidate_file=$(find /tmp -path '*/.omx/logs/autoresearch/*/candidate.json' | head -n 1)
+candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
+head_commit=$(git rev-parse HEAD)
+cat >"$candidate_file" <<EOF
+{
+  "status": "noop",
+  "candidate_commit": null,
+  "base_commit": "$head_commit",
+  "description": "noop from fake codex exec",
+  "notes": ["fake noop"],
+  "created_at": "2026-03-15T00:00:00.000Z"
+}
+EOF
+`,
+        'utf-8',
+      );
+      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+
+      const result = runOmx(
+        repo,
+        ['autoresearch', missionDir, '--dangerously-bypass-approvals-and-sandbox'],
+        { PATH: `${fakeBin}:${process.env.PATH || ''}`, OMX_TEST_REPO_ROOT: repo },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const state = JSON.parse(await readFile(join(repo, '.omx', 'state', 'autoresearch-state.json'), 'utf-8')) as { active: boolean; current_phase?: string };
+      assert.equal(state.active, false);
+      assert.equal(state.current_phase, 'cancelled');
+
+      const logsRoot = join(repo, '.omx', 'logs', 'autoresearch');
+      const [runId] = execFileSync('find', [logsRoot, '-mindepth', '1', '-maxdepth', '1', '-type', 'd', '-printf', '%f\n'], { encoding: 'utf-8' })
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+      assert.ok(runId);
+
+      const ledger = JSON.parse(await readFile(join(logsRoot, runId, 'iteration-ledger.json'), 'utf-8')) as {
+        entries: Array<{ decision: string }>;
+      };
+      assert.deepEqual(ledger.entries.map((entry) => entry.decision), ['baseline', 'noop', 'noop', 'noop']);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(fakeBin, { recursive: true, force: true });
     }
   });
 });

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -1,0 +1,186 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error?: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const r = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+      ...envOverrides,
+    },
+  });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
+}
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-test-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+describe('omx autoresearch', () => {
+  it('documents autoresearch in top-level help', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-help-'));
+    try {
+      const result = runOmx(cwd, ['--help']);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /omx autoresearch\s+Launch thin-supervisor autoresearch with keep\/discard\/reset parity/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('routes autoresearch --help to command-local help', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-local-help-'));
+    try {
+      const result = runOmx(cwd, ['autoresearch', '--help']);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /Usage:\s*omx autoresearch <mission-dir>/i);
+      assert.doesNotMatch(result.stdout, /oh-my-codex \(omx\) - Multi-agent orchestration for Codex CLI/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('documents --resume in command-local help', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-resume-help-'));
+    try {
+      const result = runOmx(cwd, ['autoresearch', '--help']);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /--resume <run-id>/i);
+      assert.match(result.stdout, /run-tagged/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails fast when mission dir is missing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-missing-arg-'));
+    try {
+      const result = runOmx(cwd, ['autoresearch']);
+      assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /mission-dir|Usage:\s*omx autoresearch <mission-dir>/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects mission directories outside a git repo', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-outside-git-'));
+    try {
+      await writeFile(join(cwd, 'mission.md'), '# Mission\n', 'utf-8');
+      await writeFile(join(cwd, 'sandbox.md'), '---\nevaluator:\n  command: node eval.js\n---\n', 'utf-8');
+
+      const result = runOmx(cwd, ['autoresearch', cwd]);
+      assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /git repo|git repository|inside a git repo/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects missing mission.md inside an in-repo mission dir', async () => {
+    const repo = await initRepo();
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await writeFile(join(missionDir, 'sandbox.md'), '---\nevaluator:\n  command: node eval.js\n---\n', 'utf-8');
+
+      const result = runOmx(repo, ['autoresearch', missionDir]);
+      assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /mission\.md/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects missing sandbox.md inside an in-repo mission dir', async () => {
+    const repo = await initRepo();
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\n', 'utf-8');
+
+      const result = runOmx(repo, ['autoresearch', missionDir]);
+      assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /sandbox\.md/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects sandbox.md without evaluator frontmatter', async () => {
+    const repo = await initRepo();
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\n', 'utf-8');
+      await writeFile(join(missionDir, 'sandbox.md'), 'No frontmatter here.\n', 'utf-8');
+
+      const result = runOmx(repo, ['autoresearch', missionDir]);
+      assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /frontmatter|evaluator/i);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects autoresearch launch when root ralph mode is already active', async () => {
+    const repo = await initRepo();
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\n', 'utf-8');
+      await writeFile(
+        join(missionDir, 'sandbox.md'),
+        '---\nevaluator:\n  command: node eval.js\n  format: json\n---\nStay inside the mission boundary.\n',
+        'utf-8',
+      );
+      await mkdir(join(repo, '.omx', 'state'), { recursive: true });
+      await writeFile(
+        join(repo, '.omx', 'state', 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'ralph',
+          iteration: 0,
+          max_iterations: 50,
+          current_phase: 'executing',
+          task_description: 'existing root ralph lane',
+          started_at: '2026-03-14T00:00:00.000Z',
+        }, null, 2),
+        'utf-8',
+      );
+
+      const result = runOmx(repo, ['autoresearch', missionDir]);
+      assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /Cannot start autoresearch: ralph is already active/i);
+
+      const worktreePath = join(repo, '..', `${basename(repo)}.omx-worktrees`, 'autoresearch-missions-demo');
+      assert.equal(existsSync(worktreePath), false, 'expected launch to abort before creating autoresearch worktree');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -287,9 +287,10 @@ EOF
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
-      const state = JSON.parse(await readFile(join(repo, '.omx', 'state', 'autoresearch-state.json'), 'utf-8')) as { active: boolean; current_phase?: string };
+      const state = JSON.parse(await readFile(join(repo, '.omx', 'state', 'autoresearch-state.json'), 'utf-8')) as {
+        active: boolean;
+      };
       assert.equal(state.active, false);
-      assert.equal(state.current_phase, 'cancelled');
 
       const logsRoot = join(repo, '.omx', 'logs', 'autoresearch');
       const [runId] = execFileSync('find', [logsRoot, '-mindepth', '1', '-maxdepth', '1', '-type', 'd', '-printf', '%f\n'], { encoding: 'utf-8' })
@@ -298,10 +299,23 @@ EOF
         .filter(Boolean);
       assert.ok(runId);
 
+      const manifest = JSON.parse(await readFile(join(logsRoot, runId, 'manifest.json'), 'utf-8')) as {
+        status: string;
+        stop_reason: string | null;
+        completed_at: string | null;
+      };
+      assert.equal(manifest.status, 'stopped');
+      assert.equal(manifest.stop_reason, 'repeated noop limit reached (3)');
+      assert.match(manifest.completed_at || '', /^\d{4}-\d{2}-\d{2}T/);
+
       const ledger = JSON.parse(await readFile(join(logsRoot, runId, 'iteration-ledger.json'), 'utf-8')) as {
         entries: Array<{ decision: string }>;
       };
       assert.deepEqual(ledger.entries.map((entry) => entry.decision), ['baseline', 'noop', 'noop', 'noop']);
+
+      const resumeResult = runOmx(repo, ['autoresearch', '--resume', runId]);
+      assert.notEqual(resumeResult.status, 0, resumeResult.stderr || resumeResult.stdout);
+      assert.match(`${resumeResult.stderr}\n${resumeResult.stdout}`, /autoresearch_resume_terminal_run/i);
     } finally {
       await rm(repo, { recursive: true, force: true });
       await rm(fakeBin, { recursive: true, force: true });

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -292,7 +292,7 @@ describe('resolveTeamWorkerLaunchArgsEnv (spark)', () => {
 
 describe('commandOwnsLocalHelp', () => {
   it('returns true for nested commands that render their own help output', () => {
-    for (const command of ['agents-init', 'ask', 'deepinit', 'hooks', 'hud', 'ralph', 'resume', 'session', 'sparkshell', 'team', 'tmux-hook']) {
+    for (const command of ['agents-init', 'ask', 'autoresearch', 'deepinit', 'hooks', 'hud', 'ralph', 'resume', 'session', 'sparkshell', 'team', 'tmux-hook']) {
       assert.equal(commandOwnsLocalHelp(command), true, `expected ${command} to own local help`);
     }
   });
@@ -315,6 +315,13 @@ describe('resolveCliInvocation', () => {
   it('resolves ask to ask command', () => {
     assert.deepEqual(resolveCliInvocation(['ask', 'claude', 'hello']), {
       command: 'ask',
+      launchArgs: [],
+    });
+  });
+
+  it('resolves autoresearch to autoresearch command', () => {
+    assert.deepEqual(resolveCliInvocation(['autoresearch', 'missions/demo']), {
+      command: 'autoresearch',
       launchArgs: [],
     });
   });

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -25,6 +25,7 @@ function runOmx(cwd: string, argv: string[]) {
 describe('nested help routing', () => {
   for (const [argv, expectedUsage] of [
     [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
+    [['autoresearch', '--help'], /Usage:\s*omx autoresearch <mission-dir>/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
     [['tmux-hook', '--help'], /Usage:\s*\n\s*omx tmux-hook init/i],

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -24,6 +24,7 @@ describe('omx session help', () => {
       const mainHelp = runOmx(cwd, ['--help']);
       assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
       assert.match(mainHelp.stdout, /omx resume\s+Resume a previous interactive Codex session/i);
+      assert.match(mainHelp.stdout, /omx autoresearch\s+Launch thin-supervisor autoresearch with keep\/discard\/reset parity/i);
       assert.match(mainHelp.stdout, /omx session\s+Search prior local session transcripts/i);
 
       const sessionHelp = runOmx(cwd, ['session', '--help']);

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -1,13 +1,15 @@
-import { execFileSync } from 'child_process';
-import { launchWithHud } from './index.js';
+import { execFileSync, spawnSync } from 'child_process';
+import { readFileSync } from 'fs';
 import { ensureWorktree, planWorktreeTarget } from '../team/worktree.js';
 import { loadAutoresearchMissionContract } from '../autoresearch/contracts.js';
 import {
+  countTrailingAutoresearchNoops,
   loadAutoresearchRunManifest,
   materializeAutoresearchMissionToWorktree,
   prepareAutoresearchRuntime,
   processAutoresearchCandidate,
   resumeAutoresearchRuntime,
+  stopAutoresearchRuntime,
   buildAutoresearchRunTag,
 } from '../autoresearch/runtime.js';
 import { assertModeStartAllowed } from '../modes/base.js';
@@ -31,6 +33,27 @@ Behavior:
 `;
 
 const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
+const AUTORESEARCH_MAX_CONSECUTIVE_NOOPS = 3;
+
+function runAutoresearchTurn(worktreePath: string, instructionsFile: string, codexArgs: string[]): void {
+  const prompt = readFileSync(instructionsFile, 'utf-8');
+  const launchArgs = ['exec', ...codexArgs, '-'];
+  const result = spawnSync('codex', launchArgs, {
+    cwd: worktreePath,
+    stdio: ['pipe', 'inherit', 'inherit'],
+    input: prompt,
+    encoding: 'utf-8',
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exitCode = typeof result.status === 'number' ? result.status : 1;
+    throw new Error(`autoresearch_codex_exec_failed:${result.status ?? 'unknown'}`);
+  }
+}
 
 export interface ParsedAutoresearchArgs {
   missionDir: string | null;
@@ -91,15 +114,20 @@ async function runAutoresearchLoop(
 
   try {
     while (true) {
-      process.chdir(runtime.worktreePath);
-      await launchWithHud(codexArgs);
-      process.chdir(originalCwd);
+      runAutoresearchTurn(runtime.worktreePath, runtime.instructionsFile, codexArgs);
 
       const contract = await loadAutoresearchMissionContract(missionDir);
       const manifest = await loadAutoresearchRunManifest(runtime.repoRoot, JSON.parse(execFileSync('cat', [runtime.manifestFile], { encoding: 'utf-8' })).run_id);
       const decision = await processAutoresearchCandidate(contract, manifest, runtime.repoRoot);
       if (decision === 'abort' || decision === 'error') {
         return;
+      }
+      if (decision === 'noop') {
+        const trailingNoops = await countTrailingAutoresearchNoops(manifest.ledger_file);
+        if (trailingNoops >= AUTORESEARCH_MAX_CONSECUTIVE_NOOPS) {
+          await stopAutoresearchRuntime(runtime.repoRoot);
+          return;
+        }
       }
       process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = runtime.instructionsFile;
     }

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -1,0 +1,149 @@
+import { execFileSync } from 'child_process';
+import { launchWithHud } from './index.js';
+import { ensureWorktree, planWorktreeTarget } from '../team/worktree.js';
+import { loadAutoresearchMissionContract } from '../autoresearch/contracts.js';
+import {
+  loadAutoresearchRunManifest,
+  materializeAutoresearchMissionToWorktree,
+  prepareAutoresearchRuntime,
+  processAutoresearchCandidate,
+  resumeAutoresearchRuntime,
+  buildAutoresearchRunTag,
+} from '../autoresearch/runtime.js';
+import { assertModeStartAllowed } from '../modes/base.js';
+
+export const AUTORESEARCH_HELP = `omx autoresearch - Launch OMX autoresearch with thin-supervisor parity semantics
+
+Usage:
+  omx autoresearch <mission-dir> [codex-args...]
+  omx autoresearch --resume <run-id> [codex-args...]
+
+Arguments:
+  <mission-dir>    Directory inside a git repository containing mission.md and sandbox.md
+  <run-id>         Existing autoresearch run id from .omx/logs/autoresearch/<run-id>/manifest.json
+
+Behavior:
+  - validates mission.md and sandbox.md
+  - requires sandbox.md YAML frontmatter with evaluator.command and evaluator.format=json
+  - fresh launch creates a run-tagged autoresearch/<slug>/<run-tag> lane
+  - supervisor records baseline, candidate, keep/discard/reset, and results artifacts under .omx/logs/autoresearch/
+  - --resume loads the authoritative per-run manifest and continues from the last kept commit
+`;
+
+const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
+
+export interface ParsedAutoresearchArgs {
+  missionDir: string | null;
+  runId: string | null;
+  codexArgs: string[];
+}
+
+function resolveRepoRoot(cwd: string): string {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+export function parseAutoresearchArgs(args: readonly string[]): ParsedAutoresearchArgs {
+  const values = [...args];
+  if (values.length === 0) {
+    throw new Error(`mission-dir is required.\n${AUTORESEARCH_HELP}`);
+  }
+  const first = values[0];
+  if (first === '--help' || first === '-h' || first === 'help') {
+    return { missionDir: '--help', runId: null, codexArgs: [] };
+  }
+  if (first === '--resume') {
+    const runId = values[1]?.trim();
+    if (!runId) {
+      throw new Error(`--resume requires <run-id>.\n${AUTORESEARCH_HELP}`);
+    }
+    return { missionDir: null, runId, codexArgs: values.slice(2) };
+  }
+  if (first.startsWith('--resume=')) {
+    const runId = first.slice('--resume='.length).trim();
+    if (!runId) {
+      throw new Error(`--resume requires <run-id>.\n${AUTORESEARCH_HELP}`);
+    }
+    return { missionDir: null, runId, codexArgs: values.slice(1) };
+  }
+  if (first.startsWith('-')) {
+    throw new Error(`mission-dir must be the first positional argument unless using --resume.\n${AUTORESEARCH_HELP}`);
+  }
+  return { missionDir: first, runId: null, codexArgs: values.slice(1) };
+}
+
+async function runAutoresearchLoop(
+  codexArgs: string[],
+  runtime: {
+    instructionsFile: string;
+    manifestFile: string;
+    repoRoot: string;
+    worktreePath: string;
+  },
+  missionDir: string,
+): Promise<void> {
+  const previousInstructionsFile = process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
+  const originalCwd = process.cwd();
+  process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = runtime.instructionsFile;
+
+  try {
+    while (true) {
+      process.chdir(runtime.worktreePath);
+      await launchWithHud(codexArgs);
+      process.chdir(originalCwd);
+
+      const contract = await loadAutoresearchMissionContract(missionDir);
+      const manifest = await loadAutoresearchRunManifest(runtime.repoRoot, JSON.parse(execFileSync('cat', [runtime.manifestFile], { encoding: 'utf-8' })).run_id);
+      const decision = await processAutoresearchCandidate(contract, manifest, runtime.repoRoot);
+      if (decision === 'abort' || decision === 'error') {
+        return;
+      }
+      process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = runtime.instructionsFile;
+    }
+  } finally {
+    process.chdir(originalCwd);
+    if (typeof previousInstructionsFile === 'string') {
+      process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = previousInstructionsFile;
+    } else {
+      delete process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
+    }
+  }
+}
+
+export async function autoresearchCommand(args: string[]): Promise<void> {
+  const parsed = parseAutoresearchArgs(args);
+  if (parsed.missionDir === '--help') {
+    console.log(AUTORESEARCH_HELP);
+    return;
+  }
+
+  if (parsed.runId) {
+    const repoRoot = resolveRepoRoot(process.cwd());
+    await assertModeStartAllowed('autoresearch', repoRoot);
+    const manifest = await loadAutoresearchRunManifest(repoRoot, parsed.runId);
+    const runtime = await resumeAutoresearchRuntime(repoRoot, parsed.runId);
+    await runAutoresearchLoop(parsed.codexArgs, runtime, manifest.mission_dir);
+    return;
+  }
+
+  const contract = await loadAutoresearchMissionContract(parsed.missionDir as string);
+  await assertModeStartAllowed('autoresearch', contract.repoRoot);
+  const runTag = buildAutoresearchRunTag();
+  const plan = planWorktreeTarget({
+    cwd: contract.repoRoot,
+    scope: 'autoresearch',
+    mode: { enabled: true, detached: false, name: contract.missionSlug },
+    worktreeTag: runTag,
+  });
+  const ensured = ensureWorktree(plan);
+  if (!ensured.enabled) {
+    throw new Error('autoresearch worktree planning unexpectedly disabled');
+  }
+
+  const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, ensured.worktreePath);
+  const runtime = await prepareAutoresearchRuntime(worktreeContract, contract.repoRoot, ensured.worktreePath, { runTag });
+  await runAutoresearchLoop(parsed.codexArgs, runtime, worktreeContract.missionDir);
+}

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -4,12 +4,12 @@ import { ensureWorktree, planWorktreeTarget } from '../team/worktree.js';
 import { loadAutoresearchMissionContract } from '../autoresearch/contracts.js';
 import {
   countTrailingAutoresearchNoops,
+  finalizeAutoresearchRunState,
   loadAutoresearchRunManifest,
   materializeAutoresearchMissionToWorktree,
   prepareAutoresearchRuntime,
   processAutoresearchCandidate,
   resumeAutoresearchRuntime,
-  stopAutoresearchRuntime,
   buildAutoresearchRunTag,
 } from '../autoresearch/runtime.js';
 import { assertModeStartAllowed } from '../modes/base.js';
@@ -125,7 +125,10 @@ async function runAutoresearchLoop(
       if (decision === 'noop') {
         const trailingNoops = await countTrailingAutoresearchNoops(manifest.ledger_file);
         if (trailingNoops >= AUTORESEARCH_MAX_CONSECUTIVE_NOOPS) {
-          await stopAutoresearchRuntime(runtime.repoRoot);
+          await finalizeAutoresearchRunState(runtime.repoRoot, manifest.run_id, {
+            status: 'stopped',
+            stopReason: `repeated noop limit reached (${AUTORESEARCH_MAX_CONSECUTIVE_NOOPS})`,
+          });
           return;
         }
       }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@ import { exploreCommand } from './explore.js';
 import { sparkshellCommand } from './sparkshell.js';
 import { agentsInitCommand } from './agents-init.js';
 import { sessionCommand } from './session-search.js';
+import { autoresearchCommand } from './autoresearch.js';
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -105,6 +106,7 @@ Usage:
                 Alias for agents-init (lightweight AGENTS bootstrap only)
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
   omx ralph     Launch Codex with ralph persistence mode active
+  omx autoresearch Launch thin-supervisor autoresearch with keep/discard/reset parity
   omx version   Show version information
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
   omx hooks     Manage hook plugins (init|status|validate|test)
@@ -156,6 +158,7 @@ const TEAM_WORKER_LAUNCH_ARGS_ENV = 'OMX_TEAM_WORKER_LAUNCH_ARGS';
 const TEAM_INHERIT_LEADER_FLAGS_ENV = 'OMX_TEAM_INHERIT_LEADER_FLAGS';
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = 'OMX_BYPASS_DEFAULT_SYSTEM_PROMPT';
 const OMX_MODEL_INSTRUCTIONS_FILE_ENV = 'OMX_MODEL_INSTRUCTIONS_FILE';
+const OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
 const REASONING_MODES = ['low', 'medium', 'high', 'xhigh'] as const;
 type ReasoningMode = typeof REASONING_MODES[number];
 const REASONING_MODE_SET = new Set<string>(REASONING_MODES);
@@ -171,6 +174,7 @@ type CliCommand = 'launch' | 'exec' | 'setup' | 'agents-init' | 'deepinit' | 'un
 
 const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   'ask',
+  'autoresearch',
   'agents-init',
   'deepinit',
   'exec',
@@ -479,7 +483,7 @@ export function buildHudPaneCleanupTargets(existingPaneIds: string[], createdPan
 
 export async function main(args: string[]): Promise<void> {
   const knownCommands = new Set([
-    'launch', 'exec', 'setup', 'agents-init', 'deepinit', 'uninstall', 'doctor', 'ask', 'explore', 'sparkshell', 'team', 'ralph', 'session', 'resume', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
+    'launch', 'exec', 'setup', 'agents-init', 'deepinit', 'uninstall', 'doctor', 'ask', 'autoresearch', 'explore', 'sparkshell', 'team', 'ralph', 'session', 'resume', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
   ]);
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
@@ -535,6 +539,9 @@ export async function main(args: string[]): Promise<void> {
       }
       case 'ask':
         await askCommand(args.slice(1));
+        break;
+      case 'autoresearch':
+        await autoresearchCommand(args.slice(1));
         break;
       case 'explore':
         await exploreCommand(args.slice(1));
@@ -1202,6 +1209,16 @@ export function buildDetachedSessionRollbackSteps(
 }
 
 
+async function readAutoresearchAppendInstructions(): Promise<string> {
+  const appendixPath = process.env[OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV]?.trim();
+  if (!appendixPath) return '';
+  if (!existsSync(appendixPath)) {
+    throw new Error(`autoresearch instructions file not found: ${appendixPath}`);
+  }
+  const { readFile } = await import('fs/promises');
+  return (await readFile(appendixPath, 'utf-8')).trim();
+}
+
 export function buildNotifyTempStartupMessages(
   contract: NotifyTempContract,
   hasValidProviders: boolean,
@@ -1245,7 +1262,13 @@ async function preLaunch(cwd: string, sessionId: string, notifyTempContract?: No
   // 2. Generate runtime overlay + write session-scoped model instructions file
   const orchestrationMode = await resolveSessionOrchestrationMode(cwd, sessionId);
   const overlay = await generateOverlay(cwd, sessionId, { orchestrationMode });
-  await writeSessionModelInstructionsFile(cwd, sessionId, overlay);
+  const autoresearchAppendix = await readAutoresearchAppendInstructions();
+  const sessionInstructions = autoresearchAppendix
+    ? `${overlay}
+
+${autoresearchAppendix}`
+    : overlay;
+  await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
 
   // 3. Write session state
   await resetSessionMetrics(cwd);

--- a/src/compat/fixtures/help.stdout.txt
+++ b/src/compat/fixtures/help.stdout.txt
@@ -9,6 +9,7 @@ Usage:
   omx doctor    Check installation health
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx autoresearch Launch thin-supervisor autoresearch with keep/discard/reset parity
   omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]

--- a/src/modes/__tests__/base-autoresearch-contract.test.ts
+++ b/src/modes/__tests__/base-autoresearch-contract.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readModeState, startMode } from '../base.js';
+
+describe('modes/base autoresearch contract integration', () => {
+  it('startMode blocks autoresearch when ralph is active', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autoresearch-contract-'));
+    try {
+      await startMode('ralph', 'demo', 5, wd);
+      await assert.rejects(
+        () => startMode('autoresearch', 'demo mission', 1, wd),
+        /Cannot start autoresearch: ralph is already active/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('startMode persists autoresearch state when no exclusive conflict exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autoresearch-contract-'));
+    try {
+      const started = await startMode('autoresearch', 'demo mission', 1, wd);
+      assert.equal(started.mode, 'autoresearch');
+      assert.equal(started.active, true);
+      assert.equal(started.current_phase, 'starting');
+      const persisted = await readModeState('autoresearch', wd);
+      assert.equal(persisted?.mode, 'autoresearch');
+      assert.equal(persisted?.task_description, 'demo mission');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -23,7 +23,7 @@ export interface ModeState {
   [key: string]: unknown;
 }
 
-export type ModeName = 'autopilot' | 'ralph' | 'ultrawork' | 'team' | 'ultraqa' | 'ralplan';
+export type ModeName = 'autopilot' | 'autoresearch' | 'ralph' | 'ultrawork' | 'team' | 'ultraqa' | 'ralplan';
 
 /** @deprecated These mode names were removed in v4.6. Use the canonical modes instead. */
 export type DeprecatedModeName = 'ultrapilot' | 'pipeline' | 'ecomode';
@@ -44,7 +44,7 @@ export function getDeprecationWarning(mode: string): string | null {
   return `[DEPRECATED] Mode "${mode}" is deprecated. ${warning}`;
 }
 
-const EXCLUSIVE_MODES: ModeName[] = ['autopilot', 'ralph', 'ultrawork'];
+const EXCLUSIVE_MODES: ModeName[] = ['autopilot', 'autoresearch', 'ralph', 'ultrawork'];
 
 function normalizeRalphModeStateOrThrow(state: ModeState): ModeState {
   const originalPhase = state.current_phase;
@@ -71,6 +71,33 @@ function statePath(mode: string, projectRoot?: string): string {
   return join(stateDir(projectRoot), `${mode}-state.json`);
 }
 
+export async function assertModeStartAllowed(
+  mode: ModeName,
+  projectRoot?: string,
+): Promise<void> {
+  if (!EXCLUSIVE_MODES.includes(mode)) return;
+
+  for (const other of EXCLUSIVE_MODES) {
+    if (other === mode) continue;
+    const otherPath = statePath(other, projectRoot);
+    if (!existsSync(otherPath)) continue;
+    try {
+      const raw = await readFile(otherPath, 'utf-8');
+      const otherState = JSON.parse(raw) as { active?: unknown };
+      if (otherState.active) {
+        throw new Error(`Cannot start ${mode}: ${other} is already active. Run cancel first.`);
+      }
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      if (err?.message.includes('Cannot start')) throw err;
+      if (err?.code === 'ENOENT') continue;
+      throw new Error(
+        `Cannot start ${mode}: ${other} state file is malformed or unreadable (${otherPath}). Run cancel or repair the state file.`
+      );
+    }
+  }
+}
+
 /**
  * Start a mode. Checks for exclusive mode conflicts.
  */
@@ -83,29 +110,7 @@ export async function startMode(
   const dir = stateDir(projectRoot);
   await mkdir(dir, { recursive: true });
 
-  // Check for exclusive mode conflicts
-  if (EXCLUSIVE_MODES.includes(mode)) {
-    for (const other of EXCLUSIVE_MODES) {
-      if (other === mode) continue;
-      const otherPath = statePath(other, projectRoot);
-      if (existsSync(otherPath)) {
-        try {
-          const raw = await readFile(otherPath, 'utf-8');
-          const otherState = JSON.parse(raw) as { active?: unknown };
-          if (otherState.active) {
-            throw new Error(`Cannot start ${mode}: ${other} is already active. Run cancel first.`);
-          }
-        } catch (e) {
-          const err = e as NodeJS.ErrnoException;
-          if (err?.message.includes('Cannot start')) throw err;
-          if (err?.code === 'ENOENT') continue;
-          throw new Error(
-            `Cannot start ${mode}: ${other} state file is malformed or unreadable (${otherPath}). Run cancel or repair the state file.`
-          );
-        }
-      }
-    }
-  }
+  await assertModeStartAllowed(mode, projectRoot);
 
   const stateBase: ModeState = {
     active: true,

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -26,8 +26,17 @@ import {
 
 async function setupTeam(name: string): Promise<{ cwd: string; cleanup: () => Promise<void> }> {
   const cwd = await mkdtemp(join(tmpdir(), `omx-interop-${name}-`));
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
   await initTeamState(name, 'test task', 'executor', 2, cwd);
-  return { cwd, cleanup: () => rm(cwd, { recursive: true, force: true }) };
+  return {
+    cwd,
+    cleanup: async () => {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+    },
+  };
 }
 
 // ─── resolveTeamApiOperation ──────────────────────────────────────────────

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1311,11 +1311,10 @@ process.on('SIGTERM', () => process.exit(0));
 
   it('resumeTeam preserves detached worktree metadata for live prompt workers', async () => {
     const repo = await initRepo();
-    const binDir = join(repo, 'bin');
+    const binDir = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-bin-'));
     const fakeCodexPath = join(binDir, 'codex');
-    const logDir = join(repo, 'worker-logs');
+    const logDir = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-logs-'));
     const envLogPath = join(logDir, 'env.json');
-    await mkdir(binDir, { recursive: true });
     await writeFile(
       fakeCodexPath,
       `#!/usr/bin/env node
@@ -1414,6 +1413,8 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevLogDir === 'string') process.env.OMX_TEST_LOG_DIR = prevLogDir;
       else delete process.env.OMX_TEST_LOG_DIR;
+      await rm(binDir, { recursive: true, force: true });
+      await rm(logDir, { recursive: true, force: true });
       await rm(repo, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -617,6 +617,40 @@ sleep 5
     }
   });
 
+  it('startTeam rejects dirty leader workspace before provisioning worker worktrees', async () => {
+    const repo = await initRepo();
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    await writeFile(join(repo, 'README.md'), 'dirty\n', 'utf-8');
+    await writeFile(join(repo, 'notes.txt'), 'local only\n', 'utf-8');
+    try {
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      await assert.rejects(
+        () => withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-dirty-preflight',
+            'reject dirty leader workspace',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )),
+        /leader_workspace_dirty_for_worktrees:.*M README\.md.*\?\? notes\.txt.*commit_or_stash_before_omx_team/s,
+      );
+
+      const listedWorktrees = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+        cwd: repo,
+        encoding: 'utf-8',
+      });
+      assert.doesNotMatch(listedWorktrees, /team-team-dirty-preflight-worker-1/);
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'team', 'team-dirty-preflight')), false);
+    } finally {
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam launches gemini workers with startup prompt and no default model passthrough', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-gemini-'));
     const binDir = join(cwd, 'bin');
@@ -1098,9 +1132,10 @@ exit 0
 
   it('startTeam routes detached worktree worker inbox and mailbox triggers through leader-root state references', async () => {
     const repo = await initRepo();
-    const binDir = join(repo, 'bin');
+    const toolingDir = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-tools-'));
+    const binDir = join(toolingDir, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
-    const logDir = join(repo, 'worker-logs');
+    const logDir = join(toolingDir, 'worker-logs');
     const stdinLogPath = join(logDir, 'stdin.log');
     const envLogPath = join(logDir, 'env.json');
     await mkdir(binDir, { recursive: true });
@@ -1203,13 +1238,15 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevLogDir === 'string') process.env.OMX_TEST_LOG_DIR = prevLogDir;
       else delete process.env.OMX_TEST_LOG_DIR;
+      await rm(toolingDir, { recursive: true, force: true });
       await rm(repo, { recursive: true, force: true });
     }
   });
 
   it('shutdownTeam removes team-created detached worktrees on normal shutdown', async () => {
     const repo = await initRepo();
-    const binDir = join(repo, 'bin');
+    const toolingDir = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-tools-'));
+    const binDir = join(toolingDir, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
     await mkdir(binDir, { recursive: true });
     await writeFile(
@@ -1267,6 +1304,7 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
       if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(toolingDir, { recursive: true, force: true });
       await rm(repo, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/shutdown-fallback.test.ts
+++ b/src/team/__tests__/shutdown-fallback.test.ts
@@ -31,9 +31,8 @@ function withoutTeamWorkerEnv<T>(fn: () => Promise<T>): Promise<T> {
 describe('shutdown fallback worktree reports', () => {
   it('shutdownTeam checkpoints dirty detached worker worktrees, merges them, and writes a report', async () => {
     const repo = await initRepo();
-    const binDir = join(repo, 'bin');
+    const binDir = await mkdtemp(join(tmpdir(), 'omx-shutdown-fallback-bin-'));
     const fakeCodexPath = join(binDir, 'codex');
-    await mkdir(binDir, { recursive: true });
     await writeFile(
       fakeCodexPath,
       `#!/usr/bin/env node
@@ -104,6 +103,7 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
       if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(binDir, { recursive: true, force: true }).catch(() => {});
       if (preservedWorktreePath) {
         await rm(preservedWorktreePath, { recursive: true, force: true }).catch(() => {});
       }

--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -90,6 +90,27 @@ describe('worktree parser', () => {
   });
 });
 
+describe('worktree planning', () => {
+  it('plans dedicated autoresearch branch and path naming', async () => {
+    const repo = await initRepo();
+    try {
+      const planned = planWorktreeTarget({
+        cwd: repo,
+        scope: 'autoresearch' as never,
+        mode: { enabled: true, detached: false, name: 'demo-mission' },
+        worktreeTag: '20260314T000000Z',
+      });
+      assert.equal(planned.enabled, true);
+      if (!planned.enabled) return;
+
+      assert.equal(planned.branchName, 'autoresearch/demo-mission/20260314t000000z');
+      assert.match(planned.worktreePath.replace(/\\/g, '/'), /\.omx-worktrees\/autoresearch-demo-mission-20260314t000000z$/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('worktree ensure + rollback', () => {
   it('creates and reuses detached worktree idempotently', async () => {
     const repo = await initRepo();

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -113,6 +113,7 @@ import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
 import { buildRebalanceDecisions } from './rebalance-policy.js';
 import { readModeState, updateModeState } from '../modes/base.js';
 import {
+  assertCleanLeaderWorkspaceForWorkerWorktrees,
   ensureWorktree,
   isGitRepository,
   planWorktreeTarget,
@@ -1184,6 +1185,7 @@ export async function startTeam(
   }
 
   if (activeWorktreeMode) {
+    assertCleanLeaderWorkspaceForWorkerWorktrees(leaderCwd);
     for (let i = 1; i <= workerCount; i++) {
       const workerName = `worker-${i}`;
       const planned = planWorktreeTarget({

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -17,15 +17,16 @@ export interface ParsedWorktreeMode {
 
 export interface WorktreePlanInput {
   cwd: string;
-  scope: 'launch' | 'team';
+  scope: 'launch' | 'team' | 'autoresearch';
   mode: WorktreeMode;
   teamName?: string;
   workerName?: string;
+  worktreeTag?: string;
 }
 
 export interface PlannedWorktreeTarget {
   enabled: true;
-  scope: 'launch' | 'team';
+  scope: 'launch' | 'team' | 'autoresearch';
   repoRoot: string;
   worktreePath: string;
   detached: boolean;
@@ -118,6 +119,30 @@ function isWorktreeDirty(worktreePath: string): boolean {
   return (result.stdout || '').trim() !== '';
 }
 
+export function readWorkspaceStatusLines(cwd: string): string[] {
+  const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
+    cwd,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    throw new Error(stderr || `workspace_status_failed:${cwd}`);
+  }
+  return (result.stdout || '')
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean);
+}
+
+export function assertCleanLeaderWorkspaceForWorkerWorktrees(cwd: string): void {
+  const lines = readWorkspaceStatusLines(cwd);
+  if (lines.length === 0) return;
+  const preview = lines.slice(0, 8).join(' | ');
+  throw new Error(
+    `leader_workspace_dirty_for_worktrees:${resolve(cwd)}:${preview}:commit_or_stash_before_omx_team`,
+  );
+}
+
 function listWorktrees(repoRoot: string): GitWorktreeEntry[] {
   const raw = readGit(repoRoot, ['worktree', 'list', '--porcelain']);
   if (!raw) return [];
@@ -156,6 +181,11 @@ function resolveBranchName(input: WorktreePlanInput): string | null {
     return input.mode.name;
   }
 
+  if (input.scope === 'autoresearch') {
+    const runTag = sanitizePathToken(input.worktreeTag || 'run');
+    return `autoresearch/${sanitizePathToken(input.mode.name)}/${runTag}`;
+  }
+
   const workerName = (input.workerName || '').trim();
   if (!workerName) {
     throw new Error('team_worktree_worker_name_required');
@@ -173,6 +203,14 @@ function resolveWorktreePath(input: WorktreePlanInput, repoRoot: string): string
       return join(parent, bucket, 'launch-detached');
     }
     return join(parent, bucket, `launch-${sanitizePathToken(input.mode.name)}`);
+  }
+
+  if (input.scope === 'autoresearch') {
+    if (!input.mode.enabled || input.mode.detached) {
+      throw new Error('autoresearch_worktree_requires_named_mode');
+    }
+    const runTag = sanitizePathToken(input.worktreeTag || 'run');
+    return join(parent, bucket, `autoresearch-${sanitizePathToken(input.mode.name)}-${runTag}`);
   }
 
   const teamName = sanitizePathToken(input.teamName || 'team');


### PR DESCRIPTION
Draft re-opening of the autoresearch implementation from accidentally merged PR #847.

Why this targets the revert branch for now:
- `dev` still contains the accidentally merged changes.
- This draft is based on the revert branch so the actual fix diff is reviewable immediately.
- After the revert PR merges, this draft can be retargeted back to `dev`.

Includes:
- autoresearch runtime/CLI implementation
- repeated-noop stop safeguard
- noop terminalization lifecycle fix
- CI-fix test isolation for dirty-worktree helper artifacts

Latest locally verified evidence before reopening:
- `npm test`
- `npm run coverage:team-critical`
- `npm run coverage:ts:full`
