### PR TITLE
Define the first team runtime state contract slice for #1243

### DIFF
--- a/docs/contracts/team-delivery-state-contract.md
+++ b/docs/contracts/team-delivery-state-contract.md
@@ -1,0 +1,95 @@
+# Team delivery / integration state contract
+
+This document records the currently-audited ownership contract for the states
+called out in issue #1243.
+
+## Scope
+
+- dispatch lifecycle: `pending`, `notified`, `delivered`, `failed`
+- integration lifecycle: `integrated`
+- readiness / leader-activity lifecycle: `stale`
+
+## Authoritative owners
+
+### `pending` / `notified` / `delivered` / `failed`
+
+Durable owner:
+
+- Rust runtime dispatch log when the bridge is enabled
+  - `crates/omx-runtime-core/src/dispatch.rs`
+  - surfaced through `src/runtime/bridge.ts`
+- legacy JSON fallback only when the bridge is disabled or unreadable
+  - `src/team/state/dispatch.ts`
+  - `src/team/state.ts`
+
+Observed code paths:
+
+- queue: `DispatchLog::queue()` ↔ `enqueueDispatchRequest()`
+- notify: `DispatchLog::mark_notified()` ↔ `markDispatchRequestNotified()`
+- deliver: `DispatchLog::mark_delivered()` ↔ `markDispatchRequestDelivered()`
+- fail: `DispatchLog::mark_failed()` ↔ `markDispatchRequestFailed()` / `transitionDispatchRequest(..., 'failed')`
+
+Transition contract:
+
+- `pending -> notified`
+- `pending -> failed`
+- `notified -> delivered`
+- `notified -> failed`
+- same-state reason/timestamp patching is allowed
+- `failed -> notified` is **not** allowed for the same `request_id`
+
+Rationale:
+
+- Rust already enforces `failed` as terminal for a dispatch record.
+- TS fallback must mirror that contract so hook, fallback, and replay paths do
+  not answer the same state question differently.
+
+### `integrated`
+
+Durable owner:
+
+- team monitor integration snapshot written by runtime integration logic
+  - `src/team/runtime.ts`
+  - `src/team/state.ts`
+  - `src/team/state/monitor.ts`
+
+Observed code paths:
+
+- merge/cherry-pick/rebase decisions in `integrateWorkerCommitsIntoLeader()`
+- failure path in `recordIntegrationFailure()`
+
+Success contract:
+
+- `integrated` requires durable git evidence:
+  - leader HEAD advanced, and
+  - integrated worker commit is actually reachable from leader HEAD
+
+### `stale`
+
+Durable owner depends on subject:
+
+- runtime authority staleness:
+  - `crates/omx-runtime-core/src/lib.rs`
+  - `crates/omx-runtime-core/src/engine.rs`
+  - surfaced via `src/runtime/bridge.ts`
+- leader/session staleness:
+  - `src/team/leader-activity.ts`
+  - `src/hooks/session.ts`
+
+Contract:
+
+- `stale` is an eligibility / readiness signal, not a success state
+- tmux/HUD observations may contribute evidence, but they are not the durable
+  semantic owner of dispatch or integration success
+
+## First contract hardening change
+
+When a hook-authored dispatch receipt has already become `failed`, later fallback
+confirmation must not mutate that same request back to `notified`.
+
+Instead:
+
+- keep the request `failed`
+- patch `last_reason` to record the confirmed fallback path
+- treat fallback success as an operational recovery event, not as a rewrite of
+  the original hook-attempt state machine

--- a/docs/contracts/team-runtime-state-contract.md
+++ b/docs/contracts/team-runtime-state-contract.md
@@ -1,0 +1,48 @@
+# Team runtime state contract
+
+Issue: #1243 workstream A
+
+This document records the currently authoritative owners for the team-runtime states that repeatedly drifted across team state, notify-hook, mailbox shadows, tmux observations, and runtime bridge compatibility files.
+
+## Authoritative owners
+
+### `pending`, `notified`, `delivered`, `failed`
+- Durable owner: team dispatch request state.
+- Primary TypeScript entry points:
+  - `src/team/state/dispatch.ts`
+  - `src/team/state.ts`
+- Rust bridge shape:
+  - `crates/omx-runtime-core/src/dispatch.rs`
+  - `src/runtime/bridge.ts`
+- Rule: dispatch `status` is authoritative. Timestamp fields are supporting evidence and must not contradict `status`.
+
+### `integrated`
+- Durable owner: monitor snapshot `integrationByWorker` written by team runtime.
+- Primary entry points:
+  - `src/team/runtime.ts`
+  - `src/team/state/monitor.ts`
+  - `src/team/state.ts`
+- Rule: a worker is only `integrated` after leader-head advancement / containment checks succeed. Mailbox delivery and tmux activity are not sufficient.
+
+### `stale`
+- No single shared owner yet; this remains split by boundary.
+- Runtime authority stale:
+  - `crates/omx-runtime-core/src/lib.rs`
+  - `src/runtime/bridge.ts`
+- Leader activity stale:
+  - `src/team/leader-activity.ts`
+- Session stale:
+  - `src/hooks/session.ts`
+- Rule: stale is currently boundary-specific and must not be inferred from dispatch/integration state alone.
+
+## Notify-hook boundary
+
+`notify-hook` may observe mailbox/tmux evidence, but dispatch success is still represented through dispatch-request state transitions. Mailbox `notified_at` / `delivered_at` are derivative evidence, not the dispatch contract itself.
+
+## Workstream A first change
+
+1. Centralize dispatch and integration status enums in `src/team/contracts.ts`.
+2. Sanitize persisted dispatch timestamps so they cannot contradict the authoritative dispatch `status`.
+3. Sanitize persisted integration snapshot statuses so readers only consume contract-approved values.
+
+This keeps the first fix narrow while making the contract explicit at the read/normalize boundary.

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -14,6 +14,7 @@ import {
   saveTeamConfig,
   listMailboxMessages,
   listDispatchRequests,
+  transitionDispatchRequest,
   updateWorkerHeartbeat,
   writeAtomic,
   readTask,
@@ -3684,6 +3685,78 @@ esac
             && typeof entry.reason === 'string'
             && String(entry.reason).includes('leader_mailbox_notified'));
           assert.equal(runtimeEntries.length, 1, 'leader hook-preferred confirmation should emit exactly one runtime dispatch_result entry');
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('sendWorkerMessage keeps failed hook receipts failed when fallback mailbox persistence confirms delivery', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-failed-receipt-'));
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-leader-failed-receipt-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "\${1:-}" in
+  send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async () => {
+          await initTeamState('team-leader-failed-receipt', 'leader failed receipt fallback test', 'executor', 1, cwd);
+          const cfg = await readTeamConfig('team-leader-failed-receipt', cwd);
+          assert.ok(cfg);
+          if (!cfg) throw new Error('missing team config');
+          cfg.leader_pane_id = '%55';
+          await saveTeamConfig(cfg, cwd);
+
+          const manifestPath = teamStateTestPath(cwd, 'team', 'team-leader-failed-receipt', 'manifest.v2.json');
+          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+          manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 250 };
+          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+          const sendPromise = sendWorkerMessage('team-leader-failed-receipt', 'worker-1', 'leader-fixed', 'hello failed receipt', cwd);
+
+          const deadline = Date.now() + 2_000;
+          let requestId: string | null = null;
+          while (Date.now() < deadline && !requestId) {
+            const requests = await listDispatchRequests('team-leader-failed-receipt', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+            requestId = requests[requests.length - 1]?.request_id ?? null;
+            if (!requestId) await new Promise((resolve) => setTimeout(resolve, 20));
+          }
+          assert.ok(requestId, 'expected mailbox dispatch request to be queued');
+          if (!requestId) throw new Error('missing request id');
+
+          await transitionDispatchRequest(
+            'team-leader-failed-receipt',
+            requestId,
+            'pending',
+            'failed',
+            { last_reason: 'hook_failed:test_receipt' },
+            cwd,
+          );
+
+          const outcome = await sendPromise;
+          assert.equal(outcome.ok, true);
+          assert.equal(outcome.reason, 'fallback_confirmed_after_failed_receipt:leader_mailbox_notified');
+
+          const requests = await listDispatchRequests('team-leader-failed-receipt', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+          const latest = requests[requests.length - 1];
+          assert.equal(latest?.request_id, requestId);
+          assert.equal(latest?.status, 'failed');
+          assert.equal(latest?.last_reason, 'fallback_confirmed_after_failed_receipt:leader_mailbox_notified');
+
+          const mailbox = await listMailboxMessages('team-leader-failed-receipt', 'leader-fixed', cwd);
+          assert.ok(mailbox[0]?.notified_at, 'fallback mailbox persistence should still mark notified_at');
         },
       );
     } finally {

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -42,8 +42,10 @@ import {
   markDispatchRequestDelivered,
   transitionDispatchRequest,
   readDispatchRequest,
+  readMonitorSnapshot,
   resolveDispatchLockTimeoutMs,
 } from '../state.js';
+import { normalizeDispatchRequest } from '../state/dispatch.js';
 
 const ORIGINAL_OMX_TEAM_STATE_ROOT = process.env.OMX_TEAM_STATE_ROOT;
 
@@ -1974,6 +1976,99 @@ exit 1
         }
         await rm(lockDir, { recursive: true, force: true });
       }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats dispatch status as authoritative over incompatible timestamps', () => {
+    const pending = normalizeDispatchRequest('team-contract-dispatch', {
+      kind: 'inbox',
+      to_worker: 'worker-1',
+      trigger_message: 'ping',
+      status: 'pending',
+      notified_at: '2026-04-04T00:00:00.000Z',
+      delivered_at: '2026-04-04T00:01:00.000Z',
+      failed_at: '2026-04-04T00:02:00.000Z',
+    });
+    assert.equal(pending?.status, 'pending');
+    assert.equal(pending?.notified_at, undefined);
+    assert.equal(pending?.delivered_at, undefined);
+    assert.equal(pending?.failed_at, undefined);
+
+    const notified = normalizeDispatchRequest('team-contract-dispatch', {
+      kind: 'inbox',
+      to_worker: 'worker-1',
+      trigger_message: 'ping',
+      status: 'notified',
+      notified_at: '2026-04-04T00:00:00.000Z',
+      delivered_at: '2026-04-04T00:01:00.000Z',
+      failed_at: '2026-04-04T00:02:00.000Z',
+    });
+    assert.equal(notified?.status, 'notified');
+    assert.equal(notified?.notified_at, '2026-04-04T00:00:00.000Z');
+    assert.equal(notified?.delivered_at, undefined);
+    assert.equal(notified?.failed_at, undefined);
+
+    const delivered = normalizeDispatchRequest('team-contract-dispatch', {
+      kind: 'inbox',
+      to_worker: 'worker-1',
+      trigger_message: 'ping',
+      status: 'delivered',
+      notified_at: '2026-04-04T00:00:00.000Z',
+      delivered_at: '2026-04-04T00:01:00.000Z',
+      failed_at: '2026-04-04T00:02:00.000Z',
+    });
+    assert.equal(delivered?.status, 'delivered');
+    assert.equal(delivered?.notified_at, '2026-04-04T00:00:00.000Z');
+    assert.equal(delivered?.delivered_at, '2026-04-04T00:01:00.000Z');
+    assert.equal(delivered?.failed_at, undefined);
+
+    const failed = normalizeDispatchRequest('team-contract-dispatch', {
+      kind: 'inbox',
+      to_worker: 'worker-1',
+      trigger_message: 'ping',
+      status: 'failed',
+      notified_at: '2026-04-04T00:00:00.000Z',
+      delivered_at: '2026-04-04T00:01:00.000Z',
+      failed_at: '2026-04-04T00:02:00.000Z',
+    });
+    assert.equal(failed?.status, 'failed');
+    assert.equal(failed?.notified_at, '2026-04-04T00:00:00.000Z');
+    assert.equal(failed?.delivered_at, undefined);
+    assert.equal(failed?.failed_at, '2026-04-04T00:02:00.000Z');
+  });
+
+  it('sanitizes persisted integration snapshot statuses to the contract', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-monitor-contract-'));
+    try {
+      await initTeamState('team-monitor-contract', 't', 'executor', 1, cwd);
+      const monitorPath = join(cwd, '.omx', 'state', 'team', 'team-monitor-contract', 'monitor-snapshot.json');
+      await writeFile(monitorPath, JSON.stringify({
+        taskStatusById: {},
+        workerAliveByName: {},
+        workerStateByName: {},
+        workerTurnCountByName: {},
+        workerTaskIdByName: {},
+        mailboxNotifiedByMessageId: {},
+        completedEventTaskIds: {},
+        integrationByWorker: {
+          'worker-1': {
+            status: 'integrated',
+            last_integrated_head: 'abc123',
+          },
+          'worker-2': {
+            status: 'mystery_state',
+            last_integrated_head: 'def456',
+          },
+        },
+      }, null, 2));
+
+      const snapshot = await readMonitorSnapshot('team-monitor-contract', cwd);
+      assert.equal(snapshot?.integrationByWorker?.['worker-1']?.status, 'integrated');
+      assert.equal(snapshot?.integrationByWorker?.['worker-1']?.last_integrated_head, 'abc123');
+      assert.equal(snapshot?.integrationByWorker?.['worker-2']?.status, undefined);
+      assert.equal(snapshot?.integrationByWorker?.['worker-2']?.last_integrated_head, 'def456');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -491,7 +491,7 @@ exit 1
     }
   });
 
-  it('dispatch request store allows failed reason patches and fallback recovery to notified', async () => {
+  it('dispatch request store keeps failed requests failed while allowing reason patches', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-store-failed-'));
     try {
       await initTeamState('team-dispatch-failed', 't', 'executor', 1, cwd);
@@ -519,22 +519,21 @@ exit 1
         { last_reason: 'fallback_confirmed:tmux_send_keys_sent', failed_at: undefined },
         cwd,
       );
-      assert.equal(recovered?.status, 'notified');
-      assert.equal(recovered?.last_reason, 'fallback_confirmed:tmux_send_keys_sent');
-      assert.equal(recovered?.failed_at, undefined);
+      assert.equal(recovered, null);
 
       const patched = await transitionDispatchRequest(
         'team-dispatch-failed',
         queued.request.request_id,
-        'notified',
-        'notified',
+        'failed',
+        'failed',
         { last_reason: 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent' },
         cwd,
       );
-      assert.equal(patched?.status, 'notified');
+      assert.equal(patched?.status, 'failed');
       assert.equal(patched?.last_reason, 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent');
       const reread = await readDispatchRequest('team-dispatch-failed', queued.request.request_id, cwd);
-      assert.equal(reread?.status, 'notified');
+      assert.equal(reread?.status, 'failed');
+      assert.equal(reread?.failed_at, patched?.failed_at);
       assert.equal(reread?.last_reason, 'fallback_confirmed_after_failed_receipt:tmux_send_keys_sent');
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/team/contracts.ts
+++ b/src/team/contracts.ts
@@ -22,6 +22,42 @@ export function canTransitionTeamTaskStatus(from: TeamTaskStatus, to: TeamTaskSt
   return TEAM_TASK_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
 }
 
+export const TEAM_DISPATCH_REQUEST_STATUSES = ['pending', 'notified', 'delivered', 'failed'] as const;
+export type TeamDispatchRequestStatus = (typeof TEAM_DISPATCH_REQUEST_STATUSES)[number];
+
+export const TEAM_TERMINAL_DISPATCH_REQUEST_STATUSES: ReadonlySet<TeamDispatchRequestStatus> = new Set(['delivered', 'failed']);
+export const TEAM_DISPATCH_REQUEST_STATUS_TRANSITIONS: Readonly<Record<TeamDispatchRequestStatus, readonly TeamDispatchRequestStatus[]>> = {
+  pending: ['notified', 'failed'],
+  notified: ['delivered', 'failed'],
+  delivered: [],
+  failed: [],
+};
+
+export function isTeamDispatchRequestStatus(status: unknown): status is TeamDispatchRequestStatus {
+  return TEAM_DISPATCH_REQUEST_STATUSES.includes(status as TeamDispatchRequestStatus);
+}
+
+export function isTerminalTeamDispatchRequestStatus(status: TeamDispatchRequestStatus): boolean {
+  return TEAM_TERMINAL_DISPATCH_REQUEST_STATUSES.has(status);
+}
+
+export function canTransitionTeamDispatchRequestStatus(from: TeamDispatchRequestStatus, to: TeamDispatchRequestStatus): boolean {
+  return TEAM_DISPATCH_REQUEST_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export const TEAM_WORKER_INTEGRATION_STATUSES = [
+  'idle',
+  'integrated',
+  'integration_failed',
+  'cherry_pick_conflict',
+  'rebase_conflict',
+] as const;
+export type TeamWorkerIntegrationStatus = (typeof TEAM_WORKER_INTEGRATION_STATUSES)[number];
+
+export function isTeamWorkerIntegrationStatus(status: unknown): status is TeamWorkerIntegrationStatus {
+  return TEAM_WORKER_INTEGRATION_STATUSES.includes(status as TeamWorkerIntegrationStatus);
+}
+
 export const TEAM_EVENT_TYPES = [
   'task_completed',
   'task_failed',

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3220,12 +3220,14 @@ async function dispatchCriticalInboxInstruction(params: {
   if (receipt?.status === 'failed') {
     const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
     if (fallback.ok) {
-      await markDispatchRequestNotified(
+      await transitionDispatchRequest(
         teamName,
         queued.request_id,
-        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`, failed_at: undefined },
+        'failed',
+        'failed',
+        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
         cwd,
-      ).catch(() => null);
+      ).catch(() => {});
       return {
         ok: true,
         transport: fallback.transport,
@@ -3347,12 +3349,14 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   if (receipt?.status === 'failed') {
     if (fallback.ok) {
       await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-      await markDispatchRequestNotified(
+      await transitionDispatchRequest(
         teamName,
         requestId,
-        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`, failed_at: undefined },
+        'failed',
+        'failed',
+        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
         cwd,
-      ).catch(() => null);
+      ).catch(() => {});
       const outcome = {
         ok: true,
         transport: fallback.transport,

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -53,16 +53,20 @@ import {
 } from './state/locks.js';
 import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type DispatchRecord } from '../runtime/bridge.js';
 import {
+  type TeamDispatchRequestStatus,
   TEAM_NAME_SAFE_PATTERN,
   WORKER_NAME_SAFE_PATTERN,
   TASK_ID_SAFE_PATTERN,
   TEAM_TASK_STATUSES,
+  type TeamWorkerIntegrationStatus,
   canTransitionTeamTaskStatus,
   isTerminalTeamTaskStatus,
   type TeamTaskStatus,
   type TeamEventType,
 } from './contracts.js';
 import type { WorktreeMode } from './worktree.js';
+
+export type { TeamDispatchRequestStatus, TeamWorkerIntegrationStatus } from './contracts.js';
 
 export interface TeamConfig {
   name: string;
@@ -178,7 +182,6 @@ export interface TeamGovernance {
 }
 
 export type TeamDispatchRequestKind = 'inbox' | 'mailbox' | 'nudge';
-export type TeamDispatchRequestStatus = 'pending' | 'notified' | 'delivered' | 'failed';
 export type TeamDispatchTransportPreference = 'hook_preferred_with_fallback' | 'transport_direct' | 'prompt_stdin';
 
 export interface TeamDispatchRequest {
@@ -1781,7 +1784,7 @@ export interface TeamWorkerIntegrationState {
   last_integrated_head?: string;
   last_leader_head?: string;
   last_rebased_leader_head?: string;
-  status?: 'idle' | 'integrated' | 'integration_failed' | 'cherry_pick_conflict' | 'rebase_conflict';
+  status?: TeamWorkerIntegrationStatus;
   conflict_commit?: string;
   conflict_files?: string[];
   updated_at?: string;

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -115,7 +115,6 @@ function canTransitionDispatchStatus(from: TeamDispatchRequestStatus, to: TeamDi
   if (from === to) return true;
   if (from === 'pending' && (to === 'notified' || to === 'failed')) return true;
   if (from === 'notified' && (to === 'delivered' || to === 'failed')) return true;
-  if (from === 'failed' && to === 'notified') return true;
   return false;
 }
 

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -1,9 +1,13 @@
 import { randomUUID } from 'crypto';
 import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type DispatchRecord, type RuntimeCommand } from '../../runtime/bridge.js';
 import { appendTeamDeliveryLogForCwd } from '../delivery-log.js';
+import {
+  canTransitionTeamDispatchRequestStatus,
+  isTeamDispatchRequestStatus,
+  type TeamDispatchRequestStatus,
+} from '../contracts.js';
 
 export type TeamDispatchRequestKind = 'inbox' | 'mailbox' | 'nudge';
-export type TeamDispatchRequestStatus = 'pending' | 'notified' | 'delivered' | 'failed';
 export type TeamDispatchTransportPreference = 'hook_preferred_with_fallback' | 'transport_direct' | 'prompt_stdin';
 
 export interface TeamDispatchRequest {
@@ -54,8 +58,32 @@ function isDispatchKind(value: unknown): value is TeamDispatchRequestKind {
   return value === 'inbox' || value === 'mailbox' || value === 'nudge';
 }
 
-function isDispatchStatus(value: unknown): value is TeamDispatchRequestStatus {
-  return value === 'pending' || value === 'notified' || value === 'delivered' || value === 'failed';
+function sanitizeDispatchRequestForStatus(record: TeamDispatchRequest): TeamDispatchRequest {
+  if (record.status === 'pending') {
+    return {
+      ...record,
+      notified_at: undefined,
+      delivered_at: undefined,
+      failed_at: undefined,
+    };
+  }
+  if (record.status === 'notified') {
+    return {
+      ...record,
+      delivered_at: undefined,
+      failed_at: undefined,
+    };
+  }
+  if (record.status === 'delivered') {
+    return {
+      ...record,
+      failed_at: undefined,
+    };
+  }
+  return {
+    ...record,
+    delivered_at: undefined,
+  };
 }
 
 export function normalizeDispatchRequest(
@@ -67,8 +95,8 @@ export function normalizeDispatchRequest(
   if (typeof raw.to_worker !== 'string' || raw.to_worker.trim() === '') return null;
   if (typeof raw.trigger_message !== 'string' || raw.trigger_message.trim() === '') return null;
 
-  const status = isDispatchStatus(raw.status) ? raw.status : 'pending';
-  return {
+  const status = isTeamDispatchRequestStatus(raw.status) ? raw.status : 'pending';
+  return sanitizeDispatchRequestForStatus({
     request_id: typeof raw.request_id === 'string' && raw.request_id.trim() !== '' ? raw.request_id : randomUUID(),
     kind: raw.kind,
     team_name: teamName,
@@ -92,7 +120,7 @@ export function normalizeDispatchRequest(
     delivered_at: typeof raw.delivered_at === 'string' && raw.delivered_at !== '' ? raw.delivered_at : undefined,
     failed_at: typeof raw.failed_at === 'string' && raw.failed_at !== '' ? raw.failed_at : undefined,
     last_reason: typeof raw.last_reason === 'string' && raw.last_reason !== '' ? raw.last_reason : undefined,
-  };
+  });
 }
 
 function equivalentPendingDispatch(existing: TeamDispatchRequest, input: TeamDispatchRequestInput): boolean {
@@ -113,9 +141,7 @@ function equivalentPendingDispatch(existing: TeamDispatchRequest, input: TeamDis
 
 function canTransitionDispatchStatus(from: TeamDispatchRequestStatus, to: TeamDispatchRequestStatus): boolean {
   if (from === to) return true;
-  if (from === 'pending' && (to === 'notified' || to === 'failed')) return true;
-  if (from === 'notified' && (to === 'delivered' || to === 'failed')) return true;
-  return false;
+  return canTransitionTeamDispatchRequestStatus(from, to);
 }
 
 function buildDispatchMetadata(teamName: string, requestInput: TeamDispatchRequestInput): Record<string, unknown> {
@@ -306,13 +332,13 @@ export async function transitionDispatchRequest(
         : (existing.status === to ? existing.attempt_count : existing.attempt_count + 1),
     );
 
-    const next: TeamDispatchRequest = {
+    const next = sanitizeDispatchRequestForStatus({
       ...existing,
       ...patch,
       status: to,
       attempt_count: Math.max(0, nextAttemptCount),
       updated_at: nowIso,
-    };
+    });
     if (to === 'notified') {
       next.notified_at = patch.notified_at ?? nowIso;
       next.failed_at = patch.failed_at;

--- a/src/team/state/monitor.ts
+++ b/src/team/state/monitor.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { performance } from 'perf_hooks';
+import { isTeamWorkerIntegrationStatus, type TeamWorkerIntegrationStatus } from '../contracts.js';
 
 export interface TeamSummary {
   teamName: string;
@@ -36,7 +37,7 @@ export interface TeamWorkerIntegrationState {
   last_integrated_head?: string;
   last_leader_head?: string;
   last_rebased_leader_head?: string;
-  status?: 'idle' | 'integrated' | 'integration_failed' | 'cherry_pick_conflict' | 'rebase_conflict';
+  status?: TeamWorkerIntegrationStatus;
   conflict_commit?: string;
   conflict_files?: string[];
   updated_at?: string;
@@ -87,6 +88,37 @@ interface MonitorDeps {
   monitorSnapshotPath: (teamName: string, cwd: string) => string;
   teamPhasePath: (teamName: string, cwd: string) => string;
   writeAtomic: (filePath: string, data: string) => Promise<void>;
+}
+
+function normalizeWorkerIntegrationState(value: unknown): TeamWorkerIntegrationState | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  return {
+    last_seen_head: typeof raw.last_seen_head === 'string' && raw.last_seen_head !== '' ? raw.last_seen_head : undefined,
+    last_integrated_head:
+      typeof raw.last_integrated_head === 'string' && raw.last_integrated_head !== '' ? raw.last_integrated_head : undefined,
+    last_leader_head: typeof raw.last_leader_head === 'string' && raw.last_leader_head !== '' ? raw.last_leader_head : undefined,
+    last_rebased_leader_head:
+      typeof raw.last_rebased_leader_head === 'string' && raw.last_rebased_leader_head !== '' ? raw.last_rebased_leader_head : undefined,
+    status: isTeamWorkerIntegrationStatus(raw.status) ? raw.status : undefined,
+    conflict_commit: typeof raw.conflict_commit === 'string' && raw.conflict_commit !== '' ? raw.conflict_commit : undefined,
+    conflict_files:
+      Array.isArray(raw.conflict_files)
+        ? raw.conflict_files.filter((entry): entry is string => typeof entry === 'string' && entry !== '')
+        : undefined,
+    updated_at: typeof raw.updated_at === 'string' && raw.updated_at !== '' ? raw.updated_at : undefined,
+  };
+}
+
+function normalizeIntegrationByWorker(value: unknown): Record<string, TeamWorkerIntegrationState> {
+  if (!value || typeof value !== 'object') return {};
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([workerName, state]) => {
+      const normalized = normalizeWorkerIntegrationState(state);
+      return normalized ? [workerName, normalized] as const : null;
+    })
+    .filter((entry): entry is readonly [string, TeamWorkerIntegrationState] => entry !== null);
+  return Object.fromEntries(entries);
 }
 
 export async function readSummarySnapshot(teamName: string, cwd: string, summarySnapshotPath: MonitorDeps['summarySnapshotPath']): Promise<TeamSummarySnapshot | null> {
@@ -232,7 +264,7 @@ export async function readMonitorSnapshot(
       workerTaskIdByName: parsed.workerTaskIdByName ?? {},
       mailboxNotifiedByMessageId: parsed.mailboxNotifiedByMessageId ?? {},
       completedEventTaskIds: parsed.completedEventTaskIds ?? {},
-      integrationByWorker: parsed.integrationByWorker ?? {},
+      integrationByWorker: normalizeIntegrationByWorker(parsed.integrationByWorker),
       monitorTimings,
     };
   } catch {

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -1,5 +1,5 @@
 import type { TeamPhase, TerminalPhase } from '../orchestrator.js';
-import type { TeamTaskStatus, TeamEventType } from '../contracts.js';
+import type { TeamDispatchRequestStatus, TeamEventType, TeamTaskStatus } from '../contracts.js';
 import type { WorktreeMode } from '../worktree.js';
 
 export interface TeamConfig {
@@ -111,7 +111,6 @@ export interface TeamGovernance {
 }
 
 export type TeamDispatchRequestKind = 'inbox' | 'mailbox' | 'nudge';
-export type TeamDispatchRequestStatus = 'pending' | 'notified' | 'delivered' | 'failed';
 export type TeamDispatchTransportPreference = 'hook_preferred_with_fallback' | 'transport_direct' | 'prompt_stdin';
 
 export interface TeamDispatchRequest {


### PR DESCRIPTION
## Summary\n- document the current authoritative owners for dispatch, integration, and stale state in the team runtime seam\n- centralize dispatch and integration status enums in team contracts\n- sanitize persisted dispatch timestamps and monitor snapshot integration statuses so mirrors cannot outrank the contract\n\n## Testing\n- npm run build\n- npm run lint\n- node --test dist/team/__tests__/state.test.js dist/hooks/__tests__/notify-hook-team-dispatch.test.js\n\nRelated: #1243