### PR TITLE
fix(windows): read git info from filesystem to eliminate conhost flicker

### DIFF
--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -5,7 +5,7 @@
  */
 
 import { readFile } from 'fs/promises';
-import { readFileSync } from 'fs';
+import { readFileSync, statSync } from 'fs';
 import { execSync } from 'child_process';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
@@ -175,7 +175,89 @@ export function readVersion(): string | null {
 
 export type GitRunner = (cwd: string, args: string[]) => string | null;
 
+/**
+ * Find the .git directory by walking up from `startCwd`.
+ * Returns the path to the `.git` directory, or null if not found.
+ */
+function findGitDir(startCwd: string): string | null {
+  let dir = startCwd;
+  for (;;) {
+    const candidate = join(dir, '.git');
+    try {
+      if (statSync(candidate).isDirectory()) return candidate;
+    } catch { /* not found, walk up */ }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Read a file inside the .git directory. Returns trimmed content or null.
+ */
+function readGitFile(gitDir: string, ...parts: string[]): string | null {
+  try {
+    return readFileSync(join(gitDir, ...parts), 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * On Windows, read common git queries directly from .git/ files to avoid
+ * spawning console windows (conhost.exe flicker).  Falls back to execSync
+ * for non-Windows platforms or unrecognised arguments.
+ *
+ * See: https://github.com/Yeachan-Heo/oh-my-codex/issues/1100
+ */
 function runGit(cwd: string, args: string[]): string | null {
+  if (process.platform === 'win32') {
+    try {
+      const gitDir = findGitDir(cwd);
+      if (gitDir) {
+        const cmd = args.join(' ');
+
+        if (cmd === 'rev-parse --abbrev-ref HEAD') {
+          const head = readGitFile(gitDir, 'HEAD');
+          if (head?.startsWith('ref: refs/heads/'))
+            return head.slice('ref: refs/heads/'.length);
+          return head; // detached HEAD — raw SHA
+        }
+
+        if (cmd.startsWith('remote get-url ')) {
+          const remoteName = args[2];
+          const config = readGitFile(gitDir, 'config');
+          if (config) {
+            const re = new RegExp(
+              `\\[remote "${remoteName}"\\][\\s\\S]*?url\\s*=\\s*(.+)`,
+              'm',
+            );
+            const m = config.match(re);
+            if (m) return m[1].trim();
+          }
+          return null;
+        }
+
+        if (cmd === 'remote') {
+          const config = readGitFile(gitDir, 'config');
+          if (config) {
+            const matches = [...config.matchAll(/\[remote "([^"]+)"\]/g)];
+            if (matches.length > 0) return matches.map((m) => m[1]).join('\n');
+          }
+          return null;
+        }
+
+        if (cmd === 'rev-parse --show-toplevel') {
+          return dirname(gitDir);
+        }
+      }
+    } catch { /* fall through to execSync */ }
+  }
+
+  return runGitExec(cwd, args);
+}
+
+function runGitExec(cwd: string, args: string[]): string | null {
   try {
     return execSync(`git ${args.join(' ')}`, {
       cwd,

--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { omxStateDir } from '../utils/paths.js';
@@ -40,7 +40,76 @@ function parseEpochSecondsMs(value: string): number {
   return Number.isFinite(seconds) ? seconds * 1000 : Number.NaN;
 }
 
+/**
+ * Find the .git directory by walking up from `startCwd`.
+ */
+function findGitDir(startCwd: string): string | null {
+  let dir = startCwd;
+  for (;;) {
+    const candidate = join(dir, '.git');
+    try {
+      if (statSync(candidate).isDirectory()) return candidate;
+    } catch { /* walk up */ }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function readGitFile(gitDir: string, ...parts: string[]): string | null {
+  try {
+    return readFileSync(join(gitDir, ...parts), 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * On Windows, read git info from .git/ files directly to avoid spawning
+ * console windows (conhost.exe flicker on every poll cycle).
+ *
+ * See: https://github.com/Yeachan-Heo/oh-my-codex/issues/1100
+ */
 function tryReadGitValue(cwd: string, args: string[]): string | null {
+  if (process.platform === 'win32') {
+    try {
+      const gitDir = findGitDir(cwd);
+      if (gitDir) {
+        const cmd = args.join(' ');
+
+        if (cmd === 'rev-parse --git-dir') return gitDir;
+
+        if (cmd === 'symbolic-ref --quiet --short HEAD') {
+          const head = readGitFile(gitDir, 'HEAD');
+          if (head?.startsWith('ref: refs/heads/'))
+            return head.slice('ref: refs/heads/'.length);
+          return null; // detached HEAD
+        }
+
+        if (cmd === 'rev-parse --git-path logs/HEAD') {
+          return join(gitDir, 'logs', 'HEAD');
+        }
+
+        if (cmd.startsWith('rev-parse --git-path logs/refs/heads/')) {
+          const branch = args[args.length - 1].replace('logs/', '');
+          return join(gitDir, 'logs', branch);
+        }
+
+        if (cmd === 'show -s --format=%ct HEAD') {
+          // Use HEAD file mtime as a proxy for last-commit timestamp.
+          try {
+            const headMs = statSync(join(gitDir, 'HEAD')).mtimeMs;
+            return String(Math.floor(headMs / 1000));
+          } catch { return null; }
+        }
+      }
+    } catch { /* fall through */ }
+  }
+
+  return tryReadGitValueExec(cwd, args);
+}
+
+function tryReadGitValueExec(cwd: string, args: string[]): string | null {
   try {
     const value = execFileSync('git', args, {
       cwd,


### PR DESCRIPTION
## Summary

On Windows, `windowsHide: true` doesn't prevent terminal flicker for console-subsystem binaries like `git.exe`. This adds a `process.platform === 'win32'` fast path that reads `.git/HEAD`, `.git/config`, and file stats directly via `fs` instead of spawning git subprocesses.

## Changes

- **`src/hud/state.ts`** — `runGit()` filesystem fast path for `rev-parse --abbrev-ref HEAD`, `remote get-url`, `remote`, `rev-parse --show-toplevel`
- **`src/team/leader-activity.ts`** — `tryReadGitValue()` filesystem fast path for `rev-parse --git-dir`, `symbolic-ref`, `rev-parse --git-path`, `show -s --format=%ct HEAD`

Non-Windows platforms and unrecognized args fall through to existing subprocess path unchanged.

## Credit

Based on analysis and solution direction from @lloyd1515 (PR #1110).

## Verification
- `npm run build` ✅
- Tests: 134/134 pass ✅

Fixes #1100

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*