### PR TITLE
fix(test): resolve macOS test failures in autoresearch (symlink + BSD find)

### DIFF
--- a/src/autoresearch/__tests__/contracts.test.ts
+++ b/src/autoresearch/__tests__/contracts.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { realpathSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
@@ -12,7 +13,8 @@ import {
 } from '../contracts.js';
 
 async function initRepo(): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-contracts-'));
+  const raw = await mkdtemp(join(tmpdir(), 'omx-autoresearch-contracts-'));
+  const cwd = realpathSync(raw);
   execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, realpathSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -31,7 +31,8 @@ function runOmx(
 }
 
 async function initRepo(): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-test-'));
+  const raw = await mkdtemp(join(tmpdir(), 'omx-autoresearch-test-'));
+  const cwd = realpathSync(raw);
   execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
@@ -312,10 +313,9 @@ EOF
       assert.equal(state.active, false);
 
       const logsRoot = join(repo, '.omx', 'logs', 'autoresearch');
-      const [runId] = execFileSync('find', [logsRoot, '-mindepth', '1', '-maxdepth', '1', '-type', 'd', '-printf', '%f\n'], { encoding: 'utf-8' })
-        .trim()
-        .split('\n')
-        .filter(Boolean);
+      const [runId] = readdirSync(logsRoot, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name);
       assert.ok(runId);
 
       const manifest = JSON.parse(await readFile(join(logsRoot, runId, 'manifest.json'), 'utf-8')) as {


### PR DESCRIPTION
## Summary

Fixes 7 autoresearch test failures on macOS caused by platform-specific assumptions:

- **Symlink resolution**: `initRepo()` helpers now use `realpathSync` on the tmpdir path so it matches `git rev-parse --show-toplevel` on macOS (where `/var/folders` symlinks to `/private/var/folders`). Without this, `ensurePathInside` rejects the mission directory as outside the repo.
- **BSD find compatibility**: Replace GNU-only `find -printf '%f\n'` with Node.js `readdirSync` in the noop exhaustion test. macOS ships BSD find which lacks `-printf`.

These tests pass on Linux CI (no symlink, GNU find) but fail on macOS local dev.

## Test plan

- [x] `npm run build` passes
- [x] `node --test dist/cli/__tests__/autoresearch.test.js` — 14/14 pass (was 8/14 on macOS)
- [x] `node --test dist/autoresearch/__tests__/contracts.test.js` — 13/13 pass (was 12/13 on macOS)
- [x] No runtime code changes — test-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)