### PR TITLE
fix: restore intrinsic notifications for project-scope sessions

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -22,6 +22,20 @@ export OMX_OPENCLAW_COMMAND=1
 export OMX_OPENCLAW_COMMAND_TIMEOUT_MS=120000
 ```
 
+## Actual intrinsic trigger model
+
+As of April 2, 2026, OMX intrinsically emits these notification events:
+
+- `session-start` — at `omx` session launch
+- `session-idle` — after completed turns when the idle cooldown allows it
+- `session-end` — when the `omx` session exits
+
+Important caveats:
+
+- `ask-user-question` and `stop`/`session-stop` are part of the config/template schema, but they are **not currently emitted automatically** by the core runtime.
+- `ask-user-question` therefore requires either a future runtime emitter or a custom/derived hook path.
+- Notification config is resolved from `${CODEX_HOME:-$HOME/.codex}/.omx-config.json`, so project-scope setups use `./.codex/.omx-config.json` during `omx` launches.
+
 ## Prompt tuning guide (concise + context-aware)
 
 For OpenClaw integrations, the most important quality lever is the hook
@@ -111,7 +125,7 @@ Use this profile when you want detailed but quickly scannable notifications:
 ### Quick update command (jq)
 
 ```bash
-CONFIG_FILE="$HOME/.codex/.omx-config.json"
+CONFIG_FILE="${CODEX_HOME:-$HOME/.codex}/.omx-config.json"
 
 jq '.notifications.verbosity = "verbose" |
     .notifications.openclaw.hooks["session-start"].instruction = "[session-start|exec]\\nproject={{projectName}} session={{sessionId}} tmux={{tmuxSession}}\\n요약: 시작 맥락 1문장\\n우선순위: 지금 할 일 1~2개\\n주의사항: 리스크/의존성(없으면 없음)" |

--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -29,12 +29,23 @@ Unified and only entry point for notification setup.
 - **Native integrations (first-class):** Discord, Telegram, Slack
 - **Generic extensibility integrations:** `custom_webhook_command`, `custom_cli_command`
 
+Current intrinsic runtime events:
+- `session-start`
+- `session-idle`
+- `session-end`
+
+Schema-only for now (not intrinsically emitted by core runtime):
+- `ask-user-question`
+- `stop` / `session-stop`
+
+Use `${CODEX_HOME:-$HOME/.codex}/.omx-config.json` as the effective config path so project-scope setups resolve correctly.
+
 > Standalone configure skills (`configure-discord`, `configure-telegram`, `configure-slack`, `configure-openclaw`) are removed.
 
 ## Step 1: Inspect Current State
 
 ```bash
-CONFIG_FILE="$HOME/.codex/.omx-config.json"
+CONFIG_FILE="${CODEX_HOME:-$HOME/.codex}/.omx-config.json"
 
 if [ -f "$CONFIG_FILE" ]; then
   jq -r '

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -33,6 +33,7 @@ import {
   resolveNotifyTempContract,
   buildNotifyTempStartupMessages,
   buildNotifyFallbackWatcherEnv,
+  runWithCodexHomeOverride,
   resolveNotifyFallbackWatcherScript,
   resolveHookDerivedWatcherScript,
   resolveNotifyHookScript,
@@ -251,6 +252,36 @@ describe("watcher script path resolution", () => {
       resolveNotifyHookScript("/pkg"),
       "/pkg/dist/scripts/notify-hook.js",
     );
+  });
+});
+
+describe("runWithCodexHomeOverride", () => {
+  it("temporarily applies CODEX_HOME and restores the previous value", async () => {
+    const previous = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = "/tmp/original-codex-home";
+
+    try {
+      const seen = await runWithCodexHomeOverride("/tmp/override-codex-home", async () => process.env.CODEX_HOME);
+      assert.equal(seen, "/tmp/override-codex-home");
+      assert.equal(process.env.CODEX_HOME, "/tmp/original-codex-home");
+    } finally {
+      if (typeof previous === "string") process.env.CODEX_HOME = previous;
+      else delete process.env.CODEX_HOME;
+    }
+  });
+
+  it("removes CODEX_HOME after the callback when no previous value existed", async () => {
+    const previous = process.env.CODEX_HOME;
+    delete process.env.CODEX_HOME;
+
+    try {
+      const seen = await runWithCodexHomeOverride("/tmp/project-codex-home", async () => process.env.CODEX_HOME);
+      assert.equal(seen, "/tmp/project-codex-home");
+      assert.equal(process.env.CODEX_HOME, undefined);
+    } finally {
+      if (typeof previous === "string") process.env.CODEX_HOME = previous;
+      else delete process.env.CODEX_HOME;
+    }
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1580,6 +1580,29 @@ export function buildNotifyFallbackWatcherEnv(
   };
 }
 
+export async function runWithCodexHomeOverride<T>(
+  codexHomeOverride: string | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!codexHomeOverride) {
+    return await fn();
+  }
+
+  const hadCodeHome = Object.prototype.hasOwnProperty.call(process.env, "CODEX_HOME");
+  const previousCodeHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHomeOverride;
+
+  try {
+    return await fn();
+  } finally {
+    if (hadCodeHome) {
+      process.env.CODEX_HOME = previousCodeHome;
+    } else {
+      delete process.env.CODEX_HOME;
+    }
+  }
+}
+
 /**
  * preLaunch: Prepare environment before Codex starts.
  * 1. Generate runtime overlay + write session-scoped model instructions file
@@ -1652,11 +1675,13 @@ ${launchAppendix}`
     } else {
       delete process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV];
     }
-    const { notifyLifecycle } = await import("../notifications/index.js");
-    await notifyLifecycle("session-start", {
-      sessionId,
-      projectPath: cwd,
-      projectName: basename(cwd),
+    await runWithCodexHomeOverride(codexHomeOverride, async () => {
+      const { notifyLifecycle } = await import("../notifications/index.js");
+      await notifyLifecycle("session-start", {
+        sessionId,
+        projectPath: cwd,
+        projectName: basename(cwd),
+      });
     });
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
@@ -2159,16 +2184,18 @@ async function postLaunch(
 
   // 4. Send session-end lifecycle notification (best effort)
   try {
-    const { notifyLifecycle } = await import("../notifications/index.js");
     const durationMs = sessionStartedAt
       ? Date.now() - new Date(sessionStartedAt).getTime()
       : undefined;
-    await notifyLifecycle("session-end", {
-      sessionId,
-      projectPath: cwd,
-      projectName: basename(cwd),
-      durationMs,
-      reason: "session_exit",
+    await runWithCodexHomeOverride(codexHomeOverride, async () => {
+      const { notifyLifecycle } = await import("../notifications/index.js");
+      await notifyLifecycle("session-end", {
+        sessionId,
+        projectPath: cwd,
+        projectName: basename(cwd),
+        durationMs,
+        reason: "session_exit",
+      });
     });
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);


### PR DESCRIPTION
## Summary
- restore intrinsic lifecycle notifications for project-scope OMX sessions by dispatching under the resolved CODEX_HOME override
- add regression coverage for temporary CODEX_HOME override application/restoration
- clarify the actual intrinsic notification trigger model in the OpenClaw guide and notification setup skill

## Root cause
Intrinsic session-start/session-end notifications read notification config via CODEX_HOME, but the launch/exit paths were not applying the resolved project-scope CODEX_HOME override. That let project-scope sessions fall back to ~/.codex/.omx-config.json even when manual Telegram transport tests succeeded.

## Testing
- npm run build
- node --test dist/cli/__tests__/index.test.js dist/notifications/__tests__/verbosity.test.js
- npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts