### PR TITLE
Tighten pane-capture contracts and harden watcher buffering checks

### DIFF
--- a/crates/omx-mux/src/lib.rs
+++ b/crates/omx-mux/src/lib.rs
@@ -1,7 +1,7 @@
 mod tmux;
 mod types;
 
-pub use tmux::TmuxAdapter;
+pub use tmux::{build_capture_pane_args, TmuxAdapter};
 pub use types::*;
 
 pub fn canonical_contract_summary() -> String {

--- a/crates/omx-mux/src/tmux.rs
+++ b/crates/omx-mux/src/tmux.rs
@@ -56,7 +56,7 @@ pub(crate) fn build_enter_key_args(target: &str) -> Vec<String> {
 }
 
 /// Build the argument list for `tmux capture-pane`.
-pub(crate) fn build_capture_pane_args(target: &str, visible_lines: usize) -> Vec<String> {
+pub fn build_capture_pane_args(target: &str, visible_lines: usize) -> Vec<String> {
     vec![
         "capture-pane".into(),
         "-t".into(),

--- a/crates/omx-sparkshell/Cargo.toml
+++ b/crates/omx-sparkshell/Cargo.toml
@@ -8,3 +8,6 @@ repository.workspace = true
 [[bin]]
 name = "omx-sparkshell"
 path = "src/main.rs"
+
+[dependencies]
+omx-mux = { path = "../omx-mux" }

--- a/crates/omx-sparkshell/src/main.rs
+++ b/crates/omx-sparkshell/src/main.rs
@@ -10,6 +10,7 @@ use crate::codex_bridge::summarize_output;
 use crate::error::SparkshellError;
 use crate::exec::execute_command;
 use crate::threshold::{combined_visible_lines, read_line_threshold};
+use omx_mux::build_capture_pane_args;
 use std::io::{self, Write};
 use std::process;
 
@@ -44,15 +45,11 @@ fn run(args: Vec<String>) -> Result<(), SparkshellError> {
         SparkShellInput::TmuxPane {
             pane_id,
             tail_lines,
-        } => vec![
-            "tmux".to_string(),
-            "capture-pane".to_string(),
-            "-t".to_string(),
-            pane_id,
-            "-p".to_string(),
-            "-S".to_string(),
-            format!("-{tail_lines}"),
-        ],
+        } => {
+            let mut argv = vec!["tmux".to_string()];
+            argv.extend(build_capture_pane_args(&pane_id, tail_lines));
+            argv
+        }
     };
 
     let output = execute_command(&execution_argv)?;

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -18,6 +18,7 @@ import {
   resolveSparkShellBinaryPathWithHydration,
   runSparkShellBinary,
 } from '../sparkshell.js';
+import { buildCapturePaneArgv as buildNotificationCapturePaneArgv } from '../../notifications/tmux-detector.js';
 
 function runOmx(
   cwd: string,
@@ -368,6 +369,14 @@ describe('parseSparkShellFallbackInvocation', () => {
       parseSparkShellFallbackInvocation(['git', 'log', '--oneline']),
       { kind: 'command', argv: ['git', 'log', '--oneline'] },
     );
+  });
+
+  it('matches the shared notification capture-pane argv contract', () => {
+    const parsed = parseSparkShellFallbackInvocation(['--tmux-pane', '%12', '--tail-lines', '400']);
+    assert.deepEqual(parsed, {
+      kind: 'tmux-pane',
+      argv: ['tmux', ...buildNotificationCapturePaneArgv('%12', 400)],
+    });
   });
 
   it('converts tmux pane mode into capture-pane argv', () => {

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -9,6 +9,7 @@ import { isAbsolute, join, resolve } from 'path';
 import { getPackageRoot } from '../utils/package.js';
 import { classifySpawnError } from '../utils/platform-command.js';
 import { readConfiguredEnvOverrides } from '../config/models.js';
+import { buildCapturePaneArgv } from '../scripts/tmux-hook-engine.js';
 import {
   SPARKSHELL_BIN_ENV as SPARKSHELL_BIN_ENV_SHARED,
   getPackageVersion,
@@ -276,15 +277,7 @@ export function parseSparkShellFallbackInvocation(args: readonly string[]): Spar
 
   return {
     kind: 'tmux-pane',
-    argv: [
-      'tmux',
-      'capture-pane',
-      '-t',
-      paneId,
-      '-p',
-      '-S',
-      `-${sawTailLines ? tailLines : 200}`,
-    ],
+    argv: ['tmux', ...buildCapturePaneArgv(paneId, sawTailLines ? tailLines : 200)],
   };
 }
 

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -231,6 +231,87 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('streaming mode buffers partial JSON lines until the newline arrives', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-stream-partial-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-home-'));
+    const sid = randomUUID();
+    const sessionDir = todaySessionDir(tempHome);
+    const rolloutPath = join(sessionDir, `rollout-test-fallback-stream-partial-${sid}.jsonl`);
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+
+      const nowIso = new Date().toISOString();
+      const threadId = `thread-${sid}`;
+      const partialTurn = `turn-partial-${sid}`;
+
+      await writeFile(
+        rolloutPath,
+        `${JSON.stringify({
+          timestamp: nowIso,
+          type: 'session_meta',
+          payload: { id: threadId, cwd: wd },
+        })}
+`
+      );
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const turnLog = join(wd, '.omx', 'logs', `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const child = spawn(
+        process.execPath,
+        [watcherScript, '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '75'],
+        { cwd: wd, stdio: 'ignore', env: buildCleanNotifyEnv({ HOME: tempHome }) }
+      );
+
+      await waitFor(async () => {
+        try {
+          const state = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+          return state.tracked_files === 1;
+        } catch {
+          return false;
+        }
+      });
+
+      const partialPrefix = JSON.stringify({
+        timestamp: new Date(Date.now() + 500).toISOString(),
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: partialTurn,
+          last_agent_message: 'partial message',
+        },
+      });
+      const splitAt = Math.floor(partialPrefix.length / 2);
+      await writeFile(rolloutPath, `${await readFile(rolloutPath, 'utf-8')}${partialPrefix.slice(0, splitAt)}`);
+
+      await sleep(250);
+      const beforeLines = await readLines(turnLog);
+      assert.equal(beforeLines.length, 0, 'partial line should not be emitted before newline completes it');
+
+      await writeFile(rolloutPath, `${await readFile(rolloutPath, 'utf-8')}${partialPrefix.slice(splitAt)}\n`);
+
+      await waitFor(async () => {
+        const turnLines = await readLines(turnLog);
+        return turnLines.length === 1 && new RegExp(partialTurn).test(turnLines[0] ?? '');
+      }, 4000, 75);
+
+      child.kill('SIGTERM');
+      await once(child, 'exit');
+
+      const turnLines = await readLines(turnLog);
+      assert.equal(turnLines.length, 1);
+      assert.match(turnLines[0], new RegExp(partialTurn));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+      await rm(rolloutPath, { force: true });
+    }
+  });
+
   it('streaming mode tails from EOF and does not replay backlog', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-stream-'));
     const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-home-'));

--- a/src/notifications/tmux-detector.ts
+++ b/src/notifications/tmux-detector.ts
@@ -8,6 +8,7 @@
 import { execFileSync, spawnSync } from 'child_process';
 import { sleepSync } from '../utils/sleep.js';
 import { resolveCommandPathForPlatform } from '../utils/platform-command.js';
+import { buildCapturePaneArgv as sharedBuildCapturePaneArgv } from '../scripts/tmux-hook-engine.js';
 
 export function isTmuxAvailable(): boolean {
   return resolveCommandPathForPlatform('tmux') !== null;
@@ -19,7 +20,7 @@ export function isTmuxAvailable(): boolean {
  * command injection through a malicious paneId value (issue #156).
  */
 export function buildCapturePaneArgv(paneId: string, lines: number): string[] {
-  return ['capture-pane', '-t', paneId, '-p', '-S', `-${lines}`];
+  return sharedBuildCapturePaneArgv(paneId, lines);
 }
 
 export function capturePaneContent(paneId: string, lines: number = 15): string {

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -5,6 +5,7 @@
  */
 
 import { execFileSync, execSync } from "child_process";
+import { buildCapturePaneArgv } from "./tmux-detector.js";
 
 const TMUX_PANE_TARGET_RE = /^%\d+$/;
 const DEFAULT_CAPTURE_LINES = 12;
@@ -146,7 +147,7 @@ export function captureTmuxPane(paneId?: string | null, lines: number = 12): str
   const clampedLines = Math.max(1, Math.min(MAX_CAPTURE_LINES, safeLines));
 
   try {
-    const output = execFileSync("tmux", ["capture-pane", "-t", target, "-p", "-S", `-${clampedLines}`], {
+    const output = execFileSync("tmux", buildCapturePaneArgv(target, clampedLines), {
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -1101,6 +1101,15 @@ async function ensureTrackedFiles(): Promise<void> {
   }
 }
 
+function splitBufferedLines(partial: string, delta: string): { lines: string[]; partial: string } {
+  const merged = partial + delta;
+  const lines = merged.split('\n');
+  return {
+    lines,
+    partial: lines.pop() || '',
+  };
+}
+
 async function pollFiles(): Promise<void> {
   for (const [path, meta] of fileState.entries()) {
     const currentSize = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
@@ -1109,9 +1118,9 @@ async function pollFiles(): Promise<void> {
     if (!content) continue;
     const delta = content.slice(meta.offset);
     meta.offset = currentSize;
-    const merged = meta.partial + delta;
-    const lines = merged.split('\n');
-    meta.partial = lines.pop() || '';
+    const buffered = splitBufferedLines(meta.partial, delta);
+    const lines = buffered.lines;
+    meta.partial = buffered.partial;
     for (const line of lines) {
       if (!line.trim()) continue;
       await processLine(meta, line, path);

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -310,6 +310,10 @@ export function buildCapturePaneArgv(paneTarget: any, tailLines = 80): string[] 
   return ['capture-pane', '-t', paneTarget, '-p', '-S', `-${tailLines}`];
 }
 
+export function buildVisibleCapturePaneArgv(paneTarget: any): string[] {
+  return ['capture-pane', '-t', paneTarget, '-p'];
+}
+
 export function buildSendKeysArgv({ paneTarget, prompt, dryRun, submitKeyPresses = 2 }: any): any {
   if (dryRun) return null;
   const pressCountRaw = Number.isFinite(submitKeyPresses) ? Math.floor(submitKeyPresses) : 2;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1328,6 +1328,33 @@ describe('tmux-dependent functions when tmux is unavailable', () => {
     });
   });
 
+  it('waitForWorkerReady uses visible capture-pane argv without tail flags', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-worker-ready-visible-capture-',
+      (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        assert.equal(waitForWorkerReady('omx-team-x', 1, 1_000), true);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /capture-pane -t omx-team-x:1 -p/);
+        assert.doesNotMatch(log, /capture-pane -t omx-team-x:1 -p -S/);
+      },
+    );
+  });
+
   it('waitForWorkerReady accepts Codex 0.114.0-style welcome helper text', async () => {
     await withMockTmuxFixture(
       'omx-tmux-worker-ready-hello-',
@@ -1437,6 +1464,46 @@ esac
     withEmptyPath(() => {
       assert.equal(waitForWorkerReady('omx-team-x', 1, 1), false);
     });
+  });
+});
+
+describe('dismissTrustPromptIfPresent capture shape', () => {
+  it('uses visible capture-pane argv without tail flags', async () => {
+    const previousAutoTrust = process.env.OMX_TEAM_AUTO_TRUST;
+    delete process.env.OMX_TEAM_AUTO_TRUST;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-dismiss-trust-visible-capture-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    cat <<'EOF'
+Do you trust the contents of this directory?
+Press enter to continue
+EOF
+    exit 0
+    ;;
+  send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          assert.equal(dismissTrustPromptIfPresent('omx-team-x', 1), true);
+          const log = await readFile(logPath, 'utf-8');
+          assert.match(log, /capture-pane -t omx-team-x:1 -p/);
+          assert.doesNotMatch(log, /capture-pane -t omx-team-x:1 -p -S/);
+        },
+      );
+    } finally {
+      if (typeof previousAutoTrust === 'string') process.env.OMX_TEAM_AUTO_TRUST = previousAutoTrust;
+      else delete process.env.OMX_TEAM_AUTO_TRUST;
+    }
   });
 });
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -11,6 +11,7 @@ import {
 } from '../cli/constants.js';
 import {
   buildCapturePaneArgv as sharedBuildCapturePaneArgv,
+  buildVisibleCapturePaneArgv as sharedBuildVisibleCapturePaneArgv,
   normalizeTmuxCapture as sharedNormalizeTmuxCapture,
   paneHasActiveTask as sharedPaneHasActiveTask,
   paneIsBootstrapping as sharedPaneIsBootstrapping,
@@ -1214,7 +1215,7 @@ export function waitForWorkerReady(
 
   const check = (): boolean => {
     const target = paneTarget(sessionName, workerIndex, workerPaneId);
-    const result = runTmux(['capture-pane', '-t', target, '-p']);
+    const result = runTmux(sharedBuildVisibleCapturePaneArgv(target));
     if (!result.ok) return false;
     if (dismissClaudeBypassPermissionsPromptIfPresent(target, result.stdout)) {
       promptDismissed = true;
@@ -1269,7 +1270,7 @@ export function dismissTrustPromptIfPresent(
   if (process.env.OMX_TEAM_AUTO_TRUST === '0') return false;
   if (!isTmuxAvailable()) return false;
   const target = paneTarget(sessionName, workerIndex, workerPaneId);
-  const result = runTmux(['capture-pane', '-t', target, '-p']);
+  const result = runTmux(sharedBuildVisibleCapturePaneArgv(target));
   if (!result.ok) return false;
   if (!paneHasTrustPrompt(result.stdout)) return false;
   // Trust prompt detected; send C-m twice to dismiss (trust + follow-up splash)

--- a/src/types/tmux-hook-engine.d.ts
+++ b/src/types/tmux-hook-engine.d.ts
@@ -44,6 +44,7 @@ declare module '*tmux-hook-engine.js' {
     state: Record<string, unknown>;
   }): { allow: boolean; reason: string; dedupeKey?: string };
   export function buildCapturePaneArgv(paneTarget: string, tailLines?: number): string[];
+  export function buildVisibleCapturePaneArgv(paneTarget: string): string[];
   export function normalizeTmuxCapture(value: unknown): string;
   export function paneIsBootstrapping(lines: string[] | string): boolean;
   export function paneLooksReady(captured: string): boolean;


### PR DESCRIPTION
## Why

This slice grows Rust ownership in low-risk runtime-adjacent paths while keeping the riskiest watcher control-plane logic out of scope.

It focuses on:
- making tailed tmux pane capture more canonical across Rust and TS,
- separating **visible** vs **tailed** capture semantics where they genuinely differ,
- and hardening watcher buffered-line parsing with explicit regression coverage.

## What changed

### Rust / native lane
- export the tailed `capture-pane` argv builder from `omx-mux`
- update `omx-sparkshell` to consume that builder instead of rebuilding argv inline

### TypeScript pane-capture contract
- reuse the shared tailed capture builder in:
  - `src/cli/sparkshell.ts`
  - `src/notifications/tmux-detector.ts`
  - `src/notifications/tmux.ts`
- add parity coverage tying sparkshell fallback parsing to the shared notification capture contract

### Visible vs tailed capture split
- add an explicit **visible-capture** helper in `tmux-hook-engine`
- update `tmux-session` readiness / trust-prompt flows to use visible capture instead of tailed capture
- add tests locking the no-`-S` capture shape for those flows

### Watcher parser hardening
- extract buffered line splitting in `notify-fallback-watcher` into `splitBufferedLines()`
- add a regression test proving partial JSON lines are buffered until newline completion
- preserve existing EOF/backlog behavior

## Files touched

- `crates/omx-mux/src/{lib.rs,tmux.rs}`
- `crates/omx-sparkshell/{Cargo.toml,src/main.rs}`
- `src/cli/{sparkshell.ts,__tests__/sparkshell-cli.test.ts}`
- `src/notifications/{tmux.ts,tmux-detector.ts}`
- `src/scripts/{tmux-hook-engine.ts,notify-fallback-watcher.ts}`
- `src/team/{tmux-session.ts,__tests__/tmux-session.test.ts}`
- `src/hooks/__tests__/notify-fallback-watcher.test.ts`
- `src/types/tmux-hook-engine.d.ts`

## Verification

### Rust
- `cargo fmt --check && cargo test -p omx-mux -p omx-sparkshell` ✅

### TS changed-file lint
- `npx biome lint ...` on changed TS files ✅

### Focused TS verification
- sparkshell parity subset ✅
- notifications tmux + tmux-detector suites ✅
- tmux-session visible-capture subset ✅
- watcher partial-line + EOF/backlog subset ✅

### Full watcher-suite verification
- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js` on current checkpoint ✅
- same suite on `HEAD^` baseline in a temporary worktree ✅

## Conservative review result

A conservative `omx team` review was run across four lanes:
- pane-capture Rust/native contract
- TS sparkshell/notification parity
- tmux-session visible-vs-tailed split
- watcher buffered-line parser behavior

Final outcome:
- no concrete regression found in A–D
- an earlier lane-D warning was not reproducible after direct suite re-check
- the broader watcher suite is green on both the current checkpoint and its immediate parent baseline

## Risk / follow-up

The main remaining risk is **future architectural drift** if broader `notify-fallback-watcher` control-plane changes get mixed into the same slice.

Recommended follow-up:
- keep future watcher control-plane refactors separate from pane-contract slices
- rerun the full watcher suite whenever buffered-line parsing changes
