### PR TITLE
fix: normalize autoresearch codex args for sandbox bypass

### DIFF
--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -6,6 +6,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { normalizeAutoresearchCodexArgs } from '../autoresearch.js';
 
 function runOmx(
   cwd: string,
@@ -39,6 +40,20 @@ async function initRepo(): Promise<string> {
   execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
   return cwd;
 }
+
+describe('normalizeAutoresearchCodexArgs', () => {
+  it('adds sandbox bypass by default for autoresearch workers', () => {
+    assert.deepEqual(normalizeAutoresearchCodexArgs(['--model', 'gpt-5']), ['--model', 'gpt-5', '--dangerously-bypass-approvals-and-sandbox']);
+  });
+
+  it('deduplicates explicit bypass flags', () => {
+    assert.deepEqual(normalizeAutoresearchCodexArgs(['--dangerously-bypass-approvals-and-sandbox']), ['--dangerously-bypass-approvals-and-sandbox']);
+  });
+
+  it('normalizes --madmax to the canonical bypass flag', () => {
+    assert.deepEqual(normalizeAutoresearchCodexArgs(['--madmax']), ['--dangerously-bypass-approvals-and-sandbox']);
+  });
+});
 
 describe('omx autoresearch', () => {
   it('documents autoresearch in top-level help', async () => {

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -13,6 +13,7 @@ import {
   buildAutoresearchRunTag,
 } from '../autoresearch/runtime.js';
 import { assertModeStartAllowed } from '../modes/base.js';
+import { CODEX_BYPASS_FLAG, MADMAX_FLAG } from './constants.js';
 
 export const AUTORESEARCH_HELP = `omx autoresearch - Launch OMX autoresearch with thin-supervisor parity semantics
 
@@ -35,9 +36,38 @@ Behavior:
 const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
 const AUTORESEARCH_MAX_CONSECUTIVE_NOOPS = 3;
 
+export function normalizeAutoresearchCodexArgs(codexArgs: readonly string[]): string[] {
+  const normalized: string[] = [];
+  let hasBypass = false;
+
+  for (const arg of codexArgs) {
+    if (arg === MADMAX_FLAG) {
+      if (!hasBypass) {
+        normalized.push(CODEX_BYPASS_FLAG);
+        hasBypass = true;
+      }
+      continue;
+    }
+    if (arg === CODEX_BYPASS_FLAG) {
+      if (!hasBypass) {
+        normalized.push(arg);
+        hasBypass = true;
+      }
+      continue;
+    }
+    normalized.push(arg);
+  }
+
+  if (!hasBypass) {
+    normalized.push(CODEX_BYPASS_FLAG);
+  }
+
+  return normalized;
+}
+
 function runAutoresearchTurn(worktreePath: string, instructionsFile: string, codexArgs: string[]): void {
   const prompt = readFileSync(instructionsFile, 'utf-8');
-  const launchArgs = ['exec', ...codexArgs, '-'];
+  const launchArgs = ['exec', ...normalizeAutoresearchCodexArgs(codexArgs), '-'];
   const result = spawnSync('codex', launchArgs, {
     cwd: worktreePath,
     stdio: ['pipe', 'inherit', 'inherit'],


### PR DESCRIPTION
## Summary

Autoresearch workers currently launch Codex with raw CLI args. That leaves worker sandbox posture dependent on caller provided flags and lets the madmax alias pass through as non-canonical input.

This change normalizes autoresearch worker launch args so workers always receive the canonical bypass flag and madmax is converted to dangerously-bypass-approvals-and-sandbox.

## Changes

- add normalizeAutoresearchCodexArgs in src/cli/autoresearch.ts
- inject the canonical bypass flag by default for autoresearch worker launches
- normalize madmax to dangerously-bypass-approvals-and-sandbox
- deduplicate explicit bypass flags
- add focused regression coverage in src/cli/__tests__/autoresearch.test.ts

## Validation

- [x] npm run lint
- [x] npm run build
- [x] node --test dist/cli/__tests__/autoresearch.test.js
- [ ] omx doctor (not needed; no setup or config behavior changed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed (not needed; runtime behavior only)
- [x] Backward compatibility impact considered

## Related

Closes #
