### PR TITLE
fix(agents): keep standard native agents off customized root models

### DIFF
--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -41,7 +41,7 @@ describe("agents/native-config", () => {
     const toml = generateAgentToml(agent, prompt);
 
     assert.match(toml, /# oh-my-codex agent: executor/);
-    assert.match(toml, /model = "gpt-5\.4-mini"/);
+    assert.match(toml, /model = "gpt-5\.4"/);
     assert.match(toml, /model_reasoning_effort = "medium"/);
     assert.ok(!toml.includes("title: demo"));
     assert.ok(toml.includes("Instruction line"));
@@ -56,15 +56,15 @@ describe("agents/native-config", () => {
     );
   });
 
-  it("applies exact-model mini guidance only for resolved gpt-5.4-mini", () => {
+  it("applies exact-model mini guidance only for resolved gpt-5.4-mini standard roles", () => {
     const agent: AgentDefinition = {
-      name: "executor",
-      description: "Code implementation",
+      name: "debugger",
+      description: "Root-cause analysis",
       reasoningEffort: "medium",
       posture: "deep-worker",
       modelClass: "standard",
       routingRole: "executor",
-      tools: "execution",
+      tools: "analysis",
       category: "build",
     };
 
@@ -107,7 +107,7 @@ describe("agents/native-config", () => {
         join(outDir, "executor.toml"),
         "utf8",
       );
-      assert.match(executorToml, /model = "gpt-5\.4-mini"/);
+      assert.match(executorToml, /model = "gpt-5\.4"/);
       assert.match(executorToml, /model_reasoning_effort = "high"/);
 
       const skipped = await installNativeAgentConfigs(root, {
@@ -119,7 +119,7 @@ describe("agents/native-config", () => {
     }
   });
 
-  it("preserves a custom active root model for standard agents when no OMX standard override is set", async () => {
+  it("keeps standard agents off a custom gpt-5.2 root model", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-native-config-root-model-"));
     const codexHome = join(root, ".codex");
     const promptsDir = join(root, "prompts");
@@ -131,12 +131,39 @@ describe("agents/native-config", () => {
       process.env.CODEX_HOME = codexHome;
       await mkdir(promptsDir, { recursive: true });
       await mkdir(codexHome, { recursive: true });
-      await writeFile(join(codexHome, "config.toml"), 'model = "claude-opus-4"\n');
+      await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.2"\n');
+      await writeFile(join(promptsDir, "debugger.md"), "debugger prompt");
+
+      await installNativeAgentConfigs(root, { agentsDir: outDir });
+      const debuggerToml = await readFile(join(outDir, "debugger.toml"), "utf8");
+      assert.match(debuggerToml, /model = "gpt-5\.4-mini"/);
+      assert.doesNotMatch(debuggerToml, /model = "gpt-5\.2"/);
+    } finally {
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      process.env.OMX_DEFAULT_STANDARD_MODEL = "gpt-5.4-mini";
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps executor on the frontier lane so an explicit gpt-5.2 root model still applies there", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-config-executor-model-"));
+    const codexHome = join(root, ".codex");
+    const promptsDir = join(root, "prompts");
+    const outDir = join(codexHome, "agents");
+    const previousCodexHome = process.env.CODEX_HOME;
+
+    try {
+      delete process.env.OMX_DEFAULT_STANDARD_MODEL;
+      process.env.CODEX_HOME = codexHome;
+      await mkdir(promptsDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, "config.toml"), 'model = "gpt-5.2"\n');
       await writeFile(join(promptsDir, "executor.md"), "executor prompt");
 
       await installNativeAgentConfigs(root, { agentsDir: outDir });
       const executorToml = await readFile(join(outDir, "executor.toml"), "utf8");
-      assert.match(executorToml, /model = "claude-opus-4"/);
+      assert.match(executorToml, /model = "gpt-5\.2"/);
     } finally {
       if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
       else delete process.env.CODEX_HOME;

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -8,7 +8,6 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { AGENT_DEFINITIONS, AgentDefinition } from "./definitions.js";
 import {
-  DEFAULT_FRONTIER_MODEL,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
   getSparkDefaultModel,
@@ -141,14 +140,12 @@ function resolveFrontierModel(options: AgentModelResolutionOptions): string {
 }
 
 function resolveStandardModel(options: AgentModelResolutionOptions): string {
-  const frontierModel = resolveFrontierModel(options);
   const explicitStandardModel = getEnvConfiguredStandardDefaultModel(
     options.env ?? process.env,
     options.codexHomeOverride,
   );
 
   if (explicitStandardModel) return explicitStandardModel;
-  if (frontierModel !== DEFAULT_FRONTIER_MODEL) return frontierModel;
   return getStandardDefaultModel(options.codexHomeOverride);
 }
 
@@ -156,6 +153,10 @@ function resolveAgentModel(
   agent: AgentDefinition,
   options: AgentModelResolutionOptions = {},
 ): string {
+  if (agent.name === "executor") {
+    return resolveFrontierModel(options);
+  }
+
   switch (agent.modelClass) {
     case "frontier":
       return resolveFrontierModel(options);


### PR DESCRIPTION
Closes #1027

## Summary
This PR prevents standard native agents from inheriting a customized root model such as `gpt-5.2` while preserving the current executor frontier-lane behavior.

## Problem statement
Recent local traces showed repeated `gpt-5.2` invocations in scenarios where OMX should have been using the standard native-agent lane for standard roles. Although the repository already documents and enforces a role split across runtime/model-contract paths, the native-agent config generation path still had a hole that could leak the root model into standard roles.

## Root cause
`src/agents/native-config.ts` still allowed standard native-agent model resolution to drift onto the root/frontier model when the root model was customized. That behavior conflicted with the existing contract in:
- `src/team/model-contract.ts`, which resolves `executor` to the frontier/main lane and standard roles to the standard lane
- `src/utils/agents-model-table.ts`, which surfaces the same split in the generated model table

Because of that mismatch, a root model like `gpt-5.2` could still propagate into standard native agents even though the intended policy had already moved those roles onto the standard lane.

## What changed
- Kept standard native-agent resolution on the explicit standard lane
- Preserved `executor` as an explicit frontier/root-lane exception
- Updated native-config regression coverage to prove:
  - standard roles stay off a custom `gpt-5.2` root model
  - `executor` still follows the frontier/root lane
- Updated the exact-mini guidance test to match current `upstream/dev` behavior after this routing correction

## Why this design
This is a narrow follow-up instead of a broader model-routing rewrite.

The goal is to close the remaining native-config leak without changing the already-established role contract elsewhere in OMX. By making `executor` the explicit frontier exception and keeping standard roles on the standard lane, the fix aligns native-agent generation with the existing runtime/model-table contract rather than inventing a new policy.

## Overlap assessment
- Related PRs: #940, #942, #955, #1018
- Classification: **Follow-up**
- Relationship:
  - #940 and #955 established the native-agent role/model split
  - #942 updated the concrete standard-lane default to `gpt-5.4-mini`
  - #1018 tightened child-agent prompt inheritance
  - this PR closes a remaining native-config leak where standard roles could still inherit a customized root model such as `gpt-5.2`

## Validation
- `npm run build`
- `node --test dist/agents/__tests__/native-config.test.js dist/utils/__tests__/agents-model-table.test.js dist/team/__tests__/model-contract.test.js`
- `biome lint --config-path ./biome.json src/agents/native-config.ts src/agents/__tests__/native-config.test.ts`
- `lsp_diagnostics_directory` on the repo reported 0 TypeScript errors before delivery

## Risk / compatibility
- Risk level: narrow
- Behavior change: standard native agents no longer follow a customized root model
- Preserved behavior: `executor` still follows the frontier/root lane
- Remaining risk: existing local generated native-agent TOMLs may need regeneration (for example via `omx setup --force`) to pick up the corrected model mapping after upgrade

## Files changed
- `src/agents/native-config.ts`
- `src/agents/__tests__/native-config.test.ts`
