### PR TITLE
fix(team-ralph): keep the linked leader orchestration alive while the team runs

### DIFF
--- a/src/cli/__tests__/team-linked-ralph.test.ts
+++ b/src/cli/__tests__/team-linked-ralph.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readModeState, startMode, updateModeState } from '../../modes/base.js';
+import { ensureLinkedRalphModeState } from '../../team/linked-ralph-bridge.js';
+
+describe('ensureLinkedRalphModeState', () => {
+  it('creates a linked Ralph mode state when none exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-linked-ralph-'));
+    try {
+      await ensureLinkedRalphModeState('ship it', 'ship-it', wd);
+      const state = await readModeState('ralph', wd);
+      assert.ok(state, 'expected ralph state to be created');
+      assert.equal(state?.active, true);
+      assert.equal(state?.current_phase, 'executing');
+      assert.equal(state?.task_description, 'ship it');
+      assert.equal(state?.linked_team, true);
+      assert.equal(state?.team_name, 'ship-it');
+      assert.equal(typeof state?.linked_team_started_at, 'string');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updates the active Ralph state to reflect linked team monitoring', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-linked-ralph-update-'));
+    try {
+      await startMode('ralph', 'old task', 50, wd);
+      await updateModeState('ralph', {
+        current_phase: 'verifying',
+      }, wd);
+
+      await ensureLinkedRalphModeState('new linked task', 'alpha', wd);
+
+      const state = await readModeState('ralph', wd);
+      assert.ok(state, 'expected ralph state to exist');
+      assert.equal(state?.active, true);
+      assert.equal(state?.current_phase, 'executing');
+      assert.equal(state?.task_description, 'new linked task');
+      assert.equal(state?.linked_team, true);
+      assert.equal(state?.team_name, 'alpha');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -11,6 +11,7 @@ import { classifyTaskSize } from '../hooks/task-size-detector.js';
 import { readApprovedExecutionLaunchHint } from '../planning/artifacts.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import { allocateTasksToWorkers } from '../team/allocation-policy.js';
+import { ensureLinkedRalphModeState, runLinkedRalphBridge } from '../team/linked-ralph-bridge.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
@@ -2461,8 +2462,19 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
   );
 
   await ensureTeamModeState(effectiveParsed, tasks);
+  if (parsed.ralph) {
+    await ensureLinkedRalphModeState(parsed.task, parsed.teamName, cwd);
+  }
   if (options.verbose) {
     console.log(`linked_ralph=${parsed.ralph}`);
   }
   await renderStartSummary(runtime, staffingPlan);
+  if (parsed.ralph) {
+    await runLinkedRalphBridge({
+      teamName: runtime.teamName,
+      task: parsed.task,
+      cwd,
+      log: (message) => console.log(message),
+    });
+  }
 }

--- a/src/team/__tests__/linked-ralph-bridge.test.ts
+++ b/src/team/__tests__/linked-ralph-bridge.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { runLinkedRalphBridge } from '../linked-ralph-bridge.js';
+import type { TeamSnapshot } from '../runtime.js';
+import type { TeamEvent } from '../state/types.js';
+
+function makeSnapshot(phase: TeamSnapshot['phase']): TeamSnapshot {
+  return {
+    teamName: 'alpha',
+    phase,
+    workers: [],
+    tasks: {
+      total: 1,
+      pending: phase === 'team-exec' ? 1 : 0,
+      blocked: 0,
+      in_progress: phase === 'team-exec' ? 1 : 0,
+      completed: phase === 'complete' ? 1 : 0,
+      failed: phase === 'failed' ? 1 : 0,
+      items: [],
+    },
+    allTasksTerminal: phase === 'complete' || phase === 'failed' || phase === 'cancelled',
+    deadWorkers: [],
+    nonReportingWorkers: [],
+    recommendations: [],
+  };
+}
+
+describe('runLinkedRalphBridge', () => {
+  it('keeps monitoring until the linked team reaches a terminal phase', async () => {
+    const snapshots = [makeSnapshot('team-exec'), makeSnapshot('team-exec'), makeSnapshot('complete')];
+    let snapshotIndex = 0;
+
+    const updates: Array<Record<string, unknown>> = [];
+    const logs: string[] = [];
+    let ensureCalls = 0;
+    let finalizeCalls = 0;
+
+    const event: TeamEvent = {
+      event_id: 'evt-1',
+      team: 'alpha',
+      type: 'worker_state_changed',
+      worker: 'worker-1',
+      state: 'idle',
+      prev_state: 'working',
+      created_at: '2026-03-22T08:30:00.000Z',
+    };
+
+    const result = await runLinkedRalphBridge(
+      {
+        teamName: 'alpha',
+        task: 'ship linked bridge fix',
+        cwd: '/tmp/demo',
+        waitTimeoutMs: 1_000,
+        log: (message) => logs.push(message),
+      },
+      {
+        ensureLinkedRalphModeState: async () => { ensureCalls += 1; },
+        updateLinkedRalphHeartbeat: async (_teamName, _cwd, patch) => { updates.push(patch); },
+        finalizeLinkedRalph: async (_teamName, _cwd, terminalPhase, patch) => {
+          finalizeCalls += 1;
+          updates.push({ terminalPhase, ...patch });
+        },
+        monitorTeam: async () => snapshots[Math.min(snapshotIndex++, snapshots.length - 1)] ?? null,
+        waitForTeamEvent: async (_teamName, _cwd, opts) => {
+          if (!opts.afterEventId) {
+            return { status: 'event', event, cursor: event.event_id };
+          }
+          return { status: 'timeout', cursor: opts.afterEventId ?? '' };
+        },
+      },
+    );
+
+    assert.equal(ensureCalls, 1);
+    assert.equal(finalizeCalls, 1);
+    assert.equal(result.status, 'terminal');
+    assert.equal(result.terminalPhase, 'complete');
+    assert.equal(result.cursor, 'evt-1');
+    assert.ok(
+      updates.some((patch) => patch.linked_team_last_event_type === 'worker_state_changed'),
+      'expected bridge to record wake event details',
+    );
+    assert.ok(
+      updates.some((patch) => patch.terminalPhase === 'complete'),
+      'expected bridge to finalize Ralph when the team completes',
+    );
+    assert.ok(
+      logs.some((line) => line.includes('bridge active')),
+      'expected bridge startup log',
+    );
+    assert.ok(
+      logs.some((line) => line.includes('worker_state_changed')),
+      'expected event log while bridge is active',
+    );
+  });
+});

--- a/src/team/linked-ralph-bridge.ts
+++ b/src/team/linked-ralph-bridge.ts
@@ -1,0 +1,173 @@
+import { readModeState, startMode, updateModeState } from '../modes/base.js';
+import { monitorTeam, type TeamSnapshot } from './runtime.js';
+import { waitForTeamEvent } from './state/events.js';
+import type { TeamEvent } from './state/types.js';
+import type { TerminalPhase } from './orchestrator.js';
+
+const TERMINAL_PHASES = new Set<TerminalPhase>(['complete', 'failed', 'cancelled']);
+const DEFAULT_WAIT_TIMEOUT_MS = 30_000;
+
+export interface LinkedRalphBridgeOptions {
+  teamName: string;
+  task: string;
+  cwd: string;
+  waitTimeoutMs?: number;
+  log?: (message: string) => void;
+}
+
+export interface LinkedRalphBridgeResult {
+  status: 'terminal' | 'missing';
+  terminalPhase?: TerminalPhase;
+  cursor: string;
+}
+
+export interface LinkedRalphBridgeDeps {
+  ensureLinkedRalphModeState: (task: string, teamName: string, cwd: string) => Promise<void>;
+  updateLinkedRalphHeartbeat: (
+    teamName: string,
+    cwd: string,
+    updates: Record<string, unknown>,
+  ) => Promise<void>;
+  finalizeLinkedRalph: (
+    teamName: string,
+    cwd: string,
+    terminalPhase: TerminalPhase,
+    updates?: Record<string, unknown>,
+  ) => Promise<void>;
+  monitorTeam: (teamName: string, cwd: string) => Promise<TeamSnapshot | null>;
+  waitForTeamEvent: typeof waitForTeamEvent;
+}
+
+function isTerminalPhase(value: string): value is TerminalPhase {
+  return TERMINAL_PHASES.has(value as TerminalPhase);
+}
+
+function formatEvent(event: TeamEvent): string {
+  return [
+    `event=${event.type}`,
+    `worker=${event.worker}`,
+    event.state ? `state=${event.state}` : '',
+    event.prev_state ? `prev=${event.prev_state}` : '',
+    event.task_id ? `task=${event.task_id}` : '',
+  ].filter(Boolean).join(' ');
+}
+
+export async function ensureLinkedRalphModeState(
+  task: string,
+  teamName: string,
+  cwd: string,
+): Promise<void> {
+  const existing = await readModeState('ralph', cwd);
+  if (existing?.active === true) {
+    await updateModeState('ralph', {
+      current_phase: 'executing',
+      task_description: task,
+      linked_team: true,
+      team_name: teamName,
+      linked_team_started_at: new Date().toISOString(),
+    }, cwd);
+    return;
+  }
+
+  await startMode('ralph', task, 50, cwd);
+  await updateModeState('ralph', {
+    current_phase: 'executing',
+    linked_team: true,
+    team_name: teamName,
+    linked_team_started_at: new Date().toISOString(),
+  }, cwd);
+}
+
+export async function updateLinkedRalphHeartbeat(
+  _teamName: string,
+  cwd: string,
+  updates: Record<string, unknown>,
+): Promise<void> {
+  await updateModeState('ralph', {
+    current_phase: 'executing',
+    linked_team: true,
+    ...updates,
+  }, cwd);
+}
+
+export async function finalizeLinkedRalph(
+  _teamName: string,
+  cwd: string,
+  terminalPhase: TerminalPhase,
+  updates: Record<string, unknown> = {},
+): Promise<void> {
+  await updateModeState('ralph', {
+    active: false,
+    current_phase: terminalPhase,
+    completed_at: new Date().toISOString(),
+    linked_team: true,
+    linked_team_terminal_phase: terminalPhase,
+    linked_team_terminal_at: new Date().toISOString(),
+    ...updates,
+  }, cwd);
+}
+
+export async function runLinkedRalphBridge(
+  options: LinkedRalphBridgeOptions,
+  deps: LinkedRalphBridgeDeps = {
+    ensureLinkedRalphModeState,
+    updateLinkedRalphHeartbeat,
+    finalizeLinkedRalph,
+    monitorTeam,
+    waitForTeamEvent,
+  },
+): Promise<LinkedRalphBridgeResult> {
+  const waitTimeoutMs = Math.max(1_000, Math.floor(options.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS));
+  let cursor = '';
+  let heartbeatCount = 0;
+
+  await deps.ensureLinkedRalphModeState(options.task, options.teamName, options.cwd);
+  options.log?.(`[linked-ralph] bridge active for team=${options.teamName}`);
+
+  while (true) {
+    const snapshot = await deps.monitorTeam(options.teamName, options.cwd);
+    if (!snapshot) {
+      options.log?.(`[linked-ralph] team state missing for team=${options.teamName}`);
+      return { status: 'missing', cursor };
+    }
+
+    if (isTerminalPhase(snapshot.phase)) {
+      await deps.finalizeLinkedRalph(options.teamName, options.cwd, snapshot.phase, {
+        linked_team_phase: snapshot.phase,
+        linked_team_event_cursor: cursor,
+        linked_team_last_snapshot_at: new Date().toISOString(),
+      });
+      options.log?.(`[linked-ralph] team=${options.teamName} terminal phase=${snapshot.phase}`);
+      return { status: 'terminal', terminalPhase: snapshot.phase, cursor };
+    }
+
+    heartbeatCount += 1;
+    await deps.updateLinkedRalphHeartbeat(options.teamName, options.cwd, {
+      linked_team_phase: snapshot.phase,
+      linked_team_all_tasks_terminal: snapshot.allTasksTerminal,
+      linked_team_heartbeat_count: heartbeatCount,
+      linked_team_last_snapshot_at: new Date().toISOString(),
+    });
+
+    const eventResult = await deps.waitForTeamEvent(options.teamName, options.cwd, {
+      ...(cursor ? { afterEventId: cursor } : {}),
+      timeoutMs: waitTimeoutMs,
+      pollMs: 100,
+      wakeableOnly: true,
+    });
+
+    if (eventResult.status === 'event' && eventResult.event) {
+      cursor = eventResult.cursor;
+      await deps.updateLinkedRalphHeartbeat(options.teamName, options.cwd, {
+        linked_team_event_cursor: cursor,
+        linked_team_last_event_type: eventResult.event.type,
+        linked_team_last_event_at: eventResult.event.created_at,
+        linked_team_last_event_worker: eventResult.event.worker,
+      });
+      options.log?.(`[linked-ralph] team=${options.teamName} ${formatEvent(eventResult.event)}`);
+      continue;
+    }
+
+    options.log?.(`[linked-ralph] team=${options.teamName} waiting... phase=${snapshot.phase}`);
+  }
+}


### PR DESCRIPTION
## Summary

This PR fixes a remaining linked-runtime gap in `omx team ralph ...`.

The linked launch path already had pieces for:

- team-side linked state (`team.linked_ralph`), and
- later terminal propagation into Ralph state,

but it still lacked a **leader-owned linked bridge loop** that stays active while the team is still running.

In practice that meant a linked `team + ralph` run could feel operationally idle from the leader/main orchestration perspective until a worker result finally arrived, even though:

- plain `omx team ...` was acceptable, and
- plain `omx ralph ...` was acceptable.

This patch closes that middle gap.

Closes #1010.

---

## Problem statement

The bug was not primarily about generic team waiting semantics.

It was specifically about the **linked orchestration contract** for `omx team ralph ...`:

1. launch the team,
2. keep the linked leader orchestration alive while the team is non-terminal,
3. observe intermediate wakeable events,
4. update linked Ralph progress coherently,
5. finalize only when the linked team actually finishes.

Before this patch, the real launch path effectively handled the beginning and the end, but not the middle:

- launch could mark the team-side link,
- watcher/runtime code could later propagate a terminal phase,
- but there was no canonical runtime-owned loop that continuously bridged the linked run between those two points.

That made linked executions look stalled from the leader side.

---

## Root cause

The linked runtime path in `src/cli/team.ts` started the team and persisted team mode state, but it did not keep a dedicated `team+ralph` orchestration loop alive after startup.

More concretely:

- `startTeam(...)` launched the team runtime correctly.
- `ensureTeamModeState(...)` persisted the team-side state correctly.
- linked terminal propagation existed elsewhere.
- however, there was **no canonical runtime-owned follow-up loop** that:
  - ensured Ralph linked state existed,
  - kept monitoring snapshots/events while the team was active,
  - and terminalized Ralph only when the linked team actually became terminal.

So the linked path had:

- launch linkage at the start,
- terminal sync at the end,
- but no durable bridge in between.

---

## What changed

### 1. Added a dedicated linked bridge module

New file:

- `src/team/linked-ralph-bridge.ts`

This module introduces a focused linked-runtime bridge that:

- ensures Ralph linked mode state exists for `omx team ralph ...`
- keeps monitoring the linked team while its phase is non-terminal
- waits on wakeable team events through existing primitives
- records linked execution metadata back into Ralph state
- finalizes Ralph when the linked team reaches a terminal phase

The bridge intentionally reuses existing control-plane primitives instead of adding a second orchestration model:

- `monitorTeam(...)`
- `waitForTeamEvent(...)`
- existing mode-state writers

### 2. Wired the bridge into the real CLI launch path

Updated:

- `src/cli/team.ts`

For `parsed.ralph === true`, the CLI now:

- ensures linked Ralph state exists immediately after team startup/state persistence
- runs the linked bridge loop after the startup summary

This keeps the leader-side orchestration alive until the linked team becomes terminal.

### 3. Added focused regression coverage

New tests:

- `src/cli/__tests__/team-linked-ralph.test.ts`
- `src/team/__tests__/linked-ralph-bridge.test.ts`

Coverage added for:

- creating/updating Ralph linked state from the linked team path
- keeping the linked bridge alive until terminal team completion
- recording wake event metadata
- finalizing Ralph when the linked team reaches a terminal phase

---

## Why this design

I intentionally kept this fix **narrow and runtime-owned**.

### Why not redesign generic team waiting?
Because the user-facing bug here is not that all team waiting is wrong.

The bug is that **linked `team+ralph` mode lacked a durable bridge loop**, while plain team and plain Ralph were already acceptable in the reported scenario.

### Why put the fix in the runtime path?
Because linked execution ownership should live in the actual linked launch path, not be reconstructed later through watcher-only side effects.

Watcher-side nudges and terminal sync can remain useful, but they are not a substitute for a canonical linked execution bridge.

### Why reuse existing primitives?
Because `monitorTeam(...)` and `waitForTeamEvent(...)` already provide the right building blocks.

That keeps the patch small, reviewable, and reversible.

---

## Overlap assessment

This PR is related to earlier linked team/Ralph work, but it is **not a duplicate** of it.

### Prior work it builds on
- #742 / PR #749 — established Ralph-side linked state on launch paths
- #743 / PR #750 — improved linked terminal propagation
- #747 / PR #779 — clarified watcher/control-plane responsibility boundaries

### Why this PR is still needed
Those changes addressed:

- launch-link coherence, and
- terminal sync correctness,

but they still left the **non-terminal execution bridge** underpowered.

This PR fills the remaining gap between:

- launch linkage, and
- terminal propagation.

In other words:

- previous fixes addressed the edges,
- this one addresses the missing middle.

---

## Validation

### Focused test validation
In the modified checkout, I verified:

- linked Ralph state bootstrap/update behavior
- linked bridge loop behavior until terminal team completion
- existing team CLI and linked terminal-sync tests still passing together

### Real prompt-mode E2E validation
I also ran a real prompt-mode `team ralph` scenario with a fake worker process to validate the runtime behavior end-to-end:

- the leader process stayed alive after startup,
- linked Ralph state showed active execution metadata while the team was non-terminal,
- a worker/task completion event woke the linked bridge,
- the bridge observed the event and then finalized Ralph coherently.

Observed linked log sequence included:

- bridge startup
- wake on `task_completed`
- terminal completion handling

### Lint
Targeted lint passed for the modified files.

---

## Notes on baseline branch health

A full clean-worktree `npm run build` on current `upstream/dev` is blocked by **pre-existing unrelated TypeScript errors** already present on that branch (for example unrelated `@iarna/toml` resolution and older team test contract mismatches).

I did **not** expand this PR to fix those unrelated baseline problems because they are outside the scope of the linked `team+ralph` bridge bug.

---

## Risk / compatibility

### Expected behavior change
Only linked `omx team ralph ...` runs should change meaningfully:

- the leader/main orchestration now remains alive while the linked team is still running,
- instead of behaving like a launch-only linkage followed by later terminal sync.

### What should remain unchanged
- plain `omx team ...`
- generic team wait semantics for unrelated callers
- watcher-driven nudges/dispatch outside this linked runtime fix

### Remaining follow-up worth watching
The linked bridge now finalizes Ralph coherently. If future work wants richer team-mode terminal mirroring in every related state artifact, that can be layered on separately without reopening the bridge-gap bug itself.

---

## Files changed

- `src/cli/team.ts`
- `src/team/linked-ralph-bridge.ts`
- `src/cli/__tests__/team-linked-ralph.test.ts`
- `src/team/__tests__/linked-ralph-bridge.test.ts`
