### PR TITLE
Fix #900: add omx cleanup command for orphaned MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ omx team ...       # Start/status/resume/shutdown coordinated team workers (defa
 omx setup          # Install prompts/skills/config by scope + project .omx + scope-specific AGENTS.md
 omx agents-init .  # Bootstrap lightweight AGENTS.md files for a repo/subtree
 omx doctor         # Installation/runtime diagnostics
+omx cleanup        # Kill orphaned OMX MCP server processes (--dry-run to inspect)
 omx doctor --team  # Team Mode diagnostics
 omx ask ...        # Ask local provider advisor (claude|gemini), writes .omx/artifacts/*
 omx resume         # Resume a previous interactive Codex session

--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -1,0 +1,124 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  cleanupOmxMcpProcesses,
+  findCleanupCandidates,
+  type ProcessEntry,
+} from '../cleanup.js';
+
+const CURRENT_SESSION_PROCESSES: ProcessEntry[] = [
+  { pid: 700, ppid: 500, command: 'codex' },
+  { pid: 701, ppid: 700, command: 'node /repo/bin/omx.js cleanup --dry-run' },
+  {
+    pid: 710,
+    ppid: 700,
+    command: 'node /repo/oh-my-codex/dist/mcp/state-server.js',
+  },
+  {
+    pid: 800,
+    ppid: 1,
+    command: 'node /tmp/oh-my-codex/dist/mcp/memory-server.js',
+  },
+  {
+    pid: 810,
+    ppid: 42,
+    command: 'node /tmp/worktree/dist/mcp/trace-server.js',
+  },
+  {
+    pid: 811,
+    ppid: 810,
+    command: 'node /tmp/worktree/dist/mcp/team-server.js',
+  },
+  {
+    pid: 900,
+    ppid: 1,
+    command: 'node /tmp/not-omx/other-server.js',
+  },
+];
+
+describe('findCleanupCandidates', () => {
+  it('selects orphaned OMX MCP processes while preserving the current session tree', () => {
+    assert.deepEqual(
+      findCleanupCandidates(CURRENT_SESSION_PROCESSES, 701),
+      [
+        {
+          pid: 800,
+          ppid: 1,
+          command: 'node /tmp/oh-my-codex/dist/mcp/memory-server.js',
+          reason: 'ppid=1',
+        },
+        {
+          pid: 810,
+          ppid: 42,
+          command: 'node /tmp/worktree/dist/mcp/trace-server.js',
+          reason: 'outside-current-session',
+        },
+        {
+          pid: 811,
+          ppid: 810,
+          command: 'node /tmp/worktree/dist/mcp/team-server.js',
+          reason: 'outside-current-session',
+        },
+      ],
+    );
+  });
+});
+
+describe('cleanupOmxMcpProcesses', () => {
+  it('supports dry-run without sending signals', async () => {
+    const lines: string[] = [];
+    let signalCount = 0;
+
+    const result = await cleanupOmxMcpProcesses(['--dry-run'], {
+      currentPid: 701,
+      listProcesses: () => CURRENT_SESSION_PROCESSES,
+      sendSignal: () => {
+        signalCount += 1;
+      },
+      writeLine: (line) => lines.push(line),
+    });
+
+    assert.equal(result.dryRun, true);
+    assert.equal(result.candidates.length, 3);
+    assert.equal(signalCount, 0);
+    assert.match(lines.join('\n'), /Dry run: would terminate 3 orphaned OMX MCP server process/);
+    assert.match(lines.join('\n'), /PID 800/);
+    assert.match(lines.join('\n'), /PID 810/);
+  });
+
+  it('sends SIGTERM, waits, and escalates with SIGKILL when needed', async () => {
+    const lines: string[] = [];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const alive = new Set([800, 810]);
+    let fakeNow = 0;
+
+    const result = await cleanupOmxMcpProcesses([], {
+      currentPid: 701,
+      listProcesses: () => [
+        ...CURRENT_SESSION_PROCESSES.filter((processEntry) => processEntry.pid !== 811),
+      ],
+      isPidAlive: (pid) => alive.has(pid),
+      sendSignal: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === 'SIGTERM' && pid === 800) alive.delete(pid);
+        if (signal === 'SIGKILL') alive.delete(pid);
+      },
+      sleep: async (ms) => {
+        fakeNow += ms;
+      },
+      now: () => fakeNow,
+      writeLine: (line) => lines.push(line),
+    });
+
+    assert.equal(result.terminatedCount, 2);
+    assert.equal(result.forceKilledCount, 1);
+    assert.deepEqual(result.failedPids, []);
+    assert.deepEqual(signals, [
+      { pid: 800, signal: 'SIGTERM' },
+      { pid: 810, signal: 'SIGTERM' },
+      { pid: 810, signal: 'SIGKILL' },
+    ]);
+    assert.match(lines.join('\n'), /Escalating to SIGKILL for 1 process/);
+    assert.match(lines.join('\n'), /Killed 2 orphaned OMX MCP server process\(es\) \(1 required SIGKILL\)\./);
+  });
+});

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -1,0 +1,312 @@
+import { execFileSync } from 'child_process';
+
+const HELP = [
+  'Usage: omx cleanup [--dry-run]',
+  '',
+  'Kill orphaned OMX MCP server processes left behind by previous Codex App sessions.',
+  '',
+  'Options:',
+  '  --dry-run  List matching orphaned processes without sending signals',
+  '  --help     Show this help message',
+].join('\n');
+
+const PROCESS_EXIT_POLL_MS = 100;
+const SIGTERM_GRACE_MS = 5_000;
+const OMX_MCP_SERVER_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/](?:state|memory|code-intel|trace|team)-server\.(?:[cm]?js|ts)\b/i;
+const CODEX_PROCESS_PATTERN = /(?:^|[\\/\s])codex(?:\.js)?(?:\s|$)|@openai[\\/]codex/i;
+
+export interface ProcessEntry {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+export interface CleanupCandidate extends ProcessEntry {
+  reason: 'ppid=1' | 'outside-current-session';
+}
+
+export interface CleanupResult {
+  dryRun: boolean;
+  candidates: CleanupCandidate[];
+  terminatedCount: number;
+  forceKilledCount: number;
+  failedPids: number[];
+}
+
+export interface CleanupDependencies {
+  currentPid?: number;
+  listProcesses?: () => ProcessEntry[];
+  isPidAlive?: (pid: number) => boolean;
+  sendSignal?: (pid: number, signal: NodeJS.Signals) => void;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  writeLine?: (line: string) => void;
+}
+
+function normalizeCommand(command: string): string {
+  return command.replace(/\\+/g, '/').trim();
+}
+
+export function isOmxMcpProcess(command: string): boolean {
+  const normalized = normalizeCommand(command);
+  return normalized.includes('oh-my-codex/dist/mcp') || OMX_MCP_SERVER_PATTERN.test(normalized);
+}
+
+export function parsePsOutput(output: string): ProcessEntry[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      if (!match) return null;
+      const pid = Number.parseInt(match[1], 10);
+      const ppid = Number.parseInt(match[2], 10);
+      const command = match[3]?.trim();
+      if (!Number.isInteger(pid) || pid <= 0) return null;
+      if (!Number.isInteger(ppid) || ppid < 0) return null;
+      if (!command) return null;
+      return { pid, ppid, command } satisfies ProcessEntry;
+    })
+    .filter((entry): entry is ProcessEntry => entry !== null);
+}
+
+export function listOmxProcesses(): ProcessEntry[] {
+  const output = execFileSync('ps', ['axww', '-o', 'pid=,ppid=,command='], {
+    encoding: 'utf-8',
+  });
+  return parsePsOutput(output);
+}
+
+function isCodexSessionProcess(command: string): boolean {
+  return CODEX_PROCESS_PATTERN.test(normalizeCommand(command));
+}
+
+function resolveProtectedRootPid(
+  processes: readonly ProcessEntry[],
+  currentPid: number,
+): number {
+  const parentByPid = new Map<number, number>();
+  const commandByPid = new Map<number, string>();
+
+  for (const processEntry of processes) {
+    parentByPid.set(processEntry.pid, processEntry.ppid);
+    commandByPid.set(processEntry.pid, processEntry.command);
+  }
+
+  let pid: number | undefined = currentPid;
+  while (typeof pid === 'number' && pid > 1) {
+    const command = commandByPid.get(pid);
+    if (command && isCodexSessionProcess(command)) return pid;
+    const parentPid = parentByPid.get(pid);
+    if (typeof parentPid !== 'number' || parentPid <= 0 || parentPid === pid) break;
+    pid = parentPid;
+  }
+
+  return currentPid;
+}
+
+export function buildProtectedPidSet(
+  processes: readonly ProcessEntry[],
+  currentPid: number,
+): Set<number> {
+  const childrenByPid = new Map<number, number[]>();
+
+  for (const processEntry of processes) {
+    const siblings = childrenByPid.get(processEntry.ppid) ?? [];
+    siblings.push(processEntry.pid);
+    childrenByPid.set(processEntry.ppid, siblings);
+  }
+
+  const protectedRootPid = resolveProtectedRootPid(processes, currentPid);
+  const protectedPids = new Set<number>();
+  const descendants = [protectedRootPid];
+
+  while (descendants.length > 0) {
+    const pid = descendants.pop()!;
+    if (protectedPids.has(pid)) continue;
+    protectedPids.add(pid);
+    for (const childPid of childrenByPid.get(pid) ?? []) {
+      if (!protectedPids.has(childPid)) descendants.push(childPid);
+    }
+  }
+
+  return protectedPids;
+}
+
+export function findCleanupCandidates(
+  processes: readonly ProcessEntry[],
+  currentPid: number,
+): CleanupCandidate[] {
+  const protectedPids = buildProtectedPidSet(processes, currentPid);
+
+  return processes
+    .filter((processEntry) => processEntry.pid !== currentPid)
+    .filter((processEntry) => isOmxMcpProcess(processEntry.command))
+    .filter((processEntry) => !protectedPids.has(processEntry.pid))
+    .sort((left, right) => left.pid - right.pid)
+    .map((processEntry) => ({
+      ...processEntry,
+      reason: processEntry.ppid <= 1 ? 'ppid=1' : 'outside-current-session',
+    }));
+}
+
+function defaultIsPidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
+    throw err;
+  }
+}
+
+async function waitForPidsToExit(
+  pids: readonly number[],
+  timeoutMs: number,
+  isPidAlive: (pid: number) => boolean,
+  sleep: (ms: number) => Promise<void>,
+  now: () => number,
+): Promise<Set<number>> {
+  const remaining = new Set(
+    pids.filter((pid) => Number.isFinite(pid) && pid > 0 && isPidAlive(pid)),
+  );
+  if (remaining.size === 0) return remaining;
+
+  const deadline = now() + Math.max(0, timeoutMs);
+  while (now() < deadline && remaining.size > 0) {
+    await sleep(PROCESS_EXIT_POLL_MS);
+    for (const pid of [...remaining]) {
+      if (!isPidAlive(pid)) remaining.delete(pid);
+    }
+  }
+
+  for (const pid of [...remaining]) {
+    if (!isPidAlive(pid)) remaining.delete(pid);
+  }
+
+  return remaining;
+}
+
+function formatCandidate(candidate: CleanupCandidate): string {
+  return `PID ${candidate.pid} (PPID ${candidate.ppid}, ${candidate.reason}) ${candidate.command}`;
+}
+
+export async function cleanupOmxMcpProcesses(
+  args: readonly string[],
+  dependencies: CleanupDependencies = {},
+): Promise<CleanupResult> {
+  if (args.includes('--help') || args.includes('-h')) {
+    dependencies.writeLine?.(HELP) ?? console.log(HELP);
+    return {
+      dryRun: true,
+      candidates: [],
+      terminatedCount: 0,
+      forceKilledCount: 0,
+      failedPids: [],
+    };
+  }
+
+  const dryRun = args.includes('--dry-run');
+  const writeLine = dependencies.writeLine ?? ((line: string) => console.log(line));
+  const currentPid = dependencies.currentPid ?? process.pid;
+  const listProcessesImpl = dependencies.listProcesses ?? listOmxProcesses;
+  const isPidAlive = dependencies.isPidAlive ?? defaultIsPidAlive;
+  const sendSignal = dependencies.sendSignal ?? ((pid: number, signal: NodeJS.Signals) => process.kill(pid, signal));
+  const sleep = dependencies.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const now = dependencies.now ?? Date.now;
+
+  const candidates = findCleanupCandidates(listProcessesImpl(), currentPid);
+  if (candidates.length === 0) {
+    writeLine(dryRun
+      ? 'Dry run: no orphaned OMX MCP server processes found.'
+      : 'No orphaned OMX MCP server processes found.');
+    return {
+      dryRun,
+      candidates,
+      terminatedCount: 0,
+      forceKilledCount: 0,
+      failedPids: [],
+    };
+  }
+
+  if (dryRun) {
+    writeLine(`Dry run: would terminate ${candidates.length} orphaned OMX MCP server process(es):`);
+    for (const candidate of candidates) writeLine(`  ${formatCandidate(candidate)}`);
+    return {
+      dryRun: true,
+      candidates,
+      terminatedCount: 0,
+      forceKilledCount: 0,
+      failedPids: [],
+    };
+  }
+
+  writeLine(`Found ${candidates.length} orphaned OMX MCP server process(es). Sending SIGTERM...`);
+  for (const candidate of candidates) {
+    try {
+      sendSignal(candidate.pid, 'SIGTERM');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
+        throw err;
+      }
+    }
+  }
+
+  const remainingAfterTerm = await waitForPidsToExit(
+    candidates.map((candidate) => candidate.pid),
+    SIGTERM_GRACE_MS,
+    isPidAlive,
+    sleep,
+    now,
+  );
+  const stillRunning = candidates.filter((candidate) =>
+    remainingAfterTerm.has(candidate.pid),
+  );
+  let terminatedCount = candidates.length - stillRunning.length;
+
+  let forceKilledCount = 0;
+  const failedPids: number[] = [];
+  if (stillRunning.length > 0) {
+    writeLine(`Escalating to SIGKILL for ${stillRunning.length} process(es) still alive after ${SIGTERM_GRACE_MS / 1000}s.`);
+    for (const candidate of stillRunning) {
+      try {
+        sendSignal(candidate.pid, 'SIGKILL');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
+          throw err;
+        }
+      }
+
+    }
+
+    const remainingAfterKill = await waitForPidsToExit(
+      stillRunning.map((candidate) => candidate.pid),
+      PROCESS_EXIT_POLL_MS,
+      isPidAlive,
+      sleep,
+      now,
+    );
+    forceKilledCount = stillRunning.length - remainingAfterKill.size;
+    terminatedCount += forceKilledCount;
+    failedPids.push(...remainingAfterKill);
+  }
+
+  writeLine(`Killed ${terminatedCount} orphaned OMX MCP server process(es)${forceKilledCount > 0 ? ` (${forceKilledCount} required SIGKILL)` : ''}.`);
+  if (failedPids.length > 0) {
+    writeLine(`Warning: ${failedPids.length} process(es) still appear alive: ${failedPids.join(', ')}`);
+  }
+
+  return {
+    dryRun: false,
+    candidates,
+    terminatedCount,
+    forceKilledCount,
+    failedPids,
+  };
+}
+
+export async function cleanupCommand(args: string[]): Promise<void> {
+  await cleanupOmxMcpProcesses(args);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
 import { ralphthonCommand } from "./ralphthon.js";
 import { askCommand } from "./ask.js";
+import { cleanupCommand } from "./cleanup.js";
 import { exploreCommand } from "./explore.js";
 import { sparkshellCommand } from "./sparkshell.js";
 import { agentsInitCommand } from "./agents-init.js";
@@ -106,6 +107,7 @@ Usage:
   omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md
   omx uninstall Remove OMX configuration and clean up installed artifacts
   omx doctor    Check installation health
+  omx cleanup   Kill orphaned OMX MCP server processes from prior sessions
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx resume    Resume a previous interactive Codex session
@@ -208,6 +210,7 @@ type CliCommand =
   | "deepinit"
   | "uninstall"
   | "doctor"
+  | "cleanup"
   | "ask"
   | "explore"
   | "sparkshell"
@@ -227,6 +230,7 @@ type CliCommand =
 
 const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "ask",
+  "cleanup",
   "autoresearch",
   "agents",
   "agents-init",
@@ -558,6 +562,7 @@ export async function main(args: string[]): Promise<void> {
     "deepinit",
     "uninstall",
     "doctor",
+    "cleanup",
     "ask",
     "autoresearch",
     "explore",
@@ -633,6 +638,9 @@ export async function main(args: string[]): Promise<void> {
       }
       case "ask":
         await askCommand(args.slice(1));
+        break;
+      case "cleanup":
+        await cleanupCommand(args.slice(1));
         break;
       case "autoresearch":
         await autoresearchCommand(args.slice(1));

--- a/src/compat/fixtures/help.stdout.txt
+++ b/src/compat/fixtures/help.stdout.txt
@@ -7,6 +7,7 @@ Usage:
   omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md
   omx uninstall Remove OMX configuration and clean up installed artifacts
   omx doctor    Check installation health
+  omx cleanup   Kill orphaned OMX MCP server processes from prior sessions
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx autoresearch Launch thin-supervisor autoresearch with keep/discard/reset parity


### PR DESCRIPTION
## Summary
- add a new `omx cleanup` CLI command with `--dry-run` support for orphaned OMX MCP processes
- protect the current Codex session tree, terminate stale OMX MCP processes with SIGTERM, and escalate to SIGKILL after 5s when needed
- cover the cleanup selection/escalation logic with tests and document the new command in the README/help output

## Testing
- npm run build
- npm run lint -- src/cli/cleanup.ts src/cli/__tests__/cleanup.test.ts src/cli/index.ts README.md
- npm run check:no-unused
- node --test dist/cli/__tests__/cleanup.test.js dist/cli/__tests__/nested-help-routing.test.js
- npm run test:node

Fixes #900
