### PR TITLE
fix(config): auto-repair duplicate [tui] sections before Codex CLI launch

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -64,6 +64,7 @@ import {
 } from '../team/tmux-session.js';
 import { getPackageRoot } from '../utils/package.js';
 import { codexConfigPath } from '../utils/paths.js';
+import { repairConfigIfNeeded } from '../config/generator.js';
 import { HUD_TMUX_HEIGHT_LINES } from '../hud/constants.js';
 import { classifySpawnError, spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { buildHookEvent } from '../hooks/extensibility/events.js';
@@ -728,6 +729,19 @@ export async function launchWithHud(args: string[]): Promise<void> {
     // Non-fatal: star prompt must never block launch
   }
 
+  // ── Phase 0.5: config repair ────────────────────────────────────────────
+  // After an omx version upgrade the OLD setup code (still in memory) may
+  // have written a config.toml with duplicate [tui] sections.  Codex CLI's
+  // TOML parser rejects duplicates, so we repair before spawning the CLI.
+  try {
+    const repaired = await repairConfigIfNeeded(codexConfigPath(), getPackageRoot());
+    if (repaired) {
+      console.log('[omx] Repaired duplicate [tui] section in config.toml.');
+    }
+  } catch {
+    // Non-fatal: repair failure must not block launch
+  }
+
   // ── Phase 1: preLaunch ──────────────────────────────────────────────────
   try {
     await preLaunch(cwd, sessionId, notifyTempResult.contract);
@@ -780,6 +794,15 @@ export async function execWithOverlay(args: string[]): Promise<void> {
     await maybePromptGithubStar();
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
+  }
+
+  try {
+    const repaired = await repairConfigIfNeeded(codexConfigPath(), getPackageRoot());
+    if (repaired) {
+      console.log('[omx] Repaired duplicate [tui] section in config.toml.');
+    }
+  } catch {
+    // Non-fatal
   }
 
   try {

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildMergedConfig, mergeConfig } from "../generator.js";
+import { buildMergedConfig, mergeConfig, repairConfigIfNeeded } from "../generator.js";
 
 /** Count occurrences of a pattern in text */
 function count(text: string, pattern: RegExp): number {
@@ -497,6 +497,89 @@ describe("config generator idempotency (#384)", () => {
       assert.doesNotMatch(toml, /^\[agents\."style-reviewer"\]$/m, "merged agent omitted");
       assert.doesNotMatch(toml, /^\[agents\."quality-reviewer"\]$/m, "merged agent omitted");
       assert.doesNotMatch(toml, /^\[agents\."product-manager"\]$/m, "merged product agent omitted");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs config with duplicate [tui] sections from upgrade", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      // Simulate a broken config left by an older omx setup: an orphaned
+      // [tui] outside the OMX block AND another [tui] inside the block.
+      const broken = [
+        '[mcp_servers.figma]',
+        'url = "https://mcp.figma.com/mcp"',
+        '',
+        '# OMX TUI StatusLine (Codex CLI v0.101.0+)',
+        '[tui]',
+        'status_line = ["git-branch"]',
+        '',
+        '# ============================================================',
+        '# End oh-my-codex',
+        '',
+        '# ============================================================',
+        '# oh-my-codex (OMX) Configuration',
+        '# Managed by omx setup - manual edits preserved on next setup',
+        '# ============================================================',
+        '',
+        '[mcp_servers.omx_state]',
+        'command = "node"',
+        `args = ["${join(wd, "dist/mcp/state-server.js")}"]`,
+        'enabled = true',
+        '',
+        '# OMX TUI StatusLine (Codex CLI v0.101.0+)',
+        '[tui]',
+        'status_line = ["model-with-reasoning", "git-branch"]',
+        '',
+        '# ============================================================',
+        '# End oh-my-codex',
+        '',
+      ].join("\n");
+      await writeFile(configPath, broken);
+
+      // buildMergedConfig should produce a clean config with only one [tui]
+      const toml = buildMergedConfig(broken, wd);
+      assert.equal(count(toml, /^\[tui\]$/gm), 1, "[tui] should appear once");
+      assert.equal(
+        count(toml, /# End oh-my-codex/g),
+        1,
+        "End marker should appear once",
+      );
+      // User MCP server must survive
+      assert.match(toml, /^\[mcp_servers\.figma\]$/m, "user MCP preserved");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("repairConfigIfNeeded fixes duplicate [tui] and is a no-op when clean", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+
+      // First: create a clean config
+      await mergeConfig(configPath, wd);
+      const clean = await readFile(configPath, "utf-8");
+      assert.equal(count(clean, /^\[tui\]$/gm), 1);
+
+      // repairConfigIfNeeded should be a no-op
+      const wasRepaired = await repairConfigIfNeeded(configPath, wd);
+      assert.equal(wasRepaired, false, "clean config should not need repair");
+
+      // Now break it by appending a second [tui]
+      await writeFile(configPath, clean + "\n[tui]\nstatus_line = [\"git-branch\"]\n");
+      const broken = await readFile(configPath, "utf-8");
+      assert.equal(count(broken, /^\[tui\]$/gm), 2);
+
+      // repairConfigIfNeeded should fix it
+      const didRepair = await repairConfigIfNeeded(configPath, wd);
+      assert.equal(didRepair, true, "broken config should be repaired");
+
+      const repaired = await readFile(configPath, "utf-8");
+      assert.equal(count(repaired, /^\[tui\]$/gm), 1, "[tui] should appear once after repair");
+      assertSingleOmxBlock(repaired);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -745,6 +745,32 @@ export function buildMergedConfig(
   return topLines.join("\n") + "\n\n" + body + "\n" + tablesBlock;
 }
 
+/**
+ * Detect and repair duplicate TOML table headers (e.g. [tui]) in config.toml.
+ *
+ * After an omx version upgrade the OLD setup code (still loaded in memory)
+ * may write a config with duplicate [tui] sections.  The Codex CLI TOML
+ * parser rejects duplicates, so we must fix them before the CLI is spawned.
+ *
+ * Returns `true` if a repair was performed.
+ */
+export async function repairConfigIfNeeded(
+  configPath: string,
+  pkgRoot: string,
+  options: MergeOptions = {},
+): Promise<boolean> {
+  if (!existsSync(configPath)) return false;
+
+  const content = await readFile(configPath, "utf-8");
+  const tuiCount = (content.match(/^\s*\[tui\]\s*$/gm) || []).length;
+  if (tuiCount <= 1) return false;
+
+  // Duplicate [tui] detected — run full merge to repair
+  const repaired = buildMergedConfig(content, pkgRoot, options);
+  await writeFile(configPath, repaired);
+  return true;
+}
+
 export async function mergeConfig(
   configPath: string,
   pkgRoot: string,


### PR DESCRIPTION
Rebased version of #862 (by @sigridjineth) onto latest `dev`, with scope-creep doc changes removed.

## Summary
- Added `repairConfigIfNeeded()` in `generator.ts` that detects duplicate `[tui]` via regex count and auto-repairs using `buildMergedConfig()`
- Called in both `launchWithHud()` and `execWithOverlay()` as a non-fatal pre-launch step
- 2 new tests for repair + no-op behavior

Original PR: #862 by @sigridjineth
Closes #865 (black screen after upgrade likely caused by duplicate [tui])

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*