### PR TITLE
fix: clean up detached tmux session on leader interrupt

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -804,7 +804,7 @@ describe("detached tmux new-session sequencing", () => {
     assert.equal(steps[1]?.args.at(-1), hudCmd);
   });
 
-  it("buildDetachedSessionBootstrapSteps kills detached tmux session when leader exits", () => {
+  it("buildDetachedSessionBootstrapSteps kills detached tmux session on exit and interrupt", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",
       "/tmp/project",
@@ -815,9 +815,11 @@ describe("detached tmux new-session sequencing", () => {
     const leaderCmd = steps[0]?.args.at(-1);
     assert.equal(typeof leaderCmd, "string");
     assert.match(leaderCmd!, /^\/bin\/sh -lc '/);
+    assert.match(leaderCmd!, /trap '/);
+    assert.match(leaderCmd!, /0 INT TERM HUP/);
     assert.match(leaderCmd!, /tmux kill-session -t/);
-    assert.match(leaderCmd!, /omx-demo/);
-    assert.match(leaderCmd!, /exit \$status'/);
+    assert.match(leaderCmd!, /"omx-demo"/);
+    assert.match(leaderCmd!, /exit \$status/);
   });
 
   it("buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach", () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1344,6 +1344,24 @@ function detectDetachedSessionWindowIndex(sessionName: string): string | null {
   }
 }
 
+function escapeShellDoubleQuotedValue(value: string): string {
+  return value.replace(/["\\$`]/g, "\\$&");
+}
+
+function buildDetachedSessionLeaderCommand(
+  sessionName: string,
+  codexCmd: string,
+): string {
+  const cleanupTrap = [
+    "status=$?;",
+    "trap - 0 INT TERM HUP;",
+    `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
+    "exit $status;",
+  ].join(" ");
+  const wrapped = [`trap '${cleanupTrap}' 0 INT TERM HUP;`, codexCmd].join(" ");
+  return `/bin/sh -lc ${quoteShellArg(wrapped)}`;
+}
+
 export function buildDetachedSessionBootstrapSteps(
   sessionName: string,
   cwd: string,
@@ -1356,9 +1374,7 @@ export function buildDetachedSessionBootstrapSteps(
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
-    : `/bin/sh -lc ${quoteShellArg(
-        `${codexCmd}; status=$?; tmux kill-session -t ${quoteShellArg(sessionName)} >/dev/null 2>&1 || true; exit $status`,
-      )}`;
+    : buildDetachedSessionLeaderCommand(sessionName, codexCmd);
   const newSessionArgs: string[] = [
     "new-session",
     "-d",


### PR DESCRIPTION
## Summary
- reproduce issue #936 where a detached tmux launch can leave the HUD/session alive after the leader is interrupted
- switch the detached leader wrapper to trap-driven tmux session cleanup so EXIT/INT/TERM/HUP all tear down the detached session while preserving status
- strengthen detached-launch regression coverage around the generated leader command contract

## Reproduction
Before this patch, a detached tmux launch could be reproduced by attaching to a detached leader+HUD session, pressing Ctrl-C once, and observing tmux stay attached while focus moved to the remaining pane. A second Ctrl-C was then needed to fully exit.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/index.test.js`
- `npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts`
- runtime-style detached tmux verification using `buildDetachedSessionBootstrapSteps(...)` and a one-shot `C-c` to confirm the session is gone
