### PR TITLE
Fix prompt-mode Ralph bridge blocking the persistence gate

### DIFF
--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -2470,6 +2470,9 @@ export async function teamCommand(args: string[], options: TeamCliOptions = {}):
   }
   await renderStartSummary(runtime, staffingPlan);
   if (parsed.ralph) {
+    if (runtime.config.worker_launch_mode === 'prompt') {
+      return;
+    }
     await runLinkedRalphBridge({
       teamName: runtime.teamName,
       task: parsed.task,


### PR DESCRIPTION
## Summary
- skip the linked Ralph bridge loop for prompt-mode team Ralph launches after startup state is established
- preserve the existing awaited bridge behavior for non-prompt launches
- restore the notify-hook linked terminal sync regression introduced by #1011

## Verification
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/hooks/__tests__/notify-hook-linked-sync.test.js dist/team/__tests__/linked-ralph-bridge.test.js dist/cli/__tests__/team.test.js