### PR TITLE
feat(setup): add portable Bash project config style for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ Most users should think of OMX as **better task routing + better workflow + bett
 4. Use `$ralplan "..."` to approve the plan and review tradeoffs
 5. Choose `$team` for coordinated parallel execution or `$ralph` for persistent completion loops
 
+### Portable project setup for Bash environments
+
+If you want a project-scoped OMX install that is easier to move between macOS, Linux, and WSL machines that have Bash available, use:
+
+```bash
+omx setup --scope project --project-config-style portable-bash
+```
+
+This opt-in mode avoids embedding repo-local absolute paths for OMX-managed notify hooks and MCP launchers in the generated project config. The default `omx setup` behavior stays unchanged.
+
 ## Recommended workflow
 
 1. `$deep-interview` — clarify scope when the request or boundaries are still vague.

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -24,6 +24,7 @@ import {
   injectModelInstructionsBypassArgs,
   resolveWorkerSparkModel,
   resolveSetupScopeArg,
+  resolveProjectConfigStyleArg,
   readPersistedSetupPreferences,
   readPersistedSetupScope,
   resolveCodexHomeForLaunch,
@@ -764,6 +765,49 @@ describe("resolveSetupScopeArg", () => {
     );
   });
 });
+
+describe("resolveProjectConfigStyleArg", () => {
+  it("returns undefined when project config style is omitted", () => {
+    assert.equal(resolveProjectConfigStyleArg(["--dry-run"]), undefined);
+  });
+
+  it("parses --project-config-style <value> form", () => {
+    assert.equal(
+      resolveProjectConfigStyleArg([
+        "--dry-run",
+        "--project-config-style",
+        "portable-bash",
+      ]),
+      "portable-bash",
+    );
+  });
+
+  it("parses --project-config-style=<value> form", () => {
+    assert.equal(
+      resolveProjectConfigStyleArg(["--project-config-style=portable-bash"]),
+      "portable-bash",
+    );
+  });
+
+  it("throws on invalid project config style", () => {
+    assert.throws(
+      () =>
+        resolveProjectConfigStyleArg([
+          "--project-config-style",
+          "workspace-portable",
+        ]),
+      /Invalid project config style: workspace-portable/,
+    );
+  });
+
+  it("throws when --project-config-style value is missing", () => {
+    assert.throws(
+      () => resolveProjectConfigStyleArg(["--project-config-style"]),
+      /Missing project config style value after --project-config-style/,
+    );
+  });
+});
+
 describe("project launch scope helpers", () => {
   it("reads persisted setup scope when valid", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
@@ -779,16 +823,17 @@ describe("project launch scope helpers", () => {
     }
   });
 
-  it("reads persisted setup preferences when skill target is present", async () => {
+  it("reads persisted setup preferences when project config style is present", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
     try {
       await mkdir(join(wd, ".omx"), { recursive: true });
       await writeFile(
         join(wd, ".omx", "setup-scope.json"),
-        JSON.stringify({ scope: "user" }),
+        JSON.stringify({ scope: "user", projectConfigStyle: "portable-bash" }),
       );
       assert.deepEqual(readPersistedSetupPreferences(wd), {
         scope: "user",
+        projectConfigStyle: "portable-bash",
       });
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -225,6 +225,38 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("writes portable-bash project config without repo-local absolute script paths when requested", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+
+      await runSetupInTempDir(wd, {
+        scope: "project",
+        projectConfigStyle: "portable-bash",
+      });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.ok(
+        config.includes(
+          'notify = ["bash", "-c", "node \\"$(npm root -g)/oh-my-codex/dist/scripts/notify-hook.js\\" \\"$1\\"", "notify-hook"]',
+        ),
+      );
+      assert.ok(
+        config.includes(
+          'args = ["-c", "exec node \\"$(npm root -g)/oh-my-codex/dist/mcp/state-server.js\\""]',
+        ),
+      );
+      assert.doesNotMatch(
+        config,
+        new RegExp(
+          `${wd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}.*(notify-hook|state-server|memory-server|code-intel-server|trace-server)\\.js`,
+        ),
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("offers an upgrade from gpt-5.3-codex to gpt-5.4 when accepted", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -80,6 +80,42 @@ describe("omx setup scope behavior", () => {
     }
   });
 
+  it("accepts --project-config-style portable-bash and persists it for project scope", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-scope-"));
+    try {
+      const home = join(wd, "home");
+      await mkdir(home, { recursive: true });
+
+      const res = runOmx(
+        wd,
+        [
+          "setup",
+          "--scope",
+          "project",
+          "--project-config-style",
+          "portable-bash",
+        ],
+        { HOME: home },
+      );
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /Using setup scope: project/);
+      assert.match(res.stdout, /Using project config style: portable-bash/);
+
+      const persisted = JSON.parse(
+        await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
+      ) as { scope: string; projectConfigStyle?: string };
+      assert.equal(persisted.scope, "project");
+      assert.equal(persisted.projectConfigStyle, "portable-bash");
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(config, /^notify = \["bash", "-c", "node/m);
+      assert.match(config, /^command = "bash"$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("uses persisted setup scope when --scope is omitted", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-scope-"));
     try {
@@ -98,6 +134,37 @@ describe("omx setup scope behavior", () => {
       assert.match(
         res.stdout,
         /Using setup scope: project \(from \.omx\/setup-scope\.json\)/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("uses persisted portable-bash project config style when the CLI flag is omitted", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-scope-"));
+    try {
+      const omxDir = join(wd, ".omx");
+      const home = join(wd, "home");
+      await mkdir(omxDir, { recursive: true });
+      await mkdir(home, { recursive: true });
+      await writeFile(
+        join(omxDir, "setup-scope.json"),
+        JSON.stringify({
+          scope: "project",
+          projectConfigStyle: "portable-bash",
+        }),
+      );
+
+      const res = runOmx(wd, ["setup", "--dry-run"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Using setup scope: project \(from \.omx\/setup-scope\.json\)/,
+      );
+      assert.match(
+        res.stdout,
+        /Using project config style: portable-bash \(from \.omx\/setup-scope\.json\)/,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -98,6 +98,60 @@ function buildOmxConfig(): string {
 
 /** Build a config with OMX entries mixed with user entries */
 
+function buildPortableBashOmxConfig(): string {
+  return [
+    '# oh-my-codex top-level settings (must be before any [table])',
+    'notify = ["bash", "-c", "node \\"$(npm root -g)/oh-my-codex/dist/scripts/notify-hook.js\\" \\"$1\\"", "notify-hook"]',
+    'model_reasoning_effort = "high"',
+    'developer_instructions = "You have oh-my-codex installed."',
+    '',
+    '[features]',
+    'multi_agent = true',
+    'child_agents_md = true',
+    '',
+    '# ============================================================',
+    '# oh-my-codex (OMX) Configuration',
+    '# Managed by omx setup - manual edits preserved on next setup',
+    '# ============================================================',
+    '',
+    '# OMX State Management MCP Server',
+    '[mcp_servers.omx_state]',
+    'command = "bash"',
+    'args = ["-c", "exec node \\"$(npm root -g)/oh-my-codex/dist/mcp/state-server.js\\""]',
+    'enabled = true',
+    'startup_timeout_sec = 5',
+    '',
+    '# OMX Project Memory MCP Server',
+    '[mcp_servers.omx_memory]',
+    'command = "bash"',
+    'args = ["-c", "exec node \\"$(npm root -g)/oh-my-codex/dist/mcp/memory-server.js\\""]',
+    'enabled = true',
+    'startup_timeout_sec = 5',
+    '',
+    '# OMX Code Intelligence MCP Server',
+    '[mcp_servers.omx_code_intel]',
+    'command = "bash"',
+    'args = ["-c", "exec node \\"$(npm root -g)/oh-my-codex/dist/mcp/code-intel-server.js\\""]',
+    'enabled = true',
+    'startup_timeout_sec = 10',
+    '',
+    '# OMX Trace MCP Server',
+    '[mcp_servers.omx_trace]',
+    'command = "bash"',
+    'args = ["-c", "exec node \\"$(npm root -g)/oh-my-codex/dist/mcp/trace-server.js\\""]',
+    'enabled = true',
+    'startup_timeout_sec = 5',
+    '',
+    '# OMX TUI StatusLine (Codex CLI v0.101.0+)',
+    '[tui]',
+    'status_line = ["model-with-reasoning", "git-branch"]',
+    '',
+    '# ============================================================',
+    '# End oh-my-codex',
+    '',
+  ].join('\n');
+}
+
 function buildConfigWithSeededModelContext(): string {
   return [
     '# oh-my-codex top-level settings (must be before any [table])',
@@ -235,6 +289,29 @@ describe('omx uninstall', () => {
       assert.doesNotMatch(config, /developer_instructions\s*=/);
       assert.doesNotMatch(config, /multi_agent\s*=/);
       assert.doesNotMatch(config, /child_agents_md\s*=/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes portable-bash OMX block from config.toml', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildPortableBashOmxConfig());
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /Removed OMX configuration block/);
+
+      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
+      assert.doesNotMatch(config, /notify-hook\.js/);
+      assert.doesNotMatch(config, /\[mcp_servers\.omx_state\]/);
+      assert.doesNotMatch(config, /exec node \\".*state-server\.js\\"/);
+      assert.doesNotMatch(config, /command = "bash"/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,7 +7,13 @@ import { execFileSync, spawn } from "child_process";
 import { basename, dirname, join } from "path";
 import { existsSync, readFileSync } from "fs";
 import { constants as osConstants } from "os";
-import { setup, SETUP_SCOPES, type SetupScope } from "./setup.js";
+import {
+  setup,
+  SETUP_SCOPES,
+  PROJECT_CONFIG_STYLES,
+  type SetupScope,
+  type ProjectConfigStyle,
+} from "./setup.js";
 import { uninstall } from "./uninstall.js";
 import { version } from "./version.js";
 import { tmuxHookCommand } from "./tmux-hook.js";
@@ -181,6 +187,9 @@ Options:
   --verbose     Show detailed output
   --scope       Setup scope for "omx setup" only:
                 user | project
+  --project-config-style
+                Project-scope config generation for "omx setup" only:
+                absolute-path | portable-bash
   --skill-target
                 User-scope skills target for "omx setup" only:
                 codex-home
@@ -282,20 +291,36 @@ export function readPersistedSetupScope(cwd: string): SetupScope | undefined {
 
 export function readPersistedSetupPreferences(
   cwd: string,
-): Partial<{ scope: SetupScope }> | undefined {
+): Partial<{
+  scope: SetupScope;
+  projectConfigStyle: ProjectConfigStyle;
+}> | undefined {
   const scopePath = join(cwd, ".omx", "setup-scope.json");
   if (!existsSync(scopePath)) return undefined;
   try {
     const parsed = JSON.parse(readFileSync(scopePath, "utf-8")) as Partial<{
       scope: string;
+      projectConfigStyle: string;
     }>;
-    const persisted: Partial<{ scope: SetupScope }> = {};
+    const persisted: Partial<{
+      scope: SetupScope;
+      projectConfigStyle: ProjectConfigStyle;
+    }> = {};
     if (typeof parsed.scope === "string") {
       if (SETUP_SCOPES.includes(parsed.scope as SetupScope)) {
         persisted.scope = parsed.scope as SetupScope;
       }
       const migrated = LEGACY_SCOPE_MIGRATION_SYNC[parsed.scope];
       if (migrated) persisted.scope = migrated;
+    }
+    if (
+      typeof parsed.projectConfigStyle === "string" &&
+      PROJECT_CONFIG_STYLES.includes(
+        parsed.projectConfigStyle as ProjectConfigStyle,
+      )
+    ) {
+      persisted.projectConfigStyle =
+        parsed.projectConfigStyle as ProjectConfigStyle;
     }
     return Object.keys(persisted).length > 0 ? persisted : undefined;
   } catch (err) {
@@ -342,6 +367,36 @@ export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {
   }
   throw new Error(
     `Invalid setup scope: ${value}. Expected one of: ${SETUP_SCOPES.join(", ")}`,
+  );
+}
+
+export function resolveProjectConfigStyleArg(
+  args: string[],
+): ProjectConfigStyle | undefined {
+  let value: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--project-config-style") {
+      const next = args[index + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(
+          `Missing project config style value after --project-config-style. Expected one of: ${PROJECT_CONFIG_STYLES.join(", ")}`,
+        );
+      }
+      value = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--project-config-style=")) {
+      value = arg.slice("--project-config-style=".length);
+    }
+  }
+  if (!value) return undefined;
+  if (PROJECT_CONFIG_STYLES.includes(value as ProjectConfigStyle)) {
+    return value as ProjectConfigStyle;
+  }
+  throw new Error(
+    `Invalid project config style: ${value}. Expected one of: ${PROJECT_CONFIG_STYLES.join(", ")}`,
   );
 }
 
@@ -629,6 +684,7 @@ export async function main(args: string[]): Promise<void> {
           dryRun: options.dryRun,
           verbose: options.verbose,
           scope: resolveSetupScopeArg(args.slice(1)),
+          projectConfigStyle: resolveProjectConfigStyleArg(args.slice(1)),
         });
         break;
       case "agents":

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -58,6 +58,7 @@ interface SetupOptions {
   force?: boolean;
   dryRun?: boolean;
   scope?: SetupScope;
+  projectConfigStyle?: ProjectConfigStyle;
   verbose?: boolean;
   agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
   modelUpgradePrompt?: (
@@ -78,6 +79,11 @@ const LEGACY_SCOPE_MIGRATION: Record<string, "project"> = {
 
 export const SETUP_SCOPES = ["user", "project"] as const;
 export type SetupScope = (typeof SETUP_SCOPES)[number];
+export const PROJECT_CONFIG_STYLES = [
+  "absolute-path",
+  "portable-bash",
+] as const;
+export type ProjectConfigStyle = (typeof PROJECT_CONFIG_STYLES)[number];
 
 export interface ScopeDirectories {
   codexConfigFile: string;
@@ -144,13 +150,19 @@ function applyScopePathRewritesToAgentsTemplate(
   return content.replaceAll("~/.codex", "./.codex");
 }
 
-interface PersistedSetupScope {
+interface PersistedSetupPreferences {
   scope: SetupScope;
+  projectConfigStyle?: ProjectConfigStyle;
 }
 
 interface ResolvedSetupScope {
   scope: SetupScope;
   source: "cli" | "persisted" | "prompt" | "default";
+}
+
+interface ResolvedProjectConfigStyle {
+  projectConfigStyle: ProjectConfigStyle;
+  source: "cli" | "persisted" | "default";
 }
 
 const REQUIRED_TEAM_CLI_API_MARKERS = [
@@ -160,6 +172,7 @@ const REQUIRED_TEAM_CLI_API_MARKERS = [
 ] as const;
 
 const DEFAULT_SETUP_SCOPE: SetupScope = "user";
+const DEFAULT_PROJECT_CONFIG_STYLE: ProjectConfigStyle = "absolute-path";
 const LEGACY_SETUP_MODEL = "gpt-5.3-codex";
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
 const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
@@ -372,6 +385,11 @@ function logCategorySummary(name: string, summary: SetupCategorySummary): void {
 function isSetupScope(value: string): value is SetupScope {
   return SETUP_SCOPES.includes(value as SetupScope);
 }
+
+function isProjectConfigStyle(value: string): value is ProjectConfigStyle {
+  return PROJECT_CONFIG_STYLES.includes(value as ProjectConfigStyle);
+}
+
 function getScopeFilePath(projectRoot: string): string {
   return join(projectRoot, ".omx", "setup-scope.json");
 }
@@ -401,13 +419,13 @@ export function resolveScopeDirectories(
 
 async function readPersistedSetupPreferences(
   projectRoot: string,
-): Promise<Partial<PersistedSetupScope> | undefined> {
+): Promise<Partial<PersistedSetupPreferences> | undefined> {
   const scopePath = getScopeFilePath(projectRoot);
   if (!existsSync(scopePath)) return undefined;
   try {
     const raw = await readFile(scopePath, "utf-8");
-    const parsed = JSON.parse(raw) as Partial<PersistedSetupScope>;
-    const persisted: Partial<PersistedSetupScope> = {};
+    const parsed = JSON.parse(raw) as Partial<PersistedSetupPreferences>;
+    const persisted: Partial<PersistedSetupPreferences> = {};
     if (parsed && typeof parsed.scope === "string") {
       // Direct match to current scopes
       if (isSetupScope(parsed.scope)) {
@@ -421,6 +439,11 @@ async function readPersistedSetupPreferences(
             `(see issue #243: simplified to user/project).`,
         );
         persisted.scope = migrated;
+      }
+    }
+    if (parsed && typeof parsed.projectConfigStyle === "string") {
+      if (isProjectConfigStyle(parsed.projectConfigStyle)) {
+        persisted.projectConfigStyle = parsed.projectConfigStyle;
       }
     }
     return Object.keys(persisted).length > 0 ? persisted : undefined;
@@ -555,6 +578,26 @@ async function resolveSetupScope(
   return { scope: DEFAULT_SETUP_SCOPE, source: "default" };
 }
 
+async function resolveProjectConfigStyle(
+  projectRoot: string,
+  requestedProjectConfigStyle?: ProjectConfigStyle,
+): Promise<ResolvedProjectConfigStyle> {
+  if (requestedProjectConfigStyle) {
+    return { projectConfigStyle: requestedProjectConfigStyle, source: "cli" };
+  }
+  const persisted = await readPersistedSetupPreferences(projectRoot);
+  if (persisted?.projectConfigStyle) {
+    return {
+      projectConfigStyle: persisted.projectConfigStyle,
+      source: "persisted",
+    };
+  }
+  return {
+    projectConfigStyle: DEFAULT_PROJECT_CONFIG_STYLE,
+    source: "default",
+  };
+}
+
 function hasGitignoreEntry(content: string, entry: string): boolean {
   return content
     .split(/\r?\n/)
@@ -629,9 +672,10 @@ async function ensureProjectGitignore(
   return destinationExists ? "updated" : "created";
 }
 
-async function persistSetupScope(
+async function persistSetupPreferences(
   projectRoot: string,
   scope: SetupScope,
+  projectConfigStyle: ProjectConfigStyle,
   options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
   const scopePath = getScopeFilePath(projectRoot);
@@ -640,7 +684,7 @@ async function persistSetupScope(
     return;
   }
   await mkdir(dirname(scopePath), { recursive: true });
-  const payload: PersistedSetupScope = { scope };
+  const payload: PersistedSetupPreferences = { scope, projectConfigStyle };
   await writeFile(scopePath, JSON.stringify(payload, null, 2) + "\n");
   if (options.verbose) console.log(`  Wrote ${scopePath}`);
 }
@@ -650,15 +694,24 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     force = false,
     dryRun = false,
     scope: requestedScope,
+    projectConfigStyle: requestedProjectConfigStyle,
     verbose = false,
     modelUpgradePrompt,
   } = options;
   const pkgRoot = getPackageRoot();
   const projectRoot = process.cwd();
   const resolvedScope = await resolveSetupScope(projectRoot, requestedScope);
+  const resolvedProjectConfigStyle = await resolveProjectConfigStyle(
+    projectRoot,
+    requestedProjectConfigStyle,
+  );
   const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
   const scopeSourceMessage =
     resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
+  const projectConfigStyleSourceMessage =
+    resolvedProjectConfigStyle.source === "persisted"
+      ? " (from .omx/setup-scope.json)"
+      : "";
   const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
 
   console.log("oh-my-codex setup");
@@ -666,6 +719,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   console.log(
     `Using setup scope: ${resolvedScope.scope}${scopeSourceMessage}\n`,
   );
+  if (resolvedScope.scope === "project") {
+    console.log(
+      `Using project config style: ${resolvedProjectConfigStyle.projectConfigStyle}${projectConfigStyleSourceMessage}\n`,
+    );
+  }
 
   // Step 1: Ensure directories exist
   console.log("[1/8] Creating directories...");
@@ -684,10 +742,15 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     }
     if (verbose) console.log(`  mkdir ${dir}`);
   }
-  await persistSetupScope(projectRoot, resolvedScope.scope, {
-    dryRun,
-    verbose,
-  });
+  await persistSetupPreferences(
+    projectRoot,
+    resolvedScope.scope,
+    resolvedProjectConfigStyle.projectConfigStyle,
+    {
+      dryRun,
+      verbose,
+    },
+  );
   console.log("  Done.\n");
 
   if (resolvedScope.scope === "project") {
@@ -819,7 +882,16 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     sharedMcpRegistry,
     summary.config,
     backupContext,
-    { codexVersionProbe: options.codexVersionProbe, dryRun, verbose, modelUpgradePrompt },
+    {
+      codexVersionProbe: options.codexVersionProbe,
+      dryRun,
+      verbose,
+      modelUpgradePrompt,
+      projectConfigStyle:
+        resolvedScope.scope === "project"
+          ? resolvedProjectConfigStyle.projectConfigStyle
+          : undefined,
+    },
   );
   const resolvedConfig = managedConfig.finalConfig;
   if (resolvedScope.scope === "user") {
@@ -1534,7 +1606,11 @@ async function updateManagedConfig(
   backupContext: SetupBackupContext,
   options: Pick<
     SetupOptions,
-    "codexVersionProbe" | "dryRun" | "verbose" | "modelUpgradePrompt"
+    | "codexVersionProbe"
+    | "dryRun"
+    | "verbose"
+    | "modelUpgradePrompt"
+    | "projectConfigStyle"
   >,
 ): Promise<ManagedConfigResult> {
   const existing = existsSync(configPath)
@@ -1563,6 +1639,7 @@ async function updateManagedConfig(
   const finalConfig = buildMergedConfig(existing, pkgRoot, {
     includeTui: omxManagesTui,
     modelOverride,
+    projectConfigStyle: options.projectConfigStyle,
     sharedMcpServers: sharedMcpRegistry.servers,
     sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
     verbose: options.verbose,

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -73,8 +73,10 @@ function detectOmxConfigArtifacts(config: string): {
     /^\[tui\]/m.test(config) &&
     config.includes("oh-my-codex (OMX) Configuration");
 
+  const hasManagedNotify =
+    /^\s*notify\s*=\s*\[/m.test(config) && config.includes("notify-hook.js");
   const hasTopLevelKeys =
-    /^\s*notify\s*=.*node/m.test(config) ||
+    hasManagedNotify ||
     /^\s*model_reasoning_effort\s*=/m.test(config) ||
     /^\s*developer_instructions\s*=.*oh-my-codex/m.test(config);
 

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -120,6 +120,42 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
+  it("portable-bash project config stays idempotent and removes repo-local script paths", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+
+      await mergeConfig(configPath, wd);
+      await mergeConfig(configPath, wd, {
+        projectConfigStyle: "portable-bash",
+      });
+
+      const firstPortable = await readFile(configPath, "utf-8");
+      assertSingleOmxBlock(firstPortable);
+      assert.ok(
+        firstPortable.includes(
+          'notify = ["bash", "-c", "node \\"$(npm root -g)/oh-my-codex/dist/scripts/notify-hook.js\\" \\"$1\\"", "notify-hook"]',
+        ),
+      );
+      assert.doesNotMatch(
+        firstPortable,
+        new RegExp(
+          `${wd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}.*(notify-hook|state-server|memory-server|code-intel-server|trace-server)\\.js`,
+        ),
+        "portable project config should not preserve repo-local absolute script paths",
+      );
+
+      await mergeConfig(configPath, wd, {
+        projectConfigStyle: "portable-bash",
+      });
+      const secondPortable = await readFile(configPath, "utf-8");
+      assertSingleOmxBlock(secondPortable);
+      assert.equal(secondPortable, firstPortable);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("triple run stays clean", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -54,6 +54,37 @@ describe('config generator', () => {
     }
   });
 
+  it('writes portable-bash notify and MCP launchers when requested', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
+    try {
+      const configPath = join(wd, 'config.toml');
+      await mergeConfig(configPath, wd, { projectConfigStyle: 'portable-bash' });
+      const toml = await readFile(configPath, 'utf-8');
+
+      assert.ok(
+        toml.includes(
+          'notify = ["bash", "-c", "node \\"$(npm root -g)/oh-my-codex/dist/scripts/notify-hook.js\\" \\"$1\\"", "notify-hook"]',
+        ),
+        'portable notify hook should resolve the global install via npm root -g',
+      );
+      assert.ok(
+        toml.includes('[mcp_servers.omx_state]\ncommand = "bash"\nargs = ["-c", "exec node \\"$(npm root -g)/oh-my-codex/dist/mcp/state-server.js\\""]'),
+        'portable state MCP launcher should use bash + npm root -g',
+      );
+      assert.ok(
+        toml.includes('[mcp_servers.omx_memory]\ncommand = "bash"\nargs = ["-c", "exec node \\"$(npm root -g)/oh-my-codex/dist/mcp/memory-server.js\\""]'),
+        'portable memory MCP launcher should use bash + npm root -g',
+      );
+      assert.doesNotMatch(
+        toml,
+        new RegExp(wd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+        'portable project config should not embed repo-local absolute paths',
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds gpt-5.4 model and context defaults for fresh configs', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
     try {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -20,6 +20,7 @@ import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 interface MergeOptions {
   includeTui?: boolean;
   modelOverride?: string;
+  projectConfigStyle?: ProjectConfigStyle;
   sharedMcpServers?: UnifiedMcpRegistryServer[];
   sharedMcpRegistrySource?: string;
   verbose?: boolean;
@@ -39,8 +40,14 @@ const OMX_TOP_LEVEL_KEYS = [
   "model_reasoning_effort",
   "developer_instructions",
 ] as const;
+export const PROJECT_CONFIG_STYLES = [
+  "absolute-path",
+  "portable-bash",
+] as const;
+export type ProjectConfigStyle = (typeof PROJECT_CONFIG_STYLES)[number];
 
 const DEFAULT_SETUP_MODEL = DEFAULT_FRONTIER_MODEL;
+const DEFAULT_PROJECT_CONFIG_STYLE: ProjectConfigStyle = "absolute-path";
 const DEFAULT_SETUP_MODEL_CONTEXT_WINDOW = 1000000;
 const DEFAULT_SETUP_MODEL_AUTO_COMPACT_TOKEN_LIMIT = 900000;
 const SHARED_MCP_REGISTRY_MARKER = "oh-my-codex (OMX) Shared MCP Registry Sync";
@@ -52,6 +59,7 @@ const OMX_EXPLORE_ROUTING_DEFAULT = '1';
 const OMX_EXPLORE_CMD_ENV = 'USE_OMX_EXPLORE_CMD';
 const OMX_TUI_STATUS_LINE =
   'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"]';
+const PORTABLE_BASH_GLOBAL_OMX_ROOT = "$(npm root -g)/oh-my-codex";
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
 
@@ -79,14 +87,17 @@ function getOmxTopLevelLines(
   pkgRoot: string,
   existingConfig = "",
   modelOverride?: string,
+  projectConfigStyle: ProjectConfigStyle = DEFAULT_PROJECT_CONFIG_STYLE,
 ): string[] {
-  const notifyHookPath = join(pkgRoot, "dist", "scripts", "notify-hook.js");
-  const escapedPath = escapeTomlString(notifyHookPath);
   const rootValues = parseRootKeyValues(existingConfig);
+  const notifyLine =
+    projectConfigStyle === "portable-bash"
+      ? `notify = ["bash", "-c", "${escapeTomlString(`node "${PORTABLE_BASH_GLOBAL_OMX_ROOT}/dist/scripts/notify-hook.js" "$1"`)}", "notify-hook"]`
+      : `notify = ["node", "${escapeTomlString(join(pkgRoot, "dist", "scripts", "notify-hook.js"))}"]`;
 
   const lines = [
     "# oh-my-codex top-level settings (must be before any [table])",
-    `notify = ["node", "${escapedPath}"]`,
+    notifyLine,
     'model_reasoning_effort = "high"',
     `developer_instructions = "You have oh-my-codex installed. AGENTS.md is your orchestration brain and the main orchestration surface. Use skill/keyword routing like $name plus spawned role-specialized subagents for specialized work. Codex native subagents are available via .codex/agents and may be used for independent parallel subtasks within a single session or team pane. Skills are loaded from installed SKILL.md files under .codex/skills, not from native agent TOMLs. Use workflow skills via $name when explicitly invoked or clearly routed by AGENTS.md. Treat installed prompts as narrower internal execution surfaces under AGENTS.md authority, even when user-facing docs prefer $name keywords."`,
   ];
@@ -710,19 +721,30 @@ function getSharedMcpRegistryBlock(
  * OMX table-section block (MCP servers, TUI).
  * Contains ONLY [table] sections — no bare keys.
  */
-function getOmxTablesBlock(pkgRoot: string, includeTui = true): string {
-  const stateServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "state-server.js"),
-  );
-  const memoryServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "memory-server.js"),
-  );
-  const codeIntelServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "code-intel-server.js"),
-  );
-  const traceServerPath = escapeTomlString(
-    join(pkgRoot, "dist", "mcp", "trace-server.js"),
-  );
+function getOmxTablesBlock(
+  pkgRoot: string,
+  includeTui = true,
+  projectConfigStyle: ProjectConfigStyle = DEFAULT_PROJECT_CONFIG_STYLE,
+): string {
+  const stateServerPath =
+    projectConfigStyle === "portable-bash"
+      ? undefined
+      : escapeTomlString(join(pkgRoot, "dist", "mcp", "state-server.js"));
+  const memoryServerPath =
+    projectConfigStyle === "portable-bash"
+      ? undefined
+      : escapeTomlString(join(pkgRoot, "dist", "mcp", "memory-server.js"));
+  const codeIntelServerPath =
+    projectConfigStyle === "portable-bash"
+      ? undefined
+      : escapeTomlString(join(pkgRoot, "dist", "mcp", "code-intel-server.js"));
+  const traceServerPath =
+    projectConfigStyle === "portable-bash"
+      ? undefined
+      : escapeTomlString(join(pkgRoot, "dist", "mcp", "trace-server.js"));
+  const portableBashCommand = 'command = "bash"';
+  const portableBashArgs = (scriptName: string) =>
+    `args = ["-c", "${escapeTomlString(`exec node "${PORTABLE_BASH_GLOBAL_OMX_ROOT}/dist/mcp/${scriptName}"`)}"]`;
 
   return [
     "",
@@ -733,29 +755,37 @@ function getOmxTablesBlock(pkgRoot: string, includeTui = true): string {
     "",
     "# OMX State Management MCP Server",
     "[mcp_servers.omx_state]",
-    'command = "node"',
-    `args = ["${stateServerPath}"]`,
+    projectConfigStyle === "portable-bash" ? portableBashCommand : 'command = "node"',
+    projectConfigStyle === "portable-bash"
+      ? portableBashArgs("state-server.js")
+      : `args = ["${stateServerPath}"]`,
     "enabled = true",
     "startup_timeout_sec = 5",
     "",
     "# OMX Project Memory MCP Server",
     "[mcp_servers.omx_memory]",
-    'command = "node"',
-    `args = ["${memoryServerPath}"]`,
+    projectConfigStyle === "portable-bash" ? portableBashCommand : 'command = "node"',
+    projectConfigStyle === "portable-bash"
+      ? portableBashArgs("memory-server.js")
+      : `args = ["${memoryServerPath}"]`,
     "enabled = true",
     "startup_timeout_sec = 5",
     "",
     "# OMX Code Intelligence MCP Server (LSP diagnostics, AST search)",
     "[mcp_servers.omx_code_intel]",
-    'command = "node"',
-    `args = ["${codeIntelServerPath}"]`,
+    projectConfigStyle === "portable-bash" ? portableBashCommand : 'command = "node"',
+    projectConfigStyle === "portable-bash"
+      ? portableBashArgs("code-intel-server.js")
+      : `args = ["${codeIntelServerPath}"]`,
     "enabled = true",
     "startup_timeout_sec = 10",
     "",
     "# OMX Trace MCP Server (agent flow timeline & statistics)",
     "[mcp_servers.omx_trace]",
-    'command = "node"',
-    `args = ["${traceServerPath}"]`,
+    projectConfigStyle === "portable-bash" ? portableBashCommand : 'command = "node"',
+    projectConfigStyle === "portable-bash"
+      ? portableBashArgs("trace-server.js")
+      : `args = ["${traceServerPath}"]`,
     "enabled = true",
     "startup_timeout_sec = 5",
     ...(includeTui
@@ -823,10 +853,12 @@ export function buildMergedConfig(
     pkgRoot,
     existing,
     options.modelOverride,
+    options.projectConfigStyle,
   );
   const tablesBlock = getOmxTablesBlock(
     pkgRoot,
     includeTui && !tuiUpsert.hadExistingTui,
+    options.projectConfigStyle,
   );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(
     options.sharedMcpServers ?? [],
@@ -834,7 +866,7 @@ export function buildMergedConfig(
     existing,
   );
 
-  let body = existing.trimEnd();
+  let body = existing.trim();
   if (sharedRegistryBlock) {
     body = body ? `${body}\n\n${sharedRegistryBlock}` : sharedRegistryBlock;
   }


### PR DESCRIPTION
## Summary
- add an opt-in `--project-config-style portable-bash` mode for `omx setup --scope project`
- generate OMX-managed notify and MCP launchers through `bash` + `npm root -g` instead of repo-local absolute paths
- persist project setup scope/style in `.omx/setup-scope.json` so reruns stay consistent
- document the portable setup flow in `README.md` and cover setup, refresh, uninstall, and idempotency with tests

## Why
Project-scoped setup currently embeds repo-local absolute paths for OMX-managed scripts. That breaks when the same repository is shared across macOS, Linux, and WSL machines, or when the repository/home path changes during migration.

This PR keeps the current behavior as the default and adds a Bash-friendly opt-in project config style for multi-machine workspaces and migrations.

## Verification
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/cli/__tests__/index.test.js dist/config/__tests__/generator-notify.test.js dist/config/__tests__/generator-idempotent.test.js dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/uninstall.test.js`