### PR TITLE
Fix stale detached MCP servers piling up across launches

### DIFF
--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -54,6 +54,12 @@ async function initRepo(): Promise<string> {
   return cwd;
 }
 
+async function installFakePs(fakeBin: string): Promise<void> {
+  const fakePsPath = join(fakeBin, 'ps');
+  await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n', 'utf-8');
+  execFileSync('chmod', ['+x', fakePsPath], { stdio: 'ignore' });
+}
+
 describe('normalizeAutoresearchCodexArgs', () => {
   it('adds sandbox bypass by default for autoresearch workers', () => {
     assert.deepEqual(normalizeAutoresearchCodexArgs(['--model', 'gpt-5']), ['--model', 'gpt-5', '--dangerously-bypass-approvals-and-sandbox']);
@@ -242,6 +248,7 @@ touch -t 202603180000 "$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/r
         'utf-8',
       );
       execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+      await installFakePs(fakeBin);
 
       const result = runOmx(repo, ['autoresearch', '--topic', 'Investigate flaky onboarding behavior', '--evaluator', 'node scripts/eval.js', '--slug', 'test-launch'], {
         PATH: `${fakeBin}:${process.env.PATH || ''}`,
@@ -351,6 +358,7 @@ EOF
         'utf-8',
       );
       execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+      await installFakePs(fakeBin);
 
       const fakeTmuxPath = join(fakeBin, 'tmux');
       await writeFile(
@@ -459,6 +467,7 @@ perl -0pi -e "s/HEAD_PLACEHOLDER/$head_commit/g" "$candidate_file"
         'utf-8',
       );
       execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+      await installFakePs(fakeBin);
 
       const fakeTmuxPath = join(fakeBin, 'tmux');
       await writeFile(
@@ -564,6 +573,7 @@ perl -0pi -e "s/HEAD_PLACEHOLDER/$head_commit/g" "$candidate_file"
         'utf-8',
       );
       execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+      await installFakePs(fakeBin);
 
       const fakeTmuxPath = join(fakeBin, 'tmux');
       await writeFile(
@@ -761,6 +771,7 @@ printf '{\\n  "status": "abort",\\n  "candidate_commit": null,\\n  "base_commit"
         'utf-8',
       );
       execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+      await installFakePs(fakeBin);
 
       const result = runOmx(
         repo,
@@ -814,6 +825,7 @@ EOF
         'utf-8',
       );
       execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
+      await installFakePs(fakeBin);
 
       const result = runOmx(
         repo,

--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -123,6 +123,24 @@ describe('findCleanupCandidates', () => {
       ],
     );
   });
+
+  it('keeps detached MCP candidates whose ancestor chain is live but unrelated to Codex or OMX launchers', () => {
+    const unrelatedAncestorProcesses: ProcessEntry[] = [
+      { pid: 701, ppid: 700, command: 'node /repo/bin/omx.js' },
+      { pid: 840, ppid: 841, command: 'node /tmp/unrelated/dist/mcp/state-server.js' },
+      { pid: 841, ppid: 842, command: 'node worker.js' },
+      { pid: 842, ppid: 1, command: 'bash' },
+    ];
+
+    assert.deepEqual(findLaunchSafeCleanupCandidates(unrelatedAncestorProcesses, 701), [
+      {
+        pid: 840,
+        ppid: 841,
+        command: 'node /tmp/unrelated/dist/mcp/state-server.js',
+        reason: 'outside-current-session',
+      },
+    ]);
+  });
 });
 
 describe('cleanupOmxMcpProcesses', () => {

--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -43,6 +43,16 @@ const CURRENT_SESSION_PROCESSES: ProcessEntry[] = [
     command: 'node /tmp/other-session/dist/mcp/state-server.js',
   },
   {
+    pid: 830,
+    ppid: 50,
+    command: 'node /repo/bin/omx.js autoresearch --topic launch',
+  },
+  {
+    pid: 831,
+    ppid: 830,
+    command: 'node /tmp/parallel-session/dist/mcp/memory-server.js',
+  },
+  {
     pid: 900,
     ppid: 1,
     command: 'node /tmp/not-omx/other-server.js',
@@ -78,11 +88,17 @@ describe('findCleanupCandidates', () => {
           command: 'node /tmp/other-session/dist/mcp/state-server.js',
           reason: 'outside-current-session',
         },
+        {
+          pid: 831,
+          ppid: 830,
+          command: 'node /tmp/parallel-session/dist/mcp/memory-server.js',
+          reason: 'outside-current-session',
+        },
       ],
     );
   });
 
-  it('limits launch-safe cleanup to OMX MCP processes with no live Codex ancestor', () => {
+  it('limits launch-safe cleanup to OMX MCP processes with no live Codex or OMX launch ancestor', () => {
     assert.deepEqual(
       findLaunchSafeCleanupCandidates(CURRENT_SESSION_PROCESSES, 701),
       [
@@ -124,9 +140,9 @@ describe('cleanupOmxMcpProcesses', () => {
     });
 
     assert.equal(result.dryRun, true);
-    assert.equal(result.candidates.length, 4);
+    assert.equal(result.candidates.length, 5);
     assert.equal(signalCount, 0);
-    assert.match(lines.join('\n'), /Dry run: would terminate 4 orphaned OMX MCP server process/);
+    assert.match(lines.join('\n'), /Dry run: would terminate 5 orphaned OMX MCP server process/);
     assert.match(lines.join('\n'), /PID 800/);
     assert.match(lines.join('\n'), /PID 810/);
   });
@@ -140,7 +156,7 @@ describe('cleanupOmxMcpProcesses', () => {
     const result = await cleanupOmxMcpProcesses([], {
       currentPid: 701,
       listProcesses: () => [
-        ...CURRENT_SESSION_PROCESSES.filter((processEntry) => processEntry.pid !== 811 && processEntry.pid !== 821),
+        ...CURRENT_SESSION_PROCESSES.filter((processEntry) => processEntry.pid !== 811 && processEntry.pid !== 821 && processEntry.pid !== 831),
       ],
       isPidAlive: (pid) => alive.has(pid),
       sendSignal: (pid, signal) => {
@@ -210,6 +226,7 @@ describe('cleanupOmxMcpProcesses', () => {
     ]);
     assert.match(lines.join('\n'), /Found 3 orphaned OMX MCP server process/);
     assert.doesNotMatch(lines.join('\n'), /PID 821/);
+    assert.doesNotMatch(lines.join('\n'), /PID 831/);
   });
 });
 

--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -5,6 +5,7 @@ import {
   cleanupOmxMcpProcesses,
   cleanupStaleTmpDirectories,
   findCleanupCandidates,
+  findLaunchSafeCleanupCandidates,
   type ProcessEntry,
 } from '../cleanup.js';
 
@@ -32,6 +33,16 @@ const CURRENT_SESSION_PROCESSES: ProcessEntry[] = [
     command: 'node /tmp/worktree/dist/mcp/team-server.js',
   },
   {
+    pid: 820,
+    ppid: 50,
+    command: 'codex --model gpt-5',
+  },
+  {
+    pid: 821,
+    ppid: 820,
+    command: 'node /tmp/other-session/dist/mcp/state-server.js',
+  },
+  {
     pid: 900,
     ppid: 1,
     command: 'node /tmp/not-omx/other-server.js',
@@ -42,6 +53,38 @@ describe('findCleanupCandidates', () => {
   it('selects orphaned OMX MCP processes while preserving the current session tree', () => {
     assert.deepEqual(
       findCleanupCandidates(CURRENT_SESSION_PROCESSES, 701),
+      [
+        {
+          pid: 800,
+          ppid: 1,
+          command: 'node /tmp/oh-my-codex/dist/mcp/memory-server.js',
+          reason: 'ppid=1',
+        },
+        {
+          pid: 810,
+          ppid: 42,
+          command: 'node /tmp/worktree/dist/mcp/trace-server.js',
+          reason: 'outside-current-session',
+        },
+        {
+          pid: 811,
+          ppid: 810,
+          command: 'node /tmp/worktree/dist/mcp/team-server.js',
+          reason: 'outside-current-session',
+        },
+        {
+          pid: 821,
+          ppid: 820,
+          command: 'node /tmp/other-session/dist/mcp/state-server.js',
+          reason: 'outside-current-session',
+        },
+      ],
+    );
+  });
+
+  it('limits launch-safe cleanup to OMX MCP processes with no live Codex ancestor', () => {
+    assert.deepEqual(
+      findLaunchSafeCleanupCandidates(CURRENT_SESSION_PROCESSES, 701),
       [
         {
           pid: 800,
@@ -81,9 +124,9 @@ describe('cleanupOmxMcpProcesses', () => {
     });
 
     assert.equal(result.dryRun, true);
-    assert.equal(result.candidates.length, 3);
+    assert.equal(result.candidates.length, 4);
     assert.equal(signalCount, 0);
-    assert.match(lines.join('\n'), /Dry run: would terminate 3 orphaned OMX MCP server process/);
+    assert.match(lines.join('\n'), /Dry run: would terminate 4 orphaned OMX MCP server process/);
     assert.match(lines.join('\n'), /PID 800/);
     assert.match(lines.join('\n'), /PID 810/);
   });
@@ -97,7 +140,7 @@ describe('cleanupOmxMcpProcesses', () => {
     const result = await cleanupOmxMcpProcesses([], {
       currentPid: 701,
       listProcesses: () => [
-        ...CURRENT_SESSION_PROCESSES.filter((processEntry) => processEntry.pid !== 811),
+        ...CURRENT_SESSION_PROCESSES.filter((processEntry) => processEntry.pid !== 811 && processEntry.pid !== 821),
       ],
       isPidAlive: (pid) => alive.has(pid),
       sendSignal: (pid, signal) => {
@@ -122,6 +165,51 @@ describe('cleanupOmxMcpProcesses', () => {
     ]);
     assert.match(lines.join('\n'), /Escalating to SIGKILL for 1 process/);
     assert.match(lines.join('\n'), /Killed 2 orphaned OMX MCP server process\(es\) \(1 required SIGKILL\)\./);
+  });
+
+  it('supports launch-safe candidate selection for automatic cleanup', async () => {
+    const lines: string[] = [];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+
+    const result = await cleanupOmxMcpProcesses([], {
+      currentPid: 701,
+      listProcesses: () => CURRENT_SESSION_PROCESSES,
+      selectCandidates: findLaunchSafeCleanupCandidates,
+      isPidAlive: () => false,
+      sendSignal: (pid, signal) => {
+        signals.push({ pid, signal });
+      },
+      writeLine: (line) => lines.push(line),
+    });
+
+    assert.equal(result.terminatedCount, 3);
+    assert.deepEqual(result.candidates, [
+      {
+        pid: 800,
+        ppid: 1,
+        command: 'node /tmp/oh-my-codex/dist/mcp/memory-server.js',
+        reason: 'ppid=1',
+      },
+      {
+        pid: 810,
+        ppid: 42,
+        command: 'node /tmp/worktree/dist/mcp/trace-server.js',
+        reason: 'outside-current-session',
+      },
+      {
+        pid: 811,
+        ppid: 810,
+        command: 'node /tmp/worktree/dist/mcp/team-server.js',
+        reason: 'outside-current-session',
+      },
+    ]);
+    assert.deepEqual(signals, [
+      { pid: 800, signal: 'SIGTERM' },
+      { pid: 810, signal: 'SIGTERM' },
+      { pid: 811, signal: 'SIGTERM' },
+    ]);
+    assert.match(lines.join('\n'), /Found 3 orphaned OMX MCP server process/);
+    assert.doesNotMatch(lines.join('\n'), /PID 821/);
   });
 });
 

--- a/src/cli/__tests__/exec.test.ts
+++ b/src/cli/__tests__/exec.test.ts
@@ -42,6 +42,7 @@ describe('omx exec', () => {
       const home = join(wd, 'home');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
 
       await mkdir(join(home, '.codex'), { recursive: true });
       await mkdir(fakeBin, { recursive: true });
@@ -66,6 +67,8 @@ describe('omx exec', () => {
         ].join('\n'),
       );
       await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
 
       const result = runOmx(wd, ['exec', '--model', 'gpt-5', 'say hi'], {
         HOME: home,
@@ -100,11 +103,14 @@ describe('omx exec', () => {
       const home = join(wd, 'home');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
 
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
       await writeFile(fakeCodexPath, '#!/bin/sh\nprintf \'fake-codex:%s\\n\' \"$*\"\n');
       await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
 
       const result = runOmx(wd, ['exec', '--help'], {
         HOME: home,

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -272,6 +272,16 @@ describe("cleanupLaunchOrphanedMcpProcesses", () => {
         ppid: 820,
         command: "node /tmp/other-session/dist/mcp/state-server.js",
       },
+      {
+        pid: 830,
+        ppid: 50,
+        command: "node /repo/bin/omx.js autoresearch --topic launch",
+      },
+      {
+        pid: 831,
+        ppid: 830,
+        command: "node /tmp/parallel-session/dist/mcp/memory-server.js",
+      },
     ];
     const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
     const alive = new Set([800, 810]);
@@ -299,6 +309,11 @@ describe("cleanupLaunchOrphanedMcpProcesses", () => {
       signals.some(({ pid }) => pid === 821),
       false,
       "launch-safe cleanup must preserve OMX MCP processes still attached to another live Codex tree",
+    );
+    assert.equal(
+      signals.some(({ pid }) => pid === 831),
+      false,
+      "launch-safe cleanup must preserve OMX MCP processes still attached to another live OMX launch tree",
     );
   });
 });

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -34,6 +34,7 @@ import {
   resolveNotifyTempContract,
   buildNotifyTempStartupMessages,
   buildNotifyFallbackWatcherEnv,
+  cleanupLaunchOrphanedMcpProcesses,
   resolveBackgroundHelperLaunchMode,
   shouldDetachBackgroundHelper,
   resolveNotifyFallbackWatcherScript,
@@ -45,6 +46,7 @@ import {
   DEFAULT_FRONTIER_MODEL,
   getTeamLowComplexityModel,
 } from "../../config/models.js";
+import type { ProcessEntry } from "../cleanup.js";
 
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
   return getTeamLowComplexityModel(codexHomeOverride);
@@ -237,6 +239,67 @@ describe("resolveNotifyTempContract", () => {
     assert.equal(parsed.contract.active, true);
     assert.equal(parsed.contract.source, "env");
     assert.deepEqual(parsed.passthroughArgs, ["--model", "gpt-5"]);
+  });
+});
+
+describe("cleanupLaunchOrphanedMcpProcesses", () => {
+  it("reaps only detached OMX MCP processes without a live Codex ancestor", async () => {
+    const processes: ProcessEntry[] = [
+      { pid: 700, ppid: 500, command: "codex" },
+      { pid: 701, ppid: 700, command: "node /repo/bin/omx.js" },
+      {
+        pid: 710,
+        ppid: 700,
+        command: "node /repo/oh-my-codex/dist/mcp/state-server.js",
+      },
+      {
+        pid: 800,
+        ppid: 1,
+        command: "node /tmp/oh-my-codex/dist/mcp/memory-server.js",
+      },
+      {
+        pid: 810,
+        ppid: 42,
+        command: "node /tmp/oh-my-codex/dist/mcp/trace-server.js",
+      },
+      {
+        pid: 820,
+        ppid: 50,
+        command: "codex --model gpt-5",
+      },
+      {
+        pid: 821,
+        ppid: 820,
+        command: "node /tmp/other-session/dist/mcp/state-server.js",
+      },
+    ];
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const alive = new Set([800, 810]);
+
+    const result = await cleanupLaunchOrphanedMcpProcesses({
+      currentPid: 701,
+      listProcesses: () => processes,
+      isPidAlive: (pid) => alive.has(pid),
+      sendSignal: (pid, signal) => {
+        signals.push({ pid, signal });
+        alive.delete(pid);
+      },
+      sleep: async () => {},
+      now: () => 0,
+    });
+
+    assert.equal(result.terminatedCount, 2);
+    assert.equal(result.forceKilledCount, 0);
+    assert.deepEqual(result.failedPids, []);
+    assert.deepEqual(signals, [
+      { pid: 800, signal: "SIGTERM" },
+      { pid: 810, signal: "SIGTERM" },
+    ]);
+    assert.equal(
+      signals.some(({ pid }) => pid === 821),
+      false,
+      "launch-safe cleanup must preserve OMX MCP processes still attached to another live Codex tree",
+    );
   });
 });
 

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -41,6 +41,7 @@ describe('omx launch fallback when tmux is unavailable', () => {
       const home = join(wd, 'home');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
 
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
@@ -49,6 +50,8 @@ describe('omx launch fallback when tmux is unavailable', () => {
         '#!/bin/sh\nprintf \'fake-codex:%s\\n\' \"$*\"\n',
       );
       await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
 
       const result = runOmx(
         wd,

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -37,11 +37,14 @@ describe('omx resume', () => {
       const home = join(wd, 'home');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
 
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
       await writeFile(fakeCodexPath, '#!/bin/sh\nprintf \'fake-codex:%s\\n\' \"$*\"\n');
       await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
 
       const result = runOmx(wd, ['resume', '--last'], {
         HOME: home,
@@ -64,11 +67,14 @@ describe('omx resume', () => {
       const home = join(wd, 'home');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
 
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
       await writeFile(fakeCodexPath, '#!/bin/sh\nprintf \'fake-codex:%s\\n\' \"$*\"\n');
       await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
 
       const result = runOmx(wd, ['resume', '--help'], {
         HOME: home,

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -18,6 +18,7 @@ const SIGTERM_GRACE_MS = 5_000;
 const STALE_TMP_MAX_AGE_MS = 60 * 60 * 1000;
 const OMX_MCP_SERVER_PATTERN = /(?:^|[\\/])dist[\\/]mcp[\\/](?:state|memory|code-intel|trace|team)-server\.(?:[cm]?js|ts)\b/i;
 const CODEX_PROCESS_PATTERN = /(?:^|[\\/\s])codex(?:\.js)?(?:\s|$)|@openai[\\/]codex/i;
+const OMX_LAUNCH_PROCESS_PATTERN = /(?:^|[\\/\s])omx(?:\.js)?(?:\s|$)|(?:^|[\\/])(?:bin|dist[\\/]cli)[\\/]omx\.js(?:\s|$)|oh-my-codex[\\/]dist[\\/]cli[\\/]omx\.js/i;
 const OMX_TMP_DIRECTORY_PATTERN = /^(omc|omx|oh-my-codex)-/;
 
 export interface ProcessEntry {
@@ -115,9 +116,14 @@ function isCodexSessionProcess(command: string): boolean {
   return CODEX_PROCESS_PATTERN.test(normalizeCommand(command));
 }
 
-function hasCodexAncestor(
+function isOmxLaunchProcess(command: string): boolean {
+  return OMX_LAUNCH_PROCESS_PATTERN.test(normalizeCommand(command));
+}
+
+function hasAncestorMatching(
   processByPid: ReadonlyMap<number, ProcessEntry>,
   pid: number,
+  predicate: (command: string) => boolean,
 ): boolean {
   const seen = new Set<number>();
   let currentPid = processByPid.get(pid)?.ppid;
@@ -126,7 +132,7 @@ function hasCodexAncestor(
     seen.add(currentPid);
     const parent = processByPid.get(currentPid);
     if (!parent) return false;
-    if (isCodexSessionProcess(parent.command)) return true;
+    if (predicate(parent.command)) return true;
     currentPid = parent.ppid;
   }
 
@@ -211,7 +217,8 @@ export function findLaunchSafeCleanupCandidates(
   );
 
   return findCleanupCandidates(processes, currentPid)
-    .filter((candidate) => !hasCodexAncestor(processByPid, candidate.pid));
+    .filter((candidate) => !hasAncestorMatching(processByPid, candidate.pid, isCodexSessionProcess))
+    .filter((candidate) => !hasAncestorMatching(processByPid, candidate.pid, isOmxLaunchProcess));
 }
 
 function defaultIsPidAlive(pid: number): boolean {

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -41,6 +41,10 @@ export interface CleanupResult {
 export interface CleanupDependencies {
   currentPid?: number;
   listProcesses?: () => ProcessEntry[];
+  selectCandidates?: (
+    processes: readonly ProcessEntry[],
+    currentPid: number,
+  ) => CleanupCandidate[];
   isPidAlive?: (pid: number) => boolean;
   sendSignal?: (pid: number, signal: NodeJS.Signals) => void;
   sleep?: (ms: number) => Promise<void>;
@@ -109,6 +113,24 @@ export function listOmxProcesses(): ProcessEntry[] {
 
 function isCodexSessionProcess(command: string): boolean {
   return CODEX_PROCESS_PATTERN.test(normalizeCommand(command));
+}
+
+function hasCodexAncestor(
+  processByPid: ReadonlyMap<number, ProcessEntry>,
+  pid: number,
+): boolean {
+  const seen = new Set<number>();
+  let currentPid = processByPid.get(pid)?.ppid;
+
+  while (typeof currentPid === 'number' && currentPid > 0 && !seen.has(currentPid)) {
+    seen.add(currentPid);
+    const parent = processByPid.get(currentPid);
+    if (!parent) return false;
+    if (isCodexSessionProcess(parent.command)) return true;
+    currentPid = parent.ppid;
+  }
+
+  return false;
 }
 
 function resolveProtectedRootPid(
@@ -180,6 +202,18 @@ export function findCleanupCandidates(
     }));
 }
 
+export function findLaunchSafeCleanupCandidates(
+  processes: readonly ProcessEntry[],
+  currentPid: number,
+): CleanupCandidate[] {
+  const processByPid = new Map(
+    processes.map((processEntry) => [processEntry.pid, processEntry] as const),
+  );
+
+  return findCleanupCandidates(processes, currentPid)
+    .filter((candidate) => !hasCodexAncestor(processByPid, candidate.pid));
+}
+
 function defaultIsPidAlive(pid: number): boolean {
   if (!Number.isFinite(pid) || pid <= 0) return false;
   try {
@@ -241,12 +275,13 @@ export async function cleanupOmxMcpProcesses(
   const writeLine = dependencies.writeLine ?? ((line: string) => console.log(line));
   const currentPid = dependencies.currentPid ?? process.pid;
   const listProcessesImpl = dependencies.listProcesses ?? listOmxProcesses;
+  const selectCandidates = dependencies.selectCandidates ?? findCleanupCandidates;
   const isPidAlive = dependencies.isPidAlive ?? defaultIsPidAlive;
   const sendSignal = dependencies.sendSignal ?? ((pid: number, signal: NodeJS.Signals) => process.kill(pid, signal));
   const sleep = dependencies.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
   const now = dependencies.now ?? Date.now;
 
-  const candidates = findCleanupCandidates(listProcessesImpl(), currentPid);
+  const candidates = selectCandidates(listProcessesImpl(), currentPid);
   if (candidates.length === 0) {
     writeLine(dryRun
       ? 'Dry run: no orphaned OMX MCP server processes found.'

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,7 +16,13 @@ import { hudCommand } from "../hud/index.js";
 import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
 import { askCommand } from "./ask.js";
-import { cleanupCommand } from "./cleanup.js";
+import {
+  cleanupCommand,
+  cleanupOmxMcpProcesses,
+  findLaunchSafeCleanupCandidates,
+  type CleanupDependencies,
+  type CleanupResult,
+} from "./cleanup.js";
 import { exploreCommand } from "./explore.js";
 import { sparkshellCommand } from "./sparkshell.js";
 import { agentsInitCommand } from "./agents-init.js";
@@ -1588,14 +1594,25 @@ export function buildNotifyFallbackWatcherEnv(
   };
 }
 
+export async function cleanupLaunchOrphanedMcpProcesses(
+  dependencies: CleanupDependencies = {},
+): Promise<CleanupResult> {
+  return cleanupOmxMcpProcesses([], {
+    ...dependencies,
+    selectCandidates: dependencies.selectCandidates ?? findLaunchSafeCleanupCandidates,
+    writeLine: dependencies.writeLine ?? (() => {}),
+  });
+}
+
 /**
  * preLaunch: Prepare environment before Codex starts.
- * 1. Generate runtime overlay + write session-scoped model instructions file
- * 2. Write session.json
+ * 1. Best-effort launch-safe orphan cleanup for detached OMX MCP processes
+ * 2. Generate runtime overlay + write session-scoped model instructions file
+ * 3. Write session.json
  *
- * Automatic stale-session cleanup is intentionally disabled here. Destructive
- * cleanup must be explicit via `omx cleanup` so normal launches never reap
- * files or processes from other OMX sessions.
+ * Automatic broad stale-session cleanup remains disabled here. Only detached
+ * OMX MCP processes without a live Codex ancestor are reaped so new launches
+ * do not accumulate stale processes from prior crashed/closed sessions.
  */
 async function preLaunch(
   cwd: string,
@@ -1604,7 +1621,25 @@ async function preLaunch(
   codexHomeOverride?: string,
   enableNotifyFallbackAuthority: boolean = false,
 ): Promise<void> {
-  // 1. Generate runtime overlay + write session-scoped model instructions file
+  // 1. Best-effort launch-safe orphan cleanup
+  try {
+    const cleanup = await cleanupLaunchOrphanedMcpProcesses();
+    if (cleanup.terminatedCount > 0) {
+      console.log(
+        `[omx] Reaped ${cleanup.terminatedCount} orphaned OMX MCP process(es) before launch.`,
+      );
+    }
+    if (cleanup.failedPids.length > 0) {
+      console.warn(
+        `[omx] Failed to reap ${cleanup.failedPids.length} orphaned OMX MCP process(es); continuing launch.`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write(`[cli/index] operation failed: ${err}\n`);
+    // Non-fatal
+  }
+
+  // 2. Generate runtime overlay + write session-scoped model instructions file
   const orchestrationMode = await resolveSessionOrchestrationMode(
     cwd,
     sessionId,
@@ -1619,11 +1654,11 @@ ${launchAppendix}`
       : overlay;
   await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
 
-  // 2. Write session state
+  // 3. Write session state
   await resetSessionMetrics(cwd);
   await writeSessionStart(cwd, sessionId);
 
-  // 3. Start notify fallback watcher (best effort)
+  // 4. Start notify fallback watcher (best effort)
   try {
     await startNotifyFallbackWatcher(cwd, { codexHomeOverride, enableAuthority: enableNotifyFallbackAuthority, sessionId });
   } catch (err) {
@@ -1631,7 +1666,7 @@ ${launchAppendix}`
     // Non-fatal
   }
 
-  // 4. Start derived watcher (best effort, opt-in)
+  // 5. Start derived watcher (best effort, opt-in)
   try {
     await startHookDerivedWatcher(cwd);
   } catch (err) {
@@ -1639,7 +1674,7 @@ ${launchAppendix}`
     // Non-fatal
   }
 
-  // 5. Emit temp notification startup summary + warnings, then send session-start lifecycle notification (best effort)
+  // 6. Emit temp notification startup summary + warnings, then send session-start lifecycle notification (best effort)
   try {
     if (notifyTempContract?.active) {
       process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV] =
@@ -1671,7 +1706,7 @@ ${launchAppendix}`
     // Non-fatal: notification failures must never block launch
   }
 
-  // 6. Dispatch native hook event (best effort)
+  // 7. Dispatch native hook event (best effort)
   try {
     await emitNativeHookEvent(cwd, "session-start", {
       session_id: sessionId,


### PR DESCRIPTION
## Summary
- add launch-safe cleanup for detached OMX MCP servers before a new Codex launch
- preserve MCP processes that still belong to a live Codex ancestor tree
- add regression coverage for cleanup candidate selection and the prelaunch helper path

## Root cause
OMX was only treating a narrow PPID=1 orphan shape as safe to reap. In long-running or repeatedly relaunched environments, detached OMX MCP servers could survive without a live Codex owner while no longer matching that narrow orphan heuristic, so each fresh launch could leave stale detached servers around and pile up more processes.

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/cli/__tests__/cleanup.test.js dist/cli/__tests__/index.test.js`
- manual fake-Codex repro showing detached MCP count stays flat across launches (`1 -> 1`) with PID replacement

Closes #1182