### PR TITLE
Fix leader mailbox dedupe and linked Ralph missing-team finalization

### DIFF
--- a/src/team/__tests__/linked-ralph-bridge.test.ts
+++ b/src/team/__tests__/linked-ralph-bridge.test.ts
@@ -92,4 +92,35 @@ describe('runLinkedRalphBridge', () => {
       'expected event log while bridge is active',
     );
   });
+
+  it('finalizes linked Ralph when team state disappears unexpectedly', async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    let finalizeCalls = 0;
+
+    const result = await runLinkedRalphBridge(
+      {
+        teamName: 'alpha',
+        task: 'ship linked bridge fix',
+        cwd: '/tmp/demo',
+        waitTimeoutMs: 1_000,
+      },
+      {
+        ensureLinkedRalphModeState: async () => {},
+        updateLinkedRalphHeartbeat: async () => {},
+        finalizeLinkedRalph: async (_teamName, _cwd, terminalPhase, patch) => {
+          finalizeCalls += 1;
+          updates.push({ terminalPhase, ...patch });
+        },
+        monitorTeam: async () => null,
+        waitForTeamEvent: async () => ({ status: 'timeout', cursor: '' }),
+      },
+    );
+
+    assert.equal(result.status, 'missing');
+    assert.equal(finalizeCalls, 1);
+    assert.ok(
+      updates.some((patch) => patch.terminalPhase === 'failed' && patch.linked_team_missing === true),
+      'expected missing team state to finalize linked Ralph as failed',
+    );
+  });
 });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -3473,6 +3473,56 @@ esac
     }
   });
 
+
+  it('sendWorkerMessage keeps hook-preferred duplicate leader mailbox sends idempotent after notification', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-dedupe-notified-'));
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-leader-dedupe-notified-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$$*" >> "${tmuxLogPath}"
+case "\${1:-}" in
+  send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async () => {
+          await initTeamState('team-leader-dedupe-notified', 'leader mailbox dedupe notified test', 'executor', 1, cwd);
+          const cfg = await readTeamConfig('team-leader-dedupe-notified', cwd);
+          assert.ok(cfg);
+          if (!cfg) throw new Error('missing team config');
+          cfg.leader_pane_id = '%55';
+          await saveTeamConfig(cfg, cwd);
+
+          const manifestPath = teamStateTestPath(cwd, 'team', 'team-leader-dedupe-notified', 'manifest.v2.json');
+          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+          manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 100 };
+          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+          await sendWorkerMessage('team-leader-dedupe-notified', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
+          await sendWorkerMessage('team-leader-dedupe-notified', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
+
+          const messages = await listMailboxMessages('team-leader-dedupe-notified', 'leader-fixed', cwd);
+          const workerMessages = messages.filter((message) => message.from_worker === 'worker-1' && message.body === 'INTEGRATED: same-body');
+          assert.equal(workerMessages.length, 1);
+          assert.ok(workerMessages[0]?.notified_at);
+
+          const requests = await listDispatchRequests('team-leader-dedupe-notified', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+          assert.ok(requests.some((request) => request.status === 'notified' && request.message_id === workerMessages[0]?.message_id));
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('sendWorkerMessage hook-preferred path persists leader mailbox guidance when leader pane exists', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-inject-'));
     try {

--- a/src/team/linked-ralph-bridge.ts
+++ b/src/team/linked-ralph-bridge.ts
@@ -127,6 +127,12 @@ export async function runLinkedRalphBridge(
   while (true) {
     const snapshot = await deps.monitorTeam(options.teamName, options.cwd);
     if (!snapshot) {
+      await deps.finalizeLinkedRalph(options.teamName, options.cwd, 'failed', {
+        linked_team_phase: 'missing',
+        linked_team_event_cursor: cursor,
+        linked_team_last_snapshot_at: new Date().toISOString(),
+        linked_team_missing: true,
+      });
       options.log?.(`[linked-ralph] team state missing for team=${options.teamName}`);
       return { status: 'missing', cursor };
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3308,7 +3308,8 @@ export async function sendWorkerMessage(
       ),
     });
     let finalOutcome = outcome;
-    if (leaderTransportPreference === 'hook_preferred_with_fallback' && !config.leader_pane_id) {
+    const mailboxAlreadyNotified = outcome.ok && outcome.reason === 'existing_message_already_notified';
+    if (!mailboxAlreadyNotified && leaderTransportPreference === 'hook_preferred_with_fallback' && !config.leader_pane_id) {
       if (outcome.request_id) {
         await markDispatchRequestLeaderPaneMissingDeferred({
           teamName: sanitized,
@@ -3325,7 +3326,7 @@ export async function sendWorkerMessage(
       };
     }
     const canLeaderFallbackDirectly = Boolean(config.leader_pane_id) && isTmuxAvailable();
-    if (leaderTransportPreference === 'hook_preferred_with_fallback' && canLeaderFallbackDirectly) {
+    if (!mailboxAlreadyNotified && leaderTransportPreference === 'hook_preferred_with_fallback' && canLeaderFallbackDirectly) {
       if (!outcome.request_id || !outcome.message_id) {
         throw new Error('mailbox_notify_failed:dispatch_request_missing_id');
       }
@@ -3376,7 +3377,8 @@ export async function sendWorkerMessage(
     ),
   });
   let finalOutcome = outcome;
-  if (transportPreference === 'hook_preferred_with_fallback') {
+  const mailboxAlreadyNotified = outcome.ok && outcome.reason === 'existing_message_already_notified';
+  if (!mailboxAlreadyNotified && transportPreference === 'hook_preferred_with_fallback') {
     if (!outcome.request_id || !outcome.message_id) {
       throw new Error('mailbox_notify_failed:dispatch_request_missing_id');
     }


### PR DESCRIPTION
## Summary
- keep hook-preferred duplicate leader mailbox sends idempotent after a message is already notified
- finalize linked Ralph as failed when the paired team state disappears unexpectedly
- add targeted runtime coverage for both cases

## Verification
- `npm run build`
- `node --test dist/team/__tests__/linked-ralph-bridge.test.js dist/team/__tests__/runtime.test.js`
  - result: `88/88` passing

## Why separate from release PR
- keeps the `0.11.7` release-prep PR focused on release metadata + degraded-state nudge verification
- lets the team-runtime correctness fixes review on their own merits
