### PR TITLE
fix(autoresearch): exclude .omx/ runtime files from worktree clean check

### DIFF
--- a/src/autoresearch/__tests__/runtime.test.ts
+++ b/src/autoresearch/__tests__/runtime.test.ts
@@ -75,6 +75,21 @@ describe('autoresearch runtime', () => {
     }
   });
 
+  it('allows untracked .omx runtime files when checking reset safety', async () => {
+    const repo = await initRepo();
+    try {
+      await mkdir(join(repo, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(repo, '.omx', 'state'), { recursive: true });
+      await writeFile(join(repo, '.omx', 'logs', 'hooks-2026-03-15.jsonl'), '{}\n', 'utf-8');
+      await writeFile(join(repo, '.omx', 'metrics.json'), '{}\n', 'utf-8');
+      await writeFile(join(repo, '.omx', 'state', 'hud-state.json'), '{}\n', 'utf-8');
+
+      assert.doesNotThrow(() => assertResetSafeWorktree(repo));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('prepares runtime artifacts and persists autoresearch mode state', async () => {
     const repo = await initRepo();
     try {

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -129,7 +129,7 @@ interface AutoresearchInstructionLedgerSummary {
 }
 
 const AUTORESEARCH_RESULTS_HEADER = 'iteration\tcommit\tpass\tscore\tstatus\tdescription\n';
-const AUTORESEARCH_WORKTREE_EXCLUDES = ['results.tsv', 'run.log', 'node_modules'];
+const AUTORESEARCH_WORKTREE_EXCLUDES = ['results.tsv', 'run.log', 'node_modules', '.omx/'];
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -246,7 +246,9 @@ function isAllowedRuntimeDirtyLine(line: string): boolean {
   const trimmed = line.trim();
   if (trimmed.length < 4) return false;
   const path = trimmed.slice(3).trim();
-  return trimmed.startsWith('?? ') && AUTORESEARCH_WORKTREE_EXCLUDES.includes(path);
+  return trimmed.startsWith('?? ') && AUTORESEARCH_WORKTREE_EXCLUDES.some((exclude) => exclude.endsWith('/')
+    ? path.startsWith(exclude) || path === exclude.slice(0, -1)
+    : path === exclude);
 }
 
 export function assertResetSafeWorktree(worktreePath: string): void {


### PR DESCRIPTION
## Summary
- add `.omx/` to autoresearch worktree excludes and ensure runtime exclude writing includes it
- allow directory excludes in reset-safe dirty-line matching via exact or prefix checks
- add a regression test covering untracked `.omx/` runtime files

Closes #857