### PR TITLE
Ported session-history search from TypeScript to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +46,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "omx-explore-harness"
 version = "0.11.8"
 
@@ -56,6 +80,15 @@ name = "omx-runtime-core"
 version = "0.11.8"
 dependencies = [
  "fs2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "omx-session-search"
+version = "0.11.8"
+dependencies = [
+ "chrono",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/omx-mux",
   "crates/omx-runtime-core",
   "crates/omx-runtime",
+  "crates/omx-session-search",
   "crates/omx-sparkshell",
 ]
 resolver = "2"

--- a/crates/omx-session-search/Cargo.toml
+++ b/crates/omx-session-search/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "omx-session-search"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "omx-session-search"
+path = "src/main.rs"
+
+[dependencies]
+chrono = { version = "0.4", default-features = false, features = ["std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/omx-session-search/src/lib.rs
+++ b/crates/omx-session-search/src/lib.rs
@@ -1,0 +1,816 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+const DEFAULT_LIMIT: u32 = 10;
+const DEFAULT_CONTEXT: u32 = 80;
+const MAX_LIMIT: u32 = 100;
+const MAX_CONTEXT: u32 = 400;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SessionSearchOptions {
+    pub query: String,
+    pub limit: Option<u32>,
+    pub session: Option<String>,
+    pub since: Option<String>,
+    pub project: Option<String>,
+    pub context: Option<u32>,
+    #[serde(default, rename = "caseSensitive")]
+    pub case_sensitive: bool,
+    pub cwd: Option<String>,
+    pub now: Option<i64>,
+    #[serde(rename = "codexHomeDir")]
+    pub codex_home_dir: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SessionSearchResult {
+    pub session_id: String,
+    pub timestamp: Option<String>,
+    pub cwd: Option<String>,
+    pub transcript_path: String,
+    pub transcript_path_relative: String,
+    pub record_type: String,
+    pub line_number: u32,
+    pub snippet: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SessionSearchReport {
+    pub query: String,
+    pub searched_files: u32,
+    pub matched_sessions: u32,
+    pub results: Vec<SessionSearchResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionMeta {
+    session_id: String,
+    timestamp: Option<String>,
+    cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SearchableText {
+    text: String,
+    record_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SearchExecutionOptions {
+    query: String,
+    limit: u32,
+    context: u32,
+    case_sensitive: bool,
+    session: Option<String>,
+    since_cutoff: Option<i64>,
+    project_filter: Option<String>,
+    cwd: String,
+    codex_home_dir: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchError(pub String);
+
+impl std::fmt::Display for SearchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SearchError {}
+
+fn clamp_integer(value: Option<u32>, fallback: u32, max: u32) -> u32 {
+    let candidate = value.unwrap_or(fallback);
+    candidate.min(max)
+}
+
+fn normalize_project_filter(project: Option<&str>, cwd: &str) -> Option<String> {
+    let trimmed = project?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    match trimmed {
+        "current" => Some(cwd.to_string()),
+        "all" => None,
+        _ => Some(trimmed.to_string()),
+    }
+}
+
+pub fn parse_since_spec(value: Option<&str>, now: i64) -> Result<Option<i64>, SearchError> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    if let Some((amount, unit)) = parse_duration_spec(trimmed) {
+        let multiplier = match unit {
+            's' => 1_000_i64,
+            'm' => 60_000_i64,
+            'h' => 3_600_000_i64,
+            'd' => 86_400_000_i64,
+            'w' => 604_800_000_i64,
+            _ => unreachable!(),
+        };
+        return Ok(Some(now - (amount as i64) * multiplier));
+    }
+
+    if let Ok(dt) = DateTime::parse_from_rfc3339(trimmed) {
+        return Ok(Some(dt.timestamp_millis()));
+    }
+
+    if let Ok(date) = NaiveDate::parse_from_str(trimmed, "%Y-%m-%d") {
+        let naive = date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| SearchError(format_invalid_since(raw)))?;
+        let utc = DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc);
+        return Ok(Some(utc.timestamp_millis()));
+    }
+
+    Err(SearchError(format_invalid_since(raw)))
+}
+
+fn format_invalid_since(raw: &str) -> String {
+    format!("Invalid --since value \"{raw}\". Use formats like 7d, 24h, or 2026-03-10.")
+}
+
+fn parse_duration_spec(input: &str) -> Option<(u64, char)> {
+    if input.len() < 2 {
+        return None;
+    }
+    let unit = input.chars().last()?.to_ascii_lowercase();
+    if !matches!(unit, 's' | 'm' | 'h' | 'd' | 'w') {
+        return None;
+    }
+    let amount = input[..input.len() - unit.len_utf8()].parse::<u64>().ok()?;
+    Some((amount, unit))
+}
+
+fn list_rollout_files(root: &Path) -> Vec<PathBuf> {
+    if !root.exists() {
+        return Vec::new();
+    }
+
+    let mut files = Vec::new();
+    let mut queue = vec![root.to_path_buf()];
+
+    while let Some(dir) = queue.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                queue.push(path);
+                continue;
+            }
+            if file_type.is_file() {
+                let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                    continue;
+                };
+                if name.starts_with("rollout-") && name.ends_with(".jsonl") {
+                    files.push(path);
+                }
+            }
+        }
+    }
+
+    files.sort_by(|a, b| b.to_string_lossy().cmp(&a.to_string_lossy()));
+    files
+}
+
+fn as_trimmed_string(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn collect_text_fragments(value: &Value, fragments: &mut Vec<String>) {
+    match value {
+        Value::String(text) => {
+            if !text.trim().is_empty() {
+                fragments.push(text.clone());
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_text_fragments(item, fragments);
+            }
+        }
+        Value::Object(map) => {
+            for (key, child) in map {
+                if key == "base_instructions" || key == "developer_instructions" {
+                    continue;
+                }
+                collect_text_fragments(child, fragments);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn extract_session_meta(parsed: Option<&Value>) -> Option<SessionMeta> {
+    let parsed = parsed?;
+    if parsed.get("type").and_then(Value::as_str) != Some("session_meta") {
+        return None;
+    }
+    let payload = parsed.get("payload")?.as_object()?;
+    let session_id = as_trimmed_string(payload.get("id")?)?;
+    Some(SessionMeta {
+        session_id,
+        timestamp: payload.get("timestamp").and_then(as_trimmed_string),
+        cwd: payload.get("cwd").and_then(as_trimmed_string),
+    })
+}
+
+fn join_fragments(fragments: &[String]) -> String {
+    fragments.join(" \n ").trim().to_string()
+}
+
+fn extract_searchable_texts(parsed: Option<&Value>, raw_line: &str) -> Vec<SearchableText> {
+    let Some(parsed) = parsed else {
+        return vec![SearchableText {
+            text: raw_line.to_string(),
+            record_type: "raw".to_string(),
+        }];
+    };
+
+    let top_type = parsed
+        .get("type")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .unwrap_or("unknown");
+
+    if top_type == "session_meta" {
+        let Some(payload) = parsed.get("payload").and_then(Value::as_object) else {
+            return Vec::new();
+        };
+        let summary = ["id", "cwd", "agent_role", "agent_nickname"]
+            .iter()
+            .filter_map(|field| payload.get(*field).and_then(as_trimmed_string))
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_string();
+        if summary.is_empty() {
+            return Vec::new();
+        }
+        return vec![SearchableText {
+            text: summary,
+            record_type: "session_meta".to_string(),
+        }];
+    }
+
+    if top_type == "event_msg" {
+        let payload = parsed.get("payload");
+        let payload_type = payload
+            .and_then(Value::as_object)
+            .and_then(|object| object.get("type"))
+            .and_then(as_trimmed_string)
+            .unwrap_or_else(|| "unknown".to_string());
+        let mut fragments = Vec::new();
+        if let Some(payload) = payload {
+            collect_text_fragments(payload, &mut fragments);
+        }
+        let text = join_fragments(&fragments);
+        if text.is_empty() {
+            return Vec::new();
+        }
+        return vec![SearchableText {
+            text,
+            record_type: format!("event_msg:{payload_type}"),
+        }];
+    }
+
+    if top_type == "response_item" {
+        let Some(payload) = parsed.get("payload") else {
+            return Vec::new();
+        };
+        let Some(payload_object) = payload.as_object() else {
+            return Vec::new();
+        };
+        let payload_type = payload_object
+            .get("type")
+            .and_then(as_trimmed_string)
+            .unwrap_or_else(|| "unknown".to_string());
+
+        if payload_type == "message" {
+            let role = payload_object
+                .get("role")
+                .and_then(as_trimmed_string)
+                .unwrap_or_else(|| "unknown".to_string());
+            if role != "assistant" && role != "user" {
+                return Vec::new();
+            }
+            let mut fragments = Vec::new();
+            if let Some(content) = payload_object.get("content") {
+                collect_text_fragments(content, &mut fragments);
+            }
+            let text = join_fragments(&fragments);
+            if text.is_empty() {
+                return Vec::new();
+            }
+            return vec![SearchableText {
+                text,
+                record_type: format!("response_item:{payload_type}:{role}"),
+            }];
+        }
+
+        let mut fragments = Vec::new();
+        match payload_type.as_str() {
+            "function_call" => {
+                if let Some(name) = payload_object.get("name").and_then(as_trimmed_string) {
+                    fragments.push(name);
+                }
+                if let Some(arguments_text) =
+                    payload_object.get("arguments").and_then(as_trimmed_string)
+                {
+                    fragments.push(arguments_text);
+                }
+            }
+            "function_call_output" => {
+                if let Some(output) = payload_object.get("output") {
+                    collect_text_fragments(output, &mut fragments);
+                }
+            }
+            _ => collect_text_fragments(payload, &mut fragments),
+        }
+
+        let text = join_fragments(&fragments);
+        if text.is_empty() {
+            return Vec::new();
+        }
+        return vec![SearchableText {
+            text,
+            record_type: format!("response_item:{payload_type}"),
+        }];
+    }
+
+    vec![SearchableText {
+        text: raw_line.to_string(),
+        record_type: top_type.to_string(),
+    }]
+}
+
+fn collapse_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn build_snippet(text: &str, query: &str, context: u32, case_sensitive: bool) -> Option<String> {
+    if text.is_empty() {
+        return None;
+    }
+
+    let (haystack, needle) = if case_sensitive {
+        (text.to_string(), query.to_string())
+    } else {
+        (text.to_lowercase(), query.to_lowercase())
+    };
+
+    let index = haystack.find(&needle)?;
+    let start = index.saturating_sub(context as usize);
+    let end = (index + query.len() + context as usize).min(text.len());
+    let prefix = if start > 0 { "…" } else { "" };
+    let suffix = if end < text.len() { "…" } else { "" };
+    let slice = text.get(start..end)?;
+    Some(format!(
+        "{prefix}{}{suffix}",
+        collapse_whitespace(slice).trim()
+    ))
+}
+
+fn matches_filter(value: Option<&str>, filter: Option<&str>, case_sensitive: bool) -> bool {
+    let Some(filter) = filter else {
+        return true;
+    };
+    let Some(value) = value else {
+        return false;
+    };
+
+    let matches = if case_sensitive {
+        value.contains(filter)
+    } else {
+        value.to_lowercase().contains(&filter.to_lowercase())
+    };
+    if matches {
+        return true;
+    }
+
+    if looks_like_absolute_path(value) && looks_like_absolute_path(filter) {
+        let normalized_value = normalize_comparable_path(value);
+        let normalized_filter = normalize_comparable_path(filter);
+        if case_sensitive {
+            return normalized_value.contains(&normalized_filter);
+        }
+        return normalized_value
+            .to_lowercase()
+            .contains(&normalized_filter.to_lowercase());
+    }
+
+    false
+}
+
+fn looks_like_absolute_path(value: &str) -> bool {
+    value.starts_with('/')
+        || value
+            .as_bytes()
+            .get(1)
+            .zip(value.as_bytes().get(2))
+            .map(|(colon, slash)| *colon == b':' && (*slash == b'/' || *slash == b'\\'))
+            .unwrap_or(false)
+}
+
+fn normalize_comparable_path(value: &str) -> String {
+    fs::canonicalize(value)
+        .unwrap_or_else(|_| PathBuf::from(value))
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn session_timestamp_millis(timestamp: Option<&str>) -> Option<i64> {
+    let timestamp = timestamp?;
+    DateTime::parse_from_rfc3339(timestamp)
+        .map(|value| value.timestamp_millis())
+        .ok()
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|_| path.to_string_lossy().replace('\\', "/"))
+}
+
+fn fallback_session_id_from_path(file_path: &Path) -> String {
+    let file_name = file_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    if let Some(suffix) = file_name.strip_prefix("rollout-") {
+        return suffix.trim_end_matches(".jsonl").to_string();
+    }
+    file_path.to_string_lossy().to_string()
+}
+
+fn search_rollout_file(
+    file_path: &Path,
+    options: &SearchExecutionOptions,
+) -> Result<Vec<SessionSearchResult>, SearchError> {
+    let file = File::open(file_path)
+        .map_err(|error| SearchError(format!("failed to read {}: {error}", file_path.display())))?;
+    let reader = BufReader::new(file);
+    let mut results = Vec::new();
+    let mut meta: Option<SessionMeta> = None;
+    let mut line_number = 0_u32;
+    let mut skip_file = false;
+
+    for line_result in reader.lines() {
+        let line = line_result.map_err(|error| {
+            SearchError(format!(
+                "failed to read line from {}: {error}",
+                file_path.display()
+            ))
+        })?;
+        line_number += 1;
+        let parsed_value = serde_json::from_str::<Value>(&line).ok();
+
+        if line_number == 1 {
+            meta = extract_session_meta(parsed_value.as_ref()).or_else(|| {
+                Some(SessionMeta {
+                    session_id: fallback_session_id_from_path(file_path),
+                    timestamp: None,
+                    cwd: None,
+                })
+            });
+
+            if let Some(meta_ref) = meta.as_ref() {
+                if let Some(since_cutoff) = options.since_cutoff {
+                    if let Some(timestamp) = session_timestamp_millis(meta_ref.timestamp.as_deref())
+                    {
+                        if timestamp < since_cutoff {
+                            skip_file = true;
+                            break;
+                        }
+                    }
+                }
+
+                if !matches_filter(
+                    Some(meta_ref.session_id.as_str()),
+                    options.session.as_deref(),
+                    options.case_sensitive,
+                ) {
+                    skip_file = true;
+                    break;
+                }
+
+                if !matches_filter(
+                    meta_ref.cwd.as_deref(),
+                    options.project_filter.as_deref(),
+                    options.case_sensitive,
+                ) {
+                    skip_file = true;
+                    break;
+                }
+            }
+        }
+
+        for candidate in extract_searchable_texts(parsed_value.as_ref(), &line) {
+            let Some(meta_ref) = meta.as_ref() else {
+                continue;
+            };
+            let Some(snippet) = build_snippet(
+                &candidate.text,
+                &options.query,
+                options.context,
+                options.case_sensitive,
+            ) else {
+                continue;
+            };
+
+            results.push(SessionSearchResult {
+                session_id: meta_ref.session_id.clone(),
+                timestamp: meta_ref.timestamp.clone(),
+                cwd: meta_ref.cwd.clone(),
+                transcript_path: file_path.to_string_lossy().replace('\\', "/"),
+                transcript_path_relative: relative_path(
+                    Path::new(&options.codex_home_dir),
+                    file_path,
+                ),
+                record_type: candidate.record_type,
+                line_number,
+                snippet,
+            });
+
+            if results.len() >= options.limit as usize {
+                return Ok(results);
+            }
+        }
+    }
+
+    if skip_file {
+        return Ok(Vec::new());
+    }
+
+    Ok(results)
+}
+
+pub fn search_session_history(
+    options: SessionSearchOptions,
+) -> Result<SessionSearchReport, SearchError> {
+    let query = options.query.trim().to_string();
+    if query.is_empty() {
+        return Err(SearchError("Search query must not be empty.".to_string()));
+    }
+
+    let cwd = options.cwd.clone().unwrap_or_else(|| {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .to_string_lossy()
+            .to_string()
+    });
+    let codex_home_dir = options.codex_home_dir.clone().unwrap_or_else(|| {
+        std::env::var("CODEX_HOME").unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            format!("{home}/.codex")
+        })
+    });
+    let now = options.now.unwrap_or_else(current_time_millis);
+    let limit = clamp_integer(options.limit, DEFAULT_LIMIT, MAX_LIMIT).max(1);
+    let context = clamp_integer(options.context, DEFAULT_CONTEXT, MAX_CONTEXT);
+    let since_cutoff = parse_since_spec(options.since.as_deref(), now)?;
+    let project_filter = normalize_project_filter(options.project.as_deref(), &cwd);
+    let rollout_root = Path::new(&codex_home_dir).join("sessions");
+    let files = list_rollout_files(&rollout_root);
+
+    let exec_options = SearchExecutionOptions {
+        query: query.clone(),
+        limit,
+        context,
+        case_sensitive: options.case_sensitive,
+        session: options.session.clone(),
+        since_cutoff,
+        project_filter,
+        cwd,
+        codex_home_dir,
+    };
+
+    let mut results = Vec::new();
+    let mut searched_files = 0_u32;
+    let mut matched_sessions = HashSet::new();
+
+    for file_path in files {
+        if results.len() >= limit as usize {
+            break;
+        }
+
+        if let Some(since_cutoff) = since_cutoff {
+            if let Ok(metadata) = fs::metadata(&file_path) {
+                if let Ok(modified) = metadata.modified() {
+                    if let Ok(duration) = modified.duration_since(UNIX_EPOCH) {
+                        if (duration.as_millis() as i64) < since_cutoff {
+                            continue;
+                        }
+                    }
+                }
+            } else {
+                continue;
+            }
+        }
+
+        searched_files += 1;
+        let mut file_results = search_rollout_file(&file_path, &exec_options)?;
+        let remaining = limit as usize - results.len();
+        if file_results.len() > remaining {
+            file_results.truncate(remaining);
+        }
+
+        for result in file_results {
+            matched_sessions.insert(result.session_id.clone());
+            results.push(result);
+            if results.len() >= limit as usize {
+                break;
+            }
+        }
+    }
+
+    Ok(SessionSearchReport {
+        query,
+        searched_files,
+        matched_sessions: matched_sessions.len() as u32,
+        results,
+    })
+}
+
+fn current_time_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_since_spec, search_session_history, SessionSearchOptions};
+    use std::fs::{create_dir_all, write};
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("omx-session-search-{name}-{nanos}"))
+    }
+
+    fn write_rollout(
+        codex_home: &Path,
+        iso_date: &str,
+        file_name: &str,
+        lines: &[&str],
+    ) -> PathBuf {
+        let year = &iso_date[0..4];
+        let month = &iso_date[5..7];
+        let day = &iso_date[8..10];
+        let dir = codex_home.join("sessions").join(year).join(month).join(day);
+        create_dir_all(&dir).unwrap();
+        let file_path = dir.join(file_name);
+        write(&file_path, format!("{}\n", lines.join("\n"))).unwrap();
+        file_path
+    }
+
+    #[test]
+    fn parses_duration_and_date_since_specs() {
+        let now = 1_710_000_000_000_i64;
+        assert_eq!(
+            parse_since_spec(Some("24h"), now).unwrap(),
+            Some(now - 24 * 3_600_000)
+        );
+        assert_eq!(
+            parse_since_spec(Some("2026-03-09"), now).unwrap(),
+            Some(
+                chrono::NaiveDate::from_ymd_opt(2026, 3, 9)
+                    .unwrap()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap()
+                    .and_utc()
+                    .timestamp_millis()
+            )
+        );
+    }
+
+    #[test]
+    fn finds_matches_in_rollout_transcripts() {
+        let cwd = temp_dir("smoke");
+        let codex_home = cwd.join(".codex-home");
+        let file_name = "rollout-2026-03-10T12-00-00-session-a.jsonl";
+        write_rollout(
+            &codex_home,
+            "2026-03-10T12:00:00.000Z",
+            file_name,
+            &[
+                r#"{"type":"session_meta","payload":{"id":"session-a","timestamp":"2026-03-10T12:00:00.000Z","cwd":"/tmp/project-a"}}"#,
+                r#"{"type":"event_msg","payload":{"type":"user_message","message":"Please investigate the worker inbox path issue in team mode."}}"#,
+            ],
+        );
+
+        let report = search_session_history(SessionSearchOptions {
+            query: "worker inbox path".to_string(),
+            limit: None,
+            session: None,
+            since: None,
+            project: None,
+            context: None,
+            case_sensitive: false,
+            cwd: Some(cwd.to_string_lossy().to_string()),
+            now: None,
+            codex_home_dir: Some(codex_home.to_string_lossy().to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.matched_sessions, 1);
+        assert_eq!(report.results[0].session_id, "session-a");
+        assert_eq!(report.results[0].record_type, "event_msg:user_message");
+        assert!(report.results[0]
+            .snippet
+            .contains("worker inbox path issue"));
+        assert_eq!(
+            report.results[0].transcript_path_relative,
+            format!("sessions/2026/03/10/{file_name}")
+        );
+    }
+
+    #[test]
+    fn supports_project_session_and_since_filters() {
+        let cwd = temp_dir("filters");
+        let codex_home = cwd.join(".codex-home");
+        write_rollout(
+            &codex_home,
+            "2026-03-10T12:00:00.000Z",
+            "rollout-2026-03-10T12-00-00-session-a.jsonl",
+            &[
+                r#"{"type":"session_meta","payload":{"id":"session-a","timestamp":"2026-03-10T12:00:00.000Z","cwd":"/repo/current"}}"#,
+                r#"{"type":"response_item","payload":{"type":"function_call_output","output":"all_workers_idle fired after startup evidence was missing"}}"#,
+            ],
+        );
+        write_rollout(
+            &codex_home,
+            "2026-03-09T12:00:00.000Z",
+            "rollout-2026-03-09T12-00-00-session-b.jsonl",
+            &[
+                r#"{"type":"session_meta","payload":{"id":"session-b","timestamp":"2026-03-09T12:00:00.000Z","cwd":"/repo/other"}}"#,
+                r#"{"type":"event_msg","payload":{"type":"agent_message","message":"all_workers_idle should remain searchable in older sessions too"}}"#,
+            ],
+        );
+
+        let project_report = search_session_history(SessionSearchOptions {
+            query: "all_workers_idle".to_string(),
+            limit: Some(1),
+            session: Some("session-a".to_string()),
+            since: None,
+            project: Some("/repo/current".to_string()),
+            context: None,
+            case_sensitive: false,
+            cwd: Some(cwd.to_string_lossy().to_string()),
+            now: None,
+            codex_home_dir: Some(codex_home.to_string_lossy().to_string()),
+        })
+        .unwrap();
+        assert_eq!(project_report.results.len(), 1);
+        assert_eq!(project_report.results[0].session_id, "session-a");
+
+        let since_report = search_session_history(SessionSearchOptions {
+            query: "all_workers_idle".to_string(),
+            limit: None,
+            session: None,
+            since: Some("12h".to_string()),
+            project: None,
+            context: None,
+            case_sensitive: false,
+            cwd: Some(cwd.to_string_lossy().to_string()),
+            now: Some(
+                chrono::DateTime::parse_from_rfc3339("2026-03-10T18:00:00.000Z")
+                    .unwrap()
+                    .timestamp_millis(),
+            ),
+            codex_home_dir: Some(codex_home.to_string_lossy().to_string()),
+        })
+        .unwrap();
+        assert_eq!(since_report.results.len(), 1);
+        assert_eq!(since_report.results[0].session_id, "session-a");
+    }
+}

--- a/crates/omx-session-search/src/main.rs
+++ b/crates/omx-session-search/src/main.rs
@@ -1,0 +1,47 @@
+use omx_session_search::{search_session_history, SearchError, SessionSearchOptions};
+
+fn usage() -> &'static str {
+    "usage: omx-session-search --input <json-options>\n"
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("omx-session-search: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), SearchError> {
+    let mut args = std::env::args().skip(1);
+    let Some(flag) = args.next() else {
+        return Err(SearchError(usage().trim_end().to_string()));
+    };
+
+    if flag == "--help" || flag == "-h" {
+        print!("{}", usage());
+        return Ok(());
+    }
+
+    if flag != "--input" {
+        return Err(SearchError(usage().trim_end().to_string()));
+    }
+
+    let Some(input) = args.next() else {
+        return Err(SearchError(
+            "missing JSON payload after --input".to_string(),
+        ));
+    };
+    if args.next().is_some() {
+        return Err(SearchError("unexpected extra arguments".to_string()));
+    }
+
+    let options: SessionSearchOptions = serde_json::from_str(&input)
+        .map_err(|error| SearchError(format!("invalid JSON options: {error}")))?;
+    let report = search_session_history(options)?;
+    println!(
+        "{}",
+        serde_json::to_string(&report)
+            .map_err(|error| SearchError(format!("failed to encode search report: {error}")))?
+    );
+    Ok(())
+}

--- a/src/session-history/__tests__/search-native.test.ts
+++ b/src/session-history/__tests__/search-native.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  SESSION_SEARCH_BINARY_ENV,
+  SESSION_SEARCH_FORCE_TS_ENV,
+  resolveSessionSearchBinaryPath,
+  searchSessionHistory,
+} from '../search.js';
+
+describe('resolveSessionSearchBinaryPath', () => {
+  it('prefers explicit environment override', () => {
+    const previous = process.env[SESSION_SEARCH_BINARY_ENV];
+    try {
+      process.env[SESSION_SEARCH_BINARY_ENV] = '/custom/session-search';
+      assert.equal(
+        resolveSessionSearchBinaryPath({
+          cwd: '/repo',
+          env: process.env,
+          exists: () => false,
+        }),
+        '/custom/session-search',
+      );
+    } finally {
+      if (typeof previous === 'string') process.env[SESSION_SEARCH_BINARY_ENV] = previous;
+      else delete process.env[SESSION_SEARCH_BINARY_ENV];
+    }
+  });
+});
+
+describe('searchSessionHistory native bridge', () => {
+  it('uses the native binary when explicitly configured', async () => {
+    if (process.platform === 'win32') return;
+
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-native-'));
+    const fakeBinary = join(cwd, 'fake-session-search');
+    const previousBinary = process.env[SESSION_SEARCH_BINARY_ENV];
+    const previousForceTs = process.env[SESSION_SEARCH_FORCE_TS_ENV];
+
+    try {
+      await writeFile(
+        fakeBinary,
+        [
+          '#!/bin/sh',
+          'printf \'{"query":"native route","searched_files":1,"matched_sessions":1,"results":[{"session_id":"native-session","timestamp":"2026-03-10T12:00:00.000Z","cwd":"/repo/native","transcript_path":"/tmp/native.jsonl","transcript_path_relative":"sessions/2026/03/10/native.jsonl","record_type":"event_msg:user_message","line_number":2,"snippet":"native result"}]}\'',
+          '',
+        ].join('\n'),
+        'utf-8',
+      );
+      await chmod(fakeBinary, 0o755);
+      process.env[SESSION_SEARCH_BINARY_ENV] = fakeBinary;
+      delete process.env[SESSION_SEARCH_FORCE_TS_ENV];
+
+      const report = await searchSessionHistory({
+        query: 'native route',
+        cwd,
+        codexHomeDir: join(cwd, '.codex-home'),
+      });
+
+      assert.equal(report.results.length, 1);
+      assert.equal(report.results[0].session_id, 'native-session');
+      assert.equal(report.results[0].snippet, 'native result');
+    } finally {
+      if (typeof previousBinary === 'string') process.env[SESSION_SEARCH_BINARY_ENV] = previousBinary;
+      else delete process.env[SESSION_SEARCH_BINARY_ENV];
+      if (typeof previousForceTs === 'string') process.env[SESSION_SEARCH_FORCE_TS_ENV] = previousForceTs;
+      else delete process.env[SESSION_SEARCH_FORCE_TS_ENV];
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/session-history/search.ts
+++ b/src/session-history/search.ts
@@ -1,8 +1,9 @@
-import { createReadStream, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { createReadStream, existsSync, realpathSync } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
-import { codexHome } from '../utils/paths.js';
+import { codexHome, packageRoot } from '../utils/paths.js';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -53,6 +54,88 @@ const DEFAULT_CONTEXT = 80;
 const MAX_LIMIT = 100;
 const MAX_CONTEXT = 400;
 const DURATION_RE = /^(\d+)([smhdw])$/i;
+export const SESSION_SEARCH_BINARY_ENV = 'OMX_SESSION_SEARCH_BINARY';
+export const SESSION_SEARCH_FORCE_TS_ENV = 'OMX_SESSION_SEARCH_FORCE_TS';
+
+function sessionSearchBinaryName(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'omx-session-search.exe' : 'omx-session-search';
+}
+
+export function resolveSessionSearchBinaryPath(
+  options: {
+    cwd?: string;
+    packageRootDir?: string;
+    exists?: (path: string) => boolean;
+    env?: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+  } = {},
+): string | null {
+  const {
+    cwd = process.cwd(),
+    packageRootDir = packageRoot(),
+    exists = existsSync,
+    env = process.env,
+    platform = process.platform,
+  } = options;
+
+  const override = env[SESSION_SEARCH_BINARY_ENV]?.trim();
+  if (override) {
+    return isAbsolute(override) ? override : resolve(cwd, override);
+  }
+
+  const binaryName = sessionSearchBinaryName(platform);
+  const candidates = [
+    join(packageRootDir, 'target', 'debug', binaryName),
+    join(packageRootDir, 'target', 'release', binaryName),
+  ];
+
+  for (const candidate of candidates) {
+    if (exists(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+function maybeSearchSessionHistoryNative(options: Required<Pick<SessionSearchOptions, 'query' | 'cwd' | 'now' | 'codexHomeDir'>> & SessionSearchOptions): SessionSearchReport | null {
+  if (process.env[SESSION_SEARCH_FORCE_TS_ENV] === '1') return null;
+
+  const binaryPath = resolveSessionSearchBinaryPath({
+    cwd: options.cwd,
+    env: process.env,
+  });
+  if (!binaryPath) return null;
+
+  const payload = JSON.stringify({
+    query: options.query,
+    limit: options.limit,
+    session: options.session,
+    since: options.since,
+    project: options.project,
+    context: options.context,
+    caseSensitive: options.caseSensitive === true,
+    cwd: options.cwd,
+    now: options.now,
+    codexHomeDir: options.codexHomeDir,
+  });
+
+  try {
+    const stdout = execFileSync(binaryPath, ['--input', payload], {
+      cwd: options.cwd,
+      encoding: 'utf-8',
+      env: process.env,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return JSON.parse(stdout) as SessionSearchReport;
+  } catch (error) {
+    const execError = error as { stderr?: string | Buffer; message?: string };
+    const stderr = typeof execError.stderr === 'string'
+      ? execError.stderr.trim()
+      : Buffer.isBuffer(execError.stderr)
+        ? execError.stderr.toString('utf-8').trim()
+        : '';
+    throw new Error(stderr ? `omx-session-search failed: ${stderr}` : `omx-session-search failed: ${execError.message ?? 'unknown error'}`);
+  }
+}
 
 function clampInteger(value: number, fallback: number, max: number): number {
   if (!Number.isInteger(value) || value < 0) return fallback;
@@ -250,8 +333,31 @@ function buildSnippet(text: string, query: string, context: number, caseSensitiv
 function matchesFilter(value: string | null, filter: string | undefined, caseSensitive: boolean): boolean {
   if (!filter) return true;
   if (!value) return false;
-  if (caseSensitive) return value.includes(filter);
-  return value.toLowerCase().includes(filter.toLowerCase());
+  const matches = caseSensitive
+    ? value.includes(filter)
+    : value.toLowerCase().includes(filter.toLowerCase());
+  if (matches) return true;
+
+  if (looksLikeAbsolutePath(value) && looksLikeAbsolutePath(filter)) {
+    const normalizedValue = normalizeComparablePath(value);
+    const normalizedFilter = normalizeComparablePath(filter);
+    if (caseSensitive) return normalizedValue.includes(normalizedFilter);
+    return normalizedValue.toLowerCase().includes(normalizedFilter.toLowerCase());
+  }
+
+  return false;
+}
+
+function looksLikeAbsolutePath(value: string): boolean {
+  return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function normalizeComparablePath(value: string): string {
+  try {
+    return realpathSync.native(value);
+  } catch {
+    return resolve(value);
+  }
 }
 
 async function searchRolloutFile(
@@ -323,7 +429,7 @@ async function searchRolloutFile(
   return skipFile ? { meta, results: [] } : { meta, results };
 }
 
-export async function searchSessionHistory(options: SessionSearchOptions): Promise<SessionSearchReport> {
+async function searchSessionHistoryFallback(options: SessionSearchOptions): Promise<SessionSearchReport> {
   const query = options.query.trim();
   if (query === '') {
     throw new Error('Search query must not be empty.');
@@ -378,4 +484,26 @@ export async function searchSessionHistory(options: SessionSearchOptions): Promi
     matched_sessions: matchedSessions.size,
     results,
   };
+}
+
+export async function searchSessionHistory(options: SessionSearchOptions): Promise<SessionSearchReport> {
+  const query = options.query.trim();
+  if (query === '') {
+    throw new Error('Search query must not be empty.');
+  }
+
+  const normalizedOptions: SessionSearchOptions & Required<Pick<SessionSearchOptions, 'cwd' | 'now' | 'codexHomeDir'>> = {
+    ...options,
+    query,
+    cwd: options.cwd ?? process.cwd(),
+    now: options.now ?? Date.now(),
+    codexHomeDir: options.codexHomeDir ?? codexHome(),
+  };
+
+  const nativeReport = maybeSearchSessionHistoryNative(normalizedOptions);
+  if (nativeReport) {
+    return nativeReport;
+  }
+
+  return searchSessionHistoryFallback(normalizedOptions);
 }


### PR DESCRIPTION
## Summary

This ports the `session-history search engine` from TypeScript to Rust, while also preserving the existing CLI and TypeScript surface to ensure compatibility. This was chosen as one of the earlier modules to port to Rust due to its modularity and the expected gains in performance. This includes fully rewriting the `omx-session-search` crate in Rust; however, special consideration has been taken, so that this is explicitly compatible with the rest of the codebase written in TypeScript.

### What changed
- New, native crate will perform the session-history search from now on:
  - `crates/omx-session-search`
- Kept the TypeScript API/CLI stable:
  - `src/session-history/search.ts`
  - `src/cli/session-search.ts`
- Added native bridge coverage:
  - `src/session-history/__tests__/search-native.test.ts`

## Why this is needed, and beneficial:

Porting Session-History search to Rust from Typescript may be beneficial for the following reasons:
- **self-contained**: mostly transcript walking, JSONL parsing, filtering, and snippet generation; doesn't alter the existing TypeScript codebase too much.
- **performance-sensitive**: Rust based native scanning is a better fit than JS, especially for repeated file traversal and parsing.
- **low blast radius**: the CLI contract stays the same, and the TypeScript layer remains thin, yet mostly compatible with the existing codebase.

This led us to a Rust port with:
- **clean Rust core**
- **minimal TS adapter**
- **backward-compatible behavior**
- a migration path consistent with existing OMX native helpers like `omx-runtime`, `omx-explore`, and `omx-sparkshell`

## Design notes

- Rust now owns the session transcript search logic.
- TypeScript still owns:
  - CLI arg parsing
  - help text
  - human-readable report formatting
  - fallback behavior if the native binary is unavailable
- The result shape and CLI semantics were preserved.

## Considerations and Verification

- [x] `npm run build`
- [x] `npm test`
- [x] `omx doctor` (when setup/config behavior changes) — not required; no setup/config behavior changed
- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed for this change
- [x] Backward-compatibility impact considered

### Additional verification run
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `npm run lint`
- [x] Node 22 typecheck
- [x] Node 20 typecheck
- [x] Session-history smoke tests against the real native binary
- [x] Ralph persistence gate
- [x] CI Rust gate tests

## Scope

The scpe of this pull request was intentionally kept narrow:
- adds just one additional Rust crate
- Fully wired seamlessly to the existing codebase
- adds a thin, trivial TypeScript bridge
- preserves existing user-facing session search behavior, as is

## Backward compatibility

Backward compatibility was explicitly considered:
- `omx session search` interface remains unchanged
- TypeScript exports still remain intact
- fallback TypeScript based path remains available if the Rust binary is unavaiable for some reason

## Follow-ups

- This may be part of an overall plan of porting OMX to Rust from TypeScript in general.
- Though it wasn't performed yet, we may run a stress-test on the session-history search engine before and after the Rust rewrite, to determine whether if this addon really enhanced performance or not.
