### PR TITLE
hotfix: restore launch-path watcher authority and CODEX_HOME fallback discovery

### DIFF
--- a/scripts/notify-fallback-watcher.js
+++ b/scripts/notify-fallback-watcher.js
@@ -214,6 +214,63 @@ async function resolveActiveRalphState() {
   return resolveActiveModeState('ralph');
 }
 
+async function resolveActiveTeamState() {
+  return resolveActiveModeState('team');
+}
+
+async function resolveRolloutTrackingEvidence(nowMs = Date.now()) {
+  for (const [path, meta] of fileState.entries()) {
+    const fileInfo = await stat(path).catch(() => null);
+    if (!fileInfo || (nowMs - fileInfo.mtimeMs) > fileWindowMs) continue;
+    return {
+      active: true,
+      reason: 'tracked_rollout',
+      path,
+      threadId: safeString(meta?.threadId),
+    };
+  }
+
+  const discovered = await discoverRolloutFiles();
+  if (discovered.length > 0) {
+    const path = discovered[0];
+    const line = await readFirstLine(path).catch(() => '');
+    return {
+      active: true,
+      reason: 'recent_rollout',
+      path,
+      threadId: shouldTrackSessionMeta(line) || '',
+    };
+  }
+
+  return {
+    active: false,
+    reason: 'none',
+    path: '',
+    threadId: '',
+  };
+}
+
+async function resolveAuthorityGate() {
+  if (authorityEnabled) {
+    return { enabled: true, reason: 'hud_authority_enabled' };
+  }
+  if (!parentIsGone()) {
+    return { enabled: false, reason: HUD_AUTHORITY_REASON };
+  }
+
+  const activeRalph = await resolveActiveRalphState();
+  if (activeRalph.active) {
+    return { enabled: true, reason: 'parent_gone_fail_open_active_ralph' };
+  }
+
+  const activeTeam = await resolveActiveTeamState();
+  if (activeTeam.active) {
+    return { enabled: true, reason: 'parent_gone_fail_open_active_team' };
+  }
+
+  return { enabled: false, reason: HUD_AUTHORITY_REASON };
+}
+
 async function emitRalphContinueSteer(paneId, message) {
   const markedText = `${message} ${DEFAULT_MARKER}`;
   await new Promise((resolve) => {
@@ -247,8 +304,9 @@ async function runRalphContinueSteerTick() {
     pane_current_command: '',
   };
 
-  if (!authorityEnabled) {
-    lastRalphContinueSteer.last_reason = HUD_AUTHORITY_REASON;
+  const authorityGate = await resolveAuthorityGate();
+  if (!authorityGate.enabled) {
+    lastRalphContinueSteer.last_reason = authorityGate.reason;
     return;
   }
 
@@ -433,12 +491,40 @@ async function enforceLifecycleGuards() {
   if (runOnce) return false;
   if (parentIsGone()) {
     const activeRalph = await resolveActiveRalphState();
-    if (activeRalph.active && authorityEnabled) {
-      const currentPhase = safeString(activeRalph.state?.current_phase);
-      const nextParentGuard = {
+    const activeTeam = await resolveActiveTeamState();
+
+    let deferredGuard = null;
+    if (activeRalph.active) {
+      deferredGuard = {
         reason: 'parent_gone_deferred_for_active_ralph',
         state_path: activeRalph.path,
-        current_phase: currentPhase,
+        current_phase: safeString(activeRalph.state?.current_phase),
+        thread_id: null,
+      };
+    } else if (activeTeam.active) {
+      deferredGuard = {
+        reason: 'parent_gone_deferred_for_active_team',
+        state_path: activeTeam.path,
+        current_phase: safeString(activeTeam.state?.current_phase),
+        thread_id: null,
+      };
+    } else if (!authorityOnly) {
+      const rolloutEvidence = await resolveRolloutTrackingEvidence();
+      if (rolloutEvidence.active) {
+        deferredGuard = {
+          reason: 'parent_gone_deferred_for_rollout_tracking',
+          state_path: rolloutEvidence.path,
+          current_phase: rolloutEvidence.reason,
+          thread_id: rolloutEvidence.threadId || null,
+        };
+      }
+    }
+
+    if (deferredGuard) {
+      const nextParentGuard = {
+        reason: deferredGuard.reason,
+        state_path: deferredGuard.state_path,
+        current_phase: deferredGuard.current_phase,
       };
       if (
         lastParentGuard.reason !== nextParentGuard.reason
@@ -447,14 +533,16 @@ async function enforceLifecycleGuards() {
       ) {
         await eventLog({
           type: 'watcher_parent_guard',
-          reason: nextParentGuard.reason,
-          state_path: nextParentGuard.state_path,
-          current_phase: currentPhase || null,
+          reason: deferredGuard.reason,
+          state_path: deferredGuard.state_path,
+          current_phase: deferredGuard.current_phase || null,
+          thread_id: deferredGuard.thread_id,
         });
         lastParentGuard = nextParentGuard;
       }
       return false;
     }
+
     lastParentGuard = { reason: '', state_path: '', current_phase: '' };
     await requestShutdown('parent_gone');
     return true;
@@ -467,10 +555,10 @@ async function enforceLifecycleGuards() {
 }
 
 function sessionDirs() {
+  const codexHome = safeString(process.env.CODEX_HOME).trim() || join(homedir(), '.codex');
   const now = new Date();
   const today = join(
-    homedir(),
-    '.codex',
+    codexHome,
     'sessions',
     String(now.getUTCFullYear()),
     String(now.getUTCMonth() + 1).padStart(2, '0'),
@@ -478,8 +566,7 @@ function sessionDirs() {
   );
   const yesterdayDate = new Date(now.getTime() - 24 * 60 * 60 * 1000);
   const yesterday = join(
-    homedir(),
-    '.codex',
+    codexHome,
     'sessions',
     String(yesterdayDate.getUTCFullYear()),
     String(yesterdayDate.getUTCMonth() + 1).padStart(2, '0'),
@@ -624,7 +711,8 @@ async function runLeaderNudgeTick() {
   const leaderOnly = safeString(process.env.OMX_TEAM_WORKER || '').trim() === '';
   const staleThresholdMs = resolveLeaderStalenessThresholdMs();
 
-  if (!authorityEnabled) {
+  const authorityGate = await resolveAuthorityGate();
+  if (!authorityGate.enabled) {
     leaderNudgeRuns += 1;
     lastLeaderNudge = {
       enabled: false,
@@ -632,13 +720,13 @@ async function runLeaderNudgeTick() {
       stale_threshold_ms: staleThresholdMs,
       precomputed_leader_stale: null,
       last_tick_at: startedIso,
-      last_error: HUD_AUTHORITY_REASON,
+      last_error: authorityGate.reason,
     };
     await eventLog({
       type: 'leader_nudge_tick',
       leader_only: leaderOnly,
       run_count: leaderNudgeRuns,
-      reason: HUD_AUTHORITY_REASON,
+      reason: authorityGate.reason,
       stale_threshold_ms: staleThresholdMs,
     });
     return;
@@ -707,12 +795,13 @@ async function runLeaderNudgeTick() {
 
 async function runDispatchDrainTick() {
   const startedIso = new Date().toISOString();
-  if (!authorityEnabled) {
+  const authorityGate = await resolveAuthorityGate();
+  if (!authorityGate.enabled) {
     dispatchDrainRuns += 1;
     lastDispatchDrain = {
       leader_only: safeString(process.env.OMX_TEAM_WORKER || '').trim() === '',
       last_tick_at: startedIso,
-      last_result: { processed: 0, reason: HUD_AUTHORITY_REASON },
+      last_result: { processed: 0, reason: authorityGate.reason },
       last_error: null,
     };
     await eventLog({
@@ -721,7 +810,7 @@ async function runDispatchDrainTick() {
       dispatch_max_per_tick: dispatchTickMax,
       run_count: dispatchDrainRuns,
       processed: 0,
-      reason: HUD_AUTHORITY_REASON,
+      reason: authorityGate.reason,
     });
     return;
   }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -32,6 +32,7 @@ import {
   buildDetachedSessionRollbackSteps,
   resolveNotifyTempContract,
   buildNotifyTempStartupMessages,
+  buildNotifyFallbackWatcherEnv,
 } from "../index.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../../hud/constants.js";
 import {
@@ -230,6 +231,27 @@ describe("resolveNotifyTempContract", () => {
     assert.equal(parsed.contract.active, true);
     assert.equal(parsed.contract.source, "env");
     assert.deepEqual(parsed.passthroughArgs, ["--model", "gpt-5"]);
+  });
+});
+
+describe("buildNotifyFallbackWatcherEnv", () => {
+  it("enables watcher authority and propagates CODEX_HOME override when requested", () => {
+    const env = buildNotifyFallbackWatcherEnv(
+      { HOME: "/tmp/home", OMX_HUD_AUTHORITY: "0" },
+      { codexHomeOverride: "/tmp/codex-home", enableAuthority: true },
+    );
+    assert.equal(env.OMX_HUD_AUTHORITY, "1");
+    assert.equal(env.CODEX_HOME, "/tmp/codex-home");
+    assert.equal(env.HOME, "/tmp/home");
+  });
+
+  it("disables watcher authority explicitly when not requested", () => {
+    const env = buildNotifyFallbackWatcherEnv(
+      { HOME: "/tmp/home", OMX_HUD_AUTHORITY: "1" },
+      { enableAuthority: false },
+    );
+    assert.equal(env.OMX_HUD_AUTHORITY, "0");
+    assert.equal(env.HOME, "/tmp/home");
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -813,6 +813,13 @@ export async function launchWithHud(args: string[]): Promise<void> {
     process.env,
   );
   const codexHomeOverride = resolveCodexHomeForLaunch(launchCwd, process.env);
+  const launchPolicy = resolveCodexLaunchPolicy(
+    process.env,
+    process.platform,
+    undefined,
+    isNativeWindows(),
+  );
+  const enableNotifyFallbackAuthority = launchPolicy === "direct";
   const workerSparkModel = resolveWorkerSparkModel(
     notifyTempResult.passthroughArgs,
     codexHomeOverride,
@@ -866,7 +873,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
 
   // ── Phase 1: preLaunch ──────────────────────────────────────────────────
   try {
-    await preLaunch(cwd, sessionId, notifyTempResult.contract);
+    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, enableNotifyFallbackAuthority);
   } catch (err) {
     // preLaunch errors must NOT prevent Codex from starting
     console.error(
@@ -889,7 +896,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
     );
   } finally {
     // ── Phase 3: postLaunch ─────────────────────────────────────────────
-    await postLaunch(cwd, sessionId);
+    await postLaunch(cwd, sessionId, codexHomeOverride, enableNotifyFallbackAuthority);
   }
 }
 
@@ -945,7 +952,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
   }
 
   try {
-    await preLaunch(cwd, sessionId, notifyTempResult.contract);
+    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, true);
   } catch (err) {
     console.error(
       `[omx] preLaunch warning: ${err instanceof Error ? err.message : err}`,
@@ -973,7 +980,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
       : codexEnvBase;
     runCodexBlocking(cwd, codexArgs, codexEnv);
   } finally {
-    await postLaunch(cwd, sessionId);
+    await postLaunch(cwd, sessionId, codexHomeOverride, true);
   }
 }
 
@@ -1540,6 +1547,20 @@ export function buildNotifyTempStartupMessages(
   return { infoLines, warningLines };
 }
 
+export function buildNotifyFallbackWatcherEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  options: {
+    codexHomeOverride?: string;
+    enableAuthority?: boolean;
+  } = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    ...(options.codexHomeOverride ? { CODEX_HOME: options.codexHomeOverride } : {}),
+    OMX_HUD_AUTHORITY: options.enableAuthority ? "1" : "0",
+  };
+}
+
 /**
  * preLaunch: Prepare environment before Codex starts.
  * 1. Generate runtime overlay + write session-scoped model instructions file
@@ -1553,6 +1574,8 @@ async function preLaunch(
   cwd: string,
   sessionId: string,
   notifyTempContract?: NotifyTempContract,
+  codexHomeOverride?: string,
+  enableNotifyFallbackAuthority: boolean = false,
 ): Promise<void> {
   // 1. Generate runtime overlay + write session-scoped model instructions file
   const orchestrationMode = await resolveSessionOrchestrationMode(
@@ -1575,7 +1598,7 @@ ${launchAppendix}`
 
   // 3. Start notify fallback watcher (best effort)
   try {
-    await startNotifyFallbackWatcher(cwd);
+    await startNotifyFallbackWatcher(cwd, { codexHomeOverride, enableAuthority: enableNotifyFallbackAuthority });
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
     // Non-fatal
@@ -2023,7 +2046,12 @@ function scheduleDetachedWindowsCodexLaunch(
  * postLaunch: Clean up after Codex exits.
  * Each step is independently fault-tolerant (try/catch per step).
  */
-async function postLaunch(cwd: string, sessionId: string): Promise<void> {
+async function postLaunch(
+  cwd: string,
+  sessionId: string,
+  codexHomeOverride?: string,
+  enableNotifyFallbackAuthority: boolean = false,
+): Promise<void> {
   // Capture session start time before cleanup (writeSessionEnd deletes session.json)
   let sessionStartedAt: string | undefined;
   try {
@@ -2036,7 +2064,7 @@ async function postLaunch(cwd: string, sessionId: string): Promise<void> {
 
   // 0. Flush fallback watcher once to reduce race with fast codex exit.
   try {
-    await flushNotifyFallbackOnce(cwd);
+    await flushNotifyFallbackOnce(cwd, { codexHomeOverride, enableAuthority: enableNotifyFallbackAuthority });
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
     // Non-fatal
@@ -2216,7 +2244,10 @@ function tryKillPid(pid: number, signal: NodeJS.Signals = "SIGTERM"): boolean {
   }
 }
 
-async function startNotifyFallbackWatcher(cwd: string): Promise<void> {
+async function startNotifyFallbackWatcher(
+  cwd: string,
+  options: { codexHomeOverride?: string; enableAuthority?: boolean } = {},
+): Promise<void> {
   if (process.env.OMX_NOTIFY_FALLBACK === "0") return;
 
   const { mkdir, writeFile, readFile } = await import("fs/promises");
@@ -2277,10 +2308,10 @@ async function startNotifyFallbackWatcher(cwd: string): Promise<void> {
       cwd,
       detached: true,
       stdio: "ignore",
-      env: {
-        ...process.env,
-        OMX_HUD_AUTHORITY: "0",
-      },
+      env: buildNotifyFallbackWatcherEnv(process.env, {
+        codexHomeOverride: options.codexHomeOverride,
+        enableAuthority: options.enableAuthority === true,
+      }),
     },
   );
   child.unref();
@@ -2428,7 +2459,10 @@ async function stopHookDerivedWatcher(cwd: string): Promise<void> {
   });
 }
 
-async function flushNotifyFallbackOnce(cwd: string): Promise<void> {
+async function flushNotifyFallbackOnce(
+  cwd: string,
+  options: { codexHomeOverride?: string; enableAuthority?: boolean } = {},
+): Promise<void> {
   const { spawnSync } = await import("child_process");
   const pkgRoot = getPackageRoot();
   const watcherScript = join(pkgRoot, "scripts", "notify-fallback-watcher.js");
@@ -2441,10 +2475,10 @@ async function flushNotifyFallbackOnce(cwd: string): Promise<void> {
       cwd,
       stdio: "ignore",
       timeout: 3000,
-      env: {
-        ...process.env,
-        OMX_HUD_AUTHORITY: "0",
-      },
+      env: buildNotifyFallbackWatcherEnv(process.env, {
+        codexHomeOverride: options.codexHomeOverride,
+        enableAuthority: options.enableAuthority === true,
+      }),
     },
   );
 }

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -796,7 +796,7 @@ describe('notify-fallback watcher', () => {
     }
   });
 
-  it('stops after parent loss when HUD authority disables fallback Ralph steering', async () => {
+  it('keeps fallback Ralph steering alive after parent loss even when HUD authority is unavailable, then stops once Ralph is terminal', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-ralph-active-'));
     const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-ralph-home-'));
     const fakeBinDir = join(wd, 'fake-bin');
@@ -847,17 +847,31 @@ describe('notify-fallback watcher', () => {
         {
           cwd: wd,
           stdio: 'ignore',
-          env: { ...process.env, HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` },
+          env: { ...process.env, HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}`, OMX_HUD_AUTHORITY: '0' },
         }
       );
+
+      await waitFor(async () => {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
+        return /send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/.test(tmuxLog);
+      }, 4000, 50);
+
+      assert.ok(isPidAlive(child.pid), 'expected watcher to stay alive while Ralph remains active');
+
+      await writeFile(ralphStatePath, JSON.stringify({
+        active: false,
+        current_phase: 'complete',
+        completed_at: new Date().toISOString(),
+        tmux_pane_id: '%42',
+      }, null, 2));
 
       await waitForExit(child, 4000);
       assert.equal(child.exitCode, 0);
 
-      const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /Ralph loop active continue/);
-
       const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_ralph'
+      )));
       assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
         entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
       )));
@@ -870,4 +884,443 @@ describe('notify-fallback watcher', () => {
       await rm(tempHome, { recursive: true, force: true });
     }
   });
+
+  it('keeps team fallback dispatch alive after parent loss without HUD authority, then stops once team is terminal', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-team-active-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-team-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const captureFile = join(wd, 'capture.txt');
+    const stateDir = join(wd, '.omx', 'state');
+    const teamStatePath = join(stateDir, 'team-state.json');
+    const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+    const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(captureFile, 'ready\n› ');
+
+      await initTeamState('dispatch-team', 'task', 'executor', 1, wd);
+      const queued = await enqueueDispatchRequest('dispatch-team', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        pane_id: '%42',
+        trigger_message: 'dispatch ping',
+      }, wd);
+      await writeFile(teamStatePath, JSON.stringify({
+        active: true,
+        team_name: 'dispatch-team',
+        current_phase: 'team-exec',
+      }, null, 2));
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--dispatch-max-per-tick',
+          '1',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: {
+            ...process.env,
+            HOME: tempHome,
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_HUD_AUTHORITY: '0',
+            OMX_TEST_CAPTURE_FILE: captureFile,
+          },
+        }
+      );
+
+      await waitFor(async () => {
+        const request = await readDispatchRequest('dispatch-team', queued.request.request_id, wd);
+        return Boolean(request && request.status !== 'pending');
+      }, 4000, 50);
+
+      assert.ok(isPidAlive(child.pid), 'expected watcher to stay alive while team remains active');
+
+      await writeFile(teamStatePath, JSON.stringify({
+        active: false,
+        team_name: 'dispatch-team',
+        current_phase: 'complete',
+        completed_at: new Date().toISOString(),
+      }, null, 2));
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+      )));
+      assert.ok(logEntries.some((entry: { type?: string; processed?: number }) => (
+        entry.type === 'dispatch_drain_tick' && entry.processed === 1
+      )));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
+      )));
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps rollout fallback tracking alive briefly after parent loss so recent task_complete events still notify', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-rollout-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-rollout-home-'));
+    const sid = randomUUID();
+    const sessionDir = todaySessionDir(tempHome);
+    const rolloutPath = join(sessionDir, `rollout-parent-rollout-${sid}.jsonl`);
+    const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+    const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+    const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+    const turnLog = join(wd, '.omx', 'logs', `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+
+      const threadId = `thread-${sid}`;
+      await writeFile(
+        rolloutPath,
+        `${JSON.stringify({
+          timestamp: new Date().toISOString(),
+          type: 'session_meta',
+          payload: { id: threadId, cwd: wd },
+        })}\n`
+      );
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: { ...process.env, HOME: tempHome, OMX_HUD_AUTHORITY: '0' },
+        }
+      );
+
+      await waitFor(async () => {
+        try {
+          const state = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+          return state.tracked_files === 1;
+        } catch {
+          return false;
+        }
+      }, 4000, 50);
+
+      const turnId = `turn-parent-rollout-${sid}`;
+      await appendLine(rolloutPath, {
+        timestamp: new Date(Date.now() + 500).toISOString(),
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: turnId,
+          last_agent_message: 'fresh message after parent exit',
+        },
+      });
+
+      await waitFor(async () => {
+        const turnLines = await readLines(turnLog);
+        return turnLines.length === 1 && new RegExp(turnId).test(turnLines[0] ?? '');
+      }, 4000, 50);
+
+      assert.ok(isPidAlive(child.pid), 'expected watcher to survive parent loss long enough to forward rollout events');
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_rollout_tracking'
+      )));
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+      await rm(rolloutPath, { force: true });
+    }
+  });
+
+  it('devils-advocate: keeps draining bounded team dispatch across multiple ticks after parent loss without HUD authority', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-team-multitick-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-team-multitick-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const captureFile = join(wd, 'capture.txt');
+    const stateDir = join(wd, '.omx', 'state');
+    const teamStatePath = join(stateDir, 'team-state.json');
+    const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+    const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(captureFile, 'ready\n› ');
+
+      await initTeamState('dispatch-team', 'task', 'executor', 1, wd);
+      const first = await enqueueDispatchRequest('dispatch-team', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        pane_id: '%42',
+        trigger_message: 'dispatch ping 1',
+      }, wd);
+      const second = await enqueueDispatchRequest('dispatch-team', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        pane_id: '%42',
+        trigger_message: 'dispatch ping 2',
+      }, wd);
+      await writeFile(teamStatePath, JSON.stringify({
+        active: true,
+        team_name: 'dispatch-team',
+        current_phase: 'team-exec',
+      }, null, 2));
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--dispatch-max-per-tick',
+          '1',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: {
+            ...process.env,
+            HOME: tempHome,
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_HUD_AUTHORITY: '0',
+            OMX_TEST_CAPTURE_FILE: captureFile,
+          },
+        }
+      );
+
+      await waitFor(async () => {
+        const firstReq = await readDispatchRequest('dispatch-team', first.request.request_id, wd);
+        const secondReq = await readDispatchRequest('dispatch-team', second.request.request_id, wd);
+        return Boolean(firstReq && firstReq.status !== 'pending' && secondReq && secondReq.status !== 'pending');
+      }, 5000, 50);
+
+      assert.ok(isPidAlive(child.pid), 'expected watcher to survive parent loss across multiple team dispatch ticks');
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(tmuxLog, /send-keys -t %42 -l dispatch ping 1/);
+      assert.match(tmuxLog, /send-keys -t %42 -l dispatch ping 2/);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const processedTicks = logEntries.filter((entry: { type?: string; processed?: number }) => entry.type === 'dispatch_drain_tick' && entry.processed === 1);
+      assert.ok(processedTicks.length >= 2, `expected at least 2 processed dispatch ticks, got ${processedTicks.length}`);
+
+      await writeFile(teamStatePath, JSON.stringify({
+        active: false,
+        team_name: 'dispatch-team',
+        current_phase: 'complete',
+        completed_at: new Date().toISOString(),
+      }, null, 2));
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('devils-advocate: keeps fallback auto-nudge injection alive after parent loss for rollout stall messages', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-rollout-nudge-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-rollout-nudge-home-'));
+    const codexHome = join(wd, 'codex-home');
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const sid = randomUUID();
+    const now = new Date();
+    const sessionDir = join(
+      codexHome,
+      'sessions',
+      String(now.getUTCFullYear()),
+      String(now.getUTCMonth() + 1).padStart(2, '0'),
+      String(now.getUTCDate()).padStart(2, '0')
+    );
+    const rolloutPath = join(sessionDir, `rollout-parent-rollout-nudge-${sid}.jsonl`);
+    const watcherScript = new URL('../../../scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../scripts/notify-hook.js', import.meta.url).pathname;
+    const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        autoNudge: { enabled: true, delaySec: 0 },
+      }, null, 2));
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const threadId = `thread-${sid}`;
+      await writeFile(
+        rolloutPath,
+        `${JSON.stringify({
+          timestamp: new Date().toISOString(),
+          type: 'session_meta',
+          payload: { id: threadId, cwd: wd },
+        })}\n`
+      );
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: {
+            ...process.env,
+            HOME: tempHome,
+            CODEX_HOME: codexHome,
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            TMUX_PANE: '%99',
+            TMUX: '1',
+            OMX_TEAM_WORKER: '',
+            OMX_TEAM_LEADER_NUDGE_MS: '9999999',
+            OMX_TEAM_LEADER_STALE_MS: '9999999',
+            OMX_HUD_AUTHORITY: '0',
+          },
+        }
+      );
+
+      await waitFor(async () => {
+        try {
+          const state = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+          return state.tracked_files === 1;
+        } catch {
+          return false;
+        }
+      }, 4000, 50);
+
+      await appendLine(rolloutPath, {
+        timestamp: new Date(Date.now() + 500).toISOString(),
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: `turn-parent-rollout-nudge-${sid}`,
+          last_agent_message: 'If you want me to keep going, let me know.',
+        },
+      });
+
+      await waitFor(async () => {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
+        return /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/.test(tmuxLog);
+      }, 4000, 50);
+
+      assert.ok(isPidAlive(child.pid), 'expected watcher to survive parent loss long enough to auto-nudge from rollout fallback');
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+      await rm(rolloutPath, { force: true });
+    }
+  });
+
 });


### PR DESCRIPTION
## Summary
- restore notify fallback watcher authority for direct/no-HUD launch paths
- keep HUD-owned authority behavior for authority-only/HUD loops
- make rollout fallback discovery honor `CODEX_HOME`
- add harder watcher lifecycle + devil's-advocate smoke coverage for team delivery and "if you want" fallback injection

## Failure theory
Two regressions combined in 0.10.5:
1. launch/flush paths forced `OMX_HUD_AUTHORITY=0`, so the fallback watcher process could exist but still skip dispatch drain / leader nudge / Ralph steer in normal launch flows
2. rollout fallback discovery still read `~/.codex/sessions` instead of resolved `CODEX_HOME/sessions`, so fallback injection could miss events entirely under overridden/project Codex homes

## Scope
Temporary production hotfix, not the final authority redesign.

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/cli/__tests__/index.test.js dist/hud/__tests__/authority.test.js dist/cli/__tests__/launch-fallback.test.js`

## Notes
Requested operational handling: skip waiting for CI and merge directly to `dev` after PR creation.
