### PR TITLE
Rust Ports of some Team related Functionality

### DIFF
--- a/crates/omx-runtime-core/src/engine.rs
+++ b/crates/omx-runtime-core/src/engine.rs
@@ -18,6 +18,7 @@ pub enum EngineError {
     Mailbox(MailboxError),
     Io(std::io::Error),
     Json(serde_json::Error),
+    UnsupportedCommand(&'static str),
 }
 
 impl fmt::Display for EngineError {
@@ -28,6 +29,7 @@ impl fmt::Display for EngineError {
             Self::Mailbox(e) => write!(f, "mailbox error: {e}"),
             Self::Io(e) => write!(f, "io error: {e}"),
             Self::Json(e) => write!(f, "json error: {e}"),
+            Self::UnsupportedCommand(message) => write!(f, "{message}"),
         }
     }
 }
@@ -40,6 +42,7 @@ impl std::error::Error for EngineError {
             Self::Mailbox(e) => Some(e),
             Self::Io(e) => Some(e),
             Self::Json(e) => Some(e),
+            Self::UnsupportedCommand(_) => None,
         }
     }
 }
@@ -182,6 +185,11 @@ impl RuntimeEngine {
             RuntimeCommand::MarkMailboxDelivered { message_id } => {
                 self.mailbox.mark_delivered(&message_id)?;
                 RuntimeEvent::MailboxDelivered { message_id }
+            }
+            _ => {
+                return Err(EngineError::UnsupportedCommand(
+                    "team-state commands must be handled by the team-state executor",
+                ));
             }
         };
 
@@ -368,6 +376,7 @@ fn replay_event(engine: &mut RuntimeEngine, event: &RuntimeEvent) {
         RuntimeEvent::MailboxDelivered { message_id } => {
             let _ = engine.mailbox.mark_delivered(message_id);
         }
+        _ => {}
     }
 }
 

--- a/crates/omx-runtime-core/src/lib.rs
+++ b/crates/omx-runtime-core/src/lib.rs
@@ -7,12 +7,16 @@ pub mod dispatch;
 pub mod engine;
 pub mod mailbox;
 pub mod replay;
+pub mod team_state;
 
 pub use authority::{AuthorityError, AuthorityLease};
 pub use dispatch::{DispatchError, DispatchLog, DispatchRecord, DispatchStatus};
 pub use engine::{derive_readiness, EngineError, RuntimeEngine};
 pub use mailbox::{MailboxError, MailboxLog, MailboxRecord};
 pub use replay::ReplayState;
+pub use team_state::{
+    execute_event as execute_team_state_command, is_team_state_command, TeamStateError,
+};
 
 pub const RUNTIME_SCHEMA_VERSION: u32 = 1;
 pub const RUNTIME_COMMAND_NAMES: &[&str] = &[
@@ -27,6 +31,33 @@ pub const RUNTIME_COMMAND_NAMES: &[&str] = &[
     "create-mailbox-message",
     "mark-mailbox-notified",
     "mark-mailbox-delivered",
+    "append-team-event",
+    "write-team-worker-identity",
+    "read-team-worker-heartbeat",
+    "update-team-worker-heartbeat",
+    "read-team-worker-status",
+    "write-team-worker-status",
+    "write-team-worker-inbox",
+    "write-team-shutdown-request",
+    "read-team-shutdown-ack",
+    "read-team-phase",
+    "write-team-phase",
+    "write-team-task-approval",
+    "read-team-task-approval",
+    "read-team-task",
+    "list-team-tasks",
+    "read-team-monitor-snapshot",
+    "write-team-monitor-snapshot",
+    "read-team-summary-snapshot",
+    "write-team-summary-snapshot",
+    "acquire-team-scaling-lock",
+    "release-team-scaling-lock",
+    "acquire-team-create-task-lock",
+    "release-team-create-task-lock",
+    "acquire-team-task-claim-lock",
+    "release-team-task-claim-lock",
+    "acquire-team-mailbox-lock",
+    "release-team-mailbox-lock",
 ];
 pub const RUNTIME_EVENT_NAMES: &[&str] = &[
     "authority-acquired",
@@ -40,6 +71,33 @@ pub const RUNTIME_EVENT_NAMES: &[&str] = &[
     "mailbox-message-created",
     "mailbox-notified",
     "mailbox-delivered",
+    "team-event-appended",
+    "team-worker-identity-written",
+    "team-worker-heartbeat-read",
+    "team-worker-heartbeat-updated",
+    "team-worker-status-read",
+    "team-worker-status-written",
+    "team-worker-inbox-written",
+    "team-shutdown-request-written",
+    "team-shutdown-ack-read",
+    "team-phase-read",
+    "team-phase-written",
+    "team-task-approval-written",
+    "team-task-approval-read",
+    "team-task-read",
+    "team-tasks-listed",
+    "team-monitor-snapshot-read",
+    "team-monitor-snapshot-written",
+    "team-summary-snapshot-read",
+    "team-summary-snapshot-written",
+    "team-scaling-lock-acquired",
+    "team-scaling-lock-released",
+    "team-create-task-lock-acquired",
+    "team-create-task-lock-released",
+    "team-task-claim-lock-acquire-result",
+    "team-task-claim-lock-released",
+    "team-mailbox-lock-acquired",
+    "team-mailbox-lock-released",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -232,6 +290,147 @@ pub enum RuntimeCommand {
     MarkMailboxDelivered {
         message_id: String,
     },
+    AppendTeamEvent {
+        state_root: String,
+        team_name: String,
+        event_json: String,
+    },
+    WriteTeamWorkerIdentity {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+        identity_json: String,
+    },
+    ReadTeamWorkerHeartbeat {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+    },
+    UpdateTeamWorkerHeartbeat {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+        heartbeat_json: String,
+    },
+    ReadTeamWorkerStatus {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+    },
+    WriteTeamWorkerStatus {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+        status_json: String,
+    },
+    WriteTeamWorkerInbox {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+        prompt: String,
+    },
+    WriteTeamShutdownRequest {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+        request_json: String,
+    },
+    ReadTeamShutdownAck {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+    },
+    ReadTeamPhase {
+        state_root: String,
+        team_name: String,
+    },
+    WriteTeamPhase {
+        state_root: String,
+        team_name: String,
+        phase_json: String,
+    },
+    WriteTeamTaskApproval {
+        state_root: String,
+        team_name: String,
+        task_id: String,
+        approval_json: String,
+    },
+    ReadTeamTaskApproval {
+        state_root: String,
+        team_name: String,
+        task_id: String,
+    },
+    ReadTeamTask {
+        state_root: String,
+        team_name: String,
+        task_id: String,
+    },
+    ListTeamTasks {
+        state_root: String,
+        team_name: String,
+    },
+    ReadTeamMonitorSnapshot {
+        state_root: String,
+        team_name: String,
+    },
+    WriteTeamMonitorSnapshot {
+        state_root: String,
+        team_name: String,
+        snapshot_json: String,
+    },
+    ReadTeamSummarySnapshot {
+        state_root: String,
+        team_name: String,
+    },
+    WriteTeamSummarySnapshot {
+        state_root: String,
+        team_name: String,
+        snapshot_json: String,
+    },
+    AcquireTeamScalingLock {
+        state_root: String,
+        team_name: String,
+        lock_stale_ms: u64,
+    },
+    ReleaseTeamScalingLock {
+        state_root: String,
+        team_name: String,
+        owner_token: String,
+    },
+    AcquireTeamCreateTaskLock {
+        state_root: String,
+        team_name: String,
+        lock_stale_ms: u64,
+    },
+    ReleaseTeamCreateTaskLock {
+        state_root: String,
+        team_name: String,
+        owner_token: String,
+    },
+    AcquireTeamTaskClaimLock {
+        state_root: String,
+        team_name: String,
+        task_id: String,
+        lock_stale_ms: u64,
+    },
+    ReleaseTeamTaskClaimLock {
+        state_root: String,
+        team_name: String,
+        task_id: String,
+        owner_token: String,
+    },
+    AcquireTeamMailboxLock {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+        lock_stale_ms: u64,
+    },
+    ReleaseTeamMailboxLock {
+        state_root: String,
+        team_name: String,
+        worker_name: String,
+        owner_token: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -278,6 +477,74 @@ pub enum RuntimeEvent {
     MailboxDelivered {
         message_id: String,
     },
+    TeamEventAppended,
+    TeamWorkerIdentityWritten,
+    TeamWorkerHeartbeatRead {
+        heartbeat: Option<serde_json::Value>,
+    },
+    TeamWorkerHeartbeatUpdated,
+    TeamWorkerStatusRead {
+        status: Option<serde_json::Value>,
+    },
+    TeamWorkerStatusWritten,
+    TeamWorkerInboxWritten,
+    TeamShutdownRequestWritten,
+    TeamShutdownAckRead {
+        ack: Option<serde_json::Value>,
+    },
+    TeamPhaseRead {
+        phase: Option<serde_json::Value>,
+    },
+    TeamPhaseWritten,
+    TeamTaskApprovalWritten,
+    TeamTaskApprovalRead {
+        approval: Option<serde_json::Value>,
+    },
+    TeamTaskRead {
+        task: Option<serde_json::Value>,
+    },
+    TeamTasksListed {
+        tasks: Vec<serde_json::Value>,
+    },
+    TeamMonitorSnapshotRead {
+        snapshot: Option<serde_json::Value>,
+    },
+    TeamMonitorSnapshotWritten,
+    TeamSummarySnapshotRead {
+        snapshot: Option<serde_json::Value>,
+    },
+    TeamSummarySnapshotWritten,
+    TeamScalingLockAcquired {
+        owner_token: String,
+    },
+    TeamScalingLockReleased {
+        released: bool,
+    },
+    TeamCreateTaskLockAcquired {
+        owner_token: String,
+    },
+    TeamCreateTaskLockReleased {
+        released: bool,
+    },
+    TeamTaskClaimLockAcquireResult {
+        ok: bool,
+        owner_token: Option<String>,
+    },
+    TeamTaskClaimLockReleased {
+        released: bool,
+    },
+    TeamMailboxLockAcquired {
+        owner_token: String,
+    },
+    TeamMailboxLockReleased {
+        released: bool,
+    },
+}
+
+impl RuntimeCommand {
+    pub fn is_team_state_command(&self) -> bool {
+        team_state::is_team_state_command(self)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/omx-runtime-core/src/team_state.rs
+++ b/crates/omx-runtime-core/src/team_state.rs
@@ -1,0 +1,835 @@
+use crate::{RuntimeCommand, RuntimeEvent};
+use serde_json::Value;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const SCALING_LOCK_TIMEOUT_MS: u64 = 10_000;
+const DEFAULT_LOCK_TIMEOUT_MS: u64 = 5_000;
+const LOCK_OWNER_RETRY_MS: u64 = 25;
+
+#[derive(Debug)]
+pub enum TeamStateError {
+    Io(io::Error),
+    Json(serde_json::Error),
+    Message(String),
+}
+
+impl fmt::Display for TeamStateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "io error: {error}"),
+            Self::Json(error) => write!(f, "json error: {error}"),
+            Self::Message(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for TeamStateError {}
+
+impl From<io::Error> for TeamStateError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for TeamStateError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+pub fn is_team_state_command(command: &RuntimeCommand) -> bool {
+    matches!(
+        command,
+        RuntimeCommand::AppendTeamEvent { .. }
+            | RuntimeCommand::WriteTeamWorkerIdentity { .. }
+            | RuntimeCommand::ReadTeamWorkerHeartbeat { .. }
+            | RuntimeCommand::UpdateTeamWorkerHeartbeat { .. }
+            | RuntimeCommand::ReadTeamWorkerStatus { .. }
+            | RuntimeCommand::WriteTeamWorkerStatus { .. }
+            | RuntimeCommand::WriteTeamWorkerInbox { .. }
+            | RuntimeCommand::WriteTeamShutdownRequest { .. }
+            | RuntimeCommand::ReadTeamShutdownAck { .. }
+            | RuntimeCommand::ReadTeamPhase { .. }
+            | RuntimeCommand::WriteTeamPhase { .. }
+            | RuntimeCommand::WriteTeamTaskApproval { .. }
+            | RuntimeCommand::ReadTeamTaskApproval { .. }
+            | RuntimeCommand::ReadTeamTask { .. }
+            | RuntimeCommand::ListTeamTasks { .. }
+            | RuntimeCommand::ReadTeamMonitorSnapshot { .. }
+            | RuntimeCommand::WriteTeamMonitorSnapshot { .. }
+            | RuntimeCommand::ReadTeamSummarySnapshot { .. }
+            | RuntimeCommand::WriteTeamSummarySnapshot { .. }
+            | RuntimeCommand::AcquireTeamScalingLock { .. }
+            | RuntimeCommand::ReleaseTeamScalingLock { .. }
+            | RuntimeCommand::AcquireTeamCreateTaskLock { .. }
+            | RuntimeCommand::ReleaseTeamCreateTaskLock { .. }
+            | RuntimeCommand::AcquireTeamTaskClaimLock { .. }
+            | RuntimeCommand::ReleaseTeamTaskClaimLock { .. }
+            | RuntimeCommand::AcquireTeamMailboxLock { .. }
+            | RuntimeCommand::ReleaseTeamMailboxLock { .. }
+    )
+}
+
+pub fn execute_event(command: RuntimeCommand) -> Result<RuntimeEvent, TeamStateError> {
+    match command {
+        RuntimeCommand::AppendTeamEvent { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamEventAppended)
+        }
+        RuntimeCommand::WriteTeamWorkerIdentity { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamWorkerIdentityWritten)
+        }
+        RuntimeCommand::ReadTeamWorkerHeartbeat { .. } => {
+            let heartbeat = execute(command)?;
+            Ok(RuntimeEvent::TeamWorkerHeartbeatRead {
+                heartbeat: if heartbeat.is_null() { None } else { Some(heartbeat) },
+            })
+        }
+        RuntimeCommand::UpdateTeamWorkerHeartbeat { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamWorkerHeartbeatUpdated)
+        }
+        RuntimeCommand::ReadTeamWorkerStatus { .. } => {
+            let status = execute(command)?;
+            Ok(RuntimeEvent::TeamWorkerStatusRead {
+                status: if status.is_null() { None } else { Some(status) },
+            })
+        }
+        RuntimeCommand::WriteTeamWorkerStatus { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamWorkerStatusWritten)
+        }
+        RuntimeCommand::WriteTeamWorkerInbox { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamWorkerInboxWritten)
+        }
+        RuntimeCommand::WriteTeamShutdownRequest { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamShutdownRequestWritten)
+        }
+        RuntimeCommand::ReadTeamShutdownAck { .. } => {
+            let ack = execute(command)?;
+            Ok(RuntimeEvent::TeamShutdownAckRead {
+                ack: if ack.is_null() { None } else { Some(ack) },
+            })
+        }
+        RuntimeCommand::ReadTeamPhase { .. } => {
+            let phase = execute(command)?;
+            Ok(RuntimeEvent::TeamPhaseRead {
+                phase: if phase.is_null() { None } else { Some(phase) },
+            })
+        }
+        RuntimeCommand::WriteTeamPhase { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamPhaseWritten)
+        }
+        RuntimeCommand::WriteTeamTaskApproval { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamTaskApprovalWritten)
+        }
+        RuntimeCommand::ReadTeamTaskApproval { .. } => {
+            let approval = execute(command)?;
+            Ok(RuntimeEvent::TeamTaskApprovalRead {
+                approval: if approval.is_null() { None } else { Some(approval) },
+            })
+        }
+        RuntimeCommand::ReadTeamTask { .. } => {
+            let task = execute(command)?;
+            Ok(RuntimeEvent::TeamTaskRead {
+                task: if task.is_null() { None } else { Some(task) },
+            })
+        }
+        RuntimeCommand::ListTeamTasks { .. } => {
+            let tasks = execute(command)?;
+            Ok(RuntimeEvent::TeamTasksListed {
+                tasks: tasks.as_array().cloned().unwrap_or_default(),
+            })
+        }
+        RuntimeCommand::ReadTeamMonitorSnapshot { .. } => {
+            let snapshot = execute(command)?;
+            Ok(RuntimeEvent::TeamMonitorSnapshotRead {
+                snapshot: if snapshot.is_null() { None } else { Some(snapshot) },
+            })
+        }
+        RuntimeCommand::WriteTeamMonitorSnapshot { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamMonitorSnapshotWritten)
+        }
+        RuntimeCommand::ReadTeamSummarySnapshot { .. } => {
+            let snapshot = execute(command)?;
+            Ok(RuntimeEvent::TeamSummarySnapshotRead {
+                snapshot: if snapshot.is_null() { None } else { Some(snapshot) },
+            })
+        }
+        RuntimeCommand::WriteTeamSummarySnapshot { .. } => {
+            let _ = execute(command)?;
+            Ok(RuntimeEvent::TeamSummarySnapshotWritten)
+        }
+        RuntimeCommand::AcquireTeamScalingLock { .. } => {
+            let value = execute(command)?;
+            Ok(RuntimeEvent::TeamScalingLockAcquired {
+                owner_token: value
+                    .get("owner_token")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        }
+        RuntimeCommand::ReleaseTeamScalingLock { .. } => {
+            let value = execute(command)?;
+            Ok(RuntimeEvent::TeamScalingLockReleased {
+                released: value.get("ok").and_then(Value::as_bool).unwrap_or(false),
+            })
+        }
+        RuntimeCommand::AcquireTeamCreateTaskLock { .. } => {
+            let value = execute(command)?;
+            Ok(RuntimeEvent::TeamCreateTaskLockAcquired {
+                owner_token: value
+                    .get("owner_token")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        }
+        RuntimeCommand::ReleaseTeamCreateTaskLock { .. } => {
+            let value = execute(command)?;
+            Ok(RuntimeEvent::TeamCreateTaskLockReleased {
+                released: value.get("ok").and_then(Value::as_bool).unwrap_or(false),
+            })
+        }
+        RuntimeCommand::AcquireTeamTaskClaimLock { .. } => {
+            let value = execute(command)?;
+            Ok(RuntimeEvent::TeamTaskClaimLockAcquireResult {
+                ok: value.get("ok").and_then(Value::as_bool).unwrap_or(false),
+                owner_token: value
+                    .get("owner_token")
+                    .and_then(Value::as_str)
+                    .map(|token| token.to_string()),
+            })
+        }
+        RuntimeCommand::ReleaseTeamTaskClaimLock { .. } => {
+            let value = execute(command)?;
+            Ok(RuntimeEvent::TeamTaskClaimLockReleased {
+                released: value.get("ok").and_then(Value::as_bool).unwrap_or(false),
+            })
+        }
+        RuntimeCommand::AcquireTeamMailboxLock { .. } => {
+            let value = execute(command)?;
+            Ok(RuntimeEvent::TeamMailboxLockAcquired {
+                owner_token: value
+                    .get("owner_token")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        }
+        RuntimeCommand::ReleaseTeamMailboxLock { .. } => {
+            let value = execute(command)?;
+            Ok(RuntimeEvent::TeamMailboxLockReleased {
+                released: value.get("ok").and_then(Value::as_bool).unwrap_or(false),
+            })
+        }
+        _ => Err(TeamStateError::Message(
+            "non team-state command provided to event executor".to_string(),
+        )),
+    }
+}
+
+pub fn execute(command: RuntimeCommand) -> Result<Value, TeamStateError> {
+    match command {
+        RuntimeCommand::AppendTeamEvent {
+            state_root,
+            team_name,
+            event_json,
+        } => {
+            validate_json_string(&event_json)?;
+            append_line(&team_event_log_path(&state_root, &team_name)?, &event_json)?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::WriteTeamWorkerIdentity {
+            state_root,
+            team_name,
+            worker_name,
+            identity_json,
+        } => {
+            validate_json_string(&identity_json)?;
+            write_atomic_string(
+                &worker_dir(&state_root, &team_name, &worker_name)?.join("identity.json"),
+                &identity_json,
+            )?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::ReadTeamWorkerHeartbeat {
+            state_root,
+            team_name,
+            worker_name,
+        } => Ok(
+            read_json_value(&worker_dir(&state_root, &team_name, &worker_name)?.join("heartbeat.json"))?
+                .unwrap_or(Value::Null),
+        ),
+        RuntimeCommand::UpdateTeamWorkerHeartbeat {
+            state_root,
+            team_name,
+            worker_name,
+            heartbeat_json,
+        } => {
+            validate_json_string(&heartbeat_json)?;
+            write_atomic_string(
+                &worker_dir(&state_root, &team_name, &worker_name)?.join("heartbeat.json"),
+                &heartbeat_json,
+            )?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::ReadTeamWorkerStatus {
+            state_root,
+            team_name,
+            worker_name,
+        } => Ok(
+            read_json_value(&worker_dir(&state_root, &team_name, &worker_name)?.join("status.json"))?
+                .unwrap_or(Value::Null),
+        ),
+        RuntimeCommand::WriteTeamWorkerStatus {
+            state_root,
+            team_name,
+            worker_name,
+            status_json,
+        } => {
+            validate_json_string(&status_json)?;
+            write_atomic_string(
+                &worker_dir(&state_root, &team_name, &worker_name)?.join("status.json"),
+                &status_json,
+            )?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::WriteTeamWorkerInbox {
+            state_root,
+            team_name,
+            worker_name,
+            prompt,
+        } => {
+            write_atomic_string(
+                &worker_dir(&state_root, &team_name, &worker_name)?.join("inbox.md"),
+                &prompt,
+            )?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::WriteTeamShutdownRequest {
+            state_root,
+            team_name,
+            worker_name,
+            request_json,
+        } => {
+            validate_json_string(&request_json)?;
+            write_atomic_string(
+                &worker_dir(&state_root, &team_name, &worker_name)?.join("shutdown-request.json"),
+                &request_json,
+            )?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::ReadTeamShutdownAck {
+            state_root,
+            team_name,
+            worker_name,
+        } => Ok(
+            read_json_value(&worker_dir(&state_root, &team_name, &worker_name)?.join("shutdown-ack.json"))?
+                .unwrap_or(Value::Null),
+        ),
+        RuntimeCommand::ReadTeamPhase {
+            state_root,
+            team_name,
+        } => Ok(read_json_value(&team_dir(&state_root, &team_name)?.join("phase.json"))?
+            .unwrap_or(Value::Null)),
+        RuntimeCommand::WriteTeamPhase {
+            state_root,
+            team_name,
+            phase_json,
+        } => {
+            validate_json_string(&phase_json)?;
+            write_atomic_string(&team_dir(&state_root, &team_name)?.join("phase.json"), &phase_json)?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::WriteTeamTaskApproval {
+            state_root,
+            team_name,
+            task_id,
+            approval_json,
+        } => {
+            validate_json_string(&approval_json)?;
+            write_atomic_string(&approval_path(&state_root, &team_name, &task_id)?, &approval_json)?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::ReadTeamTaskApproval {
+            state_root,
+            team_name,
+            task_id,
+        } => Ok(read_json_value(&approval_path(&state_root, &team_name, &task_id)?)?
+            .unwrap_or(Value::Null)),
+        RuntimeCommand::ReadTeamTask {
+            state_root,
+            team_name,
+            task_id,
+        } => Ok(
+            read_json_value(&task_path(&state_root, &team_name, &task_id)?)?
+                .filter(is_team_task_value)
+                .unwrap_or(Value::Null),
+        ),
+        RuntimeCommand::ListTeamTasks {
+            state_root,
+            team_name,
+        } => Ok(Value::Array(list_tasks(&state_root, &team_name)?)),
+        RuntimeCommand::ReadTeamMonitorSnapshot {
+            state_root,
+            team_name,
+        } => Ok(
+            read_json_value(&team_dir(&state_root, &team_name)?.join("monitor-snapshot.json"))?
+                .unwrap_or(Value::Null),
+        ),
+        RuntimeCommand::WriteTeamMonitorSnapshot {
+            state_root,
+            team_name,
+            snapshot_json,
+        } => {
+            validate_json_string(&snapshot_json)?;
+            write_atomic_string(
+                &team_dir(&state_root, &team_name)?.join("monitor-snapshot.json"),
+                &snapshot_json,
+            )?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::ReadTeamSummarySnapshot {
+            state_root,
+            team_name,
+        } => Ok(
+            read_json_value(&team_dir(&state_root, &team_name)?.join("summary-snapshot.json"))?
+                .unwrap_or(Value::Null),
+        ),
+        RuntimeCommand::WriteTeamSummarySnapshot {
+            state_root,
+            team_name,
+            snapshot_json,
+        } => {
+            validate_json_string(&snapshot_json)?;
+            write_atomic_string(
+                &team_dir(&state_root, &team_name)?.join("summary-snapshot.json"),
+                &snapshot_json,
+            )?;
+            Ok(ok_response())
+        }
+        RuntimeCommand::AcquireTeamScalingLock {
+            state_root,
+            team_name,
+            lock_stale_ms,
+        } => {
+            let owner_token = acquire_lock(
+                &team_dir(&state_root, &team_name)?.join(".lock.scaling"),
+                LockAcquireOptions {
+                    lock_stale_ms,
+                    timeout_ms: SCALING_LOCK_TIMEOUT_MS,
+                    retry_ms: 50,
+                    create_parent_recursive: true,
+                    require_root_exists: false,
+                },
+            )?
+            .ok_or_else(|| TeamStateError::Message(format!("Timed out acquiring scaling lock for team {team_name}")))?;
+            Ok(owner_token_response(owner_token))
+        }
+        RuntimeCommand::ReleaseTeamScalingLock {
+            state_root,
+            team_name,
+            owner_token,
+        } => {
+            release_lock(&team_dir(&state_root, &team_name)?.join(".lock.scaling"), &owner_token);
+            Ok(ok_response())
+        }
+        RuntimeCommand::AcquireTeamCreateTaskLock {
+            state_root,
+            team_name,
+            lock_stale_ms,
+        } => {
+            let owner_token = acquire_lock(
+                &team_dir(&state_root, &team_name)?.join(".lock.create-task"),
+                LockAcquireOptions {
+                    lock_stale_ms,
+                    timeout_ms: DEFAULT_LOCK_TIMEOUT_MS,
+                    retry_ms: LOCK_OWNER_RETRY_MS,
+                    create_parent_recursive: false,
+                    require_root_exists: false,
+                },
+            )?
+            .ok_or_else(|| TeamStateError::Message(format!("Timed out acquiring team task lock for {team_name}")))?;
+            Ok(owner_token_response(owner_token))
+        }
+        RuntimeCommand::ReleaseTeamCreateTaskLock {
+            state_root,
+            team_name,
+            owner_token,
+        } => {
+            release_lock(&team_dir(&state_root, &team_name)?.join(".lock.create-task"), &owner_token);
+            Ok(ok_response())
+        }
+        RuntimeCommand::AcquireTeamTaskClaimLock {
+            state_root,
+            team_name,
+            task_id,
+            lock_stale_ms,
+        } => {
+            let owner_token = acquire_lock(
+                &task_claim_lock_dir(&state_root, &team_name, &task_id)?,
+                LockAcquireOptions {
+                    lock_stale_ms,
+                    timeout_ms: DEFAULT_LOCK_TIMEOUT_MS,
+                    retry_ms: LOCK_OWNER_RETRY_MS,
+                    create_parent_recursive: false,
+                    require_root_exists: false,
+                },
+            )?;
+            Ok(task_claim_lock_response(owner_token))
+        }
+        RuntimeCommand::ReleaseTeamTaskClaimLock {
+            state_root,
+            team_name,
+            task_id,
+            owner_token,
+        } => {
+            release_lock(&task_claim_lock_dir(&state_root, &team_name, &task_id)?, &owner_token);
+            Ok(ok_response())
+        }
+        RuntimeCommand::AcquireTeamMailboxLock {
+            state_root,
+            team_name,
+            worker_name,
+            lock_stale_ms,
+        } => {
+            let root = team_dir(&state_root, &team_name)?;
+            if !root.exists() {
+                return Err(TeamStateError::Message(format!("Team {team_name} not found")));
+            }
+            let owner_token = acquire_lock(
+                &mailbox_lock_dir(&state_root, &team_name, &worker_name)?,
+                LockAcquireOptions {
+                    lock_stale_ms,
+                    timeout_ms: DEFAULT_LOCK_TIMEOUT_MS,
+                    retry_ms: LOCK_OWNER_RETRY_MS,
+                    create_parent_recursive: true,
+                    require_root_exists: true,
+                },
+            )?
+            .ok_or_else(|| TeamStateError::Message(format!("Timed out acquiring mailbox lock for {team_name}/{worker_name}")))?;
+            Ok(owner_token_response(owner_token))
+        }
+        RuntimeCommand::ReleaseTeamMailboxLock {
+            state_root,
+            team_name,
+            worker_name,
+            owner_token,
+        } => {
+            release_lock(&mailbox_lock_dir(&state_root, &team_name, &worker_name)?, &owner_token);
+            Ok(ok_response())
+        }
+        _ => Err(TeamStateError::Message(
+            "non team-state command provided to team_state executor".to_string(),
+        )),
+    }
+}
+
+fn ok_response() -> Value {
+    serde_json::json!({ "ok": true })
+}
+
+fn owner_token_response(owner_token: String) -> Value {
+    serde_json::json!({ "owner_token": owner_token })
+}
+
+fn task_claim_lock_response(owner_token: Option<String>) -> Value {
+    match owner_token {
+        Some(owner_token) => serde_json::json!({ "ok": true, "owner_token": owner_token }),
+        None => serde_json::json!({ "ok": false }),
+    }
+}
+
+fn validate_json_string(data: &str) -> Result<(), TeamStateError> {
+    let _ = serde_json::from_str::<Value>(data)?;
+    Ok(())
+}
+
+fn read_json_value(path: &Path) -> Result<Option<Value>, TeamStateError> {
+    match fs::read_to_string(path) {
+        Ok(raw) => match serde_json::from_str::<Value>(&raw) {
+            Ok(value) => Ok(Some(value)),
+            Err(_) => Ok(None),
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn write_atomic_string(path: &Path, data: &str) -> Result<(), TeamStateError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| TeamStateError::Message(format!("path has no parent: {}", path.display())))?;
+    fs::create_dir_all(parent)?;
+
+    let temp_path = PathBuf::from(format!(
+        "{}.tmp.{}.{}.{}",
+        path.display(),
+        std::process::id(),
+        now_millis(),
+        now_nanos()
+    ));
+    fs::write(&temp_path, data)?;
+    match fs::rename(&temp_path, path) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            if error.kind() == io::ErrorKind::NotFound && path.exists() {
+                if let Ok(existing) = fs::read_to_string(path) {
+                    if existing == data {
+                        return Ok(());
+                    }
+                }
+            }
+            Err(error.into())
+        }
+    }
+}
+
+fn append_line(path: &Path, line: &str) -> Result<(), TeamStateError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| TeamStateError::Message(format!("path has no parent: {}", path.display())))?;
+    fs::create_dir_all(parent)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(line.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn team_dir(state_root: &str, team_name: &str) -> Result<PathBuf, TeamStateError> {
+    validate_team_name(team_name)?;
+    Ok(PathBuf::from(state_root).join("team").join(team_name))
+}
+
+fn worker_dir(state_root: &str, team_name: &str, worker_name: &str) -> Result<PathBuf, TeamStateError> {
+    validate_worker_name(worker_name)?;
+    Ok(team_dir(state_root, team_name)?.join("workers").join(worker_name))
+}
+
+fn team_event_log_path(state_root: &str, team_name: &str) -> Result<PathBuf, TeamStateError> {
+    Ok(team_dir(state_root, team_name)?.join("events").join("events.ndjson"))
+}
+
+fn approval_path(state_root: &str, team_name: &str, task_id: &str) -> Result<PathBuf, TeamStateError> {
+    validate_task_id(task_id)?;
+    Ok(team_dir(state_root, team_name)?.join("approvals").join(format!("task-{task_id}.json")))
+}
+
+fn task_path(state_root: &str, team_name: &str, task_id: &str) -> Result<PathBuf, TeamStateError> {
+    validate_task_id(task_id)?;
+    Ok(team_dir(state_root, team_name)?.join("tasks").join(format!("task-{task_id}.json")))
+}
+
+fn task_claim_lock_dir(state_root: &str, team_name: &str, task_id: &str) -> Result<PathBuf, TeamStateError> {
+    validate_task_id(task_id)?;
+    Ok(team_dir(state_root, team_name)?.join("claims").join(format!("task-{task_id}.lock")))
+}
+
+fn mailbox_lock_dir(state_root: &str, team_name: &str, worker_name: &str) -> Result<PathBuf, TeamStateError> {
+    validate_worker_name(worker_name)?;
+    Ok(team_dir(state_root, team_name)?.join("mailbox").join(format!(".lock-{worker_name}")))
+}
+
+fn is_team_task_value(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    let Some(status) = object.get("status").and_then(Value::as_str) else {
+        return false;
+    };
+    matches!(status, "pending" | "blocked" | "in_progress" | "completed" | "failed")
+        && object.get("id").and_then(Value::as_str).is_some()
+        && object.get("subject").and_then(Value::as_str).is_some()
+        && object.get("description").and_then(Value::as_str).is_some()
+        && object.get("created_at").and_then(Value::as_str).is_some()
+}
+
+fn list_tasks(state_root: &str, team_name: &str) -> Result<Vec<Value>, TeamStateError> {
+    let tasks_root = team_dir(state_root, team_name)?.join("tasks");
+    if !tasks_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries: Vec<(u128, Value)> = Vec::new();
+    for entry in fs::read_dir(tasks_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        let Some(raw_id) = parse_task_filename(&file_name) else {
+            continue;
+        };
+
+        let Some(task_value) = read_json_value(&entry.path())? else {
+            continue;
+        };
+        if !is_team_task_value(&task_value) {
+            continue;
+        }
+        if task_value.get("id").and_then(Value::as_str) != Some(raw_id.as_str()) {
+            continue;
+        }
+        let sort_key = raw_id.parse::<u128>().unwrap_or(u128::MAX);
+        entries.push((sort_key, task_value));
+    }
+
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(entries.into_iter().map(|(_, value)| value).collect())
+}
+
+fn parse_task_filename(file_name: &str) -> Option<String> {
+    if !file_name.starts_with("task-") || !file_name.ends_with(".json") {
+        return None;
+    }
+    let raw = &file_name[5..file_name.len() - 5];
+    if raw.is_empty() || raw.len() > 20 || !raw.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    Some(raw.to_string())
+}
+
+fn validate_team_name(team_name: &str) -> Result<(), TeamStateError> {
+    validate_name(team_name, 30, "team")
+}
+
+fn validate_worker_name(worker_name: &str) -> Result<(), TeamStateError> {
+    validate_name(worker_name, 64, "worker")
+}
+
+fn validate_name(value: &str, max_len: usize, label: &str) -> Result<(), TeamStateError> {
+    if value.is_empty() || value.len() > max_len {
+        return Err(TeamStateError::Message(format!("Invalid {label} name: {value}")));
+    }
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return Err(TeamStateError::Message(format!("Invalid {label} name: {value}")));
+    };
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return Err(TeamStateError::Message(format!("Invalid {label} name: {value}")));
+    }
+    if !chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-') {
+        return Err(TeamStateError::Message(format!("Invalid {label} name: {value}")));
+    }
+    Ok(())
+}
+
+fn validate_task_id(task_id: &str) -> Result<(), TeamStateError> {
+    if task_id.is_empty() || task_id.len() > 20 || !task_id.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(TeamStateError::Message(format!("Invalid task ID: {task_id}")));
+    }
+    Ok(())
+}
+
+struct LockAcquireOptions {
+    lock_stale_ms: u64,
+    timeout_ms: u64,
+    retry_ms: u64,
+    create_parent_recursive: bool,
+    require_root_exists: bool,
+}
+
+fn acquire_lock(lock_dir: &Path, options: LockAcquireOptions) -> Result<Option<String>, TeamStateError> {
+    if options.require_root_exists {
+        let root = lock_dir
+            .parent()
+            .and_then(Path::parent)
+            .ok_or_else(|| TeamStateError::Message(format!("path has no root: {}", lock_dir.display())))?;
+        if !root.exists() {
+            return Err(TeamStateError::Message(format!(
+                "Team {} not found",
+                root.file_name().and_then(|name| name.to_str()).unwrap_or("unknown")
+            )));
+        }
+    }
+    if options.create_parent_recursive {
+        if let Some(parent) = lock_dir.parent() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    let owner_token = format!("{}.{}.{}", std::process::id(), now_millis(), now_nanos());
+    let owner_path = lock_dir.join("owner");
+    let deadline = Instant::now() + Duration::from_millis(options.timeout_ms);
+
+    loop {
+        match fs::create_dir(lock_dir) {
+            Ok(()) => {
+                if let Err(error) = fs::write(&owner_path, &owner_token) {
+                    let _ = fs::remove_dir_all(lock_dir);
+                    return Err(error.into());
+                }
+                return Ok(Some(owner_token));
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                if maybe_recover_stale_lock(lock_dir, options.lock_stale_ms)? {
+                    continue;
+                }
+                if Instant::now() >= deadline {
+                    return Ok(None);
+                }
+                thread::sleep(Duration::from_millis(options.retry_ms));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
+fn maybe_recover_stale_lock(lock_dir: &Path, lock_stale_ms: u64) -> Result<bool, TeamStateError> {
+    let metadata = match fs::metadata(lock_dir) {
+        Ok(metadata) => metadata,
+        Err(_) => return Ok(false),
+    };
+    let modified = match metadata.modified() {
+        Ok(modified) => modified,
+        Err(_) => return Ok(false),
+    };
+    let age_ms = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default()
+        .as_millis();
+    if age_ms > u128::from(lock_stale_ms) {
+        fs::remove_dir_all(lock_dir).ok();
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn release_lock(lock_dir: &Path, owner_token: &str) -> bool {
+    let owner_path = lock_dir.join("owner");
+    let Ok(current_owner) = fs::read_to_string(owner_path) else {
+        return false;
+    };
+    if current_owner.trim() != owner_token {
+        return false;
+    }
+    fs::remove_dir_all(lock_dir).is_ok()
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn now_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}

--- a/crates/omx-runtime/src/main.rs
+++ b/crates/omx-runtime/src/main.rs
@@ -1,5 +1,8 @@
 use omx_mux::{canonical_contract_summary, MuxAdapter, MuxOperation, MuxTarget, TmuxAdapter};
-use omx_runtime_core::{runtime_contract_summary, RuntimeCommand, RuntimeEngine};
+use omx_runtime_core::{
+    execute_team_state_command, is_team_state_command, runtime_contract_summary, RuntimeCommand,
+    RuntimeEngine,
+};
 use std::env;
 use std::process;
 
@@ -71,28 +74,34 @@ fn run() -> Result<(), String> {
             let json_input = second.ok_or("exec requires a JSON command argument")?;
             let state_dir = args.iter().find_map(|a| a.strip_prefix("--state-dir="));
             let compact = args.iter().any(|a| a == "--compact");
-            let mut engine = match state_dir {
-                Some(dir) => RuntimeEngine::load(dir)
-                    .unwrap_or_else(|_| RuntimeEngine::new().with_state_dir(dir)),
-                None => RuntimeEngine::new(),
-            };
-
             let command: RuntimeCommand =
                 serde_json::from_str(json_input).map_err(|e| format!("invalid JSON: {e}"))?;
-            let event = engine.process(command).map_err(|e| e.to_string())?;
+            let payload: serde_json::Value = if is_team_state_command(&command) {
+                let event = execute_team_state_command(command).map_err(|e| e.to_string())?;
+                serde_json::to_value(event).map_err(|e| e.to_string())?
+            } else {
+                let mut engine = match state_dir {
+                    Some(dir) => RuntimeEngine::load(dir)
+                        .unwrap_or_else(|_| RuntimeEngine::new().with_state_dir(dir)),
+                    None => RuntimeEngine::new(),
+                };
+                let event = engine.process(command).map_err(|e| e.to_string())?;
 
-            if compact {
-                engine.compact();
-            }
+                if compact {
+                    engine.compact();
+                }
 
-            if state_dir.is_some() {
-                let _ = engine.persist();
-                let _ = engine.write_compatibility_view();
-            }
+                if state_dir.is_some() {
+                    let _ = engine.persist();
+                    let _ = engine.write_compatibility_view();
+                }
+
+                serde_json::to_value(event).map_err(|e| e.to_string())?
+            };
 
             println!(
                 "{}",
-                serde_json::to_string_pretty(&event).map_err(|e| e.to_string())?
+                serde_json::to_string_pretty(&payload).map_err(|e| e.to_string())?
             );
             Ok(())
         }

--- a/crates/omx-runtime/tests/execution.rs
+++ b/crates/omx-runtime/tests/execution.rs
@@ -210,3 +210,86 @@ fn snapshot_from_state_dir_reads_persisted_state() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn exec_team_state_phase_commands_round_trip() {
+    let root = std::env::temp_dir().join("omx-runtime-test-team-phase");
+    let _ = std::fs::remove_dir_all(&root);
+
+    let write_json = serde_json::json!({
+        "command": "WriteTeamPhase",
+        "state_root": root.display().to_string(),
+        "team_name": "team-1",
+        "phase_json": r#"{"current_phase":"team-exec","max_fix_attempts":3,"current_fix_attempt":0,"transitions":[],"updated_at":"2026-03-23T00:00:00.000Z"}"#,
+    })
+    .to_string();
+    let write_output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .args(["exec", &write_json])
+        .output()
+        .expect("ran omx-runtime");
+    assert!(write_output.status.success());
+
+    let read_json = serde_json::json!({
+        "command": "ReadTeamPhase",
+        "state_root": root.display().to_string(),
+        "team_name": "team-1",
+    })
+    .to_string();
+    let read_output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .args(["exec", &read_json])
+        .output()
+        .expect("ran omx-runtime");
+    assert!(read_output.status.success());
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&read_output.stdout).expect("valid JSON");
+    assert_eq!(parsed["event"], "TeamPhaseRead");
+    assert_eq!(parsed["phase"]["current_phase"], "team-exec");
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn exec_team_state_task_listing_preserves_filtering_and_sorting() {
+    let root = std::env::temp_dir().join("omx-runtime-test-team-tasks");
+    let tasks_dir = root.join("team").join("team-1").join("tasks");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&tasks_dir).unwrap();
+    std::fs::write(
+        tasks_dir.join("task-10.json"),
+        r#"{"id":"10","subject":"b","description":"b","status":"pending","created_at":"2026-03-23T00:00:00.000Z"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tasks_dir.join("task-2.json"),
+        r#"{"id":"2","subject":"a","description":"a","status":"pending","created_at":"2026-03-23T00:00:00.000Z"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tasks_dir.join("task-3.json"),
+        r#"{"id":"999","subject":"bad","description":"bad","status":"pending","created_at":"2026-03-23T00:00:00.000Z"}"#,
+    )
+    .unwrap();
+    std::fs::write(tasks_dir.join("task-4.json"), r#"{"bad":true}"#).unwrap();
+
+    let cmd_json = format!(
+        "{{\"command\":\"ListTeamTasks\",\"state_root\":\"{}\",\"team_name\":\"team-1\"}}",
+        root.display()
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .args(["exec", &cmd_json])
+        .output()
+        .expect("ran omx-runtime");
+    assert!(output.status.success());
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(parsed["event"], "TeamTasksListed");
+    let tasks = parsed["tasks"].as_array().expect("tasks array");
+    let ids: Vec<&str> = tasks
+        .iter()
+        .filter_map(|entry| entry["id"].as_str())
+        .collect();
+    assert_eq!(ids, vec!["2", "10"]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/src/runtime/__tests__/bridge.test.ts
+++ b/src/runtime/__tests__/bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveRuntimeBinaryPath } from '../bridge.js';
+import { clearBridgeCachesForTests, getDefaultBridge, resolveRuntimeBinaryPath } from '../bridge.js';
 
 describe('resolveRuntimeBinaryPath', () => {
   it('prefers explicit OMX_RUNTIME_BINARY override', () => {
@@ -48,5 +48,26 @@ describe('resolveRuntimeBinaryPath', () => {
       exists: () => false,
     });
     assert.equal(actual, 'omx-runtime');
+  });
+});
+
+describe('getDefaultBridge', () => {
+  it('caches bridge instances per state directory', () => {
+    clearBridgeCachesForTests();
+    const first = getDefaultBridge('/tmp/omx-state-a');
+    const second = getDefaultBridge('/tmp/omx-state-a');
+    const third = getDefaultBridge('/tmp/omx-state-b');
+
+    assert.equal(first, second);
+    assert.notEqual(first, third);
+  });
+
+  it('can reset cached bridge instances for tests', () => {
+    clearBridgeCachesForTests();
+    const first = getDefaultBridge('/tmp/omx-state-reset');
+    clearBridgeCachesForTests();
+    const second = getDefaultBridge('/tmp/omx-state-reset');
+
+    assert.notEqual(first, second);
   });
 });

--- a/src/runtime/bridge.ts
+++ b/src/runtime/bridge.ts
@@ -1,21 +1,14 @@
+
 /**
  * TS Runtime Bridge — thin wrapper over omx-runtime binary.
- *
- * All semantic state mutations route through `execCommand()`.
- * All state queries read Rust-authored compatibility JSON files.
- * Set OMX_RUNTIME_BRIDGE=0 to disable bridge (fallback to TS-direct).
  */
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync, existsSync } from 'node:fs';
-import { join, resolve, dirname } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __bridge_dirname = dirname(fileURLToPath(import.meta.url));
-
-// ---------------------------------------------------------------------------
-// Types matching Rust JSON schema
-// ---------------------------------------------------------------------------
 
 export interface RuntimeSnapshot {
   schema_version: number;
@@ -52,7 +45,9 @@ export interface ReadinessSnapshot {
   reasons: string[];
 }
 
-// Rust RuntimeCommand variants (serde tag="command")
+export type JsonObject = Record<string, unknown>;
+export interface TeamStateCommandContext { stateRoot: string; teamName: string; }
+
 export type RuntimeCommand =
   | { command: 'AcquireAuthority'; owner: string; lease_id: string; leased_until: string }
   | { command: 'RenewAuthority'; owner: string; lease_id: string; leased_until: string }
@@ -66,47 +61,57 @@ export type RuntimeCommand =
   | { command: 'MarkMailboxNotified'; message_id: string }
   | { command: 'MarkMailboxDelivered'; message_id: string };
 
-// Rust RuntimeEvent variants (serde tag="event")
-export type RuntimeEvent =
-  | { event: 'AuthorityAcquired'; owner: string; lease_id: string; leased_until: string }
-  | { event: 'AuthorityRenewed'; owner: string; lease_id: string; leased_until: string }
-  | { event: 'DispatchQueued'; request_id: string; target: string; metadata?: Record<string, unknown> }
-  | { event: 'DispatchNotified'; request_id: string; channel: string }
-  | { event: 'DispatchDelivered'; request_id: string }
-  | { event: 'DispatchFailed'; request_id: string; reason: string }
-  | { event: 'ReplayRequested'; cursor?: string }
-  | { event: 'SnapshotCaptured' }
-  | { event: 'MailboxMessageCreated'; message_id: string; from_worker: string; to_worker: string }
-  | { event: 'MailboxNotified'; message_id: string }
-  | { event: 'MailboxDelivered'; message_id: string };
+export type TeamStateCommand =
+  | { command: 'AppendTeamEvent'; state_root: string; team_name: string; event_json: string }
+  | { command: 'WriteTeamWorkerIdentity'; state_root: string; team_name: string; worker_name: string; identity_json: string }
+  | { command: 'ReadTeamWorkerHeartbeat'; state_root: string; team_name: string; worker_name: string }
+  | { command: 'UpdateTeamWorkerHeartbeat'; state_root: string; team_name: string; worker_name: string; heartbeat_json: string }
+  | { command: 'ReadTeamWorkerStatus'; state_root: string; team_name: string; worker_name: string }
+  | { command: 'WriteTeamWorkerStatus'; state_root: string; team_name: string; worker_name: string; status_json: string }
+  | { command: 'WriteTeamWorkerInbox'; state_root: string; team_name: string; worker_name: string; prompt: string }
+  | { command: 'WriteTeamShutdownRequest'; state_root: string; team_name: string; worker_name: string; request_json: string }
+  | { command: 'ReadTeamShutdownAck'; state_root: string; team_name: string; worker_name: string }
+  | { command: 'ReadTeamPhase'; state_root: string; team_name: string }
+  | { command: 'WriteTeamPhase'; state_root: string; team_name: string; phase_json: string }
+  | { command: 'WriteTeamTaskApproval'; state_root: string; team_name: string; task_id: string; approval_json: string }
+  | { command: 'ReadTeamTaskApproval'; state_root: string; team_name: string; task_id: string }
+  | { command: 'ReadTeamTask'; state_root: string; team_name: string; task_id: string }
+  | { command: 'ListTeamTasks'; state_root: string; team_name: string }
+  | { command: 'ReadTeamMonitorSnapshot'; state_root: string; team_name: string }
+  | { command: 'WriteTeamMonitorSnapshot'; state_root: string; team_name: string; snapshot_json: string }
+  | { command: 'ReadTeamSummarySnapshot'; state_root: string; team_name: string }
+  | { command: 'WriteTeamSummarySnapshot'; state_root: string; team_name: string; snapshot_json: string }
+  | { command: 'AcquireTeamScalingLock'; state_root: string; team_name: string; owner_token: string; lock_stale_ms: number }
+  | { command: 'ReleaseTeamScalingLock'; state_root: string; team_name: string; owner_token: string }
+  | { command: 'AcquireTeamCreateTaskLock'; state_root: string; team_name: string; owner_token: string; lock_stale_ms: number }
+  | { command: 'ReleaseTeamCreateTaskLock'; state_root: string; team_name: string; owner_token: string }
+  | { command: 'AcquireTeamTaskClaimLock'; state_root: string; team_name: string; task_id: string; owner_token: string; lock_stale_ms: number }
+  | { command: 'ReleaseTeamTaskClaimLock'; state_root: string; team_name: string; task_id: string; owner_token: string }
+  | { command: 'AcquireTeamMailboxLock'; state_root: string; team_name: string; worker_name: string; owner_token: string; lock_stale_ms: number }
+  | { command: 'ReleaseTeamMailboxLock'; state_root: string; team_name: string; worker_name: string; owner_token: string };
 
-export interface DispatchRecord {
-  request_id: string;
-  target: string;
-  status: 'pending' | 'notified' | 'delivered' | 'failed';
-  created_at: string;
-  notified_at: string | null;
-  delivered_at: string | null;
-  failed_at: string | null;
-  reason: string | null;
-  metadata: Record<string, unknown> | null;
-}
+export type RuntimeEvent = { event: string; [key: string]: unknown };
+export interface DispatchRecord { request_id: string; target: string; status: 'pending' | 'notified' | 'delivered' | 'failed'; created_at: string; notified_at: string | null; delivered_at: string | null; failed_at: string | null; reason: string | null; metadata: Record<string, unknown> | null; }
+export interface MailboxRecord { message_id: string; from_worker: string; to_worker: string; body: string; created_at: string; notified_at: string | null; delivered_at: string | null; }
+export interface TeamTaskListEntryPayload { file_id: string; task: unknown; }
+interface RuntimeSchema { schema_version?: number; commands?: string[]; events?: string[]; transport?: string; }
 
-export interface MailboxRecord {
-  message_id: string;
-  from_worker: string;
-  to_worker: string;
-  body: string;
-  created_at: string;
-  notified_at: string | null;
-  delivered_at: string | null;
-}
+const LEGACY_COMMAND_NAMES: Record<RuntimeCommand['command'], string> = {
+  AcquireAuthority: 'acquire-authority',
+  RenewAuthority: 'renew-authority',
+  QueueDispatch: 'queue-dispatch',
+  MarkNotified: 'mark-notified',
+  MarkDelivered: 'mark-delivered',
+  MarkFailed: 'mark-failed',
+  RequestReplay: 'request-replay',
+  CaptureSnapshot: 'capture-snapshot',
+  CreateMailboxMessage: 'create-mailbox-message',
+  MarkMailboxNotified: 'mark-mailbox-notified',
+  MarkMailboxDelivered: 'mark-mailbox-delivered',
+};
 
-// ---------------------------------------------------------------------------
-// Bridge class
-// ---------------------------------------------------------------------------
-
-let schemaValidated = false;
+const schemaCache = new Map<string, RuntimeSchema>();
+const bridgeCache = new Map<string, RuntimeBridge>();
 
 export interface RuntimeBinaryDiscoveryOptions {
   debugPath?: string;
@@ -119,13 +124,10 @@ export function resolveRuntimeBinaryPath(options: RuntimeBinaryDiscoveryOptions 
   const exists = options.exists ?? existsSync;
   const envOverride = process.env.OMX_RUNTIME_BINARY?.trim();
   if (envOverride) return envOverride;
-
   const workspaceDebug = options.debugPath ?? resolve(__bridge_dirname, '../../target/debug/omx-runtime');
   if (exists(workspaceDebug)) return workspaceDebug;
-
   const workspaceRelease = options.releasePath ?? resolve(__bridge_dirname, '../../target/release/omx-runtime');
   if (exists(workspaceRelease)) return workspaceRelease;
-
   return options.fallbackBinary ?? 'omx-runtime';
 }
 
@@ -136,142 +138,83 @@ export class RuntimeBridge {
 
   constructor(options: { stateDir?: string; binaryPath?: string } = {}) {
     this.enabled = process.env.OMX_RUNTIME_BRIDGE !== '0';
-    this.stateDir = options.stateDir;
+    this.stateDir = options.stateDir ? resolve(options.stateDir) : undefined;
     this.binaryPath = options.binaryPath ?? resolveRuntimeBinaryPath();
   }
 
-  /** Whether the bridge is enabled (OMX_RUNTIME_BRIDGE != '0'). */
-  isEnabled(): boolean {
-    return this.enabled;
-  }
+  isEnabled(): boolean { return this.enabled; }
 
-  /** Execute a RuntimeCommand and return the resulting RuntimeEvent. */
   execCommand(cmd: RuntimeCommand, options?: { compact?: boolean }): RuntimeEvent {
-    this.validateSchemaOnce();
-    const json = JSON.stringify(cmd);
-    const args = ['exec', json];
-    if (this.stateDir) args.push(`--state-dir=${this.stateDir}`);
-    if (options?.compact) args.push('--compact');
-    const stdout = this.run(args);
-    return JSON.parse(stdout) as RuntimeEvent;
+    return this.execJson<RuntimeEvent>(this.execArgs(cmd, options), [LEGACY_COMMAND_NAMES[cmd.command]]);
   }
 
-  /** Read the current RuntimeSnapshot. */
   readSnapshot(): RuntimeSnapshot {
     const args = ['snapshot', '--json'];
     if (this.stateDir) args.push(`--state-dir=${this.stateDir}`);
-    const stdout = this.run(args);
-    return JSON.parse(stdout) as RuntimeSnapshot;
+    return JSON.parse(this.run(args)) as RuntimeSnapshot;
   }
 
-  /** Initialize a fresh state directory. */
   initStateDir(dir: string): void {
     this.run(['init', dir]);
-    this.stateDir = dir;
+    this.stateDir = resolve(dir);
   }
 
-  /** Read a Rust-authored compatibility file as typed JSON. */
   readCompatFile<T>(filename: string): T | null {
     if (!this.stateDir) return null;
     const filePath = join(this.stateDir, filename);
     if (!existsSync(filePath)) return null;
-    const content = readFileSync(filePath, 'utf-8');
-    return JSON.parse(content) as T;
+    return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
   }
 
-  /** Read authority snapshot from compatibility file. */
-  readAuthority(): AuthoritySnapshot | null {
-    return this.readCompatFile<AuthoritySnapshot>('authority.json');
-  }
+  readAuthority(): AuthoritySnapshot | null { return this.readCompatFile<AuthoritySnapshot>('authority.json'); }
+  readReadiness(): ReadinessSnapshot | null { return this.readCompatFile<ReadinessSnapshot>('readiness.json'); }
+  readBacklog(): BacklogSnapshot | null { return this.readCompatFile<BacklogSnapshot>('backlog.json'); }
+  readDispatchRecords(): DispatchRecord[] { return this.readCompatFile<{ records: DispatchRecord[] }>('dispatch.json')?.records ?? []; }
+  readMailboxRecords(): MailboxRecord[] { return this.readCompatFile<{ records: MailboxRecord[] }>('mailbox.json')?.records ?? []; }
 
-  /** Read readiness snapshot from compatibility file. */
-  readReadiness(): ReadinessSnapshot | null {
-    return this.readCompatFile<ReadinessSnapshot>('readiness.json');
-  }
+  appendTeamEvent(context: TeamStateCommandContext, line: string): void { this.execTeamStateOk({ command: 'AppendTeamEvent', state_root: context.stateRoot, team_name: context.teamName, event_json: line.endsWith('\n') ? line.slice(0, -1) : line }, ['append-team-event']); }
+  writeTeamWorkerIdentity(context: TeamStateCommandContext, workerName: string, content: string): void { this.execTeamStateOk({ command: 'WriteTeamWorkerIdentity', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName, identity_json: content }, ['write-team-worker-identity']); }
+  readTeamWorkerHeartbeat(context: TeamStateCommandContext, workerName: string): unknown | null { return this.execTeamStateJson({ command: 'ReadTeamWorkerHeartbeat', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName }, ['read-team-worker-heartbeat']); }
+  updateTeamWorkerHeartbeat(context: TeamStateCommandContext, workerName: string, content: string): void { this.execTeamStateOk({ command: 'UpdateTeamWorkerHeartbeat', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName, heartbeat_json: content }, ['update-team-worker-heartbeat']); }
+  readTeamWorkerStatus(context: TeamStateCommandContext, workerName: string): unknown | null { return this.execTeamStateJson({ command: 'ReadTeamWorkerStatus', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName }, ['read-team-worker-status']); }
+  writeTeamWorkerStatus(context: TeamStateCommandContext, workerName: string, content: string): void { this.execTeamStateOk({ command: 'WriteTeamWorkerStatus', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName, status_json: content }, ['write-team-worker-status']); }
+  writeTeamWorkerInbox(context: TeamStateCommandContext, workerName: string, prompt: string): void { this.execTeamStateOk({ command: 'WriteTeamWorkerInbox', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName, prompt }, ['write-team-worker-inbox']); }
+  writeTeamShutdownRequest(context: TeamStateCommandContext, workerName: string, content: string): void { this.execTeamStateOk({ command: 'WriteTeamShutdownRequest', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName, request_json: content }, ['write-team-shutdown-request']); }
+  readTeamShutdownAck(context: TeamStateCommandContext, workerName: string): unknown | null { return this.execTeamStateJson({ command: 'ReadTeamShutdownAck', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName }, ['read-team-shutdown-ack']); }
+  readTeamPhase(context: TeamStateCommandContext): unknown | null { return this.execTeamStateJson({ command: 'ReadTeamPhase', state_root: context.stateRoot, team_name: context.teamName }, ['read-team-phase']); }
+  writeTeamPhase(context: TeamStateCommandContext, content: string): void { this.execTeamStateOk({ command: 'WriteTeamPhase', state_root: context.stateRoot, team_name: context.teamName, phase_json: content }, ['write-team-phase']); }
+  writeTeamTaskApproval(context: TeamStateCommandContext, taskId: string, content: string): void { this.execTeamStateOk({ command: 'WriteTeamTaskApproval', state_root: context.stateRoot, team_name: context.teamName, task_id: taskId, approval_json: content }, ['write-team-task-approval']); }
+  readTeamTaskApproval(context: TeamStateCommandContext, taskId: string): unknown | null { return this.execTeamStateJson({ command: 'ReadTeamTaskApproval', state_root: context.stateRoot, team_name: context.teamName, task_id: taskId }, ['read-team-task-approval']); }
+  readTeamTask(context: TeamStateCommandContext, taskId: string): unknown | null { return this.execTeamStateJson({ command: 'ReadTeamTask', state_root: context.stateRoot, team_name: context.teamName, task_id: taskId }, ['read-team-task']); }
+  listTeamTasks(context: TeamStateCommandContext): TeamTaskListEntryPayload[] { const response = this.execTeamStateJson<unknown>({ command: 'ListTeamTasks', state_root: context.stateRoot, team_name: context.teamName }, ['list-team-tasks']); return Array.isArray(response) ? response as TeamTaskListEntryPayload[] : []; }
+  readTeamMonitorSnapshot(context: TeamStateCommandContext): unknown | null { return this.execTeamStateJson({ command: 'ReadTeamMonitorSnapshot', state_root: context.stateRoot, team_name: context.teamName }, ['read-team-monitor-snapshot']); }
+  writeTeamMonitorSnapshot(context: TeamStateCommandContext, content: string): void { this.execTeamStateOk({ command: 'WriteTeamMonitorSnapshot', state_root: context.stateRoot, team_name: context.teamName, snapshot_json: content }, ['write-team-monitor-snapshot']); }
+  readTeamSummarySnapshot(context: TeamStateCommandContext): unknown | null { return this.execTeamStateJson({ command: 'ReadTeamSummarySnapshot', state_root: context.stateRoot, team_name: context.teamName }, ['read-team-summary-snapshot']); }
+  writeTeamSummarySnapshot(context: TeamStateCommandContext, content: string): void { this.execTeamStateOk({ command: 'WriteTeamSummarySnapshot', state_root: context.stateRoot, team_name: context.teamName, snapshot_json: content }, ['write-team-summary-snapshot']); }
+  acquireScalingLock(context: TeamStateCommandContext, lockStaleMs: number): string { const ownerToken = makeLockOwnerToken(); const response = this.execTeamStateJson<{ owner_token?: string }>({ command: 'AcquireTeamScalingLock', state_root: context.stateRoot, team_name: context.teamName, owner_token: ownerToken, lock_stale_ms: lockStaleMs }, ['acquire-team-scaling-lock']); if (typeof response.owner_token !== 'string' || response.owner_token.trim() === '') throw new Error('omx-runtime returned an empty owner token for scaling lock'); return response.owner_token; }
+  releaseScalingLock(context: TeamStateCommandContext, ownerToken: string): void { this.execTeamStateOk({ command: 'ReleaseTeamScalingLock', state_root: context.stateRoot, team_name: context.teamName, owner_token: ownerToken }, ['release-team-scaling-lock']); }
+  acquireTeamLock(context: TeamStateCommandContext, lockStaleMs: number): string { const ownerToken = makeLockOwnerToken(); const response = this.execTeamStateJson<{ owner_token?: string }>({ command: 'AcquireTeamCreateTaskLock', state_root: context.stateRoot, team_name: context.teamName, owner_token: ownerToken, lock_stale_ms: lockStaleMs }, ['acquire-team-create-task-lock']); if (typeof response.owner_token !== 'string' || response.owner_token.trim() === '') throw new Error('omx-runtime returned an empty owner token for team lock'); return response.owner_token; }
+  releaseTeamLock(context: TeamStateCommandContext, ownerToken: string): void { this.execTeamStateOk({ command: 'ReleaseTeamCreateTaskLock', state_root: context.stateRoot, team_name: context.teamName, owner_token: ownerToken }, ['release-team-create-task-lock']); }
+  acquireTaskClaimLock(context: TeamStateCommandContext, taskId: string, lockStaleMs: number): string | null { const ownerToken = makeLockOwnerToken(); const response = this.execTeamStateJson<{ ok?: boolean; owner_token?: string | null }>({ command: 'AcquireTeamTaskClaimLock', state_root: context.stateRoot, team_name: context.teamName, task_id: taskId, owner_token: ownerToken, lock_stale_ms: lockStaleMs }, ['acquire-team-task-claim-lock']); if (response.ok !== true) return null; return typeof response.owner_token === 'string' && response.owner_token.trim() !== '' ? response.owner_token : null; }
+  releaseTaskClaimLock(context: TeamStateCommandContext, taskId: string, ownerToken: string): void { this.execTeamStateOk({ command: 'ReleaseTeamTaskClaimLock', state_root: context.stateRoot, team_name: context.teamName, task_id: taskId, owner_token: ownerToken }, ['release-team-task-claim-lock']); }
+  acquireMailboxLock(context: TeamStateCommandContext, workerName: string, lockStaleMs: number): string { const ownerToken = makeLockOwnerToken(); const response = this.execTeamStateJson<{ owner_token?: string }>({ command: 'AcquireTeamMailboxLock', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName, owner_token: ownerToken, lock_stale_ms: lockStaleMs }, ['acquire-team-mailbox-lock']); if (typeof response.owner_token !== 'string' || response.owner_token.trim() === '') throw new Error('omx-runtime returned an empty owner token for mailbox lock'); return response.owner_token; }
+  releaseMailboxLock(context: TeamStateCommandContext, workerName: string, ownerToken: string): void { this.execTeamStateOk({ command: 'ReleaseTeamMailboxLock', state_root: context.stateRoot, team_name: context.teamName, worker_name: workerName, owner_token: ownerToken }, ['release-team-mailbox-lock']); }
 
-  /** Read backlog snapshot from compatibility file. */
-  readBacklog(): BacklogSnapshot | null {
-    return this.readCompatFile<BacklogSnapshot>('backlog.json');
-  }
-
-  /**
-   * Read dispatch records from compatibility file.
-   * Transforms Rust format ({ records: [...] }) to flat array,
-   * and maps `target` → `to_worker` + merges metadata fields.
-   */
-  readDispatchRecords(): DispatchRecord[] {
-    const raw = this.readCompatFile<{ records: DispatchRecord[] }>('dispatch.json');
-    if (!raw?.records) return [];
-    return raw.records;
-  }
-
-  /** Read mailbox records from compatibility file. */
-  readMailboxRecords(): MailboxRecord[] {
-    const raw = this.readCompatFile<{ records: MailboxRecord[] }>('mailbox.json');
-    if (!raw?.records) return [];
-    return raw.records;
-  }
-
-  // -------------------------------------------------------------------------
-  // Private helpers
-  // -------------------------------------------------------------------------
-
-  private validateSchemaOnce(): void {
-    if (schemaValidated) return;
-    try {
-      const stdout = this.run(['schema', '--json']);
-      const schema = JSON.parse(stdout);
-      const expectedCommands = [
-        'acquire-authority', 'renew-authority', 'queue-dispatch',
-        'mark-notified', 'mark-delivered', 'mark-failed',
-        'request-replay', 'capture-snapshot',
-      ];
-      const missing = expectedCommands.filter(
-        (c) => !schema.commands?.includes(c),
-      );
-      if (missing.length > 0) {
-        throw new Error(
-          `omx-runtime schema missing commands: ${missing.join(', ')}. ` +
-          `Bridge types may be out of sync with the Rust binary.`,
-        );
-      }
-      schemaValidated = true;
-    } catch (err) {
-      if (err instanceof Error && err.message.includes('schema missing')) throw err;
-      // Binary not available — schema validation skipped
-      schemaValidated = true;
-    }
-  }
-
-  private run(args: string[]): string {
-    try {
-      const result = execFileSync(this.binaryPath, args, {
-        encoding: 'utf-8',
-        timeout: 10_000,
-        maxBuffer: 1024 * 1024,
-      });
-      return result;
-    } catch (err: unknown) {
-      const execErr = err as { stderr?: string; message?: string };
-      const stderr = execErr.stderr?.trim() ?? execErr.message ?? 'unknown error';
-      throw new Error(`omx-runtime ${args[0]} failed: ${stderr}`);
-    }
-  }
+  private execTeamStateOk(command: TeamStateCommand, requiredCommands: string[]): void { void this.execTeamStateJson<unknown>(command, requiredCommands); }
+  private execTeamStateJson<T>(command: TeamStateCommand, requiredCommands: string[]): T { this.validateSchema(requiredCommands); const event = JSON.parse(this.run(this.execArgs(command))) as RuntimeEvent; return this.unwrapTeamStatePayload<T>(command.command, event); }
+  private execArgs(command: RuntimeCommand | TeamStateCommand, options?: { compact?: boolean }): string[] { const args = ['exec', JSON.stringify(command)]; if (this.stateDir) args.push(`--state-dir=${this.stateDir}`); if (options?.compact) args.push('--compact'); return args; }
+  private execJson<T>(args: string[], requiredCommands: string[] = []): T { this.validateSchema(requiredCommands); return JSON.parse(this.run(args)) as T; }
+  private unwrapTeamStatePayload<T>(commandName: TeamStateCommand['command'], event: RuntimeEvent): T { switch (commandName) { case 'AppendTeamEvent': if (event.event === 'TeamEventAppended') return { ok: true } as T; break; case 'WriteTeamWorkerIdentity': if (event.event === 'TeamWorkerIdentityWritten') return { ok: true } as T; break; case 'ReadTeamWorkerHeartbeat': if (event.event === 'TeamWorkerHeartbeatRead') return (event.heartbeat ?? null) as T; break; case 'UpdateTeamWorkerHeartbeat': if (event.event === 'TeamWorkerHeartbeatUpdated') return { ok: true } as T; break; case 'ReadTeamWorkerStatus': if (event.event === 'TeamWorkerStatusRead') return (event.status ?? null) as T; break; case 'WriteTeamWorkerStatus': if (event.event === 'TeamWorkerStatusWritten') return { ok: true } as T; break; case 'WriteTeamWorkerInbox': if (event.event === 'TeamWorkerInboxWritten') return { ok: true } as T; break; case 'WriteTeamShutdownRequest': if (event.event === 'TeamShutdownRequestWritten') return { ok: true } as T; break; case 'ReadTeamShutdownAck': if (event.event === 'TeamShutdownAckRead') return (event.ack ?? null) as T; break; case 'ReadTeamPhase': if (event.event === 'TeamPhaseRead') return (event.phase ?? null) as T; break; case 'WriteTeamPhase': if (event.event === 'TeamPhaseWritten') return { ok: true } as T; break; case 'WriteTeamTaskApproval': if (event.event === 'TeamTaskApprovalWritten') return { ok: true } as T; break; case 'ReadTeamTaskApproval': if (event.event === 'TeamTaskApprovalRead') return (event.approval ?? null) as T; break; case 'ReadTeamTask': if (event.event === 'TeamTaskRead') return (event.task ?? null) as T; break; case 'ListTeamTasks': if (event.event === 'TeamTasksListed') return event.tasks as T; break; case 'ReadTeamMonitorSnapshot': if (event.event === 'TeamMonitorSnapshotRead') return (event.snapshot ?? null) as T; break; case 'WriteTeamMonitorSnapshot': if (event.event === 'TeamMonitorSnapshotWritten') return { ok: true } as T; break; case 'ReadTeamSummarySnapshot': if (event.event === 'TeamSummarySnapshotRead') return (event.snapshot ?? null) as T; break; case 'WriteTeamSummarySnapshot': if (event.event === 'TeamSummarySnapshotWritten') return { ok: true } as T; break; case 'AcquireTeamScalingLock': if (event.event === 'TeamScalingLockAcquired') return { owner_token: event.owner_token } as T; break; case 'ReleaseTeamScalingLock': if (event.event === 'TeamScalingLockReleased') return { ok: true, released: event.released } as T; break; case 'AcquireTeamCreateTaskLock': if (event.event === 'TeamCreateTaskLockAcquired') return { owner_token: event.owner_token } as T; break; case 'ReleaseTeamCreateTaskLock': if (event.event === 'TeamCreateTaskLockReleased') return { ok: true, released: event.released } as T; break; case 'AcquireTeamTaskClaimLock': if (event.event === 'TeamTaskClaimLockAcquireResult') return { ok: event.ok, owner_token: event.owner_token ?? null } as T; break; case 'ReleaseTeamTaskClaimLock': if (event.event === 'TeamTaskClaimLockReleased') return { ok: true, released: event.released } as T; break; case 'AcquireTeamMailboxLock': if (event.event === 'TeamMailboxLockAcquired') return { owner_token: event.owner_token } as T; break; case 'ReleaseTeamMailboxLock': if (event.event === 'TeamMailboxLockReleased') return { ok: true, released: event.released } as T; break; default: break; } throw new Error(`omx-runtime returned unexpected event for ${commandName}: ${event.event}`); }
+  private validateSchema(requiredCommands: string[]): void { if (requiredCommands.length === 0) return; const schema = this.loadSchema(); const commands = new Set(schema.commands ?? []); const missing = requiredCommands.filter((command) => !commands.has(command)); if (missing.length > 0) throw new Error(`omx-runtime schema missing commands: ${missing.join(', ')}. Bridge types may be out of sync with the Rust binary.`); }
+  private loadSchema(): RuntimeSchema { const cached = schemaCache.get(this.binaryPath); if (cached) return cached; try { const schema = JSON.parse(this.run(['schema', '--json'])) as RuntimeSchema; schemaCache.set(this.binaryPath, schema); return schema; } catch { const fallback: RuntimeSchema = {}; schemaCache.set(this.binaryPath, fallback); return fallback; } }
+  private run(args: string[]): string { try { return execFileSync(this.binaryPath, args, { encoding: 'utf-8', timeout: 10_000, maxBuffer: 1024 * 1024 }); } catch (error: unknown) { const execError = error as { stderr?: string; message?: string }; const stderr = execError.stderr?.trim() ?? execError.message ?? 'unknown error'; throw new Error(`omx-runtime ${args[0]} failed: ${stderr}`); } }
 }
 
-// ---------------------------------------------------------------------------
-// Module-level singleton for convenience
-// ---------------------------------------------------------------------------
+export function getDefaultBridge(stateDir?: string): RuntimeBridge { const binaryPath = resolveRuntimeBinaryPath(); const key = `${binaryPath}::${stateDir ? resolve(stateDir) : 'default'}`; const cached = bridgeCache.get(key); if (cached) return cached; const bridge = new RuntimeBridge({ stateDir, binaryPath }); bridgeCache.set(key, bridge); return bridge; }
+export function clearBridgeCachesForTests(): void { bridgeCache.clear(); schemaCache.clear(); }
+export function resetRuntimeBridgeCachesForTests(): void { clearBridgeCachesForTests(); }
+export function isBridgeEnabled(): boolean { return process.env.OMX_RUNTIME_BRIDGE !== '0'; }
 
-let _defaultBridge: RuntimeBridge | undefined;
-
-export function getDefaultBridge(stateDir?: string): RuntimeBridge {
-  if (!_defaultBridge) {
-    _defaultBridge = new RuntimeBridge({ stateDir });
-  }
-  return _defaultBridge;
-}
-
-export function isBridgeEnabled(): boolean {
-  return process.env.OMX_RUNTIME_BRIDGE !== '0';
+function makeLockOwnerToken(): string {
+  return String(process.pid) + '.' + String(Date.now()) + '.' + Math.random().toString(16).slice(2);
 }

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve, sep } from 'path';
 import { existsSync } from 'fs';
 import { randomUUID } from 'crypto';
 import { omxStateDir } from '../utils/paths.js';
+import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import { type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
   computeTaskReadiness as computeTaskReadinessImpl,
@@ -35,9 +36,12 @@ import {
 import {
   writeTaskApproval as writeTaskApprovalImpl,
   readTaskApproval as readTaskApprovalImpl,
+  parseTaskApprovalContent,
 } from './state/approvals.js';
 import {
   getTeamSummary as getTeamSummaryImpl,
+  readSummarySnapshot as readSummarySnapshotImpl,
+  writeSummarySnapshot as writeSummarySnapshotImpl,
   readMonitorSnapshot as readMonitorSnapshotImpl,
   writeMonitorSnapshot as writeMonitorSnapshotImpl,
   readTeamPhase as readTeamPhaseImpl,
@@ -611,6 +615,201 @@ function summarySnapshotPath(teamName: string, cwd: string): string {
   return join(teamDir(teamName, cwd), 'summary-snapshot.json');
 }
 
+function getTeamStateBridge(cwd: string) {
+  return getDefaultBridge(resolveTeamStateRoot(cwd));
+}
+
+function getTeamStateBridgeContext(teamName: string, cwd: string) {
+  return { stateRoot: resolveTeamStateRoot(cwd), teamName };
+}
+
+function parseBridgeObject(raw: unknown): Record<string, unknown> | null {
+  return raw && typeof raw === 'object' && !Array.isArray(raw) ? raw as Record<string, unknown> : null;
+}
+
+function normalizeBridgeErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) return 'unknown error';
+  return error.message.replace(/^omx-runtime exec failed:\s*/, '').trim();
+}
+
+function shouldPropagateBridgeLockError(error: unknown): boolean {
+  const message = normalizeBridgeErrorMessage(error);
+  return /Timed out acquiring|^Team .* not found$/.test(message);
+}
+
+function isBridgeLocksEnabled(): boolean {
+  return isBridgeEnabled() && process.env.OMX_RUNTIME_BRIDGE_LOCKS === '1';
+}
+
+async function appendTeamEventViaBridge(
+  teamName: string,
+  fullEvent: TeamEvent,
+  cwd: string,
+): Promise<boolean> {
+  if (!isBridgeEnabled()) return false;
+  try {
+    const context = getTeamStateBridgeContext(teamName, cwd);
+    getTeamStateBridge(cwd).appendTeamEvent(context, JSON.stringify(fullEvent));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeBridgeTeamFile(
+  command:
+    | 'WriteTeamWorkerIdentity'
+    | 'UpdateTeamWorkerHeartbeat'
+    | 'WriteTeamWorkerStatus'
+    | 'WriteTeamShutdownRequest'
+    | 'WriteTeamPhase'
+    | 'WriteTeamMonitorSnapshot'
+    | 'WriteTeamSummarySnapshot',
+  teamName: string,
+  cwd: string,
+  content: string,
+  extra: { worker_name?: string } = {},
+): Promise<boolean> {
+  if (!isBridgeEnabled()) return false;
+  try {
+    const bridge = getTeamStateBridge(cwd);
+    const context = getTeamStateBridgeContext(teamName, cwd);
+    switch (command) {
+      case 'WriteTeamWorkerIdentity':
+        if (!extra.worker_name) return false;
+        bridge.writeTeamWorkerIdentity(context, extra.worker_name, content);
+        break;
+      case 'UpdateTeamWorkerHeartbeat':
+        if (!extra.worker_name) return false;
+        bridge.updateTeamWorkerHeartbeat(context, extra.worker_name, content);
+        break;
+      case 'WriteTeamWorkerStatus':
+        if (!extra.worker_name) return false;
+        bridge.writeTeamWorkerStatus(context, extra.worker_name, content);
+        break;
+      case 'WriteTeamShutdownRequest':
+        if (!extra.worker_name) return false;
+        bridge.writeTeamShutdownRequest(context, extra.worker_name, content);
+        break;
+      case 'WriteTeamPhase':
+        bridge.writeTeamPhase(context, content);
+        break;
+      case 'WriteTeamMonitorSnapshot':
+        bridge.writeTeamMonitorSnapshot(context, content);
+        break;
+      case 'WriteTeamSummarySnapshot':
+        bridge.writeTeamSummarySnapshot(context, content);
+        break;
+      default:
+        return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readBridgeTeamObject(
+  command:
+    | 'ReadTeamWorkerHeartbeat'
+    | 'ReadTeamWorkerStatus'
+    | 'ReadTeamShutdownAck'
+    | 'ReadTeamPhase'
+    | 'ReadTeamTaskApproval'
+    | 'ReadTeamTask'
+    | 'ReadTeamMonitorSnapshot'
+    | 'ReadTeamSummarySnapshot',
+  teamName: string,
+  cwd: string,
+  extra: { worker_name?: string; task_id?: string } = {},
+): Promise<Record<string, unknown> | null | undefined> {
+  if (!isBridgeEnabled()) return undefined;
+  try {
+    const bridge = getTeamStateBridge(cwd);
+    const context = getTeamStateBridgeContext(teamName, cwd);
+    switch (command) {
+      case 'ReadTeamWorkerHeartbeat':
+        return parseBridgeObject(bridge.readTeamWorkerHeartbeat(context, extra.worker_name ?? ''));
+      case 'ReadTeamWorkerStatus':
+        return parseBridgeObject(bridge.readTeamWorkerStatus(context, extra.worker_name ?? ''));
+      case 'ReadTeamShutdownAck':
+        return parseBridgeObject(bridge.readTeamShutdownAck(context, extra.worker_name ?? ''));
+      case 'ReadTeamPhase':
+        return parseBridgeObject(bridge.readTeamPhase(context));
+      case 'ReadTeamTaskApproval':
+        return parseBridgeObject(bridge.readTeamTaskApproval(context, extra.task_id ?? ''));
+      case 'ReadTeamTask':
+        return parseBridgeObject(bridge.readTeamTask(context, extra.task_id ?? ''));
+      case 'ReadTeamMonitorSnapshot':
+        return parseBridgeObject(bridge.readTeamMonitorSnapshot(context));
+      case 'ReadTeamSummarySnapshot':
+        return parseBridgeObject(bridge.readTeamSummarySnapshot(context));
+      default:
+        return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeSummarySnapshotValue(raw: unknown): {
+  workerTurnCountByName: Record<string, number>;
+  workerTaskByName: Record<string, string>;
+} | null {
+  const parsed = parseBridgeObject(raw);
+  if (!parsed) return null;
+  return {
+    workerTurnCountByName: parseBridgeObject(parsed.workerTurnCountByName) as Record<string, number> ?? {},
+    workerTaskByName: parseBridgeObject(parsed.workerTaskByName) as Record<string, string> ?? {},
+  };
+}
+
+function normalizeMonitorSnapshotValue(raw: unknown): TeamMonitorSnapshotState | null {
+  const parsed = parseBridgeObject(raw);
+  if (!parsed) return null;
+  const timings = parseBridgeObject(parsed.monitorTimings);
+  const normalizedTimings = timings
+    && typeof timings.list_tasks_ms === 'number'
+    && typeof timings.worker_scan_ms === 'number'
+    && typeof timings.mailbox_delivery_ms === 'number'
+    && typeof timings.total_ms === 'number'
+    && typeof timings.updated_at === 'string'
+      ? {
+          list_tasks_ms: timings.list_tasks_ms,
+          worker_scan_ms: timings.worker_scan_ms,
+          mailbox_delivery_ms: timings.mailbox_delivery_ms,
+          total_ms: timings.total_ms,
+          updated_at: timings.updated_at,
+        }
+      : undefined;
+
+  return {
+    taskStatusById: parseBridgeObject(parsed.taskStatusById) as Record<string, string> ?? {},
+    workerAliveByName: parseBridgeObject(parsed.workerAliveByName) as Record<string, boolean> ?? {},
+    workerStateByName: parseBridgeObject(parsed.workerStateByName) as Record<string, string> ?? {},
+    workerTurnCountByName: parseBridgeObject(parsed.workerTurnCountByName) as Record<string, number> ?? {},
+    workerTaskIdByName: parseBridgeObject(parsed.workerTaskIdByName) as Record<string, string> ?? {},
+    mailboxNotifiedByMessageId: parseBridgeObject(parsed.mailboxNotifiedByMessageId) as Record<string, string> ?? {},
+    completedEventTaskIds: parseBridgeObject(parsed.completedEventTaskIds) as Record<string, boolean> ?? {},
+    integrationByWorker: parseBridgeObject(parsed.integrationByWorker) as Record<string, TeamWorkerIntegrationState> ?? {},
+    monitorTimings: normalizedTimings,
+  };
+}
+
+function normalizeTeamPhaseValue(raw: unknown): TeamPhaseState | null {
+  const parsed = parseBridgeObject(raw);
+  if (!parsed) return null;
+  return {
+    current_phase: typeof parsed.current_phase === 'string' ? parsed.current_phase as TeamPhase | TerminalPhase : 'team-exec',
+    max_fix_attempts: typeof parsed.max_fix_attempts === 'number' ? parsed.max_fix_attempts : 3,
+    current_fix_attempt: typeof parsed.current_fix_attempt === 'number' ? parsed.current_fix_attempt : 0,
+    transitions: Array.isArray(parsed.transitions)
+      ? parsed.transitions as Array<{ from: string; to: string; at: string; reason?: string }>
+      : [],
+    updated_at: typeof parsed.updated_at === 'string' ? parsed.updated_at : new Date().toISOString(),
+  };
+}
+
 // Validate team name: alphanumeric + hyphens only, max 30 chars
 function validateTeamName(name: string): void {
   if (!TEAM_NAME_SAFE_PATTERN.test(name)) {
@@ -1062,6 +1261,14 @@ export async function writeWorkerIdentity(
   identity: WorkerInfo,
   cwd: string
 ): Promise<void> {
+  const bridged = await writeBridgeTeamFile(
+    'WriteTeamWorkerIdentity',
+    teamName,
+    cwd,
+    JSON.stringify(identity, null, 2),
+    { worker_name: workerName },
+  );
+  if (bridged) return;
   const p = join(workerDir(teamName, workerName, cwd), 'identity.json');
   await writeAtomic(p, JSON.stringify(identity, null, 2));
 }
@@ -1072,6 +1279,10 @@ export async function readWorkerHeartbeat(
   workerName: string,
   cwd: string
 ): Promise<WorkerHeartbeat | null> {
+  const bridged = await readBridgeTeamObject('ReadTeamWorkerHeartbeat', teamName, cwd, { worker_name: workerName });
+  if (bridged !== undefined) {
+    return isWorkerHeartbeat(bridged) ? bridged : null;
+  }
   const p = join(workerDir(teamName, workerName, cwd), 'heartbeat.json');
   try {
     const raw = await readFile(p, 'utf8');
@@ -1090,6 +1301,14 @@ export async function updateWorkerHeartbeat(
   heartbeat: WorkerHeartbeat,
   cwd: string
 ): Promise<void> {
+  const bridged = await writeBridgeTeamFile(
+    'UpdateTeamWorkerHeartbeat',
+    teamName,
+    cwd,
+    JSON.stringify(heartbeat, null, 2),
+    { worker_name: workerName },
+  );
+  if (bridged) return;
   const p = join(workerDir(teamName, workerName, cwd), 'heartbeat.json');
   await writeAtomic(p, JSON.stringify(heartbeat, null, 2));
 }
@@ -1097,6 +1316,10 @@ export async function updateWorkerHeartbeat(
 // Read worker status (returns {state:'unknown'} on missing/malformed)
 export async function readWorkerStatus(teamName: string, workerName: string, cwd: string): Promise<WorkerStatus> {
   const unknownStatus: WorkerStatus = { state: 'unknown', updated_at: '1970-01-01T00:00:00.000Z' };
+  const bridged = await readBridgeTeamObject('ReadTeamWorkerStatus', teamName, cwd, { worker_name: workerName });
+  if (bridged !== undefined) {
+    return isWorkerStatus(bridged) ? bridged : unknownStatus;
+  }
   const p = join(workerDir(teamName, workerName, cwd), 'status.json');
   try {
     const raw = await readFile(p, 'utf8');
@@ -1118,6 +1341,14 @@ export async function writeWorkerStatus(
   status: WorkerStatus,
   cwd: string
 ): Promise<void> {
+  const bridged = await writeBridgeTeamFile(
+    'WriteTeamWorkerStatus',
+    teamName,
+    cwd,
+    JSON.stringify(status, null, 2),
+    { worker_name: workerName },
+  );
+  if (bridged) return;
   const p = join(workerDir(teamName, workerName, cwd), 'status.json');
   await writeAtomic(p, JSON.stringify(status, null, 2));
 }
@@ -1128,6 +1359,26 @@ export async function withScalingLock<T>(
   cwd: string,
   fn: () => Promise<T>,
 ): Promise<T> {
+  if (isBridgeLocksEnabled()) {
+    try {
+      const bridge = getTeamStateBridge(cwd);
+      const context = getTeamStateBridgeContext(teamName, cwd);
+      const ownerToken = bridge.acquireScalingLock(context, LOCK_STALE_MS);
+      try {
+        return await fn();
+      } finally {
+        try {
+          bridge.releaseScalingLock(context, ownerToken);
+        } catch {
+          // best-effort release
+        }
+      }
+    } catch (error) {
+      if (shouldPropagateBridgeLockError(error)) {
+        throw new Error(normalizeBridgeErrorMessage(error));
+      }
+    }
+  }
   return await withScalingLockImpl(teamName, cwd, LOCK_STALE_MS, { teamDir, taskClaimLockDir, mailboxLockDir }, fn);
 }
 
@@ -1138,6 +1389,15 @@ export async function writeWorkerInbox(
   prompt: string,
   cwd: string
 ): Promise<void> {
+  if (isBridgeEnabled()) {
+    try {
+      const context = getTeamStateBridgeContext(teamName, cwd);
+      getTeamStateBridge(cwd).writeTeamWorkerInbox(context, workerName, prompt);
+      return;
+    } catch {
+      // fall through to TS write path
+    }
+  }
   const p = join(workerDir(teamName, workerName, cwd), 'inbox.md');
   await writeAtomic(p, prompt);
 }
@@ -1150,6 +1410,26 @@ function taskFilePath(teamName: string, taskId: string, cwd: string): string {
 }
 
 async function withTeamLock<T>(teamName: string, cwd: string, fn: () => Promise<T>): Promise<T> {
+  if (isBridgeLocksEnabled()) {
+    try {
+      const bridge = getTeamStateBridge(cwd);
+      const context = getTeamStateBridgeContext(teamName, cwd);
+      const ownerToken = bridge.acquireTeamLock(context, LOCK_STALE_MS);
+      try {
+        return await fn();
+      } finally {
+        try {
+          bridge.releaseTeamLock(context, ownerToken);
+        } catch {
+          // best-effort release
+        }
+      }
+    } catch (error) {
+      if (shouldPropagateBridgeLockError(error)) {
+        throw new Error(normalizeBridgeErrorMessage(error));
+      }
+    }
+  }
   return await withTeamLockImpl(teamName, cwd, LOCK_STALE_MS, { teamDir, taskClaimLockDir, mailboxLockDir }, fn);
 }
 
@@ -1159,6 +1439,27 @@ async function withTaskClaimLock<T>(
   cwd: string,
   fn: () => Promise<T>
 ): Promise<{ ok: true; value: T } | { ok: false }> {
+  if (isBridgeLocksEnabled()) {
+    try {
+      const bridge = getTeamStateBridge(cwd);
+      const context = getTeamStateBridgeContext(teamName, cwd);
+      const ownerToken = bridge.acquireTaskClaimLock(context, taskId, LOCK_STALE_MS);
+      if (!ownerToken) return { ok: false };
+      try {
+        return { ok: true, value: await fn() };
+      } finally {
+        try {
+          bridge.releaseTaskClaimLock(context, taskId, ownerToken);
+        } catch {
+          // best-effort release
+        }
+      }
+    } catch (error) {
+      if (shouldPropagateBridgeLockError(error)) {
+        throw new Error(normalizeBridgeErrorMessage(error));
+      }
+    }
+  }
   return await withTaskClaimLockImpl(teamName, taskId, cwd, LOCK_STALE_MS, { teamDir, taskClaimLockDir, mailboxLockDir }, fn);
 }
 
@@ -1168,6 +1469,30 @@ async function withMailboxLock<T>(
   cwd: string,
   fn: () => Promise<T>,
 ): Promise<T> {
+  if (isBridgeLocksEnabled()) {
+    try {
+      const root = teamDir(teamName, cwd);
+      if (!existsSync(root)) {
+        throw new Error(`Team ${teamName} not found`);
+      }
+      const bridge = getTeamStateBridge(cwd);
+      const context = getTeamStateBridgeContext(teamName, cwd);
+      const ownerToken = bridge.acquireMailboxLock(context, workerName, LOCK_STALE_MS);
+      try {
+        return await fn();
+      } finally {
+        try {
+          bridge.releaseMailboxLock(context, workerName, ownerToken);
+        } catch {
+          // best-effort release
+        }
+      }
+    } catch (error) {
+      if (shouldPropagateBridgeLockError(error)) {
+        throw new Error(normalizeBridgeErrorMessage(error));
+      }
+    }
+  }
   return await withMailboxLockImpl(teamName, workerName, cwd, LOCK_STALE_MS, { teamDir, taskClaimLockDir, mailboxLockDir }, fn);
 }
 
@@ -1207,6 +1532,10 @@ export async function createTask(
 
 // Read a task (returns null on missing/malformed)
 export async function readTask(teamName: string, taskId: string, cwd: string): Promise<TeamTask | null> {
+  const bridged = await readBridgeTeamObject('ReadTeamTask', teamName, cwd, { task_id: taskId });
+  if (bridged !== undefined) {
+    return isTeamTask(bridged) ? normalizeTask(bridged as TeamTask) : null;
+  }
   try {
     const p = taskFilePath(teamName, taskId, cwd);
     if (!existsSync(p)) return null;
@@ -1256,6 +1585,19 @@ export async function updateTask(
 
 // List all tasks sorted by numeric ID
 export async function listTasks(teamName: string, cwd: string): Promise<TeamTask[]> {
+  if (isBridgeEnabled()) {
+    try {
+      const context = getTeamStateBridgeContext(teamName, cwd);
+      return getTeamStateBridge(cwd)
+        .listTeamTasks(context)
+        .flatMap((entry) => {
+          const candidate = parseBridgeObject(entry)?.task ?? entry;
+          return isTeamTask(candidate) ? [normalizeTask(candidate as TeamTask)] : [];
+        });
+    } catch {
+      // fall through to TS reader
+    }
+  }
   return await listTasksImpl(teamName, cwd, {
     teamDir,
     isTeamTask,
@@ -1358,9 +1700,12 @@ export async function appendTeamEvent(teamName: string, event: Omit<TeamEvent, '
     team: teamName,
     created_at: new Date().toISOString(),
   } as TeamEvent;
-  const p = teamEventLogPath(teamName, cwd);
-  await mkdir(dirname(p), { recursive: true });
-  await appendFile(p, `${JSON.stringify(full)}\n`, 'utf8');
+  const bridged = await appendTeamEventViaBridge(teamName, full, cwd);
+  if (!bridged) {
+    const p = teamEventLogPath(teamName, cwd);
+    await mkdir(dirname(p), { recursive: true });
+    await appendFile(p, `${JSON.stringify(full)}\n`, 'utf8');
+  }
   return full;
 }
 
@@ -1593,6 +1938,34 @@ export async function writeTaskApproval(
   approval: TaskApprovalRecord,
   cwd: string
 ): Promise<void> {
+  let wroteWithBridge = false;
+  if (isBridgeEnabled()) {
+    try {
+      const context = getTeamStateBridgeContext(teamName, cwd);
+      getTeamStateBridge(cwd).writeTeamTaskApproval(
+        context,
+        approval.task_id,
+        JSON.stringify(approval, null, 2),
+      );
+      wroteWithBridge = true;
+    } catch {
+      wroteWithBridge = false;
+    }
+  }
+  if (wroteWithBridge) {
+    await appendTeamEvent(
+      teamName,
+      {
+        type: 'approval_decision',
+        worker: approval.reviewer,
+        task_id: approval.task_id,
+        message_id: null,
+        reason: `${approval.status}:${approval.decision_reason}`,
+      },
+      cwd,
+    );
+    return;
+  }
   await writeTaskApprovalImpl(approval, {
     teamName,
     cwd,
@@ -1607,6 +1980,10 @@ export async function readTaskApproval(
   taskId: string,
   cwd: string
 ): Promise<TaskApprovalRecord | null> {
+  const bridged = await readBridgeTeamObject('ReadTeamTaskApproval', teamName, cwd, { task_id: taskId });
+  if (bridged !== undefined) {
+    return parseTaskApprovalContent(JSON.stringify(bridged), taskId);
+  }
   return await readTaskApprovalImpl(taskId, {
     teamName,
     cwd,
@@ -1629,6 +2006,21 @@ export async function getTeamSummary(teamName: string, cwd: string): Promise<Tea
     monitorSnapshotPath,
     teamPhasePath,
     writeAtomic,
+    readSummarySnapshot: async (targetTeamName, targetCwd) => {
+      const bridged = await readBridgeTeamObject('ReadTeamSummarySnapshot', targetTeamName, targetCwd);
+      if (bridged !== undefined) return normalizeSummarySnapshotValue(bridged);
+      return await readSummarySnapshotImpl(targetTeamName, targetCwd, summarySnapshotPath);
+    },
+    writeSummarySnapshot: async (targetTeamName, snapshot, targetCwd) => {
+      const bridged = await writeBridgeTeamFile(
+        'WriteTeamSummarySnapshot',
+        targetTeamName,
+        targetCwd,
+        JSON.stringify(snapshot, null, 2),
+      );
+      if (bridged) return;
+      await writeSummarySnapshotImpl(targetTeamName, snapshot, targetCwd, summarySnapshotPath, writeAtomic);
+    },
   });
 }
 
@@ -1646,6 +2038,14 @@ export async function writeShutdownRequest(
   requestedBy: string,
   cwd: string,
 ): Promise<void> {
+  const bridged = await writeBridgeTeamFile(
+    'WriteTeamShutdownRequest',
+    teamName,
+    cwd,
+    JSON.stringify({ requested_at: new Date().toISOString(), requested_by: requestedBy }, null, 2),
+    { worker_name: workerName },
+  );
+  if (bridged) return;
   const p = join(workerDir(teamName, workerName, cwd), 'shutdown-request.json');
   await writeAtomic(p, JSON.stringify({ requested_at: new Date().toISOString(), requested_by: requestedBy }, null, 2));
 }
@@ -1656,6 +2056,18 @@ export async function readShutdownAck(
   cwd: string,
   minUpdatedAt?: string,
 ): Promise<ShutdownAck | null> {
+  const bridged = await readBridgeTeamObject('ReadTeamShutdownAck', teamName, cwd, { worker_name: workerName });
+  if (bridged !== undefined) {
+    if (bridged === null) return null;
+    const parsed = bridged as unknown as ShutdownAck;
+    if (parsed.status !== 'accept' && parsed.status !== 'reject') return null;
+    if (typeof minUpdatedAt === 'string' && minUpdatedAt.trim() !== '') {
+      const minTs = Date.parse(minUpdatedAt);
+      const ackTs = Date.parse(parsed.updated_at ?? '');
+      if (!Number.isFinite(minTs) || !Number.isFinite(ackTs) || ackTs < minTs) return null;
+    }
+    return parsed;
+  }
   const ackPath = join(workerDir(teamName, workerName, cwd), 'shutdown-ack.json');
   try {
     const raw = await readFile(ackPath, 'utf-8');
@@ -1726,6 +2138,10 @@ export async function readMonitorSnapshot(
   teamName: string,
   cwd: string,
 ): Promise<TeamMonitorSnapshotState | null> {
+  const bridged = await readBridgeTeamObject('ReadTeamMonitorSnapshot', teamName, cwd);
+  if (bridged !== undefined) {
+    return normalizeMonitorSnapshotValue(bridged);
+  }
   return await readMonitorSnapshotImpl(teamName, cwd, monitorSnapshotPath);
 }
 
@@ -1734,6 +2150,13 @@ export async function writeMonitorSnapshot(
   snapshot: TeamMonitorSnapshotState,
   cwd: string,
 ): Promise<void> {
+  const bridged = await writeBridgeTeamFile(
+    'WriteTeamMonitorSnapshot',
+    teamName,
+    cwd,
+    JSON.stringify(snapshot, null, 2),
+  );
+  if (bridged) return;
   await writeMonitorSnapshotImpl(teamName, snapshot, cwd, monitorSnapshotPath, writeAtomic);
 }
 
@@ -1741,6 +2164,10 @@ export async function readTeamPhase(
   teamName: string,
   cwd: string,
 ): Promise<TeamPhaseState | null> {
+  const bridged = await readBridgeTeamObject('ReadTeamPhase', teamName, cwd);
+  if (bridged !== undefined) {
+    return normalizeTeamPhaseValue(bridged);
+  }
   const phase = await readTeamPhaseImpl(teamName, cwd, teamPhasePath);
   return phase as TeamPhaseState | null;
 }
@@ -1750,6 +2177,13 @@ export async function writeTeamPhase(
   phaseState: TeamPhaseState,
   cwd: string,
 ): Promise<void> {
+  const bridged = await writeBridgeTeamFile(
+    'WriteTeamPhase',
+    teamName,
+    cwd,
+    JSON.stringify(phaseState, null, 2),
+  );
+  if (bridged) return;
   await writeTeamPhaseImpl(teamName, phaseState, cwd, teamPhasePath, writeAtomic);
 }
 

--- a/src/team/state/approvals.ts
+++ b/src/team/state/approvals.ts
@@ -44,16 +44,25 @@ export async function writeTaskApproval(approval: TaskApprovalRecord, deps: Appr
   );
 }
 
+export function parseTaskApprovalContent(raw: string | null, taskId: string): TaskApprovalRecord | null {
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as TaskApprovalRecord;
+    if (parsed.task_id !== taskId) return null;
+    if (!['pending', 'approved', 'rejected'].includes(parsed.status)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 export async function readTaskApproval(taskId: string, deps: ApprovalDeps): Promise<TaskApprovalRecord | null> {
   const p = deps.approvalPath(deps.teamName, taskId, deps.cwd);
   if (!existsSync(p)) return null;
 
   try {
     const raw = await readFile(p, 'utf-8');
-    const parsed = JSON.parse(raw) as TaskApprovalRecord;
-    if (parsed.task_id !== taskId) return null;
-    if (!['pending', 'approved', 'rejected'].includes(parsed.status)) return null;
-    return parsed;
+    return parseTaskApprovalContent(raw, taskId);
   } catch {
     return null;
   }

--- a/src/team/state/monitor.ts
+++ b/src/team/state/monitor.ts
@@ -26,7 +26,7 @@ export interface TeamSummaryPerformance {
   worker_count: number;
 }
 
-interface TeamSummarySnapshot {
+export interface TeamSummarySnapshot {
   workerTurnCountByName: Record<string, number>;
   workerTaskByName: Record<string, string>;
 }
@@ -87,19 +87,107 @@ interface MonitorDeps {
   monitorSnapshotPath: (teamName: string, cwd: string) => string;
   teamPhasePath: (teamName: string, cwd: string) => string;
   writeAtomic: (filePath: string, data: string) => Promise<void>;
+  readSummarySnapshot?: (teamName: string, cwd: string) => Promise<TeamSummarySnapshot | null>;
+  writeSummarySnapshot?: (teamName: string, snapshot: TeamSummarySnapshot, cwd: string) => Promise<void>;
+}
+
+export function normalizeSummarySnapshotValue(value: unknown): TeamSummarySnapshot | null {
+  if (!value || typeof value !== 'object') return null;
+  const parsed = value as Partial<TeamSummarySnapshot>;
+  return {
+    workerTurnCountByName: parsed.workerTurnCountByName ?? {},
+    workerTaskByName: parsed.workerTaskByName ?? {},
+  };
+}
+
+export function parseSummarySnapshotContent(raw: string | null): TeamSummarySnapshot | null {
+  if (raw === null) return null;
+  try {
+    return normalizeSummarySnapshotValue(JSON.parse(raw) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+export function serializeSummarySnapshot(snapshot: TeamSummarySnapshot): string {
+  return JSON.stringify(snapshot, null, 2);
+}
+
+export function normalizeMonitorSnapshotValue(value: unknown): TeamMonitorSnapshotState | null {
+  if (!value || typeof value !== 'object') return null;
+  const parsed = value as Partial<TeamMonitorSnapshotState>;
+  const monitorTimings = (() => {
+    const candidate = parsed.monitorTimings as TeamMonitorSnapshotState['monitorTimings'];
+    if (!candidate || typeof candidate !== 'object') return undefined;
+    if (
+      typeof candidate.list_tasks_ms !== 'number' ||
+      typeof candidate.worker_scan_ms !== 'number' ||
+      typeof candidate.mailbox_delivery_ms !== 'number' ||
+      typeof candidate.total_ms !== 'number' ||
+      typeof candidate.updated_at !== 'string'
+    ) {
+      return undefined;
+    }
+    return candidate;
+  })();
+
+  return {
+    taskStatusById: parsed.taskStatusById ?? {},
+    workerAliveByName: parsed.workerAliveByName ?? {},
+    workerStateByName: parsed.workerStateByName ?? {},
+    workerTurnCountByName: parsed.workerTurnCountByName ?? {},
+    workerTaskIdByName: parsed.workerTaskIdByName ?? {},
+    mailboxNotifiedByMessageId: parsed.mailboxNotifiedByMessageId ?? {},
+    completedEventTaskIds: parsed.completedEventTaskIds ?? {},
+    integrationByWorker: parsed.integrationByWorker ?? {},
+    monitorTimings,
+  };
+}
+
+export function parseMonitorSnapshotContent(raw: string | null): TeamMonitorSnapshotState | null {
+  if (raw === null) return null;
+  try {
+    return normalizeMonitorSnapshotValue(JSON.parse(raw) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+export function serializeMonitorSnapshot(snapshot: TeamMonitorSnapshotState): string {
+  return JSON.stringify(snapshot, null, 2);
+}
+
+export function normalizeTeamPhaseValue(value: unknown): TeamPhaseState | null {
+  if (!value || typeof value !== 'object') return null;
+  const parsed = value as Partial<TeamPhaseState>;
+  const currentPhase = typeof parsed.current_phase === 'string' ? parsed.current_phase : 'team-exec';
+  return {
+    current_phase: currentPhase,
+    max_fix_attempts: typeof parsed.max_fix_attempts === 'number' ? parsed.max_fix_attempts : 3,
+    current_fix_attempt: typeof parsed.current_fix_attempt === 'number' ? parsed.current_fix_attempt : 0,
+    transitions: Array.isArray(parsed.transitions) ? parsed.transitions : [],
+    updated_at: typeof parsed.updated_at === 'string' ? parsed.updated_at : new Date().toISOString(),
+  };
+}
+
+export function parseTeamPhaseContent(raw: string | null): TeamPhaseState | null {
+  if (raw === null) return null;
+  try {
+    return normalizeTeamPhaseValue(JSON.parse(raw) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+export function serializeTeamPhaseContent(phaseState: TeamPhaseState): string {
+  return JSON.stringify(phaseState, null, 2);
 }
 
 export async function readSummarySnapshot(teamName: string, cwd: string, summarySnapshotPath: MonitorDeps['summarySnapshotPath']): Promise<TeamSummarySnapshot | null> {
   const p = summarySnapshotPath(teamName, cwd);
   if (!existsSync(p)) return null;
   try {
-    const raw = await readFile(p, 'utf8');
-    const parsed = JSON.parse(raw) as Partial<TeamSummarySnapshot>;
-    if (!parsed || typeof parsed !== 'object') return null;
-    return {
-      workerTurnCountByName: parsed.workerTurnCountByName ?? {},
-      workerTaskByName: parsed.workerTaskByName ?? {},
-    };
+    return parseSummarySnapshotContent(await readFile(p, 'utf8'));
   } catch {
     return null;
   }
@@ -112,7 +200,7 @@ export async function writeSummarySnapshot(
   summarySnapshotPath: MonitorDeps['summarySnapshotPath'],
   writeAtomic: MonitorDeps['writeAtomic'],
 ): Promise<void> {
-  await writeAtomic(summarySnapshotPath(teamName, cwd), JSON.stringify(snapshot, null, 2));
+  await writeAtomic(summarySnapshotPath(teamName, cwd), serializeSummarySnapshot(snapshot));
 }
 
 export async function getTeamSummary(deps: MonitorDeps): Promise<TeamSummary | null> {
@@ -124,7 +212,9 @@ export async function getTeamSummary(deps: MonitorDeps): Promise<TeamSummary | n
   const tasks = await deps.listTasks(deps.teamName, deps.cwd);
   const tasksLoadedMs = performance.now() - tasksStartMs;
   const taskById = new Map(tasks.map((task) => [task.id, task] as const));
-  const previousSnapshot = await readSummarySnapshot(deps.teamName, deps.cwd, deps.summarySnapshotPath);
+  const previousSnapshot = deps.readSummarySnapshot
+    ? await deps.readSummarySnapshot(deps.teamName, deps.cwd)
+    : await readSummarySnapshot(deps.teamName, deps.cwd, deps.summarySnapshotPath);
 
   const counts = { total: tasks.length, pending: 0, blocked: 0, in_progress: 0, completed: 0, failed: 0 };
   for (const t of tasks) {
@@ -179,7 +269,11 @@ export async function getTeamSummary(deps: MonitorDeps): Promise<TeamSummary | n
     nextSnapshot.workerTaskByName[worker.name] = currentTaskId;
   }
 
-  await writeSummarySnapshot(deps.teamName, nextSnapshot, deps.cwd, deps.summarySnapshotPath, deps.writeAtomic);
+  if (deps.writeSummarySnapshot) {
+    await deps.writeSummarySnapshot(deps.teamName, nextSnapshot, deps.cwd);
+  } else {
+    await writeSummarySnapshot(deps.teamName, nextSnapshot, deps.cwd, deps.summarySnapshotPath, deps.writeAtomic);
+  }
 
   return {
     teamName: cfg.name,
@@ -206,35 +300,7 @@ export async function readMonitorSnapshot(
   if (!existsSync(p)) return null;
 
   try {
-    const raw = await readFile(p, 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<TeamMonitorSnapshotState>;
-    if (!parsed || typeof parsed !== 'object') return null;
-    const monitorTimings = (() => {
-      const candidate = parsed.monitorTimings as TeamMonitorSnapshotState['monitorTimings'];
-      if (!candidate || typeof candidate !== 'object') return undefined;
-      if (
-        typeof candidate.list_tasks_ms !== 'number' ||
-        typeof candidate.worker_scan_ms !== 'number' ||
-        typeof candidate.mailbox_delivery_ms !== 'number' ||
-        typeof candidate.total_ms !== 'number' ||
-        typeof candidate.updated_at !== 'string'
-      ) {
-        return undefined;
-      }
-      return candidate;
-    })();
-
-    return {
-      taskStatusById: parsed.taskStatusById ?? {},
-      workerAliveByName: parsed.workerAliveByName ?? {},
-      workerStateByName: parsed.workerStateByName ?? {},
-      workerTurnCountByName: parsed.workerTurnCountByName ?? {},
-      workerTaskIdByName: parsed.workerTaskIdByName ?? {},
-      mailboxNotifiedByMessageId: parsed.mailboxNotifiedByMessageId ?? {},
-      completedEventTaskIds: parsed.completedEventTaskIds ?? {},
-      integrationByWorker: parsed.integrationByWorker ?? {},
-      monitorTimings,
-    };
+    return parseMonitorSnapshotContent(await readFile(p, 'utf-8'));
   } catch {
     return null;
   }
@@ -247,7 +313,7 @@ export async function writeMonitorSnapshot(
   monitorSnapshotPath: MonitorDeps['monitorSnapshotPath'],
   writeAtomic: MonitorDeps['writeAtomic'],
 ): Promise<void> {
-  await writeAtomic(monitorSnapshotPath(teamName, cwd), JSON.stringify(snapshot, null, 2));
+  await writeAtomic(monitorSnapshotPath(teamName, cwd), serializeMonitorSnapshot(snapshot));
 }
 
 export async function readTeamPhase(teamName: string, cwd: string, teamPhasePath: MonitorDeps['teamPhasePath']): Promise<TeamPhaseState | null> {
@@ -255,17 +321,7 @@ export async function readTeamPhase(teamName: string, cwd: string, teamPhasePath
   if (!existsSync(p)) return null;
 
   try {
-    const raw = await readFile(p, 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<TeamPhaseState>;
-    if (!parsed || typeof parsed !== 'object') return null;
-    const currentPhase = typeof parsed.current_phase === 'string' ? parsed.current_phase : 'team-exec';
-    return {
-      current_phase: currentPhase,
-      max_fix_attempts: typeof parsed.max_fix_attempts === 'number' ? parsed.max_fix_attempts : 3,
-      current_fix_attempt: typeof parsed.current_fix_attempt === 'number' ? parsed.current_fix_attempt : 0,
-      transitions: Array.isArray(parsed.transitions) ? parsed.transitions : [],
-      updated_at: typeof parsed.updated_at === 'string' ? parsed.updated_at : new Date().toISOString(),
-    };
+    return parseTeamPhaseContent(await readFile(p, 'utf-8'));
   } catch {
     return null;
   }
@@ -278,5 +334,5 @@ export async function writeTeamPhase(
   teamPhasePath: MonitorDeps['teamPhasePath'],
   writeAtomic: MonitorDeps['writeAtomic'],
 ): Promise<void> {
-  await writeAtomic(teamPhasePath(teamName, cwd), JSON.stringify(phaseState, null, 2));
+  await writeAtomic(teamPhasePath(teamName, cwd), serializeTeamPhaseContent(phaseState));
 }


### PR DESCRIPTION
## Summary
This PR moves the **low-risk, file-kernel side** of team-state handling into the Rust runtime while **intentionally preserving TypeScript as the public contract and orchestration layer**.

The result is a cleaner boundary:
- **Rust now owns** the most mechanical, failure-prone persistence/parsing paths: append-only event writes, worker/shutdown/phase/snapshot/approval file IO, task read/list parsing, and lock primitives.
- **TypeScript still owns** the user-facing API, path/root resolution, orchestration, event semantics, summary computation, task lifecycle rules, and compatibility fallback behavior.

That split is important. It improves durability and consistency where Rust helps most, without forcing a destabilizing rewrite of the higher-level team runtime.

## Why this change was needed
Before this change, the codebase had a good TypeScript team-state implementation, but the lowest-level persistence responsibilities were spread across TS wrappers that also had to carry higher-level policy. That had a few costs:

1. **Mechanical file IO and orchestration lived too close together.**
   Event appends, snapshot reads/writes, worker state files, task approval files, and lock directories are all fundamentally file-kernel work. Keeping that work in TS made the boundary fuzzier than it needed to be.

2. **The runtime bridge was too narrow for team-state expansion.**
   The old bridge model was fine for the earlier runtime commands, but it was not ready to safely expand into multi-team state operations without a cleaner command/event contract and per-state-dir bridge caching.

3. **Read/write normalization logic was duplicated.**
   Approval parsing, monitor snapshot parsing, summary snapshot parsing, and phase normalization needed better reuse so the Rust-backed path and TS fallback path could behave the same way.

4. **We wanted stronger low-level guarantees without rewriting policy.**
   The plan in `.omx/plans/simple-rust-fixes-consensus.md` and `../simple_rust_fixes.md` explicitly called for a compatibility-first port: move persistence/parsing first, keep public TS contracts stable, and preserve on-disk compatibility exactly.

This PR follows that plan closely.

## What changed
### 1) Added a dedicated Rust team-state executor
**Added:** `crates/omx-runtime-core/src/team_state.rs`

This is the core of the change.

It introduces a dedicated Rust execution surface for team-state operations, including:
- event append
- worker identity / heartbeat / status / inbox file operations
- shutdown request / shutdown ack reads
- phase reads/writes
- task approval reads/writes
- task reads / task listing with malformed-record filtering and numeric sorting
- monitor snapshot reads/writes
- summary snapshot reads/writes
- scaling / create-task / task-claim / mailbox lock acquire/release primitives

Why this mattered:
- These are the most mechanical operations in the system.
- They benefit from a single implementation of path validation, atomic write behavior, malformed JSON handling, append discipline, and lock directory handling.
- They are exactly the kind of low-level durability/parsing work that the consensus plan said should move first.

### 2) Expanded the Rust runtime contract to expose team-state commands/events
**Modified:** `crates/omx-runtime-core/src/lib.rs`

This file now defines the runtime commands and events needed to bridge the new team-state executor.

Why this mattered:
- Without an explicit contract, the TS bridge would have to guess at shapes or tunnel opaque payloads.
- The new command/event pairs make the Rust/TS boundary explicit, testable, and schema-checkable.
- This keeps the bridge honest and future-proof: if Rust and TS drift, schema validation will catch it.

### 3) Routed `omx-runtime exec` team-state traffic through the dedicated Rust executor
**Modified:** `crates/omx-runtime/src/main.rs`

`omx-runtime exec` now detects team-state commands and routes them through the dedicated team-state executor instead of the general runtime engine.

Why this mattered:
- Team-state commands are not backlog/replay/authority/mailbox lifecycle commands.
- Pushing them through the engine would blur responsibilities and create accidental coupling.
- This change keeps the runtime engine focused on runtime-state semantics, while the new executor handles file-backed team-state operations.

### 4) Added an explicit guardrail in the runtime engine
**Modified:** `crates/omx-runtime-core/src/engine.rs`

The engine now rejects team-state commands directly.

Why this mattered:
- This prevents future regressions where team-state commands silently take the wrong path.
- It documents the architectural boundary in code, not just in prose.
- It makes failures sharper and easier to debug.

### 5) Upgraded the TypeScript runtime bridge for real team-state support
**Modified:** `src/runtime/bridge.ts`
**Modified:** `src/runtime/__tests__/bridge.test.ts`

The TS bridge now knows how to send team-state commands to Rust and unwrap the corresponding runtime events.

Important improvements here:
- expanded typed team-state command set
- event unwrapping for team-state responses
- schema validation for the new command family
- **per-state-dir bridge caching**, instead of a single unsafe module-global cache
- targeted test coverage proving the cache is keyed by state directory and resettable in tests

Why this mattered:
- The plan explicitly called out bridge instancing as a prerequisite for safe multi-team/team-state growth.
- Without per-state-dir caching, a bridge created for one state root could be incorrectly reused for another.
- This was one of the most important hidden correctness fixes in the PR.

### 6) Moved TS team-state wrappers to a Rust-first / TS-fallback model
**Modified:** `src/team/state.ts`

This is the main integration layer. It now routes the relevant low-level operations through the Rust bridge first, while preserving TS fallback behavior.

Bridged operations now include:
- appendTeamEvent
- worker identity / heartbeat / status / inbox
- readTask / listTasks
- task approval read/write
- shutdown request / shutdown ack
- monitor snapshot read/write
- summary snapshot read/write (internal helper level)
- team phase read/write
- lock primitives behind `OMX_RUNTIME_BRIDGE_LOCKS=1`

Why this mattered:
- This preserves the existing TS API and call sites.
- If the bridge is disabled or Rust errors, the TS implementation still works.
- That gives us a safe migration path instead of a brittle cutover.

### 7) Centralized approval parsing logic
**Modified:** `src/team/state/approvals.ts`

Added shared approval parsing so the Rust-backed read path and the TS fallback path use the same validation logic.

Why this mattered:
- Prevents subtle drift between “read from file directly” and “read via runtime bridge”.
- Keeps approval shape validation in one place.
- Supports the compatibility goal: same file, same shape, same read outcome.

### 8) Centralized snapshot/phase normalization and serialization helpers
**Modified:** `src/team/state/monitor.ts`

This file now exports reusable helpers for:
- summary snapshot normalization / parsing / serialization
- monitor snapshot normalization / parsing / serialization
- phase normalization / parsing / serialization

Why this mattered:
- It reduces duplicated JSON-handling logic.
- It gives both the Rust-backed bridge path and TS fallback path a single source of truth.
- It keeps higher-level summary computation in TS while letting raw snapshot storage move to Rust.

### 9) Added runtime execution coverage for the new command path
**Modified:** `crates/omx-runtime/tests/execution.rs`

Added tests covering at least:
- team phase write/read round-trip through `omx-runtime exec`
- task listing filtering/sorting parity through `omx-runtime exec`

Why this mattered:
- These tests prove that the CLI/runtime contract works end-to-end, not just inside isolated helpers.
- They directly validate the contract that the TS bridge depends on.

## Why these pieces were ported to Rust
These pieces were ported because they are the **lowest-risk, highest-leverage** slices:
- file creation and atomic replacement
- append-only writes
- malformed JSON tolerance
- task-file enumeration and filtering
- lock directory acquisition/release and stale-lock recovery

Those are mechanical and deterministic. Rust gives us tighter control and a more unified implementation without forcing policy churn.

## Why some parts were intentionally left in TypeScript
Just as important: several areas were **not** ported, and that was deliberate.

These remain in TS because they are policy-heavy, orchestration-heavy, or part of the stable public surface:
- `src/team/team-ops.ts` public contract
- event read/query/normalization and waiting semantics (`src/team/state/events.ts`)
- task create/update/claim/release/transition logic (`src/team/state/tasks.ts`)
- mailbox lifecycle policy
- dispatch lifecycle policy
- summary computation / monitor decisions
- runtime/orchestrator/CLI behavior and gating
- path/root resolution and compatibility wrapper behavior in TS

That split matters for maintainability:
- Rust handles the file-kernel work.
- TypeScript keeps the behavior that changes more often and is closer to product/runtime policy.

This is exactly why the port is safer than a broad rewrite.

## Backward compatibility
This PR was designed to be compatibility-first.

What stayed stable:
- no public `team-ops` API changes
- no caller-facing TypeScript signature changes
- no on-disk path/layout renames
- no NDJSON/JSON format redesign
- no removal of TS fallback behavior

Compatibility protections included in this PR:
- TS still resolves state roots and team paths, then passes explicit bounded context to Rust
- TS falls back when the bridge is disabled or a Rust command fails
- event semantics stay in TS, so existing readers and waiting logic keep their current behavior
- lock bridging is guarded by `OMX_RUNTIME_BRIDGE_LOCKS=1`, so higher-risk lock ownership is not forced on by default

## Risks / things reviewers should keep in mind
1. **The Rust command surface is larger now.**
   Future changes should keep the contract explicit and schema-validated rather than slipping back into ad-hoc bridging.

2. **Fallback behavior is intentional, not transitional clutter.**
   Please do not remove the TS fallback path unless parity is proven across the broader team-state surface.

3. **The lock path is implemented but still intentionally guarded.**
   That guard should remain until broader contention/stale-lock parity is proven in real workflows.

4. **Public contracts still belong to TS.**
   If future work starts moving orchestration logic into Rust, that should be a separate architectural decision, not a quiet extension of this PR.

## Next steps after this PR
Recommended follow-ups:
1. Add dedicated Rust unit tests around stale-lock recovery edge cases and owner-token mismatch behavior.
2. Expand parity coverage for task read/list edge cases in the compatibility suite.
3. Validate lock-path behavior under real multi-worker contention before enabling Rust locks by default.
4. Keep event read/query/wait semantics in TS unless there is a strong measured reason to move them.
5. Fix the unrelated pre-existing full-suite failures listed below so branch-level `npm test` can return green again.

## Verification
- [x] `cargo test -p omx-runtime-core -p omx-runtime`
  - Passed.
  - Confirms the Rust runtime contract, runtime core behavior, and new team-state execution path are working.

- [x] `node --test dist/runtime/__tests__/bridge.test.js dist/team/__tests__/state.test.js`
  - Passed.
  - Confirms the TS bridge integration and team-state compatibility layer behavior for the touched surfaces.

- [x] `npm run build`
  - Passed.
  - Confirms the TypeScript build remains healthy after the bridge/state integration changes.

- [x] `npm test`
  - Executed and reviewed.
  - The repo-wide suite is currently **not fully green**, but the observed failures are in untouched areas outside this diff:
    - `dist/cli/__tests__/ask.test.js`
    - `dist/cli/__tests__/explore.test.js`
    - `dist/hooks/__tests__/notify-fallback-watcher.test.js`
    - `dist/hooks/__tests__/notify-hook-auto-nudge.test.js`
    - `dist/team/__tests__/runtime.test.js`
  - The targeted tests for the code changed in this PR passed.

- [x] `omx doctor` (when setup/config behavior changes)
  - Executed defensively even though this PR does not change setup/config behavior.
  - Passed: `10 passed, 0 warnings, 0 failed`.

- [x] PR is focused and avoids unrelated changes
  - The diff is limited to Rust runtime/team-state plumbing, the TS bridge, the TS compatibility wrapper, and targeted tests for that work.

- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
  - Reviewed.
  - No doc updates were required because this PR changes internal runtime/team-state plumbing without changing the public user workflow or documented CLI contract.

- [x] Backward-compatibility impact considered
  - Public TS surfaces remain stable.
  - On-disk team-state layout remains stable.
  - TS fallback remains intact.
  - Rust locks remain opt-in via `OMX_RUNTIME_BRIDGE_LOCKS=1`.

## Files changed in this repo
### Added
- `crates/omx-runtime-core/src/team_state.rs`
  - New Rust team-state executor for low-risk file IO, parsing, and lock primitives.

### Modified
- `crates/omx-runtime-core/src/engine.rs`
  - Rejects team-state commands in the generic runtime engine so the architectural boundary is explicit.
- `crates/omx-runtime-core/src/lib.rs`
  - Adds the runtime command/event contract and exports for the new team-state executor.
- `crates/omx-runtime/src/main.rs`
  - Routes team-state `exec` commands through the dedicated Rust executor.
- `crates/omx-runtime/tests/execution.rs`
  - Adds end-to-end execution tests for the new team-state command surface.
- `src/runtime/__tests__/bridge.test.ts`
  - Adds bridge cache coverage for per-state-dir behavior.
- `src/runtime/bridge.ts`
  - Expands the TS bridge to support team-state commands, event unwrapping, schema validation, and safe caching.
- `src/team/state.ts`
  - Integrates Rust-first / TS-fallback team-state operations while preserving TS contracts.
- `src/team/state/approvals.ts`
  - Centralizes approval parsing for parity between bridge and fallback reads.
- `src/team/state/monitor.ts`
  - Centralizes snapshot/phase normalization and serialization helpers used by both paths.

### Removed
- None.

## Merge case
This PR is worth taking because it improves the correctness of the **lowest-level persistence boundary** without destabilizing the rest of the team runtime.

It solves a real architectural problem: low-level storage concerns were mixed with higher-level policy, and the runtime bridge was too narrow for the next stage of team-state growth. The new split fixes that cleanly:
- Rust handles the deterministic file-kernel work.
- TypeScript keeps the contracts and orchestration that should remain easy to evolve.

That is the right tradeoff for this codebase, and it matches the plan that was explicitly approved.
