### PR TITLE
fix: prefer musl Linux natives before glibc fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,11 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
           - runner: macos-15-intel

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,6 +13,6 @@ ci = "github"
 # The installers to generate for each app
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Where to host releases
 hosting = "github"

--- a/scripts/generate-native-release-manifest.mjs
+++ b/scripts/generate-native-release-manifest.mjs
@@ -29,10 +29,10 @@ function parseChecksum(raw) {
 
 function mapTriple(triple) {
   switch (triple) {
-    case 'x86_64-unknown-linux-gnu': return { platform: 'linux', arch: 'x64' };
-    case 'aarch64-unknown-linux-gnu': return { platform: 'linux', arch: 'arm64' };
-    case 'x86_64-unknown-linux-musl': return { platform: 'linux', arch: 'x64' };
-    case 'aarch64-unknown-linux-musl': return { platform: 'linux', arch: 'arm64' };
+    case 'x86_64-unknown-linux-gnu': return { platform: 'linux', arch: 'x64', libc: 'glibc' };
+    case 'aarch64-unknown-linux-gnu': return { platform: 'linux', arch: 'arm64', libc: 'glibc' };
+    case 'x86_64-unknown-linux-musl': return { platform: 'linux', arch: 'x64', libc: 'musl' };
+    case 'aarch64-unknown-linux-musl': return { platform: 'linux', arch: 'arm64', libc: 'musl' };
     case 'x86_64-apple-darwin': return { platform: 'darwin', arch: 'x64' };
     case 'aarch64-apple-darwin': return { platform: 'darwin', arch: 'arm64' };
     case 'x86_64-pc-windows-msvc': return { platform: 'win32', arch: 'x64' };
@@ -73,6 +73,8 @@ for (const artifact of Object.values(plan.artifacts)) {
     version,
     platform: mapped.platform,
     arch: mapped.arch,
+    target: triple,
+    ...(mapped.libc ? { libc: mapped.libc } : {}),
     archive: artifact.name,
     binary: executable.name,
     binary_path: executable.path,
@@ -87,7 +89,14 @@ const manifest = {
   version: plan.announcement_tag.replace(/^v/, ''),
   tag: plan.announcement_tag,
   generated_at: new Date().toISOString(),
-  assets: assets.sort((a, b) => `${a.product}-${a.platform}-${a.arch}`.localeCompare(`${b.product}-${b.platform}-${b.arch}`)),
+  assets: assets.sort((a, b) => {
+    const keyCompare = `${a.product}-${a.platform}-${a.arch}`.localeCompare(`${b.product}-${b.platform}-${b.arch}`);
+    if (keyCompare !== 0) return keyCompare;
+    const libcOrder = { musl: 0, glibc: 1 };
+    const libcCompare = (libcOrder[a.libc] ?? 2) - (libcOrder[b.libc] ?? 2);
+    if (libcCompare !== 0) return libcCompare;
+    return a.archive.localeCompare(b.archive);
+  }),
 };
 for (const product of requireProducts) {
   if (!manifest.assets.some((asset) => asset.product === product)) {

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -8,7 +8,11 @@ import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import {
   hydrateNativeBinary,
+  inferNativeAssetLibc,
+  resolveCachedNativeBinaryCandidatePaths,
   resolveCachedNativeBinaryPath,
+  type NativeReleaseManifest,
+  resolveNativeReleaseAssetCandidates,
   resolveNativeReleaseBaseUrl,
 } from '../native-assets.js';
 
@@ -39,6 +43,79 @@ function sha256(buffer: Buffer): string {
 }
 
 describe('native asset helpers', () => {
+  it('infers Linux libc variants from manifest metadata', () => {
+    assert.equal(inferNativeAssetLibc({
+      archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz',
+      target: 'x86_64-unknown-linux-musl',
+      libc: undefined,
+    }), 'musl');
+    assert.equal(inferNativeAssetLibc({
+      archive: 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz',
+      target: 'x86_64-unknown-linux-gnu',
+      libc: undefined,
+    }), 'glibc');
+  });
+
+  it('prefers musl cache paths before glibc and legacy Linux cache paths', () => {
+    assert.deepEqual(
+      resolveCachedNativeBinaryCandidatePaths('omx-sparkshell', '0.8.15', 'linux', 'x64', {
+        OMX_NATIVE_CACHE_DIR: '/tmp/omx-native-cache',
+      }, {
+        linuxLibcPreference: ['musl', 'glibc'],
+      }),
+      [
+        '/tmp/omx-native-cache/0.8.15/linux-x64-musl/omx-sparkshell/omx-sparkshell',
+        '/tmp/omx-native-cache/0.8.15/linux-x64-glibc/omx-sparkshell/omx-sparkshell',
+        '/tmp/omx-native-cache/0.8.15/linux-x64/omx-sparkshell/omx-sparkshell',
+      ],
+    );
+  });
+
+  it('orders manifest assets musl-first for Linux hydration', () => {
+    const manifest: NativeReleaseManifest = {
+      version: '0.8.15',
+      assets: [
+        {
+          product: 'omx-sparkshell',
+          version: '0.8.15',
+          platform: 'linux',
+          arch: 'x64',
+          target: 'x86_64-unknown-linux-gnu',
+          libc: 'glibc',
+          archive: 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz',
+          binary: 'omx-sparkshell',
+          binary_path: 'omx-sparkshell',
+          sha256: 'glibc',
+          download_url: 'https://example.invalid/glibc',
+        },
+        {
+          product: 'omx-sparkshell',
+          version: '0.8.15',
+          platform: 'linux',
+          arch: 'x64',
+          target: 'x86_64-unknown-linux-musl',
+          libc: 'musl',
+          archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz',
+          binary: 'omx-sparkshell',
+          binary_path: 'omx-sparkshell',
+          sha256: 'musl',
+          download_url: 'https://example.invalid/musl',
+        },
+      ],
+    };
+
+    const ordered = resolveNativeReleaseAssetCandidates(manifest, 'omx-sparkshell', '0.8.15', 'linux', 'x64', {
+      linuxLibcPreference: ['musl', 'glibc'],
+    });
+    assert.deepEqual(
+      ordered.map((asset) => asset.archive),
+      [
+        'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz',
+        'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz',
+      ],
+    );
+  });
+
   it('derives GitHub release base url from package.json repository + version', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-native-base-'));
     try {
@@ -111,7 +188,7 @@ describe('native asset helpers', () => {
 
         assert.equal(hydrated, resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', {
           OMX_NATIVE_CACHE_DIR: cacheDir,
-        }));
+        }, 'musl'));
         assert.equal(await readFile(hydrated!, 'utf-8'), '#!/bin/sh\necho hydrated\n');
       } finally {
         await server.close();
@@ -179,7 +256,7 @@ describe('native asset helpers', () => {
 
         assert.equal(hydrated, resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', {
           OMX_NATIVE_CACHE_DIR: cacheDir,
-        }));
+        }, 'musl'));
         assert.equal(await readFile(hydrated!, 'utf-8'), '#!/bin/sh\necho hydrated-nested\n');
       } finally {
         await server.close();

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import {
   isSparkShellNativeCompatibilityFailure,
   nestedRepoLocalSparkShellBinaryPath,
+  packagedSparkShellBinaryCandidatePaths,
   parseSparkShellFallbackInvocation,
   repoLocalSparkShellBinaryPath,
   resolveSparkShellBinaryPath,
@@ -74,6 +75,44 @@ describe('resolveSparkShellBinaryPath', () => {
       repoLocal,
     );
     assert.notEqual(packaged, repoLocal);
+  });
+
+  it('checks Linux musl packaged paths before glibc and legacy paths', () => {
+    assert.deepEqual(
+      packagedSparkShellBinaryCandidatePaths('/repo', 'linux', 'x64', {}, ['musl', 'glibc']),
+      [
+        '/repo/bin/native/linux-x64-musl/omx-sparkshell',
+        '/repo/bin/native/linux-x64-glibc/omx-sparkshell',
+        '/repo/bin/native/linux-x64/omx-sparkshell',
+      ],
+    );
+  });
+
+  it('tries Linux musl packaged binaries before glibc fallbacks', () => {
+    const packageRoot = '/repo';
+    const seen: string[] = [];
+    const glibcPath = '/repo/bin/native/linux-x64-glibc/omx-sparkshell';
+
+    assert.equal(
+      resolveSparkShellBinaryPath({
+        packageRoot,
+        platform: 'linux',
+        arch: 'x64',
+        linuxLibcPreference: ['musl', 'glibc'],
+        exists: (path) => {
+          seen.push(path);
+          return path === glibcPath;
+        },
+      }),
+      glibcPath,
+    );
+    assert.deepEqual(
+      seen.slice(0, 2),
+      [
+        '/repo/bin/native/linux-x64-musl/omx-sparkshell',
+        '/repo/bin/native/linux-x64-glibc/omx-sparkshell',
+      ],
+    );
   });
 
   it('falls back to nested repo-local native build artifact when present', () => {

--- a/src/cli/explore.ts
+++ b/src/cli/explore.ts
@@ -13,7 +13,7 @@ import {
   EXPLORE_BIN_ENV as EXPLORE_BIN_ENV_SHARED,
   hydrateNativeBinary,
   isRepositoryCheckout,
-  resolveCachedNativeBinaryPath,
+  resolveCachedNativeBinaryCandidatePaths,
   getPackageVersion,
 } from './native-assets.js';
 
@@ -305,9 +305,10 @@ export async function resolveExploreHarnessCommandWithHydration(
   }
 
   const version = await getPackageVersion(packageRoot);
-  const cached = resolveCachedNativeBinaryPath('omx-explore-harness', version, process.platform, process.arch, env);
-  if (existsSync(cached)) {
-    return { command: cached, args: [] };
+  for (const cached of resolveCachedNativeBinaryCandidatePaths('omx-explore-harness', version, process.platform, process.arch, env)) {
+    if (existsSync(cached)) {
+      return { command: cached, args: [] };
+    }
   }
 
   const packaged = resolvePackagedExploreHarnessCommand(packageRoot);

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { chmodSync, createWriteStream, existsSync } from 'node:fs';
+import { chmodSync, createWriteStream, existsSync, readdirSync } from 'node:fs';
 import { copyFile, mkdir, mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, extname, join, resolve } from 'node:path';
@@ -9,12 +9,15 @@ import { spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { getPackageRoot } from '../utils/package.js';
 
 export type NativeProduct = 'omx-explore-harness' | 'omx-sparkshell';
+export type NativeLibc = 'musl' | 'glibc';
 
 export interface NativeReleaseAsset {
   product: NativeProduct;
   version: string;
   platform: NodeJS.Platform;
   arch: string;
+  target?: string;
+  libc?: NativeLibc;
   archive: string;
   binary: string;
   binary_path: string;
@@ -36,6 +39,15 @@ export interface HydrateNativeBinaryOptions {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   arch?: string;
+}
+
+export interface NativeBinaryCandidateOptions {
+  linuxLibcPreference?: readonly NativeLibc[];
+}
+
+export interface ResolveLinuxNativeLibcPreferenceOptions {
+  env?: NodeJS.ProcessEnv;
+  detectedRuntime?: NativeLibc;
 }
 
 const NATIVE_AUTO_FETCH_ENV = 'OMX_NATIVE_AUTO_FETCH';
@@ -109,9 +121,108 @@ export function resolveCachedNativeBinaryPath(
   platform: NodeJS.Platform = process.platform,
   arch: string = process.arch,
   env: NodeJS.ProcessEnv = process.env,
+  libc?: NativeLibc,
 ): string {
   const binary = platform === 'win32' ? `${product}.exe` : product;
-  return join(resolveNativeCacheRoot(env), version, `${platform}-${arch}`, product, binary);
+  const platformKey = libc ? `${platform}-${arch}-${libc}` : `${platform}-${arch}`;
+  return join(resolveNativeCacheRoot(env), version, platformKey, product, binary);
+}
+
+const MUSL_LOADER_DIRS = ['/lib', '/lib64', '/usr/lib', '/usr/local/lib'];
+const MUSL_LOADER_PATTERN = /^ld-musl-.*\.so(?:\.\d+)*$/i;
+
+function inferRuntimeLibcFromText(text: string | undefined): NativeLibc | undefined {
+  const normalized = String(text || '').toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized.includes('musl')) return 'musl';
+  if (normalized.includes('glibc') || normalized.includes('gnu libc')) return 'glibc';
+  return undefined;
+}
+
+export function resolveLinuxNativeLibcPreference(
+  options: ResolveLinuxNativeLibcPreferenceOptions = {},
+): NativeLibc[] {
+  const { env = process.env, detectedRuntime } = options;
+  const runtime = detectedRuntime ?? detectLinuxRuntimeLibc(env);
+  if (runtime === 'musl') return ['musl'];
+  return ['musl', 'glibc'];
+}
+
+function detectLinuxRuntimeLibc(env: NodeJS.ProcessEnv = process.env): NativeLibc | undefined {
+  if (process.platform !== 'linux') return undefined;
+
+  const lddProbe = spawnPlatformCommandSync('ldd', ['--version'], { encoding: 'utf-8' }, process.platform, env);
+  const lddRuntime = inferRuntimeLibcFromText(`${lddProbe.result.stdout || ''}\n${lddProbe.result.stderr || ''}`);
+  if (lddRuntime) return lddRuntime;
+
+  const getconfProbe = spawnPlatformCommandSync('getconf', ['GNU_LIBC_VERSION'], { encoding: 'utf-8' }, process.platform, env);
+  const getconfRuntime = inferRuntimeLibcFromText(`${getconfProbe.result.stdout || ''}\n${getconfProbe.result.stderr || ''}`);
+  if (getconfRuntime) return getconfRuntime;
+
+  for (const directory of MUSL_LOADER_DIRS) {
+    if (!existsSync(directory)) continue;
+    try {
+      if (readdirSync(directory).some((entry) => MUSL_LOADER_PATTERN.test(entry))) {
+        return 'musl';
+      }
+    } catch {
+      // Ignore unreadable loader directories.
+    }
+  }
+
+  return undefined;
+}
+
+export function inferNativeAssetLibc(asset: Pick<NativeReleaseAsset, 'archive' | 'target' | 'libc'>): NativeLibc | undefined {
+  if (asset.libc === 'musl' || asset.libc === 'glibc') return asset.libc;
+  const hint = [asset.target, asset.archive].filter(Boolean).join(' ').toLowerCase();
+  if (hint.includes('musl')) return 'musl';
+  if (hint.includes('linux-gnu') || hint.includes('glibc')) return 'glibc';
+  return undefined;
+}
+
+export function resolveCachedNativeBinaryCandidatePaths(
+  product: NativeProduct,
+  version: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+  env: NodeJS.ProcessEnv = process.env,
+  options: NativeBinaryCandidateOptions = {},
+): string[] {
+  const candidates: string[] = [];
+  if (platform === 'linux') {
+    for (const libc of options.linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env })) {
+      candidates.push(resolveCachedNativeBinaryPath(product, version, platform, arch, env, libc));
+    }
+  }
+  candidates.push(resolveCachedNativeBinaryPath(product, version, platform, arch, env));
+  return [...new Set(candidates)];
+}
+
+export function resolveNativeReleaseAssetCandidates(
+  manifest: NativeReleaseManifest,
+  product: NativeProduct,
+  version: string,
+  platform: NodeJS.Platform,
+  arch: string,
+  options: NativeBinaryCandidateOptions = {},
+): NativeReleaseAsset[] {
+  const candidates = manifest.assets.filter((asset) => asset.product === product
+    && asset.version === version
+    && asset.platform === platform
+    && asset.arch === arch);
+  if (platform !== 'linux') return candidates;
+
+  const preference = options.linuxLibcPreference ?? resolveLinuxNativeLibcPreference();
+  const preferenceIndex = new Map(preference.map((libc, index) => [libc, index]));
+  return [...candidates].sort((left, right) => {
+    const leftLibc = inferNativeAssetLibc(left);
+    const rightLibc = inferNativeAssetLibc(right);
+    const leftRank = leftLibc ? (preferenceIndex.get(leftLibc) ?? preference.length + 1) : preference.length;
+    const rightRank = rightLibc ? (preferenceIndex.get(rightLibc) ?? preference.length + 1) : preference.length;
+    if (leftRank !== rightRank) return leftRank - rightRank;
+    return left.archive.localeCompare(right.archive);
+  });
 }
 
 export function isRepositoryCheckout(packageRoot = getPackageRoot()): boolean {
@@ -137,17 +248,10 @@ function isUnavailableManifestError(error: unknown): boolean {
     || /fetch failed/i.test(error.message);
 }
 
-function findManifestAsset(
-  manifest: NativeReleaseManifest,
-  product: NativeProduct,
-  version: string,
-  platform: NodeJS.Platform,
-  arch: string,
-): NativeReleaseAsset | undefined {
-  return manifest.assets.find((asset) => asset.product === product
-    && asset.version === version
-    && asset.platform === platform
-    && asset.arch === arch);
+function isUnavailableArchiveError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /\[native-assets\] failed to download /i.test(error.message)
+    || /fetch failed/i.test(error.message);
 }
 
 async function downloadFile(url: string, destinationPath: string): Promise<void> {
@@ -229,8 +333,9 @@ export async function hydrateNativeBinary(
   if (!['x64', 'arm64'].includes(arch)) return undefined;
 
   const version = await getPackageVersion(packageRoot);
-  const cachedBinaryPath = resolveCachedNativeBinaryPath(product, version, platform, arch, env);
-  if (existsSync(cachedBinaryPath)) return cachedBinaryPath;
+  for (const cachedBinaryPath of resolveCachedNativeBinaryCandidatePaths(product, version, platform, arch, env)) {
+    if (existsSync(cachedBinaryPath)) return cachedBinaryPath;
+  }
 
   let manifest: NativeReleaseManifest;
   try {
@@ -239,34 +344,57 @@ export async function hydrateNativeBinary(
     if (isUnavailableManifestError(error)) return undefined;
     throw error;
   }
-  const asset = findManifestAsset(manifest, product, version, platform, arch);
-  if (!asset) return undefined;
+  const assets = resolveNativeReleaseAssetCandidates(manifest, product, version, platform, arch, {
+    linuxLibcPreference: platform === 'linux' ? resolveLinuxNativeLibcPreference({ env }) : undefined,
+  });
+  if (assets.length === 0) return undefined;
 
   const tempRoot = await mkdtemp(join(tmpdir(), `${product}-${platform}-${arch}-`));
-  const archivePath = join(tempRoot, asset.archive);
   const extractDir = join(tempRoot, 'extract');
 
   try {
-    await downloadFile(asset.download_url, archivePath);
-    const archiveStat = await stat(archivePath);
-    if (typeof asset.size === 'number' && asset.size > 0 && archiveStat.size !== asset.size) {
-      throw new Error(`[native-assets] downloaded archive size mismatch for ${asset.archive}`);
-    }
-    const digest = await sha256ForFile(archivePath);
-    if (digest !== asset.sha256) {
-      throw new Error(`[native-assets] checksum mismatch for ${asset.archive}`);
-    }
+    for (let index = 0; index < assets.length; index += 1) {
+      const asset = assets[index]!;
+      const archivePath = join(tempRoot, asset.archive);
+      const cachedBinaryPath = resolveCachedNativeBinaryPath(
+        product,
+        version,
+        platform,
+        arch,
+        env,
+        inferNativeAssetLibc(asset),
+      );
+      try {
+        await downloadFile(asset.download_url, archivePath);
+        const archiveStat = await stat(archivePath);
+        if (typeof asset.size === 'number' && asset.size > 0 && archiveStat.size !== asset.size) {
+          throw new Error(`[native-assets] downloaded archive size mismatch for ${asset.archive}`);
+        }
+        const digest = await sha256ForFile(archivePath);
+        if (digest !== asset.sha256) {
+          throw new Error(`[native-assets] checksum mismatch for ${asset.archive}`);
+        }
 
-    await extractArchive(archivePath, extractDir);
-    const extractedBinaryPath = await findExtractedBinaryPath(extractDir, asset.binary_path);
-    if (!extractedBinaryPath) {
-      throw new Error(`[native-assets] extracted archive missing expected binary ${asset.binary_path}`);
-    }
+        await extractArchive(archivePath, extractDir);
+        const extractedBinaryPath = await findExtractedBinaryPath(extractDir, asset.binary_path);
+        if (!extractedBinaryPath) {
+          throw new Error(`[native-assets] extracted archive missing expected binary ${asset.binary_path}`);
+        }
 
-    await mkdir(dirname(cachedBinaryPath), { recursive: true });
-    await copyFile(extractedBinaryPath, cachedBinaryPath);
-    if (platform !== 'win32') chmodSync(cachedBinaryPath, 0o755);
-    return cachedBinaryPath;
+        await mkdir(dirname(cachedBinaryPath), { recursive: true });
+        await copyFile(extractedBinaryPath, cachedBinaryPath);
+        if (platform !== 'win32') chmodSync(cachedBinaryPath, 0o755);
+        return cachedBinaryPath;
+      } catch (error) {
+        if (index < assets.length - 1 && isUnavailableArchiveError(error)) {
+          await rm(archivePath, { force: true });
+          await rm(extractDir, { recursive: true, force: true });
+          continue;
+        }
+        throw error;
+      }
+    }
+    return undefined;
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -13,7 +13,8 @@ import {
   SPARKSHELL_BIN_ENV as SPARKSHELL_BIN_ENV_SHARED,
   getPackageVersion,
   hydrateNativeBinary,
-  resolveCachedNativeBinaryPath,
+  resolveLinuxNativeLibcPreference,
+  resolveCachedNativeBinaryCandidatePaths,
 } from './native-assets.js';
 
 const OMX_SPARKSHELL_BIN_ENV = SPARKSHELL_BIN_ENV_SHARED;
@@ -32,6 +33,7 @@ export interface ResolveSparkShellBinaryPathOptions {
   packageRoot?: string;
   platform?: NodeJS.Platform;
   arch?: string;
+  linuxLibcPreference?: readonly ('musl' | 'glibc')[];
   exists?: (path: string) => boolean;
 }
 
@@ -58,8 +60,27 @@ export function packagedSparkShellBinaryPath(
   packageRoot = getPackageRoot(),
   platform: NodeJS.Platform = process.platform,
   arch: string = osArch(),
+  libc?: 'musl' | 'glibc',
 ): string {
-  return join(packageRoot, 'bin', 'native', `${platform}-${arch}`, sparkshellBinaryName(platform));
+  const platformKey = libc ? `${platform}-${arch}-${libc}` : `${platform}-${arch}`;
+  return join(packageRoot, 'bin', 'native', platformKey, sparkshellBinaryName(platform));
+}
+
+export function packagedSparkShellBinaryCandidatePaths(
+  packageRoot = getPackageRoot(),
+  platform: NodeJS.Platform = process.platform,
+  arch: string = osArch(),
+  env: NodeJS.ProcessEnv = process.env,
+  linuxLibcPreference?: readonly ('musl' | 'glibc')[],
+): string[] {
+  const candidates: string[] = [];
+  if (platform === 'linux') {
+    for (const libc of linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env })) {
+      candidates.push(packagedSparkShellBinaryPath(packageRoot, platform, arch, libc));
+    }
+  }
+  candidates.push(packagedSparkShellBinaryPath(packageRoot, platform, arch));
+  return [...new Set(candidates)];
 }
 
 export function repoLocalSparkShellBinaryPath(
@@ -83,6 +104,7 @@ export function resolveSparkShellBinaryPath(options: ResolveSparkShellBinaryPath
     packageRoot = getPackageRoot(),
     platform = process.platform,
     arch = osArch(),
+    linuxLibcPreference,
     exists = existsSync,
   } = options;
 
@@ -91,8 +113,9 @@ export function resolveSparkShellBinaryPath(options: ResolveSparkShellBinaryPath
     return isAbsolute(override) ? override : resolve(cwd, override);
   }
 
-  const packaged = packagedSparkShellBinaryPath(packageRoot, platform, arch);
-  if (exists(packaged)) return packaged;
+  for (const packaged of packagedSparkShellBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference)) {
+    if (exists(packaged)) return packaged;
+  }
 
   const repoLocal = repoLocalSparkShellBinaryPath(packageRoot, platform);
   if (exists(repoLocal)) return repoLocal;
@@ -100,8 +123,9 @@ export function resolveSparkShellBinaryPath(options: ResolveSparkShellBinaryPath
   const nestedRepoLocal = nestedRepoLocalSparkShellBinaryPath(packageRoot, platform);
   if (exists(nestedRepoLocal)) return nestedRepoLocal;
 
+  const packagedCandidates = packagedSparkShellBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference);
   throw new Error(
-    `[sparkshell] native binary not found. Checked ${packaged}, ${repoLocal}, and ${nestedRepoLocal}. `
+    `[sparkshell] native binary not found. Checked ${packagedCandidates.join(', ')}, ${repoLocal}, and ${nestedRepoLocal}. `
       + `Set ${OMX_SPARKSHELL_BIN_ENV} to override the path.`
   );
 }
@@ -115,6 +139,7 @@ export async function resolveSparkShellBinaryPathWithHydration(
     packageRoot = getPackageRoot(),
     platform = process.platform,
     arch = osArch(),
+    linuxLibcPreference,
     exists = existsSync,
   } = options;
 
@@ -124,11 +149,17 @@ export async function resolveSparkShellBinaryPathWithHydration(
   }
 
   const version = await getPackageVersion(packageRoot);
-  const cached = resolveCachedNativeBinaryPath('omx-sparkshell', version, platform, arch, env);
-  if (exists(cached)) return cached;
+  for (const cached of resolveCachedNativeBinaryCandidatePaths('omx-sparkshell', version, platform, arch, env, {
+    linuxLibcPreference: platform === 'linux'
+      ? (linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env }))
+      : undefined,
+  })) {
+    if (exists(cached)) return cached;
+  }
 
-  const packaged = packagedSparkShellBinaryPath(packageRoot, platform, arch);
-  if (exists(packaged)) return packaged;
+  for (const packaged of packagedSparkShellBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference)) {
+    if (exists(packaged)) return packaged;
+  }
 
   const repoLocal = repoLocalSparkShellBinaryPath(packageRoot, platform);
   if (exists(repoLocal)) return repoLocal;
@@ -140,7 +171,7 @@ export async function resolveSparkShellBinaryPathWithHydration(
   if (hydrated) return hydrated;
 
   throw new Error(
-    `[sparkshell] native binary not found. Checked ${cached}, ${packaged}, ${repoLocal}, and ${nestedRepoLocal}. `
+    `[sparkshell] native binary not found. Checked cached/native candidates under ${packageRoot}, ${repoLocal}, and ${nestedRepoLocal}. `
       + `Reconnect to the network so OMX can fetch the release asset, or set ${OMX_SPARKSHELL_BIN_ENV} to override the path.`
   );
 }

--- a/src/verification/__tests__/explore-harness-release-workflow.test.ts
+++ b/src/verification/__tests__/explore-harness-release-workflow.test.ts
@@ -15,7 +15,9 @@ describe('native release workflow', () => {
     assert.match(workflow, /id-token:\s*write/);
     assert.match(workflow, /ubuntu-24\.04/);
     assert.match(workflow, /ubuntu-24\.04-arm/);
+    assert.match(workflow, /x86_64-unknown-linux-gnu/);
     assert.match(workflow, /x86_64-unknown-linux-musl/);
+    assert.match(workflow, /aarch64-unknown-linux-gnu/);
     assert.match(workflow, /aarch64-unknown-linux-musl/);
     assert.match(workflow, /macos-15-intel/);
     assert.match(workflow, /macos-14/);
@@ -43,6 +45,17 @@ describe('native release workflow', () => {
     assert.match(workflow, /needs:\s*\[older-linux-runtime-proof\]/);
     assert.match(workflow, /smoke-packed-install\.mjs --release-assets-dir release-assets/);
     assert.match(workflow, /npm publish --access public --provenance/);
+  });
+
+  it('keeps cargo-dist Linux targets aligned with musl-first plus glibc fallback assets', () => {
+    const distWorkspacePath = join(process.cwd(), 'dist-workspace.toml');
+    assert.equal(existsSync(distWorkspacePath), true, `missing cargo-dist config: ${distWorkspacePath}`);
+
+    const config = readFileSync(distWorkspacePath, 'utf-8');
+    assert.match(config, /aarch64-unknown-linux-gnu/);
+    assert.match(config, /aarch64-unknown-linux-musl/);
+    assert.match(config, /x86_64-unknown-linux-gnu/);
+    assert.match(config, /x86_64-unknown-linux-musl/);
   });
 
   it('retires the old explore-only release workflow', () => {

--- a/src/verification/__tests__/native-release-manifest.test.ts
+++ b/src/verification/__tests__/native-release-manifest.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('native release manifest generator', () => {
+  it('annotates Linux libc variants and sorts musl assets before glibc fallbacks', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-native-release-manifest-'));
+    try {
+      const artifactsDir = join(root, 'artifacts');
+      await mkdir(artifactsDir, { recursive: true });
+
+      const muslArchive = 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz';
+      const glibcArchive = 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz';
+      await writeFile(join(artifactsDir, muslArchive), 'musl');
+      await writeFile(join(artifactsDir, `${muslArchive}.sha256`), 'musl-checksum\n');
+      await writeFile(join(artifactsDir, glibcArchive), 'glibc');
+      await writeFile(join(artifactsDir, `${glibcArchive}.sha256`), 'glibc-checksum\n');
+
+      const planPath = join(root, 'dist-plan.json');
+      await writeFile(planPath, JSON.stringify({
+        announcement_tag: 'v0.10.2',
+        releases: [
+          { app_name: 'omx-sparkshell', app_version: '0.10.2' },
+        ],
+        artifacts: {
+          linuxGlibc: {
+            kind: 'executable-zip',
+            name: glibcArchive,
+            checksum: `${glibcArchive}.sha256`,
+            target_triples: ['x86_64-unknown-linux-gnu'],
+            assets: [
+              {
+                kind: 'executable',
+                name: 'omx-sparkshell',
+                path: 'omx-sparkshell',
+              },
+            ],
+          },
+          linuxMusl: {
+            kind: 'executable-zip',
+            name: muslArchive,
+            checksum: `${muslArchive}.sha256`,
+            target_triples: ['x86_64-unknown-linux-musl'],
+            assets: [
+              {
+                kind: 'executable',
+                name: 'omx-sparkshell',
+                path: 'omx-sparkshell',
+              },
+            ],
+          },
+        },
+      }, null, 2));
+
+      const outputPath = join(root, 'native-release-manifest.json');
+      const result = spawnSync(process.execPath, [
+        join(process.cwd(), 'scripts', 'generate-native-release-manifest.mjs'),
+        '--plan',
+        planPath,
+        '--artifacts-dir',
+        artifactsDir,
+        '--out',
+        outputPath,
+        '--release-base-url',
+        'https://github.com/example/releases/download/v0.10.2',
+      ], {
+        cwd: process.cwd(),
+        encoding: 'utf-8',
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const manifest = JSON.parse(await readFile(outputPath, 'utf-8')) as {
+        assets: Array<{ archive: string; libc?: string; target?: string }>;
+      };
+      assert.deepEqual(
+        manifest.assets.map((asset) => asset.archive),
+        [muslArchive, glibcArchive],
+      );
+      assert.deepEqual(
+        manifest.assets.map((asset) => asset.libc),
+        ['musl', 'glibc'],
+      );
+      assert.deepEqual(
+        manifest.assets.map((asset) => asset.target),
+        ['x86_64-unknown-linux-musl', 'x86_64-unknown-linux-gnu'],
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- prefer musl Linux native assets/caches before glibc fallbacks for sparkshell and explore hydration
- annotate/sort release manifest Linux assets with libc metadata and add glibc fallback targets to the release matrix
- add regression coverage for musl-first cache resolution, manifest ordering, and release workflow config

## Verification
- npm run build
- node --test dist/cli/__tests__/native-assets.test.js dist/cli/__tests__/sparkshell-cli.test.js dist/cli/__tests__/explore.test.js dist/verification/__tests__/explore-harness-release-workflow.test.js dist/verification/__tests__/native-release-manifest.test.js scripts/__tests__/smoke-packed-install.test.mjs
- npm run lint
- npm test *(currently fails in unrelated existing team status assertion: `dist/cli/__tests__/team.test.js` expecting `dead_workers: worker-1 worker-2`, actual `dead_workers: worker-2`)*

Fixes #910