### PR TITLE
fix(cli): harden Windows psmux detached bootstrap

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -659,11 +659,12 @@ describe('detached tmux new-session sequencing', () => {
   });
 
   it('buildDetachedSessionBootstrapSteps starts native Windows detached sessions with powershell', () => {
+    const hudCmd = buildWindowsPromptCommand('node', ['omx.js', 'hud', '--watch']);
     const steps = buildDetachedSessionBootstrapSteps(
       'omx-demo',
       'C:/project',
       "'codex' '--dangerously-bypass-approvals-and-sandbox'",
-      "'node' 'omx.js' 'hud' '--watch'",
+      hudCmd,
       '--model gpt-5',
       'C:/codex-home',
       null,
@@ -671,6 +672,8 @@ describe('detached tmux new-session sequencing', () => {
     );
     assert.equal(steps[0]?.name, 'new-session');
     assert.equal(steps[0]?.args.at(-1), 'powershell.exe');
+    assert.equal(steps[1]?.name, 'split-and-capture-hud-pane');
+    assert.equal(steps[1]?.args.at(-1), hudCmd);
   });
 
   it('buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach', () => {
@@ -779,10 +782,18 @@ describe('buildTmuxPaneCommand', () => {
 });
 
 describe('buildWindowsPromptCommand', () => {
-  it('quotes detached Windows codex commands for PowerShell prompt injection', () => {
+  it('encodes detached Windows commands for safe PowerShell prompt injection', () => {
+    const result = buildWindowsPromptCommand(
+      'codex',
+      ['--dangerously-bypass-approvals-and-sandbox', '-c', 'model_reasoning_effort="high"', "it's"],
+    );
+    const prefix = 'powershell.exe -NoLogo -NoExit -EncodedCommand ';
+    assert.ok(result.startsWith(prefix));
+    const payload = result.slice(prefix.length);
+    const decoded = Buffer.from(payload, 'base64').toString('utf16le');
     assert.equal(
-      buildWindowsPromptCommand('codex', ['--dangerously-bypass-approvals-and-sandbox', '-c', 'model_reasoning_effort="high"', "it's"]),
-      "& 'codex' '--dangerously-bypass-approvals-and-sandbox' '-c' 'model_reasoning_effort=\"high\"' 'it''s'",
+      decoded,
+      "$ErrorActionPreference = 'Stop'; & { & 'codex' '--dangerously-bypass-approvals-and-sandbox' '-c' 'model_reasoning_effort=\"high\"' 'it''s' }",
     );
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -169,6 +169,7 @@ const ALLOWED_SHELLS = new Set([
   '/usr/local/bin/bash', '/usr/local/bin/zsh', '/usr/local/bin/fish',
 ]);
 const WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS = 2500;
+const CODEX_VERSION_FLAGS = new Set(['--version', '-V']);
 
 type CliCommand = 'launch' | 'exec' | 'setup' | 'agents-init' | 'deepinit' | 'uninstall' | 'doctor' | 'ask' | 'explore' | 'sparkshell' | 'team' | 'session' | 'resume' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
 
@@ -1351,8 +1352,11 @@ function runCodex(
     process.env,
     sessionModelInstructionsPath(cwd, sessionId),
   );
+  const nativeWindows = isNativeWindows();
   const omxBin = process.argv[1];
-  const hudCmd = buildTmuxPaneCommand('node', [omxBin, 'hud', '--watch']);
+  const hudCmd = nativeWindows
+    ? buildWindowsPromptCommand('node', [omxBin, 'hud', '--watch'])
+    : buildTmuxPaneCommand('node', [omxBin, 'hud', '--watch']);
   const inheritLeaderFlags = process.env[TEAM_INHERIT_LEADER_FLAGS_ENV] !== '0';
   const workerLaunchArgs = resolveTeamWorkerLaunchArgsEnv(
     process.env[TEAM_WORKER_LAUNCH_ARGS_ENV],
@@ -1371,6 +1375,11 @@ function runCodex(
     : codexEnv;
 
   const launchPolicy = resolveCodexLaunchPolicy(process.env);
+
+  if (isCodexVersionRequest(launchArgs)) {
+    runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+    return;
+  }
 
   if (launchPolicy === 'inside-tmux') {
     // Already in tmux: launch codex in current pane, HUD in bottom split
@@ -1423,7 +1432,6 @@ function runCodex(
     runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
   } else {
     // Not in tmux: create a new tmux session with codex + HUD pane
-    const nativeWindows = isNativeWindows();
     const codexCmd = buildTmuxPaneCommand('codex', launchArgs);
     const detachedWindowsCodexCmd = nativeWindows
       ? buildWindowsPromptCommand('codex', launchArgs)
@@ -1552,8 +1560,21 @@ export function buildTmuxShellCommand(command: string, args: string[]): string {
   return [quoteShellArg(command), ...args.map(quoteShellArg)].join(' ');
 }
 
+function encodePowerShellCommand(commandText: string): string {
+  return Buffer.from(commandText, 'utf16le').toString('base64');
+}
+
+function isCodexVersionRequest(args: string[]): boolean {
+  return args.some((arg) => CODEX_VERSION_FLAGS.has(arg));
+}
+
 export function buildWindowsPromptCommand(command: string, args: string[]): string {
-  return ['&', quotePowerShellArg(command), ...args.map(quotePowerShellArg)].join(' ');
+  const invocation = ['&', quotePowerShellArg(command), ...args.map(quotePowerShellArg)].join(' ');
+  const wrappedCommand = [
+    "$ErrorActionPreference = 'Stop'",
+    `& { ${invocation} }`,
+  ].join('; ');
+  return `powershell.exe -NoLogo -NoExit -EncodedCommand ${encodePowerShellCommand(wrappedCommand)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- switch native Windows detached pane commands to PowerShell encoded commands
- use the Windows prompt command for the HUD pane and bypass detached tmux bootstrap for Codex version requests
- update CLI tests to decode and verify the encoded PowerShell payload

Closes #853