### PR TITLE
fix(team): eliminate dual-write seam gaps in dispatch and mailbox transitions (#1108)

### DIFF
--- a/docs/contracts/rust-runtime-thin-adapter-contract.md
+++ b/docs/contracts/rust-runtime-thin-adapter-contract.md
@@ -7,6 +7,7 @@ Rust core is the single semantic owner for:
 - authority
 - lifecycle/session state
 - dispatch/backlog
+- mailbox delivery state
 - replay/recovery
 - readiness/diagnostics
 - canonical mux operations
@@ -42,6 +43,7 @@ The `RuntimeEngine` (in `crates/omx-runtime-core/src/engine.rs`) writes the foll
 | `readiness.json` | `write_compatibility_view()` | `ReadinessSnapshot` (`ready`, `reasons`) for TS readers |
 | `replay.json` | `write_compatibility_view()` | `ReplaySnapshot` state for TS readers |
 | `dispatch.json` | `write_compatibility_view()` | Full `DispatchLog` (array of `DispatchRecord` entries) for team status readers |
+| `mailbox.json` | `write_compatibility_view()` | Full `MailboxLog` (array of `MailboxRecord` entries) for team/message readers |
 
 All files are written atomically to the configured `state_dir`. TS readers must treat these files as read-only; the Rust engine is the sole writer.
 
@@ -52,7 +54,9 @@ All files are written atomically to the configured `state_dir`. TS readers must 
 2. Legacy tmux typing is delivery only; it does not establish semantic truth.
 3. If Rust-authored compatibility files and legacy JS defaults disagree, the
    Rust-authored file wins.
-4. Unknown delivery failures are surfaced as adapter failures, not as semantic
+4. JS file writes remain fallback-only for lanes where the bridge is disabled or
+   unavailable; they are not canonical when the Rust bridge succeeds.
+5. Unknown delivery failures are surfaced as adapter failures, not as semantic
    owner changes.
 
 ## Consumer matrix

--- a/docs/qa/runtime-team-seam-audit-2026-04-01.md
+++ b/docs/qa/runtime-team-seam-audit-2026-04-01.md
@@ -9,18 +9,20 @@ This note records the remaining high-value runtime seam gaps after the Rust thin
 
 ## Summary
 
-The team/runtime stack is no longer missing a Rust contract surface. The remaining risk is narrower:
+The team/runtime stack is no longer missing a Rust contract surface. As of the
+issue #1108 seam-hardening pass, the dispatch/mailbox dual-write gap is closed;
+the remaining risk is narrower:
 
-1. **Rust runtime ↔ TS team state is still dual-written in cutover paths**
-2. **Team metadata resolution still falls back across multiple files**
-3. **The declared Rust semantic-owner model is ahead of some TS canonical writers**
-4. **Compatibility readers still carry legacy/current precedence logic**
+1. **Team metadata resolution still falls back across multiple files**
+2. **Compatibility readers still carry legacy/current precedence logic**
 
 These are follow-up seam-hardening gaps, not evidence that the Rust runtime direction was wrong.
 
 ## Remaining seam gaps
 
 ### 1. Rust runtime ↔ TS team state dual-write
+
+Status: **resolved by issue #1108**
 
 Evidence:
 
@@ -29,14 +31,14 @@ Evidence:
 
 Current state:
 
-- Rust bridge writes are attempted first
-- bridge failures are explicitly non-fatal
-- TS file writes remain canonical during cutover
+- Rust bridge / compat files are now the canonical dispatch and mailbox surface
+- legacy TS dispatch/mailbox files remain fallback-only for degraded lanes where the bridge is disabled, unavailable, or unreadable
+- watcher/runtime paths were narrowed so bridge-owned success paths no longer semantically dual-write legacy mailbox/dispatch state
 
 Risk:
 
-- state divergence between Rust-authored compatibility output and TS-owned team files
-- harder debugging when status, delivery, or mailbox transitions disagree
+- residual regressions are now more likely to come from incorrect fallback activation than from active dual-write divergence
+- future refactors could accidentally widen fallback behavior unless tests/docs keep the canonical-owner rule explicit
 
 Desired end state:
 
@@ -66,6 +68,8 @@ Desired end state:
 
 ### 3. Runtime ownership contract vs. cutover reality
 
+Status: **resolved by issue #1108 for dispatch/mailbox ownership**
+
 Evidence:
 
 - `src/runtime/bridge.ts:2-6`
@@ -74,13 +78,13 @@ Evidence:
 
 Current state:
 
-- the bridge contract says semantic mutations route through Rust
-- the team cutover paths still treat TS files as canonical in some flows
+- the bridge contract and the team dispatch/mailbox write paths now agree on Rust ownership
+- remaining ownership work is outside dispatch/mailbox and focuses on broader metadata/fallback simplification
 
 Risk:
 
-- contributor confusion about which layer is allowed to establish semantic truth
-- longer-lived dual-write migration pressure
+- contributors may still misread broader metadata/fallback layers as ownership layers if the docs are not kept precise
+- future compatibility work could accidentally reintroduce JS canonical writes without contract/test coverage
 
 Desired end state:
 
@@ -111,10 +115,8 @@ Desired end state:
 
 ## Recommended follow-up order
 
-1. Remove semantic dual-write from dispatch transitions
-2. Remove semantic dual-write from mailbox transitions
-3. Collapse team state-root / working-directory resolution to one canonical metadata source
-4. Reduce compatibility fallback layers after the write path is single-owner
+1. Collapse team state-root / working-directory resolution to one canonical metadata source
+2. Reduce compatibility fallback layers after the write path is single-owner
 
 ## Out of scope
 

--- a/docs/qa/rust-runtime-thin-adapter-gate.md
+++ b/docs/qa/rust-runtime-thin-adapter-gate.md
@@ -33,6 +33,5 @@ failing.
 
 The current thin-adapter cutover still carries a small number of known seam gaps
 that are intentionally tracked outside the release gate. See
-`docs/qa/runtime-team-seam-audit-2026-04-01.md` for the remaining dual-write,
-metadata-resolution, and compatibility-reader follow-ups.
-
+`docs/qa/runtime-team-seam-audit-2026-04-01.md` for the remaining
+metadata-resolution and compatibility-reader follow-ups.

--- a/src/compat/__tests__/rust-runtime-compat.test.ts
+++ b/src/compat/__tests__/rust-runtime-compat.test.ts
@@ -5,7 +5,7 @@ import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { initTeamState } from '../../team/state.js';
+import { enqueueDispatchRequest, initTeamState, listDispatchRequests, listMailboxMessages, sendDirectMessage } from '../../team/state.js';
 import { readTeamState } from '../../hud/state.js';
 
 function repoRoot(): string {
@@ -42,6 +42,60 @@ async function withTempTeamStateRoot<T>(
     if (previousRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
     else process.env.OMX_TEAM_STATE_ROOT = previousRoot;
   }
+}
+
+async function writeCompatRuntimeFixture(runtimePath: string): Promise<void> {
+  await writeFile(
+    runtimePath,
+    `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const argv = process.argv.slice(2);
+function argValue(prefix) {
+  const entry = argv.find((value) => value.startsWith(prefix));
+  return entry ? entry.slice(prefix.length) : null;
+}
+function stateDir() {
+  return argValue('--state-dir=') || process.cwd();
+}
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return fallback; }
+}
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value, null, 2) + '\\n');
+}
+function nowIso() { return new Date().toISOString(); }
+if (argv[0] === 'schema') {
+  process.stdout.write(JSON.stringify({ schema_version: 1, commands: ['acquire-authority','renew-authority','queue-dispatch','mark-notified','mark-delivered','mark-failed','request-replay','capture-snapshot'], events: [], transport: 'tmux' }) + '\\n');
+  process.exit(0);
+}
+if (argv[0] !== 'exec') process.exit(1);
+const command = JSON.parse(argv[1] || '{}');
+const dir = stateDir();
+const dispatchPath = path.join(dir, 'dispatch.json');
+const mailboxPath = path.join(dir, 'mailbox.json');
+const dispatch = readJson(dispatchPath, { records: [] });
+const mailbox = readJson(mailboxPath, { records: [] });
+const timestamp = nowIso();
+switch (command.command) {
+  case 'QueueDispatch':
+    dispatch.records.push({ request_id: command.request_id, target: command.target, status: 'pending', created_at: timestamp, notified_at: null, delivered_at: null, failed_at: null, reason: null, metadata: command.metadata ?? null });
+    writeJson(dispatchPath, dispatch);
+    process.stdout.write(JSON.stringify({ event: 'DispatchQueued', request_id: command.request_id, target: command.target }) + '\\n');
+    process.exit(0);
+  case 'CreateMailboxMessage':
+    mailbox.records.push({ message_id: command.message_id, from_worker: command.from_worker, to_worker: command.to_worker, body: command.body, created_at: timestamp, notified_at: null, delivered_at: null });
+    writeJson(mailboxPath, mailbox);
+    process.stdout.write(JSON.stringify({ event: 'MailboxMessageCreated', message_id: command.message_id, from_worker: command.from_worker, to_worker: command.to_worker }) + '\\n');
+    process.exit(0);
+  default:
+    process.stdout.write(JSON.stringify({ event: 'ok' }) + '\\n');
+    process.exit(0);
+}
+`,
+  );
+  await chmod(runtimePath, 0o755);
 }
 
 describe('rust runtime legacy-reader compatibility', () => {
@@ -165,6 +219,50 @@ describe('rust runtime legacy-reader compatibility', () => {
       assert.equal(state?.current_phase, 'executing');
       assert.equal(state?.agent_count, 3);
     } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers bridge-authored dispatch/mailbox compatibility views over stale legacy files', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-rust-compat-bridge-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    try {
+      const teamStateRoot = join(wd, '.omx', 'state');
+      await withTempTeamStateRoot(teamStateRoot, async () => {
+        await initTeamState('rust-compat-bridge', 'compatibility lane', 'executor', 2, wd);
+        const fakeBin = join(wd, 'bin');
+        await mkdir(fakeBin, { recursive: true });
+        const runtimePath = join(fakeBin, 'omx-runtime');
+        await writeCompatRuntimeFixture(runtimePath);
+        process.env.OMX_RUNTIME_BINARY = runtimePath;
+
+        const teamDir = join(teamStateRoot, 'team', 'rust-compat-bridge');
+        await writeFile(
+          join(teamDir, 'dispatch', 'requests.json'),
+          JSON.stringify([{ request_id: 'legacy-only', kind: 'mailbox', team_name: 'rust-compat-bridge', to_worker: 'worker-2', trigger_message: 'legacy', status: 'pending', attempt_count: 0, created_at: '2026-04-01T00:00:00.000Z', updated_at: '2026-04-01T00:00:00.000Z', message_id: 'legacy-msg' }], null, 2),
+        );
+        await writeFile(
+          join(teamDir, 'mailbox', 'worker-2.json'),
+          JSON.stringify({ worker: 'worker-2', messages: [{ message_id: 'legacy-msg', from_worker: 'worker-1', to_worker: 'worker-2', body: 'legacy body', created_at: '2026-04-01T00:00:00.000Z' }] }, null, 2),
+        );
+
+        const queued = await enqueueDispatchRequest(
+          'rust-compat-bridge',
+          { kind: 'mailbox', to_worker: 'worker-2', message_id: 'bridge-msg', trigger_message: 'bridge trigger' },
+          wd,
+        );
+        const message = await sendDirectMessage('rust-compat-bridge', 'worker-1', 'worker-2', 'bridge body', wd);
+        const dispatch = await listDispatchRequests('rust-compat-bridge', wd);
+        const mailbox = await listMailboxMessages('rust-compat-bridge', 'worker-2', wd);
+
+        assert.equal(dispatch.some((entry) => entry.request_id === queued.request.request_id), true);
+        assert.equal(dispatch.some((entry) => entry.request_id === 'legacy-only'), false, 'bridge compat view should win over stale legacy dispatch file');
+        assert.equal(mailbox.some((entry) => entry.message_id === message.message_id), true);
+        assert.equal(mailbox.some((entry) => entry.message_id === 'legacy-msg'), false, 'bridge compat view should win over stale legacy mailbox file');
+      });
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
       await rm(wd, { recursive: true, force: true });
     }
   });

--- a/src/runtime/bridge.ts
+++ b/src/runtime/bridge.ts
@@ -10,6 +10,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { omxStateDir } from '../utils/paths.js';
 
 const __bridge_dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -127,6 +128,14 @@ export function resolveRuntimeBinaryPath(options: RuntimeBinaryDiscoveryOptions 
   if (exists(workspaceRelease)) return workspaceRelease;
 
   return options.fallbackBinary ?? 'omx-runtime';
+}
+
+export function resolveBridgeStateDir(cwd: string, env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env.OMX_TEAM_STATE_ROOT;
+  if (typeof explicit === 'string' && explicit.trim() !== '') {
+    return resolve(cwd, explicit.trim());
+  }
+  return omxStateDir(cwd);
 }
 
 export class RuntimeBridge {
@@ -267,6 +276,9 @@ export class RuntimeBridge {
 let _defaultBridge: RuntimeBridge | undefined;
 
 export function getDefaultBridge(stateDir?: string): RuntimeBridge {
+  if (stateDir) {
+    return new RuntimeBridge({ stateDir });
+  }
   if (!_defaultBridge) {
     _defaultBridge = new RuntimeBridge({ stateDir });
   }

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -5,7 +5,7 @@ import { execFileSync } from 'child_process';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'node:url';
 import { safeString } from './utils.js';
-import { resolveRuntimeBinaryPath } from '../../runtime/bridge.js';
+import { resolveBridgeStateDir, resolveRuntimeBinaryPath } from '../../runtime/bridge.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -21,14 +21,16 @@ import {
 
 /**
  * Route dispatch state transitions through the Rust runtime binary.
- * Non-fatal: if the binary is missing or fails, the JS path remains canonical.
+ * Non-fatal: if the binary is missing or fails, the legacy JSON fallback lane
+ * remains available when the caller is already operating outside the bridge-
+ * owned path.
  * Disable entirely with OMX_RUNTIME_BRIDGE=0.
  */
-function runtimeExec(command) {
+function runtimeExec(command, stateDir) {
   if (process.env.OMX_RUNTIME_BRIDGE === '0') return;
   try {
     const binaryPath = resolveRuntimeBinaryPath();
-    execFileSync(binaryPath, ['exec', JSON.stringify(command)], {
+    execFileSync(binaryPath, ['exec', JSON.stringify(command), `--state-dir=${stateDir}`], {
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
@@ -42,6 +44,47 @@ function readJson(path, fallback) {
   return readFile(path, 'utf8')
     .then((raw) => JSON.parse(raw))
     .catch(() => fallback);
+}
+
+async function readBridgeDispatchRequests(stateDir, teamName) {
+  const candidate = join(stateDir, 'dispatch.json');
+  if (!existsSync(candidate)) return null;
+  const parsed = await readJson(candidate, null);
+  if (!parsed || !Array.isArray(parsed.records)) return null;
+  return parsed.records
+    .map((record) => {
+      if (!record || typeof record !== 'object') return null;
+      const metadata = record.metadata && typeof record.metadata === 'object' ? record.metadata : {};
+      const metadataTeam = safeString(metadata.team_name).trim();
+      if (metadataTeam && metadataTeam !== teamName) return null;
+      return {
+        request_id: safeString(record.request_id).trim(),
+        kind: safeString(metadata.kind).trim() || 'inbox',
+        team_name: teamName,
+        to_worker: safeString(record.target).trim(),
+        worker_index: typeof metadata.worker_index === 'number' ? metadata.worker_index : undefined,
+        pane_id: safeString(metadata.pane_id).trim() || undefined,
+        trigger_message: safeString(metadata.trigger_message).trim() || safeString(record.reason).trim() || safeString(record.request_id).trim(),
+        message_id: safeString(metadata.message_id).trim() || undefined,
+        inbox_correlation_key: safeString(metadata.inbox_correlation_key).trim() || undefined,
+        transport_preference: safeString(metadata.transport_preference).trim() || 'hook_preferred_with_fallback',
+        fallback_allowed: typeof metadata.fallback_allowed === 'boolean' ? metadata.fallback_allowed : true,
+        status: safeString(record.status).trim() || 'pending',
+        attempt_count: 0,
+        created_at: safeString(record.created_at).trim() || new Date().toISOString(),
+        updated_at:
+          safeString(record.delivered_at).trim()
+          || safeString(record.failed_at).trim()
+          || safeString(record.notified_at).trim()
+          || safeString(record.created_at).trim()
+          || new Date().toISOString(),
+        notified_at: safeString(record.notified_at).trim() || undefined,
+        delivered_at: safeString(record.delivered_at).trim() || undefined,
+        failed_at: safeString(record.failed_at).trim() || undefined,
+        last_reason: safeString(record.reason).trim() || undefined,
+      };
+    })
+    .filter((record) => record && record.request_id && record.to_worker && record.trigger_message);
 }
 
 async function writeJsonAtomic(path, value) {
@@ -319,7 +362,7 @@ function capturedPaneContainsTriggerNearTail(captured, trigger, nonEmptyTailLine
 const INJECT_VERIFY_DELAY_MS = 250;
 const INJECT_VERIFY_ROUNDS = 3;
 
-async function injectDispatchRequest(request, config, cwd) {
+async function injectDispatchRequest(request, config, cwd, stateDir) {
   const target = defaultInjectTarget(request, config);
   if (!target) {
     return { ok: false, reason: 'missing_tmux_target' };
@@ -391,7 +434,7 @@ async function injectDispatchRequest(request, config, cwd) {
       const wideCap = await runProcess('tmux', verifyWideArgv, 2000);
       // Worker is actively processing (mirrors sync path tmux-session.ts:1292-1294)
       if (paneHasActiveTask(wideCap.stdout)) {
-        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id });
+        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir);
         return { ok: true, reason: 'tmux_send_keys_confirmed_active_task', pane: resolution.paneTarget };
       }
       // Do not declare success while a *worker* pane is still bootstrapping / not
@@ -404,7 +447,7 @@ async function injectDispatchRequest(request, config, cwd) {
       const triggerInNarrow = capturedPaneContainsTrigger(narrowCap.stdout, request.trigger_message);
       const triggerNearTail = capturedPaneContainsTriggerNearTail(wideCap.stdout, request.trigger_message);
       if (!triggerInNarrow && !triggerNearTail) {
-        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id });
+        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir);
         return { ok: true, reason: 'tmux_send_keys_confirmed', pane: resolution.paneTarget };
       }
     } catch {
@@ -451,7 +494,7 @@ async function appendDispatchLog(logsDir, event) {
 
 export async function drainPendingTeamDispatch({
   cwd,
-  stateDir = join(cwd, '.omx', 'state'),
+  stateDir = resolveBridgeStateDir(cwd),
   logsDir = join(cwd, '.omx', 'logs'),
   maxPerTick = 5,
   injector = injectDispatchRequest,
@@ -476,11 +519,12 @@ export async function drainPendingTeamDispatch({
     const manifestPath = join(teamDirPath, 'manifest.v2.json');
     const configPath = join(teamDirPath, 'config.json');
     const requestsPath = join(teamDirPath, 'dispatch', 'requests.json');
-    if (!existsSync(requestsPath)) continue;
 
     const config = await readJson(existsSync(manifestPath) ? manifestPath : configPath, {});
     await withDispatchLock(teamDirPath, async () => {
-      const requests = await readJson(requestsPath, []);
+      const bridgeRequests = await readBridgeDispatchRequests(stateDir, teamName);
+      const usingLegacyRequests = bridgeRequests === null;
+      const requests = usingLegacyRequests ? await readJson(requestsPath, []) : bridgeRequests;
       if (!Array.isArray(requests)) return;
       const issueCooldownState = await readIssueCooldownState(teamDirPath);
       const triggerCooldownState = await readTriggerCooldownState(teamDirPath);
@@ -519,8 +563,9 @@ export async function drainPendingTeamDispatch({
               leader_pane_id: safeString(config?.leader_pane_id).trim() || null,
               tmux_injection_attempted: false,
             });
-            // Requests JSON is the canonical queue state; this event is a progress artifact
-            // for hook/watcher readers until shared readers normalize everything later.
+            // On the legacy fallback lane, requests.json still carries the queue
+            // state for this deferred request; this event stays a progress
+            // artifact for hook/watcher readers.
             await appendLeaderNotificationDeferredEvent({
               stateDir,
               teamName,
@@ -555,7 +600,7 @@ export async function drainPendingTeamDispatch({
           }
         }
 
-        const result = await injector(request, config, resolve(cwd));
+        const result = await injector(request, config, resolve(cwd), stateDir);
         if (issueKey && issueCooldownMs > 0) {
           issueCooldownByIssue[issueKey] = Date.now();
           mutated = true;
@@ -603,7 +648,7 @@ export async function drainPendingTeamDispatch({
             request.status = 'failed';
             request.failed_at = nowIso;
             request.last_reason = 'unconfirmed_after_max_retries';
-            runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: 'unconfirmed_after_max_retries' });
+            runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: 'unconfirmed_after_max_retries' }, stateDir);
             processed += 1;
             failed += 1;
             mutated = true;
@@ -630,8 +675,9 @@ export async function drainPendingTeamDispatch({
           request.status = 'notified';
           request.notified_at = nowIso;
           request.last_reason = result.reason;
-          runtimeExec({ command: 'MarkNotified', request_id: request.request_id, channel: 'tmux' });
-          if (request.kind === 'mailbox' && request.message_id) {
+          runtimeExec({ command: 'MarkNotified', request_id: request.request_id, channel: 'tmux' }, stateDir);
+          if (usingLegacyRequests && request.kind === 'mailbox' && request.message_id) {
+            runtimeExec({ command: 'MarkMailboxNotified', message_id: request.message_id }, stateDir);
             await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(() => {});
           }
           processed += 1;
@@ -648,7 +694,7 @@ export async function drainPendingTeamDispatch({
           request.status = 'failed';
           request.failed_at = nowIso;
           request.last_reason = result.reason;
-          runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: result.reason });
+          runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: result.reason }, stateDir);
           processed += 1;
           failed += 1;
           mutated = true;
@@ -679,7 +725,9 @@ export async function drainPendingTeamDispatch({
         await writeJsonAtomic(issueCooldownStatePath(teamDirPath), issueCooldownState);
         triggerCooldownState.by_trigger = triggerCooldownByKey;
         await writeJsonAtomic(triggerCooldownStatePath(teamDirPath), triggerCooldownState);
-        await writeJsonAtomic(requestsPath, requests);
+        if (usingLegacyRequests) {
+          await writeJsonAtomic(requestsPath, requests);
+        }
       }
     });
   }

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -57,6 +57,164 @@ afterEach(() => {
   else delete process.env.OMX_TEAM_STATE_ROOT;
 });
 
+async function writeCompatRuntimeFixture(runtimePath: string, runtimeLogPath: string): Promise<void> {
+  await writeFile(
+    runtimePath,
+    `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const argv = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(runtimeLogPath)}, argv.join(' ') + '\\n');
+
+function argValue(prefix) {
+  const entry = argv.find((value) => value.startsWith(prefix));
+  return entry ? entry.slice(prefix.length) : null;
+}
+
+function stateDir() {
+  return argValue('--state-dir=') || process.cwd();
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function readJson(file, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(file, value) {
+  ensureDir(path.dirname(file));
+  fs.writeFileSync(file, JSON.stringify(value, null, 2) + '\\n');
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+if (argv[0] === 'schema') {
+  process.stdout.write(JSON.stringify({
+    schema_version: 1,
+    commands: [
+      'acquire-authority',
+      'renew-authority',
+      'queue-dispatch',
+      'mark-notified',
+      'mark-delivered',
+      'mark-failed',
+      'request-replay',
+      'capture-snapshot',
+    ],
+    events: [],
+    transport: 'tmux',
+  }) + '\\n');
+  process.exit(0);
+}
+
+if (argv[0] !== 'exec') process.exit(1);
+
+const command = JSON.parse(argv[1] || '{}');
+const dir = stateDir();
+const dispatchPath = path.join(dir, 'dispatch.json');
+const mailboxPath = path.join(dir, 'mailbox.json');
+const dispatch = readJson(dispatchPath, { records: [] });
+const mailbox = readJson(mailboxPath, { records: [] });
+const timestamp = nowIso();
+
+switch (command.command) {
+  case 'QueueDispatch': {
+    dispatch.records.push({
+      request_id: command.request_id,
+      target: command.target,
+      status: 'pending',
+      created_at: timestamp,
+      notified_at: null,
+      delivered_at: null,
+      failed_at: null,
+      reason: null,
+      metadata: command.metadata ?? null,
+    });
+    writeJson(dispatchPath, dispatch);
+    process.stdout.write(JSON.stringify({ event: 'DispatchQueued', request_id: command.request_id, target: command.target, metadata: command.metadata ?? null }) + '\\n');
+    process.exit(0);
+  }
+  case 'MarkNotified': {
+    const record = dispatch.records.find((entry) => entry.request_id === command.request_id);
+    if (record) {
+      record.status = 'notified';
+      record.notified_at = timestamp;
+      record.reason = command.channel;
+      writeJson(dispatchPath, dispatch);
+    }
+    process.stdout.write(JSON.stringify({ event: 'DispatchNotified', request_id: command.request_id, channel: command.channel }) + '\\n');
+    process.exit(0);
+  }
+  case 'MarkDelivered': {
+    const record = dispatch.records.find((entry) => entry.request_id === command.request_id);
+    if (record) {
+      record.status = 'delivered';
+      record.delivered_at = timestamp;
+      writeJson(dispatchPath, dispatch);
+    }
+    process.stdout.write(JSON.stringify({ event: 'DispatchDelivered', request_id: command.request_id }) + '\\n');
+    process.exit(0);
+  }
+  case 'MarkFailed': {
+    const record = dispatch.records.find((entry) => entry.request_id === command.request_id);
+    if (record) {
+      record.status = 'failed';
+      record.failed_at = timestamp;
+      record.reason = command.reason;
+      writeJson(dispatchPath, dispatch);
+    }
+    process.stdout.write(JSON.stringify({ event: 'DispatchFailed', request_id: command.request_id, reason: command.reason }) + '\\n');
+    process.exit(0);
+  }
+  case 'CreateMailboxMessage': {
+    mailbox.records.push({
+      message_id: command.message_id,
+      from_worker: command.from_worker,
+      to_worker: command.to_worker,
+      body: command.body,
+      created_at: timestamp,
+      notified_at: null,
+      delivered_at: null,
+    });
+    writeJson(mailboxPath, mailbox);
+    process.stdout.write(JSON.stringify({ event: 'MailboxMessageCreated', message_id: command.message_id, from_worker: command.from_worker, to_worker: command.to_worker }) + '\\n');
+    process.exit(0);
+  }
+  case 'MarkMailboxNotified': {
+    const record = mailbox.records.find((entry) => entry.message_id === command.message_id);
+    if (record) {
+      record.notified_at = timestamp;
+      writeJson(mailboxPath, mailbox);
+    }
+    process.stdout.write(JSON.stringify({ event: 'MailboxNotified', message_id: command.message_id }) + '\\n');
+    process.exit(0);
+  }
+  case 'MarkMailboxDelivered': {
+    const record = mailbox.records.find((entry) => entry.message_id === command.message_id);
+    if (record) {
+      record.delivered_at = timestamp;
+      writeJson(mailboxPath, mailbox);
+    }
+    process.stdout.write(JSON.stringify({ event: 'MailboxDelivered', message_id: command.message_id }) + '\\n');
+    process.exit(0);
+  }
+  default:
+    process.exit(1);
+}
+`,
+  );
+  await chmod(runtimePath, 0o755);
+}
+
 describe('team state', () => {
   it('initTeamState creates correct directory structure and config.json', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-state-'));
@@ -284,6 +442,51 @@ exit 1
       assert.equal(listed.length, 1);
       assert.equal(listed[0]?.message_id, 'msg-1');
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers bridge-authored dispatch records without mutating the legacy requests file', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-bridge-authority-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    try {
+      await initTeamState('team-dispatch-bridge-authority', 't', 'executor', 1, cwd);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const runtimeLogPath = join(cwd, 'runtime.log');
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCompatRuntimeFixture(join(fakeBinDir, 'omx-runtime'), runtimeLogPath);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+
+      const legacyPath = join(cwd, '.omx', 'state', 'team', 'team-dispatch-bridge-authority', 'dispatch', 'requests.json');
+      const before = await readFile(legacyPath, 'utf8');
+      assert.equal(JSON.parse(before).length, 0);
+
+      const queued = await enqueueDispatchRequest(
+        'team-dispatch-bridge-authority',
+        {
+          kind: 'mailbox',
+          to_worker: 'worker-1',
+          message_id: 'bridge-msg-1',
+          trigger_message: 'check mailbox',
+        },
+        cwd,
+      );
+
+      const requests = await listDispatchRequests('team-dispatch-bridge-authority', cwd);
+      assert.equal(requests.length, 1);
+      assert.equal(requests[0]?.request_id, queued.request.request_id);
+      assert.equal(requests[0]?.message_id, 'bridge-msg-1');
+
+      await markDispatchRequestNotified('team-dispatch-bridge-authority', queued.request.request_id, {}, cwd);
+      await markDispatchRequestDelivered('team-dispatch-bridge-authority', queued.request.request_id, {}, cwd);
+      const delivered = await readDispatchRequest('team-dispatch-bridge-authority', queued.request.request_id, cwd);
+      assert.equal(delivered?.status, 'delivered');
+
+      const after = await readFile(legacyPath, 'utf8');
+      assert.deepEqual(JSON.parse(after), [], 'bridge-success path should not rewrite legacy dispatch requests.json');
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -992,6 +1195,42 @@ exit 1
       const parsed = JSON.parse(mailboxDisk) as { messages: Array<{ delivered_at?: string }> };
       assert.ok(parsed.messages.some((m) => typeof m.delivered_at === 'string'));
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers bridge-authored mailbox records without mutating the legacy mailbox file', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-bridge-authority-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    try {
+      await initTeamState('team-mailbox-bridge-authority', 't', 'executor', 2, cwd);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const runtimeLogPath = join(cwd, 'runtime.log');
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCompatRuntimeFixture(join(fakeBinDir, 'omx-runtime'), runtimeLogPath);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+
+      const legacyPath = join(cwd, '.omx', 'state', 'team', 'team-mailbox-bridge-authority', 'mailbox', 'worker-2.json');
+      assert.equal(existsSync(legacyPath), false);
+
+      const message = await sendDirectMessage('team-mailbox-bridge-authority', 'worker-1', 'worker-2', 'hello', cwd);
+      assert.equal(message.to_worker, 'worker-2');
+      await markMessageNotified('team-mailbox-bridge-authority', 'worker-2', message.message_id, cwd);
+      await markMessageDelivered('team-mailbox-bridge-authority', 'worker-2', message.message_id, cwd);
+
+      const messages = await listMailboxMessages('team-mailbox-bridge-authority', 'worker-2', cwd);
+      assert.equal(messages.length, 1);
+      assert.equal(messages[0]?.message_id, message.message_id);
+      assert.equal(typeof messages[0]?.notified_at, 'string');
+      assert.equal(typeof messages[0]?.delivered_at, 'string');
+
+      if (existsSync(legacyPath)) {
+        const after = JSON.parse(await readFile(legacyPath, 'utf8')) as { messages: unknown[] };
+        assert.equal(after.messages.length, 0, 'bridge-success path should not rewrite legacy mailbox JSON');
+      }
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -107,7 +107,6 @@ import {
   type TeamReasoningEffort,
 } from './model-contract.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
-import { isBridgeEnabled, getDefaultBridge } from '../runtime/bridge.js';
 import { inferPhaseTargetFromTaskCounts, reconcilePhaseStateForMonitor } from './phase-controller.js';
 import { getTeamTmuxSessions } from '../notifications/tmux.js';
 import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
@@ -2694,22 +2693,6 @@ async function dispatchCriticalInboxInstruction(params: {
     requireWorkerStartupEvidence,
   } = params;
 
-  // --- Rust runtime bridge: dual-write dispatch mutations ---
-  if (isBridgeEnabled()) {
-    try {
-      const bridge = getDefaultBridge(cwd);
-      const bridgeRequestId = `dispatch-${workerName}-${Date.now()}`;
-      bridge.execCommand({
-        command: 'QueueDispatch',
-        request_id: bridgeRequestId,
-        target: workerName,
-        metadata: { kind: 'inbox', inbox_correlation_key: inboxCorrelationKey },
-      });
-    } catch (_bridgeErr) {
-      // Bridge failure is non-fatal — fall through to existing JS logic
-    }
-  }
-
   if (config.worker_launch_mode === 'prompt') {
     return await queueInboxInstruction({
       teamName,
@@ -2790,9 +2773,6 @@ async function dispatchCriticalInboxInstruction(params: {
   if (receipt?.status === 'failed') {
     const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
     if (fallback.ok) {
-      if (isBridgeEnabled()) {
-        try { getDefaultBridge(cwd).execCommand({ command: 'MarkNotified', request_id: queued.request_id, channel: `fallback_confirmed_after_failed_receipt:${fallback.reason}` }); } catch (_) { /* non-fatal */ }
-      }
       await markDispatchRequestNotified(
         teamName,
         queued.request_id,
@@ -2805,9 +2785,6 @@ async function dispatchCriticalInboxInstruction(params: {
         reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
         request_id: queued.request_id,
       };
-    }
-    if (isBridgeEnabled()) {
-      try { getDefaultBridge(cwd).execCommand({ command: 'MarkFailed', request_id: queued.request_id, reason: `fallback_attempted_but_unconfirmed:${fallback.reason}` }); } catch (_) { /* non-fatal */ }
     }
     await transitionDispatchRequest(
       teamName,
@@ -2833,9 +2810,6 @@ async function dispatchCriticalInboxInstruction(params: {
     ? `${startupFallbackLabel}_fallback_failed:${fallback.reason}`
     : `fallback_attempted_but_unconfirmed:${fallback.reason}`;
   if (fallback.ok) {
-    if (isBridgeEnabled()) {
-      try { getDefaultBridge(cwd).execCommand({ command: 'MarkNotified', request_id: queued.request_id, channel: `fallback_confirmed:${fallback.reason}` }); } catch (_) { /* non-fatal */ }
-    }
     const marked = await markDispatchRequestNotified(
       teamName,
       queued.request_id,
@@ -2843,9 +2817,6 @@ async function dispatchCriticalInboxInstruction(params: {
       cwd,
     );
     if (!marked) {
-      if (isBridgeEnabled()) {
-        try { getDefaultBridge(cwd).execCommand({ command: 'MarkFailed', request_id: queued.request_id, reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` }); } catch (_) { /* non-fatal */ }
-      }
       await transitionDispatchRequest(
         teamName,
         queued.request_id,
@@ -2867,9 +2838,6 @@ async function dispatchCriticalInboxInstruction(params: {
 
   const current = await readDispatchRequest(teamName, queued.request_id, cwd);
   if (current && current.status !== 'failed') {
-    if (isBridgeEnabled()) {
-      try { getDefaultBridge(cwd).execCommand({ command: 'MarkFailed', request_id: queued.request_id, reason: fallbackFailureReason }); } catch (_) { /* non-fatal */ }
-    }
     await transitionDispatchRequest(
       teamName,
       queued.request_id,
@@ -3084,20 +3052,6 @@ async function deliverPendingMailboxMessages(
         1,
         resolveInstructionStateRoot(workerInfo.worktree_path),
       );
-      // --- Rust runtime bridge: dual-write mailbox dispatch ---
-      if (isBridgeEnabled()) {
-        try {
-          const bridge = getDefaultBridge(cwd);
-          bridge.execCommand({
-            command: 'QueueDispatch',
-            request_id: `mailbox-${msg.message_id}-${Date.now()}`,
-            target: worker.name,
-            metadata: { kind: 'mailbox', message_id: msg.message_id },
-          });
-        } catch (_bridgeErr) {
-          // Bridge failure is non-fatal — fall through to existing JS logic
-        }
-      }
       const transportPreference = config.worker_launch_mode === 'prompt'
         ? 'prompt_stdin'
         : (dispatchPolicy.dispatch_mode === 'transport_direct' ? 'transport_direct' : 'hook_preferred_with_fallback');
@@ -3135,10 +3089,6 @@ async function deliverPendingMailboxMessages(
         const direct = await notifyWorkerOutcome(config, workerInfo.index, triggerMessage, workerInfo.pane_id);
         outcome = { ...direct, request_id: queued.request.request_id, message_id: msg.message_id };
         if (outcome.ok) {
-          if (isBridgeEnabled()) {
-            try { getDefaultBridge(cwd).execCommand({ command: 'MarkNotified', request_id: queued.request.request_id, channel: `direct:${outcome.reason}` }); } catch (_) { /* non-fatal */ }
-            try { getDefaultBridge(cwd).execCommand({ command: 'MarkMailboxNotified', message_id: msg.message_id }); } catch (_) { /* non-fatal */ }
-          }
           await markMessageNotified(teamName, worker.name, msg.message_id, cwd).catch(() => false);
           await markDispatchRequestNotified(
             teamName,
@@ -3174,23 +3124,6 @@ export async function sendWorkerMessage(
   if (!config) throw new Error(`Team ${sanitized} not found`);
   const manifest = await readTeamManifestV2(sanitized, cwd);
   const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
-
-  // --- Rust runtime bridge: dual-write mailbox message creation ---
-  if (isBridgeEnabled()) {
-    try {
-      const bridge = getDefaultBridge(cwd);
-      const bridgeMessageId = `msg-${fromWorker}-${toWorker}-${Date.now()}`;
-      bridge.execCommand({
-        command: 'CreateMailboxMessage',
-        message_id: bridgeMessageId,
-        from_worker: fromWorker,
-        to_worker: toWorker,
-        body,
-      });
-    } catch (_bridgeErr) {
-      // Bridge failure is non-fatal — fall through to existing JS logic
-    }
-  }
 
   if (toWorker === 'leader-fixed') {
     const leaderTriggerMessage = generateLeaderMailboxTriggerMessage(sanitized, fromWorker);
@@ -3318,25 +3251,6 @@ export async function broadcastWorkerMessage(
   const transportPreference = config.worker_launch_mode === 'prompt'
     ? 'prompt_stdin'
     : (dispatchPolicy.dispatch_mode === 'transport_direct' ? 'transport_direct' : 'hook_preferred_with_fallback');
-
-  // --- Rust runtime bridge: dual-write broadcast mailbox messages ---
-  if (isBridgeEnabled()) {
-    try {
-      const bridge = getDefaultBridge(cwd);
-      for (const w of config.workers) {
-        const bridgeMessageId = `bcast-${fromWorker}-${w.name}-${Date.now()}`;
-        bridge.execCommand({
-          command: 'CreateMailboxMessage',
-          message_id: bridgeMessageId,
-          from_worker: fromWorker,
-          to_worker: w.name,
-          body,
-        });
-      }
-    } catch (_bridgeErr) {
-      // Bridge failure is non-fatal — fall through to existing JS logic
-    }
-  }
 
   const outcomes = await queueBroadcastMailboxMessage({
     teamName: sanitized,

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -18,6 +18,7 @@ import {
   markMessageDelivered as markMessageDeliveredImpl,
   markMessageNotified as markMessageNotifiedImpl,
   listMailboxMessages as listMailboxMessagesImpl,
+  normalizeBridgeMailboxMessage,
 } from './state/mailbox.js';
 import {
   enqueueDispatchRequest as enqueueDispatchRequestImpl,
@@ -26,6 +27,7 @@ import {
   transitionDispatchRequest as transitionDispatchRequestImpl,
   markDispatchRequestNotified as markDispatchRequestNotifiedImpl,
   markDispatchRequestDelivered as markDispatchRequestDeliveredImpl,
+  normalizeBridgeDispatchRecord,
   normalizeDispatchRequest as normalizeDispatchRequestImpl,
 } from './state/dispatch.js';
 import {
@@ -49,6 +51,7 @@ import {
   withTaskClaimLock as withTaskClaimLockImpl,
   withMailboxLock as withMailboxLockImpl,
 } from './state/locks.js';
+import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir } from '../runtime/bridge.js';
 import {
   TEAM_NAME_SAFE_PATTERN,
   WORKER_NAME_SAFE_PATTERN,
@@ -1365,6 +1368,21 @@ export async function appendTeamEvent(teamName: string, event: Omit<TeamEvent, '
 }
 
 async function readMailbox(teamName: string, workerName: string, cwd: string): Promise<TeamMailbox> {
+  if (isBridgeEnabled()) {
+    try {
+      const bridge = getDefaultBridge(resolveBridgeStateDir(cwd));
+      const compat = bridge.readCompatFile<{ records?: unknown[] }>('mailbox.json');
+      if (compat) {
+        const messages = bridge.readMailboxRecords()
+          .filter((record) => record.to_worker === workerName)
+          .map((record) => normalizeBridgeMailboxMessage(record));
+        return { worker: workerName, messages };
+      }
+    } catch {
+      // fall through to legacy file fallback
+    }
+  }
+
   const p = mailboxPath(teamName, workerName, cwd);
   try {
     if (!existsSync(p)) return { worker: workerName, messages: [] };
@@ -1385,6 +1403,21 @@ async function writeMailbox(teamName: string, mailbox: TeamMailbox, cwd: string)
 }
 
 async function readDispatchRequests(teamName: string, cwd: string): Promise<TeamDispatchRequest[]> {
+  if (isBridgeEnabled()) {
+    try {
+      const bridge = getDefaultBridge(resolveBridgeStateDir(cwd));
+      const compat = bridge.readCompatFile<{ records?: unknown[] }>('dispatch.json');
+      if (compat) {
+        const nowIso = new Date().toISOString();
+        return bridge.readDispatchRecords()
+          .map((record) => normalizeBridgeDispatchRecord(teamName, record, nowIso))
+          .filter((record): record is TeamDispatchRequest => record !== null);
+      }
+    } catch {
+      // fall through to legacy file fallback
+    }
+  }
+
   const path = dispatchRequestsPath(teamName, cwd);
   try {
     if (!existsSync(path)) return [];

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { getDefaultBridge, isBridgeEnabled } from '../../runtime/bridge.js';
+import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type DispatchRecord, type RuntimeCommand } from '../../runtime/bridge.js';
 
 export type TeamDispatchRequestKind = 'inbox' | 'mailbox' | 'nudge';
 export type TeamDispatchRequestStatus = 'pending' | 'notified' | 'delivered' | 'failed';
@@ -118,6 +118,89 @@ function canTransitionDispatchStatus(from: TeamDispatchRequestStatus, to: TeamDi
   return false;
 }
 
+function buildDispatchMetadata(teamName: string, requestInput: TeamDispatchRequestInput): Record<string, unknown> {
+  return {
+    kind: requestInput.kind,
+    team_name: teamName,
+    worker_index: requestInput.worker_index,
+    pane_id: requestInput.pane_id,
+    trigger_message: requestInput.trigger_message,
+    message_id: requestInput.message_id,
+    inbox_correlation_key: requestInput.inbox_correlation_key,
+    transport_preference: requestInput.transport_preference,
+    fallback_allowed: requestInput.fallback_allowed,
+  };
+}
+
+function executeBridgeCommand(cwd: string, command: RuntimeCommand): boolean {
+  if (!isBridgeEnabled()) return false;
+  try {
+    getDefaultBridge(resolveBridgeStateDir(cwd)).execCommand(command);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function coerceMetadataValue<T extends string | number | boolean>(
+  value: unknown,
+  predicate: (candidate: unknown) => candidate is T,
+): T | undefined {
+  return predicate(value) ? value : undefined;
+}
+
+export function normalizeBridgeDispatchRecord(
+  teamName: string,
+  record: DispatchRecord,
+  nowIso: string = new Date().toISOString(),
+): TeamDispatchRequest | null {
+  const metadata = record.metadata && typeof record.metadata === 'object'
+    ? (record.metadata as Record<string, unknown>)
+    : {};
+  const metadataTeamName = typeof metadata.team_name === 'string' && metadata.team_name.trim() !== ''
+    ? metadata.team_name.trim()
+    : null;
+  if (metadataTeamName !== null && metadataTeamName !== teamName) return null;
+
+  return normalizeDispatchRequest(
+    teamName,
+    {
+      request_id: record.request_id,
+      kind: coerceMetadataValue(metadata.kind, isDispatchKind) ?? 'inbox',
+      to_worker: record.target,
+      worker_index: typeof metadata.worker_index === 'number' ? metadata.worker_index : undefined,
+      pane_id: typeof metadata.pane_id === 'string' && metadata.pane_id !== '' ? metadata.pane_id : undefined,
+      trigger_message:
+        typeof metadata.trigger_message === 'string' && metadata.trigger_message.trim() !== ''
+          ? metadata.trigger_message
+          : record.reason ?? record.request_id,
+      message_id: typeof metadata.message_id === 'string' && metadata.message_id !== '' ? metadata.message_id : undefined,
+      inbox_correlation_key:
+        typeof metadata.inbox_correlation_key === 'string' && metadata.inbox_correlation_key !== ''
+          ? metadata.inbox_correlation_key
+          : undefined,
+      transport_preference: coerceMetadataValue(
+        metadata.transport_preference,
+        (candidate): candidate is TeamDispatchTransportPreference =>
+          candidate === 'hook_preferred_with_fallback' || candidate === 'transport_direct' || candidate === 'prompt_stdin',
+      ),
+      fallback_allowed:
+        typeof metadata.fallback_allowed === 'boolean'
+          ? metadata.fallback_allowed
+          : undefined,
+      status: record.status,
+      attempt_count: 0,
+      created_at: record.created_at,
+      updated_at: record.delivered_at ?? record.failed_at ?? record.notified_at ?? record.created_at ?? nowIso,
+      notified_at: record.notified_at ?? undefined,
+      delivered_at: record.delivered_at ?? undefined,
+      failed_at: record.failed_at ?? undefined,
+      last_reason: record.reason ?? undefined,
+    },
+    nowIso,
+  );
+}
+
 export async function enqueueDispatchRequest(
   requestInput: TeamDispatchRequestInput,
   deps: DispatchDeps,
@@ -148,30 +231,18 @@ export async function enqueueDispatchRequest(
     );
     if (!request) throw new Error('failed_to_normalize_dispatch_request');
 
-    requests.push(request);
-    await deps.writeDispatchRequests(deps.teamName, requests, deps.cwd);
-
-    if (isBridgeEnabled()) {
-      try {
-        getDefaultBridge(deps.cwd).execCommand({
-          command: 'QueueDispatch',
-          request_id: request.request_id,
-          target: requestInput.to_worker,
-          metadata: {
-            kind: requestInput.kind,
-            team_name: deps.teamName,
-            worker_index: requestInput.worker_index,
-            pane_id: requestInput.pane_id,
-            trigger_message: requestInput.trigger_message,
-            message_id: requestInput.message_id,
-            inbox_correlation_key: requestInput.inbox_correlation_key,
-            transport_preference: requestInput.transport_preference,
-            fallback_allowed: requestInput.fallback_allowed,
-          },
-        });
-      } catch { /* bridge failure non-fatal */ }
+    if (executeBridgeCommand(deps.cwd, {
+      command: 'QueueDispatch',
+      request_id: request.request_id,
+      target: requestInput.to_worker,
+      metadata: buildDispatchMetadata(deps.teamName, requestInput),
+    })) {
+      const bridgeRequest = await readDispatchRequest(request.request_id, deps);
+      if (bridgeRequest) return { request: bridgeRequest, deduped: false };
     }
 
+    requests.push(request);
+    await deps.writeDispatchRequests(deps.teamName, requests, deps.cwd);
     return { request, deduped: false };
   });
 }
@@ -243,12 +314,16 @@ export async function markDispatchRequestNotified(
   patch: Partial<TeamDispatchRequest> = {},
   deps: DispatchDeps,
 ): Promise<TeamDispatchRequest | null> {
-  if (isBridgeEnabled()) {
-    try { getDefaultBridge(deps.cwd).execCommand({ command: 'MarkNotified', request_id: requestId, channel: patch.message_id ?? 'tmux' }); } catch {}
-  }
   const current = await readDispatchRequest(requestId, deps);
   if (!current) return null;
   if (current.status === 'notified' || current.status === 'delivered') return current;
+  if (executeBridgeCommand(deps.cwd, {
+    command: 'MarkNotified',
+    request_id: requestId,
+    channel: patch.last_reason ?? patch.message_id ?? 'tmux',
+  })) {
+    return await readDispatchRequest(requestId, deps) ?? current;
+  }
   return await transitionDispatchRequest(requestId, current.status, 'notified', patch, deps);
 }
 
@@ -257,12 +332,12 @@ export async function markDispatchRequestDelivered(
   patch: Partial<TeamDispatchRequest> = {},
   deps: DispatchDeps,
 ): Promise<TeamDispatchRequest | null> {
-  if (isBridgeEnabled()) {
-    try { getDefaultBridge(deps.cwd).execCommand({ command: 'MarkDelivered', request_id: requestId }); } catch {}
-  }
   const current = await readDispatchRequest(requestId, deps);
   if (!current) return null;
   if (current.status === 'delivered') return current;
+  if (executeBridgeCommand(deps.cwd, { command: 'MarkDelivered', request_id: requestId })) {
+    return await readDispatchRequest(requestId, deps) ?? current;
+  }
   return await transitionDispatchRequest(requestId, current.status, 'delivered', patch, deps);
 }
 
@@ -271,9 +346,8 @@ export async function markDispatchRequestFailed(
   reason: string,
   deps: DispatchDeps,
 ): Promise<void> {
-  if (isBridgeEnabled()) {
-    try { getDefaultBridge(deps.cwd).execCommand({ command: 'MarkFailed', request_id: requestId, reason }); } catch {}
+  if (executeBridgeCommand(deps.cwd, { command: 'MarkFailed', request_id: requestId, reason })) {
+    return;
   }
-  // Fallback: delegate to existing transition when bridge disabled
   await transitionDispatchRequest(requestId, 'pending', 'failed', { last_reason: reason }, deps);
 }

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { getDefaultBridge, isBridgeEnabled } from '../../runtime/bridge.js';
+import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type MailboxRecord, type RuntimeCommand } from '../../runtime/bridge.js';
 
 export interface TeamMailboxMessage {
   message_id: string;
@@ -36,6 +36,28 @@ interface MailboxDeps {
   readTeamConfig: (teamName: string, cwd: string) => Promise<{ workers: Array<{ name: string }> } | null>;
 }
 
+function executeBridgeCommand(cwd: string, command: RuntimeCommand): boolean {
+  if (!isBridgeEnabled()) return false;
+  try {
+    getDefaultBridge(resolveBridgeStateDir(cwd)).execCommand(command);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeBridgeMailboxMessage(record: MailboxRecord): TeamMailboxMessage {
+  return {
+    message_id: record.message_id,
+    from_worker: record.from_worker,
+    to_worker: record.to_worker,
+    body: record.body,
+    created_at: record.created_at,
+    notified_at: record.notified_at ?? undefined,
+    delivered_at: record.delivered_at ?? undefined,
+  };
+}
+
 export async function sendDirectMessage(
   fromWorker: string,
   toWorker: string,
@@ -58,10 +80,21 @@ export async function sendDirectMessage(
       return;
     }
 
-    // Dual-write: Rust bridge (non-fatal) + TS file (canonical during cutover)
     const msgId = randomUUID();
-    if (isBridgeEnabled()) {
-      try { getDefaultBridge(deps.cwd).execCommand({ command: 'CreateMailboxMessage', message_id: msgId, from_worker: fromWorker, to_worker: toWorker, body }); } catch {}
+    if (executeBridgeCommand(deps.cwd, {
+      command: 'CreateMailboxMessage',
+      message_id: msgId,
+      from_worker: fromWorker,
+      to_worker: toWorker,
+      body,
+    })) {
+      const bridgeMailbox = await deps.readMailbox(deps.teamName, toWorker, deps.cwd);
+      const bridgeMessage = bridgeMailbox.messages.find((candidate) => candidate.message_id === msgId);
+      if (bridgeMessage) {
+        msg = bridgeMessage;
+        created = true;
+        return;
+      }
     }
 
     msg = {
@@ -112,8 +145,9 @@ export async function markMessageDelivered(
   messageId: string,
   deps: MailboxDeps,
 ): Promise<boolean> {
-  if (isBridgeEnabled()) {
-    try { getDefaultBridge(deps.cwd).execCommand({ command: 'MarkMailboxDelivered', message_id: messageId }); } catch {}
+  if (executeBridgeCommand(deps.cwd, { command: 'MarkMailboxDelivered', message_id: messageId })) {
+    const mailbox = await deps.readMailbox(deps.teamName, workerName, deps.cwd);
+    if (mailbox.messages.some((message) => message.message_id === messageId)) return true;
   }
   return await deps.withMailboxLock(deps.teamName, workerName, deps.cwd, async () => {
     const mailbox = await deps.readMailbox(deps.teamName, workerName, deps.cwd);
@@ -132,8 +166,9 @@ export async function markMessageNotified(
   messageId: string,
   deps: MailboxDeps,
 ): Promise<boolean> {
-  if (isBridgeEnabled()) {
-    try { getDefaultBridge(deps.cwd).execCommand({ command: 'MarkMailboxNotified', message_id: messageId }); } catch {}
+  if (executeBridgeCommand(deps.cwd, { command: 'MarkMailboxNotified', message_id: messageId })) {
+    const mailbox = await deps.readMailbox(deps.teamName, workerName, deps.cwd);
+    if (mailbox.messages.some((message) => message.message_id === messageId)) return true;
   }
   return await deps.withMailboxLock(deps.teamName, workerName, deps.cwd, async () => {
     const mailbox = await deps.readMailbox(deps.teamName, workerName, deps.cwd);


### PR DESCRIPTION
## Summary

Fixes #1108 — removes dual-write seam gaps in the team runtime thin-adapter cutover.

### Changes
- **Rust bridge is now canonical dispatch/mailbox writer** — eliminates TS-side dual-write mutations
- **Compat readers prefer Rust-authored dispatch.json / mailbox.json**
- **Watcher uses canonical runtime state dir** — only touches legacy mailbox state on fallback lanes
- Added focused bridge-authority regression coverage
- Updated contracts and QA audit docs

### Verification
- `npm run build` ✅
- `npm run lint` ✅
- Type diagnostics ✅
- `npm run test:node` ✅ (2771 pass, 0 fail)
- Targeted test suites ✅ (state, rust-runtime-compat, notify-hook-team-dispatch)
- Architect verification ✅

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*