### PR TITLE
fix(setup): skip OMX [tui] for Codex >= 0.107

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -232,6 +232,52 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("skips OMX-managed [tui] writes for Codex CLI >= 0.107.0 and preserves an existing [tui] table", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".codex"), { recursive: true });
+      await writeFile(
+        join(wd, ".codex", "config.toml"),
+        ['model = "gpt-5.4"', "", "[tui]", 'theme = "night"', 'status_line = ["git-branch"]', ""].join("\n"),
+      );
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: "project",
+        codexVersionProbe: () => "codex-cli 0.107.0",
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.equal(config.match(/^\[tui\]$/gm)?.length ?? 0, 1);
+      assert.match(config, /^theme = "night"$/m);
+      assert.match(config, /^status_line = \["git-branch"\]$/m);
+      assert.match(
+        output,
+        /Codex CLI >= 0\.107\.0 manages \[tui\]; OMX left that section untouched\./,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps OMX-managed [tui] writes for older Codex CLI versions", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: "project",
+        codexVersionProbe: () => "codex-cli 0.106.0",
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(config, /^\[tui\]$/m);
+      assert.match(output, /StatusLine configured in config\.toml via \[tui\] section\./);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("syncs shared MCP registry entries into config.toml during setup", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -49,8 +49,10 @@ import {
   resolveAgentsModelTableContext,
   upsertAgentsModelTable,
 } from "../utils/agents-model-table.js";
+import { spawnPlatformCommandSync } from "../utils/platform-command.js";
 
 interface SetupOptions {
+  codexVersionProbe?: () => string | null;
   force?: boolean;
   dryRun?: boolean;
   scope?: SetupScope;
@@ -104,6 +106,11 @@ interface SetupBackupContext {
   baseRoot: string;
 }
 
+interface ManagedConfigResult {
+  finalConfig: string;
+  omxManagesTui: boolean;
+}
+
 export interface SkillFrontmatterMetadata {
   name: string;
   description: string;
@@ -138,6 +145,7 @@ const DEFAULT_SETUP_SCOPE: SetupScope = "user";
 const LEGACY_SETUP_MODEL = "gpt-5.3-codex";
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
 const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
+const TUI_OWNED_BY_CODEX_VERSION = [0, 107, 0] as const;
 
 function createEmptyCategorySummary(): SetupCategorySummary {
   return {
@@ -425,6 +433,38 @@ async function promptForModelUpgrade(
   }
 }
 
+function parseSemverTriplet(version: string): [number, number, number] | null {
+  const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function semverGte(
+  version: [number, number, number],
+  minimum: readonly [number, number, number],
+): boolean {
+  if (version[0] !== minimum[0]) return version[0] > minimum[0];
+  if (version[1] !== minimum[1]) return version[1] > minimum[1];
+  return version[2] >= minimum[2];
+}
+
+function probeInstalledCodexVersion(): string | null {
+  const { result } = spawnPlatformCommandSync("codex", ["--version"], {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0) return null;
+  const stdout = (result.stdout || "").trim();
+  return stdout === "" ? null : stdout;
+}
+
+function shouldOmxManageTuiFromCodexVersion(versionOutput: string | null): boolean {
+  if (!versionOutput) return true;
+  const parsed = parseSemverTriplet(versionOutput);
+  if (!parsed) return true;
+  return !semverGte(parsed, TUI_OWNED_BY_CODEX_VERSION);
+}
+
 async function promptForAgentsOverwrite(
   destinationPath: string,
 ): Promise<boolean> {
@@ -696,14 +736,15 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   for (const warning of sharedMcpRegistry.warnings) {
     console.log(`  warning: ${warning}`);
   }
-  const resolvedConfig = await updateManagedConfig(
+  const managedConfig = await updateManagedConfig(
     scopeDirs.codexConfigFile,
     pkgRoot,
     sharedMcpRegistry,
     summary.config,
     backupContext,
-    { dryRun, verbose, modelUpgradePrompt },
+    { codexVersionProbe: options.codexVersionProbe, dryRun, verbose, modelUpgradePrompt },
   );
+  const resolvedConfig = managedConfig.finalConfig;
   if (resolvedScope.scope === "user") {
     await syncClaudeCodeMcpSettings(
       sharedMcpRegistry,
@@ -856,7 +897,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   } else {
     console.log("  HUD config already exists (use --force to overwrite).");
   }
-  console.log("  StatusLine configured in config.toml via [tui] section.");
+  if (managedConfig.omxManagesTui) {
+    console.log("  StatusLine configured in config.toml via [tui] section.");
+  } else {
+    console.log("  Codex CLI >= 0.107.0 manages [tui]; OMX left that section untouched.");
+  }
   console.log();
 
   console.log("Setup refresh summary:");
@@ -1402,13 +1447,19 @@ async function updateManagedConfig(
   sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
   summary: SetupCategorySummary,
   backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt">,
-): Promise<string> {
+  options: Pick<
+    SetupOptions,
+    "codexVersionProbe" | "dryRun" | "verbose" | "modelUpgradePrompt"
+  >,
+): Promise<ManagedConfigResult> {
   const existing = existsSync(configPath)
     ? await readFile(configPath, "utf-8")
     : "";
   const currentModel = getRootModelName(existing);
   let modelOverride: string | undefined;
+  const codexVersion =
+    options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
+  const omxManagesTui = shouldOmxManageTuiFromCodexVersion(codexVersion);
 
   if (currentModel === LEGACY_SETUP_MODEL) {
     const shouldPrompt =
@@ -1425,6 +1476,7 @@ async function updateManagedConfig(
   }
 
   const finalConfig = buildMergedConfig(existing, pkgRoot, {
+    includeTui: omxManagesTui,
     modelOverride,
     sharedMcpServers: sharedMcpRegistry.servers,
     sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
@@ -1434,7 +1486,7 @@ async function updateManagedConfig(
 
   if (!changed) {
     summary.unchanged += 1;
-    return finalConfig;
+    return { finalConfig, omxManagesTui };
   }
 
   if (
@@ -1469,7 +1521,7 @@ async function updateManagedConfig(
       `  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
     );
   }
-  return finalConfig;
+  return { finalConfig, omxManagesTui };
 }
 
 function getClaudeCodeSettingsPath(homeDir = homedir()): string {

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -357,6 +357,15 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
+  it("skips emitting an OMX [tui] table when includeTui is disabled", () => {
+    const toml = buildMergedConfig("", "/tmp/omx", {
+      includeTui: false,
+    });
+
+    assert.doesNotMatch(toml, /^\[tui\]$/m);
+    assert.match(toml, /^\[mcp_servers\.omx_state\]$/m);
+  });
+
   it("replaces an existing OMX notify entry without leaving orphan fragments behind", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -18,6 +18,7 @@ import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 
 interface MergeOptions {
+  includeTui?: boolean;
   modelOverride?: string;
   sharedMcpServers?: UnifiedMcpRegistryServer[];
   sharedMcpRegistrySource?: string;
@@ -713,6 +714,7 @@ export function buildMergedConfig(
   options: MergeOptions = {},
 ): string {
   let existing = existingConfig;
+  const includeTui = options.includeTui !== false;
 
   if (existing.includes("oh-my-codex (OMX) Configuration")) {
     const stripped = stripExistingOmxBlocks(existing);
@@ -731,7 +733,9 @@ export function buildMergedConfig(
   existing = stripOrphanedOmxSections(existing);
   existing = upsertFeatureFlags(existing);
   existing = upsertAgentsSettings(existing);
-  const tuiUpsert = upsertTuiStatusLine(existing);
+  const tuiUpsert = includeTui
+    ? upsertTuiStatusLine(existing)
+    : { cleaned: existing, hadExistingTui: false };
   existing = tuiUpsert.cleaned;
 
   const topLines = getOmxTopLevelLines(
@@ -739,7 +743,10 @@ export function buildMergedConfig(
     existing,
     options.modelOverride,
   );
-  const tablesBlock = getOmxTablesBlock(pkgRoot, !tuiUpsert.hadExistingTui);
+  const tablesBlock = getOmxTablesBlock(
+    pkgRoot,
+    includeTui && !tuiUpsert.hadExistingTui,
+  );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(
     options.sharedMcpServers ?? [],
     options.sharedMcpRegistrySource,


### PR DESCRIPTION
## Summary
- detect the installed Codex CLI version during setup and stop OMX from managing `[tui]` on Codex >= 0.107.0
- keep legacy OMX-managed `[tui]` behavior for older Codex versions and make the setup messaging reflect the owner
- add regression coverage for the new and legacy version paths plus a generator-level `includeTui` guard

Closes #1044

## Testing
- npm run build
- node --test dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-refresh.test.js
- npm run lint
- npm run check:no-unused