### PR TITLE
fix(team): canonicalize team cwd metadata resolution to manifest.v2

### DIFF
--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -481,6 +481,47 @@ describe('executeTeamApiOperation: list-tasks', () => {
     }
   });
 
+
+  it('resolves team working directory from manifest metadata over worker identity/config fallbacks', async () => {
+    const teamName = 'list-tsk-meta';
+    const cwdA = await mkdtemp(join(tmpdir(), 'omx-interop-meta-a-'));
+    const cwdB = await mkdtemp(join(tmpdir(), 'omx-interop-meta-b-'));
+    const prevTeamWorker = process.env.OMX_TEAM_WORKER;
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_TEAM_WORKER = `${teamName}/worker-1`;
+
+    try {
+      await initTeamState(teamName, 'metadata precedence', 'executor', 2, cwdA);
+      await initTeamState(teamName, 'metadata precedence', 'executor', 2, cwdB);
+      await createTask(teamName, { subject: 'From manifest root', description: 'B lane', status: 'pending' }, cwdB);
+
+      const teamRootA = join(cwdA, '.omx', 'state', 'team', teamName);
+      const configPath = join(teamRootA, 'config.json');
+      const manifestPath = join(teamRootA, 'manifest.v2.json');
+
+      const config = JSON.parse(await readFile(configPath, 'utf-8')) as Record<string, unknown>;
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as Record<string, unknown>;
+
+      config.team_state_root = join(cwdA, '.omx', 'state');
+      manifest.team_state_root = join(cwdB, '.omx', 'state');
+
+      await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+      await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+      const result = await executeTeamApiOperation('list-tasks', { team_name: teamName }, cwdA);
+      assert.equal(result.ok, true);
+      if (!result.ok) throw new Error('expected list-tasks to succeed');
+      assert.equal(result.data.count, 1);
+    } finally {
+      if (typeof prevTeamWorker === 'string') process.env.OMX_TEAM_WORKER = prevTeamWorker;
+      else delete process.env.OMX_TEAM_WORKER;
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwdA, { recursive: true, force: true });
+      await rm(cwdB, { recursive: true, force: true });
+    }
+  });
   it('returns error when team_name missing', async () => {
     const result = await executeTeamApiOperation('list-tasks', {}, '/tmp');
     assert.equal(result.ok, false);

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -391,14 +391,7 @@ function teamStateExists(teamName: string, candidateCwd: string): boolean {
   return existsSync(join(teamRoot, 'config.json')) || existsSync(join(teamRoot, 'tasks')) || existsSync(teamRoot);
 }
 
-function parseTeamWorkerEnv(raw: string | undefined): { teamName: string; workerName: string } | null {
-  if (typeof raw !== 'string' || raw.trim() === '') return null;
-  const match = /^([a-z0-9][a-z0-9-]{0,29})\/(worker-\d+)$/.exec(raw.trim());
-  if (!match) return null;
-  return { teamName: match[1], workerName: match[2] };
-}
-
-function readTeamStateRootFromFile(path: string): string | null {
+function readTeamStateRootFromManifest(path: string): string | null {
   if (!existsSync(path)) return null;
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf8')) as { team_state_root?: unknown };
@@ -415,26 +408,14 @@ function stateRootToWorkingDirectory(stateRoot: string): string {
   return dirname(dirname(absolute));
 }
 
-function resolveTeamWorkingDirectoryFromMetadata(
-  teamName: string,
-  candidateCwd: string,
-  workerContext: { teamName: string; workerName: string } | null,
-): string | null {
+function resolveTeamWorkingDirectoryFromMetadata(teamName: string, candidateCwd: string): string | null {
   const teamRoot = join(candidateCwd, '.omx', 'state', 'team', teamName);
   if (!existsSync(teamRoot)) return null;
 
-  if (workerContext?.teamName === teamName) {
-    const workerRoot = readTeamStateRootFromFile(join(teamRoot, 'workers', workerContext.workerName, 'identity.json'));
-    if (workerRoot) return stateRootToWorkingDirectory(workerRoot);
-  }
+  const fromManifest = readTeamStateRootFromManifest(join(teamRoot, 'manifest.v2.json'));
+  if (!fromManifest) return null;
 
-  const fromManifest = readTeamStateRootFromFile(join(teamRoot, 'manifest.v2.json'));
-  if (fromManifest) return stateRootToWorkingDirectory(fromManifest);
-
-  const fromConfig = readTeamStateRootFromFile(join(teamRoot, 'config.json'));
-  if (fromConfig) return stateRootToWorkingDirectory(fromConfig);
-
-  return null;
+  return stateRootToWorkingDirectory(fromManifest);
 }
 
 function resolveTeamWorkingDirectory(teamName: string, preferredCwd: string): string {
@@ -451,12 +432,11 @@ function resolveTeamWorkingDirectory(teamName: string, preferredCwd: string): st
     if (!seeds.includes(seed)) seeds.push(seed);
   }
 
-  const workerContext = parseTeamWorkerEnv(process.env.OMX_TEAM_WORKER);
   for (const seed of seeds) {
     let cursor = seed;
     while (cursor) {
       if (teamStateExists(normalizedTeamName, cursor)) {
-        return resolveTeamWorkingDirectoryFromMetadata(normalizedTeamName, cursor, workerContext) ?? cursor;
+        return resolveTeamWorkingDirectoryFromMetadata(normalizedTeamName, cursor) ?? cursor;
       }
       const parent = dirname(cursor);
       if (!parent || parent === cursor) break;


### PR DESCRIPTION
## Summary
- make team working-directory resolution read team metadata only from `.omx/state/team/<team>/manifest.v2.json`
- remove fallback parsing paths from `workers/<worker>/identity.json` and `config.json`
- keep behavior safe by falling back to the discovered cwd when manifest metadata is absent

## Testing
- npm run build
- node --test dist/team/__tests__/api-interop.test.js

Fixes #1108
