### PR TITLE
Restore OMX tmux injection targeting and dispatch ID parity

### DIFF
--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -191,6 +191,106 @@ describe('notify-hook auto-nudge', () => {
     });
   });
 
+  it('auto-nudges from active mode state by upgrading an anchored shell pane to the sibling codex pane', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0 },
+      });
+
+      await writeJson(join(stateDir, 'ralph-state.json'), {
+        active: true,
+        tmux_pane_id: '%99',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%99" ]]; then
+    echo "sh"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%100" ]]; then
+    echo "node"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%100" ]]; then
+    echo "codex --model gpt-5"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%100" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$format" == "#S" && "$target" == "%99" ]]; then
+    echo "devsess"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  target=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -t) target="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ "$target" == "devsess" ]]; then
+    printf "%%99\tsh\tbash\n%%100\tnode\tcodex --model gpt-5\n"
+    exit 0
+  fi
+  echo "%1 12345"
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  printf "How can I help?\n› "
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(join(fakeBinDir, 'tmux'), fakeTmux);
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'If you want, I can keep going from here.',
+      }, {
+        TMUX_PANE: '',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /display-message -t %99 -p #S/, 'should anchor off the active mode pane');
+      assert.match(tmuxLog, /send-keys -t %100 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should upgrade anchored shell pane to sibling codex pane');
+    });
+  });
+
   it('still auto-nudges in team-worker context using the worker state root', async () => {
     await withTempWorkingDir(async (cwd) => {
       const workerStateRoot = join(cwd, 'leader-state-root');

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -287,11 +287,42 @@ export async function capturePane(paneId, lines = 10) {
   }
 }
 
+async function resolveCodexPaneFromAnchor(anchorPane) {
+  const paneId = safeString(anchorPane).trim();
+  if (!paneId) return '';
+
+  try {
+    const sessionResult = await runProcess('tmux', ['display-message', '-t', paneId, '-p', '#S'], 2000);
+    const sessionName = safeString(sessionResult.stdout).trim();
+    if (!sessionName) return '';
+
+    const panesResult = await runProcess(
+      'tmux',
+      ['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}'],
+      2000,
+    );
+    const panes = safeString(panesResult.stdout).trim().split('\n').filter(Boolean);
+    for (const line of panes) {
+      const [candidatePaneId, , rawStartCommand = ''] = line.split('\t');
+      const startCommand = safeString(rawStartCommand).toLowerCase();
+      if (!candidatePaneId) continue;
+      if (/\bomx\b.*\bhud\b.*--watch/i.test(startCommand)) continue;
+      if (startCommand.includes('codex')) return candidatePaneId;
+    }
+  } catch {
+    // Fall back to the anchored pane when session scanning is unavailable.
+  }
+
+  return '';
+}
+
 export async function resolveNudgePaneTarget(stateDir: any) {
   // Use canonical codex pane resolver — validates pane is running an agent, not a shell
   const { resolveCodexPane } = await import('../tmux-hook-engine.js');
   const codexPane = resolveCodexPane();
   if (codexPane) return codexPane;
+
+  let fallbackPane = '';
 
   try {
     const scopedDirs = await getScopedStateDirsForCurrentSession(stateDir);
@@ -303,7 +334,11 @@ export async function resolveNudgePaneTarget(stateDir: any) {
         try {
           const state = JSON.parse(await readFile(path, 'utf-8'));
           if (state && state.active && state.tmux_pane_id) {
-            return safeString(state.tmux_pane_id);
+            const anchoredPane = safeString(state.tmux_pane_id).trim();
+            if (!anchoredPane) continue;
+            const upgradedPane = await resolveCodexPaneFromAnchor(anchoredPane);
+            if (upgradedPane) return upgradedPane;
+            if (!fallbackPane) fallbackPane = anchoredPane;
           }
         } catch {
           // skip malformed state
@@ -314,7 +349,7 @@ export async function resolveNudgePaneTarget(stateDir: any) {
     // Non-critical
   }
 
-  return '';
+  return fallbackPane;
 }
 
 export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile, readFile, mkdir, utimes } from 'fs/promises';
+import { chmod, mkdtemp, rm, writeFile, readFile, mkdir, utimes } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync, readFileSync } from 'fs';
@@ -189,6 +189,58 @@ describe('team state', () => {
         await rm(freshCwd, { recursive: true, force: true });
       }
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('dispatch bridge queue uses the same request id as the TS store', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-bridge-sync-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    try {
+      await initTeamState('team-dispatch-sync', 't', 'executor', 1, cwd);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const runtimeLogPath = join(cwd, 'runtime.log');
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, 'omx-runtime'),
+        `#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >> "${runtimeLogPath}"
+if [[ "\${1:-}" == "schema" ]]; then
+  printf '{"schema_version":1,"commands":["acquire-authority","renew-authority","queue-dispatch","mark-notified","mark-delivered","mark-failed","request-replay","capture-snapshot"],"events":[],"transport":"tmux"}\n'
+  exit 0
+fi
+if [[ "\${1:-}" == "exec" ]]; then
+  printf '{"event":"DispatchQueued","request_id":"ok","target":"worker-1"}\n'
+  exit 0
+fi
+exit 1
+`,
+      );
+      await chmod(join(fakeBinDir, 'omx-runtime'), 0o755);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+
+      const queued = await enqueueDispatchRequest(
+        'team-dispatch-sync',
+        {
+          kind: 'inbox',
+          to_worker: 'worker-1',
+          trigger_message: 'ping',
+        },
+        cwd,
+      );
+
+      const runtimeLog = await readFile(runtimeLogPath, 'utf8');
+      const queueLine = runtimeLog.split('\n').find((line) => line.startsWith('exec {"command":"QueueDispatch"'));
+      assert.ok(queueLine, 'expected QueueDispatch bridge call');
+      const jsonStart = queueLine.indexOf('{');
+      const stateDirFlag = queueLine.lastIndexOf(' --state-dir=');
+      const jsonPayload = stateDirFlag > jsonStart ? queueLine.slice(jsonStart, stateDirFlag) : queueLine.slice(jsonStart);
+      const payload = JSON.parse(jsonPayload) as { request_id: string };
+      assert.equal(payload.request_id, queued.request.request_id);
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -127,18 +127,6 @@ export async function enqueueDispatchRequest(
   }
   deps.validateWorkerName(requestInput.to_worker);
 
-  // Dual-write: Rust bridge (non-fatal) + TS file (canonical during cutover)
-  if (isBridgeEnabled()) {
-    try {
-      getDefaultBridge(deps.cwd).execCommand({
-        command: 'QueueDispatch',
-        request_id: 'pre-' + Date.now(),
-        target: requestInput.to_worker,
-        metadata: { kind: requestInput.kind, team_name: deps.teamName, worker_index: requestInput.worker_index, pane_id: requestInput.pane_id, trigger_message: requestInput.trigger_message, message_id: requestInput.message_id, inbox_correlation_key: requestInput.inbox_correlation_key, transport_preference: requestInput.transport_preference, fallback_allowed: requestInput.fallback_allowed },
-      });
-    } catch { /* bridge failure non-fatal */ }
-  }
-
   return await deps.withDispatchLock(deps.teamName, deps.cwd, async () => {
     const requests = await deps.readDispatchRequests(deps.teamName, deps.cwd);
     const existing = requests.find((req) => equivalentPendingDispatch(req, requestInput));
@@ -161,6 +149,28 @@ export async function enqueueDispatchRequest(
 
     requests.push(request);
     await deps.writeDispatchRequests(deps.teamName, requests, deps.cwd);
+
+    if (isBridgeEnabled()) {
+      try {
+        getDefaultBridge(deps.cwd).execCommand({
+          command: 'QueueDispatch',
+          request_id: request.request_id,
+          target: requestInput.to_worker,
+          metadata: {
+            kind: requestInput.kind,
+            team_name: deps.teamName,
+            worker_index: requestInput.worker_index,
+            pane_id: requestInput.pane_id,
+            trigger_message: requestInput.trigger_message,
+            message_id: requestInput.message_id,
+            inbox_correlation_key: requestInput.inbox_correlation_key,
+            transport_preference: requestInput.transport_preference,
+            fallback_allowed: requestInput.fallback_allowed,
+          },
+        });
+      } catch { /* bridge failure non-fatal */ }
+    }
+
     return { request, deduped: false };
   });
 }


### PR DESCRIPTION
## Summary
- restore auto-nudge retargeting from anchored wrapper panes to sibling live Codex panes
- use the persisted TS dispatch request ID for bridge QueueDispatch writes
- add regression coverage for both the tmux injection path and dispatch ID sync

## Why
Auto-nudge could anchor to a stale shell pane and miss the live Codex pane in real tmux sessions, which regressed `[OMX_TMUX_INJECT]` delivery. Separately, dispatch bridge writes used a pre-generated request ID before the TS store existed, allowing runtime and TS dispatch state to drift.

## Testing
- npm run build
- node --test dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/team/__tests__/state.test.js
- node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js
- real tmux auto-nudge dogfood delivering `yes, proceed [OMX_TMUX_INJECT]` to the sibling Codex pane

## Notes
Full team worker startup dispatch is a separate non-`[OMX_TMUX_INJECT]` path and was intentionally not framed as part of this PR.
