### PR TITLE
Fix team leader queueing and detached-worktree false integration reports

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -965,6 +965,103 @@ exit 0
     });
   });
 
+  it('injects leader nudge even while the leader pane has an active task', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'busy-leader-queue';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'busy-leader-queue:0',
+        leader_pane_id: '%73',
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'm1',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'please review queued message',
+            created_at: '2026-03-12T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%73" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%73" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  printf "• Running tests (3m 12s • esc to interrupt)\\n"
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /capture-pane/);
+      assert.match(tmuxLog, /send-keys -t %73/, 'should inject into a busy leader pane so Codex can queue the message');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      if (existsSync(eventsPath)) {
+        const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+        const deferred = events.find((entry: { type?: string; reason?: string }) =>
+          entry.type === 'leader_notification_deferred' && entry.reason === 'pane_has_active_task');
+        assert.equal(deferred, undefined, 'busy leader pane should no longer defer notifications');
+      }
+    });
+  });
+
   it('does not inject leader nudge while leader pane is in copy-mode', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/runtime/bridge.ts
+++ b/src/runtime/bridge.ts
@@ -10,7 +10,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { omxStateDir } from '../utils/paths.js';
+import { resolveCanonicalTeamStateRoot } from '../team/state-root.js';
 
 const __bridge_dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -131,11 +131,7 @@ export function resolveRuntimeBinaryPath(options: RuntimeBinaryDiscoveryOptions 
 }
 
 export function resolveBridgeStateDir(cwd: string, env: NodeJS.ProcessEnv = process.env): string {
-  const explicit = env.OMX_TEAM_STATE_ROOT;
-  if (typeof explicit === 'string' && explicit.trim() !== '') {
-    return resolve(cwd, explicit.trim());
-  }
-  return omxStateDir(cwd);
+  return resolveCanonicalTeamStateRoot(cwd, env);
 }
 
 export class RuntimeBridge {

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -182,8 +182,7 @@ function parseTriggerCooldownEntry(entry) {
   };
 }
 
-async function withDispatchLock(teamDirPath, fn) {
-  const lockDir = join(teamDirPath, 'dispatch', '.lock');
+async function withLockDirectory(lockDir, timeoutError, fn) {
   const ownerPath = join(lockDir, 'owner');
   const ownerToken = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
   const deadline = Date.now() + 5_000;
@@ -210,7 +209,7 @@ async function withDispatchLock(teamDirPath, fn) {
       } catch {
         // best effort
       }
-      if (Date.now() > deadline) throw new Error(`Timed out acquiring dispatch lock for ${teamDirPath}`);
+      if (Date.now() > deadline) throw new Error(timeoutError);
       await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
     }
   }
@@ -229,51 +228,20 @@ async function withDispatchLock(teamDirPath, fn) {
   }
 }
 
+async function withDispatchLock(teamDirPath, fn) {
+  return await withLockDirectory(
+    join(teamDirPath, 'dispatch', '.lock'),
+    `Timed out acquiring dispatch lock for ${teamDirPath}`,
+    fn,
+  );
+}
+
 async function withMailboxLock(teamDirPath, workerName, fn) {
-  const lockDir = join(teamDirPath, 'mailbox', `.lock-${workerName}`);
-  const ownerPath = join(lockDir, 'owner');
-  const ownerToken = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
-  const deadline = Date.now() + 5_000;
-  await mkdir(dirname(lockDir), { recursive: true });
-
-  while (true) {
-    try {
-      await mkdir(lockDir, { recursive: false });
-      try {
-        await writeFile(ownerPath, ownerToken, 'utf8');
-      } catch (error) {
-        await rm(lockDir, { recursive: true, force: true });
-        throw error;
-      }
-      break;
-    } catch (error) {
-      if (error?.code !== 'EEXIST') throw error;
-      try {
-        const info = await stat(lockDir);
-        if (Date.now() - info.mtimeMs > DISPATCH_LOCK_STALE_MS) {
-          await rm(lockDir, { recursive: true, force: true });
-          continue;
-        }
-      } catch {
-        // best effort
-      }
-      if (Date.now() > deadline) throw new Error(`Timed out acquiring mailbox lock for ${teamDirPath}/${workerName}`);
-      await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
-    }
-  }
-
-  try {
-    return await fn();
-  } finally {
-    try {
-      const currentOwner = await readFile(ownerPath, 'utf8');
-      if (currentOwner.trim() === ownerToken) {
-        await rm(lockDir, { recursive: true, force: true });
-      }
-    } catch {
-      // best effort
-    }
-  }
+  return await withLockDirectory(
+    join(teamDirPath, 'mailbox', `.lock-${workerName}`),
+    `Timed out acquiring mailbox lock for ${teamDirPath}/${workerName}`,
+    fn,
+  );
 }
 
 function resolveLeaderPaneId(config) {

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -770,7 +770,12 @@ export async function maybeNudgeTeamLeader({
       continue;
     }
 
-    const paneGuard = await evaluatePaneInjectionReadiness(tmuxTarget, { skipIfScrolling: true });
+    const paneGuard = await evaluatePaneInjectionReadiness(tmuxTarget, {
+      skipIfScrolling: true,
+      requireRunningAgent: true,
+      requireReady: false,
+      requireIdle: false,
+    });
     if (!paneGuard.ok) {
       const deferredReason = paneGuard.reason === 'pane_running_shell'
         ? LEADER_PANE_SHELL_NO_INJECTION_REASON

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -588,6 +588,46 @@ describe('executeTeamApiOperation: list-tasks', () => {
       await rm(cwdB, { recursive: true, force: true });
     }
   });
+
+  it('prefers OMX_TEAM_STATE_ROOT over manifest metadata when resolving the team working directory', async () => {
+    const teamName = 'list-tsk-env-root';
+    const cwdA = await mkdtemp(join(tmpdir(), 'omx-interop-env-a-'));
+    const cwdB = await mkdtemp(join(tmpdir(), 'omx-interop-env-b-'));
+    const prevTeamWorker = process.env.OMX_TEAM_WORKER;
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_TEAM_WORKER = `${teamName}/worker-1`;
+
+    try {
+      await initTeamState(teamName, 'env root precedence', 'executor', 2, cwdA);
+      await initTeamState(teamName, 'env root precedence', 'executor', 2, cwdB);
+      await createTask(teamName, { subject: 'From env root', description: 'A lane', status: 'pending' }, cwdA);
+      await createTask(teamName, { subject: 'From manifest root', description: 'B lane', status: 'pending' }, cwdB);
+
+      const teamRootA = join(cwdA, '.omx', 'state', 'team', teamName);
+      const manifestPath = join(teamRootA, 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as Record<string, unknown>;
+      manifest.team_state_root = join(cwdB, '.omx', 'state');
+      await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+      process.env.OMX_TEAM_STATE_ROOT = join(cwdA, '.omx', 'state');
+
+      const result = await executeTeamApiOperation('list-tasks', { team_name: teamName }, cwdB);
+      assert.equal(result.ok, true);
+      if (!result.ok) throw new Error('expected list-tasks to succeed');
+      assert.equal(result.data.count, 1);
+      const tasks = result.data.tasks as Array<{ subject?: string }>;
+      assert.equal(tasks[0]?.subject, 'From env root');
+    } finally {
+      if (typeof prevTeamWorker === 'string') process.env.OMX_TEAM_WORKER = prevTeamWorker;
+      else delete process.env.OMX_TEAM_WORKER;
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwdA, { recursive: true, force: true });
+      await rm(cwdB, { recursive: true, force: true });
+    }
+  });
+
   it('returns error when team_name missing', async () => {
     const result = await executeTeamApiOperation('list-tasks', {}, '/tmp');
     assert.equal(result.ok, false);

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -74,6 +74,40 @@ describe('runtime-cli helpers', () => {
     assert.equal(liveBehavior.fixingWithNoWorkers, false);
   });
 
+  it('reads task results from explicit OMX_TEAM_STATE_ROOT during shutdown collection', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-env-root-cwd-'));
+    const explicitStateRoot = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-env-root-state-'));
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_TEAM_STATE_ROOT = explicitStateRoot;
+    try {
+      await initTeamState('env-root-results', 'task', 'executor', 1, cwd);
+      await createTask('env-root-results', {
+        subject: 'completed task',
+        description: 'stored under explicit state root',
+        status: 'completed',
+        owner: 'worker-1',
+        result: 'PASS: explicit root task result',
+      }, cwd);
+
+      const runtimeCli = await loadRuntimeCliModule();
+      const stateRoot = runtimeCli.resolveRuntimeCliStateRoot(cwd);
+      assert.equal(stateRoot, explicitStateRoot);
+      assert.deepEqual(
+        runtimeCli.collectTaskResults(stateRoot, 'env-root-results'),
+        [{
+          taskId: '1',
+          status: 'completed',
+          summary: 'PASS: explicit root task result',
+        }],
+      );
+    } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(explicitStateRoot, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('gracefully shuts down only when the leader explicitly requests shutdown', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-shutdown-'));
     const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2138,6 +2138,86 @@ process.on('SIGTERM', () => process.exit(0));
     }
   });
 
+  it('monitorTeam integrates detached worker worktree by commit sha instead of merging leader HEAD into itself', async () => {
+    const repo = await initRepo();
+    let workerPath = '';
+    try {
+      workerPath = await addWorktree(repo, 'wk1-detached-merge-branch', 'omx-runtime-wk1-detached-merge-');
+
+      await writeFile(join(workerPath, 'detached-feature.txt'), 'detached worker feature\n', 'utf-8');
+      execFileSync('git', ['add', 'detached-feature.txt'], { cwd: workerPath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'detached worker feature'], { cwd: workerPath, stdio: 'ignore' });
+      execFileSync('git', ['checkout', '--detach', 'HEAD'], { cwd: workerPath, stdio: 'ignore' });
+
+      const workerHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: workerPath, encoding: 'utf-8' }).trim();
+      const detachedName = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: workerPath, encoding: 'utf-8' }).trim();
+      assert.equal(detachedName, 'HEAD');
+
+      const leaderHeadBefore = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
+
+      await initTeamState('team-merge-detached', 'merge detached head test', 'executor', 1, repo);
+      const cfg = await readTeamConfig('team-merge-detached', repo);
+      assert.ok(cfg);
+      if (!cfg) throw new Error('missing config');
+      cfg.leader_pane_id = '';
+      cfg.workers[0] = {
+        ...cfg.workers[0],
+        assigned_tasks: ['1'],
+        worktree_repo_root: repo,
+        worktree_path: workerPath,
+        worktree_branch: undefined,
+        worktree_detached: true,
+        worktree_created: false,
+      };
+      await saveTeamConfig(cfg, repo);
+
+      await monitorTeam('team-merge-detached', repo);
+
+      const leaderHeadAfter = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
+      assert.notEqual(leaderHeadAfter, leaderHeadBefore, 'leader HEAD should advance for detached worker integration');
+      assert.equal(await readFile(join(repo, 'detached-feature.txt'), 'utf-8'), 'detached worker feature\n');
+
+      const commitObj = execFileSync('git', ['cat-file', '-p', leaderHeadAfter], { cwd: repo, encoding: 'utf-8' });
+      const parentCount = commitObj.split('\n').filter((l: string) => l.startsWith('parent ')).length;
+      assert.equal(parentCount, 2, 'detached worker integration should still produce a merge commit');
+
+      const workerMerged = execFileSync('git', ['merge-base', '--is-ancestor', workerHead, 'HEAD'], { cwd: repo, encoding: 'utf-8' });
+      assert.equal(workerMerged.length >= 0, true);
+
+      const leaderMailbox = await listMailboxMessages('team-merge-detached', 'leader-fixed', repo);
+      assert.equal(
+        leaderMailbox.some((message) =>
+          message.body.includes(`INTEGRATED: merged worker-1 (${workerHead.slice(0, 12)})`)
+          && message.body.includes(leaderHeadAfter.slice(0, 12))),
+        true,
+      );
+
+      const ledgerPath = join(repo, '.omx', 'reports', 'team-commit-hygiene', 'team-merge-detached.ledger.json');
+      const ledger = JSON.parse(await readFile(ledgerPath, 'utf-8')) as {
+        entries: Array<{
+          operation: string;
+          status: string;
+          source_commit?: string;
+          leader_head_before?: string;
+          leader_head_after?: string;
+        }>;
+      };
+      assert.equal(
+        ledger.entries.some((entry) =>
+          entry.operation === 'integration_merge'
+          && entry.status === 'applied'
+          && entry.source_commit === workerHead
+          && entry.leader_head_before !== entry.leader_head_after),
+        true,
+      );
+    } finally {
+      if (workerPath) {
+        await rm(workerPath, { recursive: true, force: true });
+      }
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('monitorTeam uses cherry-pick for diverged worker (hybrid cherry-pick path)', async () => {
     const repo = await initRepo();
     let workerPath = '';

--- a/src/team/__tests__/state-root.test.ts
+++ b/src/team/__tests__/state-root.test.ts
@@ -5,9 +5,26 @@ import { resolveCanonicalTeamStateRoot } from '../state-root.js';
 describe('state-root', () => {
   it('resolveCanonicalTeamStateRoot resolves to leader .omx/state', () => {
     assert.equal(
-      resolveCanonicalTeamStateRoot('/tmp/demo/project'),
+      resolveCanonicalTeamStateRoot('/tmp/demo/project', {}),
       '/tmp/demo/project/.omx/state',
     );
   });
-});
 
+  it('prefers OMX_TEAM_STATE_ROOT when present', () => {
+    assert.equal(
+      resolveCanonicalTeamStateRoot('/tmp/demo/project', {
+        OMX_TEAM_STATE_ROOT: '/tmp/shared/team-state',
+      }),
+      '/tmp/shared/team-state',
+    );
+  });
+
+  it('resolves relative OMX_TEAM_STATE_ROOT from the leader cwd', () => {
+    assert.equal(
+      resolveCanonicalTeamStateRoot('/tmp/demo/project', {
+        OMX_TEAM_STATE_ROOT: '../shared/state',
+      }),
+      '/tmp/demo/shared/state',
+    );
+  });
+});

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -12,6 +12,7 @@ import { join } from 'path';
 import { startTeam, monitorTeam, shutdownTeam } from './runtime.js';
 import type { TeamRuntime, TeamShutdownSummary } from './runtime.js';
 import { teamReadConfig as readTeamConfig } from './team-ops.js';
+import { resolveCanonicalTeamStateRoot } from './state-root.js';
 
 interface CliInput {
   teamName: string;
@@ -95,7 +96,11 @@ export function detectDeadWorkerFailure(
   };
 }
 
-function collectTaskResults(stateRoot: string, teamName: string): TaskResult[] {
+export function resolveRuntimeCliStateRoot(cwd: string, env: NodeJS.ProcessEnv = process.env): string {
+  return resolveCanonicalTeamStateRoot(cwd, env);
+}
+
+export function collectTaskResults(stateRoot: string, teamName: string): TaskResult[] {
   const tasksDir = join(stateRoot, 'team', teamName, 'tasks');
   try {
     const files = readdirSync(tasksDir).filter(f => f.endsWith('.json'));
@@ -167,7 +172,7 @@ async function main(): Promise<void> {
   } = input;
 
   const workerCount = input.workerCount ?? agentTypes.length;
-  const stateRoot = join(cwd, '.omx', 'state');
+  const stateRoot = resolveRuntimeCliStateRoot(cwd);
 
   let runtime: TeamRuntime | null = null;
   let finalStatus: 'completed' | 'failed' = 'failed';

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -393,6 +393,16 @@ function appendIntegrationReport(
   appendFileSync(reportPath, existsSync(reportPath) ? line : `# Integration Report\n\n${line}`);
 }
 
+function resolveWorkerMergeRef(branchResult: CommandResult, workerHead: string): string {
+  const branchRef = branchResult.ok ? branchResult.stdout.trim() : '';
+  if (!branchRef || branchRef === 'HEAD') return workerHead;
+  return branchRef;
+}
+
+function leaderContainsCommit(repoRoot: string, cwd: string, commit: string): boolean {
+  return runGitCommand(repoRoot, ['merge-base', '--is-ancestor', commit, 'HEAD'], cwd).ok;
+}
+
 async function integrateWorkerCommitsIntoLeader(params: {
   teamName: string;
   config: TeamConfig;
@@ -460,40 +470,69 @@ async function integrateWorkerCommitsIntoLeader(params: {
     if (workerIsAheadOfLeader) {
       // Worker is cleanly ahead → merge --no-ff -X theirs
       const workerBranch = runGitCommand(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD'], worktreePath);
-      const branchRef = workerBranch.ok && workerBranch.stdout ? workerBranch.stdout : workerHead;
+      const branchRef = resolveWorkerMergeRef(workerBranch, workerHead);
       const merge = runGitCommand(repoRoot, ['merge', '--no-ff', '-X', 'theirs', '-m', `omx(team): merge ${worker.name}`, branchRef], cwd);
 
       if (merge.ok) {
         const newLeaderHead = resolveLeaderHead(repoRoot, cwd) ?? leaderHead;
-        state.last_integrated_head = workerHead;
-        state.last_leader_head = newLeaderHead;
-        state.status = 'integrated';
-        state.conflict_commit = undefined;
-        state.conflict_files = undefined;
-        state.updated_at = new Date().toISOString();
-        integratedWorkerNames.add(worker.name);
-        await appendIntegrationEvent(teamName, 'worker_merge_applied', worker, {
-          worker_name: worker.name,
-          worker_head: workerHead,
-          leader_head_before: leaderHead,
-          leader_head_after: newLeaderHead,
-          worktree_path: worktreePath,
-          summary: `merged ${worker.name} into leader via --no-ff -X theirs`,
-        }, cwd);
-        await sendIntegrationMessageToLeader(teamName, worker, `INTEGRATED: merged ${worker.name} (${workerHead.slice(0, 12)}) into leader HEAD ${newLeaderHead.slice(0, 12)} via merge --no-ff.`, cwd);
-        commitHygieneEntries.push({
-          recorded_at: new Date().toISOString(),
-          operation: 'integration_merge',
-          worker_name: worker.name,
-          task_id: worker.assigned_tasks[0],
-          status: 'applied',
-          operational_commit: newLeaderHead,
-          source_commit: workerHead,
-          leader_head_before: leaderHead,
-          leader_head_after: newLeaderHead,
-          worktree_path: worktreePath,
-          detail: 'Leader created a runtime merge commit to integrate worker history.',
-        });
+        const workerIntegrated = leaderContainsCommit(repoRoot, cwd, workerHead);
+        const leaderAdvanced = newLeaderHead !== leaderHead;
+        if (workerIntegrated && leaderAdvanced) {
+          state.last_integrated_head = workerHead;
+          state.last_leader_head = newLeaderHead;
+          state.status = 'integrated';
+          state.conflict_commit = undefined;
+          state.conflict_files = undefined;
+          state.updated_at = new Date().toISOString();
+          integratedWorkerNames.add(worker.name);
+          await appendIntegrationEvent(teamName, 'worker_merge_applied', worker, {
+            worker_name: worker.name,
+            worker_head: workerHead,
+            leader_head_before: leaderHead,
+            leader_head_after: newLeaderHead,
+            worktree_path: worktreePath,
+            summary: `merged ${worker.name} into leader via --no-ff -X theirs`,
+          }, cwd);
+          await sendIntegrationMessageToLeader(teamName, worker, `INTEGRATED: merged ${worker.name} (${workerHead.slice(0, 12)}) into leader HEAD ${newLeaderHead.slice(0, 12)} via merge --no-ff.`, cwd);
+          commitHygieneEntries.push({
+            recorded_at: new Date().toISOString(),
+            operation: 'integration_merge',
+            worker_name: worker.name,
+            task_id: worker.assigned_tasks[0],
+            status: 'applied',
+            operational_commit: newLeaderHead,
+            source_commit: workerHead,
+            leader_head_before: leaderHead,
+            leader_head_after: newLeaderHead,
+            worktree_path: worktreePath,
+            detail: 'Leader created a runtime merge commit to integrate worker history.',
+          });
+        } else {
+          state.last_leader_head = newLeaderHead;
+          state.status = 'idle';
+          state.updated_at = new Date().toISOString();
+          appendIntegrationReport(teamName, {
+            workerName: worker.name,
+            operation: 'merge',
+            strategy: '-X theirs',
+            files: [],
+            detail: `merge reported success but leader HEAD did not advance cleanly (leader_before=${leaderHead.slice(0, 12)}, leader_after=${newLeaderHead.slice(0, 12)}, worker_integrated=${workerIntegrated}, merge_ref=${branchRef}).`,
+          }, cwd);
+          await sendIntegrationMessageToLeader(teamName, worker, `INTEGRATION NO-OP: merge for ${worker.name} using ${branchRef.slice(0, 12)} reported success but leader HEAD stayed ${newLeaderHead.slice(0, 12)}. Inspect ${worktreePath}.`, cwd);
+          commitHygieneEntries.push({
+            recorded_at: new Date().toISOString(),
+            operation: 'integration_merge',
+            worker_name: worker.name,
+            task_id: worker.assigned_tasks[0],
+            status: 'skipped',
+            operational_commit: newLeaderHead,
+            source_commit: workerHead,
+            leader_head_before: leaderHead,
+            leader_head_after: newLeaderHead,
+            worktree_path: worktreePath,
+            detail: 'Merge command reported success but leader HEAD did not advance or contain the worker commit; runtime refused to report false integration.',
+          });
+        }
       } else {
         // Merge failed even with -X theirs (e.g. binary conflict) — abort and log
         const conflictFiles = listConflictFiles(repoRoot, cwd);

--- a/src/team/state-root.ts
+++ b/src/team/state-root.ts
@@ -1,9 +1,16 @@
-import { join, resolve } from 'path';
+import { resolve } from 'path';
+import { omxStateDir } from '../utils/paths.js';
 
 /**
  * Resolve the canonical OMX team state root for a leader working directory.
  */
-export function resolveCanonicalTeamStateRoot(leaderCwd: string): string {
-  return resolve(join(leaderCwd, '.omx', 'state'));
+export function resolveCanonicalTeamStateRoot(
+  leaderCwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const explicit = env.OMX_TEAM_STATE_ROOT;
+  if (typeof explicit === 'string' && explicit.trim() !== '') {
+    return resolve(leaderCwd, explicit.trim());
+  }
+  return resolve(omxStateDir(leaderCwd));
 }
-


### PR DESCRIPTION
## Summary
This PR fixes two team-runtime regressions uncovered while validating the TypeScript -> Rust runtime handoff:

1. **Busy leader panes now receive queued leader nudges** instead of deferring on `pane_has_active_task`.
2. **Detached worker worktrees no longer produce false `INTEGRATED` success reports** when leader HEAD never actually advances.

Closes #1221
Closes #1222

## What changed
### Leader nudge queueing
- allow `team-leader-nudge` to inject into an active Codex leader pane
- keep shell panes and copy-mode / scrolling panes blocked
- add regression coverage for a busy leader pane that should still queue the prompt

### Integration verification
- treat detached worker worktrees as commit-SHA merge sources instead of merging detached `HEAD` as if it were a branch ref
- verify that leader HEAD both **advances** and **contains the worker commit** before emitting `INTEGRATED:` success
- downgrade merge no-ops to a recorded skipped/no-op integration instead of a false success report
- add a regression test for the detached-worktree case

## Why
During a real team run, worker mailbox messages arrived correctly, but:
- busy leader panes deferred instead of queueing the message
- multiple worker worktrees reported `INTEGRATED:` despite leader HEAD remaining unchanged
- the commit hygiene ledger showed repeated `integration_merge` entries where `leader_head_before == leader_head_after`

This PR makes both signals reflect actual runtime behavior.

## Verification
- `npm run build`
- `npx biome lint src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts src/runtime/bridge.ts src/scripts/notify-hook/team-dispatch.ts src/scripts/notify-hook/team-leader-nudge.ts src/team/__tests__/api-interop.test.ts src/team/__tests__/runtime-cli.test.ts src/team/__tests__/runtime.test.ts src/team/__tests__/state-root.test.ts src/team/runtime-cli.ts src/team/runtime.ts src/team/state-root.ts`
- `node --test --test-name-pattern "detached worker worktree|uses merge for worker cleanly ahead|uses cherry-pick for diverged|auto-commits dirty worker worktree|integration ledger" dist/team/__tests__/runtime.test.js`
- `node dist/scripts/run-test-files.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/team/__tests__/state-root.test.js dist/team/__tests__/runtime-cli.test.js dist/team/__tests__/api-interop.test.js dist/compat/__tests__/rust-runtime-compat.test.js`

## Risks / follow-up
- This removes the clearest false-success integration path we reproduced, but there may be other bookkeeping paths that still need stronger git-state verification.
- The broader team runtime still deserves a follow-up pass around stale worker state / shutdown cleanup semantics.
