### PR TITLE
Make leader mailbox delivery failures observable without breaking live nudge behavior

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -37,7 +37,9 @@ if [[ "$cmd" == "capture-pane" ]]; then
   fi
   if [[ -n "\${OMX_TEST_CAPTURE_FILE:-}" && -f "\${OMX_TEST_CAPTURE_FILE}" ]]; then
     cat "\${OMX_TEST_CAPTURE_FILE}"
+    exit 0
   fi
+  printf "› ready\\n"
   exit 0
 fi
 if [[ "$cmd" == "display-message" ]]; then
@@ -620,6 +622,109 @@ exit 0
       else delete process.env.PATH;
       if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
       else delete process.env.TMUX_PANE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('leader-fixed dispatch fails without false notification when the resolved leader pane is in copy-mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    const prevPath = process.env.PATH;
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, 'tmux'),
+        `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  fmt=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -t)
+        shift
+        target="$1"
+        ;;
+      *)
+        fmt="$1"
+        ;;
+    esac
+    shift || true
+  done
+  if [[ "$fmt" == "#{pane_in_mode}" && "$target" == "%77" ]]; then
+    echo "1"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_id}" && "$target" == "%77" ]]; then
+    echo "%77"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_path}" ]]; then
+    dirname "${tmuxLogPath}"
+    exit 0
+  fi
+  if [[ "$fmt" == "#{pane_current_command}" && "$target" == "%77" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$fmt" == "#S" ]]; then
+    echo "devsess"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  printf "%%77\\t1\\tcodex\\tcodex\\n"
+  exit 0
+fi
+exit 0
+`,
+      );
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      process.env.PATH = `${fakeBinDir}:${prevPath || ''}`;
+
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      const cfg = await readTeamConfig('alpha', cwd);
+      assert.ok(cfg);
+      if (!cfg) throw new Error('missing team config');
+      cfg.leader_pane_id = '%77';
+      await saveTeamConfig(cfg, cwd);
+
+      const msg = await sendDirectMessage('alpha', 'worker-1', 'leader-fixed', 'hello leader', cwd);
+      const queued = await enqueueDispatchRequest('alpha', {
+        kind: 'mailbox',
+        to_worker: 'leader-fixed',
+        message_id: msg.message_id,
+        trigger_message: 'Read .omx/state/team/alpha/mailbox/leader-fixed.json; worker-1 sent a new message. Review it and decide the next concrete step.',
+      }, cwd);
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({ cwd, maxPerTick: 5 });
+      assert.equal(result.processed, 1);
+      assert.equal(result.failed, 1);
+
+      const request = await readDispatchRequest('alpha', queued.request.request_id, cwd);
+      assert.equal(request?.status, 'failed');
+      assert.equal(request?.last_reason, 'scroll_active');
+
+      const mailbox = await listMailboxMessages('alpha', 'leader-fixed', cwd);
+      const mailboxMessage = mailbox.find((entry) => entry.message_id === msg.message_id);
+      assert.equal(mailboxMessage?.notified_at, undefined, 'guard failure should not mark leader mailbox message notified');
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(tmuxLog, /display-message -p -t %77 #\{pane_in_mode\}/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %77/, 'copy-mode leader pane must not receive injected keys');
+    } finally {
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1184,6 +1184,102 @@ exit 0
     });
   });
 
+  it('injects leader nudge when capture-pane fails but the leader pane is a live codex pane', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'capture-failure-live-leader';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'capture-failure-live-leader:0',
+        leader_pane_id: '%74',
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'm1',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'please review capture failure path',
+            created_at: '2026-03-12T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%74" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%74" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  echo "capture failed" >&2
+  exit 1
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /capture-pane -t %74 -p -S -80/);
+      assert.match(tmuxLog, /send-keys -t %74/, 'capture failures should not suppress leader injection into a live codex pane');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      if (existsSync(eventsPath)) {
+        const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+        const deferred = events.find((entry: { type?: string }) => entry.type === 'leader_notification_deferred');
+        assert.equal(deferred, undefined, 'capture failure alone should not defer a live codex leader pane');
+      }
+    });
+  });
+
   it('does not inject leader nudge while leader pane is in copy-mode', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
@@ -41,6 +41,31 @@ function runSendPaneInputInChild(params: {
   });
 }
 
+function runEvaluatePaneInjectionReadinessInChild(params: {
+  fakeBinDir: string;
+  moduleUrl: string;
+  paneTarget: string;
+  options?: Record<string, unknown>;
+}) {
+  const payload = JSON.stringify({
+    paneTarget: params.paneTarget,
+    options: params.options ?? {},
+  });
+  const script = `
+    import { evaluatePaneInjectionReadiness } from ${JSON.stringify(params.moduleUrl)};
+    const input = ${payload};
+    const result = await evaluatePaneInjectionReadiness(input.paneTarget, input.options);
+    process.stdout.write(JSON.stringify(result));
+  `;
+  return spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      PATH: `${params.fakeBinDir}:${process.env.PATH ?? ''}`,
+    },
+  });
+}
+
 describe('notify-hook team tmux guard bridge', () => {
   it('submits without typing when typePrompt=false', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-tmux-guard-'));
@@ -107,6 +132,115 @@ describe('notify-hook team tmux guard bridge', () => {
       const lines = log.trim().split('\n').filter(Boolean);
       assert.equal(lines.length, 2);
       assert.match(lines[1], /send-keys -t %42 C-m/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports pane_not_ready with capture context when the pane is not input-ready', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-tmux-guard-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, 'tmux'),
+        `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  format="\${@: -1}"
+  if [[ "$format" == "#{pane_current_command}" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_in_mode}" ]]; then
+    echo "0"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  printf "loading workspace state...\\n"
+  exit 0
+fi
+exit 0
+`,
+      );
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const moduleUrl = new URL('../../../dist/scripts/notify-hook/team-tmux-guard.js', import.meta.url).href;
+      const result = runEvaluatePaneInjectionReadinessInChild({
+        fakeBinDir,
+        moduleUrl,
+        paneTarget: '%42',
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.error, undefined);
+      const parsed = JSON.parse(result.stdout);
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.reason, 'pane_not_ready');
+      assert.equal(parsed.paneCurrentCommand, 'codex');
+      assert.match(parsed.paneCapture, /loading workspace state/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats capture-pane failure as non-blocking for a live codex pane', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-tmux-guard-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, 'tmux'),
+        `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  format="\${@: -1}"
+  if [[ "$format" == "#{pane_current_command}" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_in_mode}" ]]; then
+    echo "0"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  echo "capture failed" >&2
+  exit 1
+fi
+exit 0
+`,
+      );
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const moduleUrl = new URL('../../../dist/scripts/notify-hook/team-tmux-guard.js', import.meta.url).href;
+      const result = runEvaluatePaneInjectionReadinessInChild({
+        fakeBinDir,
+        moduleUrl,
+        paneTarget: '%42',
+        options: { skipIfScrolling: true },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.error, undefined);
+      const parsed = JSON.parse(result.stdout);
+      assert.equal(parsed.ok, true);
+      assert.equal(parsed.reason, 'ok');
+      assert.equal(parsed.paneCurrentCommand, 'codex');
+      assert.equal(parsed.paneCapture, '');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -373,6 +373,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
   if (!target) {
     return { ok: false, reason: 'missing_tmux_target' };
   }
+  const leaderTargeted = request.to_worker === 'leader-fixed';
   let resolution;
   if (target.type === 'session') {
     const paneId = await resolveSessionToPane(target.value).catch(() => null);
@@ -385,14 +386,24 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
   if (!resolution.paneTarget) {
     return { ok: false, reason: `target_resolution_failed:${resolution.reason}` };
   }
+  const isLeaderMailboxDispatch = request.to_worker === 'leader-fixed';
   const paneGuard = await evaluatePaneInjectionReadiness(resolution.paneTarget, {
     skipIfScrolling: true,
-    requireRunningAgent: false,
+    requireRunningAgent: leaderTargeted,
     requireReady: false,
     requireIdle: false,
+    requireObservableState: leaderTargeted,
   });
   if (!paneGuard.ok) {
-    return { ok: false, reason: paneGuard.reason };
+    return {
+      ok: false,
+      reason: paneGuard.reason,
+      pane: resolution.paneTarget,
+      pane_source: resolution.source || null,
+      readiness_evidence: paneGuard.readinessEvidence || null,
+      pane_current_command: paneGuard.paneCurrentCommand || null,
+      tmux_injection_attempted: false,
+    };
   }
 
   const attemptCountAtStart = Number.isFinite(request.attempt_count)
@@ -428,7 +439,15 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
     typePrompt: shouldTypePrompt,
   });
   if (!sendResult.ok) {
-    return { ok: false, reason: sendResult.error || sendResult.reason };
+    return {
+      ok: false,
+      reason: sendResult.error || sendResult.reason,
+      pane: resolution.paneTarget,
+      pane_source: resolution.source || null,
+      readiness_evidence: paneGuard.readinessEvidence || null,
+      pane_current_command: paneGuard.paneCurrentCommand || null,
+      tmux_injection_attempted: true,
+    };
   }
 
   // Post-injection verification: confirm the trigger text was consumed.
@@ -449,7 +468,15 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       // Worker is actively processing (mirrors sync path tmux-session.ts:1292-1294)
       if (paneHasActiveTask(wideCap.stdout)) {
         runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir);
-        return { ok: true, reason: 'tmux_send_keys_confirmed_active_task', pane: resolution.paneTarget };
+        return {
+          ok: true,
+          reason: 'tmux_send_keys_confirmed_active_task',
+          pane: resolution.paneTarget,
+          pane_source: resolution.source || null,
+          readiness_evidence: paneGuard.readinessEvidence || null,
+          pane_current_command: paneGuard.paneCurrentCommand || null,
+          tmux_injection_attempted: true,
+        };
       }
       // Do not declare success while a *worker* pane is still bootstrapping / not
       // input-ready. Otherwise a pre-ready send can be marked "confirmed" and later
@@ -462,7 +489,15 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       const triggerNearTail = capturedPaneContainsTriggerNearTail(wideCap.stdout, request.trigger_message);
       if (!triggerInNarrow && !triggerNearTail) {
         runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir);
-        return { ok: true, reason: 'tmux_send_keys_confirmed', pane: resolution.paneTarget };
+        return {
+          ok: true,
+          reason: 'tmux_send_keys_confirmed',
+          pane: resolution.paneTarget,
+          pane_source: resolution.source || null,
+          readiness_evidence: paneGuard.readinessEvidence || null,
+          pane_current_command: paneGuard.paneCurrentCommand || null,
+          tmux_injection_attempted: true,
+        };
       }
     } catch {
       // capture failed; fall through to retry C-m
@@ -477,7 +512,15 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
   }
 
   // Trigger text is still visible after all retry rounds.
-  return { ok: true, reason: 'tmux_send_keys_unconfirmed', pane: resolution.paneTarget };
+  return {
+    ok: true,
+    reason: 'tmux_send_keys_unconfirmed',
+    pane: resolution.paneTarget,
+    pane_source: resolution.source || null,
+    readiness_evidence: paneGuard.readinessEvidence || null,
+    pane_current_command: paneGuard.paneCurrentCommand || null,
+    tmux_injection_attempted: true,
+  };
 }
 
 function shouldSkipRequest(request) {
@@ -511,6 +554,19 @@ async function appendDeliveryTelemetry(logsDir, event) {
     source: 'notify-hook.team-dispatch',
     ...event,
   }).catch(() => {});
+}
+
+function buildDispatchAttemptEvidence(result, fallback = {}) {
+  return {
+    pane_target: safeString(result?.pane || fallback.pane || '').trim() || null,
+    pane_source: safeString(result?.pane_source || fallback.pane_source || '').trim() || null,
+    readiness_evidence: safeString(result?.readiness_evidence || fallback.readiness_evidence || '').trim() || null,
+    pane_current_command: safeString(result?.pane_current_command || fallback.pane_current_command || '').trim() || null,
+    tmux_injection_attempted:
+      typeof result?.tmux_injection_attempted === 'boolean'
+        ? result.tmux_injection_attempted
+        : (typeof fallback.tmux_injection_attempted === 'boolean' ? fallback.tmux_injection_attempted : null),
+  };
 }
 
 export async function drainPendingTeamDispatch({
@@ -589,6 +645,10 @@ export async function drainPendingTeamDispatch({
               tmux_session: safeString(config?.tmux_session).trim() || null,
               leader_pane_id: safeString(config?.leader_pane_id).trim() || null,
               tmux_injection_attempted: false,
+              pane_target: null,
+              pane_source: null,
+              readiness_evidence: null,
+              pane_current_command: null,
             });
             await appendDeliveryTelemetry(logsDir, {
               event: 'dispatch_result',
@@ -669,6 +729,7 @@ export async function drainPendingTeamDispatch({
               worker: request.to_worker,
               attempt: request.attempt_count,
               reason: result.reason,
+              ...buildDispatchAttemptEvidence(result),
             });
             await appendDeliveryTelemetry(logsDir, {
               event: 'dispatch_result',
@@ -706,6 +767,7 @@ export async function drainPendingTeamDispatch({
               worker: request.to_worker,
               message_id: request.message_id || null,
               reason: request.last_reason,
+              ...buildDispatchAttemptEvidence(result),
             });
             await appendDeliveryTelemetry(logsDir, {
               event: 'dispatch_result',
@@ -748,6 +810,7 @@ export async function drainPendingTeamDispatch({
             worker: request.to_worker,
             message_id: request.message_id || null,
             reason: result.reason,
+            ...buildDispatchAttemptEvidence(result),
           });
           await appendDeliveryTelemetry(logsDir, {
             event: 'dispatch_result',
@@ -774,6 +837,7 @@ export async function drainPendingTeamDispatch({
             worker: request.to_worker,
             message_id: request.message_id || null,
             reason: result.reason,
+            ...buildDispatchAttemptEvidence(result),
           });
           await appendDeliveryTelemetry(logsDir, {
             event: 'dispatch_result',

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -11,6 +11,7 @@ import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-i
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
+import { resolvePaneTarget } from './tmux-injection.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
@@ -610,7 +611,21 @@ export async function maybeNudgeTeamLeader({
       : [];
     const canonicalLeaderPaneId = safeString(leaderPaneId).trim();
     if (!tmuxSession && !canonicalLeaderPaneId) continue;
-    const tmuxTarget = canonicalLeaderPaneId;
+    let tmuxTarget = canonicalLeaderPaneId;
+    if (canonicalLeaderPaneId) {
+      const resolvedLeaderTarget = await resolvePaneTarget(
+        { type: 'pane', value: canonicalLeaderPaneId },
+        '',
+        canonicalLeaderPaneId,
+        '',
+        {},
+      ).catch(() => null);
+      if (resolvedLeaderTarget?.paneTarget) {
+        tmuxTarget = safeString(resolvedLeaderTarget.paneTarget).trim();
+      } else if (resolvedLeaderTarget && ['target_is_hud_pane', 'pane_cwd_mismatch'].includes(safeString(resolvedLeaderTarget.reason).trim())) {
+        tmuxTarget = '';
+      }
+    }
     const paneStatus = tmuxSession
       ? await checkWorkerPanesAlive(tmuxSession, workerPaneIds)
       : { alive: false, paneCount: 0 };
@@ -814,6 +829,8 @@ export async function maybeNudgeTeamLeader({
           leader_pane_id: leaderPaneId || null,
           tmux_session: tmuxSession || null,
           tmux_injection_attempted: false,
+          pane_target: tmuxTarget,
+          readiness_evidence: paneGuard.readinessEvidence || null,
           pane_current_command: paneGuard.paneCurrentCommand || null,
           injection_skip_reason: paneGuard.reason,
           source_type: 'leader_nudge',

--- a/src/scripts/notify-hook/team-tmux-guard.ts
+++ b/src/scripts/notify-hook/team-tmux-guard.ts
@@ -10,6 +10,8 @@ import {
   paneLooksReady,
 } from '../tmux-hook-engine.js';
 
+export const PANE_READINESS_UNVERIFIED_REASON = 'pane_readiness_unverified';
+
 export function mapPaneInjectionReadinessReason(reason: any): any {
   return reason === 'pane_running_shell' ? 'agent_not_running' : reason;
 }
@@ -20,7 +22,10 @@ export async function evaluatePaneInjectionReadiness(paneTarget: any, {
   requireRunningAgent = true,
   requireReady = true,
   requireIdle = true,
+  requireObservableState = false,
+  requireCaptureEvidence = undefined,
 } = {}): Promise<any> {
+  const normalizedRequireObservableState = typeof requireCaptureEvidence === 'boolean' ? requireCaptureEvidence : requireObservableState;
   const target = safeString(paneTarget).trim();
   if (!target) {
     return {
@@ -52,6 +57,15 @@ export async function evaluatePaneInjectionReadiness(paneTarget: any, {
 
   let paneCurrentCommand = '';
   let paneRunningShell = false;
+  const buildReadinessResult = (ok: boolean, reason: string, paneCapture: string, readinessEvidence: string) => ({
+    ok,
+    sent: false,
+    reason,
+    paneTarget: target,
+    paneCurrentCommand,
+    paneCapture,
+    readinessEvidence,
+  });
   try {
     const result = await runProcess('tmux', buildPaneCurrentCommandArgv(target), 1000);
     paneCurrentCommand = safeString(result.stdout).trim();
@@ -63,40 +77,33 @@ export async function evaluatePaneInjectionReadiness(paneTarget: any, {
   try {
     const capture = await runProcess('tmux', buildCapturePaneArgv(target, captureLines), 1000);
     const paneCapture = safeString(capture.stdout);
-    if (paneCapture.trim() !== '') {
+    const hasCaptureEvidence = paneCapture.trim() !== '';
+    if (hasCaptureEvidence) {
       const paneShowsLiveAgent = paneLooksReady(paneCapture) || paneHasActiveTask(paneCapture);
       if (paneRunningShell && !paneShowsLiveAgent) {
-        return {
-          ok: false,
-          sent: false,
-          reason: 'pane_running_shell',
-          paneTarget: target,
-          paneCurrentCommand,
-          paneCapture,
-        };
+        return buildReadinessResult(false, 'pane_running_shell', paneCapture, 'captured');
       }
       if (requireIdle && paneHasActiveTask(paneCapture)) {
-        return {
-          ok: false,
-          sent: false,
-          reason: 'pane_has_active_task',
-          paneTarget: target,
-          paneCurrentCommand,
-          paneCapture,
-        };
+        return buildReadinessResult(false, 'pane_has_active_task', paneCapture, 'captured');
       }
       if (requireReady && !paneLooksReady(paneCapture)) {
+        return buildReadinessResult(false, 'pane_not_ready', paneCapture, 'captured');
+      }
+      if (normalizedRequireObservableState && !paneShowsLiveAgent) {
+        return buildReadinessResult(false, PANE_READINESS_UNVERIFIED_REASON, paneCapture, 'captured_unverified');
+      }
+      if (requireObservableState && !paneShowsLiveAgent) {
         return {
           ok: false,
           sent: false,
-          reason: 'pane_not_ready',
+          reason: 'pane_state_unverified',
           paneTarget: target,
           paneCurrentCommand,
           paneCapture,
         };
       }
     }
-    if (paneRunningShell && paneCapture.trim() === '') {
+    if (paneRunningShell && !hasCaptureEvidence) {
       return {
         ok: false,
         sent: false,
@@ -106,33 +113,18 @@ export async function evaluatePaneInjectionReadiness(paneTarget: any, {
         paneCapture,
       };
     }
-    return {
-      ok: true,
-      sent: false,
-      reason: 'ok',
-      paneTarget: target,
-      paneCurrentCommand,
-      paneCapture,
-    };
+    if (normalizedRequireObservableState && !hasCaptureEvidence && !paneCurrentCommand) {
+      return buildReadinessResult(false, PANE_READINESS_UNVERIFIED_REASON, paneCapture, 'capture_empty');
+    }
+    return buildReadinessResult(true, 'ok', paneCapture, hasCaptureEvidence ? 'captured' : (paneCurrentCommand ? 'command_only' : 'none'));
   } catch {
     if (paneRunningShell) {
-      return {
-        ok: false,
-        sent: false,
-        reason: 'pane_running_shell',
-        paneTarget: target,
-        paneCurrentCommand,
-        paneCapture: '',
-      };
+      return buildReadinessResult(false, 'pane_running_shell', '', 'capture_failed');
     }
-    return {
-      ok: true,
-      sent: false,
-      reason: 'ok',
-      paneTarget: target,
-      paneCurrentCommand,
-      paneCapture: '',
-    };
+    if (normalizedRequireObservableState) {
+      return buildReadinessResult(false, PANE_READINESS_UNVERIFIED_REASON, '', 'capture_failed');
+    }
+    return buildReadinessResult(true, 'ok', '', paneCurrentCommand ? 'command_only' : 'none');
   }
 }
 

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -529,6 +529,63 @@ describe('executeTeamApiOperation: mailbox-mark-delivered', () => {
     }
   });
 
+  it('marks leader-fixed mailbox delivery from a worker worktree and resolves the matching dispatch receipt', async () => {
+    const teamName = 'mark-dlv-leader-worktree';
+    const repoCwd = await mkdtemp(join(tmpdir(), 'omx-interop-mark-dlv-root-'));
+    const workerCwd = await mkdtemp(join(tmpdir(), 'omx-interop-mark-dlv-worktree-'));
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+
+    try {
+      await initTeamState(teamName, 'leader mailbox delivery receipt', 'executor', 2, repoCwd);
+      process.env.OMX_TEAM_STATE_ROOT = join(repoCwd, '.omx', 'state');
+
+      const sendResult = await executeTeamApiOperation('send-message', {
+        team_name: teamName,
+        from_worker: 'worker-1',
+        to_worker: 'leader-fixed',
+        body: 'DONE: worker-1 finished a mailbox integrity probe',
+      }, workerCwd);
+      assert.equal(sendResult.ok, true);
+      if (!sendResult.ok) throw new Error('expected successful leader send-message result');
+
+      const message = sendResult.data.message as Record<string, unknown>;
+      const messageId = String(message.message_id ?? '');
+      assert.ok(messageId, 'leader mailbox message should include a message_id');
+
+      const pendingRequests = await listDispatchRequests(teamName, repoCwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+      const pendingDispatch = pendingRequests.find((request) => request.message_id === messageId);
+      assert.ok(pendingDispatch, 'leader mailbox send should enqueue a matching dispatch request');
+
+      const result = await executeTeamApiOperation('mailbox-mark-delivered', {
+        team_name: teamName,
+        worker: 'leader-fixed',
+        message_id: messageId,
+      }, workerCwd);
+      assert.equal(result.ok, true);
+      if (!result.ok) throw new Error('expected successful leader mailbox-mark-delivered result');
+      assert.equal(result.data.updated, true);
+      assert.equal(result.data.dispatch_request_id, pendingDispatch?.request_id);
+      assert.equal(result.data.dispatch_updated, true);
+
+      const updatedDispatch = await readDispatchRequest(teamName, pendingDispatch!.request_id, repoCwd);
+      assert.equal(updatedDispatch?.status, 'delivered');
+      assert.ok(updatedDispatch?.delivered_at, 'leader dispatch receipt should record delivered_at');
+
+      const leaderMailbox = JSON.parse(await readFile(
+        join(repoCwd, '.omx', 'state', 'team', teamName, 'mailbox', 'leader-fixed.json'),
+        'utf-8',
+      )) as { messages?: Array<Record<string, unknown>> };
+      const deliveredMessage = (leaderMailbox.messages ?? []).find((entry) => entry.message_id === messageId);
+      assert.equal(typeof deliveredMessage?.delivered_at, 'string');
+    } finally {
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(repoCwd, { recursive: true, force: true });
+      await rm(workerCwd, { recursive: true, force: true });
+    }
+  });
+
   it('reports when no matching mailbox dispatch request exists', async () => {
     const { cwd, cleanup } = await setupTeam('mark-dlv-no-dispatch');
     try {


### PR DESCRIPTION
## Summary
- make worker -> leader mailbox delivery attempts record explicit pane/readiness/injection evidence in the dispatch path
- keep leader-targeted copy-mode and related non-success states explicit without over-claiming successful delivery
- preserve current leader nudge behavior for live Codex panes while tightening the dispatch-side integrity surface
- add targeted regression coverage for dispatch, leader nudge, tmux guard, and leader mailbox receipt interop

Closes #1278

## Problem statement
The worker -> `leader-fixed` path still had a narrow but important integrity gap.

Mailbox persistence itself was not the main failure anymore. The remaining problem sat in the post-mailbox seam:
- which pane was actually targeted
- whether the leader-targeted pane had enough observable readiness evidence
- whether dispatch state could look more successful than the real in-pane delivery state
- whether tests clearly separated dispatch-side false-success prevention from leader-nudge operator semantics

That meant the runtime could still become hard to reason about under copy-mode / readiness / stale-pane style failures even after earlier fixes in the same area.

## Root cause
The seam was still mixing two different concerns:

1. **Dispatch correctness** — the runtime needs explicit evidence for pane target, readiness, and injection attempts so a failed or ambiguous leader-targeted dispatch does not look healthier than it is.
2. **Leader nudge operator behavior** — the live leader nudge path still needs to behave like an operator-facing prompt path for active Codex panes, not like a strictly gated dispatch receipt path.

When those two concerns are handled with the same strictness, one of two bad outcomes appears:
- dispatch remains too opaque, or
- leader nudges become over-gated and stop surfacing live mailbox activity.

## What changed
1. **Dispatch evidence hardening**
   - enriched leader-targeted dispatch outcomes with attempt-local evidence such as pane target, pane source, readiness evidence, current pane command, and whether tmux injection was attempted
   - made leader-targeted copy-mode / similar non-success outcomes explicit in the dispatch path instead of letting them blur into generic failures

2. **Guard semantics cleanup**
   - tightened the guard-side readiness contract for leader-targeted dispatch accounting
   - aligned the tmux-guard regression surface around the canonical readiness failure reason taxonomy used by the new dispatch evidence path

3. **Leader nudge compatibility preservation**
   - kept the existing live leader nudge behavior intact for Codex panes so this PR does not silently convert a mailbox-integrity fix into a broader leader-nudge redesign
   - kept the notify-hook leader-context authority-handoff test aligned with the current implementation contract instead of broadening semantics inside this PR

4. **Regression coverage**
   - expanded targeted tests for:
     - leader-targeted pane targeting
     - stale HUD vs canonical Codex pane resolution
     - copy-mode / non-success handling
     - tmux-guard readiness semantics
     - leader mailbox receipt marking through API interop

## Why this design
This PR intentionally uses the smallest effective move.

The repo already has an open roadmap issue (#1243) and an overlapping open PR (#1277) in the same runtime seam. A broad redesign here would multiply review risk, cross-wire contracts, and make it harder to tell whether the mailbox-integrity fix itself worked.

So this PR keeps the current feature shape and makes one narrow distinction explicit:
- **dispatch** becomes more evidence-driven
- **leader nudge** keeps current operator semantics unless a separate follow-up explicitly changes that contract

That gets the seam into a less misleading state without pretending this PR solves the whole notify-hook authority model.

## Overlap assessment
- **Follow-up:** #1243 — this PR is one concrete delivery-integrity slice under that roadmap.
- **Adjacent but distinct:** #1221 — that issue fixed busy live Codex leader nudge queueing; this PR keeps that behavior intact while tightening dispatch-side evidence.
- **Adjacent but distinct:** #1222 — that issue covered false `INTEGRATED` success at the leader branch level; this PR focuses on worker -> leader mailbox delivery evidence and pane/readiness accounting.
- **Adjacent but distinct:** #1250 — that PR aligned failed dispatch receipts with the audited delivery contract; this PR adds richer attempt evidence plus targeted regression coverage around leader-targeted dispatch / guard behavior.
- **Adjacent but overlapping:** #1277 — that open PR focuses on leader-nudge pane resolution and delivery verification. This PR is broader on the dispatch / tmux-guard side and preserves the current leader-nudge contract rather than redefining the leader-context authority boundary.
- **Classification:** adjacent but distinct follow-up within the same runtime seam.

## Validation
Clean delivery branch verification:
- `npm ci`
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-hook-team-tmux-guard.test.js`
- `npx @biomejs/biome lint src/scripts/notify-hook/team-dispatch.ts src/scripts/notify-hook/team-leader-nudge.ts src/scripts/notify-hook/team-tmux-guard.ts src/hooks/__tests__/notify-hook-team-dispatch.test.ts src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts src/team/__tests__/api-interop.test.ts`

Result:
- build passed
- targeted suite passed (`61` tests, `0` failed)
- focused lint passed

## Risk / compatibility
- **Intended behavior change:** leader-targeted dispatch now carries clearer attempt evidence and explicit non-success context.
- **Intended behavior preserved:** live leader nudge behavior for active Codex panes remains compatible with the current operator flow.
- **Not changed here:** broader notify-hook authority-handoff redesign, full runtime state-machine refactor, or global mailbox/leader semantics beyond this seam.
- **Residual risk:** this PR is deliberately scoped; broader runtime / notify-hook authority boundaries still belong to separate follow-up work under #1243.

## Files changed
- `src/scripts/notify-hook/team-dispatch.ts`
- `src/scripts/notify-hook/team-leader-nudge.ts`
- `src/scripts/notify-hook/team-tmux-guard.ts`
- `src/hooks/__tests__/notify-hook-team-dispatch.test.ts`
- `src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts`
- `src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts`
- `src/team/__tests__/api-interop.test.ts`
