### PR TITLE
fix(setup): restore Codex >= 0.107 [tui] guard

### DIFF
--- a/src/cli/__tests__/setup-codex-version.test.ts
+++ b/src/cli/__tests__/setup-codex-version.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parseCodexVersion, setup } from '../setup.js';
+
+async function writeFakeCodex(binDir: string): Promise<void> {
+  const codexPath = join(binDir, 'codex');
+  const script = [
+    '#!/usr/bin/env node',
+    'if (process.argv.includes("--version")) {',
+    '  process.stdout.write(process.env.OMX_TEST_CODEX_VERSION_OUTPUT ?? "0.106.0");',
+    '  process.exit(0);',
+    '}',
+    'process.exit(1);',
+    '',
+  ].join('\n');
+  await writeFile(codexPath, script, { mode: 0o755 });
+  await chmod(codexPath, 0o755);
+}
+
+async function runSetupWithCapturedLogs(
+  cwd: string,
+  env: Record<string, string>,
+): Promise<string> {
+  const previousCwd = process.cwd();
+  const previousEnv = {
+    HOME: process.env.HOME,
+    PATH: process.env.PATH,
+    OMX_TEST_CODEX_VERSION_OUTPUT: process.env.OMX_TEST_CODEX_VERSION_OUTPUT,
+  };
+  const logs: string[] = [];
+  const originalLog = console.log;
+
+  process.chdir(cwd);
+  process.env.HOME = env.HOME;
+  process.env.PATH = env.PATH;
+  process.env.OMX_TEST_CODEX_VERSION_OUTPUT = env.OMX_TEST_CODEX_VERSION_OUTPUT;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((arg) => String(arg)).join(' '));
+  };
+
+  try {
+    await setup({ scope: 'project' });
+    return logs.join('\n');
+  } finally {
+    console.log = originalLog;
+    process.chdir(previousCwd);
+    process.env.HOME = previousEnv.HOME;
+    process.env.PATH = previousEnv.PATH;
+    process.env.OMX_TEST_CODEX_VERSION_OUTPUT =
+      previousEnv.OMX_TEST_CODEX_VERSION_OUTPUT;
+  }
+}
+
+describe('omx setup codex version handling', () => {
+  it('parses codex versions from common --version outputs', () => {
+    assert.equal(parseCodexVersion('0.107.0'), '0.107.0');
+    assert.equal(parseCodexVersion('codex 0.107.1'), '0.107.1');
+    assert.equal(parseCodexVersion('v0.106.2'), '0.106.2');
+    assert.equal(parseCodexVersion('codex version: unknown'), undefined);
+  });
+
+  it('skips [tui] for codex >= 0.107.0', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-codex-version-'));
+    try {
+      const home = join(wd, 'home');
+      const binDir = join(wd, 'bin');
+      await mkdir(home, { recursive: true });
+      await mkdir(binDir, { recursive: true });
+      await writeFakeCodex(binDir);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+        OMX_TEST_CODEX_VERSION_OUTPUT: 'codex 0.107.1',
+      });
+
+      const config = await readFile(join(wd, '.codex', 'config.toml'), 'utf-8');
+      assert.doesNotMatch(config, /^\[tui\]$/m);
+      assert.match(
+        output,
+        /StatusLine \[tui\] skipped \(detected codex 0\.107\.1 >= 0\.107\.0\)\./,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps [tui] when codex version is unparseable (compatibility default)', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-codex-version-'));
+    try {
+      const home = join(wd, 'home');
+      const binDir = join(wd, 'bin');
+      await mkdir(home, { recursive: true });
+      await mkdir(binDir, { recursive: true });
+      await writeFakeCodex(binDir);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+        OMX_TEST_CODEX_VERSION_OUTPUT: 'codex version: unknown',
+      });
+
+      const config = await readFile(join(wd, '.codex', 'config.toml'), 'utf-8');
+      assert.match(config, /^\[tui\]$/m);
+      assert.match(
+        output,
+        /StatusLine configured in config\.toml via \[tui\] section \(codex version unparseable; compatibility mode\)\./,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -47,6 +47,14 @@ interface SetupOptions {
   ) => Promise<boolean>;
 }
 
+const CODEX_TUI_REMOVED_VERSION = [0, 107, 0] as const;
+
+interface CodexVersionDetection {
+  includeTuiSection: boolean;
+  version?: string;
+  reason: "detected" | "unavailable" | "unparseable";
+}
+
 /**
  * Legacy scope values that may appear in persisted setup-scope.json files.
  * Both 'project-local' (renamed) and old 'project' (minimal, removed) are
@@ -117,6 +125,55 @@ const DEFAULT_SETUP_SCOPE: SetupScope = "user";
 
 const LEGACY_SETUP_MODEL = "gpt-5.3-codex";
 const DEFAULT_SETUP_MODEL = "gpt-5.4";
+
+export function parseCodexVersion(output: string): string | undefined {
+  const match = output.match(/(?:^|\s|\b)v?(\d+)\.(\d+)\.(\d+)(?=\b|\s|$)/i);
+  if (!match) return undefined;
+  return `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`;
+}
+
+function parseSemverTriplet(
+  version: string,
+): [number, number, number] | undefined {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemverTriplet(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number],
+): number {
+  if (left[0] !== right[0]) return left[0] - right[0];
+  if (left[1] !== right[1]) return left[1] - right[1];
+  return left[2] - right[2];
+}
+
+export function shouldIncludeTuiSection(version: string): boolean {
+  const parsed = parseSemverTriplet(version);
+  if (!parsed) return true;
+  return compareSemverTriplet(parsed, CODEX_TUI_REMOVED_VERSION) < 0;
+}
+
+function detectCodexVersion(): CodexVersionDetection {
+  const result = spawnSync("codex", ["--version"], { encoding: "utf-8" });
+  if (result.status !== 0) {
+    return { includeTuiSection: true, reason: "unavailable" };
+  }
+
+  const versionText = parseCodexVersion(
+    `${result.stdout || ""}\n${result.stderr || ""}`,
+  );
+  if (!versionText) {
+    return { includeTuiSection: true, reason: "unparseable" };
+  }
+
+  return {
+    includeTuiSection: shouldIncludeTuiSection(versionText),
+    version: versionText,
+    reason: "detected",
+  };
+}
 
 function createEmptyCategorySummary(): SetupCategorySummary {
   return {
@@ -353,6 +410,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
   const scopeSourceMessage =
     resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
+  const codexVersion = detectCodexVersion();
 
   console.log("oh-my-codex setup");
   console.log("=================\n");
@@ -472,7 +530,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     scopeDirs.nativeAgentsDir,
     summary.config,
     backupContext,
-    { dryRun, verbose, modelUpgradePrompt },
+    {
+      dryRun,
+      verbose,
+      modelUpgradePrompt,
+      includeTuiSection: codexVersion.includeTuiSection,
+    },
   );
   console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
 
@@ -564,7 +627,25 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   } else {
     console.log("  HUD config already exists (use --force to overwrite).");
   }
-  console.log("  StatusLine configured in config.toml via [tui] section.");
+  if (codexVersion.includeTuiSection) {
+    if (codexVersion.reason === "detected" && codexVersion.version) {
+      console.log(
+        `  StatusLine configured in config.toml via [tui] section (codex ${codexVersion.version}).`,
+      );
+    } else if (codexVersion.reason === "unavailable") {
+      console.log(
+        "  StatusLine configured in config.toml via [tui] section (codex version unavailable; compatibility mode).",
+      );
+    } else {
+      console.log(
+        "  StatusLine configured in config.toml via [tui] section (codex version unparseable; compatibility mode).",
+      );
+    }
+  } else {
+    console.log(
+      `  StatusLine [tui] skipped (detected codex ${codexVersion.version} >= 0.107.0).`,
+    );
+  }
   console.log();
 
   console.log("Setup refresh summary:");
@@ -959,7 +1040,10 @@ async function updateManagedConfig(
   agentsConfigDir: string,
   summary: SetupCategorySummary,
   backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt">,
+  options: Pick<
+    SetupOptions,
+    "dryRun" | "verbose" | "modelUpgradePrompt"
+  > & { includeTuiSection: boolean },
 ): Promise<void> {
   const existing = existsSync(configPath)
     ? await readFile(configPath, "utf-8")
@@ -983,6 +1067,7 @@ async function updateManagedConfig(
 
   const finalConfig = buildMergedConfig(existing, pkgRoot, {
     agentsConfigDir,
+    includeTuiSection: options.includeTuiSection,
     modelOverride,
     verbose: options.verbose,
   });

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -345,4 +345,34 @@ describe('config generator', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('skips [tui] section when includeTuiSection is false', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd, { includeTuiSection: false });
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.doesNotMatch(toml, /^\[tui\]$/m);
+      assert.doesNotMatch(toml, /^status_line = \[/m);
+      assert.match(toml, /^\[mcp_servers\.omx_state\]$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes prior OMX [tui] section when rerun with includeTuiSection false', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd);
+      await mergeConfig(configPath, wd, { includeTuiSection: false });
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.doesNotMatch(toml, /^\[tui\]$/m);
+      assert.doesNotMatch(toml, /^status_line = \[/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -19,6 +19,7 @@ import { omxAgentsConfigDir } from "../utils/paths.js";
 
 interface MergeOptions {
   agentsConfigDir?: string;
+  includeTuiSection?: boolean;
   modelOverride?: string;
   verbose?: boolean;
 }
@@ -423,7 +424,11 @@ function getAgentEntries(agentsConfigDir: string): string[] {
  * OMX table-section block (MCP servers, TUI).
  * Contains ONLY [table] sections — no bare keys.
  */
-function getOmxTablesBlock(pkgRoot: string, agentsConfigDir: string): string {
+function getOmxTablesBlock(
+  pkgRoot: string,
+  agentsConfigDir: string,
+  includeTuiSection = true,
+): string {
   const stateServerPath = escapeTomlString(
     join(pkgRoot, "dist", "mcp", "state-server.js"),
   );
@@ -440,7 +445,7 @@ function getOmxTablesBlock(pkgRoot: string, agentsConfigDir: string): string {
     join(pkgRoot, "dist", "mcp", "team-server.js"),
   );
 
-  return [
+  const lines = [
     "",
     "# ============================================================",
     "# oh-my-codex (OMX) Configuration",
@@ -482,15 +487,25 @@ function getOmxTablesBlock(pkgRoot: string, agentsConfigDir: string): string {
     "enabled = true",
     "startup_timeout_sec = 5",
     ...getAgentEntries(agentsConfigDir),
-    "",
-    "# OMX TUI StatusLine (Codex CLI v0.101.0+)",
-    "[tui]",
-    'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit"]',
+  ];
+
+  if (includeTuiSection) {
+    lines.push(
+      "",
+      "# OMX TUI StatusLine (Codex CLI v0.101.0+)",
+      "[tui]",
+      'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit"]',
+    );
+  }
+
+  lines.push(
     "",
     "# ============================================================",
     "# End oh-my-codex",
     "",
-  ].join("\n");
+  );
+
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -534,6 +549,7 @@ export function buildMergedConfig(
   const tablesBlock = getOmxTablesBlock(
     pkgRoot,
     options.agentsConfigDir || omxAgentsConfigDir(),
+    options.includeTuiSection ?? true,
   );
 
   return topLines.join("\n") + "\n\n" + existing.trimEnd() + "\n" + tablesBlock;


### PR DESCRIPTION
## Summary

Restore the Codex-version gate that skips managed `[tui]` config on Codex CLI `>= 0.107.0`.

This fixes the regression reported in #1044, where rerunning `omx setup` against an existing config that already contains `[tui]` can append a second `[tui]` table and leave Codex with an invalid `config.toml`.

## Root cause

`main` currently has three pieces of behavior that combine badly on modern Codex:
- `src/config/generator.ts` still appends a managed `[tui]` block unconditionally
- the config merge path intentionally preserves pre-existing user-owned `[tui]` sections
- `src/cli/setup.ts` no longer gates `[tui]` generation on the local Codex CLI version

That means `omx setup` can reintroduce an invalid duplicate `[tui]` table on Codex versions where OMX should not be writing `[tui]` at all.

## Changes

- detect the local Codex CLI version during `omx setup`
- skip managed `[tui]` generation for Codex `>= 0.107.0`
- thread `includeTuiSection` through config generation so reruns remove prior OMX-managed `[tui]`
- add regression coverage for version parsing/setup behavior and config generation without `[tui]`

## Why this fix

This restores the behavior already documented in the v0.8.2 release notes and keeps the patch narrowly scoped:
- modern Codex gets the intended no-`[tui]` behavior back
- older/unparseable/unavailable Codex detection still falls back to compatibility mode
- the existing legacy `[tui]` merge strategy is left unchanged rather than risk deleting user-owned settings

Follow-up for the older-Codex merge edge case: #1046.

## Validation

- [x] `npm run build`
- [ ] `npm test` (still reports unrelated existing failures in current `main`, including `omx ask`, `omx launch fallback when tmux is unavailable`, `omx session search`, and some notify/team suites)
- [x] `omx doctor` (manual temp-home repro after `omx setup` on codex-cli `0.116.0`)

Additional checks run:
- [x] `npm run lint`
- [x] `node --test dist/cli/__tests__/setup-codex-version.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/doctor-invalid-config.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — no doc diff needed because this restores the already-documented behavior from v0.8.2
- [x] Backward-compatibility impact considered

## Related

Closes #1044
Follow-up: #1046
