### PR TITLE
fix: ignore non-agent panes when resolving managed TMUX_PANE

### DIFF
--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -657,7 +657,7 @@ exit 0
     });
   });
 
-  it('injects into the managed current pane when the wrapper shell pane remains the canonical target', async () => {
+  it('falls back to the sibling codex pane when TMUX_PANE is a managed non-agent shell pane', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
       const stateDir = join(omxDir, 'state');
@@ -752,7 +752,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p #S/);
       assert.ok(tmuxLog.includes('display-message -p -t %99 #S'), 'should inspect the anchored shell pane before upgrading');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.match(tmuxLog, /send-keys -t %100 -l yes, proceed \[OMX_TMUX_INJECT\]/);
     });
   });
 

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -227,11 +227,34 @@ export async function verifyManagedPaneTarget(paneId: string, cwd: string, paylo
   }
 }
 
+
+async function readManagedPaneCommandState(paneTarget: string): Promise<{ currentCommand: string; startCommand: string }> {
+  try {
+    const [currentResult, startResult] = await Promise.all([
+      runProcess('tmux', ['display-message', '-p', '-t', paneTarget, '#{pane_current_command}'], 2000),
+      runProcess('tmux', ['display-message', '-p', '-t', paneTarget, '#{pane_start_command}'], 2000),
+    ]);
+    return {
+      currentCommand: safeString(currentResult.stdout).trim().toLowerCase(),
+      startCommand: safeString(startResult.stdout).trim().toLowerCase(),
+    };
+  } catch {
+    return { currentCommand: '', startCommand: '' };
+  }
+}
+
+function paneLooksLikeManagedAgent({ currentCommand, startCommand }: { currentCommand: string; startCommand: string }): boolean {
+  if (/omx.*hud.*--watch/i.test(startCommand)) return false;
+  if (startCommand.includes('codex')) return true;
+  return currentCommand === 'codex' || currentCommand === 'node' || currentCommand === 'npx';
+}
 export async function resolveManagedCurrentPane(cwd: string, payload: any, { allowTeamWorker = false } = {}): Promise<string> {
   const paneTarget = safeString(process.env.TMUX_PANE || '').trim();
   if (!paneTarget) return '';
   const verdict = await verifyManagedPaneTarget(paneTarget, cwd, payload, { allowTeamWorker });
-  return verdict.ok ? paneTarget : '';
+  if (!verdict.ok) return '';
+  const commandState = await readManagedPaneCommandState(paneTarget);
+  return paneLooksLikeManagedAgent(commandState) ? paneTarget : '';
 }
 
 export async function resolveManagedSessionPane(cwd: string, payload: any): Promise<string> {


### PR DESCRIPTION
## Summary
- skip HUD/non-agent TMUX_PANE targets before accepting managed current panes
- fall back to sibling managed Codex panes when the hook runs from a managed shell/HUD pane
- align notify-hook regression fixtures with managed tmux session ownership expectations

## Why
Managed-session validation should not lock routing onto the current pane when that pane is not the actual agent pane. This caused managed HUD/shell panes to short-circuit sibling resolution and misroute notify-hook sends.

## Validation
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js`
- `npm test`

## Result
- full local suite green
- 2781 tests passed, 0 failed
