### PR TITLE
Prevent false-positive leader stale nudges when any leader activity is fresh

### DIFF
--- a/src/cli/__tests__/doctor-team.test.ts
+++ b/src/cli/__tests__/doctor-team.test.ts
@@ -213,6 +213,42 @@ describe('omx doctor --team', () => {
     }
   });
 
+  it('does not emit stale_leader when leader recently checked team status', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const teamRoot = join(stateDir, 'team', 'eta');
+      await mkdir(join(teamRoot, 'workers', 'worker-1'), { recursive: true });
+      await writeFile(join(teamRoot, 'config.json'), JSON.stringify({
+        name: 'eta',
+        tmux_session: 'omx-team-eta',
+      }));
+
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_turn_at: new Date(Date.now() - 300_000).toISOString(),
+        turn_count: 5,
+      }));
+      await writeFile(join(stateDir, 'leader-runtime-activity.json'), JSON.stringify({
+        last_activity_at: new Date(Date.now() - 5_000).toISOString(),
+        last_source: 'team_status',
+        last_team_name: 'eta',
+      }));
+
+      const fakeBin = join(wd, 'bin');
+      await mkdir(fakeBin, { recursive: true });
+      const tmuxPath = join(fakeBin, 'tmux');
+      await writeFile(tmuxPath, '#!/bin/sh\nif [ "$1" = "list-sessions" ]; then echo "omx-team-eta"; exit 0; fi\nexit 0\n');
+      spawnSync('chmod', ['+x', tmuxPath], { encoding: 'utf-8' });
+
+      const res = runOmx(wd, ['doctor', '--team'], { PATH: `${fakeBin}:${process.env.PATH || ''}` });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.doesNotMatch(res.stdout, /stale_leader/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('does not emit orphan_tmux_session when tmux reports no server running', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-'));
     try {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1347,6 +1347,35 @@ describe('teamCommand status', () => {
     }
   });
 
+  it('records leader runtime activity when team status is read', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-activity-'));
+    const previousCwd = process.cwd();
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      process.chdir(wd);
+      await withoutTeamTestWorkerEnv(() => initTeamState('activity-team', 'inspect activity', 'executor', 1, wd));
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+
+      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'activity-team', '--json']));
+
+      const activity = JSON.parse(await readFile(join(wd, '.omx', 'state', 'leader-runtime-activity.json'), 'utf-8')) as {
+        last_activity_at?: string;
+        last_team_status_at?: string;
+        last_source?: string;
+        last_team_name?: string;
+      };
+      assert.equal(activity.last_source, 'team_status');
+      assert.equal(activity.last_team_name, 'activity-team');
+      assert.ok(typeof activity.last_activity_at === 'string' && activity.last_activity_at.length > 0);
+      assert.ok(typeof activity.last_team_status_at === 'string' && activity.last_team_status_at.length > 0);
+    } finally {
+      console.log = originalLog;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('supports custom tail lines for generated sparkshell commands', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-tail-lines-'));
     const previousCwd = process.cwd();

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -15,6 +15,7 @@ import { parse as parseToml } from '@iarna/toml';
 import { resolvePackagedExploreHarnessCommand, EXPLORE_BIN_ENV } from './explore.js';
 import { getPackageRoot } from '../utils/package.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
+import { isLeaderRuntimeStale } from '../team/leader-activity.js';
 
 interface DoctorOptions {
   verbose?: boolean;
@@ -335,12 +336,10 @@ async function collectTeamDoctorIssues(cwd: string): Promise<TeamDoctorIssue[]> 
 
   // stale_leader: team has active workers but leader has no recent activity
   const hudStatePath = join(stateDir, 'hud-state.json');
-  if (existsSync(hudStatePath) && teamDirs.length > 0) {
+  const leaderActivityPath = join(stateDir, 'leader-runtime-activity.json');
+  if ((existsSync(hudStatePath) || existsSync(leaderActivityPath)) && teamDirs.length > 0) {
     try {
-      const hudRaw = await readFile(hudStatePath, 'utf-8');
-      const hudState = JSON.parse(hudRaw) as { last_turn_at?: string };
-      const lastTurnMs = hudState.last_turn_at ? Date.parse(hudState.last_turn_at) : NaN;
-      const leaderIsStale = !Number.isFinite(lastTurnMs) || (nowMs - lastTurnMs > leaderStaleThresholdMs);
+      const leaderIsStale = await isLeaderRuntimeStale(stateDir, leaderStaleThresholdMs, nowMs);
 
       if (leaderIsStale && !tmuxUnavailable) {
         // Check if any team tmux session has live worker panes

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -23,6 +23,7 @@ import {
   type TeamApiOperation,
 } from '../team/api-interop.js';
 import { teamReadConfig as readTeamConfig, teamReadTaskApproval as readTaskApproval } from '../team/team-ops.js';
+import { recordLeaderRuntimeActivity } from '../team/leader-activity.js';
 
 type TeamWorkerCli = Exclude<WorkerInfo['worker_cli'], undefined>;
 
@@ -2220,6 +2221,7 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
     const name = teamArgs[1];
     const wantsJson = teamArgs.includes('--json');
     if (!name) throw new Error('Usage: omx team status <team-name> [--json]');
+    await recordLeaderRuntimeActivity(cwd, 'team_status', name);
     const snapshot = await monitorTeam(name, cwd);
     if (!snapshot) {
       if (wantsJson) {

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -178,9 +178,68 @@ describe('notify-hook leader-side authority handoff', () => {
       assert.equal(request?.status, 'failed');
     });
   });
+
+  it('does not nudge stale leader when recent team status activity proves the leader is active', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'beta-active-status';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(join(workersDir, 'worker-1'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'omx-team-beta-active-status',
+        leader_pane_id: '%92',
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10' },
+        ],
+      });
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: new Date(Date.now() - 300_000).toISOString(),
+        turn_count: 5,
+      });
+      await writeJson(join(stateDir, 'leader-runtime-activity.json'), {
+        last_activity_at: new Date(Date.now() - 5_000).toISOString(),
+        last_team_status_at: new Date(Date.now() - 5_000).toISOString(),
+        last_source: 'team_status',
+        last_team_name: teamName,
+      });
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'working',
+        current_task_id: '1',
+        updated_at: new Date().toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345']));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /Team beta-active-status:/);
+        assert.doesNotMatch(tmuxLog, /leader stale/);
+      }
+    });
+  });
 });
 
-describe.skip('notify-hook team leader nudge', () => {
+describe('notify-hook team leader nudge', () => {
   it('sends immediate all-workers-idle nudge for active team (leader context)', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -12,6 +12,7 @@ import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { DEFAULT_MARKER, resolveCodexPane } from '../tmux-hook-engine.js';
+import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
@@ -135,14 +136,7 @@ export async function checkWorkerPanesAlive(tmuxTarget, workerPaneIds = []) {
 }
 
 export async function isLeaderStale(stateDir, thresholdMs, nowMs) {
-  const hudStatePath = join(stateDir, 'hud-state.json');
-  const hudState = await readJsonIfExists(hudStatePath, null);
-  if (!hudState || typeof hudState !== 'object') return true;
-  const lastTurnAt = safeString(hudState.last_turn_at || '');
-  if (!lastTurnAt) return true;
-  const lastMs = Date.parse(lastTurnAt);
-  if (!Number.isFinite(lastMs)) return true;
-  return (nowMs - lastMs) >= thresholdMs;
+  return isLeaderRuntimeStale(stateDir, thresholdMs, nowMs);
 }
 
 function resolveTerminalAtFromPhaseDoc(parsed, fallbackIso) {

--- a/src/team/__tests__/leader-activity.test.ts
+++ b/src/team/__tests__/leader-activity.test.ts
@@ -1,0 +1,154 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  isLeaderRuntimeStale,
+  readLatestLeaderActivityMsFromStateDir,
+  recordLeaderRuntimeActivity,
+} from '../leader-activity.js';
+
+describe('leader runtime activity', () => {
+  it('records team status activity with shared leader activity metadata', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-'));
+    try {
+      const nowIso = '2026-03-21T04:11:12.000Z';
+      await recordLeaderRuntimeActivity(cwd, 'team_status', 'alpha', nowIso);
+
+      const activity = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'leader-runtime-activity.json'), 'utf-8')) as {
+        last_activity_at?: string;
+        last_team_status_at?: string;
+        last_source?: string;
+        last_team_name?: string;
+      };
+
+      assert.equal(activity.last_activity_at, nowIso);
+      assert.equal(activity.last_team_status_at, nowIso);
+      assert.equal(activity.last_source, 'team_status');
+      assert.equal(activity.last_team_name, 'alpha');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the newest runtime signal across hud and explicit leader activity', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_turn_at: '2026-03-21T04:00:00.000Z',
+      }));
+      await writeFile(join(stateDir, 'leader-runtime-activity.json'), JSON.stringify({
+        last_activity_at: '2026-03-21T04:05:00.000Z',
+        last_source: 'team_status',
+      }));
+
+      const lastActivityMs = await readLatestLeaderActivityMsFromStateDir(stateDir);
+      assert.equal(lastActivityMs, Date.parse('2026-03-21T04:05:00.000Z'));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+
+  it('treats the leader as active when any runtime signal is still fresh', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      const nowMs = Date.parse('2026-03-21T04:10:00.000Z');
+
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_turn_at: '2026-03-21T04:00:00.000Z',
+      }));
+      await writeFile(join(stateDir, 'leader-runtime-activity.json'), JSON.stringify({
+        last_activity_at: '2026-03-21T04:09:50.000Z',
+        last_source: 'team_status',
+      }));
+
+      assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, nowMs), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats the leader as stale only when every valid runtime signal is stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      const nowMs = Date.parse('2026-03-21T04:10:00.000Z');
+
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_turn_at: '2026-03-21T04:00:00.000Z',
+      }));
+      await writeFile(join(stateDir, 'leader-runtime-activity.json'), JSON.stringify({
+        last_activity_at: '2026-03-21T04:05:00.000Z',
+        last_source: 'team_status',
+      }));
+
+      assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, nowMs), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+
+  it('treats recent leader-branch git movement as activity even when runtime timestamps are stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-git-'));
+    try {
+      execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+      await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+      execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_turn_at: '2026-03-21T04:00:00.000Z',
+      }));
+      await writeFile(join(stateDir, 'leader-runtime-activity.json'), JSON.stringify({
+        last_activity_at: '2026-03-21T04:00:00.000Z',
+        last_source: 'team_status',
+      }));
+
+      await writeFile(join(cwd, 'README.md'), 'hello world\n', 'utf-8');
+      execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'leader progress'], { cwd, stdio: 'ignore' });
+
+      const headMs = Number(execFileSync('git', ['show', '-s', '--format=%ct', 'HEAD'], {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim()) * 1000;
+
+      assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, headMs + 5_000), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats missing or invalid runtime evidence as not stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+
+      assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, Date.now()), false);
+
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'not-a-date' }));
+      await writeFile(join(stateDir, 'leader-runtime-activity.json'), JSON.stringify({ last_activity_at: '' }));
+
+      assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, Date.now()), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -1,0 +1,168 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { omxStateDir } from '../utils/paths.js';
+
+interface LeaderRuntimeActivityDoc {
+  last_activity_at?: string;
+  last_team_status_at?: string;
+  last_source?: string;
+  last_team_name?: string;
+}
+
+interface LeaderRuntimeSignalStatus {
+  source: 'hud' | 'leader_runtime_activity' | 'leader_branch_git_activity';
+  at: string | null;
+  ms: number;
+  valid: boolean;
+  fresh: boolean;
+}
+
+async function readJsonIfExists(path: string): Promise<Record<string, unknown> | null> {
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function parseIsoMs(value: unknown): number {
+  if (typeof value !== 'string' || value.trim().length === 0) return Number.NaN;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function parseEpochSecondsMs(value: string): number {
+  const trimmed = value.trim();
+  if (!trimmed) return Number.NaN;
+  const seconds = Number(trimmed);
+  return Number.isFinite(seconds) ? seconds * 1000 : Number.NaN;
+}
+
+function tryReadGitValue(cwd: string, args: string[]): string | null {
+  try {
+    const value = execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+async function statMsIfExists(path: string | null): Promise<number> {
+  if (!path || !existsSync(path)) return Number.NaN;
+  try {
+    return (await stat(path)).mtimeMs;
+  } catch {
+    return Number.NaN;
+  }
+}
+
+function stateDirToProjectRoot(stateDir: string): string {
+  return dirname(dirname(stateDir));
+}
+
+async function readLeaderBranchGitActivityMs(stateDir: string): Promise<number> {
+  const cwd = stateDirToProjectRoot(stateDir);
+  const gitDir = tryReadGitValue(cwd, ['rev-parse', '--git-dir']);
+  if (!gitDir) return Number.NaN;
+
+  const branch = tryReadGitValue(cwd, ['symbolic-ref', '--quiet', '--short', 'HEAD']);
+  const headLogPath = tryReadGitValue(cwd, ['rev-parse', '--git-path', 'logs/HEAD']);
+  const branchLogPath = branch
+    ? tryReadGitValue(cwd, ['rev-parse', '--git-path', `logs/refs/heads/${branch}`])
+    : null;
+  const headCommitEpoch = tryReadGitValue(cwd, ['show', '-s', '--format=%ct', 'HEAD']);
+
+  const [headLogMs, branchLogMs] = await Promise.all([
+    statMsIfExists(headLogPath ? join(cwd, headLogPath) : null),
+    statMsIfExists(branchLogPath ? join(cwd, branchLogPath) : null),
+  ]);
+  const headCommitMs = headCommitEpoch ? parseEpochSecondsMs(headCommitEpoch) : Number.NaN;
+
+  const candidates = [headLogMs, branchLogMs, headCommitMs].filter((ms) => Number.isFinite(ms));
+  return candidates.length > 0 ? Math.max(...candidates) : Number.NaN;
+}
+
+export function leaderRuntimeActivityPath(cwd: string): string {
+  return join(omxStateDir(cwd), 'leader-runtime-activity.json');
+}
+
+export async function recordLeaderRuntimeActivity(
+  cwd: string,
+  source: string,
+  teamName?: string,
+  nowIso = new Date().toISOString(),
+): Promise<void> {
+  const stateDir = omxStateDir(cwd);
+  await mkdir(stateDir, { recursive: true });
+  const path = leaderRuntimeActivityPath(cwd);
+  const existingRaw = await readJsonIfExists(path);
+  const existing: LeaderRuntimeActivityDoc = existingRaw && typeof existingRaw === 'object'
+    ? existingRaw as LeaderRuntimeActivityDoc
+    : {};
+  const next: LeaderRuntimeActivityDoc = {
+    ...existing,
+    last_activity_at: nowIso,
+    last_source: source,
+  };
+  if (source === 'team_status') next.last_team_status_at = nowIso;
+  if (teamName) next.last_team_name = teamName;
+  await writeFile(path, JSON.stringify(next, null, 2));
+}
+
+export async function readLeaderRuntimeSignalStatuses(
+  stateDir: string,
+  thresholdMs: number,
+  nowMs: number,
+): Promise<LeaderRuntimeSignalStatus[]> {
+  const hudPath = join(stateDir, 'hud-state.json');
+  const leaderActivityPath = join(stateDir, 'leader-runtime-activity.json');
+
+  const [hudState, leaderActivity, leaderGitActivityMs] = await Promise.all([
+    existsSync(hudPath) ? readJsonIfExists(hudPath) : Promise.resolve(null),
+    existsSync(leaderActivityPath) ? readJsonIfExists(leaderActivityPath) : Promise.resolve(null),
+    readLeaderBranchGitActivityMs(stateDir),
+  ]);
+
+  const signals: Array<{ source: LeaderRuntimeSignalStatus['source']; at: unknown; ms?: number }> = [
+    { source: 'hud', at: hudState?.last_turn_at },
+    { source: 'leader_runtime_activity', at: leaderActivity?.last_activity_at },
+    {
+      source: 'leader_branch_git_activity',
+      at: Number.isFinite(leaderGitActivityMs) ? new Date(leaderGitActivityMs).toISOString() : null,
+      ms: leaderGitActivityMs,
+    },
+  ];
+
+  return signals.map(({ source, at, ms: providedMs }) => {
+    const ms = Number.isFinite(providedMs) ? Number(providedMs) : parseIsoMs(at);
+    const valid = Number.isFinite(ms);
+    const fresh = valid && (nowMs - ms) < thresholdMs;
+    return {
+      source,
+      at: typeof at === 'string' && at.trim().length > 0 ? at : null,
+      ms,
+      valid,
+      fresh,
+    };
+  });
+}
+
+export async function readLatestLeaderActivityMsFromStateDir(stateDir: string): Promise<number> {
+  const statuses = await readLeaderRuntimeSignalStatuses(stateDir, Number.MAX_SAFE_INTEGER, Date.now());
+  const validMs = statuses.filter((status) => status.valid).map((status) => status.ms);
+  return validMs.length > 0 ? Math.max(...validMs) : Number.NaN;
+}
+
+export async function isLeaderRuntimeStale(stateDir: string, thresholdMs: number, nowMs: number): Promise<boolean> {
+  const statuses = await readLeaderRuntimeSignalStatuses(stateDir, thresholdMs, nowMs);
+  const validStatuses = statuses.filter((status) => status.valid);
+  if (validStatuses.length === 0) return false;
+  return validStatuses.every((status) => !status.fresh);
+}


### PR DESCRIPTION
## Summary

Leader stale detection was too eager and could nudge even when the leader had recent activity through `omx team status` or recent leader-branch progress.

This change centralizes stale evaluation, treats any fresh leader activity signal as sufficient proof of activity, aligns `notify-hook` and `doctor --team`, and activates the full notify-hook leader-nudge test suite.

## Changes

- add shared leader activity/staleness logic in `src/team/leader-activity.ts`
- treat the leader as stale only when **all valid activity signals** are stale
- count these as leader activity signals:
  - HUD `last_turn_at`
  - explicit leader runtime activity (`leader-runtime-activity.json`)
  - leader-branch git activity / HEAD movement
- make `omx team status` record leader runtime activity
- make `doctor --team` reuse the shared stale heuristic
- make notify-hook leader stale checks reuse the shared stale heuristic
- stop treating missing/invalid runtime timestamps as automatically stale
- unskip and activate the notify-hook leader-nudge test suite
- add regression coverage for:
  - recent `team status` suppressing stale leader nudges
  - any fresh signal suppressing stale status
  - leader-branch git movement suppressing stale status

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Focused verification run:
- [x] `node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
- [x] `node --test dist/team/__tests__/leader-activity.test.js dist/cli/__tests__/team.test.js dist/cli/__tests__/doctor-team.test.js dist/compat/__tests__/rust-runtime-compat.test.js`
- [x] `npm run lint`
- [x] `npm run check:no-unused`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
