### PR TITLE
Fix Windows worktree leader-activity path resolution

### DIFF
--- a/src/team/__tests__/leader-activity.test.ts
+++ b/src/team/__tests__/leader-activity.test.ts
@@ -22,18 +22,19 @@ async function withWindowsPlatform(run: () => Promise<void> | void): Promise<voi
   }
 }
 
-async function createWorktreePointerFixture(cwd: string): Promise<{ gitDir: string }> {
+async function createWorktreePointerFixture(cwd: string): Promise<{ gitDir: string; commonDir: string }> {
   const gitDir = join(cwd, '.git-admin', 'worktrees', 'feature');
   const commonDir = join(cwd, '.git-admin');
-  await mkdir(join(gitDir, 'logs', 'refs', 'heads'), { recursive: true });
+  await mkdir(join(gitDir, 'logs'), { recursive: true });
+  await mkdir(join(commonDir, 'logs', 'refs', 'heads'), { recursive: true });
   await mkdir(commonDir, { recursive: true });
   await writeFile(join(cwd, '.git'), `gitdir: ${relative(cwd, gitDir)}\n`);
   await writeFile(join(gitDir, 'HEAD'), 'ref: refs/heads/worktree-branch\n');
   await writeFile(join(gitDir, 'commondir'), '../..\n');
   await writeFile(join(gitDir, 'logs', 'HEAD'), 'old\n');
-  await writeFile(join(gitDir, 'logs', 'refs', 'heads', 'worktree-branch'), 'new\n');
+  await writeFile(join(commonDir, 'logs', 'refs', 'heads', 'worktree-branch'), 'new\n');
   await writeFile(join(commonDir, 'config'), '');
-  return { gitDir };
+  return { gitDir, commonDir };
 }
 
 describe('leader runtime activity', () => {
@@ -164,7 +165,7 @@ describe('leader runtime activity', () => {
   it('treats worktree .git file pointers as recent branch activity on Windows', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-worktree-'));
     try {
-      const { gitDir } = await createWorktreePointerFixture(cwd);
+      const { gitDir, commonDir } = await createWorktreePointerFixture(cwd);
       const stateDir = join(cwd, '.omx', 'state');
       await mkdir(stateDir, { recursive: true });
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
@@ -175,16 +176,73 @@ describe('leader runtime activity', () => {
         last_source: 'team_status',
       }));
 
+      const staleMs = Date.parse('2026-03-21T04:00:00.000Z');
       const recentMs = Date.parse('2026-03-21T04:10:00.000Z');
+      const staleDate = new Date(staleMs);
       const recentDate = new Date(recentMs);
-      await utimes(join(gitDir, 'HEAD'), recentDate, recentDate);
-      await utimes(join(gitDir, 'logs', 'HEAD'), recentDate, recentDate);
-      await utimes(join(gitDir, 'logs', 'refs', 'heads', 'worktree-branch'), recentDate, recentDate);
+      await utimes(join(gitDir, 'HEAD'), staleDate, staleDate);
+      await utimes(join(gitDir, 'logs', 'HEAD'), staleDate, staleDate);
+      await utimes(join(commonDir, 'logs', 'refs', 'heads', 'worktree-branch'), recentDate, recentDate);
 
       await withWindowsPlatform(async () => {
         assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, recentMs + 5_000), false);
       });
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses absolute git-path results for real worktree reflogs', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-worktree-real-'));
+    const worktreePath = `${cwd}-wt`;
+    try {
+      execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+      await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+      execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'init'], {
+        cwd,
+        stdio: 'ignore',
+        env: {
+          ...process.env,
+          GIT_AUTHOR_DATE: '2026-03-21T04:00:00.000Z',
+          GIT_COMMITTER_DATE: '2026-03-21T04:00:00.000Z',
+        },
+      });
+      execFileSync('git', ['worktree', 'add', '-b', 'feature', worktreePath], { cwd, stdio: 'ignore' });
+
+      const stateDir = join(worktreePath, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_turn_at: '2026-03-21T04:00:00.000Z',
+      }));
+      await writeFile(join(stateDir, 'leader-runtime-activity.json'), JSON.stringify({
+        last_activity_at: '2026-03-21T04:00:00.000Z',
+        last_source: 'team_status',
+      }));
+
+      const headLogPath = execFileSync('git', ['rev-parse', '--git-path', 'logs/HEAD'], {
+        cwd: worktreePath,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      const branchLogPath = execFileSync('git', ['rev-parse', '--git-path', 'logs/refs/heads/feature'], {
+        cwd: worktreePath,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+
+      const staleMs = Date.parse('2026-03-21T04:00:00.000Z');
+      const recentMs = Date.parse('2026-03-21T04:10:00.000Z');
+      const staleDate = new Date(staleMs);
+      const recentDate = new Date(recentMs);
+      await utimes(headLogPath, staleDate, staleDate);
+      await utimes(branchLogPath, recentDate, recentDate);
+
+      assert.equal(await isLeaderRuntimeStale(stateDir, 30_000, recentMs + 5_000), false);
+    } finally {
+      await rm(worktreePath, { recursive: true, force: true });
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname, join, posix, resolve, win32 } from 'node:path';
 import { omxStateDir } from '../utils/paths.js';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 
@@ -41,6 +41,12 @@ function parseEpochSecondsMs(value: string): number {
   return Number.isFinite(seconds) ? seconds * 1000 : Number.NaN;
 }
 
+function resolveGitOutputPath(cwd: string, gitPath: string | null): string | null {
+  if (!gitPath) return null;
+  if (posix.isAbsolute(gitPath) || win32.isAbsolute(gitPath)) return gitPath;
+  return resolve(cwd, gitPath);
+}
+
 /**
  * On Windows, read git info from .git/ files directly to avoid spawning
  * console windows (conhost.exe flicker on every poll cycle).
@@ -69,7 +75,7 @@ function tryReadGitValue(cwd: string, args: string[]): string | null {
 
         if (cmd.startsWith('rev-parse --git-path logs/refs/heads/')) {
           const branch = args[args.length - 1].replace('logs/', '');
-          return join(gitLayout.gitDir, 'logs', branch);
+          return join(gitLayout.commonDir, 'logs', branch);
         }
 
         if (cmd === 'show -s --format=%ct HEAD') {
@@ -127,8 +133,8 @@ async function readLeaderBranchGitActivityMs(stateDir: string): Promise<number> 
   const headCommitEpoch = tryReadGitValue(cwd, ['show', '-s', '--format=%ct', 'HEAD']);
 
   const [headLogMs, branchLogMs] = await Promise.all([
-    statMsIfExists(headLogPath ? join(cwd, headLogPath) : null),
-    statMsIfExists(branchLogPath ? join(cwd, branchLogPath) : null),
+    statMsIfExists(resolveGitOutputPath(cwd, headLogPath)),
+    statMsIfExists(resolveGitOutputPath(cwd, branchLogPath)),
   ]);
   const headCommitMs = headCommitEpoch ? parseEpochSecondsMs(headCommitEpoch) : Number.NaN;
 


### PR DESCRIPTION
## Summary
- stop double-joining absolute git-path results before statting reflogs
- read linked-worktree branch reflogs from the shared common git dir instead of the per-worktree git dir
- add regression coverage for synthetic worktree pointers and real worktree absolute-path behavior

## Verification
- npm run build
- npx tsc --noEmit
- npx @biomejs/biome lint src/team/leader-activity.ts src/team/__tests__/leader-activity.test.ts
- node --test dist/team/__tests__/leader-activity.test.js
- node --test dist/hud/__tests__/state.test.js
