### PR TITLE
feat: add final Ralph deslop launch wiring

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { extractRalphTaskDescription, normalizeRalphCliArgs, filterRalphCodexArgs } from '../ralph.js';
+import {
+  buildRalphAppendInstructions,
+  buildRalphChangedFilesSeedContents,
+  extractRalphTaskDescription,
+  normalizeRalphCliArgs,
+  filterRalphCodexArgs,
+} from '../ralph.js';
 
 describe('extractRalphTaskDescription', () => {
   it('returns plain task text from positional args', () => {
@@ -38,5 +44,41 @@ describe('filterRalphCodexArgs', () => {
   });
   it('preserves non-omx flags', () => {
     assert.deepEqual(filterRalphCodexArgs(['--model', 'gpt-5', '--yolo', 'fix', 'it']), ['--model', 'gpt-5', '--yolo', 'fix', 'it']);
+  });
+});
+
+
+describe('ralph deslop launch wiring', () => {
+  it('consumes --no-deslop so it is not forwarded to codex', () => {
+    assert.deepEqual(filterRalphCodexArgs(['--no-deslop', '--model', 'gpt-5', 'fix', 'it']), ['--model', 'gpt-5', 'fix', 'it']);
+  });
+
+  it('documents changed-files-only deslop guidance by default', () => {
+    const instructions = buildRalphAppendInstructions('fix issue 920', {
+      changedFilesPath: '.omx/ralph/changed-files.txt',
+      noDeslop: false,
+    });
+    assert.match(instructions, /ai-slop-cleaner/i);
+    assert.match(instructions, /changed files only/i);
+    assert.match(instructions, /\.omx\/ralph\/changed-files\.txt/);
+    assert.match(instructions, /standard mode/i);
+    assert.match(instructions, /rerun the current tests\/build\/lint verification/i);
+  });
+
+  it('documents the --no-deslop opt-out when enabled', () => {
+    const instructions = buildRalphAppendInstructions('fix issue 920', {
+      changedFilesPath: '.omx/ralph/changed-files.txt',
+      noDeslop: true,
+    });
+    assert.match(instructions, /--no-deslop/);
+    assert.match(instructions, /skip the mandatory ai-slop-cleaner final pass/i);
+    assert.match(instructions, /latest successful pre-deslop verification evidence/i);
+  });
+
+  it('seeds the changed-files artifact with bounded-scope guidance', () => {
+    const seed = buildRalphChangedFilesSeedContents();
+    assert.match(seed, /mandatory final ai-slop-cleaner pass/i);
+    assert.match(seed, /one repo-relative path per line/i);
+    assert.match(seed, /strictly scoped/i);
   });
 });

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -18,6 +18,7 @@ Options:
   --help, -h           Show this help message
   --prd <task text>    PRD mode shortcut: mark the task text explicitly
   --prd=<task text>    Same as --prd "<task text>"
+  --no-deslop         Skip the final ai-slop-cleaner pass
 
 PRD mode:
   Ralph initializes persistence artifacts in .omx/ so PRD and progress
@@ -32,7 +33,7 @@ Common patterns:
 `;
 
 const VALUE_TAKING_FLAGS = new Set(['--model', '--provider', '--config', '-c', '-i', '--images-dir']);
-const RALPH_OMX_FLAGS = new Set(['--prd']);
+const RALPH_OMX_FLAGS = new Set(['--prd', '--no-deslop']);
 const RALPH_APPEND_ENV = 'OMX_RALPH_APPEND_INSTRUCTIONS_FILE';
 
 export function extractRalphTaskDescription(args: readonly string[]): string {
@@ -89,7 +90,23 @@ export function filterRalphCodexArgs(args: readonly string[]): string[] {
   return filtered;
 }
 
-function buildRalphAppendInstructions(task: string): string {
+interface RalphSessionFiles {
+  instructionsPath: string;
+  changedFilesPath: string;
+}
+
+export function buildRalphChangedFilesSeedContents(): string {
+  return [
+    '# Ralph changed files for the mandatory final ai-slop-cleaner pass',
+    '# Add one repo-relative path per line as Ralph edits files during the session.',
+    '# Step 7.5 must keep ai-slop-cleaner strictly scoped to the paths listed here.',
+  ].join('\n');
+}
+
+export function buildRalphAppendInstructions(
+  task: string,
+  options: { changedFilesPath: string; noDeslop: boolean },
+): string {
   return [
     '<ralph_native_subagents>',
     'You are in OMX Ralph persistence mode.',
@@ -99,16 +116,35 @@ function buildRalphAppendInstructions(task: string): string {
     '- Treat `.omx/state/subagent-tracking.json` as the native subagent activity ledger for this session.',
     '- Do not declare the task complete, and do not transition into final verification/completion, while active native subagent threads are still running.',
     '- Before closing a verification wave, confirm that active native subagent threads have drained.',
+    'Final deslop guidance:',
+    options.noDeslop
+      ? '- `--no-deslop` is active for this Ralph run, so skip the mandatory ai-slop-cleaner final pass and use the latest successful pre-deslop verification evidence.'
+      : `- Step 7.5 must run oh-my-codex:ai-slop-cleaner in standard mode on changed files only, using the repo-relative paths listed in \`${options.changedFilesPath}\`.`,
+    options.noDeslop
+      ? '- Do not run ai-slop-cleaner unless the user explicitly re-enables the deslop pass.'
+      : '- Keep the cleaner scope bounded to that file list; do not widen the pass to the full codebase or unrelated files.',
+    options.noDeslop
+      ? '- Step 7.6 stays satisfied by the latest successful pre-deslop verification evidence because this run opted out of the deslop pass.'
+      : '- Step 7.6 must rerun the current tests/build/lint verification after ai-slop-cleaner; if regression fails, roll back cleaner changes or fix and retry before completion.',
     '</ralph_native_subagents>',
   ].join('\n');
 }
 
-async function writeRalphAppendInstructionsFile(cwd: string, task: string): Promise<string> {
+async function writeRalphSessionFiles(
+  cwd: string,
+  task: string,
+  options: { noDeslop: boolean },
+): Promise<RalphSessionFiles> {
   const dir = join(cwd, '.omx', 'ralph');
   await mkdir(dir, { recursive: true });
-  const path = join(dir, 'session-instructions.md');
-  await writeFile(path, `${buildRalphAppendInstructions(task)}\n`);
-  return path;
+  const instructionsPath = join(dir, 'session-instructions.md');
+  const changedFilesPath = join(dir, 'changed-files.txt');
+  await writeFile(changedFilesPath, `${buildRalphChangedFilesSeedContents()}\n`);
+  await writeFile(
+    instructionsPath,
+    `${buildRalphAppendInstructions(task, { changedFilesPath: '.omx/ralph/changed-files.txt', noDeslop: options.noDeslop })}\n`,
+  );
+  return { instructionsPath, changedFilesPath: '.omx/ralph/changed-files.txt' };
 }
 
 export async function ralphCommand(args: string[]): Promise<void> {
@@ -120,9 +156,11 @@ export async function ralphCommand(args: string[]): Promise<void> {
   }
   const artifacts = await ensureCanonicalRalphArtifacts(cwd);
   const task = extractRalphTaskDescription(normalizedArgs);
+  const noDeslop = normalizedArgs.some((arg) => arg.toLowerCase() === '--no-deslop');
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
   const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes);
   await startMode('ralph', task, 50);
+  const sessionFiles = await writeRalphSessionFiles(cwd, task, { noDeslop });
   await updateModeState('ralph', {
     current_phase: 'starting',
     canonical_progress_path: artifacts.canonicalProgressPath,
@@ -132,6 +170,10 @@ export async function ralphCommand(args: string[]): Promise<void> {
     native_subagents_enabled: true,
     native_subagent_tracking_path: '.omx/state/subagent-tracking.json',
     native_subagent_policy: 'Parallel Codex subagents are allowed for independent work, but phase completion must wait for active native subagent threads to finish.',
+    deslop_enabled: !noDeslop,
+    deslop_opt_out: noDeslop,
+    deslop_changed_files_path: sessionFiles.changedFilesPath,
+    deslop_scope: 'changed-files-only',
     ...(artifacts.canonicalPrdPath ? { canonical_prd_path: artifacts.canonicalPrdPath } : {}),
   });
   if (artifacts.migratedPrd) {
@@ -145,7 +187,7 @@ export async function ralphCommand(args: string[]): Promise<void> {
   console.log(`[ralph] staffing_plan: ${staffingPlan.staffingSummary}`);
   const { launchWithHud } = await import('./index.js');
   const codexArgs = filterRalphCodexArgs(normalizedArgs);
-  const appendixPath = await writeRalphAppendInstructionsFile(cwd, task);
+  const appendixPath = sessionFiles.instructionsPath;
   const previousAppendixEnv = process.env[RALPH_APPEND_ENV];
   process.env[RALPH_APPEND_ENV] = appendixPath;
   try {


### PR DESCRIPTION
## Summary
- add explicit Ralph CLI support for `--no-deslop`
- seed a Ralph session changed-files artifact and pass changed-files-only deslop guidance into session instructions
- record deslop state metadata and cover the new launch wiring with targeted tests

## Verification
- npm run build
- npm run lint -- src/cli/ralph.ts src/cli/__tests__/ralph.test.ts
- node --test dist/cli/__tests__/ralph.test.js dist/cli/__tests__/ralph-deslop-contract.test.js dist/cli/__tests__/ralph-prd-deep-interview.test.js

Closes #920.
