### PR TITLE
Show weekly usage

### DIFF
--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -349,7 +349,7 @@ describe("config generator idempotency (#384)", () => {
       assert.match(toml, /^theme = "night"$/m, "user tui key preserved");
       assert.match(
         toml,
-        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit"\]$/m,
+        /^status_line = \["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"\]$/m,
         "status_line updated in-place",
       );
     } finally {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -48,7 +48,7 @@ const SHARED_MCP_REGISTRY_END_MARKER =
 const OMX_AGENTS_MAX_THREADS = 6;
 const OMX_AGENTS_MAX_DEPTH = 2;
 const OMX_TUI_STATUS_LINE =
-  'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit"]';
+  'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"]';
 
 function unwrapTomlString(value: string | undefined): string | undefined {
   return value?.match(/^"(.*)"$/)?.[1];


### PR DESCRIPTION
## Summary

Show weekly usage remaining at Codex CLI.

## Changes

- src/config/generator.ts
- src/config/__tests__/generator-idempotent.test.ts

Uses StatusLineItem::WeeklyLimit, native Codex CLI feature at:
https://github.com/openai/codex/blob/main/codex-rs/tui/src/bottom_pane/status_line_setup.rs
https://github.com/openai/codex/blob/main/codex-rs/tui/src/chatwidget/status_surfaces.rs

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
