### PR TITLE
fix(prompts): keep child agents on the current frontier default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,9 @@ Rules:
 - `worker` is a team-runtime surface, not a general-purpose child role.
 - Child agents should report recommended handoffs upward.
 - Child agents should finish their assigned role, not recursively orchestrate unless explicitly told to do so.
+- Prefer inheriting the leader model by omitting `spawn_agent.model` unless a task truly requires a different model.
+- Do not hardcode stale frontier-model overrides for Codex native child agents. If an explicit frontier override is necessary, use the current frontier default from `OMX_DEFAULT_FRONTIER_MODEL` / the repo model contract (currently `gpt-5.4`), not older values such as `gpt-5.2`.
+- Prefer role-appropriate `reasoning_effort` over explicit `model` overrides when the only goal is to make a child think harder or lighter.
 </child_agent_protocol>
 
 <invocation_conventions>
@@ -96,6 +99,8 @@ Match role to task shape:
 - Low complexity: `explore`, `style-reviewer`, `writer`
 - Standard: `executor`, `debugger`, `test-engineer`
 - High complexity: `architect`, `executor`, `critic`
+
+For Codex native child agents, model routing defaults to inheritance/current repo defaults unless the caller has a concrete reason to override it.
 </model_routing>
 
 ---

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -151,6 +151,9 @@ Rules:
 - `worker` is a team-runtime surface, not a general-purpose child role.
 - Child agents should report recommended handoffs upward.
 - Child agents should finish their assigned role, not recursively orchestrate unless explicitly told to do so.
+- Prefer inheriting the leader model by omitting `spawn_agent.model` unless a task truly requires a different model.
+- Do not hardcode stale frontier-model overrides for Codex native child agents. If an explicit frontier override is necessary, use the current frontier default from `OMX_DEFAULT_FRONTIER_MODEL` / the repo model contract (currently `gpt-5.4`), not older values such as `gpt-5.2`.
+- Prefer role-appropriate `reasoning_effort` over explicit `model` overrides when the only goal is to make a child think harder or lighter.
 </child_agent_protocol>
 
 <invocation_conventions>
@@ -164,6 +167,8 @@ Match role to task shape:
 - Low complexity: `explore`, `style-reviewer`, `writer`
 - Standard: `executor`, `debugger`, `test-engineer`
 - High complexity: `architect`, `executor`, `critic`
+
+For Codex native child agents, model routing defaults to inheritance/current repo defaults unless the caller has a concrete reason to override it.
 </model_routing>
 
 ---


### PR DESCRIPTION
## Summary

This PR updates the root AGENTS contract so Codex native child agents inherit the leader/current frontier model by default instead of encouraging explicit stale model pins.

It adds a narrow guardrail to both `AGENTS.md` and `templates/AGENTS.md`:
- omit `spawn_agent.model` unless a task truly needs a different model
- do not hardcode stale frontier overrides such as `gpt-5.2`
- prefer `reasoning_effort` when the real goal is “think harder/lighter”, not “switch models”

## Problem statement

Recent local rollout traces showed OMX spawning planner/architect/critic child agents with explicit `model: "gpt-5.2"` overrides while the leader session was running on `gpt-5.4`.

That is not a runtime display bug. It means the child agents were actually launched on an older frontier model because the prompt contract did not clearly steer future child-agent delegation toward:
- leader-model inheritance as the default
- current repo frontier defaults when an explicit override is truly necessary

## Root cause

The repo already tightened runtime/default model resolution, but the top-level prompt contract still left room for assistants to emit explicit `spawn_agent.model` pins that drifted behind the current frontier contract.

In practice, the gap was:
- runtime/config code knows the current frontier default is `gpt-5.4`
- root AGENTS already defines delegation boundaries
- but root/template AGENTS did not explicitly say “inherit the leader model unless you have a concrete reason not to”
- so child-agent delegation could still regress into stale hardcoded frontier overrides from older task patterns

## What changed

### 1. Added leader-model inheritance guidance to the child-agent protocol
Both `AGENTS.md` and `templates/AGENTS.md` now explicitly tell child-agent callers to prefer omitting `spawn_agent.model` so the leader/current default model is inherited.

### 2. Added a stale-override prohibition
Both surfaces now explicitly forbid stale frontier-model pins for Codex native child agents and point callers back to the current frontier contract (`OMX_DEFAULT_FRONTIER_MODEL`, currently `gpt-5.4`) when an explicit override is truly required.

### 3. Clarified the model-vs-reasoning boundary
Both surfaces now instruct callers to prefer `reasoning_effort` when they only want a child to think harder/lighter, instead of switching the child model unnecessarily.

### 4. Tightened model-routing intent
The root/template model-routing section now states that Codex native child agents default to inheritance/current repo defaults unless the caller has a concrete reason to override them.

## Why this design

This is intentionally a **root-contract fix**, not a runtime-model-resolution patch.

Why:
- the observed bad launches came from explicit `spawn_agent` model overrides in session prompts
- runtime model resolution was not the component selecting `gpt-5.2` in those cases
- fixing the root/template AGENTS contract is the narrowest change that influences future prompt behavior across the same delegation surface
- inheritance is safer than forcing `gpt-5.4` in code because it preserves future frontier-default changes without needing another prompt patch

## Overlap assessment

### Classification
**Adjacent but distinct**

### Related PRs
- #625 — `fix(prompts): enforce leader-only orchestration boundaries`
- #646 — `Tighten root prompt contracts with explicit safety and workflow rationale`
- #1016 — `Add an exact-model prompt seam for gpt-5.4-mini subagents`

### Relationship
- **#625** established upward-only orchestration boundaries for child prompts, but it did not explicitly prevent stale explicit child-model pins.
- **#646** tightened the root prompt contract broadly, but it did not add a model-inheritance/default-frontier rule for Codex native child-agent calls.
- **#1016** fixed exact-model prompt composition for `gpt-5.4-mini` in native/team runtime paths, but it did not address explicit session-level `spawn_agent.model` overrides emitted from the root prompt contract.

I did not find an existing open issue/PR in this repo specifically covering stale explicit frontier-model overrides for Codex native child-agent delegation.

## Validation

Verified in a clean delivery worktree from `origin/dev`:

```bash
npm run build
node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js dist/hooks/__tests__/prompt-orchestration-boundary.test.js dist/hooks/__tests__/deep-interview-contract.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js dist/hooks/__tests__/prompt-team-routing.test.js
```

## Risk / compatibility

### Risk level
Low.

### Why
- no runtime code changes
- no agent catalog changes
- no model-resolution code changes
- no team worker launch-contract changes
- only root/template AGENTS guidance tightened

### Compatibility impact
Future native child-agent delegation should now favor inheritance/current frontier defaults instead of stale explicit pins.

This PR does **not** retroactively change already-running child-agent sessions that were spawned before the contract update.

## Files changed

- `AGENTS.md`
- `templates/AGENTS.md`
