### PR TITLE
fix(autoresearch): replace execFileSync('cat') with readFileSync and fix macOS test compatibility

### DIFF
--- a/src/autoresearch/__tests__/contracts.test.ts
+++ b/src/autoresearch/__tests__/contracts.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { realpathSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
@@ -12,7 +13,8 @@ import {
 } from '../contracts.js';
 
 async function initRepo(): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-contracts-'));
+  const raw = await mkdtemp(join(tmpdir(), 'omx-autoresearch-contracts-'));
+  const cwd = realpathSync(raw);
   execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, realpathSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -31,7 +31,8 @@ function runOmx(
 }
 
 async function initRepo(): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-test-'));
+  const raw = await mkdtemp(join(tmpdir(), 'omx-autoresearch-test-'));
+  const cwd = realpathSync(raw);
   execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
@@ -309,10 +310,9 @@ EOF
       assert.equal(state.active, false);
 
       const logsRoot = join(repo, '.omx', 'logs', 'autoresearch');
-      const [runId] = execFileSync('find', [logsRoot, '-mindepth', '1', '-maxdepth', '1', '-type', 'd', '-printf', '%f\n'], { encoding: 'utf-8' })
-        .trim()
-        .split('\n')
-        .filter(Boolean);
+      const [runId] = readdirSync(logsRoot, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name);
       assert.ok(runId);
 
       const manifest = JSON.parse(await readFile(join(logsRoot, runId, 'manifest.json'), 'utf-8')) as {

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -162,7 +162,7 @@ async function runAutoresearchLoop(
       runAutoresearchTurn(runtime.worktreePath, runtime.instructionsFile, codexArgs);
 
       const contract = await loadAutoresearchMissionContract(missionDir);
-      const manifest = await loadAutoresearchRunManifest(runtime.repoRoot, JSON.parse(execFileSync('cat', [runtime.manifestFile], { encoding: 'utf-8' })).run_id);
+      const manifest = await loadAutoresearchRunManifest(runtime.repoRoot, JSON.parse(readFileSync(runtime.manifestFile, 'utf-8')).run_id);
       const decision = await processAutoresearchCandidate(contract, manifest, runtime.repoRoot);
       if (decision === 'abort' || decision === 'error') {
         return;


### PR DESCRIPTION
## Summary

- Replace `execFileSync('cat', [manifestFile])` with `readFileSync(manifestFile)` in `runAutoresearchLoop` — the `readFileSync` import already exists on line 2, and `cat` is unavailable on Windows
- Resolve tmpdir symlinks with `realpathSync` in test `initRepo()` helpers so paths match `git rev-parse --show-toplevel` on macOS (where `/var/folders` → `/private/var/folders`)
- Replace GNU-only `find -printf` with Node.js `readdirSync` in the noop exhaustion test for BSD/macOS compatibility

## Test plan

- [x] `npm run build` passes
- [x] `node --test dist/cli/__tests__/autoresearch.test.js` — 14/14 pass (was 8/14)
- [x] `node --test dist/autoresearch/__tests__/contracts.test.js` — 13/13 pass (was 12/13)
- [x] No changes to runtime behavior — only the manifest file read method and test utilities are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)