### PR TITLE
Fix notify-hook runtime exec binary resolution

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -242,6 +242,65 @@ describe('notify-hook team dispatch consumer', () => {
     }
   });
 
+  it('invokes omx-runtime exec via shared bridge fallback', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const runtimeLogPath = join(cwd, 'runtime.log');
+    const previousPath = process.env.PATH;
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, 'omx-runtime'),
+        `#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >> "${runtimeLogPath}"
+if [[ "\${1:-}" == "schema" ]]; then
+  printf '{"schema_version":1,"commands":["acquire-authority","renew-authority","queue-dispatch","mark-notified","mark-delivered","mark-failed","request-replay","capture-snapshot"],"events":[],"transport":"tmux"}\n'
+  exit 0
+fi
+if [[ "\${1:-}" == "exec" ]]; then
+  printf '{"event":"DispatchNotified","request_id":"runtime-fallback","channel":"tmux"}\n'
+  exit 0
+fi
+exit 1
+`,
+      );
+      await chmod(join(fakeBinDir, 'omx-runtime'), 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath || ''}`;
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      const queued = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        pane_id: '%42',
+        trigger_message: 'ping',
+      }, cwd);
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => ({ ok: true, reason: 'injected_for_test' }),
+      });
+
+      const runtimeLog = await readFile(runtimeLogPath, 'utf8');
+      assert.match(runtimeLog, /^exec \{"command":"MarkNotified"/m);
+
+      const request = await readDispatchRequest('alpha', queued.request.request_id, cwd);
+      assert.equal(request?.status, 'notified');
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('leader-fixed dispatch uses pane target only when leader_pane_id exists', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
     const fakeBinDir = join(cwd, 'fake-bin');

--- a/src/runtime/__tests__/bridge.test.ts
+++ b/src/runtime/__tests__/bridge.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveRuntimeBinaryPath } from '../bridge.js';
+
+describe('resolveRuntimeBinaryPath', () => {
+  it('prefers explicit OMX_RUNTIME_BINARY override', () => {
+    const previous = process.env.OMX_RUNTIME_BINARY;
+    try {
+      process.env.OMX_RUNTIME_BINARY = '/custom/runtime';
+      const actual = resolveRuntimeBinaryPath({
+        debugPath: '/debug/runtime',
+        releasePath: '/release/runtime',
+        fallbackBinary: 'omx-runtime',
+        exists: () => false,
+      });
+      assert.equal(actual, '/custom/runtime');
+    } finally {
+      if (typeof previous === 'string') process.env.OMX_RUNTIME_BINARY = previous;
+      else delete process.env.OMX_RUNTIME_BINARY;
+    }
+  });
+
+  it('prefers debug build over release and PATH fallback', () => {
+    const actual = resolveRuntimeBinaryPath({
+      debugPath: '/debug/runtime',
+      releasePath: '/release/runtime',
+      fallbackBinary: 'omx-runtime',
+      exists: (candidate) => candidate === '/debug/runtime' || candidate === '/release/runtime',
+    });
+    assert.equal(actual, '/debug/runtime');
+  });
+
+  it('falls back to release build when debug is unavailable', () => {
+    const actual = resolveRuntimeBinaryPath({
+      debugPath: '/debug/runtime',
+      releasePath: '/release/runtime',
+      fallbackBinary: 'omx-runtime',
+      exists: (candidate) => candidate === '/release/runtime',
+    });
+    assert.equal(actual, '/release/runtime');
+  });
+
+  it('falls back to PATH binary when local builds are unavailable', () => {
+    const actual = resolveRuntimeBinaryPath({
+      debugPath: '/debug/runtime',
+      releasePath: '/release/runtime',
+      fallbackBinary: 'omx-runtime',
+      exists: () => false,
+    });
+    assert.equal(actual, 'omx-runtime');
+  });
+});

--- a/src/runtime/bridge.ts
+++ b/src/runtime/bridge.ts
@@ -108,6 +108,27 @@ export interface MailboxRecord {
 
 let schemaValidated = false;
 
+export interface RuntimeBinaryDiscoveryOptions {
+  debugPath?: string;
+  releasePath?: string;
+  fallbackBinary?: string;
+  exists?: (path: string) => boolean;
+}
+
+export function resolveRuntimeBinaryPath(options: RuntimeBinaryDiscoveryOptions = {}): string {
+  const exists = options.exists ?? existsSync;
+  const envOverride = process.env.OMX_RUNTIME_BINARY?.trim();
+  if (envOverride) return envOverride;
+
+  const workspaceDebug = options.debugPath ?? resolve(__bridge_dirname, '../../target/debug/omx-runtime');
+  if (exists(workspaceDebug)) return workspaceDebug;
+
+  const workspaceRelease = options.releasePath ?? resolve(__bridge_dirname, '../../target/release/omx-runtime');
+  if (exists(workspaceRelease)) return workspaceRelease;
+
+  return options.fallbackBinary ?? 'omx-runtime';
+}
+
 export class RuntimeBridge {
   private binaryPath: string;
   private stateDir: string | undefined;
@@ -116,7 +137,7 @@ export class RuntimeBridge {
   constructor(options: { stateDir?: string; binaryPath?: string } = {}) {
     this.enabled = process.env.OMX_RUNTIME_BRIDGE !== '0';
     this.stateDir = options.stateDir;
-    this.binaryPath = options.binaryPath ?? this.discoverBinary();
+    this.binaryPath = options.binaryPath ?? resolveRuntimeBinaryPath();
   }
 
   /** Whether the bridge is enabled (OMX_RUNTIME_BRIDGE != '0'). */
@@ -194,18 +215,6 @@ export class RuntimeBridge {
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
-
-  private discoverBinary(): string {
-    // Check workspace-local build first (crates/ layout)
-    const workspaceDebug = resolve(__bridge_dirname, '../../target/debug/omx-runtime');
-    if (existsSync(workspaceDebug)) return workspaceDebug;
-
-    const workspaceRelease = resolve(__bridge_dirname, '../../target/release/omx-runtime');
-    if (existsSync(workspaceRelease)) return workspaceRelease;
-
-    // Fall back to PATH
-    return 'omx-runtime';
-  }
 
   private validateSchemaOnce(): void {
     if (schemaValidated) return;

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -5,6 +5,7 @@ import { execFileSync } from 'child_process';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'node:url';
 import { safeString } from './utils.js';
+import { resolveRuntimeBinaryPath } from '../../runtime/bridge.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -26,7 +27,7 @@ import {
 function runtimeExec(command) {
   if (process.env.OMX_RUNTIME_BRIDGE === '0') return;
   try {
-    const binaryPath = resolve(__dirname, '../../target/debug/omx-runtime');
+    const binaryPath = resolveRuntimeBinaryPath();
     execFileSync(binaryPath, ['exec', JSON.stringify(command)], {
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- share omx-runtime binary discovery across the runtime bridge and notify-hook team dispatch
- keep notify-hook runtime exec quiet/non-fatal by preserving piped stdio
- add regression coverage for resolver precedence and hook dispatch runtime exec fallback

## Testing
- cargo test -p omx-runtime
- cargo build -p omx-runtime && ./target/debug/omx-runtime exec '{"command":"CaptureSnapshot"}'
- npm run lint
- node --test dist/runtime/__tests__/bridge.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js
- npm test