### PR TITLE
fix: ignore repo-local .codex setup output

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import {
   mkdtemp,
   mkdir,
@@ -95,19 +96,22 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("creates .gitignore with a .omx/ entry during project-scoped setup", async () => {
+  it("creates .gitignore with .omx/ and .codex/ entries during project-scoped setup", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await runSetupInTempDir(wd, { scope: "project" });
 
       assert.equal(existsSync(join(wd, ".omx", "state")), true);
-      assert.equal(await readFile(join(wd, ".gitignore"), "utf-8"), ".omx/\n");
+      assert.equal(
+        await readFile(join(wd, ".gitignore"), "utf-8"),
+        ".omx/\n.codex/\n",
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it("appends .omx/ to an existing project .gitignore without duplicating it", async () => {
+  it("appends missing .omx/ and .codex/ entries to an existing project .gitignore without duplicating them", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await writeFile(join(wd, ".gitignore"), "node_modules/\n");
@@ -116,8 +120,30 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await runSetupInTempDir(wd, { scope: "project" });
 
       const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
-      assert.equal(gitignore, "node_modules/\n.omx/\n");
+      assert.equal(gitignore, "node_modules/\n.omx/\n.codex/\n");
       assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 1);
+      assert.equal(gitignore.match(/^\.codex\/$/gm)?.length ?? 0, 1);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps repo-local .codex ignored in a fresh git repo after project-scoped setup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      const initResult = spawnSync("git", ["init", "-q"], { cwd: wd });
+      assert.equal(initResult.status, 0);
+
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      const status = spawnSync(
+        "git",
+        ["status", "--short", "--ignored", ".codex", ".gitignore", "AGENTS.md"],
+        { cwd: wd, encoding: "utf-8" },
+      );
+      assert.equal(status.status, 0);
+      assert.match(status.stdout, /^!! \.codex\/$/m);
+      assert.doesNotMatch(status.stdout, /^\?\? \.codex\/$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -122,7 +122,7 @@ export interface SkillFrontmatterMetadata {
   description: string;
 }
 
-const PROJECT_OMX_GITIGNORE_ENTRY = ".omx/";
+const PROJECT_GITIGNORE_ENTRIES = [".omx/", ".codex/"] as const;
 
 function applyScopePathRewritesToAgentsTemplate(
   content: string,
@@ -550,7 +550,7 @@ function hasGitignoreEntry(content: string, entry: string): boolean {
     .some((line) => line === entry);
 }
 
-async function ensureProjectOmxGitignore(
+async function ensureProjectGitignore(
   projectRoot: string,
   backupContext: SetupBackupContext,
   options: Pick<SetupOptions, "dryRun" | "verbose">,
@@ -561,13 +561,17 @@ async function ensureProjectOmxGitignore(
     ? await readFile(gitignorePath, "utf-8")
     : "";
 
-  if (hasGitignoreEntry(existing, PROJECT_OMX_GITIGNORE_ENTRY)) {
+  const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter(
+    (entry) => !hasGitignoreEntry(existing, entry),
+  );
+
+  if (missingEntries.length === 0) {
     return "unchanged";
   }
 
   const nextContent = destinationExists
-    ? `${existing}${existing.endsWith("\n") || existing.length === 0 ? "" : "\n"}${PROJECT_OMX_GITIGNORE_ENTRY}\n`
-    : `${PROJECT_OMX_GITIGNORE_ENTRY}\n`;
+    ? `${existing}${existing.endsWith("\n") || existing.length === 0 ? "" : "\n"}${missingEntries.join("\n")}\n`
+    : `${PROJECT_GITIGNORE_ENTRIES.join("\n")}\n`;
 
   if (
     await ensureBackup(gitignorePath, destinationExists, backupContext, options)
@@ -581,7 +585,7 @@ async function ensureProjectOmxGitignore(
 
   if (options.verbose) {
     console.log(
-      `  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore (${PROJECT_OMX_GITIGNORE_ENTRY})`,
+      `  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore (${missingEntries.join(", ")})`,
     );
   }
 
@@ -650,18 +654,18 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   console.log("  Done.\n");
 
   if (resolvedScope.scope === "project") {
-    const gitignoreResult = await ensureProjectOmxGitignore(
+    const gitignoreResult = await ensureProjectGitignore(
       projectRoot,
       backupContext,
       { dryRun, verbose },
     );
     if (gitignoreResult === "created") {
       console.log(
-        "  Created .gitignore with .omx/ so local OMX runtime state stays out of source control.\n",
+        "  Created .gitignore with .omx/ and .codex/ so local OMX runtime/config state stays out of source control.\n",
       );
     } else if (gitignoreResult === "updated") {
       console.log(
-        "  Added .omx/ to .gitignore so local OMX runtime state stays out of source control.\n",
+        "  Added .omx/ and/or .codex/ to .gitignore so local OMX runtime/config state stays out of source control.\n",
       );
     }
   }


### PR DESCRIPTION
## Summary
- reproduce issue #1197 in a fresh git repo and confirm project-scoped `omx setup` leaves `.codex/` unignored while `.codex/config.toml` contains absolute local paths
- auto-ignore both `.omx/` and `.codex/` during project-scoped setup as an immediate containment fix
- add regression coverage for `.gitignore` creation/update and a fresh-repo git-status containment check

## Repro
Before this change, a fresh repo after `node dist/cli/omx.js setup --scope project` showed:
- `.gitignore` containing only `.omx/`
- `git status --short` reporting `?? .codex/`
- `.codex/config.toml` embedding absolute local paths to OMX scripts/MCP servers

## Verification
- `npm run build`
- `npm run lint -- src/cli/setup.ts src/cli/__tests__/setup-refresh.test.ts`
- `node --test dist/cli/__tests__/setup-refresh.test.js`
- manual fresh-repo repro confirming `git status --short --ignored` now shows `!! .codex/`

Closes #1197.
