### PR TITLE
fix: clean up stale obsolete native agents

### DIFF
--- a/src/cli/__tests__/setup-prompts-overwrite.test.ts
+++ b/src/cli/__tests__/setup-prompts-overwrite.test.ts
@@ -7,6 +7,8 @@ import { tmpdir } from 'node:os';
 import { setup } from '../setup.js';
 
 describe('omx setup prompt/native-agent overwrite behavior', () => {
+  const obsoleteNativeAgentField = ['skill', 'ref'].join('_');
+
   it('installs only active/internal catalog prompts and native agents', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
     const previousCwd = process.cwd();
@@ -107,6 +109,37 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
       for (const staleAgent of staleAgents) {
         assert.equal(existsSync(join(wd, '.codex', 'agents', staleAgent)), false);
       }
+      assert.equal(existsSync(join(wd, '.codex', 'agents', 'executor.toml')), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes stale native agents with the obsolete bridge field during normal setup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const stalePath = join(wd, '.codex', 'agents', 'legacy-skill-agent.toml');
+      await writeFile(
+        stalePath,
+        [
+          'name = "legacy-skill-agent"',
+          'description = "obsolete generated bridge agent"',
+          `${obsoleteNativeAgentField} = "skills/legacy"`,
+          '',
+        ].join('\n'),
+      );
+      assert.equal(existsSync(stalePath), true);
+
+      await setup({ scope: 'project' });
+
+      assert.equal(existsSync(stalePath), false);
       assert.equal(existsSync(join(wd, '.codex', 'agents', 'executor.toml')), true);
     } finally {
       process.chdir(previousCwd);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -137,6 +137,7 @@ const REQUIRED_TEAM_CLI_API_MARKERS = [
 const DEFAULT_SETUP_SCOPE: SetupScope = "user";
 const LEGACY_SETUP_MODEL = "gpt-5.3-codex";
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
+const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
 
 function createEmptyCategorySummary(): SetupCategorySummary {
   return {
@@ -207,6 +208,11 @@ async function filesDiffer(src: string, dst: string): Promise<boolean> {
     readFile(dst, "utf-8"),
   ]);
   return srcContent !== dstContent;
+}
+
+function containsTomlKey(content: string, key: string): boolean {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^\\s*${escapedKey}\\s*=`, "m").test(content);
 }
 
 function parseSkillFrontmatterScalar(
@@ -1205,7 +1211,7 @@ async function refreshNativeAgentConfigs(
     );
   }
 
-  summary.removed += await cleanupSkillBridgeNativeAgents(
+  summary.removed += await cleanupObsoleteNativeAgents(
     agentsDir,
     backupContext,
     options,
@@ -1244,7 +1250,7 @@ async function refreshNativeAgentConfigs(
   return summary;
 }
 
-async function cleanupSkillBridgeNativeAgents(
+async function cleanupObsoleteNativeAgents(
   agentsDir: string,
   backupContext: SetupBackupContext,
   options: Pick<SetupOptions, "dryRun" | "verbose">,
@@ -1265,18 +1271,18 @@ async function cleanupSkillBridgeNativeAgents(
       continue;
     }
 
-    if (!/^\s*skill_ref\s*=/m.test(content)) continue;
+    if (!containsTomlKey(content, OBSOLETE_NATIVE_AGENT_FIELD)) continue;
 
     if (await ensureBackup(fullPath, true, backupContext, options)) {
-      // backup created for pre-existing skill bridge config
+      // backup created for pre-existing obsolete native agent config
     }
     if (!options.dryRun) {
       await rm(fullPath, { force: true });
     }
     if (options.verbose) {
       const prefix = options.dryRun
-        ? "would remove stale skill-bridge native agent"
-        : "removed stale skill-bridge native agent";
+        ? "would remove stale obsolete native agent"
+        : "removed stale obsolete native agent";
       console.log(`  ${prefix} ${file}`);
     }
     removed += 1;


### PR DESCRIPTION
## Summary
- remove lingering obsolete native-agent cleanup references from setup and keep stale cleanup in normal refresh runs
- delete stale .codex/agents/*.toml files that contain the unsupported pre-#897 bridge field during setup
- add regression coverage proving normal project setup removes those stale files

## Testing
- npm run lint
- npm run check:no-unused
- node --test dist/cli/__tests__/setup-prompts-overwrite.test.js
- npm test

Closes #898.