### PR TITLE
Align failed dispatch receipts with the audited delivery contract

### DIFF
--- a/docs/contracts/team-delivery-state-contract.md
+++ b/docs/contracts/team-delivery-state-contract.md
@@ -1,0 +1,95 @@
+# Team delivery / integration state contract
+
+This document records the currently-audited ownership contract for the states
+called out in issue #1243.
+
+## Scope
+
+- dispatch lifecycle: `pending`, `notified`, `delivered`, `failed`
+- integration lifecycle: `integrated`
+- readiness / leader-activity lifecycle: `stale`
+
+## Authoritative owners
+
+### `pending` / `notified` / `delivered` / `failed`
+
+Durable owner:
+
+- Rust runtime dispatch log when the bridge is enabled
+  - `crates/omx-runtime-core/src/dispatch.rs`
+  - surfaced through `src/runtime/bridge.ts`
+- legacy JSON fallback only when the bridge is disabled or unreadable
+  - `src/team/state/dispatch.ts`
+  - `src/team/state.ts`
+
+Observed code paths:
+
+- queue: `DispatchLog::queue()` ↔ `enqueueDispatchRequest()`
+- notify: `DispatchLog::mark_notified()` ↔ `markDispatchRequestNotified()`
+- deliver: `DispatchLog::mark_delivered()` ↔ `markDispatchRequestDelivered()`
+- fail: `DispatchLog::mark_failed()` ↔ `markDispatchRequestFailed()` / `transitionDispatchRequest(..., 'failed')`
+
+Transition contract:
+
+- `pending -> notified`
+- `pending -> failed`
+- `notified -> delivered`
+- `notified -> failed`
+- same-state reason/timestamp patching is allowed
+- `failed -> notified` is **not** allowed for the same `request_id`
+
+Rationale:
+
+- Rust already enforces `failed` as terminal for a dispatch record.
+- TS fallback must mirror that contract so hook, fallback, and replay paths do
+  not answer the same state question differently.
+
+### `integrated`
+
+Durable owner:
+
+- team monitor integration snapshot written by runtime integration logic
+  - `src/team/runtime.ts`
+  - `src/team/state.ts`
+  - `src/team/state/monitor.ts`
+
+Observed code paths:
+
+- merge/cherry-pick/rebase decisions in `integrateWorkerCommitsIntoLeader()`
+- failure path in `recordIntegrationFailure()`
+
+Success contract:
+
+- `integrated` requires durable git evidence:
+  - leader HEAD advanced, and
+  - integrated worker commit is actually reachable from leader HEAD
+
+### `stale`
+
+Durable owner depends on subject:
+
+- runtime authority staleness:
+  - `crates/omx-runtime-core/src/lib.rs`
+  - `crates/omx-runtime-core/src/engine.rs`
+  - surfaced via `src/runtime/bridge.ts`
+- leader/session staleness:
+  - `src/team/leader-activity.ts`
+  - `src/hooks/session.ts`
+
+Contract:
+
+- `stale` is an eligibility / readiness signal, not a success state
+- tmux/HUD observations may contribute evidence, but they are not the durable
+  semantic owner of dispatch or integration success
+
+## First contract hardening change
+
+When a hook-authored dispatch receipt has already become `failed`, later fallback
+confirmation must not mutate that same request back to `notified`.
+
+Instead:
+
+- keep the request `failed`
+- patch `last_reason` to record the confirmed fallback path
+- treat fallback success as an operational recovery event, not as a rewrite of
+  the original hook-attempt state machine

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -14,6 +14,7 @@ import {
   saveTeamConfig,
   listMailboxMessages,
   listDispatchRequests,
+  transitionDispatchRequest,
   updateWorkerHeartbeat,
   writeAtomic,
   readTask,
@@ -3684,6 +3685,78 @@ esac
             && typeof entry.reason === 'string'
             && String(entry.reason).includes('leader_mailbox_notified'));
           assert.equal(runtimeEntries.length, 1, 'leader hook-preferred confirmation should emit exactly one runtime dispatch_result entry');
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('sendWorkerMessage keeps failed hook receipts failed when fallback mailbox persistence confirms delivery', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-failed-receipt-'));
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-leader-failed-receipt-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "\${1:-}" in
+  send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async () => {
+          await initTeamState('team-leader-failed-receipt', 'leader failed receipt fallback test', 'executor', 1, cwd);
+          const cfg = await readTeamConfig('team-leader-failed-receipt', cwd);
+          assert.ok(cfg);
+          if (!cfg) throw new Error('missing team config');
+          cfg.leader_pane_id = '%55';
+          await saveTeamConfig(cfg, cwd);
+
+          const manifestPath = teamStateTestPath(cwd, 'team', 'team-leader-failed-receipt', 'manifest.v2.json');
+          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+          manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 250 };
+          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+          const sendPromise = sendWorkerMessage('team-leader-failed-receipt', 'worker-1', 'leader-fixed', 'hello failed receipt', cwd);
+
+          const deadline = Date.now() + 2_000;
+          let requestId: string | null = null;
+          while (Date.now() < deadline && !requestId) {
+            const requests = await listDispatchRequests('team-leader-failed-receipt', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+            requestId = requests[requests.length - 1]?.request_id ?? null;
+            if (!requestId) await new Promise((resolve) => setTimeout(resolve, 20));
+          }
+          assert.ok(requestId, 'expected mailbox dispatch request to be queued');
+          if (!requestId) throw new Error('missing request id');
+
+          await transitionDispatchRequest(
+            'team-leader-failed-receipt',
+            requestId,
+            'pending',
+            'failed',
+            { last_reason: 'hook_failed:test_receipt' },
+            cwd,
+          );
+
+          const outcome = await sendPromise;
+          assert.equal(outcome.ok, true);
+          assert.equal(outcome.reason, 'fallback_confirmed_after_failed_receipt:leader_mailbox_notified');
+
+          const requests = await listDispatchRequests('team-leader-failed-receipt', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+          const latest = requests[requests.length - 1];
+          assert.equal(latest?.request_id, requestId);
+          assert.equal(latest?.status, 'failed');
+          assert.equal(latest?.last_reason, 'fallback_confirmed_after_failed_receipt:leader_mailbox_notified');
+
+          const mailbox = await listMailboxMessages('team-leader-failed-receipt', 'leader-fixed', cwd);
+          assert.ok(mailbox[0]?.notified_at, 'fallback mailbox persistence should still mark notified_at');
         },
       );
     } finally {

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -491,7 +491,7 @@ exit 1
     }
   });
 
-  it('dispatch request store allows failed reason patches and fallback recovery to notified', async () => {
+  it('dispatch request store keeps failed requests failed while allowing reason patches', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-store-failed-'));
     try {
       await initTeamState('team-dispatch-failed', 't', 'executor', 1, cwd);
@@ -519,22 +519,21 @@ exit 1
         { last_reason: 'fallback_confirmed:tmux_send_keys_sent', failed_at: undefined },
         cwd,
       );
-      assert.equal(recovered?.status, 'notified');
-      assert.equal(recovered?.last_reason, 'fallback_confirmed:tmux_send_keys_sent');
-      assert.equal(recovered?.failed_at, undefined);
+      assert.equal(recovered, null);
 
       const patched = await transitionDispatchRequest(
         'team-dispatch-failed',
         queued.request.request_id,
-        'notified',
-        'notified',
+        'failed',
+        'failed',
         { last_reason: 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent' },
         cwd,
       );
-      assert.equal(patched?.status, 'notified');
+      assert.equal(patched?.status, 'failed');
       assert.equal(patched?.last_reason, 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent');
       const reread = await readDispatchRequest('team-dispatch-failed', queued.request.request_id, cwd);
-      assert.equal(reread?.status, 'notified');
+      assert.equal(reread?.status, 'failed');
+      assert.equal(reread?.failed_at, patched?.failed_at);
       assert.equal(reread?.last_reason, 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent');
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3220,12 +3220,14 @@ async function dispatchCriticalInboxInstruction(params: {
   if (receipt?.status === 'failed') {
     const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
     if (fallback.ok) {
-      await markDispatchRequestNotified(
+      await transitionDispatchRequest(
         teamName,
         queued.request_id,
-        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`, failed_at: undefined },
+        'failed',
+        'failed',
+        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
         cwd,
-      ).catch(() => null);
+      ).catch(() => {});
       return {
         ok: true,
         transport: fallback.transport,
@@ -3347,12 +3349,14 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   if (receipt?.status === 'failed') {
     if (fallback.ok) {
       await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-      await markDispatchRequestNotified(
+      await transitionDispatchRequest(
         teamName,
         requestId,
-        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`, failed_at: undefined },
+        'failed',
+        'failed',
+        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
         cwd,
-      ).catch(() => null);
+      ).catch(() => {});
       const outcome = {
         ok: true,
         transport: fallback.transport,

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -115,7 +115,6 @@ function canTransitionDispatchStatus(from: TeamDispatchRequestStatus, to: TeamDi
   if (from === to) return true;
   if (from === 'pending' && (to === 'notified' || to === 'failed')) return true;
   if (from === 'notified' && (to === 'delivered' || to === 'failed')) return true;
-  if (from === 'failed' && to === 'notified') return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary\n- document the audited owners for pending/notified/delivered/failed/integrated/stale in a delivery state contract note\n- align the TS dispatch fallback transition matrix with the Rust runtime contract by keeping failed request_ids terminal\n- keep fallback confirmation after a failed hook receipt as a failed-state reason patch and add regressions for the state store and runtime mailbox path\n\n## Testing\n- npm run build\n- npx biome lint src/team/state/dispatch.ts src/team/runtime.ts src/team/__tests__/state.test.ts src/team/__tests__/runtime.test.ts docs/contracts/team-delivery-state-contract.md\n- node --test --test-name-pattern "dispatch request store keeps failed requests failed while allowing reason patches" dist/team/__tests__/state.test.js\n- node --test --test-name-pattern "sendWorkerMessage keeps failed hook receipts failed when fallback mailbox persistence confirms delivery" dist/team/__tests__/runtime.test.js\n\nCloses #1243