### PR TITLE
fix: use deep-interview launch for autoresearch intake

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-interview
 description: Socratic deep interview with mathematical ambiguity gating before execution
-argument-hint: "<idea or vague description>"
+argument-hint: "[--quick|--standard|--deep] [--autoresearch] <idea or vague description>"
 ---
 
 <Purpose>
@@ -30,8 +30,13 @@ Execution quality is usually bottlenecked by intent clarity, not just missing im
 - **Quick (`--quick`)**: fast pre-PRD pass; target threshold `<= 0.30`; max rounds 5
 - **Standard (`--standard`, default)**: full requirement interview; target threshold `<= 0.20`; max rounds 12
 - **Deep (`--deep`)**: high-rigor exploration; target threshold `<= 0.15`; max rounds 20
+- **Autoresearch (`--autoresearch`)**: same interview rigor as Standard, but specialized for `omx autoresearch` launch readiness and `.omx/specs/` mission/sandbox artifact handoff
 
 If no flag is provided, use **Standard**.
+
+<Mode_Flags>
+- **`--autoresearch`**: switch the interview into autoresearch-intake mode for `omx autoresearch` handoff. In this mode, the interview should converge on a launch-ready research mission, write canonical artifacts under `.omx/specs/`, and preserve the explicit `refine further` vs `launch` boundary for downstream CLI intake.
+</Mode_Flags>
 </Depth_Profiles>
 
 <Execution_Policy>
@@ -196,18 +201,25 @@ Spec should include:
 
 ### Autoresearch specialization
 
-When the clarified task is specifically about `omx autoresearch`, keep the interview domain-specific and emit a canonical artifact that downstream CLI intake can compile into launch-ready mission scaffolding without skipping clarification.
+When the clarified task is specifically about `omx autoresearch`, or the skill is invoked with `--autoresearch`, keep the interview domain-specific and emit launch-consumable artifacts without skipping clarification.
 
 - **Accepted seed inputs:** `topic`, `evaluator`, `keep-policy`, `slug`, existing mission draft text, and prior evaluator examples/templates
 - **Required interview focus:** mission clarity, evaluator readiness, keep policy, slug/session naming, and whether the draft is ready to launch now or should refine further
 - **Canonical artifact path:** `.omx/specs/deep-interview-autoresearch-{slug}.md`
+- **Launch artifact bundle:** `.omx/specs/autoresearch-{slug}/mission.md`, `.omx/specs/autoresearch-{slug}/sandbox.md`, and `.omx/specs/autoresearch-{slug}/result.json`
+- **Launch artifact directory:** `.omx/specs/autoresearch-{slug}/`
 - **Required artifact sections:**
   - `Mission Draft`
   - `Evaluator Draft`
   - `Launch Readiness`
   - `Seed Inputs`
   - `Confirmation Bridge`
+- **Required launch artifacts under `.omx/specs/autoresearch-{slug}/`:**
+  - `mission.md`
+  - `sandbox.md`
+  - `result.json`
 - **Launch-readiness rule:** mark the draft as **not launch-ready** while the evaluator command still contains placeholder markers such as `<...>`, `TODO`, `TBD`, `REPLACE_ME`, `CHANGEME`, or `your-command-here`
+- **Structured result contract:** `result.json` should point to the draft + mission/sandbox artifacts and carry the finalized `topic`, `evaluatorCommand`, `keepPolicy`, `slug`, `launchReady`, and `blockedReasons` fields so `omx autoresearch` can consume it directly
 - **Confirmation bridge:** after artifact generation, offer at least `refine further` and `launch`; do not launch detached tmux until the user explicitly confirms `launch`
 - **Handoff rule:** downstream execution must preserve the clarified mission intent, evaluator expectations, decision boundaries, and launch-readiness status from this artifact rather than bypassing the draft review step
 

--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -5,8 +5,20 @@ import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { parseSandboxContract } from '../../autoresearch/contracts.js';
-import { isLaunchReadyEvaluatorCommand, writeAutoresearchDraftArtifact } from '../autoresearch-intake.js';
-import { initAutoresearchMission, parseInitArgs, checkTmuxAvailable, runAutoresearchNoviceBridge, type AutoresearchQuestionIO } from '../autoresearch-guided.js';
+import {
+  isLaunchReadyEvaluatorCommand,
+  resolveAutoresearchDeepInterviewResult,
+  writeAutoresearchDeepInterviewArtifacts,
+  writeAutoresearchDraftArtifact,
+} from '../autoresearch-intake.js';
+import {
+  buildAutoresearchDeepInterviewPrompt,
+  initAutoresearchMission,
+  parseInitArgs,
+  checkTmuxAvailable,
+  runAutoresearchNoviceBridge,
+  type AutoresearchQuestionIO,
+} from '../autoresearch-guided.js';
 
 async function initRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-guided-test-'));
@@ -223,6 +235,54 @@ describe('autoresearch intake draft artifacts', () => {
     assert.equal(isLaunchReadyEvaluatorCommand('node scripts/eval.js'), true);
     assert.equal(isLaunchReadyEvaluatorCommand('bash scripts/eval.sh'), true);
   });
+
+  it('writes launch-consumable mission/sandbox/result artifacts and resolves them back', async () => {
+    const repo = await initRepo();
+    try {
+      const artifacts = await writeAutoresearchDeepInterviewArtifacts({
+        repoRoot: repo,
+        topic: 'Measure onboarding friction',
+        evaluatorCommand: 'node scripts/eval.js',
+        keepPolicy: 'pass_only',
+        slug: 'onboarding-friction',
+        seedInputs: { topic: 'Measure onboarding friction' },
+      });
+
+      assert.match(artifacts.draftArtifactPath, /deep-interview-autoresearch-onboarding-friction\.md$/);
+      assert.match(artifacts.missionArtifactPath, /autoresearch-onboarding-friction\/mission\.md$/);
+      assert.match(artifacts.sandboxArtifactPath, /autoresearch-onboarding-friction\/sandbox\.md$/);
+      assert.match(artifacts.resultPath, /autoresearch-onboarding-friction\/result\.json$/);
+
+      const resolved = await resolveAutoresearchDeepInterviewResult(repo, { slug: 'onboarding-friction' });
+      assert.ok(resolved);
+      assert.equal(resolved?.compileTarget.slug, 'onboarding-friction');
+      assert.equal(resolved?.compileTarget.keepPolicy, 'pass_only');
+      assert.equal(resolved?.launchReady, true);
+      assert.match(resolved?.missionContent || '', /Measure onboarding friction/);
+      assert.match(resolved?.sandboxContent || '', /command: node scripts\/eval\.js/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildAutoresearchDeepInterviewPrompt', () => {
+  it('activates deep-interview --autoresearch and includes seed inputs', () => {
+    const prompt = buildAutoresearchDeepInterviewPrompt({
+      topic: 'Investigate flaky tests',
+      evaluatorCommand: 'node scripts/eval.js',
+      keepPolicy: 'score_improvement',
+      slug: 'flaky-tests',
+    });
+
+    assert.match(prompt, /\$deep-interview --autoresearch/);
+    assert.match(prompt, /deep-interview-autoresearch-\{slug\}\.md/);
+    assert.match(prompt, /autoresearch-\{slug\}\/mission\.md/);
+    assert.match(prompt, /- topic: Investigate flaky tests/);
+    assert.match(prompt, /- evaluator: node scripts\/eval\.js/);
+    assert.match(prompt, /- keep_policy: score_improvement/);
+    assert.match(prompt, /- slug: flaky-tests/);
+  });
 });
 
 describe('runAutoresearchNoviceBridge', () => {
@@ -249,11 +309,13 @@ describe('runAutoresearchNoviceBridge', () => {
       ));
 
       const draftContent = await readFile(join(repo, '.omx', 'specs', 'deep-interview-autoresearch-ux-eval.md'), 'utf-8');
+      const resultContent = await readFile(join(repo, '.omx', 'specs', 'autoresearch-ux-eval', 'result.json'), 'utf-8');
       const missionContent = await readFile(join(result.missionDir, 'mission.md'), 'utf-8');
       const sandboxContent = await readFile(join(result.missionDir, 'sandbox.md'), 'utf-8');
 
       assert.equal(result.slug, 'ux-eval');
       assert.match(draftContent, /Launch-ready: yes/);
+      assert.match(resultContent, /"launchReady": true/);
       assert.match(missionContent, /Improve evaluator UX/);
       assert.match(sandboxContent, /command: node scripts\/eval\.js/);
       assert.match(sandboxContent, /keep_policy: pass_only/);

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -6,7 +6,19 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { normalizeAutoresearchCodexArgs, parseAutoresearchArgs } from '../autoresearch.js';
+import { autoresearchCommand, normalizeAutoresearchCodexArgs, parseAutoresearchArgs } from '../autoresearch.js';
+
+function withMockedTty<T>(fn: () => Promise<T>): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+  Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+  return fn().finally(() => {
+    if (descriptor) {
+      Object.defineProperty(process.stdin, 'isTTY', descriptor);
+    } else {
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
+    }
+  });
+}
 
 function runOmx(
   cwd: string,
@@ -76,7 +88,7 @@ describe('omx autoresearch', () => {
       assert.match(result.stdout, /Usage:[\s\S]*omx autoresearch <mission-dir>/i);
       assert.match(result.stdout, /omx autoresearch init/i);
       assert.match(result.stdout, /--topic\/\.\.\./i);
-      assert.match(result.stdout, /novice bridge/i);
+      assert.match(result.stdout, /deep-interview/i);
       assert.doesNotMatch(result.stdout, /oh-my-codex \(omx\) - Multi-agent orchestration for Codex CLI/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -106,7 +118,7 @@ describe('omx autoresearch', () => {
     }
   });
 
-  it('treats top-level topic/evaluator flags as seeded novice-bridge input', () => {
+  it('treats top-level topic/evaluator flags as seeded deep-interview input', () => {
     const parsed = parseAutoresearchArgs(['--topic', 'Improve docs', '--evaluator', 'node eval.js', '--slug', 'docs-run']);
     assert.equal(parsed.guided, true);
     assert.equal(parsed.seedArgs?.topic, 'Improve docs');
@@ -122,6 +134,159 @@ describe('omx autoresearch', () => {
     const flagged = parseAutoresearchArgs(['init', '--topic', 'Ship feature']);
     assert.equal(flagged.guided, true);
     assert.deepEqual(flagged.initArgs, ['--topic', 'Ship feature']);
+  });
+
+  it('launches interactive deep-interview intake, materializes mission files, and then spawns tmux', async () => {
+    const repo = await initRepo();
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-deep-interview-bin-'));
+    try {
+      const codexLog = join(repo, 'codex-launch.log');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      await writeFile(
+        fakeCodexPath,
+        `#!/bin/sh
+printf '%s\\n' "$*" >>"${codexLog}"
+mkdir -p "$OMX_TEST_REPO_ROOT/.omx/specs/deep-int"
+mkdir -p "$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch"
+cat >"$OMX_TEST_REPO_ROOT/.omx/specs/deep-interview-autoresearch-test-launch.md" <<'EOF'
+# Deep Interview Autoresearch Draft — test-launch
+
+## Mission Draft
+Investigate flaky onboarding behavior
+
+## Evaluator Draft
+node scripts/eval.js
+
+## Keep Policy
+score_improvement
+
+## Session Slug
+test-launch
+
+## Seed Inputs
+- topic: (none)
+- evaluator: (none)
+- keep_policy: (none)
+- slug: (none)
+
+## Launch Readiness
+Launch-ready: yes
+- Evaluator command is concrete and can be compiled into sandbox.md
+
+## Confirmation Bridge
+- refine further
+- launch
+EOF
+cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/mission.md" <<'EOF'
+# Mission
+
+Investigate flaky onboarding behavior
+EOF
+cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/sandbox.md" <<'EOF'
+---
+evaluator:
+  command: node scripts/eval.js
+  format: json
+  keep_policy: score_improvement
+---
+EOF
+cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/result.json" <<'EOF'
+{
+  "kind": "omx.autoresearch.deep-interview/v1",
+  "compileTarget": {
+    "topic": "Investigate flaky onboarding behavior",
+    "evaluatorCommand": "node scripts/eval.js",
+    "keepPolicy": "score_improvement",
+    "slug": "test-launch",
+    "repoRoot": "${repo}"
+  },
+  "draftArtifactPath": "${repo}/.omx/specs/deep-interview-autoresearch-test-launch.md",
+  "missionArtifactPath": "${repo}/.omx/specs/autoresearch-test-launch/mission.md",
+  "sandboxArtifactPath": "${repo}/.omx/specs/autoresearch-test-launch/sandbox.md",
+  "launchReady": true,
+  "blockedReasons": []
+}
+EOF
+`,
+        'utf-8',
+      );
+      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+
+      const fakeTmuxPath = join(fakeBin, 'tmux');
+      await writeFile(
+        fakeTmuxPath,
+        `#!/bin/sh
+case "$1" in
+  -V)
+    printf 'tmux 3.4\\n'
+    exit 0
+    ;;
+  has-session)
+    exit 1
+    ;;
+  new-session)
+    last=""
+    for arg in "$@"; do
+      last="$arg"
+    done
+    case " $* " in
+      *" -P "*)
+        printf '%%1\\n'
+        ;;
+    esac
+    if [ -n "$last" ] && [ "$last" != "$1" ]; then
+      /bin/sh -lc "$last"
+    fi
+    exit 0
+    ;;
+  split-window)
+    printf '%%2\\n'
+    exit 0
+    ;;
+  attach-session|set-option|display-message|set-hook|kill-session|kill-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        'utf-8',
+      );
+      execFileSync('chmod', ['+x', fakeTmuxPath], { stdio: 'ignore' });
+
+      const originalPath = process.env.PATH;
+      const descriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+      const originalCwd = process.cwd();
+      process.env.PATH = `${fakeBin}:${process.env.PATH || ''}`;
+      process.env.OMX_TEST_REPO_ROOT = repo;
+      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+      process.chdir(repo);
+      try {
+        await autoresearchCommand([]);
+      } finally {
+        process.chdir(originalCwd);
+        if (typeof originalPath === 'string') process.env.PATH = originalPath;
+        else delete process.env.PATH;
+        delete process.env.OMX_TEST_REPO_ROOT;
+        if (descriptor) {
+          Object.defineProperty(process.stdin, 'isTTY', descriptor);
+        } else {
+          Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
+        }
+      }
+
+      const codexArgs = await readFile(codexLog, 'utf-8');
+      assert.match(codexArgs, /\$deep-interview --autoresearch/);
+
+      const missionContent = await readFile(join(repo, 'missions', 'test-launch', 'mission.md'), 'utf-8');
+      const sandboxContent = await readFile(join(repo, 'missions', 'test-launch', 'sandbox.md'), 'utf-8');
+      assert.match(missionContent, /Investigate flaky onboarding behavior/);
+      assert.match(sandboxContent, /command: node scripts\/eval\.js/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(fakeBin, { recursive: true, force: true });
+    }
   });
 
   it('rejects mission directories outside a git repo', async () => {

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -5,7 +5,14 @@ import { mkdir, writeFile } from 'fs/promises';
 import { dirname, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { type AutoresearchKeepPolicy, parseSandboxContract, slugifyMissionName } from '../autoresearch/contracts.js';
-import { type AutoresearchSeedInputs, isLaunchReadyEvaluatorCommand, writeAutoresearchDraftArtifact } from './autoresearch-intake.js';
+import {
+  buildMissionContent,
+  buildSandboxContent,
+  type AutoresearchDeepInterviewResult,
+  type AutoresearchSeedInputs,
+  isLaunchReadyEvaluatorCommand,
+  writeAutoresearchDeepInterviewArtifacts,
+} from './autoresearch-intake.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -30,15 +37,6 @@ export interface AutoresearchQuestionIO {
 
 function shellQuote(s: string): string {
   return "'" + s.replace(/'/g, "'\\''") + "'";
-}
-
-function buildMissionContent(topic: string): string {
-  return `# Mission\n\n${topic}\n`;
-}
-
-function buildSandboxContent(evaluatorCommand: string, keepPolicy: AutoresearchKeepPolicy): string {
-  const safeCommand = evaluatorCommand.replace(/[\r\n]/g, ' ').trim();
-  return `---\nevaluator:\n  command: ${safeCommand}\n  format: json\n  keep_policy: ${keepPolicy}\n---\n`;
 }
 
 function createQuestionIO(): AutoresearchQuestionIO {
@@ -77,6 +75,41 @@ function ensureLaunchReadyEvaluator(command: string): void {
   if (!isLaunchReadyEvaluatorCommand(command)) {
     throw new Error('Evaluator command is still a placeholder/template. Refine further before launch.');
   }
+}
+
+export function buildAutoresearchDeepInterviewPrompt(
+  seedInputs: AutoresearchSeedInputs = {},
+): string {
+  const seedLines = [
+    `- topic: ${seedInputs.topic?.trim() || '(none)'}`,
+    `- evaluator: ${seedInputs.evaluatorCommand?.trim() || '(none)'}`,
+    `- keep_policy: ${seedInputs.keepPolicy || '(none)'}`,
+    `- slug: ${seedInputs.slug?.trim() || '(none)'}`,
+  ];
+
+  return [
+    '$deep-interview --autoresearch',
+    'Run the deep-interview skill in autoresearch mode for `omx autoresearch`.',
+    'Guide the user through research topic definition, evaluator readiness, keep policy, and slug/session naming.',
+    'Do not launch tmux or run `omx autoresearch` yourself.',
+    'When the user confirms launch and the evaluator is concrete, write/update these canonical artifacts under `.omx/specs/`:',
+    '- `deep-interview-autoresearch-{slug}.md`',
+    '- `autoresearch-{slug}/mission.md`',
+    '- `autoresearch-{slug}/sandbox.md`',
+    '- `autoresearch-{slug}/result.json`',
+    'Use the contract and helper functions in `src/cli/autoresearch-intake.ts` for the artifact shape.',
+    'If the evaluator command still contains placeholders or the user has not confirmed launch, keep refining instead of finalizing launch-ready output.',
+    '',
+    'Seed inputs:',
+    ...seedLines,
+  ].join('\n');
+}
+
+export async function materializeAutoresearchDeepInterviewResult(
+  result: AutoresearchDeepInterviewResult,
+): Promise<InitAutoresearchResult> {
+  ensureLaunchReadyEvaluator(result.compileTarget.evaluatorCommand);
+  return initAutoresearchMission(result.compileTarget);
 }
 
 export async function initAutoresearchMission(opts: InitAutoresearchOptions): Promise<InitAutoresearchResult> {
@@ -179,7 +212,7 @@ export async function runAutoresearchNoviceBridge(
       slug = await promptWithDefault(io, '\nMission slug', slug || slugifyMissionName(topic));
       slug = slugifyMissionName(slug);
 
-      const draft = await writeAutoresearchDraftArtifact({
+      const deepInterview = await writeAutoresearchDeepInterviewArtifacts({
         repoRoot,
         topic,
         evaluatorCommand,
@@ -188,16 +221,15 @@ export async function runAutoresearchNoviceBridge(
         seedInputs,
       });
 
-      console.log(`\nDraft saved: ${draft.path}`);
-      console.log(`Launch readiness: ${draft.launchReady ? 'ready' : draft.blockedReasons.join(' ')}`);
+      console.log(`\nDraft saved: ${deepInterview.draftArtifactPath}`);
+      console.log(`Launch readiness: ${deepInterview.launchReady ? 'ready' : deepInterview.blockedReasons.join(' ')}`);
 
-      const action = await promptAction(io, draft.launchReady);
+      const action = await promptAction(io, deepInterview.launchReady);
       if (action === 'refine') {
         continue;
       }
 
-      ensureLaunchReadyEvaluator(draft.compileTarget.evaluatorCommand);
-      return initAutoresearchMission(draft.compileTarget);
+      return materializeAutoresearchDeepInterviewResult(deepInterview);
     }
   } finally {
     io.close();

--- a/src/cli/autoresearch-intake.ts
+++ b/src/cli/autoresearch-intake.ts
@@ -1,4 +1,5 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { type AutoresearchKeepPolicy, parseSandboxContract, slugifyMissionName } from '../autoresearch/contracts.js';
 
@@ -25,6 +26,28 @@ export interface AutoresearchDraftArtifact {
   blockedReasons: string[];
 }
 
+export interface AutoresearchDeepInterviewResult {
+  compileTarget: AutoresearchDraftCompileTarget;
+  draftArtifactPath: string;
+  missionArtifactPath: string;
+  sandboxArtifactPath: string;
+  resultPath: string;
+  missionContent: string;
+  sandboxContent: string;
+  launchReady: boolean;
+  blockedReasons: string[];
+}
+
+interface PersistedAutoresearchDeepInterviewResultV1 {
+  kind: typeof AUTORESEARCH_DEEP_INTERVIEW_RESULT_KIND;
+  compileTarget: AutoresearchDraftCompileTarget;
+  draftArtifactPath: string;
+  missionArtifactPath: string;
+  sandboxArtifactPath: string;
+  launchReady: boolean;
+  blockedReasons: string[];
+}
+
 const BLOCKED_EVALUATOR_PATTERNS = [
   /<[^>]+>/i,
   /\bTODO\b/i,
@@ -34,9 +57,71 @@ const BLOCKED_EVALUATOR_PATTERNS = [
   /your-command-here/i,
 ] as const;
 
+const DEEP_INTERVIEW_DRAFT_PREFIX = 'deep-interview-autoresearch-';
+const AUTORESEARCH_ARTIFACT_DIR_PREFIX = 'autoresearch-';
+export const AUTORESEARCH_DEEP_INTERVIEW_RESULT_KIND = 'omx.autoresearch.deep-interview/v1';
+
 function defaultDraftEvaluator(topic: string): string {
   const detail = topic.trim() || 'the mission';
   return `TODO replace with evaluator command for: ${detail}`;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractMarkdownSection(markdown: string, heading: string): string {
+  const pattern = new RegExp(`^##\\s+${escapeRegex(heading)}\\s*$`, 'im');
+  const match = pattern.exec(markdown);
+  if (!match || match.index < 0) return '';
+  const start = match.index + match[0].length;
+  const remainder = markdown.slice(start);
+  const nextHeading = remainder.search(/^##\s+/m);
+  return (nextHeading >= 0 ? remainder.slice(0, nextHeading) : remainder).trim();
+}
+
+function parseLaunchReadinessSection(section: string): { launchReady: boolean; blockedReasons: string[] } {
+  const normalized = section.trim();
+  if (!normalized) {
+    return { launchReady: false, blockedReasons: ['Launch readiness section is missing.'] };
+  }
+
+  const launchReady = /Launch-ready:\s*yes/i.test(normalized);
+  const blockedReasons = launchReady
+    ? []
+    : normalized
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^-\s+/.test(line))
+      .map((line) => line.replace(/^-\s+/, '').trim())
+      .filter(Boolean);
+
+  return { launchReady, blockedReasons };
+}
+
+function normalizeKeepPolicy(raw: string): AutoresearchKeepPolicy {
+  return raw.trim().toLowerCase() === 'pass_only' ? 'pass_only' : 'score_improvement';
+}
+
+function buildArtifactDir(repoRoot: string, slug: string): string {
+  return join(repoRoot, '.omx', 'specs', `${AUTORESEARCH_ARTIFACT_DIR_PREFIX}${slug}`);
+}
+
+function buildDraftArtifactPath(repoRoot: string, slug: string): string {
+  return join(repoRoot, '.omx', 'specs', `${DEEP_INTERVIEW_DRAFT_PREFIX}${slug}.md`);
+}
+
+function buildResultPath(repoRoot: string, slug: string): string {
+  return join(buildArtifactDir(repoRoot, slug), 'result.json');
+}
+
+export function buildMissionContent(topic: string): string {
+  return `# Mission\n\n${topic}\n`;
+}
+
+export function buildSandboxContent(evaluatorCommand: string, keepPolicy: AutoresearchKeepPolicy): string {
+  const safeCommand = evaluatorCommand.replace(/[\r\n]/g, ' ').trim();
+  return `---\nevaluator:\n  command: ${safeCommand}\n  format: json\n  keep_policy: ${keepPolicy}\n---\n`;
 }
 
 export function isLaunchReadyEvaluatorCommand(command: string): boolean {
@@ -129,15 +214,224 @@ export async function writeAutoresearchDraftArtifact(input: {
   }
 
   if (blockedReasons.length === 0) {
-    parseSandboxContract(`---\nevaluator:\n  command: ${evaluatorCommand}\n  format: json\n  keep_policy: ${input.keepPolicy}\n---\n`);
+    parseSandboxContract(buildSandboxContent(evaluatorCommand, input.keepPolicy));
   }
 
   const launchReady = blockedReasons.length === 0;
   const specsDir = join(input.repoRoot, '.omx', 'specs');
   await mkdir(specsDir, { recursive: true });
-  const path = join(specsDir, `deep-interview-autoresearch-${slug}.md`);
+  const path = buildDraftArtifactPath(input.repoRoot, slug);
   const content = buildAutoresearchDraftArtifactContent(compileTarget, input.seedInputs || {}, launchReady, blockedReasons);
   await writeFile(path, content, 'utf-8');
 
   return { compileTarget, path, content, launchReady, blockedReasons };
+}
+
+export async function writeAutoresearchDeepInterviewArtifacts(input: {
+  repoRoot: string;
+  topic: string;
+  evaluatorCommand?: string;
+  keepPolicy: AutoresearchKeepPolicy;
+  slug?: string;
+  seedInputs?: AutoresearchSeedInputs;
+}): Promise<AutoresearchDeepInterviewResult> {
+  const draft = await writeAutoresearchDraftArtifact(input);
+  const artifactDir = buildArtifactDir(input.repoRoot, draft.compileTarget.slug);
+  await mkdir(artifactDir, { recursive: true });
+
+  const missionArtifactPath = join(artifactDir, 'mission.md');
+  const sandboxArtifactPath = join(artifactDir, 'sandbox.md');
+  const resultPath = buildResultPath(input.repoRoot, draft.compileTarget.slug);
+  const missionContent = buildMissionContent(draft.compileTarget.topic);
+  const sandboxContent = buildSandboxContent(draft.compileTarget.evaluatorCommand, draft.compileTarget.keepPolicy);
+
+  parseSandboxContract(sandboxContent);
+  await writeFile(missionArtifactPath, missionContent, 'utf-8');
+  await writeFile(sandboxArtifactPath, sandboxContent, 'utf-8');
+
+  const persisted: PersistedAutoresearchDeepInterviewResultV1 = {
+    kind: AUTORESEARCH_DEEP_INTERVIEW_RESULT_KIND,
+    compileTarget: draft.compileTarget,
+    draftArtifactPath: draft.path,
+    missionArtifactPath,
+    sandboxArtifactPath,
+    launchReady: draft.launchReady,
+    blockedReasons: draft.blockedReasons,
+  };
+  await writeFile(resultPath, `${JSON.stringify(persisted, null, 2)}\n`, 'utf-8');
+
+  return {
+    compileTarget: draft.compileTarget,
+    draftArtifactPath: draft.path,
+    missionArtifactPath,
+    sandboxArtifactPath,
+    resultPath,
+    missionContent,
+    sandboxContent,
+    launchReady: draft.launchReady,
+    blockedReasons: draft.blockedReasons,
+  };
+}
+
+function parseDraftArtifactContent(content: string, repoRoot: string, draftArtifactPath: string): AutoresearchDeepInterviewResult {
+  const missionDraft = extractMarkdownSection(content, 'Mission Draft').trim();
+  const evaluatorDraft = extractMarkdownSection(content, 'Evaluator Draft').trim().replace(/[\r\n]+/g, ' ');
+  const keepPolicyRaw = extractMarkdownSection(content, 'Keep Policy').trim();
+  const slugRaw = extractMarkdownSection(content, 'Session Slug').trim();
+  const launchReadiness = parseLaunchReadinessSection(extractMarkdownSection(content, 'Launch Readiness'));
+
+  if (!missionDraft) {
+    throw new Error(`Missing Mission Draft section in ${draftArtifactPath}`);
+  }
+  if (!evaluatorDraft) {
+    throw new Error(`Missing Evaluator Draft section in ${draftArtifactPath}`);
+  }
+
+  const slug = slugifyMissionName(slugRaw || missionDraft);
+  const compileTarget: AutoresearchDraftCompileTarget = {
+    topic: missionDraft,
+    evaluatorCommand: evaluatorDraft,
+    keepPolicy: normalizeKeepPolicy(keepPolicyRaw || 'score_improvement'),
+    slug,
+    repoRoot,
+  };
+  const missionContent = buildMissionContent(compileTarget.topic);
+  const sandboxContent = buildSandboxContent(compileTarget.evaluatorCommand, compileTarget.keepPolicy);
+  parseSandboxContract(sandboxContent);
+
+  return {
+    compileTarget,
+    draftArtifactPath,
+    missionArtifactPath: join(buildArtifactDir(repoRoot, slug), 'mission.md'),
+    sandboxArtifactPath: join(buildArtifactDir(repoRoot, slug), 'sandbox.md'),
+    resultPath: buildResultPath(repoRoot, slug),
+    missionContent,
+    sandboxContent,
+    launchReady: launchReadiness.launchReady,
+    blockedReasons: launchReadiness.blockedReasons,
+  };
+}
+
+async function readPersistedResult(resultPath: string): Promise<AutoresearchDeepInterviewResult> {
+  const raw = await readFile(resultPath, 'utf-8');
+  const parsed = JSON.parse(raw) as Partial<PersistedAutoresearchDeepInterviewResultV1>;
+  if (parsed.kind !== AUTORESEARCH_DEEP_INTERVIEW_RESULT_KIND) {
+    throw new Error(`Unsupported autoresearch deep-interview result payload: ${resultPath}`);
+  }
+  if (!parsed.compileTarget) {
+    throw new Error(`Missing compileTarget in ${resultPath}`);
+  }
+
+  const compileTarget = parsed.compileTarget as AutoresearchDraftCompileTarget;
+  const draftArtifactPath = typeof parsed.draftArtifactPath === 'string' ? parsed.draftArtifactPath : buildDraftArtifactPath(compileTarget.repoRoot, compileTarget.slug);
+  const missionArtifactPath = typeof parsed.missionArtifactPath === 'string' ? parsed.missionArtifactPath : join(buildArtifactDir(compileTarget.repoRoot, compileTarget.slug), 'mission.md');
+  const sandboxArtifactPath = typeof parsed.sandboxArtifactPath === 'string' ? parsed.sandboxArtifactPath : join(buildArtifactDir(compileTarget.repoRoot, compileTarget.slug), 'sandbox.md');
+  const missionContent = await readFile(missionArtifactPath, 'utf-8');
+  const sandboxContent = await readFile(sandboxArtifactPath, 'utf-8');
+  parseSandboxContract(sandboxContent);
+
+  return {
+    compileTarget,
+    draftArtifactPath,
+    missionArtifactPath,
+    sandboxArtifactPath,
+    resultPath,
+    missionContent,
+    sandboxContent,
+    launchReady: parsed.launchReady === true,
+    blockedReasons: Array.isArray(parsed.blockedReasons)
+      ? parsed.blockedReasons.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      : [],
+  };
+}
+
+async function listMarkdownDraftPaths(repoRoot: string): Promise<string[]> {
+  const specsDir = join(repoRoot, '.omx', 'specs');
+  if (!existsSync(specsDir)) return [];
+  const entries = await readdir(specsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.startsWith(DEEP_INTERVIEW_DRAFT_PREFIX) && entry.name.endsWith('.md'))
+    .map((entry) => join(specsDir, entry.name));
+}
+
+export async function listAutoresearchDeepInterviewResultPaths(repoRoot: string): Promise<string[]> {
+  const specsDir = join(repoRoot, '.omx', 'specs');
+  if (!existsSync(specsDir)) return [];
+
+  const entries = await readdir(specsDir, { withFileTypes: true });
+  const resultPaths = entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(AUTORESEARCH_ARTIFACT_DIR_PREFIX))
+    .map((entry) => join(specsDir, entry.name, 'result.json'))
+    .filter((path) => existsSync(path));
+
+  return resultPaths.sort((left, right) => left.localeCompare(right));
+}
+
+async function filterRecentPaths(paths: readonly string[], newerThanMs?: number, excludePaths?: ReadonlySet<string>): Promise<string[]> {
+  const filtered: string[] = [];
+  for (const path of paths) {
+    if (excludePaths?.has(path)) {
+      continue;
+    }
+    if (typeof newerThanMs === 'number') {
+      const metadata = await stat(path).catch(() => null);
+      if (!metadata || metadata.mtimeMs < newerThanMs) {
+        continue;
+      }
+    }
+    filtered.push(path);
+  }
+  return filtered;
+}
+
+export async function resolveAutoresearchDeepInterviewResult(
+  repoRoot: string,
+  options: {
+    slug?: string;
+    newerThanMs?: number;
+    excludeResultPaths?: ReadonlySet<string>;
+  } = {},
+): Promise<AutoresearchDeepInterviewResult | null> {
+  const slug = options.slug?.trim() ? slugifyMissionName(options.slug) : null;
+
+  if (slug) {
+    const resultPath = buildResultPath(repoRoot, slug);
+    if (existsSync(resultPath)) {
+      const metadata = await stat(resultPath).catch(() => null);
+      if (!metadata || options.newerThanMs == null || metadata.mtimeMs >= options.newerThanMs) {
+        return readPersistedResult(resultPath);
+      }
+    }
+
+    const draftArtifactPath = buildDraftArtifactPath(repoRoot, slug);
+    if (existsSync(draftArtifactPath)) {
+      const metadata = await stat(draftArtifactPath).catch(() => null);
+      if (!metadata || options.newerThanMs == null || metadata.mtimeMs >= options.newerThanMs) {
+        const draftContent = await readFile(draftArtifactPath, 'utf-8');
+        return parseDraftArtifactContent(draftContent, repoRoot, draftArtifactPath);
+      }
+    }
+    return null;
+  }
+
+  const resultPaths = await filterRecentPaths(
+    await listAutoresearchDeepInterviewResultPaths(repoRoot),
+    options.newerThanMs,
+    options.excludeResultPaths,
+  );
+  const resultEntries = await Promise.all(resultPaths.map(async (path) => ({ path, metadata: await stat(path) })));
+  const newestResultPath = resultEntries.sort((left, right) => right.metadata.mtimeMs - left.metadata.mtimeMs)[0]?.path;
+  if (newestResultPath) {
+    return readPersistedResult(newestResultPath);
+  }
+
+  const draftPaths = await filterRecentPaths(await listMarkdownDraftPaths(repoRoot), options.newerThanMs);
+  const draftEntries = await Promise.all(draftPaths.map(async (path) => ({ path, metadata: await stat(path) })));
+  const newestDraftPath = draftEntries.sort((left, right) => right.metadata.mtimeMs - left.metadata.mtimeMs)[0]?.path;
+  if (!newestDraftPath) {
+    return null;
+  }
+
+  const draftContent = await readFile(newestDraftPath, 'utf-8');
+  return parseDraftArtifactContent(draftContent, repoRoot, newestDraftPath);
 }

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -13,28 +13,35 @@ import {
   buildAutoresearchRunTag,
 } from '../autoresearch/runtime.js';
 import { assertModeStartAllowed } from '../modes/base.js';
-import { guidedAutoresearchSetup, initAutoresearchMission, parseInitArgs, runAutoresearchNoviceBridge, spawnAutoresearchTmux } from "./autoresearch-guided.js";
-import { CODEX_BYPASS_FLAG, MADMAX_FLAG } from "./constants.js";
+import {
+  buildAutoresearchDeepInterviewPrompt,
+  initAutoresearchMission,
+  materializeAutoresearchDeepInterviewResult,
+  parseInitArgs,
+  spawnAutoresearchTmux,
+} from './autoresearch-guided.js';
+import { resolveAutoresearchDeepInterviewResult } from './autoresearch-intake.js';
+import { CODEX_BYPASS_FLAG, MADMAX_FLAG } from './constants.js';
 
 export const AUTORESEARCH_HELP = `omx autoresearch - Launch OMX autoresearch with thin-supervisor parity semantics
 
 Usage:
-  omx autoresearch                                                (interactive novice bridge + background launch)
+  omx autoresearch                                                (launch Codex CLI deep-interview intake, then background launch)
   omx autoresearch [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
   omx autoresearch init [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
   omx autoresearch <mission-dir> [codex-args...]
   omx autoresearch --resume <run-id> [codex-args...]
 
 Arguments:
-  (no args)        Interactive novice bridge: interviews/refines topic, evaluator, policy, and slug,
-                   writes a draft artifact, then launches only after explicit confirmation.
-  --topic/...      Seed the novice bridge with draft values; still requires refinement/confirmation before launch.
-  init             Bare init is an interactive novice-bridge alias on TTYs; init with flags is the expert scaffold path.
+  (no args)        Launch an interactive Codex session that activates deep-interview --autoresearch,
+                   writes .omx/specs artifacts, then launches only after explicit confirmation.
+  --topic/...      Seed the deep-interview intake with draft values; still requires refinement/confirmation before launch.
+  init             Bare init is an interactive deep-interview alias on TTYs; init with flags is the expert scaffold path.
   <mission-dir>    Directory inside a git repository containing mission.md and sandbox.md
   <run-id>         Existing autoresearch run id from .omx/logs/autoresearch/<run-id>/manifest.json
 
 Behavior:
-  - novice intake writes a canonical draft artifact under .omx/specs before launch
+  - deep-interview intake writes canonical artifacts under .omx/specs before launch
   - validates mission.md and sandbox.md
   - requires sandbox.md YAML frontmatter with evaluator.command and evaluator.format=json
   - fresh launch creates a run-tagged autoresearch/<slug>/<run-tag> lane
@@ -44,6 +51,63 @@ Behavior:
 
 const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
 const AUTORESEARCH_MAX_CONSECUTIVE_NOOPS = 3;
+
+function buildAutoresearchDeepInterviewAppendix(): string {
+  return [
+    '<autoresearch_deep_interview_mode>',
+    'You are in OMX autoresearch intake mode.',
+    'Run the deep-interview skill in autoresearch mode and clarify the research mission before launch.',
+    'Do not start tmux, do not launch `omx autoresearch`, and do not bypass the user confirmation boundary.',
+    'When the user confirms launch and the evaluator is concrete, persist canonical artifacts under `.omx/specs/` using the contracts in `src/cli/autoresearch-intake.ts`.',
+    '- Required outputs: `deep-interview-autoresearch-{slug}.md`, `autoresearch-{slug}/mission.md`, `autoresearch-{slug}/sandbox.md`, `autoresearch-{slug}/result.json`.',
+    '- If the evaluator is still a placeholder or the user wants to refine further, keep interviewing instead of finalizing launch-ready output.',
+    '</autoresearch_deep_interview_mode>',
+  ].join('\n');
+}
+
+async function writeAutoresearchDeepInterviewAppendixFile(repoRoot: string): Promise<string> {
+  const { mkdir, writeFile } = await import('node:fs/promises');
+  const { join } = await import('node:path');
+  const dir = join(repoRoot, '.omx', 'autoresearch');
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, 'deep-interview-session-instructions.md');
+  await writeFile(path, `${buildAutoresearchDeepInterviewAppendix()}\n`, 'utf-8');
+  return path;
+}
+
+async function runGuidedAutoresearchDeepInterview(
+  repoRoot: string,
+  seedArgs?: ReturnType<typeof parseInitArgs>,
+): Promise<Awaited<ReturnType<typeof initAutoresearchMission>>> {
+  const previousInstructionsFile = process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
+  const appendixPath = await writeAutoresearchDeepInterviewAppendixFile(repoRoot);
+  const startedAtMs = Date.now();
+  process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = appendixPath;
+
+  try {
+    const { launchWithHud } = await import('./index.js');
+    await launchWithHud([buildAutoresearchDeepInterviewPrompt(seedArgs ?? {})]);
+  } finally {
+    if (typeof previousInstructionsFile === 'string') {
+      process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = previousInstructionsFile;
+    } else {
+      delete process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
+    }
+  }
+
+  const result = await resolveAutoresearchDeepInterviewResult(repoRoot, {
+    newerThanMs: startedAtMs,
+  });
+  if (!result) {
+    throw new Error('autoresearch deep-interview did not produce .omx/specs launch artifacts.');
+  }
+  if (!result.launchReady) {
+    throw new Error(
+      `autoresearch deep-interview exited without a launch-ready result. ${result.blockedReasons.join(' ') || 'Refine the interview result and retry.'}`,
+    );
+  }
+  return materializeAutoresearchDeepInterviewResult(result);
+}
 
 export function normalizeAutoresearchCodexArgs(codexArgs: readonly string[]): string[] {
   const normalized: string[] = [];
@@ -221,11 +285,9 @@ export async function autoresearchCommand(args: string[]): Promise<void> {
         keepPolicy: initOpts.keepPolicy || 'score_improvement',
         slug: initOpts.slug,
         repoRoot,
-      });
+        });
     } else {
-      result = parsed.seedArgs
-        ? await runAutoresearchNoviceBridge(repoRoot, parsed.seedArgs)
-        : await guidedAutoresearchSetup(repoRoot);
+      result = await runGuidedAutoresearchDeepInterview(repoRoot, parsed.seedArgs);
     }
     spawnAutoresearchTmux(result.missionDir, result.slug);
     return;


### PR DESCRIPTION
Fixes #911

## Summary
- replace the no-arg autoresearch readline flow with an interactive Codex deep-interview launch
- persist launch-consumable autoresearch artifacts under `.omx/specs/` and compile them into `missions/<slug>/` before tmux launch
- keep expert autoresearch paths (`init --flags`, `<mission-dir>`, `--resume`) working and add regression coverage

## Verification
- npm run lint
- npm test