### PR TITLE
fix: ship musl-first Linux native assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,9 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
           - runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
           - runner: macos-15-intel
             target: x86_64-apple-darwin
           - runner: macos-14
@@ -53,6 +53,24 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      - name: Install Linux musl toolchain
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+      - name: Configure Linux musl environment
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-musl)
+              echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+              ;;
+            aarch64-unknown-linux-musl)
+              echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+              ;;
+          esac
       - name: Install cargo-dist
         shell: bash
         run: cargo install cargo-dist --locked --version "$CARGO_DIST_VERSION"
@@ -158,10 +176,30 @@ jobs:
       - name: Smoke test packed install with hydrated native assets
         run: node scripts/smoke-packed-install.mjs --release-assets-dir release-assets
 
+  older-linux-runtime-proof:
+    name: Older Linux Runtime Proof
+    runs-on: ubuntu-latest
+    needs: [smoke-packed-install]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: native-release-assets
+          path: release-assets
+      - name: Verify Docker is available
+        run: docker version
+      - name: Run packed-install hydration smoke on older Linux runtime
+        run: |
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            node:20-bullseye \
+            bash -lc 'npm ci && node scripts/smoke-packed-install.mjs --release-assets-dir ./release-assets --require-no-fallback'
+
   publish-npm:
     name: Publish npm Package
     runs-on: ubuntu-latest
-    needs: [smoke-packed-install]
+    needs: [older-linux-runtime-proof]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -340,10 +340,10 @@ Packaging / install notes:
 
 - Published npm packages now include the Rust workspace files for the explore harness (`Cargo.toml`, `Cargo.lock`, `crates/`).
 - npm publishes no longer rely on publisher-platform native binaries.
-- Tagged releases build multi-platform native archives for both `omx-explore-harness` and `omx-sparkshell` via cargo-dist and attach them to the GitHub Release from `.github/workflows/release.yml`.
+- Tagged releases build multi-platform native archives for both `omx-explore-harness` and `omx-sparkshell` via cargo-dist and attach them to the GitHub Release from `.github/workflows/release.yml`, with Linux published from musl-first targets for broader runtime compatibility.
 - Runtime now prefers `OMX_*_BIN` overrides, then a hydrated per-user native cache, then repo-local development artifacts.
 - `omx explore` keeps a source-install `cargo run --manifest-path crates/omx-explore/Cargo.toml -- ...` fallback in repository checkouts; packaged installs rely on release-asset hydration unless `OMX_EXPLORE_BIN` is set.
-- `omx sparkshell` hydrates from release assets when no override or repo-local build output is available.
+- `omx sparkshell` hydrates from release assets when no override or repo-local build output is available; the release gate now proves that hydrated Linux assets still work in an older Dockerized Linux runtime before npm publish.
 - Release assets now include `native-release-manifest.json` with per-target download metadata and SHA-256 checksums.
 - Helpful local commands:
 
@@ -353,6 +353,7 @@ npm run build:explore
 npm run build:explore:release
 npm run test:explore
 node scripts/smoke-packed-install.mjs --release-assets-dir ./release-assets
+# release workflow also reruns the same smoke in node:20-bullseye as an older-Linux-runtime proof gate
 node scripts/check-version-sync.mjs --tag v$(node -p "require('./package.json').version")
 ```
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,6 +13,6 @@ ci = "github"
 # The installers to generate for each app
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Where to host releases
 hosting = "github"

--- a/scripts/__tests__/smoke-packed-install.test.mjs
+++ b/scripts/__tests__/smoke-packed-install.test.mjs
@@ -4,29 +4,38 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import {
+  hasSparkShellFallbackBanner,
   prepareLocalHydrationAssetDirectory,
   rewriteManifestDownloadUrls,
 } from '../smoke-packed-install.mjs';
+
+test('detects the sparkshell GLIBC fallback banner', () => {
+  assert.equal(
+    hasSparkShellFallbackBanner('[sparkshell] GLIBC-incompatible native sidecar detected; falling back to raw command execution without summary support.\n'),
+    true,
+  );
+  assert.equal(hasSparkShellFallbackBanner('node v20.0.0\n'), false);
+});
 
 test('rewrites copied native manifest download urls to the local smoke server', async () => {
   const root = await mkdtemp(join(tmpdir(), 'omx-smoke-packed-install-'));
   try {
     const sourceDir = join(root, 'source-release-assets');
     await mkdir(sourceDir, { recursive: true });
-    await writeFile(join(sourceDir, 'omx-explore-harness-x86_64-unknown-linux-gnu.tar.xz'), 'explore');
-    await writeFile(join(sourceDir, 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.xz'), 'sparkshell');
+    await writeFile(join(sourceDir, 'omx-explore-harness-x86_64-unknown-linux-musl.tar.xz'), 'explore');
+    await writeFile(join(sourceDir, 'omx-sparkshell-x86_64-unknown-linux-musl.tar.xz'), 'sparkshell');
     await writeFile(join(sourceDir, 'native-release-manifest.json'), JSON.stringify({
       version: '0.9.0',
       assets: [
         {
           product: 'omx-explore-harness',
-          archive: 'omx-explore-harness-x86_64-unknown-linux-gnu.tar.xz',
-          download_url: 'https://github.com/example/omx-explore-harness-x86_64-unknown-linux-gnu.tar.xz',
+          archive: 'omx-explore-harness-x86_64-unknown-linux-musl.tar.xz',
+          download_url: 'https://github.com/example/omx-explore-harness-x86_64-unknown-linux-musl.tar.xz',
         },
         {
           product: 'omx-sparkshell',
-          archive: 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.xz',
-          download_url: 'https://github.com/example/omx-sparkshell-x86_64-unknown-linux-gnu.tar.xz',
+          archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.xz',
+          download_url: 'https://github.com/example/omx-sparkshell-x86_64-unknown-linux-musl.tar.xz',
         },
       ],
     }, null, 2));
@@ -41,8 +50,8 @@ test('rewrites copied native manifest download urls to the local smoke server', 
     assert.deepEqual(
       copiedManifest.assets.map((asset) => asset.download_url),
       [
-        'http://127.0.0.1:43123/omx-explore-harness-x86_64-unknown-linux-gnu.tar.xz',
-        'http://127.0.0.1:43123/omx-sparkshell-x86_64-unknown-linux-gnu.tar.xz',
+        'http://127.0.0.1:43123/omx-explore-harness-x86_64-unknown-linux-musl.tar.xz',
+        'http://127.0.0.1:43123/omx-sparkshell-x86_64-unknown-linux-musl.tar.xz',
       ],
     );
   } finally {

--- a/scripts/generate-native-release-manifest.mjs
+++ b/scripts/generate-native-release-manifest.mjs
@@ -31,6 +31,8 @@ function mapTriple(triple) {
   switch (triple) {
     case 'x86_64-unknown-linux-gnu': return { platform: 'linux', arch: 'x64' };
     case 'aarch64-unknown-linux-gnu': return { platform: 'linux', arch: 'arm64' };
+    case 'x86_64-unknown-linux-musl': return { platform: 'linux', arch: 'x64' };
+    case 'aarch64-unknown-linux-musl': return { platform: 'linux', arch: 'arm64' };
     case 'x86_64-apple-darwin': return { platform: 'darwin', arch: 'x64' };
     case 'aarch64-apple-darwin': return { platform: 'darwin', arch: 'arm64' };
     case 'x86_64-pc-windows-msvc': return { platform: 'win32', arch: 'x64' };

--- a/scripts/smoke-packed-install.mjs
+++ b/scripts/smoke-packed-install.mjs
@@ -8,15 +8,20 @@ import { pathToFileURL } from 'node:url';
 
 function usage() {
   return [
-    'Usage: node scripts/smoke-packed-install.mjs [--release-assets-dir <dir>]',
+    'Usage: node scripts/smoke-packed-install.mjs [--release-assets-dir <dir>] [--require-no-fallback]',
     '',
     'Creates an npm tarball, installs it into an isolated prefix, and smoke tests the installed omx CLI.',
     'When --release-assets-dir is provided, native hydration is also exercised using a local HTTP server.',
   ].join('\n');
 }
 
+export function hasSparkShellFallbackBanner(stderr) {
+  return /GLIBC-incompatible native sidecar detected/i.test(String(stderr || ''));
+}
+
 function parseArgs(argv) {
   let releaseAssetsDir;
+  let requireNoFallback = false;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === '--help' || token === '-h') {
@@ -30,9 +35,13 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (token === '--require-no-fallback') {
+      requireNoFallback = true;
+      continue;
+    }
     throw new Error(`Unknown argument: ${token}\n${usage()}`);
   }
-  return { releaseAssetsDir };
+  return { releaseAssetsDir, requireNoFallback };
 }
 
 function run(cmd, args, options = {}) {
@@ -153,7 +162,7 @@ export function rewriteManifestDownloadUrls(manifestPath, baseUrl) {
 }
 
 async function main() {
-  const { releaseAssetsDir } = parseArgs(process.argv.slice(2));
+  const { releaseAssetsDir, requireNoFallback } = parseArgs(process.argv.slice(2));
   const repoRoot = process.cwd();
   const tempRoot = mkdtempSync(join(tmpdir(), 'omx-packed-install-'));
   const prefixDir = join(tempRoot, 'prefix');
@@ -192,6 +201,9 @@ async function main() {
       };
 
       const sparkshell = run(omxPath, ['sparkshell', 'node', '--version'], { cwd: repoRoot, env });
+      if (requireNoFallback && hasSparkShellFallbackBanner(sparkshell.stderr)) {
+        throw new Error(`Unexpected sparkshell fallback stderr:\n${sparkshell.stderr}`);
+      }
       if (!/v\d+\./.test(sparkshell.stdout)) {
         throw new Error(`Unexpected sparkshell stdout:\n${sparkshell.stdout}`);
       }

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -393,7 +393,7 @@ describe('resolveExploreHarnessCommand', () => {
       await writeFile(binaryPath, '#!/bin/sh\necho hydrated-explore\n');
       await chmod(binaryPath, 0o755);
 
-      const archivePath = join(assetRoot, 'omx-explore-harness-x86_64-unknown-linux-gnu.tar.gz');
+      const archivePath = join(assetRoot, 'omx-explore-harness-x86_64-unknown-linux-musl.tar.gz');
       const archive = spawnSync('tar', ['-czf', archivePath, '-C', stagingDir, packagedExploreHarnessBinaryName()], { encoding: 'utf-8' });
       assert.equal(archive.status, 0, archive.stderr || archive.stdout);
       const archiveBuffer = await readFile(archivePath);
@@ -429,12 +429,12 @@ describe('resolveExploreHarnessCommand', () => {
             version: '0.8.15',
             platform: 'linux',
             arch: 'x64',
-            archive: 'omx-explore-harness-x86_64-unknown-linux-gnu.tar.gz',
+            archive: 'omx-explore-harness-x86_64-unknown-linux-musl.tar.gz',
             binary: 'omx-explore-harness',
             binary_path: 'omx-explore-harness',
             sha256: checksum,
             size: archiveBuffer.length,
-            download_url: `${server.baseUrl}/omx-explore-harness-x86_64-unknown-linux-gnu.tar.gz`,
+            download_url: `${server.baseUrl}/omx-explore-harness-x86_64-unknown-linux-musl.tar.gz`,
           }],
         }, null, 2));
 

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -70,7 +70,7 @@ describe('native asset helpers', () => {
       await writeFile(binaryPath, '#!/bin/sh\necho hydrated\n');
       await chmod(binaryPath, 0o755);
 
-      const archivePath = join(assetRoot, 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz');
+      const archivePath = join(assetRoot, 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz');
       const archive = spawnSync('tar', ['-czf', archivePath, '-C', stagingDir, 'omx-sparkshell'], { encoding: 'utf-8' });
       assert.equal(archive.status, 0, archive.stderr || archive.stdout);
       const archiveBuffer = await readFile(archivePath);
@@ -84,7 +84,7 @@ describe('native asset helpers', () => {
             version: '0.8.15',
             platform: 'linux',
             arch: 'x64',
-            archive: 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz',
+            archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz',
             binary: 'omx-sparkshell',
             binary_path: 'omx-sparkshell',
             sha256: sha256(archiveBuffer),
@@ -132,14 +132,14 @@ describe('native asset helpers', () => {
         repository: { url: 'git+https://github.com/Yeachan-Heo/oh-my-codex.git' },
       }));
 
-      const stagingDir = join(wd, 'staging', 'omx-sparkshell-x86_64-unknown-linux-gnu');
+      const stagingDir = join(wd, 'staging', 'omx-sparkshell-x86_64-unknown-linux-musl');
       await mkdir(stagingDir, { recursive: true });
       const binaryPath = join(stagingDir, 'omx-sparkshell');
       await writeFile(binaryPath, '#!/bin/sh\necho hydrated-nested\n');
       await chmod(binaryPath, 0o755);
 
-      const archivePath = join(assetRoot, 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz');
-      const archive = spawnSync('tar', ['-czf', archivePath, '-C', join(wd, 'staging'), 'omx-sparkshell-x86_64-unknown-linux-gnu'], { encoding: 'utf-8' });
+      const archivePath = join(assetRoot, 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz');
+      const archive = spawnSync('tar', ['-czf', archivePath, '-C', join(wd, 'staging'), 'omx-sparkshell-x86_64-unknown-linux-musl'], { encoding: 'utf-8' });
       assert.equal(archive.status, 0, archive.stderr || archive.stdout);
       const archiveBuffer = await readFile(archivePath);
 
@@ -152,7 +152,7 @@ describe('native asset helpers', () => {
             version: '0.8.15',
             platform: 'linux',
             arch: 'x64',
-            archive: 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz',
+            archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz',
             binary: 'omx-sparkshell',
             binary_path: 'omx-sparkshell',
             sha256: sha256(archiveBuffer),

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -114,7 +114,7 @@ describe('resolveSparkShellBinaryPath', () => {
 
       const archiveName = process.platform === 'win32'
         ? 'omx-sparkshell-x86_64-pc-windows-msvc.zip'
-        : 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz';
+        : 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz';
       const archivePath = join(assetRoot, archiveName);
       const buildArchive = process.platform === 'win32'
         ? spawnSync('powershell', ['-NoLogo', '-NoProfile', '-Command', `Compress-Archive -Path '${stagedBinary.replace(/'/g, "''")}' -DestinationPath '${archivePath.replace(/'/g, "''")}' -Force`], { encoding: 'utf-8' })

--- a/src/verification/__tests__/explore-harness-release-workflow.test.ts
+++ b/src/verification/__tests__/explore-harness-release-workflow.test.ts
@@ -15,9 +15,14 @@ describe('native release workflow', () => {
     assert.match(workflow, /id-token:\s*write/);
     assert.match(workflow, /ubuntu-24\.04/);
     assert.match(workflow, /ubuntu-24\.04-arm/);
+    assert.match(workflow, /x86_64-unknown-linux-musl/);
+    assert.match(workflow, /aarch64-unknown-linux-musl/);
     assert.match(workflow, /macos-15-intel/);
     assert.match(workflow, /macos-14/);
     assert.match(workflow, /windows-latest/);
+    assert.match(workflow, /musl-tools/);
+    assert.match(workflow, /CC_x86_64_unknown_linux_musl=musl-gcc/);
+    assert.match(workflow, /CC_aarch64_unknown_linux_musl=musl-gcc/);
     assert.match(workflow, /cargo install cargo-dist/);
     assert.match(workflow, /dist build -a local/);
     assert.match(workflow, /dist plan --output-format=json/);
@@ -30,8 +35,12 @@ describe('native release workflow', () => {
     assert.match(workflow, /Publish Native Assets/);
     assert.match(workflow, /Smoke Verify Native Assets/);
     assert.match(workflow, /Smoke Test Packed Global Install/);
+    assert.match(workflow, /Older Linux Runtime Proof/);
+    assert.match(workflow, /node:20-bullseye/);
+    assert.match(workflow, /docker run --rm/);
+    assert.match(workflow, /smoke-packed-install\.mjs --release-assets-dir \.\/release-assets --require-no-fallback/);
     assert.match(workflow, /Publish npm Package/);
-    assert.match(workflow, /needs:\s*\[smoke-packed-install\]/);
+    assert.match(workflow, /needs:\s*\[older-linux-runtime-proof\]/);
     assert.match(workflow, /smoke-packed-install\.mjs --release-assets-dir release-assets/);
     assert.match(workflow, /npm publish --access public --provenance/);
   });


### PR DESCRIPTION
## Summary

Fix Linux native asset compatibility for `omx sparkshell` by switching release defaults to musl-first artifacts and adding an older-runtime smoke gate before npm publish.

## Changes

- switch Linux cargo-dist/release targets from GNU to musl-first targets
- keep manifest hydration keyed by `platform + arch` while adding musl triple support
- add an older-Linux Docker proof job that runs packed-install hydration smoke with `--require-no-fallback`
- update smoke/install tests and native asset fixtures from `unknown-linux-gnu` to `unknown-linux-musl`
- document the musl-first Linux native asset strategy in the README

## Validation

- [x] `npm run build`
- [x] targeted tests:
  - `node --test dist/verification/__tests__/explore-harness-release-workflow.test.js dist/cli/__tests__/explore.test.js dist/cli/__tests__/sparkshell-cli.test.js dist/cli/__tests__/native-assets.test.js scripts/__tests__/smoke-packed-install.test.mjs`
- [ ] `npm test` *(currently fails in unrelated existing test: `dist/cli/__tests__/exec.test.js` expecting `# User Instructions`)*
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #812
