### PR TITLE
fix(setup): deduplicate skills across project and user scope

### DIFF
--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -501,6 +501,42 @@ describe('session-scoped model instructions file', () => {
     assert.equal(projectAfter, projectContent);
   });
 
+  it('deduplicates duplicate skill references when project and user scopes both install the same skill', async () => {
+    const userAgentsMd = join(tempDir, 'home', '.codex', 'AGENTS.md');
+    const projectAgentsMd = join(tempDir, 'AGENTS.md');
+    const userSkillDir = join(tempDir, 'home', '.codex', 'skills', 'help');
+    const projectSkillDir = join(tempDir, '.agents', 'skills', 'help');
+    await mkdir(join(tempDir, 'home', '.codex'), { recursive: true });
+    await mkdir(userSkillDir, { recursive: true });
+    await mkdir(projectSkillDir, { recursive: true });
+    await writeFile(join(userSkillDir, 'SKILL.md'), '# user help\n');
+    await writeFile(join(projectSkillDir, 'SKILL.md'), '# project help\n');
+    await writeFile(
+      userAgentsMd,
+      [
+        '# User instructions',
+        '',
+        '- help: user copy (file: /tmp/home/.codex/skills/help/SKILL.md)',
+      ].join('\n'),
+    );
+    await writeFile(
+      projectAgentsMd,
+      [
+        '# Project instructions',
+        '',
+        '- help: project copy (file: /tmp/project/.agents/skills/help/SKILL.md)',
+      ].join('\n'),
+    );
+
+    const overlay = await generateOverlay(tempDir, 'session-dedupe');
+    const writtenPath = await writeSessionModelInstructionsFile(tempDir, 'session-dedupe', overlay);
+    const sessionContent = await readFile(writtenPath, 'utf-8');
+
+    assert.equal((sessionContent.match(/skills\/help\/SKILL\.md/g) || []).length, 1);
+    assert.doesNotMatch(sessionContent, /user copy/);
+    assert.match(sessionContent, /project copy/);
+  });
+
   it('writes overlay-only session file when no base AGENTS.md files exist', async () => {
     await rm(join(tempDir, 'home'), { recursive: true, force: true });
     await rm(join(tempDir, 'AGENTS.md'), { force: true });

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -19,6 +19,7 @@ import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 import {
   codexHome,
+  listInstalledSkillDirectories,
   omxNotepadPath,
   omxProjectMemoryPath,
   packageRoot,
@@ -34,6 +35,7 @@ const END_MARKER = '<!-- OMX:RUNTIME:END -->';
 const WORKER_START_MARKER = '<!-- OMX:TEAM:WORKER:START -->';
 const WORKER_END_MARKER = '<!-- OMX:TEAM:WORKER:END -->';
 const MAX_OVERLAY_SIZE = 3500;
+const SKILL_REFERENCE_PATTERN = /\/skills\/([^/\s`]+)\/SKILL\.md\b/g;
 
 // ── Lock helpers ─────────────────────────────────────────────────────────────
 
@@ -496,6 +498,27 @@ export function sessionModelInstructionsPath(cwd: string, sessionId: string): st
   return join(getStateDir(cwd, sessionId), 'AGENTS.md');
 }
 
+function dropShadowedSkillReferenceLines(
+  content: string,
+  shadowedSkillNames: ReadonlySet<string>,
+): string {
+  if (shadowedSkillNames.size === 0) return content;
+
+  const lines = content.split('\n');
+  const keptLines = lines.filter((line) => {
+    SKILL_REFERENCE_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = SKILL_REFERENCE_PATTERN.exec(line)) !== null) {
+      if (shadowedSkillNames.has(match[1] || '')) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  return keptLines.join('\n');
+}
+
 /**
  * Build a session-scoped AGENTS.md that combines user-level CODEX_HOME
  * instructions, project instructions (if any), and the runtime overlay,
@@ -515,6 +538,12 @@ export async function writeSessionModelInstructionsFile(
     join(cwd, 'AGENTS.md'),
   ];
   const seenPaths = new Set<string>();
+  const installedSkills = await listInstalledSkillDirectories(cwd);
+  const projectSkillNames = new Set(
+    installedSkills
+      .filter((skill) => skill.scope === 'project')
+      .map((skill) => skill.name),
+  );
 
   for (const sourcePath of sourcePaths) {
     if (seenPaths.has(sourcePath) || !existsSync(sourcePath)) continue;
@@ -522,6 +551,9 @@ export async function writeSessionModelInstructionsFile(
 
     let content = await readFile(sourcePath, 'utf-8');
     content = stripOverlayContent(content).trim();
+    if (sourcePath === join(codexHome(), 'AGENTS.md')) {
+      content = dropShadowedSkillReferenceLines(content, projectSkillNames).trim();
+    }
     if (!content) continue;
     baseParts.push(content);
   }

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -414,6 +414,36 @@ describe('worker bootstrap', () => {
     }
   });
 
+  it('writeTeamWorkerInstructionsFile deduplicates duplicate skill references in favor of project scope', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-worker-bootstrap-'));
+    const restoreCodexHome = setMockCodexHome(join(cwd, 'home', '.codex'));
+    try {
+      const userAgentsPath = join(cwd, 'home', '.codex', 'AGENTS.md');
+      const projectAgentsPath = join(cwd, 'AGENTS.md');
+      const userSkillDir = join(cwd, 'home', '.codex', 'skills', 'help');
+      const projectSkillDir = join(cwd, '.agents', 'skills', 'help');
+
+      await mkdir(join(cwd, 'home', '.codex'), { recursive: true });
+      await mkdir(userSkillDir, { recursive: true });
+      await mkdir(projectSkillDir, { recursive: true });
+      await writeFile(join(userSkillDir, 'SKILL.md'), '# user help\n', 'utf8');
+      await writeFile(join(projectSkillDir, 'SKILL.md'), '# project help\n', 'utf8');
+      await writeFile(userAgentsPath, '- help user (file: /tmp/home/.codex/skills/help/SKILL.md)\n', 'utf8');
+      await writeFile(projectAgentsPath, '- help project (file: /tmp/project/.agents/skills/help/SKILL.md)\n', 'utf8');
+
+      const overlay = generateWorkerOverlay('dedupe-team');
+      const outPath = await writeTeamWorkerInstructionsFile('dedupe-team', cwd, overlay);
+      const content = await readFile(outPath, 'utf8');
+
+      assert.equal((content.match(/skills\/help\/SKILL\.md/g) || []).length, 1);
+      assert.doesNotMatch(content, /help user/);
+      assert.match(content, /help project/);
+    } finally {
+      restoreCodexHome();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
 
   it('writeWorkerRoleInstructionsFile layers role prompt on top of team worker instructions', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-worker-bootstrap-'));

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -2,11 +2,12 @@ import type { TeamTask } from './state.js';
 import { mkdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { getFixLoopInstructions, getVerificationInstructions } from '../verification/verifier.js';
-import { codexHome } from '../utils/paths.js';
+import { codexHome, listInstalledSkillDirectories } from '../utils/paths.js';
 import { sleep } from '../utils/sleep.js';
 
 const TEAM_OVERLAY_START = '<!-- OMX:TEAM:WORKER:START -->';
 const TEAM_OVERLAY_END = '<!-- OMX:TEAM:WORKER:END -->';
+const SKILL_REFERENCE_PATTERN = /\/skills\/([^/\s`]+)\/SKILL\.md\b/g;
 const AGENTS_LOCK_PATH = ['.omx', 'state', 'agents-md.lock'];
 const LOCK_OWNER_FILE = 'owner.json';
 const LOCK_TIMEOUT_MS = 5000;
@@ -148,6 +149,27 @@ function stripOverlayFromContent(content: string): string {
   return before + (after ? '\n\n' + after : '') + '\n';
 }
 
+function dropShadowedSkillReferenceLines(
+  content: string,
+  shadowedSkillNames: ReadonlySet<string>,
+): string {
+  if (shadowedSkillNames.size === 0) return content;
+
+  const lines = content.split('\n');
+  const keptLines = lines.filter((line) => {
+    SKILL_REFERENCE_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = SKILL_REFERENCE_PATTERN.exec(line)) !== null) {
+      if (shadowedSkillNames.has(match[1] || '')) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  return keptLines.join('\n');
+}
+
 /**
  * Write a team-scoped model instructions file that composes user-level
  * CODEX_HOME AGENTS.md, the project's AGENTS.md (if any), and the worker
@@ -161,11 +183,18 @@ export async function writeTeamWorkerInstructionsFile(
   overlay: string,
 ): Promise<string> {
   const baseParts: string[] = [];
+  const userAgentsPath = join(codexHome(), 'AGENTS.md');
   const sourcePaths = [
-    join(codexHome(), 'AGENTS.md'),
+    userAgentsPath,
     join(cwd, 'AGENTS.md'),
   ];
   const seenPaths = new Set<string>();
+  const installedSkills = await listInstalledSkillDirectories(cwd);
+  const projectSkillNames = new Set(
+    installedSkills
+      .filter((skill) => skill.scope === 'project')
+      .map((skill) => skill.name),
+  );
 
   for (const sourcePath of sourcePaths) {
     if (seenPaths.has(sourcePath)) continue;
@@ -179,6 +208,9 @@ export async function writeTeamWorkerInstructionsFile(
     }
 
     content = stripOverlayFromContent(content).trim();
+    if (sourcePath === userAgentsPath) {
+      content = dropShadowedSkillReferenceLines(content, projectSkillNames).trim();
+    }
     if (!content) continue;
     baseParts.push(content);
   }

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { join } from 'path';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { existsSync } from 'fs';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
 import {
   codexHome,
   codexConfigPath,
@@ -10,6 +11,7 @@ import {
   userSkillsDir,
   legacyUserSkillsDir,
   projectSkillsDir,
+  listInstalledSkillDirectories,
   omxStateDir,
   omxProjectMemoryPath,
   omxNotepadPath,
@@ -120,6 +122,63 @@ describe('projectSkillsDir', () => {
 
   it('defaults to cwd when no projectRoot given', () => {
     assert.equal(projectSkillsDir(), join(process.cwd(), '.agents', 'skills'));
+  });
+});
+
+describe('listInstalledSkillDirectories', () => {
+  let originalCodexHome: string | undefined;
+
+  beforeEach(() => {
+    originalCodexHome = process.env.CODEX_HOME;
+  });
+
+  afterEach(() => {
+    if (typeof originalCodexHome === 'string') {
+      process.env.CODEX_HOME = originalCodexHome;
+    } else {
+      delete process.env.CODEX_HOME;
+    }
+  });
+
+  it('deduplicates by skill name and prefers project skills over user skills', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'omx-paths-project-'));
+    const codexHomeRoot = await mkdtemp(join(tmpdir(), 'omx-paths-codex-'));
+    process.env.CODEX_HOME = codexHomeRoot;
+
+    try {
+      const projectHelpDir = join(projectRoot, '.agents', 'skills', 'help');
+      const projectOnlyDir = join(projectRoot, '.agents', 'skills', 'project-only');
+      const userHelpDir = join(codexHomeRoot, 'skills', 'help');
+      const userOnlyDir = join(codexHomeRoot, 'skills', 'user-only');
+
+      await mkdir(projectHelpDir, { recursive: true });
+      await mkdir(projectOnlyDir, { recursive: true });
+      await mkdir(userHelpDir, { recursive: true });
+      await mkdir(userOnlyDir, { recursive: true });
+
+      await writeFile(join(projectHelpDir, 'SKILL.md'), '# project help\n');
+      await writeFile(join(projectOnlyDir, 'SKILL.md'), '# project only\n');
+      await writeFile(join(userHelpDir, 'SKILL.md'), '# user help\n');
+      await writeFile(join(userOnlyDir, 'SKILL.md'), '# user only\n');
+
+      const skills = await listInstalledSkillDirectories(projectRoot);
+
+      assert.deepEqual(
+        skills.map((skill) => ({
+          name: skill.name,
+          scope: skill.scope,
+        })),
+        [
+          { name: 'help', scope: 'project' },
+          { name: 'project-only', scope: 'project' },
+          { name: 'user-only', scope: 'user' },
+        ],
+      );
+      assert.equal(skills[0]?.path, projectHelpDir);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+      await rm(codexHomeRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -7,6 +7,7 @@ import { dirname, join } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
+import { readdir } from 'fs/promises';
 
 /** Codex CLI home directory (~/.codex/) */
 export function codexHome(): string {
@@ -36,6 +37,59 @@ export function legacyUserSkillsDir(): string {
 /** Project-level skills directory (.agents/skills/) */
 export function projectSkillsDir(projectRoot?: string): string {
   return join(projectRoot || process.cwd(), '.agents', 'skills');
+}
+
+export type InstalledSkillScope = 'project' | 'user';
+
+export interface InstalledSkillDirectory {
+  name: string;
+  path: string;
+  scope: InstalledSkillScope;
+}
+
+async function readInstalledSkillsFromDir(
+  dir: string,
+  scope: InstalledSkillScope,
+): Promise<InstalledSkillDirectory[]> {
+  if (!existsSync(dir)) return [];
+
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      name: entry.name,
+      path: join(dir, entry.name),
+      scope,
+    }))
+    .filter((entry) => existsSync(join(entry.path, 'SKILL.md')))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Installed skill directories in scope-precedence order.
+ * Project skills win over user-level skills with the same directory basename.
+ */
+export async function listInstalledSkillDirectories(
+  projectRoot?: string,
+): Promise<InstalledSkillDirectory[]> {
+  const orderedDirs: Array<{ dir: string; scope: InstalledSkillScope }> = [
+    { dir: projectSkillsDir(projectRoot), scope: 'project' },
+    { dir: userSkillsDir(), scope: 'user' },
+  ];
+
+  const deduped: InstalledSkillDirectory[] = [];
+  const seenNames = new Set<string>();
+
+  for (const { dir, scope } of orderedDirs) {
+    const skills = await readInstalledSkillsFromDir(dir, scope);
+    for (const skill of skills) {
+      if (seenNames.has(skill.name)) continue;
+      seenNames.add(skill.name);
+      deduped.push(skill);
+    }
+  }
+
+  return deduped;
 }
 
 /** oh-my-codex state directory (.omx/state/) */


### PR DESCRIPTION
## Summary
- deduplicate installed skills by directory name with project scope taking precedence over user scope
- filter shadowed user-scope skill references out of composed session and team worker AGENTS instructions
- add regression coverage for deduped installed-skill discovery and composed instructions

## Verification
- npx tsc --noEmit
- npx tsc -p tsconfig.no-unused.json
- npm test