### PR TITLE
fix: harden ralphthon state readers and remove redundant bootstrap call

### DIFF
--- a/src/cli/ralphthon.ts
+++ b/src/cli/ralphthon.ts
@@ -182,7 +182,7 @@ async function ensureInitialRalphthonArtifacts(cwd: string, parsed: ParsedRalpht
     prd = await bootstrapRalphthonPrdFromExistingArtifacts(cwd, parsed.taskDescription);
   }
   if (!prd) {
-    prd = await bootstrapRalphthonPrdFromExistingArtifacts(cwd, parsed.taskDescription) ?? createRalphthonPrd({
+    prd = createRalphthonPrd({
       project: parsed.taskDescription,
       config: {
         ...(parsed.maxWaves == null ? {} : { maxHardeningWaves: parsed.maxWaves }),

--- a/src/ralphthon/prd.ts
+++ b/src/ralphthon/prd.ts
@@ -177,8 +177,11 @@ export function createRalphthonPrd(input: CreateRalphthonPrdInput): RalphthonPrd
 export async function readRalphthonPrd(cwd: string): Promise<RalphthonPrd | null> {
   const prdPath = resolveExistingRalphthonPrdPath(cwd);
   if (!prdPath) return null;
-  const raw = await readFile(prdPath, 'utf-8');
-  return parseRalphthonPrd(JSON.parse(raw));
+  try {
+    return parseRalphthonPrd(JSON.parse(await readFile(prdPath, 'utf-8')));
+  } catch {
+    return null;
+  }
 }
 
 export async function writeRalphthonPrd(cwd: string, prd: RalphthonPrd): Promise<string> {

--- a/src/ralphthon/runtime.ts
+++ b/src/ralphthon/runtime.ts
@@ -64,8 +64,11 @@ export function parseRalphthonRuntimeState(input: unknown): RalphthonRuntimeStat
 export async function readRalphthonRuntimeState(cwd: string): Promise<RalphthonRuntimeState | null> {
   const path = canonicalRalphthonRuntimePath(cwd);
   if (!existsSync(path)) return null;
-  const raw = await readFile(path, 'utf-8');
-  return parseRalphthonRuntimeState(JSON.parse(raw));
+  try {
+    return parseRalphthonRuntimeState(JSON.parse(await readFile(path, 'utf-8')));
+  } catch {
+    return null;
+  }
 }
 
 export async function writeRalphthonRuntimeState(cwd: string, state: RalphthonRuntimeState): Promise<string> {


### PR DESCRIPTION
## Summary

- Wrap `readRalphthonRuntimeState` and `readRalphthonPrd` in try-catch to return `null` on corrupt/truncated JSON instead of crashing the orchestrator polling loop
  - Consistent with the existing defensive pattern in `readSubagentTrackingState` and `resolveExistingRalphthonPrdPath`
- Remove redundant second call to `bootstrapRalphthonPrdFromExistingArtifacts` in `ensureInitialRalphthonArtifacts` — when the first call returns `null`, the identical re-invocation with the same arguments will always return `null` again

## Test plan

- [x] `npm test` passes — all ralphthon-related tests green
- [x] 14 pre-existing failures are unrelated (omx ask, autoresearch, explore, session search, team, update, notify-hook)