### PR TITLE
fix: skip directory hits during Windows command resolution

### DIFF
--- a/src/utils/__tests__/platform-command.test.ts
+++ b/src/utils/__tests__/platform-command.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   buildPlatformCommandSpec,
@@ -169,6 +169,39 @@ describe('buildPlatformCommandSpec', () => {
       await rm(fakeBin, { recursive: true, force: true });
     }
   });
+
+  it('skips directory PATH candidates when resolving the PowerShell executable for .ps1 shims', async () => {
+    const shimBin = await mkdtemp(join(tmpdir(), 'omx-platform-ps1-shim-'));
+    const badPowerShellBin = await mkdtemp(join(tmpdir(), 'omx-platform-bad-powershell-'));
+    const goodPowerShellBin = await mkdtemp(join(tmpdir(), 'omx-platform-good-powershell-'));
+    try {
+      const ps1Path = join(shimBin, 'codex.ps1');
+      const powershellDirectory = join(badPowerShellBin, 'powershell');
+      const powershellExePath = join(goodPowerShellBin, 'powershell.exe');
+      await writeFile(ps1Path, '');
+      await mkdir(powershellDirectory, { recursive: true });
+      await writeFile(powershellExePath, '');
+
+      const spec = buildPlatformCommandSpec(
+        ps1Path,
+        ['--version'],
+        'win32',
+        {
+          PATH: [badPowerShellBin, goodPowerShellBin].join(delimiter),
+          PATHEXT: '.EXE;.CMD;.PS1',
+        },
+      );
+
+      assert.equal(spec.command, powershellExePath);
+      assert.deepEqual(spec.args.slice(0, 5), ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File']);
+      assert.equal(spec.args[5], ps1Path);
+      assert.notEqual(spec.command, powershellDirectory);
+    } finally {
+      await rm(shimBin, { recursive: true, force: true });
+      await rm(badPowerShellBin, { recursive: true, force: true });
+      await rm(goodPowerShellBin, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('resolveCommandPathForPlatform', () => {
@@ -190,6 +223,32 @@ describe('resolveCommandPathForPlatform', () => {
       );
     } finally {
       await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores directory candidates on Windows even when they appear before a real executable', async () => {
+    const badPowerShellBin = await mkdtemp(join(tmpdir(), 'omx-platform-path-dir-'));
+    const goodPowerShellBin = await mkdtemp(join(tmpdir(), 'omx-platform-path-exe-'));
+    try {
+      const powershellDirectory = join(badPowerShellBin, 'powershell');
+      const powershellExePath = join(goodPowerShellBin, 'powershell.exe');
+      await mkdir(powershellDirectory, { recursive: true });
+      await writeFile(powershellExePath, '');
+
+      assert.equal(
+        resolveCommandPathForPlatform(
+          'powershell',
+          'win32',
+          {
+            PATH: [badPowerShellBin, goodPowerShellBin].join(delimiter),
+            PATHEXT: '.EXE;.CMD;.PS1',
+          },
+        ),
+        powershellExePath,
+      );
+    } finally {
+      await rm(badPowerShellBin, { recursive: true, force: true });
+      await rm(goodPowerShellBin, { recursive: true, force: true });
     }
   });
 

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { statSync } from 'fs';
 import { spawnSync, type SpawnSyncOptionsWithStringEncoding, type SpawnSyncReturns } from 'child_process';
 import { basename, delimiter, dirname, extname, join, resolve } from 'path';
 
@@ -26,6 +26,14 @@ const NODE_HOSTED_SCRIPT_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
 const WINDOWS_NODE_HOSTED_COMMANDS: Record<string, string[]> = {
   codex: ['node_modules', '@openai', 'codex', 'bin', 'codex.js'],
 };
+
+function existsFileSync(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
 
 function isWindowsPathLike(command: string): boolean {
   return /^[A-Za-z]:/.test(command) || /[\\/]/.test(command);
@@ -175,7 +183,7 @@ export function resolveCommandPathForPlatform(
   command: string,
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
-  existsImpl: ExistsSyncLike = existsSync,
+  existsImpl: ExistsSyncLike = existsFileSync,
 ): string | null {
   if (platform === 'win32') {
     return resolveWindowsCommandPath(command, env, existsImpl);
@@ -188,7 +196,7 @@ export function buildPlatformCommandSpec(
   args: string[],
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
-  existsImpl: ExistsSyncLike = existsSync,
+  existsImpl: ExistsSyncLike = existsFileSync,
 ): PlatformCommandSpec {
   if (platform !== 'win32') {
     return { command, args: [...args] };
@@ -238,7 +246,7 @@ export function spawnPlatformCommandSync(
   options: SpawnSyncOptionsWithStringEncoding = { encoding: 'utf-8' },
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
-  existsImpl: ExistsSyncLike = existsSync,
+  existsImpl: ExistsSyncLike = existsFileSync,
   spawnImpl: SpawnSyncLike = spawnSync,
 ): ProbedPlatformCommand {
   const spec = buildPlatformCommandSpec(command, args, platform, env, existsImpl);


### PR DESCRIPTION
## Summary
- switch the default platform-command existence predicate from `existsSync` behavior to a file-only `statSync(...).isFile()` check
- add focused Windows regression tests that prove directory PATH candidates are skipped during command and PowerShell executable resolution
- keep the change scoped to the directory-vs-file bug in Windows command resolution

## Exact resolution path traced
1. `src/cli/index.ts#runCodexBlocking()` launches Codex via `spawnPlatformCommandSync("codex", ...)`.
2. `spawnPlatformCommandSync()` calls `buildPlatformCommandSpec()` in `src/utils/platform-command.ts`.
3. On Windows, `buildPlatformCommandSpec()` resolves the command with `resolveWindowsCommandPath()`.
4. If the resolved command is a `.ps1`, `buildPlatformCommandSpec()` calls `resolvePowerShellExecutable()`.
5. `resolvePowerShellExecutable()` calls `resolveWindowsCommandPath("powershell", ...)`.
6. Before this fix, the default resolver predicate treated any existing path as valid, including directories, so `C:\\Windows\\System32\\powershell` could be returned and then fail at spawn time with `ENOENT`.

## Reproduction / confirmation
- Confirmed the pre-fix resolver behavior with a small Node reproduction using the old `existsSync`-style logic: when PATH contained a `powershell/` directory before a real `powershell.exe`, resolution returned the directory.
- Locked that behavior down with tests that now require:
  - `resolveCommandPathForPlatform('powershell', 'win32', ...)` to skip directory candidates
  - `buildPlatformCommandSpec(<ps1 path>, ..., 'win32', ...)` to choose the real `powershell.exe` instead of a `powershell/` directory

## Verification
- `npm run build`
- `node --test dist/utils/__tests__/platform-command.test.js`
- `npx biome lint src/utils/platform-command.ts src/utils/__tests__/platform-command.test.ts`

Closes #1274.
