### PR TITLE
Prevent duplicate fallback nudges from HUD authority ticks

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -605,7 +605,7 @@ describe('notify-fallback watcher', () => {
       assert.equal(watcherState.authority_backoff?.active, true);
       assert.equal(watcherState.authority_backoff?.reason, 'primary_watcher_healthy');
       assert.equal(watcherState.authority_backoff?.primary_pid, process.pid);
-      assert.match(watcherState.dispatch_drain?.last_tick_at ?? '', /^\\d{4}-\\d{2}-\\d{2}T/);
+      assert.match(watcherState.dispatch_drain?.last_tick_at ?? '', /^\d{4}-\d{2}-\d{2}T/);
 
       const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
       const logContent = await readFile(logPath, 'utf-8').catch(() => '');

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -962,6 +962,15 @@ async function writeState(extra: Record<string, unknown> = {}): Promise<void> {
   await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
 }
 
+async function writeAuthorityBackoffState(): Promise<void> {
+  await mkdir(stateDir, { recursive: true }).catch(() => {});
+  const existing = await readJsonObject(statePath);
+  const state = existing && typeof existing === 'object'
+    ? { ...existing, authority_backoff: lastAuthorityBackoff }
+    : { authority_backoff: lastAuthorityBackoff };
+  await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
+}
+
 async function readJsonObject(path: string): Promise<Record<string, unknown> | null> {
   return readFile(path, 'utf-8')
     .then((content) => JSON.parse(content) as Record<string, unknown>)
@@ -1462,24 +1471,7 @@ async function runWatcherCycle(): Promise<void> {
     const authorityBackoff = await resolveAuthorityPrimaryWatcherHealth();
     lastAuthorityBackoff = authorityBackoff;
     if (authorityBackoff.active) {
-      lastDispatchDrain = {
-        ...lastDispatchDrain,
-        last_tick_at: null,
-        last_result: { processed: 0, reason: authorityBackoff.reason },
-        last_error: null,
-      };
-      lastLeaderNudge = {
-        ...lastLeaderNudge,
-        last_tick_at: null,
-        last_error: authorityBackoff.reason,
-      };
-      lastFallbackAutoNudge = {
-        ...lastFallbackAutoNudge,
-        last_tick_at: null,
-        last_reason: authorityBackoff.reason,
-        last_error: null,
-      };
-      await writeState();
+      await writeAuthorityBackoffState();
       return;
     }
   } else {


### PR DESCRIPTION
## Summary
- gate authority-only fallback watcher takeover on primary watcher health
- back off HUD authority one-shot ticks when the primary watcher pid/state is live and fresh
- add a regression proving authority-only ticks do not duplicate fallback nudges while primary watcher recovery stays intact

## Testing
- npm run build
- npm run lint
- npm run check:no-unused
- node --test --test-reporter=spec dist/hooks/__tests__/notify-fallback-watcher.test.js
- node --test --test-reporter=spec dist/hooks/__tests__/notify-hook-auto-nudge.test.js
