### PR TITLE
Fix leader mailbox delivery regressions across runtime and CLI seams

### DIFF
--- a/crates/omx-runtime-core/src/engine.rs
+++ b/crates/omx-runtime-core/src/engine.rs
@@ -592,15 +592,17 @@ mod tests {
         .unwrap();
         std::fs::write(
             dir.join("mailbox.json"),
-            serde_json::to_string_pretty(&MailboxLog::from(vec![crate::mailbox::MailboxRecord {
-                message_id: "msg-legacy".into(),
-                from_worker: "worker-1".into(),
-                to_worker: "leader-fixed".into(),
-                body: "recovered body".into(),
-                created_at: "2026-04-04T00:00:00.000Z".into(),
-                notified_at: None,
-                delivered_at: None,
-            }]))
+            serde_json::to_string_pretty(&serde_json::json!({
+                "records": [{
+                    "message_id": "msg-legacy",
+                    "from_worker": "worker-1",
+                    "to_worker": "leader-fixed",
+                    "body": "recovered body",
+                    "created_at": "2026-04-04T00:00:00.000Z",
+                    "notified_at": null,
+                    "delivered_at": null
+                }]
+            }))
             .unwrap(),
         )
         .unwrap();

--- a/crates/omx-runtime-core/src/engine.rs
+++ b/crates/omx-runtime-core/src/engine.rs
@@ -293,7 +293,10 @@ impl RuntimeEngine {
         lock_file.lock_shared()?;
 
         let events_json = std::fs::read_to_string(dir.join("events.json"))?;
-        let events: Vec<RuntimeEvent> = serde_json::from_str(&events_json)?;
+        let mut events: Vec<RuntimeEvent> = serde_json::from_str(&events_json)?;
+        let mailbox = std::fs::read_to_string(dir.join("mailbox.json"))
+            .ok()
+            .and_then(|mailbox_json| serde_json::from_str::<MailboxLog>(&mailbox_json).ok());
 
         drop(lock_file);
 
@@ -302,6 +305,32 @@ impl RuntimeEngine {
         for event in &events {
             replay_event(&mut engine, event);
         }
+
+        if let Some(mailbox_state) = mailbox {
+            let body_by_message_id: std::collections::HashMap<&str, &str> = mailbox_state
+                .records()
+                .iter()
+                .map(|record| (record.message_id.as_str(), record.body.as_str()))
+                .collect();
+
+            for event in &mut events {
+                if let RuntimeEvent::MailboxMessageCreated {
+                    message_id, body, ..
+                } = event
+                {
+                    if body.is_none() {
+                        if let Some(record_body) = body_by_message_id.get(message_id.as_str()) {
+                            if !record_body.is_empty() {
+                                *body = Some((*record_body).to_string());
+                            }
+                        }
+                    }
+                }
+            }
+
+            engine.mailbox = mailbox_state;
+        }
+
         engine.event_log = events;
 
         Ok(engine)
@@ -511,6 +540,88 @@ mod tests {
         assert_eq!(original_snap.authority, loaded_snap.authority);
         assert_eq!(original_snap.backlog, loaded_snap.backlog);
         assert_eq!(loaded.event_log().len(), 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn persist_and_load_round_trip_preserves_mailbox_body() {
+        let dir = std::env::temp_dir().join("omx-runtime-test-mailbox-body");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut engine = RuntimeEngine::new().with_state_dir(&dir);
+        engine
+            .process(RuntimeCommand::CreateMailboxMessage {
+                message_id: "msg-1".into(),
+                from_worker: "worker-1".into(),
+                to_worker: "leader-fixed".into(),
+                body: "ACK: worker-1 initialized".into(),
+            })
+            .unwrap();
+        engine.persist().unwrap();
+
+        let loaded = RuntimeEngine::load(&dir).unwrap();
+        loaded.write_compatibility_view().unwrap();
+
+        let mailbox_json = std::fs::read_to_string(dir.join("mailbox.json")).unwrap();
+        let mailbox: serde_json::Value = serde_json::from_str(&mailbox_json).unwrap();
+        assert_eq!(
+            mailbox["records"][0]["body"],
+            serde_json::Value::String("ACK: worker-1 initialized".into())
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_backfills_legacy_mailbox_event_body_from_mailbox_json() {
+        let dir = std::env::temp_dir().join("omx-runtime-test-mailbox-backfill");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        std::fs::write(
+            dir.join("events.json"),
+            serde_json::to_string_pretty(&vec![RuntimeEvent::MailboxMessageCreated {
+                message_id: "msg-legacy".into(),
+                from_worker: "worker-1".into(),
+                to_worker: "leader-fixed".into(),
+                body: None,
+            }])
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("mailbox.json"),
+            serde_json::to_string_pretty(&MailboxLog::from(vec![crate::mailbox::MailboxRecord {
+                message_id: "msg-legacy".into(),
+                from_worker: "worker-1".into(),
+                to_worker: "leader-fixed".into(),
+                body: "recovered body".into(),
+                created_at: "2026-04-04T00:00:00.000Z".into(),
+                notified_at: None,
+                delivered_at: None,
+            }]))
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(dir.join("engine.lock"), "").unwrap();
+
+        let loaded = RuntimeEngine::load(&dir).unwrap();
+        loaded.persist().unwrap();
+
+        let events_json = std::fs::read_to_string(dir.join("events.json")).unwrap();
+        let persisted_events: Vec<RuntimeEvent> = serde_json::from_str(&events_json).unwrap();
+        assert!(matches!(
+            &persisted_events[0],
+            RuntimeEvent::MailboxMessageCreated { body: Some(body), .. } if body == "recovered body"
+        ));
+
+        let mailbox_json = std::fs::read_to_string(dir.join("mailbox.json")).unwrap();
+        let mailbox: serde_json::Value = serde_json::from_str(&mailbox_json).unwrap();
+        assert_eq!(
+            mailbox["records"][0]["body"],
+            serde_json::Value::String("recovered body".into())
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/omx-runtime-core/src/engine.rs
+++ b/crates/omx-runtime-core/src/engine.rs
@@ -173,6 +173,7 @@ impl RuntimeEngine {
                     message_id,
                     from_worker,
                     to_worker,
+                    body: Some(body),
                 }
             }
             RuntimeCommand::MarkMailboxNotified { message_id } => {
@@ -386,10 +387,16 @@ fn replay_event(engine: &mut RuntimeEngine, event: &RuntimeEvent) {
             message_id,
             from_worker,
             to_worker,
+            body,
         } => {
             engine
                 .mailbox
-                .create(message_id, from_worker, to_worker, "");
+                .create(
+                    message_id,
+                    from_worker,
+                    to_worker,
+                    body.as_deref().unwrap_or(""),
+                );
         }
         RuntimeEvent::MailboxNotified { message_id } => {
             let _ = engine.mailbox.mark_notified(message_id);

--- a/crates/omx-runtime-core/src/engine.rs
+++ b/crates/omx-runtime-core/src/engine.rs
@@ -389,14 +389,12 @@ fn replay_event(engine: &mut RuntimeEngine, event: &RuntimeEvent) {
             to_worker,
             body,
         } => {
-            engine
-                .mailbox
-                .create(
-                    message_id,
-                    from_worker,
-                    to_worker,
-                    body.as_deref().unwrap_or(""),
-                );
+            engine.mailbox.create(
+                message_id,
+                from_worker,
+                to_worker,
+                body.as_deref().unwrap_or(""),
+            );
         }
         RuntimeEvent::MailboxNotified { message_id } => {
             let _ = engine.mailbox.mark_notified(message_id);

--- a/crates/omx-runtime-core/src/lib.rs
+++ b/crates/omx-runtime-core/src/lib.rs
@@ -271,6 +271,8 @@ pub enum RuntimeEvent {
         message_id: String,
         from_worker: String,
         to_worker: String,
+        #[serde(default)]
+        body: Option<String>,
     },
     MailboxNotified {
         message_id: String,
@@ -632,5 +634,20 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: RuntimeEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn mailbox_message_created_event_deserializes_without_body_for_back_compat() {
+        let json = r#"{"event":"MailboxMessageCreated","message_id":"msg-1","from_worker":"worker-1","to_worker":"leader-fixed"}"#;
+        let deserialized: RuntimeEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            deserialized,
+            RuntimeEvent::MailboxMessageCreated {
+                message_id: "msg-1".into(),
+                from_worker: "worker-1".into(),
+                to_worker: "leader-fixed".into(),
+                body: None,
+            }
+        );
     }
 }

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -751,6 +751,189 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('runs stalled-worker leader nudges from the fallback watcher even when the leader is not stale', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-worker-stall-nudge-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'workers', 'worker-1'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'tasks'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      const tmuxScript = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  fmt=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -t)
+        shift
+        target="$1"
+        ;;
+      *)
+        fmt="$1"
+        ;;
+    esac
+    shift || true
+  done
+  if [[ "$fmt" == "#{pane_in_mode}" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_id}" ]]; then
+    echo "\${target:-%42}"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_path}" ]]; then
+    dirname "${tmuxLogPath}"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_command}" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$fmt" == "#S" ]]; then
+    echo "omx-team-dispatch-team"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  target=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -t)
+        shift
+        target="$1"
+        ;;
+    esac
+    shift || true
+  done
+  if [[ -n "$target" ]]; then
+    printf "%%42 12345\n%%10 12346\n%%11 12347\n"
+    exit 0
+  fi
+  echo "%42 1"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(join(fakeBinDir, 'tmux'), tmuxScript);
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const now = Date.now();
+      await writeFile(join(wd, '.omx', 'state', 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'dispatch-team',
+        current_phase: 'team-exec',
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+        last_turn_at: new Date().toISOString(),
+        turn_count: 3,
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'config.json'), JSON.stringify({
+        name: 'dispatch-team',
+        tmux_session: 'omx-team-dispatch-team',
+        leader_pane_id: '%42',
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10' },
+          { name: 'worker-2', index: 2, pane_id: '%11' },
+        ],
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'tasks', 'task-1.json'), JSON.stringify({
+        id: '1',
+        subject: 'Pending work',
+        description: 'Needs attention',
+        status: 'pending',
+        created_at: new Date().toISOString(),
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'workers', 'worker-1', 'status.json'), JSON.stringify({
+        state: 'working',
+        current_task_id: '1',
+        updated_at: new Date(now - 180_000).toISOString(),
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'workers', 'worker-1', 'heartbeat.json'), JSON.stringify({
+        alive: true,
+        pid: 101,
+        turn_count: 2,
+        last_turn_at: new Date(now - 180_000).toISOString(),
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'team-leader-nudge.json'), JSON.stringify({
+        last_nudged_by_team: {
+          'dispatch-team': {
+            at: new Date(now - 5_000).toISOString(),
+            last_message_id: '',
+            reason: 'new_mailbox_message',
+          },
+        },
+        progress_by_team: {
+          'dispatch-team': {
+            signature: JSON.stringify({
+              tasks: [{ id: '1', owner: '', status: 'pending' }],
+              workers: [
+                {
+                  worker: 'worker-1',
+                  state: 'working',
+                  current_task_id: '1',
+                  status_missing: false,
+                  turn_count: 2,
+                  heartbeat_missing: false,
+                },
+                {
+                  worker: 'worker-2',
+                  state: 'unknown',
+                  current_task_id: '',
+                  status_missing: true,
+                  turn_count: null,
+                  heartbeat_missing: true,
+                },
+              ],
+            }),
+            last_progress_at: new Date(now - 180_000).toISOString(),
+          },
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_TEAM_PROGRESS_STALL_MS: '60000',
+            OMX_TEAM_LEADER_NUDGE_MS: '30000',
+            OMX_TEAM_LEADER_STALE_MS: '60000',
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(tmuxLog, /send-keys -t %42 -l Team dispatch-team: worker panes stalled, no progress 3m/);
+      assert.doesNotMatch(tmuxLog, /leader stale/);
+
+      const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.leader_nudge?.enabled, true);
+      assert.equal(watcherState.leader_nudge?.leader_only, true);
+      assert.equal(watcherState.leader_nudge?.run_count, 1);
+      assert.equal(watcherState.leader_nudge?.precomputed_leader_stale, false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('auto-nudges stalled session output even when no active mode state exists', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-auto-nudge-stalled-'));
     const fakeBinDir = join(wd, 'fake-bin');

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -137,6 +137,60 @@ describe('notify-hook per-worker idle notification', () => {
     });
   });
 
+  it('fires notification on working->done transition', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'done-team';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'done-sess:0',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'done',
+        current_task_id: 'task-42',
+        reason: 'task complete',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      assert.ok(existsSync(eventsPath), 'events.ndjson should exist for done-state leader notification');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+      const event = events.find((entry: { type?: string; reason?: string; worker?: string; to_worker?: string }) =>
+        entry.type === 'leader_notification_deferred'
+        && entry.reason === 'leader_pane_missing_no_injection'
+        && entry.worker === 'worker-1'
+        && entry.to_worker === 'leader-fixed');
+      assert.ok(event, 'done transition should still notify the leader through the deferred path when no pane is available');
+      assert.equal(event.tmux_session, 'done-sess:0');
+      assert.equal(event.leader_pane_id, null);
+      assert.equal(event.tmux_injection_attempted, false);
+    });
+  });
+
 
   it('does not inject worker-idle notification into a shell leader pane', async () => {
     await withTempWorkingDir(async (cwd) => {

--- a/src/runtime/bridge.ts
+++ b/src/runtime/bridge.ts
@@ -77,7 +77,7 @@ export type RuntimeEvent =
   | { event: 'DispatchFailed'; request_id: string; reason: string }
   | { event: 'ReplayRequested'; cursor?: string }
   | { event: 'SnapshotCaptured' }
-  | { event: 'MailboxMessageCreated'; message_id: string; from_worker: string; to_worker: string }
+  | { event: 'MailboxMessageCreated'; message_id: string; from_worker: string; to_worker: string; body?: string }
   | { event: 'MailboxNotified'; message_id: string }
   | { event: 'MailboxDelivered'; message_id: string };
 

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -1228,9 +1228,13 @@ async function runLeaderNudgeTick(): Promise<void> {
 
   try {
     const preComputedLeaderStale = await isLeaderStale(stateDir, staleThresholdMs, Date.now());
-    if (preComputedLeaderStale) {
-      await maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderStale });
-    }
+    await maybeNudgeTeamLeader({
+      cwd,
+      stateDir,
+      logsDir,
+      preComputedLeaderStale,
+      allowFreshMailboxNudges: false,
+    });
     leaderNudgeRuns += 1;
     lastLeaderNudge = {
       enabled: true,

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -510,7 +510,13 @@ async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmu
   }
 }
 
-export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderStale }) {
+export async function maybeNudgeTeamLeader({
+  cwd,
+  stateDir,
+  logsDir,
+  preComputedLeaderStale,
+  allowFreshMailboxNudges = true,
+}) {
   const intervalMs = resolveLeaderNudgeIntervalMs();
   const idleCooldownMs = resolveLeaderAllIdleNudgeCooldownMs();
   const fallbackProgressStallThresholdMs = resolveFallbackProgressStallThresholdMs();
@@ -683,7 +689,8 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
     const stalledTeamNudge = teamProgressStalled && (dueByTime || !previousStalledTeamNudge);
     const staleFollowupDue = stalePanesNudge && dueByTime;
 
-    if (!shouldSendAllIdleNudge && !hasNewMessage && !stalledTeamNudge && !staleFollowupDue) continue;
+    const hasActionableNewMessage = hasNewMessage && (allowFreshMailboxNudges || leaderStale);
+    if (!shouldSendAllIdleNudge && !hasActionableNewMessage && !stalledTeamNudge && !staleFollowupDue) continue;
 
     let nudgeReason = '';
     let text = '';
@@ -717,7 +724,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
         `Team ${teamName}: ${stallPrefix}no progress ${formatDurationMs(stalledForMs)}. `
         + `${leaderActionGuidance} `
         + `(p:${pending} ip:${in_progress} b:${blocked}${missingSignals})`;
-    } else if (stalePanesNudge && hasNewMessage) {
+    } else if (stalePanesNudge && hasActionableNewMessage) {
       nudgeReason = 'stale_leader_with_messages';
       text =
         `Team ${teamName}: leader stale, ${paneStatus.paneCount} pane(s) active, ${messages.length} msg(s) pending. `
@@ -727,7 +734,7 @@ export async function maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputed
       text =
         `Team ${teamName}: leader stale, ${paneStatus.paneCount} worker pane(s) still active. `
         + leaderActionGuidance;
-    } else if (hasNewMessage) {
+    } else if (hasActionableNewMessage) {
       nudgeReason = 'new_mailbox_message';
       text = `Team ${teamName}: ${messages.length} msg(s) for leader. ${buildMailboxCheckReminder(teamName)}`;
     } else {

--- a/src/scripts/notify-hook/team-worker.ts
+++ b/src/scripts/notify-hook/team-worker.ts
@@ -541,8 +541,8 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
     await rename(tmpPath, prevStatePath);
   } catch { /* best effort */ }
 
-  // Only fire on working->idle transition (non-idle to idle)
-  if (currentState !== 'idle') return;
+  // Fire when a worker leaves active work into an idle-ish terminal state.
+  if (currentState !== 'idle' && currentState !== 'done') return;
   if (!statusFresh) return;
   if (prevState === 'idle' || prevState === 'done') return;
 
@@ -608,7 +608,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
   }
 
   // Build notification message with context
-  const parts = [`[OMX] ${workerName} idle`];
+  const parts = [`[OMX] ${workerName} ${currentState}`];
   if (prevState && prevState !== 'unknown') parts.push(`(was: ${prevState})`);
   if (currentTaskId) parts.push(`task: ${currentTaskId}`);
   if (currentReason) parts.push(`reason: ${currentReason}`);

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -194,6 +194,62 @@ describe('executeTeamApiOperation: send-message', () => {
     }
   });
 
+  it('returns the persisted leader mailbox message when hook-targeted sends are deduped from a worker worktree', async () => {
+    const teamName = 'msg-team-leader-dedupe';
+    const repoCwd = await mkdtemp(join(tmpdir(), 'omx-interop-send-root-'));
+    const workerCwd = await mkdtemp(join(tmpdir(), 'omx-interop-send-worktree-'));
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+
+    try {
+      await initTeamState(teamName, 'leader mailbox dedupe', 'executor', 2, repoCwd);
+
+      const manifestPath = join(repoCwd, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
+        leader_pane_id?: string;
+      };
+      manifest.leader_pane_id = '%55';
+      await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+      process.env.OMX_TEAM_STATE_ROOT = join(repoCwd, '.omx', 'state');
+
+      const first = await executeTeamApiOperation('send-message', {
+        team_name: teamName,
+        from_worker: 'worker-1',
+        to_worker: 'leader-fixed',
+        body: 'ACK: worker-1 initialized',
+      }, workerCwd);
+      assert.equal(first.ok, true);
+      if (!first.ok) throw new Error('expected first send-message call to succeed');
+
+      const second = await executeTeamApiOperation('send-message', {
+        team_name: teamName,
+        from_worker: 'worker-1',
+        to_worker: 'leader-fixed',
+        body: 'ACK: worker-1 initialized',
+      }, workerCwd);
+      assert.equal(second.ok, true);
+      if (!second.ok) throw new Error('expected duplicate send-message call to succeed');
+
+      const firstMessage = first.data.message as Record<string, unknown>;
+      const secondMessage = second.data.message as Record<string, unknown>;
+      assert.equal(secondMessage.message_id, firstMessage.message_id);
+      assert.equal(secondMessage.to_worker, 'leader-fixed');
+      assert.equal(secondMessage.body, 'ACK: worker-1 initialized');
+
+      const mailbox = JSON.parse(await readFile(
+        join(repoCwd, '.omx', 'state', 'team', teamName, 'mailbox', 'leader-fixed.json'),
+        'utf-8',
+      )) as { messages?: Array<Record<string, unknown>> };
+      assert.equal(mailbox.messages?.length, 1, 'deduped leader sends should not append duplicate mailbox rows');
+    } finally {
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(repoCwd, { recursive: true, force: true });
+      await rm(workerCwd, { recursive: true, force: true });
+    }
+  });
+
   it('returns error when from_worker missing', async () => {
     const result = await executeTeamApiOperation('send-message', {
       team_name: 'any', to_worker: 'w2', body: 'hi',

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -18,6 +18,7 @@ import {
   sendDirectMessage,
   enqueueDispatchRequest,
   readDispatchRequest,
+  listDispatchRequests,
   appendTeamEvent,
   updateWorkerHeartbeat,
   writeMonitorSnapshot,
@@ -184,9 +185,8 @@ describe('executeTeamApiOperation: send-message', () => {
       const messageId = String(message.message_id ?? '');
       assert.ok(messageId, 'message should include a message_id');
 
-      const requests = await readFile(join(cwd, '.omx', 'state', 'team', 'msg-team', 'dispatch', 'requests.json'), 'utf-8');
-      const parsedRequests = JSON.parse(requests) as Array<Record<string, unknown>>;
-      const mailboxRequest = parsedRequests.find((request) => request.kind === 'mailbox' && request.message_id === messageId);
+      const parsedRequests = await listDispatchRequests('msg-team', cwd, { kind: 'mailbox' });
+      const mailboxRequest = parsedRequests.find((request) => request.message_id === messageId);
       assert.ok(mailboxRequest, 'send-message should enqueue a mailbox dispatch request');
       assert.equal(mailboxRequest?.to_worker, 'worker-2');
     } finally {

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -204,6 +204,13 @@ describe('executeTeamApiOperation: send-message', () => {
     try {
       await initTeamState(teamName, 'leader mailbox dedupe', 'executor', 2, repoCwd);
 
+      const configPath = join(repoCwd, '.omx', 'state', 'team', teamName, 'config.json');
+      const config = JSON.parse(await readFile(configPath, 'utf-8')) as {
+        leader_pane_id?: string;
+      };
+      config.leader_pane_id = '%55';
+      await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+
       const manifestPath = join(repoCwd, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
         leader_pane_id?: string;
@@ -241,7 +248,10 @@ describe('executeTeamApiOperation: send-message', () => {
         join(repoCwd, '.omx', 'state', 'team', teamName, 'mailbox', 'leader-fixed.json'),
         'utf-8',
       )) as { messages?: Array<Record<string, unknown>> };
-      assert.equal(mailbox.messages?.length, 1, 'deduped leader sends should not append duplicate mailbox rows');
+      const workerMessages = (mailbox.messages ?? []).filter((message) =>
+        message.from_worker === 'worker-1' && message.to_worker === 'leader-fixed',
+      );
+      assert.equal(workerMessages.length, 1, 'deduped leader sends should not append duplicate worker mailbox rows');
     } finally {
       if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
       else delete process.env.OMX_TEAM_STATE_ROOT;

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -1199,7 +1199,7 @@ exit 1
     }
   });
 
-  it('prefers bridge-authored mailbox records without mutating the legacy mailbox file', async () => {
+  it('uses bridge-authored mailbox records while shadowing legacy mailbox bodies for recovery', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-bridge-authority-'));
     const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
     try {
@@ -1221,13 +1221,26 @@ exit 1
       const messages = await listMailboxMessages('team-mailbox-bridge-authority', 'worker-2', cwd);
       assert.equal(messages.length, 1);
       assert.equal(messages[0]?.message_id, message.message_id);
+      assert.equal(messages[0]?.body, 'hello');
       assert.equal(typeof messages[0]?.notified_at, 'string');
       assert.equal(typeof messages[0]?.delivered_at, 'string');
 
-      if (existsSync(legacyPath)) {
-        const after = JSON.parse(await readFile(legacyPath, 'utf8')) as { messages: unknown[] };
-        assert.equal(after.messages.length, 0, 'bridge-success path should not rewrite legacy mailbox JSON');
-      }
+      assert.equal(existsSync(legacyPath), true, 'bridge-success path should shadow-write legacy mailbox JSON for body recovery');
+      const after = JSON.parse(await readFile(legacyPath, 'utf8')) as { messages: Array<{ message_id: string; body: string }> };
+      assert.equal(after.messages.length, 1);
+      assert.equal(after.messages[0]?.message_id, message.message_id);
+      assert.equal(after.messages[0]?.body, 'hello');
+
+      const compatPath = join(cwd, '.omx', 'state', 'mailbox.json');
+      const compat = JSON.parse(await readFile(compatPath, 'utf8')) as { records: Array<{ message_id: string; body: string }> };
+      const compatRecord = compat.records.find((entry) => entry.message_id === message.message_id);
+      assert.ok(compatRecord);
+      compatRecord!.body = '';
+      await writeFile(compatPath, JSON.stringify(compat, null, 2));
+
+      const recovered = await listMailboxMessages('team-mailbox-bridge-authority', 'worker-2', cwd);
+      assert.equal(recovered.length, 1);
+      assert.equal(recovered[0]?.body, 'hello', 'legacy shadow mailbox should backfill blank compat bodies');
     } finally {
       if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
       else delete process.env.OMX_RUNTIME_BINARY;

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -446,23 +446,6 @@ function resolveTeamWorkingDirectory(teamName: string, preferredCwd: string): st
   return preferredCwd;
 }
 
-function readLegacyMailboxMessage(
-  teamName: string,
-  workerName: string,
-  messageId: string,
-  cwd: string,
-): Record<string, unknown> | null {
-  const mailboxPath = join(cwd, '.omx', 'state', 'team', teamName, 'mailbox', `${workerName}.json`);
-  if (!existsSync(mailboxPath)) return null;
-  try {
-    const parsed = JSON.parse(readFileSync(mailboxPath, 'utf8')) as { messages?: Array<Record<string, unknown>> };
-    const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
-    return messages.find((message) => String(message.message_id || '') === messageId) ?? null;
-  } catch {
-    return null;
-  }
-}
-
 function readLegacyMailboxMessages(
   teamName: string,
   workerName: string,
@@ -476,6 +459,16 @@ function readLegacyMailboxMessages(
   } catch {
     return [];
   }
+}
+
+function readLegacyMailboxMessage(
+  teamName: string,
+  workerName: string,
+  messageId: string,
+  cwd: string,
+): Record<string, unknown> | null {
+  return readLegacyMailboxMessages(teamName, workerName, cwd)
+    .find((message) => String(message.message_id || '') === messageId) ?? null;
 }
 
 function normalizeTeamName(toolOrOperationName: string): string {

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -533,10 +533,7 @@ export async function executeTeamApiOperation(
         const beforeIds = new Set(beforeMessages.map((message) => message.message_id));
 
         const outcome = hasLiveTmuxTarget
-          ? (await (async () => {
-            await sendWorkerMessage(teamName, fromWorker, toWorker, body, cwd);
-            return { ok: true, transport: 'hook', reason: 'api_send_message_via_runtime', message_id: '' };
-          })())
+          ? await sendWorkerMessage(teamName, fromWorker, toWorker, body, cwd)
           : await queueDirectMailboxMessage({
             teamName,
             fromWorker,
@@ -554,11 +551,18 @@ export async function executeTeamApiOperation(
         const messages = await listMailboxMessages(teamName, toWorker, cwd);
         const matching = outcome.message_id
           ? messages.find((message) => message.message_id === outcome.message_id)
-          : [...messages].reverse().find((message) => !beforeIds.has(message.message_id) && message.from_worker === fromWorker && message.body === body);
+          : [...messages].reverse().find((message) =>
+            !beforeIds.has(message.message_id)
+            && message.from_worker === fromWorker
+            && message.to_worker === toWorker,
+          );
         if (!matching) {
           throw new Error(`send-message could not locate persisted mailbox message for ${fromWorker} -> ${toWorker}`);
         }
-        return { ok: true, operation, data: { message: matching, dispatch: outcome } };
+        const message = matching.body || !body
+          ? matching
+          : { ...matching, body };
+        return { ok: true, operation, data: { message, dispatch: outcome } };
       }
       case 'broadcast': {
         const teamName = String(args.team_name || '').trim();

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -446,6 +446,38 @@ function resolveTeamWorkingDirectory(teamName: string, preferredCwd: string): st
   return preferredCwd;
 }
 
+function readLegacyMailboxMessage(
+  teamName: string,
+  workerName: string,
+  messageId: string,
+  cwd: string,
+): Record<string, unknown> | null {
+  const mailboxPath = join(cwd, '.omx', 'state', 'team', teamName, 'mailbox', `${workerName}.json`);
+  if (!existsSync(mailboxPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(mailboxPath, 'utf8')) as { messages?: Array<Record<string, unknown>> };
+    const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+    return messages.find((message) => String(message.message_id || '') === messageId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readLegacyMailboxMessages(
+  teamName: string,
+  workerName: string,
+  cwd: string,
+): Array<Record<string, unknown>> {
+  const mailboxPath = join(cwd, '.omx', 'state', 'team', teamName, 'mailbox', `${workerName}.json`);
+  if (!existsSync(mailboxPath)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(mailboxPath, 'utf8')) as { messages?: Array<Record<string, unknown>> };
+    return Array.isArray(parsed.messages) ? parsed.messages : [];
+  } catch {
+    return [];
+  }
+}
+
 function normalizeTeamName(toolOrOperationName: string): string {
   const normalized = toolOrOperationName.trim().toLowerCase();
   const withoutPrefix = normalized.startsWith('team_') ? normalized.slice('team_'.length) : normalized;
@@ -556,12 +588,23 @@ export async function executeTeamApiOperation(
             && message.from_worker === fromWorker
             && message.to_worker === toWorker,
           );
-        if (!matching) {
+        const legacyMatching = !matching && outcome.message_id
+          ? readLegacyMailboxMessage(teamName, toWorker, outcome.message_id, cwd)
+          : null;
+        const legacySenderFallback = !matching && !legacyMatching
+          ? [...readLegacyMailboxMessages(teamName, toWorker, cwd)].reverse().find((message) =>
+            !beforeIds.has(String(message.message_id || ''))
+            && String(message.from_worker || '') === fromWorker
+            && String(message.to_worker || '') === toWorker,
+          ) ?? null
+          : null;
+        const persisted = matching ?? legacyMatching ?? legacySenderFallback;
+        if (!persisted) {
           throw new Error(`send-message could not locate persisted mailbox message for ${fromWorker} -> ${toWorker}`);
         }
-        const message = matching.body || !body
-          ? matching
-          : { ...matching, body };
+        const message = persisted.body || !body
+          ? persisted
+          : { ...persisted, body };
         return { ok: true, operation, data: { message, dispatch: outcome } };
       }
       case 'broadcast': {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3431,7 +3431,7 @@ export async function sendWorkerMessage(
   toWorker: string,
   body: string,
   cwd: string,
-): Promise<void> {
+): Promise<DispatchOutcome> {
   const sanitized = sanitizeTeamName(teamName);
   const config = await readTeamConfig(sanitized, cwd);
   if (!config) throw new Error(`Team ${sanitized} not found`);
@@ -3496,7 +3496,7 @@ export async function sendWorkerMessage(
       });
     }
     if (!finalOutcome.ok) throw new Error(`mailbox_notify_failed:${finalOutcome.reason}`);
-    return;
+    return finalOutcome;
   }
 
   const recipient = config.workers.find((w) => w.name === toWorker);
@@ -3548,6 +3548,7 @@ export async function sendWorkerMessage(
     });
   }
   if (!finalOutcome.ok) throw new Error(`mailbox_notify_failed:${finalOutcome.reason}`);
+  return finalOutcome;
 }
 
 export async function broadcastWorkerMessage(

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1368,50 +1368,51 @@ export async function appendTeamEvent(teamName: string, event: Omit<TeamEvent, '
 }
 
 async function readMailbox(teamName: string, workerName: string, cwd: string): Promise<TeamMailbox> {
-  const readLegacyMailbox = async (): Promise<TeamMailbox> => {
-    const p = mailboxPath(teamName, workerName, cwd);
-    try {
-      if (!existsSync(p)) return { worker: workerName, messages: [] };
-      const raw = await readFile(p, 'utf8');
-      const parsed = JSON.parse(raw) as unknown;
-      if (!parsed || typeof parsed !== 'object') return { worker: workerName, messages: [] };
-      const v = parsed as { worker?: unknown; messages?: unknown };
-      if (v.worker !== workerName || !Array.isArray(v.messages)) return { worker: workerName, messages: [] };
-      return { worker: workerName, messages: v.messages as TeamMailboxMessage[] };
-    } catch {
-      return { worker: workerName, messages: [] };
-    }
-  };
+  const legacyMailbox = await readLegacyMailbox(teamName, workerName, cwd);
 
   if (isBridgeEnabled()) {
     try {
       const bridge = getDefaultBridge(resolveBridgeStateDir(cwd));
       const compat = bridge.readCompatFile<{ records?: unknown[] }>('mailbox.json');
       if (compat) {
-        const legacyMailbox = await readLegacyMailbox();
-        const legacyBodies = new Map(
+        const legacyById = new Map(
           legacyMailbox.messages
-            .filter((message) => typeof message.message_id === 'string' && typeof message.body === 'string' && message.body !== '')
-            .map((message) => [message.message_id, message.body]),
+            .filter((message) => typeof message.message_id === 'string' && message.message_id !== '')
+            .map((message) => [message.message_id, message]),
         );
-        const messages = bridge.readMailboxRecords()
+        const bridgeMessages = bridge.readMailboxRecords()
           .filter((record) => record.to_worker === workerName)
           .map((record) => {
             const normalized = normalizeBridgeMailboxMessage(record);
             if (!normalized.body) {
-              const legacyBody = legacyBodies.get(normalized.message_id);
-              if (legacyBody) return { ...normalized, body: legacyBody };
+              const legacyMessage = legacyById.get(normalized.message_id);
+              if (legacyMessage?.body) return { ...normalized, body: legacyMessage.body };
             }
             return normalized;
           });
-        return { worker: workerName, messages };
+        return { worker: workerName, messages: bridgeMessages };
       }
     } catch {
       // fall through to legacy file fallback
     }
   }
 
-  return await readLegacyMailbox();
+  return legacyMailbox;
+}
+
+async function readLegacyMailbox(teamName: string, workerName: string, cwd: string): Promise<TeamMailbox> {
+  const p = mailboxPath(teamName, workerName, cwd);
+  try {
+    if (!existsSync(p)) return { worker: workerName, messages: [] };
+    const raw = await readFile(p, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return { worker: workerName, messages: [] };
+    const v = parsed as { worker?: unknown; messages?: unknown };
+    if (v.worker !== workerName || !Array.isArray(v.messages)) return { worker: workerName, messages: [] };
+    return { worker: workerName, messages: v.messages as TeamMailboxMessage[] };
+  } catch {
+    return { worker: workerName, messages: [] };
+  }
 }
 
 async function writeMailbox(teamName: string, mailbox: TeamMailbox, cwd: string): Promise<void> {
@@ -1565,6 +1566,7 @@ export async function sendDirectMessage(
     cwd,
     withMailboxLock,
     readMailbox,
+    readLegacyMailbox,
     writeMailbox,
     appendTeamEvent,
     readTeamConfig,
@@ -1582,6 +1584,7 @@ export async function broadcastMessage(
     cwd,
     withMailboxLock,
     readMailbox,
+    readLegacyMailbox,
     writeMailbox,
     appendTeamEvent,
     readTeamConfig,
@@ -1599,6 +1602,7 @@ export async function markMessageDelivered(
     cwd,
     withMailboxLock,
     readMailbox,
+    readLegacyMailbox,
     writeMailbox,
     appendTeamEvent,
     readTeamConfig,
@@ -1616,6 +1620,7 @@ export async function markMessageNotified(
     cwd,
     withMailboxLock,
     readMailbox,
+    readLegacyMailbox,
     writeMailbox,
     appendTeamEvent,
     readTeamConfig,
@@ -1632,6 +1637,7 @@ export async function listMailboxMessages(
     cwd,
     withMailboxLock,
     readMailbox,
+    readLegacyMailbox,
     writeMailbox,
     appendTeamEvent,
     readTeamConfig,

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1368,14 +1368,42 @@ export async function appendTeamEvent(teamName: string, event: Omit<TeamEvent, '
 }
 
 async function readMailbox(teamName: string, workerName: string, cwd: string): Promise<TeamMailbox> {
+  const readLegacyMailbox = async (): Promise<TeamMailbox> => {
+    const p = mailboxPath(teamName, workerName, cwd);
+    try {
+      if (!existsSync(p)) return { worker: workerName, messages: [] };
+      const raw = await readFile(p, 'utf8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (!parsed || typeof parsed !== 'object') return { worker: workerName, messages: [] };
+      const v = parsed as { worker?: unknown; messages?: unknown };
+      if (v.worker !== workerName || !Array.isArray(v.messages)) return { worker: workerName, messages: [] };
+      return { worker: workerName, messages: v.messages as TeamMailboxMessage[] };
+    } catch {
+      return { worker: workerName, messages: [] };
+    }
+  };
+
   if (isBridgeEnabled()) {
     try {
       const bridge = getDefaultBridge(resolveBridgeStateDir(cwd));
       const compat = bridge.readCompatFile<{ records?: unknown[] }>('mailbox.json');
       if (compat) {
+        const legacyMailbox = await readLegacyMailbox();
+        const legacyBodies = new Map(
+          legacyMailbox.messages
+            .filter((message) => typeof message.message_id === 'string' && typeof message.body === 'string' && message.body !== '')
+            .map((message) => [message.message_id, message.body]),
+        );
         const messages = bridge.readMailboxRecords()
           .filter((record) => record.to_worker === workerName)
-          .map((record) => normalizeBridgeMailboxMessage(record));
+          .map((record) => {
+            const normalized = normalizeBridgeMailboxMessage(record);
+            if (!normalized.body) {
+              const legacyBody = legacyBodies.get(normalized.message_id);
+              if (legacyBody) return { ...normalized, body: legacyBody };
+            }
+            return normalized;
+          });
         return { worker: workerName, messages };
       }
     } catch {
@@ -1383,18 +1411,7 @@ async function readMailbox(teamName: string, workerName: string, cwd: string): P
     }
   }
 
-  const p = mailboxPath(teamName, workerName, cwd);
-  try {
-    if (!existsSync(p)) return { worker: workerName, messages: [] };
-    const raw = await readFile(p, 'utf8');
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== 'object') return { worker: workerName, messages: [] };
-    const v = parsed as { worker?: unknown; messages?: unknown };
-    if (v.worker !== workerName || !Array.isArray(v.messages)) return { worker: workerName, messages: [] };
-    return { worker: workerName, messages: v.messages as TeamMailboxMessage[] };
-  } catch {
-    return { worker: workerName, messages: [] };
-  }
+  return await readLegacyMailbox();
 }
 
 async function writeMailbox(teamName: string, mailbox: TeamMailbox, cwd: string): Promise<void> {

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -107,8 +107,8 @@ export async function sendDirectMessage(
       const bridgeMessage = bridgeMailbox.messages.find((candidate) => candidate.message_id === msgId);
       if (bridgeMessage) {
         msg = {
-            ...bridgeMessage,
-            body: bridgeMessage.body || body,
+          ...bridgeMessage,
+          body: bridgeMessage.body || body,
         };
         const shadowMailbox = {
           worker: legacyMailbox.worker,

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -70,9 +70,11 @@ export async function sendDirectMessage(
 
   await deps.withMailboxLock(deps.teamName, toWorker, deps.cwd, async () => {
     const mailbox = await deps.readMailbox(deps.teamName, toWorker, deps.cwd);
+    const legacyMailbox = deps.readLegacyMailbox
+      ? await deps.readLegacyMailbox(deps.teamName, toWorker, deps.cwd)
+      : mailbox;
     const dedupeCandidates = [...mailbox.messages];
     if (deps.readLegacyMailbox) {
-      const legacyMailbox = await deps.readLegacyMailbox(deps.teamName, toWorker, deps.cwd);
       const seenMessageIds = new Set(dedupeCandidates.map((candidate) => candidate.message_id));
       for (const legacyMessage of legacyMailbox.messages) {
         if (!seenMessageIds.has(legacyMessage.message_id)) {
@@ -105,13 +107,17 @@ export async function sendDirectMessage(
       const bridgeMessage = bridgeMailbox.messages.find((candidate) => candidate.message_id === msgId);
       if (bridgeMessage) {
         msg = {
-          ...bridgeMessage,
-          body: bridgeMessage.body || body,
+            ...bridgeMessage,
+            body: bridgeMessage.body || body,
         };
-        const shadowIndex = mailbox.messages.findIndex((candidate) => candidate.message_id === msgId);
-        if (shadowIndex >= 0) mailbox.messages[shadowIndex] = msg;
-        else mailbox.messages.push(msg);
-        await deps.writeMailbox(deps.teamName, mailbox, deps.cwd);
+        const shadowMailbox = {
+          worker: legacyMailbox.worker,
+          messages: [...legacyMailbox.messages],
+        };
+        const shadowIndex = shadowMailbox.messages.findIndex((candidate) => candidate.message_id === msgId);
+        if (shadowIndex >= 0) shadowMailbox.messages[shadowIndex] = msg;
+        else shadowMailbox.messages.push(msg);
+        await deps.writeMailbox(deps.teamName, shadowMailbox, deps.cwd);
         created = true;
         return;
       }
@@ -124,8 +130,11 @@ export async function sendDirectMessage(
       body,
       created_at: new Date().toISOString(),
     };
-    mailbox.messages.push(msg);
-    await deps.writeMailbox(deps.teamName, mailbox, deps.cwd);
+    const shadowMailbox = {
+      worker: legacyMailbox.worker,
+      messages: [...legacyMailbox.messages, msg],
+    };
+    await deps.writeMailbox(deps.teamName, shadowMailbox, deps.cwd);
     created = true;
   });
 

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -21,6 +21,7 @@ interface MailboxDeps {
   cwd: string;
   withMailboxLock: <T>(teamName: string, workerName: string, cwd: string, fn: () => Promise<T>) => Promise<T>;
   readMailbox: (teamName: string, workerName: string, cwd: string) => Promise<TeamMailbox>;
+  readLegacyMailbox?: (teamName: string, workerName: string, cwd: string) => Promise<TeamMailbox>;
   writeMailbox: (teamName: string, mailbox: TeamMailbox, cwd: string) => Promise<void>;
   appendTeamEvent: (
     teamName: string,
@@ -69,7 +70,19 @@ export async function sendDirectMessage(
 
   await deps.withMailboxLock(deps.teamName, toWorker, deps.cwd, async () => {
     const mailbox = await deps.readMailbox(deps.teamName, toWorker, deps.cwd);
-    const existing = mailbox.messages.find((candidate) =>
+    const dedupeCandidates = [...mailbox.messages];
+    if (deps.readLegacyMailbox) {
+      const legacyMailbox = await deps.readLegacyMailbox(deps.teamName, toWorker, deps.cwd);
+      const seenMessageIds = new Set(dedupeCandidates.map((candidate) => candidate.message_id));
+      for (const legacyMessage of legacyMailbox.messages) {
+        if (!seenMessageIds.has(legacyMessage.message_id)) {
+          dedupeCandidates.push(legacyMessage);
+          seenMessageIds.add(legacyMessage.message_id);
+        }
+      }
+    }
+
+    const existing = dedupeCandidates.find((candidate) =>
       candidate.from_worker === fromWorker
       && candidate.to_worker === toWorker
       && candidate.body === body

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -91,7 +91,14 @@ export async function sendDirectMessage(
       const bridgeMailbox = await deps.readMailbox(deps.teamName, toWorker, deps.cwd);
       const bridgeMessage = bridgeMailbox.messages.find((candidate) => candidate.message_id === msgId);
       if (bridgeMessage) {
-        msg = bridgeMessage;
+        msg = {
+          ...bridgeMessage,
+          body: bridgeMessage.body || body,
+        };
+        const shadowIndex = mailbox.messages.findIndex((candidate) => candidate.message_id === msgId);
+        if (shadowIndex >= 0) mailbox.messages[shadowIndex] = msg;
+        else mailbox.messages.push(msg);
+        await deps.writeMailbox(deps.teamName, mailbox, deps.cwd);
         created = true;
         return;
       }


### PR DESCRIPTION
## Summary
- preserve mailbox bodies across the Rust runtime / TS bridge seam
- recover leader mailbox bodies from the team-local shadow mailbox when bridge compat lags
- return real dispatch metadata from `sendWorkerMessage()` so API callers can rediscover persisted leader messages
- cover `working -> done` leader notification and leader-fixed/worktree dedupe regressions

## Verification
- `cargo test -p omx-runtime-core`
- `npm run build && node dist/scripts/run-test-files.js dist/team/__tests__/api-interop.test.js dist/team/__tests__/state.test.js dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/compat/__tests__/rust-runtime-compat.test.js && npx tsc --noEmit`
- live repo-local CLI verification: `node dist/cli/omx.js team api send-message --input ... --json` succeeded against a running demo team and wrote non-empty `leader-fixed.json` mailbox bodies

## Notes
- the repo-local CLI path is verified working
- a separately installed global `omx` wrapper may still point at an older build outside this worktree until reinstalled/rebuilt
