### PR TITLE
feat: add Qwen provider + enhance Gemini multi-provider documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,29 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 | Windows | `winget install psmux` |
 | Windows (WSL2) | `sudo apt install tmux` |
 
+### External provider support
+
+OMX supports routing work to external CLI providers in both `omx ask` and team mode:
+
+| Provider | CLI binary | Team mode | Ask routing | Default model env var |
+| --- | --- | --- | --- | --- |
+| Codex (default) | `codex` | yes | no | `OMX_DEFAULT_FRONTIER_MODEL` |
+| Claude | `claude` | yes | `omx ask claude "..."` | - |
+| Gemini | `gemini` | yes | `omx ask gemini "..."` | `OMX_DEFAULT_GEMINI_MODEL` |
+| Qwen | `qwen` | yes | `omx ask qwen "..."` | `OMX_DEFAULT_QWEN_MODEL` |
+
+Set per-worker providers in team mode with:
+
+```bash
+# All workers use one provider
+OMX_TEAM_WORKER_CLI=gemini omx team 2:executor "task"
+
+# Mixed team: per-worker CLI assignment
+OMX_TEAM_WORKER_CLI_MAP=codex,qwen,claude,gemini omx team 4:executor "task"
+```
+
+All non-Codex providers (Claude, Gemini, Qwen) use direct Enter-only submit in team mode. Codex may use queue-first Tab on busy panes depending on strategy.
+
 ## Known issues
 
 ### Intel Mac: high `syspolicyd` / `trustd` CPU during startup

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "doctor": "node dist/cli/omx.js doctor",
     "ask:claude": "./src/scripts/ask-claude.sh",
     "ask:gemini": "./src/scripts/ask-gemini.sh",
+    "ask:qwen": "./src/scripts/ask-qwen.sh",
     "test:explore": "cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js",
     "test:team:cross-rebase-smoke": "npm run build && node --test dist/team/__tests__/cross-rebase-smoke.test.js",
     "test:node": "node --test $(find dist -name '*.test.js')",

--- a/skills/ask-qwen/SKILL.md
+++ b/skills/ask-qwen/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: ask-qwen
+description: Ask Qwen via local CLI and capture a reusable artifact
+---
+
+# Ask Qwen (Local CLI)
+
+Use the locally installed Qwen CLI as a direct external advisor for brainstorming, design feedback, and second opinions.
+
+## Usage
+
+```bash
+/ask-qwen <question or task>
+```
+
+## Routing
+
+### Preferred: Local CLI execution
+Run Qwen through the canonical OMX CLI command path (no MCP routing):
+
+```bash
+omx ask qwen "{{ARGUMENTS}}"
+```
+
+Exact non-interactive Qwen CLI command from `qwen --help`:
+
+```bash
+qwen -p "{{ARGUMENTS}}"
+# equivalent: qwen --prompt "{{ARGUMENTS}}"
+```
+
+If needed, adapt to the user's installed Qwen CLI variant while keeping local execution as the default path.
+
+Legacy compatibility entrypoints (`./scripts/ask-qwen.sh`, `npm run ask:qwen -- ...`) are transitional wrappers.
+
+### Missing binary behavior
+If `qwen` is not found, do **not** switch to MCP.
+Instead:
+1. Explain that local Qwen CLI is required for this skill.
+2. Ask the user to install/configure Qwen CLI.
+3. Provide a quick verification command:
+
+```bash
+qwen --version
+```
+
+## Artifact requirement
+After local execution, save a markdown artifact to:
+
+```text
+.omx/artifacts/qwen-<slug>-<timestamp>.md
+```
+
+Minimum artifact sections:
+1. Original user task
+2. Final prompt sent to Qwen CLI
+3. Qwen output (raw)
+4. Concise summary
+5. Action items / next steps
+
+Task: {{ARGUMENTS}}

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -76,6 +76,47 @@ OMX_TEAM_WORKER_CLI_MAP=codex,claude omx team 2:executor "split doc/code tasks"
 OMX_TEAM_WORKER_CLI=auto OMX_TEAM_WORKER_LAUNCH_ARGS="--model claude-..." omx team 2:executor "run mixed validation"
 ```
 
+### Gemini teammates (v0.7.0+)
+
+Gemini workers use the same env-var mechanism as Claude teammates. The CLI binary is `gemini`.
+
+```bash
+# Force all teammates to Gemini CLI
+OMX_TEAM_WORKER_CLI=gemini omx team 2:executor "validate docs and tests"
+
+# Mixed team (worker 1 = Codex, worker 2 = Gemini)
+OMX_TEAM_WORKER_CLI_MAP=codex,gemini omx team 2:executor "split code/docs tasks"
+
+# Three-provider mix
+OMX_TEAM_WORKER_CLI_MAP=codex,gemini,claude omx team 3:executor "parallel validation"
+```
+
+Trigger submit strategy for Gemini workers:
+- Gemini uses direct Enter-only (`C-m`) rounds, the same strategy as Claude.
+- Gemini does **not** use queue-first `Tab` (that is Codex-specific and strategy-dependent).
+
+Default model override: set `OMX_DEFAULT_GEMINI_MODEL` to control the default model used when launching Gemini workers without an explicit `--model` flag.
+
+### Qwen teammates (v0.7.0+)
+
+Qwen workers follow the same pattern. The CLI binary is `qwen`.
+
+```bash
+# Force all teammates to Qwen CLI
+OMX_TEAM_WORKER_CLI=qwen omx team 2:executor "review and fix lint issues"
+
+# Mixed team (worker 1 = Codex, worker 2 = Qwen)
+OMX_TEAM_WORKER_CLI_MAP=codex,qwen omx team 2:executor "parallel implementation"
+
+# Qwen + Claude mix
+OMX_TEAM_WORKER_CLI_MAP=qwen,claude omx team 2:executor "cross-provider validation"
+```
+
+Trigger submit strategy for Qwen workers:
+- Qwen uses direct Enter-only (`C-m`) rounds, the same strategy as Claude and Gemini.
+
+Default model override: set `OMX_DEFAULT_QWEN_MODEL` to control the default model used when launching Qwen workers without an explicit `--model` flag.
+
 ## Preconditions
 
 Before running `$team`, confirm:
@@ -152,7 +193,7 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 Important:
 
 - Leader remains in existing pane
-- Worker panes are independent full Codex/Claude CLI sessions
+- Worker panes are independent full Codex/Claude/Gemini/Qwen CLI sessions
 - Workers may run in separate git worktrees (`omx team --worktree[=<name>]`) while sharing one team state root
 - Worker ACKs go to `mailbox/leader-fixed.json`
 - Notify hook updates worker heartbeat and nudges leader during active team mode
@@ -164,6 +205,8 @@ Important:
 - Trigger submit differs by CLI:
   - Codex may use queue-first `Tab` on busy panes (strategy-dependent).
   - Claude always uses direct Enter-only (`C-m`) rounds (never queue-first `Tab`).
+  - Gemini uses direct Enter-only (`C-m`) rounds, same as Claude.
+  - Qwen uses direct Enter-only (`C-m`) rounds, same as Claude.
 
 ### Team worker model + thinking resolution (current contract)
 
@@ -344,14 +387,14 @@ Useful runtime env vars:
 - `OMX_TEAM_WORKER_LAUNCH_ARGS`
   - Extra args passed to worker launch command
 - `OMX_TEAM_WORKER_CLI`
-  - Worker CLI selector: `auto|codex|claude` (default: `auto`)
-  - `auto` chooses `claude` when worker `--model` contains `claude`, otherwise `codex`
-  - In `claude` mode, workers launch with exactly one `--dangerously-skip-permissions`
+  - Worker CLI selector: `auto|codex|claude|gemini|qwen` (default: `auto`)
+  - `auto` chooses `claude` when worker `--model` contains `claude`, `gemini` when it contains `gemini`, `qwen` when it contains `qwen`, otherwise `codex`
+  - In `claude`/`gemini`/`qwen` mode, workers launch with exactly one `--dangerously-skip-permissions`
     and ignore explicit model/config/effort launch overrides (uses default `settings.json`)
 - `OMX_TEAM_WORKER_CLI_MAP`
-  - Per-worker CLI selector (comma-separated `auto|codex|claude`)
+  - Per-worker CLI selector (comma-separated `auto|codex|claude|gemini|qwen`)
   - Length must be `1` (broadcast) or exactly the team worker count
-  - Example: `OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude`
+  - Example: `OMX_TEAM_WORKER_CLI_MAP=codex,gemini,claude,qwen`
   - When present, overrides `OMX_TEAM_WORKER_CLI`
 - `OMX_TEAM_AUTO_INTERRUPT_RETRY`
   - Trigger submit fallback (default: enabled)

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -88,6 +88,20 @@ describe('parseAskArgs', () => {
     });
   });
 
+  it('parses qwen provider with positional prompt', () => {
+    assert.deepEqual(parseAskArgs(['qwen', 'explain', 'this']), {
+      provider: 'qwen',
+      prompt: 'explain this',
+    });
+  });
+
+  it('parses qwen provider with --prompt form', () => {
+    assert.deepEqual(parseAskArgs(['qwen', '--prompt', 'design', 'review']), {
+      provider: 'qwen',
+      prompt: 'design review',
+    });
+  });
+
   it('throws for invalid provider', () => {
     assert.throws(() => parseAskArgs(['openai', 'hello']), /Invalid provider/);
   });
@@ -111,6 +125,7 @@ describe('omx ask', () => {
       assert.equal(res.status, 1, res.stderr || res.stdout);
       assert.match(res.stderr, /claude --print/);
       assert.match(res.stderr, /gemini --prompt/);
+      assert.match(res.stderr, /qwen --prompt/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,16 @@ import { getPackageRoot } from '../utils/package.js';
 import { codexPromptsDir } from '../utils/paths.js';
 
 export const ASK_USAGE = [
-  'Usage: omx ask <claude|gemini> <question or task>',
-  '   or: omx ask <claude|gemini> -p "<prompt>"',
+  'Usage: omx ask <claude|gemini|qwen> <question or task>',
+  '   or: omx ask <claude|gemini|qwen> -p "<prompt>"',
   '   or: omx ask claude --print "<prompt>"',
   '   or: omx ask gemini --prompt "<prompt>"',
-  '   or: omx ask <claude|gemini> --agent-prompt <role> "<prompt>"',
-  '   or: omx ask <claude|gemini> --agent-prompt=<role> --prompt "<prompt>"',
+  '   or: omx ask qwen --prompt "<prompt>"',
+  '   or: omx ask <claude|gemini|qwen> --agent-prompt <role> "<prompt>"',
+  '   or: omx ask <claude|gemini|qwen> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'gemini'] as const;
+const ASK_PROVIDERS = ['claude', 'gemini', 'qwen'] as const;
 type AskProvider = typeof ASK_PROVIDERS[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 const ASK_ADVISOR_SCRIPT_ENV = 'OMX_ASK_ADVISOR_SCRIPT';

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -40,6 +40,8 @@ export const OMX_DEFAULT_FRONTIER_MODEL_ENV = 'OMX_DEFAULT_FRONTIER_MODEL';
 export const OMX_DEFAULT_STANDARD_MODEL_ENV = 'OMX_DEFAULT_STANDARD_MODEL';
 export const OMX_DEFAULT_SPARK_MODEL_ENV = 'OMX_DEFAULT_SPARK_MODEL';
 export const OMX_SPARK_MODEL_ENV = 'OMX_SPARK_MODEL';
+export const OMX_DEFAULT_GEMINI_MODEL_ENV = 'OMX_DEFAULT_GEMINI_MODEL';
+export const OMX_DEFAULT_QWEN_MODEL_ENV = 'OMX_DEFAULT_QWEN_MODEL';
 
 function readOmxConfigFile(codexHomeOverride?: string): OmxConfigFile | null {
   const configPath = join(codexHomeOverride || codexHome(), '.omx-config.json');
@@ -185,4 +187,28 @@ export function getSparkDefaultModel(codexHomeOverride?: string): string {
  */
 export function getTeamLowComplexityModel(codexHomeOverride?: string): string {
   return readTeamLowComplexityOverride(codexHomeOverride) ?? getSparkDefaultModel(codexHomeOverride);
+}
+
+/**
+ * Get the envvar-backed default Gemini model.
+ * Resolution: OMX_DEFAULT_GEMINI_MODEL env > config env > undefined
+ */
+export function getGeminiDefaultModel(
+  env: NodeJS.ProcessEnv = process.env,
+  codexHomeOverride?: string,
+): string | undefined {
+  return normalizeConfiguredValue(env[OMX_DEFAULT_GEMINI_MODEL_ENV])
+    ?? readConfigEnvValue(OMX_DEFAULT_GEMINI_MODEL_ENV, codexHomeOverride);
+}
+
+/**
+ * Get the envvar-backed default Qwen model.
+ * Resolution: OMX_DEFAULT_QWEN_MODEL env > config env > undefined
+ */
+export function getQwenDefaultModel(
+  env: NodeJS.ProcessEnv = process.env,
+  codexHomeOverride?: string,
+): string | undefined {
+  return normalizeConfiguredValue(env[OMX_DEFAULT_QWEN_MODEL_ENV])
+    ?? readConfigEnvValue(OMX_DEFAULT_QWEN_MODEL_ENV, codexHomeOverride);
 }

--- a/src/hooks/__tests__/task-size-detector.test.ts
+++ b/src/hooks/__tests__/task-size-detector.test.ts
@@ -390,6 +390,9 @@ describe('task-size-detector', () => {
       assert.equal(isHeavyMode('codex'), false);
     });
 
+    // 'gemini' is a provider/CLI name, not an execution mode -- it is correctly
+    // classified as non-heavy because heavy mode detection applies to workflow
+    // modes (ralph, team, autopilot, etc.), not to provider identifiers.
     it('returns false for gemini', () => {
       assert.equal(isHeavyMode('gemini'), false);
     });
@@ -408,6 +411,9 @@ describe('task-size-detector', () => {
     });
 
     it('does not contain lightweight modes', () => {
+      // 'codex' and 'gemini' are provider names, not execution modes -- they
+      // correctly stay outside HEAVY_MODE_KEYWORDS alongside actual lightweight
+      // modes like 'plan' and 'analyze'.
       const lightweight = ['cancel', 'plan', 'tdd', 'ultrathink', 'deepsearch', 'analyze', 'codex', 'gemini'];
       for (const mode of lightweight) {
         assert.ok(!HEAVY_MODE_KEYWORDS.has(mode), `Expected HEAVY_MODE_KEYWORDS NOT to contain "${mode}"`);

--- a/src/scripts/run-provider-advisor.ts
+++ b/src/scripts/run-provider-advisor.ts
@@ -7,14 +7,16 @@ import { spawnSync } from 'child_process';
 const PROVIDER_BINARIES: Record<string, string> = {
   claude: 'claude',
   gemini: 'gemini',
+  qwen: 'qwen',
 };
 const ASK_ORIGINAL_TASK_ENV = 'OMX_ASK_ORIGINAL_TASK';
 
 function usage(): void {
-  console.error('Usage: omx ask <claude|gemini> "<prompt>"');
-  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini> <prompt...>');
+  console.error('Usage: omx ask <claude|gemini|qwen> "<prompt>"');
+  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini|qwen> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
+  console.error('                 or: node scripts/run-provider-advisor.js qwen --prompt "<prompt>"');
 }
 
 function slugify(value: string): string {

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -8,6 +8,7 @@ import {
   resolveTeamWorkerLaunchArgs,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   resolveTeamLowComplexityDefaultModel,
+  resolveProviderDefaultModel,
 } from '../model-contract.js';
 
 function expectedLowComplexityModel(): string {
@@ -160,5 +161,63 @@ describe('resolveTeamWorkerLaunchArgs - teammate reasoning allocation', () => {
     });
     const joined = result.join(' ');
     assert.ok(!joined.includes('model_reasoning_effort'), `Expected no reasoning in: ${joined}`);
+  });
+
+  describe('resolveProviderDefaultModel', () => {
+    it('returns undefined for gemini when OMX_DEFAULT_GEMINI_MODEL is not set', () => {
+      const saved = process.env.OMX_DEFAULT_GEMINI_MODEL;
+      delete process.env.OMX_DEFAULT_GEMINI_MODEL;
+      try {
+        assert.equal(resolveProviderDefaultModel('gemini'), undefined);
+      } finally {
+        if (saved !== undefined) process.env.OMX_DEFAULT_GEMINI_MODEL = saved;
+      }
+    });
+
+    it('returns env value for gemini when OMX_DEFAULT_GEMINI_MODEL is set', () => {
+      const saved = process.env.OMX_DEFAULT_GEMINI_MODEL;
+      process.env.OMX_DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
+      try {
+        assert.equal(resolveProviderDefaultModel('gemini'), 'gemini-2.5-pro');
+      } finally {
+        if (saved !== undefined) {
+          process.env.OMX_DEFAULT_GEMINI_MODEL = saved;
+        } else {
+          delete process.env.OMX_DEFAULT_GEMINI_MODEL;
+        }
+      }
+    });
+
+    it('returns undefined for qwen when OMX_DEFAULT_QWEN_MODEL is not set', () => {
+      const saved = process.env.OMX_DEFAULT_QWEN_MODEL;
+      delete process.env.OMX_DEFAULT_QWEN_MODEL;
+      try {
+        assert.equal(resolveProviderDefaultModel('qwen'), undefined);
+      } finally {
+        if (saved !== undefined) process.env.OMX_DEFAULT_QWEN_MODEL = saved;
+      }
+    });
+
+    it('returns env value for qwen when OMX_DEFAULT_QWEN_MODEL is set', () => {
+      const saved = process.env.OMX_DEFAULT_QWEN_MODEL;
+      process.env.OMX_DEFAULT_QWEN_MODEL = 'qwen3-coder';
+      try {
+        assert.equal(resolveProviderDefaultModel('qwen'), 'qwen3-coder');
+      } finally {
+        if (saved !== undefined) {
+          process.env.OMX_DEFAULT_QWEN_MODEL = saved;
+        } else {
+          delete process.env.OMX_DEFAULT_QWEN_MODEL;
+        }
+      }
+    });
+
+    it('returns undefined for codex provider (no provider-specific override)', () => {
+      assert.equal(resolveProviderDefaultModel('codex'), undefined);
+    });
+
+    it('returns undefined for claude provider (no provider-specific override)', () => {
+      assert.equal(resolveProviderDefaultModel('claude'), undefined);
+    });
   });
 });

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -23,9 +23,17 @@ describe('runtime-cli helpers', () => {
       runtimeCli.normalizeAgentTypes(['gemini'], 3),
       ['gemini'],
     );
+    assert.deepEqual(
+      runtimeCli.normalizeAgentTypes(['qwen', 'codex'], 2),
+      ['qwen', 'codex'],
+    );
+    assert.deepEqual(
+      runtimeCli.normalizeAgentTypes(['qwen'], 2),
+      ['qwen'],
+    );
     assert.throws(
       () => runtimeCli.normalizeAgentTypes(['codex', 'invalid'], 2),
-      /Expected codex\\|claude\\|gemini/,
+      /Expected codex\\|claude\\|gemini\\|qwen/,
     );
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1072,6 +1072,7 @@ describe('team worker CLI helpers', () => {
     assert.equal(resolveTeamWorkerCli(['--model', 'claude-3-7-sonnet'], {}), 'claude');
     assert.equal(resolveTeamWorkerCli(['--model=claude-sonnet-4-6'], {}), 'claude');
     assert.equal(resolveTeamWorkerCli(['--model', 'gemini-2.0-pro'], {}), 'gemini');
+    assert.equal(resolveTeamWorkerCli(['--model', 'qwen-2.5-coder'], {}), 'qwen');
     assert.equal(resolveTeamWorkerCli(['--model', 'gpt-5'], {}), 'codex');
     assert.equal(resolveTeamWorkerCli([], {}), 'codex');
   });
@@ -1080,9 +1081,18 @@ describe('team worker CLI helpers', () => {
     assert.equal(resolveTeamWorkerCli([], { OMX_TEAM_WORKER_CLI: 'gemini' }), 'gemini');
   });
 
+  it('resolveTeamWorkerCli accepts explicit qwen override', () => {
+    assert.equal(resolveTeamWorkerCli([], { OMX_TEAM_WORKER_CLI: 'qwen' }), 'qwen');
+  });
+
   it('resolveTeamWorkerCliPlan accepts gemini in CLI map', () => {
     const plan = resolveTeamWorkerCliPlan(3, [], { OMX_TEAM_WORKER_CLI_MAP: 'codex,gemini,claude' });
     assert.deepEqual(plan, ['codex', 'gemini', 'claude']);
+  });
+
+  it('resolveTeamWorkerCliPlan accepts qwen in CLI map', () => {
+    const plan = resolveTeamWorkerCliPlan(3, [], { OMX_TEAM_WORKER_CLI_MAP: 'codex,qwen,claude' });
+    assert.deepEqual(plan, ['codex', 'qwen', 'claude']);
   });
 
   it('translateWorkerLaunchArgsForCli preserves args for codex', () => {
@@ -1123,6 +1133,32 @@ describe('team worker CLI helpers', () => {
     );
   });
 
+  it('translateWorkerLaunchArgsForCli emits qwen sandbox-mode and adds -p when initial prompt is provided', () => {
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('qwen', ['--model', 'qwen-2.5-coder', '--json']),
+      ['--sandbox-mode', 'none', '--model', 'qwen-2.5-coder'],
+    );
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('qwen', ['--model', 'qwen-2.5-coder', '--json'], 'Read worker inbox'),
+      ['--sandbox-mode', 'none', '-p', 'Read worker inbox', '--model', 'qwen-2.5-coder'],
+    );
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('qwen', ['--json']),
+      ['--sandbox-mode', 'none'],
+    );
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('qwen', ['--json'], 'Read worker inbox'),
+      ['--sandbox-mode', 'none', '-p', 'Read worker inbox'],
+    );
+  });
+
+  it('translateWorkerLaunchArgsForCli omits non-qwen default models for qwen workers', () => {
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('qwen', ['--model', 'gpt-5.3-codex-spark'], 'Read worker inbox'),
+      ['--sandbox-mode', 'none', '-p', 'Read worker inbox'],
+    );
+  });
+
   it('assertTeamWorkerCliBinaryAvailable throws clear error when binary missing', () => {
     assert.throws(
       () => assertTeamWorkerCliBinaryAvailable('claude', () => false),
@@ -1137,6 +1173,15 @@ describe('team worker CLI helpers', () => {
       { OMX_TEAM_WORKER_CLI_MAP: 'codex,codex,gemini,claude' },
     );
     assert.deepEqual(plan, ['codex', 'codex', 'gemini', 'claude']);
+  });
+
+  it('resolveTeamWorkerCliPlan supports mixed per-worker CLI map with qwen', () => {
+    const plan = resolveTeamWorkerCliPlan(
+      5,
+      [],
+      { OMX_TEAM_WORKER_CLI_MAP: 'codex,codex,gemini,claude,qwen' },
+    );
+    assert.deepEqual(plan, ['codex', 'codex', 'gemini', 'claude', 'qwen']);
   });
 
   it('resolveTeamWorkerCliPlan accepts single-value map and expands to all workers', () => {

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -4,6 +4,8 @@ import {
   getMainDefaultModel,
   getSparkDefaultModel,
   getStandardDefaultModel,
+  getGeminiDefaultModel,
+  getQwenDefaultModel,
 } from '../config/models.js';
 
 const MADMAX_FLAG = '--madmax';
@@ -200,4 +202,22 @@ export function isLowComplexityAgentType(agentType?: string): boolean {
 
 export function resolveTeamLowComplexityDefaultModel(codexHomeOverride?: string): string {
   return getSparkDefaultModel(codexHomeOverride);
+}
+
+/**
+ * Resolve a provider-specific default model when a team worker uses a non-Codex CLI.
+ * Returns the env-configured default for the given provider, or undefined if not set.
+ */
+export function resolveProviderDefaultModel(
+  provider: string,
+  codexHomeOverride?: string,
+): string | undefined {
+  switch (provider) {
+    case 'gemini':
+      return getGeminiDefaultModel(process.env, codexHomeOverride);
+    case 'qwen':
+      return getQwenDefaultModel(process.env, codexHomeOverride);
+    default:
+      return undefined;
+  }
 }

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -22,7 +22,7 @@ interface CliInput {
   pollIntervalMs?: number;
 }
 
-type TeamWorkerProvider = 'codex' | 'claude' | 'gemini';
+type TeamWorkerProvider = 'codex' | 'claude' | 'gemini' | 'qwen';
 
 interface TaskResult {
   taskId: string;
@@ -119,9 +119,9 @@ function collectTaskResults(stateRoot: string, teamName: string): TaskResult[] {
 
 export function normalizeAgentTypes(raw: string[], workerCount: number): TeamWorkerProvider[] {
   const providers = raw.map((entry) => String(entry || '').trim().toLowerCase());
-  const invalid = providers.filter((entry) => entry !== 'codex' && entry !== 'claude' && entry !== 'gemini');
+  const invalid = providers.filter((entry) => entry !== 'codex' && entry !== 'claude' && entry !== 'gemini' && entry !== 'qwen');
   if (invalid.length > 0) {
-    throw new Error(`Invalid agentTypes entries: ${invalid.join(', ')}. Expected codex|claude|gemini.`);
+    throw new Error(`Invalid agentTypes entries: ${invalid.join(', ')}. Expected codex|claude|gemini|qwen.`);
   }
   if (providers.length !== 1 && providers.length !== workerCount) {
     throw new Error(`agentTypes length must be 1 or ${workerCount}; received ${providers.length}.`);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1142,7 +1142,7 @@ function spawnPromptWorker(
   workerCwd: string,
   launchArgs: string[],
   workerEnv: Record<string, string>,
-  workerCli: 'codex' | 'claude' | 'gemini',
+  workerCli: 'codex' | 'claude' | 'gemini' | 'qwen',
   initialPrompt?: string,
 ): ChildProcessByStdio<Writable, null, null> {
   const processSpec = buildWorkerProcessLaunchSpec(
@@ -1204,6 +1204,8 @@ export function resolveWorkerLaunchArgsFromEnv(
     console.log('[omx:team] worker startup resolution: model=claude source=local-settings');
   } else if (effectiveWorkerCli === 'gemini') {
     console.log('[omx:team] worker startup resolution: model=gemini source=local-settings');
+  } else if (effectiveWorkerCli === 'qwen') {
+    console.log('[omx:team] worker startup resolution: model=qwen source=local-settings');
   } else {
     console.log(`[omx:team] worker startup resolution: model=${resolvedModel} thinking_level=${thinkingLevel} source=${source}`);
   }
@@ -1214,7 +1216,7 @@ export function resolveWorkerLaunchArgsFromEnv(
 function resolveEffectiveWorkerCliForStartupLog(
   resolvedLaunchArgs: string[],
   env: NodeJS.ProcessEnv,
-): 'codex' | 'claude' | 'gemini' {
+): 'codex' | 'claude' | 'gemini' | 'qwen' {
   const rawCliMap = String(env.OMX_TEAM_WORKER_CLI_MAP ?? '').trim();
   if (rawCliMap !== '') {
     const entries = rawCliMap
@@ -1226,13 +1228,14 @@ function resolveEffectiveWorkerCliForStartupLog(
         ...env,
         OMX_TEAM_WORKER_CLI: 'auto',
       });
-      const resolvedMap = entries.map((entry): 'codex' | 'claude' | 'gemini' | null => {
+      const resolvedMap = entries.map((entry): 'codex' | 'claude' | 'gemini' | 'qwen' | null => {
         if (entry === 'auto') return autoCli;
-        if (entry === 'codex' || entry === 'claude' || entry === 'gemini') return entry;
+        if (entry === 'codex' || entry === 'claude' || entry === 'gemini' || entry === 'qwen') return entry;
         return null;
       });
       if (resolvedMap.every((entry) => entry === 'claude')) return 'claude';
       if (resolvedMap.every((entry) => entry === 'gemini')) return 'gemini';
+      if (resolvedMap.every((entry) => entry === 'qwen')) return 'qwen';
       if (resolvedMap.some((entry) => entry === 'codex')) return 'codex';
     }
   }
@@ -1453,7 +1456,7 @@ export async function startTeam(
         sanitized,
         resolveInstructionStateRoot(workerWorkspace.worktreePath),
       );
-      const initialPrompt = workerCliPlan[i - 1] === 'gemini' ? trigger : undefined;
+      const initialPrompt = (workerCliPlan[i - 1] === 'gemini' || workerCliPlan[i - 1] === 'qwen') ? trigger : undefined;
       if (initialPrompt) {
         await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
       }

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -169,7 +169,7 @@ async function notifyWorkerPaneOutcome(
   workerIndex: number,
   message: string,
   paneId?: string,
-  workerCli?: 'codex' | 'claude' | 'gemini',
+  workerCli?: 'codex' | 'claude' | 'gemini' | 'qwen',
 ): Promise<DispatchOutcome> {
   try {
     await sendToWorker(sessionName, workerIndex, message, paneId, workerCli);

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -93,7 +93,7 @@ export interface WorkerInfo {
   name: string; // "worker-1"
   index: number; // tmux window index (1-based)
   role: string; // agent type
-  worker_cli?: 'codex' | 'claude' | 'gemini';
+  worker_cli?: 'codex' | 'claude' | 'gemini' | 'qwen';
   assigned_tasks: string[]; // task IDs
   pid?: number;
   pane_id?: string;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -29,7 +29,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude' | 'gemini';
+  worker_cli?: 'codex' | 'claude' | 'gemini' | 'qwen';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -50,10 +50,13 @@ const CLAUDE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 const GEMINI_PROMPT_INTERACTIVE_FLAG = '-i';
 const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
 const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
+const QWEN_PROMPT_FLAG = '-p';
+const QWEN_SANDBOX_MODE_FLAG = '--sandbox-mode';
+const QWEN_SANDBOX_MODE_NONE = 'none';
 const OMX_LEADER_NODE_PATH_ENV = 'OMX_LEADER_NODE_PATH';
 const OMX_LEADER_CLI_PATH_ENV = 'OMX_LEADER_CLI_PATH';
 
-export type TeamWorkerCli = 'codex' | 'claude' | 'gemini';
+export type TeamWorkerCli = 'codex' | 'claude' | 'gemini' | 'qwen';
 type TeamWorkerCliMode = 'auto' | TeamWorkerCli;
 export type TeamWorkerLaunchMode = 'interactive' | 'prompt';
 
@@ -455,8 +458,8 @@ function hasModelInstructionsOverride(args: string[]): boolean {
 function normalizeTeamWorkerCliMode(raw: string | undefined, sourceEnv: string = OMX_TEAM_WORKER_CLI_ENV): TeamWorkerCliMode {
   const normalized = String(raw ?? 'auto').trim().toLowerCase();
   if (normalized === '' || normalized === 'auto') return 'auto';
-  if (normalized === 'codex' || normalized === 'claude' || normalized === 'gemini') return normalized;
-  throw new Error(`Invalid ${sourceEnv} value "${raw}". Expected: auto, codex, claude, gemini`);
+  if (normalized === 'codex' || normalized === 'claude' || normalized === 'gemini' || normalized === 'qwen') return normalized;
+  throw new Error(`Invalid ${sourceEnv} value "${raw}". Expected: auto, codex, claude, gemini, qwen`);
 }
 
 export function resolveTeamWorkerLaunchMode(
@@ -498,6 +501,7 @@ function resolveTeamWorkerCliFromLaunchArgs(launchArgs: string[] = []): TeamWork
   const model = extractModelOverride(launchArgs);
   if (model && /claude/i.test(model)) return 'claude';
   if (model && /gemini/i.test(model)) return 'gemini';
+  if (model && /qwen/i.test(model)) return 'qwen';
   return 'codex';
 }
 
@@ -526,7 +530,7 @@ export function resolveTeamWorkerCliPlan(
   if (entries.length === 0 || entries.every((part) => part.length === 0)) {
     throw new Error(
       `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} value "${env[OMX_TEAM_WORKER_CLI_MAP_ENV]}". `
-        + `Expected comma-separated values: auto|codex|claude|gemini.`,
+        + `Expected comma-separated values: auto|codex|claude|gemini|qwen.`,
     );
   }
   if (entries.some((part) => part.length === 0)) {
@@ -558,6 +562,15 @@ export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: 
     const trimmedPrompt = initialPrompt?.trim();
     if (trimmedPrompt) translatedArgs.push(GEMINI_PROMPT_INTERACTIVE_FLAG, trimmedPrompt);
     if (geminiModel) translatedArgs.push(MODEL_FLAG, geminiModel);
+    return translatedArgs;
+  }
+  if (workerCli === 'qwen') {
+    const model = extractModelOverride(args);
+    const qwenModel = model && /qwen/i.test(model) ? model : null;
+    const translatedArgs = [QWEN_SANDBOX_MODE_FLAG, QWEN_SANDBOX_MODE_NONE];
+    const trimmedPrompt = initialPrompt?.trim();
+    if (trimmedPrompt) translatedArgs.push(QWEN_PROMPT_FLAG, trimmedPrompt);
+    if (qwenModel) translatedArgs.push(MODEL_FLAG, qwenModel);
     return translatedArgs;
   }
 
@@ -602,7 +615,7 @@ export function assertTeamWorkerCliBinaryAvailable(
   if (existsImpl(workerCli)) return;
   throw new Error(
     `Selected team worker CLI "${workerCli}" is not available on PATH. `
-      + `Install "${workerCli}" or set ${OMX_TEAM_WORKER_CLI_ENV}=codex|claude|gemini.`,
+      + `Install "${workerCli}" or set ${OMX_TEAM_WORKER_CLI_ENV}=codex|claude|gemini|qwen.`,
   );
 }
 

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -327,7 +327,7 @@ When calling \`omx team api send-message\`, you MUST always include:
 
 ## Startup Handshake (Required)
 Before doing any task work, send exactly one startup ACK to the leader.
-Keep the body short and deterministic so all worker CLIs (Codex/Claude) behave consistently.
+Keep the body short and deterministic so all worker CLIs (Codex/Claude/Gemini/Qwen) behave consistently.
 
 Example:
 omx team api send-message --input "{\"team_name\":\"${teamName}\",\"from_worker\":\"<your-worker-name>\",\"to_worker\":\"leader-fixed\",\"body\":\"ACK: <your-worker-name> initialized\"}" --json
@@ -344,7 +344,7 @@ When your mailbox receives a message, process delivery explicitly:
 - If you need to modify a shared file, report to the lead by writing to your status file with state "blocked"
 - Do NOT write lifecycle fields (\`status\`, \`owner\`, \`result\`, \`error\`) directly in task files; use claim-safe lifecycle APIs
 - If blocked, write {"state": "blocked", "reason": "..."} to your status file
-- You may spawn Codex native subagents when parallel execution improves throughput.
+- You may spawn Codex native subagents when parallel execution improves throughput (applies to Codex workers; Gemini/Qwen/Claude workers use their own subagent mechanisms).
 - Use subagents only for independent, bounded subtasks that can run safely within this worker pane.
 </team_worker_protocol>
 ${TEAM_OVERLAY_END}`;
@@ -711,7 +711,7 @@ When you are notified about mailbox messages, always follow this exact flow:
 2. For each undelivered message, mark delivery:
    \`omx team api mailbox-mark-delivered --input "{\"team_name\":\"${teamName}\",\"worker\":\"${workerName}\",\"message_id\":\"<MESSAGE_ID>\"}" --json\`
 
-Use terse ACK bodies (single line) for consistent parsing across Codex and Claude workers.
+Use terse ACK bodies (single line) for consistent parsing across Codex, Claude, Gemini, and Qwen workers.
 After any mailbox reply, continue executing your assigned work or the next feasible task; do not stop after sending the reply.
 
 ## Message Protocol


### PR DESCRIPTION
## Summary

- Add **Qwen** as an external provider for team mode and ask routing
- Enhance **Gemini** documentation and model-contract awareness
- Add comprehensive tests for both providers

> 🇰🇷 **한국어 요약**: **Qwen을 외부 프로바이더로 추가**하여 팀 모드와 ask 라우팅에서 사용할 수 있게 합니다. `OMX_TEAM_WORKER_CLI=qwen`으로 팀 워커 실행, `omx ask qwen`으로 Qwen 자문이 가능합니다. 또한 **Gemini의 모델 설정 함수(`getGeminiDefaultModel`)와 team SKILL.md 문서를 대폭 보강**하여 Gemini/Qwen 멀티 프로바이더 패리티를 개선합니다.

## Changes

### Qwen Provider Support
- Extended `TeamWorkerCli` and all team state types with `'qwen'`
- Added Qwen CLI spawn logic (`--sandbox-mode none`, `-p` prompt flag)
- Added `omx ask qwen` routing + `skills/ask-qwen/SKILL.md`
- Added `getQwenDefaultModel()` with `OMX_DEFAULT_QWEN_MODEL` env var support
- Updated scaling, runtime, and runtime-cli modules

### Gemini Enhancements
- Added `getGeminiDefaultModel()` with `OMX_DEFAULT_GEMINI_MODEL` env var support
- Added `resolveProviderDefaultModel()` dispatcher for Gemini/Qwen model resolution
- **Major documentation update**: Added "Gemini teammates" and "Qwen teammates" sections to `skills/team/SKILL.md`
- Updated worker-bootstrap overlay to mention all 4 CLIs (Codex/Claude/Gemini/Qwen)
- Added clarifying comments to task-size-detector for Gemini classification

### Tests
- Added tmux-session tests for Qwen (auto-detect, CLI override, launch args, mixed CLI map)
- Added runtime-cli tests for Qwen normalization
- Added 6 model-contract tests for `resolveProviderDefaultModel` (Gemini + Qwen)
- Added ask routing tests for Qwen provider parsing

### Documentation
- Updated README with external provider comparison table and multi-CLI examples
- Updated team SKILL.md with comprehensive Gemini/Qwen documentation

## Test Plan

- [x] TypeScript compilation — zero errors
- [x] tmux-session tests — 144/144 pass
- [x] runtime-cli tests — 6/6 pass
- [x] model-contract tests — 20/20 pass (6 new)
- [x] task-size-detector tests — 85/85 pass
- [x] ask tests — 17/18 pass (1 pre-existing failure requiring `claude` binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)