### PR TITLE
Add an exact-model prompt seam for gpt-5.4-mini subagents

### DIFF
--- a/docs/prompt-guidance-contract.md
+++ b/docs/prompt-guidance-contract.md
@@ -28,6 +28,28 @@ In this repository, `prompts/*.md` remain the canonical source files even when t
 
 This document is the contributor-oriented index for those surfaces.
 
+## Exact-model mini adaptation seam
+
+OMX also has a narrow **instruction-composition seam** for subagents/workers whose **final resolved model** is exactly `gpt-5.4-mini`.
+That seam is part of prompt delivery, but it is intentionally narrower than the general GPT-5.4 behavioral contract described below.
+
+Contributor rules for that seam:
+
+- Key mini-specific instruction adaptation off the **final resolved model string**, not off role name, lane, or default tier membership.
+- Use **exact string equality** for `gpt-5.4-mini`; do not widen behavior to `gpt-5.4`, `gpt-5.4-mini-tuned`, or other variants.
+- Keep one shared **inner role-instruction composition helper** as the source of truth for model-gated prompt adaptation.
+- Keep `src/team/worker-bootstrap.ts` limited to **outer AGENTS/runtime wrapping**. It should wrap already-composed instructions, not own model-specific adaptation logic.
+- Keep `src/team/role-router.ts` as a raw role-prompt loader unless a minimal plumbing change is unavoidable.
+
+Primary implementation surfaces for this seam:
+
+| Responsibility | Primary sources |
+|---|---|
+| shared inner prompt composition | `src/agents/native-config.ts`, `src/agents/__tests__/native-config.test.ts` |
+| team runtime/scaling plumbing | `src/team/runtime.ts`, `src/team/scaling.ts`, associated runtime/scaling tests |
+| outer wrapper boundary | `src/team/worker-bootstrap.ts`, `src/team/__tests__/worker-bootstrap.test.ts` |
+
+
 ## What this contract is — and is not
 
 This contract is about **how OMX prompts should behave**.
@@ -158,6 +180,7 @@ Keep these separate when editing docs and prompts:
 | Topic | Primary sources |
 |---|---|
 | GPT-5.4 prompt behavior contract | `AGENTS.md`, `templates/AGENTS.md`, canonical XML-tagged role prompt surfaces in `prompts/*.md`, `src/config/generator.ts`, `src/hooks/__tests__/prompt-guidance-*.test.ts` |
+| exact-model mini composition seam | `src/agents/native-config.ts`, `src/team/runtime.ts`, `src/team/scaling.ts`, `src/team/worker-bootstrap.ts`, targeted native/runtime/scaling/bootstrap tests |
 | role/tier/posture routing | `README.md:133-179`, `docs/shared/agent-tiers.md:7-56`, `src/agents/native-config.ts:12-40` |
 
 If a change only affects posture overlays or native agent metadata, document it in the routing docs rather than expanding this contract unnecessarily.
@@ -177,8 +200,9 @@ Before opening a PR that changes prompt text, confirm all of the following:
 1. **Preserve the four core behaviors.** Your change should keep or strengthen compact output, low-risk follow-through, scoped overrides, and grounded tool use/verification.
 2. **Keep role-specific wording role-specific.** The phrasing can differ by role, but the behavior should stay semantically aligned.
 3. **Update scenario examples when behavior changes.** If you change how prompts handle `continue`, `make a PR`, or `merge if CI green`, update the prompt examples and the related tests.
-4. **Do not confuse routing metadata with prompt behavior.** Posture/tier updates belong in routing docs/tests unless they also change prompt prose.
-5. **Update regression coverage when the contract changes.** Start with `src/hooks/__tests__/prompt-guidance-contract.test.ts`, `prompt-guidance-wave-two.test.ts`, `prompt-guidance-scenarios.test.ts`, and `prompt-guidance-catalog.test.ts`.
+4. **Keep the mini-only seam exact and centralized.** If you touch mini adaptation, gate it on the final resolved model with exact `gpt-5.4-mini` equality, keep the shared inner helper as the source of truth, and keep `worker-bootstrap.ts` wrapper-only.
+5. **Do not confuse routing metadata with prompt behavior.** Posture/tier updates belong in routing docs/tests unless they also change prompt prose.
+6. **Update regression coverage when the contract changes.** Start with `src/hooks/__tests__/prompt-guidance-contract.test.ts`, `prompt-guidance-wave-two.test.ts`, `prompt-guidance-scenarios.test.ts`, and `prompt-guidance-catalog.test.ts`; add native/runtime/scaling/bootstrap coverage when the mini-only seam changes.
 
 ## Validation workflow for contributors
 
@@ -191,6 +215,16 @@ node --test \
   dist/hooks/__tests__/prompt-guidance-wave-two.test.js \
   dist/hooks/__tests__/prompt-guidance-scenarios.test.js \
   dist/hooks/__tests__/prompt-guidance-catalog.test.js
+```
+
+If you touch the exact-model `gpt-5.4-mini` composition seam, also run:
+
+```bash
+node --test \
+  dist/agents/__tests__/native-config.test.js \
+  dist/team/__tests__/runtime.test.js \
+  dist/team/__tests__/scaling.test.js \
+  dist/team/__tests__/worker-bootstrap.test.js
 ```
 
 For broader prompt or skill changes, prefer the full suite:

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -55,6 +55,37 @@ describe("agents/native-config", () => {
       "only TOML delimiters should remain as raw triple quotes",
     );
   });
+
+  it("applies exact-model mini guidance only for resolved gpt-5.4-mini", () => {
+    const agent: AgentDefinition = {
+      name: "executor",
+      description: "Code implementation",
+      reasoningEffort: "medium",
+      posture: "deep-worker",
+      modelClass: "standard",
+      routingRole: "executor",
+      tools: "execution",
+      category: "build",
+    };
+
+    const prompt = "Instruction line";
+    const exactMiniToml = generateAgentToml(agent, prompt, {
+      env: { OMX_DEFAULT_STANDARD_MODEL: "gpt-5.4-mini" } as NodeJS.ProcessEnv,
+    });
+    const frontierToml = generateAgentToml(agent, prompt, {
+      env: { OMX_DEFAULT_STANDARD_MODEL: "gpt-5.4" } as NodeJS.ProcessEnv,
+    });
+    const tunedToml = generateAgentToml(agent, prompt, {
+      env: { OMX_DEFAULT_STANDARD_MODEL: "gpt-5.4-mini-tuned" } as NodeJS.ProcessEnv,
+    });
+
+    assert.match(exactMiniToml, /exact gpt-5\.4-mini model/);
+    assert.match(exactMiniToml, /strict execution order: inspect -> plan -> act -> verify/);
+    assert.match(exactMiniToml, /resolved_model: gpt-5\.4-mini/);
+    assert.doesNotMatch(frontierToml, /exact gpt-5\.4-mini model/);
+    assert.doesNotMatch(tunedToml, /exact gpt-5\.4-mini model/);
+  });
+
   it("installs only agents with prompt files and skips existing files without force", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-native-config-"));
     const promptsDir = join(root, "prompts");

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -17,6 +17,8 @@ import {
 import { getRootModelName } from "../config/generator.js";
 import { codexAgentsDir } from "../utils/paths.js";
 
+export const EXACT_GPT_5_4_MINI_MODEL = "gpt-5.4-mini";
+
 const POSTURE_OVERLAYS: Record<AgentDefinition["posture"], string> = {
   "frontier-orchestrator": [
     "<posture_overlay>",
@@ -84,6 +86,18 @@ const MODEL_CLASS_OVERLAYS: Record<AgentDefinition["modelClass"], string> = {
   ].join("\n"),
 };
 
+const EXACT_MINI_MODEL_OVERLAY = [
+  "<exact_model_guidance>",
+  "",
+  `This role is executing under the exact ${EXACT_GPT_5_4_MINI_MODEL} model.`,
+  "- Use a strict execution order: inspect -> plan -> act -> verify.",
+  "- Treat completion criteria as explicit: only report done after the requested work is implemented and fresh verification passes.",
+  "- If requirements are ambiguous or a blocker appears, state the blocker plainly and stop guessing until the missing decision is resolved.",
+  "- Do not bluff, pad, or invent results; report missing evidence and incomplete work honestly.",
+  "",
+  "</exact_model_guidance>",
+].join("\n");
+
 export interface GeneratedNativeAgentConfig {
   name: string;
   description: string;
@@ -96,6 +110,13 @@ interface AgentModelResolutionOptions {
   codexHomeOverride?: string;
   configTomlContent?: string;
   env?: NodeJS.ProcessEnv;
+}
+
+interface RoleInstructionMetadata {
+  name: string;
+  posture: AgentDefinition["posture"];
+  modelClass: AgentDefinition["modelClass"];
+  routingRole: AgentDefinition["routingRole"];
 }
 
 function readConfigTomlContent(
@@ -146,24 +167,72 @@ function resolveAgentModel(
   }
 }
 
-function buildPromptInstructions(
-  agent: AgentDefinition,
+function isExactMiniModel(resolvedModel?: string | null): boolean {
+  return resolvedModel?.trim() === EXACT_GPT_5_4_MINI_MODEL;
+}
+
+export function composeRoleInstructions(
   promptContent: string,
+  metadata: RoleInstructionMetadata | null,
+  resolvedModel?: string,
 ): string {
   const instructions = stripFrontmatter(promptContent);
-  return [
-    instructions,
-    "",
-    POSTURE_OVERLAYS[agent.posture],
-    "",
-    MODEL_CLASS_OVERLAYS[agent.modelClass],
-    "",
-    "## OMX Agent Metadata",
-    `- role: ${agent.name}`,
-    `- posture: ${agent.posture}`,
-    `- model_class: ${agent.modelClass}`,
-    `- routing_role: ${agent.routingRole}`,
-  ].join("\n");
+  const parts = [instructions];
+
+  if (metadata) {
+    parts.push(
+      "",
+      POSTURE_OVERLAYS[metadata.posture],
+      "",
+      MODEL_CLASS_OVERLAYS[metadata.modelClass],
+    );
+  }
+
+  if (isExactMiniModel(resolvedModel)) {
+    parts.push("", EXACT_MINI_MODEL_OVERLAY);
+  }
+
+  const metadataLines = [];
+  if (metadata) {
+    metadataLines.push(
+      "## OMX Agent Metadata",
+      `- role: ${metadata.name}`,
+      `- posture: ${metadata.posture}`,
+      `- model_class: ${metadata.modelClass}`,
+      `- routing_role: ${metadata.routingRole}`,
+    );
+  }
+  if (resolvedModel) {
+    if (metadataLines.length === 0) {
+      metadataLines.push("## OMX Agent Metadata");
+    }
+    metadataLines.push(`- resolved_model: ${resolvedModel}`);
+  }
+  if (metadataLines.length > 0) {
+    parts.push("", ...metadataLines);
+  }
+
+  return parts.join("\n");
+}
+
+export function composeRoleInstructionsForRole(
+  roleName: string,
+  promptContent: string,
+  resolvedModel?: string,
+): string {
+  const agent = AGENT_DEFINITIONS[roleName];
+  return composeRoleInstructions(
+    promptContent,
+    agent
+      ? {
+          name: agent.name,
+          posture: agent.posture,
+          modelClass: agent.modelClass,
+          routingRole: agent.routingRole,
+        }
+      : null,
+    resolvedModel,
+  );
 }
 
 /**
@@ -226,11 +295,12 @@ export function generateAgentToml(
   promptContent: string,
   options: AgentModelResolutionOptions = {},
 ): string {
+  const resolvedModel = resolveAgentModel(agent, options);
   return generateStandaloneAgentToml({
     name: agent.name,
     description: agent.description,
-    developerInstructions: buildPromptInstructions(agent, promptContent),
-    model: resolveAgentModel(agent, options),
+    developerInstructions: composeRoleInstructions(promptContent, agent, resolvedModel),
+    model: resolvedModel,
     reasoningEffort: agent.reasoningEffort,
   });
 }

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -908,8 +908,11 @@ process.on('SIGTERM', () => process.exit(0));
       const worker2Instructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-2', 'AGENTS.md'), 'utf-8');
       assert.match(worker1Instructions, /You are operating as the \*\*test-engineer\*\* role/);
       assert.match(worker1Instructions, /Test Engineer/);
+      assert.doesNotMatch(worker1Instructions, /exact gpt-5\.4-mini model/);
       assert.match(worker2Instructions, /You are operating as the \*\*writer\*\* role/);
       assert.match(worker2Instructions, /You are Writer\./);
+      assert.match(worker2Instructions, /exact gpt-5\.4-mini model/);
+      assert.match(worker2Instructions, /strict execution order: inspect -> plan -> act -> verify/);
 
       let worker1Args: string[] | null = null;
       let worker2Args: string[] | null = null;
@@ -951,6 +954,102 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
       else delete process.env.OMX_ARGV_CAPTURE_DIR;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam does not apply mini guidance for exact-match negatives like gpt-5.4-mini-tuned', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-mini-tuned-'));
+    const binDir = join(cwd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const captureDir = join(cwd, 'captures');
+    const promptsDir = join(cwd, '.codex', 'prompts');
+    await mkdir(binDir, { recursive: true });
+    await mkdir(captureDir, { recursive: true });
+    await mkdir(promptsDir, { recursive: true });
+    await writeFile(join(promptsDir, 'writer.md'), '<identity>You are Writer.</identity>');
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const worker = String(process.env.OMX_TEAM_WORKER || 'unknown').replace(/[^a-zA-Z0-9_-]+/g, '__');
+const out = path.join(process.env.OMX_ARGV_CAPTURE_DIR, worker + '.json');
+fs.writeFileSync(out, JSON.stringify({ argv: process.argv.slice(2), worker }, null, 2));
+process.stdin.resume();
+setTimeout(() => process.exit(0), 5000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+      { mode: 0o755 },
+    );
+
+    const prevPath = process.env.PATH;
+    const prevTmux = process.env.TMUX;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
+    const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+
+    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
+    delete process.env.TMUX;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+    process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+    process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.4-mini-tuned';
+
+    let runtime: TeamRuntime | null = null;
+    try {
+      runtime = await withoutTeamWorkerEnv(() =>
+        startTeam(
+          'team-mini-tuned-routing',
+          'mini tuned routing handoff',
+          'executor',
+          1,
+          [
+            { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-1', role: 'writer' },
+          ],
+          cwd,
+        ));
+
+      const workerInstructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'AGENTS.md'), 'utf-8');
+      assert.match(workerInstructions, /You are operating as the \*\*writer\*\* role/);
+      assert.match(workerInstructions, /You are Writer\./);
+      assert.doesNotMatch(workerInstructions, /exact gpt-5\.4-mini model/);
+      assert.doesNotMatch(workerInstructions, /strict execution order: inspect -> plan -> act -> verify/);
+      assert.match(workerInstructions, /resolved_model: gpt-5\.4-mini-tuned/);
+
+      let workerArgs: string[] | null = null;
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        const workerPath = join(captureDir, 'team-mini-tuned-routing__worker-1.json');
+        if (existsSync(workerPath)) {
+          workerArgs = JSON.parse(await readFile(workerPath, 'utf-8')).argv;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      assert.ok(workerArgs, 'worker argv capture file should be written');
+      const workerJoined = workerArgs!.join(' ');
+      assert.match(workerJoined, /--model gpt-5\.4-mini-tuned/);
+
+      await shutdownTeam(runtime.teamName, cwd, { force: true });
+      runtime = null;
+    } finally {
+      if (runtime) {
+        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
+      else delete process.env.OMX_ARGV_CAPTURE_DIR;
+      if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -544,7 +544,11 @@ exit 0
         'executor',
         [{ subject: 'write docs', description: 'write docs', owner: 'worker-2', role: 'writer' }],
         cwd,
-        { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
+        {
+          OMX_TEAM_SCALING_ENABLED: '1',
+          OMX_TEAM_SKIP_READY_WAIT: '1',
+          OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gpt-5.4-mini',
+        },
       );
       assert.equal(result.ok, true);
       if (!result.ok) return;
@@ -556,6 +560,175 @@ exit 0
       const rootAgents = await readFile(join(cwd, '.omx', 'team', 'canonical-root', 'worktrees', 'worker-2', 'AGENTS.md'), 'utf-8');
       assert.match(rootAgents, /You are operating as the \*\*writer\*\* role/);
       assert.match(rootAgents, /<identity>You are Writer\.<\/identity>/);
+      assert.match(rootAgents, /exact gpt-5\.4-mini model/);
+      assert.match(rootAgents, /strict execution order: inspect -> plan -> act -> verify/);
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not apply mini guidance during scale-up when the final worker model is gpt-5.4', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-frontier-role-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-frontier-role-bin-'));
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+
+    try {
+      await writeFile(
+        tmuxStubPath,
+        `#!/bin/sh
+set -eu
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.2a"
+    ;;
+  split-window)
+    echo "%31"
+    ;;
+  list-panes)
+    echo "42424"
+    ;;
+  capture-pane)
+    echo ""
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(tmuxStubPath, 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+      await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
+      await writeFile(join(cwd, '.codex', 'prompts', 'test-engineer.md'), '<identity>Test Engineer</identity>');
+      await mkdir(join(cwd, '.omx', 'state', 'team', 'frontier-role'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'team', 'frontier-role', 'worker-agents.md'), '# Base worker instructions\n');
+
+      await initTeamState('frontier-role', 'task', 'executor', 1, cwd);
+      await createTask('frontier-role', {
+        subject: 'existing task',
+        description: 'already persisted',
+        status: 'pending',
+        owner: 'worker-1',
+      }, cwd);
+
+      const config = await readTeamConfig('frontier-role', cwd);
+      assert.ok(config);
+      if (!config) return;
+      config.tmux_session = 'omx-team-frontier-role';
+      config.leader_pane_id = '%11';
+      config.workers[0]!.pane_id = '%21';
+      await saveTeamConfig(config, cwd);
+
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'frontier-role', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
+      manifest.policy = {
+        ...(manifest.policy ?? {}),
+        dispatch_mode: 'transport_direct',
+      };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = await scaleUp(
+        'frontier-role',
+        1,
+        'executor',
+        [{ subject: 'test routing report only', description: 'test routing report only', owner: 'worker-2', role: 'test-engineer' }],
+        cwd,
+        { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
+      );
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+
+      const workerAgents = await readFile(join(cwd, '.omx', 'state', 'team', 'frontier-role', 'workers', 'worker-2', 'AGENTS.md'), 'utf-8');
+      assert.match(workerAgents, /You are operating as the \*\*test-engineer\*\* role/);
+      assert.match(workerAgents, /<identity>Test Engineer<\/identity>/);
+      assert.doesNotMatch(workerAgents, /exact gpt-5\.4-mini model/);
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not apply mini guidance during scale-up for gpt-5.4-mini-tuned overrides', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-mini-tuned-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-mini-tuned-bin-'));
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+
+    try {
+      await writeFile(
+        tmuxStubPath,
+        `#!/bin/sh
+set -eu
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.2a"
+    ;;
+  split-window)
+    echo "%31"
+    ;;
+  list-panes)
+    echo "42424"
+    ;;
+  capture-pane)
+    echo ""
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(tmuxStubPath, 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+      await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
+      await writeFile(join(cwd, '.codex', 'prompts', 'writer.md'), '<identity>You are Writer.</identity>');
+      await writeFile(join(cwd, 'AGENTS.md'), '# Root project instructions\n');
+      await initCommittedGitRepo(cwd);
+      await initTeamState('mini-tuned-root', 'task', 'executor', 1, cwd, undefined, process.env, {
+        workspace_mode: 'worktree',
+        leader_cwd: cwd,
+        team_state_root: join(cwd, '.omx', 'state'),
+      });
+
+      const config = await readTeamConfig('mini-tuned-root', cwd);
+      assert.ok(config);
+      if (!config) return;
+      config.tmux_session = 'omx-team-mini-tuned-root';
+      config.leader_pane_id = '%11';
+      config.workers[0]!.pane_id = '%21';
+      await saveTeamConfig(config, cwd);
+
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'mini-tuned-root', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
+      manifest.policy = {
+        ...(manifest.policy ?? {}),
+        dispatch_mode: 'transport_direct',
+      };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = await scaleUp(
+        'mini-tuned-root',
+        1,
+        'executor',
+        [{ subject: 'write docs', description: 'write docs', owner: 'worker-2', role: 'writer' }],
+        cwd,
+        {
+          OMX_TEAM_SCALING_ENABLED: '1',
+          OMX_TEAM_SKIP_READY_WAIT: '1',
+          OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gpt-5.4-mini-tuned',
+        },
+      );
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+
+      const rootAgents = await readFile(join(cwd, '.omx', 'team', 'mini-tuned-root', 'worktrees', 'worker-2', 'AGENTS.md'), 'utf-8');
+      assert.match(rootAgents, /You are operating as the \*\*writer\*\* role/);
+      assert.match(rootAgents, /<identity>You are Writer\.<\/identity>/);
+      assert.doesNotMatch(rootAgents, /exact gpt-5\.4-mini model/);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -20,6 +20,7 @@ import {
   generateMailboxTriggerMessage,
   generateLeaderMailboxTriggerMessage,
 } from "../worker-bootstrap.js";
+import { composeRoleInstructionsForRole } from "../../agents/native-config.js";
 import type { TeamTask } from "../state.js";
 
 function setMockCodexHome(codexHomePath: string): () => void {
@@ -671,6 +672,41 @@ describe("worker bootstrap", () => {
       assert.match(content, /<!-- OMX:TEAM:ROLE:START -->/);
       assert.match(content, /\*\*writer\*\* role/);
       assert.match(content, /<identity>Writer role prompt<\/identity>/);
+      assert.doesNotMatch(content, /exact gpt-5\.4-mini model/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("writeWorkerRoleInstructionsFile preserves precomposed mini guidance as wrapper-only content", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-worker-bootstrap-"));
+    try {
+      const overlay = generateWorkerOverlay("mini-role-team");
+      const basePath = await writeTeamWorkerInstructionsFile(
+        "mini-role-team",
+        cwd,
+        overlay,
+      );
+      const composedRoleInstructions = composeRoleInstructionsForRole(
+        "writer",
+        "---\ndescription: demo\n---\n\n<identity>You are Writer.</identity>",
+        "gpt-5.4-mini",
+      );
+      const outPath = await writeWorkerRoleInstructionsFile(
+        "mini-role-team",
+        "worker-2",
+        cwd,
+        basePath,
+        "writer",
+        composedRoleInstructions,
+      );
+
+      const content = await readFile(outPath, "utf8");
+      assert.match(content, /<identity>You are Writer\.<\/identity>/);
+      assert.match(content, /exact gpt-5\.4-mini model/);
+      assert.match(content, /strict execution order: inspect -> plan -> act -> verify/);
+      assert.equal((content.match(/<exact_model_guidance>/g) || []).length, 1);
+      assert.equal((content.match(/resolved_model: gpt-5\.4-mini/g) || []).length, 1);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -95,6 +95,7 @@ import {
   writeWorkerRoleInstructionsFile,
 } from './worker-bootstrap.js';
 import { loadRolePrompt } from './role-router.js';
+import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
 import { type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
@@ -1469,8 +1470,20 @@ export async function startTeam(
       const workerRole = taskRoles.length > 0 && uniqueTaskRoles.size === 1
         ? taskRoles[0]
         : agentType;
-      const rolePromptContent = await loadRolePrompt(workerRole, join(leaderCwd, '.codex', 'prompts'))
+      const rawRolePromptContent = await loadRolePrompt(workerRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(workerRole, codexPromptsDir());
+      const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
+      const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
+        process.env,
+        workerRole,
+        undefined,
+        preferredReasoning,
+        workerCliPlan[i - 1],
+      );
+      const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
+      const rolePromptContent = rawRolePromptContent
+        ? composeRoleInstructionsForRole(workerRole, rawRolePromptContent, resolvedWorkerModel)
+        : null;
       const workerWorktreePath = workerWorkspace.worktreePath ?? undefined;
       const fallbackInstructionsPath = workerInstructionsPath ?? join(leaderCwd, 'AGENTS.md');
       const instructionsFilePath = workerWorktreePath
@@ -1490,21 +1503,13 @@ export async function startTeam(
         teamStateRoot,
         leaderCwd,
         workerRole,
-        rolePromptContent: rolePromptContent ?? undefined,
+        rolePromptContent: rawRolePromptContent ?? undefined,
         worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
       });
       const trigger = generateTriggerMessage(
         workerName,
         sanitized,
         resolveInstructionStateRoot(workerWorkspace.worktreePath),
-      );
-      const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
-      const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
-        process.env,
-        workerRole,
-        undefined,
-        preferredReasoning,
-        workerCliPlan[i - 1],
       );
       const initialPrompt = workerCliPlan[i - 1] === 'gemini' ? trigger : undefined;
       if (initialPrompt) {

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -57,12 +57,13 @@ import {
   removeWorkerWorktreeRootAgentsFile,
 } from './worker-bootstrap.js';
 import { loadRolePrompt } from './role-router.js';
+import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
 import {
+  parseTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchArgs,
-  isLowComplexityAgentType,
+  resolveAgentDefaultModel,
   resolveAgentReasoningEffort,
-  resolveTeamLowComplexityDefaultModel,
   type TeamReasoningEffort,
 } from './model-contract.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
@@ -346,8 +347,14 @@ export async function scaleUp(
       const workerCwd = workerWorkspace ? workerWorkspace.worktreePath : leaderCwd;
 
       // Build startup command and create tmux pane
-      const rolePromptContent = await loadRolePrompt(workerRole, join(leaderCwd, '.codex', 'prompts'))
+      const rawRolePromptContent = await loadRolePrompt(workerRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(workerRole, codexPromptsDir());
+      const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
+      const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, workerRole, preferredReasoning);
+      const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
+      const rolePromptContent = rawRolePromptContent
+        ? composeRoleInstructionsForRole(workerRole, rawRolePromptContent, resolvedWorkerModel)
+        : null;
       const teamInstructionsPath = join(leaderCwd, '.omx', 'state', 'team', sanitized, 'worker-agents.md');
       const instructionsFilePath = workerWorkspace
         ? await writeWorkerWorktreeRootAgentsFile({
@@ -374,8 +381,6 @@ export async function scaleUp(
         }
         extraEnv.OMX_TEAM_WORKTREE_DETACHED = workerWorkspace.detached ? '1' : '0';
       }
-      const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
-      const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, agentType, preferredReasoning);
       const cmd = buildWorkerStartupCommand(
         sanitized,
         workerIndex,
@@ -455,7 +460,7 @@ export async function scaleUp(
         teamStateRoot,
         leaderCwd,
         workerRole,
-        rolePromptContent: rolePromptContent ?? undefined,
+        rolePromptContent: rawRolePromptContent ?? undefined,
         worktreeRootAgentsCanonical: Boolean(workerWorkspace?.worktreePath),
       });
 
@@ -801,9 +806,7 @@ function resolveWorkerLaunchArgsForScaling(
   preferredReasoning?: TeamReasoningEffort,
 ): string[] {
   const inheritedArgs: string[] = [];
-  const fallbackModel = isLowComplexityAgentType(agentType)
-    ? resolveTeamLowComplexityDefaultModel(env.CODEX_HOME)
-    : undefined;
+  const fallbackModel = resolveAgentDefaultModel(agentType, env.CODEX_HOME);
 
   return resolveTeamWorkerLaunchArgs({
     existingRaw: env.OMX_TEAM_WORKER_LAUNCH_ARGS,


### PR DESCRIPTION
## Summary

This PR teaches OMX to apply mini-specific prompt guidance only when a subagent or team worker's **final resolved model** is exactly `gpt-5.4-mini`.

It centralizes that behavior in a shared instruction-composition seam, then wires the same seam through:
- native agent TOML generation
- team runtime worker instruction generation
- team scale-up worker instruction generation

The change preserves existing role semantics and keeps `worker-bootstrap.ts` as an outer wrapper rather than a model-aware adaptation site.

## Problem statement

OMX already resolves many standard-capability roles to `gpt-5.4-mini`, but prompt composition previously had no exact-model seam for mini-specific delivery guidance.

That created two related problems:

1. **Native agents** had no exact-model path for small-model-specific execution guidance.
2. **Team workers** loaded role prompts before final worker launch args were resolved, so mini-specific prompt behavior could not be applied consistently from the actual resolved model.

The practical gap was that `gpt-5.4-mini`-routed workers were treated like generic standard-capability lanes even when the approved plan required:
- explicit execution order
- explicit completion criteria
- explicit blocker/ambiguity behavior
- anti-bluff / anti-deviation guidance

## Root cause

Prompt composition and model resolution were split across multiple surfaces:

- `src/agents/native-config.ts` already composed prompt body + overlays + metadata, but had no exact-model hook.
- `src/team/runtime.ts` and `src/team/scaling.ts` loaded raw role prompt markdown and only later resolved worker launch args.
- `src/team/worker-bootstrap.ts` correctly wrapped worker instructions, but it was not the right place to own model-aware behavior.

So there was no single place where OMX could say:
> “Now that I know the final resolved model is exactly `gpt-5.4-mini`, compose the role instructions differently.”

## What changed

### 1. Added a shared exact-model composition seam
In `src/agents/native-config.ts` this PR adds:
- `EXACT_GPT_5_4_MINI_MODEL`
- `composeRoleInstructions(...)`
- `composeRoleInstructionsForRole(...)`
- an `EXACT_MINI_MODEL_OVERLAY`

The mini overlay adds structure for:
- strict execution order
- explicit completion criteria
- explicit blocker handling
- explicit anti-bluff guidance

### 2. Kept the gate exact
The mini overlay is applied only when the **final resolved model string** is exactly:

```text
gpt-5.4-mini
```

It does **not** apply to:
- `gpt-5.4`
- `gpt-5.4-mini-tuned`
- other non-exact variants

### 3. Wired the seam into native agent generation
`generateAgentToml(...)` now resolves the effective model first, then composes developer instructions with the resolved model available.

### 4. Wired the seam into team runtime and scale-up
Both team startup paths now:
- load the raw role prompt
- resolve worker launch args
- extract the final resolved model from those launch args
- compose role instructions from that resolved model
- pass the composed instructions into the worker instruction file

This means team workers now use the same mini-only exact-model seam as native agent generation.

### 5. Kept wrapper boundaries intact
This PR intentionally keeps:
- `src/team/worker-bootstrap.ts` as an **outer wrapper**
- `src/team/role-router.ts` as a **raw prompt loader**

That separation was part of the approved plan and is preserved here.

## Why this design

This design was chosen because it is the narrowest way to support mini-specific prompt behavior without:
- adding new roles
- renaming roles
- duplicating per-role prompt files
- widening behavior to non-mini models
- turning wrapper code into model-routing logic

The result is one shared seam with multiple callers rather than multiple divergent seams.

## Overlap assessment

### Classification
**Adjacent but distinct**

### Related issue
- #1014 — `team/worktree run can stall on invalid plan paths, queued follow-ups, duplicate integration messages, and hung shutdown`

### Relationship to #1014
This PR is **not** the fix for #1014.

Issue #1014 documents a separate `omx team` runtime/orchestration stall encountered while trying to execute this work in linked `team + ralph` mode.

This PR only covers the approved feature work for the mini-specific prompt-composition seam.
It does **not** attempt to fix:
- worktree plan-path mismatches
- mailbox follow-up loops
- repeated integration-message noise
- hung `omx team shutdown --force --ralph`

### Prior overlap check
I did not find an existing open PR in this repo covering the same exact-model `gpt-5.4-mini` instruction-composition seam across native + runtime + scaling.

## Validation

Verified on the delivery branch with repo-local dependencies linked into the clean worktree:

```bash
npm run build
node --test dist/agents/__tests__/native-config.test.js dist/team/__tests__/runtime.test.js
node --test dist/team/__tests__/scaling.test.js dist/team/__tests__/worker-bootstrap.test.js
node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/prompt-guidance-scenarios.test.js dist/hooks/__tests__/prompt-guidance-catalog.test.js
```

## Risks / compatibility

### Low-risk behavior expansion
The implementation now records `resolved_model` metadata in composed instructions when a resolved model is known, including non-mini cases.

That is helpful for observability, but it is slightly broader than a mini-overlay-only textual change.

### Intentional non-goals
This PR does **not**:
- change `gpt-5.4` behavior beyond shared composition plumbing
- add nano-specific behavior
- redesign team routing
- fix issue #1014

## Changed files

- `docs/prompt-guidance-contract.md`
- `src/agents/native-config.ts`
- `src/agents/__tests__/native-config.test.ts`
- `src/team/runtime.ts`
- `src/team/scaling.ts`
- `src/team/__tests__/runtime.test.ts`
- `src/team/__tests__/scaling.test.ts`
- `src/team/__tests__/worker-bootstrap.test.ts`
