### PR TITLE
Fix #908: add stale /tmp cleanup to omx cleanup

### DIFF
--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  cleanupCommand,
   cleanupOmxMcpProcesses,
+  cleanupStaleTmpDirectories,
   findCleanupCandidates,
   type ProcessEntry,
 } from '../cleanup.js';
@@ -120,5 +122,124 @@ describe('cleanupOmxMcpProcesses', () => {
     ]);
     assert.match(lines.join('\n'), /Escalating to SIGKILL for 1 process/);
     assert.match(lines.join('\n'), /Killed 2 orphaned OMX MCP server process\(es\) \(1 required SIGKILL\)\./);
+  });
+});
+
+describe('cleanupStaleTmpDirectories', () => {
+  const tmpEntries = [
+    { name: 'omx-stale-a', isDirectory: () => true },
+    { name: 'omc-stale-b', isDirectory: () => true },
+    { name: 'oh-my-codex-fresh', isDirectory: () => true },
+    { name: 'oh-my-codex-file', isDirectory: () => false },
+    { name: 'other-stale', isDirectory: () => true },
+  ];
+
+  it('supports dry-run and reports stale matching directories older than one hour', async () => {
+    const lines: string[] = [];
+    const removedPaths: string[] = [];
+    const now = 10 * 60 * 60 * 1000;
+
+    const removedCount = await cleanupStaleTmpDirectories(['--dry-run'], {
+      tmpRoot: '/tmp',
+      listTmpEntries: async () => tmpEntries,
+      statPath: async (path) => ({
+        mtimeMs:
+          path === '/tmp/oh-my-codex-fresh'
+            ? now - 30 * 60 * 1000
+            : now - 2 * 60 * 60 * 1000,
+      }),
+      removePath: async (path) => {
+        removedPaths.push(path);
+      },
+      now: () => now,
+      writeLine: (line) => lines.push(line),
+    });
+
+    assert.equal(removedCount, 0);
+    assert.deepEqual(removedPaths, []);
+    assert.match(
+      lines.join('\n'),
+      /Dry run: would remove 2 stale OMX \/tmp directories:/,
+    );
+    assert.match(lines.join('\n'), /\/tmp\/omc-stale-b/);
+    assert.match(lines.join('\n'), /\/tmp\/omx-stale-a/);
+    assert.doesNotMatch(lines.join('\n'), /oh-my-codex-fresh/);
+    assert.doesNotMatch(lines.join('\n'), /other-stale/);
+  });
+
+  it('removes only stale matching directories and returns the removed count', async () => {
+    const lines: string[] = [];
+    const removedPaths: string[] = [];
+    const now = 10 * 60 * 60 * 1000;
+
+    const removedCount = await cleanupStaleTmpDirectories([], {
+      tmpRoot: '/tmp',
+      listTmpEntries: async () => tmpEntries,
+      statPath: async (path) => ({
+        mtimeMs:
+          path === '/tmp/oh-my-codex-fresh'
+            ? now - 30 * 60 * 1000
+            : now - 2 * 60 * 60 * 1000,
+      }),
+      removePath: async (path) => {
+        removedPaths.push(path);
+      },
+      now: () => now,
+      writeLine: (line) => lines.push(line),
+    });
+
+    assert.equal(removedCount, 2);
+    assert.deepEqual(removedPaths, ['/tmp/omc-stale-b', '/tmp/omx-stale-a']);
+    assert.match(lines.join('\n'), /Removed stale \/tmp directory: \/tmp\/omc-stale-b/);
+    assert.match(lines.join('\n'), /Removed stale \/tmp directory: \/tmp\/omx-stale-a/);
+    assert.match(lines.join('\n'), /Removed 2 stale OMX \/tmp directories\./);
+  });
+});
+
+describe('cleanupCommand', () => {
+  it('runs tmp cleanup after orphaned MCP cleanup', async () => {
+    const calls: string[] = [];
+
+    await cleanupCommand(['--dry-run'], {
+      cleanupProcesses: async () => {
+        calls.push('processes');
+        return {
+          dryRun: true,
+          candidates: [],
+          terminatedCount: 0,
+          forceKilledCount: 0,
+          failedPids: [],
+        };
+      },
+      cleanupTmpDirectories: async () => {
+        calls.push('tmp');
+        return 0;
+      },
+    });
+
+    assert.deepEqual(calls, ['processes', 'tmp']);
+  });
+
+  it('skips tmp cleanup when showing help', async () => {
+    const calls: string[] = [];
+
+    await cleanupCommand(['--help'], {
+      cleanupProcesses: async () => {
+        calls.push('processes');
+        return {
+          dryRun: true,
+          candidates: [],
+          terminatedCount: 0,
+          forceKilledCount: 0,
+          failedPids: [],
+        };
+      },
+      cleanupTmpDirectories: async () => {
+        calls.push('tmp');
+        return 0;
+      },
+    });
+
+    assert.deepEqual(calls, ['processes']);
   });
 });

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -1,19 +1,24 @@
 import { execFileSync } from 'child_process';
+import { readdir, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const HELP = [
   'Usage: omx cleanup [--dry-run]',
   '',
-  'Kill orphaned OMX MCP server processes left behind by previous Codex App sessions.',
+  'Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories left behind by previous Codex App sessions.',
   '',
   'Options:',
-  '  --dry-run  List matching orphaned processes without sending signals',
+  '  --dry-run  List matching orphaned processes and stale /tmp directories without removing them',
   '  --help     Show this help message',
 ].join('\n');
 
 const PROCESS_EXIT_POLL_MS = 100;
 const SIGTERM_GRACE_MS = 5_000;
+const STALE_TMP_MAX_AGE_MS = 60 * 60 * 1000;
 const OMX_MCP_SERVER_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/](?:state|memory|code-intel|trace|team)-server\.(?:[cm]?js|ts)\b/i;
 const CODEX_PROCESS_PATTERN = /(?:^|[\\/\s])codex(?:\.js)?(?:\s|$)|@openai[\\/]codex/i;
+const OMX_TMP_DIRECTORY_PATTERN = /^(omc|omx|oh-my-codex)-/;
 
 export interface ProcessEntry {
   pid: number;
@@ -43,8 +48,31 @@ export interface CleanupDependencies {
   writeLine?: (line: string) => void;
 }
 
+interface TmpDirectoryEntry {
+  name: string;
+  isDirectory(): boolean;
+}
+
+export interface TmpCleanupDependencies {
+  tmpRoot?: string;
+  listTmpEntries?: (tmpRoot: string) => Promise<TmpDirectoryEntry[]>;
+  statPath?: (path: string) => Promise<{ mtimeMs: number }>;
+  removePath?: (path: string) => Promise<void>;
+  now?: () => number;
+  writeLine?: (line: string) => void;
+}
+
+export interface CleanupCommandDependencies {
+  cleanupProcesses?: (args: readonly string[]) => Promise<CleanupResult>;
+  cleanupTmpDirectories?: (args: readonly string[]) => Promise<number>;
+}
+
 function normalizeCommand(command: string): string {
   return command.replace(/\\+/g, '/').trim();
+}
+
+function formatPlural(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
 }
 
 export function isOmxMcpProcess(command: string): boolean {
@@ -278,7 +306,6 @@ export async function cleanupOmxMcpProcesses(
           throw err;
         }
       }
-
     }
 
     const remainingAfterKill = await waitForPidsToExit(
@@ -307,6 +334,86 @@ export async function cleanupOmxMcpProcesses(
   };
 }
 
-export async function cleanupCommand(args: string[]): Promise<void> {
-  await cleanupOmxMcpProcesses(args);
+export async function cleanupStaleTmpDirectories(
+  args: readonly string[],
+  dependencies: TmpCleanupDependencies = {},
+): Promise<number> {
+  const dryRun = args.includes('--dry-run');
+  const tmpRoot = dependencies.tmpRoot ?? tmpdir();
+  const listTmpEntries = dependencies.listTmpEntries ?? ((root: string) => readdir(root, { withFileTypes: true }));
+  const statPath = dependencies.statPath ?? stat;
+  const removePath = dependencies.removePath ?? ((path: string) => rm(path, { recursive: true, force: true }));
+  const now = dependencies.now ?? Date.now;
+  const writeLine = dependencies.writeLine ?? ((line: string) => console.log(line));
+
+  const staleDirectories: string[] = [];
+  for (const entry of await listTmpEntries(tmpRoot)) {
+    if (!entry.isDirectory() || !OMX_TMP_DIRECTORY_PATTERN.test(entry.name)) continue;
+
+    const entryPath = join(tmpRoot, entry.name);
+    let entryStat: { mtimeMs: number };
+    try {
+      entryStat = await statPath(entryPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+
+    if (now() - entryStat.mtimeMs <= STALE_TMP_MAX_AGE_MS) continue;
+    staleDirectories.push(entryPath);
+  }
+  staleDirectories.sort((left, right) => left.localeCompare(right));
+
+  if (staleDirectories.length === 0) {
+    writeLine(dryRun
+      ? 'Dry run: no stale OMX /tmp directories found.'
+      : 'No stale OMX /tmp directories found.');
+    return 0;
+  }
+
+  const summaryTarget = formatPlural(
+    staleDirectories.length,
+    'stale OMX /tmp directory',
+    'stale OMX /tmp directories',
+  );
+  if (dryRun) {
+    writeLine(`Dry run: would remove ${summaryTarget}:`);
+    for (const directoryPath of staleDirectories) {
+      writeLine(`  ${directoryPath}`);
+    }
+    return 0;
+  }
+
+  let removedCount = 0;
+  for (const directoryPath of staleDirectories) {
+    try {
+      await removePath(directoryPath);
+      removedCount += 1;
+      writeLine(`Removed stale /tmp directory: ${directoryPath}`);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+  }
+
+  writeLine(
+    `Removed ${formatPlural(
+      removedCount,
+      'stale OMX /tmp directory',
+      'stale OMX /tmp directories',
+    )}.`,
+  );
+  return removedCount;
+}
+
+export async function cleanupCommand(
+  args: string[],
+  dependencies: CleanupCommandDependencies = {},
+): Promise<void> {
+  const cleanupProcesses = dependencies.cleanupProcesses ?? cleanupOmxMcpProcesses;
+  const cleanupTmpDirectories = dependencies.cleanupTmpDirectories ?? cleanupStaleTmpDirectories;
+
+  await cleanupProcesses(args);
+  if (args.includes('--help') || args.includes('-h')) return;
+  await cleanupTmpDirectories(args);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -107,7 +107,7 @@ Usage:
   omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md
   omx uninstall Remove OMX configuration and clean up installed artifacts
   omx doctor    Check installation health
-  omx cleanup   Kill orphaned OMX MCP server processes from prior sessions
+  omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx resume    Resume a previous interactive Codex session


### PR DESCRIPTION
## Summary
- add stale `/tmp` directory cleanup to `omx cleanup` for `omc-*`, `omx-*`, and `oh-my-codex-*` directories older than 1 hour
- preserve `--dry-run` behavior and report matching or removed directories
- add focused tests for stale tmp cleanup and cleanup command integration

## Verification
- `npm run build`
- `npm run lint -- src/cli/cleanup.ts src/cli/__tests__/cleanup.test.ts src/cli/index.ts`
- `node --test dist/cli/__tests__/cleanup.test.js`
- `npm run test:node` *(currently fails on existing unrelated `dist/cli/__tests__/team.test.js` expectation around `dead_workers` output)*

Fixes #908