### PR TITLE
fix(ralph): gate continue steer on stale progress

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -164,6 +164,27 @@ function buildCleanNotifyEnv(
   };
 }
 
+async function writeHudTurnState(
+  stateDir: string,
+  options: {
+    ageMs?: number;
+    turnCount?: number;
+    lastAgentOutput?: string;
+  } = {},
+): Promise<void> {
+  const {
+    ageMs = 61_000,
+    turnCount = 3,
+    lastAgentOutput = 'Ralph is working.',
+  } = options;
+  const payload: Record<string, unknown> = {
+    last_turn_at: new Date(Date.now() - ageMs).toISOString(),
+    turn_count: turnCount,
+  };
+  if (lastAgentOutput) payload.last_agent_output = lastAgentOutput;
+  await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify(payload, null, 2));
+}
+
 describe('notify-fallback watcher', () => {
   it('one-shot mode forwards only recent task_complete events', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-once-'));
@@ -833,7 +854,150 @@ describe('notify-fallback watcher', () => {
     }
   });
 
-  it('sends bounded periodic Ralph continue steer while Ralph state stays active', async () => {
+  it('does not send Ralph continue steer while Ralph is still making fresh progress', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-fresh-progress-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const stateDir = join(wd, '.omx', 'state');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const statePath = join(stateDir, 'notify-fallback-state.json');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeHudTurnState(stateDir, { ageMs: 1_000, turnCount: 8 });
+      await writeFile(statePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...buildCleanNotifyEnv(),
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      };
+
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'fresh turns should suppress Ralph continue steer even after the cooldown window');
+
+      const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'recent_turn_activity');
+      assert.equal(watcherState.ralph_continue_steer?.last_turn_count, 8);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not send Ralph continue steer when no Ralph progress signal exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-missing-progress-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const stateDir = join(wd, '.omx', 'state');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const statePath = join(stateDir, 'notify-fallback-state.json');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(statePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...buildCleanNotifyEnv(),
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      };
+
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'missing progress metadata should fail closed instead of guessing Ralph is stale');
+
+      const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'progress_signal_missing');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not send Ralph continue steer when the progress signal is missing', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-missing-progress-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const stateDir = join(wd, '.omx', 'state');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const statePath = join(stateDir, 'notify-fallback-state.json');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(statePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...buildCleanNotifyEnv(),
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      };
+
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'missing progress signal should fail closed');
+
+      const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'progress_signal_missing');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('sends Ralph continue steer only after the latest Ralph turn is stale', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-active-'));
     const fakeBinDir = join(wd, 'fake-bin');
     const stateDir = join(wd, '.omx', 'state');
@@ -850,6 +1014,7 @@ describe('notify-fallback watcher', () => {
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
+      await writeHudTurnState(stateDir, { ageMs: 61_000, turnCount: 7 });
       await writeFile(statePath, JSON.stringify({
         ralph_continue_steer: {
           last_sent_at: new Date(Date.now() - 61_000).toISOString(),
@@ -909,7 +1074,7 @@ describe('notify-fallback watcher', () => {
 
       const finalLog = await readFile(tmuxLogPath, 'utf8');
       sends = finalLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
-      assert.equal(sends.length, 2, 'Ralph steer should fire again once the 60s cadence elapses');
+      assert.equal(sends.length, 2, 'Ralph steer should fire again once the cooldown elapses and the latest turn is still stale');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -931,6 +1096,7 @@ describe('notify-fallback watcher', () => {
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
+      await writeHudTurnState(stateDir, { ageMs: 61_000, turnCount: 4 });
       await writeFile(statePath, JSON.stringify({
         ralph_continue_steer: {
           last_sent_at: '',
@@ -991,6 +1157,7 @@ describe('notify-fallback watcher', () => {
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
+      await writeHudTurnState(stateDir, { ageMs: 61_000, turnCount: 5 });
       await writeFile(statePath, JSON.stringify({
         ralph_continue_steer: {
           last_sent_at: 'not-a-date',
@@ -1049,6 +1216,7 @@ describe('notify-fallback watcher', () => {
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
+      await writeHudTurnState(stateDir, { ageMs: 61_000, turnCount: 6 });
       await writeFile(watcherStatePath, JSON.stringify({
         ralph_continue_steer: {
           last_sent_at: new Date(Date.now() - 61_000).toISOString(),
@@ -1118,6 +1286,7 @@ describe('notify-fallback watcher', () => {
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
+      await writeHudTurnState(stateDir, { ageMs: 61_000, turnCount: 9 });
       await writeFile(join(stateDir, 'notify-fallback-state.json'), JSON.stringify({
         ralph_continue_steer: {
           last_sent_at: new Date(Date.now() - 61_000).toISOString(),
@@ -1166,6 +1335,54 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('does not guess a fallback pane when Ralph state has no bound tmux pane', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-missing-pane-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    const statePath = join(stateDir, 'notify-fallback-state.json');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+      }, null, 2));
+      await writeHudTurnState(stateDir, { ageMs: 61_000, turnCount: 4 });
+      await writeFile(statePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const env = buildCleanNotifyEnv({
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+        TMUX: '1',
+        TMUX_PANE: '%42',
+      });
+
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'Ralph continue steer should fail closed when the mode state has no bound pane');
+
+      const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'pane_missing');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('keeps team control-plane pumping when Ralph continue steer fails', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-control-plane-split-'));
     const fakeBinDir = join(wd, 'fake-bin');
@@ -1190,6 +1407,7 @@ describe('notify-fallback watcher', () => {
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
+      await writeHudTurnState(join(wd, '.omx', 'state'), { ageMs: 61_000, turnCount: 11 });
       await writeFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), JSON.stringify({
         ralph_continue_steer: {
           last_sent_at: new Date(Date.now() - 61_000).toISOString(),
@@ -1373,6 +1591,7 @@ describe('notify-fallback watcher', () => {
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
+      await writeHudTurnState(stateDir, { ageMs: 61_000, turnCount: 5 });
       await writeFile(join(stateDir, 'notify-fallback-state.json'), JSON.stringify({
         ralph_continue_steer: {
           last_sent_at: new Date(Date.now() - 61_000).toISOString(),

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -8,7 +8,6 @@ import { homedir } from 'os';
 import { drainPendingTeamDispatch } from './notify-hook/team-dispatch.js';
 import {
   maybeAutoNudge,
-  resolveNudgePaneTarget,
   isDeepInterviewStateActive,
   resolveAutoNudgeSignature,
 } from './notify-hook/auto-nudge.js';
@@ -97,6 +96,7 @@ const ralphSteerLockPath = join(stateDir, 'ralph-continue-steer.lock');
 const watcherOwnerToken = `${process.pid}-${startedAt}-${Math.random().toString(36).slice(2, 10)}`;
 const RALPH_CONTINUE_TEXT = 'Ralph loop active continue';
 const RALPH_CONTINUE_CADENCE_MS = 60_000;
+const RALPH_CONTINUE_STALE_MS = RALPH_CONTINUE_CADENCE_MS;
 const RALPH_STEER_LOCK_STALE_MS = 30_000;
 const RALPH_TERMINAL_PHASES = new Set(['complete', 'failed', 'cancelled']);
 
@@ -111,9 +111,13 @@ interface RalphContinueSteerState {
   enabled: boolean;
   cadence_ms: number;
   message: string;
+  stale_threshold_ms: number;
   active: boolean;
   last_state_check_at: string | null;
   last_sent_at: string;
+  last_turn_at: string;
+  last_turn_count: number | null;
+  last_turn_age_ms: number | null;
   cooldown_anchor_at: string;
   last_reason: string;
   last_error: string | null;
@@ -211,9 +215,13 @@ let lastRalphContinueSteer: RalphContinueSteerState = {
   enabled: true,
   cadence_ms: RALPH_CONTINUE_CADENCE_MS,
   message: RALPH_CONTINUE_TEXT,
+  stale_threshold_ms: RALPH_CONTINUE_STALE_MS,
   active: false,
   last_state_check_at: null,
   last_sent_at: '',
+  last_turn_at: '',
+  last_turn_count: null,
+  last_turn_age_ms: null,
   cooldown_anchor_at: '',
   last_reason: 'init',
   last_error: null,
@@ -256,9 +264,15 @@ function normalizeRalphContinueSteerState(raw: Record<string, unknown> | null | 
     enabled: raw.enabled !== false,
     cadence_ms: Number.isFinite(raw.cadence_ms) && (raw.cadence_ms as number) > 0 ? raw.cadence_ms as number : RALPH_CONTINUE_CADENCE_MS,
     message: safeString(raw.message) || RALPH_CONTINUE_TEXT,
+    stale_threshold_ms: Number.isFinite(raw.stale_threshold_ms) && (raw.stale_threshold_ms as number) > 0
+      ? raw.stale_threshold_ms as number
+      : RALPH_CONTINUE_STALE_MS,
     active: raw.active === true,
     last_state_check_at: safeString(raw.last_state_check_at) || null,
     last_sent_at: safeString(raw.last_sent_at),
+    last_turn_at: safeString(raw.last_turn_at),
+    last_turn_count: Number.isFinite(raw.last_turn_count) ? raw.last_turn_count as number : null,
+    last_turn_age_ms: Number.isFinite(raw.last_turn_age_ms) ? raw.last_turn_age_ms as number : null,
     cooldown_anchor_at: safeString(raw.cooldown_anchor_at),
     last_reason: safeString(raw.last_reason) || 'init',
     last_error: safeString(raw.last_error) || null,
@@ -359,6 +373,48 @@ async function resolveActiveModeState(mode: string): Promise<ActiveModeResult> {
 
 async function resolveActiveRalphState(): Promise<ActiveModeResult> {
   return resolveActiveModeState('ralph');
+}
+
+async function resolveRalphContinueProgressSignal(now: number): Promise<{
+  ok: boolean;
+  reason: string;
+  lastTurnAt: string;
+  turnCount: number | null;
+  ageMs: number | null;
+}> {
+  const hudState = await readJsonObject(join(stateDir, 'hud-state.json'));
+  const lastTurnAt = safeString(hudState?.last_turn_at).trim();
+  const turnCount = Number.isFinite(hudState?.turn_count) ? hudState?.turn_count as number : null;
+  const lastTurnMs = parseIsoMillis(lastTurnAt);
+
+  if (!lastTurnAt || lastTurnMs === null || turnCount === null || turnCount < 1) {
+    return {
+      ok: false,
+      reason: 'progress_signal_missing',
+      lastTurnAt,
+      turnCount,
+      ageMs: null,
+    };
+  }
+
+  const ageMs = Math.max(0, now - lastTurnMs);
+  if (ageMs < RALPH_CONTINUE_STALE_MS) {
+    return {
+      ok: false,
+      reason: 'recent_turn_activity',
+      lastTurnAt,
+      turnCount,
+      ageMs,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: 'stale_turn_activity',
+    lastTurnAt,
+    turnCount,
+    ageMs,
+  };
 }
 
 async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
@@ -576,20 +632,34 @@ async function runRalphContinueSteerTick(): Promise<void> {
   const nowIso = new Date(now).toISOString();
   const startupIso = new Date(startedAt).toISOString();
   const activeRalph = await resolveActiveRalphState();
+  const progressSignal = activeRalph.active
+    ? await resolveRalphContinueProgressSignal(now)
+    : {
+      ok: false,
+      reason: activeRalph.reason,
+      lastTurnAt: '',
+      turnCount: null,
+      ageMs: null,
+    };
   lastRalphContinueSteer = {
     ...lastRalphContinueSteer,
     active: activeRalph.active,
     current_phase: safeString(activeRalph.state?.current_phase),
     last_state_check_at: nowIso,
-    last_reason: activeRalph.reason,
+    last_reason: progressSignal.reason,
     last_error: null,
     state_path: activeRalph.path,
     pane_current_command: '',
+    stale_threshold_ms: RALPH_CONTINUE_STALE_MS,
+    last_turn_at: progressSignal.lastTurnAt,
+    last_turn_count: progressSignal.turnCount,
+    last_turn_age_ms: progressSignal.ageMs,
     shared_timestamp_path: ralphSteerTimestampPath,
     singleton_lock_path: ralphSteerLockPath,
   };
 
   if (!activeRalph.active) return;
+  if (!progressSignal.ok) return;
 
   if (parseIsoMillis(lastRalphContinueSteer.last_sent_at) === null && parseIsoMillis(lastRalphContinueSteer.cooldown_anchor_at) === null) {
     lastRalphContinueSteer.cooldown_anchor_at = startupIso;
@@ -618,7 +688,7 @@ async function runRalphContinueSteerTick(): Promise<void> {
       return { sent: false, skipped: true };
     }
 
-    const paneId = safeString(activeRalph.state?.tmux_pane_id).trim() || await resolveNudgePaneTarget(stateDir);
+    const paneId = safeString(activeRalph.state?.tmux_pane_id).trim();
     if (!paneId) {
       lastRalphContinueSteer.last_reason = 'pane_missing';
       lastRalphContinueSteer.pane_id = '';
@@ -756,6 +826,7 @@ async function writeState(extra: Record<string, unknown> = {}): Promise<void> {
       enabled: true,
       cadence_ms: RALPH_CONTINUE_CADENCE_MS,
       message: RALPH_CONTINUE_TEXT,
+      stale_threshold_ms: RALPH_CONTINUE_STALE_MS,
     },
     fallback_auto_nudge: {
       ...lastFallbackAutoNudge,


### PR DESCRIPTION
## Summary

Fixes #1065.

Gate Ralph continue steer on stale progress instead of any active Ralph state.

This patch changes `notify-fallback-watcher` so `Ralph loop active continue` only becomes eligible when the latest HUD turn is stale, and it stops guessing a fallback pane when the Ralph state has no bound `tmux_pane_id`.

## What changed

- add a HUD progress-signal gate for Ralph continue steer using `hud-state.json:last_turn_at`
- require the latest Ralph turn to be stale before the continue steer can send
- record Ralph progress metadata in watcher state for easier debugging
- remove the fallback pane guess for Ralph continue steer when `tmux_pane_id` is missing
- add regression tests for:
  - fresh-turn suppression
  - missing-progress fail-closed behavior
  - stale-turn send path
  - missing-pane fail-closed behavior
  - existing cooldown / terminal / concurrent-send paths under stale-turn conditions

## Why

The current watcher behavior is broader than the intended recovery path. It treats any active Ralph state as eligible once cooldown expires, even if Ralph has made a recent turn. That creates false positive self-steers. When `tmux_pane_id` is missing, the inferred fallback pane can also route that steer to the wrong live pane.

This patch narrows the trigger to the stale-loop case that the recovery path was originally meant to cover.

## Verification

- `npm run build`
- `npx biome lint src/scripts/notify-fallback-watcher.ts src/hooks/__tests__/notify-fallback-watcher.test.ts`
- `node --test --test-name-pattern "Ralph" dist/hooks/__tests__/notify-fallback-watcher.test.js`

## Notes

The full `dist/hooks/__tests__/notify-fallback-watcher.test.js` suite already fails on current `main` in this environment with the same opaque harness-level failure, so verification was scoped to the Ralph-specific coverage touched by this patch.
