### PR TITLE
fix(team): improve worker readiness detection for Codex 0.114.0

### DIFF
--- a/scripts/tmux-hook-engine.js
+++ b/scripts/tmux-hook-engine.js
@@ -222,6 +222,9 @@ export function paneLooksReady(captured) {
   const hasClaudePromptLine = lines.some((line) => /^\s*❯\s*/u.test(line));
   if (hasCodexPromptLine || hasClaudePromptLine) return true;
 
+  const hasCodexWelcomePrompt = lines.some((line) => /\bhow can i help(?: you)?\b/i.test(line));
+  if (hasCodexWelcomePrompt) return true;
+
   return lines.some((line) => /^\s*(?:[›>❯]\s*)?[A-Z][A-Z0-9]+-\d+\s+only(?:\s*(?:…|\.{3}))?\s*$/iu.test(line));
 }
 

--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -331,6 +331,14 @@ describe('paneLooksReady', () => {
     assert.equal(paneLooksReady('model: loading\n› '), false);
   });
 
+  it('accepts Codex welcome-screen helper text', () => {
+    assert.equal(paneLooksReady('How can I help you today?'), true);
+  });
+
+  it('accepts Codex welcome-screen suggestion rows with a prompt glyph', () => {
+    assert.equal(paneLooksReady('› Explain this codebase'), true);
+  });
+
   it('accepts issue-only prompts without a glyph', () => {
     assert.equal(paneLooksReady('IND-123 only...'), true);
   });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1267,6 +1267,37 @@ describe('tmux-dependent functions when tmux is unavailable', () => {
     });
   });
 
+  it('waitForWorkerReady accepts Codex 0.114.0-style welcome helper text', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-worker-ready-hello-',
+      (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    cat <<'EOF'
+╭────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.114.0)                 │
+│                                            │
+│ model:     gpt-5.4 high   /model to change │
+│ directory: ~/Workspace/demo                │
+╰────────────────────────────────────────────╯
+
+How can I help you today?
+EOF
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async () => {
+        assert.equal(waitForWorkerReady('omx-team-x', 1, 1_000), true);
+      },
+    );
+  });
+
   it('waitForWorkerReady returns false on timeout', () => {
     withEmptyPath(() => {
       assert.equal(waitForWorkerReady('omx-team-x', 1, 1), false);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2118,7 +2118,12 @@ export async function assignTask(
       if (outcome.ok) break;
       if (attempt < maxAssignRetries && config.worker_launch_mode === 'interactive' && config.tmux_session) {
         if (dismissTrustPromptIfPresent(config.tmux_session, workerInfo.index, workerInfo.pane_id)) {
-          waitForWorkerReady(config.tmux_session, workerInfo.index, 15_000, workerInfo.pane_id);
+          waitForWorkerReady(
+            config.tmux_session,
+            workerInfo.index,
+            resolveWorkerReadyTimeoutMs(process.env),
+            workerInfo.pane_id,
+          );
         } else {
           await new Promise<void>(r => setTimeout(r, assignRetryDelayS * 1000));
         }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1162,16 +1162,16 @@ async function attemptSubmitRounds(
   return false;
 }
 
-// Poll tmux capture-pane for Codex prompt indicator (> or similar)
-// Uses exponential backoff: 1s, 2s, 4s, 8s (total ~15s)
-// Returns true if ready, false on timeout
+// Poll tmux capture-pane for a worker-ready Codex/Claude prompt or welcome screen.
+// Start with short waits so we notice the first ready frame quickly, then back off.
+// Returns true if ready, false on timeout.
 export function waitForWorkerReady(
   sessionName: string,
   workerIndex: number,
-  timeoutMs: number = 15000,
+  timeoutMs: number = 30_000,
   workerPaneId?: string,
 ): boolean {
-  const initialBackoffMs = 300;
+  const initialBackoffMs = 150;
   const maxBackoffMs = 8000;
   const startedAt = Date.now();
   let blockedByTrustPrompt = false;


### PR DESCRIPTION
## Summary
- accept Codex 0.114.0 welcome helper text in worker readiness detection
- increase the default worker-ready wait to 30s with a faster initial poll
- reuse the configured ready timeout after trust-prompt dismissal and cover the fix with tests

Closes #866.