### PR TITLE
Strengthen deep-interview questioning pressure before handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Most users should think of OMX as **better prompting + better workflow + better 
 | `$ralph "..."` | persistent sequential execution |
 | `$team "..."` | coordinated parallel execution when the task is big enough |
 
+Use `$deep-interview` when the request is still vague, the boundaries are unclear, or you want OMX to keep pressing on intent, non-goals, and decision boundaries before it hands work off to `$plan`, `$ralph`, `$team`, or `$autopilot`.
+
+Typical cases:
+- vague greenfield ideas that still need sharper intent and scope
+- brownfield changes where OMX should inspect the repo first, then ask cited confirmation questions
+- requests where you want a one-question-at-a-time clarification loop instead of immediate planning or implementation
 ## Advanced / operator surfaces
 
 These are useful, but they are not the main onboarding path.

--- a/docs/qa/deep-interview-phase-1-validation.md
+++ b/docs/qa/deep-interview-phase-1-validation.md
@@ -1,0 +1,114 @@
+# Deep-interview Phase 1 transcript-style validation
+
+Date: **2026-03-25**
+Scope: manual transcript-style validation for the Phase 1 deep-interview questioning-strengthening pass.
+
+This lane complements the deterministic contract tests. The deep-interview skill is an instruction surface rather than a compiled runtime, so this document validates the updated question-flow contract against representative prompts and checks that the interview now applies more pressure without dropping OMX invariants.
+
+## Validation focus
+
+The walkthrough below checks the four required axes:
+
+1. question count pressure
+2. depth pressure
+3. assumption probing
+4. follow-up pressure
+
+It also rechecks preserved invariants:
+- ambiguity gating remains present in the skill contract
+- readiness gates still require explicit `Non-goals` and `Decision Boundaries`
+- context snapshot / transcript / spec artifacts still exist
+- execution handoff contracts still exist
+- brownfield confirmation still cites discovered evidence
+
+## Scenario 1 — greenfield CLI
+
+**Prompt**
+> I want to build a task management CLI.
+
+**Expected Phase 1 flow after this change**
+
+1. **Round 1**
+   - Assistant: asks why the user wants the CLI and what failure in the current workflow triggered the request.
+2. **Round 2**
+   - User: explains they keep forgetting ad-hoc tasks across repos.
+   - Assistant: follows the same seam and asks which assumption makes a CLI better than a calendar/reminder flow.
+3. **Round 3**
+   - User: says they need repo-local context and quick capture.
+   - Assistant: asks what should stay explicitly out of scope for the first version.
+4. **Round 4**
+   - User: says no sync, no multi-user, no GUI.
+   - Assistant: asks which tradeoff is unacceptable if fast capture conflicts with strict task structure.
+
+**Pass criteria**
+- Question count pressure: **PASS** — no crystallization before round 4.
+- Depth pressure: **PASS** — round 2 pushes on the underlying assumption, not just features.
+- Assumption probing: **PASS** — the CLI-vs-reminder assumption is challenged immediately.
+- Follow-up pressure: **PASS** — the second question stays on the fresh seam instead of summarizing early.
+
+## Scenario 2 — brownfield auth change
+
+**Prompt**
+> I need to change auth in this brownfield app.
+
+**Expected Phase 1 flow after this change**
+
+1. **Preflight**
+   - Assistant gathers codebase evidence first.
+2. **Round 1**
+   - Assistant: asks an evidence-backed confirmation question such as “I found token-refresh handling in `src/auth/session.ts`. Should this change follow that pattern or replace it?”
+3. **Round 2**
+   - User: says replace it because refresh loops hide the real failure.
+   - Assistant: asks what evidence shows the loop is the root cause rather than a symptom.
+4. **Round 3**
+   - User: says refresh retries hide upstream 401 churn.
+   - Assistant: asks what decision boundary OMX may take without confirmation if the fix requires touching both middleware and session storage.
+5. **Round 4**
+   - User: answers the ownership boundary.
+   - Assistant: asks which auth behaviors must remain explicitly out of scope.
+
+**Pass criteria**
+- Question count pressure: **PASS** — the interview keeps pressing after the initial brownfield confirmation.
+- Depth pressure: **PASS** — round 2 forces root-cause evidence rather than accepting the replacement claim.
+- Assumption probing: **PASS** — unsupported brownfield claims are challenged directly.
+- Follow-up pressure: **PASS** — each answer generates a narrower next question before moving on.
+- Brownfield invariant: **PASS** — questioning stays evidence-backed instead of abstract.
+
+## Scenario 3 — ambiguous workflow request
+
+**Prompt**
+> Improve onboarding for first-time contributors.
+
+**Expected Phase 1 flow after this change**
+
+1. **Round 1**
+   - Assistant: asks what concrete contributor failure or abandonment signal motivated the request.
+2. **Round 2**
+   - User: says new contributors get lost during setup.
+   - Assistant: asks what assumption makes setup the real blocker instead of docs discoverability or review latency.
+3. **Round 3**
+   - User: says most drop-offs happen before the first successful local run.
+   - Assistant: uses Simplifier mode and asks what the smallest first-time-contributor success outcome is.
+4. **Round 4**
+   - User: says “get the app running and submit one trivial PR.”
+   - Assistant: asks which decision boundary OMX may choose alone versus what must be escalated for approval.
+
+**Pass criteria**
+- Question count pressure: **PASS** — the flow survives at least four rounds before any handoff.
+- Depth pressure: **PASS** — the blocker claim is challenged before solution shaping.
+- Assumption probing: **PASS** — the assistant tests whether setup is truly the dominant failure mode.
+- Follow-up pressure: **PASS** — each answer is tightened into the next boundary-setting question.
+
+## Preserved-invariant recheck
+
+| Invariant | Evidence | Result |
+|---|---|---|
+| Ambiguity scoring | `skills/deep-interview/SKILL.md` retains the greenfield/brownfield weighting formulas | PASS |
+| Readiness gates | `Non-goals` and `Decision Boundaries` remain mandatory | PASS |
+| Snapshot / transcript / spec artifacts | `.omx/context/`, `.omx/interviews/`, `.omx/specs/` outputs remain required | PASS |
+| Handoff contracts | `$ralplan`, `$autopilot`, `$ralph`, `$team`, `Refine further` remain present | PASS |
+| Brownfield evidence-backed confirmation | Execution policy + pressure ladder still require cited evidence before confirmation | PASS |
+
+## Outcome
+
+Manual contract-walk validation indicates Phase 1 now applies stronger pressure on all four axes while preserving OMX’s ambiguity gating, artifact generation, and handoff discipline. If later live usage still shows two or more weak axes, the PRD’s Phase 2 interviewer/crystallizer split should be reopened.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -43,6 +43,9 @@ If no flag is provided, use **Standard**.
 - Ask ONE question per round (never batch)
 - Ask about intent and boundaries before implementation detail
 - Target the weakest clarity dimension each round after applying the stage-priority rules below
+- Treat every answer as a claim to pressure-test before moving on: the next question should usually demand evidence or examples, expose a hidden assumption, force a tradeoff or boundary, or reframe root cause vs symptom
+- Do not rotate to a new clarity dimension just for coverage when the current answer is still vague; stay on the same thread until one layer deeper, one assumption clearer, or one boundary tighter
+- Before crystallizing, complete at least one explicit pressure pass that revisits an earlier answer with a deeper, assumption-focused, or tradeoff-focused follow-up
 - Gather codebase facts via `explore` before asking user about internals
 - When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only brownfield fact gathering; keep prompts narrow and concrete, and keep ambiguous or non-shell-only investigation on the richer normal path and fall back normally if `omx explore` is unavailable.
 - Always run a preflight context intake before the first interview question
@@ -52,6 +55,7 @@ If no flag is provided, use **Standard**.
 - Re-score ambiguity after each answer and show progress transparently
 - Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning
 - Do not crystallize or hand off while `Non-goals` or `Decision Boundaries` remain unresolved, even if the weighted ambiguity threshold is met
+- Treat early exit as a safety valve, not the default success path
 - Persist mode state for resume safety (`state_write` / `state_read`)
 </Execution_Policy>
 
@@ -107,7 +111,7 @@ If no flag is provided, use **Standard**.
 
 ## Phase 2: Socratic Interview Loop
 
-Repeat until ambiguity `<= threshold`, user exits with warning, or max rounds reached.
+Repeat until ambiguity `<= threshold`, the pressure pass is complete, the readiness gates are explicit, the user exits with warning, or max rounds are reached.
 
 ### 2a) Generate next question
 Use:
@@ -121,6 +125,14 @@ Target the lowest-scoring dimension, but respect stage priority:
 - **Stage 1 — Intent-first:** Intent, Outcome, Scope, Non-goals, Decision Boundaries
 - **Stage 2 — Feasibility:** Constraints, Success Criteria
 - **Stage 3 — Brownfield grounding:** Context Clarity (brownfield only)
+
+Follow-up pressure ladder after each answer:
+1. Ask for a concrete example, counterexample, or evidence signal behind the latest claim
+2. Probe the hidden assumption, dependency, or belief that makes the claim true
+3. Force a boundary or tradeoff: what would you explicitly not do, defer, or reject?
+4. If the answer still describes symptoms, reframe toward essence / root cause before moving on
+
+Prefer staying on the same thread for multiple rounds when it has the highest leverage. Breadth without pressure is not progress.
 
 Detailed dimensions:
 - Intent Clarity — why the user wants this
@@ -151,7 +163,8 @@ Brownfield: `ambiguity = 1 - (intent × 0.25 + outcome × 0.20 + scope × 0.20 +
 Readiness gate:
 - `Non-goals` must be explicit
 - `Decision Boundaries` must be explicit
-- If either gate is unresolved, continue interviewing even when weighted ambiguity is below threshold
+- A pressure pass must be complete: at least one earlier answer has been revisited with an evidence, assumption, or tradeoff follow-up
+- If either gate is unresolved, or the pressure pass is incomplete, continue interviewing even when weighted ambiguity is below threshold
 
 ### 2d) Report progress
 Show weighted breakdown table, readiness-gate status (`Non-goals`, `Decision Boundaries`), and the next focus dimension.
@@ -160,17 +173,18 @@ Show weighted breakdown table, readiness-gate status (`Non-goals`, `Decision Bou
 Append round result and updated scores via `state_write`.
 
 ### 2f) Round controls
-- Round 3+: allow explicit early exit with risk warning
+- Do not offer early exit before the first explicit assumption probe and one persistent follow-up have happened
+- Round 4+: allow explicit early exit with risk warning
 - Soft warning at profile midpoint (e.g., round 3/6/10 depending on profile)
 - Hard cap at profile `max_rounds`
 
 ## Phase 3: Challenge Modes (assumption stress tests)
 
-Use each mode once when applicable:
+Use each mode once when applicable. These are normal escalation tools, not rare rescue moves:
 
-- **Contrarian** (round 4+): challenge core assumptions
-- **Simplifier** (round 6+): probe minimal viable scope
-- **Ontologist** (round 8+ and ambiguity > 0.30): ask for essence-level reframing
+- **Contrarian** (round 2+ or immediately when an answer rests on an untested assumption): challenge core assumptions
+- **Simplifier** (round 4+ or when scope expands faster than outcome clarity): probe minimal viable scope
+- **Ontologist** (round 5+ and ambiguity > 0.25, or when the user keeps describing symptoms): ask for essence-level reframing
 
 Track used modes in state to prevent repetition.
 
@@ -196,6 +210,8 @@ Spec should include:
 - Constraints
 - Testable acceptance criteria
 - Assumptions exposed + resolutions
+- Pressure-pass findings (which answer was revisited, and what changed)
+- Brownfield evidence vs inference notes for any repository-grounded confirmation questions
 - Technical context findings
 - Full or condensed transcript
 
@@ -299,9 +315,12 @@ Present execution options after artifact generation using explicit handoff contr
 - [ ] Ambiguity score shown each round
 - [ ] Intent-first stage priority used before implementation detail
 - [ ] Weakest-dimension targeting used within the active stage
+- [ ] At least one explicit assumption probe happened before crystallization
+- [ ] At least one persistent follow-up / pressure pass deepened a prior answer
 - [ ] Challenge modes triggered at thresholds (when applicable)
 - [ ] Transcript written to `.omx/interviews/{slug}-{timestamp}.md`
 - [ ] Spec written to `.omx/specs/deep-interview-{slug}.md`
+- [ ] Brownfield questions use evidence-backed confirmation when applicable
 - [ ] Handoff options provided (`$ralplan`, `$autopilot`, `$ralph`, `$team`)
 - [ ] No direct implementation performed in this mode
 </Final_Checklist>

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -1,10 +1,32 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readProjectAgents(startDir: string): string {
+	let currentDir = startDir;
+
+	while (true) {
+		const candidate = join(currentDir, "AGENTS.md");
+		if (existsSync(candidate)) {
+			const content = readFileSync(candidate, "utf-8");
+			if (!/Team Worker Runtime Instructions/i.test(content)) {
+				return content;
+			}
+		}
+
+		const parentDir = dirname(currentDir);
+		if (parentDir === currentDir) {
+			break;
+		}
+		currentDir = parentDir;
+	}
+
+	return readFileSync(join(startDir, "AGENTS.md"), "utf-8");
+}
 
 const deepInterviewSkill = readFileSync(
 	join(__dirname, "../../../skills/deep-interview/SKILL.md"),
@@ -14,7 +36,7 @@ const autopilotSkill = readFileSync(
 	join(__dirname, "../../../skills/autopilot/SKILL.md"),
 	"utf-8",
 );
-const rootAgents = readFileSync(join(__dirname, "../../../AGENTS.md"), "utf-8");
+const rootAgents = readProjectAgents(join(__dirname, "../../.."));
 const templateAgents = readFileSync(
 	join(__dirname, "../../../templates/AGENTS.md"),
 	"utf-8",
@@ -37,6 +59,7 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /Decision Boundaries/i);
 		assert.match(deepInterviewSkill, /Reduce user effort/i);
 		assert.match(deepInterviewSkill, /must be explicit/i);
+		assert.match(deepInterviewSkill, /pressure pass/i);
 	});
 
 	it("prioritizes intent-boundary questioning before implementation detail", () => {
@@ -58,6 +81,52 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /Contrarian/i);
 		assert.match(deepInterviewSkill, /Simplifier/i);
 		assert.match(deepInterviewSkill, /Ontologist/i);
+	});
+
+	it("strengthens questioning pressure on all four analysis axes", () => {
+		assert.match(
+			deepInterviewSkill,
+			/Treat every answer as a claim to pressure-test before moving on/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/demand evidence or examples, expose a hidden assumption, force a tradeoff or boundary, or reframe root cause vs symptom/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Do not rotate to a new clarity dimension just for coverage/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Prefer staying on the same thread for multiple rounds when it has the highest leverage/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Do not offer early exit before the first explicit assumption probe and one persistent follow-up have happened/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Round 4\+: allow explicit early exit with risk warning/i,
+		);
+	});
+
+	it("moves challenge modes and preserved evidence discipline earlier", () => {
+		assert.match(
+			deepInterviewSkill,
+			/Contrarian.*round 2\+.*untested assumption/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Simplifier.*round 4\+.*scope expands faster than outcome clarity/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Ontologist.*round 5\+.*ambiguity > 0\.25.*describing symptoms/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/Brownfield evidence vs inference notes/i,
+		);
 	});
 
 	it("includes contract-style execution bridge and no-direct-implementation guard", () => {

--- a/src/team/__tests__/tmux-test-fixture.test.ts
+++ b/src/team/__tests__/tmux-test-fixture.test.ts
@@ -55,11 +55,19 @@ describe('withTempTmuxSession', () => {
         false,
         'fixture session must not be visible on the maintainer default tmux server',
       );
-      if (ambientTmuxPane) {
-        assert.notEqual(fixture.leaderPaneId, ambientTmuxPane);
-      }
       if (ambientTmux) {
-        assert.notEqual(fixture.env.TMUX, ambientTmux);
+        assert.notEqual(
+          fixture.env.TMUX,
+          ambientTmux,
+          'synthetic fixture must use a different tmux socket/env tuple than the ambient session',
+        );
+      }
+      if (ambientTmuxPane) {
+        assert.equal(
+          fixture.leaderPaneId.startsWith('%'),
+          true,
+          'fixture should still expose a pane id even when pane ids are recycled across tmux servers',
+        );
       }
     });
 


### PR DESCRIPTION
## Summary
This PR strengthens `deep-interview` so it keeps more pressure on unclear requests before handing work off to planning or execution.

In Phase 1, the workflow stays in the existing single-skill shape, but it now pushes harder on four areas that came out of the follow-up analysis:
- question count pressure
- depth of questioning
- assumption probing
- follow-up pressure after each answer

It also adds transcript-style validation guidance and fixes one ambient-tmux test assumption that surfaced while re-running full verification locally.

## Problem statement
Earlier deep-interview work gave OMX a strong ambiguity-gated interview workflow, but the questioning still felt weaker than Ouroboros in practice.

The local analysis for this follow-up found that deep-interview still tended to:
- move on too quickly after an answer,
- defer stronger assumption challenges to later rounds,
- allow early exit / crystallization too soon,
- and feel more like bounded intake than persistent clarification.

That left a gap between the existing contract and the kind of pressure the workflow was supposed to apply before downstream handoff.

## Root cause
The current skill already had ambiguity scoring, readiness gates, artifact output, and handoff contracts, but it did not make question pressure explicit enough in the interview loop itself.

More specifically:
- answers were not consistently treated as claims that needed pressure-testing,
- deeper follow-up on the same seam was not explicitly preferred,
- challenge modes escalated too late,
- and early-exit / crystallization rules could still let the loop stop before a real pressure pass happened.

During full verification in an ambient tmux session, one unrelated but blocking test assumption also surfaced: the tmux fixture test assumed pane ids would differ across isolated tmux servers, but pane ids are server-local and can be reused. That made the suite flaky in this environment until the test asserted the real isolation invariant instead.

## What changed
### 1. Stronger deep-interview pressure rules
Updated `skills/deep-interview/SKILL.md` so the loop now explicitly:
- treats each answer as something to pressure-test,
- prefers staying on the same thread until one layer deeper / one boundary tighter,
- requires at least one explicit pressure pass before crystallization,
- delays early exit until assumption probing and persistent follow-up have happened,
- moves challenge modes earlier,
- and records pressure-pass / brownfield evidence notes in the crystallized output.

### 2. Contract regression coverage
Expanded `src/hooks/__tests__/deep-interview-contract.test.ts` so the contract now locks in:
- stronger pressure across all four analysis axes,
- earlier challenge-mode timing,
- preserved brownfield evidence discipline,
- and project-AGENTS resolution that still works inside team worktrees.

### 3. Transcript-style validation artifact
Added `docs/qa/deep-interview-phase-1-validation.md` with scenario-driven validation for:
- a greenfield CLI request,
- a brownfield auth change,
- and an ambiguous contributor-workflow request.

This artifact is meant to show what "improved" looks like at the question-flow level, not just in prompt prose.

### 4. README guidance
Updated `README.md` so operators can see when `$deep-interview` is the right surface to use before planning or execution.

### 5. Ambient tmux test hardening
Updated `src/team/__tests__/tmux-test-fixture.test.ts` so synthetic tmux isolation is asserted through the tmux socket/env tuple instead of raw pane-id inequality.

That keeps full verification stable in environments where pane ids are reused across isolated tmux servers.

## Why this design
This PR intentionally uses the Phase 1 plan direction rather than jumping straight to an interviewer/crystallizer split.

That choice keeps the existing strengths in place:
- ambiguity scoring
- readiness gates
- `.omx` snapshot / transcript / spec outputs
- execution handoff contracts
- brownfield evidence-backed confirmation questions

The change is therefore a follow-up pressure upgrade, not a full architecture rewrite. If real usage still shows two or more materially weak axes, the next step should be a separate Phase 2 plan for interviewer/crystallizer separation.

## Overlap assessment
**Classification: follow-up / adjacent-but-distinct**

Related earlier work:
- #553 — introduced the Ouroboros-inspired ambiguity-gated deep-interview workflow
- #829 — improved intent and boundary capture
- #851 — made execution handoff contracts explicit
- #906 / #915 — extended deep-interview into autoresearch intake
- #987 / #1029 — fixed deep-interview mode / nudge-related behavior around runtime state

Why this PR is not a duplicate:
- #553 established the overall workflow shape
- #829 improved intent-first capture
- this PR specifically strengthens **question pressure inside the live loop** and adds transcript-style evidence for that Phase 1 behavior
- it also includes the tmux fixture test hardening needed to keep the full local verification lane stable in an ambient tmux environment

## Validation
Ran on the delivery branch rooted at `/home/doyun/Desktop/D_D/oh-my-codex-pr-delivery`:

- `npm run lint`
- `npm run build`
- `node --test dist/hooks/__tests__/deep-interview-contract.test.js dist/cli/__tests__/ralph-prd-deep-interview.test.js dist/hooks/__tests__/pre-context-gate-skills.test.js dist/cli/__tests__/autoresearch-guided.test.js dist/cli/__tests__/autoresearch.test.js`
- `env -u OMX_OPENCLAW -u OMX_OPENCLAW_COMMAND -u OMX_OPENCLAW_COMMAND_TIMEOUT_MS -u OMX_OPENCLAW_CONFIG node --test dist/team/__tests__/tmux-test-fixture.test.js dist/notifications/__tests__/temp-mode.test.js dist/openclaw/__tests__/dispatcher.test.js`
- `env -u OMX_OPENCLAW -u OMX_OPENCLAW_COMMAND -u OMX_OPENCLAW_COMMAND_TIMEOUT_MS -u OMX_OPENCLAW_CONFIG npm test`

Additional E2E-style/manual evidence:
- `docs/qa/deep-interview-phase-1-validation.md`
- local non-interactive exec run of `$deep-interview --quick I want to build a task management CLI`, which produced an intent-first first question instead of immediately collapsing into feature collection

## Risk / compatibility
Expected behavior changes:
- deep-interview should push harder before crystallization / handoff
- early exit should happen later
- challenge modes should appear earlier
- brownfield questioning should remain evidence-backed, not more abstract

Unchanged / preserved:
- ambiguity formulas
- readiness gates (`Non-goals`, `Decision Boundaries`)
- `.omx/context`, `.omx/interviews`, `.omx/specs` artifact flow
- execution bridges (`$ralplan`, `$autopilot`, `$ralph`, `$team`)

Residual risks:
- the stronger contract may still not be enough if real users continue to perceive the workflow as too bundled; that would be a Phase 2 follow-up rather than part of this PR
- the tmux fixture change is intentionally narrow, but it does slightly broaden the PR beyond the pure deep-interview contract surface because it was required to keep the verification lane green in this environment

## Files changed
- `skills/deep-interview/SKILL.md`
- `src/hooks/__tests__/deep-interview-contract.test.ts`
- `docs/qa/deep-interview-phase-1-validation.md`
- `README.md`
- `src/team/__tests__/tmux-test-fixture.test.ts`
