### PR TITLE
Add dedicated team delivery telemetry logs

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -33,6 +33,15 @@ async function readLines(path: string): Promise<string[]> {
   return content.split('\n').map(s => s.trim()).filter(Boolean);
 }
 
+async function readJsonLines(path: string): Promise<Array<Record<string, unknown>>> {
+  const content = await readFile(path, 'utf-8').catch(() => '');
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -721,6 +730,14 @@ describe('notify-fallback watcher', () => {
       assert.ok(nudgeEvent, 'expected leader_nudge_tick log event');
       assert.equal(nudgeEvent.leader_only, true);
       assert.equal(nudgeEvent.precomputed_leader_stale, true);
+
+      const deliveryLogPath = join(wd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
+      const deliveryEntries = await readJsonLines(deliveryLogPath);
+      assert.ok(deliveryEntries.some((entry) =>
+        entry.event === 'nudge_triggered'
+        && entry.source === 'notify_fallback_watcher'
+        && entry.transport === 'send-keys'
+        && entry.result === 'sent'));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -92,6 +92,16 @@ exit 0
 `;
 }
 
+async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
+  const path = join(cwd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
+  const raw = await readFile(path, 'utf-8').catch(() => '');
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
 async function writeCompatRuntimeFixture(runtimePath: string): Promise<void> {
   await writeFile(
     runtimePath,
@@ -293,6 +303,14 @@ describe('notify-hook team dispatch consumer', () => {
       assert.ok(deferredLog.tmux_session.length > 0);
       assert.equal(deferredLog.leader_pane_id, null);
       assert.equal(deferredLog.tmux_injection_attempted, false);
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'dispatch_result'
+        && entry.source === 'notify-hook.team-dispatch'
+        && entry.request_id === queued.request.request_id
+        && entry.result === 'deferred'
+        && entry.reason === 'leader_pane_missing_deferred'));
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -326,6 +344,14 @@ describe('notify-hook team dispatch consumer', () => {
       const deferredLogs = dispatchLogs.filter((entry: { type?: string; request_id?: string }) =>
         entry.type === 'dispatch_deferred' && entry.request_id === queued.request.request_id);
       assert.equal(deferredLogs.length, 1, 'should only log one dispatch_deferred artifact per missing-pane request until state changes');
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      const deferredDeliveryLogs = deliveryLog.filter((entry) =>
+        entry.event === 'dispatch_result'
+        && entry.source === 'notify-hook.team-dispatch'
+        && entry.request_id === queued.request.request_id
+        && entry.result === 'deferred');
+      assert.equal(deferredDeliveryLogs.length, 1, 'should only log one deferred team-delivery artifact per missing-pane request until state changes');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -22,6 +22,16 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
+  const path = join(cwd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
+  const raw = await readFile(path, 'utf-8').catch(() => '');
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
 function buildFakeTmux(tmuxLogPath: string): string {
   return `#!/usr/bin/env bash
 set -eu
@@ -668,6 +678,15 @@ describe('notify-hook team leader nudge', () => {
       assert.doesNotMatch(tmuxLog, /-t devsess:0/);
       assert.match(tmuxLog, /Team alpha:/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'nudge_triggered'
+        && entry.source === 'notify_hook'
+        && entry.team === teamName
+        && entry.to_worker === 'leader-fixed'
+        && entry.transport === 'send-keys'
+        && entry.result === 'sent'));
     });
   });
 

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -1239,6 +1239,7 @@ async function runLeaderNudgeTick(): Promise<void> {
       logsDir,
       preComputedLeaderStale,
       allowFreshMailboxNudges: false,
+      source: 'notify_fallback_watcher',
     });
     leaderNudgeRuns += 1;
     lastLeaderNudge = {

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'node:url';
 import { safeString } from './utils.js';
 import { resolveBridgeStateDir, resolveRuntimeBinaryPath } from '../../runtime/bridge.js';
+import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -505,6 +506,13 @@ async function appendDispatchLog(logsDir, event) {
   await appendFile(path, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
 }
 
+async function appendDeliveryTelemetry(logsDir, event) {
+  await appendTeamDeliveryLog(logsDir, {
+    source: 'notify-hook.team-dispatch',
+    ...event,
+  }).catch(() => {});
+}
+
 export async function drainPendingTeamDispatch({
   cwd,
   stateDir = resolveBridgeStateDir(cwd),
@@ -582,6 +590,16 @@ export async function drainPendingTeamDispatch({
               leader_pane_id: safeString(config?.leader_pane_id).trim() || null,
               tmux_injection_attempted: false,
             });
+            await appendDeliveryTelemetry(logsDir, {
+              event: 'dispatch_result',
+              team: teamName,
+              request_id: request.request_id,
+              message_id: request.message_id || null,
+              to_worker: request.to_worker,
+              transport: 'send-keys',
+              result: 'deferred',
+              reason: LEADER_PANE_MISSING_DEFERRED_REASON,
+            });
             // On the legacy fallback lane, requests.json still carries the queue
             // state for this deferred request; this event stays a progress
             // artifact for hook/watcher readers.
@@ -652,6 +670,16 @@ export async function drainPendingTeamDispatch({
               attempt: request.attempt_count,
               reason: result.reason,
             });
+            await appendDeliveryTelemetry(logsDir, {
+              event: 'dispatch_result',
+              team: teamName,
+              request_id: request.request_id,
+              message_id: request.message_id || null,
+              to_worker: request.to_worker,
+              transport: 'send-keys',
+              result: 'retry',
+              reason: result.reason,
+            });
             await emitOperationalHookEvent(cwd, 'retry-needed', {
               team: teamName,
               worker: request.to_worker,
@@ -677,6 +705,16 @@ export async function drainPendingTeamDispatch({
               request_id: request.request_id,
               worker: request.to_worker,
               message_id: request.message_id || null,
+              reason: request.last_reason,
+            });
+            await appendDeliveryTelemetry(logsDir, {
+              event: 'dispatch_result',
+              team: teamName,
+              request_id: request.request_id,
+              message_id: request.message_id || null,
+              to_worker: request.to_worker,
+              transport: 'send-keys',
+              result: 'failed',
               reason: request.last_reason,
             });
             await emitOperationalHookEvent(cwd, 'failed', {
@@ -711,6 +749,16 @@ export async function drainPendingTeamDispatch({
             message_id: request.message_id || null,
             reason: result.reason,
           });
+          await appendDeliveryTelemetry(logsDir, {
+            event: 'dispatch_result',
+            team: teamName,
+            request_id: request.request_id,
+            message_id: request.message_id || null,
+            to_worker: request.to_worker,
+            transport: 'send-keys',
+            result: 'notified',
+            reason: result.reason,
+          });
         } else {
           request.status = 'failed';
           request.failed_at = nowIso;
@@ -725,6 +773,16 @@ export async function drainPendingTeamDispatch({
             request_id: request.request_id,
             worker: request.to_worker,
             message_id: request.message_id || null,
+            reason: result.reason,
+          });
+          await appendDeliveryTelemetry(logsDir, {
+            event: 'dispatch_result',
+            team: teamName,
+            request_id: request.request_id,
+            message_id: request.message_id || null,
+            to_worker: request.to_worker,
+            transport: 'send-keys',
+            result: 'failed',
             reason: result.reason,
           });
           await emitOperationalHookEvent(cwd, result.reason === LEADER_PANE_MISSING_DEFERRED_REASON ? 'handoff-needed' : 'failed', {

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -13,6 +13,7 @@ import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
+import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
@@ -516,6 +517,7 @@ export async function maybeNudgeTeamLeader({
   logsDir,
   preComputedLeaderStale,
   allowFreshMailboxNudges = true,
+  source = 'notify_hook',
 }) {
   const intervalMs = resolveLeaderNudgeIntervalMs();
   const idleCooldownMs = resolveLeaderAllIdleNudgeCooldownMs();
@@ -767,6 +769,15 @@ export async function maybeNudgeTeamLeader({
           source_type: 'leader_nudge',
         });
       } catch { /* ignore */ }
+      await appendTeamDeliveryLog(logsDir, {
+        event: 'nudge_triggered',
+        source,
+        team: teamName,
+        to_worker: 'leader-fixed',
+        transport: 'none',
+        result: 'deferred',
+        reason: LEADER_PANE_MISSING_NO_INJECTION_REASON,
+      }).catch(() => {});
       continue;
     }
 
@@ -808,6 +819,15 @@ export async function maybeNudgeTeamLeader({
           source_type: 'leader_nudge',
         });
       } catch { /* ignore */ }
+      await appendTeamDeliveryLog(logsDir, {
+        event: 'nudge_triggered',
+        source,
+        team: teamName,
+        to_worker: 'leader-fixed',
+        transport: 'none',
+        result: 'deferred',
+        reason: deferredReason,
+      }).catch(() => {});
       continue;
     }
 
@@ -842,6 +862,15 @@ export async function maybeNudgeTeamLeader({
           missing_signal_workers: progressSnapshot.missingSignalWorkers,
         });
       } catch { /* ignore */ }
+      await appendTeamDeliveryLog(logsDir, {
+        event: 'nudge_triggered',
+        source,
+        team: teamName,
+        to_worker: 'leader-fixed',
+        transport: 'send-keys',
+        result: 'sent',
+        reason: nudgeReason,
+      }).catch(() => {});
     } catch (err) {
       try {
         await logTmuxHookEvent(logsDir, {
@@ -853,6 +882,16 @@ export async function maybeNudgeTeamLeader({
           error: safeString(err && err.message ? err.message : err),
         });
       } catch { /* ignore */ }
+      await appendTeamDeliveryLog(logsDir, {
+        event: 'nudge_triggered',
+        source,
+        team: teamName,
+        to_worker: 'leader-fixed',
+        transport: 'send-keys',
+        result: 'failed',
+        reason: nudgeReason,
+        error: safeString(err && err.message ? err.message : err),
+      }).catch(() => {});
     }
   }
 

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -40,6 +40,16 @@ async function setupTeam(name: string): Promise<{ cwd: string; cleanup: () => Pr
   };
 }
 
+async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
+  const path = join(cwd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
+  const raw = await readFile(path, 'utf-8').catch(() => '');
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
 // ─── resolveTeamApiOperation ──────────────────────────────────────────────
 
 describe('resolveTeamApiOperation', () => {
@@ -189,6 +199,18 @@ describe('executeTeamApiOperation: send-message', () => {
       const mailboxRequest = parsedRequests.find((request) => request.message_id === messageId);
       assert.ok(mailboxRequest, 'send-message should enqueue a mailbox dispatch request');
       assert.equal(mailboxRequest?.to_worker, 'worker-2');
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'mailbox_created'
+        && entry.message_id === messageId
+        && entry.from_worker === 'worker-1'
+        && entry.to_worker === 'worker-2'));
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'dispatch_attempted'
+        && entry.request_id === mailboxRequest?.request_id
+        && entry.message_id === messageId
+        && entry.to_worker === 'worker-2'));
     } finally {
       await cleanup();
     }
@@ -252,6 +274,17 @@ describe('executeTeamApiOperation: send-message', () => {
         message.from_worker === 'worker-1' && message.to_worker === 'leader-fixed',
       );
       assert.equal(workerMessages.length, 1, 'deduped leader sends should not append duplicate worker mailbox rows');
+
+      const deliveryLog = [
+        ...(await readTeamDeliveryLog(repoCwd)),
+        ...(await readTeamDeliveryLog(workerCwd)),
+      ];
+      const createdEvents = deliveryLog.filter((entry) =>
+        entry.event === 'mailbox_created'
+        && entry.from_worker === 'worker-1'
+        && entry.to_worker === 'leader-fixed'
+        && entry.message_id === firstMessage.message_id);
+      assert.equal(createdEvents.length, 1, 'deduped leader sends should only emit one mailbox_created event');
     } finally {
       if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
       else delete process.env.OMX_TEAM_STATE_ROOT;
@@ -378,6 +411,17 @@ describe('executeTeamApiOperation: mailbox-mark-delivered', () => {
 
       const updatedDispatch = await readDispatchRequest('mark-dlv', dispatch.request.request_id, cwd);
       assert.equal(updatedDispatch?.status, 'delivered');
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'delivered'
+        && entry.message_id === msgId
+        && entry.to_worker === 'worker-2'));
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'mark_delivered'
+        && entry.message_id === msgId
+        && entry.request_id === dispatch.request.request_id
+        && entry.dispatch_updated === true));
     } finally {
       await cleanup();
     }

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -59,6 +59,17 @@ async function addWorktree(repo: string, branchName: string, pathPrefix: string)
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
   return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
 }
+
+async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
+  const path = join(cwd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
+  const raw = await readFile(path, 'utf-8').catch(() => '');
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
 function withEmptyPath<T>(fn: () => T): T {
   const prev = process.env.PATH;
   process.env.PATH = '';
@@ -3591,6 +3602,17 @@ esac
           const latest = requests[requests.length - 1];
           assert.equal(latest?.status, 'notified');
           assert.equal(latest?.last_reason, 'fallback_confirmed:leader_mailbox_notified');
+
+          const deliveryLog = await readTeamDeliveryLog(cwd);
+          const runtimeEntries = deliveryLog.filter((entry) =>
+            entry.event === 'dispatch_result'
+            && entry.source === 'team.runtime'
+            && entry.to_worker === 'leader-fixed'
+            && entry.transport === 'mailbox'
+            && entry.result === 'confirmed'
+            && typeof entry.reason === 'string'
+            && String(entry.reason).includes('leader_mailbox_notified'));
+          assert.equal(runtimeEntries.length, 1, 'leader hook-preferred confirmation should emit exactly one runtime dispatch_result entry');
         },
       );
     } finally {
@@ -3620,6 +3642,15 @@ esac
         r.status === 'pending' && r.to_worker === 'leader-fixed');
       assert.ok(pending, 'expected a pending leader-fixed dispatch request');
       assert.equal(pending?.last_reason, 'leader_pane_missing_deferred');
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      const runtimeEntries = deliveryLog.filter((entry) =>
+        entry.event === 'dispatch_result'
+        && entry.source === 'team.runtime'
+        && entry.to_worker === 'leader-fixed'
+        && entry.transport === 'mailbox'
+        && entry.reason === 'leader_pane_missing_mailbox_persisted');
+      assert.equal(runtimeEntries.length, 1, 'leader missing-pane fallback should emit exactly one runtime dispatch_result entry');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -14,6 +14,7 @@ import {
 } from './contracts.js';
 import { readTeamEvents, waitForTeamEvent } from './state/events.js';
 import { queueDirectMailboxMessage } from './mcp-comm.js';
+import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
 import { generateLeaderMailboxTriggerMessage, generateMailboxTriggerMessage } from './worker-bootstrap.js';
 import {
   teamBroadcast as broadcastMessage,
@@ -630,6 +631,16 @@ export async function executeTeamApiOperation(
         }
         const updated = await markMessageDelivered(teamName, worker, messageId, cwd);
         const dispatch = await markLatestMailboxDispatchDelivered(teamName, worker, messageId, cwd);
+        await appendTeamDeliveryLogForCwd(cwd, {
+          event: 'mark_delivered',
+          source: 'team.api-interop',
+          team: teamName,
+          message_id: messageId,
+          to_worker: worker,
+          request_id: dispatch.matched_request_id,
+          result: updated ? 'updated' : 'missing',
+          dispatch_updated: dispatch.dispatch_updated,
+        });
         return {
           ok: true,
           operation,

--- a/src/team/delivery-log.ts
+++ b/src/team/delivery-log.ts
@@ -1,0 +1,71 @@
+import { appendFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+
+export type TeamDeliveryEventName =
+  | 'mailbox_created'
+  | 'dispatch_attempted'
+  | 'dispatch_result'
+  | 'delivered'
+  | 'mark_delivered'
+  | 'nudge_triggered';
+
+export type TeamDeliveryResult =
+  | 'created'
+  | 'queued'
+  | 'ok'
+  | 'confirmed'
+  | 'notified'
+  | 'updated'
+  | 'missing'
+  | 'retry'
+  | 'deferred'
+  | 'sent'
+  | 'failed';
+
+export interface TeamDeliveryLogEvent {
+  event: TeamDeliveryEventName;
+  source: string;
+  team: string;
+  transport?: string;
+  result?: TeamDeliveryResult;
+  [key: string]: unknown;
+}
+
+function normalizeTransport(transport: unknown): string | undefined {
+  if (typeof transport !== 'string') return undefined;
+  switch (transport) {
+    case 'tmux_send_keys':
+      return 'send-keys';
+    case 'prompt_stdin':
+      return 'prompt-stdin';
+    default:
+      return transport;
+  }
+}
+
+function compactObject<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, candidate]) => candidate !== undefined),
+  ) as T;
+}
+
+export function teamDeliveryLogPath(logsDir: string, now: Date = new Date()): string {
+  return join(logsDir, `team-delivery-${now.toISOString().slice(0, 10)}.jsonl`);
+}
+
+export async function appendTeamDeliveryLog(logsDir: string, event: TeamDeliveryLogEvent): Promise<void> {
+  const now = new Date();
+  const entry = compactObject({
+    timestamp: now.toISOString(),
+    kind: 'team_delivery',
+    ...event,
+    transport: normalizeTransport(event.transport),
+  });
+
+  await mkdir(logsDir, { recursive: true }).catch(() => {});
+  await appendFile(teamDeliveryLogPath(logsDir, now), `${JSON.stringify(entry)}\n`).catch(() => {});
+}
+
+export async function appendTeamDeliveryLogForCwd(cwd: string, event: TeamDeliveryLogEvent): Promise<void> {
+  await appendTeamDeliveryLog(join(cwd, '.omx', 'logs'), event);
+}

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -10,6 +10,7 @@ import {
   type TeamDispatchRequest,
   type TeamDispatchRequestInput,
 } from './team-ops.js';
+import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
 
 export interface TeamNotifierTarget {
   workerName: string;
@@ -60,6 +61,36 @@ function fallbackTransportForPreference(
 function notifyExceptionReason(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return `notify_exception:${message}`;
+}
+
+async function logDispatchOutcome(params: {
+  cwd: string;
+  teamName: string;
+  source: string;
+  requestId?: string;
+  messageId?: string;
+  toWorker: string;
+  dispatchKind: 'inbox' | 'mailbox';
+  outcome: DispatchOutcome;
+  transportPreference?: TeamDispatchRequestInput['transport_preference'];
+}): Promise<void> {
+  const { cwd, teamName, source, requestId, messageId, toWorker, dispatchKind, outcome, transportPreference } = params;
+  const result = outcome.ok
+    ? (outcome.reason === 'queued_for_hook_dispatch' ? 'queued' : 'ok')
+    : 'failed';
+  await appendTeamDeliveryLogForCwd(cwd, {
+    event: 'dispatch_result',
+    source,
+    team: teamName,
+    request_id: requestId,
+    message_id: messageId,
+    to_worker: toWorker,
+    dispatch_kind: dispatchKind,
+    transport_preference: transportPreference,
+    transport: outcome.transport,
+    result,
+    reason: outcome.reason,
+  });
 }
 
 async function markImmediateDispatchFailure(params: {
@@ -180,6 +211,17 @@ export async function queueInboxInstruction(params: QueueInboxParams): Promise<D
     });
   }
 
+  await logDispatchOutcome({
+    cwd: params.cwd,
+    teamName: params.teamName,
+    source: 'team.mcp-comm',
+    requestId: queued.request.request_id,
+    toWorker: params.workerName,
+    dispatchKind: 'inbox',
+    outcome,
+    transportPreference: params.transportPreference,
+  });
+
   return outcome;
 }
 
@@ -200,13 +242,24 @@ interface QueueDirectMessageParams {
 export async function queueDirectMailboxMessage(params: QueueDirectMessageParams): Promise<DispatchOutcome> {
   const message = await sendDirectMessage(params.teamName, params.fromWorker, params.toWorker, params.body, params.cwd);
   if (message.notified_at && !message.delivered_at) {
-    return {
+    const outcome = {
       ok: true,
       transport: params.toWorker === 'leader-fixed' ? 'mailbox' : fallbackTransportForPreference(params.transportPreference),
       reason: 'existing_message_already_notified',
       message_id: message.message_id,
       to_worker: params.toWorker,
     };
+    await logDispatchOutcome({
+      cwd: params.cwd,
+      teamName: params.teamName,
+      source: 'team.mcp-comm',
+      messageId: message.message_id,
+      toWorker: params.toWorker,
+      dispatchKind: 'mailbox',
+      outcome,
+      transportPreference: params.transportPreference,
+    });
+    return outcome;
   }
   const queued = await enqueueDispatchRequest(
     params.teamName,
@@ -255,6 +308,17 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
       cwd: params.cwd,
       messageId: message.message_id,
     });
+    await logDispatchOutcome({
+      cwd: params.cwd,
+      teamName: params.teamName,
+      source: 'team.mcp-comm',
+      requestId: queued.request.request_id,
+      messageId: message.message_id,
+      toWorker: params.toWorker,
+      dispatchKind: 'mailbox',
+      outcome,
+      transportPreference: params.transportPreference,
+    });
     return outcome;
   }
   if (isConfirmedNotification(outcome)) {
@@ -274,6 +338,17 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
       cwd: params.cwd,
     });
   }
+  await logDispatchOutcome({
+    cwd: params.cwd,
+    teamName: params.teamName,
+    source: 'team.mcp-comm',
+    requestId: queued.request.request_id,
+    messageId: message.message_id,
+    toWorker: params.toWorker,
+    dispatchKind: 'mailbox',
+    outcome,
+    transportPreference: params.transportPreference,
+  });
   return outcome;
 }
 
@@ -360,6 +435,17 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
         cwd: params.cwd,
       });
     }
+    await logDispatchOutcome({
+      cwd: params.cwd,
+      teamName: params.teamName,
+      source: 'team.mcp-comm',
+      requestId: queued.request.request_id,
+      messageId: message.message_id,
+      toWorker: recipient.workerName,
+      dispatchKind: 'mailbox',
+      outcome,
+      transportPreference: params.transportPreference,
+    });
   }
 
   return outcomes;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -79,6 +79,7 @@ import {
   waitForDispatchReceipt,
   type DispatchOutcome,
 } from './mcp-comm.js';
+import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
 import {
   generateWorkerOverlay,
   writeTeamWorkerInstructionsFile,
@@ -213,6 +214,29 @@ interface ShutdownOptions {
 
 export interface TeamShutdownSummary {
   commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null;
+}
+
+async function logRuntimeDispatchOutcome(params: {
+  cwd: string;
+  teamName: string;
+  workerName: string;
+  requestId?: string;
+  messageId?: string;
+  outcome: DispatchOutcome;
+  source?: string;
+}): Promise<void> {
+  const { cwd, teamName, workerName, requestId, messageId, outcome, source = 'team.runtime' } = params;
+  await appendTeamDeliveryLogForCwd(cwd, {
+    event: 'dispatch_result',
+    source,
+    team: teamName,
+    request_id: requestId,
+    message_id: messageId,
+    to_worker: workerName,
+    transport: outcome.transport,
+    result: outcome.ok ? 'confirmed' : 'failed',
+    reason: outcome.reason,
+  });
 }
 
 function collectProvisionedShutdownWorktrees(config: TeamConfig): EnsureWorktreeResult[] {
@@ -3239,7 +3263,9 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   });
   if (receipt && (receipt.status === 'notified' || receipt.status === 'delivered')) {
     await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-    return { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: requestId, message_id: messageId };
+    const outcome = { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: requestId, message_id: messageId } as const;
+    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+    return outcome;
   }
 
   const fallback: DispatchOutcome = fallbackNotify
@@ -3256,13 +3282,15 @@ async function finalizeHookPreferredMailboxDispatch(params: {
         { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`, failed_at: undefined },
         cwd,
       ).catch(() => null);
-      return {
+      const outcome = {
         ok: true,
         transport: fallback.transport,
         reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
         request_id: requestId,
         message_id: messageId,
-      };
+      } as const;
+      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+      return outcome;
     }
     await transitionDispatchRequest(
       teamName,
@@ -3272,13 +3300,15 @@ async function finalizeHookPreferredMailboxDispatch(params: {
       { message_id: messageId, last_reason: `fallback_attempted_but_unconfirmed:${fallback.reason}` },
       cwd,
     ).catch(() => {});
-    return {
+    const outcome = {
       ok: false,
       transport: fallback.transport,
       reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
       request_id: requestId,
       message_id: messageId,
-    };
+    } as const;
+    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+    return outcome;
   }
 
   if (fallback.ok) {
@@ -3289,13 +3319,15 @@ async function finalizeHookPreferredMailboxDispatch(params: {
         messageId,
         cwd,
       });
-      return {
+      const outcome = {
         ok: true,
         transport: fallback.transport,
         reason: 'leader_pane_missing_mailbox_persisted',
         request_id: requestId,
         message_id: messageId,
-      };
+      } as const;
+      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+      return outcome;
     }
 
     await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
@@ -3315,13 +3347,15 @@ async function finalizeHookPreferredMailboxDispatch(params: {
         cwd,
       ).catch(() => {});
     }
-    return {
+    const outcome = {
       ok: true,
       transport: fallback.transport,
       reason: `hook_timeout_fallback_confirmed:${fallback.reason}`,
       request_id: requestId,
       message_id: messageId,
-    };
+    } as const;
+    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+    return outcome;
   }
 
   const current = await readDispatchRequest(teamName, requestId, cwd);
@@ -3335,13 +3369,15 @@ async function finalizeHookPreferredMailboxDispatch(params: {
       cwd,
     ).catch(() => {});
   }
-  return {
+  const outcome = {
     ok: false,
     transport: fallback.transport,
     reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
     request_id: requestId,
     message_id: messageId,
-  };
+  } as const;
+  await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+  return outcome;
 }
 
 async function notifyLeaderAsync(config: TeamConfig, message: string, cwd: string): Promise<DispatchOutcome> {
@@ -3449,6 +3485,14 @@ async function deliverPendingMailboxMessages(
             cwd,
           ).catch(() => null);
         }
+        await logRuntimeDispatchOutcome({
+          cwd,
+          teamName,
+          workerName: worker.name,
+          requestId: queued.request.request_id,
+          messageId: msg.message_id,
+          outcome,
+        });
       }
 
       if (outcome.ok) {
@@ -3515,6 +3559,14 @@ export async function sendWorkerMessage(
         transport: 'mailbox',
         reason: 'leader_pane_missing_mailbox_persisted',
       };
+      await logRuntimeDispatchOutcome({
+        cwd,
+        teamName: sanitized,
+        workerName: 'leader-fixed',
+        requestId: finalOutcome.request_id,
+        messageId: finalOutcome.message_id,
+        outcome: finalOutcome,
+      });
     }
     const canLeaderFallbackDirectly = Boolean(config.leader_pane_id) && isTmuxAvailable();
     if (!mailboxAlreadyNotified && leaderTransportPreference === 'hook_preferred_with_fallback' && canLeaderFallbackDirectly) {

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type DispatchRecord, type RuntimeCommand } from '../../runtime/bridge.js';
+import { appendTeamDeliveryLogForCwd } from '../delivery-log.js';
 
 export type TeamDispatchRequestKind = 'inbox' | 'mailbox' | 'nudge';
 export type TeamDispatchRequestStatus = 'pending' | 'notified' | 'delivered' | 'failed';
@@ -211,7 +212,7 @@ export async function enqueueDispatchRequest(
   }
   deps.validateWorkerName(requestInput.to_worker);
 
-  return await deps.withDispatchLock(deps.teamName, deps.cwd, async () => {
+  const queued = await deps.withDispatchLock(deps.teamName, deps.cwd, async () => {
     const requests = await deps.readDispatchRequests(deps.teamName, deps.cwd);
     const existing = requests.find((req) => equivalentPendingDispatch(req, requestInput));
     if (existing) return { request: existing, deduped: true };
@@ -238,13 +239,30 @@ export async function enqueueDispatchRequest(
       metadata: buildDispatchMetadata(deps.teamName, requestInput),
     })) {
       const bridgeRequest = await readDispatchRequest(request.request_id, deps);
-      if (bridgeRequest) return { request: bridgeRequest, deduped: false };
+      if (bridgeRequest) {
+        return { request: bridgeRequest, deduped: false, queuedTransport: 'bridge' as const };
+      }
     }
 
     requests.push(request);
     await deps.writeDispatchRequests(deps.teamName, requests, deps.cwd);
-    return { request, deduped: false };
+    return { request, deduped: false, queuedTransport: 'legacy-json' as const };
   });
+  if (!queued.deduped) {
+    await appendTeamDeliveryLogForCwd(deps.cwd, {
+      event: 'dispatch_attempted',
+      source: 'team.state.dispatch',
+      team: deps.teamName,
+      request_id: queued.request.request_id,
+      message_id: queued.request.message_id,
+      to_worker: queued.request.to_worker,
+      dispatch_kind: queued.request.kind,
+      transport: queued.request.transport_preference,
+      result: 'queued',
+      storage: queued.queuedTransport,
+    });
+  }
+  return { request: queued.request, deduped: queued.deduped };
 }
 
 export async function listDispatchRequests(

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type MailboxRecord, type RuntimeCommand } from '../../runtime/bridge.js';
+import { appendTeamDeliveryLogForCwd } from '../delivery-log.js';
 
 export interface TeamMailboxMessage {
   message_id: string;
@@ -67,6 +68,7 @@ export async function sendDirectMessage(
 ): Promise<TeamMailboxMessage> {
   let created = false;
   let msg: TeamMailboxMessage | null = null;
+  let creationTransport: 'bridge' | 'legacy-json' = 'legacy-json';
 
   await deps.withMailboxLock(deps.teamName, toWorker, deps.cwd, async () => {
     const mailbox = await deps.readMailbox(deps.teamName, toWorker, deps.cwd);
@@ -106,6 +108,7 @@ export async function sendDirectMessage(
       const bridgeMailbox = await deps.readMailbox(deps.teamName, toWorker, deps.cwd);
       const bridgeMessage = bridgeMailbox.messages.find((candidate) => candidate.message_id === msgId);
       if (bridgeMessage) {
+        creationTransport = 'bridge';
         msg = {
           ...bridgeMessage,
           body: bridgeMessage.body || body,
@@ -149,6 +152,16 @@ export async function sendDirectMessage(
       { type: 'message_received', worker: toWorker, task_id: undefined, message_id: persistedMessage.message_id, reason: undefined },
       deps.cwd,
     );
+    await appendTeamDeliveryLogForCwd(deps.cwd, {
+      event: 'mailbox_created',
+      source: 'team.state.mailbox',
+      team: deps.teamName,
+      message_id: persistedMessage.message_id,
+      from_worker: fromWorker,
+      to_worker: toWorker,
+      transport: creationTransport,
+      result: 'created',
+    });
   }
   return persistedMessage;
 }
@@ -175,7 +188,7 @@ export async function markMessageDelivered(
   deps: MailboxDeps,
 ): Promise<boolean> {
   if (executeBridgeCommand(deps.cwd, { command: 'MarkMailboxDelivered', message_id: messageId })) {
-    return await deps.withMailboxLock(deps.teamName, workerName, deps.cwd, async () => {
+    const updated = await deps.withMailboxLock(deps.teamName, workerName, deps.cwd, async () => {
       const mailbox = await deps.readMailbox(deps.teamName, workerName, deps.cwd);
       const msg = mailbox.messages.find((message) => message.message_id === messageId);
       if (!msg) return false;
@@ -187,8 +200,20 @@ export async function markMessageDelivered(
       }
       return true;
     });
+    if (updated) {
+      await appendTeamDeliveryLogForCwd(deps.cwd, {
+        event: 'delivered',
+        source: 'team.state.mailbox',
+        team: deps.teamName,
+        message_id: messageId,
+        to_worker: workerName,
+        transport: 'bridge',
+        result: 'updated',
+      });
+    }
+    return updated;
   }
-  return await deps.withMailboxLock(deps.teamName, workerName, deps.cwd, async () => {
+  const updated = await deps.withMailboxLock(deps.teamName, workerName, deps.cwd, async () => {
     const mailbox = await deps.readMailbox(deps.teamName, workerName, deps.cwd);
     const msg = mailbox.messages.find((m) => m.message_id === messageId);
     if (!msg) return false;
@@ -198,6 +223,18 @@ export async function markMessageDelivered(
     }
     return true;
   });
+  if (updated) {
+    await appendTeamDeliveryLogForCwd(deps.cwd, {
+      event: 'delivered',
+      source: 'team.state.mailbox',
+      team: deps.teamName,
+      message_id: messageId,
+      to_worker: workerName,
+      transport: 'legacy-json',
+      result: 'updated',
+    });
+  }
+  return updated;
 }
 
 export async function markMessageNotified(


### PR DESCRIPTION
## Summary
- add a shared `team-delivery` JSONL log stream under `.omx/logs`
- instrument mailbox, dispatch, runtime fallback, and leader/fallback nudge seams with concise machine-parseable delivery events
- extend focused tests for mailbox creation, deferred dispatch, runtime leader fallback, and leader/fallback nudge telemetry

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/team/__tests__/api-interop.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
- `npx tsc --noEmit --pretty false --project tsconfig.json`
- custom runtime leader-mailbox fallback verification (exactly one matching `team.runtime` delivery log entry)
