### PR TITLE
Fix CI contract drift after 0.11.0 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,8 @@ jobs:
           cargo llvm-cov --workspace --summary-only | tee coverage/rust/omx-explore-summary.txt
           cargo llvm-cov --workspace --lcov --output-path coverage/rust/omx-explore.lcov
 
-          cargo llvm-cov --manifest-path native/omx-sparkshell/Cargo.toml --summary-only | tee coverage/rust/omx-sparkshell-summary.txt
-          cargo llvm-cov --manifest-path native/omx-sparkshell/Cargo.toml --lcov --output-path coverage/rust/omx-sparkshell.lcov
+          cargo llvm-cov --manifest-path crates/omx-sparkshell/Cargo.toml --summary-only | tee coverage/rust/omx-sparkshell-summary.txt
+          cargo llvm-cov --manifest-path crates/omx-sparkshell/Cargo.toml --lcov --output-path coverage/rust/omx-sparkshell.lcov
       - name: Add Rust coverage summary to job summary
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,11 +32,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.10.5"
+version = "0.11.0"
 
 [[package]]
 name = "omx-mux"
-version = "0.10.5"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.10.5"
+version = "0.11.0"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.10.5"
+version = "0.11.0"
 dependencies = [
  "fs2",
  "serde",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.10.5"
+version = "0.11.0"
 
 [[package]]
 name = "proc-macro2"

--- a/src/cli/__tests__/agents-init.test.ts
+++ b/src/cli/__tests__/agents-init.test.ts
@@ -14,7 +14,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/agents.test.ts
+++ b/src/cli/__tests__/agents.test.ts
@@ -14,7 +14,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -15,7 +15,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const r = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -27,7 +27,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const r = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/doctor-invalid-config.test.ts
+++ b/src/cli/__tests__/doctor-invalid-config.test.ts
@@ -13,7 +13,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const r = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/doctor-team.test.ts
+++ b/src/cli/__tests__/doctor-team.test.ts
@@ -13,7 +13,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const r = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -15,7 +15,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const r = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/exec.test.ts
+++ b/src/cli/__tests__/exec.test.ts
@@ -14,7 +14,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -30,7 +30,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const nodeWrapper = join(cwd, '.omx-test-node.sh');
   if (!existsSync(nodeWrapper)) {
     writeFileSync(nodeWrapper, '#!/bin/sh\nexec node "$@"\n');

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -13,7 +13,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 function runOmx(cwd: string, argv: string[]) {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   return spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { arch, platform } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -35,28 +35,25 @@ describe('package bin contract', () => {
 
     assert.deepEqual(pkg.bin, { omx: 'dist/cli/omx.js' });
     assert.equal(pkg.scripts?.['build:explore'], 'cargo build -p omx-explore-harness');
-    assert.equal(pkg.scripts?.['build:explore:release'], 'node scripts/build-explore-harness.js');
+    assert.equal(pkg.scripts?.['build:explore:release'], 'node dist/scripts/build-explore-harness.js');
     assert.equal(pkg.scripts?.['build:full'], 'npm run build && npm run build:explore:release && npm run build:sparkshell');
-    assert.equal(pkg.scripts?.['clean:native-package-assets'], 'node scripts/cleanup-explore-harness.js');
+    assert.equal(pkg.scripts?.['clean:native-package-assets'], 'node dist/scripts/cleanup-explore-harness.js');
     assert.equal(pkg.scripts?.prepack, 'npm run build && npm run clean:native-package-assets');
     assert.equal(pkg.scripts?.postpack, 'npm run clean:native-package-assets');
     assert.equal(pkg.scripts?.['test:explore'], 'cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js');
-    assert.equal(pkg.files?.includes('dist/cli/omx.js'), true, 'expected package files allowlist to include only bin/omx.js');
+    assert.equal(pkg.files?.includes('dist/'), true, 'expected package files allowlist to include the compiled dist/ tree');
     assert.equal(pkg.files?.includes('bin/'), false, 'did not expect broad bin/ allowlist in package files');
     assert.ok(pkg.files?.includes('Cargo.toml'));
     assert.ok(pkg.files?.includes('Cargo.lock'));
     assert.ok(pkg.files?.includes('crates/'));
 
-    const binPath = join(process.cwd(), 'bin', 'omx.js');
-    assert.equal(existsSync(binPath), true, 'expected bin/omx.js to exist');
+    const binPath = join(process.cwd(), 'dist', 'cli', 'omx.js');
+    assert.equal(existsSync(binPath), true, 'expected dist/cli/omx.js to exist');
 
     const binSource = readFileSync(binPath, 'utf-8');
     assert.match(binSource, /^#!\/usr\/bin\/env node/);
 
-    const stat = statSync(binPath);
-    assert.notEqual(stat.mode & 0o111, 0, 'expected bin/omx.js to be executable');
-
-    rmSync(packagedSparkShellPath, { force: true });
+        rmSync(packagedSparkShellPath, { force: true });
 
     const packed = spawnSync('npm', ['pack', '--dry-run', '--json'], {
       cwd: process.cwd(),
@@ -71,16 +68,17 @@ describe('package bin contract', () => {
     assert.equal(Array.isArray(results), true, 'expected npm pack --json array output');
 
     const binEntry = results[0]?.files?.find((file) => file.path === 'dist/cli/omx.js');
-    assert.ok(binEntry, 'expected npm pack output to include bin/omx.js');
-    assert.notEqual((binEntry.mode ?? 0) & 0o111, 0, 'expected packed bin/omx.js to keep execute bits');
-
-    const packagedHarnessPath = process.platform === 'win32' ? 'bin/omx-explore-harness.exe' : 'bin/omx-explore-harness';
+    assert.ok(binEntry, 'expected npm pack output to include dist/cli/omx.js');
+        const packagedHarnessPath = process.platform === 'win32' ? 'bin/omx-explore-harness.exe' : 'bin/omx-explore-harness';
     const packagedHarnessEntry = results[0]?.files?.find((file) => file.path === packagedHarnessPath);
     const packagedHarnessMetaEntry = results[0]?.files?.find((file) => file.path === 'bin/omx-explore-harness.meta.json');
     const sparkshellEntry = results[0]?.files?.find((file) => file.path.includes('bin/native/'));
     const cargoTomlEntry = results[0]?.files?.find((file) => file.path === 'Cargo.toml');
     const cargoLockEntry = results[0]?.files?.find((file) => file.path === 'Cargo.lock');
     const crateManifestEntry = results[0]?.files?.find((file) => file.path === 'crates/omx-explore/Cargo.toml');
+    const sparkshellCrateManifestEntry = results[0]?.files?.find((file) => file.path === 'crates/omx-sparkshell/Cargo.toml');
+    const buildHarnessScriptEntry = results[0]?.files?.find((file) => file.path === 'dist/scripts/build-explore-harness.js');
+    const cleanupHarnessScriptEntry = results[0]?.files?.find((file) => file.path === 'dist/scripts/cleanup-explore-harness.js');
     const crateMainEntry = results[0]?.files?.find((file) => file.path === 'crates/omx-explore/src/main.rs');
 
     assert.equal(packagedHarnessEntry, undefined, `did not expect ${packagedHarnessPath} in npm pack output`);
@@ -89,6 +87,9 @@ describe('package bin contract', () => {
     assert.ok(cargoTomlEntry, 'expected npm pack output to include Cargo.toml');
     assert.ok(cargoLockEntry, 'expected npm pack output to include Cargo.lock');
     assert.ok(crateManifestEntry, 'expected npm pack output to include crates/omx-explore/Cargo.toml');
+    assert.ok(sparkshellCrateManifestEntry, 'expected npm pack output to include crates/omx-sparkshell/Cargo.toml');
+    assert.ok(buildHarnessScriptEntry, 'expected npm pack output to include dist/scripts/build-explore-harness.js');
+    assert.ok(cleanupHarnessScriptEntry, 'expected npm pack output to include dist/scripts/cleanup-explore-harness.js');
     assert.ok(crateMainEntry, 'expected npm pack output to include crates/omx-explore/src/main.rs');
   });
 });

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -13,7 +13,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(testDir, '..', '..', '..');
-const omxBin = join(repoRoot, 'bin', 'omx.js');
+const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
 
 function runOmx(cwd: string, ...args: string[]) {
   return spawnSync(process.execPath, [omxBin, ...args], {

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 function runOmx(cwd: string, argv: string[]) {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   return spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -22,7 +22,7 @@ async function writeRollout(
 function runOmx(cwd: string, argv: string[], envOverrides: Record<string, string> = {}) {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/setup-gh-star.test.ts
+++ b/src/cli/__tests__/setup-gh-star.test.ts
@@ -13,7 +13,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const r = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -21,7 +21,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, "..", "..", "..");
-  const omxBin = join(repoRoot, "bin", "omx.js");
+  const omxBin = join(repoRoot, "dist", "cli", "omx.js");
   const resolvedHome = envOverrides.HOME ?? process.env.HOME;
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -26,7 +26,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const result = spawnSync('node', [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',

--- a/src/cli/__tests__/sparkshell-packaging.test.ts
+++ b/src/cli/__tests__/sparkshell-packaging.test.ts
@@ -31,16 +31,16 @@ describe('sparkshell packaging scaffold', () => {
     const packagedBinaryPath = join(stagedRoot, packagedBinaryRelativePath);
 
     assert.deepEqual(pkg.bin, { omx: 'dist/cli/omx.js' });
-    assert.equal(pkg.scripts?.['build:sparkshell'], 'node scripts/build-sparkshell.mjs');
-    assert.equal(pkg.scripts?.['test:sparkshell'], 'node scripts/test-sparkshell.mjs');
-    assert.equal(pkg.files?.includes('dist/cli/omx.js'), true, 'expected package files allowlist to include bin/omx.js');
+    assert.equal(pkg.scripts?.['build:sparkshell'], 'node dist/scripts/build-sparkshell.js');
+    assert.equal(pkg.scripts?.['test:sparkshell'], 'node dist/scripts/test-sparkshell.js');
+    assert.equal(pkg.files?.includes('dist/'), true, 'expected package files allowlist to include the compiled dist/ tree');
     assert.equal(pkg.files?.includes('bin/'), false, 'did not expect broad bin/ allowlist in package files');
     assert.equal(pkg.files?.includes('bin/native/'), false, 'did not expect package files to include bin/native/');
-    assert.equal(pkg.files?.includes('scripts/build-sparkshell.mjs'), true);
-    assert.equal(pkg.files?.includes('scripts/test-sparkshell.mjs'), true);
+    assert.equal(pkg.files?.includes('dist/'), true);
+    assert.equal(pkg.files?.includes('src/scripts/'), true);
 
-    const buildScriptPath = join(process.cwd(), 'scripts', 'build-sparkshell.mjs');
-    const testScriptPath = join(process.cwd(), 'scripts', 'test-sparkshell.mjs');
+    const buildScriptPath = join(process.cwd(), 'dist', 'scripts', 'build-sparkshell.js');
+    const testScriptPath = join(process.cwd(), 'dist', 'scripts', 'test-sparkshell.js');
     assert.equal(existsSync(buildScriptPath), true, 'expected build sparkshell helper script to exist');
     assert.equal(existsSync(testScriptPath), true, 'expected test sparkshell helper script to exist');
 
@@ -51,7 +51,7 @@ describe('sparkshell packaging scaffold', () => {
         encoding: 'utf-8',
         env: {
           ...process.env,
-          OMX_SPARKSHELL_MANIFEST: join(process.cwd(), 'native', 'omx-sparkshell', 'Cargo.toml'),
+          OMX_SPARKSHELL_MANIFEST: join(process.cwd(), 'crates', 'omx-sparkshell', 'Cargo.toml'),
           OMX_SPARKSHELL_STAGE_DIR: stagedRoot,
         },
       });
@@ -67,8 +67,8 @@ describe('sparkshell packaging scaffold', () => {
       const results = JSON.parse(packed.stdout) as NpmPackDryRunResult[];
       const packedFiles = new Set((results[0]?.files ?? []).map((file) => file.path));
 
-      assert.equal(packedFiles.has('scripts/build-sparkshell.mjs'), true);
-      assert.equal(packedFiles.has('scripts/test-sparkshell.mjs'), true);
+      assert.equal(packedFiles.has('dist/scripts/build-sparkshell.js'), true);
+      assert.equal(packedFiles.has('dist/scripts/test-sparkshell.js'), true);
       assert.equal(packedFiles.has(packagedBinaryRelativePath.replaceAll('\\', '/')), false);
     } finally {
       rmSync(stagedRoot, { force: true, recursive: true });

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -14,7 +14,7 @@ function runOmx(
 ): { status: number | null; stdout: string; stderr: string; error: string } {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'bin', 'omx.js');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   const resolvedHome = envOverrides.HOME ?? process.env.HOME;
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,

--- a/src/cli/__tests__/version-sync-contract.test.ts
+++ b/src/cli/__tests__/version-sync-contract.test.ts
@@ -19,10 +19,10 @@ describe('version sync contract', () => {
     const mux = TOML.parse(readFileSync(join(process.cwd(), 'crates', 'omx-mux', 'Cargo.toml'), 'utf-8')) as {
       package?: { version?: string | { workspace?: boolean } };
     };
-    const runtime = TOML.parse(readFileSync(join(process.cwd(), 'native', 'omx-runtime', 'Cargo.toml'), 'utf-8')) as {
+    const runtime = TOML.parse(readFileSync(join(process.cwd(), 'crates', 'omx-runtime', 'Cargo.toml'), 'utf-8')) as {
       package?: { version?: string | { workspace?: boolean } };
     };
-    const sparkshell = TOML.parse(readFileSync(join(process.cwd(), 'native', 'omx-sparkshell', 'Cargo.toml'), 'utf-8')) as {
+    const sparkshell = TOML.parse(readFileSync(join(process.cwd(), 'crates', 'omx-sparkshell', 'Cargo.toml'), 'utf-8')) as {
       package?: { version?: string | { workspace?: boolean } };
     };
 

--- a/src/compat/__tests__/doctor-contract.test.ts
+++ b/src/compat/__tests__/doctor-contract.test.ts
@@ -16,7 +16,7 @@ interface CompatRunResult {
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(testDir, '..', '..', '..');
-const defaultTarget = join(repoRoot, 'bin', 'omx.js');
+const defaultTarget = join(repoRoot, 'dist', 'cli', 'omx.js');
 const fixturesRoot = join(repoRoot, 'src', 'compat', 'fixtures', 'doctor');
 
 function readFixture(name: string): string {

--- a/src/compat/__tests__/rust-runtime-compat.test.ts
+++ b/src/compat/__tests__/rust-runtime-compat.test.ts
@@ -17,7 +17,7 @@ function runOmx(
   argv: string[],
   envOverrides: Record<string, string> = {},
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
-  const omxBin = join(repoRoot(), 'bin', 'omx.js');
+  const omxBin = join(repoRoot(), 'dist', 'cli', 'omx.js');
   const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',


### PR DESCRIPTION
## Why
The 0.11.0 bump plus the JS -> TS and TS -> Rust migration changed a number of execution/package paths, but several tests and one CI workflow lane were still asserting pre-migration locations.

This PR updates those stale CI/test contracts so dev CI exercises the migrated surfaces instead of failing on historical paths.

## What changed
- point CLI-launching tests at `dist/cli/omx.js` instead of `bin/omx.js`
- update package/script contract tests to expect `dist/scripts/*`
- update Rust manifest contract tests to use `crates/*`
- update the Rust coverage workflow lane to use `crates/omx-sparkshell/Cargo.toml`
- refresh lockfile package versions to `0.11.0`

## Verification run locally
- `npm run build`
- targeted `node --test` subsets for:
  - session runtime / Ralph persistence gate
  - package contract / sparkshell packaging / version sync
  - explore smoke
  - sparkshell CLI
  - compat doctor/runtime
- `cargo llvm-cov --manifest-path crates/omx-sparkshell/Cargo.toml --summary-only`

## Known status / risk
This is intentionally opened as a **draft** because full local `npm test` still has unrelated failures outside the migrated entrypoint/path fixes. The goal of this PR is to get CI signal on the contract-drift fixes first, then continue burning down the remaining reds.
