### PR TITLE
Fix team worker readiness when the prompt is below the visible tmux viewport

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1386,6 +1386,55 @@ esac
     );
   });
 
+  it('waitForWorkerReady falls back to scrollback when the visible Codex viewport hides the prompt', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-worker-ready-tail-fallback-',
+      (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if [ "$#" -ge 6 ] && [ "\${5:-}" = "-S" ] && [ "\${6:-}" = "-80" ]; then
+      cat <<'EOF'
+╭────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.118.0)                 │
+│                                            │
+│ model:     gpt-5.4 high   /model to change │
+│ directory: ~/Workspace/demo                │
+╰────────────────────────────────────────────╯
+
+⚠ MCP startup incomplete (failed: hf-mcp-server, stripe, vercel)
+
+› Explain this codebase
+EOF
+    else
+      cat <<'EOF'
+╭────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.118.0)                 │
+│                                            │
+│ model:     gpt-5.4 high   /model to change │
+│ directory: ~/Workspace/demo                │
+╰────────────────────────────────────────────╯
+
+⚠ MCP startup incomplete (failed: hf-mcp-server, stripe, vercel)
+EOF
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        assert.equal(waitForWorkerReady('omx-team-x', 1, 1_000), true);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /capture-pane -t omx-team-x:1 -p/);
+        assert.match(log, /capture-pane -t omx-team-x:1 -p -S -80/);
+      },
+    );
+  });
+
   it('waitForWorkerReady auto-accepts the Claude bypass prompt', async () => {
     await withMockTmuxFixture(
       'omx-tmux-claude-bypass-ready-',

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1235,7 +1235,21 @@ export function waitForWorkerReady(
       blockedByTrustPrompt = true;
       return false;
     }
-    return paneLooksReady(result.stdout);
+    if (paneLooksReady(result.stdout)) return true;
+
+    // A small worker pane can show the Codex welcome box plus MCP startup
+    // warnings while the actual prompt sits just below the visible viewport.
+    // Fall back to a short scrollback capture only when the visible pane
+    // already looks like a live Codex screen rather than a bootstrap screen.
+    const normalizedVisible = normalizeTmuxCapture(result.stdout);
+    const looksLikeCodexViewport = /\bOpenAI Codex\b/i.test(normalizedVisible)
+      || /\bMCP startup incomplete\b/i.test(normalizedVisible)
+      || /\bmodel:\s+.*\/model to change\b/i.test(normalizedVisible);
+    if (!looksLikeCodexViewport) return false;
+
+    const tailResult = runTmux(sharedBuildCapturePaneArgv(target, 80));
+    if (!tailResult.ok) return false;
+    return paneLooksReady(tailResult.stdout);
   };
 
   let delayMs = initialBackoffMs;


### PR DESCRIPTION
## Summary

Fix `omx team` worker readiness false negatives when a small tmux worker pane shows the Codex welcome viewport plus startup warnings, but the actual prompt has already scrolled just below the visible slice.

Closes #1092.

## What changed

- keep the existing visible-capture path for trust / bypass / bootstrap checks
- if visible capture is not ready but already looks like a live Codex viewport, fall back to a short scrollback capture (`capture-pane -p -S -80`)
- add a regression test covering the overflow case

## Why this shape

The bug is not that every welcome box means "ready". The specific failure mode is a small pane where the worker is already alive, but the visible viewport is dominated by the welcome frame and warnings. The fallback stays narrow by only engaging when the visible content already looks like a real Codex screen.

## Verification

- `npm run build`
- `node --test --test-name-pattern='waitForWorkerReady|paneLooksReady gate|paneLooksReady' dist/hooks/__tests__/tmux-hook-engine.test.js dist/team/__tests__/tmux-session.test.js`
- local smoke using `node dist/cli/omx.js team ...`, which advanced from startup into `Team started: ...` and delivered the inbox prompt to the worker instead of failing immediately on readiness

## Notes

I also disabled unrelated noisy plugins in my local Codex config during reproduction (`hugging-face` and `build-web-apps`) so the worker panes no longer emitted `hf/stripe/vercel` startup warnings. That config change is not part of this PR.
