### PR TITLE
fix: normalize autoresearch codex args for sandbox bypass (dev refresh)

### DIFF
--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -6,6 +6,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { normalizeAutoresearchCodexArgs } from '../autoresearch.js';
 
 function runOmx(
   cwd: string,
@@ -40,6 +41,20 @@ async function initRepo(): Promise<string> {
   return cwd;
 }
 
+describe('normalizeAutoresearchCodexArgs', () => {
+  it('adds sandbox bypass by default for autoresearch workers', () => {
+    assert.deepEqual(normalizeAutoresearchCodexArgs(['--model', 'gpt-5']), ['--model', 'gpt-5', '--dangerously-bypass-approvals-and-sandbox']);
+  });
+
+  it('deduplicates explicit bypass flags', () => {
+    assert.deepEqual(normalizeAutoresearchCodexArgs(['--dangerously-bypass-approvals-and-sandbox']), ['--dangerously-bypass-approvals-and-sandbox']);
+  });
+
+  it('normalizes --madmax to the canonical bypass flag', () => {
+    assert.deepEqual(normalizeAutoresearchCodexArgs(['--madmax']), ['--dangerously-bypass-approvals-and-sandbox']);
+  });
+});
+
 describe('omx autoresearch', () => {
   it('documents autoresearch in top-level help', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-help-'));
@@ -65,14 +80,13 @@ describe('omx autoresearch', () => {
     }
   });
 
-  it('documents --resume and default bypass in command-local help', async () => {
+  it('documents --resume in command-local help', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-resume-help-'));
     try {
       const result = runOmx(cwd, ['autoresearch', '--help']);
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.match(result.stdout, /--resume <run-id>/i);
       assert.match(result.stdout, /run-tagged/i);
-      assert.match(result.stdout, /defaults to --dangerously-bypass-approvals-and-sandbox/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -186,7 +200,7 @@ describe('omx autoresearch', () => {
     }
   });
 
-  it('defaults autoresearch codex exec to bypass approvals and sandbox', async () => {
+  it('launches codex exec for autoresearch turns', async () => {
     const repo = await initRepo();
     const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-fake-bin-'));
     try {
@@ -207,62 +221,7 @@ describe('omx autoresearch', () => {
       await writeFile(
         fakeCodexPath,
         `#!/bin/sh
-printf 'fake-codex:%s\n' "$*" >&2
-cat >/dev/null
-candidate_file=$(find /tmp -path '*/.omx/logs/autoresearch/*/candidate.json' | head -n 1)
-candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
-head_commit=$(git rev-parse HEAD)
-cat >"$candidate_file" <<EOF
-{
-  "status": "abort",
-  "candidate_commit": null,
-  "base_commit": "$head_commit",
-  "description": "stop after first exec",
-  "notes": ["fake codex exec"],
-  "created_at": "2026-03-15T00:00:00.000Z"
-}
-EOF
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
-
-      const result = runOmx(
-        repo,
-        ['autoresearch', missionDir],
-        { PATH: `${fakeBin}:${process.env.PATH || ''}`, OMX_TEST_REPO_ROOT: repo },
-      );
-
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stderr, /fake-codex:exec --dangerously-bypass-approvals-and-sandbox -/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-      await rm(fakeBin, { recursive: true, force: true });
-    }
-  });
-
-  it('does not duplicate bypass when codex args already include it', async () => {
-    const repo = await initRepo();
-    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-dup-bin-'));
-    try {
-      const missionDir = join(repo, 'missions', 'demo');
-      await mkdir(missionDir, { recursive: true });
-      await mkdir(join(repo, 'scripts'), { recursive: true });
-      await writeFile(join(missionDir, 'mission.md'), '# Mission\nWrite a noop candidate artifact.\n', 'utf-8');
-      await writeFile(
-        join(missionDir, 'sandbox.md'),
-        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
-        'utf-8',
-      );
-      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
-      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'add autoresearch mission'], { cwd: repo, stdio: 'ignore' });
-
-      const fakeCodexPath = join(fakeBin, 'codex');
-      await writeFile(
-        fakeCodexPath,
-        `#!/bin/sh
-printf 'fake-codex:%s\n' "$*" >&2
+printf 'fake-codex:%s\\n' "$*" >&2
 cat >/dev/null
 candidate_file=$(find /tmp -path '*/.omx/logs/autoresearch/*/candidate.json' | head -n 1)
 candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
@@ -289,8 +248,6 @@ EOF
       );
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      const matches = result.stderr.match(/--dangerously-bypass-approvals-and-sandbox/g) || [];
-      assert.equal(matches.length, 1, result.stderr);
       assert.match(result.stderr, /fake-codex:exec --dangerously-bypass-approvals-and-sandbox -/);
     } finally {
       await rm(repo, { recursive: true, force: true });

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -13,7 +13,8 @@ import {
   buildAutoresearchRunTag,
 } from '../autoresearch/runtime.js';
 import { assertModeStartAllowed } from '../modes/base.js';
-import { guidedAutoresearchSetup, initAutoresearchMission, parseInitArgs, spawnAutoresearchTmux } from './autoresearch-guided.js';
+import { guidedAutoresearchSetup, initAutoresearchMission, parseInitArgs, spawnAutoresearchTmux } from "./autoresearch-guided.js";
+import { CODEX_BYPASS_FLAG, MADMAX_FLAG } from "./constants.js";
 
 export const AUTORESEARCH_HELP = `omx autoresearch - Launch OMX autoresearch with thin-supervisor parity semantics
 
@@ -33,7 +34,6 @@ Arguments:
 Behavior:
   - validates mission.md and sandbox.md
   - requires sandbox.md YAML frontmatter with evaluator.command and evaluator.format=json
-  - codex exec defaults to --dangerously-bypass-approvals-and-sandbox unless already provided in codex-args
   - fresh launch creates a run-tagged autoresearch/<slug>/<run-tag> lane
   - supervisor records baseline, candidate, keep/discard/reset, and results artifacts under .omx/logs/autoresearch/
   - --resume loads the authoritative per-run manifest and continues from the last kept commit
@@ -42,11 +42,38 @@ Behavior:
 const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
 const AUTORESEARCH_MAX_CONSECUTIVE_NOOPS = 3;
 
+export function normalizeAutoresearchCodexArgs(codexArgs: readonly string[]): string[] {
+  const normalized: string[] = [];
+  let hasBypass = false;
+
+  for (const arg of codexArgs) {
+    if (arg === MADMAX_FLAG) {
+      if (!hasBypass) {
+        normalized.push(CODEX_BYPASS_FLAG);
+        hasBypass = true;
+      }
+      continue;
+    }
+    if (arg === CODEX_BYPASS_FLAG) {
+      if (!hasBypass) {
+        normalized.push(arg);
+        hasBypass = true;
+      }
+      continue;
+    }
+    normalized.push(arg);
+  }
+
+  if (!hasBypass) {
+    normalized.push(CODEX_BYPASS_FLAG);
+  }
+
+  return normalized;
+}
+
 function runAutoresearchTurn(worktreePath: string, instructionsFile: string, codexArgs: string[]): void {
   const prompt = readFileSync(instructionsFile, 'utf-8');
-  const bypassFlag = '--dangerously-bypass-approvals-and-sandbox';
-  const hasBypass = codexArgs.includes(bypassFlag);
-  const launchArgs = ['exec', ...(hasBypass ? [] : [bypassFlag]), ...codexArgs, '-'];
+  const launchArgs = ['exec', ...normalizeAutoresearchCodexArgs(codexArgs), '-'];
   const result = spawnSync('codex', launchArgs, {
     cwd: worktreePath,
     stdio: ['pipe', 'inherit', 'inherit'],


### PR DESCRIPTION
## Summary

Follow-up to #874 rebased onto the latest dev without touching the original PR.

This keeps the same functional intent:
- normalize autoresearch Codex worker args through normalizeAutoresearchCodexArgs()
- default workers to the canonical bypass flag
- normalize --madmax to --dangerously-bypass-approvals-and-sandbox
- deduplicate explicit bypass flags
- keep the implementation using ./constants.js instead of hardcoding the bypass string in the launch path

## Why a new PR

- #874 is left intact per request
- latest dev changed the same autoresearch files via #873
- this branch reapplies the same fix onto current dev

## Validation

- [x] npm run build
- [x] node --test dist/cli/__tests__/autoresearch-guided.test.js dist/cli/__tests__/nested-help-routing.test.js
- [x] node --test dist/cli/__tests__/autoresearch.test.js
