### PR TITLE
docs: align local memory surfaces with strict formal memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,8 +296,8 @@ Do not cancel while recoverable work remains.
 <state_management>
 OMX persists runtime state under `.omx/`:
 - `.omx/state/` — mode state
-- `.omx/notepad.md` — session notes
-- `.omx/project-memory.json` — cross-session memory
+- `.omx/notepad.md` — run-local session scratch and hot context
+- `.omx/project-memory.json` — local compatibility cache, not the formal memory authority
 - `.omx/plans/` — plans
 - `.omx/logs/` — logs
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,7 +62,7 @@
         <article class="card"><h3>Agent Prompts</h3><p>Specialized roles for implementation, review, design, and planning.</p></article>
         <article class="card"><h3>Skills</h3><p>Composable workflows from autopilot and team pipelines to setup, release, and tracing.</p></article>
         <article class="card"><h3>Team Orchestration</h3><p>Staged execution pipeline with verification and fix loops.</p></article>
-        <article class="card"><h3>MCP State Management</h3><p>Persistent lifecycle state, notepad, and project memory across sessions.</p></article>
+        <article class="card"><h3>MCP State Management</h3><p>Persistent lifecycle state, run-local notepad scratch, and local project-memory compatibility tools.</p></article>
       </div>
 
       <h2>Quick Start</h2>

--- a/skills/note/SKILL.md
+++ b/skills/note/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: note
-description: Save notes to notepad.md for compaction resilience
+description: Save run-local notes to notepad.md for compaction resilience
 ---
 
 # Note Skill
 
-Save important context to `.omx/notepad.md` that survives conversation compaction.
+Save run-local context to `.omx/notepad.md` so important breadcrumbs survive conversation compaction without becoming a second long-term memory source.
 
 ## Usage
 
@@ -24,6 +24,7 @@ Save important context to `.omx/notepad.md` that survives conversation compactio
 - **Always** injected on session start
 - Use for critical facts: "Project uses pnpm", "API in src/api/client.ts"
 - Keep it SHORT - this eats into your context budget
+- Treat this as hot context, not the formal long-term memory authority
 
 ### Working Memory
 - Timestamped session notes
@@ -32,8 +33,9 @@ Save important context to `.omx/notepad.md` that survives conversation compactio
 
 ### MANUAL
 - Never auto-pruned
-- User-controlled permanent notes
-- Good for: team contacts, deployment info
+- User-controlled sticky run-local notes
+- Good for: team contacts, deployment info that should stay handy during this workspace/session flow
+- If something should become durable shared knowledge, promote it through the external memory pipeline instead of treating MANUAL as the authority source
 
 ## Examples
 
@@ -60,3 +62,4 @@ Notepad content is automatically loaded on session start:
 - Working Memory: Loaded if recent entries exist
 
 This helps survive conversation compaction without losing critical context.
+Notepad remains run-local scratch/hot context; it is not a replacement for formal long-term memory.

--- a/src/hooks/__tests__/strict-memory-surface-contract.test.ts
+++ b/src/hooks/__tests__/strict-memory-surface-contract.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadSurface } from './prompt-guidance-test-helpers.js';
+
+for (const surface of ['AGENTS.md', 'templates/AGENTS.md']) {
+  describe(`${surface} strict-memory state-management contract`, () => {
+    it('describes notepad as run-local scratch instead of durable memory authority', () => {
+      const content = loadSurface(surface);
+      assert.match(content, /\.omx\/notepad\.md` — run-local session scratch and hot context/i);
+      assert.match(content, /\.omx\/project-memory\.json` — local compatibility cache, not the formal memory authority/i);
+      assert.doesNotMatch(content, /\.omx\/project-memory\.json` — cross-session memory/i);
+    });
+  });
+}
+
+describe('strict-memory prompt surfaces', () => {
+  it('keeps the note skill aligned with run-local scratch semantics', () => {
+    const skill = loadSurface('skills/note/SKILL.md');
+    assert.match(skill, /Save run-local context to `.omx\/notepad\.md`/i);
+    assert.match(skill, /not the formal long-term memory authority/i);
+    assert.match(skill, /external memory pipeline/i);
+  });
+
+  it('keeps overlay compaction guidance aligned with scratch-only local memory semantics', () => {
+    const overlaySource = loadSurface('src/hooks/agents-overlay.ts');
+    assert.match(overlaySource, /Save run-local breadcrumbs to notepad via notepad_write_working/i);
+    assert.match(overlaySource, /local project memory as scratch\/compatibility state, not the formal memory authority/i);
+  });
+
+  it('describes MCP state management as lifecycle state plus local compatibility tools', () => {
+    const docsIndex = loadSurface('docs/index.html');
+    assert.match(docsIndex, /run-local notepad scratch, and local project-memory compatibility tools/i);
+  });
+});

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -277,8 +277,9 @@ function getCompactionInstructions(): string {
   return [
     "Before context compaction, preserve critical state:",
     "1. Write progress checkpoint via state_write MCP tool",
-    "2. Save key decisions to notepad via notepad_write_working",
-    "3. If context is >80% full, proactively checkpoint state",
+    "2. Save run-local breadcrumbs to notepad via notepad_write_working",
+    "3. Treat notepad and local project memory as scratch/compatibility state, not the formal memory authority",
+    "4. If context is >80% full, proactively checkpoint state",
   ].join("\n");
 }
 

--- a/src/mcp/__tests__/memory-server.test.ts
+++ b/src/mcp/__tests__/memory-server.test.ts
@@ -37,4 +37,13 @@ describe('mcp/memory-server module contract', () => {
     assert.doesNotMatch(src, /new StdioServerTransport\(\)/);
     assert.doesNotMatch(src, /server\.connect\(transport\)\.catch\(console\.error\);/);
   });
+
+  it('describes local compatibility semantics for project memory and notepad', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/memory-server.ts'), 'utf8');
+
+    assert.match(src, /local project-memory compatibility tools and run-local notepad tools/i);
+    assert.match(src, /strict formal-memory mode, project-memory writes are rejected or downgraded/i);
+    assert.match(src, /formal workspace memory summary; otherwise it reads the local compatibility cache/i);
+    assert.match(src, /run-local notepad content/i);
+  });
 });

--- a/src/mcp/memory-server.ts
+++ b/src/mcp/memory-server.ts
@@ -1,7 +1,8 @@
 /**
  * OMX Project Memory & Notepad MCP Server
- * Provides persistent project memory and session notepad tools
+ * Provides local project-memory compatibility tools and run-local notepad tools.
  * Storage: .omx/project-memory.json, .omx/notepad.md
+ * In strict formal-memory mode, project-memory writes are rejected or downgraded.
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -43,7 +44,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     // Project Memory tools
     {
       name: 'project_memory_read',
-      description: 'Read project memory. Can read full memory or a specific section.',
+      description: 'Read the project memory view. In strict mode this resolves to the formal workspace memory summary; otherwise it reads the local compatibility cache.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -54,7 +55,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'project_memory_write',
-      description: 'Write/update project memory. Can replace entirely or merge.',
+      description: 'Write/update the local project-memory compatibility cache. In strict mode this is rejected.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -67,7 +68,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'project_memory_add_note',
-      description: 'Add a categorized note to project memory.',
+      description: 'Add a categorized note to the local project-memory compatibility cache. In strict mode this downgrades to a local intake artifact.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -80,7 +81,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'project_memory_add_directive',
-      description: 'Add a persistent directive to project memory.',
+      description: 'Add a directive to the local project-memory compatibility cache. In strict mode this downgrades to a local intake artifact.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -95,7 +96,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     // Notepad tools
     {
       name: 'notepad_read',
-      description: 'Read notepad content. Can read full or a specific section (priority, working, manual).',
+      description: 'Read run-local notepad content. Can read full or a specific section (priority, working, manual).',
       inputSchema: {
         type: 'object',
         properties: {
@@ -106,7 +107,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'notepad_write_priority',
-      description: 'Write to Priority Context section. Replaces existing. Keep under 500 chars.',
+      description: 'Write to the run-local Priority Context section. Replaces existing. Keep under 500 chars.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -118,7 +119,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'notepad_write_working',
-      description: 'Add timestamped entry to Working Memory section.',
+      description: 'Add a run-local timestamped entry to Working Memory.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -130,7 +131,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'notepad_write_manual',
-      description: 'Add entry to Manual section. Never auto-pruned.',
+      description: 'Add a run-local sticky entry to Manual. Never auto-pruned automatically.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -365,8 +365,8 @@ Do not cancel while recoverable work remains.
 <state_management>
 OMX persists runtime state under `.omx/`:
 - `.omx/state/` — mode state
-- `.omx/notepad.md` — session notes
-- `.omx/project-memory.json` — cross-session memory
+- `.omx/notepad.md` — run-local session scratch and hot context
+- `.omx/project-memory.json` — local compatibility cache, not the formal memory authority
 - `.omx/plans/` — plans
 - `.omx/logs/` — logs
 


### PR DESCRIPTION
## Summary
- align AGENTS/template state-management wording with strict formal-memory semantics
- update note skill and overlay compaction guidance so notepad is described as run-local scratch, not a second memory authority
- clarify MCP memory tool descriptions and add contract tests for these prompt/documentation surfaces

## Verification
- npm run build
- node --test dist/hooks/__tests__/strict-memory-surface-contract.test.js dist/mcp/__tests__/memory-server.test.js dist/hooks/__tests__/agents-overlay.test.js dist/hooks/__tests__/prompt-team-routing.test.js

## Notes
- This stays separate from the strict formal-memory runtime adapter PR and the notify/tmux stability PR so prompt/documentation alignment can be reviewed on its own.