### PR TITLE
fix(notify-hook): dedupe unchanged session-idle hook alerts

### DIFF
--- a/src/hooks/__tests__/notify-hook-session-idle-dedupe.test.ts
+++ b/src/hooks/__tests__/notify-hook-session-idle-dedupe.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SESSION_ID = 'sess-idle-dedupe';
+
+function buildSessionIdlePlugin(targetPath: string): string {
+  return `import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const TARGET_PATH = ${JSON.stringify(targetPath)};
+
+export async function onHookEvent(event) {
+  if (event.event !== 'session-idle') return;
+  mkdirSync(dirname(TARGET_PATH), { recursive: true });
+  let count = 0;
+  try {
+    const existing = JSON.parse(readFileSync(TARGET_PATH, 'utf-8'));
+    count = Number(existing?.count) || 0;
+  } catch {
+    count = 0;
+  }
+  writeFileSync(TARGET_PATH, JSON.stringify({
+    count: count + 1,
+    last_reason: event.context?.reason || '',
+    last_status: event.context?.status || '',
+    last_session_name: event.context?.session_name || '',
+  }, null, 2));
+}
+`;
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, 'utf-8')) as T;
+}
+
+function runNotifyHook(
+  repoRoot: string,
+  cwd: string,
+  lastAssistantMessage: string,
+  turnId: string,
+  envOverrides: Record<string, string> = {},
+) {
+  const payload = {
+    cwd,
+    type: 'agent-turn-complete',
+    thread_id: 'thread-session-idle',
+    turn_id: turnId,
+    input_messages: [],
+    last_assistant_message: lastAssistantMessage,
+  };
+
+  return spawnSync(process.execPath, ['dist/scripts/notify-hook.js', JSON.stringify(payload)], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      OMX_TEAM_WORKER: '',
+      TMUX: '',
+      TMUX_PANE: '',
+      ...envOverrides,
+    },
+  });
+}
+
+describe('notify-hook session-idle dedupe', () => {
+  it('suppresses repeated unchanged post_turn_idle_notification hook events once the first hook dispatch succeeds', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-idle-dedupe-'));
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const hooksDir = join(wd, '.omx', 'hooks');
+      const pluginStatePath = join(wd, '.omx', 'plugin-state', 'session-idle.json');
+      const hookStatePath = join(stateDir, 'sessions', SESSION_ID, 'session-idle-hook-state.json');
+
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(hooksDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: SESSION_ID }, null, 2));
+      await writeFile(join(hooksDir, 'session-idle-counter.mjs'), buildSessionIdlePlugin(pluginStatePath), 'utf-8');
+
+      const first = runNotifyHook(repoRoot, wd, 'Waiting for your next instruction.', 'turn-idle-1');
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+
+      const second = runNotifyHook(repoRoot, wd, 'Waiting for your next instruction.', 'turn-idle-2');
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+
+      const pluginState = await readJson<{ count: number; last_reason: string; last_status: string }>(pluginStatePath);
+      assert.equal(pluginState.count, 1);
+      assert.equal(pluginState.last_reason, 'post_turn_idle_notification');
+      assert.equal(pluginState.last_status, 'blocked');
+      assert.equal(existsSync(hookStatePath), true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('re-emits session-idle hook events when the idle fingerprint meaningfully changes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-idle-dedupe-change-'));
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const hooksDir = join(wd, '.omx', 'hooks');
+      const pluginStatePath = join(wd, '.omx', 'plugin-state', 'session-idle.json');
+
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(hooksDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: SESSION_ID }, null, 2));
+      await writeFile(join(hooksDir, 'session-idle-counter.mjs'), buildSessionIdlePlugin(pluginStatePath), 'utf-8');
+
+      const first = runNotifyHook(repoRoot, wd, 'Waiting on review.', 'turn-idle-3');
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+
+      const second = runNotifyHook(repoRoot, wd, 'Waiting on user input.', 'turn-idle-4');
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+
+      const pluginState = await readJson<{ count: number }>(pluginStatePath);
+      assert.equal(pluginState.count, 2);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps post_turn_idle_notification hook dedupe active even when lifecycle cooldown is disabled', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-idle-dedupe-zero-cooldown-'));
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const hooksDir = join(wd, '.omx', 'hooks');
+      const pluginStatePath = join(wd, '.omx', 'plugin-state', 'session-idle.json');
+
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(hooksDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: SESSION_ID }, null, 2));
+      await writeFile(join(hooksDir, 'session-idle-counter.mjs'), buildSessionIdlePlugin(pluginStatePath), 'utf-8');
+
+      const first = runNotifyHook(repoRoot, wd, 'Waiting for your next instruction.', 'turn-idle-5', {
+        OMX_IDLE_COOLDOWN_SECONDS: '0',
+      });
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+
+      const second = runNotifyHook(repoRoot, wd, 'Waiting for your next instruction.', 'turn-idle-6', {
+        OMX_IDLE_COOLDOWN_SECONDS: '0',
+      });
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+
+      const pluginState = await readJson<{ count: number; last_reason: string }>(pluginStatePath);
+      assert.equal(pluginState.count, 1);
+      assert.equal(pluginState.last_reason, 'post_turn_idle_notification');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/notifications/__tests__/idle-cooldown.test.ts
+++ b/src/notifications/__tests__/idle-cooldown.test.ts
@@ -12,6 +12,8 @@ import {
   getIdleNotificationCooldownSeconds,
   shouldSendIdleNotification,
   recordIdleNotificationSent,
+  shouldSendSessionIdleHookEvent,
+  recordSessionIdleHookEventSent,
 } from '../idle-cooldown.js';
 
 function makeTmpStateDir(): string {
@@ -200,5 +202,39 @@ describe('recordIdleNotificationSent', () => {
     const content = JSON.parse(readFileSync(sessionFile, 'utf-8')) as { lastSentAt: string; fingerprint?: string };
     assert.equal(content.fingerprint, fingerprint);
     assert.equal(typeof content.lastSentAt, 'string');
+  });
+});
+
+describe('session-idle hook event dedupe', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = makeTmpStateDir();
+    delete process.env.OMX_IDLE_COOLDOWN_SECONDS;
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.OMX_IDLE_COOLDOWN_SECONDS;
+  });
+
+  it('suppresses unchanged hook fingerprints even when lifecycle cooldown is disabled', () => {
+    process.env.OMX_IDLE_COOLDOWN_SECONDS = '0';
+    const sessionId = 'test-session-hook-zero-cooldown';
+    const fingerprint = '{"phase":"idle","summary":"Waiting for input"}';
+
+    recordSessionIdleHookEventSent(stateDir, sessionId, fingerprint);
+
+    assert.equal(shouldSendSessionIdleHookEvent(stateDir, sessionId, fingerprint), false);
+  });
+
+  it('re-emits when the hook fingerprint changes', () => {
+    const sessionId = 'test-session-hook-change';
+    recordSessionIdleHookEventSent(stateDir, sessionId, '{"phase":"idle","summary":"Waiting on review"}');
+
+    assert.equal(
+      shouldSendSessionIdleHookEvent(stateDir, sessionId, '{"phase":"idle","summary":"Waiting on user input"}'),
+      true,
+    );
   });
 });

--- a/src/notifications/idle-cooldown.ts
+++ b/src/notifications/idle-cooldown.ts
@@ -19,6 +19,8 @@ import { codexHome } from '../utils/paths.js';
 const DEFAULT_COOLDOWN_SECONDS = 60;
 const SESSION_ID_SAFE_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 const MAX_IDLE_FINGERPRINT_LENGTH = 512;
+const IDLE_NOTIFICATION_STATE_FILE = 'idle-notif-cooldown.json';
+const SESSION_IDLE_HOOK_STATE_FILE = 'session-idle-hook-state.json';
 
 interface IdleNotificationState {
   lastSentAt?: string;
@@ -65,11 +67,19 @@ export function getIdleNotificationCooldownSeconds(): number {
  * Resolve the path to the cooldown state file.
  * Uses a session-scoped path when sessionId is provided and safe.
  */
-function getCooldownStatePath(stateDir: string, sessionId?: string): string {
+function getScopedStatePath(stateDir: string, fileName: string, sessionId?: string): string {
   if (sessionId && SESSION_ID_SAFE_PATTERN.test(sessionId)) {
-    return join(stateDir, 'sessions', sessionId, 'idle-notif-cooldown.json');
+    return join(stateDir, 'sessions', sessionId, fileName);
   }
-  return join(stateDir, 'idle-notif-cooldown.json');
+  return join(stateDir, fileName);
+}
+
+function getCooldownStatePath(stateDir: string, sessionId?: string): string {
+  return getScopedStatePath(stateDir, IDLE_NOTIFICATION_STATE_FILE, sessionId);
+}
+
+function getSessionIdleHookStatePath(stateDir: string, sessionId?: string): string {
+  return getScopedStatePath(stateDir, SESSION_IDLE_HOOK_STATE_FILE, sessionId);
 }
 
 function normalizeIdleFingerprint(fingerprint: string | null | undefined): string {
@@ -91,6 +101,21 @@ function readIdleNotificationState(cooldownPath: string): IdleNotificationState 
     };
   } catch {
     return null;
+  }
+}
+
+function writeIdleNotificationState(cooldownPath: string, fingerprint?: string): void {
+  try {
+    const dir = dirname(cooldownPath);
+    mkdirSync(dir, { recursive: true });
+    const normalizedFingerprint = normalizeIdleFingerprint(fingerprint);
+    const state: IdleNotificationState = { lastSentAt: new Date().toISOString() };
+    if (normalizedFingerprint) {
+      state.fingerprint = normalizedFingerprint;
+    }
+    writeFileSync(cooldownPath, JSON.stringify(state, null, 2));
+  } catch {
+    // ignore write errors — best effort
   }
 }
 
@@ -134,16 +159,30 @@ export function shouldSendIdleNotification(stateDir: string, sessionId?: string,
  */
 export function recordIdleNotificationSent(stateDir: string, sessionId?: string, fingerprint?: string): void {
   const cooldownPath = getCooldownStatePath(stateDir, sessionId);
-  try {
-    const dir = dirname(cooldownPath);
-    mkdirSync(dir, { recursive: true });
-    const normalizedFingerprint = normalizeIdleFingerprint(fingerprint);
-    const state: IdleNotificationState = { lastSentAt: new Date().toISOString() };
-    if (normalizedFingerprint) {
-      state.fingerprint = normalizedFingerprint;
-    }
-    writeFileSync(cooldownPath, JSON.stringify(state, null, 2));
-  } catch {
-    // ignore write errors — best effort
-  }
+  writeIdleNotificationState(cooldownPath, fingerprint);
+}
+
+/**
+ * Check whether the coarse session-idle hook event should be dispatched.
+ *
+ * This path intentionally stays transition-based even when the lifecycle
+ * notification cooldown is set to 0, because downstream hook consumers only
+ * see the coarse `post_turn_idle_notification` reason and otherwise cannot
+ * distinguish unchanged repeats from new blocked states.
+ */
+export function shouldSendSessionIdleHookEvent(stateDir: string, sessionId?: string, fingerprint?: string): boolean {
+  const normalizedFingerprint = normalizeIdleFingerprint(fingerprint);
+  if (!normalizedFingerprint) return true;
+
+  const state = readIdleNotificationState(getSessionIdleHookStatePath(stateDir, sessionId));
+  if (!state) return true;
+
+  return state.fingerprint !== normalizedFingerprint;
+}
+
+/**
+ * Record that the coarse session-idle hook event was dispatched.
+ */
+export function recordSessionIdleHookEventSent(stateDir: string, sessionId?: string, fingerprint?: string): void {
+  writeIdleNotificationState(getSessionIdleHookStatePath(stateDir, sessionId), fingerprint);
 }

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -514,7 +514,12 @@ async function main() {
   if (!isTeamWorker) {
     try {
       const { notifyLifecycle } = await import('../notifications/index.js');
-      const { shouldSendIdleNotification, recordIdleNotificationSent } = await import('../notifications/idle-cooldown.js');
+      const {
+        shouldSendIdleNotification,
+        recordIdleNotificationSent,
+        shouldSendSessionIdleHookEvent,
+        recordSessionIdleHookEventSent,
+      } = await import('../notifications/idle-cooldown.js');
       const sessionJsonPath = join(stateDir, 'session.json');
       const idleFingerprint = buildIdleNotificationFingerprint(payload);
       let notifySessionId = '';
@@ -523,37 +528,50 @@ async function main() {
         notifySessionId = safeString(sessionData && sessionData.session_id ? sessionData.session_id : '');
       } catch { /* no session file */ }
 
-      if (notifySessionId && shouldSendIdleNotification(stateDir, notifySessionId, idleFingerprint)) {
-        const idleResult = await notifyLifecycle('session-idle', {
-          sessionId: notifySessionId,
-          projectPath: cwd,
-        });
-        if (idleResult && idleResult.anySuccess) {
-          recordIdleNotificationSent(stateDir, notifySessionId, idleFingerprint);
-        }
-        try {
-          const { buildNativeHookEvent } = await import('../hooks/extensibility/events.js');
-          const { dispatchHookEvent } = await import('../hooks/extensibility/dispatcher.js');
-          const event = buildNativeHookEvent('session-idle', {
-            ...buildOperationalContext({
-              cwd,
-              normalizedEvent: 'blocked',
-              sessionId: notifySessionId,
-              status: 'blocked',
-              extra: {
-                project_path: cwd,
-                reason: 'post_turn_idle_notification',
-              },
-            }),
-          }, {
-            session_id: notifySessionId,
-            thread_id: safeString(payload['thread-id'] || payload.thread_id || ''),
-            turn_id: safeString(payload['turn-id'] || payload.turn_id || ''),
-            mode: safeString(payload.mode || ''),
+      const shouldNotifyLifecycle = notifySessionId
+        && shouldSendIdleNotification(stateDir, notifySessionId, idleFingerprint);
+      const shouldDispatchSessionIdleHookEvent = notifySessionId
+        && shouldSendSessionIdleHookEvent(stateDir, notifySessionId, idleFingerprint);
+
+      if (shouldNotifyLifecycle || shouldDispatchSessionIdleHookEvent) {
+        if (shouldNotifyLifecycle) {
+          const idleResult = await notifyLifecycle('session-idle', {
+            sessionId: notifySessionId,
+            projectPath: cwd,
           });
-          await dispatchHookEvent(event, { cwd });
-        } catch {
-          // Non-fatal
+          if (idleResult && idleResult.anySuccess) {
+            recordIdleNotificationSent(stateDir, notifySessionId, idleFingerprint);
+          }
+        }
+
+        if (shouldDispatchSessionIdleHookEvent) {
+          try {
+            const { buildNativeHookEvent } = await import('../hooks/extensibility/events.js');
+            const { dispatchHookEvent } = await import('../hooks/extensibility/dispatcher.js');
+            const event = buildNativeHookEvent('session-idle', {
+              ...buildOperationalContext({
+                cwd,
+                normalizedEvent: 'blocked',
+                sessionId: notifySessionId,
+                status: 'blocked',
+                extra: {
+                  project_path: cwd,
+                  reason: 'post_turn_idle_notification',
+                },
+              }),
+            }, {
+              session_id: notifySessionId,
+              thread_id: safeString(payload['thread-id'] || payload.thread_id || ''),
+              turn_id: safeString(payload['turn-id'] || payload.turn_id || ''),
+              mode: safeString(payload.mode || ''),
+            });
+            const hookDispatchResult = await dispatchHookEvent(event, { cwd });
+            if (hookDispatchResult.results.some((result) => result.ok)) {
+              recordSessionIdleHookEventSent(stateDir, notifySessionId, idleFingerprint);
+            }
+          } catch {
+            // Non-fatal
+          }
         }
       }
     } catch {


### PR DESCRIPTION
## Summary

Fix issue #1174 by deduplicating unchanged `post_turn_idle_notification` hook emissions at the notify-hook source.

The repeated blocked alerts were coming from the coarse session-idle hook path sharing lifecycle cooldown state. That meant unchanged blocked idle states could keep re-emitting for downstream hook consumers, especially when lifecycle delivery was disabled or when `OMX_IDLE_COOLDOWN_SECONDS=0` was set.

## Changes

- add a separate session-idle hook-event fingerprint state file and transition-based guard in `idle-cooldown`
- keep lifecycle `session-idle` notification cooldown behavior separate from the coarse hook-event guard
- update `notify-hook.ts` to gate lifecycle notification and coarse hook dispatch independently
- add notify-hook integration coverage for unchanged, changed, and zero-cooldown idle fingerprints
- add unit coverage for the new hook-event dedupe helpers

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1174
