### PR TITLE
fix(watcher): keep team fallback orchestration alive while live worker panes remain

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1444,6 +1444,191 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('stays alive after parent exit while an active team still has live worker panes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-team-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-team-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const teamStatePath = join(wd, '.omx', 'state', 'team-state.json');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state', 'team', 'dispatch-team'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(teamStatePath, JSON.stringify({
+        active: true,
+        team_name: 'dispatch-team',
+        current_phase: 'team-exec',
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'config.json'), JSON.stringify({
+        name: 'dispatch-team',
+        tmux_session: 'dispatch-team:0',
+        leader_pane_id: '%99',
+        workers: [
+          { name: 'worker-1', pane_id: '%42' },
+        ],
+      }, null, 2));
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        }
+      );
+
+      await waitFor(async () => isPidAlive(child?.pid), 4000, 50);
+      await waitFor(async () => {
+        const logEntries = (await readFile(logPath, 'utf-8').catch(() => ''))
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map((line) => JSON.parse(line));
+        return logEntries.some((entry: { type?: string; reason?: string }) => (
+          entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+        ));
+      }, 4000, 50);
+
+      assert.ok(isPidAlive(child.pid), 'expected watcher to stay alive while team worker panes remain active');
+
+      await writeFile(teamStatePath, JSON.stringify({
+        active: false,
+        team_name: 'dispatch-team',
+        current_phase: 'complete',
+        completed_at: new Date().toISOString(),
+      }, null, 2));
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+      )));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
+      )));
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('does not defer parent-loss shutdown for a team that is already terminal in phase.json', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-terminal-team-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-terminal-team-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state', 'team', 'dispatch-team'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'dispatch-team',
+        current_phase: 'team-exec',
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'phase.json'), JSON.stringify({
+        current_phase: 'complete',
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'config.json'), JSON.stringify({
+        name: 'dispatch-team',
+        tmux_session: 'dispatch-team:0',
+        leader_pane_id: '%99',
+        workers: [
+          { name: 'worker-1', pane_id: '%42' },
+        ],
+      }, null, 2));
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        }
+      );
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.equal(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+      )), false);
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
+      )));
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
   it('replaces a stale watcher from the per-cwd pid file', async () => {
     const replacementTimeoutMs = 20000; // c8-instrumented Node20 full runs can delay watcher handoff well beyond 8s.
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-stale-pid-'));

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -14,11 +14,13 @@ import {
 } from './notify-hook/auto-nudge.js';
 import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
 import {
+  checkWorkerPanesAlive,
   isLeaderStale,
   maybeNudgeTeamLeader,
   resolveLeaderStalenessThresholdMs,
 } from './notify-hook/team-leader-nudge.js';
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
+import { isTerminalPhase } from './notify-hook/utils.js';
 
 function argValue(name: string, fallback = ''): string {
   const idx = process.argv.indexOf(name);
@@ -158,6 +160,17 @@ interface ParentGuardState {
   reason: string;
   state_path: string;
   current_phase: string;
+  team_name?: string;
+  pane_count?: number;
+}
+
+interface ActiveTeamResult {
+  active: boolean;
+  reason: string;
+  path: string;
+  state: Record<string, unknown> | null;
+  team_name: string;
+  pane_count: number;
 }
 
 interface FallbackAutoNudgeState {
@@ -346,6 +359,79 @@ async function resolveActiveModeState(mode: string): Promise<ActiveModeResult> {
 
 async function resolveActiveRalphState(): Promise<ActiveModeResult> {
   return resolveActiveModeState('ralph');
+}
+
+async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
+  const candidateDirs: string[] = [];
+  const sessionPath = join(stateDir, 'session.json');
+  try {
+    const session = JSON.parse(await readFile(sessionPath, 'utf-8')) as Record<string, unknown>;
+    const sessionId = safeString(session?.session_id).trim();
+    if (sessionId) {
+      candidateDirs.push(join(stateDir, 'sessions', sessionId));
+    }
+  } catch {
+    // No active session file; fall back to root state only.
+  }
+  if (!candidateDirs.includes(stateDir)) candidateDirs.push(stateDir);
+
+  for (const dir of candidateDirs) {
+    const path = join(dir, 'team-state.json');
+    if (!existsSync(path)) continue;
+    const parsed = await readFile(path, 'utf-8')
+      .then((content) => JSON.parse(content) as Record<string, unknown>)
+      .catch(() => null);
+    if (!parsed || typeof parsed !== 'object' || parsed.active !== true) continue;
+
+    const teamName = safeString(parsed.team_name).trim();
+    if (!teamName) continue;
+
+    const teamConfigDir = join(stateDir, 'team', teamName);
+    const phasePath = join(teamConfigDir, 'phase.json');
+    const phaseState = existsSync(phasePath)
+      ? await readFile(phasePath, 'utf-8')
+        .then((content) => JSON.parse(content) as Record<string, unknown>)
+        .catch(() => null)
+      : null;
+    const phase = safeString(phaseState?.current_phase).trim();
+    if (phase && isTerminalPhase(phase)) continue;
+
+    const manifestPath = join(teamConfigDir, 'manifest.v2.json');
+    const configPath = join(teamConfigDir, 'config.json');
+    const teamConfigPath = existsSync(manifestPath) ? manifestPath : configPath;
+    const teamConfig = existsSync(teamConfigPath)
+      ? await readFile(teamConfigPath, 'utf-8')
+        .then((content) => JSON.parse(content) as Record<string, unknown>)
+        .catch(() => null)
+      : null;
+    const tmuxSession = safeString(teamConfig?.tmux_session).trim();
+    if (!tmuxSession) continue;
+
+    const workers = Array.isArray(teamConfig?.workers) ? teamConfig.workers as Array<Record<string, unknown>> : [];
+    const workerPaneIds: string[] = workers
+      .map((worker) => safeString(worker?.pane_id).trim())
+      .filter(Boolean);
+    const paneStatus = await checkWorkerPanesAlive(tmuxSession, workerPaneIds as any);
+    if (!paneStatus.alive) continue;
+
+    return {
+      active: true,
+      reason: 'active',
+      path,
+      state: parsed,
+      team_name: teamName,
+      pane_count: paneStatus.paneCount,
+    };
+  }
+
+  return {
+    active: false,
+    reason: 'cleared',
+    path: '',
+    state: null,
+    team_name: '',
+    pane_count: 0,
+  };
 }
 
 async function emitRalphContinueSteer(paneId: string, message: string): Promise<void> {
@@ -825,6 +911,8 @@ async function enforceLifecycleGuards(): Promise<boolean> {
         lastParentGuard.reason !== nextParentGuard.reason
         || lastParentGuard.state_path !== nextParentGuard.state_path
         || lastParentGuard.current_phase !== nextParentGuard.current_phase
+        || lastParentGuard.team_name !== nextParentGuard.team_name
+        || lastParentGuard.pane_count !== nextParentGuard.pane_count
       ) {
         await eventLog({
           type: 'watcher_parent_guard',
@@ -836,6 +924,37 @@ async function enforceLifecycleGuards(): Promise<boolean> {
       }
       return false;
     }
+
+    const activeTeam = await resolveActiveTeamState();
+    if (activeTeam.active) {
+      const currentPhase = safeString(activeTeam.state?.current_phase);
+      const nextParentGuard: ParentGuardState = {
+        reason: 'parent_gone_deferred_for_active_team',
+        state_path: activeTeam.path,
+        current_phase: currentPhase,
+        team_name: activeTeam.team_name,
+        pane_count: activeTeam.pane_count,
+      };
+      if (
+        lastParentGuard.reason !== nextParentGuard.reason
+        || lastParentGuard.state_path !== nextParentGuard.state_path
+        || lastParentGuard.current_phase !== nextParentGuard.current_phase
+        || lastParentGuard.team_name !== nextParentGuard.team_name
+        || lastParentGuard.pane_count !== nextParentGuard.pane_count
+      ) {
+        await eventLog({
+          type: 'watcher_parent_guard',
+          reason: nextParentGuard.reason,
+          state_path: nextParentGuard.state_path,
+          current_phase: currentPhase || null,
+          team_name: activeTeam.team_name,
+          pane_count: activeTeam.pane_count,
+        });
+        lastParentGuard = nextParentGuard;
+      }
+      return false;
+    }
+
     lastParentGuard = { reason: '', state_path: '', current_phase: '' };
     await requestShutdown('parent_gone');
     return true;


### PR DESCRIPTION
## Summary
This PR keeps the fallback watcher alive after leader parent loss when an active team still has live worker panes.

Closes #1042.

## Problem statement
Users can end up with tmux workers that are still running while the main leader-side orchestration stops. The fallback watcher is responsible for control-plane recovery work such as dispatch draining and leader nudges, but its parent-loss guard only deferred shutdown for active Ralph state.

That meant a plain team run could still lose its fallback control plane even though workers were visibly alive.

## Root cause
`enforceLifecycleGuards()` in `src/scripts/notify-fallback-watcher.ts` treated parent loss as survivable only for active Ralph state. It did not check whether an active team still had live worker panes, so the watcher exited and left the team without leader-side fallback orchestration.

## What changed
- added an active-team resolver in `src/scripts/notify-fallback-watcher.ts`
- taught the parent-loss lifecycle guard to defer shutdown when an active team still has live worker panes
- added a regression test proving the watcher survives parent loss until the active team becomes terminal

## Why this design
I kept the patch narrow and tied to the observed regression:
- it only changes the parent-loss guard
- it requires both active team state and live worker panes
- it avoids keeping the watcher alive for stale/crashed teams that only left behind state files

A broader redesign of watcher lifetime or max-lifetime handling would be riskier and belongs in a separate follow-up.

## Overlap assessment
**Classification:** Follow-up.

Related prior work:
- #1042 tracks this remaining parent-loss gap for plain active team runs
- #1010 / PR #1011 fixed linked `team + ralph` orchestration survival
- PR #965 restored launch-path watcher authority

This PR closes a remaining gap for plain active team runs: parent-loss shutdown still ignored active teams with live worker panes.

## Validation
- `npm run build`
- `npx biome lint src/scripts/notify-fallback-watcher.ts src/hooks/__tests__/notify-fallback-watcher.test.ts`
- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js`

## Risk / compatibility
- Expected behavior change: the watcher now survives parent loss for active teams that still have live worker panes.
- Unchanged behavior: the watcher still exits when the team becomes terminal, and it still shuts down for stale teams without live worker panes.
- Remaining risk: max-lifetime behavior for very long-lived active teams is unchanged in this patch.

## Files changed
- `src/scripts/notify-fallback-watcher.ts`
- `src/hooks/__tests__/notify-fallback-watcher.test.ts`
