### PR TITLE
Prepare 0.11.7 release with real tmux-verified nudge fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.11.7] - 2026-03-23
+
+Patch release for team delivery parity, degraded-state auto-nudge recovery, and real tmux release verification.
+
+### Fixed
+- **Leader mailbox resend recovery** — hook-preferred duplicate mailbox sends no longer regress into missing dispatch IDs after notification, restoring idempotent delivery confirmation in the leader control path.
+- **Linked Ralph terminal sync on missing team state** — linked Ralph mode now finalizes cleanly when the paired team state disappears instead of remaining active indefinitely.
+- **Degraded-state auto-nudge fallback** — the fallback watcher now reuses stalled HUD turn state to trigger auto-nudge when no active mode state is available, and can resolve the live Codex pane by cwd when anchor state is missing.
+- **Stale leader / worker nudge accuracy** — release now includes the current `origin/dev` fixes for reduced false stalled nudges and recovered fallback dispatch success state. (PRs #1021, #1023)
+
+### Verified
+- **Targeted hook + watcher regression suite** — `notify-fallback-watcher` and `notify-hook auto-nudge` pass with the new degraded-state coverage.
+- **Real tmux smoke for degraded auto-nudge** — a live Codex pane received `yes, proceed [OMX_TMUX_INJECT]` from the fallback watcher after a 5s stalled-turn window with only HUD state available.
+- **Real tmux smoke for Ralph anti-spam** — two back-to-back fallback watcher ticks did not emit repeated `Ralph loop active continue` sends; the persisted state stayed in cooldown (`startup_cooldown`).
+
 ## [0.11.6] - 2026-03-21
 
 Patch release for Ralph continue-steer restart throttling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,11 +32,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.11.6"
+version = "0.11.7"
 
 [[package]]
 name = "omx-mux"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "fs2",
  "serde",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.11.6"
+version = "0.11.7"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.11.6"
+version = "0.11.7"
 
 edition = "2021"
 license = "MIT"

--- a/docs/release-notes-0.11.7.md
+++ b/docs/release-notes-0.11.7.md
@@ -1,0 +1,47 @@
+# Release notes — 0.11.7
+
+## Summary
+
+`0.11.7` packages the current `origin/dev` hotfix train after `0.11.6`, with emphasis on degraded-state auto-nudge recovery and the latest team control-plane correctness fixes.
+
+## Included fixes
+
+- `#1023` — keep leader control mailbox-only and reduce false stalled nudges
+- `#1021` — recover successful fallback dispatches to notified state
+- `#1020` — restore tmux injection targeting and dispatch ID parity
+- `#1018` — keep child agents on the current frontier default
+- `#1017` — deduplicate repeated undelivered leader mailbox messages
+- `#1016` — add exact-model prompt seam for gpt-5.4-mini subagents
+- `#1013` / `#1012` / `#1011` — linked Ralph/team follow-up fixes
+- local release fix — fallback watcher degraded-state auto-nudge coverage + cwd pane fallback resolution
+
+## Verification evidence
+
+### Targeted regression suite
+
+- `npm run build` ✅
+- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js` ✅
+  - result: `49/49` passing
+
+### Real tmux / OMX smoke
+
+#### Degraded-state auto-nudge
+
+- branch: `release/0.11.7-refresh` at `1bc3dde`
+- setup: live tmux pane running a long-lived fake `codex` process, stalled `hud-state.json` with `If you want, I can keep going from here.` and 5s stall threshold
+- result: **PASS**
+  - watcher result: `fallback_auto_nudge.last_reason = sent`
+  - `auto-nudge-state.json`: `nudgeCount = 1`
+  - pane capture contained: `yes, proceed [OMX_TMUX_INJECT]`
+
+#### Ralph continue-steer anti-spam
+
+- setup: live tmux pane with active `ralph-state.json`, watcher run twice back-to-back in `--once` mode
+- result: **PASS** for immediate anti-spam check
+  - second run ended in `startup_cooldown`
+  - no immediate repeat continue-steer was observed in the back-to-back smoke
+
+## Remaining risk
+
+- The real smoke used isolated disposable tmux sessions with a long-lived fake `codex` process, not a full interactive Codex conversation loop.
+- Full release confidence is strong for the nudge / watcher path, but broader team startup behavior should still rely on the targeted runtime suite in addition to this smoke.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -420,6 +420,109 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('auto-nudges stalled session output even when no active mode state exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-auto-nudge-stalled-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const codexHome = join(wd, 'codex-home');
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        autoNudge: { enabled: true, delaySec: 0 },
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+        last_turn_at: new Date(Date.now() - 6_000).toISOString(),
+        turn_count: 7,
+        last_agent_output: 'If you want, I can keep going from here.',
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            CODEX_HOME: codexHome,
+            TMUX: '1',
+            TMUX_PANE: '%42',
+            OMX_NOTIFY_FALLBACK_AUTO_NUDGE_STALL_MS: '5000',
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.fallback_auto_nudge?.last_reason, 'sent');
+      assert.equal(watcherState.fallback_auto_nudge?.last_turn_count, 7);
+      assert.match(watcherState.fallback_auto_nudge?.last_nudged_at ?? '', /^\d{4}-\d{2}-\d{2}T/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not auto-nudge stalled-like output when the latest turn is still fresh', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-auto-nudge-fresh-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const codexHome = join(wd, 'codex-home');
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        autoNudge: { enabled: true, delaySec: 0 },
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+        last_turn_at: new Date(Date.now() - 1_000).toISOString(),
+        turn_count: 8,
+        last_agent_output: 'If you want, I can keep going from here.',
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            CODEX_HOME: codexHome,
+            TMUX: '1',
+            TMUX_PANE: '%42',
+            OMX_NOTIFY_FALLBACK_AUTO_NUDGE_STALL_MS: '5000',
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.fallback_auto_nudge?.last_reason, 'recent_turn_activity');
+      assert.equal(watcherState.fallback_auto_nudge?.last_turn_count, 8);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('runs bounded non-turn team dispatch drain tick in leader context', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-dispatch-'));
     try {

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -6,7 +6,7 @@ import { spawnSync } from 'child_process';
 import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { drainPendingTeamDispatch } from './notify-hook/team-dispatch.js';
-import { resolveNudgePaneTarget } from './notify-hook/auto-nudge.js';
+import { maybeAutoNudge, resolveNudgePaneTarget } from './notify-hook/auto-nudge.js';
 import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
 import {
   isLeaderStale,
@@ -155,6 +155,19 @@ interface ParentGuardState {
   current_phase: string;
 }
 
+interface FallbackAutoNudgeState {
+  enabled: boolean;
+  stall_ms: number;
+  last_tick_at: string | null;
+  last_turn_at: string;
+  last_turn_count: number | null;
+  last_message: string;
+  last_reason: string;
+  last_error: string | null;
+  last_nudged_signature: string;
+  last_nudged_at: string;
+}
+
 const fileState = new Map<string, WatcherFileMeta>();
 const seenTurnKeys = new Set<string>();
 let stopping = false;
@@ -199,6 +212,22 @@ let lastParentGuard: ParentGuardState = {
   state_path: '',
   current_phase: '',
 };
+const AUTO_NUDGE_STALL_MS = Math.max(
+  pollMs,
+  asNumber(process.env.OMX_NOTIFY_FALLBACK_AUTO_NUDGE_STALL_MS || '5000', 5000),
+);
+let lastFallbackAutoNudge: FallbackAutoNudgeState = {
+  enabled: true,
+  stall_ms: AUTO_NUDGE_STALL_MS,
+  last_tick_at: null,
+  last_turn_at: '',
+  last_turn_count: null,
+  last_message: '',
+  last_reason: 'init',
+  last_error: null,
+  last_nudged_signature: '',
+  last_nudged_at: '',
+};
 function eventLog(event: Record<string, unknown>): Promise<void> {
   return appendFile(logPath, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
 }
@@ -239,6 +268,23 @@ async function loadPersistedWatcherState(): Promise<void> {
     .then((content) => JSON.parse(content) as Record<string, unknown>)
     .catch(() => null);
   lastRalphContinueSteer = normalizeRalphContinueSteerState(persisted?.ralph_continue_steer as Record<string, unknown> | null | undefined);
+  const persistedAutoNudge = persisted?.fallback_auto_nudge as Record<string, unknown> | null | undefined;
+  if (persistedAutoNudge && typeof persistedAutoNudge === 'object') {
+    lastFallbackAutoNudge = {
+      enabled: persistedAutoNudge.enabled !== false,
+      stall_ms: Number.isFinite(persistedAutoNudge.stall_ms) && (persistedAutoNudge.stall_ms as number) > 0
+        ? persistedAutoNudge.stall_ms as number
+        : AUTO_NUDGE_STALL_MS,
+      last_tick_at: safeString(persistedAutoNudge.last_tick_at) || null,
+      last_turn_at: safeString(persistedAutoNudge.last_turn_at),
+      last_turn_count: Number.isFinite(persistedAutoNudge.last_turn_count) ? persistedAutoNudge.last_turn_count as number : null,
+      last_message: safeString(persistedAutoNudge.last_message),
+      last_reason: safeString(persistedAutoNudge.last_reason) || 'init',
+      last_error: safeString(persistedAutoNudge.last_error) || null,
+      last_nudged_signature: safeString(persistedAutoNudge.last_nudged_signature),
+      last_nudged_at: safeString(persistedAutoNudge.last_nudged_at),
+    };
+  }
 }
 
 interface ActiveModeResult {
@@ -620,9 +666,106 @@ async function writeState(extra: Record<string, unknown> = {}): Promise<void> {
       cadence_ms: RALPH_CONTINUE_CADENCE_MS,
       message: RALPH_CONTINUE_TEXT,
     },
+    fallback_auto_nudge: {
+      ...lastFallbackAutoNudge,
+      enabled: true,
+      stall_ms: AUTO_NUDGE_STALL_MS,
+    },
     ...extra,
   };
   await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
+}
+
+async function readJsonObject(path: string): Promise<Record<string, unknown> | null> {
+  return readFile(path, 'utf-8')
+    .then((content) => JSON.parse(content) as Record<string, unknown>)
+    .catch(() => null);
+}
+
+async function readAutoNudgeCount(): Promise<number> {
+  const parsed = await readJsonObject(join(stateDir, 'auto-nudge-state.json'));
+  return Math.max(0, Math.trunc(asNumber(parsed?.nudgeCount as string | number | undefined, 0)));
+}
+
+async function runFallbackAutoNudgeTick(): Promise<void> {
+  const now = Date.now();
+  const nowIso = new Date(now).toISOString();
+  const hudStatePath = join(stateDir, 'hud-state.json');
+  const hudState = await readJsonObject(hudStatePath);
+
+  lastFallbackAutoNudge = {
+    ...lastFallbackAutoNudge,
+    enabled: true,
+    stall_ms: AUTO_NUDGE_STALL_MS,
+    last_tick_at: nowIso,
+    last_error: null,
+  };
+
+  if (!hudState) {
+    lastFallbackAutoNudge.last_reason = 'hud_state_missing';
+    return;
+  }
+
+  const lastTurnAt = safeString(hudState.last_turn_at);
+  const turnCount = Number.isFinite(hudState.turn_count) ? hudState.turn_count as number : null;
+  const lastMessage = safeString(hudState.last_agent_output || hudState.last_agent_message || '');
+  const lastTurnMs = parseIsoMillis(lastTurnAt);
+
+  lastFallbackAutoNudge.last_turn_at = lastTurnAt;
+  lastFallbackAutoNudge.last_turn_count = turnCount;
+  lastFallbackAutoNudge.last_message = lastMessage.slice(0, 400);
+
+  if (!lastTurnAt || lastTurnMs === null || turnCount === null || turnCount < 1) {
+    lastFallbackAutoNudge.last_reason = 'hud_state_incomplete';
+    return;
+  }
+  if (!lastMessage.trim()) {
+    lastFallbackAutoNudge.last_reason = 'no_last_message';
+    return;
+  }
+  if (now - lastTurnMs < AUTO_NUDGE_STALL_MS) {
+    lastFallbackAutoNudge.last_reason = 'recent_turn_activity';
+    return;
+  }
+
+  const signature = `${turnCount}|${lastTurnAt}|${lastMessage}`;
+  if (lastFallbackAutoNudge.last_nudged_signature === signature) {
+    lastFallbackAutoNudge.last_reason = 'duplicate_stall_signature';
+    return;
+  }
+
+  const beforeCount = await readAutoNudgeCount();
+  await maybeAutoNudge({
+    cwd,
+    stateDir,
+    logsDir,
+    payload: {
+      type: 'agent-turn-complete',
+      cwd,
+      source: 'notify-fallback-watcher-stall',
+      'thread-id': 'notify-fallback-watcher-stall',
+      'turn-id': `stalled-turn-${turnCount}`,
+      'input-messages': ['[notify-fallback] synthesized from stalled hud-state'],
+      'last-assistant-message': lastMessage,
+    },
+  });
+  const afterCount = await readAutoNudgeCount();
+
+  if (afterCount > beforeCount) {
+    lastFallbackAutoNudge.last_nudged_signature = signature;
+    lastFallbackAutoNudge.last_nudged_at = nowIso;
+    lastFallbackAutoNudge.last_reason = 'sent';
+    await eventLog({
+      type: 'fallback_auto_nudge_tick',
+      reason: 'sent',
+      turn_count: turnCount,
+      last_turn_at: lastTurnAt,
+      stall_ms: AUTO_NUDGE_STALL_MS,
+    });
+    return;
+  }
+
+  lastFallbackAutoNudge.last_reason = 'eligible_but_not_sent';
 }
 
 async function requestShutdown(reason: string, signal: string | null = null): Promise<void> {
@@ -939,6 +1082,7 @@ async function runDispatchDrainTick(): Promise<void> {
 async function pumpTeamControlPlaneTick(): Promise<void> {
   await runDispatchDrainTick();
   await runLeaderNudgeTick();
+  await runFallbackAutoNudgeTick();
 }
 
 

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -5,6 +5,7 @@
  */
 
 import { readFile, writeFile } from 'fs/promises';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { homedir } from 'os';
 import { asNumber, safeString } from './utils.js';
@@ -287,6 +288,35 @@ export async function capturePane(paneId, lines = 10) {
   }
 }
 
+function resolveCodexPaneByCwdFallback(cwd) {
+  const normalizedCwd = safeString(cwd).trim();
+  if (!normalizedCwd) return '';
+
+  try {
+    const panes = execFileSync('tmux', [
+      'list-panes', '-a', '-F', '#{pane_id}	#{pane_current_path}	#{pane_current_command}	#{pane_start_command}',
+    ], { encoding: 'utf-8', timeout: 2000 })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+
+    for (const line of panes) {
+      const [paneId, panePath = '', paneCommand = '', startCommand = ''] = line.split('\t');
+      const normalizedPanePath = safeString(panePath).trim();
+      const normalizedStart = safeString(startCommand).toLowerCase();
+      const normalizedCommand = safeString(paneCommand).trim().toLowerCase();
+      if (!paneId || normalizedPanePath !== normalizedCwd) continue;
+      if (/\bomx\b.*\bhud\b.*--watch/i.test(normalizedStart)) continue;
+      if (normalizedStart.includes('codex')) return paneId;
+      if (normalizedCommand === 'codex' || normalizedCommand === 'node' || normalizedCommand === 'npx') return paneId;
+    }
+  } catch {
+    // Fall back to empty when tmux scan is unavailable.
+  }
+
+  return '';
+}
+
 async function resolveCodexPaneFromAnchor(anchorPane) {
   const paneId = safeString(anchorPane).trim();
   if (!paneId) return '';
@@ -316,7 +346,7 @@ async function resolveCodexPaneFromAnchor(anchorPane) {
   return '';
 }
 
-export async function resolveNudgePaneTarget(stateDir: any) {
+export async function resolveNudgePaneTarget(stateDir: any, cwd = '') {
   // Use canonical codex pane resolver — validates pane is running an agent, not a shell
   const { resolveCodexPane } = await import('../tmux-hook-engine.js');
   const codexPane = resolveCodexPane();
@@ -349,7 +379,9 @@ export async function resolveNudgePaneTarget(stateDir: any) {
     // Non-critical
   }
 
-  return fallbackPane;
+  if (fallbackPane) return fallbackPane;
+
+  return resolveCodexPaneByCwdFallback(cwd);
 }
 
 export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
@@ -379,7 +411,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     const nudgeCount = asNumber(nudgeState.nudgeCount) ?? 0;
     if (Number.isFinite(config.maxNudgesPerSession) && nudgeCount >= config.maxNudgesPerSession) return;
 
-    const paneId = await resolveNudgePaneTarget(stateDir);
+    const paneId = await resolveNudgePaneTarget(stateDir, cwd);
 
     let detected = detectStallPattern(lastMessage, config.patterns);
     let source = 'payload';

--- a/src/team/__tests__/linked-ralph-bridge.test.ts
+++ b/src/team/__tests__/linked-ralph-bridge.test.ts
@@ -92,4 +92,35 @@ describe('runLinkedRalphBridge', () => {
       'expected event log while bridge is active',
     );
   });
+
+  it('finalizes linked Ralph when team state disappears unexpectedly', async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    let finalizeCalls = 0;
+
+    const result = await runLinkedRalphBridge(
+      {
+        teamName: 'alpha',
+        task: 'ship linked bridge fix',
+        cwd: '/tmp/demo',
+        waitTimeoutMs: 1_000,
+      },
+      {
+        ensureLinkedRalphModeState: async () => {},
+        updateLinkedRalphHeartbeat: async () => {},
+        finalizeLinkedRalph: async (_teamName, _cwd, terminalPhase, patch) => {
+          finalizeCalls += 1;
+          updates.push({ terminalPhase, ...patch });
+        },
+        monitorTeam: async () => null,
+        waitForTeamEvent: async () => ({ status: 'timeout', cursor: '' }),
+      },
+    );
+
+    assert.equal(result.status, 'missing');
+    assert.equal(finalizeCalls, 1);
+    assert.ok(
+      updates.some((patch) => patch.terminalPhase === 'failed' && patch.linked_team_missing === true),
+      'expected missing team state to finalize linked Ralph as failed',
+    );
+  });
 });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -3473,6 +3473,56 @@ esac
     }
   });
 
+
+  it('sendWorkerMessage keeps hook-preferred duplicate leader mailbox sends idempotent after notification', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-dedupe-notified-'));
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-leader-dedupe-notified-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$$*" >> "${tmuxLogPath}"
+case "\${1:-}" in
+  send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async () => {
+          await initTeamState('team-leader-dedupe-notified', 'leader mailbox dedupe notified test', 'executor', 1, cwd);
+          const cfg = await readTeamConfig('team-leader-dedupe-notified', cwd);
+          assert.ok(cfg);
+          if (!cfg) throw new Error('missing team config');
+          cfg.leader_pane_id = '%55';
+          await saveTeamConfig(cfg, cwd);
+
+          const manifestPath = teamStateTestPath(cwd, 'team', 'team-leader-dedupe-notified', 'manifest.v2.json');
+          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+          manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 100 };
+          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+          await sendWorkerMessage('team-leader-dedupe-notified', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
+          await sendWorkerMessage('team-leader-dedupe-notified', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
+
+          const messages = await listMailboxMessages('team-leader-dedupe-notified', 'leader-fixed', cwd);
+          const workerMessages = messages.filter((message) => message.from_worker === 'worker-1' && message.body === 'INTEGRATED: same-body');
+          assert.equal(workerMessages.length, 1);
+          assert.ok(workerMessages[0]?.notified_at);
+
+          const requests = await listDispatchRequests('team-leader-dedupe-notified', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+          assert.ok(requests.some((request) => request.status === 'notified' && request.message_id === workerMessages[0]?.message_id));
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('sendWorkerMessage hook-preferred path persists leader mailbox guidance when leader pane exists', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-inject-'));
     try {

--- a/src/team/linked-ralph-bridge.ts
+++ b/src/team/linked-ralph-bridge.ts
@@ -127,6 +127,12 @@ export async function runLinkedRalphBridge(
   while (true) {
     const snapshot = await deps.monitorTeam(options.teamName, options.cwd);
     if (!snapshot) {
+      await deps.finalizeLinkedRalph(options.teamName, options.cwd, 'failed', {
+        linked_team_phase: 'missing',
+        linked_team_event_cursor: cursor,
+        linked_team_last_snapshot_at: new Date().toISOString(),
+        linked_team_missing: true,
+      });
       options.log?.(`[linked-ralph] team state missing for team=${options.teamName}`);
       return { status: 'missing', cursor };
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3308,7 +3308,8 @@ export async function sendWorkerMessage(
       ),
     });
     let finalOutcome = outcome;
-    if (leaderTransportPreference === 'hook_preferred_with_fallback' && !config.leader_pane_id) {
+    const mailboxAlreadyNotified = outcome.ok && outcome.reason === 'existing_message_already_notified';
+    if (!mailboxAlreadyNotified && leaderTransportPreference === 'hook_preferred_with_fallback' && !config.leader_pane_id) {
       if (outcome.request_id) {
         await markDispatchRequestLeaderPaneMissingDeferred({
           teamName: sanitized,
@@ -3325,7 +3326,7 @@ export async function sendWorkerMessage(
       };
     }
     const canLeaderFallbackDirectly = Boolean(config.leader_pane_id) && isTmuxAvailable();
-    if (leaderTransportPreference === 'hook_preferred_with_fallback' && canLeaderFallbackDirectly) {
+    if (!mailboxAlreadyNotified && leaderTransportPreference === 'hook_preferred_with_fallback' && canLeaderFallbackDirectly) {
       if (!outcome.request_id || !outcome.message_id) {
         throw new Error('mailbox_notify_failed:dispatch_request_missing_id');
       }
@@ -3376,7 +3377,8 @@ export async function sendWorkerMessage(
     ),
   });
   let finalOutcome = outcome;
-  if (transportPreference === 'hook_preferred_with_fallback') {
+  const mailboxAlreadyNotified = outcome.ok && outcome.reason === 'existing_message_already_notified';
+  if (!mailboxAlreadyNotified && transportPreference === 'hook_preferred_with_fallback') {
     if (!outcome.request_id || !outcome.message_id) {
       throw new Error('mailbox_notify_failed:dispatch_request_missing_id');
     }


### PR DESCRIPTION
## Summary
- prepare the 0.11.7 release from the current `origin/dev` baseline
- add degraded-state fallback watcher auto-nudge coverage plus cwd-based live Codex pane resolution
- include the latest linked Ralph / dispatch / leader-control fixes already present on current dev
- document real tmux smoke evidence for degraded auto-nudge and immediate Ralph anti-spam cooldown behavior

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js`
- real tmux smoke: stalled HUD-only state injected `yes, proceed [OMX_TMUX_INJECT]`
- real tmux smoke: two back-to-back Ralph watcher ticks stayed in `startup_cooldown` without repeat continue-steer injection

## Notes
- this branch was refreshed from `origin/dev` because the previous local `release/0.11.7` worktree was based on a stale local `dev` tip
- release notes added in `docs/release-notes-0.11.7.md`
