### PR TITLE
docs: remove inherited issue/help wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions and usage help
-    url: https://github.com/anthropics/claude-code/issues
-    about: For Claude Code-specific issues, report in the upstream tracker.
+    url: https://yeachan-heo.github.io/oh-my-codex-website/
+    about: For oh-my-codex usage questions, start with the OMX docs and guides.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 [![Discord](https://img.shields.io/discord/1452487457085063218?color=5865F2&logo=discord&logoColor=white&label=Discord)](https://discord.gg/PUwSMR9XNk)
 
 **Website:** https://yeachan-heo.github.io/oh-my-codex-website/  
-**Docs:** [Getting Started](./docs/getting-started.html) · [Agents](./docs/agents.html) · [Skills](./docs/skills.html) · [Integrations](./docs/integrations.html) · [Demo](./DEMO.md) · [OpenClaw guide](./docs/openclaw-integration.md)
+**Docs:** [Getting Started](./docs/getting-started.html) · [Agents](./docs/agents.html) · [Skills](./docs/skills.html) · [Integrations](./docs/integrations.html) · [Demo](./DEMO.md) · [OpenClaw guide](./docs/openclaw-integration.md)  
+**Community:** [Discord](https://discord.gg/PUwSMR9XNk) — shared OMX/community server for oh-my-codex and related tooling.
 
 OMX is a workflow layer for [OpenAI Codex CLI](https://github.com/openai/codex).
 


### PR DESCRIPTION
## Summary
- replace the leftover Claude Code issue-template help link with OMX docs wording
- add one short README note clarifying that the Discord link is a shared OMX/community server
- keep the change docs-only and limited to the two reported entry points

## Verification
- manual diff review
- confirmed `.github/ISSUE_TEMPLATE/config.yml` and `README.md` no longer contain `Claude Code` or the Anthropics tracker URL

Closes #1268
Closes #1269