### PR TITLE
fix(explore): tolerate missing rg in packed install allowlist wrappers

### DIFF
--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -384,16 +384,8 @@ fn prepare_allowlist_environment() -> Result<AllowlistEnvironment, String> {
         .ok_or_else(|| "failed to locate host sh for allowlist wrapper".to_string())?;
 
     for command in ALLOWED_DIRECT_COMMANDS {
-        let real = resolve_host_command(command).ok_or_else(|| {
-            format!("failed to locate host command `{command}` for allowlist wrapper")
-        })?;
         let wrapper_path = bin_dir.join(command);
-        let wrapper = format!(
-            "#!/bin/sh\nexec {} {} {} \"$@\"\n",
-            shell_quote(&self_exe.display().to_string()),
-            shell_quote(INTERNAL_DIRECT_WRAPPER_FLAG),
-            shell_quote(&format!("{command}:{}", real.display())),
-        );
+        let wrapper = build_direct_wrapper(&self_exe, command);
         write_executable(&wrapper_path, &wrapper)?;
     }
 
@@ -449,6 +441,24 @@ fn write_executable(path: &Path, content: &str) -> Result<(), String> {
             .map_err(|err| format!("failed to chmod wrapper {}: {err}", path.display()))?;
     }
     Ok(())
+}
+
+fn build_direct_wrapper(self_exe: &Path, command: &str) -> String {
+    if let Some(real) = resolve_host_command(command) {
+        return format!(
+            "#!/bin/sh\nexec {} {} {} \"$@\"\n",
+            shell_quote(&self_exe.display().to_string()),
+            shell_quote(INTERNAL_DIRECT_WRAPPER_FLAG),
+            shell_quote(&format!("{command}:{}", real.display())),
+        );
+    }
+
+    format!(
+        "#!/bin/sh\nprintf '%s\\n' {} >&2\nexit 127\n",
+        shell_quote(&format!(
+            "omx explore allowlisted host command `{command}` is unavailable on this host"
+        )),
+    )
 }
 
 fn resolve_host_command(command: &str) -> Option<PathBuf> {
@@ -875,6 +885,42 @@ mod tests {
         let expected_node = resolve_host_command("node").expect("host node path");
         assert_eq!(launch.program, expected_node.display().to_string());
         assert_eq!(launch.leading_args, vec![script_path.display().to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_allowlist_environment_tolerates_missing_rg_by_stubbing_wrapper() {
+        use std::os::unix::fs::symlink;
+
+        let _guard = env_lock();
+        let root = temp_allowlist_dir().expect("temp root");
+        let host_bin = root.path.join("host-bin");
+        create_dir_all(&host_bin).expect("create host bin");
+        let bash = resolve_host_command("bash").expect("host bash path");
+        let sh = resolve_host_command("sh").expect("host sh path");
+        symlink(&bash, host_bin.join("bash")).expect("symlink bash");
+        symlink(&sh, host_bin.join("sh")).expect("symlink sh");
+
+        let original_path = env::var_os("PATH");
+        unsafe {
+            env::set_var("PATH", &host_bin);
+        }
+
+        let allowlist = prepare_allowlist_environment().expect("allowlist environment");
+        let rg_output = Command::new(allowlist.bin_dir.join("rg"))
+            .arg("needle")
+            .arg("src")
+            .output()
+            .expect("run rg stub");
+
+        match original_path {
+            Some(value) => unsafe { env::set_var("PATH", value) },
+            None => unsafe { env::remove_var("PATH") },
+        }
+
+        assert_eq!(rg_output.status.code(), Some(127));
+        assert!(String::from_utf8_lossy(&rg_output.stderr).contains("`rg` is unavailable"));
+        assert!(allowlist.bin_dir.join("grep").exists());
     }
 
     #[test]

--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -959,7 +959,7 @@ mod tests {
             ALLOWED_DIRECT_COMMANDS
                 .iter()
                 .copied()
-                .filter(|command| *command != "grep"),
+                .filter(|command| *command != "grep" && *command != "rg"),
         );
         let (_root, host_bin) = create_host_bin_with_commands(&commands);
 

--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -385,7 +385,7 @@ fn prepare_allowlist_environment() -> Result<AllowlistEnvironment, String> {
 
     for command in ALLOWED_DIRECT_COMMANDS {
         let wrapper_path = bin_dir.join(command);
-        let wrapper = build_direct_wrapper(&self_exe, command);
+        let wrapper = build_direct_wrapper(&self_exe, command)?;
         write_executable(&wrapper_path, &wrapper)?;
     }
 
@@ -443,22 +443,28 @@ fn write_executable(path: &Path, content: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn build_direct_wrapper(self_exe: &Path, command: &str) -> String {
+fn build_direct_wrapper(self_exe: &Path, command: &str) -> Result<String, String> {
     if let Some(real) = resolve_host_command(command) {
-        return format!(
+        return Ok(format!(
             "#!/bin/sh\nexec {} {} {} \"$@\"\n",
             shell_quote(&self_exe.display().to_string()),
             shell_quote(INTERNAL_DIRECT_WRAPPER_FLAG),
             shell_quote(&format!("{command}:{}", real.display())),
-        );
+        ));
     }
 
-    format!(
+    if command != "rg" {
+        return Err(format!(
+            "failed to locate host command `{command}` for allowlist wrapper"
+        ));
+    }
+
+    Ok(format!(
         "#!/bin/sh\nprintf '%s\\n' {} >&2\nexit 127\n",
         shell_quote(&format!(
             "omx explore allowlisted host command `{command}` is unavailable on this host"
         )),
-    )
+    ))
 }
 
 fn resolve_host_command(command: &str) -> Option<PathBuf> {
@@ -783,6 +789,9 @@ mod tests {
     use super::*;
     use std::sync::{Mutex, OnceLock};
 
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
@@ -888,39 +897,90 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[test]
-    fn prepare_allowlist_environment_tolerates_missing_rg_by_stubbing_wrapper() {
-        use std::os::unix::fs::symlink;
-
-        let _guard = env_lock();
+    fn create_host_bin_with_commands(commands: &[&str]) -> (TempDirGuard, PathBuf) {
         let root = temp_allowlist_dir().expect("temp root");
         let host_bin = root.path.join("host-bin");
         create_dir_all(&host_bin).expect("create host bin");
-        let bash = resolve_host_command("bash").expect("host bash path");
-        let sh = resolve_host_command("sh").expect("host sh path");
-        symlink(&bash, host_bin.join("bash")).expect("symlink bash");
-        symlink(&sh, host_bin.join("sh")).expect("symlink sh");
+        for command in commands {
+            let resolved =
+                resolve_host_command(command).unwrap_or_else(|| panic!("host {command} path"));
+            symlink(&resolved, host_bin.join(command))
+                .unwrap_or_else(|err| panic!("symlink {command}: {err}"));
+        }
+        (root, host_bin)
+    }
 
+    #[cfg(unix)]
+    fn with_path<T>(path: &Path, f: impl FnOnce() -> T) -> T {
         let original_path = env::var_os("PATH");
         unsafe {
-            env::set_var("PATH", &host_bin);
+            env::set_var("PATH", path);
         }
+        let result = f();
+        match original_path {
+            Some(value) => unsafe { env::set_var("PATH", value) },
+            None => unsafe { env::remove_var("PATH") },
+        }
+        result
+    }
 
-        let allowlist = prepare_allowlist_environment().expect("allowlist environment");
+    #[cfg(unix)]
+    #[test]
+    fn prepare_allowlist_environment_tolerates_missing_rg_by_stubbing_wrapper() {
+        let _guard = env_lock();
+        let mut commands = vec!["bash", "sh"];
+        commands.extend(
+            ALLOWED_DIRECT_COMMANDS
+                .iter()
+                .copied()
+                .filter(|command| *command != "rg"),
+        );
+        let (_root, host_bin) = create_host_bin_with_commands(&commands);
+
+        let allowlist =
+            with_path(&host_bin, prepare_allowlist_environment).expect("allowlist environment");
         let rg_output = Command::new(allowlist.bin_dir.join("rg"))
             .arg("needle")
             .arg("src")
             .output()
             .expect("run rg stub");
 
-        match original_path {
-            Some(value) => unsafe { env::set_var("PATH", value) },
-            None => unsafe { env::remove_var("PATH") },
-        }
-
         assert_eq!(rg_output.status.code(), Some(127));
         assert!(String::from_utf8_lossy(&rg_output.stderr).contains("`rg` is unavailable"));
         assert!(allowlist.bin_dir.join("grep").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_allowlist_environment_still_fails_fast_when_non_rg_command_is_missing() {
+        let _guard = env_lock();
+        let mut commands = vec!["bash", "sh"];
+        commands.extend(
+            ALLOWED_DIRECT_COMMANDS
+                .iter()
+                .copied()
+                .filter(|command| *command != "grep"),
+        );
+        let (_root, host_bin) = create_host_bin_with_commands(&commands);
+
+        let error = with_path(&host_bin, prepare_allowlist_environment)
+            .expect_err("missing non-rg command should fail");
+
+        assert!(error.contains("failed to locate host command `grep`"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_allowlist_environment_preserves_present_command_wrapper_execution() {
+        let self_exe = env::current_exe().expect("current exe");
+        let pwd = resolve_host_command("pwd").expect("host pwd path");
+
+        let wrapper = build_direct_wrapper(&self_exe, "pwd").expect("pwd wrapper");
+
+        assert!(wrapper.contains(INTERNAL_DIRECT_WRAPPER_FLAG));
+        assert!(wrapper.contains(&self_exe.display().to_string()));
+        assert!(wrapper.contains(&format!("pwd:{}", pwd.display())));
+        assert!(!wrapper.contains("exit 127"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep packed-install explore startup from failing when optional host tools like `rg` are missing
- make direct allowlist wrappers lazy so unresolved host commands fail only if actually invoked
- add regression coverage for the missing-`rg` wrapper bootstrap path

## Root cause
GitHub Actions release smoke for v0.11.0 failed in the packed global install step before Codex ran:

- command: `omx explore --prompt where is buildExploreRoutingGuidance defined`
- stderr: `[omx explore] spark attempt failed to launch: failed to locate host command `rg` for allowlist wrapper`

The Rust explore harness currently resolves every allowlisted direct command during `prepare_allowlist_environment()`. In packed installs on hosts without `rg` on PATH, that hard-fails wrapper bootstrap even though `rg` is only a preferred read-only tool, not a required precondition for startup.

## Fix
- keep `bash`/`sh` resolution strict for the shell wrapper
- generate direct wrappers lazily:
  - if the host command resolves, exec it exactly as before
  - if it does not, emit a clear 127 "unavailable on this host" error only when that wrapper is invoked

## Verification
- `cargo test -p omx-explore-harness`
- `cargo build -p omx-explore-harness`
- direct smoke-style harness run with PATH limited to `bash`/`sh` and no `rg`, using an `OMX_EXPLORE_CODEX_BIN` stub -> returned expected markdown successfully

Refs #964
