### PR TITLE
feat: add a real ralplan runtime state producer

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -208,6 +208,21 @@ describe('additional HUD mode state readers', () => {
     });
   });
 
+  it('prefers session-scoped ralplan state over root fallback', async () => {
+    await withTempRepo('omx-hud-ralplan-session-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-ralplan-authority';
+      const sessionStateDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(rootStateDir, 'ralplan-state.json'), JSON.stringify({ active: true, current_phase: 'draft', iteration: 9 }));
+      await writeFile(join(sessionStateDir, 'ralplan-state.json'), JSON.stringify({ active: true, current_phase: 'critic-review', iteration: 2, planning_complete: false }));
+
+      const state = await readRalplanState(cwd);
+      assert.deepEqual(state, { active: true, current_phase: 'critic-review', iteration: 2, planning_complete: false });
+    });
+  });
+
   it('reads deep-interview input lock from nested state payload', async () => {
     await withTempRepo('omx-hud-interview-', async (cwd) => {
       await writeModeState(cwd, 'deep-interview', { active: true, current_phase: 'intent-first', input_lock: { active: true } });

--- a/src/modes/__tests__/base-session-scope.test.ts
+++ b/src/modes/__tests__/base-session-scope.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readModeState, startMode, updateModeState } from '../base.js';
+
+describe('modes/base session-scoped persistence', () => {
+  it('writes mode state into the current session scope when session.json exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-session-scope-'));
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-base-write' }));
+
+      await startMode('ralplan', 'write in session scope', 5, wd);
+
+      const scopedPath = join(wd, '.omx', 'state', 'sessions', 'sess-base-write', 'ralplan-state.json');
+      assert.equal(existsSync(scopedPath), true);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'ralplan-state.json')), false);
+
+      const raw = JSON.parse(await readFile(scopedPath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(raw.mode, 'ralplan');
+      assert.equal(raw.current_phase, 'starting');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers session-scoped reads over root fallback and writes updates back to the session scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-session-read-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-base-read';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({ active: true, current_phase: 'root-only', iteration: 9 }));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({ active: true, current_phase: 'draft', iteration: 1 }));
+
+      const state = await readModeState('ralplan', wd);
+      assert.equal(state?.current_phase, 'draft');
+      assert.equal(state?.iteration, 1);
+
+      await updateModeState('ralplan', { current_phase: 'architect-review', iteration: 2 }, wd);
+      const scoped = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      const root = JSON.parse(await readFile(join(stateDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+
+      assert.equal(scoped.current_phase, 'architect-review');
+      assert.equal(scoped.iteration, 2);
+      assert.equal(root.current_phase, 'root-only');
+      assert.equal(root.iteration, 9);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -3,11 +3,17 @@
  * All execution modes (autopilot, autoresearch, deep-interview, ralph, ultrawork, team, ultraqa, ralplan) share this base.
  */
 
-import { readFile, writeFile, mkdir } from 'fs/promises';
-import { join } from 'path';
+import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { withModeRuntimeContext } from '../state/mode-state-context.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
+import {
+  getBaseStateDir,
+  getReadScopedStateDirs,
+  getReadScopedStatePaths,
+  getStatePath,
+  resolveStateScope,
+} from '../mcp/state-paths.js';
 
 export interface ModeState {
   active: boolean;
@@ -64,11 +70,7 @@ function normalizeRalphModeStateOrThrow(state: ModeState): ModeState {
 }
 
 function stateDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), '.omx', 'state');
-}
-
-function statePath(mode: string, projectRoot?: string): string {
-  return join(stateDir(projectRoot), `${mode}-state.json`);
+  return getBaseStateDir(projectRoot);
 }
 
 export async function assertModeStartAllowed(
@@ -79,21 +81,24 @@ export async function assertModeStartAllowed(
 
   for (const other of EXCLUSIVE_MODES) {
     if (other === mode) continue;
-    const otherPath = statePath(other, projectRoot);
-    if (!existsSync(otherPath)) continue;
-    try {
-      const raw = await readFile(otherPath, 'utf-8');
-      const otherState = JSON.parse(raw) as { active?: unknown };
-      if (otherState.active) {
-        throw new Error(`Cannot start ${mode}: ${other} is already active. Run cancel first.`);
+    const otherPaths = await getReadScopedStatePaths(other, projectRoot);
+    for (const otherPath of otherPaths) {
+      if (!existsSync(otherPath)) continue;
+      try {
+        const raw = await readFile(otherPath, 'utf-8');
+        const otherState = JSON.parse(raw) as { active?: unknown };
+        if (otherState.active) {
+          throw new Error(`Cannot start ${mode}: ${other} is already active. Run cancel first.`);
+        }
+        break;
+      } catch (e) {
+        const err = e as NodeJS.ErrnoException;
+        if (err?.message.includes('Cannot start')) throw err;
+        if (err?.code === 'ENOENT') continue;
+        throw new Error(
+          `Cannot start ${mode}: ${other} state file is malformed or unreadable (${otherPath}). Run cancel or repair the state file.`
+        );
       }
-    } catch (e) {
-      const err = e as NodeJS.ErrnoException;
-      if (err?.message.includes('Cannot start')) throw err;
-      if (err?.code === 'ENOENT') continue;
-      throw new Error(
-        `Cannot start ${mode}: ${other} state file is malformed or unreadable (${otherPath}). Run cancel or repair the state file.`
-      );
     }
   }
 }
@@ -111,6 +116,8 @@ export async function startMode(
   await mkdir(dir, { recursive: true });
 
   await assertModeStartAllowed(mode, projectRoot);
+  const scope = await resolveStateScope(projectRoot);
+  await mkdir(scope.stateDir, { recursive: true });
 
   const stateBase: ModeState = {
     active: true,
@@ -126,7 +133,7 @@ export async function startMode(
   const state = mode === 'ralph'
     ? normalizeRalphModeStateOrThrow(withContext)
     : withContext;
-  await writeFile(statePath(mode, projectRoot), JSON.stringify(state, null, 2));
+  await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(state, null, 2));
   return state;
 }
 
@@ -134,13 +141,16 @@ export async function startMode(
  * Read current mode state
  */
 export async function readModeState(mode: string, projectRoot?: string): Promise<ModeState | null> {
-  const path = statePath(mode, projectRoot);
-  if (!existsSync(path)) return null;
-  try {
-    return JSON.parse(await readFile(path, 'utf-8'));
-  } catch {
-    return null;
+  const paths = await getReadScopedStatePaths(mode, projectRoot);
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+    try {
+      return JSON.parse(await readFile(path, 'utf-8'));
+    } catch {
+      return null;
+    }
   }
+  return null;
 }
 
 /**
@@ -153,13 +163,15 @@ export async function updateModeState(
 ): Promise<ModeState> {
   const current = await readModeState(mode, projectRoot);
   if (!current) throw new Error(`Mode ${mode} not found`);
+  const scope = await resolveStateScope(projectRoot);
+  await mkdir(scope.stateDir, { recursive: true });
 
   const updatedBase = { ...current, ...updates };
   const normalizedBase = mode === 'ralph'
     ? normalizeRalphModeStateOrThrow(updatedBase as ModeState)
     : updatedBase;
   const updated = withModeRuntimeContext(current, normalizedBase) as ModeState;
-  await writeFile(statePath(mode, projectRoot), JSON.stringify(updated, null, 2));
+  await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(updated, null, 2));
   return updated;
 }
 
@@ -181,20 +193,23 @@ export async function cancelMode(mode: string, projectRoot?: string): Promise<vo
  * Cancel all active modes
  */
 export async function cancelAllModes(projectRoot?: string): Promise<string[]> {
-  const { readdir } = await import('fs/promises');
-  const dir = stateDir(projectRoot);
+  const dirs = await getReadScopedStateDirs(projectRoot);
   const cancelled: string[] = [];
+  const seenModes = new Set<string>();
 
-  if (!existsSync(dir)) return cancelled;
-
-  const files = await readdir(dir);
-  for (const f of files) {
-    if (!f.endsWith('-state.json')) continue;
-    const mode = f.replace('-state.json', '');
-    const state = await readModeState(mode, projectRoot);
-    if (state?.active) {
-      await cancelMode(mode, projectRoot);
-      cancelled.push(mode);
+  for (const dir of dirs) {
+    if (!existsSync(dir)) continue;
+    const files = await readdir(dir);
+    for (const f of files) {
+      if (!f.endsWith('-state.json')) continue;
+      const mode = f.replace('-state.json', '');
+      if (seenModes.has(mode)) continue;
+      seenModes.add(mode);
+      const state = await readModeState(mode, projectRoot);
+      if (state?.active) {
+        await cancelMode(mode, projectRoot);
+        cancelled.push(mode);
+      }
     }
   }
   return cancelled;
@@ -204,19 +219,22 @@ export async function cancelAllModes(projectRoot?: string): Promise<string[]> {
  * List all active modes
  */
 export async function listActiveModes(projectRoot?: string): Promise<Array<{ mode: string; state: ModeState }>> {
-  const { readdir } = await import('fs/promises');
-  const dir = stateDir(projectRoot);
+  const dirs = await getReadScopedStateDirs(projectRoot);
   const active: Array<{ mode: string; state: ModeState }> = [];
+  const seenModes = new Set<string>();
 
-  if (!existsSync(dir)) return active;
-
-  const files = await readdir(dir);
-  for (const f of files) {
-    if (!f.endsWith('-state.json')) continue;
-    const mode = f.replace('-state.json', '');
-    const state = await readModeState(mode, projectRoot);
-    if (state?.active) {
-      active.push({ mode, state });
+  for (const dir of dirs) {
+    if (!existsSync(dir)) continue;
+    const files = await readdir(dir);
+    for (const f of files) {
+      if (!f.endsWith('-state.json')) continue;
+      const mode = f.replace('-state.json', '');
+      if (seenModes.has(mode)) continue;
+      seenModes.add(mode);
+      const state = await readModeState(mode, projectRoot);
+      if (state?.active) {
+        active.push({ mode, state });
+      }
     }
   }
   return active;

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -103,6 +103,36 @@ describe('RALPLAN Stage', () => {
     assert.equal(artifacts.planningComplete, false);
   });
 
+  it('can execute a real ralplan runtime when an executor is provided', async () => {
+    const stage = createRalplanStage({
+      executor: {
+        async draft() {
+          const plansDir = join(tempDir, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-runtime.md');
+          await writeFile(prdPath, '# Runtime Plan\n');
+          await writeFile(join(plansDir, 'test-spec-runtime.md'), '# Runtime Tests\n');
+          return { summary: 'drafted', planPath: prdPath, artifacts: { runtimeDrafted: true } };
+        },
+        async architectReview() {
+          return { verdict: 'approve', summary: 'architect ok' };
+        },
+        async criticReview() {
+          return { verdict: 'approve', summary: 'critic ok' };
+        },
+      },
+    });
+
+    const result = await stage.run(makeCtx({ task: 'live ralplan run' }));
+    const artifacts = result.artifacts as Record<string, unknown>;
+
+    assert.equal(result.status, 'completed');
+    assert.equal(artifacts.runtime, true);
+    assert.equal(artifacts.planningComplete, true);
+    assert.equal(artifacts.iteration, 1);
+    assert.equal(artifacts.runtimeDrafted, true);
+  });
+
   it('canSkip returns false for non-prd plan files', async () => {
     const plansDir = join(tempDir, '.omx', 'plans');
     await mkdir(plansDir, { recursive: true });

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -25,6 +25,7 @@ export {
 } from './orchestrator.js';
 
 export { createRalplanStage } from './stages/ralplan.js';
+export type { CreateRalplanStageOptions } from './stages/ralplan.js';
 export { createTeamExecStage, buildTeamInstruction } from './stages/team-exec.js';
 export type { TeamExecStageOptions, TeamExecDescriptor } from './stages/team-exec.js';
 export { createRalphVerifyStage, buildRalphInstruction } from './stages/ralph-verify.js';

--- a/src/pipeline/stages/ralplan.ts
+++ b/src/pipeline/stages/ralplan.ts
@@ -7,6 +7,15 @@
 
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
 import { isPlanningComplete, readPlanningArtifacts } from '../../planning/artifacts.js';
+import {
+  runRalplanConsensus,
+  type RalplanConsensusExecutor,
+} from '../../ralplan/runtime.js';
+
+export interface CreateRalplanStageOptions {
+  executor?: RalplanConsensusExecutor;
+  maxIterations?: number;
+}
 
 /**
  * Create a RALPLAN pipeline stage.
@@ -15,11 +24,11 @@ import { isPlanningComplete, readPlanningArtifacts } from '../../planning/artifa
  * architect, and critic agents. It outputs a plan file that downstream
  * stages (team-exec) consume.
  *
- * This is a structural adapter — actual agent orchestration happens at
- * the skill layer. The stage manages lifecycle, artifact discovery, and
- * skip detection.
+ * By default this remains a structural adapter — actual agent orchestration
+ * happens at the skill layer. When an executor is provided, the stage can
+ * drive the real ralplan runtime and persist live mode state.
  */
-export function createRalplanStage(): PipelineStage {
+export function createRalplanStage(options: CreateRalplanStageOptions = {}): PipelineStage {
   return {
     name: 'ralplan',
 
@@ -30,6 +39,38 @@ export function createRalplanStage(): PipelineStage {
     async run(ctx: StageContext): Promise<StageResult> {
       const startTime = Date.now();
       try {
+        if (options.executor) {
+          const runtimeResult = await runRalplanConsensus(options.executor, {
+            task: ctx.task,
+            cwd: ctx.cwd,
+            maxIterations: options.maxIterations,
+          });
+
+          const planningArtifacts = readPlanningArtifacts(ctx.cwd);
+          return {
+            status: runtimeResult.status === 'completed' ? 'completed' : 'failed',
+            artifacts: {
+              plansDir: planningArtifacts.plansDir,
+              specsDir: planningArtifacts.specsDir,
+              task: ctx.task,
+              prdPaths: planningArtifacts.prdPaths,
+              testSpecPaths: planningArtifacts.testSpecPaths,
+              deepInterviewSpecPaths: planningArtifacts.deepInterviewSpecPaths,
+              planningComplete: runtimeResult.planningComplete,
+              stage: 'ralplan',
+              runtime: true,
+              iteration: runtimeResult.iteration,
+              latestPlanPath: runtimeResult.latestPlanPath,
+              drafts: runtimeResult.drafts,
+              architectReviews: runtimeResult.architectReviews,
+              criticReviews: runtimeResult.criticReviews,
+              ...runtimeResult.artifacts,
+            },
+            duration_ms: Date.now() - startTime,
+            error: runtimeResult.error,
+          };
+        }
+
         const planningArtifacts = readPlanningArtifacts(ctx.cwd);
 
         return {

--- a/src/ralplan/__tests__/runtime.test.ts
+++ b/src/ralplan/__tests__/runtime.test.ts
@@ -1,0 +1,180 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readModeState, startMode } from '../../modes/base.js';
+import { cancelRalplanConsensus, runRalplanConsensus } from '../runtime.js';
+
+function sessionStatePath(cwd: string, sessionId: string): string {
+  return join(cwd, '.omx', 'state', 'sessions', sessionId, 'ralplan-state.json');
+}
+
+async function readScopedRalplanState(cwd: string, sessionId: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(sessionStatePath(cwd, sessionId), 'utf-8'));
+}
+
+describe('ralplan runtime', () => {
+  it('persists a successful session-scoped lifecycle through complete', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-'));
+    const sessionId = 'sess-ralplan-success';
+    try {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      const seenPhases: string[] = [];
+      const result = await runRalplanConsensus({
+        async draft(ctx) {
+          const state = await readScopedRalplanState(cwd, sessionId);
+          seenPhases.push(String(state.current_phase));
+          assert.equal(state.current_phase, 'draft');
+          assert.equal(state.iteration, 1);
+
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-success.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-success.md'), '# tests\n');
+          return { summary: `draft-${ctx.iteration}`, planPath: prdPath, artifacts: { drafted: true } };
+        },
+        async architectReview() {
+          const state = await readScopedRalplanState(cwd, sessionId);
+          seenPhases.push(String(state.current_phase));
+          assert.equal(state.current_phase, 'architect-review');
+          assert.equal(state.iteration, 1);
+          return { verdict: 'approve', summary: 'architect-ok', artifacts: { architected: true } };
+        },
+        async criticReview() {
+          const state = await readScopedRalplanState(cwd, sessionId);
+          seenPhases.push(String(state.current_phase));
+          assert.equal(state.current_phase, 'critic-review');
+          assert.equal(state.iteration, 1);
+          return { verdict: 'approve', summary: 'critic-ok', artifacts: { critiqued: true } };
+        },
+      }, { task: 'implement live ralplan runtime', cwd });
+
+      assert.equal(result.status, 'completed');
+      assert.equal(result.phase, 'complete');
+      assert.equal(result.iteration, 1);
+      assert.equal(result.planningComplete, true);
+      assert.deepEqual(seenPhases, ['draft', 'architect-review', 'critic-review']);
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'ralplan-state.json')), false);
+      assert.equal(existsSync(sessionStatePath(cwd, sessionId)), true);
+
+      const finalState = await readModeState('ralplan', cwd);
+      assert.equal(finalState?.active, false);
+      assert.equal(finalState?.current_phase, 'complete');
+      assert.equal(finalState?.iteration, 1);
+      assert.equal(finalState?.planning_complete, true);
+      assert.equal(finalState?.latest_architect_verdict, 'approve');
+      assert.equal(finalState?.latest_critic_verdict, 'approve');
+      assert.equal(Array.isArray(finalState?.review_history), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('increments iteration when critic requests a re-review loop', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-loop-'));
+    const sessionId = 'sess-ralplan-loop';
+    try {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      const draftIterations: number[] = [];
+      const criticVerdicts: string[] = [];
+      let criticCalls = 0;
+
+      const result = await runRalplanConsensus({
+        async draft(ctx) {
+          const state = await readScopedRalplanState(cwd, sessionId);
+          draftIterations.push(Number(state.iteration));
+          assert.equal(state.current_phase, 'draft');
+
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-loop.md');
+          await writeFile(prdPath, '# loop plan\n');
+          await writeFile(join(plansDir, 'test-spec-loop.md'), '# loop tests\n');
+          return { summary: `draft-${ctx.iteration}`, planPath: prdPath };
+        },
+        async architectReview(ctx) {
+          const state = await readScopedRalplanState(cwd, sessionId);
+          assert.equal(state.current_phase, 'architect-review');
+          return { verdict: 'approve', summary: `architect-${ctx.iteration}` };
+        },
+        async criticReview(ctx) {
+          const state = await readScopedRalplanState(cwd, sessionId);
+          assert.equal(state.current_phase, 'critic-review');
+          criticCalls += 1;
+          const verdict = criticCalls === 1 ? 'iterate' : 'approve';
+          criticVerdicts.push(verdict);
+          return { verdict, summary: `critic-${ctx.iteration}-${verdict}` };
+        },
+      }, { task: 'loop until approval', cwd, maxIterations: 3 });
+
+      assert.equal(result.status, 'completed');
+      assert.equal(result.iteration, 2);
+      assert.deepEqual(draftIterations, [1, 2]);
+      assert.deepEqual(criticVerdicts, ['iterate', 'approve']);
+
+      const finalState = await readModeState('ralplan', cwd);
+      assert.equal(finalState?.current_phase, 'complete');
+      assert.equal(finalState?.iteration, 2);
+      assert.equal((finalState?.review_history as Array<unknown>).length, 2);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('marks failed cleanly when execution throws', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-fail-'));
+    const sessionId = 'sess-ralplan-fail';
+    try {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      const result = await runRalplanConsensus({
+        async draft() {
+          return { summary: 'draft' };
+        },
+        async architectReview() {
+          throw new Error('architect blew up');
+        },
+        async criticReview() {
+          throw new Error('should not run');
+        },
+      }, { task: 'failing ralplan runtime', cwd });
+
+      assert.equal(result.status, 'failed');
+      assert.match(result.error || '', /architect blew up/);
+
+      const finalState = await readModeState('ralplan', cwd);
+      assert.equal(finalState?.active, false);
+      assert.equal(finalState?.current_phase, 'failed');
+      assert.match(String(finalState?.error || ''), /architect blew up/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('marks cancelled state cleanly', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-cancel-'));
+    const sessionId = 'sess-ralplan-cancel';
+    try {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      await startMode('ralplan', 'cancel me', 2, cwd);
+      await cancelRalplanConsensus(cwd);
+
+      const finalState = await readModeState('ralplan', cwd);
+      assert.equal(finalState?.active, false);
+      assert.equal(finalState?.current_phase, 'cancelled');
+      assert.ok(typeof finalState?.completed_at === 'string' && finalState.completed_at.length > 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -1,0 +1,296 @@
+import { cancelMode, readModeState, startMode, updateModeState } from '../modes/base.js';
+import { readPlanningArtifacts } from '../planning/artifacts.js';
+
+export const RALPLAN_ACTIVE_PHASES = [
+  'draft',
+  'architect-review',
+  'critic-review',
+  'complete',
+] as const;
+
+export type RalplanActivePhase = (typeof RALPLAN_ACTIVE_PHASES)[number];
+export type RalplanTerminalPhase = 'complete' | 'cancelled' | 'failed';
+export type RalplanReviewVerdict = 'approve' | 'iterate' | 'reject';
+
+export interface RalplanDraftResult {
+  summary?: string;
+  planPath?: string;
+  artifacts?: Record<string, unknown>;
+}
+
+export interface RalplanReviewResult {
+  verdict: RalplanReviewVerdict;
+  summary?: string;
+  artifacts?: Record<string, unknown>;
+}
+
+export interface RalplanConsensusIterationContext {
+  task: string;
+  cwd: string;
+  iteration: number;
+  priorDrafts: RalplanDraftResult[];
+  architectReviews: RalplanReviewResult[];
+  criticReviews: RalplanReviewResult[];
+}
+
+export interface RalplanConsensusExecutor {
+  draft(ctx: RalplanConsensusIterationContext): Promise<RalplanDraftResult>;
+  architectReview(
+    ctx: RalplanConsensusIterationContext & { draft: RalplanDraftResult },
+  ): Promise<RalplanReviewResult>;
+  criticReview(
+    ctx: RalplanConsensusIterationContext & {
+      draft: RalplanDraftResult;
+      architectReview: RalplanReviewResult;
+    },
+  ): Promise<RalplanReviewResult>;
+}
+
+export interface RunRalplanConsensusOptions {
+  task: string;
+  cwd?: string;
+  maxIterations?: number;
+}
+
+export interface RalplanRuntimeResult {
+  status: 'completed' | 'failed' | 'cancelled';
+  iteration: number;
+  phase: RalplanTerminalPhase;
+  planningComplete: boolean;
+  drafts: RalplanDraftResult[];
+  architectReviews: RalplanReviewResult[];
+  criticReviews: RalplanReviewResult[];
+  latestPlanPath?: string;
+  artifacts: Record<string, unknown>;
+  error?: string;
+}
+
+interface RalplanModeUpdates {
+  active?: boolean;
+  current_phase?: string;
+  completed_at?: string;
+  error?: string;
+  planning_complete?: boolean;
+  iteration?: number;
+  latest_plan_path?: string;
+  latest_draft_summary?: string;
+  latest_architect_verdict?: RalplanReviewVerdict;
+  latest_architect_summary?: string;
+  latest_critic_verdict?: RalplanReviewVerdict;
+  latest_critic_summary?: string;
+  review_history?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+function buildReviewHistory(
+  drafts: RalplanDraftResult[],
+  architectReviews: RalplanReviewResult[],
+  criticReviews: RalplanReviewResult[],
+): Array<Record<string, unknown>> {
+  const entries: Array<Record<string, unknown>> = [];
+  const total = Math.max(drafts.length, architectReviews.length, criticReviews.length);
+  for (let index = 0; index < total; index++) {
+    entries.push({
+      iteration: index + 1,
+      draft: drafts[index] ?? null,
+      architect_review: architectReviews[index] ?? null,
+      critic_review: criticReviews[index] ?? null,
+    });
+  }
+  return entries;
+}
+
+async function updateRalplanState(
+  cwd: string,
+  updates: RalplanModeUpdates,
+): Promise<void> {
+  await updateModeState('ralplan', updates, cwd);
+}
+
+export async function runRalplanConsensus(
+  executor: RalplanConsensusExecutor,
+  options: RunRalplanConsensusOptions,
+): Promise<RalplanRuntimeResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const maxIterations = options.maxIterations ?? 5;
+  const drafts: RalplanDraftResult[] = [];
+  const architectReviews: RalplanReviewResult[] = [];
+  const criticReviews: RalplanReviewResult[] = [];
+  const aggregatedArtifacts: Record<string, unknown> = {};
+  let latestPlanPath: string | undefined;
+  let iteration = 1;
+
+  const existing = await readModeState('ralplan', cwd);
+  if (existing?.active) {
+    throw new Error('ralplan_active_mode_exists');
+  }
+
+  await startMode('ralplan', options.task, maxIterations, cwd);
+
+  try {
+    while (iteration <= maxIterations) {
+      const iterationContext: RalplanConsensusIterationContext = {
+        task: options.task,
+        cwd,
+        iteration,
+        priorDrafts: [...drafts],
+        architectReviews: [...architectReviews],
+        criticReviews: [...criticReviews],
+      };
+
+      await updateRalplanState(cwd, {
+        iteration,
+        current_phase: 'draft',
+        planning_complete: false,
+        review_history: buildReviewHistory(drafts, architectReviews, criticReviews),
+      });
+      const draft = await executor.draft(iterationContext);
+      drafts.push(draft);
+      if (draft.artifacts) Object.assign(aggregatedArtifacts, draft.artifacts);
+      if (draft.planPath) latestPlanPath = draft.planPath;
+
+      await updateRalplanState(cwd, {
+        iteration,
+        current_phase: 'architect-review',
+        latest_plan_path: latestPlanPath,
+        latest_draft_summary: draft.summary,
+        review_history: buildReviewHistory(drafts, architectReviews, criticReviews),
+      });
+      const architectReview = await executor.architectReview({
+        ...iterationContext,
+        draft,
+      });
+      architectReviews.push(architectReview);
+      if (architectReview.artifacts) Object.assign(aggregatedArtifacts, architectReview.artifacts);
+
+      await updateRalplanState(cwd, {
+        iteration,
+        current_phase: 'critic-review',
+        latest_architect_verdict: architectReview.verdict,
+        latest_architect_summary: architectReview.summary,
+        review_history: buildReviewHistory(drafts, architectReviews, criticReviews),
+      });
+      const criticReview = await executor.criticReview({
+        ...iterationContext,
+        draft,
+        architectReview,
+      });
+      criticReviews.push(criticReview);
+      if (criticReview.artifacts) Object.assign(aggregatedArtifacts, criticReview.artifacts);
+
+      const reviewHistory = buildReviewHistory(drafts, architectReviews, criticReviews);
+      await updateRalplanState(cwd, {
+        iteration,
+        current_phase: criticReview.verdict === 'approve' ? 'complete' : 'critic-review',
+        latest_critic_verdict: criticReview.verdict,
+        latest_critic_summary: criticReview.summary,
+        review_history: reviewHistory,
+      });
+
+      if (criticReview.verdict === 'approve') {
+        const planningArtifacts = readPlanningArtifacts(cwd);
+        const planningComplete = planningArtifacts.prdPaths.length > 0 && planningArtifacts.testSpecPaths.length > 0;
+        await updateRalplanState(cwd, {
+          active: false,
+          iteration,
+          current_phase: 'complete',
+          completed_at: new Date().toISOString(),
+          planning_complete: planningComplete,
+          latest_plan_path: latestPlanPath,
+          review_history: reviewHistory,
+        });
+        return {
+          status: 'completed',
+          iteration,
+          phase: 'complete',
+          planningComplete,
+          drafts,
+          architectReviews,
+          criticReviews,
+          latestPlanPath,
+          artifacts: aggregatedArtifacts,
+        };
+      }
+
+      if (iteration >= maxIterations) {
+        const error = `ralplan_consensus_not_reached_after_${maxIterations}_iterations`;
+        await updateRalplanState(cwd, {
+          active: false,
+          iteration,
+          current_phase: 'failed',
+          completed_at: new Date().toISOString(),
+          planning_complete: false,
+          latest_plan_path: latestPlanPath,
+          latest_critic_verdict: criticReview.verdict,
+          latest_critic_summary: criticReview.summary,
+          review_history: reviewHistory,
+          error,
+        });
+        return {
+          status: 'failed',
+          iteration,
+          phase: 'failed',
+          planningComplete: false,
+          drafts,
+          architectReviews,
+          criticReviews,
+          latestPlanPath,
+          artifacts: aggregatedArtifacts,
+          error,
+        };
+      }
+
+      iteration += 1;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await updateRalplanState(cwd, {
+      active: false,
+      iteration,
+      current_phase: 'failed',
+      completed_at: new Date().toISOString(),
+      planning_complete: false,
+      latest_plan_path: latestPlanPath,
+      review_history: buildReviewHistory(drafts, architectReviews, criticReviews),
+      error: message,
+    });
+    return {
+      status: 'failed',
+      iteration,
+      phase: 'failed',
+      planningComplete: false,
+      drafts,
+      architectReviews,
+      criticReviews,
+      latestPlanPath,
+      artifacts: aggregatedArtifacts,
+      error: message,
+    };
+  }
+
+  const unreachableError = 'ralplan_runtime_unreachable_state';
+  await updateRalplanState(cwd, {
+    active: false,
+    iteration,
+    current_phase: 'failed',
+    completed_at: new Date().toISOString(),
+    planning_complete: false,
+    error: unreachableError,
+  });
+  return {
+    status: 'failed',
+    iteration,
+    phase: 'failed',
+    planningComplete: false,
+    drafts,
+    architectReviews,
+    criticReviews,
+    latestPlanPath,
+    artifacts: aggregatedArtifacts,
+    error: unreachableError,
+  };
+}
+
+export async function cancelRalplanConsensus(cwd?: string): Promise<void> {
+  await cancelMode('ralplan', cwd);
+}


### PR DESCRIPTION
## Summary
- add a real src/ralplan/runtime.ts consensus runtime that owns draft/architect-review/critic-review/complete state transitions
- persist ralplan mode state through src/modes/base.ts using current session scope so HUD state readers observe live runs
- keep the existing pipeline stage as a structural fallback while allowing it to opt into the real runtime, with tests for lifecycle, iteration, and HUD/session behavior

## Testing
- npm run lint
- node --test dist/ralplan/__tests__/runtime.test.js dist/modes/__tests__/base-session-scope.test.js dist/hud/__tests__/state.test.js dist/pipeline/__tests__/stages.test.js dist/modes/__tests__/base-autoresearch-contract.test.js dist/modes/__tests__/base-tmux-pane.test.js
- npm test

Closes #1059
