### PR TITLE
feat: implement phase 1 of codex native subagent integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,10 @@
+<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->
+YOU ARE AN AUTONOMOUS CODING AGENT. EXECUTE TASKS TO COMPLETION WITHOUT ASKING FOR PERMISSION.
+DO NOT STOP TO ASK "SHOULD I PROCEED?" — PROCEED. DO NOT WAIT FOR CONFIRMATION ON OBVIOUS NEXT STEPS.
+IF BLOCKED, TRY AN ALTERNATIVE APPROACH. ONLY ASK WHEN TRULY AMBIGUOUS OR DESTRUCTIVE.
+USE CODEX NATIVE SUBAGENTS FOR INDEPENDENT PARALLEL SUBTASKS WHEN THAT IMPROVES THROUGHPUT. THIS IS COMPLEMENTARY TO OMX TEAM MODE.
+<!-- END AUTONOMY DIRECTIVE -->
+
 # oh-my-codex - Intelligent Multi-Agent Orchestration
 <!-- omx:generated:agents-md -->
 
@@ -28,6 +35,7 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Prefer evidence over assumption; verify before claiming completion.
 - Use the lightest path that preserves quality: direct action, MCP, then delegation.
 - Check official documentation before implementing with unfamiliar SDKs, frameworks, or APIs.
+- Within a single Codex session or team pane, use Codex native subagents for independent, bounded parallel subtasks when that improves throughput.
 <!-- OMX:GUIDANCE:OPERATING:START -->
 - Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -1,13 +1,13 @@
 /**
- * Native agent config generator for Codex CLI multi-agent roles
- * Generates per-agent .toml files at ~/.omx/agents/<name>.toml
+ * Native agent config generators for Codex CLI.
+ * Writes standalone TOML files under ~/.codex/agents/ or ./.codex/agents/.
  */
 
 import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { AGENT_DEFINITIONS, AgentDefinition } from './definitions.js';
-import { omxAgentsConfigDir } from '../utils/paths.js';
+import { codexAgentsDir } from '../utils/paths.js';
 
 const POSTURE_OVERLAYS: Record<AgentDefinition['posture'], string> = {
   'frontier-orchestrator': [
@@ -76,6 +76,14 @@ const MODEL_CLASS_OVERLAYS: Record<AgentDefinition['modelClass'], string> = {
   ].join('\n'),
 };
 
+export interface GeneratedNativeAgentConfig {
+  name: string;
+  description: string;
+  developerInstructions: string;
+  model?: string;
+  reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
+}
+
 function buildPromptInstructions(agent: AgentDefinition, promptContent: string): string {
   const instructions = stripFrontmatter(promptContent);
   return [
@@ -85,7 +93,7 @@ function buildPromptInstructions(agent: AgentDefinition, promptContent: string):
     '',
     MODEL_CLASS_OVERLAYS[agent.modelClass],
     '',
-    `## OMX Agent Metadata`,
+    '## OMX Agent Metadata',
     `- role: ${agent.name}`,
     `- posture: ${agent.posture}`,
     `- model_class: ${agent.modelClass}`,
@@ -94,9 +102,9 @@ function buildPromptInstructions(agent: AgentDefinition, promptContent: string):
 }
 
 /**
- * Strip YAML frontmatter (between --- markers) from markdown content
+ * Strip YAML frontmatter (between --- markers) from markdown content.
  */
-function stripFrontmatter(content: string): string {
+export function stripFrontmatter(content: string): string {
   const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
   if (match) {
     return content.slice(match[0].length).trim();
@@ -109,41 +117,87 @@ function stripFrontmatter(content: string): string {
  * TOML """ strings only need to escape sequences of 3+ consecutive quotes.
  */
 function escapeTomlMultiline(s: string): string {
-  // Replace sequences of 3+ double quotes with escaped versions
   return s.replace(/"{3,}/g, (match) => match.split('').join('\\'));
 }
 
-/**
- * Generate TOML content for a single agent config file
- */
-export function generateAgentToml(agent: AgentDefinition, promptContent: string): string {
-  const instructions = buildPromptInstructions(agent, promptContent);
-  const effort = agent.reasoningEffort;
-  const escaped = escapeTomlMultiline(instructions);
+function escapeTomlBasicString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
 
-  return [
-    `# oh-my-codex agent: ${agent.name}`,
-    `model_reasoning_effort = "${effort}"`,
-    `developer_instructions = """`,
-    escaped,
-    `"""`,
+export function generateStandaloneAgentToml(config: GeneratedNativeAgentConfig): string {
+  const escapedInstructions = escapeTomlMultiline(config.developerInstructions);
+  const lines = [
+    `# oh-my-codex agent: ${config.name}`,
+    `name = "${escapeTomlBasicString(config.name)}"`,
+    `description = "${escapeTomlBasicString(config.description)}"`,
+  ];
+
+  if (config.model) {
+    lines.push(`model = "${escapeTomlBasicString(config.model)}"`);
+  }
+  if (config.reasoningEffort) {
+    lines.push(`model_reasoning_effort = "${config.reasoningEffort}"`);
+  }
+
+  lines.push(
+    'developer_instructions = """',
+    escapedInstructions,
+    '"""',
     '',
-  ].join('\n');
+  );
+
+  return lines.join('\n');
 }
 
 /**
- * Install native agent config .toml files to ~/.omx/agents/
- * Returns the number of agents installed
+ * Generate TOML content for a prompt-backed OMX role agent.
+ */
+export function generateAgentToml(agent: AgentDefinition, promptContent: string): string {
+  return generateStandaloneAgentToml({
+    name: agent.name,
+    description: agent.description,
+    developerInstructions: buildPromptInstructions(agent, promptContent),
+    reasoningEffort: agent.reasoningEffort,
+  });
+}
+
+/**
+ * Generate TOML content for a skill-backed OMX native agent.
+ */
+export function generateSkillAgentToml(
+  name: string,
+  description: string,
+  skillContent: string,
+): string {
+  const instructions = [
+    `You are the oh-my-codex skill agent "${name}".`,
+    `Purpose: ${description}`,
+    '- Follow the embedded OMX skill instructions below as your operating procedure.',
+    '- When parallel execution helps, you may use Codex native subagents for independent subtasks.',
+    '',
+    stripFrontmatter(skillContent),
+  ].join('\n');
+
+  return generateStandaloneAgentToml({
+    name,
+    description,
+    developerInstructions: instructions,
+  });
+}
+
+/**
+ * Install prompt-backed native agent config .toml files to ~/.codex/agents/
+ * Returns the number of agent files written.
  */
 export async function installNativeAgentConfigs(
   pkgRoot: string,
-  options: { force?: boolean; dryRun?: boolean; verbose?: boolean; agentsDir?: string } = {}
+  options: { force?: boolean; dryRun?: boolean; verbose?: boolean; agentsDir?: string } = {},
 ): Promise<number> {
   const {
     force = false,
     dryRun = false,
     verbose = false,
-    agentsDir = omxAgentsConfigDir(),
+    agentsDir = codexAgentsDir(),
   } = options;
 
   if (!dryRun) {
@@ -172,7 +226,7 @@ export async function installNativeAgentConfigs(
       await writeFile(dst, toml);
     }
     if (verbose) console.log(`  ${name}.toml`);
-    count++;
+    count += 1;
   }
 
   return count;

--- a/src/cli/__tests__/agents.test.ts
+++ b/src/cli/__tests__/agents.test.ts
@@ -1,0 +1,138 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error?: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const result = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...envOverrides },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message,
+  };
+}
+
+function shouldSkipForSpawnPermissions(err?: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+describe('omx agents', () => {
+  it('lists project and user native agents with name, description, and model', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-cli-'));
+    const home = join(wd, 'home');
+    try {
+      const projectAgentsDir = join(wd, '.codex', 'agents');
+      const userAgentsDir = join(home, '.codex', 'agents');
+      await mkdir(projectAgentsDir, { recursive: true });
+      await mkdir(userAgentsDir, { recursive: true });
+
+      await writeFile(
+        join(projectAgentsDir, 'planner.toml'),
+        'name = "planner"\ndescription = "Project planner"\nmodel = "gpt-5.4"\ndeveloper_instructions = """plan"""\n',
+      );
+      await writeFile(
+        join(userAgentsDir, 'reviewer.toml'),
+        'name = "reviewer"\ndescription = "User reviewer"\ndeveloper_instructions = """review"""\n',
+      );
+
+      const result = runOmx(wd, ['agents', 'list'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /scope\s+name\s+model\s+description/i);
+      assert.match(result.stdout, /project\s+planner\s+gpt-5\.4\s+Project planner/);
+      assert.match(result.stdout, /user\s+reviewer\s+-\s+User reviewer/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('adds a scaffolded agent TOML file with required fields and commented optional fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-cli-'));
+    const home = join(wd, 'home');
+    try {
+      await mkdir(home, { recursive: true });
+
+      const result = runOmx(wd, ['agents', 'add', 'my-helper', '--scope', 'project'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const agentPath = join(wd, '.codex', 'agents', 'my-helper.toml');
+      assert.equal(existsSync(agentPath), true);
+
+      const content = await readFile(agentPath, 'utf-8');
+      assert.match(content, /^name = "my-helper"$/m);
+      assert.match(content, /^description = "TODO: describe this agent's purpose"$/m);
+      assert.match(content, /^developer_instructions = """$/m);
+      assert.match(content, /^# model = "gpt-5\.4"$/m);
+      assert.match(content, /^# model_reasoning_effort = "medium"$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('edits an existing agent via $EDITOR and removes it with --force', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-cli-'));
+    const home = join(wd, 'home');
+    try {
+      const projectAgentsDir = join(wd, '.codex', 'agents');
+      await mkdir(projectAgentsDir, { recursive: true });
+      await mkdir(home, { recursive: true });
+      const agentPath = join(projectAgentsDir, 'editor-test.toml');
+      await writeFile(
+        agentPath,
+        'name = "editor-test"\ndescription = "Before edit"\ndeveloper_instructions = """before"""\n',
+      );
+
+      const editorScript = join(wd, 'editor.sh');
+      await writeFile(
+        editorScript,
+        '#!/usr/bin/env bash\nprintf \'\\nmodel = "gpt-5.4"\\n\' >> \"$1\"\n',
+      );
+      await chmod(editorScript, 0o755);
+
+      const editResult = runOmx(wd, ['agents', 'edit', 'editor-test', '--scope', 'project'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+        EDITOR: editorScript,
+      });
+      if (shouldSkipForSpawnPermissions(editResult.error)) return;
+
+      assert.equal(editResult.status, 0, editResult.stderr || editResult.stdout);
+      assert.match(await readFile(agentPath, 'utf-8'), /^model = "gpt-5\.4"$/m);
+
+      const removeResult = runOmx(wd, ['agents', 'remove', 'editor-test', '--scope', 'project', '--force'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(removeResult.error)) return;
+
+      assert.equal(removeResult.status, 0, removeResult.stderr || removeResult.stdout);
+      assert.equal(existsSync(agentPath), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/setup-prompts-overwrite.test.ts
+++ b/src/cli/__tests__/setup-prompts-overwrite.test.ts
@@ -17,7 +17,7 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       await setup({ scope: 'project' });
 
       const promptsDir = join(wd, '.codex', 'prompts');
-      const nativeAgentsDir = join(wd, '.omx', 'agents');
+      const nativeAgentsDir = join(wd, '.codex', 'agents');
       const installedPrompts = new Set(await readdir(promptsDir));
       const installedNativeAgents = new Set(await readdir(nativeAgentsDir));
 
@@ -38,6 +38,8 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       assert.equal(installedNativeAgents.has('executor.toml'), true);
       assert.equal(installedNativeAgents.has('team-executor.toml'), true);
       assert.equal(installedNativeAgents.has('code-reviewer.toml'), true);
+      assert.equal(installedNativeAgents.has('code-review.toml'), true);
+      assert.equal(installedNativeAgents.has('plan.toml'), true);
       assert.equal(installedNativeAgents.has('style-reviewer.toml'), false);
       assert.equal(installedNativeAgents.has('quality-reviewer.toml'), false);
       assert.equal(installedNativeAgents.has('api-reviewer.toml'), false);
@@ -91,7 +93,7 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
 
       const staleAgents = ['style-reviewer.toml', 'quality-reviewer.toml'];
       for (const staleAgent of staleAgents) {
-        const stalePath = join(wd, '.omx', 'agents', staleAgent);
+        const stalePath = join(wd, '.codex', 'agents', staleAgent);
         await writeFile(stalePath, '# stale native agent\n');
         assert.equal(existsSync(stalePath), true);
       }
@@ -99,9 +101,9 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       await setup({ scope: 'project', force: true });
 
       for (const staleAgent of staleAgents) {
-        assert.equal(existsSync(join(wd, '.omx', 'agents', staleAgent)), false);
+        assert.equal(existsSync(join(wd, '.codex', 'agents', staleAgent)), false);
       }
-      assert.equal(existsSync(join(wd, '.omx', 'agents', 'executor.toml')), true);
+      assert.equal(existsSync(join(wd, '.codex', 'agents', 'executor.toml')), true);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -130,7 +130,7 @@ describe('omx setup scope behavior', () => {
       const localPrompts = join(wd, '.codex', 'prompts');
       const localSkills = join(wd, '.agents', 'skills');
       const localConfig = join(wd, '.codex', 'config.toml');
-      const localAgents = join(wd, '.omx', 'agents');
+      const localAgents = join(wd, '.codex', 'agents');
       const scopeFile = join(wd, '.omx', 'setup-scope.json');
       const agentsMdPath = join(wd, 'AGENTS.md');
 
@@ -146,7 +146,9 @@ describe('omx setup scope behavior', () => {
       assert.equal(existsSync(agentsMdPath), true);
 
       const configToml = await readFile(localConfig, 'utf-8');
-      assert.match(configToml, /\.omx\/agents\/executor\.toml/);
+      assert.match(configToml, /^\[agents\]$/m);
+      assert.match(configToml, /^max_threads = 6$/m);
+      assert.match(configToml, /^max_depth = 2$/m);
       const agentsMd = await readFile(agentsMdPath, 'utf-8');
       assert.match(agentsMd, /\.\/\.codex\/prompts/);
       assert.match(agentsMd, /\.\/\.agents\/skills/);
@@ -173,7 +175,7 @@ describe('omx setup scope behavior', () => {
       assert.equal(existsSync(join(home, '.codex', 'prompts')), true);
       assert.equal(existsSync(join(home, '.codex', 'skills')), true);
       assert.equal(existsSync(join(home, '.agents', 'skills')), false);
-      assert.equal(existsSync(join(home, '.omx', 'agents')), true);
+      assert.equal(existsSync(join(home, '.codex', 'agents')), true);
       assert.equal(existsSync(join(home, '.codex', 'AGENTS.md')), true);
       assert.equal(existsSync(join(wd, '.omx', 'setup-scope.json')), true);
       const persistedScope = JSON.parse(await readFile(join(wd, '.omx', 'setup-scope.json'), 'utf-8')) as { scope: string };
@@ -193,7 +195,7 @@ describe('omx setup scope behavior', () => {
       const home = join(wd, 'home');
       await mkdir(join(home, '.codex', 'prompts'), { recursive: true });
       await mkdir(join(home, '.codex', 'skills', 'sample-skill'), { recursive: true });
-      await mkdir(join(home, '.omx', 'agents'), { recursive: true });
+      await mkdir(join(home, '.codex', 'agents'), { recursive: true });
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'user' }));
       await writeFile(join(home, '.codex', 'AGENTS.md'), '# user agents\n');
@@ -240,7 +242,7 @@ describe('omx setup scope behavior', () => {
       await mkdir(join(home, '.codex', 'prompts'), { recursive: true });
       await mkdir(join(home, '.codex', 'skills', 'sample-skill'), { recursive: true });
       await mkdir(join(home, '.agents', 'skills', 'legacy-skill'), { recursive: true });
-      await mkdir(join(home, '.omx', 'agents'), { recursive: true });
+      await mkdir(join(home, '.codex', 'agents'), { recursive: true });
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(
         join(wd, '.omx', 'setup-scope.json'),

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { createInterface } from 'node:readline/promises';
+import { basename, join } from 'node:path';
+import TOML from '@iarna/toml';
+import { codexAgentsDir, projectCodexAgentsDir } from '../utils/paths.js';
+
+export const RESERVED_NATIVE_AGENT_NAMES = new Set(['default', 'worker', 'explorer']);
+const DEFAULT_AGENT_MODEL = 'gpt-5.4';
+const AGENTS_USAGE = [
+  'Usage:',
+  '  omx agents list [--scope user|project]',
+  '  omx agents add <name> [--scope user|project] [--force]',
+  '  omx agents edit <name> [--scope user|project]',
+  '  omx agents remove <name> [--scope user|project] [--force]',
+  '',
+  'Manage Codex native agent TOML files under ~/.codex/agents/ or ./.codex/agents/.',
+  '',
+  'Notes:',
+  '  - list shows project + user agents by default',
+  '  - add defaults to project scope when this repo is set up for project scope; otherwise user',
+  '  - remove prompts for confirmation unless --force is passed',
+].join('\n');
+
+type AgentScope = 'user' | 'project';
+
+export interface NativeAgentInfo {
+  scope: AgentScope;
+  path: string;
+  file: string;
+  name: string;
+  description: string;
+  model?: string;
+}
+
+function isReservedNativeAgentName(name: string): boolean {
+  return RESERVED_NATIVE_AGENT_NAMES.has(name.trim());
+}
+
+function normalizeAgentName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error('agent name must not be empty');
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(trimmed)) {
+    throw new Error(`invalid agent name: ${name}`);
+  }
+  if (isReservedNativeAgentName(trimmed)) {
+    throw new Error(`"${trimmed}" is reserved by Codex built-in agents`);
+  }
+  return trimmed;
+}
+
+function resolveAgentsDir(scope: AgentScope, cwd = process.cwd()): string {
+  return scope === 'project' ? projectCodexAgentsDir(cwd) : codexAgentsDir();
+}
+
+function parseScopeArg(args: string[]): AgentScope | undefined {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--scope') {
+      const value = args[i + 1];
+      if (value === 'user' || value === 'project') return value;
+      throw new Error('Expected --scope user|project');
+    }
+    if (arg === '--scope=user') return 'user';
+    if (arg === '--scope=project') return 'project';
+  }
+  return undefined;
+}
+
+function inferMutationScope(cwd = process.cwd()): AgentScope {
+  const persistedScopePath = join(cwd, '.omx', 'setup-scope.json');
+  if (existsSync(persistedScopePath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(persistedScopePath, 'utf8')) as { scope?: string };
+      if (parsed.scope === 'project' || parsed.scope === 'project-local') return 'project';
+      if (parsed.scope === 'user') return 'user';
+    } catch {
+      // fall through
+    }
+  }
+  return existsSync(join(cwd, '.codex')) ? 'project' : 'user';
+}
+
+function getAgentFilePath(name: string, scope: AgentScope, cwd = process.cwd()): string {
+  return join(resolveAgentsDir(scope, cwd), `${name}.toml`);
+}
+
+function scaffoldAgentToml(name: string): string {
+  const normalized = normalizeAgentName(name);
+  return [
+    `# Codex native agent: ${normalized}`,
+    `name = "${normalized}"`,
+    'description = "TODO: describe this agent\'s purpose"',
+    'developer_instructions = """',
+    'TODO: add the operating instructions for this agent.',
+    '"""',
+    '',
+    '# Optional fields:',
+    `# model = "${DEFAULT_AGENT_MODEL}"`,
+    '# model_reasoning_effort = "medium"',
+    '# temperature = 0.2',
+    '# tools = ["shell", "apply_patch"]',
+    '',
+  ].join('\n');
+}
+
+function parseAgentInfo(
+  content: string,
+  path: string,
+  scope: AgentScope,
+): NativeAgentInfo {
+  const fallbackName = basename(path, '.toml');
+  try {
+    const parsed = TOML.parse(content) as Record<string, unknown>;
+    return {
+      scope,
+      path,
+      file: basename(path),
+      name: typeof parsed.name === 'string' && parsed.name.trim() !== '' ? parsed.name : fallbackName,
+      description: typeof parsed.description === 'string' ? parsed.description : '',
+      model: typeof parsed.model === 'string' ? parsed.model : undefined,
+    };
+  } catch {
+    return {
+      scope,
+      path,
+      file: basename(path),
+      name: fallbackName,
+      description: '<invalid TOML>',
+    };
+  }
+}
+
+async function readScopeAgents(scope: AgentScope, cwd = process.cwd()): Promise<NativeAgentInfo[]> {
+  const dir = resolveAgentsDir(scope, cwd);
+  if (!existsSync(dir)) return [];
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  const agents: NativeAgentInfo[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.toml')) continue;
+    const path = join(dir, entry.name);
+    const content = await readFile(path, 'utf8');
+    agents.push(parseAgentInfo(content, path, scope));
+  }
+  return agents.sort((a, b) => a.name.localeCompare(b.name) || a.scope.localeCompare(b.scope));
+}
+
+export async function listNativeAgents(
+  cwd = process.cwd(),
+  scope?: AgentScope,
+): Promise<NativeAgentInfo[]> {
+  if (scope) return readScopeAgents(scope, cwd);
+  const [projectAgents, userAgents] = await Promise.all([
+    readScopeAgents('project', cwd),
+    readScopeAgents('user', cwd),
+  ]);
+  return [...projectAgents, ...userAgents].sort((a, b) => a.name.localeCompare(b.name) || a.scope.localeCompare(b.scope));
+}
+
+async function addNativeAgent(
+  name: string,
+  options: { cwd?: string; scope?: AgentScope; force?: boolean } = {},
+): Promise<string> {
+  const cwd = options.cwd ?? process.cwd();
+  const scope = options.scope ?? inferMutationScope(cwd);
+  const normalized = normalizeAgentName(name);
+  const path = getAgentFilePath(normalized, scope, cwd);
+  if (existsSync(path) && !options.force) {
+    throw new Error(`agent already exists: ${path}`);
+  }
+  await mkdir(resolveAgentsDir(scope, cwd), { recursive: true });
+  await writeFile(path, scaffoldAgentToml(normalized));
+  return path;
+}
+
+function resolveExistingAgentPath(
+  name: string,
+  options: { cwd?: string; scope?: AgentScope } = {},
+): string {
+  const cwd = options.cwd ?? process.cwd();
+  const normalized = normalizeAgentName(name);
+  const candidateScopes: AgentScope[] = options.scope ? [options.scope] : ['project', 'user'];
+  for (const scope of candidateScopes) {
+    const path = getAgentFilePath(normalized, scope, cwd);
+    if (existsSync(path)) return path;
+  }
+  throw new Error(`agent not found: ${normalized}`);
+}
+
+async function confirmRemove(path: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`Delete native agent ${path}? [y/N]: `)).trim().toLowerCase();
+    return answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+async function editNativeAgent(
+  name: string,
+  options: { cwd?: string; scope?: AgentScope; editor?: string } = {},
+): Promise<string> {
+  const path = resolveExistingAgentPath(name, options);
+  const editor = options.editor ?? process.env.EDITOR ?? process.env.VISUAL ?? 'vi';
+  const result = spawnSync(editor, [path], {
+    stdio: 'inherit',
+    shell: true,
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(`editor exited with status ${result.status ?? 'unknown'}`);
+  }
+  return path;
+}
+
+async function removeNativeAgent(
+  name: string,
+  options: { cwd?: string; scope?: AgentScope; force?: boolean } = {},
+): Promise<string> {
+  const path = resolveExistingAgentPath(name, options);
+  if (!options.force) {
+    const confirmed = await confirmRemove(path);
+    if (!confirmed) {
+      throw new Error('remove aborted (pass --force to skip confirmation)');
+    }
+  }
+  await rm(path, { force: true });
+  return path;
+}
+
+function printAgentsTable(agents: NativeAgentInfo[]): void {
+  if (agents.length === 0) {
+    console.log('No native agents found.');
+    return;
+  }
+
+  const rows = [
+    ['scope', 'name', 'model', 'description'],
+    ...agents.map((agent) => [
+      agent.scope,
+      agent.name,
+      agent.model ?? '-',
+      agent.description || '-',
+    ]),
+  ];
+  const widths = rows[0]!.map((_, column) => Math.max(...rows.map((row) => row[column]!.length)));
+
+  for (const row of rows) {
+    console.log(row.map((cell, column) => cell.padEnd(widths[column]!)).join('  '));
+  }
+}
+
+export async function agentsCommand(args: string[]): Promise<void> {
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(AGENTS_USAGE);
+    return;
+  }
+
+  const subcommand = args[0];
+  const scope = parseScopeArg(args.slice(1));
+  const force = args.includes('--force');
+
+  switch (subcommand) {
+    case 'list': {
+      const agents = await listNativeAgents(process.cwd(), scope);
+      printAgentsTable(agents);
+      return;
+    }
+    case 'add': {
+      const name = args[1];
+      assert.ok(name, 'Usage: omx agents add <name>');
+      const path = await addNativeAgent(name, { cwd: process.cwd(), scope, force });
+      console.log(`Created native agent: ${path}`);
+      return;
+    }
+    case 'edit': {
+      const name = args[1];
+      assert.ok(name, 'Usage: omx agents edit <name>');
+      const path = await editNativeAgent(name, { cwd: process.cwd(), scope });
+      console.log(`Edited native agent: ${path}`);
+      return;
+    }
+    case 'remove': {
+      const name = args[1];
+      assert.ok(name, 'Usage: omx agents remove <name>');
+      const path = await removeNativeAgent(name, { cwd: process.cwd(), scope, force });
+      console.log(`Removed native agent: ${path}`);
+      return;
+    }
+    default:
+      throw new Error(`unknown agents subcommand: ${subcommand}`);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@ import { askCommand } from './ask.js';
 import { exploreCommand } from './explore.js';
 import { sparkshellCommand } from './sparkshell.js';
 import { agentsInitCommand } from './agents-init.js';
+import { agentsCommand } from './agents.js';
 import { sessionCommand } from './session-search.js';
 import { autoresearchCommand } from './autoresearch.js';
 import {
@@ -105,6 +106,7 @@ Usage:
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree
+  omx agents    Manage Codex native agent TOML files
   omx deepinit [path]
                 Alias for agents-init (lightweight AGENTS bootstrap only)
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
@@ -176,11 +178,12 @@ const ALLOWED_SHELLS = new Set([
 const WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS = 2500;
 const CODEX_VERSION_FLAGS = new Set(['--version', '-V']);
 
-type CliCommand = 'launch' | 'exec' | 'setup' | 'agents-init' | 'deepinit' | 'uninstall' | 'doctor' | 'ask' | 'explore' | 'sparkshell' | 'team' | 'ralphthon' | 'session' | 'resume' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
+type CliCommand = 'launch' | 'exec' | 'setup' | 'agents' | 'agents-init' | 'deepinit' | 'uninstall' | 'doctor' | 'ask' | 'explore' | 'sparkshell' | 'team' | 'ralphthon' | 'session' | 'resume' | 'version' | 'tmux-hook' | 'hooks' | 'hud' | 'status' | 'cancel' | 'help' | 'reasoning' | string;
 
 const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   'ask',
   'autoresearch',
+  'agents',
   'agents-init',
   'deepinit',
   'exec',
@@ -487,7 +490,7 @@ export function buildHudPaneCleanupTargets(existingPaneIds: string[], createdPan
 
 export async function main(args: string[]): Promise<void> {
   const knownCommands = new Set([
-    'launch', 'exec', 'setup', 'agents-init', 'deepinit', 'uninstall', 'doctor', 'ask', 'autoresearch', 'explore', 'sparkshell', 'team', 'ralph', 'ralphthon', 'session', 'resume', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
+    'launch', 'exec', 'setup', 'agents', 'agents-init', 'deepinit', 'uninstall', 'doctor', 'ask', 'autoresearch', 'explore', 'sparkshell', 'team', 'ralph', 'ralphthon', 'session', 'resume', 'version', 'tmux-hook', 'hooks', 'hud', 'status', 'cancel', 'help', '--help', '-h',
   ]);
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
@@ -520,6 +523,9 @@ export async function main(args: string[]): Promise<void> {
           scope: resolveSetupScopeArg(args.slice(1)),
           skillTarget: resolveSetupSkillTargetArg(args.slice(1)),
         });
+        break;
+      case 'agents':
+        await agentsCommand(args.slice(1));
         break;
       case 'agents-init':
         await agentsInitCommand(args.slice(1));

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -21,21 +21,18 @@ import {
   codexHome,
   codexConfigPath,
   codexPromptsDir,
+  codexAgentsDir,
   userSkillsDir,
   legacyUserSkillsDir,
   omxStateDir,
   omxPlansDir,
   omxLogsDir,
-  omxAgentsConfigDir,
 } from "../utils/paths.js";
 import { buildMergedConfig, getRootModelName } from "../config/generator.js";
 import {
-  getUnifiedMcpRegistryCandidates,
-  loadUnifiedMcpRegistry,
-  planClaudeCodeMcpSettingsSync,
-  type UnifiedMcpRegistryLoadResult,
+  getUnifiedMcpRegistryCandidates, loadUnifiedMcpRegistry, planClaudeCodeMcpSettingsSync, type UnifiedMcpRegistryLoadResult,
 } from "../config/mcp-registry.js";
-import { generateAgentToml } from "../agents/native-config.js";
+import { generateAgentToml, generateSkillAgentToml } from "../agents/native-config.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { getPackageRoot } from "../utils/package.js";
 import { readSessionState, isSessionStale } from "../hooks/session.js";
@@ -333,7 +330,7 @@ export function resolveScopeDirectories(
     return {
       codexConfigFile: join(codexHomeDir, "config.toml"),
       codexHomeDir,
-      nativeAgentsDir: join(projectRoot, ".omx", "agents"),
+      nativeAgentsDir: join(codexHomeDir, "agents"),
       promptsDir: join(codexHomeDir, "prompts"),
       skillsDir: join(projectRoot, ".agents", "skills"),
     };
@@ -341,7 +338,7 @@ export function resolveScopeDirectories(
   return {
     codexConfigFile: codexConfigPath(),
     codexHomeDir: codexHome(),
-    nativeAgentsDir: omxAgentsConfigDir(),
+    nativeAgentsDir: codexAgentsDir(),
     promptsDir: codexPromptsDir(),
     skillsDir: skillTarget === "agents" ? legacyUserSkillsDir() : userSkillsDir(),
   };
@@ -672,26 +669,8 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     }
   }
 
-  // Step 3: Install native agent configs
-  console.log("[3/8] Installing native agent configs...");
-  {
-    summary.nativeAgents = await refreshNativeAgentConfigs(
-      pkgRoot,
-      scopeDirs.nativeAgentsDir,
-      backupContext,
-      {
-        force,
-        dryRun,
-        verbose,
-      },
-    );
-    console.log(
-      `  Native agent refresh complete (${scopeDirs.nativeAgentsDir}).\n`,
-    );
-  }
-
-  // Step 4: Install skills
-  console.log("[4/8] Installing skills...");
+  // Step 3: Install skills
+  console.log("[3/8] Installing skills...");
   {
     const skillsSrc = join(pkgRoot, "skills");
     const skillsDst = scopeDirs.skillsDir;
@@ -707,6 +686,25 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     } else {
       console.log("  Skill refresh complete.\n");
     }
+  }
+
+  // Step 4: Install native agent configs
+  console.log("[4/8] Installing native agent configs...");
+  {
+    summary.nativeAgents = await refreshNativeAgentConfigs(
+      pkgRoot,
+      scopeDirs.skillsDir,
+      scopeDirs.nativeAgentsDir,
+      backupContext,
+      {
+        force,
+        dryRun,
+        verbose,
+      },
+    );
+    console.log(
+      `  Native agent refresh complete (${scopeDirs.nativeAgentsDir}).\n`,
+    );
   }
 
   // Step 5: Update config.toml
@@ -738,7 +736,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   await updateManagedConfig(
     scopeDirs.codexConfigFile,
     pkgRoot,
-    scopeDirs.nativeAgentsDir,
     sharedMcpRegistry,
     summary.config,
     backupContext,
@@ -888,7 +885,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   );
   console.log("  3. Skills are available via /skills or implicit matching");
   console.log("  4. The AGENTS.md orchestration brain is loaded automatically");
-  console.log("  5. Native agent roles registered in config.toml [agents.*]");
+  console.log("  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/");
   console.log('  6. "omx explore" and "omx sparkshell" can hydrate native release binaries on first use; source installs still allow repo-local fallbacks and OMX_EXPLORE_BIN / OMX_SPARKSHELL_BIN overrides');
   if (isGitHubCliConfigured()) {
     console.log("\nSupport the project: gh repo star Yeachan-Heo/oh-my-codex");
@@ -1160,6 +1157,7 @@ async function installPrompts(
 
 async function refreshNativeAgentConfigs(
   pkgRoot: string,
+  skillsDir: string,
   agentsDir: string,
   backupContext: SetupBackupContext,
   options: Pick<SetupOptions, "dryRun" | "verbose" | "force">,
@@ -1174,11 +1172,18 @@ async function refreshNativeAgentConfigs(
   const agentStatusByName = manifest
     ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
     : null;
+  const skillStatusByName = manifest
+    ? new Map(manifest.skills.map((skill) => [skill.name, skill.status]))
+    : null;
   const isInstallableStatus = (status: string | undefined): boolean =>
     status === "active" || status === "internal";
   const staleCandidateNativeAgentNames = new Set(
-    manifest?.agents.map((agent) => agent.name) ?? [],
+    [
+      ...(manifest?.agents.map((agent) => agent.name) ?? []),
+      ...(manifest?.skills.map((skill) => skill.name) ?? []),
+    ],
   );
+  const reservedNativeAgentNames = new Set(["default", "worker", "explorer"]);
 
   for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
     staleCandidateNativeAgentNames.add(name);
@@ -1210,14 +1215,68 @@ async function refreshNativeAgentConfigs(
     );
   }
 
+  if (existsSync(skillsDir)) {
+    const installedSkills = await readdir(skillsDir, { withFileTypes: true });
+    for (const entry of installedSkills) {
+      if (!entry.isDirectory()) continue;
+
+      const skillName = entry.name;
+      staleCandidateNativeAgentNames.add(skillName);
+      if (reservedNativeAgentNames.has(skillName)) {
+        summary.skipped += 1;
+        if (options.verbose) {
+          console.log(`  skipped native agent ${skillName}.toml (reserved built-in agent name)`);
+        }
+        continue;
+      }
+
+      const status = skillStatusByName?.get(skillName);
+      if (skillStatusByName && !isInstallableStatus(status)) {
+        summary.skipped += 1;
+        if (options.verbose) {
+          const label = status ?? "unlisted";
+          console.log(`  skipped native skill agent ${skillName}.toml (status: ${label})`);
+        }
+        continue;
+      }
+
+      const skillMdPath = join(skillsDir, skillName, "SKILL.md");
+      if (!existsSync(skillMdPath)) continue;
+
+      const skillContent = await readFile(skillMdPath, "utf-8");
+      let skillDescription = `OMX skill agent for ${skillName}`;
+      try {
+        skillDescription = parseSkillFrontmatter(skillContent, skillMdPath).description;
+      } catch {
+        // Keep generating the skill-backed agent even if a locally modified
+        // installed skill file no longer has valid frontmatter.
+      }
+      const toml = generateSkillAgentToml(skillName, skillDescription, skillContent);
+      const dst = join(agentsDir, `${skillName}.toml`);
+      await syncManagedContent(
+        toml,
+        dst,
+        summary,
+        backupContext,
+        options,
+        `native skill agent ${skillName}.toml`,
+      );
+    }
+  }
+
   if (options.force && manifest && existsSync(agentsDir)) {
     const installedFiles = await readdir(agentsDir);
     for (const file of installedFiles) {
       if (!file.endsWith('.toml')) continue;
       const agentName = file.slice(0, -5);
-      const status = agentStatusByName?.get(agentName);
-      if (isInstallableStatus(status)) continue;
-      if (!staleCandidateNativeAgentNames.has(agentName) && status === undefined) continue;
+      const agentStatus = agentStatusByName?.get(agentName);
+      const skillStatus = skillStatusByName?.get(agentName);
+      if (isInstallableStatus(agentStatus) || isInstallableStatus(skillStatus)) continue;
+      if (
+        !staleCandidateNativeAgentNames.has(agentName) &&
+        agentStatus === undefined &&
+        skillStatus === undefined
+      ) continue;
 
       const staleAgentPath = join(agentsDir, file);
       if (!existsSync(staleAgentPath)) continue;
@@ -1228,7 +1287,7 @@ async function refreshNativeAgentConfigs(
       summary.removed += 1;
       if (options.verbose) {
         const prefix = options.dryRun ? 'would remove stale native agent' : 'removed stale native agent';
-        const label = status ?? 'unlisted';
+        const label = agentStatus ?? skillStatus ?? 'unlisted';
         console.log(`  ${prefix} ${file} (status: ${label})`);
       }
     }
@@ -1343,7 +1402,6 @@ export async function installSkills(
 async function updateManagedConfig(
   configPath: string,
   pkgRoot: string,
-  agentsConfigDir: string,
   sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
   summary: SetupCategorySummary,
   backupContext: SetupBackupContext,
@@ -1370,7 +1428,6 @@ async function updateManagedConfig(
   }
 
   const finalConfig = buildMergedConfig(existing, pkgRoot, {
-    agentsConfigDir,
     modelOverride,
     sharedMcpServers: sharedMcpRegistry.servers,
     sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -275,14 +275,11 @@ describe("config generator idempotency (#384)", () => {
       assertSingleOmxBlock(toml);
       assert.match(toml, /^\[user\.custom\]$/m, "user section preserved");
       assert.match(toml, /^name = "kept"$/m, "user key preserved");
-
-      // Verify agents appear only inside the OMX block
-      const omxBlockStart = toml.indexOf("# oh-my-codex (OMX) Configuration");
-      const agentIdx = toml.indexOf("[agents.executor]");
-      assert.ok(
-        agentIdx > omxBlockStart,
-        "agents.executor should be inside OMX block",
-      );
+      assert.match(toml, /^\[agents\]$/m, "global agents settings added");
+      assert.match(toml, /^max_threads = 6$/m, "global agents max_threads seeded");
+      assert.match(toml, /^max_depth = 2$/m, "global agents max_depth seeded");
+      assert.doesNotMatch(toml, /^\[agents\.executor\]$/m, "legacy OMX agent entry removed");
+      assert.doesNotMatch(toml, /^\[agents\.explore\]$/m, "legacy OMX agent entry removed");
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -485,18 +482,17 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
-  it("writes only installable catalog agents into the OMX agent block", async () => {
+  it("writes only the global [agents] defaults into config", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const configPath = join(wd, "config.toml");
       await mergeConfig(configPath, wd);
       const toml = await readFile(configPath, "utf-8");
 
-      assert.match(toml, /^\[agents\.executor\]$/m, "active agent kept");
-      assert.match(toml, /^\[agents\."code-simplifier"\]$/m, "internal agent kept");
-      assert.doesNotMatch(toml, /^\[agents\."style-reviewer"\]$/m, "merged agent omitted");
-      assert.doesNotMatch(toml, /^\[agents\."quality-reviewer"\]$/m, "merged agent omitted");
-      assert.doesNotMatch(toml, /^\[agents\."product-manager"\]$/m, "merged product agent omitted");
+      assert.match(toml, /^\[agents\]$/m, "global [agents] section present");
+      assert.match(toml, /^max_threads = 6$/m, "max_threads default written");
+      assert.match(toml, /^max_depth = 2$/m, "max_depth default written");
+      assert.doesNotMatch(toml, /^\[agents\.[^\]]+\]$/m, "legacy per-agent config_file entries omitted");
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -99,6 +99,7 @@ describe('config generator', () => {
       assert.match(toml, /^developer_instructions = "You have oh-my-codex installed/m);
       assert.match(toml, /AGENTS\.md is your orchestration brain and the main orchestration surface/);
       assert.match(toml, /Use \/prompts:<role> and spawned role prompts for specialized subagent work/);
+      assert.match(toml, /Codex native subagents are available via \.codex\/agents/);
       assert.match(toml, /Treat role prompts as narrower execution surfaces under AGENTS\.md authority/);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -212,6 +213,21 @@ describe('config generator', () => {
 
       // OMX feature flags added
       assert.match(toml, /^multi_agent = true$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a global [agents] section with OMX defaults', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd);
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.match(toml, /^\[agents\]$/m);
+      assert.match(toml, /^max_threads = 6$/m);
+      assert.match(toml, /^max_depth = 2$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -14,13 +14,10 @@ import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
-import { tryReadCatalogManifest } from "../catalog/reader.js";
-import { omxAgentsConfigDir } from "../utils/paths.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 
 interface MergeOptions {
-  agentsConfigDir?: string;
   modelOverride?: string;
   sharedMcpServers?: UnifiedMcpRegistryServer[];
   sharedMcpRegistrySource?: string;
@@ -48,6 +45,8 @@ const DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT = 900000;
 const SHARED_MCP_REGISTRY_MARKER = "oh-my-codex (OMX) Shared MCP Registry Sync";
 const SHARED_MCP_REGISTRY_END_MARKER =
   "# End oh-my-codex shared MCP registry sync";
+const OMX_AGENTS_MAX_THREADS = 6;
+const OMX_AGENTS_MAX_DEPTH = 2;
 const OMX_TUI_STATUS_LINE =
   'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit"]';
 
@@ -84,7 +83,7 @@ function getOmxTopLevelLines(
     "# oh-my-codex top-level settings (must be before any [table])",
     `notify = ["node", "${escapedPath}"]`,
     'model_reasoning_effort = "high"',
-    `developer_instructions = "You have oh-my-codex installed. AGENTS.md is your orchestration brain and the main orchestration surface. Use /prompts:<role> and spawned role prompts for specialized subagent work. Use workflow skills via $name when explicitly invoked or clearly routed by AGENTS.md. Treat role prompts as narrower execution surfaces under AGENTS.md authority."`,
+    `developer_instructions = "You have oh-my-codex installed. AGENTS.md is your orchestration brain and the main orchestration surface. Use /prompts:<role> and spawned role prompts for specialized subagent work. Codex native subagents are available via .codex/agents and may be used for independent parallel subtasks within a single session or team pane. Use workflow skills via $name when explicitly invoked or clearly routed by AGENTS.md. Treat role prompts as narrower execution surfaces under AGENTS.md authority."`,
   ];
 
   const existingModel = rootValues.get("model");
@@ -223,6 +222,53 @@ function upsertFeatureFlags(config: string): string {
   return lines.join("\n");
 }
 
+function upsertAgentsSettings(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const agentsStart = lines.findIndex((line) =>
+    /^\s*\[agents\]\s*$/.test(line),
+  );
+
+  if (agentsStart < 0) {
+    const base = config.trimEnd();
+    const agentsBlock = [
+      "[agents]",
+      `max_threads = ${OMX_AGENTS_MAX_THREADS}`,
+      `max_depth = ${OMX_AGENTS_MAX_DEPTH}`,
+      "",
+    ].join("\n");
+    if (base.length === 0) return agentsBlock;
+    return `${base}\n\n${agentsBlock}`;
+  }
+
+  let sectionEnd = lines.length;
+  for (let i = agentsStart + 1; i < lines.length; i++) {
+    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+
+  let maxThreadsIdx = -1;
+  let maxDepthIdx = -1;
+  for (let i = agentsStart + 1; i < sectionEnd; i++) {
+    if (/^\s*max_threads\s*=/.test(lines[i])) {
+      maxThreadsIdx = i;
+    } else if (/^\s*max_depth\s*=/.test(lines[i])) {
+      maxDepthIdx = i;
+    }
+  }
+
+  if (maxThreadsIdx < 0) {
+    lines.splice(sectionEnd, 0, `max_threads = ${OMX_AGENTS_MAX_THREADS}`);
+    sectionEnd += 1;
+  }
+  if (maxDepthIdx < 0) {
+    lines.splice(sectionEnd, 0, `max_depth = ${OMX_AGENTS_MAX_DEPTH}`);
+  }
+
+  return lines.join("\n");
+}
+
 /**
  * Remove OMX-owned feature flags from the [features] section.
  * If the section becomes empty after removal, remove the section header too.
@@ -281,16 +327,14 @@ export function stripOmxFeatureFlags(config: string): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Check whether a TOML table name belongs to an OMX-defined agent.
+ * Check whether a TOML table name belongs to a legacy OMX-managed agent entry.
  * Handles both `agents.name` and `agents."name"` forms.
  */
-function isOmxAgentSection(
-  tableName: string,
-  agentNames: Set<string>,
-): boolean {
+function isLegacyOmxAgentSection(tableName: string): boolean {
   const m = tableName.match(/^agents\.(?:"([^"]+)"|(\w[\w-]*))$/);
   if (!m) return false;
-  return agentNames.has(m[1] || m[2]);
+  const name = m[1] || m[2] || "";
+  return Object.prototype.hasOwnProperty.call(AGENT_DEFINITIONS, name);
 }
 
 /**
@@ -298,12 +342,11 @@ function isOmxAgentSection(
  * This covers legacy configs that were written before markers were added,
  * or configs where the marker was accidentally removed.
  *
- * Targets: [mcp_servers.omx_*], [agents.<omx-agent>], [tui]
+ * Targets: [mcp_servers.omx_*], legacy [agents.<name>] entries, [tui]
  */
 function stripOrphanedOmxSections(config: string): string {
   const lines = config.split(/\r?\n/);
   const result: string[] = [];
-  const omxAgentNames = new Set(Object.keys(AGENT_DEFINITIONS));
 
   let i = 0;
   while (i < lines.length) {
@@ -317,7 +360,7 @@ function stripOrphanedOmxSections(config: string): string {
       // when it lives inside the OMX marker block.
       const isOmxSection =
         /^mcp_servers\.omx_/.test(tableName) ||
-        isOmxAgentSection(tableName, omxAgentNames);
+        isLegacyOmxAgentSection(tableName);
 
       if (isOmxSection) {
         // Remove preceding OMX comment lines and blank lines
@@ -560,52 +603,11 @@ function getSharedMcpRegistryBlock(
 }
 
 /**
- * Generate [agents.<name>] entries for Codex native multi-agent support.
- * Each agent gets a description and config_file pointing to ~/.omx/agents/<name>.toml
- */
-
-function getInstallableAgentEntries(): Array<[string, (typeof AGENT_DEFINITIONS)[string]]> {
-  const manifest = tryReadCatalogManifest();
-  if (!manifest) {
-    return Object.entries(AGENT_DEFINITIONS);
-  }
-
-  const installable = new Set(
-    manifest.agents
-      .filter((agent) => agent.status === "active" || agent.status === "internal")
-      .map((agent) => agent.name),
-  );
-
-  return Object.entries(AGENT_DEFINITIONS).filter(([name]) => installable.has(name));
-}
-
-function getAgentEntries(agentsConfigDir: string): string[] {
-  const entries: string[] = [
-    "",
-    "# OMX Native Agent Roles (Codex multi-agent)",
-  ];
-
-  for (const [name, agent] of getInstallableAgentEntries()) {
-    // TOML table headers with special chars need quoting
-    const tableKey = name.includes("-") ? `agents."${name}"` : `agents.${name}`;
-    const configFile = escapeTomlString(join(agentsConfigDir, `${name}.toml`));
-
-    entries.push("");
-    entries.push(`[${tableKey}]`);
-    entries.push(`description = "${agent.description}"`);
-    entries.push(`config_file = "${configFile}"`);
-  }
-
-  return entries;
-}
-
-/**
  * OMX table-section block (MCP servers, TUI).
  * Contains ONLY [table] sections — no bare keys.
  */
 function getOmxTablesBlock(
   pkgRoot: string,
-  agentsConfigDir: string,
   includeTui = true,
 ): string {
   const stateServerPath = escapeTomlString(
@@ -665,7 +667,6 @@ function getOmxTablesBlock(
     `args = ["${teamServerPath}"]`,
     "enabled = true",
     "startup_timeout_sec = 5",
-    ...getAgentEntries(agentsConfigDir),
     ...(includeTui
       ? [
         "",
@@ -718,6 +719,7 @@ export function buildMergedConfig(
   }
   existing = stripOrphanedOmxSections(existing);
   existing = upsertFeatureFlags(existing);
+  existing = upsertAgentsSettings(existing);
   const tuiUpsert = upsertTuiStatusLine(existing);
   existing = tuiUpsert.cleaned;
 
@@ -728,7 +730,6 @@ export function buildMergedConfig(
   );
   const tablesBlock = getOmxTablesBlock(
     pkgRoot,
-    options.agentsConfigDir || omxAgentsConfigDir(),
     !tuiUpsert.hadExistingTui,
   );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -61,7 +61,8 @@ describe('worker bootstrap', () => {
     assert.match(overlay, /omx team api transition-task-status/);
     assert.match(overlay, /omx team api release-task-claim/);
     assert.doesNotMatch(overlay, /On completion: write \{"status": "completed"/);
-    assert.match(overlay, /Do NOT spawn sub-agents/);
+    assert.match(overlay, /You may spawn Codex native subagents when parallel execution improves throughput/);
+    assert.match(overlay, /Use subagents only for independent, bounded subtasks/);
     assert.match(overlay, /do not pass workingDirectory unless the lead explicitly tells you to/);
     assert.doesNotMatch(overlay, /tasks\/\{id\}\.json/);
   });

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -94,7 +94,8 @@ When your mailbox receives a message, process delivery explicitly:
 - If you need to modify a shared file, report to the lead by writing to your status file with state "blocked"
 - Do NOT write lifecycle fields (\`status\`, \`owner\`, \`result\`, \`error\`) directly in task files; use claim-safe lifecycle APIs
 - If blocked, write {"state": "blocked", "reason": "..."} to your status file
-- Do NOT spawn sub-agents (no spawn_agent). Complete work in this worker session only.
+- You may spawn Codex native subagents when parallel execution improves throughput.
+- Use subagents only for independent, bounded subtasks that can run safely within this worker pane.
 </team_worker_protocol>
 ${TEAM_OVERLAY_END}`;
 }
@@ -433,7 +434,8 @@ ${buildVerificationSection('each assigned task')}
 - Only edit files described in your task descriptions
 - Do NOT edit files that belong to other workers
 - If you need to modify a shared/common file, write \`{"state": "blocked", "reason": "need to edit shared file X"}\` to your status file and wait
-- Do NOT spawn sub-agents (no \`spawn_agent\`). Complete work in this worker session.
+- You may spawn Codex native subagents when parallel execution improves throughput.
+- Use subagents only for independent, bounded subtasks that can run safely within this worker pane.
 ${specializationSection}`;
 }
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -24,6 +24,16 @@ export function codexPromptsDir(): string {
   return join(codexHome(), 'prompts');
 }
 
+/** Codex native agents directory (~/.codex/agents/) */
+export function codexAgentsDir(codexHomeDir?: string): string {
+  return join(codexHomeDir || codexHome(), 'agents');
+}
+
+/** Project-level Codex native agents directory (.codex/agents/) */
+export function projectCodexAgentsDir(projectRoot?: string): string {
+  return join(projectRoot || process.cwd(), '.codex', 'agents');
+}
+
 /** User-level skills directory ($CODEX_HOME/skills, defaults to ~/.codex/skills/) */
 export function userSkillsDir(): string {
   return join(codexHome(), 'skills');
@@ -115,11 +125,6 @@ export function omxPlansDir(projectRoot?: string): string {
 /** oh-my-codex logs directory (.omx/logs/) */
 export function omxLogsDir(projectRoot?: string): string {
   return join(projectRoot || process.cwd(), '.omx', 'logs');
-}
-
-/** oh-my-codex native agent config directory (~/.omx/agents/) */
-export function omxAgentsConfigDir(): string {
-  return join(homedir(), '.omx', 'agents');
 }
 
 /** Get the package root directory (where agents/, skills/, prompts/ live) */

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -2,6 +2,7 @@
 YOU ARE AN AUTONOMOUS CODING AGENT. EXECUTE TASKS TO COMPLETION WITHOUT ASKING FOR PERMISSION.
 DO NOT STOP TO ASK "SHOULD I PROCEED?" — PROCEED. DO NOT WAIT FOR CONFIRMATION ON OBVIOUS NEXT STEPS.
 IF BLOCKED, TRY AN ALTERNATIVE APPROACH. ONLY ASK WHEN TRULY AMBIGUOUS OR DESTRUCTIVE.
+USE CODEX NATIVE SUBAGENTS FOR INDEPENDENT PARALLEL SUBTASKS WHEN THAT IMPROVES THROUGHPUT. THIS IS COMPLEMENTARY TO OMX TEAM MODE.
 <!-- END AUTONOMY DIRECTIVE -->
 
 # oh-my-codex - Intelligent Multi-Agent Orchestration
@@ -33,6 +34,7 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Prefer evidence over assumption; verify before claiming completion.
 - Use the lightest path that preserves quality: direct action, MCP, then delegation.
 - Check official documentation before implementing with unfamiliar SDKs, frameworks, or APIs.
+- Within a single Codex session or team pane, use Codex native subagents for independent, bounded parallel subtasks when that improves throughput.
 <!-- OMX:GUIDANCE:OPERATING:START -->
 - Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.


### PR DESCRIPTION
## Summary

Implements Phase 1 of Codex native subagent integration for issue #885.

This adds native Codex agent management to OMX, migrates setup to Codex’s `.codex/agents/*.toml` discovery path, configures global `[agents]` defaults in `config.toml`, updates AGENTS guidance to be subagent-aware, and removes the worker-bootstrap prohibition on native subagent spawning.

## What changed

### CLI: `omx agents`
Added native agent management commands:

- `omx agents list`
- `omx agents add <name>`
- `omx agents edit <name>`
- `omx agents remove <name>`

Behavior:
- lists project + user native agents with name, description, and model
- scaffolds TOML agents with required fields:
  - `name`
  - `description`
  - `developer_instructions`
- includes optional fields as commented-out examples
- uses `$EDITOR` / `$VISUAL` for `edit`
- confirms before `remove` unless `--force` is passed

### Setup integration
Updated `omx setup` to use Codex-native agent locations:

- user scope: `~/.codex/agents/`
- project scope: `./.codex/agents/`

Also:
- writes managed global `[agents]` defaults into `config.toml`
  - `max_threads = 6`
  - `max_depth = 2`
- generates TOML native agents from installable OMX prompts
- generates TOML native agents from installed OMX skills where appropriate
- skips built-in reserved names to avoid conflicts:
  - `default`
  - `worker`
  - `explorer`

### Guidance updates
Updated AGENTS/config guidance so Codex knows it may use native subagents for independent parallel work within a single session or team pane.

### Team worker bootstrap
Removed the explicit restriction:
- `Do NOT spawn sub-agents (no spawn_agent)`

Replaced with guidance allowing native subagents when parallel execution improves throughput and the subtasks are independent.

## Files changed

- `src/cli/agents.ts`
- `src/cli/__tests__/agents.test.ts`
- `src/cli/index.ts`
- `src/cli/setup.ts`
- `src/agents/native-config.ts`
- `src/config/generator.ts`
- `src/utils/paths.ts`
- `src/team/worker-bootstrap.ts`
- `src/team/__tests__/worker-bootstrap.test.ts`
- `src/config/__tests__/generator-idempotent.test.ts`
- `src/config/__tests__/generator-notify.test.ts`
- `src/cli/__tests__/setup-prompts-overwrite.test.ts`
- `src/cli/__tests__/setup-scope.test.ts`
- `AGENTS.md`
- `templates/AGENTS.md`

## Verification

Passed:
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/agents.test.js dist/agents/__tests__/native-config.test.js dist/team/__tests__/worker-bootstrap.test.js`
- `node --test dist/cli/__tests__/setup-prompts-overwrite.test.js dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/config/__tests__/generator-idempotent.test.js dist/config/__tests__/generator-notify.test.js`

## Notes

- This Phase 1 implementation moves OMX away from legacy per-agent `[agents.<name>] config_file = ...` registration and into Codex-native `.codex/agents/*.toml` discovery.
- Managed config ownership is now a global `[agents]` defaults table rather than enumerating each OMX agent in `config.toml`.
