### PR TITLE
fix: support worktree gitdir files in HUD fast path

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -38,6 +38,16 @@ async function writeModeState(cwd: string, mode: string, state: unknown): Promis
   await writeFile(join(stateDir, mode + '-state.json'), JSON.stringify(state));
 }
 
+async function withWindowsPlatform(run: () => Promise<void> | void): Promise<void> {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: 'win32' });
+  try {
+    await run();
+  } finally {
+    if (descriptor) Object.defineProperty(process, 'platform', descriptor);
+  }
+}
+
 describe('readGitBranch', () => {
   it('returns null in a non-git directory without printing git fatal noise', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-state-'));
@@ -62,6 +72,25 @@ describe('readGitBranch', () => {
     }
 
     assert.equal(stderrChunks.join('').includes('not a git repository'), false);
+  });
+});
+
+describe('readGitBranch Windows worktree fast path', () => {
+  it('reads branch from a worktree .git file without shelling out', async () => {
+    await withTempRepo('omx-hud-worktree-gitfile-', async (cwd) => {
+      const worktree = join(cwd, 'repo', 'worktree');
+      const gitDir = join(cwd, 'repo', '.git', 'worktrees', 'worktree');
+      await mkdir(worktree, { recursive: true });
+      await mkdir(gitDir, { recursive: true });
+      await writeFile(join(worktree, '.git'), `gitdir: ../.git/worktrees/worktree\n`);
+      await writeFile(join(gitDir, 'HEAD'), 'ref: refs/heads/feature/worktree-fast-path\n');
+      await writeFile(join(gitDir, 'config'), '[remote "origin"]\n  url = https://github.com/acme/oh-my-codex.git\n');
+
+      await withWindowsPlatform(async () => {
+        assert.equal(readGitBranch(worktree), 'feature/worktree-fast-path');
+        assert.equal(buildGitBranchLabel(worktree), 'oh-my-codex/feature/worktree-fast-path');
+      });
+    });
   });
 });
 

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -5,9 +5,9 @@
  */
 
 import { readFile } from 'fs/promises';
-import { readFileSync, statSync } from 'fs';
+import { existsSync, readFileSync, statSync } from 'fs';
 import { execSync } from 'child_process';
-import { join, dirname, basename } from 'path';
+import { join, dirname, basename, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { omxStateDir } from '../utils/paths.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
@@ -176,16 +176,36 @@ export function readVersion(): string | null {
 export type GitRunner = (cwd: string, args: string[]) => string | null;
 
 /**
+ * Resolve a `.git` candidate path to the actual git dir.
+ * Supports both normal repos (`.git/`) and worktrees/submodules (`.git` file with `gitdir: ...`).
+ */
+function resolveGitDir(candidate: string): string | null {
+  try {
+    if (statSync(candidate).isDirectory()) return candidate;
+  } catch {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(candidate, 'utf-8').trim();
+    const match = content.match(/^gitdir:\s*(.+)$/i);
+    if (!match) return null;
+    const resolved = match[1] ? resolve(dirname(candidate), match[1].trim()) : null;
+    return resolved && existsSync(resolved) ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Find the .git directory by walking up from `startCwd`.
- * Returns the path to the `.git` directory, or null if not found.
+ * Returns the path to the actual git directory, or null if not found.
  */
 function findGitDir(startCwd: string): string | null {
   let dir = startCwd;
   for (;;) {
-    const candidate = join(dir, '.git');
-    try {
-      if (statSync(candidate).isDirectory()) return candidate;
-    } catch { /* not found, walk up */ }
+    const gitDir = resolveGitDir(join(dir, '.git'));
+    if (gitDir) return gitDir;
     const parent = dirname(dir);
     if (parent === dir) return null;
     dir = parent;


### PR DESCRIPTION
## Summary

Support git worktree `.git` pointer files in the Windows HUD git fast path.

## Changes

- resolve `.git` pointer files (`gitdir: ...`) in addition to normal `.git/` directories
- update HUD git-dir discovery to use the resolved gitdir for worktree checkouts
- add a regression test covering a simulated Windows worktree layout

## Validation

- [x] `npm run build`
- [x] `node --test dist/hud/__tests__/state.test.js`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1189
