### PR TITLE
fix: kill detached tmux session when leader pane exits (closes #936)

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -804,6 +804,22 @@ describe("detached tmux new-session sequencing", () => {
     assert.equal(steps[1]?.args.at(-1), hudCmd);
   });
 
+  it("buildDetachedSessionBootstrapSteps kills detached tmux session when leader exits", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-demo",
+      "/tmp/project",
+      "'codex' '--model' 'gpt-5'",
+      "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null,
+    );
+    const leaderCmd = steps[0]?.args.at(-1);
+    assert.equal(typeof leaderCmd, "string");
+    assert.match(leaderCmd!, /^\/bin\/sh -lc '/);
+    assert.match(leaderCmd!, /tmux kill-session -t/);
+    assert.match(leaderCmd!, /omx-demo/);
+    assert.match(leaderCmd!, /exit \$status'/);
+  });
+
   it("buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach", () => {
     const steps = buildDetachedSessionFinalizeSteps(
       "omx-demo",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1355,6 +1355,11 @@ export function buildDetachedSessionBootstrapSteps(
   notifyTempContractRaw?: string | null,
   nativeWindows = false,
 ): DetachedSessionTmuxStep[] {
+  const detachedLeaderCmd = nativeWindows
+    ? "powershell.exe"
+    : `/bin/sh -lc ${quoteShellArg(
+        `${codexCmd}; status=$?; tmux kill-session -t ${quoteShellArg(sessionName)} >/dev/null 2>&1 || true; exit $status`,
+      )}`;
   const newSessionArgs: string[] = [
     "new-session",
     "-d",
@@ -1372,7 +1377,7 @@ export function buildDetachedSessionBootstrapSteps(
     ...(notifyTempContractRaw
       ? ["-e", `${OMX_NOTIFY_TEMP_CONTRACT_ENV}=${notifyTempContractRaw}`]
       : []),
-    nativeWindows ? "powershell.exe" : codexCmd,
+    detachedLeaderCmd,
   ];
   const splitCaptureArgs: string[] = [
     "split-window",


### PR DESCRIPTION
## Summary
- wrap detached leader pane launch in `/bin/sh -lc` cleanup logic
- kill the detached tmux session when the leader pane exits, preserving exit status
- add regression coverage for detached-session bootstrap command generation

## Testing
- npm run build && node --test dist/cli/__tests__/*.test.js