### PR TITLE
fix: honor tmux-hook disable for auto-nudge injection

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -734,6 +734,58 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('respects `.omx/tmux-hook.json` enabled:false for fallback auto-nudge', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-auto-nudge-disabled-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const codexHome = join(wd, 'codex-home');
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        autoNudge: { enabled: true, delaySec: 0, ttlMs: 30_000 },
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'tmux-hook.json'), JSON.stringify({
+        enabled: false,
+        target: { type: 'pane', value: '%42' },
+      }, null, 2));
+      await writeSessionStart(wd, 'sess-managed-fallback');
+      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+        last_turn_at: new Date(Date.now() - 6_000).toISOString(),
+        turn_count: 7,
+        last_agent_output: 'If you want, I can keep going from here.',
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            CODEX_HOME: codexHome,
+            OMX_SESSION_ID: 'sess-managed-fallback',
+            TMUX: '1',
+            TMUX_PANE: '%42',
+            OMX_NOTIFY_FALLBACK_AUTO_NUDGE_STALL_MS: '5000',
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('suppresses fallback unmanaged-session auto-nudge skip logs while idle', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-auto-nudge-unmanaged-'));
     const fakeBinDir = join(wd, 'fake-bin');

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -259,6 +259,42 @@ describe('notify-hook auto-nudge', () => {
     });
   });
 
+  it('respects `.omx/tmux-hook.json` enabled:false and skips auto-nudge injection', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeJson(join(omxDir, 'tmux-hook.json'), {
+        enabled: false,
+        target: { type: 'pane', value: '%99' },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'I analyzed the code. If you want me to make these changes, let me know.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+    });
+  });
+
   it('does not auto-nudge plain tmux Codex sessions that only inherit OMX session env', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -12,7 +12,7 @@ import { readJsonIfExists, getScopedStateDirsForCurrentSession, readdir } from '
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
-import { buildCapturePaneArgv, DEFAULT_MARKER } from '../tmux-hook-engine.js';
+import { buildCapturePaneArgv, DEFAULT_MARKER, tmuxHookExplicitlyDisablesInjection } from '../tmux-hook-engine.js';
 import {
   isManagedOmxSession,
   resolveManagedCurrentPane,
@@ -359,6 +359,13 @@ export async function loadAutoNudgeConfig() {
   return normalizeAutoNudgeConfig(raw.autoNudge);
 }
 
+async function localTmuxInjectionDisabled(cwd) {
+  const normalizedCwd = safeString(cwd).trim();
+  if (!normalizedCwd) return false;
+  const raw = await readJsonIfExists(join(normalizedCwd, '.omx', 'tmux-hook.json'), null);
+  return tmuxHookExplicitlyDisablesInjection(raw);
+}
+
 export function detectStallPattern(text, patterns) {
   if (!text || typeof text !== 'string') return false;
   const normalized = normalizeStallDetectionText(text);
@@ -413,6 +420,14 @@ export async function resolveNudgePaneTarget(stateDir: any, cwd = '', payload: a
 export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
   const config = await loadAutoNudgeConfig();
   if (!config.enabled) return;
+  if (await localTmuxInjectionDisabled(cwd)) {
+    await logTmuxHookEvent(logsDir, {
+      timestamp: new Date().toISOString(),
+      type: 'auto_nudge_skipped',
+      reason: 'tmux_hook_disabled',
+    }).catch(() => {});
+    return;
+  }
 
   const sourceName = safeString(payload?.source || '');
   const managedSession = await isManagedOmxSession(cwd, payload, { allowTeamWorker: true });

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -80,6 +80,10 @@ export function normalizeTmuxHookConfig(raw: any): any {
   };
 }
 
+export function tmuxHookExplicitlyDisablesInjection(raw: any): boolean {
+  return Boolean(raw && typeof raw === 'object' && raw.enabled === false);
+}
+
 export function pickActiveMode(activeModes: any, allowedModes: any): string | null {
   const activeSet = new Set((activeModes || []).filter((mode: any) => typeof mode === 'string'));
   for (const mode of allowedModes || []) {

--- a/src/types/tmux-hook-engine.d.ts
+++ b/src/types/tmux-hook-engine.d.ts
@@ -23,6 +23,7 @@ declare module '*tmux-hook-engine.js' {
   }
 
   export function normalizeTmuxHookConfig(raw: unknown): NormalizedTmuxHookConfig;
+  export function tmuxHookExplicitlyDisablesInjection(raw: unknown): boolean;
   export function pickActiveMode(activeModes: string[], allowedModes: string[]): string | null;
   export function buildDedupeKey(args: {
     threadId?: string;


### PR DESCRIPTION
## Summary

Users could set `.omx/tmux-hook.json` to `enabled: false`, but `Yes, proceed [OMX_TMUX_INJECT]` still came through via the auto-nudge path. This PR restores the expected local override by making auto-nudge and fallback auto-nudge honor an explicit local tmux-hook disable.

## Changes

- add a shared `tmuxHookExplicitlyDisablesInjection()` helper in the tmux-hook engine
- gate `maybeAutoNudge()` on explicit local `.omx/tmux-hook.json.enabled === false`
- add regression coverage for direct notify-hook auto-nudge and fallback watcher auto-nudge
- keep default behavior unchanged when `.omx/tmux-hook.json` is absent

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node --test dist/hooks/__tests__/tmux-hook-engine.test.js dist/hooks/__tests__/tmux-hook-engine-types-sync.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1167
