### PR TITLE
docs: rewrite Vietnamese README to match current English structure and use natural language

### DIFF
--- a/README.vi.md
+++ b/README.vi.md
@@ -3,7 +3,7 @@
 <p align="center">
   <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
   <br>
-  <em>Codex của bạn không đơn độc.</em>
+  <em>Dùng Codex hiệu quả hơn — OMX lo phần prompt, workflow và runtime khi dự án phức tạp dần.</em>
 </p>
 
 [![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
@@ -11,253 +11,212 @@
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 [![Discord](https://img.shields.io/discord/1452487457085063218?color=5865F2&logo=discord&logoColor=white&label=Discord)](https://discord.gg/PUwSMR9XNk)
 
-> **[Website](https://yeachan-heo.github.io/oh-my-codex-website/)** | **[Documentation](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** | **[CLI Reference](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** | **[Workflows](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** | **[Hướng dẫn tích hợp OpenClaw](./docs/openclaw-integration.vi.md)** | **[GitHub](https://github.com/Yeachan-Heo/oh-my-codex)** | **[npm](https://www.npmjs.com/package/oh-my-codex)**
+**Website:** https://yeachan-heo.github.io/oh-my-codex-website/  
+**Tài liệu:** [Bắt đầu](./docs/getting-started.html) · [Agent](./docs/agents.html) · [Skill](./docs/skills.html) · [Tích hợp](./docs/integrations.html) · [Demo](./DEMO.md) · [Hướng dẫn OpenClaw](./docs/openclaw-integration.md)
 
-Lớp điều phối đa tác nhân cho [OpenAI Codex CLI](https://github.com/openai/codex).
+OMX là lớp workflow mở rộng cho [OpenAI Codex CLI](https://github.com/openai/codex).
 
-## Điểm mới trong v0.9.0 — Spark Initiative
+Codex vẫn là engine chính, OMX giúp bạn:
+- cấu hình Codex tốt hơn ngay từ phiên đầu tiên
+- chạy workflow nhất quán từ làm rõ yêu cầu đến hoàn thành
+- gọi các skill chính bằng `$deep-interview`, `$ralplan`, `$team` và `$ralph`
+- lưu trữ hướng dẫn dự án, kế hoạch, log và trạng thái trong `.omx/`
 
-Spark Initiative là bản phát hành tăng cường đường đi native cho khám phá và kiểm tra trong OMX.
+## Workflow mặc định
 
-- **Native harness cho `omx explore`** — chạy khám phá kho mã chỉ đọc nhanh hơn và chặt chẽ hơn bằng harness Rust.
-- **`omx sparkshell`** — bề mặt kiểm tra native cho operator, hỗ trợ tóm tắt đầu ra dài và chụp tmux pane.
-- **Tài sản phát hành native đa nền tảng** — đường hydration cho `omx-explore-harness`, `omx-sparkshell` và `native-release-manifest.json` nay đã nằm trong pipeline phát hành.
-- **CI/CD được tăng cường** — thêm thiết lập Rust toolchain tường minh cho `build` job cùng với `cargo fmt --check` và `cargo clippy -- -D warnings`.
+Nếu bạn muốn trải nghiệm OMX nhanh nhất, bắt đầu từ đây:
 
-Xem thêm tại [ghi chú phát hành v0.9.0](./docs/release-notes-0.9.0.md) và [release body](./docs/release-body-0.9.0.md).
+```bash
+npm install -g @openai/codex oh-my-codex
+omx setup
+omx --madmax --high
+```
 
-## Phiên đầu tiên
-
-Trong Codex:
+Sau đó làm việc bình thường trong Codex:
 
 ```text
-$deep-interview "clarify the auth change"
+$deep-interview "clarify the authentication change"
 $ralplan "approve the auth plan and review tradeoffs"
 $ralph "carry the approved plan to completion"
 $team 3:executor "execute the approved plan in parallel"
 ```
 
-Từ terminal:
+Đó là flow chính.
+Khởi động OMX, làm rõ yêu cầu khi cần, duyệt kế hoạch, rồi chọn `$team` để chạy song song hoặc `$ralph` để một agent lo đến khi xong.
+
+## OMX dùng để làm gì
+
+Dùng OMX nếu bạn đã quen Codex và muốn trải nghiệm tốt hơn:
+- workflow chuẩn xoay quanh `$deep-interview`, `$ralplan`, `$team` và `$ralph`
+- các role chuyên biệt và skill hỗ trợ cho từng loại task
+- hướng dẫn dự án qua `AGENTS.md` theo scope
+- lưu trạng thái lâu dài trong `.omx/` — kế hoạch, log, memory và theo dõi mode
+
+Nếu bạn chỉ muốn dùng Codex thuần mà không cần thêm workflow, thì có lẽ không cần OMX.
+
+## Bắt đầu nhanh
+
+### Yêu cầu
+
+- Node.js 20+
+- Codex CLI đã cài: `npm install -g @openai/codex`
+- Codex đã xác thực (auth)
+- `tmux` trên macOS/Linux nếu muốn dùng team runtime
+- `psmux` trên Windows nếu muốn dùng team mode
+
+### Phiên đầu tiên
+
+Khởi chạy OMX:
 
 ```bash
-omx team 4:executor "parallelize a multi-module refactor"
-omx team status <team-name>
-omx team shutdown <team-name>
+omx --madmax --high
 ```
 
-## Quy trình được khuyến nghị
-
-1. `$deep-interview` — khi phạm vi hoặc ranh giới vẫn chưa rõ.
-2. `$ralplan` — để biến phạm vi đã làm rõ thành kế hoạch kiến trúc và triển khai đã được chốt.
-3. `$team` hoặc `$ralph` — dùng `$team` cho thực thi song song có phối hợp, hoặc `$ralph` cho vòng lặp bền bỉ để hoàn tất/xác minh với một chủ sở hữu duy nhất.
-
-## Mô hình cốt lõi
-
-OMX cài đặt và kết nối các lớp sau:
+Rồi thử workflow chính:
 
 ```text
-User
-  -> Codex CLI
-    -> AGENTS.md (bộ não điều phối)
-    -> ~/.codex/prompts/*.md (danh mục prompt tác nhân)
-    -> ~/.codex/skills/*/SKILL.md (danh mục skill)
-    -> ~/.codex/config.toml (tính năng, thông báo, MCP)
-    -> .omx/ (trạng thái runtime, bộ nhớ, kế hoạch, nhật ký)
+$deep-interview "clarify the authentication change"
+$ralplan "approve the safest implementation path"
+$ralph "carry the approved plan to completion"
+$team 3:executor "execute the approved plan in parallel"
 ```
 
-## Các lệnh chính
+Dùng `$team` khi cần nhiều worker chạy song song, hoặc `$ralph` khi muốn một agent lo từ đầu đến cuối.
+
+## Mô hình đơn giản
+
+OMX **không** thay thế Codex.
+
+OMX bổ sung một lớp hỗ trợ phía trên Codex:
+- **Codex** vẫn làm toàn bộ việc thực thi
+- **Role của OMX** giúp gọi nhanh các vai trò chuyên biệt
+- **Skill của OMX** đóng gói các workflow phổ biến thành lệnh
+- **`.omx/`** lưu kế hoạch, log, memory và trạng thái runtime
+
+Nói đơn giản: OMX giúp **phân task đúng chỗ + workflow rõ ràng + runtime ổn định hơn** — không phải một bảng điều khiển để gõ lệnh cả ngày.
+
+## Hướng dẫn cho người mới
+
+1. Chạy `omx setup`
+2. Khởi động với `omx --madmax --high`
+3. Dùng `$deep-interview "..."` khi yêu cầu còn mơ hồ
+4. Dùng `$ralplan "..."` để duyệt kế hoạch và cân nhắc trade-off
+5. Chọn `$team` để chạy song song hoặc `$ralph` để một agent lo đến khi xong
+
+## Workflow khuyến nghị
+
+1. `$deep-interview` — làm rõ scope khi yêu cầu còn mơ hồ.
+2. `$ralplan` — chuyển scope đã rõ thành kế hoạch triển khai được duyệt.
+3. `$team` hoặc `$ralph` — dùng `$team` khi cần nhiều worker song song, hoặc `$ralph` khi muốn một agent chạy liên tục đến khi xong.
+
+## Các lệnh thường dùng trong phiên
+
+| Lệnh | Dùng khi |
+| --- | --- |
+| `$deep-interview "..."` | Làm rõ ý định, scope và non-goal |
+| `$ralplan "..."` | Duyệt kế hoạch triển khai và trade-off |
+| `$ralph "..."` | Chạy liên tục đến khi hoàn thành và verify |
+| `$team "..."` | Chạy song song khi task đủ lớn |
+| `/skills` | Xem danh sách skill và helper đã cài |
+
+## Nâng cao
+
+Các phần dưới đây hữu ích nhưng không phải là bước bắt đầu chính.
+
+### Team runtime
+
+Dùng team runtime khi cần phối hợp nhiều worker qua tmux/worktree — đây không phải bước bắt đầu mặc định.
 
 ```bash
-omx                # Khởi chạy Codex (+ HUD trong tmux khi có sẵn)
-omx setup          # Cài đặt prompt/skill/config theo phạm vi + .omx của dự án + AGENTS.md theo phạm vi
-omx doctor         # Chẩn đoán cài đặt/runtime
-omx doctor --team  # Chẩn đoán Team/swarm
-omx team ...       # Khởi động/trạng thái/tiếp tục/tắt worker tmux của đội
-omx status         # Hiển thị các chế độ đang hoạt động
-omx cancel         # Hủy các chế độ thực thi đang hoạt động
-omx reasoning <mode> # low|medium|high|xhigh
-omx tmux-hook ...  # init|status|validate|test
-omx hooks ...      # init|status|validate|test (quy trình mở rộng plugin)
-omx hud ...        # --watch|--json|--preset
-omx help
-```
-
-## Mở rộng Hooks (Bề mặt bổ sung)
-
-OMX hiện bao gồm `omx hooks` cho scaffolding và xác thực plugin.
-
-- `omx tmux-hook` vẫn được hỗ trợ và không thay đổi.
-- `omx hooks` là bổ sung và không thay thế quy trình tmux-hook.
-- Tệp plugin nằm tại `.omx/hooks/*.mjs`.
-- Plugin tắt theo mặc định; kích hoạt bằng `OMX_HOOK_PLUGINS=1`.
-
-Xem `docs/hooks-extension.md` cho quy trình mở rộng đầy đủ và mô hình sự kiện.
-
-## Cờ khởi chạy
-
-```bash
---yolo
---high
---xhigh
---madmax
---force
---dry-run
---verbose
---scope <user|project>  # chỉ dành cho setup
-```
-
-`--madmax` ánh xạ đến Codex `--dangerously-bypass-approvals-and-sandbox`.
-Chỉ sử dụng trong môi trường sandbox tin cậy hoặc bên ngoài.
-
-### Chính sách workingDirectory MCP (tăng cường tùy chọn)
-
-Theo mặc định, các công cụ MCP state/memory/trace chấp nhận `workingDirectory` do người gọi cung cấp.
-Để hạn chế điều này, đặt danh sách gốc được phép:
-
-```bash
-export OMX_MCP_WORKDIR_ROOTS="/path/to/project:/path/to/another-root"
-```
-
-Khi được đặt, các giá trị `workingDirectory` ngoài các gốc này sẽ bị từ chối.
-
-## Kiểm soát Prompt Codex-First
-
-Theo mặc định, OMX tiêm:
-
-```text
--c model_instructions_file="<cwd>/AGENTS.md"
-```
-
-Điều này kết hợp `AGENTS.md` trong `CODEX_HOME` với `AGENTS.md` của dự án (nếu có), rồi thêm lớp phủ runtime.
-Mở rộng hành vi Codex, nhưng không thay thế/bỏ qua các chính sách hệ thống cốt lõi của Codex.
-
-Điều khiển:
-
-```bash
-OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx     # tắt tiêm AGENTS.md
-OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx
-```
-
-## Chế độ đội
-
-Sử dụng chế độ đội cho công việc lớn được hưởng lợi từ worker song song.
-
-Vòng đời:
-
-```text
-start -> assign scoped lanes -> monitor -> verify terminal tasks -> shutdown
-```
-
-Các lệnh vận hành:
-
-```bash
-omx team <args>
+omx team 3:executor "fix the failing tests with verification"
 omx team status <team-name>
 omx team resume <team-name>
 omx team shutdown <team-name>
 ```
 
-Quy tắc quan trọng: không tắt khi các tác vụ vẫn đang ở trạng thái `in_progress` trừ khi đang hủy bỏ.
+### Setup, doctor và HUD
 
-### Team shutdown policy
+Đây là các công cụ vận hành/hỗ trợ:
+- `omx setup` cài prompt, skill, config và scaffold AGENTS
+- `omx doctor` kiểm tra cài đặt khi có vấn đề
+- `omx hud --watch` theo dõi trạng thái, không phải workflow chính
 
-Use `omx team shutdown <team-name>` after the team reaches a terminal state.
-Team cleanup now follows one standalone path; legacy linked-Ralph shutdown handling is no longer a separate public workflow.
+### Explore và sparkshell
 
-Chọn Worker CLI cho worker của đội:
-
-```bash
-OMX_TEAM_WORKER_CLI=auto    # mặc định; sử dụng claude khi worker --model chứa "claude"
-OMX_TEAM_WORKER_CLI=codex   # ép buộc worker Codex CLI
-OMX_TEAM_WORKER_CLI=claude  # ép buộc worker Claude CLI
-OMX_TEAM_WORKER_CLI_MAP=codex,codex,claude,claude  # hỗn hợp CLI theo worker (độ dài=1 hoặc số worker)
-OMX_TEAM_AUTO_INTERRUPT_RETRY=0  # tùy chọn: tắt fallback thích ứng queue->resend
-```
-
-Lưu ý:
-- Tham số khởi chạy worker vẫn được chia sẻ qua `OMX_TEAM_WORKER_LAUNCH_ARGS`.
-- `OMX_TEAM_WORKER_CLI_MAP` ghi đè `OMX_TEAM_WORKER_CLI` cho lựa chọn theo worker.
-- Gửi trigger sử dụng thử lại thích ứng theo mặc định (queue/submit, sau đó fallback an toàn clear-line+resend khi cần).
-- Trong chế độ Claude worker, OMX khởi chạy worker dưới dạng `claude` thuần túy (không có tham số khởi chạy thêm) và bỏ qua các ghi đè rõ ràng `--model` / `--config` / `--effort` để Claude sử dụng `settings.json` mặc định.
-
-## `omx setup` ghi những gì
-
-- `.omx/setup-scope.json` (phạm vi cài đặt được lưu trữ)
-- Cài đặt phụ thuộc phạm vi:
-  - `user`: `~/.codex/prompts/`, `~/.codex/skills/`, `~/.codex/config.toml`, `~/.omx/agents/`, `~/.codex/AGENTS.md`
-  - `project`: `./.codex/prompts/`, `./.codex/skills/`, `./.codex/config.toml`, `./.omx/agents/`, `./AGENTS.md`
-- Hành vi khởi chạy: nếu phạm vi được lưu trữ là `project`, khởi chạy `omx` tự động sử dụng `CODEX_HOME=./.codex` (trừ khi `CODEX_HOME` đã được đặt).
-- Hướng dẫn khởi chạy sẽ kết hợp `~/.codex/AGENTS.md` (hoặc `CODEX_HOME/AGENTS.md` nếu đã ghi đè) với `./AGENTS.md` của dự án, rồi thêm lớp phủ runtime.
-- Các tệp `AGENTS.md` hiện có sẽ không bao giờ bị ghi đè âm thầm: ở TTY tương tác, setup hỏi trước khi thay thế; ở chế độ không tương tác, việc thay thế sẽ bị bỏ qua trừ khi dùng `--force` (kiểm tra an toàn phiên hoạt động vẫn áp dụng).
-- Cập nhật `config.toml` (cho cả hai phạm vi):
-  - `notify = ["node", "..."]`
-  - `model_reasoning_effort = "high"`
-  - `developer_instructions = "..."`
-  - `[features] multi_agent = true, child_agents_md = true`
-  - Mục máy chủ MCP (`omx_state`, `omx_memory`, `omx_code_intel`, `omx_trace`)
-  - `[tui] status_line`
-- `AGENTS.md` theo phạm vi
-- Thư mục `.omx/` runtime và cấu hình HUD
-
-## Tác nhân và skill
-
-- Prompt: `prompts/*.md` (cài vào `~/.codex/prompts/` cho `user`, `./.codex/prompts/` cho `project`)
-- Skill: `skills/*/SKILL.md` (cài vào `~/.codex/skills/` cho `user`, `./.codex/skills/` cho `project`)
+- `omx explore --prompt "..."` tìm kiếm chỉ đọc trong repository
+- `omx sparkshell <command>` chạy lệnh shell có kiểm soát output
 
 Ví dụ:
-- Tác nhân: `architect`, `planner`, `executor`, `debugger`, `verifier`, `security-reviewer`
-- Skill: `deep-interview`, `ralplan`, `team`, `ralph`, `plan`, `cancel`
-
-## Cấu trúc dự án
-
-```text
-oh-my-codex/
-  bin/omx.js
-  src/
-    cli/
-    team/
-    mcp/
-    hooks/
-    hud/
-    config/
-    modes/
-    notifications/
-    verification/
-  prompts/
-  skills/
-  templates/
-  scripts/
-```
-
-## Phát triển
 
 ```bash
-git clone https://github.com/Yeachan-Heo/oh-my-codex.git
-cd oh-my-codex
-npm install
-npm run build
-npm test
+omx explore --prompt "find where team state is written"
+omx sparkshell git status
+omx sparkshell --tmux-pane %12 --tail-lines 400
 ```
+
+### Cài tmux theo nền tảng
+
+`omx team` cần backend tương thích tmux:
+
+| Nền tảng | Cài đặt |
+| --- | --- |
+| macOS | `brew install tmux` |
+| Ubuntu/Debian | `sudo apt install tmux` |
+| Fedora | `sudo dnf install tmux` |
+| Arch | `sudo pacman -S tmux` |
+| Windows | `winget install psmux` |
+| Windows (WSL2) | `sudo apt install tmux` |
+
+## Vấn đề đã biết
+
+### Intel Mac: CPU `syspolicyd` / `trustd` cao khi khởi động
+
+Trên một số máy Intel Mac, khi khởi động OMX — đặc biệt với `--madmax --high` — CPU có thể tăng đột biến do macOS Gatekeeper xác thực nhiều tiến trình đồng thời.
+
+Nếu gặp tình trạng này, thử:
+- `xattr -dr com.apple.quarantine $(which omx)`
+- Thêm ứng dụng terminal vào danh sách Developer Tools trong cài đặt Security của macOS
+- Dùng cấu hình nhẹ hơn (bỏ `--madmax --high`)
 
 ## Tài liệu
 
-- **[Tài liệu đầy đủ](https://yeachan-heo.github.io/oh-my-codex-website/docs.html)** — Hướng dẫn hoàn chỉnh
-- **[Tham chiếu CLI](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#cli-reference)** — Tất cả lệnh `omx`, cờ và công cụ
-- **[Hướng dẫn thông báo](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#notifications)** — Cài đặt Discord, Telegram, Slack và webhook
-- **[Quy trình công việc khuyến nghị](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#workflows)** — Chuỗi skill đã thử nghiệm thực chiến cho các tác vụ phổ biến
-- **[Ghi chú phát hành](https://yeachan-heo.github.io/oh-my-codex-website/docs.html#release-notes)** — Tính năng mới trong mỗi phiên bản
+- [Bắt đầu](./docs/getting-started.html)
+- [Hướng dẫn demo](./DEMO.md)
+- [Danh mục agent](./docs/agents.html)
+- [Tham chiếu skill](./docs/skills.html)
+- [Tích hợp](./docs/integrations.html)
+- [Hướng dẫn OpenClaw / notification gateway](./docs/openclaw-integration.md)
+- [Đóng góp](./CONTRIBUTING.md)
+- [Nhật ký thay đổi](./CHANGELOG.md)
 
-## Ghi chú
+## Ngôn ngữ
 
-- Nhật ký thay đổi đầy đủ: `CHANGELOG.md`
-- Hướng dẫn di chuyển (sau v0.4.4 mainline): `docs/migration-mainline-post-v0.4.4.md`
-- Ghi chú về độ bao phủ và tương đương: `COVERAGE.md`
-- Quy trình mở rộng hook: `docs/hooks-extension.md`
-- Chi tiết cài đặt và đóng góp: `CONTRIBUTING.md`
+- [English](./README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
 
-## Lời cảm ơn
+## Đóng góp
 
-Lấy cảm hứng từ [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), được điều chỉnh cho Codex CLI.
+| Vai trò | Tên | GitHub |
+| --- | --- | --- |
+| Tác giả & Lead | Yeachan Heo | [@Yeachan-Heo](https://github.com/Yeachan-Heo) |
+| Maintainer | HaD0Yun | [@HaD0Yun](https://github.com/HaD0Yun) |
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
 
 ## Giấy phép
 


### PR DESCRIPTION
## Summary

Rewrite `README.vi.md` to:
- Match the current English README structure and content
- Use natural Vietnamese as spoken by Vietnamese developers
- Keep technical terms that are universally used in English (skill, agent, runtime, scope, trade-off...)