### PR TITLE
Fix debugger follow-ups anchoring on stale logs in long sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
+- When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
 - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
 <!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>

--- a/docs/prompt-guidance-fragments/core-operating-principles.md
+++ b/docs/prompt-guidance-fragments/core-operating-principles.md
@@ -1,4 +1,5 @@
 - Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
+- When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
 - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.

--- a/prompts/debugger.md
+++ b/prompts/debugger.md
@@ -24,6 +24,7 @@ Fixing symptoms instead of root causes creates whack-a-mole debugging cycles. Th
 
 - Default to concise, evidence-dense bug reports; expand only when the failure mode is complex or ambiguous.
 - Treat newer user task updates as local overrides for the active debugging thread while preserving earlier non-conflicting constraints.
+- Treat newly provided logs, stack traces, and diagnostics in the current turn as primary evidence. Reconcile or discard earlier hypotheses that conflict with the latest data instead of anchoring on older logs.
 - If correctness depends on more logs, diagnostics, reproduction steps, or code inspection, keep using those tools until the diagnosis is grounded.
 </constraints>
 

--- a/src/hooks/__tests__/debugger-log-recency-contract.test.ts
+++ b/src/hooks/__tests__/debugger-log-recency-contract.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadSurface } from './prompt-guidance-test-helpers.js';
+
+describe('debugger log recency guidance contract', () => {
+  it('root guidance prioritizes newer same-thread evidence over stale context', () => {
+    for (const surface of ['AGENTS.md', 'templates/AGENTS.md']) {
+      const content = loadSurface(surface);
+      assert.match(content, /newer same-thread evidence/i);
+      assert.match(content, /current source of truth/i);
+      assert.match(content, /do not anchor on older evidence unless the user reaffirms it/i);
+    }
+  });
+
+  it('debugger guidance prioritizes the latest logs in the current turn', () => {
+    const content = loadSurface('prompts/debugger.md');
+    assert.match(content, /newly provided logs, stack traces, and diagnostics in the current turn/i);
+    assert.match(content, /primary evidence/i);
+    assert.match(content, /instead of anchoring on older logs/i);
+  });
+});

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -39,6 +39,7 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
+- When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
 - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
 <!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>


### PR DESCRIPTION
## Summary
- treat newer same-thread evidence in shared AGENTS guidance as the current source of truth
- tell the debugger prompt to prioritize current-turn logs/diagnostics over stale logs
- add regression coverage for the shared guidance and debugger-specific recency contract

## Root cause
The repo did not contain a live session-history selection bug for `prompts:debugger`; instead, long-lived threads kept prior logs in scope without an explicit guidance rule that newer same-thread evidence overrides earlier evidence. In long sessions that let the model stay anchored on stale logs.

## Testing
- npm install
- npm run build
- node --test dist/hooks/__tests__/debugger-log-recency-contract.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js

Fixes #1245
