### PR TITLE
fix(notifications): preserve wrapped recent-output blocks

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -157,14 +157,50 @@ describe('parseTmuxTail', () => {
     assert.ok(result.includes('more output'));
   });
 
-  it('caps output at 10 meaningful lines', () => {
+  it('caps output at 10 meaningful blocks', () => {
     const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`);
     const result = parseTmuxTail(lines.join('\n'));
     const resultLines = result.split('\n');
     assert.strictEqual(resultLines.length, 10);
-    // Should keep the last 10 lines
+    // Should keep the last 10 single-line blocks
     assert.strictEqual(resultLines[0], 'line 11');
     assert.strictEqual(resultLines[9], 'line 20');
+  });
+
+  it('keeps wrapped Korean continuation lines in the same block', () => {
+    const raw = [
+      'block 9: previous context',
+      'block 10: 2. 아예 ~/.codex/.omx-config.json에서 조절 가능하',
+      '  게 로컬 패치하기',
+    ].join('\n');
+
+    const result = parseTmuxTail(raw);
+    assert.ok(result.includes('block 10: 2. 아예 ~/.codex/.omx-config.json에서 조절 가능하'));
+    assert.ok(result.includes('  게 로컬 패치하기'));
+    assert.ok(
+      result.indexOf('block 10: 2. 아예 ~/.codex/.omx-config.json에서 조절 가능하') <
+        result.indexOf('  게 로컬 패치하기'),
+    );
+  });
+
+  it('drops older blocks before truncating inside a wrapped block', () => {
+    const makeBlock = (label: string) =>
+      [
+        `${label}: ${'가'.repeat(420)}`,
+        `  ${'나'.repeat(120)}`,
+      ].join('\n');
+
+    const raw = [
+      makeBlock('block 1'),
+      makeBlock('block 2'),
+      makeBlock('block 3'),
+    ].join('\n');
+
+    const result = parseTmuxTail(raw);
+    assert.ok(!result.includes('block 1:'));
+    assert.ok(result.includes('block 2:'));
+    assert.ok(result.includes('block 3:'));
+    assert.ok(result.includes(`  ${'나'.repeat(120)}`));
   });
 
   it('returns empty string when all lines are filtered out', () => {
@@ -235,6 +271,13 @@ describe('parseTmuxTail', () => {
     const raw = '!@#$%^&*()  \nNormal line with words';
     const result = parseTmuxTail(raw);
     assert.ok(!result.includes('!@#$%^&*()'));
+    assert.ok(result.includes('Normal line with words'));
+  });
+
+  it('keeps long Korean lines under the Unicode-aware density check', () => {
+    const raw = '로컬 패치하기를 계속 진행합니다\nNormal line with words';
+    const result = parseTmuxTail(raw);
+    assert.ok(result.includes('로컬 패치하기를 계속 진행합니다'));
     assert.ok(result.includes('Normal line with words'));
   });
 

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -32,8 +32,14 @@ const BARE_PROMPT_RE = /^[❯>$%#]+$/;
 /** Minimum ratio of alphanumeric characters for a line to be "meaningful" */
 const MIN_ALNUM_RATIO = 0.15;
 
-/** Maximum number of meaningful lines to include in a notification */
-const MAX_TAIL_LINES = 10;
+/** Unicode-aware letters/numbers for density checks across non-Latin scripts */
+const UNICODE_ALNUM_RE = /[\p{L}\p{N}]/gu;
+
+/** Maximum number of meaningful output blocks to include in a notification */
+const MAX_TAIL_BLOCKS = 10;
+
+/** Maximum recent-output character budget before older blocks are dropped */
+const MAX_TAIL_CHARS = 1200;
 
 /**
  * Parse raw tmux pane output into clean, human-readable text suitable for
@@ -46,11 +52,12 @@ const MAX_TAIL_LINES = 10;
  * - Removes OMX HUD status lines
  * - Removes bypass-permissions indicator lines
  * - Removes bare shell prompt lines
- * - Drops lines with < 15% alphanumeric density (for lines >= 8 chars)
- * - Caps at the last 10 meaningful (non-empty) lines
+ * - Drops lines with < 15% Unicode letter/number density (for lines >= 8 chars)
+ * - Groups indented continuation lines into the previous logical block
+ * - Keeps the most recent 10 logical blocks within a 1200-character budget
  */
 export function parseTmuxTail(raw: string): string {
-  const meaningful: string[] = [];
+  const blocks: string[][] = [];
 
   for (const line of raw.split("\n")) {
     const stripped = line.replace(ANSI_RE, "");
@@ -64,14 +71,38 @@ export function parseTmuxTail(raw: string): string {
     if (BYPASS_PERM_RE.test(trimmed)) continue;
     if (BARE_PROMPT_RE.test(trimmed)) continue;
 
-    // Alphanumeric density check: drop lines mostly composed of special characters
-    const alnumCount = (trimmed.match(/[a-zA-Z0-9]/g) || []).length;
+    // Unicode-aware density check: drop lines mostly composed of special characters
+    const alnumCount = (trimmed.match(UNICODE_ALNUM_RE) || []).length;
     if (trimmed.length >= 8 && alnumCount / trimmed.length < MIN_ALNUM_RATIO) continue;
 
-    meaningful.push(stripped.trimEnd());
+    const cleanedLine = stripped.trimEnd();
+    const isContinuationLine = /^[\t ]+/.test(cleanedLine);
+
+    if (isContinuationLine && blocks.length > 0) {
+      blocks[blocks.length - 1].push(cleanedLine);
+      continue;
+    }
+
+    blocks.push([cleanedLine]);
   }
 
-  return meaningful.slice(-MAX_TAIL_LINES).join("\n");
+  const blockTexts = blocks.map((block) => block.join("\n"));
+  const recentBlocks: string[] = [];
+  let totalChars = 0;
+
+  for (let index = blockTexts.length - 1; index >= 0; index -= 1) {
+    if (recentBlocks.length >= MAX_TAIL_BLOCKS) break;
+
+    const block = blockTexts[index];
+    const nextTotalChars = totalChars + block.length + (recentBlocks.length > 0 ? 1 : 0);
+
+    if (recentBlocks.length > 0 && nextTotalChars > MAX_TAIL_CHARS) break;
+
+    recentBlocks.unshift(block);
+    totalChars = nextTotalChars;
+  }
+
+  return recentBlocks.join("\n");
 }
 
 function formatDuration(ms?: number): string {


### PR DESCRIPTION
## Summary
- switch notification tmux-tail truncation from raw lines to logical blocks
- keep indented wrapped lines attached to the previous block and bound output by recent block count plus char budget
- use a Unicode-aware letter/number density check so Korean/Japanese continuation lines survive filtering
- add regression tests for wrapped Korean lines and block-boundary truncation

## Testing
- `npx @biomejs/biome lint src/notifications/formatter.ts src/notifications/__tests__/formatter.test.ts`
- `npm run build`
- `npm run check:no-unused`
- `node --test dist/notifications/__tests__/formatter.test.js dist/notifications/__tests__/verbosity.test.js dist/notifications/__tests__/template-engine.test.js dist/cli/__tests__/lifecycle-notifications.test.js`

Closes #938
