### PR TITLE
Fix tmux-session POSIX leader node path regression

### DIFF
--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -584,14 +584,10 @@ function resolveAbsoluteBinaryPath(binary: string): string {
 
 /**
  * Resolve the leader's node binary path.
- * Caches results for the process lifetime.
+ * Re-resolve on each call so tests and worker launch prep respect the current PATH.
  */
-let _leaderPaths: { node: string; } | null = null;
 function resolveLeaderNodePath(): string {
-  if (!_leaderPaths) {
-    _leaderPaths = { node: resolveAbsoluteBinaryPath('node') };
-  }
-  return _leaderPaths.node;
+  return resolveAbsoluteBinaryPath('node');
 }
 
 export function assertTeamWorkerCliBinaryAvailable(


### PR DESCRIPTION
## Summary
- remove stale leader-node path caching in tmux-session worker startup construction
- keep `OMX_LEADER_NODE_PATH` aligned with the current `PATH` in POSIX worker startup tests/coverage lanes

## Verification
- `node --test dist/team/__tests__/tmux-session.test.js`
- `npm run coverage:team-critical`
