### PR TITLE
fix(release): slim packed-install smoke to core commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
             dist/cli/__tests__/sparkshell-cli.test.js \
             dist/hooks/__tests__/explore-routing.test.js \
             dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js \
+            dist/scripts/__tests__/smoke-packed-install.test.js \
+            dist/verification/__tests__/explore-harness-release-workflow.test.js \
             dist/compat/__tests__/*.test.js
 
   coverage-team-critical:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,43 +223,19 @@ jobs:
     needs: [smoke-verify-native]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
-        with:
-          name: native-release-assets
-          path: release-assets
       - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run build
-      - name: Smoke test packed install with hydrated native assets
-        run: npm run smoke:packed-install -- --release-assets-dir release-assets
-
-  older-linux-runtime-proof:
-    name: Older Linux Runtime Proof
-    runs-on: ubuntu-latest
-    needs: [smoke-packed-install]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v8
-        with:
-          name: native-release-assets
-          path: release-assets
-      - name: Verify Docker is available
-        run: docker version
-      - name: Run packed-install hydration smoke on older Linux runtime
-        run: |
-          docker run --rm \
-            -v "$PWD:/workspace" \
-            -w /workspace \
-            node:20-bullseye \
-            bash -lc 'npm ci && npm run build && node dist/scripts/smoke-packed-install.js --release-assets-dir ./release-assets --require-no-fallback'
+      - name: Smoke test packed install boot + core commands
+        run: npm run smoke:packed-install
 
   publish-npm:
     name: Publish npm Package
     runs-on: ubuntu-latest
-    needs: [older-linux-runtime-proof]
+    needs: [smoke-packed-install]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -1,67 +1,26 @@
 // @ts-nocheck
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import {
   ensureRepoDependencies,
-  hasSparkShellFallbackBanner,
   hasUsableNodeModules,
-  prepareLocalHydrationAssetDirectory,
+  PACKED_INSTALL_SMOKE_CORE_COMMANDS,
   resolveGitCommonDir,
   resolveReusableNodeModulesSource,
-  rewriteManifestDownloadUrls,
 } from '../smoke-packed-install.js';
 
-test('detects the sparkshell GLIBC fallback banner', () => {
+test('packed install smoke stays limited to boot + core commands', () => {
+  assert.deepEqual(PACKED_INSTALL_SMOKE_CORE_COMMANDS, [
+    ['--help'],
+    ['version'],
+  ]);
   assert.equal(
-    hasSparkShellFallbackBanner('[sparkshell] GLIBC-incompatible native sidecar detected; falling back to raw command execution without summary support.\n'),
-    true,
+    PACKED_INSTALL_SMOKE_CORE_COMMANDS.some((argv) => argv.includes('explore') || argv.includes('sparkshell')),
+    false,
   );
-  assert.equal(hasSparkShellFallbackBanner('node v20.0.0\n'), false);
-});
-
-test('rewrites copied native manifest download urls to the local smoke server', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'omx-smoke-packed-install-'));
-  try {
-    const sourceDir = join(root, 'source-release-assets');
-    await mkdir(sourceDir, { recursive: true });
-    await writeFile(join(sourceDir, 'omx-explore-harness-x86_64-unknown-linux-musl.tar.xz'), 'explore');
-    await writeFile(join(sourceDir, 'omx-sparkshell-x86_64-unknown-linux-musl.tar.xz'), 'sparkshell');
-    await writeFile(join(sourceDir, 'native-release-manifest.json'), JSON.stringify({
-      version: '0.9.0',
-      assets: [
-        {
-          product: 'omx-explore-harness',
-          archive: 'omx-explore-harness-x86_64-unknown-linux-musl.tar.xz',
-          download_url: 'https://github.com/example/omx-explore-harness-x86_64-unknown-linux-musl.tar.xz',
-        },
-        {
-          product: 'omx-sparkshell',
-          archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.xz',
-          download_url: 'https://github.com/example/omx-sparkshell-x86_64-unknown-linux-musl.tar.xz',
-        },
-      ],
-    }, null, 2));
-
-    const copiedDir = prepareLocalHydrationAssetDirectory(sourceDir, root);
-    rewriteManifestDownloadUrls(join(copiedDir, 'native-release-manifest.json'), 'http://127.0.0.1:43123');
-
-    const originalManifest = JSON.parse(await readFile(join(sourceDir, 'native-release-manifest.json'), 'utf-8')) as { assets: Array<{ download_url: string }> };
-    const copiedManifest = JSON.parse(await readFile(join(copiedDir, 'native-release-manifest.json'), 'utf-8')) as { assets: Array<{ download_url: string }> };
-
-    assert.match(originalManifest.assets[0].download_url, /^https:\/\/github\.com\//);
-    assert.deepEqual(
-      copiedManifest.assets.map((asset) => asset.download_url),
-      [
-        'http://127.0.0.1:43123/omx-explore-harness-x86_64-unknown-linux-musl.tar.xz',
-        'http://127.0.0.1:43123/omx-sparkshell-x86_64-unknown-linux-musl.tar.xz',
-      ],
-    );
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
 });
 
 test('resolveGitCommonDir resolves relative git common dir output against the repo root', () => {

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1,16 +1,11 @@
-import { createServer } from 'node:http';
-import type { AddressInfo } from 'node:net';
 import {
-  cpSync,
   existsSync,
   lstatSync,
   mkdtempSync,
-  readFileSync,
   rmSync,
   symlinkSync,
-  writeFileSync,
 } from 'node:fs';
-import { chmodSync, mkdirSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -23,12 +18,17 @@ const REQUIRED_NODE_MODULE_MARKERS = [
   join('zod', 'package.json'),
 ];
 
+export const PACKED_INSTALL_SMOKE_CORE_COMMANDS = [
+  ['--help'],
+  ['version'],
+] as const;
+
 function usage(): string {
   return [
-    'Usage: node scripts/smoke-packed-install.mjs [--release-assets-dir <dir>] [--require-no-fallback]',
+    'Usage: node scripts/smoke-packed-install.mjs',
     '',
     'Creates an npm tarball, installs it into an isolated prefix, and smoke tests the installed omx CLI.',
-    'When --release-assets-dir is provided, native hydration is also exercised using a local HTTP server.',
+    'Release smoke stays intentionally minimal: install + boot + 1-2 core commands only.',
   ].join('\n');
 }
 
@@ -151,43 +151,24 @@ export function ensureRepoDependencies(repoRoot: string, options: EnsureRepoDeps
   };
 }
 
-export function hasSparkShellFallbackBanner(stderr: string | undefined): boolean {
-  return /GLIBC-incompatible native sidecar detected/i.test(String(stderr || ''));
-}
-
-function parseArgs(argv: string[]): { releaseAssetsDir: string | undefined; requireNoFallback: boolean } {
-  let releaseAssetsDir: string | undefined;
-  let requireNoFallback = false;
-  for (let index = 0; index < argv.length; index += 1) {
-    const token = argv[index];
+function parseArgs(argv: string[]): void {
+  for (const token of argv) {
     if (token === '--help' || token === '-h') {
       console.log(usage());
       process.exit(0);
     }
-    if (token === '--release-assets-dir') {
-      const value = argv[index + 1];
-      if (!value) throw new Error('Missing value after --release-assets-dir');
-      releaseAssetsDir = resolve(value);
-      index += 1;
-      continue;
-    }
-    if (token === '--require-no-fallback') {
-      requireNoFallback = true;
-      continue;
-    }
     throw new Error(`Unknown argument: ${token}\n${usage()}`);
   }
-  return { releaseAssetsDir, requireNoFallback };
 }
 
-function run(cmd: string, args: string[], options: Record<string, unknown> = {}): ReturnType<typeof spawnSync> {
-  const result = spawnSync(cmd, args, {
+function run(cmd: string, args: readonly string[], options: Record<string, unknown> = {}): ReturnType<typeof spawnSync> {
+  const result = spawnSync(cmd, [...args], {
     encoding: 'utf-8',
     stdio: 'pipe',
     ...options,
   });
   if (result.status !== 0) {
-    throw new Error(formatCommandFailure(cmd, args, result));
+    throw new Error(formatCommandFailure(cmd, [...args], result));
   }
   return result;
 }
@@ -196,115 +177,14 @@ function npmBinName(name: string): string {
   return process.platform === 'win32' ? `${name}.cmd` : name;
 }
 
-function startStaticServer(root: string): Promise<{ baseUrl: string; close: () => Promise<void> }> {
-  return new Promise((resolveServer, reject) => {
-    const server = createServer((req, res) => {
-      try {
-        const url = new URL(req.url || '/', 'http://127.0.0.1');
-        const requested = resolve(root, url.pathname.replace(/^\//, ''));
-        if (!requested.startsWith(root) || !existsSync(requested)) {
-          res.writeHead(404);
-          res.end('missing');
-          return;
-        }
-        res.writeHead(200);
-        res.end(readFileSync(requested));
-      } catch (error) {
-        res.writeHead(500);
-        res.end(String(error));
-      }
-    });
-    server.on('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address() as AddressInfo | null;
-      if (!address || typeof address === 'string') {
-        reject(new Error('Failed to bind local asset server'));
-        return;
-      }
-      resolveServer({
-        baseUrl: `http://127.0.0.1:${address.port}`,
-        close: () => new Promise<void>((done, fail) => server.close((error) => error ? fail(error) : done())),
-      });
-    });
-  });
-}
-
-function writeCodexStub(binDir: string): string {
-  const stubPath = join(binDir, process.platform === 'win32' ? 'codex.cmd' : 'codex');
-  if (process.platform === 'win32') {
-    writeFileSync(stubPath, [
-      '@echo off',
-      'setlocal enabledelayedexpansion',
-      'set output_path=',
-      ':loop',
-      'if "%~1"=="" goto done',
-      'if "%~1"=="-o" (',
-      '  set output_path=%~2',
-      '  shift',
-      ')',
-      'shift',
-      'goto loop',
-      ':done',
-      'if "%output_path%"=="" exit /b 1',
-      '> "%output_path%" echo # Answer',
-      '>> "%output_path%" echo - packed install smoke harness',
-      'exit /b 0',
-      '',
-    ].join('\r\n'));
-  } else {
-    writeFileSync(stubPath, [
-      '#!/bin/sh',
-      'set -eu',
-      "output_path=''",
-      'while [ "$#" -gt 0 ]; do',
-      '  if [ "$1" = "-o" ] && [ "$#" -ge 2 ]; then',
-      '    output_path="$2"',
-      '    shift 2',
-      '    continue',
-      '  fi',
-      '  shift',
-      'done',
-      'if [ -z "$output_path" ]; then',
-      "  printf 'missing -o output path\\n' >&2",
-      '  exit 1',
-      'fi',
-      "printf '# Answer\\n- packed install smoke harness\\n' > \"$output_path\"",
-      '',
-    ].join('\n'));
-    chmodSync(stubPath, 0o755);
-  }
-  return stubPath;
-}
-
-export function prepareLocalHydrationAssetDirectory(sourceDir: string, tempRoot: string): string {
-  const localDir = join(tempRoot, 'hydration-assets');
-  cpSync(sourceDir, localDir, { recursive: true });
-  return localDir;
-}
-
-export function rewriteManifestDownloadUrls(manifestPath: string, baseUrl: string): void {
-  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as { assets: Array<{ archive: string; download_url: string }> };
-  manifest.assets = Array.isArray(manifest.assets)
-    ? manifest.assets.map((asset) => ({
-      ...asset,
-      download_url: new URL(asset.archive, `${baseUrl}/`).toString(),
-    }))
-    : [];
-  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
-}
-
 async function main(): Promise<void> {
-  const { releaseAssetsDir, requireNoFallback } = parseArgs(process.argv.slice(2));
+  parseArgs(process.argv.slice(2));
+
   const repoRoot = process.cwd();
   const tempRoot = mkdtempSync(join(tmpdir(), 'omx-packed-install-'));
   const prefixDir = join(tempRoot, 'prefix');
-  const cacheDir = join(tempRoot, 'cache');
-  const helperBinDir = join(tempRoot, 'bin');
   mkdirSync(prefixDir, { recursive: true });
-  mkdirSync(cacheDir, { recursive: true });
-  mkdirSync(helperBinDir, { recursive: true });
 
-  let server: { baseUrl: string; close: () => Promise<void> } | undefined;
   let tarballPath: string | undefined;
   try {
     ensureRepoDependencies(repoRoot, {
@@ -320,40 +200,13 @@ async function main(): Promise<void> {
     run('npm', ['install', '-g', tarballPath, '--prefix', prefixDir], { cwd: repoRoot });
 
     const omxPath = join(prefixDir, process.platform === 'win32' ? '' : 'bin', npmBinName('omx'));
-    run(omxPath, ['version'], { cwd: repoRoot });
-    run(omxPath, ['--help'], { cwd: repoRoot });
-
-    if (releaseAssetsDir) {
-      const hydrationAssetsDir = prepareLocalHydrationAssetDirectory(releaseAssetsDir, tempRoot);
-      server = await startStaticServer(hydrationAssetsDir);
-      rewriteManifestDownloadUrls(join(hydrationAssetsDir, 'native-release-manifest.json'), server.baseUrl);
-      const codexStub = writeCodexStub(helperBinDir);
-      const env = {
-        ...process.env,
-        PATH: `${helperBinDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH || ''}`,
-        OMX_NATIVE_MANIFEST_URL: `${server.baseUrl}/native-release-manifest.json`,
-        OMX_NATIVE_CACHE_DIR: cacheDir,
-        OMX_EXPLORE_CODEX_BIN: codexStub,
-      };
-
-      const sparkshell = run(omxPath, ['sparkshell', 'node', '--version'], { cwd: repoRoot, env });
-      if (requireNoFallback && hasSparkShellFallbackBanner(sparkshell.stderr as string)) {
-        throw new Error(`Unexpected sparkshell fallback stderr:\n${sparkshell.stderr}`);
-      }
-      if (!/v\d+\./.test(sparkshell.stdout as string)) {
-        throw new Error(`Unexpected sparkshell stdout:\n${sparkshell.stdout}`);
-      }
-
-      const explore = run(omxPath, ['explore', '--prompt', 'where is buildExploreRoutingGuidance defined'], { cwd: repoRoot, env });
-      if (!(explore.stdout as string).includes('# Answer') || !(explore.stdout as string).includes('packed install smoke harness')) {
-        throw new Error(`Unexpected explore stdout:\n${explore.stdout}`);
-      }
+    for (const argv of PACKED_INSTALL_SMOKE_CORE_COMMANDS) {
+      run(omxPath, argv, { cwd: repoRoot });
     }
 
     console.log('packed install smoke: PASS');
   } finally {
     if (tarballPath) rmSync(tarballPath, { force: true });
-    if (server) await server.close();
     rmSync(tempRoot, { recursive: true, force: true });
   }
 }

--- a/src/verification/__tests__/explore-harness-release-workflow.test.ts
+++ b/src/verification/__tests__/explore-harness-release-workflow.test.ts
@@ -37,22 +37,23 @@ describe('native release workflow', () => {
     assert.match(workflow, /Publish Native Assets/);
     assert.match(workflow, /Smoke Verify Native Assets/);
     assert.match(workflow, /Smoke Test Packed Global Install/);
-    assert.match(workflow, /Older Linux Runtime Proof/);
-    assert.match(workflow, /node:20-bullseye/);
-    assert.match(workflow, /docker run --rm/);
     assert.match(workflow, /Publish npm Package/);
-    assert.match(workflow, /needs:\s*\[older-linux-runtime-proof\]/);
+    assert.match(workflow, /needs:\s*\[smoke-packed-install\]/);
     assert.match(workflow, /npm publish --access public --provenance/);
+    assert.doesNotMatch(workflow, /Older Linux Runtime Proof/);
+    assert.doesNotMatch(workflow, /node:20-bullseye/);
+    assert.doesNotMatch(workflow, /docker run --rm/);
     assert.doesNotMatch(workflow, /scripts\/check-version-sync\.mjs/);
     assert.doesNotMatch(workflow, /scripts\/generate-native-release-manifest\.mjs/);
     assert.doesNotMatch(workflow, /scripts\/verify-native-release-assets\.mjs/);
     assert.doesNotMatch(workflow, /scripts\/smoke-packed-install\.mjs/);
+    assert.doesNotMatch(workflow, /--release-assets-dir/);
+    assert.doesNotMatch(workflow, /--require-no-fallback/);
 
     assert.match(workflow, /verify-version-sync:[\s\S]*Verify version sync against workspace crates[\s\S]*node --input-type=module/);
     assert.match(workflow, /publish-native-assets:[\s\S]*npm run build[\s\S]*node dist\/scripts\/generate-native-release-manifest\.js/);
     assert.match(workflow, /smoke-verify-native:[\s\S]*npm run build[\s\S]*node dist\/scripts\/verify-native-release-assets\.js/);
-    assert.match(workflow, /smoke-packed-install:[\s\S]*npm run build[\s\S]*npm run smoke:packed-install -- --release-assets-dir release-assets/);
-    assert.match(workflow, /older-linux-runtime-proof:[\s\S]*npm ci && npm run build && node dist\/scripts\/smoke-packed-install\.js --release-assets-dir \.\/release-assets --require-no-fallback/);
+    assert.match(workflow, /smoke-packed-install:[\s\S]*npm run build[\s\S]*Smoke test packed install boot \+ core commands[\s\S]*npm run smoke:packed-install/);
     assert.match(workflow, /publish-npm:[\s\S]*Verify version sync against workspace crates[\s\S]*npm pack --dry-run/);
   });
 


### PR DESCRIPTION
## Summary

Fix #982 by keeping release smoke narrowly focused on packed-install viability instead of optional command surfaces.

## Changes

- trim `smoke:packed-install` to install + boot-safe core commands only (`--help`, `version`)
- remove the older-runtime packed-install proof lane from the release workflow
- keep stricter workflow/harness assertions in normal CI smoke coverage via targeted tests
- add regression coverage that release smoke does not exercise `explore`/`sparkshell`

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #982
