### PR TITLE
fix: avoid Windows git polling flicker in HUD and leader activity

### DIFF
--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -6,13 +6,14 @@
 
 import { readFile } from 'fs/promises';
 import { readFileSync } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { omxStateDir } from '../utils/paths.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
 import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { tryReadGitValueFromFiles } from '../utils/git-filesystem.js';
 import type {
   RalphStateForHud,
   UltraworkStateForHud,
@@ -176,12 +177,16 @@ export function readVersion(): string | null {
 export type GitRunner = (cwd: string, args: string[]) => string | null;
 
 function runGit(cwd: string, args: string[]): string | null {
+  const fromFiles = tryReadGitValueFromFiles(cwd, args);
+  if (fromFiles !== null) return fromFiles;
+
   try {
-    return execSync(`git ${args.join(' ')}`, {
+    return execFileSync('git', args, {
       cwd,
       encoding: 'utf-8',
       timeout: 2000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim() || null;
   } catch {
     return null;

--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { omxStateDir } from '../utils/paths.js';
+import { tryReadGitBranchActivityMsFromFiles } from '../utils/git-filesystem.js';
 
 interface LeaderRuntimeActivityDoc {
   last_activity_at?: string;
@@ -47,6 +48,7 @@ function tryReadGitValue(cwd: string, args: string[]): string | null {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 2000,
+      windowsHide: true,
     }).trim();
     return value || null;
   } catch {
@@ -69,6 +71,9 @@ function stateDirToProjectRoot(stateDir: string): string {
 
 async function readLeaderBranchGitActivityMs(stateDir: string): Promise<number> {
   const cwd = stateDirToProjectRoot(stateDir);
+  const fromFiles = tryReadGitBranchActivityMsFromFiles(cwd);
+  if (Number.isFinite(fromFiles)) return fromFiles;
+
   const gitDir = tryReadGitValue(cwd, ['rev-parse', '--git-dir']);
   if (!gitDir) return Number.NaN;
 

--- a/src/utils/__tests__/git-filesystem.test.ts
+++ b/src/utils/__tests__/git-filesystem.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  tryReadGitBranchActivityMsFromFiles,
+  tryReadGitValueFromFiles,
+} from '../git-filesystem.js';
+
+async function withTempDir(prefix: string, run: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('tryReadGitValueFromFiles', () => {
+  it('returns null on non-Windows platforms', async () => {
+    if (process.platform === 'win32') return;
+    await withTempDir('omx-git-fs-nonwin-', async (cwd) => {
+      assert.equal(tryReadGitValueFromFiles(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']), null);
+    });
+  });
+
+  it('reads common git queries from a .git directory', async () => {
+    if (process.platform !== 'win32') return;
+
+    await withTempDir('omx-git-fs-dir-', async (cwd) => {
+      const gitDir = join(cwd, '.git');
+      await mkdir(gitDir, { recursive: true });
+      await writeFile(join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+      await writeFile(
+        join(gitDir, 'config'),
+        ['[remote "origin"]', '\turl = origin-repo-url', ''].join('\n'),
+      );
+
+      assert.equal(tryReadGitValueFromFiles(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']), 'main');
+      assert.equal(tryReadGitValueFromFiles(cwd, ['remote', 'get-url', 'origin']), 'origin-repo-url');
+      assert.equal(tryReadGitValueFromFiles(cwd, ['remote']), 'origin');
+      assert.equal(tryReadGitValueFromFiles(cwd, ['rev-parse', '--show-toplevel']), cwd);
+    });
+  });
+
+  it('supports worktree gitdir pointers and detached HEADs', async () => {
+    if (process.platform !== 'win32') return;
+
+    await withTempDir('omx-git-fs-worktree-', async (cwd) => {
+      const mainGitDir = join(cwd, 'main-repo', '.git');
+      const worktreeRoot = join(cwd, 'worktree');
+      const worktreeGitDir = join(mainGitDir, 'worktrees', 'feature-x');
+
+      await mkdir(mainGitDir, { recursive: true });
+      await mkdir(worktreeGitDir, { recursive: true });
+      await mkdir(worktreeRoot, { recursive: true });
+      await writeFile(join(worktreeRoot, '.git'), `gitdir: ${worktreeGitDir}\n`);
+      await writeFile(join(worktreeGitDir, 'commondir'), '../..\n');
+      await writeFile(join(worktreeGitDir, 'HEAD'), 'ref: refs/heads/feature/x\n');
+      await writeFile(
+        join(mainGitDir, 'config'),
+        [
+          '[remote "origin"]',
+          '\turl = origin-remote-url',
+          '[remote "upstream"]',
+          '\turl = upstream-remote-url',
+          '',
+        ].join('\n'),
+      );
+
+      assert.equal(tryReadGitValueFromFiles(worktreeRoot, ['rev-parse', '--abbrev-ref', 'HEAD']), 'feature/x');
+      assert.equal(tryReadGitValueFromFiles(worktreeRoot, ['remote', 'get-url', 'upstream']), 'upstream-remote-url');
+      assert.equal(tryReadGitValueFromFiles(worktreeRoot, ['remote']), 'origin\nupstream');
+
+      await writeFile(join(worktreeGitDir, 'HEAD'), 'deadbeef\n');
+      assert.equal(tryReadGitValueFromFiles(worktreeRoot, ['rev-parse', '--abbrev-ref', 'HEAD']), 'HEAD');
+    });
+  });
+});
+
+describe('tryReadGitBranchActivityMsFromFiles', () => {
+  it('returns NaN on non-Windows platforms', async () => {
+    if (process.platform === 'win32') return;
+    await withTempDir('omx-git-fs-activity-nonwin-', async (cwd) => {
+      assert.equal(Number.isNaN(tryReadGitBranchActivityMsFromFiles(cwd)), true);
+    });
+  });
+
+  it('derives branch activity from reflogs and refs', async () => {
+    if (process.platform !== 'win32') return;
+
+    await withTempDir('omx-git-fs-activity-', async (cwd) => {
+      const gitDir = join(cwd, '.git');
+      await mkdir(join(gitDir, 'logs', 'refs', 'heads'), { recursive: true });
+      await mkdir(join(gitDir, 'refs', 'heads'), { recursive: true });
+      await writeFile(join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+      await writeFile(
+        join(gitDir, 'logs', 'HEAD'),
+        '0000000 1111111 Test <t@example.com> 1712000000 +0000\tcommit: init\n',
+      );
+      await writeFile(
+        join(gitDir, 'logs', 'refs', 'heads', 'main'),
+        '1111111 2222222 Test <t@example.com> 1712001111 +0000\tcommit: next\n',
+      );
+      await writeFile(join(gitDir, 'refs', 'heads', 'main'), '2222222\n');
+
+      assert.equal(tryReadGitBranchActivityMsFromFiles(cwd), 1712001111000);
+    });
+  });
+});

--- a/src/utils/git-filesystem.ts
+++ b/src/utils/git-filesystem.ts
@@ -1,0 +1,157 @@
+import { readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+interface GitLayout {
+  workTree: string;
+  gitDir: string;
+  commonDir: string;
+}
+
+function readText(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function statMs(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return Number.NaN;
+  }
+}
+
+function resolveCommonDir(gitDir: string): string {
+  const commonDir = readText(join(gitDir, 'commondir'));
+  return commonDir ? resolve(gitDir, commonDir) : gitDir;
+}
+
+function resolveGitLayout(startCwd: string): GitLayout | null {
+  let dir = resolve(startCwd);
+  for (;;) {
+    const gitEntry = join(dir, '.git');
+
+    try {
+      if (statSync(gitEntry).isDirectory()) {
+        return { workTree: dir, gitDir: gitEntry, commonDir: resolveCommonDir(gitEntry) };
+      }
+    } catch {
+      // Fall through to gitdir-file handling.
+    }
+
+    const raw = readText(gitEntry);
+    const match = raw ? /^gitdir:\s*(.+)$/i.exec(raw) : null;
+    if (match?.[1]) {
+      const gitDir = resolve(dirname(gitEntry), match[1].trim());
+      return { workTree: dir, gitDir, commonDir: resolveCommonDir(gitDir) };
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function readBranch(layout: GitLayout): string | null {
+  const head = readText(join(layout.gitDir, 'HEAD'));
+  if (!head?.startsWith('ref: refs/heads/')) return null;
+  return head.slice('ref: refs/heads/'.length) || null;
+}
+
+function readRemoteConfig(layout: GitLayout): { names: string[]; urls: Map<string, string> } {
+  const config = readText(join(layout.commonDir, 'config'));
+  const names: string[] = [];
+  const urls = new Map<string, string>();
+  if (!config) return { names, urls };
+
+  let currentRemote: string | null = null;
+  for (const line of config.split(/\r?\n/)) {
+    const remoteMatch = /^\s*\[remote "([^"]+)"\]\s*$/.exec(line);
+    if (remoteMatch?.[1]) {
+      currentRemote = remoteMatch[1];
+      if (!names.includes(currentRemote)) names.push(currentRemote);
+      continue;
+    }
+    if (/^\s*\[/.test(line)) {
+      currentRemote = null;
+      continue;
+    }
+    if (!currentRemote) continue;
+    const urlMatch = /^\s*url\s*=\s*(.+?)\s*$/.exec(line);
+    if (urlMatch?.[1] && !urls.has(currentRemote)) {
+      urls.set(currentRemote, urlMatch[1].trim());
+    }
+  }
+
+  return { names, urls };
+}
+
+function readLatestReflogTimestampMs(path: string): number {
+  const reflog = readText(path);
+  if (!reflog) return Number.NaN;
+
+  for (const line of reflog.split(/\r?\n/).reverse()) {
+    const match = / (\d+) [+-]\d{4}(?:\t|$)/.exec(line.trim());
+    if (!match?.[1]) continue;
+    const seconds = Number(match[1]);
+    if (Number.isFinite(seconds)) return seconds * 1000;
+  }
+
+  return Number.NaN;
+}
+
+export function tryReadGitValueFromFiles(cwd: string, args: string[]): string | null {
+  if (process.platform !== 'win32') return null;
+
+  const layout = resolveGitLayout(cwd);
+  if (!layout) return null;
+
+  const command = args.join(' ');
+  if (command === 'rev-parse --abbrev-ref HEAD') {
+    return readBranch(layout) ?? (readText(join(layout.gitDir, 'HEAD')) ? 'HEAD' : null);
+  }
+  if (command === 'remote') {
+    const names = readRemoteConfig(layout).names;
+    return names.length > 0 ? names.join('\n') : null;
+  }
+  if (command === 'rev-parse --show-toplevel') {
+    return layout.workTree;
+  }
+  if (args.length === 3 && args[0] === 'remote' && args[1] === 'get-url') {
+    return readRemoteConfig(layout).urls.get(args[2] || '') ?? null;
+  }
+
+  return null;
+}
+
+export function tryReadGitBranchActivityMsFromFiles(cwd: string): number {
+  if (process.platform !== 'win32') return Number.NaN;
+
+  const layout = resolveGitLayout(cwd);
+  if (!layout) return Number.NaN;
+
+  const branch = readBranch(layout);
+  const headLogPath = join(layout.gitDir, 'logs', 'HEAD');
+  const branchLogPath = branch
+    ? join(layout.commonDir, 'logs', 'refs', 'heads', ...branch.split('/'))
+    : null;
+  const branchRefPath = branch
+    ? join(layout.commonDir, 'refs', 'heads', ...branch.split('/'))
+    : null;
+
+  const timestampCandidates = [
+    readLatestReflogTimestampMs(headLogPath),
+    branchLogPath ? readLatestReflogTimestampMs(branchLogPath) : Number.NaN,
+  ].filter((value) => Number.isFinite(value));
+  if (timestampCandidates.length > 0) return Math.max(...timestampCandidates);
+
+  const mtimeCandidates = [
+    statMs(headLogPath),
+    statMs(join(layout.gitDir, 'HEAD')),
+    branchLogPath ? statMs(branchLogPath) : Number.NaN,
+    branchRefPath ? statMs(branchRefPath) : Number.NaN,
+  ].filter((value) => Number.isFinite(value));
+  return mtimeCandidates.length > 0 ? Math.max(...mtimeCandidates) : Number.NaN;
+}


### PR DESCRIPTION
## Summary

This fixes the Windows terminal/conhost flicker caused by repeated git polling in OMX's HUD and leader-activity paths.

Instead of repeatedly spawning `git.exe` for hot polling queries on Windows, this change reads the required git metadata from repository files and falls back to subprocess git for non-Windows or unhandled queries.

## Why not inline it in two files?

The original filesystem-read approach I found in the other PR works directionally, but duplicating `.git` parsing in both HUD and leader-activity makes the Windows-only logic brittle.

This version keeps the call sites small while centralizing:
- `.git` directory vs `.git` pointer-file handling
- `commondir` resolution for worktrees
- remote/config parsing
- reflog-based branch activity detection

That avoids path bugs and worktree regressions while still keeping the Windows fast path narrow.

## Changes

- add shared Windows git-filesystem helper
- switch HUD git polling to filesystem reads on Windows
- switch leader-activity git polling to filesystem reads on Windows
- add targeted tests for normal repos, worktree layouts, detached HEAD, remotes, and branch activity

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`
- [x] `node --test dist/utils/__tests__/git-filesystem.test.js dist/hud/__tests__/state.test.js dist/team/__tests__/leader-activity.test.js`
- [x] Manual Windows interactive launch: `omx --madmax --high`

## Related

Closes #1100  
Refs #1110
