### PR TITLE
fix: use detached tmux launch policy on macOS

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -546,8 +546,8 @@ describe('project launch scope helpers', () => {
 });
 
 describe('resolveCodexLaunchPolicy', () => {
-  it('launches directly on macOS when outside tmux to preserve native image paste', () => {
-    assert.equal(resolveCodexLaunchPolicy({}, 'darwin', true), 'direct');
+  it('uses detached tmux on macOS when outside tmux and tmux is available', () => {
+    assert.equal(resolveCodexLaunchPolicy({}, 'darwin', true), 'detached-tmux');
   });
 
   it('uses tmux-aware launch path when already inside tmux', () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -329,14 +329,10 @@ export type CodexLaunchPolicy = 'inside-tmux' | 'detached-tmux' | 'direct';
 
 export function resolveCodexLaunchPolicy(
   env: NodeJS.ProcessEnv = process.env,
-  platform: NodeJS.Platform = process.platform,
+  _platform: NodeJS.Platform = process.platform,
   tmuxAvailable: boolean = isTmuxAvailable(),
 ): CodexLaunchPolicy {
   if (env.TMUX) return 'inside-tmux';
-  // On macOS, preserve the native terminal paste path for clipboard images.
-  // Detached tmux sessions strip the rich paste payload that Codex consumes,
-  // so image pastes appear to do nothing.
-  if (platform === 'darwin') return 'direct';
   return tmuxAvailable ? 'detached-tmux' : 'direct';
 }
 


### PR DESCRIPTION
## Summary
- remove the darwin-specific direct-launch override from `resolveCodexLaunchPolicy`
- update the CLI test to expect `detached-tmux` on macOS when tmux is available
- keep direct launch only as the fallback when tmux is unavailable

## Testing
- npm run lint
- npm run check:no-unused
- npm test

## Follow-up
- Created issue #877 to investigate Ghostty as an alternative tmux backend on macOS.