### PR TITLE
fix: comprehensive windowsHide for all child process spawns on Windows

### DIFF
--- a/src/autoresearch/contracts.ts
+++ b/src/autoresearch/contracts.ts
@@ -51,6 +51,7 @@ function readGit(repoPath: string, args: string[]): string {
       cwd: repoPath,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
   } catch (error) {
     const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -162,6 +162,7 @@ function readGit(repoPath: string, args: string[]): string {
       cwd: repoPath,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
   } catch (error) {
     const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };
@@ -223,7 +224,8 @@ function requireGitSuccess(worktreePath: string, args: string[]): void {
   const result = spawnSync('git', args, {
     cwd: worktreePath,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   if (result.status === 0) return;
   throw new Error((result.stderr || '').trim() || `git ${args.join(' ')} failed`);
 }
@@ -232,7 +234,8 @@ function gitStatusLines(worktreePath: string): string[] {
   const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
     cwd: worktreePath,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   if (result.status !== 0) {
     throw new Error((result.stderr || '').trim() || `git status failed for ${worktreePath}`);
   }
@@ -474,7 +477,8 @@ export async function runAutoresearchEvaluator(
     encoding: 'utf-8',
     shell: true,
     maxBuffer: 1024 * 1024,
-  });
+      windowsHide: true,
+    });
   const stdout = result.stdout?.trim() || '';
   const stderr = result.stderr?.trim() || '';
 
@@ -724,7 +728,9 @@ export async function materializeAutoresearchMissionToWorktree(
   // Commit materialized mission files so the worktree is clean for
   // assertResetSafeWorktree, which runs immediately after this step.
   try {
-    execFileSync('git', ['add', '--', missionFile, sandboxFile], { cwd: worktreePath, stdio: 'ignore' });
+    execFileSync('git', ['add', '--', missionFile, sandboxFile], { cwd: worktreePath, stdio: 'ignore',
+      windowsHide: true,
+    });
     execFileSync('git', ['commit', '-m', `autoresearch: materialize mission ${contract.missionSlug}`], {
       cwd: worktreePath,
       stdio: 'ignore',

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -241,7 +241,9 @@ export async function guidedAutoresearchSetup(repoRoot: string): Promise<InitAut
 }
 
 export function checkTmuxAvailable(): boolean {
-  const result = spawnSync('tmux', ['-V'], { stdio: 'pipe' });
+  const result = spawnSync('tmux', ['-V'], { stdio: 'pipe',
+      windowsHide: true,
+    });
   return result.status === 0;
 }
 
@@ -251,7 +253,9 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
   }
 
   const sessionName = `omx-autoresearch-${slug}`;
-  const hasSession = spawnSync('tmux', ['has-session', '-t', sessionName], { stdio: 'pipe' });
+  const hasSession = spawnSync('tmux', ['has-session', '-t', sessionName], { stdio: 'pipe',
+      windowsHide: true,
+    });
   if (hasSession.status === 0) {
     throw new Error(
       `tmux session "${sessionName}" already exists.\n`
@@ -263,7 +267,9 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
   const omxPath = resolve(join(__dirname, '..', '..', 'bin', 'omx.js'));
   const cmd = `${shellQuote(process.execPath)} ${shellQuote(omxPath)} autoresearch ${shellQuote(missionDir)}`;
 
-  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, cmd], { stdio: 'ignore' });
+  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, cmd], { stdio: 'ignore',
+      windowsHide: true,
+    });
 
   console.log(`\nAutoresearch launched in background tmux session.`);
   console.log(`  Session:  ${sessionName}`);

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -156,7 +156,8 @@ function runAutoresearchTurn(worktreePath: string, instructionsFile: string, cod
     input: prompt,
     encoding: 'utf-8',
     env: process.env,
-  });
+      windowsHide: true,
+    });
 
   if (result.error) {
     throw result.error;
@@ -182,7 +183,8 @@ function resolveRepoRoot(cwd: string): string {
     cwd,
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
-  }).trim();
+      windowsHide: true,
+    }).trim();
 }
 
 export function parseAutoresearchArgs(args: readonly string[]): ParsedAutoresearchArgs {
@@ -277,12 +279,16 @@ async function runAutoresearchLoop(
 }
 
 function checkTmuxAvailable(): boolean {
-  const result = spawnSync('tmux', ['-V'], { stdio: 'pipe' });
+  const result = spawnSync('tmux', ['-V'], { stdio: 'pipe',
+      windowsHide: true,
+    });
   return result.status === 0;
 }
 
 function tmuxDisplay(target: string, format: string): string | null {
-  const result = spawnSync('tmux', ['display-message', '-p', '-t', target, format], { encoding: 'utf-8' });
+  const result = spawnSync('tmux', ['display-message', '-p', '-t', target, format], { encoding: 'utf-8',
+      windowsHide: true,
+    });
   if (result.error || result.status !== 0) return null;
   const value = (result.stdout || '').trim();
   return value || null;

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -102,7 +102,8 @@ export function parsePsOutput(output: string): ProcessEntry[] {
 export function listOmxProcesses(): ProcessEntry[] {
   const output = execFileSync('ps', ['axww', '-o', 'pid=,ppid=,command='], {
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   return parsePsOutput(output);
 }
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1025,7 +1025,9 @@ async function cleanupLegacySkillPromptShims(
 }
 
 function isGitHubCliConfigured(): boolean {
-  const result = spawnSync("gh", ["auth", "status"], { stdio: "ignore" });
+  const result = spawnSync("gh", ["auth", "status"], { stdio: "ignore",
+      windowsHide: true,
+    });
   return result.status === 0;
 }
 

--- a/src/cli/star-prompt.ts
+++ b/src/cli/star-prompt.ts
@@ -47,7 +47,8 @@ export function isGhInstalled(): boolean {
     encoding: 'utf-8',
     stdio: ['ignore', 'ignore', 'ignore'],
     timeout: 3000,
-  });
+      windowsHide: true,
+    });
   return !result.error && result.status === 0;
 }
 

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -207,7 +207,9 @@ async function loadConfigForCommand(
 }
 
 function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
-  const result = spawnSync('tmux', args, { encoding: 'utf-8' });
+  const result = spawnSync('tmux', args, { encoding: 'utf-8',
+      windowsHide: true,
+    });
   if (result.error) {
     return { ok: false, stderr: result.error.message };
   }
@@ -447,7 +449,8 @@ async function testTmuxHook(args: string[]): Promise<void> {
   const result = spawnSync(process.execPath, [notifyHook, JSON.stringify(payload)], {
     cwd,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   if (result.error) {
     throw new Error(`failed to run notify-hook: ${result.error.message}`);
   }

--- a/src/hooks/code-simplifier/index.ts
+++ b/src/hooks/code-simplifier/index.ts
@@ -87,6 +87,7 @@ export function getModifiedFiles(
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
+      windowsHide: true,
     });
     const trimmedOutput = output.trimEnd();
     if (trimmedOutput.length === 0) {

--- a/src/hooks/codebase-map.ts
+++ b/src/hooks/codebase-map.ts
@@ -39,6 +39,7 @@ function getTrackedSourceFiles(cwd: string): string[] {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 4000,
+      windowsHide: true,
     });
     return out
       .trim()

--- a/src/hooks/extensibility/sdk/tmux.ts
+++ b/src/hooks/extensibility/sdk/tmux.ts
@@ -55,7 +55,9 @@ function sleepFractionalSeconds(seconds: number): void {
 }
 
 function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
-  const result = spawnSync('tmux', args, { encoding: 'utf-8' });
+  const result = spawnSync('tmux', args, { encoding: 'utf-8',
+      windowsHide: true,
+    });
   if (result.error) return { ok: false, stderr: result.error.message };
   if (result.status !== 0) {
     return { ok: false, stderr: (result.stderr || '').trim() || `tmux exited ${result.status}` };

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -34,7 +34,8 @@ export function getCurrentTmuxSession(): string | null {
         encoding: "utf-8",
         timeout: 3000,
         stdio: ["pipe", "pipe", "pipe"],
-      }).trim();
+      windowsHide: true,
+    }).trim();
       if (sessionName) return sessionName;
     } catch {
       // fall through to PID-based detection
@@ -94,7 +95,8 @@ function detectTmuxSessionByPid(): string | null {
           encoding: "utf-8",
           timeout: 1000,
           stdio: ["pipe", "pipe", "pipe"],
-        }).trim();
+      windowsHide: true,
+    }).trim();
         const ppid = parseInt(ppidStr, 10);
         if (isNaN(ppid) || ppid <= 1) break;
         currentPid = ppid;
@@ -151,6 +153,7 @@ export function captureTmuxPane(paneId?: string | null, lines: number = 12): str
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     }).trim();
     return output || null;
   } catch {
@@ -240,7 +243,8 @@ function detectTmuxPaneByPid(): string | null {
           encoding: "utf-8",
           timeout: 1000,
           stdio: ["pipe", "pipe", "pipe"],
-        }).trim();
+      windowsHide: true,
+    }).trim();
         const ppid = parseInt(ppidStr, 10);
         if (isNaN(ppid) || ppid <= 1) break;
         currentPid = ppid;

--- a/src/runtime/bridge.ts
+++ b/src/runtime/bridge.ts
@@ -249,7 +249,8 @@ export class RuntimeBridge {
         encoding: 'utf-8',
         timeout: 10_000,
         maxBuffer: 1024 * 1024,
-      });
+      windowsHide: true,
+    });
       return result;
     } catch (err: unknown) {
       const execErr = err as { stderr?: string; message?: string };

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -448,16 +448,22 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
 async function emitRalphContinueSteer(paneId: string, message: string): Promise<void> {
   const markedText = `${message} ${DEFAULT_MARKER}`;
   await new Promise<void>((resolve) => {
-    const typed = spawnSync('tmux', ['send-keys', '-t', paneId, '-l', markedText], { encoding: 'utf-8' });
+    const typed = spawnSync('tmux', ['send-keys', '-t', paneId, '-l', markedText], { encoding: 'utf-8',
+      windowsHide: true,
+    });
     if (typed.status !== 0) throw new Error((typed.stderr || typed.stdout || '').trim() || 'tmux send-keys failed');
     setTimeout(resolve, 100);
   });
   await new Promise<void>((resolve) => {
-    const submitA = spawnSync('tmux', ['send-keys', '-t', paneId, 'C-m'], { encoding: 'utf-8' });
+    const submitA = spawnSync('tmux', ['send-keys', '-t', paneId, 'C-m'], { encoding: 'utf-8',
+      windowsHide: true,
+    });
     if (submitA.status !== 0) throw new Error((submitA.stderr || submitA.stdout || '').trim() || 'tmux send-keys C-m failed');
     setTimeout(resolve, 100);
   });
-  const submitB = spawnSync('tmux', ['send-keys', '-t', paneId, 'C-m'], { encoding: 'utf-8' });
+  const submitB = spawnSync('tmux', ['send-keys', '-t', paneId, 'C-m'], { encoding: 'utf-8',
+      windowsHide: true,
+    });
   if (submitB.status !== 0) {
     throw new Error((submitB.stderr || submitB.stdout || '').trim() || 'tmux send-keys C-m failed');
   }
@@ -1101,7 +1107,8 @@ async function invokeNotifyHook(payload: Record<string, unknown>, filePath: stri
   const result = spawnSync(process.execPath, [notifyScript, JSON.stringify(payload)], {
     cwd,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   const ok = result.status === 0;
   await eventLog({
     type: 'fallback_notify',

--- a/src/scripts/run-provider-advisor.ts
+++ b/src/scripts/run-provider-advisor.ts
@@ -59,7 +59,8 @@ function ensureBinary(binary: string): void {
   const probe = spawnSync(binary, ['--version'], {
     stdio: 'ignore',
     encoding: 'utf8',
-  });
+      windowsHide: true,
+    });
 
   if (probe.error && (probe.error as NodeJS.ErrnoException).code === 'ENOENT') {
     const verify = `${binary} --version`;
@@ -153,7 +154,8 @@ async function main(): Promise<void> {
   const run = spawnSync(binary, ['-p', prompt], {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
-  });
+      windowsHide: true,
+    });
 
   const stdout = run.stdout || '';
   const stderr = run.stderr || '';

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -223,6 +223,7 @@ export function resolveCodexPane(): string {
   try {
     const sessionName = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#S'], {
       encoding: 'utf-8', timeout: 2000,
+      windowsHide: true,
     }).trim();
     if (!sessionName) return '';
 

--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -47,6 +47,7 @@ function tryReadGitValue(cwd: string, args: string[]): string | null {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 2000,
+      windowsHide: true,
     }).trim();
     return value || null;
   } catch {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -257,7 +257,8 @@ function runCommand(command: string, args: string[], cwd: string): CommandResult
   const result = spawnSync(command, args, {
     cwd,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   return {
     ok: result.status === 0,
     stdout: (result.stdout || '').trim(),

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -257,7 +257,9 @@ export async function scaleUp(
         }
         try {
           if (w.pane_id) {
-            execFileSync('tmux', ['kill-pane', '-t', w.pane_id], { stdio: 'pipe' });
+            execFileSync('tmux', ['kill-pane', '-t', w.pane_id], { stdio: 'pipe',
+      windowsHide: true,
+    });
           }
         } catch {}
         if (w.worktree_path) {
@@ -280,7 +282,9 @@ export async function scaleUp(
 
       if (context.paneId) {
         try {
-          execFileSync('tmux', ['kill-pane', '-t', context.paneId], { stdio: 'pipe' });
+          execFileSync('tmux', ['kill-pane', '-t', context.paneId], { stdio: 'pipe',
+      windowsHide: true,
+    });
         } catch {}
       }
 

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -126,6 +126,7 @@ function tryReadGitValue(cwd: string, args: string[]): string | null {
       cwd,
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     }).trim();
     return value || null;
   } catch {
@@ -139,6 +140,7 @@ function isTracked(worktreePath: string, fileName: string): boolean {
       cwd: worktreePath,
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
     return true;
   } catch {
@@ -183,7 +185,8 @@ export async function writeWorkerWorktreeRootAgentsFile(
         cwd: options.worktreePath,
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "pipe"],
-      });
+      windowsHide: true,
+    });
       skipWorktreeApplied = true;
     } catch {
       skipWorktreeApplied = false;
@@ -247,7 +250,8 @@ export async function removeWorkerWorktreeRootAgentsFile(
         cwd: worktreePath,
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "pipe"],
-      });
+      windowsHide: true,
+    });
     } catch {
       // Best-effort cleanup only.
     }

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -58,7 +58,8 @@ export function isGitRepository(cwd: string): boolean {
   const result = spawnSync('git', ['rev-parse', '--show-toplevel'], {
     cwd,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   return result.status === 0;
 }
 
@@ -77,6 +78,7 @@ function readGit(repoRoot: string, args: string[]): string {
       cwd: repoRoot,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
   } catch (error) {
     const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };
@@ -93,7 +95,8 @@ function validateBranchName(repoRoot: string, branchName: string): void {
   const result = spawnSync('git', ['check-ref-format', '--branch', branchName], {
     cwd: repoRoot,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   if (result.status === 0) return;
   const stderr = (result.stderr || '').trim();
   throw new Error(stderr || `invalid_worktree_branch:${branchName}`);
@@ -111,7 +114,8 @@ function isWorktreeDirty(worktreePath: string): boolean {
   const result = spawnSync('git', ['status', '--porcelain'], {
     cwd: worktreePath,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   if (result.status !== 0) {
     const stderr = (result.stderr || '').trim();
     throw new Error(stderr || `worktree_status_failed:${worktreePath}`);
@@ -123,7 +127,8 @@ export function readWorkspaceStatusLines(cwd: string): string[] {
   const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
     cwd,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   if (result.status !== 0) {
     const stderr = (result.stderr || '').trim();
     throw new Error(stderr || `workspace_status_failed:${cwd}`);
@@ -233,7 +238,8 @@ function resolveGitCommonDir(cwd: string): string | null {
   const result = spawnSync('git', ['rev-parse', '--git-common-dir'], {
     cwd,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   if (result.status !== 0) return null;
   const value = (result.stdout || '').trim();
   if (!value) return null;
@@ -252,7 +258,8 @@ function readWorktreeEntryFromPath(repoRoot: string, worktreePath: string): GitW
   const headResult = spawnSync('git', ['rev-parse', 'HEAD'], {
     cwd: worktreePath,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   if (headResult.status !== 0) return null;
   const head = (headResult.stdout || '').trim();
   if (!head) return null;
@@ -260,7 +267,8 @@ function readWorktreeEntryFromPath(repoRoot: string, worktreePath: string): GitW
   const branchResult = spawnSync('git', ['symbolic-ref', '-q', 'HEAD'], {
     cwd: worktreePath,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
   const branchRef = branchResult.status === 0 ? (branchResult.stdout || '').trim() : null;
 
   return {
@@ -402,7 +410,8 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
   const result = spawnSync('git', addArgs, {
     cwd: plan.repoRoot,
     encoding: 'utf-8',
-  });
+      windowsHide: true,
+    });
 
   if (result.status !== 0) {
     const stderr = (result.stderr || '').trim();

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -206,9 +206,10 @@ export function spawnPlatformCommandSync(
   spawnImpl: SpawnSyncLike = spawnSync,
 ): ProbedPlatformCommand {
   const spec = buildPlatformCommandSpec(command, args, platform, env, existsImpl);
+  const baseOptions = platform === 'win32' ? { ...options, windowsHide: true } : options;
   const spawnOptions = shouldUseWindowsVerbatimArguments(platform, spec)
-    ? { ...options, windowsVerbatimArguments: true }
-    : options;
+    ? { ...baseOptions, windowsVerbatimArguments: true }
+    : baseOptions;
   const result = spawnImpl(spec.command, spec.args, spawnOptions);
   if (!shouldRetryWithNodeHost(spec, result.error as NodeJS.ErrnoException | undefined, platform)) {
     return { spec, result };


### PR DESCRIPTION
## Summary

Follow-up to PR #1104 — comprehensive sweep adding `windowsHide: true` to **all** remaining child process spawn calls across the codebase.

## Problem

PR #1104 fixed the most obvious culprit (HUD git polling + notify-hook), but users reported the terminal flashing still occurs. There were many more `execSync`/`execFileSync`/`spawnSync` calls missing `windowsHide: true`.

## Changes (22 files)

### Central fix
- **`src/utils/platform-command.ts`** — `spawnPlatformCommandSync` now automatically adds `windowsHide: true` on Windows. This covers ALL callers going forward.

### Individual call sites
- `hooks/` — code-simplifier, codebase-map, extensibility/tmux
- `scripts/` — notify-fallback-watcher, run-provider-advisor, tmux-hook-engine
- `team/` — leader-activity, worker-bootstrap, worktree, runtime, scaling
- `notifications/` — tmux
- `runtime/` — bridge
- `cli/` — cleanup, setup, star-prompt, tmux-hook, autoresearch, autoresearch-guided
- `autoresearch/` — contracts, runtime

## Verification
- `npm run build` ✅
- Tests: 143/143 pass ✅

Fixes #1100

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*