### PR TITLE
feat: add mandatory deslop pass to ralph workflow (#920)

### DIFF
--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -22,6 +22,12 @@ Use this skill when:
 - Keep using inspection, tests, diagnostics, and verification until the cleanup is grounded.
 - Proceed automatically through clear, reversible cleanup steps; ask only when a choice materially changes scope or behavior.
 
+## Scoped File Lists and Ralph Workflow
+
+- This skill can accept a **file list scope** instead of a whole feature area.
+- When the caller provides a changed-files list (for example, Ralph session-owned edits), keep the cleanup strictly bounded to those files.
+- In the **Ralph workflow**, the mandatory deslop pass should run this skill on Ralph's changed files only, in standard mode unless the caller explicitly requests otherwise.
+
 ## Procedure
 
 1. **Lock behavior with regression tests first**
@@ -32,6 +38,7 @@ Use this skill when:
 2. **Create a cleanup plan before code**
    - List the specific smells to remove
    - Bound the pass to the requested files/scope
+   - If a file list scope is provided, keep the pass restricted to that changed-files list
    - Order fixes from safest/highest-signal to riskiest
    - Do not start coding until the cleanup plan is explicit
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -78,6 +78,15 @@ Complex tasks often fail silently: partial implementations get declared "done", 
    - Standard changes: STANDARD tier (architect role)
    - >20 files or security/architectural changes: THOROUGH tier (architect role)
    - Ralph floor: always at least STANDARD, even for small changes
+7.5 **Mandatory Deslop Pass**:
+   - After Step 7 passes, run `oh-my-codex:ai-slop-cleaner` on **all files changed during the Ralph session**.
+   - Scope the cleaner to **changed files only**; do not widen the pass beyond Ralph-owned edits.
+   - Run the cleaner in **standard mode** (not `--review`).
+   - If the prompt contains `--no-deslop`, skip Step 7.5 entirely and proceed with the most recent successful verification evidence.
+7.6 **Regression Re-verification**:
+   - After the deslop pass, re-run all tests/build/lint and read the output to confirm they still pass.
+   - If post-deslop regression fails, roll back cleaner changes or fix and retry. Then rerun Step 7.5 and Step 7.6 until the regression is green.
+   - Do not proceed to completion until post-deslop regression is green (unless `--no-deslop` explicitly skipped the deslop pass).
 8. **On approval**: Run `/cancel` to cleanly exit and clean up all state files
 9. **On rejection**: Fix the issues raised, then re-verify at the same tier
 </Steps>
@@ -170,6 +179,8 @@ Why bad: These are independent tasks that should run in parallel, not sequential
 - [ ] Fresh build output shows success
 - [ ] lsp_diagnostics shows 0 errors on affected files
 - [ ] Architect verification passed (STANDARD tier minimum)
+- [ ] ai-slop-cleaner pass completed on changed files (or --no-deslop specified)
+- [ ] Post-deslop regression tests pass
 - [ ] `/cancel` run for clean state cleanup
 </Final_Checklist>
 
@@ -180,6 +191,10 @@ When the user provides the `--prd` flag, initialize a Product Requirements Docum
 
 ### Detecting PRD Mode
 Check if `{{PROMPT}}` contains `--prd` or `--PRD`.
+
+### Detecting `--no-deslop`
+Check if `{{PROMPT}}` contains `--no-deslop`.
+If `--no-deslop` is present, skip the deslop pass entirely after Step 7 and continue using the latest successful pre-deslop verification evidence.
 
 ### Visual Reference Flags (Optional)
 Ralph execution supports visual reference flags for screenshot tasks:

--- a/src/cli/__tests__/ralph-deslop-contract.test.ts
+++ b/src/cli/__tests__/ralph-deslop-contract.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ralphSkill = readFileSync(join(__dirname, '../../../skills/ralph/SKILL.md'), 'utf-8');
+
+describe('ralph deslop workflow contract', () => {
+  it('requires a mandatory deslop pass after architect verification', () => {
+    assert.match(ralphSkill, /Step 7\.5/i);
+    assert.match(ralphSkill, /Mandatory Deslop Pass/i);
+    assert.match(ralphSkill, /oh-my-codex:ai-slop-cleaner/i);
+    assert.match(ralphSkill, /changed files only/i);
+    assert.match(ralphSkill, /standard mode/i);
+    assert.match(ralphSkill, /not `--review`/i);
+  });
+
+  it('requires post-deslop regression re-verification', () => {
+    assert.match(ralphSkill, /Step 7\.6/i);
+    assert.match(ralphSkill, /Regression Re-verification/i);
+    assert.match(ralphSkill, /re-run all tests\/build\/lint/i);
+    assert.match(ralphSkill, /roll back cleaner changes or fix and retry/i);
+  });
+
+  it('extends the final checklist with deslop completion and post-deslop regression proof', () => {
+    assert.match(
+      ralphSkill,
+      /\[ \] ai-slop-cleaner pass completed on changed files \(or --no-deslop specified\)/i,
+    );
+    assert.match(ralphSkill, /\[ \] Post-deslop regression tests pass/i);
+  });
+});

--- a/src/cli/__tests__/ralph-prd-deep-interview.test.ts
+++ b/src/cli/__tests__/ralph-prd-deep-interview.test.ts
@@ -13,4 +13,9 @@ describe('ralph PRD mode deep interview gate', () => {
     assert.match(ralphSkill, /\$deep-interview\s+--quick/i);
     assert.match(ralphSkill, /\.omx\/interviews\/\{slug\}-\{timestamp\}\.md/);
   });
+
+  it('documents --no-deslop as a PRD-mode opt-out for the final deslop pass', () => {
+    assert.match(ralphSkill, /--no-deslop/);
+    assert.match(ralphSkill, /skip the deslop pass/i);
+  });
 });

--- a/src/hooks/__tests__/anti-slop-workflow.test.ts
+++ b/src/hooks/__tests__/anti-slop-workflow.test.ts
@@ -54,5 +54,8 @@ describe('anti-slop workflow surfaces', () => {
     assert.match(skill, /Pass 4: Test reinforcement/i);
     assert.match(skill, /quality gates/i);
     assert.match(skill, /remaining risks/i);
+    assert.match(skill, /file list scope/i);
+    assert.match(skill, /changed files/i);
+    assert.match(skill, /Ralph workflow/i);
   });
 });


### PR DESCRIPTION
## Summary
- add Ralph Step 7.5 mandatory deslop pass on changed files only via oh-my-codex:ai-slop-cleaner
- add Ralph Step 7.6 post-deslop regression re-verification and --no-deslop PRD-mode opt-out
- extend skill-contract tests and ai-slop-cleaner guidance for file-list scope + Ralph integration

## Verification
- npm run build
- npm run lint
- npm test