### PR TITLE
fix(team): keep leader control mailbox-only and reduce false stalled nudges

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1167,7 +1167,7 @@ exit 0
     });
   });
 
-  it('nudges when team progress is stalled even if timing signals are fresh or missing', async () => {
+  it('nudges when team progress is stalled even if timing signals are fresh or missing (fallback threshold)', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
       const stateDir = join(omxDir, 'state');
@@ -1281,7 +1281,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /Team stalled-progress: leader stale, no progress 3m/);
-      assert.match(tmuxLog, /Next: inspect omx team status stalled-progress, read worker messages/);
+      assert.match(tmuxLog, /Next: omx team status stalled-progress; read worker messages; unblock\/reassign or shutdown\./);
       assert.doesNotMatch(tmuxLog, /keep polling/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/);
 
@@ -1292,7 +1292,7 @@ exit 0
     });
   });
 
-  it('nudges when team progress is stalled before the leader becomes stale', async () => {
+  it('nudges when team progress is stalled before the leader becomes stale (fallback threshold)', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
       const stateDir = join(omxDir, 'state');
@@ -1407,7 +1407,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /Team stalled-before-stale: worker panes stalled, no progress 3m/);
-      assert.match(tmuxLog, /Next: inspect omx team status stalled-before-stale, read worker messages/);
+      assert.match(tmuxLog, /Next: omx team status stalled-before-stale; read worker messages; unblock\/reassign or shutdown\./);
       assert.doesNotMatch(tmuxLog, /keep polling/);
       assert.doesNotMatch(tmuxLog, /leader stale/);
 
@@ -1415,6 +1415,229 @@ exit 0
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
       const nudgeEvent = events.find((e: { type?: string }) => e.type === 'team_leader_nudge');
       assert.equal(nudgeEvent?.reason, 'stuck_waiting_on_leader');
+    });
+  });
+
+
+
+  it('nudges stalled team after configurable worker turn stall window elapses (primary threshold)', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'worker-turn-stall-threshold';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const tasksDir = join(teamDir, 'tasks');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const nowIso = new Date().toISOString();
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(tasksDir, { recursive: true });
+      await mkdir(join(workersDir, 'worker-1'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'omx-team-worker-turn-stall-threshold',
+        leader_pane_id: '%86',
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10' },
+        ],
+      });
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: nowIso,
+        turn_count: 4,
+      });
+      await writeJson(join(tasksDir, 'task-1.json'), {
+        id: '1',
+        subject: 'Investigate stall',
+        description: 'worker-1 owns the active task',
+        status: 'in_progress',
+        owner: 'worker-1',
+        created_at: nowIso,
+      });
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'working',
+        current_task_id: '1',
+        updated_at: nowIso,
+      });
+      await writeJson(join(workersDir, 'worker-1', 'heartbeat.json'), {
+        last_turn_at: nowIso,
+        turn_count: 5,
+        alive: true,
+      });
+
+      const previousSignature = JSON.stringify({
+        tasks: [
+          { id: '1', owner: 'worker-1', status: 'in_progress' },
+        ],
+        workers: [
+          {
+            worker: 'worker-1',
+            state: 'working',
+            current_task_id: '1',
+            status_missing: false,
+            turn_count: 5,
+            heartbeat_missing: false,
+          },
+        ],
+      });
+      await writeJson(join(stateDir, 'team-leader-nudge.json'), {
+        last_nudged_by_team: {
+          [teamName]: {
+            at: new Date(Date.now() - 60_000).toISOString(),
+            last_message_id: '',
+            reason: 'new_mailbox_message',
+          },
+        },
+        progress_by_team: {
+          [teamName]: {
+            signature: previousSignature,
+            last_progress_at: new Date(Date.now() - 45_000).toISOString(),
+          },
+        },
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345']));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_TEAM_PROGRESS_STALL_MS: '120000',
+        OMX_TEAM_WORKER_TURN_STALL_MS: '30000',
+        OMX_TEAM_LEADER_NUDGE_MS: '30000',
+        OMX_TEAM_LEADER_STALE_MS: '60000',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /Team worker-turn-stall-threshold: worker panes stalled, no progress 45s/);
+    });
+  });
+
+  it('does not nudge stalled team when an in-progress worker is still advancing heartbeat turns', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'active-turns-no-stall';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const tasksDir = join(teamDir, 'tasks');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const nowIso = new Date().toISOString();
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(tasksDir, { recursive: true });
+      await mkdir(join(workersDir, 'worker-1'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'omx-team-active-turns-no-stall',
+        leader_pane_id: '%87',
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10' },
+          { name: 'worker-2', index: 2, pane_id: '%11' },
+        ],
+      });
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: nowIso,
+        turn_count: 4,
+      });
+      await writeJson(join(tasksDir, 'task-1.json'), {
+        id: '1',
+        subject: 'Investigate stall',
+        description: 'worker-1 owns the active task',
+        status: 'in_progress',
+        owner: 'worker-1',
+        created_at: nowIso,
+      });
+      await writeJson(join(tasksDir, 'task-2.json'), {
+        id: '2',
+        subject: 'Follow-up',
+        description: 'still pending',
+        status: 'pending',
+        created_at: nowIso,
+      });
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'working',
+        current_task_id: '1',
+        updated_at: nowIso,
+      });
+      await writeJson(join(workersDir, 'worker-1', 'heartbeat.json'), {
+        last_turn_at: nowIso,
+        turn_count: 8,
+        alive: true,
+      });
+
+      const previousSignature = JSON.stringify({
+        tasks: [
+          { id: '1', owner: 'worker-1', status: 'in_progress' },
+          { id: '2', owner: '', status: 'pending' },
+        ],
+        workers: [
+          {
+            worker: 'worker-1',
+            state: 'working',
+            current_task_id: '1',
+            status_missing: false,
+            turn_count: 2,
+            heartbeat_missing: false,
+          },
+          {
+            worker: 'worker-2',
+            state: 'unknown',
+            current_task_id: '',
+            status_missing: true,
+            turn_count: null,
+            heartbeat_missing: true,
+          },
+        ]
+      });
+      await writeJson(join(stateDir, 'team-leader-nudge.json'), {
+        last_nudged_by_team: {
+          [teamName]: {
+            at: new Date(Date.now() - 5_000).toISOString(),
+            last_message_id: '',
+            reason: 'new_mailbox_message',
+          },
+        },
+        progress_by_team: {
+          [teamName]: {
+            signature: previousSignature,
+            last_progress_at: new Date(Date.now() - 180_000).toISOString(),
+          },
+        },
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345', '%11 12346']));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_TEAM_PROGRESS_STALL_MS: '60000',
+        OMX_TEAM_LEADER_NUDGE_MS: '30000',
+        OMX_TEAM_LEADER_STALE_MS: '60000',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /active-turns-no-stall: worker panes stalled, no progress/);
+      assert.doesNotMatch(tmuxLog, /active-turns-no-stall: leader stale, no progress/);
     });
   });
 
@@ -1534,6 +1757,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       const sends = tmuxLog.match(/send-keys -t %88 -l Team stalled-before-stale-bounded: worker panes stalled, no progress/g) || [];
       assert.equal(sends.length, 1, 'cooldown should keep repeated stalled-team nudges bounded');
+      assert.match(tmuxLog, /Next: omx team status stalled-before-stale-bounded; read worker messages; unblock\/reassign or shutdown\./);
     });
   });
 

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -47,12 +47,21 @@ export function resolveLeaderStalenessThresholdMs() {
   return 180_000;
 }
 
-export function resolveLeaderProgressStallThresholdMs() {
+export function resolveFallbackProgressStallThresholdMs() {
   const raw = safeString(process.env.OMX_TEAM_PROGRESS_STALL_MS || '');
   const parsed = asNumber(raw);
+  // Fallback-only threshold used when worker turn-count signals are unavailable.
   // Default: 2 minutes. Guard against unreasonable values.
   if (parsed !== null && parsed >= 10_000 && parsed <= 60 * 60_000) return parsed;
   return 120_000;
+}
+
+export function resolveWorkerTurnStallThresholdMs() {
+  const raw = safeString(process.env.OMX_TEAM_WORKER_TURN_STALL_MS || '');
+  const parsed = asNumber(raw);
+  // Default: 30 seconds. Guard against unreasonable values.
+  if (parsed !== null && parsed >= 10_000 && parsed <= 10 * 60_000) return parsed;
+  return 30_000;
 }
 
 function buildStatusCheckReminder(teamName) {
@@ -108,7 +117,7 @@ function buildLeaderActionGuidance(teamName, {
     return `Next: decide whether to reconcile/merge results or gracefully shut down: omx team shutdown ${teamName}.`;
   }
   if (leaderActionState === 'stuck_waiting_on_leader') {
-    return `Next: inspect omx team status ${teamName}, read worker messages, then unblock/reassign, launch another wave, or gracefully shut down: omx team shutdown ${teamName}.`;
+    return `Next: omx team status ${teamName}; read worker messages; unblock/reassign or shutdown.`;
   }
   return buildStatusCheckReminder(teamName);
 }
@@ -330,6 +339,36 @@ async function readTeamProgressSnapshot(stateDir, teamName, workerNames) {
   };
 }
 
+function readPreviousWorkerTurnCounts(previousSignature) {
+  try {
+    const parsed = JSON.parse(previousSignature || '{}');
+    const workers = Array.isArray(parsed?.workers) ? parsed.workers : [];
+    return new Map(workers
+      .map((worker) => [safeString(worker?.worker).trim(), Number.isFinite(worker?.turn_count) ? Number(worker.turn_count) : null])
+      .filter(([workerName]) => workerName.length > 0));
+  } catch {
+    return new Map();
+  }
+}
+
+function hasWorkerTurnProgress(workerSnapshot, previousTurnCounts) {
+  return workerSnapshot.some((worker) => {
+    if (worker.state !== 'working' && worker.state !== 'blocked') return false;
+    if (!Number.isFinite(worker.turn_count) || worker.turn_count === null) return false;
+    const previousTurnCount = previousTurnCounts.get(worker.worker);
+    return Number.isFinite(previousTurnCount) && previousTurnCount !== null && worker.turn_count > previousTurnCount;
+  });
+}
+
+function hasTrackableActiveWorkerTurns(workerSnapshot, previousTurnCounts) {
+  return workerSnapshot.some((worker) => {
+    if (worker.state !== 'working' && worker.state !== 'blocked') return false;
+    if (!Number.isFinite(worker.turn_count) || worker.turn_count === null) return false;
+    const previousTurnCount = previousTurnCounts.get(worker.worker);
+    return Number.isFinite(previousTurnCount) && previousTurnCount !== null;
+  });
+}
+
 function formatDurationMs(durationMs) {
   const seconds = Math.max(1, Math.round(durationMs / 1000));
   if (seconds < 60) return `${seconds}s`;
@@ -474,7 +513,8 @@ async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmu
 export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderStale }) {
   const intervalMs = resolveLeaderNudgeIntervalMs();
   const idleCooldownMs = resolveLeaderAllIdleNudgeCooldownMs();
-  const progressStallThresholdMs = resolveLeaderProgressStallThresholdMs();
+  const fallbackProgressStallThresholdMs = resolveFallbackProgressStallThresholdMs();
+  const workerTurnStallThresholdMs = resolveWorkerTurnStallThresholdMs();
   const nowMs = Date.now();
   const nowIso = new Date().toISOString();
   const omxDir = join(cwd, '.omx');
@@ -577,18 +617,22 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     const previousSignature = safeString(prevProgress.signature || '');
     const previousProgressAtIso = safeString(prevProgress.last_progress_at || '');
     const previousProgressAtMs = previousProgressAtIso ? Date.parse(previousProgressAtIso) : NaN;
-    const progressChanged = !previousSignature || previousSignature !== progressSnapshot.signature;
+    const previousTurnCounts = readPreviousWorkerTurnCounts(previousSignature);
+    const workerTurnProgress = hasWorkerTurnProgress(progressSnapshot.workerSnapshot, previousTurnCounts);
+    const hasTrackableTurnSignals = hasTrackableActiveWorkerTurns(progressSnapshot.workerSnapshot, previousTurnCounts);
+    const progressChanged = !previousSignature || previousSignature !== progressSnapshot.signature || workerTurnProgress;
     const effectiveProgressAtMs = progressChanged || !Number.isFinite(previousProgressAtMs)
       ? nowMs
       : previousProgressAtMs;
     const effectiveProgressAtIso = new Date(effectiveProgressAtMs).toISOString();
     const stalledForMs = Math.max(0, nowMs - effectiveProgressAtMs);
+    const stallThresholdMs = hasTrackableTurnSignals ? workerTurnStallThresholdMs : fallbackProgressStallThresholdMs;
     const teamProgressStalled =
       progressSnapshot.workRemaining
       && paneStatus.alive
       && !allWorkersIdle
       && !progressChanged
-      && stalledForMs >= progressStallThresholdMs;
+      && stalledForMs >= stallThresholdMs;
     const leaderActionState = classifyLeaderActionState({
       allWorkersIdle,
       workerPanesAlive: paneStatus.alive,

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -49,6 +49,7 @@ import {
   dismissTrustPromptIfPresent,
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
+import * as tmuxSessionModule from '../tmux-session.js';
 
 function withEmptyPath<T>(fn: () => T): T {
   const prev = process.env.PATH;
@@ -1722,5 +1723,11 @@ exit 0
         assert.match(log, /kill-pane -t %405/);
       },
     );
+  });
+});
+
+describe('leader mailbox-only boundary', () => {
+  it('does not export direct leader pane injection helper', () => {
+    assert.equal('sendToLeaderPane' in tmuxSessionModule, false);
   });
 });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1569,29 +1569,13 @@ export function listTeamSessions(): string[] {
 }
 
 /**
- * Send a trigger message directly to the leader pane via tmux send-keys.
- * Used as the direct-inject fallback when hook-based dispatch to the leader
- * times out. Unlike notifyLeaderMailboxAsync (which only writes to the
- * mailbox file), this actually injects text into the leader's tmux pane
- * so the leader sees it immediately. Fixes #437.
- */
-export async function sendToLeaderPane(
-  leaderPaneId: string,
-  text: string,
-): Promise<void> {
-  const send = runTmux(['send-keys', '-t', leaderPaneId, '-l', '--', text]);
-  if (!send.ok) {
-    throw new Error(`sendToLeaderPane: failed to send text: ${send.stderr}`);
-  }
-  await sleep(150);
-  await sendKeyAsync(leaderPaneId, 'C-m');
-  await sleep(100);
-  await sendKeyAsync(leaderPaneId, 'C-m');
-}
-
-/**
- * Notify the leader via mailbox instead of tmux display-message.
- * This is the async mailbox-based replacement for notifyLeaderStatus.
+ * Notify the leader through durable mailbox state only.
+ *
+ * Team leaders are a coordination endpoint, not a direct tmux control target:
+ * workers and runtime paths may message `leader-fixed` via `omx team api`
+ * / mailbox persistence, but team code must not inject text or control keys
+ * into the leader pane. This is the async mailbox-based replacement for
+ * `notifyLeaderStatus()`.
  */
 export async function notifyLeaderMailboxAsync(
   teamName: string,


### PR DESCRIPTION
## Summary
- remove direct leader-pane injection from team tmux session helpers
- keep worker -> leader messaging on sanctioned `omx team api` / mailbox paths
- reduce false stalled-team nudges by treating advancing worker turn counts as progress
- canonicalize stall controls so worker-turn stall is primary and progress-stall is fallback-only

## Details
This change tightens the team leader boundary so leaders are coordinated through state/API surfaces instead of pane control primitives. It also fixes noisy stalled-team nudges that could fire while a worker was still actively streaming/thinking by using worker turn-count advancement as the primary progress signal.

### Canonical stall env contract
- `OMX_TEAM_WORKER_TURN_STALL_MS` — primary stall threshold when turn signals exist
- `OMX_TEAM_PROGRESS_STALL_MS` — fallback-only threshold when turn signals are unavailable

## Verification
- `npm run build`
- targeted notify-hook stalled-nudge tests
- targeted team runtime / tmux-session boundary tests
