### PR TITLE
Release v0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.11.6] - 2026-03-21
+
+Patch release for Ralph continue-steer restart throttling.
+
+### Fixed
+- **Ralph continue-steer restart throttling** — fallback watcher cooldown anchors now survive restarts and malformed persisted timestamps, preventing repeated continue-steer injection spam after Ralph resumes. (PR [#998](https://github.com/Yeachan-Heo/oh-my-codex/pull/998), closes [#996](https://github.com/Yeachan-Heo/oh-my-codex/issues/996))
+
 ## [0.11.5] - 2026-03-21
 
 Hotfix release for stale leader nudge false-positives and README onboarding clarity.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,11 +32,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.11.5"
+version = "0.11.6"
 
 [[package]]
 name = "omx-mux"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "fs2",
  "serde",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.11.5"
+version = "0.11.6"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.11.5"
+version = "0.11.6"
 
 edition = "2021"
 license = "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump npm and Cargo workspace versions to 0.11.6
- refresh JS/Rust lockfiles for the release version
- add the v0.11.6 changelog entry for the Ralph continue-steer restart throttling fix (#998, closes #996)

## Verification
- npm install
- npm run build && npm test

## Notes
- release prep only; owner will handle merge to main/tagging
