### PR TITLE
fix(ralplan): adapt plan step count to task complexity (#1072)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,9 @@ dependencies = [
 [[package]]
 name = "omx-sparkshell"
 version = "0.11.9"
+dependencies = [
+ "omx-mux",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -11,7 +11,7 @@ You are Planner (Prometheus). Turn requests into actionable work plans. You plan
 - Write plans only to `.omx/plans/*.md` and drafts only to `.omx/drafts/*.md`.
 - Do not write code files.
 - Do not generate a final plan until the user clearly requests a plan.
-- Default to 3-6 steps with testable acceptance criteria.
+- Right-size the step count to the actual scope with testable acceptance criteria; do not default to exactly five steps when the work is clearly smaller or larger.
 - Do not redesign architecture unless the task requires it.
 </scope_guard>
 
@@ -49,7 +49,7 @@ Interpret implementation requests as planning requests only when this role is ex
 
 <execution_loop>
 <success_criteria>
-- The plan has 3-6 actionable steps.
+- The plan has an adaptive number of actionable steps that matches the task scope (for example, fewer for a tight fix and more for broader work) without defaulting to five.
 - Acceptance criteria are specific and testable.
 - Codebase facts come from repository inspection, not user guesses.
 - The plan is saved to `.omx/plans/{name}.md`.
@@ -123,7 +123,7 @@ When unresolved questions remain, append them to `.omx/plans/open-questions.md` 
 
 <final_checklist>
 - Did I only ask the user about preferences, not codebase facts?
-- Does the plan have 3-6 actionable steps with acceptance criteria?
+- Does the plan use an adaptive, scope-matched step count with concrete acceptance criteria instead of defaulting to five?
 - Did the user explicitly request plan generation?
 - Did I wait for user confirmation before handoff?
 - Is the plan saved to `.omx/plans/`?

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -32,6 +32,7 @@ Jumping into code without understanding requirements leads to rework, scope cree
 - Gather codebase facts via `explore` agent before asking the user about them
 - When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups during planning; keep prompts narrow and concrete, and keep prompt-heavy or ambiguous planning work on the richer normal path and fall back normally if `omx explore` is unavailable.
 - Plans must meet quality standards: 80%+ claims cite file/line, 90%+ criteria are testable
+- Implementation step count must be right-sized to task scope; avoid defaulting to exactly five steps when the work is clearly smaller or larger
 - Consensus mode outputs the final plan by default; add `--interactive` to enable execution handoff
 - Consensus mode uses RALPLAN-DR short mode by default; switch to deliberate mode with `--deliberate` or when the request explicitly signals high risk (auth/security, data migration, destructive/irreversible changes, production incident, compliance/PII, public API breakage)
 - Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail
@@ -124,6 +125,7 @@ Every plan includes:
 - Requirements Summary
 - Acceptance Criteria (testable)
 - Implementation Steps (with file references)
+- Adaptive step count sized to the actual scope (not a fixed five-step template)
 - Risks and Mitigations
 - Verification Steps
 - For consensus/ralplan: **RALPLAN-DR summary** (Principles, Decision Drivers, Options)

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -31,6 +31,7 @@ $ralplan --interactive "task description"
 - Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail.
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints.
 - If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the consensus-planning flow is grounded.
+- Right-size implementation steps and PRD story counts to the actual scope; do not default to exactly five steps when the task is clearly smaller or larger.
 - Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent.
 
 This skill invokes the Plan skill in consensus mode:

--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeRalphCliArgs,
   filterRalphCodexArgs,
 } from '../ralph.js';
+import type { ApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 
 describe('extractRalphTaskDescription', () => {
   it('returns plain task text from positional args', () => {
@@ -14,6 +15,9 @@ describe('extractRalphTaskDescription', () => {
   });
   it('returns default when args are empty', () => {
     assert.equal(extractRalphTaskDescription([]), 'ralph-cli-launch');
+  });
+  it('reuses approved launch hint task when no explicit task is supplied', () => {
+    assert.equal(extractRalphTaskDescription([], 'Execute approved issue 1072 plan'), 'Execute approved issue 1072 plan');
   });
   it('excludes --model value from task text', () => {
     assert.equal(extractRalphTaskDescription(['--model', 'gpt-5', 'fix', 'the', 'bug']), 'fix the bug');
@@ -48,6 +52,15 @@ describe('filterRalphCodexArgs', () => {
 });
 
 
+const approvedHint: ApprovedExecutionLaunchHint = {
+  mode: 'ralph',
+  command: 'omx ralph "Execute approved issue 1072 plan"',
+  task: 'Execute approved issue 1072 plan',
+  sourcePath: '.omx/plans/prd-issue-1072.md',
+  testSpecPaths: ['.omx/plans/test-spec-issue-1072.md'],
+  deepInterviewSpecPaths: ['.omx/specs/deep-interview-issue-1072.md'],
+};
+
 describe('ralph deslop launch wiring', () => {
   it('consumes --no-deslop so it is not forwarded to codex', () => {
     assert.deepEqual(filterRalphCodexArgs(['--no-deslop', '--model', 'gpt-5', 'fix', 'it']), ['--model', 'gpt-5', 'fix', 'it']);
@@ -57,6 +70,7 @@ describe('ralph deslop launch wiring', () => {
     const instructions = buildRalphAppendInstructions('fix issue 920', {
       changedFilesPath: '.omx/ralph/changed-files.txt',
       noDeslop: false,
+      approvedHint: null,
     });
     assert.match(instructions, /ai-slop-cleaner/i);
     assert.match(instructions, /changed files only/i);
@@ -69,10 +83,26 @@ describe('ralph deslop launch wiring', () => {
     const instructions = buildRalphAppendInstructions('fix issue 920', {
       changedFilesPath: '.omx/ralph/changed-files.txt',
       noDeslop: true,
+      approvedHint: null,
     });
     assert.match(instructions, /--no-deslop/);
     assert.match(instructions, /skip the mandatory ai-slop-cleaner final pass/i);
     assert.match(instructions, /latest successful pre-deslop verification evidence/i);
+  });
+
+
+
+  it('includes approved plan and deep-interview handoff context when available', () => {
+    const instructions = buildRalphAppendInstructions('Execute approved issue 1072 plan', {
+      changedFilesPath: '.omx/ralph/changed-files.txt',
+      noDeslop: false,
+      approvedHint,
+    });
+    assert.match(instructions, /Approved planning handoff context/i);
+    assert.match(instructions, /approved plan: \.omx\/plans\/prd-issue-1072\.md/i);
+    assert.match(instructions, /test specs: \.omx\/plans\/test-spec-issue-1072\.md/i);
+    assert.match(instructions, /deep-interview specs: \.omx\/specs\/deep-interview-issue-1072\.md/i);
+    assert.match(instructions, /Carry forward the approved deep-interview requirements/i);
   });
 
   it('seeds the changed-files artifact with bounded-scope guidance', () => {

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { startMode, updateModeState } from '../modes/base.js';
+import { readApprovedExecutionLaunchHint, type ApprovedExecutionLaunchHint } from '../planning/artifacts.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import {
   buildFollowupStaffingPlan,
@@ -36,7 +37,7 @@ const VALUE_TAKING_FLAGS = new Set(['--model', '--provider', '--config', '-c', '
 const RALPH_OMX_FLAGS = new Set(['--prd', '--no-deslop']);
 const RALPH_APPEND_ENV = 'OMX_RALPH_APPEND_INSTRUCTIONS_FILE';
 
-export function extractRalphTaskDescription(args: readonly string[]): string {
+export function extractRalphTaskDescription(args: readonly string[], fallbackTask?: string): string {
   const words: string[] = [];
   let i = 0;
   while (i < args.length) {
@@ -51,7 +52,23 @@ export function extractRalphTaskDescription(args: readonly string[]): string {
     words.push(token);
     i++;
   }
-  return words.join(' ') || 'ralph-cli-launch';
+  return words.join(' ') || fallbackTask || 'ralph-cli-launch';
+}
+
+function buildRalphApprovedContextLines(approvedHint: ApprovedExecutionLaunchHint | null): string[] {
+  if (!approvedHint) return [];
+  const lines = [
+    'Approved planning handoff context:',
+    `- approved plan: ${approvedHint.sourcePath}`,
+  ];
+  if (approvedHint.testSpecPaths.length > 0) {
+    lines.push(`- test specs: ${approvedHint.testSpecPaths.join(', ')}`);
+  }
+  if (approvedHint.deepInterviewSpecPaths.length > 0) {
+    lines.push(`- deep-interview specs: ${approvedHint.deepInterviewSpecPaths.join(', ')}`);
+    lines.push('- Carry forward the approved deep-interview requirements and constraints during Ralph execution and final verification.');
+  }
+  return lines;
 }
 
 export function normalizeRalphCliArgs(args: readonly string[]): string[] {
@@ -105,7 +122,7 @@ export function buildRalphChangedFilesSeedContents(): string {
 
 export function buildRalphAppendInstructions(
   task: string,
-  options: { changedFilesPath: string; noDeslop: boolean },
+  options: { changedFilesPath: string; noDeslop: boolean; approvedHint?: ApprovedExecutionLaunchHint | null },
 ): string {
   return [
     '<ralph_native_subagents>',
@@ -116,6 +133,7 @@ export function buildRalphAppendInstructions(
     '- Treat `.omx/state/subagent-tracking.json` as the native subagent activity ledger for this session.',
     '- Do not declare the task complete, and do not transition into final verification/completion, while active native subagent threads are still running.',
     '- Before closing a verification wave, confirm that active native subagent threads have drained.',
+    ...buildRalphApprovedContextLines(options.approvedHint ?? null),
     'Final deslop guidance:',
     options.noDeslop
       ? '- `--no-deslop` is active for this Ralph run, so skip the mandatory ai-slop-cleaner final pass and use the latest successful pre-deslop verification evidence.'
@@ -133,7 +151,7 @@ export function buildRalphAppendInstructions(
 async function writeRalphSessionFiles(
   cwd: string,
   task: string,
-  options: { noDeslop: boolean },
+  options: { noDeslop: boolean; approvedHint?: ApprovedExecutionLaunchHint | null },
 ): Promise<RalphSessionFiles> {
   const dir = join(cwd, '.omx', 'ralph');
   await mkdir(dir, { recursive: true });
@@ -142,7 +160,7 @@ async function writeRalphSessionFiles(
   await writeFile(changedFilesPath, `${buildRalphChangedFilesSeedContents()}\n`);
   await writeFile(
     instructionsPath,
-    `${buildRalphAppendInstructions(task, { changedFilesPath: '.omx/ralph/changed-files.txt', noDeslop: options.noDeslop })}\n`,
+    `${buildRalphAppendInstructions(task, { changedFilesPath: '.omx/ralph/changed-files.txt', noDeslop: options.noDeslop, approvedHint: options.approvedHint ?? null })}\n`,
   );
   return { instructionsPath, changedFilesPath: '.omx/ralph/changed-files.txt' };
 }
@@ -155,12 +173,14 @@ export async function ralphCommand(args: string[]): Promise<void> {
     return;
   }
   const artifacts = await ensureCanonicalRalphArtifacts(cwd);
-  const task = extractRalphTaskDescription(normalizedArgs);
+  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'ralph');
+  const explicitTask = extractRalphTaskDescription(normalizedArgs);
+  const task = explicitTask === 'ralph-cli-launch' ? approvedHint?.task ?? explicitTask : explicitTask;
   const noDeslop = normalizedArgs.some((arg) => arg.toLowerCase() === '--no-deslop');
   const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
   const staffingPlan = buildFollowupStaffingPlan('ralph', task, availableAgentTypes);
   await startMode('ralph', task, 50);
-  const sessionFiles = await writeRalphSessionFiles(cwd, task, { noDeslop });
+  const sessionFiles = await writeRalphSessionFiles(cwd, task, { noDeslop, approvedHint });
   await updateModeState('ralph', {
     current_phase: 'starting',
     canonical_progress_path: artifacts.canonicalProgressPath,
@@ -174,6 +194,9 @@ export async function ralphCommand(args: string[]): Promise<void> {
     deslop_opt_out: noDeslop,
     deslop_changed_files_path: sessionFiles.changedFilesPath,
     deslop_scope: 'changed-files-only',
+    approved_plan_path: approvedHint?.sourcePath,
+    approved_test_spec_paths: approvedHint?.testSpecPaths ?? [],
+    approved_deep_interview_spec_paths: approvedHint?.deepInterviewSpecPaths ?? [],
     ...(artifacts.canonicalPrdPath ? { canonical_prd_path: artifacts.canonicalPrdPath } : {}),
   });
   if (artifacts.migratedPrd) {
@@ -186,7 +209,10 @@ export async function ralphCommand(args: string[]): Promise<void> {
   console.log(`[ralph] available_agent_types: ${staffingPlan.rosterSummary}`);
   console.log(`[ralph] staffing_plan: ${staffingPlan.staffingSummary}`);
   const { launchWithHud } = await import('./index.js');
-  const codexArgs = filterRalphCodexArgs(normalizedArgs);
+  const codexArgsBase = filterRalphCodexArgs(normalizedArgs);
+  const codexArgs = explicitTask === 'ralph-cli-launch' && approvedHint?.task
+    ? [...codexArgsBase, approvedHint.task]
+    : codexArgsBase;
   const appendixPath = sessionFiles.instructionsPath;
   const previousAppendixEnv = process.env[RALPH_APPEND_ENV];
   process.env[RALPH_APPEND_ENV] = appendixPath;

--- a/src/hooks/__tests__/consensus-execution-handoff.test.ts
+++ b/src/hooks/__tests__/consensus-execution-handoff.test.ts
@@ -229,6 +229,14 @@ describe('User feedback step between Planner and Architect/Critic (plan/SKILL.md
   });
 });
 
+
+
+  it('should require adaptive step sizing instead of a fixed five-step template', () => {
+    assert.match(planSkill, /adaptive step count|right-sized to task scope/i);
+    assert.match(planSkill, /do not default to exactly five steps|not a fixed five-step template/i);
+    assert.match(ralplanSkill, /do not default to exactly five steps/i);
+  });
+
 describe('RALPLAN-DR in ralplan/SKILL.md', () => {
   it('should contain RALPLAN-DR structured deliberation description', () => {
     assert.ok(

--- a/src/planning/__tests__/artifacts.test.ts
+++ b/src/planning/__tests__/artifacts.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { isPlanningComplete, readPlanningArtifacts } from '../artifacts.js';
+import { isPlanningComplete, readApprovedExecutionLaunchHint, readPlanningArtifacts } from '../artifacts.js';
 
 let tempDir: string;
 
@@ -31,6 +31,50 @@ describe('planning artifacts', () => {
     assert.equal(isPlanningComplete(artifacts), false);
     assert.equal(artifacts.prdPaths.length, 1);
     assert.equal(artifacts.testSpecPaths.length, 0);
+  });
+
+
+
+  it('includes approved Ralph launch context with test and deep-interview artifacts', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const specsDir = join(tempDir, '.omx', 'specs');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(specsDir, { recursive: true });
+    await writeFile(
+      join(plansDir, 'prd-issue-1072.md'),
+      '# PRD\n\nLaunch via omx ralph "Execute approved issue 1072 plan"\n',
+    );
+    await writeFile(join(plansDir, 'test-spec-issue-1072.md'), '# Test Spec\n');
+    await writeFile(join(specsDir, 'deep-interview-issue-1072.md'), '# Deep Interview Spec\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    assert.equal(hint?.task, 'Execute approved issue 1072 plan');
+    assert.equal(hint?.sourcePath, join(plansDir, 'prd-issue-1072.md'));
+    assert.deepEqual(hint?.testSpecPaths, [join(plansDir, 'test-spec-issue-1072.md')]);
+    assert.deepEqual(hint?.deepInterviewSpecPaths, [join(specsDir, 'deep-interview-issue-1072.md')]);
+  });
+
+
+
+  it('binds approved handoff context to the selected PRD slug in multi-plan repos', async () => {
+    const plansDir = join(tempDir, '.omx', 'plans');
+    const specsDir = join(tempDir, '.omx', 'specs');
+    await mkdir(plansDir, { recursive: true });
+    await mkdir(specsDir, { recursive: true });
+    await writeFile(join(plansDir, 'prd-alpha.md'), '# Alpha\n\nLaunch via omx ralph "Execute alpha"\n');
+    await writeFile(join(plansDir, 'test-spec-alpha.md'), '# Alpha Test Spec\n');
+    await writeFile(join(specsDir, 'deep-interview-alpha.md'), '# Alpha Deep Interview\n');
+    await writeFile(join(plansDir, 'prd-zeta.md'), '# Zeta\n\nLaunch via omx ralph "Execute zeta"\n');
+    await writeFile(join(plansDir, 'test-spec-zeta.md'), '# Zeta Test Spec\n');
+    await writeFile(join(specsDir, 'deep-interview-zeta.md'), '# Zeta Deep Interview\n');
+
+    const hint = readApprovedExecutionLaunchHint(tempDir, 'ralph');
+    assert.ok(hint);
+    assert.equal(hint?.task, 'Execute zeta');
+    assert.equal(hint?.sourcePath, join(plansDir, 'prd-zeta.md'));
+    assert.deepEqual(hint?.testSpecPaths, [join(plansDir, 'test-spec-zeta.md')]);
+    assert.deepEqual(hint?.deepInterviewSpecPaths, [join(specsDir, 'deep-interview-zeta.md')]);
   });
 
   it('surfaces deep-interview specs for downstream traceability', async () => {

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { omxPlansDir } from '../utils/paths.js';
 
 const PRD_PATTERN = /^prd-.*\.md$/i;
@@ -12,6 +12,21 @@ export interface PlanningArtifacts {
   prdPaths: string[];
   testSpecPaths: string[];
   deepInterviewSpecPaths: string[];
+}
+
+export interface ApprovedPlanContext {
+  sourcePath: string;
+  testSpecPaths: string[];
+  deepInterviewSpecPaths: string[];
+}
+
+export interface ApprovedExecutionLaunchHint extends ApprovedPlanContext {
+  mode: 'team' | 'ralph';
+  command: string;
+  task: string;
+  workerCount?: number;
+  agentType?: string;
+  linkedRalph?: boolean;
 }
 
 function readMatchingPaths(dir: string, pattern: RegExp): string[] {
@@ -46,16 +61,6 @@ export function isPlanningComplete(artifacts: PlanningArtifacts): boolean {
   return artifacts.prdPaths.length > 0 && artifacts.testSpecPaths.length > 0;
 }
 
-export interface ApprovedExecutionLaunchHint {
-  mode: 'team' | 'ralph';
-  command: string;
-  task: string;
-  workerCount?: number;
-  agentType?: string;
-  linkedRalph?: boolean;
-  sourcePath: string;
-}
-
 function decodeQuotedValue(raw: string): string | null {
   const normalized = raw.trim();
   if (!normalized) return null;
@@ -72,17 +77,34 @@ function decodeQuotedValue(raw: string): string | null {
   }
 }
 
-function readApprovedPlanText(cwd: string): { path: string; content: string } | null {
+function artifactSlug(path: string, prefixPattern: RegExp): string | null {
+  const file = basename(path);
+  const match = file.match(prefixPattern);
+  return match?.groups?.slug ?? null;
+}
+
+function filterArtifactsForSlug(paths: readonly string[], prefixPattern: RegExp, slug: string | null): string[] {
+  if (!slug) return [];
+  return paths.filter((path) => artifactSlug(path, prefixPattern) === slug);
+}
+
+function readApprovedPlanText(cwd: string): { content: string; context: ApprovedPlanContext } | null {
   const artifacts = readPlanningArtifacts(cwd);
   if (!isPlanningComplete(artifacts)) return null;
 
   const latestPrdPath = artifacts.prdPaths.at(-1);
   if (!latestPrdPath || !existsSync(latestPrdPath)) return null;
 
+  const slug = artifactSlug(latestPrdPath, /^prd-(?<slug>.*)\.md$/i);
+
   try {
     return {
-      path: latestPrdPath,
       content: readFileSync(latestPrdPath, 'utf-8'),
+      context: {
+        sourcePath: latestPrdPath,
+        testSpecPaths: filterArtifactsForSlug(artifacts.testSpecPaths, /^test-?spec-(?<slug>.*)\.md$/i, slug),
+        deepInterviewSpecPaths: filterArtifactsForSlug(artifacts.deepInterviewSpecPaths, /^deep-interview-(?<slug>.*)\.md$/i, slug),
+      },
     };
   } catch {
     return null;
@@ -93,12 +115,12 @@ export function readApprovedExecutionLaunchHint(
   cwd: string,
   mode: 'team' | 'ralph',
 ): ApprovedExecutionLaunchHint | null {
-  const planText = readApprovedPlanText(cwd);
-  if (!planText) return null;
+  const approvedPlan = readApprovedPlanText(cwd);
+  if (!approvedPlan) return null;
 
   if (mode === 'team') {
     const teamPattern = /(?<command>(?:omx\s+team|\$team)\s+(?<ralph>ralph\s+)?(?<count>\d+)(?::(?<role>[a-z][a-z0-9-]*))?\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
-    const matches = [...planText.content.matchAll(teamPattern)];
+    const matches = [...approvedPlan.content.matchAll(teamPattern)];
     const last = matches.at(-1);
     if (!last?.groups) return null;
     const task = decodeQuotedValue(last.groups.task);
@@ -110,12 +132,12 @@ export function readApprovedExecutionLaunchHint(
       workerCount: Number.parseInt(last.groups.count, 10),
       agentType: last.groups.role || undefined,
       linkedRalph: Boolean(last.groups.ralph?.trim()),
-      sourcePath: planText.path,
+      ...approvedPlan.context,
     };
   }
 
   const ralphPattern = /(?<command>(?:omx\s+ralph|\$ralph)\s+(?<task>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'))/gi;
-  const matches = [...planText.content.matchAll(ralphPattern)];
+  const matches = [...approvedPlan.content.matchAll(ralphPattern)];
   const last = matches.at(-1);
   if (!last?.groups) return null;
   const task = decodeQuotedValue(last.groups.task);
@@ -124,6 +146,6 @@ export function readApprovedExecutionLaunchHint(
     mode,
     command: last.groups.command,
     task,
-    sourcePath: planText.path,
+    ...approvedPlan.context,
   };
 }


### PR DESCRIPTION
Fixes #1072

## Changes
- Remove hardcoded 5-step limit in ralplan PRD generation
- Planner now adapts step count to actual task complexity
- Deep-interview requirements carried through to ralph-loop-codex execution
- Added regression tests for adaptive step count and requirement handoff

## Testing
- All existing tests pass (`npm test` full suite ✅)
- New regression tests for step count adaptivity
- Architect review approved

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*