### PR TITLE
Fix HUD pane misrouting by canonicalizing hook injection to the codex pane

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -237,21 +237,25 @@ describe("resolveNotifyTempContract", () => {
 describe("buildNotifyFallbackWatcherEnv", () => {
   it("enables watcher authority and propagates CODEX_HOME override when requested", () => {
     const env = buildNotifyFallbackWatcherEnv(
-      { HOME: "/tmp/home", OMX_HUD_AUTHORITY: "0" },
+      { HOME: "/tmp/home", OMX_HUD_AUTHORITY: "0", TMUX: "sock,1,0", TMUX_PANE: "%2" },
       { codexHomeOverride: "/tmp/codex-home", enableAuthority: true },
     );
     assert.equal(env.OMX_HUD_AUTHORITY, "1");
     assert.equal(env.CODEX_HOME, "/tmp/codex-home");
     assert.equal(env.HOME, "/tmp/home");
+    assert.equal(env.TMUX, undefined);
+    assert.equal(env.TMUX_PANE, undefined);
   });
 
   it("disables watcher authority explicitly when not requested", () => {
     const env = buildNotifyFallbackWatcherEnv(
-      { HOME: "/tmp/home", OMX_HUD_AUTHORITY: "1" },
+      { HOME: "/tmp/home", OMX_HUD_AUTHORITY: "1", TMUX: "sock,1,0", TMUX_PANE: "%3" },
       { enableAuthority: false },
     );
     assert.equal(env.OMX_HUD_AUTHORITY, "0");
     assert.equal(env.HOME, "/tmp/home");
+    assert.equal(env.TMUX, undefined);
+    assert.equal(env.TMUX_PANE, undefined);
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1554,8 +1554,11 @@ export function buildNotifyFallbackWatcherEnv(
     enableAuthority?: boolean;
   } = {},
 ): NodeJS.ProcessEnv {
+  const nextEnv = { ...env };
+  delete nextEnv.TMUX;
+  delete nextEnv.TMUX_PANE;
   return {
-    ...env,
+    ...nextEnv,
     ...(options.codexHomeOverride ? { CODEX_HOME: options.codexHomeOverride } : {}),
     OMX_HUD_AUTHORITY: options.enableAuthority ? "1" : "0",
   };

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { getPackageRoot } from '../utils/package.js';
+import { resolveCodexPane } from '../scripts/tmux-hook-engine.js';
 
 type TmuxTargetType = 'session' | 'pane';
 
@@ -265,11 +266,11 @@ function detectActivePaneFromList(): InitialTargetDetection | null {
 }
 
 function detectInitialTarget(): InitialTargetDetection | null {
-  const tmuxPaneEnv = process.env.TMUX_PANE;
-  if (tmuxPaneEnv) {
-    const pane = runTmux(['display-message', '-p', '-t', tmuxPaneEnv, '#{pane_id}']);
+  const canonicalPane = resolveCodexPane();
+  if (canonicalPane) {
+    const pane = runTmux(['display-message', '-p', '-t', canonicalPane, '#{pane_id}']);
     if (pane.ok && pane.stdout) {
-      const session = runTmux(['display-message', '-p', '-t', tmuxPaneEnv, '#S']);
+      const session = runTmux(['display-message', '-p', '-t', canonicalPane, '#S']);
       return {
         target: { type: 'pane', value: pane.stdout },
         sessionName: session.ok && session.stdout ? session.stdout : undefined,

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -116,7 +116,7 @@ if [[ "$cmd" == "display-message" ]]; then
     exit 0
   fi
   if [[ "$fmt" == "#{pane_current_path}" ]]; then
-    pwd
+    dirname "${tmuxLogPath}"
     exit 0
   fi
   if [[ "$fmt" == "#{pane_current_command}" ]]; then

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -47,16 +47,29 @@ if [[ "\$cmd" == "send-keys" ]]; then
   exit 0
 fi
 if [[ "\$cmd" == "display-message" ]]; then
+  target=""
   format=""
   while [[ "\$#" -gt 0 ]]; do
     case "\$1" in
       -p) shift ;;
-      -t) shift 2 ;;
+      -t) target="\$2"; shift 2 ;;
       *) format="\$1"; shift ;;
     esac
   done
   if [[ "\$format" == "#{pane_in_mode}" ]]; then
     echo "${paneInMode}"
+    exit 0
+  fi
+  if [[ "\$format" == "#{pane_current_command}" && "\$target" == "%99" ]]; then
+    echo "node"
+    exit 0
+  fi
+  if [[ "\$format" == "#{pane_start_command}" && "\$target" == "%99" ]]; then
+    echo "codex --model gpt-5"
+    exit 0
+  fi
+  if [[ "\$format" == "#S" ]]; then
+    echo "devsess"
     exit 0
   fi
   exit 0
@@ -309,7 +322,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -t %99 -p #\{pane_current_command\}/);
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'current implementation still nudges this pane');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'shell pane should not receive auto-nudge injection');
     });
   });
 
@@ -388,7 +401,7 @@ if [[ "$cmd" == "list-panes" ]]; then
     esac
   done
   if [[ "$target" == "devsess" ]]; then
-    printf "%%99\tsh\t0\t${cwd}\\n%%100\tnode\t1\t${cwd}\\n"
+    printf "%%99\t1\tsh\\n%%100\t0\tcodex --model gpt-5\\n"
     exit 0
   fi
   echo "%1 12345"
@@ -407,7 +420,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p #S/);
       assert.match(tmuxLog, /display-message -t %99 -p #\{pane_current_command\}/);
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.match(tmuxLog, /send-keys -t %100 -l yes, proceed \[OMX_TMUX_INJECT\]/);
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-regression-205.test.ts
+++ b/src/hooks/__tests__/notify-hook-regression-205.test.ts
@@ -51,6 +51,27 @@ if [[ "$cmd" == "send-keys" ]]; then
   exit 0
 fi
 if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%99" ]]; then
+    echo "node"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%99" ]]; then
+    echo "codex --model gpt-5"
+    exit 0
+  fi
+  if [[ "$format" == "#S" ]]; then
+    echo "devsess"
+    exit 0
+  fi
   exit 0
 fi
 if [[ "$cmd" == "list-panes" ]]; then

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -63,7 +63,15 @@ if [[ "$cmd" == "display-message" ]]; then
     exit 0
   fi
   if [[ "$fmt" == "#{pane_current_path}" ]]; then
-    pwd
+    dirname "${tmuxLogPath}"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_start_command}" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_command}" ]]; then
+    echo "codex"
     exit 0
   fi
   if [[ "$fmt" == "#S" ]]; then
@@ -272,6 +280,122 @@ describe('notify-hook team dispatch consumer', () => {
     } finally {
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
       else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('leader-fixed dispatch prefers the canonical codex pane over a stale HUD leader pane id', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    const prevPath = process.env.PATH;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "capture-pane" ]]; then
+  printf "› ready\\n"
+  exit 0
+fi
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  fmt=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -t)
+        shift
+        target="$1"
+        ;;
+      *)
+        fmt="$1"
+        ;;
+    esac
+    shift || true
+  done
+  if [[ "$fmt" == "#{pane_in_mode}" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_id}" ]]; then
+    echo "\${target:-%42}"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_path}" ]]; then
+    dirname "${tmuxLogPath}"
+    exit 0
+  fi
+  if [[ "$fmt" == "#S" ]]; then
+    echo "devsess"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_command}" && "$target" == "%42" ]]; then
+    echo "node"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_start_command}" && "$target" == "%91" ]]; then
+    echo "node dist/cli/omx.js hud --watch"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_start_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_command}" && "$target" == "%99" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  printf "%%42\\t1\\tnode\\tcodex\\n%%91\\t0\\tnode\\tnode dist/cli/omx.js hud --watch\\n"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(join(fakeBinDir, 'tmux'), fakeTmux);
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      process.env.PATH = `${fakeBinDir}:${prevPath || ''}`;
+      process.env.TMUX_PANE = '%42';
+
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      const cfg = await readTeamConfig('alpha', cwd);
+      assert.ok(cfg);
+      if (!cfg) throw new Error('missing team config');
+      cfg.leader_pane_id = '%91';
+      await saveTeamConfig(cfg, cwd);
+
+      const msg = await sendDirectMessage('alpha', 'worker-1', 'leader-fixed', 'hello leader', cwd);
+      await enqueueDispatchRequest('alpha', {
+        kind: 'mailbox',
+        to_worker: 'leader-fixed',
+        message_id: msg.message_id,
+        trigger_message: 'Read .omx/state/team/alpha/mailbox/leader-fixed.json; worker-1 sent a new message. Review it and decide the next concrete step.',
+      }, cwd);
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({ cwd, maxPerTick: 5 });
+      assert.equal(result.processed, 1);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(tmuxLog, /send-keys -t %42/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %91/);
+    } finally {
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -183,8 +183,24 @@ if [[ "$cmd" == "display-message" ]]; then
     echo "%42"
     exit 0
   fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
   if [[ "$format" == "#{pane_current_path}" && "$target" == "%42" ]]; then
     echo "${cwd}"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then
+    echo "codex"
     exit 0
   fi
   if [[ "$format" == "#S" && "$target" == "%42" ]]; then
@@ -296,8 +312,24 @@ if [[ "$cmd" == "display-message" ]]; then
     echo "%42"
     exit 0
   fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
   if [[ "$format" == "#{pane_current_path}" && "$target" == "%42" ]]; then
     echo "/tmp/not-the-hook-cwd"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then
+    echo "codex"
     exit 0
   fi
   if [[ "$format" == "#S" && "$target" == "%42" ]]; then
@@ -342,7 +374,7 @@ exit 1
     });
   });
 
-  it('falls back by matching pane cwd when TMUX_PANE is unavailable', async () => {
+  it('does not guess a pane by shared cwd when canonical codex pane is unavailable', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
       const stateDir = join(omxDir, 'state');
@@ -452,12 +484,125 @@ exit 1
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.last_reason, 'target_not_found');
+      assert.equal(hookState.total_injections ?? 0, 0);
+    });
+  });
+
+  it('heals a stale HUD pane target back to the canonical codex pane', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-hud-stale';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'session.json'), { session_id: sessionId });
+      await writeJson(join(sessionStateDir, 'ralph-state.json'), { active: true, iteration: 0 });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%77' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%99" ]]; then
+    echo "node"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_id}" && "$target" == "%77" ]]; then
+    echo "%77"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%77" ]]; then
+    echo "node dist/cli/omx.js hud --watch"
+    exit 0
+  fi
+  if [[ "$format" == "#S" && "$target" == "%77" ]]; then
+    echo "devsess"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_path}" && "$target" == "%99" ]]; then
+    echo "${cwd}"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%99" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#S" && "$target" == "%99" ]]; then
+    echo "devsess"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%99" ]]; then
+    echo "0"
+    exit 0
+  fi
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-test-hud-heal',
+        'turn-id': 'turn-test-hud-heal',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_WORKER: '',
+          TMUX_PANE: '%99',
+        },
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
       assert.equal(hookState.last_reason, 'injection_sent');
-      assert.equal(hookState.total_injections, 1);
+      assert.equal(hookState.last_target, '%99');
 
       const healedConfig = await readJson<{ target: { type: string; value: string } }>(configPath);
       assert.equal(healedConfig.target.type, 'pane');
-      assert.equal(healedConfig.target.value, '%42');
+      assert.equal(healedConfig.target.value, '%99');
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-tmux-scrollback.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-scrollback.test.ts
@@ -63,6 +63,14 @@ if [[ "$cmd" == "display-message" ]]; then
     echo "${cwd}"
     exit 0
   fi
+  if [[ "$format" == "#{pane_current_command}" ]]; then
+    echo "node"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" ]]; then
+    echo "codex --model gpt-5"
+    exit 0
+  fi
   if [[ "$format" == "#S" ]]; then
     echo "devsess"
     exit 0

--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -13,6 +13,7 @@ import {
   buildSendKeysArgv,
   buildPaneCurrentCommandArgv,
   isPaneRunningShell,
+  resolveCodexPane,
 } from '../../scripts/tmux-hook-engine.js';
 
 describe('normalizeTmuxHookConfig', () => {
@@ -353,5 +354,69 @@ describe('paneHasActiveTask', () => {
 
   it('returns false for idle prompts', () => {
     assert.equal(paneHasActiveTask('› ready for input'), false);
+  });
+});
+
+
+describe('resolveCodexPane', () => {
+  it('ignores HUD pane even when TMUX_PANE foreground command is node', async () => {
+    const { mkdtemp, writeFile, chmod, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-resolve-codex-pane-'));
+    const fakeTmuxPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+    const previousTmuxPane = process.env.TMUX_PANE;
+
+    try {
+      await writeFile(fakeTmuxPath, `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%2" ]]; then
+    echo "node"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%2" ]]; then
+    echo "node /pkg/dist/cli/omx.js hud --watch"
+    exit 0
+  fi
+  if [[ "$format" == "#S" && "$target" == "%2" ]]; then
+    echo "devsess"
+    exit 0
+  fi
+  echo "bad display target: $target / $format" >&2
+  exit 1
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  printf "%%2\tnode\tnode /pkg/dist/cli/omx.js hud --watch\n%%42\tnode\tcodex --model gpt-5\n"
+  exit 0
+fi
+echo "unsupported" >&2
+exit 1
+`);
+      await chmod(fakeTmuxPath, 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath || ''}`;
+      process.env.TMUX_PANE = '%2';
+
+      assert.equal(resolveCodexPane(), '%42');
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -208,6 +208,63 @@ describe('createHookPluginSdk', () => {
       }
     });
 
+
+    it('prefers non-HUD codex pane when targeting a tmux session', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-sdk-'));
+      const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-sdk-bin-'));
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const previousPath = process.env.PATH;
+      try {
+        await writeFile(fakeTmuxPath, `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "list-panes" ]]; then
+  printf "%%2	1	node /pkg/dist/cli/omx.js hud --watch
+%%42	0	codex --model gpt-5
+"
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" ]]; then
+    echo "$target"
+    exit 0
+  fi
+  exit 0
+fi
+exit 1
+`);
+        await import('node:fs/promises').then((fs) => fs.chmod(fakeTmuxPath, 0o755));
+        process.env.PATH = `${fakeBinDir}:${previousPath || ''}`;
+
+        const sdk = createHookPluginSdk({
+          cwd,
+          pluginName: 'test',
+          event: makeEvent(),
+          sideEffectsEnabled: true,
+        });
+        const result = await sdk.tmux.sendKeys({ text: 'hello', sessionName: 'devsess' });
+        assert.equal(result.ok, true);
+        assert.equal(result.target, '%42');
+      } finally {
+        if (typeof previousPath === 'string') process.env.PATH = previousPath;
+        else delete process.env.PATH;
+        await rm(cwd, { recursive: true, force: true });
+        await rm(fakeBinDir, { recursive: true, force: true });
+      }
+    });
     it('returns target_missing when no pane is resolvable', async () => {
       const cwd = await mkdtemp(join(tmpdir(), 'omx-sdk-'));
       const originalPane = process.env.TMUX_PANE;

--- a/src/hooks/extensibility/sdk.ts
+++ b/src/hooks/extensibility/sdk.ts
@@ -4,6 +4,7 @@ import { createHash } from 'crypto';
 import { dirname, join } from 'path';
 import { spawnSync } from 'child_process';
 import { sleepSync } from '../../utils/sleep.js';
+import { resolveCodexPane } from '../../scripts/tmux-hook-engine.js';
 import type {
   HookEventEnvelope,
   HookPluginSdk,
@@ -102,6 +103,43 @@ function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; st
   return { ok: true, stdout: (result.stdout || '').trim() };
 }
 
+function isHudStartCommand(startCommand: string): boolean {
+  return /\bomx\b.*\bhud\b.*--watch/i.test(startCommand);
+}
+
+function resolveSessionPaneTarget(sessionName: string): HookPluginSendKeysResult {
+  const paneList = runTmux(['list-panes', '-t', sessionName, '-F', '#{pane_id}\t#{pane_active}\t#{pane_start_command}']);
+  if (!paneList.ok) {
+    return { ok: false, reason: 'target_missing', error: paneList.stderr };
+  }
+
+  const rows = paneList.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [paneId = '', activeRaw = '0', startCommand = ''] = line.split('\t');
+      return {
+        paneId,
+        active: activeRaw === '1',
+        startCommand: startCommand.trim(),
+      };
+    })
+    .filter((row) => row.paneId.startsWith('%'));
+
+  if (rows.length === 0) return { ok: false, reason: 'target_missing' };
+
+  const nonHudRows = rows.filter((row) => !isHudStartCommand(row.startCommand));
+  const canonicalRows = nonHudRows.filter((row) => /\bcodex\b/i.test(row.startCommand));
+  const resolved = canonicalRows.find((row) => row.active)
+    || canonicalRows[0]
+    || nonHudRows.find((row) => row.active)
+    || nonHudRows[0];
+
+  if (!resolved) return { ok: false, reason: 'target_missing' };
+  return { ok: true, reason: 'ok', target: resolved.paneId, paneId: resolved.paneId };
+}
+
 function resolveTmuxTarget(options: HookPluginSendKeysOptions): HookPluginSendKeysResult {
   const paneId = typeof options.paneId === 'string' ? options.paneId.trim() : '';
   if (paneId) {
@@ -112,18 +150,10 @@ function resolveTmuxTarget(options: HookPluginSendKeysOptions): HookPluginSendKe
 
   const sessionName = typeof options.sessionName === 'string' ? options.sessionName.trim() : '';
   if (sessionName) {
-    const paneList = runTmux(['list-panes', '-t', sessionName, '-F', '#{pane_id} #{pane_active}']);
-    if (!paneList.ok) {
-      return { ok: false, reason: 'target_missing', error: paneList.stderr };
-    }
-    const lines = paneList.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
-    const active = lines.find((line) => line.endsWith(' 1')) || lines[0];
-    if (!active) return { ok: false, reason: 'target_missing' };
-    const resolved = active.split(' ')[0];
-    return resolved ? { ok: true, reason: 'ok', target: resolved, paneId: resolved } : { ok: false, reason: 'target_missing' };
+    return resolveSessionPaneTarget(sessionName);
   }
 
-  const envPane = typeof process.env.TMUX_PANE === 'string' ? process.env.TMUX_PANE.trim() : '';
+  const envPane = String(resolveCodexPane() || '').trim();
   if (envPane) return { ok: true, reason: 'ok', target: envPane, paneId: envPane };
 
   return { ok: false, reason: 'target_missing' };

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -231,9 +231,15 @@ async function withMailboxLock(teamDirPath, workerName, fn) {
   }
 }
 
+function resolveLeaderPaneId(config) {
+  return safeString(config?.leader_pane_id).trim();
+}
+
+
 function defaultInjectTarget(request, config) {
   if (request.to_worker === 'leader-fixed') {
-    if (config.leader_pane_id) return { type: 'pane', value: config.leader_pane_id };
+    const leaderPaneId = resolveLeaderPaneId(config);
+    if (leaderPaneId) return { type: 'pane', value: leaderPaneId };
     return null;
   }
   if (request.pane_id) return { type: 'pane', value: request.pane_id };
@@ -489,7 +495,7 @@ export async function drainPendingTeamDispatch({
           continue;
         }
 
-        if (request.to_worker === 'leader-fixed' && !safeString(config?.leader_pane_id).trim()) {
+        if (request.to_worker === 'leader-fixed' && !resolveLeaderPaneId(config)) {
           const nowIso = new Date().toISOString();
           const alreadyDeferred = safeString(request.last_reason).trim() === LEADER_PANE_MISSING_DEFERRED_REASON;
           request.updated_at = nowIso;

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -11,7 +11,7 @@ import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-i
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
-import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
+import { DEFAULT_MARKER, resolveCodexPane } from '../tmux-hook-engine.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
@@ -541,8 +541,9 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     const workerPaneIds = Array.isArray(workers)
       ? workers.map((w) => safeString(w && w.pane_id ? w.pane_id : '')).filter(Boolean)
       : [];
-    if (!tmuxSession && !leaderPaneId) continue;
-    const tmuxTarget = leaderPaneId;
+    const canonicalLeaderPaneId = safeString(resolveCodexPane() || leaderPaneId).trim();
+    if (!tmuxSession && !canonicalLeaderPaneId) continue;
+    const tmuxTarget = canonicalLeaderPaneId;
     const paneStatus = tmuxSession
       ? await checkWorkerPanesAlive(tmuxSession, workerPaneIds)
       : { alive: false, paneCount: 0 };

--- a/src/scripts/notify-hook/team-worker.ts
+++ b/src/scripts/notify-hook/team-worker.ts
@@ -10,6 +10,7 @@ import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
 import { checkPaneReadyForTeamSendKeys, sendPaneInput } from './team-tmux-guard.js';
+import { resolvePaneTarget } from './tmux-injection.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 
@@ -257,6 +258,21 @@ export async function readTeamWorkersForIdleCheck(stateDir, teamName) {
   }
 }
 
+async function resolveCanonicalLeaderPaneId(_tmuxSession, leaderPaneId) {
+  const normalizedLeaderPaneId = safeString(leaderPaneId).trim();
+  if (normalizedLeaderPaneId) {
+    try {
+      const resolved = await resolvePaneTarget({ type: 'pane', value: normalizedLeaderPaneId }, '', '', '');
+      const paneTarget = safeString(resolved?.paneTarget).trim();
+      if (paneTarget) return paneTarget;
+    } catch {
+      // fall through to tmux session scan
+    }
+    return normalizedLeaderPaneId;
+  }
+  return '';
+}
+
 async function emitLeaderPaneMissingDeferred({
   stateDir,
   logsDir,
@@ -342,6 +358,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   const teamInfo = await readTeamWorkersForIdleCheck(stateDir, teamName);
   if (!teamInfo) return;
   const { workers, tmuxSession, leaderPaneId } = teamInfo;
+  const canonicalLeaderPaneId = await resolveCanonicalLeaderPaneId(tmuxSession, leaderPaneId);
 
   // Check cooldown to prevent notification spam
   const idleStatePath = join(stateDir, 'team', teamName, 'all-workers-idle.json');
@@ -364,7 +381,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   );
   if (!allIdle) return;
 
-  if (!leaderPaneId) {
+  if (!canonicalLeaderPaneId) {
     const nextIdleState = {
       ...idleState,
       last_notified_at_ms: nowMs,
@@ -380,7 +397,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       workerName,
       sourceType: 'all_workers_idle',
       tmuxSession,
-      leaderPaneId,
+      leaderPaneId: canonicalLeaderPaneId,
     });
     return;
   }
@@ -388,7 +405,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   const N = workers.length;
   const nextAction = `Next: run omx team status ${teamName}, read unread worker messages, then decide whether to assign the next concrete task, reconcile results, or shut the team down.`;
   const message = `[OMX] All ${N} worker${N === 1 ? '' : 's'} idle. ${nextAction} ${DEFAULT_MARKER}`;
-  const tmuxTarget = leaderPaneId;
+  const tmuxTarget = canonicalLeaderPaneId;
   const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
   if (!paneGuard.ok) {
     const nextIdleState = {
@@ -409,7 +426,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       paneCurrentCommand: paneGuard.paneCurrentCommand,
       sourceType: 'all_workers_idle',
       tmuxSession,
-      leaderPaneId,
+      leaderPaneId: canonicalLeaderPaneId,
     });
     return;
   }
@@ -548,8 +565,9 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
   const teamInfo = await readTeamWorkersForIdleCheck(stateDir, teamName);
   if (!teamInfo) return;
   const { tmuxSession, leaderPaneId } = teamInfo;
+  const canonicalLeaderPaneId = await resolveCanonicalLeaderPaneId(tmuxSession, leaderPaneId);
 
-  if (!leaderPaneId) {
+  if (!canonicalLeaderPaneId) {
     await emitLeaderPaneMissingDeferred({
       stateDir,
       logsDir,
@@ -557,11 +575,11 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       workerName,
       sourceType: 'worker_idle',
       tmuxSession,
-      leaderPaneId,
+      leaderPaneId: canonicalLeaderPaneId,
     });
     return;
   }
-  const tmuxTarget = leaderPaneId;
+  const tmuxTarget = canonicalLeaderPaneId;
   const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
   if (!paneGuard.ok) {
     try {
@@ -584,7 +602,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       paneCurrentCommand: paneGuard.paneCurrentCommand,
       sourceType: 'worker_idle',
       tmuxSession,
-      leaderPaneId,
+      leaderPaneId: canonicalLeaderPaneId,
     });
     return;
   }

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -23,75 +23,132 @@ import {
   pickActiveMode,
   evaluateInjectionGuards,
   buildSendKeysArgv,
+  resolveCodexPane,
 } from '../tmux-hook-engine.js';
 
-export async function resolveSessionToPane(sessionName: any): Promise<string | null> {
-  const result = await runProcess('tmux', ['list-panes', '-t', sessionName, '-F', '#{pane_id} #{pane_active}']);
-  const lines = result.stdout
-    .split('\n')
-    .map((line: string) => line.trim())
-    .filter(Boolean);
-  if (lines.length === 0) return null;
-  const active = lines.find((line: string) => line.endsWith(' 1')) || lines[0];
-  const paneId = active.split(' ')[0];
-  return paneId || null;
+function isHudPaneStartCommand(startCommand: any): boolean {
+  return /\bomx\b.*\bhud\b.*--watch/i.test(safeString(startCommand));
 }
 
-export async function resolvePaneByCwd(expectedCwd: any): Promise<any> {
+async function resolvePaneCwdMismatch(paneId: string, expectedCwd: any): Promise<any | null> {
   if (!expectedCwd) return null;
-  const result = await runProcess('tmux', ['list-panes', '-a', '-F', '#{pane_id}\t#{pane_current_path}\t#{pane_active}\t#{session_name}']);
-  const lines = result.stdout
+  try {
+    const paneCwdResult = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#{pane_current_path}']);
+    const paneCwd = safeString(paneCwdResult.stdout).trim();
+    if (paneCwd && resolvePath(paneCwd) !== resolvePath(expectedCwd)) {
+      return {
+        paneTarget: null,
+        reason: 'pane_cwd_mismatch',
+        pane_cwd: paneCwd,
+        expected_cwd: expectedCwd,
+      };
+    }
+  } catch {
+    // Best effort only — if tmux cannot report cwd, keep the explicit pane target.
+  }
+  return null;
+}
+
+async function finalizeResolvedPane(paneId: string, reason: string, expectedCwd: any): Promise<any> {
+  const cwdMismatch = await resolvePaneCwdMismatch(paneId, expectedCwd);
+  if (cwdMismatch) return cwdMismatch;
+  let sessionName = '';
+  try {
+    const currentSession = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#S']);
+    sessionName = safeString(currentSession.stdout).trim();
+  } catch {
+    sessionName = '';
+  }
+  return {
+    paneTarget: paneId,
+    reason,
+    matched_session: sessionName || null,
+  };
+}
+
+async function resolveCanonicalPaneFromPaneTarget(paneTarget: any, expectedCwd: any): Promise<any> {
+  const paneResult = await runProcess('tmux', ['display-message', '-p', '-t', paneTarget, '#{pane_id}']);
+  const paneId = safeString(paneResult.stdout).trim();
+  if (!paneId) return { paneTarget: null, reason: 'target_not_found' };
+
+  let startCommand = '';
+  try {
+    const startResult = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#{pane_start_command}']);
+    startCommand = safeString(startResult.stdout).trim();
+  } catch {
+    startCommand = '';
+  }
+  if (!startCommand || !isHudPaneStartCommand(startCommand)) {
+    return finalizeResolvedPane(paneId, 'ok', expectedCwd);
+  }
+
+  let sessionName = '';
+  try {
+    const sessionResult = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#S']);
+    sessionName = safeString(sessionResult.stdout).trim();
+  } catch {
+    sessionName = '';
+  }
+  if (!sessionName) return { paneTarget: null, reason: 'target_is_hud_pane' };
+
+  const healedPaneId = await resolveSessionToPane(sessionName);
+  if (!healedPaneId) return { paneTarget: null, reason: 'target_is_hud_pane' };
+  return finalizeResolvedPane(healedPaneId, 'healed_hud_pane_target', expectedCwd);
+}
+
+export async function resolveSessionToPane(sessionName: any): Promise<string | null> {
+  const result = await runProcess('tmux', ['list-panes', '-t', sessionName, '-F', '#{pane_id}\t#{pane_active}\t#{pane_current_command}\t#{pane_start_command}']);
+  const rows = result.stdout
     .split('\n')
     .map((line: string) => line.trim())
-    .filter(Boolean);
+    .filter(Boolean)
+    .map((line: string) => {
+      const parts = line.includes('\t')
+        ? line.split('\t')
+        : line.split(/\s+/, 4);
+      const [paneId = '', activeRaw = '0', currentCommand = '', startCommand = ''] = parts;
+      return {
+        paneId,
+        active: activeRaw === '1',
+        currentCommand: safeString(currentCommand).trim().toLowerCase(),
+        startCommand: safeString(startCommand).trim(),
+      };
+    })
+    .filter((row: any) => row.paneId.startsWith('%'));
+  if (rows.length === 0) return null;
 
-  const expected = resolvePath(expectedCwd);
-  const candidates: any[] = [];
-  for (const line of lines) {
-    const parts = line.split('\t');
-    if (parts.length < 4) continue;
-    const [paneId, paneCwd, activeRaw, sessionName] = parts;
-    if (!paneId || !paneCwd) continue;
-    if (resolvePath(paneCwd) !== expected) continue;
-    const active = activeRaw === '1';
-    candidates.push({ paneId, paneCwd, active, sessionName: sessionName || null });
-  }
-  if (candidates.length === 0) return null;
+  const nonHudRows = rows.filter((row: any) => !isHudPaneStartCommand(row.startCommand));
+  const canonicalRows = nonHudRows.filter((row: any) => /\bcodex\b/i.test(row.startCommand));
+  const activeCanonical = canonicalRows.find((row: any) => row.active);
+  if (activeCanonical) return activeCanonical.paneId;
+  if (canonicalRows[0]) return canonicalRows[0].paneId;
 
-  const pick = candidates.find((c: any) => c.active) || candidates[0];
-  return pick;
+  const activeNonHud = nonHudRows.find((row: any) => row.active);
+  if (activeNonHud) return activeNonHud.paneId;
+  return nonHudRows[0]?.paneId || null;
 }
 
 export async function resolvePaneTarget(target: any, fallbackPane: any, expectedCwd: any, modePane: any): Promise<any> {
+  const canonicalFallbackPane = safeString(fallbackPane).trim();
+  if (canonicalFallbackPane) {
+    try {
+      return await finalizeResolvedPane(canonicalFallbackPane, 'fallback_current_pane', expectedCwd);
+    } catch {
+      // Fall through to mode/config probes
+    }
+  }
+
   if (modePane) {
     try {
-      const modePaneResult = await runProcess('tmux', ['display-message', '-p', '-t', modePane, '#{pane_id}']);
-      const paneId = safeString(modePaneResult.stdout).trim();
-      if (paneId) {
-        if (expectedCwd) {
-          const paneCwdResult = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#{pane_current_path}']);
-          const paneCwd = safeString(paneCwdResult.stdout).trim();
-          if (!paneCwd || resolvePath(paneCwd) === resolvePath(expectedCwd)) {
-            const currentSession = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#S']);
-            const sessionName = safeString(currentSession.stdout).trim();
-            return {
-              paneTarget: paneId,
-              reason: 'fallback_mode_state_pane',
-              matched_session: sessionName || null,
-            };
-          }
-        } else {
-          const currentSession = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#S']);
-          const sessionName = safeString(currentSession.stdout).trim();
-          return {
-            paneTarget: paneId,
-            reason: 'fallback_mode_state_pane',
-            matched_session: sessionName || null,
-          };
-        }
+      const resolved = await resolveCanonicalPaneFromPaneTarget(modePane, expectedCwd);
+      if (resolved.paneTarget) {
+        return {
+          ...resolved,
+          reason: resolved.reason === 'ok' ? 'fallback_mode_state_pane' : resolved.reason,
+        };
       }
     } catch {
-      // Fall through to config/fallback probes
+      // Fall through to config probes
     }
   }
 
@@ -99,63 +156,18 @@ export async function resolvePaneTarget(target: any, fallbackPane: any, expected
 
   if (target.type === 'pane') {
     try {
-      const result = await runProcess('tmux', ['display-message', '-p', '-t', target.value, '#{pane_id}']);
-      const paneId = safeString(result.stdout).trim();
-      if (paneId) return { paneTarget: paneId, reason: 'ok' };
+      const resolved = await resolveCanonicalPaneFromPaneTarget(target.value, expectedCwd);
+      if (resolved.paneTarget) return resolved;
     } catch {
-      // Fall through to fallback probe
+      // Fall through
     }
   } else {
     try {
       const paneId = await resolveSessionToPane(target.value);
-      if (paneId) return { paneTarget: paneId, reason: 'ok' };
-    } catch {
-      // Fall through to fallback probe
-    }
-  }
-
-  if (fallbackPane) {
-    try {
-      const currentPane = await runProcess('tmux', ['display-message', '-p', '-t', fallbackPane, '#{pane_id}']);
-      const paneId = safeString(currentPane.stdout).trim();
-      if (paneId) {
-        if (expectedCwd) {
-          const paneCwdResult = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#{pane_current_path}']);
-          const paneCwd = safeString(paneCwdResult.stdout).trim();
-          if (paneCwd && resolvePath(paneCwd) !== resolvePath(expectedCwd)) {
-            return {
-              paneTarget: null,
-              reason: 'pane_cwd_mismatch',
-              pane_cwd: paneCwd,
-              expected_cwd: expectedCwd,
-            };
-          }
-        }
-
-        const currentSession = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#S']);
-        const sessionName = safeString(currentSession.stdout).trim();
-        return {
-          paneTarget: paneId,
-          reason: 'fallback_current_pane',
-          matched_session: sessionName || null,
-        };
-      }
+      if (paneId) return await finalizeResolvedPane(paneId, 'ok', expectedCwd);
     } catch {
       // Fall through
     }
-  }
-
-  try {
-    const match = await resolvePaneByCwd(expectedCwd);
-    if (match && match.paneId) {
-      return {
-        paneTarget: match.paneId,
-        reason: 'fallback_pane_by_cwd',
-        matched_session: match.sessionName,
-      };
-    }
-  } catch {
-    // Fall through
   }
 
   return { paneTarget: null, reason: 'target_not_found' };
@@ -268,8 +280,7 @@ export async function handleTmuxInjection({
     turnId,
     timestamp: nowIso,
   }), sourceText);
-  const { resolveCodexPane } = await import('../tmux-hook-engine.js');
-  const fallbackPane = resolveCodexPane() || safeString(process.env.TMUX_PANE || '');
+  const fallbackPane = resolveCodexPane();
   const resolution = await resolvePaneTarget(config.target, fallbackPane, cwd, modePane);
   if (!resolution.paneTarget) {
     state.last_reason = resolution.reason;
@@ -307,8 +318,8 @@ export async function handleTmuxInjection({
     return;
   }
 
-  // Pane-canonical healing: persist resolved pane target so routing stops depending on session names.
-  if (config.target && config.target.type !== 'pane') {
+  // Pane-canonical healing: persist resolved pane target so routing stops depending on session names or stale pane ids.
+  if (config.target && (config.target.type !== 'pane' || safeString(config.target.value).trim() !== paneTarget)) {
     try {
       const healed = {
         ...(rawConfig && typeof rawConfig === 'object' ? rawConfig : {}),

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -182,13 +182,17 @@ export function isPaneRunningShell(paneCurrentCommand: any): boolean {
 // Codex agent commands — do NOT include 'claude' (that's Claude Code CLI, a different tool)
 const AGENT_COMMANDS = new Set(['node', 'codex', 'npx']);
 
+function isHudStartCommand(startCommand: string): boolean {
+  return /\bomx\b.*\bhud\b.*--watch/i.test(startCommand);
+}
+
 /**
  * Canonical codex pane resolver. Finds the tmux pane running a codex/claude agent.
  *
  * Resolution order:
- * 1. TMUX_PANE env var — but only if the pane is running an agent (not a shell)
- * 2. Scan all panes in the same tmux session for one running an agent command
- * 3. Fall back to TMUX_PANE even if it's a shell (best effort)
+ * 1. TMUX_PANE env var — but only if the pane looks like a real agent pane, not HUD
+ * 2. Scan all panes in the same tmux session for one started with codex
+ * 3. Fail closed instead of guessing a shell or HUD pane
  *
  * All callers (auto-nudge, ralph steer, team dispatch, tmux injection) should
  * use this instead of raw `process.env.TMUX_PANE`.
@@ -197,43 +201,42 @@ export function resolveCodexPane(): string {
   const envPane = (process.env.TMUX_PANE || '').trim();
   if (!envPane) return '';
 
-  // Check if TMUX_PANE is actually running an agent
   try {
     const cmd = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{pane_current_command}'], {
       encoding: 'utf-8', timeout: 2000,
     }).trim().toLowerCase();
+    const startCmd = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{pane_start_command}'], {
+      encoding: 'utf-8', timeout: 2000,
+    }).trim().toLowerCase();
     const base = cmd.split('/').pop()?.replace(/^-/, '') || '';
-    if (AGENT_COMMANDS.has(base)) {
-      return envPane; // TMUX_PANE is running a codex agent — use it
+    if (AGENT_COMMANDS.has(base) && !isHudStartCommand(startCmd)) {
+      return envPane;
     }
     if (!SHELL_COMMANDS.has(base)) {
-      // Not a shell and not a known agent (e.g. 'claude' = Claude Code CLI)
-      // Fall through to session scan to find the actual codex pane
+      // Not a shell and not a known agent (e.g. claude CLI) — fall through to
+      // session scan so we can still reject HUD or locate a codex pane.
     }
   } catch {
-    return envPane; // Can't check — use it as-is
+    // Fall through to session scan instead of guessing.
   }
 
-  // TMUX_PANE is a shell — find the actual agent pane in the same session
   try {
-    const sessionName = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{session_name}'], {
+    const sessionName = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#S'], {
       encoding: 'utf-8', timeout: 2000,
     }).trim();
-    if (!sessionName) return envPane;
+    if (!sessionName) return '';
 
     const panes = execFileSync('tmux', [
       'list-panes', '-s', '-t', sessionName,
       '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
     ], { encoding: 'utf-8', timeout: 2000 }).trim().split('\n');
 
-    // Find the pane that was STARTED with codex (not the HUD or shell)
     for (const line of panes) {
       const parts = line.split('\t');
       const paneId = parts[0];
       const startCmd = (parts[2] || '').toLowerCase();
       if (!paneId) continue;
-      // The codex pane has 'codex' in its start command
-      if (startCmd.includes('codex') && !startCmd.includes('hud')) {
+      if (startCmd.includes('codex') && !isHudStartCommand(startCmd)) {
         return paneId;
       }
     }
@@ -241,7 +244,6 @@ export function resolveCodexPane(): string {
     // Fall through
   }
 
-  // No agent pane found in the session — don't fall back to a shell pane
   return '';
 }
 


### PR DESCRIPTION
## Summary

This fixes an intermittent regression where leader-side hook messages (Ralph/team nudges, dispatch triggers, etc.) could be injected into the HUD pane instead of the Codex pane.

The main issue was that pane targeting still had multiple fallback paths and `resolveCodexPane()` could misclassify a HUD pane as the active agent pane when tmux reported its foreground command as `node`.

## What changed

### Canonical codex-pane resolution
- Harden `resolveCodexPane()` to reject HUD panes by checking `pane_start_command`
- Stop treating a bare `node` foreground command as sufficient evidence of a Codex pane
- Prefer codex-started panes and fail closed instead of guessing a shell/HUD pane

### Notify-hook pane routing cleanup
- Remove shared-cwd pane guessing from generic notify-hook routing
- Heal stale HUD pane targets back to the real codex pane
- Persist healed pane ids so future routing stays pane-canonical

### Leader-side routing alignment
- Route leader nudge / dispatch / worker-idle / all-workers-idle paths through canonical or healed leader pane ids
- Keep dispatch using configured leader pane ids while letting downstream canonicalization heal stale HUD targets

### Detached watcher hardening
- Strip `TMUX` and `TMUX_PANE` from detached notify fallback watcher env
- Avoid inheriting stale HUD-pane context into background leader-side control-plane flows

### Helper follow-up hardening
- Canonicalize plugin `tmux.sendKeys()` session targeting to prefer non-HUD codex panes
- Make `omx tmux-hook init` auto-detection prefer canonical codex-pane detection first

## Why

HUD and Codex often share the same cwd and can both appear as `node` in tmux metadata. That made older fallback logic vulnerable to selecting the wrong pane intermittently depending on which metadata was available at the time.

This change makes pane targeting consistent:
- Codex pane is the canonical target
- HUD panes are explicitly excluded
- fallback behavior is reduced and healed where necessary

## Files changed

- `src/scripts/tmux-hook-engine.ts`
- `src/scripts/notify-hook/tmux-injection.ts`
- `src/scripts/notify-hook/team-dispatch.ts`
- `src/scripts/notify-hook/team-leader-nudge.ts`
- `src/scripts/notify-hook/team-worker.ts`
- `src/cli/index.ts`
- `src/cli/tmux-hook.ts`
- `src/hooks/extensibility/sdk.ts`

Tests:
- `src/hooks/__tests__/tmux-hook-engine.test.ts`
- `src/hooks/__tests__/notify-hook-tmux-heal.test.ts`
- `src/hooks/__tests__/notify-hook-team-dispatch.test.ts`
- `src/hooks/__tests__/notify-fallback-watcher.test.ts`
- `src/hooks/extensibility/__tests__/sdk.test.ts`
- `src/cli/__tests__/index.test.ts`

## Verification

Ran:
- `npm ci`
- `npm run build`
- `node --test dist/cli/__tests__/index.test.js dist/hooks/__tests__/tmux-hook-engine.test.js dist/hooks/__tests__/notify-hook-tmux-heal.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js`
- `node --test dist/hooks/extensibility/__tests__/sdk.test.js dist/cli/__tests__/index.test.js dist/hooks/__tests__/tmux-hook-engine.test.js`

Result:
- targeted suite green

## Risk

Low-to-moderate:
- this touches shared pane-selection logic used by several hook/control-plane paths
- risk is mitigated by targeted regressions around HUD-vs-codex selection, stale pane healing, dispatch routing, watcher behavior, and worker/leader notifications
