### PR TITLE
fix(team): remove misleading leader reply prompt from mailbox nudges

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -257,7 +257,7 @@ describe('notify-hook team dispatch consumer', () => {
         kind: 'mailbox',
         to_worker: 'leader-fixed',
         message_id: msg.message_id,
-        trigger_message: 'Read .omx/state/team/alpha/mailbox/leader-fixed.json; worker-1 sent a new message. Reply with the next concrete step.',
+        trigger_message: 'Read .omx/state/team/alpha/mailbox/leader-fixed.json; worker-1 sent a new message. Review it and decide the next concrete step.',
       }, cwd);
 
       const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -509,7 +509,7 @@ describe("worker bootstrap", () => {
     assert.ok(message.length < 200);
   });
 
-  it("generateLeaderMailboxTriggerMessage tells the leader to read the mailbox and reply", () => {
+  it("generateLeaderMailboxTriggerMessage tells the leader to read the mailbox and decide the next step", () => {
     const message = generateLeaderMailboxTriggerMessage(
       "team-mail",
       "worker-2",
@@ -519,7 +519,8 @@ describe("worker bootstrap", () => {
       /Read .*\.omx\/state\/team\/team-mail\/mailbox\/leader-fixed\.json/,
     );
     assert.match(message, /worker-2 sent a new message/);
-    assert.match(message, /Reply with the next concrete step/);
+    assert.match(message, /Review it and decide the next concrete step/);
+    assert.doesNotMatch(message, /\bReply\b/i);
   });
 
   it("generateLeaderMailboxTriggerMessage uses provided state-root reference for worktree leaders", () => {
@@ -533,7 +534,8 @@ describe("worker bootstrap", () => {
       /read .*\$OMX_TEAM_STATE_ROOT\/team\/team-mail\/mailbox\/leader-fixed\.json/i,
     );
     assert.match(message, /new msg from worker-2/i);
-    assert.match(message, /reply next step/i);
+    assert.match(message, /review it; decide next step/i);
+    assert.doesNotMatch(message, /\breply\b/i);
     assert.ok(message.length < 200);
   });
 

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -857,7 +857,7 @@ export function generateLeaderMailboxTriggerMessage(
     "leader-fixed.json",
   );
   if (teamStateRoot !== ".omx/state") {
-    return `Read ${mailboxPath}; new msg from ${fromWorker}. Reply next step.`;
+    return `Read ${mailboxPath}; new msg from ${fromWorker}. Review it; decide next step.`;
   }
-  return `Read ${mailboxPath}; ${fromWorker} sent a new message. Reply with the next concrete step.`;
+  return `Read ${mailboxPath}; ${fromWorker} sent a new message. Review it and decide the next concrete step.`;
 }


### PR DESCRIPTION
## Summary
- change leader mailbox trigger copy from reply-oriented wording to review/decision wording
- keep the behavior unchanged while avoiding confusing guidance during shutdown-related messages
- update the targeted regression coverage for the new prompt text

## Verification
- npm run build
- node --test dist/team/__tests__/worker-bootstrap.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js
- npx @biomejs/biome lint src/team/worker-bootstrap.ts src/team/__tests__/worker-bootstrap.test.ts src/hooks/__tests__/notify-hook-team-dispatch.test.ts