### PR TITLE
Fix issue #1084 stale-turn OMX_TMUX_INJECT replay regression

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -790,7 +790,66 @@ describe('notify-fallback watcher', () => {
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
-      assert.equal(watcherState.fallback_auto_nudge?.last_reason, 'ttl_active');
+      assert.equal(watcherState.fallback_auto_nudge?.last_reason, 'already_nudged_for_signature');
+      assert.equal(watcherState.fallback_auto_nudge?.last_turn_count, 7);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not fallback auto-nudge the same stalled hud turn again after TTL expiry', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-auto-nudge-exact-dedup-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const codexHome = join(wd, 'codex-home');
+    const lastTurnAt = '2026-03-01T00:00:00.000Z';
+    const lastMessage = 'If you want, I can keep going from here.';
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        autoNudge: { enabled: true, delaySec: 0, ttlMs: 5000 },
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+        last_turn_at: lastTurnAt,
+        turn_count: 7,
+        last_agent_output: lastMessage,
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'auto-nudge-state.json'), JSON.stringify({
+        nudgeCount: 1,
+        lastNudgeAt: '2026-03-01T00:00:10.000Z',
+        lastSignature: `hud:7|${lastTurnAt}|stall:proceed_intent`,
+        lastSemanticSignature: 'stall:proceed_intent',
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            CODEX_HOME: codexHome,
+            TMUX: '1',
+            TMUX_PANE: '%42',
+            OMX_NOTIFY_FALLBACK_AUTO_NUDGE_STALL_MS: '5000',
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.fallback_auto_nudge?.last_reason, 'already_nudged_for_signature');
       assert.equal(watcherState.fallback_auto_nudge?.last_turn_count, 7);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -773,6 +773,62 @@ exit 0
     });
   });
 
+  it('does not resend the exact same stalled turn after TTL expiry', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const lastTurnAt = '2026-03-01T00:00:00.000Z';
+      const lastMessage = 'If you want, I can keep going from here.';
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 5000 },
+      });
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: lastTurnAt,
+        turn_count: 1,
+        last_agent_output: lastMessage,
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const first = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'turn-id': 'stalled-turn-1',
+        'last-assistant-message': lastMessage,
+      });
+      assert.equal(first.status, 0, `first hook failed: ${first.stderr || first.stdout}`);
+
+      const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+      const firstState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
+      await writeJson(nudgeStatePath, {
+        ...firstState,
+        lastNudgeAt: '2026-03-01T00:00:10.000Z',
+      });
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'turn-id': 'stalled-turn-1',
+        'last-assistant-message': lastMessage,
+      });
+      assert.equal(result.status, 0, `second hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
+      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 1);
+
+      const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
+      assert.equal(nudgeState.nudgeCount, 1);
+      assert.equal(nudgeState.lastSignature, firstState.lastSignature);
+    });
+  });
+
   it('uses custom response from config', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -881,6 +881,11 @@ async function runFallbackAutoNudgeTick(): Promise<void> {
   const persistedAutoNudgeState = await readAutoNudgeState();
   const autoNudgeConfig = await loadAutoNudgeConfig();
   const semanticSignature = normalizeAutoNudgeSignatureText(lastMessage);
+  if (signature && safeString(persistedAutoNudgeState?.lastSignature) === signature) {
+    lastFallbackAutoNudge.last_reason = 'already_nudged_for_signature';
+    lastFallbackAutoNudge.last_nudged_signature = signature;
+    return;
+  }
   const lastNudgeAtMs = parseIsoMillis(safeString(persistedAutoNudgeState?.lastNudgeAt));
   if (
     semanticSignature

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -512,6 +512,18 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     const signature = await resolveAutoNudgeSignature(stateDir, payload, signatureSourceText);
     const semanticSignature = normalizeAutoNudgeSignatureText(signatureSourceText);
 
+    if (signature && safeString(nudgeState.lastSignature) === signature) {
+      await logTmuxHookEvent(logsDir, {
+        timestamp: new Date().toISOString(),
+        type: 'auto_nudge_skipped',
+        reason: 'already_nudged_for_signature',
+        source,
+        signature,
+        semantic_signature: semanticSignature,
+      }).catch(() => {});
+      return;
+    }
+
     const lastNudgeAtMs = Date.parse(safeString(nudgeState.lastNudgeAt));
     if (
       semanticSignature


### PR DESCRIPTION
## Summary
- restore exact-signature suppression for already-nudged stalled turns in `maybeAutoNudge`
- mirror the same exact-signature replay block in the fallback watcher before the semantic TTL check
- add regressions for notify-hook and fallback watcher so the same stalled turn cannot reinject after TTL expiry

## Root cause
The previous fix made suppression TTL-only, keyed by `lastSemanticSignature + lastNudgeAt`, in `src/scripts/notify-hook/auto-nudge.ts:527-540` and `src/scripts/notify-fallback-watcher.ts:889-899`.

That closed rapid-fire variant prompts, but it removed the old exact-signature replay guard. For an unchanged stalled turn, the persisted exact signature (`lastSignature`) still matched the same HUD/payload turn identity, yet once the TTL elapsed the turn became eligible again. Because the fallback watcher keeps polling stalled HUD state and the primary hook can reevaluate the same stalled output, the same `yes, proceed [OMX_TMUX_INJECT]` injection could rearm every cooldown interval with no new progress.

This PR restores the exact-signature block first in `src/scripts/notify-hook/auto-nudge.ts:515-525` and `src/scripts/notify-fallback-watcher.ts:884-888`, while leaving semantic TTL suppression in place for semantically similar but genuinely new turns.

## Verification
- `npm run build`
- `node --test --test-reporter=spec dist/hooks/__tests__/notify-hook-auto-nudge.test.js && node --test --test-reporter=spec dist/hooks/__tests__/notify-fallback-watcher.test.js`
- `npm run lint`
- `npm run check:no-unused`

Closes #1084.
