### PR TITLE
fix: throttle Ralph continue steer across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,13 +32,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-explore-harness"
-
-version = "0.11.4"
+version = "0.11.5"
 
 [[package]]
 name = "omx-mux"
-version = "0.11.4"
-
+version = "0.11.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -46,9 +44,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-
-version = "0.11.4"
-
+version = "0.11.5"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -57,9 +53,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-
-version = "0.11.4"
-
+version = "0.11.5"
 dependencies = [
  "fs2",
  "serde",
@@ -68,9 +62,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-
-version = "0.11.4"
-
+version = "0.11.5"
 
 [[package]]
 name = "proc-macro2"

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -542,17 +542,23 @@ describe('notify-fallback watcher', () => {
   it('sends bounded periodic Ralph continue steer while Ralph state stays active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-active-'));
     const fakeBinDir = join(wd, 'fake-bin');
+    const stateDir = join(wd, '.omx', 'state');
     const tmuxLogPath = join(wd, 'tmux.log');
-    const statePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+    const statePath = join(stateDir, 'notify-fallback-state.json');
     try {
-      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
       await mkdir(fakeBinDir, { recursive: true });
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
-      await writeFile(join(wd, '.omx', 'state', 'ralph-state.json'), JSON.stringify({
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
         active: true,
         current_phase: 'executing',
         tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(statePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
       }, null, 2));
 
       const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
@@ -568,6 +574,18 @@ describe('notify-fallback watcher', () => {
         { encoding: 'utf-8', env },
       );
       assert.equal(first.status, 0, first.stderr || first.stdout);
+
+      const persistedAfterFirst = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.match(
+        persistedAfterFirst.ralph_continue_steer?.last_sent_at ?? '',
+        /^\d{4}-\d{2}-\d{2}T/,
+        'successful steer should persist a round-trippable ISO last_sent_at',
+      );
+      assert.equal(
+        persistedAfterFirst.ralph_continue_steer?.cooldown_anchor_at,
+        persistedAfterFirst.ralph_continue_steer?.last_sent_at,
+        'successful steer should advance the fallback cooldown anchor to the real send time',
+      );
 
       const second = spawnSync(
         process.execPath,
@@ -599,6 +617,123 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('waits a full cadence from startup when persisted Ralph steer state is empty', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-startup-cooldown-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const stateDir = join(wd, '.omx', 'state');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const statePath = join(stateDir, 'notify-fallback-state.json');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(statePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: '',
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...buildCleanNotifyEnv(),
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      };
+
+      const first = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+
+      const second = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'empty startup state should wait one cadence period before the first Ralph steer');
+
+      const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'startup_cooldown');
+      assert.equal(watcherState.ralph_continue_steer?.last_sent_at, '');
+      assert.match(
+        watcherState.ralph_continue_steer?.cooldown_anchor_at ?? '',
+        /^\d{4}-\d{2}-\d{2}T/,
+        'startup cooldown should persist an anchor so restarts stay throttled',
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to an aged persisted cooldown anchor when last_sent_at is invalid', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-invalid-last-sent-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const stateDir = join(wd, '.omx', 'state');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const statePath = join(stateDir, 'notify-fallback-state.json');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(statePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: 'not-a-date',
+          cooldown_anchor_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...buildCleanNotifyEnv(),
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      };
+
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 1, 'invalid last_sent_at should fall back to the persisted cooldown anchor once 60s have elapsed');
+
+      const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.match(
+        watcherState.ralph_continue_steer?.last_sent_at ?? '',
+        /^\d{4}-\d{2}-\d{2}T/,
+        'successful fallback send should replace the invalid last_sent_at with a valid ISO timestamp',
+      );
+      assert.equal(
+        watcherState.ralph_continue_steer?.cooldown_anchor_at,
+        watcherState.ralph_continue_steer?.last_sent_at,
+        'fallback send should also refresh the persisted cooldown anchor',
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('stops Ralph continue steer immediately once Ralph state is terminal or cleared', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-terminal-'));
     const fakeBinDir = join(wd, 'fake-bin');
@@ -615,6 +750,11 @@ describe('notify-fallback watcher', () => {
         active: true,
         current_phase: 'executing',
         tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(watcherStatePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
       }, null, 2));
 
       const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
@@ -687,6 +827,11 @@ describe('notify-fallback watcher', () => {
         active: true,
         current_phase: 'executing',
         tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
       }, null, 2));
 
       const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
@@ -865,6 +1010,11 @@ describe('notify-fallback watcher', () => {
         active: true,
         current_phase: 'executing',
         tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(join(stateDir, 'notify-fallback-state.json'), JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
       }, null, 2));
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -30,6 +30,11 @@ function safeString(v: unknown): string {
   return typeof v === 'string' ? v : '';
 }
 
+function parseIsoMillis(value: string | null | undefined): number | null {
+  const parsed = Date.parse(safeString(value).trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function isPidAlive(pid: number): boolean {
   if (!Number.isFinite(pid) || pid <= 0) return false;
   try {
@@ -98,6 +103,7 @@ interface RalphContinueSteerState {
   active: boolean;
   last_state_check_at: string | null;
   last_sent_at: string;
+  cooldown_anchor_at: string;
   last_reason: string;
   last_error: string | null;
   state_path: string;
@@ -156,6 +162,7 @@ let lastRalphContinueSteer: RalphContinueSteerState = {
   active: false,
   last_state_check_at: null,
   last_sent_at: '',
+  cooldown_anchor_at: '',
   last_reason: 'init',
   last_error: null,
   state_path: '',
@@ -181,6 +188,7 @@ function normalizeRalphContinueSteerState(raw: Record<string, unknown> | null | 
     active: raw.active === true,
     last_state_check_at: safeString(raw.last_state_check_at) || null,
     last_sent_at: safeString(raw.last_sent_at),
+    cooldown_anchor_at: safeString(raw.cooldown_anchor_at),
     last_reason: safeString(raw.last_reason) || 'init',
     last_error: safeString(raw.last_error) || null,
     state_path: safeString(raw.state_path),
@@ -283,6 +291,7 @@ async function emitRalphContinueSteer(paneId: string, message: string): Promise<
 async function runRalphContinueSteerTick(): Promise<void> {
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
+  const startupIso = new Date(startedAt).toISOString();
   const activeRalph = await resolveActiveRalphState();
   lastRalphContinueSteer = {
     ...lastRalphContinueSteer,
@@ -297,9 +306,14 @@ async function runRalphContinueSteerTick(): Promise<void> {
 
   if (!activeRalph.active) return;
 
-  const lastSentMs = Date.parse(lastRalphContinueSteer.last_sent_at);
-  if (Number.isFinite(lastSentMs) && now - lastSentMs < RALPH_CONTINUE_CADENCE_MS) {
-    lastRalphContinueSteer.last_reason = 'cooldown';
+  const lastSentMs = parseIsoMillis(lastRalphContinueSteer.last_sent_at);
+  const startupAnchorMs = parseIsoMillis(lastRalphContinueSteer.cooldown_anchor_at);
+  if (lastSentMs === null && startupAnchorMs === null) {
+    lastRalphContinueSteer.cooldown_anchor_at = startupIso;
+  }
+  const cooldownAnchorMs = lastSentMs ?? startupAnchorMs ?? startedAt;
+  if (now - cooldownAnchorMs < RALPH_CONTINUE_CADENCE_MS) {
+    lastRalphContinueSteer.last_reason = lastSentMs === null ? 'startup_cooldown' : 'cooldown';
     return;
   }
 
@@ -320,6 +334,7 @@ async function runRalphContinueSteerTick(): Promise<void> {
 
   await emitRalphContinueSteer(paneId, RALPH_CONTINUE_TEXT);
   lastRalphContinueSteer.last_sent_at = nowIso;
+  lastRalphContinueSteer.cooldown_anchor_at = nowIso;
   lastRalphContinueSteer.last_reason = 'sent';
   await eventLog({
     type: 'ralph_continue_steer',


### PR DESCRIPTION
## Summary
- harden the Ralph continue steer cooldown when persisted `last_sent_at` is empty or invalid
- persist and refresh a fallback `cooldown_anchor_at` so startup and restart paths still honor the 60s cadence
- add regression coverage for empty-state restart behavior, malformed timestamp recovery, and timestamp round-tripping
- sync `Cargo.lock` to the 0.11.5 workspace version so repo-wide verification stays green on the current `dev` base

## Verification
- `npm test`
- `npm run lint`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

Closes #996.
