### PR TITLE
feat: add strict memory refresh bridge on session exit

### DIFF
--- a/src/cli/__tests__/formal-memory-refresh.test.ts
+++ b/src/cli/__tests__/formal-memory-refresh.test.ts
@@ -1,0 +1,155 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  resolveFormalMemoryRefreshPlan,
+  resolveFormalMemoryRefreshScript,
+  scheduleFormalMemoryRefreshOnExit,
+} from "../index.js";
+
+async function createRefreshFixture(): Promise<{
+  root: string;
+  memoryRoot: string;
+  scriptPath: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "omx-formal-refresh-"));
+  const memoryRoot = join(root, "memory");
+  const scriptPath = join(root, "scripts", "refresh_memory.py");
+  await mkdir(memoryRoot, { recursive: true });
+  await mkdir(join(root, "scripts"), { recursive: true });
+  await writeFile(scriptPath, "#!/usr/bin/env python3\n", "utf-8");
+  return { root, memoryRoot, scriptPath };
+}
+
+describe("formal memory refresh bridge", () => {
+  it("prefers explicit refresh script override", () => {
+    const env = {
+      OMX_EXTERNAL_MEMORY_REFRESH_SCRIPT: "/tmp/custom-refresh.py",
+      OMX_EXTERNAL_MEMORY_ROOT: "/tmp/ignored-memory-root",
+    } satisfies NodeJS.ProcessEnv;
+    assert.equal(resolveFormalMemoryRefreshScript(env), "/tmp/custom-refresh.py");
+  });
+
+  it("infers the refresh script from the external memory root sibling scripts directory", async () => {
+    const fixture = await createRefreshFixture();
+    try {
+      const env = {
+        OMX_EXTERNAL_MEMORY_ROOT: fixture.memoryRoot,
+      } satisfies NodeJS.ProcessEnv;
+      assert.equal(resolveFormalMemoryRefreshScript(env), fixture.scriptPath);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps refresh disabled until strict mode and refresh-on-exit are both enabled", () => {
+    const disabledStrict = resolveFormalMemoryRefreshPlan("/repo", "session-1", {});
+    assert.equal(disabledStrict.enabled, false);
+    assert.equal(disabledStrict.reason, "strict_mode_disabled");
+
+    const disabledRefresh = resolveFormalMemoryRefreshPlan("/repo", "session-1", {
+      OMX_STRICT_MEMORY_MODE: "1",
+    });
+    assert.equal(disabledRefresh.enabled, false);
+    assert.equal(disabledRefresh.reason, "refresh_on_exit_disabled");
+  });
+
+  it("skips the refresh bridge for team worker processes", async () => {
+    const fixture = await createRefreshFixture();
+    try {
+      const plan = resolveFormalMemoryRefreshPlan("/repo", "session-2", {
+        OMX_STRICT_MEMORY_MODE: "1",
+        OMX_STRICT_MEMORY_REFRESH_ON_EXIT: "1",
+        OMX_EXTERNAL_MEMORY_ROOT: fixture.memoryRoot,
+        OMX_TEAM_WORKER: "alpha/worker-1",
+      });
+      assert.equal(plan.enabled, false);
+      assert.equal(plan.reason, "team_worker_process");
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("spawns a detached refresh process for leader or standalone sessions", async () => {
+    const fixture = await createRefreshFixture();
+    try {
+      let captured:
+        | {
+            command: string;
+            args: readonly string[];
+            options: {
+              cwd: string;
+              env: NodeJS.ProcessEnv;
+              detached: boolean;
+              stdio: "ignore";
+            };
+          }
+        | undefined;
+      let unrefCalled = false;
+
+      const result = scheduleFormalMemoryRefreshOnExit(
+        "/repo",
+        "session-3",
+        {
+          OMX_STRICT_MEMORY_MODE: "1",
+          OMX_STRICT_MEMORY_REFRESH_ON_EXIT: "1",
+          OMX_EXTERNAL_MEMORY_ROOT: fixture.memoryRoot,
+          OMX_EXTERNAL_MEMORY_REFRESH_PYTHON: "python3.12",
+        },
+        ((command: string, args: readonly string[], options: {
+          cwd: string;
+          env: NodeJS.ProcessEnv;
+          detached: boolean;
+          stdio: "ignore";
+        }) => {
+          captured = { command, args, options };
+          return {
+            unref() {
+              unrefCalled = true;
+            },
+          };
+        }) as never,
+      );
+
+      assert.equal(result.scheduled, true);
+      assert.equal(result.reason, "scheduled");
+      assert.equal(captured?.command, "python3.12");
+      assert.deepEqual(captured?.args, [fixture.scriptPath, "--workspace-root", "/repo"]);
+      assert.equal(captured?.options.cwd, "/repo");
+      assert.equal(captured?.options.detached, true);
+      assert.equal(captured?.options.stdio, "ignore");
+      assert.equal(captured?.options.env.OMX_EXTERNAL_MEMORY_REFRESH_SOURCE, "omx-postlaunch");
+      assert.equal(captured?.options.env.OMX_EXTERNAL_MEMORY_REFRESH_SESSION_ID, "session-3");
+      assert.equal(unrefCalled, true);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports spawn failures without throwing", async () => {
+    const fixture = await createRefreshFixture();
+    try {
+      const result = scheduleFormalMemoryRefreshOnExit(
+        "/repo",
+        "session-4",
+        {
+          OMX_STRICT_MEMORY_MODE: "1",
+          OMX_STRICT_MEMORY_REFRESH_ON_EXIT: "1",
+          OMX_EXTERNAL_MEMORY_ROOT: fixture.memoryRoot,
+        },
+        (() => {
+          throw new Error("boom");
+        }) as never,
+      );
+
+      assert.equal(result.scheduled, false);
+      assert.match(result.reason, /^spawn_failed:boom$/);
+      assert.equal(result.plan.enabled, true);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { basename, dirname, join } from "path";
+import { basename, dirname, join, resolve } from "path";
 import { existsSync, readFileSync } from "fs";
 import { constants as osConstants } from "os";
 import { setup, SETUP_SCOPES, type SetupScope } from "./setup.js";
@@ -179,6 +179,161 @@ const REASONING_KEY = "model_reasoning_effort";
 const MODEL_INSTRUCTIONS_FILE_KEY = "model_instructions_file";
 const TEAM_WORKER_LAUNCH_ARGS_ENV = "OMX_TEAM_WORKER_LAUNCH_ARGS";
 const TEAM_INHERIT_LEADER_FLAGS_ENV = "OMX_TEAM_INHERIT_LEADER_FLAGS";
+const STRICT_MEMORY_MODE_ENV = "OMX_STRICT_MEMORY_MODE";
+const STRICT_MEMORY_REFRESH_ON_EXIT_ENV = "OMX_STRICT_MEMORY_REFRESH_ON_EXIT";
+const EXTERNAL_MEMORY_ROOT_ENV = "OMX_EXTERNAL_MEMORY_ROOT";
+const EXTERNAL_MEMORY_REFRESH_SCRIPT_ENV = "OMX_EXTERNAL_MEMORY_REFRESH_SCRIPT";
+const EXTERNAL_MEMORY_REFRESH_PYTHON_ENV = "OMX_EXTERNAL_MEMORY_REFRESH_PYTHON";
+const TEAM_WORKER_ENV = "OMX_TEAM_WORKER";
+
+export interface FormalMemoryRefreshPlan {
+  enabled: boolean;
+  strictMode: boolean;
+  reason:
+    | "strict_mode_disabled"
+    | "refresh_on_exit_disabled"
+    | "team_worker_process"
+    | "refresh_script_unavailable"
+    | "enabled";
+  scriptPath?: string;
+  command?: string;
+  args?: string[];
+  childEnv?: NodeJS.ProcessEnv;
+}
+
+export interface FormalMemoryRefreshScheduleResult {
+  scheduled: boolean;
+  reason: string;
+  plan: FormalMemoryRefreshPlan;
+}
+
+type FormalMemoryRefreshSpawn = (
+  command: string,
+  args: readonly string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    detached: boolean;
+    stdio: "ignore";
+  },
+) => {
+  unref?: () => void;
+};
+
+function parseOptionalBooleanEnv(value: string | undefined): boolean | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+export function resolveFormalMemoryRefreshScript(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const explicit = env[EXTERNAL_MEMORY_REFRESH_SCRIPT_ENV]?.trim();
+  if (explicit) return explicit;
+
+  const memoryRoot = env[EXTERNAL_MEMORY_ROOT_ENV]?.trim();
+  if (!memoryRoot) return null;
+
+  const candidate = join(dirname(resolve(memoryRoot)), "scripts", "refresh_memory.py");
+  return existsSync(candidate) ? candidate : null;
+}
+
+export function resolveFormalMemoryRefreshPlan(
+  cwd: string,
+  sessionId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): FormalMemoryRefreshPlan {
+  const strictMode = parseOptionalBooleanEnv(env[STRICT_MEMORY_MODE_ENV]) === true;
+  if (!strictMode) {
+    return {
+      enabled: false,
+      strictMode,
+      reason: "strict_mode_disabled",
+    };
+  }
+
+  if (parseOptionalBooleanEnv(env[STRICT_MEMORY_REFRESH_ON_EXIT_ENV]) !== true) {
+    return {
+      enabled: false,
+      strictMode,
+      reason: "refresh_on_exit_disabled",
+    };
+  }
+
+  if (typeof env[TEAM_WORKER_ENV] === "string" && env[TEAM_WORKER_ENV].trim() !== "") {
+    return {
+      enabled: false,
+      strictMode,
+      reason: "team_worker_process",
+    };
+  }
+
+  const scriptPath = resolveFormalMemoryRefreshScript(env);
+  if (!scriptPath) {
+    return {
+      enabled: false,
+      strictMode,
+      reason: "refresh_script_unavailable",
+    };
+  }
+
+  const command = env[EXTERNAL_MEMORY_REFRESH_PYTHON_ENV]?.trim() || "python3";
+  return {
+    enabled: true,
+    strictMode,
+    reason: "enabled",
+    scriptPath,
+    command,
+    args: [scriptPath, "--workspace-root", cwd],
+    childEnv: {
+      ...process.env,
+      ...env,
+      OMX_EXTERNAL_MEMORY_REFRESH_SOURCE: "omx-postlaunch",
+      OMX_EXTERNAL_MEMORY_REFRESH_SESSION_ID: sessionId,
+    },
+  };
+}
+
+export function scheduleFormalMemoryRefreshOnExit(
+  cwd: string,
+  sessionId: string,
+  env: NodeJS.ProcessEnv = process.env,
+  spawnImpl: FormalMemoryRefreshSpawn = spawn,
+): FormalMemoryRefreshScheduleResult {
+  const plan = resolveFormalMemoryRefreshPlan(cwd, sessionId, env);
+  if (!plan.enabled || !plan.command || !plan.args || !plan.childEnv) {
+    return {
+      scheduled: false,
+      reason: plan.reason,
+      plan,
+    };
+  }
+
+  try {
+    const child = spawnImpl(plan.command, plan.args, {
+      cwd,
+      env: plan.childEnv,
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref?.();
+    return {
+      scheduled: true,
+      reason: "scheduled",
+      plan,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      scheduled: false,
+      reason: `spawn_failed:${message}`,
+      plan,
+    };
+  }
+}
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = "OMX_BYPASS_DEFAULT_SYSTEM_PROMPT";
 const OMX_MODEL_INSTRUCTIONS_FILE_ENV = "OMX_MODEL_INSTRUCTIONS_FILE";
 const OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV =
@@ -2154,6 +2309,21 @@ async function postLaunch(
   } catch (err) {
     console.error(
       `[omx] postLaunch: mode cleanup failed: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+
+  // 3.5 Trigger external formal-memory refresh on exit (strict mode opt-in, best effort).
+  try {
+    const refresh = scheduleFormalMemoryRefreshOnExit(cwd, sessionId);
+    if (!refresh.scheduled && (
+      refresh.reason === "refresh_script_unavailable"
+      || refresh.reason.startsWith("spawn_failed:")
+    )) {
+      console.warn(`[omx] postLaunch: external formal-memory refresh skipped: ${refresh.reason}`);
+    }
+  } catch (err) {
+    console.error(
+      `[omx] postLaunch: external formal-memory refresh failed: ${err instanceof Error ? err.message : err}`,
     );
   }
 


### PR DESCRIPTION
## Summary
- add an opt-in strict-memory refresh bridge on session exit
- skip refresh for team worker processes so only leader/standalone sessions schedule it
- cover refresh script discovery, gating, detached spawn, and spawn-failure fallback in CLI tests

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/formal-memory-refresh.test.js dist/cli/__tests__/index.test.js dist/cli/__tests__/lifecycle-notifications.test.js`

## Review Order
- review this PR before `#1236`
- `#1236` builds on the refresh helper introduced here

## Notes
- A wider `dist/cli/__tests__` sweep still shows unrelated baseline failures in ask/autoresearch/explore/session/team packaging paths; none reference the new refresh bridge helpers or postLaunch refresh scheduling.
- Incremental follow-up for team-complete refresh: `#1236`.