### PR TITLE
fix(hud): support git worktree .git files on Windows

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -11,6 +11,7 @@ import {
   readDeepInterviewState,
   readAutoresearchState,
   readUltraqaState,
+  resolveGitMetadataForTesting,
 } from '../state.js';
 
 function gitRunnerFromMap(map: Record<string, string | Error>) {
@@ -65,6 +66,46 @@ describe('readGitBranch', () => {
   });
 });
 
+describe('resolveGitMetadataForTesting', () => {
+  it('resolves standard .git directories as repo top-level', async () => {
+    await withTempRepo('omx-hud-gitdir-', async (cwd) => {
+      await mkdir(join(cwd, '.git'), { recursive: true });
+
+      assert.deepEqual(resolveGitMetadataForTesting(cwd), {
+        gitDir: join(cwd, '.git'),
+        topLevel: cwd,
+      });
+    });
+  });
+
+  it('resolves git worktree .git files and preserves repo top-level', async () => {
+    await withTempRepo('omx-hud-worktree-', async (cwd) => {
+      const actualGitDir = join(cwd, '..', 'main-repo', '.git', 'worktrees', 'feature-x');
+      await mkdir(actualGitDir, { recursive: true });
+      await writeFile(join(cwd, '.git'), 'gitdir: ../main-repo/.git/worktrees/feature-x\n');
+
+      assert.deepEqual(resolveGitMetadataForTesting(cwd), {
+        gitDir: actualGitDir,
+        topLevel: cwd,
+      });
+    });
+  });
+
+  it('supports nested cwd inside a worktree checkout', async () => {
+    await withTempRepo('omx-hud-worktree-nested-', async (cwd) => {
+      const actualGitDir = join(cwd, '..', 'main-repo', '.git', 'worktrees', 'feature-y');
+      const nested = join(cwd, 'packages', 'hud');
+      await mkdir(actualGitDir, { recursive: true });
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(cwd, '.git'), 'gitdir: ../main-repo/.git/worktrees/feature-y\n');
+
+      assert.deepEqual(resolveGitMetadataForTesting(nested), {
+        gitDir: actualGitDir,
+        topLevel: cwd,
+      });
+    });
+  });
+});
 describe('buildGitBranchLabel', () => {
   it('keeps the branch when origin lookup fails', () => {
     const gitRunner = gitRunnerFromMap({

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -7,7 +7,7 @@
 import { readFile } from 'fs/promises';
 import { readFileSync, statSync } from 'fs';
 import { execSync } from 'child_process';
-import { join, dirname, basename } from 'path';
+import { join, dirname, basename, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { omxStateDir } from '../utils/paths.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
@@ -175,17 +175,45 @@ export function readVersion(): string | null {
 
 export type GitRunner = (cwd: string, args: string[]) => string | null;
 
+interface GitMetadata {
+  gitDir: string;
+  topLevel: string;
+}
+
+function resolveGitMetadataFromCandidate(dir: string): GitMetadata | null {
+  const candidate = join(dir, '.git');
+
+  try {
+    if (statSync(candidate).isDirectory()) {
+      return { gitDir: candidate, topLevel: dir };
+    }
+  } catch {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(candidate, 'utf-8').trim();
+    const match = content.match(/^gitdir:\s*(.+)$/im);
+    if (!match) return null;
+
+    return {
+      gitDir: resolve(dir, match[1].trim()),
+      topLevel: dir,
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Find the .git directory by walking up from `startCwd`.
- * Returns the path to the `.git` directory, or null if not found.
+ * Find git metadata by walking up from `startCwd`.
+ * Supports both `.git/` directories and git worktree `.git` files.
  */
-function findGitDir(startCwd: string): string | null {
+function findGitMetadata(startCwd: string): GitMetadata | null {
   let dir = startCwd;
   for (;;) {
-    const candidate = join(dir, '.git');
-    try {
-      if (statSync(candidate).isDirectory()) return candidate;
-    } catch { /* not found, walk up */ }
+    const metadata = resolveGitMetadataFromCandidate(dir);
+    if (metadata) return metadata;
     const parent = dirname(dir);
     if (parent === dir) return null;
     dir = parent;
@@ -213,8 +241,9 @@ function readGitFile(gitDir: string, ...parts: string[]): string | null {
 function runGit(cwd: string, args: string[]): string | null {
   if (process.platform === 'win32') {
     try {
-      const gitDir = findGitDir(cwd);
-      if (gitDir) {
+      const gitMetadata = findGitMetadata(cwd);
+      if (gitMetadata) {
+        const { gitDir, topLevel } = gitMetadata;
         const cmd = args.join(' ');
 
         if (cmd === 'rev-parse --abbrev-ref HEAD') {
@@ -248,7 +277,7 @@ function runGit(cwd: string, args: string[]): string | null {
         }
 
         if (cmd === 'rev-parse --show-toplevel') {
-          return dirname(gitDir);
+          return topLevel;
         }
       }
     } catch { /* fall through to execSync */ }
@@ -340,6 +369,10 @@ export function buildGitBranchLabel(
 
   const repoLabel = resolveRepoLabel(cwd, config, gitRunner);
   return repoLabel ? `${repoLabel}/${branch}` : branch;
+}
+
+export function resolveGitMetadataForTesting(startCwd: string): GitMetadata | null {
+  return findGitMetadata(startCwd);
 }
 
 /** Read all state files and build the full render context */


### PR DESCRIPTION
## Summary
- support Windows HUD fast-path git lookups when `.git` is a worktree pointer file
- preserve the worktree checkout as `--show-toplevel` instead of using the resolved gitdir parent
- add regression tests for both normal repos and worktree-style `.git` files

## Testing
- built TypeScript with Node 22
- ran `node --test dist/hud/__tests__/state.test.js`

Closes #1189
