### PR TITLE
feat(autoresearch): add spark sidecar refresh path

### DIFF
--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -4,6 +4,11 @@ import { mkdir, readFile, symlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { cancelMode, readModeState, startMode, updateModeState } from '../modes/base.js';
 import {
+  initializeAutoresearchSparkPrepassSnapshot,
+  readAutoresearchSparkPrepassSnapshot,
+  type AutoresearchSparkPrepassSnapshot,
+} from './spark-prepass.js';
+import {
   parseEvaluatorResult,
   type AutoresearchKeepPolicy,
   type AutoresearchMissionContract,
@@ -24,6 +29,10 @@ export interface PreparedAutoresearchRuntime {
   resultsFile: string;
   stateFile: string;
   candidateFile: string;
+  sparkPrepassEnabled: boolean;
+  sparkPrepassStatusFile: string | null;
+  sparkPrepassPacketFile: string | null;
+  sparkSidecarEnabled: boolean;
   repoRoot: string;
   worktreePath: string;
   taskDescription: string;
@@ -87,6 +96,9 @@ export interface AutoresearchRunManifest {
   ledger_file: string;
   latest_evaluator_file: string;
   candidate_file: string;
+  spark_prepass_enabled: boolean;
+  spark_prepass_status_file: string | null;
+  spark_prepass_packet_file: string | null;
   evaluator: AutoresearchMissionContract['sandbox']['evaluator'];
   keep_policy: AutoresearchKeepPolicy;
   status: AutoresearchRunStatus;
@@ -130,6 +142,8 @@ interface AutoresearchInstructionLedgerSummary {
 
 const AUTORESEARCH_RESULTS_HEADER = 'iteration\tcommit\tpass\tscore\tstatus\tdescription\n';
 const AUTORESEARCH_WORKTREE_EXCLUDES = ['results.tsv', 'run.log', 'node_modules', '.omx/'];
+const AUTORESEARCH_SPARK_PREPASS_STATUS_FILE = 'spark-prepass-status.json';
+const AUTORESEARCH_SPARK_PREPASS_PACKET_FILE = 'spark-prepass-fact-packet.md';
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -640,6 +654,10 @@ export function buildAutoresearchInstructions(
     keepPolicy: AutoresearchKeepPolicy;
     previousIterationOutcome?: string | null;
     recentLedgerSummary?: AutoresearchInstructionLedgerSummary[];
+    sparkPrepass?: {
+      snapshot: AutoresearchSparkPrepassSnapshot | null;
+      packet: string | null;
+    } | null;
   },
 ): string {
   return [
@@ -668,9 +686,23 @@ export function buildAutoresearchInstructions(
       previous_iteration_outcome: context.previousIterationOutcome ?? 'none yet',
       recent_ledger_summary: context.recentLedgerSummary ?? [],
       keep_policy: context.keepPolicy,
+      spark_fact_packet_enabled: Boolean(context.sparkPrepass?.packet),
     }, null, 2),
     '```',
-    '',
+    ...(context.sparkPrepass?.snapshot?.enabled
+      ? [
+        '',
+        'Spark prepass status:',
+        '```json',
+        JSON.stringify(context.sparkPrepass.snapshot, null, 2),
+        '```',
+        ...(context.sparkPrepass.packet ? [
+          '',
+          'Spark prepass fact packet (read-only discovery generated before the main Codex turn; re-check critical facts in-repo before relying on them):',
+          context.sparkPrepass.packet,
+        ] : []),
+      ]
+      : []),
     'Operate as a thin autoresearch experiment worker for exactly one experiment cycle.',
     'Do not loop forever inside this session. Make at most one candidate commit, then write the candidate artifact JSON and exit.',
     '',
@@ -707,6 +739,14 @@ export function buildAutoresearchInstructions(
     trimContent(contract.sandbox.body || contract.sandboxContent),
     '```',
   ].join('\n');
+}
+
+export function autoresearchSparkPrepassPacketPath(instructionsFile: string): string {
+  return join(dirname(instructionsFile), AUTORESEARCH_SPARK_PREPASS_PACKET_FILE);
+}
+
+export function autoresearchSparkPrepassStatusPath(instructionsFile: string): string {
+  return join(dirname(instructionsFile), AUTORESEARCH_SPARK_PREPASS_STATUS_FILE);
 }
 
 export async function materializeAutoresearchMissionToWorktree(
@@ -757,6 +797,12 @@ async function writeRunManifest(manifest: AutoresearchRunManifest): Promise<void
 
 async function writeInstructionsFile(contract: AutoresearchMissionContract, manifest: AutoresearchRunManifest): Promise<void> {
   const instructionContext = await buildAutoresearchInstructionContext(manifest);
+  const sparkPrepass = manifest.spark_prepass_enabled
+    ? await readAutoresearchSparkPrepassSnapshot(
+      manifest.spark_prepass_status_file,
+      manifest.spark_prepass_packet_file,
+    )
+    : null;
   await writeFile(
     manifest.instructions_file,
     `${buildAutoresearchInstructions(contract, {
@@ -770,9 +816,17 @@ async function writeInstructionsFile(contract: AutoresearchMissionContract, mani
       keepPolicy: manifest.keep_policy,
       previousIterationOutcome: instructionContext.previousIterationOutcome,
       recentLedgerSummary: instructionContext.recentLedgerSummary,
+      sparkPrepass,
     })}\n`,
     'utf-8',
   );
+}
+
+export async function refreshAutoresearchInstructions(
+  contract: AutoresearchMissionContract,
+  manifest: AutoresearchRunManifest,
+): Promise<void> {
+  await writeInstructionsFile(contract, manifest);
 }
 
 async function seedBaseline(
@@ -814,7 +868,7 @@ export async function prepareAutoresearchRuntime(
   contract: AutoresearchMissionContract,
   projectRoot: string,
   worktreePath: string,
-  options: { runTag?: string } = {},
+  options: { runTag?: string; sparkPrepassEnabled?: boolean; sparkSidecarEnabled?: boolean } = {},
 ): Promise<PreparedAutoresearchRuntime> {
   await assertAutoresearchLockAvailable(projectRoot);
   await ensureRuntimeExcludes(worktreePath);
@@ -832,6 +886,10 @@ export async function prepareAutoresearchRuntime(
   const ledgerFile = join(runDir, 'iteration-ledger.json');
   const latestEvaluatorFile = join(runDir, 'latest-evaluator-result.json');
   const candidateFile = join(runDir, 'candidate.json');
+  const sparkSidecarEnabled = options.sparkSidecarEnabled === true;
+  const sparkPrepassEnabled = options.sparkPrepassEnabled === true || sparkSidecarEnabled;
+  const sparkPrepassStatusFile = sparkPrepassEnabled ? autoresearchSparkPrepassStatusPath(instructionsFile) : null;
+  const sparkPrepassPacketFile = sparkPrepassEnabled ? autoresearchSparkPrepassPacketPath(instructionsFile) : null;
   const resultsFile = join(worktreePath, 'results.tsv');
   const taskDescription = `autoresearch ${contract.missionRelativeDir} (${runId})`;
   const keepPolicy = contract.sandbox.evaluator.keep_policy ?? 'score_improvement';
@@ -868,6 +926,9 @@ export async function prepareAutoresearchRuntime(
     ledger_file: ledgerFile,
     latest_evaluator_file: latestEvaluatorFile,
     candidate_file: candidateFile,
+    spark_prepass_enabled: sparkPrepassEnabled,
+    spark_prepass_status_file: sparkPrepassStatusFile,
+    spark_prepass_packet_file: sparkPrepassPacketFile,
     evaluator: contract.sandbox.evaluator,
     keep_policy: keepPolicy,
     status: 'running',
@@ -878,6 +939,13 @@ export async function prepareAutoresearchRuntime(
     completed_at: null,
   };
 
+  await initializeAutoresearchSparkPrepassSnapshot(
+    sparkPrepassEnabled,
+    sparkPrepassStatusFile,
+    sparkPrepassPacketFile,
+    undefined,
+    sparkSidecarEnabled,
+  );
   await writeInstructionsFile(contract, manifest);
   await writeRunManifest(manifest);
   await writeJsonFile(ledgerFile, {
@@ -943,6 +1011,10 @@ export async function prepareAutoresearchRuntime(
     resultsFile,
     stateFile,
     candidateFile,
+    sparkPrepassEnabled,
+    sparkPrepassStatusFile,
+    sparkPrepassPacketFile,
+    sparkSidecarEnabled,
     repoRoot: projectRoot,
     worktreePath,
     taskDescription,
@@ -996,6 +1068,10 @@ export async function resumeAutoresearchRuntime(projectRoot: string, runId: stri
     resultsFile: manifest.results_file,
     stateFile: activeRunStateFile(projectRoot),
     candidateFile: manifest.candidate_file,
+    sparkPrepassEnabled: manifest.spark_prepass_enabled,
+    sparkPrepassStatusFile: manifest.spark_prepass_status_file,
+    sparkPrepassPacketFile: manifest.spark_prepass_packet_file,
+    sparkSidecarEnabled: false,
     repoRoot: manifest.repo_root,
     worktreePath: manifest.worktree_path,
     taskDescription: `autoresearch resume ${runId}`,

--- a/src/autoresearch/spark-prepass.ts
+++ b/src/autoresearch/spark-prepass.ts
@@ -1,0 +1,257 @@
+import { existsSync } from 'fs';
+import { readFile, writeFile } from 'fs/promises';
+import type { AutoresearchMissionContract } from './contracts.js';
+import { executeExplorePrompt, type ExecuteExplorePromptResult } from '../cli/explore.js';
+
+export interface AutoresearchSparkPrepassSnapshot {
+  enabled: boolean;
+  status: 'pending' | 'available' | 'fallback';
+  note: string;
+  updated_at: string;
+  packet_characters: number;
+  // Sidecar extensions (present when --spark-sidecar is active)
+  sidecar_enabled?: boolean;
+  last_refresh_iteration?: number;
+  refresh_count?: number;
+  last_refresh_reason?: string;
+}
+
+export const SPARK_SIDECAR_NOOP_TRIGGER = 2;
+export const SPARK_SIDECAR_COOLDOWN_ITERATIONS = 3;
+
+export interface ReadAutoresearchSparkPrepassResult {
+  snapshot: AutoresearchSparkPrepassSnapshot | null;
+  packet: string | null;
+}
+
+export interface RunAutoresearchSparkPrepassOptions {
+  cwd: string;
+  iteration: number;
+  lastKeptCommit: string;
+  previousIterationOutcome?: string | null;
+  recentLedgerSummary?: readonly unknown[];
+  env?: NodeJS.ProcessEnv;
+  statusFile?: string | null;
+  packetFile?: string | null;
+}
+
+interface RunAutoresearchSparkPrepassDependencies {
+  now?: () => string;
+  executeExplore?: typeof executeExplorePrompt;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function trimPreview(value: string, maxChars: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars)}\n...`;
+}
+
+export function trimAutoresearchSparkFactPacket(value: string, maxChars = 3200): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars)}\n...`;
+}
+
+export function buildAutoresearchSparkPrepassPrompt(
+  contract: AutoresearchMissionContract,
+  context: Pick<
+    RunAutoresearchSparkPrepassOptions,
+    'iteration' | 'lastKeptCommit' | 'previousIterationOutcome' | 'recentLedgerSummary'
+  >,
+): string {
+  return [
+    'You are a bounded OMX autoresearch Spark discovery sidecar.',
+    'Goal: produce a compact read-only fact packet for the next main Codex experiment turn.',
+    'Stay strictly read-only: no edits, no patches, no commits, no candidate ownership, no supervisor decisions.',
+    'Prefer cheap discovery: relevant files, key symbol/path matches, short evidence snippets, and the next files worth opening.',
+    'Return markdown with exactly these headings and short bullet lists:',
+    '## Likely relevant files',
+    '## Key matches',
+    '## Evidence snippets',
+    '## Next files to inspect',
+    'Keep the total response under 12 bullets and under 900 words.',
+    '',
+    'Current iteration context:',
+    '```json',
+    JSON.stringify({
+      iteration: context.iteration,
+      last_kept_commit: context.lastKeptCommit,
+      previous_iteration_outcome: context.previousIterationOutcome ?? 'none yet',
+      recent_ledger_summary: context.recentLedgerSummary ?? [],
+    }, null, 2),
+    '```',
+    '',
+    'Mission excerpt:',
+    '```md',
+    trimPreview(contract.missionContent, 1000),
+    '```',
+    '',
+    'Sandbox excerpt:',
+    '```md',
+    trimPreview(contract.sandbox.body || contract.sandboxContent, 1000),
+    '```',
+  ].join('\n');
+}
+
+export async function writeAutoresearchSparkPrepassSnapshot(
+  statusFile: string,
+  packetFile: string,
+  snapshot: AutoresearchSparkPrepassSnapshot,
+  packet: string | null,
+): Promise<void> {
+  await writeFile(statusFile, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf-8');
+  await writeFile(packetFile, packet ? `${packet.trim()}\n` : '', 'utf-8');
+}
+
+export async function readAutoresearchSparkPrepassSnapshot(
+  statusFile: string | null | undefined,
+  packetFile: string | null | undefined,
+): Promise<ReadAutoresearchSparkPrepassResult> {
+  if (!statusFile || !packetFile || !existsSync(statusFile)) {
+    return { snapshot: null, packet: null };
+  }
+
+  const snapshot = JSON.parse(await readFile(statusFile, 'utf-8')) as AutoresearchSparkPrepassSnapshot;
+  const packet = existsSync(packetFile)
+    ? trimAutoresearchSparkFactPacket(await readFile(packetFile, 'utf-8'))
+    : '';
+  return {
+    snapshot,
+    packet: packet || null,
+  };
+}
+
+export async function initializeAutoresearchSparkPrepassSnapshot(
+  enabled: boolean,
+  statusFile: string | null | undefined,
+  packetFile: string | null | undefined,
+  now: () => string = nowIso,
+  sidecarEnabled = false,
+): Promise<void> {
+  if (!enabled || !statusFile || !packetFile) return;
+  await writeAutoresearchSparkPrepassSnapshot(
+    statusFile,
+    packetFile,
+    {
+      enabled: true,
+      status: 'pending',
+      note: 'Spark prepass will run before the next experiment turn.',
+      updated_at: now(),
+      packet_characters: 0,
+      ...(sidecarEnabled ? {
+        sidecar_enabled: true,
+        last_refresh_iteration: 0,
+        refresh_count: 0,
+        last_refresh_reason: 'initial',
+      } : {}),
+    },
+    null,
+  );
+}
+
+export function shouldSparkSidecarRefresh(
+  snapshot: AutoresearchSparkPrepassSnapshot | null,
+  trailingNoops: number,
+  currentIteration: number,
+): boolean {
+  if (!snapshot?.sidecar_enabled) return false;
+  if (trailingNoops < SPARK_SIDECAR_NOOP_TRIGGER) return false;
+  const lastRefresh = snapshot.last_refresh_iteration ?? 0;
+  if (currentIteration - lastRefresh < SPARK_SIDECAR_COOLDOWN_ITERATIONS) return false;
+  return true;
+}
+
+export function buildSidecarRefreshSnapshot(
+  baseSnapshot: AutoresearchSparkPrepassSnapshot,
+  iteration: number,
+  reason: string,
+): Pick<AutoresearchSparkPrepassSnapshot, 'sidecar_enabled' | 'last_refresh_iteration' | 'refresh_count' | 'last_refresh_reason'> {
+  return {
+    sidecar_enabled: true,
+    last_refresh_iteration: iteration,
+    refresh_count: (baseSnapshot.refresh_count ?? 0) + 1,
+    last_refresh_reason: reason,
+  };
+}
+
+function mergeSidecarSnapshotMetadata(
+  snapshot: AutoresearchSparkPrepassSnapshot,
+  previousSnapshot: AutoresearchSparkPrepassSnapshot | null,
+): AutoresearchSparkPrepassSnapshot {
+  if (!previousSnapshot?.sidecar_enabled) return snapshot;
+  return {
+    ...snapshot,
+    sidecar_enabled: true,
+    last_refresh_iteration: previousSnapshot.last_refresh_iteration ?? 0,
+    refresh_count: previousSnapshot.refresh_count ?? 0,
+    last_refresh_reason: previousSnapshot.last_refresh_reason ?? 'initial',
+  };
+}
+
+function formatFailureNote(message: string): string {
+  return `Spark prepass unavailable; proceeding with the normal Codex experiment turn (${message}).`;
+}
+
+function renderExploreFailure(result: ExecuteExplorePromptResult): string {
+  const stderr = result.stderr.trim();
+  const stdout = result.stdout.trim();
+  if (stderr) return stderr;
+  if (stdout) return stdout;
+  return `explore backend exited with status ${result.exitCode}`;
+}
+
+export async function runAutoresearchSparkPrepass(
+  contract: AutoresearchMissionContract,
+  options: RunAutoresearchSparkPrepassOptions,
+  deps: RunAutoresearchSparkPrepassDependencies = {},
+): Promise<ReadAutoresearchSparkPrepassResult> {
+  const now = deps.now ?? nowIso;
+  const executeExplore = deps.executeExplore ?? executeExplorePrompt;
+  const env = options.env ?? process.env;
+  const previousSnapshot = options.statusFile && options.packetFile
+    ? (await readAutoresearchSparkPrepassSnapshot(options.statusFile, options.packetFile)).snapshot
+    : null;
+
+  try {
+    const prompt = buildAutoresearchSparkPrepassPrompt(contract, options);
+    const result = await executeExplore(prompt, options.cwd, env);
+    if (result.exitCode !== 0) {
+      throw new Error(renderExploreFailure(result));
+    }
+
+    const packet = trimAutoresearchSparkFactPacket(result.stdout || '');
+    if (!packet) {
+      throw new Error('explore backend returned an empty fact packet');
+    }
+
+    const snapshot = mergeSidecarSnapshotMetadata({
+      enabled: true,
+      status: 'available',
+      note: `Spark prepass fact packet captured from the explore ${result.backend} backend.`,
+      updated_at: now(),
+      packet_characters: packet.length,
+    }, previousSnapshot);
+
+    if (options.statusFile && options.packetFile) {
+      await writeAutoresearchSparkPrepassSnapshot(options.statusFile, options.packetFile, snapshot, packet);
+    }
+    return { snapshot, packet };
+  } catch (error) {
+    const snapshot = mergeSidecarSnapshotMetadata({
+      enabled: true,
+      status: 'fallback',
+      note: formatFailureNote(error instanceof Error ? error.message : String(error)),
+      updated_at: now(),
+      packet_characters: 0,
+    }, previousSnapshot);
+    if (options.statusFile && options.packetFile) {
+      await writeAutoresearchSparkPrepassSnapshot(options.statusFile, options.packetFile, snapshot, null);
+    }
+    return { snapshot, packet: null };
+  }
+}

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -6,19 +6,15 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { autoresearchCommand, normalizeAutoresearchCodexArgs, parseAutoresearchArgs } from '../autoresearch.js';
-
-function withMockedTty<T>(fn: () => Promise<T>): Promise<T> {
-  const descriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
-  Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
-  return fn().finally(() => {
-    if (descriptor) {
-      Object.defineProperty(process.stdin, 'isTTY', descriptor);
-    } else {
-      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
-    }
-  });
-}
+import { normalizeAutoresearchCodexArgs, parseAutoresearchArgs } from '../autoresearch.js';
+import {
+  buildSidecarRefreshSnapshot,
+  initializeAutoresearchSparkPrepassSnapshot,
+  readAutoresearchSparkPrepassSnapshot,
+  runAutoresearchSparkPrepass,
+  shouldSparkSidecarRefresh,
+  type AutoresearchSparkPrepassSnapshot,
+} from '../../autoresearch/spark-prepass.js';
 
 function runOmx(
   cwd: string,
@@ -54,6 +50,16 @@ async function initRepo(): Promise<string> {
   return cwd;
 }
 
+function findAutoresearchRunId(repo: string): string {
+  const logsRoot = join(repo, '.omx', 'logs', 'autoresearch');
+  const [runId] = execFileSync('find', [logsRoot, '-mindepth', '1', '-maxdepth', '1', '-type', 'd', '-printf', '%f\n'], { encoding: 'utf-8' })
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  assert.ok(runId);
+  return runId;
+}
+
 describe('normalizeAutoresearchCodexArgs', () => {
   it('adds sandbox bypass by default for autoresearch workers', () => {
     assert.deepEqual(normalizeAutoresearchCodexArgs(['--model', 'gpt-5']), ['--model', 'gpt-5', '--dangerously-bypass-approvals-and-sandbox']);
@@ -65,6 +71,70 @@ describe('normalizeAutoresearchCodexArgs', () => {
 
   it('normalizes --madmax to the canonical bypass flag', () => {
     assert.deepEqual(normalizeAutoresearchCodexArgs(['--madmax']), ['--dangerously-bypass-approvals-and-sandbox']);
+  });
+});
+
+describe('parseAutoresearchArgs', () => {
+  it('treats --spark-prepass before mission-dir as a supervisor flag', () => {
+    assert.deepEqual(parseAutoresearchArgs(['--spark-prepass', 'missions/demo', '--model', 'gpt-5']), {
+      missionDir: 'missions/demo',
+      runId: null,
+      codexArgs: ['--model', 'gpt-5'],
+      sparkPrepass: true,
+      sparkSidecar: false,
+    });
+  });
+
+  it('leaves --spark-prepass after mission-dir inside codex args', () => {
+    assert.deepEqual(parseAutoresearchArgs(['missions/demo', '--spark-prepass', '--model', 'gpt-5']), {
+      missionDir: 'missions/demo',
+      runId: null,
+      codexArgs: ['--spark-prepass', '--model', 'gpt-5'],
+      sparkPrepass: false,
+      sparkSidecar: false,
+    });
+  });
+});
+
+describe('parseAutoresearchArgs --spark-sidecar', () => {
+  it('treats --spark-sidecar before mission-dir as a supervisor flag that implies --spark-prepass', () => {
+    assert.deepEqual(parseAutoresearchArgs(['--spark-sidecar', 'missions/demo', '--model', 'gpt-5']), {
+      missionDir: 'missions/demo',
+      runId: null,
+      codexArgs: ['--model', 'gpt-5'],
+      sparkPrepass: true,
+      sparkSidecar: true,
+    });
+  });
+
+  it('supports both --spark-prepass and --spark-sidecar together', () => {
+    assert.deepEqual(parseAutoresearchArgs(['--spark-prepass', '--spark-sidecar', 'missions/demo']), {
+      missionDir: 'missions/demo',
+      runId: null,
+      codexArgs: [],
+      sparkPrepass: true,
+      sparkSidecar: true,
+    });
+  });
+
+  it('leaves --spark-sidecar after mission-dir inside codex args', () => {
+    assert.deepEqual(parseAutoresearchArgs(['missions/demo', '--spark-sidecar']), {
+      missionDir: 'missions/demo',
+      runId: null,
+      codexArgs: ['--spark-sidecar'],
+      sparkPrepass: false,
+      sparkSidecar: false,
+    });
+  });
+
+  it('supports --spark-sidecar with --resume', () => {
+    assert.deepEqual(parseAutoresearchArgs(['--spark-sidecar', '--resume', 'run-123']), {
+      missionDir: null,
+      runId: 'run-123',
+      codexArgs: [],
+      sparkPrepass: true,
+      sparkSidecar: true,
+    });
   });
 });
 
@@ -85,7 +155,8 @@ describe('omx autoresearch', () => {
     try {
       const result = runOmx(cwd, ['autoresearch', '--help']);
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stdout, /Usage:[\s\S]*omx autoresearch run <mission-dir>/i);
+      assert.match(result.stdout, /Usage:[\s\S]*omx autoresearch \[--spark-prepass\] \[--spark-sidecar\] run <mission-dir>/i);
+      assert.match(result.stdout, /--spark-sidecar/i);
       assert.match(result.stdout, /omx autoresearch init/i);
       assert.match(result.stdout, /--topic\/\.\.\./i);
       assert.match(result.stdout, /deep-interview/i);
@@ -102,6 +173,7 @@ describe('omx autoresearch', () => {
       const result = runOmx(cwd, ['autoresearch', '--help']);
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.match(result.stdout, /--resume <run-id>/i);
+      assert.match(result.stdout, /--spark-prepass/i);
       assert.match(result.stdout, /run-tagged/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -776,6 +848,161 @@ printf '{\\n  "status": "abort",\\n  "candidate_commit": null,\\n  "base_commit"
     }
   });
 
+  it('runs an optional spark prepass once and injects the fact packet into bootstrap instructions', async () => {
+    const repo = await initRepo();
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-prepass-bin-'));
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      const promptCapture = join(fakeBin, 'codex-prompt.md');
+      const exploreCapture = join(fakeBin, 'explore-args.txt');
+      await mkdir(missionDir, { recursive: true });
+      await mkdir(join(repo, 'scripts'), { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\nUse cheap discovery before the main worker turn.\n', 'utf-8');
+      await writeFile(
+        join(missionDir, 'sandbox.md'),
+        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
+        'utf-8',
+      );
+      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
+      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'add spark prepass mission'], { cwd: repo, stdio: 'ignore' });
+
+      const fakeCodexPath = join(fakeBin, 'codex');
+      await writeFile(
+        fakeCodexPath,
+        `#!/bin/sh
+cat >"$OMX_TEST_PROMPT_CAPTURE"
+candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
+head_commit=$(git rev-parse HEAD)
+cat >"$candidate_file" <<EOF
+{
+  "status": "abort",
+  "candidate_commit": null,
+  "base_commit": "$head_commit",
+  "description": "stop after spark prepass coverage",
+  "notes": ["fake codex exec"],
+  "created_at": "2026-03-17T00:00:00.000Z"
+}
+EOF
+`,
+        'utf-8',
+      );
+      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+
+      const fakeExplorePath = join(fakeBin, 'explore-harness');
+      await writeFile(
+        fakeExplorePath,
+        `#!/bin/sh
+printf '%s\n' "$@" > "$OMX_TEST_EXPLORE_CAPTURE"
+cat <<'EOF'
+## Relevant files
+- src/cli/autoresearch.ts — supervisor loop and flag parsing
+
+## Key facts
+- one Codex candidate-producing turn still owns candidate.json
+
+## Evidence
+- src/autoresearch/runtime.ts rewrites bootstrap instructions between iterations
+
+## Next reads
+- src/cli/explore.ts
+EOF
+`,
+        'utf-8',
+      );
+      execFileSync('chmod', ['+x', fakeExplorePath], { stdio: 'ignore' });
+
+      const result = runOmx(
+        repo,
+        ['autoresearch', '--spark-prepass', missionDir, '--dangerously-bypass-approvals-and-sandbox'],
+        {
+          PATH: `${fakeBin}:${process.env.PATH || ''}`,
+          OMX_EXPLORE_BIN: fakeExplorePath,
+          OMX_TEST_REPO_ROOT: repo,
+          OMX_TEST_PROMPT_CAPTURE: promptCapture,
+          OMX_TEST_EXPLORE_CAPTURE: exploreCapture,
+        },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(await readFile(promptCapture, 'utf-8'), /Spark prepass fact packet/);
+      assert.match(await readFile(promptCapture, 'utf-8'), /src\/cli\/autoresearch\.ts/);
+      assert.match(await readFile(exploreCapture, 'utf-8'), /--prompt/);
+
+      const runId = findAutoresearchRunId(repo);
+      const instructions = await readFile(join(repo, '.omx', 'logs', 'autoresearch', runId, 'bootstrap-instructions.md'), 'utf-8');
+      assert.match(instructions, /Spark prepass fact packet/);
+      assert.match(instructions, /one Codex candidate-producing turn still owns candidate\.json/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back cleanly when the spark prepass fails and still launches the main codex turn', async () => {
+    const repo = await initRepo();
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-prepass-fallback-bin-'));
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      const promptCapture = join(fakeBin, 'codex-prompt.md');
+      await mkdir(missionDir, { recursive: true });
+      await mkdir(join(repo, 'scripts'), { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\nContinue even when spark discovery fails.\n', 'utf-8');
+      await writeFile(
+        join(missionDir, 'sandbox.md'),
+        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
+        'utf-8',
+      );
+      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
+      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'add spark prepass fallback mission'], { cwd: repo, stdio: 'ignore' });
+
+      const fakeCodexPath = join(fakeBin, 'codex');
+      await writeFile(
+        fakeCodexPath,
+        `#!/bin/sh
+cat >"$OMX_TEST_PROMPT_CAPTURE"
+candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
+head_commit=$(git rev-parse HEAD)
+cat >"$candidate_file" <<EOF
+{
+  "status": "abort",
+  "candidate_commit": null,
+  "base_commit": "$head_commit",
+  "description": "continue after prepass failure",
+  "notes": ["fake codex exec"],
+  "created_at": "2026-03-17T00:00:00.000Z"
+}
+EOF
+`,
+        'utf-8',
+      );
+      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+
+      const result = runOmx(
+        repo,
+        ['autoresearch', '--spark-prepass', missionDir, '--dangerously-bypass-approvals-and-sandbox'],
+        {
+          PATH: `${fakeBin}:${process.env.PATH || ''}`,
+          OMX_EXPLORE_BIN: join(fakeBin, 'missing-explore-harness'),
+          OMX_TEST_REPO_ROOT: repo,
+          OMX_TEST_PROMPT_CAPTURE: promptCapture,
+        },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /spark prepass unavailable/i);
+      assert.doesNotMatch(await readFile(promptCapture, 'utf-8'), /Spark prepass fact packet/);
+
+      const runId = findAutoresearchRunId(repo);
+      const instructions = await readFile(join(repo, '.omx', 'logs', 'autoresearch', runId, 'bootstrap-instructions.md'), 'utf-8');
+      assert.doesNotMatch(instructions, /Spark prepass fact packet/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
   it('stops after repeated noop turns', async () => {
     const repo = await initRepo();
     const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-noop-bin-'));
@@ -829,10 +1056,7 @@ EOF
       assert.equal(state.active, false);
 
       const logsRoot = join(repo, '.omx', 'logs', 'autoresearch');
-      const [runId] = readdirSync(logsRoot, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name);
-      assert.ok(runId);
+      const runId = findAutoresearchRunId(repo);
 
       const manifest = JSON.parse(await readFile(join(logsRoot, runId, 'manifest.json'), 'utf-8')) as {
         status: string;
@@ -854,6 +1078,195 @@ EOF
     } finally {
       await rm(repo, { recursive: true, force: true });
       await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('shouldSparkSidecarRefresh', () => {
+  const baseSnapshot: AutoresearchSparkPrepassSnapshot = {
+    enabled: true,
+    status: 'available',
+    note: 'test',
+    updated_at: '2026-03-17T00:00:00.000Z',
+    packet_characters: 100,
+    sidecar_enabled: true,
+    last_refresh_iteration: 0,
+    refresh_count: 0,
+    last_refresh_reason: 'initial',
+  };
+
+  it('returns false when snapshot is null', () => {
+    assert.equal(shouldSparkSidecarRefresh(null, 2, 5), false);
+  });
+
+  it('returns false when sidecar is not enabled', () => {
+    assert.equal(shouldSparkSidecarRefresh({ ...baseSnapshot, sidecar_enabled: false }, 2, 5), false);
+  });
+
+  it('returns false when trailing noops are below trigger threshold', () => {
+    assert.equal(shouldSparkSidecarRefresh(baseSnapshot, 1, 5), false);
+  });
+
+  it('returns true when trailing noops meet trigger and cooldown is satisfied', () => {
+    assert.equal(shouldSparkSidecarRefresh(baseSnapshot, 2, 5), true);
+  });
+
+  it('returns false when cooldown period has not elapsed', () => {
+    assert.equal(shouldSparkSidecarRefresh({ ...baseSnapshot, last_refresh_iteration: 4 }, 2, 5), false);
+  });
+
+  it('returns true when cooldown period has elapsed', () => {
+    assert.equal(shouldSparkSidecarRefresh({ ...baseSnapshot, last_refresh_iteration: 2 }, 2, 5), true);
+  });
+});
+
+describe('buildSidecarRefreshSnapshot', () => {
+  const baseSnapshot: AutoresearchSparkPrepassSnapshot = {
+    enabled: true,
+    status: 'available',
+    note: 'test',
+    updated_at: '2026-03-17T00:00:00.000Z',
+    packet_characters: 100,
+    sidecar_enabled: true,
+    last_refresh_iteration: 0,
+    refresh_count: 1,
+    last_refresh_reason: 'initial',
+  };
+
+  it('increments refresh_count and records iteration and reason', () => {
+    const result = buildSidecarRefreshSnapshot(baseSnapshot, 5, '2 consecutive noops');
+    assert.deepEqual(result, {
+      sidecar_enabled: true,
+      last_refresh_iteration: 5,
+      refresh_count: 2,
+      last_refresh_reason: '2 consecutive noops',
+    });
+  });
+
+  it('handles missing refresh_count gracefully', () => {
+    const { refresh_count: _, ...withoutCount } = baseSnapshot;
+    const result = buildSidecarRefreshSnapshot(withoutCount as AutoresearchSparkPrepassSnapshot, 3, 'test');
+    assert.equal(result.refresh_count, 1);
+  });
+});
+
+
+describe('runAutoresearchSparkPrepass sidecar state preservation', () => {
+  const contract = {
+    missionContent: `# Mission
+Inspect files only.
+`,
+    sandboxContent: `---
+---
+Read-only sandbox.
+`,
+    sandbox: { body: 'Read-only sandbox.' },
+  } as any;
+
+  it('preserves sidecar metadata after a successful bootstrap prepass', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-sidecar-prepass-success-'));
+    const statusFile = join(cwd, 'spark-prepass-status.json');
+    const packetFile = join(cwd, 'spark-prepass-fact-packet.md');
+    try {
+      await initializeAutoresearchSparkPrepassSnapshot(
+        true,
+        statusFile,
+        packetFile,
+        () => '2026-03-17T00:00:00.000Z',
+        true,
+      );
+
+      const result = await runAutoresearchSparkPrepass(
+        contract,
+        {
+          cwd,
+          iteration: 1,
+          lastKeptCommit: 'abc123',
+          statusFile,
+          packetFile,
+        },
+        {
+          now: () => '2026-03-17T00:01:00.000Z',
+          executeExplore: async () => ({
+            stdout: `## Likely relevant files
+- src/cli/autoresearch.ts
+
+## Key matches
+- --spark-sidecar flag
+
+## Evidence snippets
+- supervisor loop counts noop streaks
+
+## Next files to inspect
+- src/autoresearch/runtime.ts
+`,
+            stderr: '',
+            exitCode: 0,
+            backend: 'sparkshell',
+          }),
+        },
+      );
+
+      assert.equal(result.snapshot?.status, 'available');
+      assert.equal(result.snapshot?.sidecar_enabled, true);
+      assert.equal(result.snapshot?.refresh_count, 0);
+      assert.equal(result.snapshot?.last_refresh_iteration, 0);
+      assert.equal(result.snapshot?.last_refresh_reason, 'initial');
+
+      const persisted = await readAutoresearchSparkPrepassSnapshot(statusFile, packetFile);
+      assert.equal(persisted.snapshot?.sidecar_enabled, true);
+      assert.equal(persisted.snapshot?.refresh_count, 0);
+      assert.equal(persisted.snapshot?.last_refresh_iteration, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves sidecar metadata after a fallback prepass result', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-sidecar-prepass-fallback-'));
+    const statusFile = join(cwd, 'spark-prepass-status.json');
+    const packetFile = join(cwd, 'spark-prepass-fact-packet.md');
+    try {
+      await initializeAutoresearchSparkPrepassSnapshot(
+        true,
+        statusFile,
+        packetFile,
+        () => '2026-03-17T00:00:00.000Z',
+        true,
+      );
+
+      const result = await runAutoresearchSparkPrepass(
+        contract,
+        {
+          cwd,
+          iteration: 1,
+          lastKeptCommit: 'abc123',
+          statusFile,
+          packetFile,
+        },
+        {
+          now: () => '2026-03-17T00:02:00.000Z',
+          executeExplore: async () => ({
+            stdout: '',
+            stderr: 'explore backend failed',
+            exitCode: 1,
+            backend: 'harness',
+          }),
+        },
+      );
+
+      assert.equal(result.snapshot?.status, 'fallback');
+      assert.equal(result.snapshot?.sidecar_enabled, true);
+      assert.equal(result.snapshot?.refresh_count, 0);
+      assert.equal(result.snapshot?.last_refresh_iteration, 0);
+      assert.equal(result.snapshot?.last_refresh_reason, 'initial');
+
+      const persisted = await readAutoresearchSparkPrepassSnapshot(statusFile, packetFile);
+      assert.equal(persisted.snapshot?.status, 'fallback');
+      assert.equal(persisted.snapshot?.sidecar_enabled, true);
+      assert.equal(persisted.snapshot?.refresh_count, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 });

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -25,7 +25,7 @@ function runOmx(cwd: string, argv: string[]) {
 describe('nested help routing', () => {
   for (const [argv, expectedUsage] of [
     [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
-    [['autoresearch', '--help'], /Usage:[\s\S]*omx autoresearch <mission-dir>/i],
+    [['autoresearch', '--help'], /Usage:[\s\S]*omx autoresearch \[--spark-prepass\].*<mission-dir>/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
     [['tmux-hook', '--help'], /Usage:\s*\n\s*omx tmux-hook init/i],

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -1,7 +1,10 @@
 import { execFileSync, spawnSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { ensureWorktree, planWorktreeTarget } from '../team/worktree.js';
-import { loadAutoresearchMissionContract } from '../autoresearch/contracts.js';
+import {
+  loadAutoresearchMissionContract,
+  type AutoresearchMissionContract,
+} from '../autoresearch/contracts.js';
 import {
   countTrailingAutoresearchNoops,
   finalizeAutoresearchRunState,
@@ -9,9 +12,18 @@ import {
   materializeAutoresearchMissionToWorktree,
   prepareAutoresearchRuntime,
   processAutoresearchCandidate,
+  refreshAutoresearchInstructions,
   resumeAutoresearchRuntime,
   buildAutoresearchRunTag,
+  type AutoresearchRunManifest,
 } from '../autoresearch/runtime.js';
+import {
+  buildSidecarRefreshSnapshot,
+  readAutoresearchSparkPrepassSnapshot,
+  runAutoresearchSparkPrepass,
+  shouldSparkSidecarRefresh,
+  writeAutoresearchSparkPrepassSnapshot,
+} from '../autoresearch/spark-prepass.js';
 import { assertModeStartAllowed } from '../modes/base.js';
 import {
   buildAutoresearchDeepInterviewPrompt,
@@ -33,9 +45,9 @@ Usage:
   omx autoresearch                                                (human entrypoint: launch Codex CLI deep-interview intake, then execute)
   omx autoresearch [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
   omx autoresearch init [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
-  omx autoresearch run <mission-dir> [codex-args...]              (agent/explicit execution entrypoint)
-  omx autoresearch <mission-dir> [codex-args...]                  (compatibility alias for run)
-  omx autoresearch --resume <run-id> [codex-args...]
+  omx autoresearch [--spark-prepass] [--spark-sidecar] run <mission-dir> [codex-args...]    (agent/explicit execution entrypoint)
+  omx autoresearch [--spark-prepass] [--spark-sidecar] <mission-dir> [codex-args...]        (compatibility alias for run)
+  omx autoresearch [--spark-prepass] [--spark-sidecar] --resume <run-id> [codex-args...]
 
 Arguments:
   (no args)        Launch an interactive Codex session that activates deep-interview --autoresearch,
@@ -53,11 +65,15 @@ Behavior:
   - fresh launch creates a run-tagged autoresearch/<slug>/<run-tag> lane
   - supervisor records baseline, candidate, keep/discard/reset, and results artifacts under .omx/logs/autoresearch/
   - run prefers interview|autoresearch split-pane launch inside tmux, with foreground fallback on failure
+  - --spark-prepass runs a bounded read-only omx explore prepass once per run and injects the fact packet into bootstrap instructions
+  - --spark-sidecar implies --spark-prepass plus conditional refresh after 2 consecutive noop iterations (3-iteration cooldown between refreshes)
   - --resume loads the authoritative per-run manifest and continues from the last kept commit
 `;
 
 const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
 const AUTORESEARCH_MAX_CONSECUTIVE_NOOPS = 3;
+const AUTORESEARCH_SPARK_PREPASS_FLAG = '--spark-prepass';
+const AUTORESEARCH_SPARK_SIDECAR_FLAG = '--spark-sidecar';
 
 function buildAutoresearchDeepInterviewAppendix(): string {
   return [
@@ -171,6 +187,8 @@ export interface ParsedAutoresearchArgs {
   missionDir: string | null;
   runId: string | null;
   codexArgs: string[];
+  sparkPrepass: boolean;
+  sparkSidecar: boolean;
   guided?: boolean;
   initArgs?: string[];
   seedArgs?: ReturnType<typeof parseInitArgs>;
@@ -187,46 +205,144 @@ function resolveRepoRoot(cwd: string): string {
 
 export function parseAutoresearchArgs(args: readonly string[]): ParsedAutoresearchArgs {
   const values = [...args];
+  let sparkPrepass = false;
+  let sparkSidecar = false;
+  while (values[0] === AUTORESEARCH_SPARK_PREPASS_FLAG || values[0] === AUTORESEARCH_SPARK_SIDECAR_FLAG) {
+    if (values[0] === AUTORESEARCH_SPARK_PREPASS_FLAG) sparkPrepass = true;
+    if (values[0] === AUTORESEARCH_SPARK_SIDECAR_FLAG) sparkSidecar = true;
+    values.shift();
+  }
+  if (sparkSidecar) sparkPrepass = true;
   if (values.length === 0) {
     if (!process.stdin.isTTY) {
       throw new Error(`mission-dir is required.\n${AUTORESEARCH_HELP}`);
     }
-    return { missionDir: null, runId: null, codexArgs: [], guided: true };
+    return { missionDir: null, runId: null, codexArgs: [], sparkPrepass, sparkSidecar, guided: true };
   }
 
   const first = values[0];
   if (first === 'init') {
-    return { missionDir: null, runId: null, codexArgs: [], guided: true, initArgs: values.slice(1) };
+    return { missionDir: null, runId: null, codexArgs: [], sparkPrepass, sparkSidecar, guided: true, initArgs: values.slice(1) };
   }
   if (first === '--help' || first === '-h' || first === 'help') {
-    return { missionDir: '--help', runId: null, codexArgs: [] };
+    return { missionDir: '--help', runId: null, codexArgs: [], sparkPrepass, sparkSidecar };
   }
   if (first === '--resume') {
     const runId = values[1]?.trim();
     if (!runId) {
       throw new Error(`--resume requires <run-id>.\n${AUTORESEARCH_HELP}`);
     }
-    return { missionDir: null, runId, codexArgs: values.slice(2) };
+    return { missionDir: null, runId, codexArgs: values.slice(2), sparkPrepass, sparkSidecar };
   }
   if (first.startsWith('--resume=')) {
     const runId = first.slice('--resume='.length).trim();
     if (!runId) {
       throw new Error(`--resume requires <run-id>.\n${AUTORESEARCH_HELP}`);
     }
-    return { missionDir: null, runId, codexArgs: values.slice(1) };
+    return { missionDir: null, runId, codexArgs: values.slice(1), sparkPrepass, sparkSidecar };
   }
   if (first === 'run') {
     const missionDir = values[1]?.trim();
     if (!missionDir) {
       throw new Error(`run requires <mission-dir>.\n${AUTORESEARCH_HELP}`);
     }
-    return { missionDir, runId: null, codexArgs: values.slice(2), runSubcommand: true };
+    return { missionDir, runId: null, codexArgs: values.slice(2), sparkPrepass, sparkSidecar, runSubcommand: true };
   }
   if (first.startsWith('-')) {
     const seedArgs = parseInitArgs(values);
-    return { missionDir: null, runId: null, codexArgs: [], guided: true, seedArgs };
+    return { missionDir: null, runId: null, codexArgs: [], sparkPrepass, sparkSidecar, guided: true, seedArgs };
   }
-  return { missionDir: first, runId: null, codexArgs: values.slice(1) };
+  return { missionDir: first, runId: null, codexArgs: values.slice(1), sparkPrepass, sparkSidecar };
+}
+
+async function maybeRunAutoresearchSparkPrepass(
+  enabled: boolean,
+  contract: AutoresearchMissionContract,
+  runtime: {
+    instructionsFile: string;
+    repoRoot: string;
+    runId: string;
+    worktreePath: string;
+    sparkPrepassEnabled?: boolean;
+    sparkPrepassStatusFile?: string | null;
+    sparkPrepassPacketFile?: string | null;
+  },
+): Promise<void> {
+  const shouldRun = runtime.sparkPrepassEnabled === true || enabled;
+  if (!shouldRun || !runtime.sparkPrepassStatusFile || !runtime.sparkPrepassPacketFile) {
+    return;
+  }
+
+  const existing = await readAutoresearchSparkPrepassSnapshot(
+    runtime.sparkPrepassStatusFile,
+    runtime.sparkPrepassPacketFile,
+  );
+  if (existing.snapshot?.status && existing.snapshot.status !== 'pending') {
+    const manifest = await loadAutoresearchRunManifest(runtime.repoRoot, runtime.runId);
+    await refreshAutoresearchInstructions(contract, manifest);
+    return;
+  }
+
+  const manifest = await loadAutoresearchRunManifest(runtime.repoRoot, runtime.runId);
+  const prepassResult = await runAutoresearchSparkPrepass(contract, {
+    cwd: runtime.worktreePath,
+    iteration: manifest.iteration + 1,
+    lastKeptCommit: manifest.last_kept_commit,
+    env: process.env,
+    statusFile: runtime.sparkPrepassStatusFile,
+    packetFile: runtime.sparkPrepassPacketFile,
+  });
+  if (prepassResult.snapshot?.status === 'fallback') {
+    process.stderr.write(`[autoresearch] ${prepassResult.snapshot.note}\n`);
+  }
+  await refreshAutoresearchInstructions(contract, manifest);
+}
+
+async function maybeRunSparkSidecarRefresh(
+  contract: AutoresearchMissionContract,
+  manifest: AutoresearchRunManifest,
+  runtime: {
+    worktreePath: string;
+    repoRoot: string;
+    sparkPrepassStatusFile?: string | null;
+    sparkPrepassPacketFile?: string | null;
+  },
+  trailingNoops: number,
+): Promise<void> {
+  const statusFile = runtime.sparkPrepassStatusFile ?? manifest.spark_prepass_status_file;
+  const packetFile = runtime.sparkPrepassPacketFile ?? manifest.spark_prepass_packet_file;
+  if (!statusFile || !packetFile) return;
+
+  const existing = await readAutoresearchSparkPrepassSnapshot(statusFile, packetFile);
+  if (!shouldSparkSidecarRefresh(existing.snapshot, trailingNoops, manifest.iteration)) {
+    return;
+  }
+
+  process.stderr.write(`[autoresearch] spark sidecar refresh triggered (${trailingNoops} consecutive noops at iteration ${manifest.iteration})\n`);
+
+  const prepassResult = await runAutoresearchSparkPrepass(contract, {
+    cwd: runtime.worktreePath,
+    iteration: manifest.iteration + 1,
+    lastKeptCommit: manifest.last_kept_commit,
+    env: process.env,
+    statusFile,
+    packetFile,
+  });
+
+  if (prepassResult.snapshot) {
+    const updatedSnapshot = {
+      ...prepassResult.snapshot,
+      ...buildSidecarRefreshSnapshot(
+        existing.snapshot || prepassResult.snapshot,
+        manifest.iteration,
+        `${trailingNoops} consecutive noops`,
+      ),
+    };
+    await writeAutoresearchSparkPrepassSnapshot(statusFile, packetFile, updatedSnapshot, prepassResult.packet);
+  }
+
+  const freshManifest = await loadAutoresearchRunManifest(runtime.repoRoot, manifest.run_id);
+  await refreshAutoresearchInstructions(contract, freshManifest);
 }
 
 async function runAutoresearchLoop(
@@ -236,6 +352,9 @@ async function runAutoresearchLoop(
     manifestFile: string;
     repoRoot: string;
     worktreePath: string;
+    sparkSidecarEnabled?: boolean;
+    sparkPrepassStatusFile?: string | null;
+    sparkPrepassPacketFile?: string | null;
   },
   missionDir: string,
 ): Promise<void> {
@@ -262,6 +381,9 @@ async function runAutoresearchLoop(
             stopReason: `repeated noop limit reached (${AUTORESEARCH_MAX_CONSECUTIVE_NOOPS})`,
           });
           return;
+        }
+        if (runtime.sparkSidecarEnabled) {
+          await maybeRunSparkSidecarRefresh(contract, manifest, runtime, trailingNoops);
         }
       }
       process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = runtime.instructionsFile;
@@ -314,6 +436,8 @@ function launchAutoresearchInSplitPane(args: {
   repoRoot: string;
   missionDir: string;
   codexArgs: string[];
+  sparkPrepass?: boolean;
+  sparkSidecar?: boolean;
 }): boolean {
   if (!checkTmuxAvailable()) return false;
 
@@ -327,7 +451,11 @@ function launchAutoresearchInSplitPane(args: {
   if (!omxPath) return false;
   // Re-enter through the bare compatibility alias so the new pane executes immediately
   // instead of recursively taking the split-pane branch again.
-  const launchArgs = ['autoresearch', args.missionDir, ...args.codexArgs];
+  const supervisorFlags = [
+    ...(args.sparkPrepass ? [AUTORESEARCH_SPARK_PREPASS_FLAG] : []),
+    ...(args.sparkSidecar ? [AUTORESEARCH_SPARK_SIDECAR_FLAG] : []),
+  ];
+  const launchArgs = ['autoresearch', ...supervisorFlags, args.missionDir, ...args.codexArgs];
   const command = [process.execPath, omxPath, ...launchArgs]
     .map((part) => `'${part.replace(/'/g, `'\\''`)}'`)
     .join(' ');
@@ -351,7 +479,11 @@ function launchAutoresearchInSplitPane(args: {
   return true;
 }
 
-async function executeAutoresearchMissionRun(missionDir: string, codexArgs: string[]): Promise<void> {
+async function executeAutoresearchMissionRun(
+  missionDir: string,
+  codexArgs: string[],
+  options: { sparkPrepass?: boolean; sparkSidecar?: boolean } = {},
+): Promise<void> {
   const contract = await loadAutoresearchMissionContract(missionDir);
   await assertModeStartAllowed('autoresearch', contract.repoRoot);
   const runTag = buildAutoresearchRunTag();
@@ -367,7 +499,13 @@ async function executeAutoresearchMissionRun(missionDir: string, codexArgs: stri
   }
 
   const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, ensured.worktreePath);
-  const runtime = await prepareAutoresearchRuntime(worktreeContract, contract.repoRoot, ensured.worktreePath, { runTag });
+  const sparkPrepass = options.sparkPrepass === true || options.sparkSidecar === true;
+  const runtime = await prepareAutoresearchRuntime(worktreeContract, contract.repoRoot, ensured.worktreePath, {
+    runTag,
+    sparkPrepassEnabled: sparkPrepass,
+    sparkSidecarEnabled: options.sparkSidecar === true,
+  });
+  await maybeRunAutoresearchSparkPrepass(sparkPrepass, worktreeContract, runtime);
   await runAutoresearchLoop(codexArgs, runtime, worktreeContract.missionDir);
 }
 
@@ -379,6 +517,10 @@ export async function autoresearchCommand(args: string[]): Promise<void> {
   }
 
   if (parsed.guided) {
+    if (parsed.sparkPrepass || parsed.sparkSidecar) {
+      throw new Error(`--spark-prepass and --spark-sidecar are supported only for direct <mission-dir> or --resume launches.\n${AUTORESEARCH_HELP}`);
+    }
+
     const repoRoot = resolveRepoRoot(process.cwd());
     let result;
     if (parsed.initArgs && parsed.initArgs.length > 0) {
@@ -420,7 +562,13 @@ export async function autoresearchCommand(args: string[]): Promise<void> {
     await assertModeStartAllowed('autoresearch', repoRoot);
     const manifest = await loadAutoresearchRunManifest(repoRoot, parsed.runId);
     const runtime = await resumeAutoresearchRuntime(repoRoot, parsed.runId);
-    await runAutoresearchLoop(parsed.codexArgs, runtime, manifest.mission_dir);
+    const contract = await loadAutoresearchMissionContract(manifest.mission_dir);
+    await maybeRunAutoresearchSparkPrepass(parsed.sparkPrepass, contract, runtime);
+    await runAutoresearchLoop(
+      parsed.codexArgs,
+      { ...runtime, sparkSidecarEnabled: parsed.sparkSidecar },
+      manifest.mission_dir,
+    );
     return;
   }
 
@@ -432,10 +580,15 @@ export async function autoresearchCommand(args: string[]): Promise<void> {
       repoRoot,
       missionDir: parsed.missionDir as string,
       codexArgs: parsed.codexArgs,
+      sparkPrepass: parsed.sparkPrepass,
+      sparkSidecar: parsed.sparkSidecar,
     })) {
       return;
     }
   }
 
-  await executeAutoresearchMissionRun(parsed.missionDir as string, parsed.codexArgs);
+  await executeAutoresearchMissionRun(parsed.missionDir as string, parsed.codexArgs, {
+    sparkPrepass: parsed.sparkPrepass,
+    sparkSidecar: parsed.sparkSidecar,
+  });
 }

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -62,6 +62,13 @@ export interface ExploreSparkShellRoute {
   reason: 'shell-native' | 'long-output';
 }
 
+export interface ExecuteExplorePromptResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  backend: 'sparkshell' | 'harness';
+}
+
 function tokenizeExploreShellCommand(commandText: string): string[] | undefined {
   const trimmed = commandText.trim();
   if (!trimmed || SHELL_ROUTE_DISALLOWED_PATTERN.test(trimmed) || trimmed.includes('\\')) return undefined;
@@ -134,9 +141,13 @@ export function resolveExploreSparkShellRoute(prompt: string): ExploreSparkShell
   return undefined;
 }
 
-async function runExploreViaSparkShell(route: ExploreSparkShellRoute, env: NodeJS.ProcessEnv = process.env): Promise<void> {
-  const binaryPath = await resolveSparkShellBinaryPathWithHydration({ cwd: process.cwd(), env });
-  const result = runSparkShellBinary(binaryPath, route.argv, { cwd: process.cwd(), env });
+async function runExploreViaSparkShell(
+  route: ExploreSparkShellRoute,
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ExecuteExplorePromptResult> {
+  const binaryPath = await resolveSparkShellBinaryPathWithHydration({ cwd, env });
+  const result = runSparkShellBinary(binaryPath, route.argv, { cwd, env });
 
   if (result.error) {
     const errno = result.error as NodeJS.ErrnoException;
@@ -147,12 +158,12 @@ async function runExploreViaSparkShell(route: ExploreSparkShellRoute, env: NodeJ
     throw new Error('[explore] sparkshell backend is incompatible with this Linux runtime (missing GLIBC symbols)');
   }
 
-  if (result.stdout && result.stdout.length > 0) process.stdout.write(result.stdout);
-  if (result.stderr && result.stderr.length > 0) process.stderr.write(result.stderr);
-
-  if (result.status !== 0) {
-    process.exitCode = result.status ?? 1;
-  }
+  return {
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    exitCode: result.status ?? 1,
+    backend: 'sparkshell',
+  };
 }
 
 export function packagedExploreHarnessBinaryName(platform: NodeJS.Platform = process.platform): string {
@@ -351,33 +362,21 @@ export async function loadExplorePrompt(parsed: ParsedExploreArgs): Promise<stri
   return trimmed;
 }
 
-export async function exploreCommand(args: string[]): Promise<void> {
-  const parsed = parseExploreArgs(args);
-  const prompt = await loadExplorePrompt(parsed);
-  const sparkShellRoute = resolveExploreSparkShellRoute(prompt);
-  if (sparkShellRoute) {
-    try {
-      await runExploreViaSparkShell(sparkShellRoute, process.env);
-      return;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      process.stderr.write(`[omx explore] sparkshell backend unavailable (${message}). Falling back to the explore harness.\n`);
-    }
-  }
-
+async function executeExplorePromptViaHarness(
+  prompt: string,
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ExecuteExplorePromptResult> {
   const packageRoot = getPackageRoot();
-  const harness = await resolveExploreHarnessCommandWithHydration(packageRoot, process.env);
-  const harnessArgs = [...harness.args, ...buildExploreHarnessArgs(prompt, process.cwd(), process.env, packageRoot)];
+  const harness = await resolveExploreHarnessCommandWithHydration(packageRoot, env);
+  const harnessArgs = [...harness.args, ...buildExploreHarnessArgs(prompt, cwd, env, packageRoot)];
 
   const { result } = spawnPlatformCommandSync(harness.command, harnessArgs, {
-    cwd: process.cwd(),
-    env: process.env,
+    cwd,
+    env,
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-
-  if (result.stdout && result.stdout.length > 0) process.stdout.write(result.stdout);
-  if (result.stderr && result.stderr.length > 0) process.stderr.write(result.stderr);
 
   if (result.error) {
     const errno = result.error as NodeJS.ErrnoException;
@@ -387,7 +386,43 @@ export async function exploreCommand(args: string[]): Promise<void> {
     throw new Error(`[explore] failed to launch harness: ${result.error.message}`);
   }
 
-  if (result.status !== 0) {
-    process.exitCode = result.status ?? 1;
+  return {
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    exitCode: result.status ?? 1,
+    backend: 'harness',
+  };
+}
+
+export async function executeExplorePrompt(
+  prompt: string,
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ExecuteExplorePromptResult> {
+  const sparkShellRoute = resolveExploreSparkShellRoute(prompt);
+  if (sparkShellRoute) {
+    try {
+      return await runExploreViaSparkShell(sparkShellRoute, cwd, env);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const fallback = await executeExplorePromptViaHarness(prompt, cwd, env);
+      return {
+        ...fallback,
+        stderr: `[omx explore] sparkshell backend unavailable (${message}). Falling back to the explore harness.\n${fallback.stderr}`,
+      };
+    }
+  }
+
+  return executeExplorePromptViaHarness(prompt, cwd, env);
+}
+
+export async function exploreCommand(args: string[]): Promise<void> {
+  const parsed = parseExploreArgs(args);
+  const prompt = await loadExplorePrompt(parsed);
+  const result = await executeExplorePrompt(prompt, process.cwd(), process.env);
+  if (result.stdout.length > 0) process.stdout.write(result.stdout);
+  if (result.stderr.length > 0) process.stderr.write(result.stderr);
+  if (result.exitCode !== 0) {
+    process.exitCode = result.exitCode;
   }
 }


### PR DESCRIPTION
Summary: add the spark-sidecar supervisor flag and refresh path, preserve spark-prepass compatibility, and cover parsing/help/runtime behavior with targeted tests. Validation: npx tsc; node --test dist/cli/__tests__/autoresearch.test.js; node --test dist/cli/__tests__/nested-help-routing.test.js; node bin/omx.js autoresearch --help | grep spark-sidecar.