### PR TITLE
Stop default shared MCP sync from picking up legacy gitnexus state

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -346,8 +346,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
           {
             uiTheme: "dark",
             mcpServers: {
-              gitnexus: {
-                command: "custom-gitnexus",
+              existing_server: {
+                command: "custom-existing-server",
                 args: ["serve"],
                 enabled: true,
               },
@@ -361,7 +361,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await writeFile(
         registryPath,
         JSON.stringify({
-          gitnexus: { command: "gitnexus", args: ["mcp"] },
+          existing_server: { command: "existing-server", args: ["mcp"] },
           eslint: { command: "npx", args: ["@eslint/mcp@latest"], enabled: false },
         }),
       );
@@ -378,8 +378,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
         mcpServers?: Record<string, { command: string; args: string[]; enabled: boolean }>;
       };
       assert.equal(settings.uiTheme, "dark");
-      assert.deepEqual(settings.mcpServers?.gitnexus, {
-        command: "custom-gitnexus",
+      assert.deepEqual(settings.mcpServers?.existing_server, {
+        command: "custom-existing-server",
         args: ["serve"],
         enabled: true,
       });
@@ -442,15 +442,15 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await writeFile(
         join(wd, ".omc", "mcp-registry.json"),
         JSON.stringify({
-          gitnexus: { command: "gitnexus", args: ["mcp"] },
+          legacy_helper: { command: "legacy-helper", args: ["mcp"] },
         }),
       );
 
       await runSetupInTempDir(wd, { scope: "project" });
 
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.doesNotMatch(config, /^\[mcp_servers\.gitnexus\]$/m);
-      assert.doesNotMatch(config, /Shared MCP Server: gitnexus/);
+      assert.doesNotMatch(config, /^\[mcp_servers\.legacy_helper\]$/m);
+      assert.doesNotMatch(config, /Shared MCP Server: legacy_helper/);
 
       const output = await runSetupWithCapturedLogs(wd, { scope: "project" });
       assert.match(output, /legacy shared MCP registry detected at .*\.omc\/mcp-registry\.json but ignored by default/i);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -30,6 +30,7 @@ import {
 } from "../utils/paths.js";
 import { buildMergedConfig, getRootModelName } from "../config/generator.js";
 import {
+  getLegacyUnifiedMcpRegistryCandidate,
   getUnifiedMcpRegistryCandidates,
   loadUnifiedMcpRegistry,
   planClaudeCodeMcpSettingsSync,
@@ -754,18 +755,18 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   console.log("[5/8] Updating config.toml...");
   const registryCandidates = getUnifiedMcpRegistryCandidates();
   const defaultRegistryCandidates = registryCandidates.slice(0, 1);
+  const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
   const sharedMcpRegistry = await loadUnifiedMcpRegistry({
     candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
   });
   if (
     !options.mcpRegistryCandidates &&
     !sharedMcpRegistry.sourcePath &&
-    registryCandidates.length > 1 &&
-    existsSync(registryCandidates[1]) &&
-    !existsSync(registryCandidates[0])
+    existsSync(legacyRegistryCandidate) &&
+    !existsSync(defaultRegistryCandidates[0])
   ) {
     console.log(
-      `  warning: legacy shared MCP registry detected at ${registryCandidates[1]} but ignored by default; move it to ${registryCandidates[0]} if you still want setup to sync those servers`,
+      `  warning: legacy shared MCP registry detected at ${legacyRegistryCandidate} but ignored by default; move it to ${defaultRegistryCandidates[0]} if you still want setup to sync those servers`,
     );
   }
   if (verbose && sharedMcpRegistry.sourcePath) {

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -662,7 +662,7 @@ describe("config generator idempotency (#384)", () => {
 
   it("skips shared MCP entries that already exist in user config", () => {
     const existing = [
-      "[mcp_servers.gitnexus]",
+      "[mcp_servers.existing_server]",
       'command = "custom"',
       'args = ["serve"]',
       "",
@@ -670,8 +670,8 @@ describe("config generator idempotency (#384)", () => {
     const merged = buildMergedConfig(existing, "/tmp/omx", {
       sharedMcpServers: [
         {
-          name: "gitnexus",
-          command: "gitnexus",
+          name: "existing_server",
+          command: "existing-server",
           args: ["mcp"],
           enabled: true,
         },
@@ -685,7 +685,7 @@ describe("config generator idempotency (#384)", () => {
       sharedMcpRegistrySource: "/tmp/.omx/mcp-registry.json",
     });
 
-    assert.equal(count(merged, /^\[mcp_servers\.gitnexus\]$/gm), 1);
+    assert.equal(count(merged, /^\[mcp_servers\.existing_server\]$/gm), 1);
     assert.match(merged, /command = "custom"/);
     assert.equal(count(merged, /^\[mcp_servers\.eslint\]$/gm), 1);
   });

--- a/src/config/__tests__/mcp-registry.test.ts
+++ b/src/config/__tests__/mcp-registry.test.ts
@@ -27,7 +27,7 @@ describe("unified MCP registry loader", () => {
       await writeFile(
         omcPath,
         JSON.stringify({
-          gitnexus: { command: "gitnexus", args: ["mcp"] },
+          legacy_helper: { command: "legacy-helper", args: ["mcp"] },
         }),
       );
 
@@ -40,7 +40,7 @@ describe("unified MCP registry loader", () => {
     }
   });
 
-  it("falls back to ~/.omc/mcp-registry.json when ~/.omx registry is absent", async () => {
+  it("loads a legacy registry when it is passed explicitly as a candidate", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-mcp-registry-"));
     try {
       const omcPath = join(wd, ".omc", "mcp-registry.json");
@@ -48,14 +48,14 @@ describe("unified MCP registry loader", () => {
       await writeFile(
         omcPath,
         JSON.stringify({
-          gitnexus: { command: "gitnexus", args: ["mcp"], enabled: false },
+          legacy_helper: { command: "legacy-helper", args: ["mcp"], enabled: false },
         }),
       );
 
-      const result = await loadUnifiedMcpRegistry({ homeDir: wd });
+      const result = await loadUnifiedMcpRegistry({ candidates: [omcPath] });
       assert.equal(result.sourcePath, omcPath);
       assert.equal(result.servers.length, 1);
-      assert.equal(result.servers[0].name, "gitnexus");
+      assert.equal(result.servers[0].name, "legacy_helper");
       assert.equal(result.servers[0].enabled, false);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -89,10 +89,7 @@ describe("unified MCP registry loader", () => {
 
   it("returns canonical home-based registry candidates", () => {
     const candidates = getUnifiedMcpRegistryCandidates("/tmp/home");
-    assert.deepEqual(candidates, [
-      "/tmp/home/.omx/mcp-registry.json",
-      "/tmp/home/.omc/mcp-registry.json",
-    ]);
+    assert.deepEqual(candidates, ["/tmp/home/.omx/mcp-registry.json"]);
   });
   it("plans Claude settings sync by adding only missing shared servers", () => {
     const plan = planClaudeCodeMcpSettingsSync(
@@ -100,8 +97,8 @@ describe("unified MCP registry loader", () => {
         {
           theme: "dark",
           mcpServers: {
-            gitnexus: {
-              command: "custom-gitnexus",
+            existing_server: {
+              command: "custom-existing-server",
               args: ["serve"],
               enabled: true,
             },
@@ -112,8 +109,8 @@ describe("unified MCP registry loader", () => {
       ),
       [
         {
-          name: "gitnexus",
-          command: "gitnexus",
+          name: "existing_server",
+          command: "existing-server",
           args: ["mcp"],
           enabled: true,
         },
@@ -128,7 +125,7 @@ describe("unified MCP registry loader", () => {
     );
 
     assert.deepEqual(plan.added, ["eslint"]);
-    assert.deepEqual(plan.unchanged, ["gitnexus"]);
+    assert.deepEqual(plan.unchanged, ["existing_server"]);
     assert.deepEqual(plan.warnings, []);
 
     const parsed = JSON.parse(plan.content ?? "{}") as {
@@ -136,8 +133,8 @@ describe("unified MCP registry loader", () => {
       mcpServers?: Record<string, { command: string; args: string[]; enabled: boolean }>;
     };
     assert.equal(parsed.theme, "dark");
-    assert.deepEqual(parsed.mcpServers?.gitnexus, {
-      command: "custom-gitnexus",
+    assert.deepEqual(parsed.mcpServers?.existing_server, {
+      command: "custom-existing-server",
       args: ["serve"],
       enabled: true,
     });

--- a/src/config/mcp-registry.ts
+++ b/src/config/mcp-registry.ts
@@ -104,10 +104,11 @@ function normalizeEntry(
 }
 
 export function getUnifiedMcpRegistryCandidates(homeDir = homedir()): string[] {
-  return [
-    join(homeDir, ".omx", "mcp-registry.json"),
-    join(homeDir, ".omc", "mcp-registry.json"),
-  ];
+  return [join(homeDir, ".omx", "mcp-registry.json")];
+}
+
+export function getLegacyUnifiedMcpRegistryCandidate(homeDir = homedir()): string {
+  return join(homeDir, ".omc", "mcp-registry.json");
 }
 
 export async function loadUnifiedMcpRegistry(


### PR DESCRIPTION
## Summary
- restrict default shared MCP registry discovery to the canonical `~/.omx/mcp-registry.json` path
- keep explicit registry-candidate sync behavior available for user-provided MCP registries, including legacy paths
- replace gitnexus-specific test fixtures with neutral server names and update expectations

## Verification
- `npm run build`
- `node --test dist/config/__tests__/mcp-registry.test.js dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-refresh.test.js`
- `npx biome lint src/config/mcp-registry.ts src/cli/setup.ts src/config/__tests__/mcp-registry.test.ts src/config/__tests__/generator-idempotent.test.ts src/cli/__tests__/setup-refresh.test.ts`