### PR TITLE
Deduplicate repeated undelivered leader mailbox messages in team mode

### DIFF
--- a/src/team/__tests__/mcp-comm.test.ts
+++ b/src/team/__tests__/mcp-comm.test.ts
@@ -122,6 +122,53 @@ describe('mcp-comm', () => {
     }
   });
 
+  it('queueDirectMailboxMessage does not create a new dispatch for an already-notified identical message', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-'));
+    try {
+      await initTeamState('alpha-dedupe', 'task', 'executor', 1, cwd);
+
+      const first = await queueDirectMailboxMessage({
+        teamName: 'alpha-dedupe',
+        fromWorker: 'worker-1',
+        toWorker: 'leader-fixed',
+        body: 'same-body',
+        triggerMessage: 'check mailbox',
+        cwd,
+        transportPreference: 'transport_direct',
+        fallbackAllowed: false,
+        notify: async () => ({ ok: true, transport: 'mailbox', reason: 'leader_mailbox_notified' }),
+      });
+
+      assert.equal(first.ok, true);
+      assert.equal(first.reason, 'leader_mailbox_notified');
+
+      const second = await queueDirectMailboxMessage({
+        teamName: 'alpha-dedupe',
+        fromWorker: 'worker-1',
+        toWorker: 'leader-fixed',
+        body: 'same-body',
+        triggerMessage: 'check mailbox',
+        cwd,
+        transportPreference: 'transport_direct',
+        fallbackAllowed: false,
+        notify: async () => {
+          throw new Error('should_not_notify_twice');
+        },
+      });
+
+      assert.equal(second.ok, true);
+      assert.equal(second.reason, 'existing_message_already_notified');
+
+      const mailbox = await listMailboxMessages('alpha-dedupe', 'leader-fixed', cwd);
+      assert.equal(mailbox.length, 1);
+
+      const requests = await listDispatchRequests('alpha-dedupe', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+      assert.equal(requests.length, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('queueBroadcastMailboxMessage notifies and marks notified per recipient', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-'));
     try {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -3458,6 +3458,21 @@ esac
     }
   });
 
+  it('sendWorkerMessage dedupes identical undelivered leader-fixed messages', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
+    try {
+      await initTeamState('team-leader-dedupe', 'leader mailbox dedupe test', 'executor', 1, cwd);
+      await sendWorkerMessage('team-leader-dedupe', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
+      await sendWorkerMessage('team-leader-dedupe', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
+
+      const messages = await listMailboxMessages('team-leader-dedupe', 'leader-fixed', cwd);
+      assert.equal(messages.length, 1);
+      assert.equal(messages[0]?.body, 'INTEGRATED: same-body');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('sendWorkerMessage hook-preferred path persists leader mailbox guidance when leader pane exists', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-inject-'));
     try {

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -1027,6 +1027,31 @@ describe('team state', () => {
     }
   });
 
+  it('sendDirectMessage reuses identical undelivered messages instead of appending duplicates', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-'));
+    try {
+      await initTeamState('team-msg-dedupe', 't', 'executor', 2, cwd);
+      const first = await sendDirectMessage('team-msg-dedupe', 'worker-1', 'leader-fixed', 'same-body', cwd);
+      const second = await sendDirectMessage('team-msg-dedupe', 'worker-1', 'leader-fixed', 'same-body', cwd);
+
+      assert.equal(second.message_id, first.message_id);
+
+      const mailbox = await listMailboxMessages('team-msg-dedupe', 'leader-fixed', cwd);
+      assert.equal(mailbox.length, 1);
+      assert.equal(mailbox[0]?.body, 'same-body');
+
+      const delivered = await markMessageDelivered('team-msg-dedupe', 'leader-fixed', first.message_id, cwd);
+      assert.equal(delivered, true);
+
+      const third = await sendDirectMessage('team-msg-dedupe', 'worker-1', 'leader-fixed', 'same-body', cwd);
+      assert.notEqual(third.message_id, first.message_id);
+      const mailboxAfter = await listMailboxMessages('team-msg-dedupe', 'leader-fixed', cwd);
+      assert.equal(mailboxAfter.length, 2);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('writeTaskApproval writes record and emits approval_decision event', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-approval-'));
     try {

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -199,6 +199,15 @@ interface QueueDirectMessageParams {
 
 export async function queueDirectMailboxMessage(params: QueueDirectMessageParams): Promise<DispatchOutcome> {
   const message = await sendDirectMessage(params.teamName, params.fromWorker, params.toWorker, params.body, params.cwd);
+  if (message.notified_at && !message.delivered_at) {
+    return {
+      ok: true,
+      transport: params.toWorker === 'leader-fixed' ? 'mailbox' : fallbackTransportForPreference(params.transportPreference),
+      reason: 'existing_message_already_notified',
+      message_id: message.message_id,
+      to_worker: params.toWorker,
+    };
+  }
   const queued = await enqueueDispatchRequest(
     params.teamName,
     {

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -42,32 +42,53 @@ export async function sendDirectMessage(
   body: string,
   deps: MailboxDeps,
 ): Promise<TeamMailboxMessage> {
-  // Dual-write: Rust bridge (non-fatal) + TS file (canonical during cutover)
-  const msgId = randomUUID();
-  if (isBridgeEnabled()) {
-    try { getDefaultBridge(deps.cwd).execCommand({ command: 'CreateMailboxMessage', message_id: msgId, from_worker: fromWorker, to_worker: toWorker, body }); } catch {}
-  }
-
-  const msg: TeamMailboxMessage = {
-    message_id: msgId,
-    from_worker: fromWorker,
-    to_worker: toWorker,
-    body,
-    created_at: new Date().toISOString(),
-  };
+  let created = false;
+  let msg: TeamMailboxMessage | null = null;
 
   await deps.withMailboxLock(deps.teamName, toWorker, deps.cwd, async () => {
     const mailbox = await deps.readMailbox(deps.teamName, toWorker, deps.cwd);
+    const existing = mailbox.messages.find((candidate) =>
+      candidate.from_worker === fromWorker
+      && candidate.to_worker === toWorker
+      && candidate.body === body
+      && !candidate.delivered_at,
+    );
+    if (existing) {
+      msg = existing;
+      return;
+    }
+
+    // Dual-write: Rust bridge (non-fatal) + TS file (canonical during cutover)
+    const msgId = randomUUID();
+    if (isBridgeEnabled()) {
+      try { getDefaultBridge(deps.cwd).execCommand({ command: 'CreateMailboxMessage', message_id: msgId, from_worker: fromWorker, to_worker: toWorker, body }); } catch {}
+    }
+
+    msg = {
+      message_id: msgId,
+      from_worker: fromWorker,
+      to_worker: toWorker,
+      body,
+      created_at: new Date().toISOString(),
+    };
     mailbox.messages.push(msg);
     await deps.writeMailbox(deps.teamName, mailbox, deps.cwd);
+    created = true;
   });
 
-  await deps.appendTeamEvent(
-    deps.teamName,
-    { type: 'message_received', worker: toWorker, task_id: undefined, message_id: msg.message_id, reason: undefined },
-    deps.cwd,
-  );
-  return msg;
+  if (!msg) {
+    throw new Error('failed_to_persist_mailbox_message');
+  }
+  const persistedMessage = msg as TeamMailboxMessage;
+
+  if (created) {
+    await deps.appendTeamEvent(
+      deps.teamName,
+      { type: 'message_received', worker: toWorker, task_id: undefined, message_id: persistedMessage.message_id, reason: undefined },
+      deps.cwd,
+    );
+  }
+  return persistedMessage;
 }
 
 export async function broadcastMessage(


### PR DESCRIPTION
## Summary

This PR reduces one of the most visible failure modes from #1014 by preventing repeated undelivered worker-to-leader mailbox messages from being appended and re-dispatched over and over.

In practice, this means OMX no longer keeps creating new leader-fixed mailbox entries for the same worker/body pair while the original message is still pending.

## Fixes
- Fixes #1014

## Problem statement

During the stalled `team + ralph` run documented in #1014, the leader mailbox kept growing while workers were not making meaningful progress.

One of the clearest symptoms was repeated leader-facing messages like:

```text
INTEGRATED: merged worker-3 (...) into leader HEAD ... via merge --no-ff.
```

appearing multiple times even though the underlying state had not usefully advanced.

That behavior amplified:
- leader mailbox noise
- repeated stale-leader nudges
- operator confusion about whether real progress had happened

## Root cause

Mailbox delivery for direct worker-to-leader messages had no content-level dedupe.

The old behavior was:
1. create a fresh mailbox message every time `sendDirectMessage(...)` was called
2. enqueue a fresh dispatch request for that new message
3. notify again even if an identical undelivered message was already sitting in the mailbox

That made repeated integration/progress/status writes especially noisy when the leader had not yet consumed the original message.

## What changed

### 1. Reuse identical undelivered mailbox messages
In `src/team/state/mailbox.ts`, `sendDirectMessage(...)` now checks for an existing undelivered mailbox message with the same:
- `from_worker`
- `to_worker`
- `body`

If one exists, OMX reuses that message instead of appending a new duplicate.

### 2. Skip re-dispatch for messages that are already notified
In `src/team/mcp-comm.ts`, `queueDirectMailboxMessage(...)` now short-circuits when the reused message is already:
- present
- undelivered
- already notified

Instead of creating another dispatch request / re-notifying, it returns an `existing_message_already_notified` outcome.

## Why this design

This is intentionally narrow.

I did **not** try to redesign the full team state machine in this PR.
Instead, I targeted the specific repeated-mailbox-spam path because it was:
- clearly reproducible
- strongly correlated with the observed issue symptoms
- fixable without changing worker role/routing semantics

## Scope / non-goals

This PR does **not** fully solve every symptom from #1014.
In particular, it does not by itself fix:
- worktree-relative plan artifact path mismatches
- all queued follow-up prompt behavior
- the full `shutdown --force --ralph` hang path

What it does fix is the repeated duplicate leader-mailbox message path that made the stall much noisier and harder to reason about.

## Validation

Ran:

```bash
npm run build
node --test --test-name-pattern 'sendWorkerMessage allows worker to message leader-fixed mailbox|sendWorkerMessage dedupes identical undelivered leader-fixed messages|sendWorkerMessage hook-preferred path persists leader mailbox guidance when leader pane exists|sendWorkerMessage hook-preferred path for leader waits for receipt then falls back to mailbox persistence|sendWorkerMessage transport_direct keeps leader-fixed request pending when leader_pane_id missing' dist/team/__tests__/runtime.test.js
node --test dist/team/__tests__/state.test.js dist/team/__tests__/mcp-comm.test.js
```

## Tests added / updated

- `src/team/__tests__/state.test.ts`
  - verifies identical undelivered direct messages are reused instead of appended
- `src/team/__tests__/mcp-comm.test.ts`
  - verifies already-notified identical messages do not create a fresh dispatch request
- `src/team/__tests__/runtime.test.ts`
  - verifies leader-fixed runtime messaging dedupes identical undelivered messages

## Risks / compatibility

- This change intentionally dedupes only **identical undelivered** messages.
- Delivered history is untouched.
- Legitimate retries for **unnotified** messages still proceed through the existing dispatch path.

## Changed files

- `src/team/state/mailbox.ts`
- `src/team/mcp-comm.ts`
- `src/team/__tests__/state.test.ts`
- `src/team/__tests__/mcp-comm.test.ts`
- `src/team/__tests__/runtime.test.ts`
