### PR TITLE
fix(test): isolate remaining live-session interference in OMX test/util paths

### DIFF
--- a/src/cli/__tests__/doctor-team.test.ts
+++ b/src/cli/__tests__/doctor-team.test.ts
@@ -26,6 +26,15 @@ function shouldSkipForSpawnPermissions(err?: string): boolean {
   return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
 }
 
+async function createFakeTmuxBin(wd: string, script: string): Promise<string> {
+  const fakeBin = join(wd, 'bin');
+  await mkdir(fakeBin, { recursive: true });
+  const tmuxPath = join(fakeBin, 'tmux');
+  await writeFile(tmuxPath, script);
+  spawnSync('chmod', ['+x', tmuxPath], { encoding: 'utf-8' });
+  return fakeBin;
+}
+
 describe('omx doctor --team', () => {
   it('exits non-zero and prints resume_blocker when team state references missing tmux session', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-'));
@@ -84,7 +93,8 @@ describe('omx doctor --team', () => {
       const requestedAt = new Date(Date.now() - 60_000).toISOString();
       await writeFile(join(workerDir, 'shutdown-request.json'), JSON.stringify({ requested_at: requestedAt }));
 
-      const res = runOmx(wd, ['doctor', '--team']);
+      const fakeBin = await createFakeTmuxBin(wd, '#!/bin/sh\n# list-sessions success with no sessions\nexit 0\n');
+      const res = runOmx(wd, ['doctor', '--team'], { PATH: `${fakeBin}:${process.env.PATH || ''}` });
       if (shouldSkipForSpawnPermissions(res.error)) return;
       assert.equal(res.status, 1, res.stderr || res.stdout);
       assert.match(res.stdout, /slow_shutdown/);
@@ -112,7 +122,8 @@ describe('omx doctor --team', () => {
         alive: true,
       }));
 
-      const res = runOmx(wd, ['doctor', '--team']);
+      const fakeBin = await createFakeTmuxBin(wd, '#!/bin/sh\n# list-sessions success with no sessions\nexit 0\n');
+      const res = runOmx(wd, ['doctor', '--team'], { PATH: `${fakeBin}:${process.env.PATH || ''}` });
       if (shouldSkipForSpawnPermissions(res.error)) return;
       assert.equal(res.status, 1, res.stderr || res.stdout);
       assert.match(res.stdout, /delayed_status_lag/);

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -41,6 +41,12 @@ interface InitConfigResult {
   detectedSession?: string;
 }
 
+interface InitTmuxHookConfigOptions {
+  silent?: boolean;
+  cwd?: string;
+  detectTarget?: boolean;
+}
+
 const DEFAULT_CONFIG: TmuxHookConfig = {
   enabled: true,
   target: { type: 'pane', value: '' },
@@ -306,9 +312,10 @@ function detectInitialTarget(): InitialTargetDetection | null {
   return null;
 }
 
-async function initTmuxHookConfig(opts?: { silent?: boolean; cwd?: string }): Promise<InitConfigResult> {
+async function initTmuxHookConfig(opts?: InitTmuxHookConfigOptions): Promise<InitConfigResult> {
   const cwd = opts?.cwd ?? process.cwd();
   const silent = opts?.silent ?? false;
+  const detectTarget = opts?.detectTarget ?? true;
   const configPath = tmuxHookConfigPath(cwd);
   await mkdir(omxDir(cwd), { recursive: true });
 
@@ -319,7 +326,7 @@ async function initTmuxHookConfig(opts?: { silent?: boolean; cwd?: string }): Pr
     return { configPath, created: false, usedPlaceholderTarget: false };
   }
 
-  const detected = detectInitialTarget();
+  const detected = detectTarget ? detectInitialTarget() : null;
   const initial = {
     ...DEFAULT_CONFIG,
     target: detected?.target ?? { type: 'pane' as const, value: 'replace-with-tmux-pane-id' },
@@ -350,9 +357,12 @@ async function initTmuxHookConfig(opts?: { silent?: boolean; cwd?: string }): Pr
   return result;
 }
 
-export async function ensureTmuxHookInitialized(cwd = process.cwd()): Promise<void> {
+export async function ensureTmuxHookInitialized(
+  cwd = process.cwd(),
+  options: { detectTarget?: boolean } = {},
+): Promise<void> {
   try {
-    await initTmuxHookConfig({ silent: true, cwd });
+    await initTmuxHookConfig({ silent: true, cwd, detectTarget: options.detectTarget ?? true });
   } catch {
     // Best-effort only: state tools must remain available even without tmux.
   }

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -5,6 +5,24 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+async function withAmbientTmuxEnv<T>(env: NodeJS.ProcessEnv, run: () => Promise<T>): Promise<T> {
+  const previousTmux = process.env.TMUX;
+  const previousTmuxPane = process.env.TMUX_PANE;
+  if (typeof env.TMUX === 'string') process.env.TMUX = env.TMUX;
+  else delete process.env.TMUX;
+  if (typeof env.TMUX_PANE === 'string') process.env.TMUX_PANE = env.TMUX_PANE;
+  else delete process.env.TMUX_PANE;
+
+  try {
+    return await run();
+  } finally {
+    if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+    else delete process.env.TMUX;
+    if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+    else delete process.env.TMUX_PANE;
+  }
+}
+
 describe('state-server directory initialization', () => {
   it('creates .omx/state for state tools without setup', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
@@ -26,10 +44,44 @@ describe('state-server directory initialization', () => {
 
       assert.equal(existsSync(stateDir), true);
       assert.equal(existsSync(tmuxHookConfig), true);
+      const tmuxConfig = JSON.parse(await readFile(tmuxHookConfig, 'utf-8')) as {
+        target?: { type?: string; value?: string };
+      };
+      assert.deepEqual(tmuxConfig.target, { type: 'pane', value: 'replace-with-tmux-pane-id' });
       assert.deepEqual(
         JSON.parse(response.content[0]?.text || '{}'),
-        { active_modes: [] }
+        { active_modes: [] },
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps state-tool tmux-hook bootstrap on a placeholder target even with ambient tmux env', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-test-live-'));
+    try {
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+
+      await withAmbientTmuxEnv(
+        { TMUX: '/tmp/maintainer-default,123,0', TMUX_PANE: '%777' },
+        async () => {
+          const response = await handleStateToolCall({
+            params: {
+              name: 'state_list_active',
+              arguments: { workingDirectory: wd },
+            },
+          });
+          assert.deepEqual(JSON.parse(response.content[0]?.text || '{}'), { active_modes: [] });
+        },
+      );
+
+      const tmuxConfig = JSON.parse(await readFile(tmuxHookConfig, 'utf-8')) as {
+        target?: { type?: string; value?: string };
+      };
+      assert.deepEqual(tmuxConfig.target, { type: 'pane', value: 'replace-with-tmux-pane-id' });
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -54,7 +106,7 @@ describe('state-server directory initialization', () => {
       assert.equal(existsSync(sessionDir), true);
       assert.deepEqual(
         JSON.parse(response.content[0]?.text || '{}'),
-        { statuses: {} }
+        { statuses: {} },
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -259,7 +259,7 @@ export async function handleStateToolCall(request: {
 				await mkdir(getStateDir(cwd, effectiveSessionId), { recursive: true });
 			}
 			const { ensureTmuxHookInitialized } = await import("../cli/tmux-hook.js");
-			await ensureTmuxHookInitialized(cwd);
+			await ensureTmuxHookInitialized(cwd, { detectTarget: false });
 		}
 
 		if (TEAM_COMM_TOOL_NAMES.has(name)) {

--- a/src/team/__tests__/tmux-test-fixture.test.ts
+++ b/src/team/__tests__/tmux-test-fixture.test.ts
@@ -13,33 +13,43 @@ describe('withTempTmuxSession', () => {
     skipUnlessTmux(t);
     const ambientTmuxPane = process.env.TMUX_PANE;
     let sessionName = '';
+    let serverName = '';
 
     await withTempTmuxSession(async (fixture) => {
       sessionName = fixture.sessionName;
+      serverName = fixture.serverName;
       assert.match(fixture.sessionName, /^omx-test-/);
+      assert.match(fixture.serverName, /^omx-fixture-/);
       assert.equal(process.env.TMUX, fixture.env.TMUX);
       assert.equal(process.env.TMUX_PANE, fixture.leaderPaneId);
       assert.equal(fixture.sessionExists(), true);
+      assert.equal(
+        tmuxSessionExists(fixture.sessionName),
+        false,
+        'fixture session must not be visible on the maintainer default tmux server',
+      );
       if (ambientTmuxPane) {
         assert.notEqual(fixture.leaderPaneId, ambientTmuxPane);
       }
     });
 
-    assert.equal(tmuxSessionExists(sessionName), false);
+    assert.equal(tmuxSessionExists(sessionName, serverName), false);
   });
 
   it('cleans up when the callback throws', async (t) => {
     skipUnlessTmux(t);
     let sessionName = '';
+    let serverName = '';
 
     await assert.rejects(
       () => withTempTmuxSession(async (fixture) => {
         sessionName = fixture.sessionName;
+        serverName = fixture.serverName;
         throw new Error('fixture boom');
       }),
       /fixture boom/,
     );
 
-    assert.equal(tmuxSessionExists(sessionName), false);
+    assert.equal(tmuxSessionExists(sessionName, serverName), false);
   });
 });

--- a/src/team/__tests__/tmux-test-fixture.ts
+++ b/src/team/__tests__/tmux-test-fixture.ts
@@ -1,12 +1,14 @@
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 export interface TempTmuxSessionFixture {
   sessionName: string;
+  serverName: string;
   windowTarget: string;
   leaderPaneId: string;
+  socketPath: string;
   env: {
     TMUX: string;
     TMUX_PANE: string;
@@ -14,9 +16,25 @@ export interface TempTmuxSessionFixture {
   sessionExists: () => boolean;
 }
 
-function runTmux(args: string[], options: { ignoreTmuxEnv?: boolean } = {}): string {
-  const env = options.ignoreTmuxEnv ? { ...process.env, TMUX: undefined, TMUX_PANE: undefined } : process.env;
-  return execFileSync('tmux', args, { encoding: 'utf-8', env }).trim();
+function runTmux(
+  args: string[],
+  options: { ignoreTmuxEnv?: boolean; env?: NodeJS.ProcessEnv; serverName?: string } = {},
+): string {
+  const env = options.env
+    ?? (options.ignoreTmuxEnv ? { ...process.env, TMUX: undefined, TMUX_PANE: undefined } : process.env);
+  const argv = options.serverName ? ['-L', options.serverName, ...args] : args;
+  const result = spawnSync('tmux', argv, {
+    encoding: 'utf-8',
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || '').trim() || `tmux exited ${result.status}`);
+  }
+  return (result.stdout || '').trim();
 }
 
 export function isRealTmuxAvailable(): boolean {
@@ -28,17 +46,20 @@ export function isRealTmuxAvailable(): boolean {
   }
 }
 
-export function tmuxSessionExists(sessionName: string): boolean {
+export function tmuxSessionExists(sessionName: string, serverName?: string): boolean {
   try {
-    runTmux(['has-session', '-t', sessionName], { ignoreTmuxEnv: true });
+    runTmux(['has-session', '-t', sessionName], {
+      ignoreTmuxEnv: true,
+      serverName,
+    });
     return true;
   } catch {
     return false;
   }
 }
 
-function uniqueSessionName(): string {
-  return `omx-test-${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+function uniqueTmuxIdentifier(prefix: string): string {
+  return `${prefix}-${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 export async function withTempTmuxSession<T>(fn: (fixture: TempTmuxSessionFixture) => Promise<T> | T): Promise<T> {
@@ -47,7 +68,9 @@ export async function withTempTmuxSession<T>(fn: (fixture: TempTmuxSessionFixtur
   }
 
   const fixtureCwd = await mkdtemp(join(tmpdir(), 'omx-tmux-fixture-'));
-  const sessionName = uniqueSessionName();
+  const sessionName = uniqueTmuxIdentifier('omx-test');
+  const serverName = uniqueTmuxIdentifier('omx-fixture');
+  const tmuxOptions = { ignoreTmuxEnv: true, serverName } as const;
   const created = runTmux([
     'new-session',
     '-d',
@@ -59,17 +82,17 @@ export async function withTempTmuxSession<T>(fn: (fixture: TempTmuxSessionFixtur
     '-c',
     fixtureCwd,
     'sleep 300',
-  ], { ignoreTmuxEnv: true });
+  ], tmuxOptions);
   const [windowTarget = '', leaderPaneId = ''] = created.split(/\s+/, 2);
   if (windowTarget === '' || leaderPaneId === '') {
     try {
-      runTmux(['kill-session', '-t', sessionName], { ignoreTmuxEnv: true });
+      runTmux(['kill-server'], tmuxOptions);
     } catch {}
     await rm(fixtureCwd, { recursive: true, force: true });
     throw new Error(`failed to create temporary tmux fixture: ${created}`);
   }
 
-  const socketPath = runTmux(['display-message', '-p', '-t', leaderPaneId, '#{socket_path}'], { ignoreTmuxEnv: true });
+  const socketPath = runTmux(['display-message', '-p', '-t', leaderPaneId, '#{socket_path}'], tmuxOptions);
   const previousTmux = process.env.TMUX;
   const previousTmuxPane = process.env.TMUX_PANE;
   process.env.TMUX = `${socketPath},${process.pid},0`;
@@ -77,20 +100,22 @@ export async function withTempTmuxSession<T>(fn: (fixture: TempTmuxSessionFixtur
 
   const fixture: TempTmuxSessionFixture = {
     sessionName,
+    serverName,
     windowTarget,
     leaderPaneId,
+    socketPath,
     env: {
       TMUX: process.env.TMUX,
       TMUX_PANE: leaderPaneId,
     },
-    sessionExists: () => tmuxSessionExists(sessionName),
+    sessionExists: () => tmuxSessionExists(sessionName, serverName),
   };
 
   try {
     return await fn(fixture);
   } finally {
     try {
-      runTmux(['kill-session', '-t', sessionName], { ignoreTmuxEnv: true });
+      runTmux(['kill-server'], tmuxOptions);
     } catch {}
     if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
     else delete process.env.TMUX;


### PR DESCRIPTION
## Summary
- keep state-tool tmux-hook bootstrap on a deterministic placeholder target instead of probing ambient live tmux state
- move the live tmux fixture onto its own synthetic tmux server so tests never reuse the maintainer default tmux server
- harden doctor regression coverage to use fake tmux binaries in paths that previously depended on ambient tmux availability

## Testing
- npm run build
- npm run lint -- src/cli/tmux-hook.ts src/cli/__tests__/doctor-team.test.ts src/mcp/state-server.ts src/mcp/__tests__/state-server.test.ts src/team/__tests__/tmux-test-fixture.ts src/team/__tests__/tmux-test-fixture.test.ts
- node --test dist/mcp/__tests__/state-server.test.js dist/team/__tests__/tmux-test-fixture.test.js dist/cli/__tests__/doctor-team.test.js

Closes #963
