### PR TITLE
Fix notify fallback watcher idle spin (#1229)

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -2773,6 +2773,92 @@ exit 0
     }
   });
 
+  it('backs off idle polling and resets to the base cadence after fresh rollout activity', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-idle-backoff-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-idle-backoff-home-'));
+    const sid = randomUUID();
+    const sessionDir = todaySessionDir(tempHome);
+    const rolloutPath = join(sessionDir, `rollout-test-fallback-idle-backoff-${sid}.jsonl`);
+    const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+    const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
+    const turnLogPath = join(wd, '.omx', 'logs', `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(rolloutPath, `${JSON.stringify({
+        timestamp: new Date().toISOString(),
+        type: 'session_meta',
+        payload: { id: `thread-${sid}`, cwd: wd },
+      })}
+`);
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--idle-max-poll-ms',
+          '200',
+          '--parent-pid',
+          String(process.pid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, OMX_NOTIFY_FALLBACK_IDLE_MAX_POLL_MS: '200' }),
+        }
+      );
+
+      await waitFor(async () => {
+        try {
+          const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+          return watcherState.adaptive_poll?.current_ms === 200 && watcherState.adaptive_poll?.idle_streak >= 2;
+        } catch {
+          return false;
+        }
+      }, 4000, 50);
+
+      const freshTurnId = `turn-fresh-${sid}`;
+      await appendLine(rolloutPath, {
+        timestamp: new Date().toISOString(),
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: freshTurnId,
+          last_agent_message: 'fresh message after idle backoff',
+        },
+      });
+
+      await waitFor(async () => {
+        const turnLines = await readLines(turnLogPath);
+        if (!turnLines.some((line) => line.includes(freshTurnId))) return false;
+        const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+        return watcherState.adaptive_poll?.current_ms === 50
+          && watcherState.adaptive_poll?.idle_streak === 0
+          && watcherState.adaptive_poll?.last_activity_reason === 'rollout_event';
+      }, 4000, 50);
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+      await rm(rolloutPath, { force: true });
+    }
+  });
+
   it('exits after the configured max lifetime', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-max-life-'));
     const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-max-home-'));

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -82,6 +82,10 @@ const authorityOnly = process.argv.includes('--authority-only');
 // ack budget so leaderless team dispatch + stale-alert recovery do not feel
 // laggy between native notify-hook turns.
 const pollMs = Math.max(50, asNumber(argValue('--poll-ms', '250'), 250));
+const idleMaxPollMs = Math.max(
+  pollMs,
+  asNumber(argValue('--idle-max-poll-ms', process.env.OMX_NOTIFY_FALLBACK_IDLE_MAX_POLL_MS || '1000'), 1000),
+);
 const parentPid = Math.trunc(asNumber(argValue('--parent-pid', String(process.ppid || 0)), process.ppid || 0));
 const startedAt = Date.now();
 const fileWindowMs = runOnce ? 15000 : 30000;
@@ -205,6 +209,22 @@ interface FallbackAutoNudgeState {
   last_nudged_at: string;
 }
 
+interface AdaptivePollState {
+  enabled: boolean;
+  base_ms: number;
+  max_ms: number;
+  current_ms: number;
+  idle_streak: number;
+  last_tick_at: string | null;
+  last_activity_at: string | null;
+  last_activity_reason: string;
+}
+
+interface CycleActivitySummary {
+  active: boolean;
+  reason: string;
+}
+
 const fileState = new Map<string, WatcherFileMeta>();
 const seenTurnKeys = new Set<string>();
 let stopping = false;
@@ -273,12 +293,57 @@ let lastFallbackAutoNudge: FallbackAutoNudgeState = {
   last_nudged_signature: '',
   last_nudged_at: '',
 };
+let adaptivePollState: AdaptivePollState = {
+  enabled: true,
+  base_ms: pollMs,
+  max_ms: idleMaxPollMs,
+  current_ms: pollMs,
+  idle_streak: 0,
+  last_tick_at: null,
+  last_activity_at: null,
+  last_activity_reason: 'init',
+};
 function eventLog(event: Record<string, unknown>): Promise<void> {
   return appendFile(logPath, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
 }
 
 function shouldLogLeaderNudgeTick(reason: string): boolean {
   return reason === 'leader_nudge_checked' || reason === 'leader_nudge_failed';
+}
+
+function nextIdlePollMs(currentMs: number): number {
+  return Math.min(idleMaxPollMs, Math.max(pollMs, currentMs * 2));
+}
+
+function updateAdaptivePollState(summary: CycleActivitySummary): number {
+  const nowIso = new Date().toISOString();
+  if (summary.active) {
+    adaptivePollState = {
+      ...adaptivePollState,
+      enabled: true,
+      base_ms: pollMs,
+      max_ms: idleMaxPollMs,
+      current_ms: pollMs,
+      idle_streak: 0,
+      last_tick_at: nowIso,
+      last_activity_at: nowIso,
+      last_activity_reason: summary.reason,
+    };
+    return adaptivePollState.current_ms;
+  }
+
+  const nextMs = nextIdlePollMs(adaptivePollState.current_ms);
+  adaptivePollState = {
+    ...adaptivePollState,
+    enabled: true,
+    base_ms: pollMs,
+    max_ms: idleMaxPollMs,
+    current_ms: nextMs,
+    idle_streak: adaptivePollState.idle_streak + 1,
+    last_tick_at: nowIso,
+    last_activity_reason: summary.reason,
+  };
+  return adaptivePollState.current_ms;
 }
 
 function shouldLogDispatchDrainTick(result: unknown): boolean {
@@ -343,6 +408,19 @@ async function loadPersistedWatcherState(): Promise<void> {
       last_error: safeString(persistedAutoNudge.last_error) || null,
       last_nudged_signature: safeString(persistedAutoNudge.last_nudged_signature),
       last_nudged_at: safeString(persistedAutoNudge.last_nudged_at),
+    };
+  }
+  const persistedAdaptivePoll = persisted?.adaptive_poll as Record<string, unknown> | null | undefined;
+  if (persistedAdaptivePoll && typeof persistedAdaptivePoll === 'object') {
+    adaptivePollState = {
+      enabled: persistedAdaptivePoll.enabled !== false,
+      base_ms: pollMs,
+      max_ms: idleMaxPollMs,
+      current_ms: Math.min(idleMaxPollMs, Math.max(pollMs, asNumber(persistedAdaptivePoll.current_ms as string | number | undefined, pollMs))),
+      idle_streak: Math.max(0, Math.trunc(asNumber(persistedAdaptivePoll.idle_streak as string | number | undefined, 0))),
+      last_tick_at: safeString(persistedAdaptivePoll.last_tick_at) || null,
+      last_activity_at: safeString(persistedAdaptivePoll.last_activity_at) || null,
+      last_activity_reason: safeString(persistedAdaptivePoll.last_activity_reason) || 'init',
     };
   }
 }
@@ -551,7 +629,8 @@ async function withRalphSteerLock<T>(task: () => Promise<T>): Promise<T | null> 
       if (code !== 'EEXIST') throw error;
       const existing = await readRalphSteerLock(ralphSteerLockPath);
       const lockAgeMs = parseIsoMillis(existing?.acquired_at) ?? 0;
-      const stale = !existing || !isPidAlive(existing.pid) || (lockAgeMs > 0 && Date.now() - lockAgeMs > RALPH_STEER_LOCK_STALE_MS);
+      const stale = existing !== null
+        && (!isPidAlive(existing.pid) || (lockAgeMs > 0 && Date.now() - lockAgeMs > RALPH_STEER_LOCK_STALE_MS));
       if (stale) {
         await unlink(ralphSteerLockPath).catch(() => {});
         continue;
@@ -930,6 +1009,8 @@ async function writeState(extra: Record<string, unknown> = {}): Promise<void> {
     notify_script: notifyScript,
     authority_only: authorityOnly,
     poll_ms: pollMs,
+    effective_poll_ms: adaptivePollState.current_ms,
+    idle_max_poll_ms: idleMaxPollMs,
     pid_file: runOnce ? null : pidFilePath,
     max_lifetime_ms: maxLifetimeMs,
     tracked_files: fileState.size,
@@ -957,6 +1038,12 @@ async function writeState(extra: Record<string, unknown> = {}): Promise<void> {
       stall_ms: AUTO_NUDGE_STALL_MS,
     },
     authority_backoff: lastAuthorityBackoff,
+    adaptive_poll: {
+      ...adaptivePollState,
+      enabled: true,
+      base_ms: pollMs,
+      max_ms: idleMaxPollMs,
+    },
     ...extra,
   };
   await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
@@ -1324,7 +1411,8 @@ function splitBufferedLines(partial: string, delta: string): { lines: string[]; 
   };
 }
 
-async function pollFiles(): Promise<void> {
+async function pollFiles(): Promise<number> {
+  let processedCount = 0;
   for (const [path, meta] of fileState.entries()) {
     const currentSize = (await stat(path).catch(() => ({ size: 0 }))).size || 0;
     if (currentSize <= meta.offset) continue;
@@ -1338,11 +1426,13 @@ async function pollFiles(): Promise<void> {
     for (const line of lines) {
       if (!line.trim()) continue;
       await processLine(meta, line, path);
+      processedCount += 1;
     }
   }
+  return processedCount;
 }
 
-async function runLeaderNudgeTick(): Promise<void> {
+async function runLeaderNudgeTick(): Promise<boolean> {
   const startedIso = new Date().toISOString();
   const leaderOnly = safeString(process.env.OMX_TEAM_WORKER || '').trim() === '';
   const staleThresholdMs = resolveLeaderStalenessThresholdMs();
@@ -1357,7 +1447,7 @@ async function runLeaderNudgeTick(): Promise<void> {
       last_tick_at: startedIso,
       last_error: 'worker_context',
     };
-    return;
+    return false;
   }
 
   try {
@@ -1390,6 +1480,7 @@ async function runLeaderNudgeTick(): Promise<void> {
         reason,
       });
     }
+    return preComputedLeaderStale;
   } catch (err) {
     leaderNudgeRuns += 1;
     lastLeaderNudge = {
@@ -1408,10 +1499,11 @@ async function runLeaderNudgeTick(): Promise<void> {
       reason: 'leader_nudge_failed',
       error: lastLeaderNudge.last_error,
     });
+    return true;
   }
 }
 
-async function runDispatchDrainTick(): Promise<void> {
+async function runDispatchDrainTick(): Promise<boolean> {
   const startedIso = new Date().toISOString();
   try {
     const result = await drainPendingTeamDispatch({ cwd, stateDir, logsDir, maxPerTick: dispatchTickMax } as any);
@@ -1431,6 +1523,7 @@ async function runDispatchDrainTick(): Promise<void> {
         ...(result && typeof result === 'object' ? result as Record<string, unknown> : {}),
       });
     }
+    return shouldLogDispatchDrainTick(result);
   } catch (err) {
     dispatchDrainRuns += 1;
     lastDispatchDrain = {
@@ -1447,6 +1540,7 @@ async function runDispatchDrainTick(): Promise<void> {
       reason: 'dispatch_drain_failed',
       error: lastDispatchDrain.last_error,
     });
+    return true;
   }
 }
 
@@ -1458,45 +1552,62 @@ async function shouldSuppressInteractiveFallbackTicks(): Promise<boolean> {
   return deepInterviewStateActive || deepInterviewInputLockActive;
 }
 
-async function pumpTeamControlPlaneTick(): Promise<void> {
-  await runDispatchDrainTick();
-  if (await shouldSuppressInteractiveFallbackTicks()) return;
-  await runLeaderNudgeTick();
+async function pumpTeamControlPlaneTick(): Promise<CycleActivitySummary> {
+  const dispatchActive = await runDispatchDrainTick();
+  if (await shouldSuppressInteractiveFallbackTicks()) {
+    return { active: dispatchActive, reason: dispatchActive ? 'dispatch_drain' : 'deep_interview_locked' };
+  }
+  const leaderActive = await runLeaderNudgeTick();
   await runFallbackAutoNudgeTick();
+  const autoNudgeActive = lastFallbackAutoNudge.last_reason === 'sent';
+  if (dispatchActive) return { active: true, reason: 'dispatch_drain' };
+  if (leaderActive) return { active: true, reason: 'leader_nudge' };
+  if (autoNudgeActive) return { active: true, reason: 'fallback_auto_nudge' };
+  return { active: false, reason: lastFallbackAutoNudge.last_reason || 'control_plane_idle' };
 }
 
 
-async function runWatcherCycle(): Promise<void> {
+async function runWatcherCycle(): Promise<number> {
+  let processedRolloutCount = 0;
   if (authorityOnly) {
     const authorityBackoff = await resolveAuthorityPrimaryWatcherHealth();
     lastAuthorityBackoff = authorityBackoff;
     if (authorityBackoff.active) {
       await writeAuthorityBackoffState();
-      return;
+      return processedRolloutCount;
     }
   } else {
     lastAuthorityBackoff = createAuthorityBackoffState('');
   }
-
   if (!authorityOnly) {
     await ensureTrackedFiles();
-    await pollFiles();
+    processedRolloutCount = await pollFiles();
   }
-  await pumpTeamControlPlaneTick();
+  const controlPlaneSummary = await pumpTeamControlPlaneTick();
   if (!authorityOnly && !(await shouldSuppressInteractiveFallbackTicks())) {
     await runRalphWatcherBehaviorTick();
   }
-  await writeState();
+  const ralphActive = lastRalphContinueSteer.last_reason === 'sent';
+  const summary: CycleActivitySummary = processedRolloutCount > 0
+    ? { active: true, reason: 'rollout_event' }
+    : controlPlaneSummary.active
+      ? controlPlaneSummary
+      : ralphActive
+        ? { active: true, reason: 'ralph_continue_steer' }
+        : { active: false, reason: controlPlaneSummary.reason || lastRalphContinueSteer.last_reason || 'idle' };
+  const nextDelayMs = updateAdaptivePollState(summary);
+  await writeState({ last_cycle_activity: summary.reason });
+  return nextDelayMs;
 }
 
 async function tick(): Promise<void> {
   if (stopping) return;
   if (await enforceLifecycleGuards()) return;
-  await runWatcherCycle();
+  const nextDelayMs = await runWatcherCycle();
   if (await enforceLifecycleGuards()) return;
   setTimeout(() => {
     void tick();
-  }, pollMs);
+  }, nextDelayMs);
 }
 
 function shutdown(signal: string): void {
@@ -1520,6 +1631,8 @@ async function main(): Promise<void> {
       notify_script: notifyScript,
       authority_only: authorityOnly,
       poll_ms: pollMs,
+    effective_poll_ms: adaptivePollState.current_ms,
+    idle_max_poll_ms: idleMaxPollMs,
       once: runOnce,
       parent_pid: parentPid,
       pid_file: runOnce ? null : pidFilePath,


### PR DESCRIPTION
## Summary
- add adaptive idle backoff to the notify fallback watcher so streaming mode no longer polls forever at a fixed 250ms when idle
- reset the watcher to the base poll cadence immediately when rollout or control-plane activity resumes
- add a regression test covering idle backoff recovery and harden the Ralph steer lock against concurrent empty-lock races

## Testing
- npm run build
- npx biome lint src/scripts/notify-fallback-watcher.ts src/hooks/__tests__/notify-fallback-watcher.test.ts
- node --test --test-reporter=spec dist/hooks/__tests__/notify-fallback-watcher.test.js

Closes #1229.