### PR TITLE
Recover successful fallback dispatches to notified state

### DIFF
--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -288,7 +288,7 @@ exit 1
     }
   });
 
-  it('dispatch request store allows failed->failed reason patch and blocks failed->notified', async () => {
+  it('dispatch request store allows failed reason patches and fallback recovery to notified', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-store-failed-'));
     try {
       await initTeamState('team-dispatch-failed', 't', 'executor', 1, cwd);
@@ -310,26 +310,28 @@ exit 1
         cwd,
       );
 
-      const invalidNotified = await markDispatchRequestNotified(
+      const recovered = await markDispatchRequestNotified(
         'team-dispatch-failed',
         queued.request.request_id,
-        { last_reason: 'should_not_transition' },
+        { last_reason: 'fallback_confirmed:tmux_send_keys_sent', failed_at: undefined },
         cwd,
       );
-      assert.equal(invalidNotified, null);
+      assert.equal(recovered?.status, 'notified');
+      assert.equal(recovered?.last_reason, 'fallback_confirmed:tmux_send_keys_sent');
+      assert.equal(recovered?.failed_at, undefined);
 
       const patched = await transitionDispatchRequest(
         'team-dispatch-failed',
         queued.request.request_id,
-        'failed',
-        'failed',
+        'notified',
+        'notified',
         { last_reason: 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent' },
         cwd,
       );
-      assert.equal(patched?.status, 'failed');
+      assert.equal(patched?.status, 'notified');
       assert.equal(patched?.last_reason, 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent');
       const reread = await readDispatchRequest('team-dispatch-failed', queued.request.request_id, cwd);
-      assert.equal(reread?.status, 'failed');
+      assert.equal(reread?.status, 'notified');
       assert.equal(reread?.last_reason, 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent');
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2885,16 +2885,14 @@ async function dispatchCriticalInboxInstruction(params: {
     const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
     if (fallback.ok) {
       if (isBridgeEnabled()) {
-        try { getDefaultBridge(cwd).execCommand({ command: 'MarkFailed', request_id: queued.request_id, reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` }); } catch (_) { /* non-fatal */ }
+        try { getDefaultBridge(cwd).execCommand({ command: 'MarkNotified', request_id: queued.request_id, channel: `fallback_confirmed_after_failed_receipt:${fallback.reason}` }); } catch (_) { /* non-fatal */ }
       }
-      await transitionDispatchRequest(
+      await markDispatchRequestNotified(
         teamName,
         queued.request_id,
-        'failed',
-        'failed',
-        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
+        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`, failed_at: undefined },
         cwd,
-      ).catch(() => {});
+      ).catch(() => null);
       return {
         ok: true,
         transport: fallback.transport,
@@ -3026,14 +3024,12 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   if (receipt?.status === 'failed') {
     if (fallback.ok) {
       await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-      await transitionDispatchRequest(
+      await markDispatchRequestNotified(
         teamName,
         requestId,
-        'failed',
-        'failed',
-        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
+        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`, failed_at: undefined },
         cwd,
-      ).catch(() => {});
+      ).catch(() => null);
       return {
         ok: true,
         transport: fallback.transport,

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -114,6 +114,7 @@ function canTransitionDispatchStatus(from: TeamDispatchRequestStatus, to: TeamDi
   if (from === to) return true;
   if (from === 'pending' && (to === 'notified' || to === 'failed')) return true;
   if (from === 'notified' && (to === 'delivered' || to === 'failed')) return true;
+  if (from === 'failed' && to === 'notified') return true;
   return false;
 }
 
@@ -224,7 +225,10 @@ export async function transitionDispatchRequest(
       attempt_count: Math.max(0, nextAttemptCount),
       updated_at: nowIso,
     };
-    if (to === 'notified') next.notified_at = patch.notified_at ?? nowIso;
+    if (to === 'notified') {
+      next.notified_at = patch.notified_at ?? nowIso;
+      next.failed_at = patch.failed_at;
+    }
     if (to === 'delivered') next.delivered_at = patch.delivered_at ?? nowIso;
     if (to === 'failed') next.failed_at = patch.failed_at ?? nowIso;
 


### PR DESCRIPTION
## Summary
- allow failed dispatch requests to recover to `notified`
- clear stale `failed_at` metadata when fallback delivery succeeds
- mark startup/mailbox fallback recovery as notified instead of failed

## Why
Dogfooding showed that full team startup could deliver the worker trigger via tmux fallback while the persisted dispatch request still remained in a failed-looking state. That made successful recovery paths look broken even when delivery had happened.

## Testing
- npm run build
- node --test dist/team/__tests__/state.test.js
- node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js

## Notes
This is a follow-up to the tmux injection/dispatch parity work. It addresses dispatch-state reconciliation, not the `[OMX_TMUX_INJECT]` path itself.
