### PR TITLE
feat: improve skill descriptions for oh-my-codex

### DIFF
--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-slop-cleaner
-description: Run an anti-slop cleanup/refactor/deslop workflow
+description: "Remove AI-generated slop from code — duplication, dead code, needless abstractions, and boundary violations — using a regression-tests-first, smell-by-smell cleanup workflow. Use when code works but feels bloated, noisy, or over-abstracted, or when a user says 'cleanup', 'refactor', 'deslop', or 'this code is a mess'. Keeps behavior locked and diffs minimal."
 ---
 
 # AI Slop Cleaner Skill

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze
-description: Deep analysis and investigation
+description: "Run deep investigation of architecture, bugs, performance issues, or dependencies and return structured findings with file:line evidence. Use when a user says 'analyze', 'investigate', 'why does', 'what's causing', or needs root cause analysis before making changes. Routes to architect agent or Codex MCP for thorough cross-file reasoning."
 ---
 
 <Purpose>

--- a/skills/ask-claude/SKILL.md
+++ b/skills/ask-claude/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask-claude
-description: Ask Claude via local CLI and capture a reusable artifact
+description: "Send a question or task to the locally installed Claude CLI and save the response as a reusable markdown artifact. Use when you want a second opinion, focused review, or external advisory answer from Claude without MCP routing. Requires local Claude CLI installed. Saves output to .omx/artifacts/ with slug-timestamp naming."
 ---
 
 # Ask Claude (Local CLI)

--- a/skills/ask-gemini/SKILL.md
+++ b/skills/ask-gemini/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask-gemini
-description: Ask Gemini via local CLI and capture a reusable artifact
+description: "Send a question or task to the locally installed Gemini CLI and save the response as a reusable markdown artifact. Use when you want an external second opinion, design feedback, or brainstorming from Gemini without MCP routing. Requires local Gemini CLI installed. Saves output to .omx/artifacts/ with slug-timestamp naming."
 ---
 
 # Ask Gemini (Local CLI)

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autopilot
-description: Full autonomous execution from idea to working code
+description: "Autonomously execute the full lifecycle from a product idea to working, verified code: expansion, planning, parallel implementation, QA cycling, and multi-perspective validation. Use when a user says 'autopilot', 'build me', 'create me', 'full auto', or 'I want a/an...' and wants hands-off end-to-end execution. Not for single focused fixes — use ralph or executor for those."
 ---
 
 <Purpose>

--- a/skills/build-fix/SKILL.md
+++ b/skills/build-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-fix
-description: Fix build and TypeScript errors with minimal changes
+description: "Fix build and compilation errors (TypeScript, tsc, mypy, cargo check, etc.) with the smallest possible diff — no refactoring, no architectural changes, only what's needed to make the build pass. Use when a user says 'fix the build', 'build is broken', 'type errors', or the type checker reports failures. Verifies each fix does not introduce new errors."
 ---
 
 # Build Fix Skill

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cancel
-description: Cancel any active OMX mode (autopilot, ralph, ultrawork, ecomode, ultraqa, swarm, ultrapilot, pipeline, team)
+description: "Intelligently detect and cancel any active OMX mode (autopilot, ralph, ultrawork, ecomode, ultraqa, swarm, ultrapilot, pipeline, team) with proper state cleanup and dependency-ordered teardown. Use when a user says 'cancel', 'stop', 'abort', 'cancelomc', or 'stopomc', or when an OMX workflow needs a clean exit. Use --force to clear all sessions and legacy state. Autopilot state is preserved for resume."
 ---
 
 # Cancel Skill

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Run a comprehensive code review
+description: "Conduct a thorough code review covering security (OWASP Top 10), code quality, performance, and maintainability, with severity-rated findings (CRITICAL/HIGH/MEDIUM/LOW) and file:line locations. Use when a user says 'review this code', 'code review', or before merging a PR or after a major feature. Delegates to code-reviewer agent (THOROUGH tier) and cross-validates security-sensitive changes with Codex."
 ---
 
 # Code Review Skill

--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configure-notifications
-description: Configure OMX notifications - unified entry point for all platforms
+description: "Set up and configure OMX notification integrations (Discord, Telegram, Slack, custom webhooks, and CLI commands) by writing to ~/.codex/.omx-config.json. Use when a user says 'configure notifications', 'setup discord', 'telegram bot', 'slack webhook', or 'notification settings'. Unified entry point — replaces all standalone configure-discord/telegram/slack skills."
 triggers:
   - "configure notifications"
   - "setup notifications"

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-interview
-description: Socratic deep interview with mathematical ambiguity gating before execution
-argument-hint: "[--quick|--standard|--deep] [--autoresearch] <idea or vague description>"
+description: "Run a Socratic, ambiguity-gated requirements interview to turn a vague idea into an execution-ready spec before planning or implementation. Use when a request is broad or underspecified, or when a user says 'deep interview', 'interview me', 'ask me everything', 'don't assume', or 'ouroboros'. Produces a scored spec artifact handed off to ralplan, autopilot, ralph, or team. Supports --quick (5 rounds), --standard (default, 12 rounds), --deep (20 rounds), and --autoresearch flags."
+argument-hint: "[--quick|--standard|--deep] [--autoresearch] idea or vague description"
 ---
 
 <Purpose>

--- a/skills/deepsearch/SKILL.md
+++ b/skills/deepsearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepsearch
-description: Thorough codebase search
+description: "Perform a thorough, multi-pass codebase search for a query, pattern, or concept — covering exact matches, related terms, import/export chains, and usage patterns across the codebase. Use when a user needs to find all locations of a symbol, understand how a concept is used, or trace a dependency chain. Returns primary locations, related files, usage patterns, and key insights with file:line citations."
 ---
 
 # Deep Search Mode

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doctor
-description: Diagnose and fix oh-my-codex installation issues
+description: "Diagnose and optionally auto-fix oh-my-codex (OMX) installation issues: plugin version, hook configuration, legacy bash scripts, AGENTS.md status, stale plugin cache, and curl-installed legacy content. Use when OMX is misbehaving, after an upgrade, or when a user says 'run doctor', 'omx doctor', or 'check my installation'. Outputs a structured HEALTHY/ISSUES FOUND report with per-check status and recommended fixes."
 ---
 
 # Doctor Skill

--- a/skills/ecomode/SKILL.md
+++ b/skills/ecomode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ecomode
-description: Token-efficient model routing modifier
+description: "Token-efficient model routing modifier that downgrades agent tiers to save costs. Use when you want to reduce token spend on a task — say 'eco', 'ecomode', or 'budget mode' to activate. Combines with ralph, ultrawork, and autopilot (e.g. 'eco ralph fix the tests')."
 ---
 
 # Ecomode Skill

--- a/skills/frontend-ui-ux/SKILL.md
+++ b/skills/frontend-ui-ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-ui-ux
-description: Designer-developer for UI/UX work
+description: "Routes UI/UX and frontend design tasks to the designer agent or Gemini MCP. Use when building components, fixing responsive layouts, improving accessibility, or ensuring design system consistency — say 'design this', 'fix the UI', or 'make it responsive'."
 ---
 
 # Frontend UI/UX Command

--- a/skills/git-master/SKILL.md
+++ b/skills/git-master/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-master
-description: Git expert for atomic commits, rebasing, and history management
+description: "Delegates git operations to the git-master specialist agent. Use when you need atomic conventional commits, interactive rebasing, branch cleanup, or history rewriting — say 'git master', 'clean up my commits', 'squash and rebase', or 'fix my git history'."
 ---
 
 # Git Master Command

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: help
-description: Guide on using oh-my-codex plugin
+description: "Displays the oh-my-codex (OMX) feature guide and analyzes your usage patterns to give personalized recommendations. Use when you want to learn available commands, discover magic keywords like 'ralph' or 'ulw', troubleshoot setup, or get tips on reducing token spend."
 ---
 
 # How OMX Works

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "hud"
-description: "Show or configure the OMX HUD (two-layer statusline)"
+description: "Shows or configures the OMX two-layer HUD: Codex built-in statusline (model, git branch, context) plus OMX orchestration overlay (ralph iterations, ultrawork, team workers, pipeline phase). Use when you want to monitor active workflow state, check turn counts, or switch display presets (minimal/focused/full)."
 role: "display"
 scope: ".omx/**"
 ---

--- a/skills/note/SKILL.md
+++ b/skills/note/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: note
-description: Save notes to notepad.md for compaction resilience
+description: "Saves and retrieves session context in .omx/notepad.md so important facts survive conversation compaction. Use when you want to persist a finding, set a priority fact (always loaded on session start), or store permanent team/deployment notes — say '/note my-finding', '/note --priority', or '/note --show'."
 ---
 
 # Note Skill

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omx-setup
-description: Setup and configure oh-my-codex using current CLI behavior
+description: "Installs and configures oh-my-codex for the current project and user-level directories by running 'omx setup'. Use when setting up OMX for the first time, refreshing a broken installation, or switching install scope between user and project — triggers on 'omx setup', 'install omx', or 'configure oh-my-codex'."
 ---
 
 # OMX Setup

--- a/skills/pipeline/SKILL.md
+++ b/skills/pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pipeline
-description: Configurable pipeline orchestrator for sequencing stages
+description: "Configurable multi-stage pipeline orchestrator that sequences RALPLAN → team-exec → ralph-verify with state persistence and resume support. Use when you need a structured, resumable execution pipeline with explicit stage transitions and HUD visibility — distinct from autopilot in that stages are configurable and individually skippable."
 ---
 
 # Pipeline Skill

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Strategic planning with optional interview workflow
+description: "Creates comprehensive, actionable work plans through adaptive interview or direct mode, with optional Planner/Architect/Critic consensus (RALPLAN-DR). Use when a task is broad or vague and needs scoping before code is written — say 'plan this', 'plan the feature', 'let's plan', or use '--consensus' for multi-perspective deliberation."
 ---
 
 <Purpose>

--- a/skills/ralph-init/SKILL.md
+++ b/skills/ralph-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralph-init
-description: Initialize a PRD (Product Requirements Document) for structured ralph-loop execution
+description: "Creates a structured PRD (Product Requirements Document) at .omx/plans/ via interactive interview, giving ralph a concrete definition-of-done before execution starts. Use when you want ralph to iterate against explicit acceptance criteria rather than a vague task — say 'ralph-init', 'create a PRD', or 'write requirements before we start'."
 ---
 
 # Ralph Init

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralph
-description: Self-referential loop until task completion with architect verification
+description: "Persistence loop that keeps working on a task until fully complete and architect-verified, using ultrawork parallel execution under the hood. Use when you need guaranteed completion with retry and sign-off — say 'ralph', 'don't stop', 'must complete', 'finish this', or 'keep going until done'."
 ---
 
 [RALPH + ULTRAWORK - ITERATION {{ITERATION}}/{{MAX}}]

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralplan
-description: Alias for $plan --consensus
+description: "Runs Planner → Architect → Critic consensus planning loop (RALPLAN-DR) to produce a scope-locked plan before execution. Use when an execution request is too vague for ralph to start safely — say 'ralplan', 'consensus plan', or let the ralplan-first gate redirect underspecified ralph/autopilot requests automatically."
 ---
 
 # Ralplan (Consensus Planning Alias)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Reviewer-only pass for /plan --review and cleanup artifact review
+description: "Run a critic-only verdict pass on an existing plan or cleanup artifact. Use when you have a plan file ready and need an independent reviewer (not the author) to issue APPROVED, REVISE, or REJECT — triggered by 'review plan', 'critic pass', 'approve plan', or 'review cleanup'."
 ---
 
 # Review (Reviewer-Only Pass)

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-review
-description: Run a comprehensive security review on code
+description: "Audit code for OWASP Top 10 vulnerabilities, hardcoded secrets, injection flaws, and CVEs with a severity-ranked report (CRITICAL/HIGH/MEDIUM/LOW). Use when adding authentication, API endpoints, user input handling, or before deploying to production — triggered by 'security review', 'security audit', 'check for vulnerabilities', or 'pen test'."
 ---
 
 # Security Review Skill

--- a/skills/skill/SKILL.md
+++ b/skills/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill
-description: Manage local skills - list, add, remove, search, edit, setup wizard
-argument-hint: "<command> [args]"
+description: "Create, list, search, edit, remove, and sync oh-my-codex skills across user and project scopes. Use when you want to manage your skill library — triggered by 'skill list', 'skill add', 'skill remove', 'skill edit', 'skill search', 'skill sync', or 'skill setup'."
+argument-hint: "command [args]"
 ---
 
 # Skill Management CLI

--- a/skills/swarm/SKILL.md
+++ b/skills/swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swarm
-description: N coordinated agents on shared task list (compatibility facade over team)
+description: "Launch N coordinated agents on a shared task list using the team pipeline. Use when you want parallel multi-agent execution and prefer the 'swarm' invocation style — compatibility alias for /team, triggered by 'swarm', 'coordinated swarm', or '/swarm N:agent-type'."
 ---
 
 # Swarm (Compatibility Facade)

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Test-Driven Development enforcement skill - write tests first, always
+description: "Enforce strict Red-Green-Refactor TDD cycles: write a failing test first, implement only enough code to pass it, then refactor. Use when starting a new feature, fixing a bug with test coverage, or enforcing test-first discipline — triggered by 'tdd', 'test first', 'write tests before code', or 'red green refactor'."
 ---
 
 # TDD Mode

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team
-description: N coordinated agents on shared task list using tmux-based orchestration
+description: "Orchestrate N durable tmux-based worker agents (Codex or Claude CLI) on a shared task list with mailbox coordination, worktree support, and full lifecycle control. Use for long-running parallel execution that must survive beyond one reasoning burst — triggered by 'team', 'coordinated team', 'omx team', or '/team N:agent-type'."
 ---
 
 # Team Skill

--- a/skills/trace/SKILL.md
+++ b/skills/trace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trace
-description: Show agent flow trace timeline and summary
+description: "Display a chronological event timeline and aggregate stats for the current session: hook fires, skill activations, agent delegations, keyword detections, mode transitions, and tool performance bottlenecks. Use when debugging slow or unexpected agent behavior — triggered by 'trace', 'show trace', 'agent timeline', or 'what happened'."
 ---
 
 # Agent Flow Trace

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultraqa
-description: QA cycling workflow - test, verify, fix, repeat until goal met
+description: "Run an autonomous QA cycling loop (qa-tester → architect diagnosis → executor fix → repeat) until tests pass, build succeeds, lint clears, or a custom goal is met — up to 5 cycles with early-exit on repeated failures. Use when you want hands-off quality enforcement — triggered by 'ultraqa', '/ultraqa --tests', '/ultraqa --build', '/ultraqa --lint', or '/ultraqa --typecheck'."
 ---
 
 # UltraQA Skill

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultrawork
-description: Parallel execution engine for high-throughput task completion
+description: "Fire multiple independent agents simultaneously with smart model-tier routing (LOW/STANDARD/THOROUGH) to complete parallel tasks faster. Use when you have multiple independent tasks that don't need guaranteed persistence or verification loops — triggered by 'ultrawork', 'ulw', 'parallel', or 'run these in parallel'. Use ralph instead when you need persistence; use autopilot for a full autonomous pipeline."
 ---
 
 <Purpose>

--- a/skills/visual-verdict/SKILL.md
+++ b/skills/visual-verdict/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-verdict
-description: Structured visual QA verdict for screenshot-to-reference comparisons
+description: "Compare a generated UI screenshot against reference images and return a strict JSON verdict (score 0–100, pass/revise/fail, concrete differences, actionable suggestions) to drive the next edit iteration. Use when checking visual fidelity of layout, spacing, typography, or component styling — triggered by 'visual verdict', 'compare screenshots', 'does this match the design', or 'visual QA'."
 ---
 
 <Purpose>

--- a/skills/web-clone/SKILL.md
+++ b/skills/web-clone/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-clone
-description: URL-driven website cloning with visual + functional verification
+description: "Clone a live website from its URL into working code by extracting DOM structure, computed styles, and interactions via Playwright, then iteratively verifying visual (score ≥ 85) and functional fidelity. Use when you have a target URL and want a replicated single-page clone — triggered by 'web-clone', 'clone site', 'clone website', or 'copy webpage'."
 ---
 
 <Purpose>

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worker
-description: Team worker protocol (ACK, mailbox, task lifecycle) for tmux-based OMX teams
+description: "Execute the OMX team worker protocol: send startup ACK, read inbox, claim tasks, do work, and report completion via omx team api CLI interop. Use only inside an active omx team tmux pane where OMX_TEAM_WORKER is set — not a general-purpose role. Triggered automatically by the team runtime on worker pane startup."
 ---
 
 # Worker Skill


### PR DESCRIPTION
## Summary

Hey @Yeachan-Heo 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="1290" alt="image" src="https://github.com/user-attachments/assets/1abb169c-99e5-4574-b623-349b8032ad63" />

Here's the full before/after:

![Skill Review Score Card](score_card.png)

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| git-master | 35% | 93% | +58% |
| deep-interview | 35% | 89% | +54% |
| deepsearch | 32% | 86% | +54% |
| analyze | 31% | 81% | +50% |
| autopilot | 39% | 89% | +50% |
| help | 36% | 86% | +50% |
| plan | 39% | 89% | +50% |
| ralplan | 39% | 89% | +50% |
| ecomode | 40% | 89% | +49% |
| note | 51% | 100% | +49% |
| code-review | 44% | 89% | +45% |
| ultrawork | 39% | 85% | +46% |
| ralph | 39% | 84% | +45% |
| skill | 38% | 81% | +43% |
| pipeline | 40% | 83% | +43% |
| configure-notifications | 50% | 89% | +39% |
| omx-setup | 50% | 89% | +39% |
| tdd | 54% | 93% | +39% |
| review | 54% | 93% | +39% |
| security-review | 25% | 64% | +39% |
| frontend-ui-ux | 44% | 83% | +39% |
| ai-slop-cleaner | 43% | 81% | +38% |
| ultraqa | 48% | 89% | +41% |
| swarm | 39% | 74% | +35% |
| worker | 47% | 81% | +34% |
| team | 44% | 78% | +34% |
| web-clone | 55% | 89% | +34% |
| build-fix | 48% | 81% | +33% |
| visual-verdict | 63% | 93% | +30% |
| trace | 59% | 86% | +27% |
| ask-gemini | 66% | 93% | +27% |
| doctor | 66% | 89% | +23% |
| hud | 64% | 83% | +19% |
| cancel | 59% | 64% | +5% |
| ask-claude | 0% | 0% | 0% |

> **Note:** `ask-claude` scores 0% because `tessl skill review` treats "claude" as a reserved word in skill names — this is a tessl validator constraint, not a quality issue with the skill itself. The description was still improved.

<details>
<summary>Changes made</summary>

**Across all 36 skills, the primary improvement was to the frontmatter `description` field:**

- **Added explicit "Use when..." clauses** — telling the agent exactly when to activate each skill
- **Added natural trigger terms** — the phrases users actually say ("fix the build", "clean up my commits", "this code is a mess") so the agent matches skills more reliably
- **Made descriptions specific** — replaced vague action phrases with concrete details about what each skill does, what it outputs, and how it differs from similar skills
- **Converted to quoted string format** — standardized YAML description formatting
- **Removed XML-like angle brackets** — replaced angle bracket patterns in descriptions with plain text to pass validation
- **Preserved all domain expertise** — kept OMX-specific terminology (ralph loops, RALPLAN-DR, sparkshell, explore routing) and expert framing intact
- **Added disambiguation** — for skills with close siblings (ultrawork/ralph/autopilot, swarm/team, etc.), added "use X instead for Y" guidance

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
