### PR TITLE
fix: harden managed tmux HUD targeting

### DIFF
--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -34,6 +34,7 @@ export function buildExpectedManagedTmuxSessionName(cwd: string, sessionId: stri
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 2000,
+      windowsHide: true,
     }).trim();
     if (branch) branchToken = sanitizeTmuxToken(branch);
   } catch {
@@ -244,7 +245,7 @@ async function readManagedPaneCommandState(paneTarget: string): Promise<{ curren
 }
 
 function paneLooksLikeManagedAgent({ currentCommand, startCommand }: { currentCommand: string; startCommand: string }): boolean {
-  if (/omx.*hud.*--watch/i.test(startCommand)) return false;
+  if (/\bomx\b.*\bhud\b.*--watch/i.test(startCommand)) return false;
   if (startCommand.includes('codex')) return true;
   return currentCommand === 'codex' || currentCommand === 'node' || currentCommand === 'npx';
 }

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1931,6 +1931,7 @@ esac
 
   it('restores standalone HUD panes with direct resize on native Windows', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-win32-hud-'));
+    const prevLeaderNodePath = process.env.OMX_LEADER_NODE_PATH;
     const prevMsystem = process.env.MSYSTEM;
     const prevOstype = process.env.OSTYPE;
     const prevWsl = process.env.WSL_DISTRO_NAME;
@@ -1964,12 +1965,14 @@ esac
           delete process.env.OSTYPE;
           delete process.env.WSL_DISTRO_NAME;
           delete process.env.WSL_INTEROP;
+          process.env.OMX_LEADER_NODE_PATH = 'C:\\Program Files\\nodejs\\node.exe';
           Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
           const paneId = restoreStandaloneHudPane('%11', cwd);
           assert.equal(paneId, '%44');
 
           const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /'C:\\Program Files\\nodejs\\node\.exe'/);
           assert.match(tmuxLog, new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.match(tmuxLog, /select-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/);
@@ -1979,6 +1982,8 @@ esac
       );
     } finally {
       if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+      if (typeof prevLeaderNodePath === 'string') process.env.OMX_LEADER_NODE_PATH = prevLeaderNodePath;
+      else delete process.env.OMX_LEADER_NODE_PATH;
       if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
       else delete process.env.MSYSTEM;
       if (typeof prevOstype === 'string') process.env.OSTYPE = prevOstype;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -613,6 +613,10 @@ function resolveAbsoluteBinaryPath(binary: string): string {
  */
 let _leaderPaths: { node: string; } | null = null;
 function resolveLeaderNodePath(): string {
+  const envOverride = process.env[OMX_LEADER_NODE_PATH_ENV];
+  if (typeof envOverride === 'string' && envOverride.trim() !== '') {
+    return envOverride.trim();
+  }
   if (!_leaderPaths) {
     _leaderPaths = { node: resolveAbsoluteBinaryPath('node') };
   }
@@ -1014,7 +1018,7 @@ export function restoreStandaloneHudPane(
   const omxEntry = process.argv[1];
   if (!omxEntry || omxEntry.trim() === '') return null;
 
-  const hudCmd = `node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+  const hudCmd = `${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
   const hudCwd = translatePathForMsys(cwd);
   const hudResult = runTmux([
     'split-window',


### PR DESCRIPTION
## Summary
- fix the managed tmux HUD-pane detection regex so HUD panes are excluded correctly
- use `windowsHide` for managed-session git branch lookup on Windows-sensitive paths
- restore standalone HUD panes with the resolved leader Node path instead of hardcoded `node`
- cover the Windows HUD restore path with a regression test

## Verification
- `npm run build`
- `node --test --test-name-pattern='native Windows HUD reconciliation' dist/team/__tests__/tmux-session.test.js`
