### PR TITLE
fix(release): align Cargo.toml version for v0.11.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.11.4"
+version = "0.11.5"
 
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump Cargo.toml workspace version to 0.11.5 to fix version-sync-contract test failure

## Test plan
- [x] `version-sync-contract` test passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)