### PR TITLE
refact: project .gitignore handling to include comprehensive ignore rules and remove legacy entries

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -14,6 +14,18 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { setup } from "../setup.js";
 
+const EXPECTED_PROJECT_GITIGNORE = [
+  ".omx/",
+  ".codex/*",
+  "!.codex/agents/",
+  "!.codex/agents/**",
+  "!.codex/skills/",
+  "!.codex/skills/**",
+  ".codex/skills/.system/**",
+  "!.codex/prompts/",
+  "!.codex/prompts/**",
+].join("\n") + "\n";
+
 async function runSetupWithCapturedLogs(
   cwd: string,
   options: Parameters<typeof setup>[0],
@@ -96,7 +108,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("creates .gitignore with .omx/ and .codex/ entries during project-scoped setup", async () => {
+  it("creates .gitignore with OMX project ignore rules during project-scoped setup", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await runSetupInTempDir(wd, { scope: "project" });
@@ -104,14 +116,14 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       assert.equal(existsSync(join(wd, ".omx", "state")), true);
       assert.equal(
         await readFile(join(wd, ".gitignore"), "utf-8"),
-        ".omx/\n.codex/\n",
+        EXPECTED_PROJECT_GITIGNORE,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it("appends missing .omx/ and .codex/ entries to an existing project .gitignore without duplicating them", async () => {
+  it("appends missing OMX project ignore rules to an existing project .gitignore without duplicating them", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await writeFile(join(wd, ".gitignore"), "node_modules/\n");
@@ -120,30 +132,64 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await runSetupInTempDir(wd, { scope: "project" });
 
       const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
-      assert.equal(gitignore, "node_modules/\n.omx/\n.codex/\n");
+      assert.equal(gitignore, `node_modules/\n${EXPECTED_PROJECT_GITIGNORE}`);
       assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 1);
-      assert.equal(gitignore.match(/^\.codex\/$/gm)?.length ?? 0, 1);
+      assert.equal(gitignore.match(/^\.codex\/\*$/gm)?.length ?? 0, 1);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it("keeps repo-local .codex ignored in a fresh git repo after project-scoped setup", async () => {
+  it("ignores project-local config while keeping .codex agents, skills, and prompts trackable", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       const initResult = spawnSync("git", ["init", "-q"], { cwd: wd });
       assert.equal(initResult.status, 0);
 
       await runSetupInTempDir(wd, { scope: "project" });
+      await mkdir(join(wd, ".codex", "skills", ".system"), { recursive: true });
+      await writeFile(join(wd, ".codex", "agents", "local.toml"), "# local\n");
+      await writeFile(join(wd, ".codex", "prompts", "local.md"), "# local\n");
+      await writeFile(
+        join(wd, ".codex", "skills", ".system", "cache.json"),
+        "{}\n",
+      );
 
       const status = spawnSync(
         "git",
-        ["status", "--short", "--ignored", ".codex", ".gitignore", "AGENTS.md"],
+        [
+          "status",
+          "--short",
+          "--ignored",
+          ".codex/config.toml",
+          ".codex/agents/local.toml",
+          ".codex/prompts/local.md",
+          ".codex/skills/help/SKILL.md",
+          ".codex/skills/.system/cache.json",
+        ],
         { cwd: wd, encoding: "utf-8" },
       );
       assert.equal(status.status, 0);
-      assert.match(status.stdout, /^!! \.codex\/$/m);
-      assert.doesNotMatch(status.stdout, /^\?\? \.codex\/$/m);
+      assert.match(status.stdout, /^!! \.codex\/config\.toml$/m);
+      assert.match(status.stdout, /^\?\? \.codex\/agents\/local\.toml$/m);
+      assert.match(status.stdout, /^\?\? \.codex\/prompts\/local\.md$/m);
+      assert.match(status.stdout, /^\?\? \.codex\/skills\/help\/SKILL\.md$/m);
+      assert.match(status.stdout, /^!! \.codex\/skills\/\.system\/cache\.json$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces legacy .codex/ ignores so the project allowlist can take effect", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await writeFile(join(wd, ".gitignore"), ".omx/\n.codex/\n");
+
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
+      assert.equal(gitignore, EXPECTED_PROJECT_GITIGNORE);
+      assert.equal(gitignore.match(/^\.codex\/$/gm)?.length ?? 0, 0);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -123,7 +123,18 @@ export interface SkillFrontmatterMetadata {
   description: string;
 }
 
-const PROJECT_GITIGNORE_ENTRIES = [".omx/", ".codex/"] as const;
+const PROJECT_GITIGNORE_ENTRIES = [
+  ".omx/",
+  ".codex/*",
+  "!.codex/agents/",
+  "!.codex/agents/**",
+  "!.codex/skills/",
+  "!.codex/skills/**",
+  ".codex/skills/.system/**",
+  "!.codex/prompts/",
+  "!.codex/prompts/**",
+] as const;
+const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
 
 function applyScopePathRewritesToAgentsTemplate(
   content: string,
@@ -551,6 +562,21 @@ function hasGitignoreEntry(content: string, entry: string): boolean {
     .some((line) => line === entry);
 }
 
+function stripLegacyGitignoreEntries(
+  content: string,
+  legacyEntries: readonly string[],
+): { content: string; removed: boolean } {
+  const legacyEntrySet = new Set(legacyEntries);
+  const lines = content.split(/\r?\n/);
+  const filteredLines = lines.filter((line) => !legacyEntrySet.has(line.trim()));
+  const removed = filteredLines.length !== lines.length;
+
+  return {
+    content: filteredLines.join("\n").replace(/\n+$/, "\n"),
+    removed,
+  };
+}
+
 async function ensureProjectGitignore(
   projectRoot: string,
   backupContext: SetupBackupContext,
@@ -561,17 +587,21 @@ async function ensureProjectGitignore(
   const existing = destinationExists
     ? await readFile(gitignorePath, "utf-8")
     : "";
-
-  const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter(
-    (entry) => !hasGitignoreEntry(existing, entry),
+  const normalized = stripLegacyGitignoreEntries(
+    existing,
+    LEGACY_PROJECT_GITIGNORE_ENTRIES,
   );
 
-  if (missingEntries.length === 0) {
+  const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter(
+    (entry) => !hasGitignoreEntry(normalized.content, entry),
+  );
+
+  if (missingEntries.length === 0 && !normalized.removed) {
     return "unchanged";
   }
 
   const nextContent = destinationExists
-    ? `${existing}${existing.endsWith("\n") || existing.length === 0 ? "" : "\n"}${missingEntries.join("\n")}\n`
+    ? `${normalized.content}${normalized.content.endsWith("\n") || normalized.content.length === 0 ? "" : "\n"}${missingEntries.join("\n")}${missingEntries.length > 0 ? "\n" : ""}`
     : `${PROJECT_GITIGNORE_ENTRIES.join("\n")}\n`;
 
   if (
@@ -585,8 +615,14 @@ async function ensureProjectGitignore(
   }
 
   if (options.verbose) {
+    const changedDetails = [
+      normalized.removed ? "removed legacy .codex/" : "",
+      missingEntries.length > 0 ? missingEntries.join(", ") : "",
+    ]
+      .filter(Boolean)
+      .join("; ");
     console.log(
-      `  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore (${missingEntries.join(", ")})`,
+      `  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore${changedDetails ? ` (${changedDetails})` : ""}`,
     );
   }
 
@@ -662,11 +698,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     );
     if (gitignoreResult === "created") {
       console.log(
-        "  Created .gitignore with .omx/ and .codex/ so local OMX runtime/config state stays out of source control.\n",
+        "  Created .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
       );
     } else if (gitignoreResult === "updated") {
       console.log(
-        "  Added .omx/ and/or .codex/ to .gitignore so local OMX runtime/config state stays out of source control.\n",
+        "  Updated .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
       );
     }
   }


### PR DESCRIPTION
## Summary
The PR for issue #1197 previously ignored the entire .codex directory. However, individual repositories may require project-specific skills, agents, or prompts in addition to the default configurations provided by OMX. This approach prevented teams from version-controlling their custom .codex configurations.

## Changes
- replace the project-scope `.gitignore` entries with a specific `.codex/*` allowlist
- remove legacy exact `.codex/` lines during setup refresh so existing repos can adopt the new behavior
- update setup output messaging to reflect the new project-scope ignore behavior
- add regression coverage for fresh setup, idempotent append behavior, allowlisted tracked paths, and legacy rule replacement

fix for #1197 

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
