### PR TITLE
fix: prevent ralplan from auto-triggering execution follow-ups

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -25,6 +25,16 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.deepEqual(matches.map((m) => m.skill), ['analyze']);
   });
 
+  it('limits explicit multi-skill invocation to the first contiguous $skill block', () => {
+    const matches = detectKeywords('$ralplan Fix issue #1030 and ensure other directives ($ralph, $team, $deep-interview) are not affected');
+    assert.deepEqual(matches.map((m) => m.skill), ['ralplan']);
+  });
+
+  it('does not merge implicit keyword matches when an explicit $skill is present', () => {
+    const matches = detectKeywords('please run $team and then analyze the result');
+    assert.deepEqual(matches.map((m) => m.skill), ['team']);
+  });
+
   it('does not auto-detect keywords for explicit /prompts invocation without $skills', () => {
     const matches = detectKeywords('/prompts:architect analyze this issue');
     assert.deepEqual(matches, []);

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -145,6 +145,8 @@ function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
   const results: KeywordMatch[] = [];
   const regex = /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/gi;
   let match: RegExpExecArray | null;
+  let captureStarted = false;
+  let lastMatchEnd = -1;
 
   while ((match = regex.exec(text)) !== null) {
     const token = (match[1] ?? '').toLowerCase();
@@ -153,6 +155,16 @@ function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
     const normalizedSkill = token === 'swarm' ? 'team' : token;
     const registryEntry = KEYWORD_TRIGGER_DEFINITIONS.find((entry) => entry.skill.toLowerCase() === normalizedSkill);
     if (!registryEntry) continue;
+
+    const matchStart = match.index + match[0].lastIndexOf('$');
+    if (captureStarted) {
+      const between = text.slice(lastMatchEnd, matchStart);
+      if (!/^\s*$/.test(between)) break;
+    }
+
+    captureStarted = true;
+    lastMatchEnd = matchStart + token.length + 1;
+
     if (results.some((item) => item.skill === normalizedSkill)) continue;
 
     results.push({
@@ -180,6 +192,9 @@ export function detectKeywords(text: string): KeywordMatch[] {
   const explicit = extractExplicitSkillInvocations(text);
   if (hasExplicitPromptsInvocation(text) && explicit.length === 0) {
     return [];
+  }
+  if (explicit.length > 0) {
+    return explicit;
   }
 
   const implicit: KeywordMatch[] = [];


### PR DESCRIPTION
## Summary\n- stop explicit skill parsing after the first contiguous `` block\n- avoid mixing implicit keyword matches into prompts that already use an explicit skill invocation\n- add regression coverage for ralplan prompts that mention follow-up skills only as prose references\n\n## Testing\n- npm run build && node --test dist/hooks/__tests__/keyword-detector.test.js dist/team/__tests__/followup-planner.test.js dist/hooks/__tests__/consensus-execution-handoff.test.js\n- npm run lint -- src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts\n\nCloses #1030