### PR TITLE
fix: treat linked legacy skill roots as a shared canonical root

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -16,10 +16,14 @@ function runOmx(
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
   const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
+  const mergedEnv = { ...process.env, ...envOverrides };
+  if (typeof envOverrides.HOME === 'string' && typeof envOverrides.USERPROFILE !== 'string') {
+    mergedEnv.USERPROFILE = envOverrides.HOME;
+  }
   const r = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',
-    env: { ...process.env, ...envOverrides },
+    env: mergedEnv,
   });
   return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
 }
@@ -199,8 +203,41 @@ USE_OMX_EXPLORE_CMD = "off"
       assert.equal(res.status, 0, res.stderr || res.stdout);
       assert.match(
         res.stdout,
-        /Legacy skill roots: 1 overlapping skill names between .*\.codex\/skills and .*\.agents\/skills; 1 differ in SKILL\.md content; Codex Enable\/Disable Skills may show duplicates until ~\/\.agents\/skills is cleaned up/,
+        /Legacy skill roots: 1 overlapping skill names between .*\.codex[\\/]+skills and .*\.agents[\\/]+skills; 1 differ in SKILL\.md content; Codex Enable\/Disable Skills may show duplicates until ~\/\.agents\/skills is cleaned up/,
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when legacy skill root is a link to the canonical skills directory', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-skill-link-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const canonicalSkillsRoot = join(codexDir, 'skills');
+      const canonicalHelp = join(canonicalSkillsRoot, 'help');
+      const legacyRoot = join(home, '.agents', 'skills');
+      await mkdir(canonicalHelp, { recursive: true });
+      await mkdir(join(home, '.agents'), { recursive: true });
+      await writeFile(join(canonicalHelp, 'SKILL.md'), '# canonical help\n');
+      await symlink(
+        canonicalSkillsRoot,
+        legacyRoot,
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: codexDir,
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Legacy skill roots: ~\/\.agents\/skills links to canonical .*\.codex[\\/]+skills; treating both paths as one shared skill root/,
+      );
+      assert.doesNotMatch(res.stdout, /\[!!\] Legacy skill roots:/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -678,6 +678,15 @@ async function checkLegacySkillRootOverlap(): Promise<Check> {
     };
   }
 
+  if (overlap.sameResolvedTarget) {
+    return {
+      name: 'Legacy skill roots',
+      status: 'pass',
+      message:
+        `~/.agents/skills links to canonical ${overlap.canonicalDir}; treating both paths as one shared skill root`,
+    };
+  }
+
   if (overlap.overlappingSkillNames.length === 0) {
     return {
       name: 'Legacy skill roots',

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { join } from "path";
 import { homedir, tmpdir } from "os";
 import { existsSync } from "fs";
-import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "fs/promises";
 import {
   codexHome,
   codexConfigPath,
@@ -23,9 +23,11 @@ import {
 
 describe("codexHome", () => {
   let originalCodexHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     originalCodexHome = process.env.CODEX_HOME;
+    originalUserProfile = process.env.USERPROFILE;
   });
 
   afterEach(() => {
@@ -33,6 +35,12 @@ describe("codexHome", () => {
       process.env.CODEX_HOME = originalCodexHome;
     } else {
       delete process.env.CODEX_HOME;
+    }
+
+    if (typeof originalUserProfile === "string") {
+      process.env.USERPROFILE = originalUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
     }
   });
 
@@ -49,9 +57,11 @@ describe("codexHome", () => {
 
 describe("codexConfigPath", () => {
   let originalCodexHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     originalCodexHome = process.env.CODEX_HOME;
+    originalUserProfile = process.env.USERPROFILE;
     process.env.CODEX_HOME = "/tmp/test-codex";
   });
 
@@ -61,18 +71,26 @@ describe("codexConfigPath", () => {
     } else {
       delete process.env.CODEX_HOME;
     }
+
+    if (typeof originalUserProfile === "string") {
+      process.env.USERPROFILE = originalUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
   });
 
   it("returns config.toml under codex home", () => {
-    assert.equal(codexConfigPath(), "/tmp/test-codex/config.toml");
+    assert.equal(codexConfigPath(), join("/tmp/test-codex", "config.toml"));
   });
 });
 
 describe("codexPromptsDir", () => {
   let originalCodexHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     originalCodexHome = process.env.CODEX_HOME;
+    originalUserProfile = process.env.USERPROFILE;
     process.env.CODEX_HOME = "/tmp/test-codex";
   });
 
@@ -82,18 +100,26 @@ describe("codexPromptsDir", () => {
     } else {
       delete process.env.CODEX_HOME;
     }
+
+    if (typeof originalUserProfile === "string") {
+      process.env.USERPROFILE = originalUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
   });
 
   it("returns prompts/ under codex home", () => {
-    assert.equal(codexPromptsDir(), "/tmp/test-codex/prompts");
+    assert.equal(codexPromptsDir(), join("/tmp/test-codex", "prompts"));
   });
 });
 
 describe("userSkillsDir", () => {
   let originalCodexHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     originalCodexHome = process.env.CODEX_HOME;
+    originalUserProfile = process.env.USERPROFILE;
     process.env.CODEX_HOME = "/tmp/test-codex";
   });
 
@@ -103,16 +129,22 @@ describe("userSkillsDir", () => {
     } else {
       delete process.env.CODEX_HOME;
     }
+
+    if (typeof originalUserProfile === "string") {
+      process.env.USERPROFILE = originalUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
   });
 
   it("returns CODEX_HOME/skills", () => {
-    assert.equal(userSkillsDir(), "/tmp/test-codex/skills");
+    assert.equal(userSkillsDir(), join("/tmp/test-codex", "skills"));
   });
 });
 
 describe("projectSkillsDir", () => {
   it("uses provided projectRoot", () => {
-    assert.equal(projectSkillsDir("/my/project"), "/my/project/.codex/skills");
+    assert.equal(projectSkillsDir("/my/project"), join("/my/project", ".codex", "skills"));
   });
 
   it("defaults to cwd when no projectRoot given", () => {
@@ -122,10 +154,13 @@ describe("projectSkillsDir", () => {
 
 describe("legacyUserSkillsDir", () => {
   let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
     process.env.HOME = "/tmp/test-home";
+    process.env.USERPROFILE = "/tmp/test-home";
   });
 
   afterEach(() => {
@@ -134,18 +169,28 @@ describe("legacyUserSkillsDir", () => {
     } else {
       delete process.env.HOME;
     }
+
+    if (typeof originalUserProfile === "string") {
+      process.env.USERPROFILE = originalUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
   });
 
   it("returns ~/.agents/skills under HOME", () => {
-    assert.equal(legacyUserSkillsDir(), "/tmp/test-home/.agents/skills");
+    assert.equal(legacyUserSkillsDir(), join("/tmp/test-home", ".agents", "skills"));
   });
 });
 
 describe("listInstalledSkillDirectories", () => {
   let originalCodexHome: string | undefined;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     originalCodexHome = process.env.CODEX_HOME;
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
   });
 
   afterEach(() => {
@@ -153,6 +198,18 @@ describe("listInstalledSkillDirectories", () => {
       process.env.CODEX_HOME = originalCodexHome;
     } else {
       delete process.env.CODEX_HOME;
+    }
+
+    if (typeof originalHome === "string") {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+
+    if (typeof originalUserProfile === "string") {
+      process.env.USERPROFILE = originalUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
     }
   });
 
@@ -206,6 +263,7 @@ describe("listInstalledSkillDirectories", () => {
     const codexHomeRoot = join(homeRoot, ".codex");
     const legacyRoot = join(homeRoot, ".agents", "skills");
     process.env.HOME = homeRoot;
+    process.env.USERPROFILE = homeRoot;
     process.env.CODEX_HOME = codexHomeRoot;
 
     try {
@@ -232,6 +290,42 @@ describe("listInstalledSkillDirectories", () => {
       assert.equal(overlap.legacySkillCount, 2);
       assert.deepEqual(overlap.overlappingSkillNames, ["help"]);
       assert.deepEqual(overlap.mismatchedSkillNames, ["help"]);
+      assert.equal(overlap.sameResolvedTarget, false);
+    } finally {
+      await rm(homeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a legacy link to canonical skills as the same resolved target", async () => {
+    const homeRoot = await mkdtemp(join(tmpdir(), "omx-paths-linked-home-"));
+    const codexHomeRoot = join(homeRoot, ".codex");
+    const canonicalSkillsRoot = join(codexHomeRoot, "skills");
+    const legacyParent = join(homeRoot, ".agents");
+    const legacyRoot = join(legacyParent, "skills");
+    process.env.HOME = homeRoot;
+    process.env.USERPROFILE = homeRoot;
+    process.env.CODEX_HOME = codexHomeRoot;
+
+    try {
+      const canonicalHelpDir = join(canonicalSkillsRoot, "help");
+      await mkdir(canonicalHelpDir, { recursive: true });
+      await mkdir(legacyParent, { recursive: true });
+      await writeFile(join(canonicalHelpDir, "SKILL.md"), "# canonical help\n");
+      await symlink(
+        canonicalSkillsRoot,
+        legacyRoot,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      const overlap = await detectLegacySkillRootOverlap();
+
+      assert.equal(overlap.canonicalExists, true);
+      assert.equal(overlap.legacyExists, true);
+      assert.equal(overlap.canonicalSkillCount, 1);
+      assert.equal(overlap.legacySkillCount, 1);
+      assert.equal(overlap.sameResolvedTarget, true);
+      assert.deepEqual(overlap.overlappingSkillNames, ["help"]);
+      assert.deepEqual(overlap.mismatchedSkillNames, []);
     } finally {
       await rm(homeRoot, { recursive: true, force: true });
     }
@@ -240,7 +334,7 @@ describe("listInstalledSkillDirectories", () => {
 
 describe("omxStateDir", () => {
   it("uses provided projectRoot", () => {
-    assert.equal(omxStateDir("/my/project"), "/my/project/.omx/state");
+    assert.equal(omxStateDir("/my/project"), join("/my/project", ".omx", "state"));
   });
 
   it("defaults to cwd when no projectRoot given", () => {
@@ -252,7 +346,7 @@ describe("omxProjectMemoryPath", () => {
   it("uses provided projectRoot", () => {
     assert.equal(
       omxProjectMemoryPath("/my/project"),
-      "/my/project/.omx/project-memory.json",
+      join("/my/project", ".omx", "project-memory.json"),
     );
   });
 
@@ -266,7 +360,7 @@ describe("omxProjectMemoryPath", () => {
 
 describe("omxNotepadPath", () => {
   it("uses provided projectRoot", () => {
-    assert.equal(omxNotepadPath("/my/project"), "/my/project/.omx/notepad.md");
+    assert.equal(omxNotepadPath("/my/project"), join("/my/project", ".omx", "notepad.md"));
   });
 
   it("defaults to cwd when no projectRoot given", () => {
@@ -276,7 +370,7 @@ describe("omxNotepadPath", () => {
 
 describe("omxPlansDir", () => {
   it("uses provided projectRoot", () => {
-    assert.equal(omxPlansDir("/my/project"), "/my/project/.omx/plans");
+    assert.equal(omxPlansDir("/my/project"), join("/my/project", ".omx", "plans"));
   });
 
   it("defaults to cwd when no projectRoot given", () => {
@@ -286,7 +380,7 @@ describe("omxPlansDir", () => {
 
 describe("omxLogsDir", () => {
   it("uses provided projectRoot", () => {
-    assert.equal(omxLogsDir("/my/project"), "/my/project/.omx/logs");
+    assert.equal(omxLogsDir("/my/project"), join("/my/project", ".omx", "logs"));
   });
 
   it("defaults to cwd when no projectRoot given", () => {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -5,7 +5,7 @@
 
 import { createHash } from "crypto";
 import { existsSync } from "fs";
-import { readdir, readFile } from "fs/promises";
+import { readdir, readFile, realpath } from "fs/promises";
 import { dirname, join } from "path";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
@@ -63,6 +63,9 @@ export interface SkillRootOverlapReport {
   legacyDir: string;
   canonicalExists: boolean;
   legacyExists: boolean;
+  canonicalResolvedDir: string | null;
+  legacyResolvedDir: string | null;
+  sameResolvedTarget: boolean;
   canonicalSkillCount: number;
   legacySkillCount: number;
   overlappingSkillNames: string[];
@@ -118,9 +121,13 @@ export async function detectLegacySkillRootOverlap(
   canonicalDir = userSkillsDir(),
   legacyDir = legacyUserSkillsDir(),
 ): Promise<SkillRootOverlapReport> {
-  const [canonicalSkills, legacySkills] = await Promise.all([
+  const canonicalExists = existsSync(canonicalDir);
+  const legacyExists = existsSync(legacyDir);
+  const [canonicalSkills, legacySkills, canonicalResolvedDir, legacyResolvedDir] = await Promise.all([
     readInstalledSkillsFromDir(canonicalDir, "user"),
     readInstalledSkillsFromDir(legacyDir, "user"),
+    canonicalExists ? realpath(canonicalDir).catch(() => null) : Promise.resolve(null),
+    legacyExists ? realpath(legacyDir).catch(() => null) : Promise.resolve(null),
   ]);
 
   const canonicalHashes = await hashSkillDirectory(canonicalSkills);
@@ -133,12 +140,19 @@ export async function detectLegacySkillRootOverlap(
   const mismatchedSkillNames = overlappingSkillNames.filter(
     (name) => canonicalHashes.get(name) !== legacyHashes.get(name),
   );
+  const sameResolvedTarget =
+    canonicalResolvedDir !== null &&
+    legacyResolvedDir !== null &&
+    canonicalResolvedDir === legacyResolvedDir;
 
   return {
     canonicalDir,
     legacyDir,
-    canonicalExists: existsSync(canonicalDir),
-    legacyExists: existsSync(legacyDir),
+    canonicalExists,
+    legacyExists,
+    canonicalResolvedDir,
+    legacyResolvedDir,
+    sameResolvedTarget,
     canonicalSkillCount: canonicalSkills.length,
     legacySkillCount: legacySkills.length,
     overlappingSkillNames,


### PR DESCRIPTION
## Summary
When ~/.agents/skills is only a symlink or junction to the canonical ~/.codex/skills, omx doctor currently warns about legacy skill-root overlap even though both paths resolve to the same directory.

## Changes
- compare the canonical and legacy skill roots with ealpath() inside detectLegacySkillRootOverlap
- mark linked/junctioned legacy skill roots as a pass case in doctor
- add coverage for the shared-root link scenario
- make the related path/doctor tests tolerate Windows path separators and HOME/USERPROFILE differences

## Why
Some users keep .agents/skills as a compatibility entrypoint for tools beyond Codex. In that setup, the current warning is a false positive and nudges users toward removing a path they still legitimately need.

## Verification
- 
pm run build
- 
pm run lint -- src/utils/paths.ts src/cli/doctor.ts src/utils/__tests__/paths.test.ts src/cli/__tests__/doctor-warning-copy.test.ts
- 
ode --test dist/utils/__tests__/paths.test.js dist/cli/__tests__/doctor-warning-copy.test.js
