### PR TITLE
test: stabilize notify hook tmux integration suites

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -153,12 +153,39 @@ exit 0
 function buildCleanNotifyEnv(
   overrides: Record<string, string> = {},
 ): NodeJS.ProcessEnv {
+  const isolatedHome = join(tmpdir(), `omx-fallback-home-${randomUUID()}`);
+  const basePath = process.platform === 'win32'
+    ? (process.env.PATH || '')
+    : '/usr/bin:/bin:/usr/sbin:/sbin';
   return {
-    ...process.env,
+    PATH: basePath,
+    TMPDIR: process.env.TMPDIR || '',
+    TMP: process.env.TMP || '',
+    TEMP: process.env.TEMP || '',
+    LANG: process.env.LANG || 'en_US.UTF-8',
+    LC_ALL: process.env.LC_ALL || '',
+    HOME: isolatedHome,
+    CODEX_HOME: '',
+    OMX_SESSION_ID: '',
     OMX_TEAM_WORKER: '',
     OMX_TEAM_STATE_ROOT: '',
     OMX_TEAM_LEADER_CWD: '',
     OMX_MODEL_INSTRUCTIONS_FILE: '',
+    OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS: '6000',
+    OMX_TEST_CAPTURE_FILE: '',
+    OMX_TEST_CAPTURE_SEQUENCE_FILE: '',
+    OMX_TEST_CAPTURE_COUNTER_FILE: '',
+    OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS: '',
+    OMX_TEAM_LEADER_NUDGE_MS: '',
+    OMX_TEAM_LEADER_STALE_MS: '',
+    OMX_TEAM_LEADER_ALL_IDLE_COOLDOWN_MS: '',
+    OMX_TEAM_PROGRESS_STALL_MS: '',
+    OMX_TEAM_WORKER_TURN_STALL_MS: '',
+    OMX_TEAM_WORKER_IDLE_NOTIFY: '',
+    OMX_TEAM_WORKER_IDLE_COOLDOWN_MS: '',
+    OMX_TEAM_ALL_IDLE_COOLDOWN_MS: '',
+    OMX_RUNTIME_BINARY: '',
+    USE_OMX_EXPLORE_CMD: '',
     TMUX: '',
     TMUX_PANE: '',
     ...overrides,

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -306,11 +306,13 @@ exit 1
     const fakeBinDir = join(cwd, 'fake-bin');
     const tmuxLogPath = join(cwd, 'tmux.log');
     const prevPath = process.env.PATH;
+    const prevNotifyHookTimeout = process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS;
     try {
       await mkdir(fakeBinDir, { recursive: true });
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
       process.env.PATH = `${fakeBinDir}:${prevPath || ''}`;
+      process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS = '6000';
 
       await initTeamState('alpha', 'task', 'executor', 1, cwd);
       const cfg = await readTeamConfig('alpha', cwd);
@@ -339,6 +341,8 @@ exit 1
     } finally {
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
       else delete process.env.PATH;
+      if (typeof prevNotifyHookTimeout === 'string') process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS = prevNotifyHookTimeout;
+      else delete process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -349,6 +353,7 @@ exit 1
     const tmuxLogPath = join(cwd, 'tmux.log');
     const prevPath = process.env.PATH;
     const prevTmuxPane = process.env.TMUX_PANE;
+    const prevNotifyHookTimeout = process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS;
     try {
       await mkdir(fakeBinDir, { recursive: true });
       const fakeTmux = `#!/usr/bin/env bash
@@ -426,6 +431,7 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
       process.env.PATH = `${fakeBinDir}:${prevPath || ''}`;
       process.env.TMUX_PANE = '%42';
+      process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS = '6000';
 
       await initTeamState('alpha', 'task', 'executor', 1, cwd);
       const cfg = await readTeamConfig('alpha', cwd);
@@ -455,6 +461,8 @@ exit 0
       else delete process.env.PATH;
       if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
       else delete process.env.TMUX_PANE;
+      if (typeof prevNotifyHookTimeout === 'string') process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS = prevNotifyHookTimeout;
+      else delete process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -66,6 +66,46 @@ exit 0
 `;
 }
 
+function buildIsolatedNotifyEnv(
+  cwd: string,
+  fakeBinDir: string,
+  extraEnv: Record<string, string> = {},
+): NodeJS.ProcessEnv {
+  const basePath = process.platform === 'win32'
+    ? (process.env.PATH || '')
+    : '/usr/bin:/bin:/usr/sbin:/sbin';
+  return {
+    PATH: `${fakeBinDir}:${basePath}`,
+    TMPDIR: process.env.TMPDIR || '',
+    TMP: process.env.TMP || '',
+    TEMP: process.env.TEMP || '',
+    LANG: process.env.LANG || 'en_US.UTF-8',
+    LC_ALL: process.env.LC_ALL || '',
+    HOME: join(cwd, '.test-home'),
+    CODEX_HOME: '',
+    OMX_SESSION_ID: '',
+    OMX_TEAM_LEADER_NUDGE_MS: '10000',
+    OMX_TEAM_LEADER_STALE_MS: '10000',
+    OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS: '6000',
+    OMX_TEAM_LEADER_ALL_IDLE_COOLDOWN_MS: '',
+    OMX_TEAM_PROGRESS_STALL_MS: '',
+    OMX_TEAM_WORKER_TURN_STALL_MS: '',
+    OMX_TEAM_WORKER: '',
+    OMX_TEAM_STATE_ROOT: '',
+    OMX_TEAM_LEADER_CWD: '',
+    OMX_MODEL_INSTRUCTIONS_FILE: '',
+    OMX_TEST_CAPTURE_FILE: '',
+    OMX_TEST_CAPTURE_SEQUENCE_FILE: '',
+    OMX_TEST_CAPTURE_COUNTER_FILE: '',
+    OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS: '',
+    OMX_RUNTIME_BINARY: '',
+    USE_OMX_EXPLORE_CMD: '',
+    TMUX: '',
+    TMUX_PANE: '',
+    ...extraEnv,
+  };
+}
+
 function runNotifyHook(
   cwd: string,
   fakeBinDir: string,
@@ -82,19 +122,7 @@ function runNotifyHook(
 
   return spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
     encoding: 'utf8',
-    env: {
-      ...process.env,
-      PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-      OMX_TEAM_LEADER_NUDGE_MS: '10000',
-      OMX_TEAM_LEADER_STALE_MS: '10000',
-      OMX_TEAM_WORKER: '',
-      OMX_TEAM_STATE_ROOT: '',
-      OMX_TEAM_LEADER_CWD: '',
-      OMX_MODEL_INSTRUCTIONS_FILE: '',
-      TMUX: '',
-      TMUX_PANE: '',
-      ...extraEnv,
-    },
+    env: buildIsolatedNotifyEnv(cwd, fakeBinDir, extraEnv),
   });
 }
 

--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -24,6 +24,46 @@ async function readJson<T>(path: string): Promise<T> {
   return JSON.parse(await readFile(path, 'utf-8')) as T;
 }
 
+function buildNotifyHookEnv(
+  cwd: string,
+  fakeBinDir: string,
+  extraEnv: Record<string, string> = {},
+): NodeJS.ProcessEnv {
+  const basePath = process.platform === 'win32'
+    ? (process.env.PATH || '')
+    : '/usr/bin:/bin:/usr/sbin:/sbin';
+  return {
+    PATH: `${fakeBinDir}:${basePath}`,
+    TMPDIR: process.env.TMPDIR || '',
+    TMP: process.env.TMP || '',
+    TEMP: process.env.TEMP || '',
+    LANG: process.env.LANG || 'en_US.UTF-8',
+    LC_ALL: process.env.LC_ALL || '',
+    HOME: join(cwd, '.test-home'),
+    CODEX_HOME: '',
+    OMX_SESSION_ID: '',
+    OMX_TEAM_WORKER: '',
+    OMX_TEAM_STATE_ROOT: '',
+    OMX_TEAM_LEADER_CWD: '',
+    OMX_MODEL_INSTRUCTIONS_FILE: '',
+    OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS: '6000',
+    OMX_TEAM_LEADER_NUDGE_MS: '',
+    OMX_TEAM_LEADER_STALE_MS: '',
+    OMX_TEAM_LEADER_ALL_IDLE_COOLDOWN_MS: '',
+    OMX_TEAM_PROGRESS_STALL_MS: '',
+    OMX_TEAM_WORKER_TURN_STALL_MS: '',
+    OMX_TEST_CAPTURE_FILE: '',
+    OMX_TEST_CAPTURE_SEQUENCE_FILE: '',
+    OMX_TEST_CAPTURE_COUNTER_FILE: '',
+    OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS: '',
+    OMX_RUNTIME_BINARY: '',
+    USE_OMX_EXPLORE_CMD: '',
+    TMUX: '',
+    TMUX_PANE: '',
+    ...extraEnv,
+  };
+}
+
 describe('notify-hook tmux target healing', () => {
   it('falls back to global mode state when scoped session has no allowed active mode', async () => {
     await withTempWorkingDir(async (cwd) => {
@@ -106,11 +146,7 @@ exit 1
 
       const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
         encoding: 'utf8',
-        env: {
-          ...process.env,
-          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-          OMX_TEAM_WORKER: '',
-        },
+        env: buildNotifyHookEnv(cwd, fakeBinDir),
       });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
@@ -230,12 +266,7 @@ exit 1
 
       const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
         encoding: 'utf8',
-        env: {
-          ...process.env,
-          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-          OMX_TEAM_WORKER: '',
-          TMUX_PANE: '%42',
-        },
+        env: buildNotifyHookEnv(cwd, fakeBinDir, { TMUX_PANE: '%42' }),
       });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
@@ -359,12 +390,7 @@ exit 1
 
       const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
         encoding: 'utf8',
-        env: {
-          ...process.env,
-          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-          OMX_TEAM_WORKER: '',
-          TMUX_PANE: '%42',
-        },
+        env: buildNotifyHookEnv(cwd, fakeBinDir, { TMUX_PANE: '%42' }),
       });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
@@ -475,11 +501,7 @@ exit 1
 
       const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
         encoding: 'utf8',
-        env: {
-          ...process.env,
-          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-          OMX_TEAM_WORKER: '',
-        },
+        env: buildNotifyHookEnv(cwd, fakeBinDir),
       });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
@@ -587,12 +609,7 @@ exit 1
 
       const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
         encoding: 'utf8',
-        env: {
-          ...process.env,
-          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-          OMX_TEAM_WORKER: '',
-          TMUX_PANE: '%99',
-        },
+        env: buildNotifyHookEnv(cwd, fakeBinDir, { TMUX_PANE: '%99' }),
       });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
@@ -693,11 +710,7 @@ exit 1
 
       const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
         encoding: 'utf8',
-        env: {
-          ...process.env,
-          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-          OMX_TEAM_WORKER: '',
-        },
+        env: buildNotifyHookEnv(cwd, fakeBinDir),
       });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
@@ -812,11 +825,7 @@ exit 1
 
       const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
         encoding: 'utf8',
-        env: {
-          ...process.env,
-          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-          OMX_TEAM_WORKER: '',
-        },
+        env: buildNotifyHookEnv(cwd, fakeBinDir),
       });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
@@ -918,11 +927,7 @@ exit 1
 
       const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
         encoding: 'utf8',
-        env: {
-          ...process.env,
-          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
-          OMX_TEAM_WORKER: '',
-        },
+        env: buildNotifyHookEnv(cwd, fakeBinDir),
       });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { basename, dirname, join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
-import { asNumber, safeString } from './utils.js';
+import { asNumber, resolveExternalCommandTimeoutMs, safeString } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession, readdir } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
@@ -378,11 +378,12 @@ export async function capturePane(paneId, lines = 10) {
 function resolveCodexPaneByCwdFallback(cwd) {
   const normalizedCwd = safeString(cwd).trim();
   if (!normalizedCwd) return '';
+  const tmuxTimeoutMs = resolveExternalCommandTimeoutMs(2000);
 
   try {
     const panes = execFileSync('tmux', [
       'list-panes', '-a', '-F', '#{pane_id}	#{pane_current_path}	#{pane_current_command}	#{pane_start_command}',
-    ], { encoding: 'utf-8', timeout: 2000, windowsHide: true })
+    ], { encoding: 'utf-8', timeout: tmuxTimeoutMs, windowsHide: true })
       .trim()
       .split('\n')
       .filter(Boolean);
@@ -486,11 +487,12 @@ function buildExpectedManagedTmuxSessionName(cwd, sessionId) {
 
 function readCurrentTmuxSessionName() {
   if (!process.env.TMUX) return '';
+  const tmuxTimeoutMs = resolveExternalCommandTimeoutMs(2000);
   try {
     return execFileSync('tmux', ['display-message', '-p', '#S'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 2000,
+      timeout: tmuxTimeoutMs,
     }).trim();
   } catch {
     return '';

--- a/src/scripts/notify-hook/process-runner.ts
+++ b/src/scripts/notify-hook/process-runner.ts
@@ -3,9 +3,11 @@
  */
 
 import { spawn } from 'child_process';
+import { resolveExternalCommandTimeoutMs } from './utils.js';
 
 export function runProcess(command: string, args: string[], timeoutMs = 3000): Promise<{ stdout: string; stderr: string; code: number | null }> {
   return new Promise((resolve, reject) => {
+    const effectiveTimeoutMs = resolveExternalCommandTimeoutMs(timeoutMs);
     const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
@@ -15,8 +17,8 @@ export function runProcess(command: string, args: string[], timeoutMs = 3000): P
       if (finished) return;
       finished = true;
       child.kill('SIGTERM');
-      reject(new Error(`timeout after ${timeoutMs}ms`));
-    }, timeoutMs);
+      reject(new Error(`timeout after ${effectiveTimeoutMs}ms`));
+    }, effectiveTimeoutMs);
 
     child.stdout.on('data', (chunk: any) => {
       stdout += chunk.toString();

--- a/src/scripts/notify-hook/utils.ts
+++ b/src/scripts/notify-hook/utils.ts
@@ -18,6 +18,15 @@ export function safeString(value: any, fallback = ''): string {
   return String(value);
 }
 
+export function resolveExternalCommandTimeoutMs(defaultMs: number): number {
+  const parsed = asNumber(
+    safeString(process.env.OMX_NOTIFY_HOOK_COMMAND_TIMEOUT_MS || process.env.OMX_TMUX_TIMEOUT_MS || ''),
+  );
+  if (parsed === null) return defaultMs;
+  const normalized = Math.max(250, Math.floor(parsed));
+  return Math.min(60_000, Math.max(defaultMs, normalized));
+}
+
 export function clampPct(value: any): number | null {
   if (!Number.isFinite(value)) return null;
   if (value < 0) return 0;

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
+import { resolveExternalCommandTimeoutMs } from './notify-hook/utils.js';
 
 export const DEFAULT_ALLOWED_MODES = ['ralph', 'ultrawork', 'team'];
 export const DEFAULT_MARKER = '[OMX_TMUX_INJECT]';
@@ -200,13 +201,14 @@ function isHudStartCommand(startCommand: string): boolean {
 export function resolveCodexPane(): string {
   const envPane = (process.env.TMUX_PANE || '').trim();
   if (!envPane) return '';
+  const tmuxTimeoutMs = resolveExternalCommandTimeoutMs(2000);
 
   try {
     const cmd = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{pane_current_command}'], {
-      encoding: 'utf-8', timeout: 2000,
+      encoding: 'utf-8', timeout: tmuxTimeoutMs,
     }).trim().toLowerCase();
     const startCmd = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{pane_start_command}'], {
-      encoding: 'utf-8', timeout: 2000,
+      encoding: 'utf-8', timeout: tmuxTimeoutMs,
     }).trim().toLowerCase();
     const base = cmd.split('/').pop()?.replace(/^-/, '') || '';
     if (AGENT_COMMANDS.has(base) && !isHudStartCommand(startCmd)) {
@@ -222,7 +224,7 @@ export function resolveCodexPane(): string {
 
   try {
     const sessionName = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#S'], {
-      encoding: 'utf-8', timeout: 2000,
+      encoding: 'utf-8', timeout: tmuxTimeoutMs,
       windowsHide: true,
     }).trim();
     if (!sessionName) return '';
@@ -230,7 +232,7 @@ export function resolveCodexPane(): string {
     const panes = execFileSync('tmux', [
       'list-panes', '-s', '-t', sessionName,
       '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
-    ], { encoding: 'utf-8', timeout: 2000 }).trim().split('\n');
+    ], { encoding: 'utf-8', timeout: tmuxTimeoutMs }).trim().split('\n');
 
     for (const line of panes) {
       const parts = line.split('\t');


### PR DESCRIPTION
## Summary
- isolate notify hook integration test envs from parent process leakage
- add a notify-hook command timeout override and use it only in flaky tmux-heavy stability tests
- stabilize notify fallback watcher, team leader nudge, tmux heal, and team dispatch wider-suite coverage

## Verification
- npm run build
- node --test dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-hook-tmux-heal.test.js
- node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js
- node --test $(find dist/mcp/__tests__ dist/hooks/__tests__ -name '*.test.js' | sort)

## Notes
- This intentionally stays separate from the strict formal-memory adapter PR so runtime memory integration and test-stability changes can be reviewed independently.