### PR TITLE
fix: resolve __dirname ESM error in autoresearch guided flow

### DIFF
--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -2,8 +2,12 @@ import { createInterface } from 'readline/promises';
 import { execFileSync, spawnSync } from 'child_process';
 import { existsSync } from 'fs';
 import { mkdir, writeFile } from 'fs/promises';
-import { join, relative, resolve } from 'path';
+import { dirname, join, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { type AutoresearchKeepPolicy, parseSandboxContract, slugifyMissionName } from '../autoresearch/contracts.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export interface InitAutoresearchOptions {
   topic: string;


### PR DESCRIPTION
## Problem

`omx autoresearch` and `omx-work autoresearch` crash with:
```
Error: __dirname is not defined
```

This happens because `autoresearch-guided.ts` uses `__dirname` directly, which is not available in ESM modules (`"type": "module"` in package.json).

## Fix

Use `import.meta.url` with `fileURLToPath`/`dirname` to derive `__dirname` in an ESM-compatible way.

## Reported by

@minislively

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*