### PR TITLE
docs(qa): record remaining team runtime seam gaps

### DIFF
--- a/docs/contracts/rust-runtime-thin-adapter-contract.md
+++ b/docs/contracts/rust-runtime-thin-adapter-contract.md
@@ -15,6 +15,9 @@ JS, HUD, CLI, and tmux are thin delivery/observer adapters. They may read
 compatibility artifacts, but they MUST NOT define or mutate semantic truth on
 their own.
 
+Current migration follow-ups that still fall short of this target are tracked in
+`docs/qa/runtime-team-seam-audit-2026-04-01.md`.
+
 ## Compatibility artifacts
 
 Legacy readers continue to read the same state files, but only as

--- a/docs/qa/runtime-team-seam-audit-2026-04-01.md
+++ b/docs/qa/runtime-team-seam-audit-2026-04-01.md
@@ -1,0 +1,123 @@
+# Runtime Team Seam Audit - 2026-04-01
+
+Date: **2026-04-01**  
+Baseline commit: **`51579ce`** (`upstream/dev`)
+
+## Scope
+
+This note records the remaining high-value runtime seam gaps after the Rust thin-adapter migration wave. It is intentionally documentation-only and does not change runtime behavior.
+
+## Summary
+
+The team/runtime stack is no longer missing a Rust contract surface. The remaining risk is narrower:
+
+1. **Rust runtime ↔ TS team state is still dual-written in cutover paths**
+2. **Team metadata resolution still falls back across multiple files**
+3. **The declared Rust semantic-owner model is ahead of some TS canonical writers**
+4. **Compatibility readers still carry legacy/current precedence logic**
+
+These are follow-up seam-hardening gaps, not evidence that the Rust runtime direction was wrong.
+
+## Remaining seam gaps
+
+### 1. Rust runtime ↔ TS team state dual-write
+
+Evidence:
+
+- `src/team/state/dispatch.ts:130-140`
+- `src/team/state/mailbox.ts:45-49`
+
+Current state:
+
+- Rust bridge writes are attempted first
+- bridge failures are explicitly non-fatal
+- TS file writes remain canonical during cutover
+
+Risk:
+
+- state divergence between Rust-authored compatibility output and TS-owned team files
+- harder debugging when status, delivery, or mailbox transitions disagree
+
+Desired end state:
+
+- Rust owns the semantic transition
+- TS stores only adapter-local or presentation-local metadata
+
+### 2. Team metadata resolution still spans multiple files
+
+Evidence:
+
+- `src/team/api-interop.ts:423-438`
+
+Current state:
+
+- worker identity metadata is checked first
+- then `manifest.v2.json`
+- then `config.json`
+
+Risk:
+
+- working-directory or state-root resolution can depend on fallback order instead of one canonical source
+
+Desired end state:
+
+- one canonical metadata source for team state-root / working-directory resolution
+- the remaining files become derived compatibility views only
+
+### 3. Runtime ownership contract vs. cutover reality
+
+Evidence:
+
+- `src/runtime/bridge.ts:2-6`
+- `src/team/state/dispatch.ts:130-140`
+- `src/team/state/mailbox.ts:45-49`
+
+Current state:
+
+- the bridge contract says semantic mutations route through Rust
+- the team cutover paths still treat TS files as canonical in some flows
+
+Risk:
+
+- contributor confusion about which layer is allowed to establish semantic truth
+- longer-lived dual-write migration pressure
+
+Desired end state:
+
+- Rust is the sole semantic owner for runtime state transitions
+- TS remains a thin reader / delivery adapter only
+
+### 4. Compatibility readers still carry fallback precedence logic
+
+Evidence:
+
+- `src/compat/__tests__/rust-runtime-compat.test.ts:47-170`
+- `src/hud/state.ts:107-123`
+- `src/team/api-interop.ts:432-436`
+
+Current state:
+
+- compatibility readers intentionally preserve legacy/current precedence
+- this is useful for migration safety, but it keeps the read path more complex than the target architecture
+
+Risk:
+
+- future format drift can hide inside fallback behavior instead of failing at a single canonical reader boundary
+
+Desired end state:
+
+- compatibility readers keep only the minimum fallback behavior still required by supported migration lanes
+- newer paths read one canonical Rust-authored surface first
+
+## Recommended follow-up order
+
+1. Remove semantic dual-write from dispatch transitions
+2. Remove semantic dual-write from mailbox transitions
+3. Collapse team state-root / working-directory resolution to one canonical metadata source
+4. Reduce compatibility fallback layers after the write path is single-owner
+
+## Out of scope
+
+- replacing the existing Rust runtime contract
+- removing compatibility readers immediately
+- changing release gates in this documentation pass

--- a/docs/qa/rust-runtime-thin-adapter-gate.md
+++ b/docs/qa/rust-runtime-thin-adapter-gate.md
@@ -27,4 +27,12 @@ failing.
 
 - `docs/contracts/rust-runtime-thin-adapter-contract.md`
 - `docs/interop-team-mutation-contract.md`
+- `docs/qa/runtime-team-seam-audit-2026-04-01.md` (non-gating follow-up seam snapshot)
+
+## Non-gating follow-up audit
+
+The current thin-adapter cutover still carries a small number of known seam gaps
+that are intentionally tracked outside the release gate. See
+`docs/qa/runtime-team-seam-audit-2026-04-01.md` for the remaining dual-write,
+metadata-resolution, and compatibility-reader follow-ups.
 


### PR DESCRIPTION
## Summary
Record the remaining team/runtime seam gaps after the Rust thin-adapter cutover and link the existing contract/gate docs to that audit snapshot.

## Problem statement
The repo already has a Rust runtime ownership contract and release-gate documentation, but the current migration still leaves a few non-gating seam gaps around dual-write team state paths, metadata fallback resolution, and compatibility-reader complexity. Before future cleanup work lands, contributors need one explicit repo-local reference that names those gaps and orders the follow-up work.

## Root cause
The runtime migration established the target architecture first and stabilized compatibility behavior, but it did not yet leave behind a single audit note for the remaining cutover-era seams. As a result, the ownership target is documented, while the remaining mixed-ownership realities are scattered across code comments and tests.

## What changed
- added `docs/qa/runtime-team-seam-audit-2026-04-01.md` to capture the four remaining high-value seam gaps and the recommended follow-up order
- linked `docs/contracts/rust-runtime-thin-adapter-contract.md` to that audit so the ownership target and the remaining gaps can be read together
- linked `docs/qa/rust-runtime-thin-adapter-gate.md` to the same audit as a non-gating follow-up snapshot

## Why this design
This keeps the change documentation-only and deliberately avoids pretending the remaining seam gaps are already gating failures. The repo already uses QA/docs artifacts to capture migration gaps and release-readiness follow-ups, so this approach fits the existing delivery pattern while giving future cleanup PRs one canonical reference.

## Overlap assessment
**Classification:** adjacent but distinct follow-up.

Related work:
- PR #969 — established the Rust runtime contract surface and migration direction
- PR #977 — aligned CI/contracts after the Rust+TS migration wave
- PR #1064 — hardened watcher/pane contracts during the same migration era
- Issue #1108 — tracks the actual cleanup work for the remaining seam gaps

This PR does **not** claim to remove those seams yet. It records them explicitly so the follow-up work can be scoped cleanly.

## Validation
- `npm ci`
- `npm run build`
- `node --test dist/compat/__tests__/rust-runtime-compat.test.js dist/verification/__tests__/rust-runtime-thin-adapter-gate.test.js`

## Risk / compatibility
- documentation-only change; no runtime behavior change intended
- keeps the existing release gate intact
- remaining risk is unchanged: the seam gaps are still present until follow-up implementation work lands

## Files changed
- `docs/qa/runtime-team-seam-audit-2026-04-01.md`
- `docs/qa/rust-runtime-thin-adapter-gate.md`
- `docs/contracts/rust-runtime-thin-adapter-contract.md`

## Issue reference
- Refs #1108
