### PR TITLE
fix: default omx explore routing and setup adoption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,22 +224,31 @@ Broad Request Detection:
 A request is broad when it uses vague verbs without targets, names no specific file or function, touches 3+ areas, or is a single sentence without a clear deliverable. For broad work: explore first, then plan if needed.
 
 Command Routing:
-- When `USE_OMX_EXPLORE_CMD` enables advisory routing, prefer `omx explore` as the default surface for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
+- When `USE_OMX_EXPLORE_CMD` enables advisory routing, strongly prefer `omx explore` as the default surface for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
+- For simple file/symbol lookups, use `omx explore` FIRST before attempting full code analysis.
 - Keep ambiguous, implementation-heavy, edit-heavy, or non-shell-only work on the normal Codex path.
 - If `omx explore` is unavailable or fails, gracefully fall back to the normal path.
 - Let `omx explore` keep direct inspection by default and use `omx sparkshell` only as an adaptive backend for qualifying read-only shell-native tasks.
 - For explicit tmux-pane / worker / leader / HUD inspection, prefer `omx sparkshell --tmux-pane ...` when a larger-tail read or bounded summary is useful. Sparkshell pane mode is explicit opt-in, not always-on.
 
+When to use what:
+- If the task is a simple read-only file/symbol/pattern/relationship lookup -> use `omx explore` first.
+- If the task is a noisy read-only shell command, verification run, repo-wide search/listing, or tmux-pane summary -> use `omx sparkshell`.
+- If the task needs edits, tests with exact raw stderr, MCP/web access, complex shell composition, or broad ambiguous analysis -> stay on the richer normal Codex path.
+- If `omx explore` or `omx sparkshell` returns incomplete or ambiguous results -> retry with a narrower prompt/command, then fall back to the normal path.
+
 Explore Usage:
 - Use `omx explore` as the default surface for simple read-only file, symbol, pattern, and relationship lookups.
 - Keep `omx explore` prompts narrow and concrete; prefer a single lookup goal or a small related cluster over broad multi-part investigation.
-- Prefer `omx explore --prompt ...` for quick one-off lookups and `omx explore --prompt-file ...` when the search brief is longer or reusable.
+- Prefer `omx explore --prompt ...` for quick one-off lookups and `omx explore --prompt-file ...` for longer reusable briefs.
+- Good explore examples: `omx explore --prompt "which files define TeamPolicy"` and `omx explore --prompt "find usages of buildExploreRoutingGuidance"`.
 - Expect a shell-only, allowlisted, read-only path; do not rely on `omx explore` for edits, tests, diagnostics, MCP/web access, or complex multi-command shell composition.
 - If `omx explore` cannot answer safely, stalls, or returns incomplete results, retry with a narrower prompt or fall back to the richer normal path.
 
 Sparkshell Usage:
-- Protect context budget by default: prefer `omx sparkshell` for noisy read-only and verification commands where full raw output is usually wasteful.
+- Protect context budget by default: strongly prefer `omx sparkshell` for noisy read-only and verification commands where full raw output is usually wasteful.
 - Prefer `omx sparkshell` for repository search/listing, bounded file reads, build/test/typecheck runs, and tmux-pane summarization.
+- Good sparkshell examples: `omx sparkshell -- rg -n "TeamPolicy" src`, `omx sparkshell -- npm test`, and `omx sparkshell --tmux-pane %12`.
 - Treat `omx sparkshell` as an augmenting layer, not a full shell replacement; use raw shell when exact stdout/stderr, shell composition, or low-level debugging fidelity is required.
 - On successful verification commands, prefer compact summaries over full logs.
 - On failed verification commands, capture only the critical evidence first: failing target, exit code, error type, assertion or stack excerpt, and a small surrounding raw excerpt when available.

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -30,7 +30,7 @@ Default: explore first, ask last.
 - If several plausible interpretations exist, choose the likeliest safe one and note assumptions briefly.
 - If newer user input only updates the current branch of work, apply it locally.
 - Ask one precise question only when progress is impossible.
-- When active session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups; keep prompts narrow and concrete, and keep edits, tests, ambiguous investigations, and other non-shell-only work on the richer normal path, with graceful fallback if `omx explore` is unavailable.
+- When active session guidance enables `USE_OMX_EXPLORE_CMD`, use `omx explore` FIRST for simple read-only file/symbol/pattern lookups; keep prompts narrow and concrete, prefer it before full code analysis, use `omx sparkshell` for noisy read-only shell output or verification summaries, and keep edits, tests, ambiguous investigations, and other non-shell-only work on the richer normal path, with graceful fallback if `omx explore` is unavailable.
 </ask_gate>
 
 - Do not claim completion without fresh verification output.

--- a/prompts/sisyphus-lite.md
+++ b/prompts/sisyphus-lite.md
@@ -22,7 +22,7 @@ Default: explore first, ask last.
 - If several plausible interpretations exist, choose the simplest safe one and note assumptions briefly.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - Ask only when progress is truly impossible.
-- When active session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups; keep prompts narrow and concrete, and keep edits, ambiguous work, and non-shell-only tasks on the richer normal path and fall back normally if `omx explore` is unavailable.
+- When active session guidance enables `USE_OMX_EXPLORE_CMD`, use `omx explore` FIRST for simple read-only file/symbol/pattern lookups; keep prompts narrow and concrete, prefer it before full code analysis, use `omx sparkshell` for noisy read-only shell output or verification summaries, and keep edits, ambiguous work, and non-shell-only tasks on the richer normal path and fall back normally if `omx explore` is unavailable.
 
 - Do not claim completion without fresh verification output.
 - Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -146,4 +146,33 @@ command = "node"
       }
     });
   });
+
+  it('warns when explore routing is explicitly disabled in config.toml', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-routing-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        `
+[env]
+USE_OMX_EXPLORE_CMD = "off"
+`.trimStart(),
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Explore routing: disabled in config\.toml \[env\]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -211,6 +211,8 @@ describe("omx setup scope behavior", () => {
       assert.match(configToml, /^\[agents\]$/m);
       assert.match(configToml, /^max_threads = 6$/m);
       assert.match(configToml, /^max_depth = 2$/m);
+      assert.match(configToml, /^\[env\]$/m);
+      assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
       const agentsMd = await readFile(agentsMdPath, "utf-8");
       assert.match(agentsMd, /\.\/\.codex\/prompts/);
       assert.match(agentsMd, /\.\/\.codex\/skills/);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -15,6 +15,7 @@ import { parse as parseToml } from '@iarna/toml';
 import { resolvePackagedExploreHarnessCommand, EXPLORE_BIN_ENV } from './explore.js';
 import { getPackageRoot } from '../utils/package.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
+import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
 import { isLeaderRuntimeStale } from '../team/leader-activity.js';
 
 interface DoctorOptions {
@@ -128,6 +129,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
   // Check 4: Config file
   checks.push(await checkConfig(paths.configPath));
+
+  // Check 4.5: Explore routing default
+  checks.push(await checkExploreRouting(paths.configPath));
 
   // Check 5: Prompts installed
   checks.push(await checkPrompts(paths.promptsDir));
@@ -586,6 +590,59 @@ async function checkConfig(configPath: string): Promise<Check> {
     };
   } catch {
     return { name: 'Config', status: 'fail', message: 'cannot read config.toml' };
+  }
+}
+
+
+async function checkExploreRouting(configPath: string): Promise<Check> {
+  const envValue = process.env[OMX_EXPLORE_CMD_ENV];
+  if (typeof envValue === 'string' && !isExploreCommandRoutingEnabled(process.env)) {
+    return {
+      name: 'Explore routing',
+      status: 'warn',
+      message:
+        'disabled by environment override; enable with USE_OMX_EXPLORE_CMD=1 (or remove the explicit opt-out)',
+    };
+  }
+
+  if (!existsSync(configPath)) {
+    return {
+      name: 'Explore routing',
+      status: 'pass',
+      message: 'enabled by default (config.toml not found yet)',
+    };
+  }
+
+  try {
+    const content = await readFile(configPath, 'utf-8');
+    const parsed = parseToml(content) as { env?: Record<string, unknown> };
+    const configuredValue = parsed?.env?.USE_OMX_EXPLORE_CMD;
+
+    if (
+      typeof configuredValue === 'string' &&
+      !isExploreCommandRoutingEnabled({
+        USE_OMX_EXPLORE_CMD: configuredValue,
+      })
+    ) {
+      return {
+        name: 'Explore routing',
+        status: 'warn',
+        message:
+          'disabled in config.toml [env]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing',
+      };
+    }
+
+    return {
+      name: 'Explore routing',
+      status: 'pass',
+      message: 'enabled by default',
+    };
+  } catch {
+    return {
+      name: 'Explore routing',
+      status: 'fail',
+      message: 'cannot read config.toml for explore routing check',
+    };
   }
 }
 

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -7,6 +7,7 @@ import { existsSync } from "fs";
 import { join, basename } from "path";
 import {
   stripExistingOmxBlocks,
+  stripOmxEnvSettings,
   stripOmxTopLevelKeys,
   stripOmxFeatureFlags,
 } from "../config/generator.js";
@@ -51,6 +52,7 @@ function detectOmxConfigArtifacts(config: string): {
   hasTuiSection: boolean;
   hasTopLevelKeys: boolean;
   hasFeatureFlags: boolean;
+  hasExploreRoutingEnv: boolean;
 } {
   const hasMcpServers = OMX_MCP_SERVERS.filter((name) =>
     new RegExp(`\\[mcp_servers\\.${name}\\]`).test(config),
@@ -77,6 +79,7 @@ function detectOmxConfigArtifacts(config: string): {
   const hasFeatureFlags =
     /^\s*multi_agent\s*=\s*true/m.test(config) ||
     /^\s*child_agents_md\s*=\s*true/m.test(config);
+  const hasExploreRoutingEnv = /^\s*USE_OMX_EXPLORE_CMD\s*=/m.test(config);
 
   return {
     hasMcpServers,
@@ -84,6 +87,7 @@ function detectOmxConfigArtifacts(config: string): {
     hasTuiSection,
     hasTopLevelKeys,
     hasFeatureFlags,
+    hasExploreRoutingEnv,
   };
 }
 
@@ -134,6 +138,9 @@ async function cleanConfig(
 
   // Strip feature flags
   config = stripOmxFeatureFlags(config);
+
+  // Strip OMX-managed env defaults
+  config = stripOmxEnvSettings(config);
 
   // Normalize trailing whitespace
   config = config.trimEnd() + "\n";

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -8,6 +8,7 @@ Resolved setup scope: user
   [EXPLORE_HARNESS_STATUS]
   [OK] Codex home: <CODEX_HOME>
   [!!] Config: config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)
+  [OK] Explore routing: enabled by default
   [!!] Prompts: prompts directory not found
   [!!] Skills: skills directory not found
   [!!] AGENTS.md: not found in <CODEX_HOME>/AGENTS.md (run omx setup --scope user)

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -67,6 +67,12 @@ function assertSingleOmxBlock(toml: string): void {
     1,
     "developer_instructions should appear once",
   );
+  assert.equal(count(toml, /^\[env\]$/gm), 1, "[env] should appear once");
+  assert.equal(
+    count(toml, /^USE_OMX_EXPLORE_CMD = "1"$/gm),
+    1,
+    "USE_OMX_EXPLORE_CMD should appear once",
+  );
 }
 
 describe("config generator idempotency (#384)", () => {
@@ -364,6 +370,26 @@ describe("config generator idempotency (#384)", () => {
 
     assert.doesNotMatch(toml, /^\[tui\]$/m);
     assert.match(toml, /^\[mcp_servers\.omx_state\]$/m);
+    assert.match(toml, /^\[env\]$/m);
+    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
+  });
+
+  it('seeds USE_OMX_EXPLORE_CMD=1 into generated config by default', () => {
+    const toml = buildMergedConfig('', '/tmp/omx');
+
+    assert.match(toml, /^\[env\]$/m);
+    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "1"$/m);
+  });
+
+  it('preserves existing [env] keys and explicit explore routing opt-outs', () => {
+    const toml = buildMergedConfig(
+      ['[env]', 'FOO = "bar"', 'USE_OMX_EXPLORE_CMD = "0"', ''].join('\n'),
+      '/tmp/omx',
+    );
+
+    assert.match(toml, /^\[env\]$/m);
+    assert.match(toml, /^FOO = "bar"$/m);
+    assert.match(toml, /^USE_OMX_EXPLORE_CMD = "0"$/m);
   });
 
   it("replaces an existing OMX notify entry without leaving orphan fragments behind", async () => {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -7,7 +7,7 @@
  * [table] header.  This generator therefore splits its output into:
  *   1. Top-level keys  (notify, model_reasoning_effort, developer_instructions)
  *   2. [features] flags
- *   3. [table] sections (mcp_servers, tui)
+ *   3. [table] sections (env, mcp_servers, tui)
  */
 
 import { readFile, writeFile } from "fs/promises";
@@ -48,6 +48,8 @@ const SHARED_MCP_REGISTRY_END_MARKER =
   "# End oh-my-codex shared MCP registry sync";
 const OMX_AGENTS_MAX_THREADS = 6;
 const OMX_AGENTS_MAX_DEPTH = 2;
+const OMX_EXPLORE_ROUTING_DEFAULT = '1';
+const OMX_EXPLORE_CMD_ENV = 'USE_OMX_EXPLORE_CMD';
 const OMX_TUI_STATUS_LINE =
   'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"]';
 
@@ -229,6 +231,48 @@ function upsertFeatureFlags(config: string): string {
   return lines.join("\n");
 }
 
+function upsertEnvSettings(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const envStart = lines.findIndex((line) => /^\s*\[env\]\s*$/.test(line));
+
+  if (envStart < 0) {
+    const base = config.trimEnd();
+    const envBlock = [
+      "[env]",
+      `${OMX_EXPLORE_CMD_ENV} = "${OMX_EXPLORE_ROUTING_DEFAULT}"`,
+      "",
+    ].join("\n");
+    if (base.length === 0) return envBlock;
+    return `${base}\n\n${envBlock}`;
+  }
+
+  let sectionEnd = lines.length;
+  for (let i = envStart + 1; i < lines.length; i++) {
+    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+
+  let exploreRoutingIdx = -1;
+  for (let i = envStart + 1; i < sectionEnd; i++) {
+    if (new RegExp(`^\\s*${OMX_EXPLORE_CMD_ENV}\\s*=`).test(lines[i])) {
+      exploreRoutingIdx = i;
+      break;
+    }
+  }
+
+  if (exploreRoutingIdx < 0) {
+    lines.splice(
+      sectionEnd,
+      0,
+      `${OMX_EXPLORE_CMD_ENV} = "${OMX_EXPLORE_ROUTING_DEFAULT}"`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
 function upsertAgentsSettings(config: string): string {
   const lines = config.split(/\r?\n/);
   const agentsStart = lines.findIndex((line) =>
@@ -323,6 +367,49 @@ export function stripOmxFeatureFlags(config: string): string {
     const sectionContent = filtered.slice(newFeaturesStart + 1, newSectionEnd);
     if (sectionContent.every((l) => l.trim() === "")) {
       filtered.splice(newFeaturesStart, newSectionEnd - newFeaturesStart);
+    }
+  }
+
+  return filtered.join("\n");
+}
+
+export function stripOmxEnvSettings(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const envStart = lines.findIndex((line) => /^\s*\[env\]\s*$/.test(line));
+
+  if (envStart < 0) return config;
+
+  let sectionEnd = lines.length;
+  for (let i = envStart + 1; i < lines.length; i++) {
+    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
+      sectionEnd = i;
+      break;
+    }
+  }
+
+  const filtered: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (i > envStart && i < sectionEnd) {
+      const isOmxEnvKey = new RegExp(
+        `^\\s*${OMX_EXPLORE_CMD_ENV}\\s*=`,
+      ).test(lines[i]);
+      if (isOmxEnvKey) continue;
+    }
+    filtered.push(lines[i]);
+  }
+
+  const newEnvStart = filtered.findIndex((line) => /^\s*\[env\]\s*$/.test(line));
+  if (newEnvStart >= 0) {
+    let newSectionEnd = filtered.length;
+    for (let i = newEnvStart + 1; i < filtered.length; i++) {
+      if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(filtered[i])) {
+        newSectionEnd = i;
+        break;
+      }
+    }
+    const envContent = filtered.slice(newEnvStart + 1, newSectionEnd);
+    if (envContent.every((line) => line.trim() === "")) {
+      filtered.splice(newEnvStart, newSectionEnd - newEnvStart);
     }
   }
 
@@ -705,8 +792,9 @@ function getOmxTablesBlock(pkgRoot: string, includeTui = true): string {
  * Layout:
  *   1. OMX top-level keys (notify, model_reasoning_effort, developer_instructions)
  *   2. [features] with multi_agent + child_agents_md
- *   3. … user sections …
- *   4. OMX [table] sections (mcp_servers, tui)
+ *   3. [env] with defaulted explore-routing opt-in
+ *   4. … user sections …
+ *   5. OMX [table] sections (mcp_servers, tui)
  */
 export function buildMergedConfig(
   existingConfig: string,
@@ -732,6 +820,7 @@ export function buildMergedConfig(
   }
   existing = stripOrphanedOmxSections(existing);
   existing = upsertFeatureFlags(existing);
+  existing = upsertEnvSettings(existing);
   existing = upsertAgentsSettings(existing);
   const tuiUpsert = includeTui
     ? upsertTuiStatusLine(existing)

--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -72,30 +72,27 @@ describe("generateOverlay", () => {
     assert.doesNotMatch(defaultOverlay, /\*\*Orchestration Mode:\*\* team/);
   });
 
-  it("adds advisory explore routing guidance only when USE_OMX_EXPLORE_CMD is enabled", async () => {
+  it("adds advisory explore routing guidance by default and hides it only on explicit opt-out", async () => {
     const previous = process.env.USE_OMX_EXPLORE_CMD;
     try {
       delete process.env.USE_OMX_EXPLORE_CMD;
+      const defaultOverlay = await generateOverlay(
+        tempDir,
+        "explore-routing-default",
+      );
+      assert.match(
+        defaultOverlay,
+        /\*\*Explore Command Preference:\*\*/,
+      );
+      assert.match(defaultOverlay, /default-on; opt out/i);
+      assert.match(defaultOverlay, /omx explore` FIRST before attempting full code analysis/i);
+
+      process.env.USE_OMX_EXPLORE_CMD = "off";
       const disabledOverlay = await generateOverlay(
         tempDir,
         "explore-routing-off",
       );
-      assert.doesNotMatch(
-        disabledOverlay,
-        /\*\*Explore Command Preference:\*\*/,
-      );
-
-      process.env.USE_OMX_EXPLORE_CMD = "1";
-      const enabledOverlay = await generateOverlay(
-        tempDir,
-        "explore-routing-on",
-      );
-      assert.match(
-        enabledOverlay,
-        /\*\*Explore Command Preference:\*\* enabled via `USE_OMX_EXPLORE_CMD`/,
-      );
-      assert.match(enabledOverlay, /strongly prefer `omx explore`/);
-      assert.match(enabledOverlay, /advisory steering/i);
+      assert.doesNotMatch(disabledOverlay, /\*\*Explore Command Preference:\*\*/);
     } finally {
       if (typeof previous === "string")
         process.env.USE_OMX_EXPLORE_CMD = previous;

--- a/src/hooks/__tests__/explore-routing.test.ts
+++ b/src/hooks/__tests__/explore-routing.test.ts
@@ -7,13 +7,16 @@ import {
 } from '../explore-routing.js';
 
 describe('explore-routing', () => {
-  it('treats USE_OMX_EXPLORE_CMD truthy values as enabled', () => {
+  it('defaults USE_OMX_EXPLORE_CMD to enabled and only disables explicit opt-out values', () => {
+    assert.equal(isExploreCommandRoutingEnabled({}), true);
     assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: '1' }), true);
     assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: 'true' }), true);
     assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: 'yes' }), true);
     assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: 'on' }), true);
     assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: '0' }), false);
-    assert.equal(isExploreCommandRoutingEnabled({}), false);
+    assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: 'false' }), false);
+    assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: 'no' }), false);
+    assert.equal(isExploreCommandRoutingEnabled({ USE_OMX_EXPLORE_CMD: 'off' }), false);
   });
 
   it('detects simple exploration prompts', () => {
@@ -31,14 +34,17 @@ describe('explore-routing', () => {
     assert.equal(isSimpleExplorationPrompt('investigate everything in this repo'), false);
   });
 
-  it('builds advisory guidance only when enabled', () => {
-    assert.equal(buildExploreRoutingGuidance({}), '');
-    const guidance = buildExploreRoutingGuidance({ USE_OMX_EXPLORE_CMD: '1' });
+  it('builds advisory guidance whenever routing is not explicitly disabled', () => {
+    const guidance = buildExploreRoutingGuidance({});
     assert.match(guidance, /USE_OMX_EXPLORE_CMD/);
-    assert.match(guidance, /strongly prefer `omx explore`/);
-    assert.match(guidance, /advisory steering/i);
-    assert.match(guidance, /--prompt/);
+    assert.match(guidance, /default-on; opt out/i);
+    assert.match(guidance, /agents SHOULD treat `omx explore` as the default first stop/i);
+    assert.match(guidance, /use `omx explore` FIRST before attempting full code analysis/i);
+    assert.match(guidance, /Explore examples:/);
+    assert.match(guidance, /SparkShell examples:/);
+    assert.match(guidance, /--prompt-file/);
     assert.match(guidance, /shell-only allowlisted read-only path/i);
-    assert.match(guidance, /narrower prompt/i);
+    assert.match(guidance, /gracefully fall back to the normal path/i);
+    assert.equal(buildExploreRoutingGuidance({ USE_OMX_EXPLORE_CMD: 'off' }), '');
   });
 });

--- a/src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts
+++ b/src/hooks/__tests__/explore-sparkshell-guidance-contract.test.ts
@@ -13,12 +13,13 @@ describe('explore + sparkshell guidance contract', () => {
   it('keeps AGENTS root and template aligned on conditional explore routing and opt-in sparkshell guidance', () => {
     const patterns = [
       /USE_OMX_EXPLORE_CMD/i,
-      /prefer `omx explore`/i,
+      /SHOULD treat `omx explore`|strongly prefer `omx explore`/i,
       /--prompt/i,
-      /shell-only, allowlisted, read-only path/i,
+      /shell-only, allowlisted, read-only path|shell-only allowlisted read-only path/i,
       /gracefully fall back to the normal path/i,
       /omx sparkshell --tmux-pane/i,
       /explicit opt-?in/i,
+      /When to use what/i,
     ];
 
     for (const surface of ['AGENTS.md', 'templates/AGENTS.md']) {
@@ -53,7 +54,7 @@ describe('explore + sparkshell guidance contract', () => {
     ]) {
       expectPatterns(surface, [
         /USE_OMX_EXPLORE_CMD/i,
-        /prefer `omx explore`/i,
+        /prefer `omx explore`|use `omx explore` FIRST/i,
         /fall back normally|fallback normally|graceful fallback|richer normal explore path/i,
       ]);
     }

--- a/src/hooks/explore-routing.ts
+++ b/src/hooks/explore-routing.ts
@@ -1,6 +1,6 @@
 export const OMX_EXPLORE_CMD_ENV = 'USE_OMX_EXPLORE_CMD';
 
-const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const DISABLED_VALUES = new Set(['0', 'false', 'no', 'off']);
 
 const SIMPLE_EXPLORATION_PATTERNS: RegExp[] = [
   /\b(where|find|locate|search|grep|ripgrep)\b/i,
@@ -20,8 +20,8 @@ const NON_EXPLORATION_PATTERNS: RegExp[] = [
 
 export function isExploreCommandRoutingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[OMX_EXPLORE_CMD_ENV];
-  if (typeof raw !== 'string') return false;
-  return ENABLED_VALUES.has(raw.trim().toLowerCase());
+  if (typeof raw !== 'string') return true;
+  return !DISABLED_VALUES.has(raw.trim().toLowerCase());
 }
 
 export function isSimpleExplorationPrompt(text: string): boolean {
@@ -34,12 +34,15 @@ export function isSimpleExplorationPrompt(text: string): boolean {
 export function buildExploreRoutingGuidance(env: NodeJS.ProcessEnv = process.env): string {
   if (!isExploreCommandRoutingEnabled(env)) return '';
   return [
-    `**Explore Command Preference:** enabled via \`${OMX_EXPLORE_CMD_ENV}\``,
-    '- Advisory steering only: prefer `omx explore` for direct inspection by default and reserve `omx sparkshell` for qualifying read-only shell-native tasks.',
+    `**Explore Command Preference:** enabled via \`${OMX_EXPLORE_CMD_ENV}\` (default-on; opt out with \`0\`, \`false\`, \`no\`, or \`off\`)`,
+    '- Advisory steering only: agents SHOULD treat `omx explore` as the default first stop for direct inspection and SHOULD reserve `omx sparkshell` for qualifying read-only shell-native tasks.',
+    '- For simple file/symbol lookups, use `omx explore` FIRST before attempting full code analysis.',
     '- When the user asks for a simple read-only exploration task (file/symbol/pattern/relationship lookup), strongly prefer `omx explore` as the default surface.',
+    '- Explore examples: `omx explore --prompt "which files define TeamPolicy"`, `omx explore --prompt "find usages of buildExploreRoutingGuidance"`.',
+    '- SparkShell examples: use `omx sparkshell -- rg -n "TeamPolicy" src`, `omx sparkshell -- npm test`, or `omx sparkshell --tmux-pane %12` for noisy verification, bounded shell output, or tmux-pane summaries.',
     '- Keep `omx explore` prompts narrow and concrete; prefer a single lookup goal or a small related cluster, using `--prompt` for quick asks and `--prompt-file` for longer reusable briefs.',
     '- Treat `omx explore` as a shell-only allowlisted read-only path; keep edits, tests, diagnostics, MCP/web needs, and complex shell composition on the richer normal path.',
     '- Keep implementation, refactor, test, or ambiguous broad requests on the normal Codex path.',
     '- If `omx explore` is unavailable, stalls, or fails, retry with a narrower prompt or gracefully fall back to the normal path.',
-  ].join('\n');
+  ].join("\n");
 }

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -292,22 +292,31 @@ Broad Request Detection:
 A request is broad when it uses vague verbs without targets, names no specific file or function, touches 3+ areas, or is a single sentence without a clear deliverable. For broad work: explore first, then plan if needed.
 
 Command Routing:
-- When `USE_OMX_EXPLORE_CMD` enables advisory routing, prefer `omx explore` as the default surface for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
+- When `USE_OMX_EXPLORE_CMD` enables advisory routing, strongly prefer `omx explore` as the default surface for simple read-only repository lookup tasks (files, symbols, patterns, relationships).
+- For simple file/symbol lookups, use `omx explore` FIRST before attempting full code analysis.
 - Keep ambiguous, implementation-heavy, edit-heavy, or non-shell-only work on the normal Codex path.
 - If `omx explore` is unavailable or fails, gracefully fall back to the normal path.
 - Let `omx explore` keep direct inspection by default and use `omx sparkshell` only as an adaptive backend for qualifying read-only shell-native tasks.
 - For explicit tmux-pane / worker / leader / HUD inspection, prefer `omx sparkshell --tmux-pane ...` when a larger-tail read or bounded summary is useful. Sparkshell pane mode is explicit opt-in, not always-on.
 
+When to use what:
+- If the task is a simple read-only file/symbol/pattern/relationship lookup -> use `omx explore` first.
+- If the task is a noisy read-only shell command, verification run, repo-wide search/listing, or tmux-pane summary -> use `omx sparkshell`.
+- If the task needs edits, tests with exact raw stderr, MCP/web access, complex shell composition, or broad ambiguous analysis -> stay on the richer normal Codex path.
+- If `omx explore` or `omx sparkshell` returns incomplete or ambiguous results -> retry with a narrower prompt/command, then fall back to the normal path.
+
 Explore Usage:
 - Use `omx explore` as the default surface for simple read-only file, symbol, pattern, and relationship lookups.
 - Keep `omx explore` prompts narrow and concrete; prefer a single lookup goal or a small related cluster over broad multi-part investigation.
-- Prefer `omx explore --prompt ...` for quick one-off lookups and `omx explore --prompt-file ...` when the search brief is longer or reusable.
+- Prefer `omx explore --prompt ...` for quick one-off lookups and `omx explore --prompt-file ...` for longer reusable briefs.
+- Good explore examples: `omx explore --prompt "which files define TeamPolicy"` and `omx explore --prompt "find usages of buildExploreRoutingGuidance"`.
 - Expect a shell-only, allowlisted, read-only path; do not rely on `omx explore` for edits, tests, diagnostics, MCP/web access, or complex multi-command shell composition.
 - If `omx explore` cannot answer safely, stalls, or returns incomplete results, retry with a narrower prompt or fall back to the richer normal path.
 
 Sparkshell Usage:
-- Protect context budget by default: prefer `omx sparkshell` for noisy read-only and verification commands where full raw output is usually wasteful.
+- Protect context budget by default: strongly prefer `omx sparkshell` for noisy read-only and verification commands where full raw output is usually wasteful.
 - Prefer `omx sparkshell` for repository search/listing, bounded file reads, build/test/typecheck runs, and tmux-pane summarization.
+- Good sparkshell examples: `omx sparkshell -- rg -n "TeamPolicy" src`, `omx sparkshell -- npm test`, and `omx sparkshell --tmux-pane %12`.
 - Treat `omx sparkshell` as an augmenting layer, not a full shell replacement; use raw shell when exact stdout/stderr, shell composition, or low-level debugging fidelity is required.
 - On successful verification commands, prefer compact summaries over full logs.
 - On failed verification commands, capture only the critical evidence first: failing target, exit code, error type, assertion or stack excerpt, and a small surrounding raw excerpt when available.


### PR DESCRIPTION
## Summary
- make `USE_OMX_EXPLORE_CMD` routing default-on and preserve explicit opt-outs
- strengthen explore/sparkshell guidance across hooks, prompts, and AGENTS surfaces
- seed setup config with `USE_OMX_EXPLORE_CMD = \"1\"` and add doctor warnings when routing is disabled

## Testing
- npm run build
- node --test dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/agents-overlay.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/doctor-warning-copy.test.js dist/compat/__tests__/doctor-contract.test.js
- npm test
