### PR TITLE
refactor(autoresearch): deslop contracts and runtime

### DIFF
--- a/src/autoresearch/__tests__/contracts.test.ts
+++ b/src/autoresearch/__tests__/contracts.test.ts
@@ -64,6 +64,18 @@ describe('autoresearch contracts', () => {
     );
   });
 
+  it('normalizes evaluator keep_policy casing and surrounding whitespace', () => {
+    const parsed = parseSandboxContract(`---
+evaluator:
+  command: node scripts/eval.js
+  format: json
+  keep_policy: "  SCORE_IMPROVEMENT  "
+---
+Stay in bounds.
+`);
+    assert.equal(parsed.evaluator.keep_policy, 'score_improvement');
+  });
+
   it('parses optional evaluator keep_policy', () => {
     const parsed = parseSandboxContract(`---
 evaluator:
@@ -110,6 +122,41 @@ Stay in bounds.
       () => parseEvaluatorResult('{"pass":true,"score":"high"}'),
       /score must be numeric/i,
     );
+  });
+
+  it('rejects mission directories outside a git repository', async () => {
+    const missionDir = await mkdtemp(join(tmpdir(), 'omx-autoresearch-not-git-'));
+    try {
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\nShip it\n', 'utf-8');
+      await writeFile(
+        join(missionDir, 'sandbox.md'),
+        `---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n---\nStay in bounds.\n`,
+        'utf-8',
+      );
+
+      await assert.rejects(
+        () => loadAutoresearchMissionContract(missionDir),
+        /not a git repository|mission-dir must be inside a git repository/i,
+      );
+    } finally {
+      await rm(missionDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects mission directories missing sandbox.md', async () => {
+    const repo = await initRepo();
+    try {
+      const missionDir = join(repo, 'missions', 'demo');
+      await mkdir(missionDir, { recursive: true });
+      await writeFile(join(missionDir, 'mission.md'), '# Mission\nShip it\n', 'utf-8');
+
+      await assert.rejects(
+        () => loadAutoresearchMissionContract(missionDir),
+        /sandbox\.md is required inside mission-dir/i,
+      );
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
   });
 
   it('loads mission contract from in-repo mission directory', async () => {

--- a/src/autoresearch/contracts.ts
+++ b/src/autoresearch/contracts.ts
@@ -34,6 +34,13 @@ export interface AutoresearchMissionContract {
   missionSlug: string;
 }
 
+const MISSION_DIR_GIT_ERROR = 'mission-dir must be inside a git repository.';
+const SANDBOX_FRONTMATTER_ERROR = 'sandbox.md must start with YAML frontmatter containing evaluator.command and evaluator.format=json.';
+const EVALUATOR_BLOCK_ERROR = 'sandbox.md frontmatter must define an evaluator block.';
+const EVALUATOR_COMMAND_ERROR = 'sandbox.md frontmatter evaluator.command is required.';
+const EVALUATOR_FORMAT_REQUIRED_ERROR = 'sandbox.md frontmatter evaluator.format is required and must be json in autoresearch v1.';
+const EVALUATOR_FORMAT_JSON_ERROR = 'sandbox.md frontmatter evaluator.format must be json in autoresearch v1.';
+
 function contractError(message: string): Error {
   return new Error(message);
 }
@@ -52,7 +59,7 @@ function readGit(repoPath: string, args: string[]): string {
       : err.stderr instanceof Buffer
         ? err.stderr.toString('utf-8').trim()
         : '';
-    throw contractError(stderr || 'mission-dir must be inside a git repository.');
+    throw contractError(stderr || MISSION_DIR_GIT_ERROR);
   }
 }
 
@@ -68,13 +75,13 @@ export function slugifyMissionName(value: string): string {
 function ensurePathInside(parentPath: string, childPath: string): void {
   const rel = relative(parentPath, childPath);
   if (rel === '' || (!rel.startsWith('..') && rel !== '..')) return;
-  throw contractError('mission-dir must be inside a git repository.');
+  throw contractError(MISSION_DIR_GIT_ERROR);
 }
 
 function extractFrontmatter(content: string): { frontmatter: string; body: string } {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
   if (!match) {
-    throw contractError('sandbox.md must start with YAML frontmatter containing evaluator.command and evaluator.format=json.');
+    throw contractError(SANDBOX_FRONTMATTER_ERROR);
   }
   return {
     frontmatter: match[1] || '',
@@ -142,7 +149,7 @@ export function parseSandboxContract(content: string): ParsedSandboxContract {
   const evaluatorRaw = parsedFrontmatter.evaluator;
 
   if (!evaluatorRaw || typeof evaluatorRaw !== 'object' || Array.isArray(evaluatorRaw)) {
-    throw contractError('sandbox.md frontmatter must define an evaluator block.');
+    throw contractError(EVALUATOR_BLOCK_ERROR);
   }
 
   const evaluator = evaluatorRaw as { command?: unknown; format?: unknown; keep_policy?: unknown };
@@ -155,13 +162,13 @@ export function parseSandboxContract(content: string): ParsedSandboxContract {
   const keepPolicy = parseKeepPolicy(evaluator.keep_policy);
 
   if (!command) {
-    throw contractError('sandbox.md frontmatter evaluator.command is required.');
+    throw contractError(EVALUATOR_COMMAND_ERROR);
   }
   if (!format) {
-    throw contractError('sandbox.md frontmatter evaluator.format is required and must be json in autoresearch v1.');
+    throw contractError(EVALUATOR_FORMAT_REQUIRED_ERROR);
   }
   if (format !== 'json') {
-    throw contractError('sandbox.md frontmatter evaluator.format must be json in autoresearch v1.');
+    throw contractError(EVALUATOR_FORMAT_JSON_ERROR);
   }
 
   return {
@@ -195,9 +202,10 @@ export function parseEvaluatorResult(raw: string): AutoresearchEvaluatorResult {
     throw contractError('Evaluator output score must be numeric when provided.');
   }
 
-  return result.score === undefined
-    ? { pass: result.pass }
-    : { pass: result.pass, score: result.score };
+  return {
+    pass: result.pass,
+    ...(result.score === undefined ? {} : { score: result.score }),
+  };
 }
 
 export async function loadAutoresearchMissionContract(missionDirArg: string): Promise<AutoresearchMissionContract> {

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -351,6 +351,47 @@ async function appendAutoresearchResultsRow(
   );
 }
 
+async function recordAutoresearchIteration(
+  manifest: AutoresearchRunManifest,
+  entry: {
+    status: AutoresearchDecisionStatus;
+    decisionReason: string;
+    description: string;
+    candidateStatus: AutoresearchCandidateArtifact['status'];
+    baseCommit: string;
+    candidateCommit: string | null;
+    keptCommit?: string;
+    evaluator?: AutoresearchEvaluationRecord | null;
+    notes: string[];
+    createdAt?: string;
+  },
+): Promise<void> {
+  const commit = readGitShortHead(manifest.worktree_path);
+  await appendAutoresearchResultsRow(manifest.results_file, {
+    iteration: manifest.iteration,
+    commit,
+    pass: entry.evaluator?.pass,
+    score: entry.evaluator?.score,
+    status: entry.status,
+    description: entry.description,
+  });
+  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
+    iteration: manifest.iteration,
+    kind: 'iteration',
+    decision: entry.status,
+    decision_reason: entry.decisionReason,
+    candidate_status: entry.candidateStatus,
+    base_commit: entry.baseCommit,
+    candidate_commit: entry.candidateCommit,
+    kept_commit: entry.keptCommit ?? manifest.last_kept_commit,
+    keep_policy: manifest.keep_policy,
+    evaluator: entry.evaluator ?? null,
+    created_at: entry.createdAt ?? nowIso(),
+    notes: entry.notes,
+    description: entry.description,
+  });
+}
+
 async function appendAutoresearchLedgerEntry(ledgerFile: string, entry: AutoresearchLedgerEntry): Promise<void> {
   const parsed = existsSync(ledgerFile)
     ? await readJsonFile<{
@@ -1109,6 +1150,57 @@ async function failAutoresearchIteration(
   return 'error';
 }
 
+async function recordNonEvaluatedCandidateStatus(
+  contract: AutoresearchMissionContract,
+  manifest: AutoresearchRunManifest,
+  projectRoot: string,
+  candidate: AutoresearchCandidateArtifact,
+): Promise<Extract<AutoresearchDecisionStatus, 'abort' | 'interrupted' | 'noop' | 'error'>> {
+  const sharedEntry = {
+    description: candidate.description,
+    candidateStatus: candidate.status,
+    baseCommit: candidate.base_commit,
+    candidateCommit: candidate.candidate_commit,
+    notes: candidate.notes,
+  };
+
+  if (candidate.status === 'abort') {
+    await recordAutoresearchIteration(manifest, {
+      status: 'abort',
+      decisionReason: 'candidate requested abort',
+      ...sharedEntry,
+    });
+    await finalizeRun(manifest, projectRoot, { status: 'stopped', stopReason: 'candidate abort' });
+    return 'abort';
+  }
+
+  if (candidate.status === 'interrupted') {
+    try {
+      assertResetSafeWorktree(manifest.worktree_path);
+    } catch {
+      await finalizeRun(manifest, projectRoot, { status: 'failed', stopReason: 'interrupted dirty worktree requires operator intervention' });
+      return 'error';
+    }
+    await recordAutoresearchIteration(manifest, {
+      status: 'interrupted',
+      decisionReason: 'candidate session interrupted cleanly',
+      ...sharedEntry,
+    });
+    await writeRunManifest(manifest);
+    await writeInstructionsFile(contract, manifest);
+    return 'interrupted';
+  }
+
+  await recordAutoresearchIteration(manifest, {
+    status: 'noop',
+    decisionReason: 'candidate reported noop',
+    ...sharedEntry,
+  });
+  await writeRunManifest(manifest);
+  await writeInstructionsFile(contract, manifest);
+  return 'noop';
+}
+
 export async function processAutoresearchCandidate(
   contract: AutoresearchMissionContract,
   manifest: AutoresearchRunManifest,
@@ -1133,90 +1225,8 @@ export async function processAutoresearchCandidate(
   candidate = validation.candidate;
   manifest.latest_candidate_commit = candidate.candidate_commit;
 
-  if (candidate.status === 'abort') {
-    await appendAutoresearchResultsRow(manifest.results_file, {
-      iteration: manifest.iteration,
-      commit: readGitShortHead(manifest.worktree_path),
-      status: 'abort',
-      description: candidate.description,
-    });
-    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
-      iteration: manifest.iteration,
-      kind: 'iteration',
-      decision: 'abort',
-      decision_reason: 'candidate requested abort',
-      candidate_status: candidate.status,
-      base_commit: candidate.base_commit,
-      candidate_commit: candidate.candidate_commit,
-      kept_commit: manifest.last_kept_commit,
-      keep_policy: manifest.keep_policy,
-      evaluator: null,
-      created_at: nowIso(),
-      notes: candidate.notes,
-      description: candidate.description,
-    });
-    await finalizeRun(manifest, projectRoot, { status: 'stopped', stopReason: 'candidate abort' });
-    return 'abort';
-  }
-
-  if (candidate.status === 'interrupted') {
-    try {
-      assertResetSafeWorktree(manifest.worktree_path);
-    } catch {
-      await finalizeRun(manifest, projectRoot, { status: 'failed', stopReason: 'interrupted dirty worktree requires operator intervention' });
-      return 'error';
-    }
-    await appendAutoresearchResultsRow(manifest.results_file, {
-      iteration: manifest.iteration,
-      commit: readGitShortHead(manifest.worktree_path),
-      status: 'interrupted',
-      description: candidate.description,
-    });
-    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
-      iteration: manifest.iteration,
-      kind: 'iteration',
-      decision: 'interrupted',
-      decision_reason: 'candidate session interrupted cleanly',
-      candidate_status: candidate.status,
-      base_commit: candidate.base_commit,
-      candidate_commit: candidate.candidate_commit,
-      kept_commit: manifest.last_kept_commit,
-      keep_policy: manifest.keep_policy,
-      evaluator: null,
-      created_at: nowIso(),
-      notes: candidate.notes,
-      description: candidate.description,
-    });
-    await writeRunManifest(manifest);
-    await writeInstructionsFile(contract, manifest);
-    return 'interrupted';
-  }
-
-  if (candidate.status === 'noop') {
-    await appendAutoresearchResultsRow(manifest.results_file, {
-      iteration: manifest.iteration,
-      commit: readGitShortHead(manifest.worktree_path),
-      status: 'noop',
-      description: candidate.description,
-    });
-    await appendAutoresearchLedgerEntry(manifest.ledger_file, {
-      iteration: manifest.iteration,
-      kind: 'iteration',
-      decision: 'noop',
-      decision_reason: 'candidate reported noop',
-      candidate_status: candidate.status,
-      base_commit: candidate.base_commit,
-      candidate_commit: candidate.candidate_commit,
-      kept_commit: manifest.last_kept_commit,
-      keep_policy: manifest.keep_policy,
-      evaluator: null,
-      created_at: nowIso(),
-      notes: candidate.notes,
-      description: candidate.description,
-    });
-    await writeRunManifest(manifest);
-    await writeInstructionsFile(contract, manifest);
-    return 'noop';
+  if (candidate.status !== 'candidate') {
+    return recordNonEvaluatedCandidateStatus(contract, manifest, projectRoot, candidate);
   }
 
   const evaluation = await runAutoresearchEvaluator(contract, manifest.worktree_path);
@@ -1229,28 +1239,15 @@ export async function processAutoresearchCandidate(
     resetToLastKeptCommit(manifest);
   }
 
-  await appendAutoresearchResultsRow(manifest.results_file, {
-    iteration: manifest.iteration,
-    commit: decision.keep ? readGitShortHead(manifest.worktree_path) : readGitShortHead(manifest.worktree_path),
-    pass: evaluation.pass,
-    score: evaluation.score,
+  await recordAutoresearchIteration(manifest, {
     status: decision.decision,
+    decisionReason: decision.decisionReason,
     description: candidate.description,
-  });
-  await appendAutoresearchLedgerEntry(manifest.ledger_file, {
-    iteration: manifest.iteration,
-    kind: 'iteration',
-    decision: decision.decision,
-    decision_reason: decision.decisionReason,
-    candidate_status: candidate.status,
-    base_commit: candidate.base_commit,
-    candidate_commit: candidate.candidate_commit,
-    kept_commit: manifest.last_kept_commit,
-    keep_policy: manifest.keep_policy,
+    candidateStatus: candidate.status,
+    baseCommit: candidate.base_commit,
+    candidateCommit: candidate.candidate_commit,
     evaluator: evaluation,
-    created_at: nowIso(),
     notes: [...candidate.notes, ...decision.notes],
-    description: candidate.description,
   });
   await writeRunManifest(manifest);
   await writeInstructionsFile(contract, manifest);


### PR DESCRIPTION
## Summary
- deslop `src/autoresearch/contracts.ts` by deduplicating contract error strings and simplifying evaluator result shaping
- add contract regression coverage for keep policy normalization and mission-dir/sandbox failures
- deslop `src/autoresearch/runtime.ts` by consolidating repeated non-evaluated iteration recording paths

## Verification
- `node --test dist/autoresearch/__tests__/contracts.test.js dist/autoresearch/__tests__/runtime.test.js dist/autoresearch/__tests__/runtime-parity-extra.test.js` ✅ (28 pass, 0 fail)
- focused autoresearch diagnostics reported clean in the final sweep ✅
- packed-install smoke failed locally because `npm pack`/`prepack` could not resolve `@iarna/toml` in unrelated CLI files; filing separately ❌

## Notes
- Target branch: `dev`
- Remaining cleanup beyond this point was judged low-value stylistic churn or riskier abstraction.
