### PR TITLE
fix(models): switch the mini lane default to gpt-5.4-mini

### DIFF
--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -31,7 +31,7 @@ describe("agents/native-config", () => {
     });
 
     assert.match(toml, /# oh-my-codex agent: executor/);
-    assert.match(toml, /model = "gpt-5-mini"/);
+    assert.match(toml, /model = "gpt-5\.4-mini"/);
     assert.match(toml, /model_reasoning_effort = "medium"/);
     assert.ok(!toml.includes("title: demo"));
     assert.ok(toml.includes("Instruction line"));
@@ -66,7 +66,7 @@ describe("agents/native-config", () => {
         join(outDir, "executor.toml"),
         "utf8",
       );
-      assert.match(executorToml, /model = "gpt-5-mini"/);
+      assert.match(executorToml, /model = "gpt-5\.4-mini"/);
       assert.match(executorToml, /model_reasoning_effort = "medium"/);
 
       const skipped = await installNativeAgentConfigs(root, {

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -259,7 +259,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       );
 
       assert.match(architectToml, /^model = "gpt-5\.4"$/m);
-      assert.match(executorToml, /^model = "gpt-5-mini"$/m);
+      assert.match(executorToml, /^model = "gpt-5\.4-mini"$/m);
       assert.match(exploreToml, /^model = "gpt-5\.3-codex-spark"$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -61,7 +61,7 @@ function readModelsBlock(codexHomeOverride?: string): ModelsConfig | null {
 }
 
 export const DEFAULT_FRONTIER_MODEL = 'gpt-5.4';
-export const DEFAULT_MINI_MODEL = 'gpt-5-mini';
+export const DEFAULT_MINI_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_SPARK_MODEL = 'gpt-5.3-codex-spark';
 
 function normalizeConfiguredValue(value: unknown): string | undefined {

--- a/src/utils/__tests__/agents-model-table-role-split.test.ts
+++ b/src/utils/__tests__/agents-model-table-role-split.test.ts
@@ -6,15 +6,15 @@ describe('agents model table role split', () => {
   it('renders frontier, mini, and spark recommendations from the explicit role split', () => {
     const table = buildAgentsModelTable({
       frontierModel: 'gpt-5.4',
-      miniModel: 'gpt-5-mini',
+      miniModel: 'gpt-5.4-mini',
       sparkModel: 'gpt-5.3-codex-spark',
       subagentDefaultModel: 'gpt-5.4',
     } as Parameters<typeof buildAgentsModelTable>[0]);
 
-    assert.match(table, /\| Mini \(mid-weight execution\) \| `gpt-5-mini` \| medium \|/);
+    assert.match(table, /\| Mini \(mid-weight execution\) \| `gpt-5\.4-mini` \| medium \|/);
     assert.match(table, /\| `architect` \| `gpt-5\.4` \| high \|/);
-    assert.match(table, /\| `writer` \| `gpt-5-mini` \| low \|/);
-    assert.match(table, /\| `executor` \| `gpt-5-mini` \| medium \|/);
+    assert.match(table, /\| `writer` \| `gpt-5\.4-mini` \| low \|/);
+    assert.match(table, /\| `executor` \| `gpt-5\.4-mini` \| medium \|/);
     assert.match(table, /\| `explore` \| `gpt-5\.3-codex-spark` \| low \|/);
   });
 });

--- a/src/utils/__tests__/agents-model-table.test.ts
+++ b/src/utils/__tests__/agents-model-table.test.ts
@@ -45,7 +45,7 @@ describe('agents model table', () => {
 
     assert.deepEqual(context, {
       frontierModel: 'frontier-config',
-      miniModel: 'gpt-5-mini',
+      miniModel: 'gpt-5.4-mini',
       sparkModel: 'spark-env',
       subagentDefaultModel: 'frontier-config',
     });


### PR DESCRIPTION
## Summary
This follow-up updates OMX's mini lane to use **`gpt-5.4-mini` literally** instead of `gpt-5-mini`.

PR #940 established the role-based routing contract and made native agent configs pin explicit per-role models at runtime. This PR finishes the user-facing/model-string alignment for the mini lane by changing the default mini-tier model constant and updating the surrounding verification expectations.

## Why this follow-up was needed
The previous routing PR correctly introduced explicit mini-tier behavior, but the repository still used `gpt-5-mini` as the concrete mini-lane model string.

That meant there was still a mismatch between:
- the intended policy discussed for the mini lane (`gpt-5.4-mini`), and
- the actual generated TOMLs / model table output (`gpt-5-mini`).

Even though the lane behavior was already working, the literal configured model name was still not what was requested.

## What this PR changes
### 1) Changes the default mini-tier model constant
- updates `DEFAULT_MINI_MODEL` in `src/config/models.ts`
- mini-tier resolution now defaults to **`gpt-5.4-mini`**

### 2) Updates generated runtime expectations
Because native agent TOMLs already pin explicit per-role models, changing the mini default now directly affects generated configs for mini-tier roles such as:
- `executor`
- `writer`
- `debugger`
- `researcher`
- `dependency-expert`
- `build-fixer`
- `designer`
- `git-master`
- `verifier`

### 3) Updates regression coverage
The PR updates tests that assert the concrete mini-lane output so they now expect `gpt-5.4-mini` in:
- native agent TOML generation
- model-capability table rendering
- setup regeneration checks

## Expected outcome
After this PR:
- the mini lane is still routed correctly,
- but it now resolves to **`gpt-5.4-mini` literally**,
- generated native agent TOMLs match that value,
- and the surfaced AGENTS model table shows the same mini-lane model string.

## Verification
Passed:
- `npm run build`
- `node --test dist/agents/__tests__/definitions.test.js dist/agents/__tests__/native-config.test.js dist/agents/__tests__/role-model-tier.test.js dist/utils/__tests__/agents-model-table.test.js dist/utils/__tests__/agents-model-table-role-split.test.js dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-agents-overwrite.test.js`
- `npx biome lint src/config/models.ts src/agents/__tests__/native-config.test.ts src/cli/__tests__/setup-refresh.test.ts src/utils/__tests__/agents-model-table.test.ts src/utils/__tests__/agents-model-table-role-split.test.ts`

## Scope
This PR is intentionally narrow:
- no additional role remapping,
- no runtime flow redesign,
- no team worker spawning changes.

It only updates the **concrete default mini-tier model string** and the tests that verify it.
