### PR TITLE
fix: clarify non-interactive guidance for omx agents remove

### DIFF
--- a/src/cli/__tests__/agents.test.ts
+++ b/src/cli/__tests__/agents.test.ts
@@ -109,7 +109,7 @@ describe('omx agents', () => {
       const editorScript = join(wd, 'editor.sh');
       await writeFile(
         editorScript,
-        '#!/usr/bin/env bash\nprintf \'\\nmodel = "gpt-5.4"\\n\' >> \"$1\"\n',
+        '#!/usr/bin/env bash\nprintf \'\\nmodel = "gpt-5.4"\\n\' >> "$1"\n',
       );
       await chmod(editorScript, 0o755);
 
@@ -131,6 +131,36 @@ describe('omx agents', () => {
 
       assert.equal(removeResult.status, 0, removeResult.stderr || removeResult.stdout);
       assert.equal(existsSync(agentPath), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails with clear guidance when remove runs in non-interactive mode without --force', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-agents-cli-'));
+    const home = join(wd, 'home');
+    try {
+      const projectAgentsDir = join(wd, '.codex', 'agents');
+      await mkdir(projectAgentsDir, { recursive: true });
+      await mkdir(home, { recursive: true });
+      const agentPath = join(projectAgentsDir, 'non-interactive.toml');
+      await writeFile(
+        agentPath,
+        'name = "non-interactive"\ndescription = "Remove me"\ndeveloper_instructions = """noop"""\n',
+      );
+
+      const result = runOmx(wd, ['agents', 'remove', 'non-interactive', '--scope', 'project'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.notEqual(result.status, 0, 'expected non-zero exit for non-interactive remove');
+      assert.equal(existsSync(agentPath), true, 'agent file should remain when remove aborts');
+      assert.match(
+        result.stderr,
+        /remove requires an interactive terminal; rerun with --force in non-interactive environments/i,
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -193,7 +193,6 @@ function resolveExistingAgentPath(
 }
 
 async function confirmRemove(path: string): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
     const answer = (await rl.question(`Delete native agent ${path}? [y/N]: `)).trim().toLowerCase();
@@ -201,6 +200,12 @@ async function confirmRemove(path: string): Promise<boolean> {
   } finally {
     rl.close();
   }
+}
+
+function ensureInteractiveRemove(force: boolean): void {
+  if (force) return;
+  if (process.stdin.isTTY && process.stdout.isTTY) return;
+  throw new Error('remove requires an interactive terminal; rerun with --force in non-interactive environments');
 }
 
 async function editNativeAgent(
@@ -224,11 +229,12 @@ async function removeNativeAgent(
   name: string,
   options: { cwd?: string; scope?: AgentScope; force?: boolean } = {},
 ): Promise<string> {
+  ensureInteractiveRemove(Boolean(options.force));
   const path = resolveExistingAgentPath(name, options);
   if (!options.force) {
     const confirmed = await confirmRemove(path);
     if (!confirmed) {
-      throw new Error('remove aborted (pass --force to skip confirmation)');
+      throw new Error('remove aborted by user (pass --force to skip confirmation)');
     }
   }
   await rm(path, { force: true });


### PR DESCRIPTION
## ✨ Summary

This PR improves the UX of `omx agents remove` in non-interactive environments.

### What changed

- Added an explicit non-interactive guard for `agents remove` when `--force` is not provided.
- Error message now clearly instructs the user to rerun with `--force`.
- Preserved existing interactive confirmation behavior in TTY sessions.
- Added a regression test for the non-interactive/no-force removal path.

## 🧩 Problem

Previously, running `omx agents remove` in a non-interactive shell produced a generic abort flow that looked like user cancellation. That made automation and CI logs harder to understand.

## ✅ New behavior

In non-interactive environments:

- `omx agents remove <name>`
  - fails fast with a clear actionable message
  - does **not** delete the agent file
- `omx agents remove <name> --force`
  - proceeds and removes the file

## 🧪 Validation

### Targeted checks (passing)

- `npm run build`
- `node --test dist/cli/__tests__/agents.test.js`

### Manual E2E checks (passing)

1. `agents add demo-agent`
2. `agents remove demo-agent` (non-interactive, without `--force`) → clear guidance + file preserved
3. `agents remove demo-agent --force` → success + file removed

## 📌 Note

There is an existing unrelated failure in the repo’s full test suite:

- `dist/team/__tests__/state.test.js`
- subtest: `claimTask owner write failure cleans up claim lock without orphan lock dir`

This PR does not touch team-state logic.