### PR TITLE
Fix Windows HUD git fast path for worktree .git pointers

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join, relative } from 'node:path';
 import {
   buildGitBranchLabel,
   readGitBranch,
@@ -23,6 +23,18 @@ function gitRunnerFromMap(map: Record<string, string | Error>) {
   };
 }
 
+async function withWindowsPlatform(run: () => Promise<void> | void): Promise<void> {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  try {
+    await run();
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  }
+}
+
 async function withTempRepo(prefix: string, run: (cwd: string) => Promise<void>): Promise<void> {
   const cwd = await mkdtemp(join(tmpdir(), prefix));
   try {
@@ -36,6 +48,23 @@ async function writeModeState(cwd: string, mode: string, state: unknown): Promis
   const stateDir = join(cwd, '.omx', 'state');
   await mkdir(stateDir, { recursive: true });
   await writeFile(join(stateDir, mode + '-state.json'), JSON.stringify(state));
+}
+
+async function createWorktreePointerFixture(cwd: string, options: { withOrigin?: boolean } = {}): Promise<void> {
+  const gitDir = join(cwd, '.git-admin', 'worktrees', 'feature');
+  const commonDir = join(cwd, '.git-admin');
+  await mkdir(commonDir, { recursive: true });
+  await mkdir(join(gitDir, 'logs', 'refs', 'heads'), { recursive: true });
+  await writeFile(join(cwd, '.git'), `gitdir: ${relative(cwd, gitDir)}\n`);
+  await writeFile(join(gitDir, 'HEAD'), 'ref: refs/heads/worktree-branch\n');
+  await writeFile(join(gitDir, 'commondir'), '../..\n');
+  if (options.withOrigin !== false) {
+    await writeFile(join(commonDir, 'config'), [
+      '[remote "origin"]',
+      '  url = git@github.com:acme/worktree-repo.git',
+      '',
+    ].join('\n'));
+  }
 }
 
 describe('readGitBranch', () => {
@@ -62,6 +91,15 @@ describe('readGitBranch', () => {
     }
 
     assert.equal(stderrChunks.join('').includes('not a git repository'), false);
+  });
+
+  it('uses the Windows fast path for worktree .git file pointers', async () => {
+    await withTempRepo('omx-hud-worktree-branch-', async (cwd) => {
+      await createWorktreePointerFixture(cwd);
+      await withWindowsPlatform(() => {
+        assert.equal(readGitBranch(cwd), 'worktree-branch');
+      });
+    });
   });
 });
 
@@ -142,6 +180,24 @@ describe('buildGitBranchLabel', () => {
       preset: 'focused',
       git: { display: 'repo-branch', repoLabel: 'manual' },
     }, gitRunner), 'manual/feature/test');
+  });
+
+  it('resolves remote config from the git common dir for worktree pointers on Windows', async () => {
+    await withTempRepo('omx-hud-worktree-remote-', async (cwd) => {
+      await createWorktreePointerFixture(cwd);
+      await withWindowsPlatform(() => {
+        assert.equal(buildGitBranchLabel(cwd), 'worktree-repo/worktree-branch');
+      });
+    });
+  });
+
+  it('keeps the worktree root for --show-toplevel fallback on Windows worktrees', async () => {
+    await withTempRepo('omx-hud-worktree-top-', async (cwd) => {
+      await createWorktreePointerFixture(cwd, { withOrigin: false });
+      await withWindowsPlatform(() => {
+        assert.equal(buildGitBranchLabel(cwd), `${basename(cwd)}/worktree-branch`);
+      });
+    });
   });
 });
 

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -5,11 +5,12 @@
  */
 
 import { readFile } from 'fs/promises';
-import { readFileSync, statSync } from 'fs';
+import { readFileSync } from 'fs';
 import { execSync } from 'child_process';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { omxStateDir } from '../utils/paths.js';
+import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
 import { getReadScopedStatePaths } from '../mcp/state-paths.js';
@@ -176,34 +177,6 @@ export function readVersion(): string | null {
 export type GitRunner = (cwd: string, args: string[]) => string | null;
 
 /**
- * Find the .git directory by walking up from `startCwd`.
- * Returns the path to the `.git` directory, or null if not found.
- */
-function findGitDir(startCwd: string): string | null {
-  let dir = startCwd;
-  for (;;) {
-    const candidate = join(dir, '.git');
-    try {
-      if (statSync(candidate).isDirectory()) return candidate;
-    } catch { /* not found, walk up */ }
-    const parent = dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
-  }
-}
-
-/**
- * Read a file inside the .git directory. Returns trimmed content or null.
- */
-function readGitFile(gitDir: string, ...parts: string[]): string | null {
-  try {
-    return readFileSync(join(gitDir, ...parts), 'utf-8').trim() || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * On Windows, read common git queries directly from .git/ files to avoid
  * spawning console windows (conhost.exe flicker).  Falls back to execSync
  * for non-Windows platforms or unrecognised arguments.
@@ -213,12 +186,12 @@ function readGitFile(gitDir: string, ...parts: string[]): string | null {
 function runGit(cwd: string, args: string[]): string | null {
   if (process.platform === 'win32') {
     try {
-      const gitDir = findGitDir(cwd);
-      if (gitDir) {
+      const gitLayout = findGitLayout(cwd);
+      if (gitLayout) {
         const cmd = args.join(' ');
 
         if (cmd === 'rev-parse --abbrev-ref HEAD') {
-          const head = readGitFile(gitDir, 'HEAD');
+          const head = readGitLayoutFile(gitLayout.gitDir, 'HEAD');
           if (head?.startsWith('ref: refs/heads/'))
             return head.slice('ref: refs/heads/'.length);
           return head; // detached HEAD — raw SHA
@@ -226,7 +199,8 @@ function runGit(cwd: string, args: string[]): string | null {
 
         if (cmd.startsWith('remote get-url ')) {
           const remoteName = args[2];
-          const config = readGitFile(gitDir, 'config');
+          const config = readGitLayoutFile(gitLayout.gitDir, 'config')
+            ?? readGitLayoutFile(gitLayout.commonDir, 'config');
           if (config) {
             const re = new RegExp(
               `\\[remote "${remoteName}"\\][\\s\\S]*?url\\s*=\\s*(.+)`,
@@ -239,7 +213,8 @@ function runGit(cwd: string, args: string[]): string | null {
         }
 
         if (cmd === 'remote') {
-          const config = readGitFile(gitDir, 'config');
+          const config = readGitLayoutFile(gitLayout.gitDir, 'config')
+            ?? readGitLayoutFile(gitLayout.commonDir, 'config');
           if (config) {
             const matches = [...config.matchAll(/\[remote "([^"]+)"\]/g)];
             if (matches.length > 0) return matches.map((m) => m[1]).join('\n');
@@ -248,7 +223,7 @@ function runGit(cwd: string, args: string[]): string | null {
         }
 
         if (cmd === 'rev-parse --show-toplevel') {
-          return dirname(gitDir);
+          return gitLayout.worktreeRoot;
         }
       }
     } catch { /* fall through to execSync */ }

--- a/src/team/__tests__/leader-activity.test.ts
+++ b/src/team/__tests__/leader-activity.test.ts
@@ -1,14 +1,40 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   isLeaderRuntimeStale,
   readLatestLeaderActivityMsFromStateDir,
   recordLeaderRuntimeActivity,
 } from '../leader-activity.js';
+
+async function withWindowsPlatform(run: () => Promise<void> | void): Promise<void> {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  try {
+    await run();
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  }
+}
+
+async function createWorktreePointerFixture(cwd: string): Promise<{ gitDir: string }> {
+  const gitDir = join(cwd, '.git-admin', 'worktrees', 'feature');
+  const commonDir = join(cwd, '.git-admin');
+  await mkdir(join(gitDir, 'logs', 'refs', 'heads'), { recursive: true });
+  await mkdir(commonDir, { recursive: true });
+  await writeFile(join(cwd, '.git'), `gitdir: ${relative(cwd, gitDir)}\n`);
+  await writeFile(join(gitDir, 'HEAD'), 'ref: refs/heads/worktree-branch\n');
+  await writeFile(join(gitDir, 'commondir'), '../..\n');
+  await writeFile(join(gitDir, 'logs', 'HEAD'), 'old\n');
+  await writeFile(join(gitDir, 'logs', 'refs', 'heads', 'worktree-branch'), 'new\n');
+  await writeFile(join(commonDir, 'config'), '');
+  return { gitDir };
+}
 
 describe('leader runtime activity', () => {
   it('records team status activity with shared leader activity metadata', async () => {
@@ -130,6 +156,34 @@ describe('leader runtime activity', () => {
       }).trim()) * 1000;
 
       assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, headMs + 5_000), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats worktree .git file pointers as recent branch activity on Windows', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-worktree-'));
+    try {
+      const { gitDir } = await createWorktreePointerFixture(cwd);
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_turn_at: '2026-03-21T04:00:00.000Z',
+      }));
+      await writeFile(join(stateDir, 'leader-runtime-activity.json'), JSON.stringify({
+        last_activity_at: '2026-03-21T04:00:00.000Z',
+        last_source: 'team_status',
+      }));
+
+      const recentMs = Date.parse('2026-03-21T04:10:00.000Z');
+      const recentDate = new Date(recentMs);
+      await utimes(join(gitDir, 'HEAD'), recentDate, recentDate);
+      await utimes(join(gitDir, 'logs', 'HEAD'), recentDate, recentDate);
+      await utimes(join(gitDir, 'logs', 'refs', 'heads', 'worktree-branch'), recentDate, recentDate);
+
+      await withWindowsPlatform(async () => {
+        assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, recentMs + 5_000), false);
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -1,8 +1,9 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { omxStateDir } from '../utils/paths.js';
+import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 
 interface LeaderRuntimeActivityDoc {
   last_activity_at?: string;
@@ -41,30 +42,6 @@ function parseEpochSecondsMs(value: string): number {
 }
 
 /**
- * Find the .git directory by walking up from `startCwd`.
- */
-function findGitDir(startCwd: string): string | null {
-  let dir = startCwd;
-  for (;;) {
-    const candidate = join(dir, '.git');
-    try {
-      if (statSync(candidate).isDirectory()) return candidate;
-    } catch { /* walk up */ }
-    const parent = dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
-  }
-}
-
-function readGitFile(gitDir: string, ...parts: string[]): string | null {
-  try {
-    return readFileSync(join(gitDir, ...parts), 'utf-8').trim() || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * On Windows, read git info from .git/ files directly to avoid spawning
  * console windows (conhost.exe flicker on every poll cycle).
  *
@@ -73,32 +50,32 @@ function readGitFile(gitDir: string, ...parts: string[]): string | null {
 function tryReadGitValue(cwd: string, args: string[]): string | null {
   if (process.platform === 'win32') {
     try {
-      const gitDir = findGitDir(cwd);
-      if (gitDir) {
+      const gitLayout = findGitLayout(cwd);
+      if (gitLayout) {
         const cmd = args.join(' ');
 
-        if (cmd === 'rev-parse --git-dir') return gitDir;
+        if (cmd === 'rev-parse --git-dir') return gitLayout.gitDir;
 
         if (cmd === 'symbolic-ref --quiet --short HEAD') {
-          const head = readGitFile(gitDir, 'HEAD');
+          const head = readGitLayoutFile(gitLayout.gitDir, 'HEAD');
           if (head?.startsWith('ref: refs/heads/'))
             return head.slice('ref: refs/heads/'.length);
           return null; // detached HEAD
         }
 
         if (cmd === 'rev-parse --git-path logs/HEAD') {
-          return join(gitDir, 'logs', 'HEAD');
+          return join(gitLayout.gitDir, 'logs', 'HEAD');
         }
 
         if (cmd.startsWith('rev-parse --git-path logs/refs/heads/')) {
           const branch = args[args.length - 1].replace('logs/', '');
-          return join(gitDir, 'logs', branch);
+          return join(gitLayout.gitDir, 'logs', branch);
         }
 
         if (cmd === 'show -s --format=%ct HEAD') {
           // Use HEAD file mtime as a proxy for last-commit timestamp.
           try {
-            const headMs = statSync(join(gitDir, 'HEAD')).mtimeMs;
+            const headMs = statSync(join(gitLayout.gitDir, 'HEAD')).mtimeMs;
             return String(Math.floor(headMs / 1000));
           } catch { return null; }
         }

--- a/src/utils/git-layout.ts
+++ b/src/utils/git-layout.ts
@@ -1,0 +1,67 @@
+import { readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+export interface GitLayout {
+  gitDir: string;
+  commonDir: string;
+  worktreeRoot: string;
+}
+
+function readTrimmedFile(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveGitDirPointer(path: string): string | null {
+  const raw = readTrimmedFile(path);
+  if (!raw) return null;
+
+  const match = raw.match(/^gitdir:\s*(.+)$/i);
+  if (!match) return null;
+
+  return resolve(dirname(path), match[1].trim());
+}
+
+function resolveGitCommonDir(gitDir: string): string {
+  const commonDir = readTrimmedFile(join(gitDir, 'commondir'));
+  return commonDir ? resolve(gitDir, commonDir) : gitDir;
+}
+
+export function findGitLayout(startCwd: string): GitLayout | null {
+  let dir = startCwd;
+
+  for (;;) {
+    const candidate = join(dir, '.git');
+    try {
+      const stat = statSync(candidate);
+      if (stat.isDirectory()) {
+        return {
+          gitDir: candidate,
+          commonDir: resolveGitCommonDir(candidate),
+          worktreeRoot: dir,
+        };
+      }
+      if (stat.isFile()) {
+        const gitDir = resolveGitDirPointer(candidate);
+        if (gitDir) {
+          return {
+            gitDir,
+            commonDir: resolveGitCommonDir(gitDir),
+            worktreeRoot: dir,
+          };
+        }
+      }
+    } catch { /* not found, walk up */ }
+
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+export function readGitLayoutFile(baseDir: string, ...parts: string[]): string | null {
+  return readTrimmedFile(join(baseDir, ...parts));
+}


### PR DESCRIPTION
## Summary
- resolve worktree `.git` file pointers for the Windows HUD/leader git fast paths
- read shared config from the git common dir and preserve the worktree root for top-level lookups
- add targeted regression coverage for HUD and leader activity worktree layouts

## Root cause
The Windows fast paths in `src/hud/state.ts` and `src/team/leader-activity.ts` assumed `.git` was always a directory. In git worktrees, `.git` is a file that points at the worktree admin dir. That meant the fast path missed the repo entirely and fell back to spawned git calls. Once the pointer is resolved, there are two extra worktree-specific details: `HEAD` lives in the worktree admin dir, but `config` may live in the common git dir, and `rev-parse --show-toplevel` must still resolve to the worktree root rather than `dirname(gitDir)`.

## Verification
- `npm run build`
- `node --test dist/hud/__tests__/state.test.js dist/team/__tests__/leader-activity.test.js`
- `npm run check:no-unused`
- `npx biome lint src/utils/git-layout.ts src/hud/state.ts src/hud/__tests__/state.test.ts src/team/leader-activity.ts src/team/__tests__/leader-activity.test.ts`
- actual git worktree verification via a node script importing `dist/hud/state.js` and `dist/team/leader-activity.js`

## Notes
- `npm run lint` from repo root still trips existing nested Biome root-config errors under checked-in worktree folders.
- a repo-wide `npm test` run also traversed unrelated worktree `dist/` trees and surfaced unrelated existing notify/team failures outside this fix.

Closes #1189.
