### PR TITLE
Prevent Windows launches from assuming Unix ps availability

### DIFF
--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -7,6 +7,7 @@ import {
   findCleanupCandidates,
   findLaunchSafeCleanupCandidates,
   isOmxMcpProcess,
+  listOmxProcesses,
   type ProcessEntry,
 } from '../cleanup.js';
 
@@ -128,6 +129,18 @@ describe('findCleanupCandidates', () => {
         reason: 'outside-current-session',
       },
     ]);
+  });
+});
+
+describe('listOmxProcesses', () => {
+  it('returns no processes on native Windows without shelling out to ps', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      assert.deepEqual(listOmxProcesses(), []);
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+    }
   });
 });
 

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -105,10 +105,11 @@ export function parsePsOutput(output: string): ProcessEntry[] {
 }
 
 export function listOmxProcesses(): ProcessEntry[] {
+  if (process.platform === 'win32') return [];
   const output = execFileSync('ps', ['axww', '-o', 'pid=,ppid=,command='], {
     encoding: 'utf-8',
-      windowsHide: true,
-    });
+    windowsHide: true,
+  });
   return parsePsOutput(output);
 }
 

--- a/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
+++ b/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveManagedSessionContext } from '../../scripts/notify-hook/managed-tmux.js';
+
+describe('notify-hook managed tmux windows fallback', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  const originalTmux = process.env.TMUX;
+  const originalTmuxPane = process.env.TMUX_PANE;
+  const originalTeamWorker = process.env.OMX_TEAM_WORKER;
+
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+    if (originalTmux !== undefined) process.env.TMUX = originalTmux;
+    else delete process.env.TMUX;
+    if (originalTmuxPane !== undefined) process.env.TMUX_PANE = originalTmuxPane;
+    else delete process.env.TMUX_PANE;
+    if (originalTeamWorker !== undefined) process.env.OMX_TEAM_WORKER = originalTeamWorker;
+    else delete process.env.OMX_TEAM_WORKER;
+  });
+
+  it('does not rely on ps ancestry checks on native Windows', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-win32-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'omx-test-session';
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        started_at: new Date().toISOString(),
+        cwd,
+        pid: 999999,
+        platform: 'win32',
+      }, null, 2));
+
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      delete process.env.TMUX;
+      delete process.env.TMUX_PANE;
+      process.env.OMX_TEAM_WORKER = '';
+
+      const result = await resolveManagedSessionContext(cwd, { session_id: sessionId }, { allowTeamWorker: false });
+      assert.equal(result.managed, false);
+      assert.equal(result.reason, 'stale_session');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import type { ClientRequestArgs, IncomingMessage } from 'node:http';
@@ -195,8 +195,33 @@ describe('sanitizeReplyInput', () => {
 });
 
 describe('isReplyListenerProcess', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
   it('returns false for the current process (test runner has no daemon marker)', () => {
     assert.equal(isReplyListenerProcess(process.pid), false);
+  });
+
+  it('returns false on native Windows instead of shelling out to ps', (_, done) => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const child = spawn(
+      process.execPath,
+      ['-e', 'const pollLoop = () => {}; setInterval(pollLoop, 60000);'],
+      { stdio: 'ignore' },
+    );
+    child.once('spawn', () => {
+      const pid = child.pid!;
+      const result = isReplyListenerProcess(pid);
+      child.kill();
+      assert.equal(result, false);
+      done();
+    });
+    child.once('error', (err) => {
+      done(err);
+    });
   });
 
   it('returns true for a process whose command line contains the daemon marker', (_, done) => {

--- a/src/notifications/__tests__/tmux.test.ts
+++ b/src/notifications/__tests__/tmux.test.ts
@@ -13,12 +13,18 @@ import {
 
 describe('getCurrentTmuxSession', () => {
   const originalTmux = process.env.TMUX;
+  const originalPidFallback = process.env.OMX_TMUX_PID_FALLBACK;
 
   afterEach(() => {
     if (originalTmux !== undefined) {
       process.env.TMUX = originalTmux;
     } else {
       delete process.env.TMUX;
+    }
+    if (originalPidFallback !== undefined) {
+      process.env.OMX_TMUX_PID_FALLBACK = originalPidFallback;
+    } else {
+      delete process.env.OMX_TMUX_PID_FALLBACK;
     }
   });
 
@@ -27,11 +33,24 @@ describe('getCurrentTmuxSession', () => {
     const value = getCurrentTmuxSession();
     assert.ok(value === null || typeof value === 'string');
   });
+
+  it('skips ps-based pid fallback on native Windows', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    delete process.env.TMUX;
+    process.env.OMX_TMUX_PID_FALLBACK = '1';
+    try {
+      assert.equal(getCurrentTmuxSession(), null);
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
 });
 
 describe('getCurrentTmuxPaneId', () => {
   const originalTmux = process.env.TMUX;
   const originalPane = process.env.TMUX_PANE;
+  const originalPidFallback = process.env.OMX_TMUX_PID_FALLBACK;
 
   afterEach(() => {
     if (originalTmux !== undefined) {
@@ -43,6 +62,11 @@ describe('getCurrentTmuxPaneId', () => {
       process.env.TMUX_PANE = originalPane;
     } else {
       delete process.env.TMUX_PANE;
+    }
+    if (originalPidFallback !== undefined) {
+      process.env.OMX_TMUX_PID_FALLBACK = originalPidFallback;
+    } else {
+      delete process.env.OMX_TMUX_PID_FALLBACK;
     }
   });
 
@@ -71,6 +95,19 @@ describe('getCurrentTmuxPaneId', () => {
     // Falls back to tmux command, which may or may not work
     const result = getCurrentTmuxPaneId();
     assert.ok(result === null || /^%\d+$/.test(result));
+  });
+
+  it('skips ps-based pid fallback on native Windows', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    delete process.env.TMUX;
+    delete process.env.TMUX_PANE;
+    process.env.OMX_TMUX_PID_FALLBACK = '1';
+    try {
+      assert.equal(getCurrentTmuxPaneId(), null);
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+    }
   });
 });
 

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -277,6 +277,7 @@ export function isReplyListenerProcess(pid: number): boolean {
       const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
       return cmdline.includes(DAEMON_IDENTITY_MARKER);
     }
+    if (process.platform === 'win32') return false;
     // macOS and other POSIX systems
     const result = spawnSync('ps', ['-p', String(pid), '-o', 'args='], {
       encoding: 'utf-8',

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -55,6 +55,7 @@ export function getCurrentTmuxSession(): string | null {
  * is a child of a tmux pane process.
  */
 function detectTmuxSessionByPid(): string | null {
+  if (process.platform === 'win32') return null;
   try {
     // Get all tmux pane PIDs with their session names
     const output = execSync(
@@ -209,6 +210,7 @@ export function getCurrentTmuxPaneId(): string | null {
  * Detect tmux pane ID by walking the process tree.
  */
 function detectTmuxPaneByPid(): string | null {
+  if (process.platform === 'win32') return null;
   try {
     const output = execSync(
       "tmux list-panes -a -F '#{pane_pid} #{pane_id}'",

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -72,6 +72,7 @@ function readCurrentTmuxSessionName(): string {
 function readParentPid(pid: number): number | null {
   if (!Number.isInteger(pid) || pid <= 1) return null;
   try {
+    if (process.platform === 'win32') return null;
     if (process.platform === 'linux') {
       const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
       const commandEnd = stat.lastIndexOf(')');


### PR DESCRIPTION
## Summary

Fix native Windows `spawnSync ps ENOENT` launch failures by making ps-dependent paths degrade safely instead of assuming Unix `ps` availability.

## Changes

- guard ps-dependent launch/cleanup/tmux/reply-listener/managed-tmux paths on native Windows
- return safe empty/null/false fallbacks instead of throwing on Windows
- add focused regression tests for the affected paths

## Validation

- [x] `npm run build`
- [x] targeted `node --test` coverage for touched Windows-sensitive paths
- [x] `biome lint` on touched files

## Related

Closes #1247
