### PR TITLE
feat: add --provider flag for multi-CLI support (codex, claude, cursor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 **Website:** https://yeachan-heo.github.io/oh-my-codex-website/  
 **Docs:** [Getting Started](./docs/getting-started.html) · [Agents](./docs/agents.html) · [Skills](./docs/skills.html) · [Integrations](./docs/integrations.html) · [Demo](./DEMO.md) · [OpenClaw guide](./docs/openclaw-integration.md)
 
-OMX is a workflow layer for [OpenAI Codex CLI](https://github.com/openai/codex).
+OMX is a workflow layer for AI coding tools.
 
-It keeps Codex as the execution engine and makes it easier to:
-- start a stronger Codex session by default
+It supports multiple providers — **OpenAI Codex CLI**, **Claude Code**, and **Cursor** — and makes it easier to:
+- start a stronger coding session by default
 - reuse good role/task invocations with `$name` keywords
 - invoke workflows with skills like `$plan`, `$ralph`, and `$team`
 - keep project guidance, plans, logs, and state in `.omx/`
@@ -42,9 +42,35 @@ $plan "ship this feature cleanly"
 That is the main path.
 Start OMX strongly, do the work in Codex, and let the agent pull in `$team` or other workflows only when the task actually needs them.
 
+### Using with Claude Code or Cursor
+
+Use the `--provider` flag to target a different AI coding tool:
+
+```bash
+# Claude Code
+omx setup --provider claude
+omx --provider claude
+
+# Cursor
+omx setup --provider cursor
+```
+
+You can also set it via environment variable:
+
+```bash
+export OMX_PROVIDER=claude
+omx setup
+```
+
+| Provider | Home dir | Config format | Prompt injection |
+| --- | --- | --- | --- |
+| `codex` (default) | `~/.codex/` | `config.toml` | `developer_instructions` key |
+| `claude` | `~/.claude/` | `settings.json` | `CLAUDE.md` file |
+| `cursor` | `~/.cursor/` | `settings.json` | `.cursorrules` file |
+
 ## What OMX is for
 
-Use OMX if you already like Codex and want a better day-to-day runtime around it:
+Use OMX if you already like Codex, Claude Code, or Cursor and want a better day-to-day runtime around it:
 - reusable role/task invocations such as `$architect` and `$executor`
 - reusable workflows such as `$plan`, `$ralph`, `$team`, and `$deep-interview`
 - project guidance through scoped `AGENTS.md`
@@ -57,8 +83,11 @@ If you want plain Codex with no extra workflow layer, you probably do not need O
 ### Requirements
 
 - Node.js 20+
-- Codex CLI installed: `npm install -g @openai/codex`
-- Codex auth configured
+- At least one supported provider CLI installed:
+  - Codex CLI: `npm install -g @openai/codex`
+  - Claude Code: `npm install -g @anthropic-ai/claude-code`
+  - Cursor: install from [cursor.com](https://cursor.com)
+- Provider auth configured
 - `tmux` on macOS/Linux if you later want the durable team runtime
 - `psmux` on native Windows if you later want Windows team mode
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -69,6 +69,12 @@ import {
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
 import { codexConfigPath } from "../utils/paths.js";
+import {
+  PROVIDERS,
+  isProviderName,
+  setActiveProvider,
+  type ProviderName,
+} from "../providers/index.js";
 import { repairConfigIfNeeded } from "../config/generator.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
 import {
@@ -168,6 +174,8 @@ Options:
   --keep-config Skip config.toml cleanup during uninstall
   --purge       Remove .omx/ cache directory during uninstall
   --verbose     Show detailed output
+  --provider    Target AI coding tool (default: codex):
+                codex | claude | cursor
   --scope       Setup scope for "omx setup" only:
                 user | project
   --skill-target
@@ -560,7 +568,58 @@ export function buildHudPaneCleanupTargets(
   return [...targets];
 }
 
+export function resolveProviderArg(args: string[]): ProviderName | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--provider") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(
+          `Missing provider value after --provider. Expected one of: ${PROVIDERS.join(", ")}`,
+        );
+      }
+      if (!isProviderName(next)) {
+        throw new Error(
+          `Invalid provider: ${next}. Expected one of: ${PROVIDERS.join(", ")}`,
+        );
+      }
+      return next;
+    }
+    if (arg.startsWith("--provider=")) {
+      const value = arg.slice("--provider=".length);
+      if (!isProviderName(value)) {
+        throw new Error(
+          `Invalid provider: ${value}. Expected one of: ${PROVIDERS.join(", ")}`,
+        );
+      }
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/** Strip --provider and its value from args so downstream parsers don't choke. */
+function stripProviderArg(args: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--provider") {
+      i++; // skip value
+      continue;
+    }
+    if (args[i].startsWith("--provider=")) continue;
+    result.push(args[i]);
+  }
+  return result;
+}
+
 export async function main(args: string[]): Promise<void> {
+  // Resolve and activate the target provider before anything else
+  const providerArg = resolveProviderArg(args);
+  if (providerArg) {
+    setActiveProvider(providerArg);
+  }
+  args = stripProviderArg(args);
+
   const knownCommands = new Set([
     "launch",
     "exec",

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -28,6 +28,10 @@ import {
   omxPlansDir,
   omxLogsDir,
 } from "../utils/paths.js";
+import {
+  getActiveProvider,
+  getProviderConfig,
+} from "../providers/index.js";
 import { buildMergedConfig, getRootModelName } from "../config/generator.js";
 import {
   getUnifiedMcpRegistryCandidates,
@@ -129,7 +133,8 @@ function applyScopePathRewritesToAgentsTemplate(
   scope: SetupScope,
 ): string {
   if (scope !== "project") return content;
-  return content.replaceAll("~/.codex", "./.codex");
+  const providerDir = getProviderConfig().projectDirName;
+  return content.replaceAll(`~/${providerDir}`, `./${providerDir}`);
 }
 
 interface PersistedSetupScope {
@@ -429,11 +434,13 @@ async function promptForSetupScope(
     output: process.stdout,
   });
   try {
+    const providerCfg = getProviderConfig();
+    const providerDir = providerCfg.projectDirName;
     console.log("Select setup scope:");
     console.log(
-      `  1) user (default) — installs to ~/.codex (skills default to ~/.codex/skills)`,
+      `  1) user (default) — installs to ~/${providerDir} (skills default to ~/${providerDir}/skills)`,
     );
-    console.log("  2) project — installs to ./.codex (local to project)");
+    console.log(`  2) project — installs to ./${providerDir} (local to project)`);
     const answer = (await rl.question("Scope [1-2] (default: 1): "))
       .trim()
       .toLowerCase();
@@ -620,8 +627,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
   const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
 
+  const activeProvider = getActiveProvider();
+  const providerLabel = getProviderConfig().displayName;
   console.log("oh-my-codex setup");
   console.log("=================\n");
+  console.log(`Provider: ${providerLabel} (${activeProvider})`);
   console.log(
     `Using setup scope: ${resolvedScope.scope}${scopeSourceMessage}\n`,
   );

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,157 @@
+/**
+ * Provider abstraction for oh-my-codex
+ *
+ * Defines the contract each AI coding tool must fulfill so that OMX
+ * can install prompts, skills, agents, and config into the right
+ * locations with the right format.
+ */
+
+import { homedir } from "os";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// Provider type
+// ---------------------------------------------------------------------------
+
+export const PROVIDERS = ["codex", "claude", "cursor"] as const;
+export type ProviderName = (typeof PROVIDERS)[number];
+
+export interface ProviderConfig {
+  /** Human-readable display name */
+  displayName: string;
+
+  /** CLI command used to launch the tool (null if IDE-only) */
+  cliCommand: string | null;
+
+  /** User-level home directory (e.g. ~/.codex, ~/.claude) */
+  homeDir: string;
+
+  /** Config file path relative to homeDir */
+  configFile: string;
+
+  /** Config file format */
+  configFormat: "toml" | "json";
+
+  /** Directory name used for project-local config (e.g. .codex, .claude) */
+  projectDirName: string;
+
+  /** How prompts/instructions are injected */
+  promptInjection: PromptInjectionMethod;
+
+  /** Approval-bypass flag, if any */
+  bypassFlag: string | null;
+}
+
+export type PromptInjectionMethod =
+  | { type: "config-key"; key: string }
+  | { type: "markdown-file"; filename: string }
+  | { type: "rules-file"; filename: string };
+
+// ---------------------------------------------------------------------------
+// Provider definitions
+// ---------------------------------------------------------------------------
+
+const PROVIDER_CONFIGS: Record<ProviderName, ProviderConfig> = {
+  codex: {
+    displayName: "OpenAI Codex CLI",
+    cliCommand: "codex",
+    homeDir: join(homedir(), ".codex"),
+    configFile: "config.toml",
+    configFormat: "toml",
+    projectDirName: ".codex",
+    promptInjection: { type: "config-key", key: "developer_instructions" },
+    bypassFlag: "--dangerously-bypass-approvals-and-sandbox",
+  },
+
+  claude: {
+    displayName: "Claude Code",
+    cliCommand: "claude",
+    homeDir: join(homedir(), ".claude"),
+    configFile: "settings.json",
+    configFormat: "json",
+    projectDirName: ".claude",
+    promptInjection: { type: "markdown-file", filename: "CLAUDE.md" },
+    bypassFlag: "--dangerously-skip-permissions",
+  },
+
+  cursor: {
+    displayName: "Cursor",
+    cliCommand: null,
+    homeDir: join(homedir(), ".cursor"),
+    configFile: "settings.json",
+    configFormat: "json",
+    projectDirName: ".cursor",
+    promptInjection: { type: "rules-file", filename: ".cursorrules" },
+    bypassFlag: null,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+const PROVIDER_ENV_KEY = "OMX_PROVIDER";
+
+let _activeProvider: ProviderName | undefined;
+
+/** Set the active provider for this process (called once from CLI parsing). */
+export function setActiveProvider(name: ProviderName): void {
+  _activeProvider = name;
+}
+
+/** Resolve the active provider from explicit set, env var, or default. */
+export function getActiveProvider(): ProviderName {
+  if (_activeProvider) return _activeProvider;
+  const envValue = process.env[PROVIDER_ENV_KEY];
+  if (envValue && isProviderName(envValue)) return envValue;
+  return "codex";
+}
+
+/** Get config for a specific provider. */
+export function getProviderConfig(name?: ProviderName): ProviderConfig {
+  return PROVIDER_CONFIGS[name ?? getActiveProvider()];
+}
+
+/** Type guard */
+export function isProviderName(value: string): value is ProviderName {
+  return PROVIDERS.includes(value as ProviderName);
+}
+
+// ---------------------------------------------------------------------------
+// Convenience path helpers (provider-aware replacements for paths.ts funcs)
+// ---------------------------------------------------------------------------
+
+/** Provider home directory (e.g. ~/.codex, ~/.claude, ~/.cursor) */
+export function providerHome(provider?: ProviderName): string {
+  return getProviderConfig(provider).homeDir;
+}
+
+/** Provider config file path */
+export function providerConfigPath(provider?: ProviderName): string {
+  const cfg = getProviderConfig(provider);
+  return join(cfg.homeDir, cfg.configFile);
+}
+
+/** Provider prompts directory */
+export function providerPromptsDir(provider?: ProviderName): string {
+  return join(providerHome(provider), "prompts");
+}
+
+/** Provider skills directory */
+export function providerSkillsDir(provider?: ProviderName): string {
+  return join(providerHome(provider), "skills");
+}
+
+/** Provider agents directory */
+export function providerAgentsDir(provider?: ProviderName): string {
+  return join(providerHome(provider), "agents");
+}
+
+/** Project-level provider directory */
+export function projectProviderDir(
+  provider?: ProviderName,
+  projectRoot?: string,
+): string {
+  const cfg = getProviderConfig(provider);
+  return join(projectRoot ?? process.cwd(), cfg.projectDirName);
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,6 +1,11 @@
 /**
  * Path utilities for oh-my-codex
- * Resolves Codex CLI config, skills, prompts, and state directories
+ * Resolves provider CLI config, skills, prompts, and state directories.
+ *
+ * All provider-specific paths now delegate to the provider abstraction
+ * (src/providers/index.ts).  The original function names are kept for
+ * backward compatibility so that existing call-sites continue to work
+ * without modification.
  */
 
 import { createHash } from "crypto";
@@ -9,40 +14,61 @@ import { readdir, readFile } from "fs/promises";
 import { dirname, join } from "path";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
+import {
+  providerHome,
+  providerConfigPath,
+  providerPromptsDir,
+  providerSkillsDir,
+  providerAgentsDir,
+  projectProviderDir,
+} from "../providers/index.js";
 
-/** Codex CLI home directory (~/.codex/) */
+/** Provider CLI home directory (provider-aware; defaults to ~/.codex/) */
 export function codexHome(): string {
-  return process.env.CODEX_HOME || join(homedir(), ".codex");
+  return process.env.CODEX_HOME || providerHome();
 }
 
-/** Codex config file path (~/.codex/config.toml) */
+/** Provider config file path (provider-aware) */
 export function codexConfigPath(): string {
-  return join(codexHome(), "config.toml");
+  if (process.env.CODEX_HOME) {
+    return join(process.env.CODEX_HOME, "config.toml");
+  }
+  return providerConfigPath();
 }
 
-/** Codex prompts directory (~/.codex/prompts/) */
+/** Provider prompts directory (provider-aware) */
 export function codexPromptsDir(): string {
-  return join(codexHome(), "prompts");
+  if (process.env.CODEX_HOME) {
+    return join(process.env.CODEX_HOME, "prompts");
+  }
+  return providerPromptsDir();
 }
 
-/** Codex native agents directory (~/.codex/agents/) */
+/** Provider native agents directory (provider-aware) */
 export function codexAgentsDir(codexHomeDir?: string): string {
-  return join(codexHomeDir || codexHome(), "agents");
+  if (codexHomeDir) return join(codexHomeDir, "agents");
+  if (process.env.CODEX_HOME) {
+    return join(process.env.CODEX_HOME, "agents");
+  }
+  return providerAgentsDir();
 }
 
-/** Project-level Codex native agents directory (.codex/agents/) */
+/** Project-level native agents directory (provider-aware) */
 export function projectCodexAgentsDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".codex", "agents");
+  return join(projectProviderDir(undefined, projectRoot), "agents");
 }
 
-/** User-level skills directory ($CODEX_HOME/skills, defaults to ~/.codex/skills/) */
+/** User-level skills directory (provider-aware) */
 export function userSkillsDir(): string {
-  return join(codexHome(), "skills");
+  if (process.env.CODEX_HOME) {
+    return join(process.env.CODEX_HOME, "skills");
+  }
+  return providerSkillsDir();
 }
 
-/** Project-level skills directory (.codex/skills/) */
+/** Project-level skills directory (provider-aware) */
 export function projectSkillsDir(projectRoot?: string): string {
-  return join(projectRoot || process.cwd(), ".codex", "skills");
+  return join(projectProviderDir(undefined, projectRoot), "skills");
 }
 
 /** Historical legacy user-level skills directory (~/.agents/skills/) */


### PR DESCRIPTION
Introduces a provider abstraction so OMX can target Claude Code and Cursor in addition to the default OpenAI Codex CLI. Paths, config formats, and prompt injection methods are resolved per-provider.

## Summary

Describe the problem and why this change is needed.

## Changes

-

## Validation

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [ ] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [ ] Backward-compatibility impact considered

## Related

Closes #
