### PR TITLE
fix(team): persist explicit worktree mode for scale-up

### DIFF
--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { mkdtemp, rm, readFile, writeFile, mkdir, chmod } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -13,8 +14,20 @@ import {
   readWorkerStatus,
   writeWorkerStatus,
   withScalingLock,
+  DEFAULT_MAX_WORKERS,
 } from '../state.js';
 import { isScalingEnabled, scaleUp, scaleDown } from '../scaling.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-worktree-repo-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
 
 // ── isScalingEnabled ──────────────────────────────────────────────────────────
 
@@ -443,6 +456,210 @@ exit 0
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+  it('provisions detached worktrees for scaled-up workers from persisted team worktree mode', async () => {
+    const repo = await initRepo();
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-detached-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+
+    try {
+      await writeFile(
+        tmuxStubPath,
+        [
+          '#!/bin/sh',
+          'set -eu',
+          `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          'case "${1:-}" in',
+          '  -V)',
+          '    echo "tmux 3.2a"',
+          '    ;;',
+          '  split-window)',
+          '    echo "%41"',
+          '    ;;',
+          '  list-panes)',
+          '    echo "45454"',
+          '    ;;',
+          '  capture-pane)',
+          '    echo ""',
+          '    ;;',
+          'esac',
+          'exit 0',
+          '',
+        ].join('\n'),
+      );
+      await chmod(tmuxStubPath, 0o755);
+      await writeFile(tmuxLogPath, '');
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+      const teamName = 'scale-up-detached-worktree';
+      await mkdir(join(repo, '.omx', 'state', 'team', teamName), { recursive: true });
+      await writeFile(join(repo, '.omx', 'state', 'team', teamName, 'worker-agents.md'), '# Base worker instructions\n');
+      await initTeamState(
+        teamName,
+        'task',
+        'executor',
+        1,
+        repo,
+        DEFAULT_MAX_WORKERS,
+        process.env,
+        {
+          leader_cwd: repo,
+          team_state_root: join(repo, '.omx', 'state'),
+          workspace_mode: 'worktree',
+          worktree_mode: { enabled: true, detached: true, name: null },
+        },
+      );
+
+      const config = await readTeamConfig(teamName, repo);
+      assert.ok(config);
+      if (!config) return;
+      config.tmux_session = `omx-team-${teamName}`;
+      config.leader_pane_id = '%11';
+      config.workers[0]!.pane_id = '%21';
+      await saveTeamConfig(config, repo);
+
+      const manifestPath = join(repo, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
+      manifest.policy = {
+        ...(manifest.policy ?? {}),
+        dispatch_mode: 'transport_direct',
+      };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = await scaleUp(
+        teamName,
+        1,
+        'executor',
+        [],
+        repo,
+        { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
+      );
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+
+      const updated = await readTeamConfig(teamName, repo);
+      const worker = updated?.workers.find((entry) => entry.name === 'worker-2');
+      assert.deepEqual(updated?.worktree_mode, { enabled: true, detached: true, name: null });
+      assert.ok(worker?.worktree_path, 'scaled worker should have detached worktree path');
+      assert.equal(worker?.working_dir, worker?.worktree_path);
+      assert.equal(worker?.worktree_detached, true);
+      assert.equal(worker?.worktree_created, true);
+      assert.equal(existsSync(worker?.worktree_path as string), true);
+      assert.throws(
+        () => execFileSync('git', ['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: worker?.worktree_path, stdio: 'pipe' }),
+      );
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(repo, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+  it('provisions named worktrees for scaled-up workers from persisted team worktree mode', async () => {
+    const repo = await initRepo();
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-named-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+
+    try {
+      await writeFile(
+        tmuxStubPath,
+        [
+          '#!/bin/sh',
+          'set -eu',
+          `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          'case "${1:-}" in',
+          '  -V)',
+          '    echo "tmux 3.2a"',
+          '    ;;',
+          '  split-window)',
+          '    echo "%42"',
+          '    ;;',
+          '  list-panes)',
+          '    echo "46464"',
+          '    ;;',
+          '  capture-pane)',
+          '    echo ""',
+          '    ;;',
+          'esac',
+          'exit 0',
+          '',
+        ].join('\n'),
+      );
+      await chmod(tmuxStubPath, 0o755);
+      await writeFile(tmuxLogPath, '');
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+      const teamName = 'scale-up-named-worktree';
+      const branchBase = 'feature/team-scale';
+      await mkdir(join(repo, '.omx', 'state', 'team', teamName), { recursive: true });
+      await writeFile(join(repo, '.omx', 'state', 'team', teamName, 'worker-agents.md'), '# Base worker instructions\n');
+      await initTeamState(
+        teamName,
+        'task',
+        'executor',
+        1,
+        repo,
+        DEFAULT_MAX_WORKERS,
+        process.env,
+        {
+          leader_cwd: repo,
+          team_state_root: join(repo, '.omx', 'state'),
+          workspace_mode: 'worktree',
+          worktree_mode: { enabled: true, detached: false, name: branchBase },
+        },
+      );
+
+      const config = await readTeamConfig(teamName, repo);
+      assert.ok(config);
+      if (!config) return;
+      config.tmux_session = `omx-team-${teamName}`;
+      config.leader_pane_id = '%11';
+      config.workers[0]!.pane_id = '%21';
+      await saveTeamConfig(config, repo);
+
+      const manifestPath = join(repo, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
+      manifest.policy = {
+        ...(manifest.policy ?? {}),
+        dispatch_mode: 'transport_direct',
+      };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = await scaleUp(
+        teamName,
+        1,
+        'executor',
+        [],
+        repo,
+        { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
+      );
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+
+      const updated = await readTeamConfig(teamName, repo);
+      const worker = updated?.workers.find((entry) => entry.name === 'worker-2');
+      assert.deepEqual(updated?.worktree_mode, { enabled: true, detached: false, name: branchBase });
+      assert.equal(worker?.worktree_branch, `${branchBase}/worker-2`);
+      assert.equal(worker?.working_dir, worker?.worktree_path);
+      assert.equal(worker?.worktree_detached, false);
+      assert.equal(worker?.worktree_created, true);
+      assert.equal(existsSync(worker?.worktree_path as string), true);
+      assert.equal(
+        execFileSync('git', ['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: worker?.worktree_path, encoding: 'utf-8' }).trim(),
+        `${branchBase}/worker-2`,
+      );
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(repo, { recursive: true, force: true });
       await rm(fakeBinDir, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -291,17 +291,20 @@ describe('team state', () => {
           leader_cwd: '/tmp/leader',
           team_state_root: '/tmp/leader/.omx/state',
           workspace_mode: 'worktree',
+          worktree_mode: { enabled: true, detached: false, name: 'feature/team-meta' },
         },
       );
       assert.equal(cfg.leader_cwd, '/tmp/leader');
       assert.equal(cfg.team_state_root, '/tmp/leader/.omx/state');
       assert.equal(cfg.workspace_mode, 'worktree');
+      assert.deepEqual(cfg.worktree_mode, { enabled: true, detached: false, name: 'feature/team-meta' });
 
       const manifest = await readTeamManifestV2('team-meta', cwd);
       assert.ok(manifest);
       assert.equal(manifest?.leader_cwd, '/tmp/leader');
       assert.equal(manifest?.team_state_root, '/tmp/leader/.omx/state');
       assert.equal(manifest?.workspace_mode, 'worktree');
+      assert.deepEqual(manifest?.worktree_mode, { enabled: true, detached: false, name: 'feature/team-meta' });
       assert.equal(manifest?.lifecycle_profile, 'default');
       assert.equal(manifest?.leader_pane_id, null);
       assert.equal(manifest?.hud_pane_id, null);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1411,6 +1411,7 @@ export async function startTeam(
         leader_cwd: leaderCwd,
         team_state_root: teamStateRoot,
         workspace_mode: workspaceMode,
+        worktree_mode: effectiveWorktreeMode,
       },
       options.ralph === true ? 'linked_ralph' : 'default',
     );
@@ -1420,6 +1421,7 @@ export async function startTeam(
     config.leader_cwd = leaderCwd;
     config.team_state_root = teamStateRoot;
     config.workspace_mode = workspaceMode;
+    config.worktree_mode = effectiveWorktreeMode;
 
     // 4. Create tasks
     for (const t of tasks) {

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -40,6 +40,7 @@ import {
   teamMarkDispatchRequestNotified as markDispatchRequestNotified,
   teamReadDispatchRequest as readDispatchRequest,
   teamTransitionDispatchRequest as transitionDispatchRequest,
+  type TeamConfig,
   type WorkerInfo,
   type WorkerStatus,
 } from './team-ops.js';
@@ -63,6 +64,13 @@ import {
   type TeamReasoningEffort,
 } from './model-contract.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
+import {
+  ensureWorktree,
+  planWorktreeTarget,
+  rollbackProvisionedWorktrees,
+  type EnsureWorktreeResult,
+  type WorktreeMode,
+} from './worktree.js';
 
 // ── Environment gate ──────────────────────────────────────────────────────────
 
@@ -106,6 +114,39 @@ export interface ScaleError {
 
 function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
   return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
+}
+
+function resolveLegacyScaledTeamWorktreeMode(config: Pick<TeamConfig, 'name' | 'workspace_mode' | 'worktree_mode' | 'workers'>): WorktreeMode {
+  if (config.worktree_mode) return config.worktree_mode;
+  if (config.workspace_mode !== 'worktree') return { enabled: false };
+
+  const workersWithMetadata = config.workers.filter((worker) =>
+    worker.worktree_path || worker.worktree_branch || typeof worker.worktree_detached === 'boolean',
+  );
+  if (workersWithMetadata.length === 0) {
+    throw new Error(`scale_up_missing_team_worktree_contract:${config.name}`);
+  }
+
+  if (workersWithMetadata.some((worker) => worker.worktree_detached === true)) {
+    return { enabled: true, detached: true, name: null };
+  }
+
+  const branchPrefixes = new Set(
+    workersWithMetadata
+      .map((worker) => worker.worktree_branch?.trim())
+      .filter((branch): branch is string => Boolean(branch))
+      .map((branch) => {
+        const match = /^(.*)\/worker-\d+$/.exec(branch);
+        return match?.[1]?.trim() || '';
+      })
+      .filter(Boolean),
+  );
+
+  if (branchPrefixes.size === 1) {
+    return { enabled: true, detached: false, name: [...branchPrefixes][0] };
+  }
+
+  throw new Error(`scale_up_missing_team_worktree_contract:${config.name}`);
 }
 
 async function notifyWorkerPaneOutcome(
@@ -178,12 +219,18 @@ export async function scaleUp(
       display_mode: manifest?.policy?.display_mode === 'split_pane' ? 'split_pane' : 'auto',
       worker_launch_mode: config.worker_launch_mode,
     });
+    const effectiveWorktreeMode = resolveLegacyScaledTeamWorktreeMode(config);
+    if (!config.worktree_mode && effectiveWorktreeMode.enabled) {
+      config.worktree_mode = effectiveWorktreeMode;
+      await saveTeamConfig(config, leaderCwd);
+    }
 
     // Resolve the monotonic worker index counter
     let nextIndex = config.next_worker_index ?? (currentCount + 1);
     const initialNextIndex = nextIndex;
     const addedWorkers: WorkerInfo[] = [];
     const createdTaskIds: string[] = [];
+    const provisionedWorktrees: Array<EnsureWorktreeResult | { enabled: false }> = [];
 
     const rollbackScaleUp = async (error: string, paneId?: string): Promise<ScaleError> => {
       for (const w of addedWorkers) {
@@ -206,6 +253,9 @@ export async function scaleUp(
 
       for (const taskId of createdTaskIds) {
         await rm(join(leaderCwd, '.omx', 'state', 'team', sanitized, 'tasks', `task-${taskId}.json`), { force: true }).catch(() => {});
+      }
+      if (provisionedWorktrees.length > 0) {
+        await rollbackProvisionedWorktrees(provisionedWorktrees).catch(() => {});
       }
 
       config.worker_count = config.workers.length;
@@ -260,18 +310,35 @@ export async function scaleUp(
       const instructionsFilePath = rolePromptContent
         ? await writeWorkerRoleInstructionsFile(sanitized, workerName, leaderCwd, teamInstructionsPath, workerRole, rolePromptContent)
         : teamInstructionsPath;
+      const plannedWorktree = planWorktreeTarget({
+        cwd: leaderCwd,
+        scope: 'team',
+        mode: effectiveWorktreeMode,
+        teamName: sanitized,
+        workerName,
+      });
+      const ensuredWorktree = ensureWorktree(plannedWorktree);
+      provisionedWorktrees.push(ensuredWorktree);
+      const workerCwd = ensuredWorktree.enabled ? ensuredWorktree.worktreePath : leaderCwd;
       const extraEnv: Record<string, string> = {
         OMX_TEAM_STATE_ROOT: teamStateRoot,
         OMX_TEAM_LEADER_CWD: leaderCwd,
         OMX_MODEL_INSTRUCTIONS_FILE: instructionsFilePath,
       };
+      if (ensuredWorktree.enabled) {
+        extraEnv.OMX_TEAM_WORKTREE_PATH = ensuredWorktree.worktreePath;
+        if (ensuredWorktree.branchName) {
+          extraEnv.OMX_TEAM_WORKTREE_BRANCH = ensuredWorktree.branchName;
+        }
+        extraEnv.OMX_TEAM_WORKTREE_DETACHED = ensuredWorktree.detached ? '1' : '0';
+      }
       const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
       const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, agentType, preferredReasoning);
       const cmd = buildWorkerStartupCommand(
         sanitized,
         workerIndex,
         workerLaunchArgs,
-        leaderCwd,
+        workerCwd,
         extraEnv,
         workerCliPlan[i],
       );
@@ -285,7 +352,7 @@ export async function scaleUp(
       const splitDirection = splitTarget === (config.leader_pane_id ?? '') ? '-h' : '-v';
 
       const result = spawnSync('tmux', [
-        'split-window', splitDirection, '-t', splitTarget, '-d', '-P', '-F', '#{pane_id}', '-c', leaderCwd, cmd,
+        'split-window', splitDirection, '-t', splitTarget, '-d', '-P', '-F', '#{pane_id}', '-c', workerCwd, cmd,
       ], { encoding: 'utf-8' });
 
       if (result.status !== 0) {
@@ -311,7 +378,12 @@ export async function scaleUp(
         assigned_tasks: [],
         pid: panePid ?? undefined,
         pane_id: paneId,
-        working_dir: leaderCwd,
+        working_dir: workerCwd,
+        worktree_repo_root: ensuredWorktree.enabled ? ensuredWorktree.repoRoot : undefined,
+        worktree_path: ensuredWorktree.enabled ? ensuredWorktree.worktreePath : undefined,
+        worktree_branch: ensuredWorktree.enabled ? (ensuredWorktree.branchName ?? undefined) : undefined,
+        worktree_detached: ensuredWorktree.enabled ? ensuredWorktree.detached : undefined,
+        worktree_created: ensuredWorktree.enabled ? ensuredWorktree.created : undefined,
         team_state_root: teamStateRoot,
       };
 
@@ -606,6 +678,32 @@ export async function scaleDown(
       leaderPaneId,
       hudPaneId,
     });
+    const detachedWorktreesToRollback: EnsureWorktreeResult[] = targetWorkers
+      .filter((worker) =>
+        worker.worktree_created === true
+        && worker.worktree_detached === true
+        && typeof worker.worktree_repo_root === 'string'
+        && worker.worktree_repo_root.length > 0
+        && typeof worker.worktree_path === 'string'
+        && worker.worktree_path.length > 0,
+      )
+      .map((worker) => ({
+        enabled: true,
+        repoRoot: worker.worktree_repo_root as string,
+        worktreePath: resolve(worker.worktree_path as string),
+        detached: true,
+        branchName: null,
+        created: true,
+        reused: false,
+        createdBranch: false,
+      }));
+    if (detachedWorktreesToRollback.length > 0) {
+      try {
+        await rollbackProvisionedWorktrees(detachedWorktreesToRollback);
+      } catch (error) {
+        return { ok: false, error: `scale_down_worktree_cleanup_failed:${String(error)}` };
+      }
+    }
 
     for (const w of targetWorkers) {
       removedNames.push(w.name);

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -59,6 +59,7 @@ import {
   type TeamTaskStatus,
   type TeamEventType,
 } from './contracts.js';
+import type { WorktreeMode } from './worktree.js';
 
 export interface TeamConfig {
   name: string;
@@ -75,6 +76,7 @@ export interface TeamConfig {
   leader_cwd?: string;
   team_state_root?: string;
   workspace_mode?: 'single' | 'worktree';
+  worktree_mode?: WorktreeMode;
   /** Leader's own tmux pane ID — must never be killed during worker cleanup. */
   leader_pane_id: string | null;
   /** HUD pane spawned below the leader column — excluded from worker pane cleanup. */
@@ -234,6 +236,7 @@ export interface TeamManifestV2 {
   leader_cwd?: string;
   team_state_root?: string;
   workspace_mode?: 'single' | 'worktree';
+  worktree_mode?: WorktreeMode;
   leader_pane_id: string | null;
   hud_pane_id: string | null;
   resize_hook_name: string | null;
@@ -246,6 +249,7 @@ export interface TeamWorkspaceMetadata {
   leader_cwd?: string;
   team_state_root?: string;
   workspace_mode?: 'single' | 'worktree';
+  worktree_mode?: WorktreeMode;
 }
 
 export interface TeamEvent {
@@ -763,6 +767,7 @@ export async function initTeamState(
     leader_cwd: workspace.leader_cwd,
     team_state_root: workspace.team_state_root,
     workspace_mode: workspace.workspace_mode,
+    worktree_mode: workspace.worktree_mode,
     leader_pane_id: null,
     hud_pane_id: null,
     resize_hook_name: null,
@@ -804,6 +809,7 @@ export async function initTeamState(
       leader_cwd: workspace.leader_cwd,
       team_state_root: workspace.team_state_root,
       workspace_mode: workspace.workspace_mode,
+      worktree_mode: workspace.worktree_mode,
       leader_pane_id: null,
       hud_pane_id: null,
       resize_hook_name: null,
@@ -834,6 +840,7 @@ async function writeConfig(cfg: TeamConfig, cwd: string): Promise<void> {
       leader_cwd: normalized.leader_cwd,
       team_state_root: normalized.team_state_root,
       workspace_mode: normalized.workspace_mode,
+      worktree_mode: normalized.worktree_mode,
       leader_pane_id: normalized.leader_pane_id,
       hud_pane_id: normalized.hud_pane_id,
       resize_hook_name: normalized.resize_hook_name,
@@ -865,6 +872,7 @@ function teamConfigFromManifest(manifest: TeamManifestV2): TeamConfig {
     leader_cwd: manifest.leader_cwd,
     team_state_root: manifest.team_state_root,
     workspace_mode: manifest.workspace_mode,
+    worktree_mode: manifest.worktree_mode,
     leader_pane_id: manifest.leader_pane_id,
     hud_pane_id: manifest.hud_pane_id,
     resize_hook_name: manifest.resize_hook_name,
@@ -914,6 +922,7 @@ function teamManifestFromConfig(config: TeamConfig): TeamManifestV2 {
     leader_cwd: normalized.leader_cwd,
     team_state_root: normalized.team_state_root,
     workspace_mode: normalized.workspace_mode,
+    worktree_mode: normalized.worktree_mode,
     leader_pane_id: normalized.leader_pane_id,
     hud_pane_id: normalized.hud_pane_id,
     resize_hook_name: normalized.resize_hook_name,

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -1,5 +1,6 @@
 import type { TeamPhase, TerminalPhase } from '../orchestrator.js';
 import type { TeamTaskStatus, TeamEventType } from '../contracts.js';
+import type { WorktreeMode } from '../worktree.js';
 
 export interface TeamConfig {
   name: string;
@@ -16,6 +17,7 @@ export interface TeamConfig {
   leader_cwd?: string;
   team_state_root?: string;
   workspace_mode?: 'single' | 'worktree';
+  worktree_mode?: WorktreeMode;
   leader_pane_id: string | null;
   hud_pane_id: string | null;
   resize_hook_name: string | null;
@@ -170,6 +172,7 @@ export interface TeamManifestV2 {
   leader_cwd?: string;
   team_state_root?: string;
   workspace_mode?: 'single' | 'worktree';
+  worktree_mode?: WorktreeMode;
   leader_pane_id: string | null;
   hud_pane_id: string | null;
   resize_hook_name: string | null;
@@ -181,6 +184,7 @@ export interface TeamWorkspaceMetadata {
   leader_cwd?: string;
   team_state_root?: string;
   workspace_mode?: 'single' | 'worktree';
+  worktree_mode?: WorktreeMode;
 }
 
 export interface TeamEvent {


### PR DESCRIPTION
## Summary
- persist the team-level `worktree_mode` contract during `startTeam()` initialization instead of relying on later inference
- update `scaleUp()` to consume the persisted contract directly when provisioning new workers, with a narrow legacy fallback only for older state lacking `worktree_mode`
- add regression coverage for detached and named scaled-up worktrees, plus workspace metadata persistence

## Verification
- `npm ci`
- `npm run build`
- `node --test dist/team/__tests__/state.test.js dist/team/__tests__/scaling.test.js`
- `npx biome lint src/team/state.ts src/team/state/types.ts src/team/runtime.ts src/team/scaling.ts src/team/__tests__/state.test.ts src/team/__tests__/scaling.test.ts`

## Notes
- commit and push were performed as separate steps
- the legacy fallback in `scaleUp()` is intentionally limited to preexisting team state without persisted `worktree_mode`
