### PR TITLE
Prepare 0.11.9 release from the March 25, 2026 dev tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.11.9] - 2026-03-25
+
+Patch release for deeper deep-interview / ralplan coordination, setup repair, and safer live team supervision after `0.11.8`.
+
+### Added
+- **Live ralplan state visibility** — consensus planning now exposes observable runtime state so the pipeline, HUD, and attached guidance can reflect active ralplan progress more faithfully. (PR [#1060](https://github.com/Yeachan-Heo/oh-my-codex/pull/1060))
+- **Analyze skill trace refresh** — the shipped analyze skill now follows the OmC trace methodology with restored execution-policy contract wording, improving investigation guidance. (direct commits `fa01cb5`, `c0a0e1a`)
+
+### Fixed
+- **Deep-interview lock suppresses tmux-pane nudges** — active deep-interview lock state now blocks fallback tmux-pane nudges, and planning handoff applies stronger deep-interview pressure before execution can proceed. (PRs [#1062](https://github.com/Yeachan-Heo/oh-my-codex/pull/1062), [#1058](https://github.com/Yeachan-Heo/oh-my-codex/pull/1058))
+- **Setup stays compatible with Codex-managed TUI configs** — rerunning setup no longer rebreaks managed TUI sections, while explore-routing defaults remain aligned with setup guidance. (PRs [#1048](https://github.com/Yeachan-Heo/oh-my-codex/pull/1048), [#1053](https://github.com/Yeachan-Heo/oh-my-codex/pull/1053))
+- **HUD stateful-mode visibility restored** — active stateful modes are visible in the HUD again instead of disappearing during live sessions. (PR [#1055](https://github.com/Yeachan-Heo/oh-my-codex/pull/1055))
+- **Live worker supervision remains resilient** — fallback orchestration now stays alive while team workers are still active, and team flows auto-accept the Claude bypass prompt when required. (PR [#1043](https://github.com/Yeachan-Heo/oh-my-codex/pull/1043), direct commit `3f2eb67`)
+
+### Changed
+- **Maintenance refresh** — dev dependency baselines now use `c8@11.0.0` and `@types/node@25.5.0`, and the README adds a Star History chart. (PRs [#1049](https://github.com/Yeachan-Heo/oh-my-codex/pull/1049), [#1051](https://github.com/Yeachan-Heo/oh-my-codex/pull/1051); docs commit `ed96d42`)
+- **Release metadata sync** — Node and Cargo package metadata are bumped to `0.11.9` for this patch release.
+
+### Verified
+- `npm run build`
+- `npm run lint`
+- `npm run check:no-unused`
+- `node --test --test-reporter=spec dist/cli/__tests__/version-sync-contract.test.js`
+- `node --test --test-reporter=spec dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/doctor-warning-copy.test.js`
+- `node --test --test-reporter=spec dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js dist/hooks/__tests__/deep-interview-contract.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/agents-overlay.test.js`
+- `node --test --test-reporter=spec dist/hud/__tests__/index.test.js dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js`
+- `node --test --test-reporter=spec dist/pipeline/__tests__/stages.test.js dist/ralplan/__tests__/runtime.test.js`
+
 ## [0.11.8] - 2026-03-23
 
 Hotfix release for deep-interview nudge suppression and duplicate fresh-leader nudge prevention.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,11 +32,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.11.8"
+version = "0.11.9"
 
 [[package]]
 name = "omx-mux"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "fs2",
  "serde",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.11.8"
+version = "0.11.9"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.11.8"
+version = "0.11.9"
 
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 - [Français](./README.fr.md)
 - [Italiano](./README.it.md)
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
+
 ## License
 
 MIT

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,39 +1,52 @@
-# oh-my-codex v0.11.8
+# oh-my-codex v0.11.9
 
-**Hotfix release for deep-interview nudge suppression and fresh-leader nudge dedupe hardening**
+**Patch release for deeper deep-interview / ralplan coordination, setup repair, and safer live team supervision**
 
-`0.11.8` follows `0.11.7` with a narrow fix set focused on keeping deep-interview sessions interruption-free and preventing duplicate fresh leader nudges.
+`0.11.9` follows `0.11.8` with a focused patch train that hardens deep-interview behavior, makes live ralplan progress observable, and cleans up setup / HUD / routing polish around active maintainer workflows.
 
 ## Highlights
 
-- Deep-interview state now suppresses all notify-hook and fallback-watcher nudge families.
-- Fallback watcher leader nudges remain stale-only, avoiding duplicate fresh-message nudges.
-- Node and Cargo package metadata are synchronized at `0.11.8`.
+- Deep-interview lock state now suppresses tmux-pane nudges, and the planning handoff keeps stronger deep-interview pressure before execution.
+- Live ralplan consensus planning now exposes observable runtime state for downstream HUD / pipeline visibility.
+- Setup no longer rebreaks Codex-managed TUI configs, active stateful modes stay visible in the HUD, and live worker supervision remains alive while workers are still active.
 
 ## What’s Changed
 
 ### Fixes
-- suppress leader nudges, worker-idle nudges, Ralph continue-steers, and auto-nudges whenever deep-interview state is active
-- keep fallback watcher leader nudges gated on actual leader staleness
-- add regression coverage proving the same fresh mailbox message does not re-trigger notify-hook leader nudges
+- suppress fallback tmux-pane nudges while deep-interview lock state is active
+- strengthen deep-interview pressure before planning handoff
+- keep setup compatible with Codex-managed TUI configs and align default explore-routing guidance with setup adoption
+- restore HUD visibility for active stateful modes
+- keep fallback orchestration alive while live team workers still need supervision
+- auto-accept the Claude bypass prompt in team flows when required
 
 ### Changed
-- release metadata updated from `0.11.7` to `0.11.8` across the TypeScript and Rust packages
+- expose observable ralplan runtime state during live consensus planning
+- refresh the analyze skill around OmC trace methodology and execution-policy contract wording
+- bump release metadata from `0.11.8` to `0.11.9` across the Node and Cargo packages
+- refresh maintenance baselines with `c8@11.0.0`, `@types/node@25.5.0`, and the README Star History chart
 
 ## Verification
 
 - `npm run build`
-- `node --test --test-reporter=spec dist/hooks/__tests__/notify-hook-auto-nudge.test.js`
-- `node --test --test-reporter=spec dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
-- `node --test --test-reporter=spec dist/hooks/__tests__/notify-fallback-watcher.test.js`
+- `npm run lint`
+- `npm run check:no-unused`
+- `node --test --test-reporter=spec dist/cli/__tests__/version-sync-contract.test.js`
+- `node --test --test-reporter=spec dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/doctor-warning-copy.test.js`
+- `node --test --test-reporter=spec dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js dist/hooks/__tests__/deep-interview-contract.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/agents-overlay.test.js`
+- `node --test --test-reporter=spec dist/hud/__tests__/index.test.js dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js`
+- `node --test --test-reporter=spec dist/pipeline/__tests__/stages.test.js dist/ralplan/__tests__/runtime.test.js`
 
 ## Remaining risk
 
-- This hotfix intentionally gates nudge entrypoints at the notify-hook and fallback-watcher callers; any future nudge caller should preserve the same deep-interview suppression contract.
-- Verification is targeted to the nudge paths touched by this change rather than the entire repository test suite.
+- Verification is intentionally targeted to the release-window behavior touched after `v0.11.8`; it is not a rerun of the full repository test matrix.
+- The deep-interview nudge suppression contract still depends on future nudge entrypoints preserving the same lock-state check.
+- Live ralplan observability now feeds more surfaces, so future HUD / pipeline readers should preserve the same runtime field names.
 
 ## Contributors
 
 - [@Yeachan-Heo](https://github.com/Yeachan-Heo) (Bellman)
+- [@HaD0Yun](https://github.com/HaD0Yun)
+- [@ToaruPen](https://github.com/ToaruPen)
 
-**Full Changelog**: [`v0.11.7...v0.11.8`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.11.7...v0.11.8)
+**Full Changelog**: [`v0.11.8...v0.11.9`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.11.8...v0.11.9)

--- a/docs/release-notes-0.11.9.md
+++ b/docs/release-notes-0.11.9.md
@@ -1,0 +1,36 @@
+# Release notes — 0.11.9
+
+## Summary
+
+`0.11.9` is a focused patch release after `0.11.8` that hardens deep-interview / ralplan coordination, repairs setup behavior around Codex-managed TUI configs, and keeps live worker supervision / HUD state visibility aligned with active sessions.
+
+## Included fixes and changes
+
+- deep-interview lock state now suppresses fallback tmux-pane nudges
+- planning handoff applies stronger deep-interview pressure before execution
+- live ralplan consensus planning exposes observable runtime state for HUD / pipeline visibility
+- setup no longer rebreaks Codex-managed TUI configs, and default explore-routing guidance stays aligned with setup adoption
+- active stateful modes are visible in the HUD again during live sessions
+- fallback orchestration stays alive while live team workers remain active
+- team flows auto-accept the Claude bypass prompt when required
+- the shipped analyze skill now follows the OmC trace methodology with restored execution-policy contract wording
+- release metadata is bumped to `0.11.9` across Node and Cargo packages
+
+## Verification evidence
+
+### Targeted release regression suite
+
+- `npm run build` ✅
+- `npm run lint` ✅
+- `npm run check:no-unused` ✅
+- `node --test --test-reporter=spec dist/cli/__tests__/version-sync-contract.test.js` ✅
+- `node --test --test-reporter=spec dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/doctor-warning-copy.test.js` ✅
+- `node --test --test-reporter=spec dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js dist/hooks/__tests__/deep-interview-contract.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/agents-overlay.test.js` ✅
+- `node --test --test-reporter=spec dist/hud/__tests__/index.test.js dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js` ✅
+- `node --test --test-reporter=spec dist/pipeline/__tests__/stages.test.js dist/ralplan/__tests__/runtime.test.js` ✅
+
+## Remaining risk
+
+- This release verification is intentionally targeted to the post-`0.11.8` surfaces that changed; it is not a full GitHub Actions matrix rerun.
+- Future nudge entrypoints must preserve the same deep-interview lock suppression check to keep the behavior consistent.
+- Future HUD / pipeline readers should preserve the new ralplan runtime field names if they depend on the live observability surface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.11.8",
+      "version": "0.11.9",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- re-derive the `0.11.9` release-prep artifacts from the latest `origin/dev` window as of March 25, 2026
- bump Node and Cargo release metadata to `0.11.9`
- refresh `CHANGELOG.md`, `RELEASE_BODY.md`, and add `docs/release-notes-0.11.9.md`

## Verification
- npm run build
- npm run lint
- npm run check:no-unused
- node --test --test-reporter=spec dist/cli/__tests__/version-sync-contract.test.js
- node --test --test-reporter=spec dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/doctor-warning-copy.test.js
- node --test --test-reporter=spec dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js dist/hooks/__tests__/deep-interview-contract.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/agents-overlay.test.js
- node --test --test-reporter=spec dist/hud/__tests__/index.test.js dist/hud/__tests__/render.test.js dist/hud/__tests__/state.test.js
- node --test --test-reporter=spec dist/pipeline/__tests__/stages.test.js dist/ralplan/__tests__/runtime.test.js

## Notes
- release branch/tag were pushed on March 25, 2026 UTC from commit `52647a72`
- the external GitHub Release workflow for `v0.11.9` is currently running separately from this PR flow
