### PR TITLE
fix: suppress stale leader nudges from completed or foreign-session teams

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -991,6 +991,132 @@ exit 0
     });
   });
 
+  it('does not nudge completed teams on reopen even when config and idle worker state still exist', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'completed-reopen';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const completedAt = '2026-03-21T08:40:35.471Z';
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(workersDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: false,
+        team_name: teamName,
+        current_phase: 'complete',
+        completed_at: completedAt,
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'completed-reopen:0',
+        leader_pane_id: '%91',
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10', role: 'executor' },
+          { name: 'worker-2', index: 2, pane_id: '%11', role: 'executor' },
+        ],
+      });
+      await writeJson(join(teamDir, 'phase.json'), {
+        current_phase: 'complete',
+        transitions: [{ from: 'team-verify', to: 'complete', at: completedAt }],
+        updated_at: completedAt,
+      });
+      for (const worker of ['worker-1', 'worker-2']) {
+        await mkdir(join(workersDir, worker), { recursive: true });
+        await writeJson(join(workersDir, worker, 'status.json'), {
+          state: 'idle',
+          updated_at: new Date().toISOString(),
+        });
+      }
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys/, 'completed teams must not re-nudge on reopen');
+      }
+    });
+  });
+
+  it('does not nudge a team owned by another session', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'other-session-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const nowIso = new Date().toISOString();
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(workersDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'session.json'), { session_id: 'sess-current' });
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'manifest.v2.json'), {
+        schema_version: 2,
+        name: teamName,
+        task: 'session ownership repro',
+        leader: {
+          session_id: 'sess-other',
+          worker_id: 'leader-fixed',
+          role: 'coordinator',
+        },
+        policy: {
+          worker_launch_mode: 'interactive',
+          display_mode: 'split_pane',
+          dispatch_mode: 'hook_preferred_with_fallback',
+          dispatch_ack_timeout_ms: 2000,
+        },
+        tmux_session: 'other-session-team:0',
+        leader_pane_id: '%94',
+        worker_count: 2,
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10', role: 'executor' },
+          { name: 'worker-2', index: 2, pane_id: '%11', role: 'executor' },
+        ],
+        created_at: nowIso,
+      });
+      for (const worker of ['worker-1', 'worker-2']) {
+        await mkdir(join(workersDir, worker), { recursive: true });
+        await writeJson(join(workersDir, worker, 'status.json'), {
+          state: 'idle',
+          updated_at: nowIso,
+        });
+      }
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys/, 'must not nudge teams owned by another session');
+      }
+    });
+  });
+
   it('nudges when worker panes are alive and leader is stale (no recent HUD turn)', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -11,7 +11,7 @@ import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-i
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
-import { DEFAULT_MARKER, resolveCodexPane } from '../tmux-hook-engine.js';
+import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
@@ -196,6 +196,26 @@ async function syncScopedTeamStateFromPhase(teamStatePath, teamName, phaseSnapsh
     return changed;
   } catch {
     return false;
+  }
+}
+
+async function resolveCurrentSessionId(stateDir) {
+  const fromEnv = safeString(
+    process.env.OMX_SESSION_ID
+    || process.env.CODEX_SESSION_ID
+    || process.env.SESSION_ID
+    || '',
+  ).trim();
+  if (fromEnv) return fromEnv;
+
+  const sessionPath = join(stateDir, 'session.json');
+  try {
+    if (!existsSync(sessionPath)) return '';
+    const parsed = JSON.parse(await readFile(sessionPath, 'utf-8'));
+    const sessionId = safeString(parsed && parsed.session_id ? parsed.session_id : '').trim();
+    return sessionId;
+  } catch {
+    return '';
   }
 }
 
@@ -475,6 +495,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
   }
 
   const candidateTeamNames = new Set();
+  const currentSessionId = await resolveCurrentSessionId(stateDir);
   try {
     const scopedDirs = await getScopedStateDirsForCurrentSession(stateDir);
     const candidateStateDirs = [...new Set([...scopedDirs, stateDir])];
@@ -489,8 +510,9 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
       const phaseSnapshot = await readTeamPhaseSnapshot(stateDir, teamName, nowIso);
       if (phaseSnapshot.terminal) {
         await syncScopedTeamStateFromPhase(teamStatePath, teamName, phaseSnapshot, nowIso);
+        continue;
       }
-      if (parsed.active === true || phaseSnapshot.terminal) {
+      if (parsed.active === true) {
         candidateTeamNames.add(teamName);
       }
     }
@@ -504,6 +526,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
   for (const teamName of candidateTeamNames) {
     let tmuxSession = '';
     let leaderPaneId = '';
+    let ownerSessionId = '';
     let workers = [];
     try {
       const manifestPath = join(omxDir, 'state', 'team', teamName, 'manifest.v2.json');
@@ -513,11 +536,13 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
         const raw = JSON.parse(await readFile(srcPath, 'utf-8'));
         tmuxSession = safeString(raw && raw.tmux_session ? raw.tmux_session : '').trim();
         leaderPaneId = safeString(raw && raw.leader_pane_id ? raw.leader_pane_id : '').trim();
+        ownerSessionId = safeString(raw && raw.leader && raw.leader.session_id ? raw.leader.session_id : '').trim();
         if (Array.isArray(raw && raw.workers)) workers = raw.workers;
       }
     } catch {
       // ignore
     }
+    if (currentSessionId && ownerSessionId && ownerSessionId !== currentSessionId) continue;
     let mailbox = null;
     try {
       const mailboxPath = join(omxDir, 'state', 'team', teamName, 'mailbox', 'leader-fixed.json');
@@ -535,7 +560,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     const workerPaneIds = Array.isArray(workers)
       ? workers.map((w) => safeString(w && w.pane_id ? w.pane_id : '')).filter(Boolean)
       : [];
-    const canonicalLeaderPaneId = safeString(resolveCodexPane() || leaderPaneId).trim();
+    const canonicalLeaderPaneId = safeString(leaderPaneId).trim();
     if (!tmuxSession && !canonicalLeaderPaneId) continue;
     const tmuxTarget = canonicalLeaderPaneId;
     const paneStatus = tmuxSession


### PR DESCRIPTION
## Summary

Prevent leader nudge from resurfacing stale team state when a workspace is reopened.

Today, reopening a cwd with completed team state can re-inject stale `all_workers_idle` reminders into a fresh leader session. The same path can also evaluate teams owned by a different session or fall back to the current Codex pane instead of the persisted leader pane.

https://github.com/user-attachments/assets/ebfd1a4d-0428-4bd2-bee4-ce30f6eee7d6

## Changes

- exclude terminal/completed teams from leader-nudge candidate selection
- require the persisted `leader_pane_id` for leader nudge delivery instead of falling back to the current Codex pane
- skip leader-nudge evaluation for teams whose manifest `leader.session_id` belongs to a different session
- add regression coverage for completed-team reopen and foreign-session suppression

## Validation

- [x] `npm run build`
- [ ] `npm test` *(currently fails on unrelated existing tests in `dist/cli/__tests__/ask.test.js`, `dist/cli/__tests__/autoresearch.test.js`, and `dist/cli/__tests__/explore.test.js` in this branch baseline)*
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
- [x] `node --test dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js`
- [x] `node --test dist/team/__tests__/state.test.js dist/hooks/__tests__/notify-hook-cross-worktree-heartbeat.test.js`
- [x] `node --test --test-name-pattern "runs leader nudge checks from the fallback watcher so stale alerts do not wait for a leader turn" dist/hooks/__tests__/notify-fallback-watcher.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- N/A