### PR TITLE
fix: add windowsHide to child process calls to prevent terminal flash on Windows

### DIFF
--- a/src/hud/authority.ts
+++ b/src/hud/authority.ts
@@ -39,6 +39,7 @@ async function defaultRunProcess(
     encoding: 'utf-8',
     stdio: 'ignore',
     timeout: options.timeoutMs,
+    windowsHide: true,
   });
   if (result.status !== 0) {
     throw new Error((result.stderr || result.stdout || '').trim() || `hud authority tick failed with status ${result.status ?? 'unknown'}`);

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -182,6 +182,7 @@ function runGit(cwd: string, args: string[]): string | null {
       encoding: 'utf-8',
       timeout: 2000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim() || null;
   } catch {
     return null;

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -380,7 +380,7 @@ function resolveCodexPaneByCwdFallback(cwd) {
   try {
     const panes = execFileSync('tmux', [
       'list-panes', '-a', '-F', '#{pane_id}	#{pane_current_path}	#{pane_current_command}	#{pane_start_command}',
-    ], { encoding: 'utf-8', timeout: 2000 })
+    ], { encoding: 'utf-8', timeout: 2000, windowsHide: true })
       .trim()
       .split('\n')
       .filter(Boolean);

--- a/src/scripts/notify-hook/operational-events.ts
+++ b/src/scripts/notify-hook/operational-events.ts
@@ -39,6 +39,7 @@ function gitValue(cwd: any, args: string[]): string {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 2000,
+      windowsHide: true,
     }).trim();
   } catch {
     return '';
@@ -83,6 +84,7 @@ export function resolveOperationalSessionName(cwd: any, sessionId = '', sessionN
         encoding: 'utf-8',
         stdio: ['ignore', 'pipe', 'ignore'],
         timeout: 2000,
+        windowsHide: true,
       }).trim();
       if (tmuxSession) return tmuxSession;
     } catch {

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -31,6 +31,7 @@ function runtimeExec(command) {
     execFileSync(binaryPath, ['exec', JSON.stringify(command)], {
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
   } catch {
     // non-fatal: JS path is the fallback


### PR DESCRIPTION
## Summary

Fix terminal windows flashing rapidly on Windows when running `omx`.

## Root Cause

On Windows, `execSync`/`execFileSync`/`spawnSync` calls without `windowsHide: true` open visible cmd.exe/powershell windows. The HUD watch loop calls `git` every 1 second via `execSync` in `src/hud/state.ts`, causing rapid terminal window flashing.

## Changes

Added `windowsHide: true` to all periodic/background child process spawns:

- `src/hud/state.ts` — `runGit()` (primary culprit: called every 1s in HUD watch mode)
- `src/hud/authority.ts` — authority tick `spawnSync`
- `src/scripts/notify-hook/operational-events.ts` — git value reads + tmux session detection
- `src/scripts/notify-hook/auto-nudge.ts` — tmux pane listing
- `src/scripts/notify-hook/team-dispatch.ts` — runtime bridge dispatch

## Verification

- `npm run build` ✅
- HUD tests: 128/128 pass ✅

Fixes #1100

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*