### PR TITLE
fix: resolve ensureLinkedRalphModeState import conflict (#1011 follow-up)

### DIFF
--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -11,7 +11,7 @@ import { classifyTaskSize } from '../hooks/task-size-detector.js';
 import { readApprovedExecutionLaunchHint } from '../planning/artifacts.js';
 import { routeTaskToRole } from '../team/role-router.js';
 import { allocateTasksToWorkers } from '../team/allocation-policy.js';
-import { ensureLinkedRalphModeState, runLinkedRalphBridge } from '../team/linked-ralph-bridge.js';
+import { ensureLinkedRalphModeState as ensureLinkedRalphBridgeState, runLinkedRalphBridge } from '../team/linked-ralph-bridge.js';
 import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
@@ -2463,7 +2463,7 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
 
   await ensureTeamModeState(effectiveParsed, tasks);
   if (parsed.ralph) {
-    await ensureLinkedRalphModeState(parsed.task, parsed.teamName, cwd);
+    await ensureLinkedRalphBridgeState(parsed.task, parsed.teamName, cwd);
   }
   if (options.verbose) {
     console.log(`linked_ralph=${parsed.ralph}`);


### PR DESCRIPTION
## Summary

Fixes typecheck failures introduced by #1011 merge.

## Problem

`src/cli/team.ts` already had a local function `ensureLinkedRalphModeState(parsed: ParsedTeamArgs)` (line 2085). PR #1011 imported a different `ensureLinkedRalphModeState` from `linked-ralph-bridge.ts` with a different signature `(task, teamName, cwd)`, causing:

- `TS2440`: Import declaration conflicts with local declaration
- `TS2554`: Expected 1 argument, but got 3

## Fix

Aliased the bridge import as `ensureLinkedRalphBridgeState` and updated the call site at line 2466 accordingly. The existing local function remains untouched.

## Validation

- `npx tsc --noEmit` — no team.ts errors (remaining errors are pre-existing baseline issues: `@iarna/toml`, MCP SDK types)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*