### PR TITLE
fix: bootstrap packed-install smoke deps in worktrees

### DIFF
--- a/scripts/__tests__/smoke-packed-install.test.mjs
+++ b/scripts/__tests__/smoke-packed-install.test.mjs
@@ -4,8 +4,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import {
+  ensureRepoDependencies,
   hasSparkShellFallbackBanner,
+  hasUsableNodeModules,
   prepareLocalHydrationAssetDirectory,
+  resolveGitCommonDir,
+  resolveReusableNodeModulesSource,
   rewriteManifestDownloadUrls,
 } from '../smoke-packed-install.mjs';
 
@@ -54,6 +58,122 @@ test('rewrites copied native manifest download urls to the local smoke server', 
         'http://127.0.0.1:43123/omx-sparkshell-x86_64-unknown-linux-musl.tar.xz',
       ],
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveGitCommonDir resolves relative git common dir output against the repo root', () => {
+  const commonDir = resolveGitCommonDir('/tmp/worktree', () => ({
+    status: 0,
+    stdout: '../primary/.git\n',
+    stderr: '',
+  }));
+  assert.equal(commonDir, '/tmp/primary/.git');
+});
+
+test('hasUsableNodeModules requires the packaged build dependencies', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-smoke-node-modules-'));
+  try {
+    const nodeModules = join(root, 'node_modules');
+    await mkdir(join(nodeModules, 'typescript'), { recursive: true });
+    await mkdir(join(nodeModules, '@iarna', 'toml'), { recursive: true });
+    await mkdir(join(nodeModules, '@modelcontextprotocol', 'sdk'), { recursive: true });
+    await mkdir(join(nodeModules, 'zod'), { recursive: true });
+    await writeFile(join(nodeModules, 'typescript', 'package.json'), '{}');
+    await writeFile(join(nodeModules, '@iarna', 'toml', 'package.json'), '{}');
+    await writeFile(join(nodeModules, '@modelcontextprotocol', 'sdk', 'package.json'), '{}');
+    await writeFile(join(nodeModules, 'zod', 'package.json'), '{}');
+
+    assert.equal(hasUsableNodeModules(root), true);
+
+    await rm(join(nodeModules, 'zod', 'package.json'));
+    assert.equal(hasUsableNodeModules(root), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveReusableNodeModulesSource reuses primary worktree node_modules when available', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-smoke-reuse-node-modules-'));
+  try {
+    const primaryRepo = join(root, 'primary');
+    const worktreeRepo = join(root, 'worktree');
+    await mkdir(join(primaryRepo, 'node_modules', 'typescript'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', '@iarna', 'toml'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', '@modelcontextprotocol', 'sdk'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', 'zod'), { recursive: true });
+    await writeFile(join(primaryRepo, 'node_modules', 'typescript', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', '@iarna', 'toml', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', '@modelcontextprotocol', 'sdk', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', 'zod', 'package.json'), '{}');
+    await mkdir(worktreeRepo, { recursive: true });
+
+    const reusable = resolveReusableNodeModulesSource(worktreeRepo, () => ({
+      status: 0,
+      stdout: `${join(primaryRepo, '.git')}\n`,
+      stderr: '',
+    }));
+
+    assert.equal(reusable, join(primaryRepo, 'node_modules'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('ensureRepoDependencies symlinks a reusable primary worktree node_modules', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-smoke-symlink-node-modules-'));
+  try {
+    const primaryRepo = join(root, 'primary');
+    const worktreeRepo = join(root, 'worktree');
+    await mkdir(join(primaryRepo, 'node_modules', 'typescript'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', '@iarna', 'toml'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', '@modelcontextprotocol', 'sdk'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', 'zod'), { recursive: true });
+    await writeFile(join(primaryRepo, 'node_modules', 'typescript', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', '@iarna', 'toml', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', '@modelcontextprotocol', 'sdk', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', 'zod', 'package.json'), '{}');
+    await mkdir(worktreeRepo, { recursive: true });
+
+    const events = [];
+    const result = ensureRepoDependencies(worktreeRepo, {
+      gitRunner: () => ({
+        status: 0,
+        stdout: `${join(primaryRepo, '.git')}\n`,
+        stderr: '',
+      }),
+      install: () => {
+        throw new Error('install should not be called when a reusable node_modules source exists');
+      },
+      log: (message) => events.push(message),
+    });
+
+    assert.equal(result.strategy, 'symlink');
+    assert.equal(result.sourceNodeModulesPath, join(primaryRepo, 'node_modules'));
+    assert.equal(events[0], `[smoke:packed-install] Reusing node_modules from ${join(primaryRepo, 'node_modules')}`);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('ensureRepoDependencies falls back to npm ci when no reusable node_modules source exists', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-smoke-install-node-modules-'));
+  try {
+    const installs = [];
+    const result = ensureRepoDependencies(root, {
+      gitRunner: () => ({
+        status: 1,
+        stdout: '',
+        stderr: 'not a worktree',
+      }),
+      install: (cwd) => {
+        installs.push(cwd);
+      },
+    });
+
+    assert.equal(result.strategy, 'installed');
+    assert.deepEqual(installs, [root]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/scripts/smoke-packed-install.mjs
+++ b/scripts/smoke-packed-install.mjs
@@ -1,10 +1,26 @@
 import { createServer } from 'node:http';
-import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { chmodSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
+
+const REQUIRED_NODE_MODULE_MARKERS = [
+  join('typescript', 'package.json'),
+  join('@iarna', 'toml', 'package.json'),
+  join('@modelcontextprotocol', 'sdk', 'package.json'),
+  join('zod', 'package.json'),
+];
 
 function usage() {
   return [
@@ -13,6 +29,110 @@ function usage() {
     'Creates an npm tarball, installs it into an isolated prefix, and smoke tests the installed omx CLI.',
     'When --release-assets-dir is provided, native hydration is also exercised using a local HTTP server.',
   ].join('\n');
+}
+
+function hasNodeModulesPath(nodeModulesPath) {
+  try {
+    lstatSync(nodeModulesPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function hasUsableNodeModules(repoRoot) {
+  return REQUIRED_NODE_MODULE_MARKERS.every((marker) => existsSync(join(repoRoot, 'node_modules', marker)));
+}
+
+export function resolveGitCommonDir(cwd, gitRunner = spawnSync) {
+  const result = gitRunner('git', ['rev-parse', '--git-common-dir'], {
+    cwd,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  const value = (result.stdout || '').trim();
+  if (!value) {
+    return null;
+  }
+  return resolve(cwd, value);
+}
+
+export function resolveReusableNodeModulesSource(repoRoot, gitRunner = spawnSync) {
+  const commonDir = resolveGitCommonDir(repoRoot, gitRunner);
+  if (!commonDir || basename(commonDir) !== '.git') {
+    return null;
+  }
+
+  const primaryRepoRoot = dirname(commonDir);
+  if (resolve(primaryRepoRoot) === resolve(repoRoot)) {
+    return null;
+  }
+
+  if (!hasUsableNodeModules(primaryRepoRoot)) {
+    return null;
+  }
+
+  return join(primaryRepoRoot, 'node_modules');
+}
+
+function formatCommandFailure(cmd, args, result) {
+  return [
+    `Command failed: ${cmd} ${args.join(' ')}`,
+    result.stdout?.trim() ? `stdout:\n${result.stdout.trim()}` : '',
+    result.stderr?.trim() ? `stderr:\n${result.stderr.trim()}` : '',
+  ].filter(Boolean).join('\n\n');
+}
+
+export function ensureRepoDependencies(repoRoot, options = {}) {
+  const {
+    gitRunner = spawnSync,
+    install = (cwd) => {
+      const result = spawnSync('npm', ['ci'], {
+        cwd,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+      if (result.status !== 0) {
+        throw new Error(formatCommandFailure('npm', ['ci'], result));
+      }
+    },
+    remove = rmSync,
+    symlink = symlinkSync,
+    log = () => {},
+    platformName = process.platform,
+  } = options;
+
+  if (hasUsableNodeModules(repoRoot)) {
+    return {
+      strategy: 'existing',
+      nodeModulesPath: join(repoRoot, 'node_modules'),
+    };
+  }
+
+  const targetNodeModules = join(repoRoot, 'node_modules');
+  if (hasNodeModulesPath(targetNodeModules)) {
+    remove(targetNodeModules, { recursive: true, force: true });
+  }
+
+  const reusableNodeModules = resolveReusableNodeModulesSource(repoRoot, gitRunner);
+  if (reusableNodeModules) {
+    symlink(reusableNodeModules, targetNodeModules, platformName === 'win32' ? 'junction' : 'dir');
+    log(`[smoke:packed-install] Reusing node_modules from ${reusableNodeModules}`);
+    return {
+      strategy: 'symlink',
+      nodeModulesPath: targetNodeModules,
+      sourceNodeModulesPath: reusableNodeModules,
+    };
+  }
+
+  log('[smoke:packed-install] Installing repo dependencies with npm ci');
+  install(repoRoot);
+  return {
+    strategy: 'installed',
+    nodeModulesPath: targetNodeModules,
+  };
 }
 
 export function hasSparkShellFallbackBanner(stderr) {
@@ -51,11 +171,7 @@ function run(cmd, args, options = {}) {
     ...options,
   });
   if (result.status !== 0) {
-    throw new Error([
-      `Command failed: ${cmd} ${args.join(' ')}`,
-      result.stdout?.trim() ? `stdout:\n${result.stdout.trim()}` : '',
-      result.stderr?.trim() ? `stderr:\n${result.stderr.trim()}` : '',
-    ].filter(Boolean).join('\n\n'));
+    throw new Error(formatCommandFailure(cmd, args, result));
   }
   return result;
 }
@@ -175,6 +291,10 @@ async function main() {
   let server;
   let tarballPath;
   try {
+    ensureRepoDependencies(repoRoot, {
+      log: (message) => console.log(message),
+    });
+
     const pack = run('npm', ['pack', '--json'], { cwd: repoRoot });
     const packOutput = JSON.parse(pack.stdout.slice(pack.stdout.indexOf('[')));
     const tarballName = packOutput[0]?.filename;


### PR DESCRIPTION
## Summary
- make packed-install smoke bootstrap repo dependencies before `npm pack` runs `prepack`
- reuse the primary worktree's `node_modules` via `git rev-parse --git-common-dir` when available, with `npm ci` fallback otherwise
- add regression tests for the worktree dependency bootstrap helpers

## Verification
- `node --test scripts/__tests__/smoke-packed-install.test.mjs`
- `npm run smoke:packed-install`
- `npm test`

Fixes #917
