### PR TITLE
Reduce recent cleanup churn while preserving notify/runtime behavior

### DIFF
--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -72,18 +72,12 @@ function buildBlockedAutoApprovalMatcher(blockedInputs) {
 export function isBlockedAutoApprovalInput(text, blockedInputs = DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS) {
   const normalized = normalizeBlockedAutoApprovalInput(text);
   if (!normalized) return false;
-  const normalizedBlockedInputs = blockedInputs.map((entry) => normalizeBlockedAutoApprovalInput(entry)).filter(Boolean);
-  if (normalizedBlockedInputs.includes(normalized)) return true;
-
-  const blockedPrefixes = normalizedBlockedInputs.filter((entry) => DEEP_INTERVIEW_BLOCKED_APPROVAL_PREFIXES.has(entry));
-  if (blockedPrefixes.some((prefix) => normalized.startsWith(`${prefix} `))) return true;
+  const { exactMatches, prefixedMatches, blockedTokenSet } = buildBlockedAutoApprovalMatcher(blockedInputs);
+  if (exactMatches.has(normalized)) return true;
+  if (prefixedMatches.some((prefix) => normalized.startsWith(`${prefix} `))) return true;
 
   const tokens = normalized.split(/\s+/).filter(Boolean);
   if (tokens.length === 0) return false;
-
-  const blockedTokenSet = new Set(
-    normalizedBlockedInputs.flatMap((entry) => entry.split(/\s+/).filter(Boolean)),
-  );
   return tokens.every((token) => blockedTokenSet.has(token));
 }
 


### PR DESCRIPTION
## Summary
- simplify notify fallback watcher control-plane suppression and pid parsing without changing intended behavior
- deduplicate auto-nudge blocked-input normalization and centralize dist script resolution helpers
- restore the watcher regression file and keep the new authority-only deep-interview coverage

## Validation
- `npx biome lint src/cli/__tests__/packaged-script-resolution.test.ts src/cli/index.ts src/hooks/__tests__/notify-fallback-watcher.test.ts src/hooks/__tests__/notify-hook-modules.test.ts src/scripts/notify-fallback-watcher.ts src/scripts/notify-hook/auto-nudge.ts`
- `npm run check:no-unused`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/packaged-script-resolution.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-modules.test.js`

## Notes
- Repo-wide `npm run lint` is currently blocked by nested `biome.json` configs under existing `.claude/` and `.omx/team/` worktrees.
- The broader `notify-fallback-watcher` suite still shows two out-of-scope failures on this branch (`watcher retry does not retype when pre-capture still contains trigger`, `retypes on every retry when trigger is not in narrow input area`).
