### PR TITLE
Stabilize post-0.11.0 dev CI after the Rust/TS migration wave

### DIFF
--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/scripts/check-version-sync.js';

--- a/scripts/fixtures/ask-advisor-stub.js
+++ b/scripts/fixtures/ask-advisor-stub.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../../dist/scripts/fixtures/ask-advisor-stub.js';

--- a/scripts/generate-native-release-manifest.mjs
+++ b/scripts/generate-native-release-manifest.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/scripts/generate-native-release-manifest.js';

--- a/scripts/notify-fallback-watcher.js
+++ b/scripts/notify-fallback-watcher.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/scripts/notify-fallback-watcher.js';

--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/scripts/notify-hook.js';

--- a/scripts/notify-hook/auto-nudge.js
+++ b/scripts/notify-hook/auto-nudge.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/auto-nudge.js';

--- a/scripts/notify-hook/linked-sync.js
+++ b/scripts/notify-hook/linked-sync.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/linked-sync.js';

--- a/scripts/notify-hook/log.js
+++ b/scripts/notify-hook/log.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/log.js';

--- a/scripts/notify-hook/operational-events.js
+++ b/scripts/notify-hook/operational-events.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/operational-events.js';

--- a/scripts/notify-hook/payload-parser.js
+++ b/scripts/notify-hook/payload-parser.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/payload-parser.js';

--- a/scripts/notify-hook/process-runner.js
+++ b/scripts/notify-hook/process-runner.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/process-runner.js';

--- a/scripts/notify-hook/state-io.js
+++ b/scripts/notify-hook/state-io.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/state-io.js';

--- a/scripts/notify-hook/team-dispatch.js
+++ b/scripts/notify-hook/team-dispatch.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/team-dispatch.js';

--- a/scripts/notify-hook/team-leader-nudge.js
+++ b/scripts/notify-hook/team-leader-nudge.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/team-leader-nudge.js';

--- a/scripts/notify-hook/team-tmux-guard.js
+++ b/scripts/notify-hook/team-tmux-guard.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/team-tmux-guard.js';

--- a/scripts/notify-hook/team-worker.js
+++ b/scripts/notify-hook/team-worker.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/team-worker.js';

--- a/scripts/notify-hook/tmux-injection.js
+++ b/scripts/notify-hook/tmux-injection.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/tmux-injection.js';

--- a/scripts/notify-hook/utils.js
+++ b/scripts/notify-hook/utils.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/utils.js';

--- a/scripts/notify-hook/visual-verdict.js
+++ b/scripts/notify-hook/visual-verdict.js
@@ -1,0 +1,1 @@
+export * from '../../dist/scripts/notify-hook/visual-verdict.js';

--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/scripts/run-provider-advisor.js';

--- a/scripts/smoke-packed-install.mjs
+++ b/scripts/smoke-packed-install.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/scripts/smoke-packed-install.js';

--- a/scripts/tmux-hook-engine.js
+++ b/scripts/tmux-hook-engine.js
@@ -1,0 +1,1 @@
+export * from '../dist/scripts/tmux-hook-engine.js';

--- a/scripts/verify-native-release-assets.mjs
+++ b/scripts/verify-native-release-assets.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/scripts/verify-native-release-assets.js';

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -152,8 +152,21 @@ export function resolveAskAdvisorScriptPath(
 ): string {
   const override = env[ASK_ADVISOR_SCRIPT_ENV]?.trim();
   if (override) {
-    return isAbsolute(override) ? override : join(packageRoot, override);
+    if (isAbsolute(override)) return override;
+
+    const direct = join(packageRoot, override);
+    if (existsSync(direct)) return direct;
+
+    if (override.startsWith('scripts/')) {
+      return join(packageRoot, 'dist', override);
+    }
+
+    return direct;
   }
+
+  const distPath = join(packageRoot, 'dist', 'scripts', 'run-provider-advisor.js');
+  if (existsSync(distPath)) return distPath;
+
   return join(packageRoot, 'scripts', 'run-provider-advisor.js');
 }
 

--- a/src/hooks/__tests__/codebase-map.test.ts
+++ b/src/hooks/__tests__/codebase-map.test.ts
@@ -77,7 +77,7 @@ describe('generateCodebaseMap', () => {
   it('includes non-src top-level directories', async () => {
     await mkdir(join(tempDir, 'scripts'), { recursive: true });
     await writeFile(join(tempDir, 'scripts', 'notify-hook.js'), 'export function notify() {}');
-    await gitAdd(tempDir, 'dist/scripts/notify-hook.js');
+    await gitAdd(tempDir, 'scripts/notify-hook.js');
 
     const map = await generateCodebaseMap(tempDir);
     assert.ok(map.includes('scripts'), 'should include scripts directory');

--- a/src/hooks/__tests__/notify-hook-native-dispatch-contract.test.ts
+++ b/src/hooks/__tests__/notify-hook-native-dispatch-contract.test.ts
@@ -4,11 +4,16 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 
 describe('notify-hook native dispatch contract', () => {
-  it('force-enables hook dispatch for notify-hook native and derived events', async () => {
-    const source = await readFile(join(process.cwd(), 'scripts', 'notify-hook.js'), 'utf-8');
-    assert.match(source, /dispatchHookEvent\(event, \{ cwd, enabled: true \}\);/);
-    assert.match(source, /dispatchHookEvent\(derivedEvent, \{ cwd, enabled: true \}\);/);
-    const matches = source.match(/dispatchHookEvent\(event, \{ cwd, enabled: true \}\);/g) ?? [];
-    assert.ok(matches.length >= 2, `expected notify-hook to force-enable native dispatch twice, found ${matches.length}`);
+  it('force-enables hook dispatch for notify-hook native and derived events via dispatcher policy', async () => {
+    const notifyHookSource = await readFile(join(process.cwd(), 'src', 'scripts', 'notify-hook.ts'), 'utf-8');
+    const dispatcherSource = await readFile(join(process.cwd(), 'src', 'hooks', 'extensibility', 'dispatcher.ts'), 'utf-8');
+
+    assert.match(notifyHookSource, /dispatchHookEvent\(event, \{ cwd \}\);/);
+    assert.match(notifyHookSource, /dispatchHookEvent\(derivedEvent, \{ cwd \}\);/);
+    const notifyEventMatches = notifyHookSource.match(/dispatchHookEvent\(event, \{ cwd \}\);/g) ?? [];
+    assert.ok(notifyEventMatches.length >= 2, `expected notify-hook to dispatch native events twice, found ${notifyEventMatches.length}`);
+
+    assert.match(dispatcherSource, /event\.source === "native" \|\| event\.source === "derived"/);
+    assert.match(dispatcherSource, /const enabled = options\.enabled \?\? runtimeHookDispatchEnabled;/);
   });
 });

--- a/src/hud/__tests__/authority.test.ts
+++ b/src/hud/__tests__/authority.test.ts
@@ -55,13 +55,13 @@ describe('runHudAuthorityTick', () => {
     const call = calls[0]!;
     assert.equal(call.nodePath, '/node');
     assert.deepEqual(call.args, [
-      '/pkg/scripts/notify-fallback-watcher.js',
+      '/pkg/dist/scripts/notify-fallback-watcher.js',
       '--once',
       '--authority-only',
       '--cwd',
       '/tmp/project',
       '--notify-script',
-      '/pkg/scripts/notify-hook.js',
+      '/pkg/dist/scripts/notify-hook.js',
       '--poll-ms',
       '75',
     ]);

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -129,18 +129,21 @@ export async function runWatchMode(
     }
     inFlight = true;
     try {
-      if (firstRender) {
-        dependencies.writeStdout('\x1b[2J\x1b[H');
-        firstRender = false;
-      } else {
-        dependencies.writeStdout('\x1b[H');
-      }
-      const config = await dependencies.readHudConfigFn(cwd);
-      const ctx = await dependencies.readAllStateFn(cwd, config);
-      const preset = flags.preset ?? config.preset;
-      const line = dependencies.renderHudFn(ctx, preset);
-      dependencies.writeStdout(line + '\x1b[K\n\x1b[J');
-      await dependencies.runAuthorityTickFn({ cwd });
+      do {
+        queued = false;
+        if (firstRender) {
+          dependencies.writeStdout('\x1b[2J\x1b[H');
+          firstRender = false;
+        } else {
+          dependencies.writeStdout('\x1b[H');
+        }
+        const config = await dependencies.readHudConfigFn(cwd);
+        const ctx = await dependencies.readAllStateFn(cwd, config);
+        const preset = flags.preset ?? config.preset;
+        const line = dependencies.renderHudFn(ctx, preset);
+        dependencies.writeStdout(line + '\x1b[K\n\x1b[J');
+        void dependencies.runAuthorityTickFn({ cwd }).catch(() => {});
+      } while (!stopped && queued);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       dependencies.writeStderr(`HUD watch render failed: ${message}\n`);
@@ -149,11 +152,6 @@ export async function runWatchMode(
       return;
     } finally {
       inFlight = false;
-    }
-
-    if (queued) {
-      queued = false;
-      await renderTick();
     }
   };
 

--- a/src/scripts/check-version-sync.ts
+++ b/src/scripts/check-version-sync.ts
@@ -9,8 +9,8 @@ const workspace = TOML.parse(readFileSync(join(root, 'Cargo.toml'), 'utf-8')) as
 const explore = TOML.parse(readFileSync(join(root, 'crates', 'omx-explore', 'Cargo.toml'), 'utf-8')) as Record<string, unknown>;
 const runtimeCore = TOML.parse(readFileSync(join(root, 'crates', 'omx-runtime-core', 'Cargo.toml'), 'utf-8')) as Record<string, unknown>;
 const mux = TOML.parse(readFileSync(join(root, 'crates', 'omx-mux', 'Cargo.toml'), 'utf-8')) as Record<string, unknown>;
-const runtime = TOML.parse(readFileSync(join(root, 'native', 'omx-runtime', 'Cargo.toml'), 'utf-8')) as Record<string, unknown>;
-const sparkshell = TOML.parse(readFileSync(join(root, 'native', 'omx-sparkshell', 'Cargo.toml'), 'utf-8')) as Record<string, unknown>;
+const runtime = TOML.parse(readFileSync(join(root, 'crates', 'omx-runtime', 'Cargo.toml'), 'utf-8')) as Record<string, unknown>;
+const sparkshell = TOML.parse(readFileSync(join(root, 'crates', 'omx-sparkshell', 'Cargo.toml'), 'utf-8')) as Record<string, unknown>;
 const tagArgIndex = process.argv.indexOf('--tag');
 const tag = tagArgIndex >= 0 ? process.argv[tagArgIndex + 1] : undefined;
 
@@ -33,10 +33,10 @@ if ((mux.package as Record<string, unknown>)?.version !== undefined && ((mux.pac
   problems.push('crates/omx-mux/Cargo.toml must use version.workspace = true');
 }
 if ((runtime.package as Record<string, unknown>)?.version !== undefined && ((runtime.package as Record<string, unknown>).version as Record<string, unknown>)?.workspace !== true) {
-  problems.push('native/omx-runtime/Cargo.toml must use version.workspace = true');
+  problems.push('crates/omx-runtime/Cargo.toml must use version.workspace = true');
 }
 if ((sparkshell.package as Record<string, unknown>)?.version !== undefined && ((sparkshell.package as Record<string, unknown>).version as Record<string, unknown>)?.workspace !== true) {
-  problems.push('native/omx-sparkshell/Cargo.toml must use version.workspace = true');
+  problems.push('crates/omx-sparkshell/Cargo.toml must use version.workspace = true');
 }
 if (tag && tag !== `v${pkgVersion}`) {
   problems.push(`release tag (${tag}) does not match package.json version (v${pkgVersion})`);

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -36,7 +36,6 @@ import {
   pruneRecentTurns,
   readdir,
 } from './notify-hook/state-io.js';
-import { isLeaderStale, resolveLeaderStalenessThresholdMs } from './notify-hook/team-leader-nudge.js';
 import { syncLinkedRalphOnTeamTerminal } from './notify-hook/linked-sync.js';
 import { handleTmuxInjection } from './notify-hook/tmux-injection.js';
 import { maybeAutoNudge, resolveNudgePaneTarget } from './notify-hook/auto-nudge.js';
@@ -283,18 +282,6 @@ async function main() {
       // Non-critical
     }
   }
-
-  // 3.5. Pre-compute leader staleness BEFORE updating HUD state (used by nudge in step 6)
-  let preComputedLeaderStale = false;
-  if (!isTeamWorker) {
-    try {
-      const stalenessMs = resolveLeaderStalenessThresholdMs();
-      preComputedLeaderStale = await isLeaderStale(stateDir, stalenessMs, Date.now());
-    } catch {
-      // Non-critical
-    }
-  }
-
   // 4. Write HUD state summary for `omx hud` (lead session only)
   if (!isTeamWorker) {
     const hudStatePath = join(stateDir, 'hud-state.json');

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -36,8 +36,7 @@ import {
   pruneRecentTurns,
   readdir,
 } from './notify-hook/state-io.js';
-import { isLeaderStale, resolveLeaderStalenessThresholdMs, maybeNudgeTeamLeader } from './notify-hook/team-leader-nudge.js';
-import { drainPendingTeamDispatch } from './notify-hook/team-dispatch.js';
+import { isLeaderStale, resolveLeaderStalenessThresholdMs } from './notify-hook/team-leader-nudge.js';
 import { syncLinkedRalphOnTeamTerminal } from './notify-hook/linked-sync.js';
 import { handleTmuxInjection } from './notify-hook/tmux-injection.js';
 import { maybeAutoNudge, resolveNudgePaneTarget } from './notify-hook/auto-nudge.js';
@@ -349,24 +348,6 @@ async function main() {
   if (!isTeamWorker) {
     try {
       await handleTmuxInjection({ payload, cwd, stateDir, logsDir });
-    } catch {
-      // Non-critical
-    }
-  }
-
-  // 5.5. Opportunistic team dispatch drain (leader session only).
-  if (!isTeamWorker) {
-    try {
-      await drainPendingTeamDispatch({ cwd, stateDir, logsDir, maxPerTick: 5 } as any);
-    } catch {
-      // Non-critical
-    }
-  }
-
-  // 6. Team leader nudge (lead session only): remind the leader to check teammate/mailbox state.
-  if (!isTeamWorker) {
-    try {
-      await maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderStale });
     } catch {
       // Non-critical
     }

--- a/src/scripts/notify-hook/team-tmux-guard.ts
+++ b/src/scripts/notify-hook/team-tmux-guard.ts
@@ -8,7 +8,6 @@ import {
   isPaneRunningShell,
   paneHasActiveTask,
   paneLooksReady,
-  resolveCodexPane,
 } from '../tmux-hook-engine.js';
 
 export function mapPaneInjectionReadinessReason(reason: any): any {
@@ -32,24 +31,6 @@ export async function evaluatePaneInjectionReadiness(paneTarget: any, {
       paneCurrentCommand: '',
       paneCapture: '',
     };
-  }
-
-  // Canonical bypass: if resolveCodexPane confirms this is a codex pane
-  // (via pane_start_command), skip all readiness guards. The pane IS running
-  // codex even though tmux may report cmd=sh (shell wrapper).
-  try {
-    if (resolveCodexPane() === target) {
-      return {
-        ok: true,
-        sent: false,
-        reason: 'ok',
-        paneTarget: target,
-        paneCurrentCommand: 'codex',
-        paneCapture: '',
-      };
-    }
-  } catch {
-    // Non-fatal: fall through to normal readiness checks
   }
 
   if (skipIfScrolling) {

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -199,41 +199,62 @@ export function resolveCodexPane(): string {
 
   // Check if TMUX_PANE is actually running an agent
   try {
-    const cmd = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{pane_current_command}'], {
+    const cmd = execFileSync('tmux', ['display-message', '-p', '-t', envPane, '#{pane_current_command}'], {
       encoding: 'utf-8', timeout: 2000,
     }).trim().toLowerCase();
     const base = cmd.split('/').pop()?.replace(/^-/, '') || '';
     if (AGENT_COMMANDS.has(base)) {
       return envPane; // TMUX_PANE is running a codex agent — use it
     }
-    if (!SHELL_COMMANDS.has(base)) {
-      // Not a shell and not a known agent (e.g. 'claude' = Claude Code CLI)
-      // Fall through to session scan to find the actual codex pane
-    }
   } catch {
-    return envPane; // Can't check — use it as-is
+    return '';
   }
 
   // TMUX_PANE is a shell — find the actual agent pane in the same session
   try {
-    const sessionName = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{session_name}'], {
+    const sessionName = execFileSync('tmux', ['display-message', '-p', '-t', envPane, '#S'], {
       encoding: 'utf-8', timeout: 2000,
     }).trim();
     if (!sessionName) return envPane;
 
+    const currentPath = execFileSync('tmux', ['display-message', '-p', '-t', envPane, '#{pane_current_path}'], {
+      encoding: 'utf-8', timeout: 2000,
+    }).trim();
     const panes = execFileSync('tmux', [
-      'list-panes', '-s', '-t', sessionName,
-      '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
+      'list-panes', '-t', sessionName,
+      '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_active}\t#{pane_current_path}',
     ], { encoding: 'utf-8', timeout: 2000 }).trim().split('\n');
 
-    // Find the pane that was STARTED with codex (not the HUD or shell)
+    const candidates = panes
+      .map((line) => {
+        const [paneId = '', paneCommand = '', paneActive = '', panePath = ''] = line.split('\t');
+        const base = paneCommand.toLowerCase().split('/').pop()?.replace(/^-/, '') || '';
+        return { paneId, paneActive, panePath, base };
+      })
+      .filter(({ paneId, base }) => paneId && AGENT_COMMANDS.has(base));
+
+    for (const { paneId, paneActive, panePath } of candidates) {
+      if (paneId !== envPane && paneActive === '1' && (!currentPath || panePath === currentPath)) {
+        return paneId;
+      }
+    }
+
+    for (const { paneId, panePath } of candidates) {
+      if (paneId !== envPane && (!currentPath || panePath === currentPath)) {
+        return paneId;
+      }
+    }
+
+    for (const { paneId, paneActive } of candidates) {
+      if (paneId !== envPane && paneActive === '1') {
+        return paneId;
+      }
+    }
+
     for (const line of panes) {
-      const parts = line.split('\t');
-      const paneId = parts[0];
-      const startCmd = (parts[2] || '').toLowerCase();
-      if (!paneId) continue;
-      // The codex pane has 'codex' in its start command
-      if (startCmd.includes('codex') && !startCmd.includes('hud')) {
+      const [paneId = '', paneCommand = ''] = line.split('\t');
+      const base = paneCommand.toLowerCase().split('/').pop()?.replace(/^-/, '') || '';
+      if (paneId !== envPane && AGENT_COMMANDS.has(base)) {
         return paneId;
       }
     }
@@ -241,8 +262,8 @@ export function resolveCodexPane(): string {
     // Fall through
   }
 
-  // No agent pane found in the session — don't fall back to a shell pane
-  return '';
+  // No better agent pane found — fall back to the current pane so readiness guards can decide.
+  return envPane;
 }
 
 export function normalizeTmuxCapture(value: any): string {


### PR DESCRIPTION
## Summary
- restore repo-root `scripts/` compatibility shims for source-tree CI/release/runtime contracts that still execute historical paths
- repair ask/version-sync path resolution and remove notify-hook leader-only authority from the main hook path
- fix HUD watch coalescing plus test/contract drift that surfaced after the migration wave

## What changed
- added root `scripts/` wrappers for the migrated notify/ask/release/tmux entrypoints and notify-hook submodules
- updated `ask` to prefer canonical `dist/scripts` entrypoints while still honoring legacy `scripts/...` overrides
- corrected `check-version-sync` crate paths from the old `native/` layout to `crates/`
- moved leader dispatch-drain / leader-nudge ownership out of `notify-hook` main execution so the fallback watcher remains the sole authority
- tightened tmux pane resolution/readiness handling and fixed HUD watch rerender coalescing
- refreshed the affected contract tests to match the post-migration runtime/source-of-truth boundaries

## Verification
- `npm test`
- `npm run coverage:ts:full`
- `cargo test --workspace`
- `node scripts/check-version-sync.mjs --tag v0.11.0`
