### PR TITLE
Keep team startup task metadata in sync after bootstrap

### DIFF
--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, rm, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -38,6 +38,66 @@ async function setupTeam(name: string): Promise<{ cwd: string; cleanup: () => Pr
       await rm(cwd, { recursive: true, force: true });
     },
   };
+}
+
+async function withMailboxCompatHoleRuntime<T>(cwd: string, fn: () => Promise<T>): Promise<T> {
+  const fakeBin = join(cwd, 'runtime-bin');
+  const runtimePath = join(fakeBin, 'omx-runtime');
+  const previousPath = process.env.PATH;
+  const previousBinary = process.env.OMX_RUNTIME_BINARY;
+  const previousBridge = process.env.OMX_RUNTIME_BRIDGE;
+
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(
+    runtimePath,
+    `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const argv = process.argv.slice(2);
+function argValue(prefix) {
+  const entry = argv.find((value) => value.startsWith(prefix));
+  return entry ? entry.slice(prefix.length) : null;
+}
+function stateDir() {
+  return argValue('--state-dir=') || process.cwd();
+}
+function readJson(file, fallback) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return fallback; }
+}
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value, null, 2) + '\\n');
+}
+if (argv[0] === 'schema') {
+  process.stdout.write(JSON.stringify({ schema_version: 1, commands: [], events: [], transport: 'tmux' }) + '\\n');
+  process.exit(0);
+}
+if (argv[0] !== 'exec') process.exit(1);
+const command = JSON.parse(argv[1] || '{}');
+const dir = stateDir();
+if (command.command === 'CreateMailboxMessage') {
+  writeJson(path.join(dir, 'mailbox.json'), readJson(path.join(dir, 'mailbox.json'), { records: [] }));
+  process.stdout.write(JSON.stringify({ event: 'MailboxMessageCreated', message_id: command.message_id, from_worker: command.from_worker, to_worker: command.to_worker }) + '\\n');
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({ event: 'ok' }) + '\\n');
+`,
+    'utf8',
+  );
+  await chmod(runtimePath, 0o755);
+  process.env.PATH = `${fakeBin}:${previousPath || ''}`;
+  process.env.OMX_RUNTIME_BINARY = runtimePath;
+  process.env.OMX_RUNTIME_BRIDGE = '1';
+  try {
+    return await fn();
+  } finally {
+    if (typeof previousPath === 'string') process.env.PATH = previousPath;
+    else delete process.env.PATH;
+    if (typeof previousBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousBinary;
+    else delete process.env.OMX_RUNTIME_BINARY;
+    if (typeof previousBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousBridge;
+    else delete process.env.OMX_RUNTIME_BRIDGE;
+  }
 }
 
 // ─── resolveTeamApiOperation ──────────────────────────────────────────────
@@ -257,6 +317,47 @@ describe('executeTeamApiOperation: send-message', () => {
       else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(repoCwd, { recursive: true, force: true });
       await rm(workerCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the persisted mailbox message when bridge compat omits the mailbox row under an explicit shared state root', async () => {
+    const teamName = 'msg-team-shared-root';
+    const root = await mkdtemp(join(tmpdir(), 'omx-interop-shared-root-'));
+    const leaderCwd = join(root, 'leader');
+    const workerCwd = join(root, 'worker-worktree');
+    const sharedStateRoot = join(root, 'shared-state');
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+
+    try {
+      await mkdir(leaderCwd, { recursive: true });
+      await mkdir(workerCwd, { recursive: true });
+      process.env.OMX_TEAM_STATE_ROOT = sharedStateRoot;
+      await initTeamState(teamName, 'shared state root mailbox fallback', 'executor', 2, leaderCwd);
+
+      await withMailboxCompatHoleRuntime(root, async () => {
+        const result = await executeTeamApiOperation('send-message', {
+          team_name: teamName,
+          from_worker: 'worker-1',
+          to_worker: 'leader-fixed',
+          body: 'shared-root hello',
+        }, workerCwd);
+
+        assert.equal(result.ok, true);
+        if (!result.ok) throw new Error('expected send-message call to succeed');
+
+        const message = result.data.message as Record<string, unknown>;
+        assert.equal(message.body, 'shared-root hello');
+        assert.equal(message.to_worker, 'leader-fixed');
+
+        const mailbox = JSON.parse(
+          await readFile(join(sharedStateRoot, 'team', teamName, 'mailbox', 'leader-fixed.json'), 'utf8'),
+        ) as { messages?: Array<Record<string, unknown>> };
+        assert.equal(mailbox.messages?.length, 1);
+      });
+    } finally {
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -894,10 +894,16 @@ process.on('SIGTERM', () => process.exit(0));
       assert.equal(runtime.config.worker_launch_mode, 'prompt');
       assert.equal(runtime.config.workers[0]?.role, 'test-engineer');
       assert.equal(runtime.config.workers[1]?.role, 'writer');
+      assert.equal(runtime.config.next_task_id, 3);
+      assert.deepEqual(runtime.config.workers[0]?.assigned_tasks, ['1']);
+      assert.deepEqual(runtime.config.workers[1]?.assigned_tasks, ['2']);
 
       const config = await readTeamConfig(runtime.teamName, cwd);
+      assert.equal(config?.next_task_id, 3);
       assert.equal(config?.workers[0]?.role, 'test-engineer');
       assert.equal(config?.workers[1]?.role, 'writer');
+      assert.deepEqual(config?.workers[0]?.assigned_tasks, ['1']);
+      assert.deepEqual(config?.workers[1]?.assigned_tasks, ['2']);
 
       const task1 = await readTask(runtime.teamName, '1', cwd);
       const task2 = await readTask(runtime.teamName, '2', cwd);

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -1463,6 +1463,38 @@ exit 1
     }
   });
 
+  it('createTask does not overwrite existing tasks when manifest/config next_task_id lags disk', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-state-'));
+    try {
+      await initTeamState('team-stale-next-id', 't', 'executor', 1, cwd);
+
+      const first = await createTask('team-stale-next-id', { subject: 'first', description: 'd', status: 'pending' }, cwd);
+      assert.equal(first.id, '1');
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-stale-next-id');
+      const configPath = join(teamRoot, 'config.json');
+      const manifestPath = join(teamRoot, 'manifest.v2.json');
+
+      const config = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+      config.next_task_id = 1;
+      await writeAtomic(configPath, JSON.stringify(config, null, 2));
+
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+      manifest.next_task_id = 1;
+      await writeAtomic(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const second = await createTask('team-stale-next-id', { subject: 'second', description: 'd', status: 'pending' }, cwd);
+      assert.equal(second.id, '2');
+
+      const firstTask = JSON.parse(await readFile(join(teamRoot, 'tasks', 'task-1.json'), 'utf8')) as { subject?: string };
+      const secondTask = JSON.parse(await readFile(join(teamRoot, 'tasks', 'task-2.json'), 'utf8')) as { subject?: string };
+      assert.equal(firstTask.subject, 'first');
+      assert.equal(secondTask.subject, 'second');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('listTasks returns sorted by ID', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-state-'));
     try {

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -14,6 +14,7 @@ import {
 } from './contracts.js';
 import { readTeamEvents, waitForTeamEvent } from './state/events.js';
 import { queueDirectMailboxMessage } from './mcp-comm.js';
+import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { generateLeaderMailboxTriggerMessage, generateMailboxTriggerMessage } from './worker-bootstrap.js';
 import {
   teamBroadcast as broadcastMessage,
@@ -451,7 +452,7 @@ function readLegacyMailboxMessages(
   workerName: string,
   cwd: string,
 ): Array<Record<string, unknown>> {
-  const mailboxPath = join(cwd, '.omx', 'state', 'team', teamName, 'mailbox', `${workerName}.json`);
+  const mailboxPath = join(resolveCanonicalTeamStateRoot(cwd), 'team', teamName, 'mailbox', `${workerName}.json`);
   if (!existsSync(mailboxPath)) return [];
   try {
     const parsed = JSON.parse(readFileSync(mailboxPath, 'utf8')) as { messages?: Array<Record<string, unknown>> };

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1667,6 +1667,17 @@ export async function startTeam(
         role: t.role,
       }, leaderCwd);
     }
+    const persistedConfig = await readTeamConfig(sanitized, leaderCwd);
+    if (!persistedConfig) {
+      throw new Error('failed to reload team config after initial task creation');
+    }
+    config = {
+      ...persistedConfig,
+      leader_cwd: leaderCwd,
+      team_state_root: teamStateRoot,
+      workspace_mode: workspaceMode,
+      worktree_mode: effectiveWorktreeMode,
+    };
 
     // 5. Write team-scoped worker instructions file only for single-workspace mode.
     if (workspaceMode !== 'worktree') {
@@ -1883,6 +1894,7 @@ export async function startTeam(
         config.workers[i - 1].pane_id = paneId;
         config.workers[i - 1].role = workerRole;
         config.workers[i - 1].worker_cli = workerCliPlan[i - 1];
+        config.workers[i - 1].assigned_tasks = workerTasks.map(t => t.id);
         config.workers[i - 1].working_dir = workerWorkspace.cwd;
         config.workers[i - 1].worktree_repo_root = workerWorkspace.worktreeRepoRoot;
         config.workers[i - 1].worktree_path = workerWorkspace.worktreePath;

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1185,8 +1185,9 @@ export async function createTask(
     if (!cfg) throw new Error(`Team ${teamName} not found`);
 
     let nextNumeric = normalizeNextTaskId(cfg.next_task_id);
-    if (!hasValidNextTaskId(cfg.next_task_id)) {
-      nextNumeric = await computeNextTaskIdFromDisk(teamName, cwd);
+    const nextNumericFromDisk = await computeNextTaskIdFromDisk(teamName, cwd);
+    if (!hasValidNextTaskId(cfg.next_task_id) || nextNumericFromDisk > nextNumeric) {
+      nextNumeric = nextNumericFromDisk;
     }
     const nextId = String(nextNumeric);
 


### PR DESCRIPTION
## Summary

Follow up on the #1242 investigation by keeping startup task metadata aligned with persisted team state during `startTeam`.

## Changes

- reload persisted team config after seeding initial tasks so runtime state picks up the advanced `next_task_id`
- persist `assigned_tasks` onto worker config rows during startup, matching the worker identity metadata already written to disk
- add runtime regression coverage for both `next_task_id` and `assigned_tasks` after routed startup task creation

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Related to #1242
