### PR TITLE
fix: support deep-interview in OMX state mode handling

### DIFF
--- a/src/mcp/__tests__/state-server-schema.test.ts
+++ b/src/mcp/__tests__/state-server-schema.test.ts
@@ -22,4 +22,23 @@ describe("state-server schema validation", () => {
 			false,
 		);
 	});
+
+	it("includes deep-interview anywhere mode enums are exposed", async () => {
+		process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = "1";
+		const { buildStateServerTools } = await import("../state-server.js");
+
+		const tools = buildStateServerTools();
+		const toolsWithModeEnum = tools.filter(
+			(tool: {
+				inputSchema?: { properties?: { mode?: { enum?: string[] } } };
+			}) => Array.isArray(tool.inputSchema?.properties?.mode?.enum),
+		);
+
+		assert.ok(toolsWithModeEnum.length > 0);
+		for (const tool of toolsWithModeEnum) {
+			assert.ok(
+				tool.inputSchema?.properties?.mode?.enum?.includes("deep-interview"),
+			);
+		}
+	});
 });

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -142,6 +142,59 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('writes and reads deep-interview state', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-test-'));
+    try {
+      const writeResponse = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+            active: true,
+            current_phase: 'deep-interview',
+            state: {
+              current_focus: 'intent',
+              threshold: 0.2,
+            },
+          },
+        },
+      });
+
+      assert.equal(writeResponse.isError, undefined);
+      assert.deepEqual(
+        JSON.parse(writeResponse.content[0]?.text || '{}'),
+        {
+          success: true,
+          mode: 'deep-interview',
+          path: join(wd, '.omx', 'state', 'deep-interview-state.json'),
+        },
+      );
+
+      const readResponse = await handleStateToolCall({
+        params: {
+          name: 'state_read',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'deep-interview',
+          },
+        },
+      });
+
+      assert.equal(readResponse.isError, undefined);
+      const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
+      assert.equal(readBody.active, true);
+      assert.equal(readBody.current_phase, 'deep-interview');
+      assert.equal(readBody.current_focus, 'intent');
+      assert.equal(readBody.threshold, 0.2);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('creates session-scoped state directory when session_id is provided', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -48,6 +48,7 @@ const SUPPORTED_MODES = [
 	"ultrawork",
 	"ultraqa",
 	"ralplan",
+	"deep-interview",
 ] as const;
 
 const STATE_TOOL_NAMES = new Set([

--- a/src/modes/__tests__/base-autoresearch-contract.test.ts
+++ b/src/modes/__tests__/base-autoresearch-contract.test.ts
@@ -5,6 +5,23 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { readModeState, startMode } from '../base.js';
 
+describe('modes/base deep-interview contract integration', () => {
+  it('startMode persists deep-interview state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-deep-interview-contract-'));
+    try {
+      const started = await startMode('deep-interview', 'clarify a vague request', 3, wd);
+      assert.equal(started.mode, 'deep-interview');
+      assert.equal(started.active, true);
+      assert.equal(started.current_phase, 'starting');
+      const persisted = await readModeState('deep-interview', wd);
+      assert.equal(persisted?.mode, 'deep-interview');
+      assert.equal(persisted?.task_description, 'clarify a vague request');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('modes/base autoresearch contract integration', () => {
   it('startMode blocks autoresearch when ralph is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autoresearch-contract-'));

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -1,6 +1,6 @@
 /**
  * Base mode lifecycle management for oh-my-codex
- * All execution modes (autopilot, ralph, ultrawork, team, ultraqa, ralplan) share this base.
+ * All execution modes (autopilot, autoresearch, deep-interview, ralph, ultrawork, team, ultraqa, ralplan) share this base.
  */
 
 import { readFile, writeFile, mkdir } from 'fs/promises';
@@ -23,7 +23,7 @@ export interface ModeState {
   [key: string]: unknown;
 }
 
-export type ModeName = 'autopilot' | 'autoresearch' | 'ralph' | 'ultrawork' | 'team' | 'ultraqa' | 'ralplan';
+export type ModeName = 'autopilot' | 'autoresearch' | 'deep-interview' | 'ralph' | 'ultrawork' | 'team' | 'ultraqa' | 'ralplan';
 
 /** @deprecated These mode names were removed in v4.6. Use the canonical modes instead. */
 export type DeprecatedModeName = 'ultrapilot' | 'pipeline' | 'ecomode';


### PR DESCRIPTION
## Summary
- add `deep-interview` to the MCP state-server supported mode enum so state_read/state_write/state_clear/state_get_status accept it
- extend the shared `ModeName` union in `src/modes/base.ts` so base mode helpers recognize deep-interview as a first-class mode
- add regression coverage for deep-interview schema exposure and state write/read persistence

## Testing
- npm run build
- node --test dist/mcp/__tests__/state-server.test.js dist/mcp/__tests__/state-server-schema.test.js dist/mcp/__tests__/path-traversal.test.js dist/modes/__tests__/base-autoresearch-contract.test.js
- npm run lint -- src/mcp/state-server.ts src/modes/base.ts src/mcp/__tests__/state-server.test.ts src/mcp/__tests__/state-server-schema.test.ts src/modes/__tests__/base-autoresearch-contract.test.ts
