### PR TITLE
fix(hook): restore canonical mailbox notification after #1126 seam retest

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -91,6 +91,80 @@ exit 0
 `;
 }
 
+async function writeCompatRuntimeFixture(runtimePath: string): Promise<void> {
+  await writeFile(
+    runtimePath,
+    `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const argv = process.argv.slice(2);
+function argValue(prefix) {
+  const entry = argv.find((value) => value.startsWith(prefix));
+  return entry ? entry.slice(prefix.length) : null;
+}
+function stateDir() {
+  return argValue('--state-dir=') || process.cwd();
+}
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return fallback; }
+}
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value, null, 2) + '\\n');
+}
+function nowIso() { return new Date().toISOString(); }
+if (argv[0] === 'schema') {
+  process.stdout.write(JSON.stringify({ schema_version: 1, commands: ['acquire-authority','renew-authority','queue-dispatch','mark-notified','mark-delivered','mark-failed','request-replay','capture-snapshot'], events: [], transport: 'tmux' }) + '\\n');
+  process.exit(0);
+}
+if (argv[0] !== 'exec') process.exit(1);
+const command = JSON.parse(argv[1] || '{}');
+const dir = stateDir();
+const dispatchPath = path.join(dir, 'dispatch.json');
+const mailboxPath = path.join(dir, 'mailbox.json');
+const dispatch = readJson(dispatchPath, { records: [] });
+const mailbox = readJson(mailboxPath, { records: [] });
+const timestamp = nowIso();
+switch (command.command) {
+  case 'QueueDispatch':
+    dispatch.records.push({ request_id: command.request_id, target: command.target, status: 'pending', created_at: timestamp, notified_at: null, delivered_at: null, failed_at: null, reason: null, metadata: command.metadata ?? null });
+    writeJson(dispatchPath, dispatch);
+    process.stdout.write(JSON.stringify({ event: 'DispatchQueued', request_id: command.request_id, target: command.target }) + '\\n');
+    process.exit(0);
+  case 'MarkNotified': {
+    const record = dispatch.records.find((entry) => entry.request_id === command.request_id);
+    if (record) {
+      record.status = 'notified';
+      record.notified_at = timestamp;
+      record.reason = command.channel;
+      writeJson(dispatchPath, dispatch);
+    }
+    process.stdout.write(JSON.stringify({ event: 'DispatchNotified', request_id: command.request_id, channel: command.channel }) + '\\n');
+    process.exit(0);
+  }
+  case 'CreateMailboxMessage':
+    mailbox.records.push({ message_id: command.message_id, from_worker: command.from_worker, to_worker: command.to_worker, body: command.body, created_at: timestamp, notified_at: null, delivered_at: null });
+    writeJson(mailboxPath, mailbox);
+    process.stdout.write(JSON.stringify({ event: 'MailboxMessageCreated', message_id: command.message_id, from_worker: command.from_worker, to_worker: command.to_worker }) + '\\n');
+    process.exit(0);
+  case 'MarkMailboxNotified': {
+    const record = mailbox.records.find((entry) => entry.message_id === command.message_id);
+    if (record) {
+      record.notified_at = timestamp;
+      writeJson(mailboxPath, mailbox);
+    }
+    process.stdout.write(JSON.stringify({ event: 'MailboxNotified', message_id: command.message_id }) + '\\n');
+    process.exit(0);
+  }
+  default:
+    process.stdout.write(JSON.stringify({ event: 'ok' }) + '\\n');
+    process.exit(0);
+}
+`,
+  );
+  await chmod(runtimePath, 0o755);
+}
+
 describe('notify-hook team dispatch consumer', () => {
   const originalTeamWorker = process.env.OMX_TEAM_WORKER;
   const originalTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
@@ -297,6 +371,56 @@ exit 1
       else delete process.env.PATH;
       if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
       else delete process.env.OMX_RUNTIME_BINARY;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('marks bridge-authored mailbox state as notified on canonical hook success paths', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const runtimePath = join(fakeBinDir, 'omx-runtime');
+    const previousPath = process.env.PATH;
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCompatRuntimeFixture(runtimePath);
+      process.env.PATH = `${fakeBinDir}:${previousPath || ''}`;
+      process.env.OMX_RUNTIME_BINARY = runtimePath;
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      const msg = await sendDirectMessage('alpha', 'worker-1', 'worker-1', 'hello', cwd);
+      const queued = await enqueueDispatchRequest('alpha', {
+        kind: 'mailbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        message_id: msg.message_id,
+        trigger_message: 'check mailbox',
+      }, cwd);
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => ({ ok: true, reason: 'injected_for_test' }),
+      });
+
+      assert.equal(result.processed, 1);
+      const request = await readDispatchRequest('alpha', queued.request.request_id, cwd);
+      assert.equal(request?.status, 'notified');
+
+      const mailbox = await listMailboxMessages('alpha', 'worker-1', cwd);
+      assert.equal(mailbox.length, 1);
+      assert.ok(mailbox[0]?.notified_at, 'expected canonical bridge mailbox record to gain notified_at');
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -676,9 +676,11 @@ export async function drainPendingTeamDispatch({
           request.notified_at = nowIso;
           request.last_reason = result.reason;
           runtimeExec({ command: 'MarkNotified', request_id: request.request_id, channel: 'tmux' }, stateDir);
-          if (usingLegacyRequests && request.kind === 'mailbox' && request.message_id) {
+          if (request.kind === 'mailbox' && request.message_id) {
             runtimeExec({ command: 'MarkMailboxNotified', message_id: request.message_id }, stateDir);
-            await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(() => {});
+            if (usingLegacyRequests) {
+              await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(() => {});
+            }
           }
           processed += 1;
           mutated = true;


### PR DESCRIPTION
## Summary
- retest issue #1108 / PR #1126 seam-gap claims on current `dev`
- add a notify-hook regression that reproduces the canonical bridge mailbox lane
- always forward `MarkMailboxNotified` on mailbox hook success paths while keeping legacy mailbox JSON writes fallback-only

## Why
PR #1126 claimed the Rust bridge was the canonical dispatch/mailbox writer, but `src/scripts/notify-hook/team-dispatch.ts` still gated `MarkMailboxNotified` behind `usingLegacyRequests`. On bridge-backed mailbox dispatches, the dispatch request became notified while the canonical bridge mailbox record stayed stale.

## Evidence
- reproduced with new test: `marks bridge-authored mailbox state as notified on canonical hook success paths`
- before fix: the new test failed because `mailbox[0].notified_at` stayed unset on the bridge compat surface
- after fix: targeted hook/state/compat suites pass

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/team/__tests__/state.test.js dist/compat/__tests__/rust-runtime-compat.test.js`

## Remaining note
I explicitly re-challenged whether the narrow fix is sufficient. It closes the reproduced #1126 seam in the hook success path. A broader mailbox-scoping concern still exists separately: bridge mailbox records are not team-keyed and `readMailbox(...)` filters only by `to_worker`, so multi-team shared state roots still deserve a follow-up audit.
