### PR TITLE
Add runtime-aware team commit hygiene finalization context

### DIFF
--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -2353,7 +2353,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     const name = teamArgs[1];
     if (!name) throw new Error('Usage: omx team shutdown <team-name> [--force]');
     const force = teamArgs.includes('--force');
-    await shutdownTeam(name, cwd, { force });
+    const summary = await shutdownTeam(name, cwd, { force });
     await updateModeState('team', {
       active: false,
       current_phase: 'cancelled',
@@ -2365,6 +2365,10 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
       });
     });
     console.log(`Team shutdown complete: ${name}`);
+    if (summary.commitHygieneArtifacts) {
+      console.log(`commit_hygiene_context_json: ${summary.commitHygieneArtifacts.jsonPath}`);
+      console.log(`commit_hygiene_context_md: ${summary.commitHygieneArtifacts.markdownPath}`);
+    }
     return;
   }
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1983,6 +1983,14 @@ process.on('SIGTERM', () => {
       // Verify worker's changes are integrated into leader
       const snapshot = await readMonitorSnapshot('team-auto-commit', repo);
       assert.ok(snapshot?.integrationByWorker?.['worker-1']?.last_integrated_head, 'auto-committed changes should be integrated');
+
+      const ledgerPath = join(repo, '.omx', 'reports', 'team-commit-hygiene', 'team-auto-commit.ledger.json');
+      assert.equal(existsSync(ledgerPath), true, 'commit hygiene ledger should be written for runtime operational commits');
+      const ledger = JSON.parse(await readFile(ledgerPath, 'utf-8')) as {
+        entries: Array<{ operation: string; operational_commit?: string | null }>;
+      };
+      assert.equal(ledger.entries.some((entry) => entry.operation === 'auto_checkpoint'), true);
+      assert.equal(ledger.entries.some((entry) => entry.operation === 'integration_merge'), true);
     } finally {
       if (workerPath) {
         await rm(workerPath, { recursive: true, force: true });
@@ -2154,6 +2162,15 @@ process.on('SIGTERM', () => {
       const newLeaderHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
       const mergeBase = execFileSync('git', ['merge-base', newLeaderHead, 'wk2-xr-branch'], { cwd: repo, encoding: 'utf-8' }).trim();
       assert.equal(mergeBase, newLeaderHead, 'worker-2 should be rebased onto new leader HEAD');
+
+      const ledgerPath = join(repo, '.omx', 'reports', 'team-commit-hygiene', 'team-cross-rebase.ledger.json');
+      const ledger = JSON.parse(await readFile(ledgerPath, 'utf-8')) as {
+        entries: Array<{ operation: string; worker_name: string; status: string }>;
+      };
+      assert.equal(
+        ledger.entries.some((entry) => entry.operation === 'cross_rebase' && entry.worker_name === 'worker-2' && entry.status === 'applied'),
+        true,
+      );
     } finally {
       if (worker1Path) {
         await rm(worker1Path, { recursive: true, force: true });

--- a/src/team/__tests__/shutdown-fallback.test.ts
+++ b/src/team/__tests__/shutdown-fallback.test.ts
@@ -91,6 +91,27 @@ process.on('SIGTERM', () => process.exit(0));
       assert.match(report, /merge_outcome: merged/);
       assert.doesNotMatch(report, /synthetic_commit: none/);
       assert.match(report, /worker-note\.txt/);
+
+      const commitHygieneJsonPath = join(repo, '.omx', 'reports', 'team-commit-hygiene', 'team-shutdown-fallback-report.context.json');
+      const commitHygieneMarkdownPath = join(repo, '.omx', 'reports', 'team-commit-hygiene', 'team-shutdown-fallback-report.md');
+      assert.equal(existsSync(commitHygieneJsonPath), true, 'shutdown should preserve a structured commit hygiene context artifact');
+      assert.equal(existsSync(commitHygieneMarkdownPath), true, 'shutdown should preserve a human-readable commit hygiene guide');
+
+      const commitHygieneContext = JSON.parse(await readFile(commitHygieneJsonPath, 'utf-8')) as {
+        lore_commit_protocol_required: boolean;
+        runtime_commits_are_scaffolding: boolean;
+        operational_entries: Array<{ operation: string; status: string }>;
+        leader_finalization_prompt: string;
+      };
+      assert.equal(commitHygieneContext.lore_commit_protocol_required, true);
+      assert.equal(commitHygieneContext.runtime_commits_are_scaffolding, true);
+      assert.equal(commitHygieneContext.operational_entries.some((entry) => entry.operation === 'shutdown_checkpoint'), true);
+      assert.equal(commitHygieneContext.operational_entries.some((entry) => entry.operation === 'shutdown_merge' && entry.status === 'applied'), true);
+      assert.match(commitHygieneContext.leader_finalization_prompt, /Lore-format final commit/i);
+
+      const commitHygieneGuide = await readFile(commitHygieneMarkdownPath, 'utf-8');
+      assert.match(commitHygieneGuide, /temporary scaffolding/i);
+      assert.match(commitHygieneGuide, /Suggested Leader Finalization Prompt/i);
     } finally {
       if (runtime) {
         await shutdownTeam(runtime.teamName, repo, { force: true }).catch(() => {});

--- a/src/team/commit-hygiene.ts
+++ b/src/team/commit-hygiene.ts
@@ -1,0 +1,307 @@
+import { existsSync } from 'fs'
+import { mkdir, readFile } from 'fs/promises'
+import { join, resolve } from 'path'
+import type { TeamTask } from './state.js'
+import { writeAtomic } from './state.js'
+
+export type TeamOperationalCommitKind =
+  | 'auto_checkpoint'
+  | 'integration_merge'
+  | 'integration_cherry_pick'
+  | 'cross_rebase'
+  | 'shutdown_checkpoint'
+  | 'shutdown_merge'
+
+export interface TeamOperationalCommitEntry {
+  recorded_at: string;
+  operation: TeamOperationalCommitKind;
+  worker_name: string;
+  task_id?: string;
+  status: 'applied' | 'noop' | 'conflict' | 'skipped';
+  operational_commit?: string | null;
+  source_commit?: string | null;
+  leader_head_before?: string | null;
+  leader_head_after?: string | null;
+  worker_head_before?: string | null;
+  worker_head_after?: string | null;
+  worktree_path?: string;
+  report_path?: string;
+  detail?: string;
+}
+
+export interface TeamCommitHygieneLedger {
+  version: 1;
+  team_name: string;
+  updated_at: string;
+  runtime_commits_are_scaffolding: true;
+  entries: TeamOperationalCommitEntry[];
+}
+
+export interface TeamCommitHygieneTaskSummary {
+  id: string;
+  subject: string;
+  owner?: string;
+  status: string;
+  description: string;
+  result_excerpt?: string;
+  error_excerpt?: string;
+}
+
+export interface TeamCommitHygieneContext {
+  version: 1;
+  team_name: string;
+  generated_at: string;
+  lore_commit_protocol_required: true;
+  runtime_commits_are_scaffolding: true;
+  task_summary: TeamCommitHygieneTaskSummary[];
+  operational_entries: TeamOperationalCommitEntry[];
+  recommended_next_steps: string[];
+  leader_finalization_prompt: string;
+}
+
+export interface TeamCommitHygieneArtifactPaths {
+  jsonPath: string;
+  markdownPath: string;
+}
+
+function commitHygieneReportsDir(cwd: string): string {
+  return join(resolve(cwd), '.omx', 'reports', 'team-commit-hygiene')
+}
+
+function ledgerPathFor(teamName: string, cwd: string): string {
+  return join(commitHygieneReportsDir(cwd), `${teamName}.ledger.json`)
+}
+
+export function resolveTeamCommitHygieneArtifactPaths(teamName: string, cwd: string): TeamCommitHygieneArtifactPaths {
+  const reportsDir = commitHygieneReportsDir(cwd)
+  return {
+    jsonPath: join(reportsDir, `${teamName}.context.json`),
+    markdownPath: join(reportsDir, `${teamName}.md`),
+  }
+}
+
+function excerpt(value: string | undefined, maxLength: number = 240): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  return trimmed.length <= maxLength ? trimmed : `${trimmed.slice(0, maxLength - 1)}…`
+}
+
+function entryFingerprint(entry: TeamOperationalCommitEntry): string {
+  return [
+    entry.operation,
+    entry.worker_name,
+    entry.task_id ?? '',
+    entry.status,
+    entry.operational_commit ?? '',
+    entry.source_commit ?? '',
+    entry.leader_head_before ?? '',
+    entry.leader_head_after ?? '',
+    entry.worker_head_before ?? '',
+    entry.worker_head_after ?? '',
+    entry.report_path ?? '',
+    entry.detail ?? '',
+  ].join('|')
+}
+
+export async function readTeamCommitHygieneLedger(teamName: string, cwd: string): Promise<TeamCommitHygieneLedger> {
+  const path = ledgerPathFor(teamName, cwd)
+  if (!existsSync(path)) {
+    return {
+      version: 1,
+      team_name: teamName,
+      updated_at: new Date(0).toISOString(),
+      runtime_commits_are_scaffolding: true,
+      entries: [],
+    }
+  }
+
+  try {
+    const raw = await readFile(path, 'utf-8')
+    const parsed = JSON.parse(raw) as Partial<TeamCommitHygieneLedger>
+    return {
+      version: 1,
+      team_name: typeof parsed.team_name === 'string' && parsed.team_name.trim() !== '' ? parsed.team_name : teamName,
+      updated_at: typeof parsed.updated_at === 'string' ? parsed.updated_at : new Date(0).toISOString(),
+      runtime_commits_are_scaffolding: true,
+      entries: Array.isArray(parsed.entries) ? parsed.entries : [],
+    }
+  } catch {
+    return {
+      version: 1,
+      team_name: teamName,
+      updated_at: new Date(0).toISOString(),
+      runtime_commits_are_scaffolding: true,
+      entries: [],
+    }
+  }
+}
+
+export async function appendTeamCommitHygieneEntries(
+  teamName: string,
+  entries: TeamOperationalCommitEntry[],
+  cwd: string,
+): Promise<TeamCommitHygieneLedger> {
+  const nextEntries = entries.filter(Boolean)
+  const ledger = await readTeamCommitHygieneLedger(teamName, cwd)
+  if (nextEntries.length === 0) return ledger
+
+  await mkdir(commitHygieneReportsDir(cwd), { recursive: true })
+  const seen = new Set(ledger.entries.map(entryFingerprint))
+  const deduped = nextEntries.filter((entry) => {
+    const fingerprint = entryFingerprint(entry)
+    if (seen.has(fingerprint)) return false
+    seen.add(fingerprint)
+    return true
+  })
+  if (deduped.length === 0) return ledger
+
+  const updated: TeamCommitHygieneLedger = {
+    ...ledger,
+    updated_at: new Date().toISOString(),
+    entries: [...ledger.entries, ...deduped],
+  }
+  await writeAtomic(ledgerPathFor(teamName, cwd), JSON.stringify(updated, null, 2))
+  return updated
+}
+
+function summarizeTasks(tasks: TeamTask[]): TeamCommitHygieneTaskSummary[] {
+  return tasks.map((task) => ({
+    id: task.id,
+    subject: task.subject,
+    owner: task.owner,
+    status: task.status,
+    description: task.description,
+    result_excerpt: excerpt(task.result),
+    error_excerpt: excerpt(task.error),
+  }))
+}
+
+function buildLeaderFinalizationPrompt(teamName: string, taskSummary: TeamCommitHygieneTaskSummary[]): string {
+  const completedSubjects = taskSummary
+    .filter((task) => task.status === 'completed')
+    .map((task) => task.subject)
+    .slice(0, 8)
+
+  const scopeHint = completedSubjects.length > 0
+    ? `Completed task subjects: ${completedSubjects.join(' | ')}.`
+    : 'Use the completed task descriptions and resulting diffs to infer semantic commit boundaries.'
+
+  return [
+    `Team "${teamName}" is ready for commit finalization.`,
+    'Treat runtime-originated commits (auto-checkpoints, merge/cherry-picks, cross-rebases, shutdown checkpoints) as temporary scaffolding rather than final history.',
+    'Do not reuse operational commit subjects verbatim.',
+    `${scopeHint}`,
+    'Rewrite or squash the operational history into clean Lore-format final commit(s) with intent-first subjects and relevant trailers.',
+    'Use task subjects/results and shutdown diff reports to choose semantic commit boundaries and rationale.',
+  ].join(' ')
+}
+
+export function buildTeamCommitHygieneContext(params: {
+  teamName: string;
+  tasks: TeamTask[];
+  ledger: TeamCommitHygieneLedger;
+}): TeamCommitHygieneContext {
+  const taskSummary = summarizeTasks(params.tasks)
+  const recommendedNextSteps = [
+    'Inspect the current branch diff/log and identify which runtime-originated commits should be squashed or rewritten.',
+    'Derive semantic commit boundaries from completed task subjects, code diffs, and shutdown reports rather than from omx(team) operational commit subjects.',
+    'Create final commit messages in Lore format with intent-first subjects and only the trailers that add decision context.',
+  ]
+
+  return {
+    version: 1,
+    team_name: params.teamName,
+    generated_at: new Date().toISOString(),
+    lore_commit_protocol_required: true,
+    runtime_commits_are_scaffolding: true,
+    task_summary: taskSummary,
+    operational_entries: params.ledger.entries,
+    recommended_next_steps: recommendedNextSteps,
+    leader_finalization_prompt: buildLeaderFinalizationPrompt(params.teamName, taskSummary),
+  }
+}
+
+function renderTaskSummaryMarkdown(taskSummary: TeamCommitHygieneTaskSummary[]): string {
+  if (taskSummary.length === 0) return '- No task metadata available.'
+
+  return taskSummary.map((task) => {
+    const lines = [
+      `- task-${task.id} | status=${task.status} | owner=${task.owner ?? 'unassigned'} | subject=${task.subject}`,
+      `  - description: ${task.description}`,
+    ]
+    if (task.result_excerpt) lines.push(`  - result_excerpt: ${task.result_excerpt}`)
+    if (task.error_excerpt) lines.push(`  - error_excerpt: ${task.error_excerpt}`)
+    return lines.join('\n')
+  }).join('\n')
+}
+
+function renderOperationalEntriesMarkdown(entries: TeamOperationalCommitEntry[]): string {
+  if (entries.length === 0) return '- No runtime-originated commit activity recorded.'
+
+  return entries.map((entry) => {
+    const parts = [
+      `- [${entry.recorded_at}] ${entry.operation}`,
+      `worker=${entry.worker_name}`,
+      `status=${entry.status}`,
+    ]
+    if (entry.task_id) parts.push(`task=${entry.task_id}`)
+    if (entry.operational_commit) parts.push(`operational_commit=${entry.operational_commit}`)
+    if (entry.source_commit) parts.push(`source_commit=${entry.source_commit}`)
+    if (entry.leader_head_before) parts.push(`leader_before=${entry.leader_head_before}`)
+    if (entry.leader_head_after) parts.push(`leader_after=${entry.leader_head_after}`)
+    if (entry.worker_head_before) parts.push(`worker_before=${entry.worker_head_before}`)
+    if (entry.worker_head_after) parts.push(`worker_after=${entry.worker_head_after}`)
+    if (entry.report_path) parts.push(`report_path=${entry.report_path}`)
+    if (entry.detail) parts.push(`detail=${entry.detail}`)
+    return parts.join(' | ')
+  }).join('\n')
+}
+
+export function renderTeamCommitHygieneMarkdown(context: TeamCommitHygieneContext): string {
+  return [
+    '# Team Commit Hygiene Finalization Guide',
+    '',
+    `- team: ${context.team_name}`,
+    `- generated_at: ${context.generated_at}`,
+    '- lore_commit_protocol_required: true',
+    '- runtime_commits_are_scaffolding: true',
+    '',
+    '## Suggested Leader Finalization Prompt',
+    '',
+    '```text',
+    context.leader_finalization_prompt,
+    '```',
+    '',
+    '## Task Summary',
+    '',
+    renderTaskSummaryMarkdown(context.task_summary),
+    '',
+    '## Runtime Operational Ledger',
+    '',
+    renderOperationalEntriesMarkdown(context.operational_entries),
+    '',
+    '## Finalization Guidance',
+    '',
+    '1. Treat `omx(team): ...` runtime commits as temporary scaffolding, not as the final PR history.',
+    '2. Reconcile checkpoint, merge/cherry-pick, cross-rebase, and shutdown checkpoint activity into semantic Lore-format final commit(s).',
+    '3. Use task outcomes, code diffs, and shutdown diff reports to name and scope the final commits.',
+    '',
+    '## Recommended Next Steps',
+    '',
+    ...context.recommended_next_steps.map((step, index) => `${index + 1}. ${step}`),
+    '',
+  ].join('\n')
+}
+
+export async function writeTeamCommitHygieneContext(
+  teamName: string,
+  context: TeamCommitHygieneContext,
+  cwd: string,
+): Promise<TeamCommitHygieneArtifactPaths> {
+  const paths = resolveTeamCommitHygieneArtifactPaths(teamName, cwd)
+  await mkdir(commitHygieneReportsDir(cwd), { recursive: true })
+  await writeAtomic(paths.jsonPath, JSON.stringify(context, null, 2))
+  await writeAtomic(paths.markdownPath, renderTeamCommitHygieneMarkdown(context))
+  return paths
+}

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -10,7 +10,7 @@ import { readdirSync, readFileSync } from 'fs';
 import { writeFile, rename } from 'fs/promises';
 import { join } from 'path';
 import { startTeam, monitorTeam, shutdownTeam } from './runtime.js';
-import type { TeamRuntime } from './runtime.js';
+import type { TeamRuntime, TeamShutdownSummary } from './runtime.js';
 import { teamReadConfig as readTeamConfig } from './team-ops.js';
 
 interface CliInput {
@@ -70,15 +70,15 @@ export async function loadLivePaneState(teamName: string, cwd: string): Promise<
   };
 }
 
-export async function shutdownWithForceFallback(teamName: string, cwd: string): Promise<void> {
+export async function shutdownWithForceFallback(teamName: string, cwd: string): Promise<TeamShutdownSummary> {
   try {
-    await shutdownTeam(teamName, cwd);
+    return await shutdownTeam(teamName, cwd);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (!message.includes('shutdown_gate_blocked') && !message.includes('shutdown_rejected')) {
       throw error;
     }
-    await shutdownTeam(teamName, cwd, { force: true });
+    return await shutdownTeam(teamName, cwd, { force: true });
   }
 }
 
@@ -185,17 +185,23 @@ async function main(): Promise<void> {
     const taskResults = collectTaskResults(stateRoot, teamName);
 
     // 2. Shutdown team
+    let shutdownSummary: TeamShutdownSummary | null = null;
     if (runtime) {
       try {
         if (status === 'failed') {
           // Failure/cancellation path must force cleanup to bypass shutdown gate.
-          await shutdownTeam(runtime.teamName, runtime.cwd, { force: true });
+          shutdownSummary = await shutdownTeam(runtime.teamName, runtime.cwd, { force: true });
         } else {
-          await shutdownWithForceFallback(runtime.teamName, runtime.cwd);
+          shutdownSummary = await shutdownWithForceFallback(runtime.teamName, runtime.cwd);
         }
       } catch (err) {
         process.stderr.write(`[runtime-cli] shutdownTeam error: ${err}\n`);
       }
+    }
+
+    if (shutdownSummary?.commitHygieneArtifacts) {
+      process.stderr.write(`[runtime-cli] commit_hygiene_context_json=${shutdownSummary.commitHygieneArtifacts.jsonPath}\n`);
+      process.stderr.write(`[runtime-cli] commit_hygiene_context_md=${shutdownSummary.commitHygieneArtifacts.markdownPath}\n`);
     }
 
     const duration = (Date.now() - startTime) / 1000;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -113,6 +113,13 @@ import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
 import { buildRebalanceDecisions } from './rebalance-policy.js';
 import { readModeState, updateModeState } from '../modes/base.js';
 import {
+  appendTeamCommitHygieneEntries,
+  buildTeamCommitHygieneContext,
+  writeTeamCommitHygieneContext,
+  type TeamCommitHygieneArtifactPaths,
+  type TeamOperationalCommitEntry,
+} from './commit-hygiene.js';
+import {
   assertCleanLeaderWorkspaceForWorkerWorktrees,
   ensureWorktree,
   isGitRepository,
@@ -204,6 +211,10 @@ interface ShutdownOptions {
   force?: boolean;
 }
 
+export interface TeamShutdownSummary {
+  commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null;
+}
+
 function collectProvisionedShutdownWorktrees(config: TeamConfig): EnsureWorktreeResult[] {
   const seenWorktreePaths = new Set<string>();
   const worktrees: EnsureWorktreeResult[] = [];
@@ -250,6 +261,8 @@ interface WorkerShutdownMergeReport {
   summaryText: string | null;
   mergeOutcome: 'merged' | 'conflict' | 'noop' | 'skipped';
   mergeDetail: string;
+  leaderHeadBefore: string | null;
+  leaderHeadAfter: string | null;
 }
 
 function runCommand(command: string, args: string[], cwd: string): CommandResult {
@@ -390,6 +403,8 @@ async function integrateWorkerCommitsIntoLeader(params: {
   const next: Record<string, TeamWorkerIntegrationState> = { ...(previous?.integrationByWorker ?? {}) };
   const leaderHeadAtCycleStart = resolveLeaderHead(resolve(config.workers[0]?.worktree_repo_root ?? cwd), cwd);
   const integratedWorkerNames = new Set<string>();
+  const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
+  const artifactCwd = config.leader_cwd ?? cwd;
 
   // ── Phase A: Auto-commit dirty worktrees ──
   for (const worker of config.workers) {
@@ -402,6 +417,16 @@ async function integrateWorkerCommitsIntoLeader(params: {
         worktree_path: resolve(worker.worktree_path),
         summary: `auto-committed dirty worktree for ${worker.name}`,
       }, cwd);
+      commitHygieneEntries.push({
+        recorded_at: new Date().toISOString(),
+        operation: 'auto_checkpoint',
+        worker_name: worker.name,
+        task_id: worker.assigned_tasks[0],
+        status: 'applied',
+        operational_commit: commitHash,
+        worktree_path: resolve(worker.worktree_path),
+        detail: 'Dirty worker worktree checkpointed before runtime integration.',
+      });
     }
   }
 
@@ -456,6 +481,19 @@ async function integrateWorkerCommitsIntoLeader(params: {
           summary: `merged ${worker.name} into leader via --no-ff -X theirs`,
         }, cwd);
         await sendIntegrationMessageToLeader(teamName, worker, `INTEGRATED: merged ${worker.name} (${workerHead.slice(0, 12)}) into leader HEAD ${newLeaderHead.slice(0, 12)} via merge --no-ff.`, cwd);
+        commitHygieneEntries.push({
+          recorded_at: new Date().toISOString(),
+          operation: 'integration_merge',
+          worker_name: worker.name,
+          task_id: worker.assigned_tasks[0],
+          status: 'applied',
+          operational_commit: newLeaderHead,
+          source_commit: workerHead,
+          leader_head_before: leaderHead,
+          leader_head_after: newLeaderHead,
+          worktree_path: worktreePath,
+          detail: 'Leader created a runtime merge commit to integrate worker history.',
+        });
       } else {
         // Merge failed even with -X theirs (e.g. binary conflict) — abort and log
         const conflictFiles = listConflictFiles(repoRoot, cwd);
@@ -550,6 +588,19 @@ async function integrateWorkerCommitsIntoLeader(params: {
           summary: `cherry-picked ${commit.slice(0, 12)} from ${worker.name} with -X theirs`,
         }, cwd);
         await sendIntegrationMessageToLeader(teamName, worker, `INTEGRATED: cherry-picked ${commit.slice(0, 12)} from ${worker.name} into leader HEAD ${newLeaderHead.slice(0, 12)} (-X theirs).`, cwd);
+        commitHygieneEntries.push({
+          recorded_at: new Date().toISOString(),
+          operation: 'integration_cherry_pick',
+          worker_name: worker.name,
+          task_id: worker.assigned_tasks[0],
+          status: 'applied',
+          operational_commit: newLeaderHead,
+          source_commit: commit,
+          leader_head_before: leaderHead,
+          leader_head_after: newLeaderHead,
+          worktree_path: worktreePath,
+          detail: 'Leader created a runtime cherry-pick commit while integrating diverged worker history.',
+        });
       }
 
       if (allPicked) {
@@ -599,8 +650,10 @@ async function integrateWorkerCommitsIntoLeader(params: {
       }
 
       // Rebase with -X ours (in rebase context, "ours" = upstream = leader wins)
+      const workerHeadBeforeRebase = resolveWorkerHead(worktreePath);
       const rebase = runGitCommand(repoRoot, ['rebase', '-X', 'ours', newLeaderHead], worktreePath);
       if (rebase.ok) {
+        const workerHeadAfterRebase = resolveWorkerHead(worktreePath);
         const state = next[worker.name] ?? {};
         state.last_rebased_leader_head = newLeaderHead;
         state.status = 'idle';
@@ -614,6 +667,19 @@ async function integrateWorkerCommitsIntoLeader(params: {
           worktree_path: worktreePath,
           summary: `cross-rebased ${worker.name} onto ${newLeaderHead.slice(0, 12)} (-X ours)`,
         }, cwd);
+        commitHygieneEntries.push({
+          recorded_at: new Date().toISOString(),
+          operation: 'cross_rebase',
+          worker_name: worker.name,
+          task_id: worker.assigned_tasks[0],
+          status: 'applied',
+          operational_commit: workerHeadAfterRebase,
+          leader_head_after: newLeaderHead,
+          worker_head_before: workerHeadBeforeRebase,
+          worker_head_after: workerHeadAfterRebase,
+          worktree_path: worktreePath,
+          detail: 'Runtime rebase rewrote worker history onto the updated leader head.',
+        });
       } else {
         // Rebase failed — abort to restore worktree, log for retry next cycle
         const conflictFiles = listConflictFiles(repoRoot, worktreePath);
@@ -638,6 +704,10 @@ async function integrateWorkerCommitsIntoLeader(params: {
     }
   }
 
+  if (commitHygieneEntries.length > 0) {
+    await appendTeamCommitHygieneEntries(teamName, commitHygieneEntries, artifactCwd)
+  }
+
   return next;
 }
 
@@ -651,6 +721,8 @@ function renderWorktreeMergeReport(report: WorkerShutdownMergeReport): string {
     `- synthetic_commit: ${report.syntheticCommit ?? 'none'}`,
     `- merge_outcome: ${report.mergeOutcome}`,
     `- merge_detail: ${report.mergeDetail}`,
+    `- leader_head_before: ${report.leaderHeadBefore ?? 'none'}`,
+    `- leader_head_after: ${report.leaderHeadAfter ?? 'none'}`,
     '',
     '## Summary',
     report.summaryText ?? 'sparkshell summary unavailable; using raw diff fallback.',
@@ -689,6 +761,8 @@ async function prepareShutdownMergeReport(
         summaryText: null,
         mergeOutcome: 'skipped',
         mergeDetail: addResult.stderr || 'git add -A failed',
+        leaderHeadBefore: resolveLeaderHead(repoRoot, leaderCwd),
+        leaderHeadAfter: resolveLeaderHead(repoRoot, leaderCwd),
       };
     }
     const commitResult = runGitCommand(
@@ -710,6 +784,8 @@ async function prepareShutdownMergeReport(
         summaryText: null,
         mergeOutcome: 'skipped',
         mergeDetail: commitResult.stderr || 'git commit failed',
+        leaderHeadBefore: resolveLeaderHead(repoRoot, leaderCwd),
+        leaderHeadAfter: resolveLeaderHead(repoRoot, leaderCwd),
       };
     }
   }
@@ -719,9 +795,11 @@ async function prepareShutdownMergeReport(
   const diffText = getWorktreeDiffText(worktreePath);
   const summaryText = summarizeWorktreeDiffWithSparkShell(worktreePath);
   const reportPath = join(worktreePath, '.omx', 'diff.md');
+  const leaderHeadBefore = resolveLeaderHead(repoRoot, leaderCwd);
 
   let mergeOutcome: WorkerShutdownMergeReport['mergeOutcome'] = 'skipped';
   let mergeDetail = 'worktree merge skipped';
+  let leaderHeadAfter = leaderHeadBefore;
   if (sourceRef) {
     const alreadyMerged = runGitCommand(repoRoot, ['merge-base', '--is-ancestor', sourceRef, 'HEAD'], leaderCwd);
     if (alreadyMerged.ok) {
@@ -732,10 +810,12 @@ async function prepareShutdownMergeReport(
       if (mergeResult.ok) {
         mergeOutcome = 'merged';
         mergeDetail = mergeResult.stdout || 'merged successfully';
+        leaderHeadAfter = resolveLeaderHead(repoRoot, leaderCwd) ?? leaderHeadBefore;
       } else {
         mergeOutcome = 'conflict';
         mergeDetail = mergeResult.stderr || mergeResult.stdout || 'merge failed';
         runGitCommand(repoRoot, ['merge', '--abort'], leaderCwd);
+        leaderHeadAfter = resolveLeaderHead(repoRoot, leaderCwd) ?? leaderHeadBefore;
       }
     }
   }
@@ -750,6 +830,8 @@ async function prepareShutdownMergeReport(
     summaryText,
     mergeOutcome,
     mergeDetail,
+    leaderHeadBefore,
+    leaderHeadAfter,
   };
 
   await mkdir(join(worktreePath, '.omx'), { recursive: true });
@@ -758,11 +840,13 @@ async function prepareShutdownMergeReport(
   return report;
 }
 
-async function prepareWorkerWorktreeShutdownReports(config: TeamConfig, leaderCwd: string): Promise<void> {
+async function prepareWorkerWorktreeShutdownReports(config: TeamConfig, leaderCwd: string): Promise<WorkerShutdownMergeReport[]> {
+  const reports: WorkerShutdownMergeReport[] = []
   for (const worker of config.workers) {
     if (!worker.worktree_path || !worker.worktree_repo_root) continue;
     try {
-      await prepareShutdownMergeReport(worker, leaderCwd);
+      const report = await prepareShutdownMergeReport(worker, leaderCwd);
+      if (report) reports.push(report);
     } catch (error) {
       const worktreePath = resolve(worker.worktree_path);
       const reportPath = join(worktreePath, '.omx', 'diff.md');
@@ -780,6 +864,7 @@ async function prepareWorkerWorktreeShutdownReports(config: TeamConfig, leaderCw
       process.stdout.write(`${fallback}\n`);
     }
   }
+  return reports
 }
 
 export interface TeamStartOptions {
@@ -2152,7 +2237,7 @@ export async function reassignTask(
 /**
  * Graceful shutdown: send shutdown inbox to all workers, wait, force kill, cleanup.
  */
-export async function shutdownTeam(teamName: string, cwd: string, options: ShutdownOptions = {}): Promise<void> {
+export async function shutdownTeam(teamName: string, cwd: string, options: ShutdownOptions = {}): Promise<TeamShutdownSummary> {
   const force = options.force === true;
   const sanitized = sanitizeTeamName(teamName);
   const config = await readTeamConfig(sanitized, cwd);
@@ -2165,7 +2250,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
     await cleanupTeamState(sanitized, cwd);
     restoreTeamModelInstructionsFile(sanitized);
-    return;
+    return { commitHygieneArtifacts: null };
   }
   const manifest = await readTeamManifestV2(sanitized, cwd);
   const governance = resolveGovernancePolicy(
@@ -2355,7 +2440,53 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
   }
 
-  await prepareWorkerWorktreeShutdownReports(config, cwd);
+  const shutdownReports = await prepareWorkerWorktreeShutdownReports(config, cwd);
+
+  const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
+  for (const report of shutdownReports) {
+    const worker = config.workers.find((entry) => entry.name === report.workerName);
+    if (report.syntheticCommit) {
+      commitHygieneEntries.push({
+        recorded_at: new Date().toISOString(),
+        operation: 'shutdown_checkpoint',
+        worker_name: report.workerName,
+        task_id: worker?.assigned_tasks[0],
+        status: 'applied',
+        operational_commit: report.syntheticCommit,
+        source_commit: report.sourceRef,
+        worktree_path: report.worktreePath,
+        report_path: report.reportPath,
+        detail: 'Runtime created a shutdown checkpoint commit to preserve worker worktree changes.',
+      });
+    }
+
+    if (report.sourceRef && report.mergeOutcome !== 'skipped') {
+      commitHygieneEntries.push({
+        recorded_at: new Date().toISOString(),
+        operation: 'shutdown_merge',
+        worker_name: report.workerName,
+        task_id: worker?.assigned_tasks[0],
+        status: report.mergeOutcome === 'merged' ? 'applied' : report.mergeOutcome,
+        operational_commit: report.mergeOutcome === 'merged' ? report.leaderHeadAfter : null,
+        source_commit: report.sourceRef,
+        leader_head_before: report.leaderHeadBefore,
+        leader_head_after: report.leaderHeadAfter,
+        worktree_path: report.worktreePath,
+        report_path: report.reportPath,
+        detail: report.mergeDetail,
+      });
+    }
+  }
+
+  const artifactCwd = config.leader_cwd ?? cwd;
+  const ledger = await appendTeamCommitHygieneEntries(sanitized, commitHygieneEntries, artifactCwd)
+  const taskView = await listTasks(sanitized, cwd).catch(() => [])
+  const commitHygieneContext = buildTeamCommitHygieneContext({
+    teamName: sanitized,
+    tasks: taskView,
+    ledger,
+  })
+  const commitHygieneArtifacts = await writeTeamCommitHygieneContext(sanitized, commitHygieneContext, artifactCwd)
 
   // 5. Remove worker worktree-root instructions and team-scoped fallback instructions.
   for (const worker of config.workers) {
@@ -2400,6 +2531,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   if (cleanupErrors.length > 0) {
     throw new Error(cleanupErrors.join(' | '));
   }
+
+  return { commitHygieneArtifacts }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a structured team commit hygiene ledger for runtime-generated operational commits
- preserve JSON/Markdown finalization context artifacts that guide the leader toward clean Lore-format final commits
- surface the artifact paths on shutdown and cover monitor/shutdown flows with focused tests

## Testing
- npm run build
- npx biome lint src/team/commit-hygiene.ts src/team/runtime.ts src/team/runtime-cli.ts src/cli/team.ts src/team/__tests__/runtime.test.ts src/team/__tests__/shutdown-fallback.test.ts
- node --test --test-name-pattern='(monitorTeam auto-commits dirty worker worktree before integration|monitorTeam rebases idle workers after integration lands on leader \(cross-worker rebase\)|shutdownTeam checkpoints dirty detached worker worktrees, merges them, and writes a report)' dist/team/__tests__/runtime.test.js dist/team/__tests__/shutdown-fallback.test.js
