### PR TITLE
docs: document Intel Mac syspolicyd startup issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 | Windows | `winget install psmux` |
 | Windows (WSL2) | `sudo apt install tmux` |
 
+## Known issues
+
+### Intel Mac: high `syspolicyd` / `trustd` CPU during startup
+
+On some Intel Macs, OMX startup — especially with `--madmax --high` — can spike `syspolicyd` / `trustd` CPU usage while macOS Gatekeeper validates many concurrent process launches.
+
+If this happens, try:
+- `xattr -dr com.apple.quarantine $(which omx)`
+- adding your terminal app to the Developer Tools allowlist in macOS Security settings
+- using lower concurrency (for example, avoid `--madmax --high`)
+
 ## Documentation
 
 - [Getting Started](./docs/getting-started.html)


### PR DESCRIPTION
## Summary
- add a Known issues README section for Intel Mac syspolicyd/trustd startup spikes
- explain the Gatekeeper-related trigger during concurrent OMX startup
- document quarantine, Developer Tools allowlist, and reduced-concurrency workarounds

Closes #1077