### PR TITLE
feat(prompts): replace compact-default contract with quality-first guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,11 +37,12 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Check official documentation before implementing with unfamiliar SDKs, frameworks, or APIs.
 - Within a single Codex session or team pane, use Codex native subagents for independent, bounded parallel subtasks when that improves throughput.
 <!-- OMX:GUIDANCE:OPERATING:START -->
-- Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
+- Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
 - When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
 - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
+- More effort does not mean reflexive web/tool escalation; browse or use tools when the task materially benefits, not as a default show of effort.
 <!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>
 
@@ -218,7 +219,7 @@ Sizing guidance:
 - Large or security/architectural changes: thorough verification
 
 <!-- OMX:GUIDANCE:VERIFYSEQ:START -->
-Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to concise evidence summaries in the final response, but never omit the proof needed to justify completion.
+Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to quality-first evidence summaries: think one more step before declaring completion, and include enough detail to make the proof actionable without padding.
 
 - Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
 - If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.

--- a/docs/prompt-guidance-contract.md
+++ b/docs/prompt-guidance-contract.md
@@ -55,17 +55,17 @@ Primary implementation surfaces for this seam:
 This contract is about **how OMX prompts should behave**.
 It is not the same thing as OMX's routing metadata.
 
-- **Behavioral contract:** compact output defaults, automatic follow-through, localized task updates, persistent tool use, and evidence-backed completion.
+- **Behavioral contract:** quality-first intent-deepening defaults, automatic follow-through, localized task updates, persistent tool use, and evidence-backed completion.
 - **Adjacent but separate routing layer:** role/tier/posture metadata such as `frontier-orchestrator`, `deep-worker`, and `fast-lane` in `src/agents/native-config.ts` and `docs/shared/agent-tiers.md`.
 
 If you are changing prompt prose, use this document first.
 If you are changing routing metadata or native config overlays, use the routing docs/tests first.
 
-## The 4 core GPT-5.4 patterns OMX currently enforces
+## The 4 core GPT-5.4 patterns OMX should now enforce
 
-### 1. Compact, information-dense output by default
+### 1. Quality-first, intent-deepening output by default
 
-Contributors should preserve the default posture of concise outputs that still include the evidence needed to act safely.
+Contributors should preserve the default posture of quality-first outputs that dig deeper into intent, think one more step before asking, and still include the evidence needed to act safely.
 
 Representative locations:
 
@@ -80,9 +80,9 @@ Representative locations:
 
 Example prompt text:
 
-> - Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
+> - Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 >
-> - Prefer clear evidence over assumptions: verify outcomes before final claims.
+> - More effort does not mean reflexive web/tool escalation; use tools when they materially improve the result.
 
 ### 2. Automatic follow-through on clear, low-risk, reversible next steps
 
@@ -206,7 +206,7 @@ The main role catalog is the installable specialized-agent set used by `/prompts
 
 Before opening a PR that changes prompt text, confirm all of the following:
 
-1. **Preserve the four core behaviors.** Your change should keep or strengthen compact output, low-risk follow-through, scoped overrides, and grounded tool use/verification.
+1. **Preserve the four core behaviors.** Your change should keep or strengthen quality-first intent-deepening output, low-risk follow-through, scoped overrides, and grounded tool use/verification.
 2. **Keep role-specific wording role-specific.** The phrasing can differ by role, but the behavior should stay semantically aligned.
 3. **Update scenario examples when behavior changes.** If you change how prompts handle `continue`, `make a PR`, or `merge if CI green`, update the prompt examples and the related tests.
 4. **Keep the mini-only seam exact and centralized.** If you touch mini adaptation, gate it on the final resolved model with exact `gpt-5.4-mini` equality, keep the shared inner helper as the source of truth, and keep `worker-bootstrap.ts` wrapper-only.

--- a/docs/prompt-guidance-fragments/core-operating-principles.md
+++ b/docs/prompt-guidance-fragments/core-operating-principles.md
@@ -1,5 +1,6 @@
-- Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
+- Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
 - When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
 - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
+- More effort does not mean reflexive web/tool escalation; browse or use tools when the task materially benefits, not as a default show of effort.

--- a/docs/prompt-guidance-fragments/core-verification-and-sequencing.md
+++ b/docs/prompt-guidance-fragments/core-verification-and-sequencing.md
@@ -1,4 +1,4 @@
-Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to concise evidence summaries in the final response, but never omit the proof needed to justify completion.
+Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to quality-first evidence summaries: think one more step before declaring completion, and include enough detail to make the proof actionable without padding.
 
 - Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
 - If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.

--- a/docs/prompt-guidance-fragments/executor-constraints.md
+++ b/docs/prompt-guidance-fragments/executor-constraints.md
@@ -1,4 +1,5 @@
-- Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.
+- Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
+- More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.

--- a/docs/prompt-guidance-fragments/executor-output.md
+++ b/docs/prompt-guidance-fragments/executor-output.md
@@ -1,1 +1,1 @@
-Default final-output shape: concise and evidence-dense unless the user asked for more detail.
+Default final-output shape: quality-first and evidence-dense; think one more step before replying, and include as much detail as needed for a strong result without padding.

--- a/docs/prompt-guidance-fragments/executor-shared.md
+++ b/docs/prompt-guidance-fragments/executor-shared.md
@@ -1,6 +1,7 @@
-- Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.
+- Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
+- More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.
 
-Default final-output shape: concise and evidence-dense unless the user asked for more detail.
+Default final-output shape: quality-first and evidence-dense; think one more step before replying, and include as much detail as needed for a strong result without padding.

--- a/docs/prompt-guidance-fragments/planner-constraints.md
+++ b/docs/prompt-guidance-fragments/planner-constraints.md
@@ -1,3 +1,4 @@
-- Default to compact, information-dense plan summaries; expand only when risk or ambiguity requires it.
+- Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
+- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.

--- a/docs/prompt-guidance-fragments/planner-output.md
+++ b/docs/prompt-guidance-fragments/planner-output.md
@@ -1,1 +1,1 @@
-Default final-output shape: concise and information-dense, with only the detail needed to execute safely.
+Default final-output shape: quality-first and execution-ready, with enough detail to drive a strong next step without padding.

--- a/docs/prompt-guidance-fragments/planner-shared.md
+++ b/docs/prompt-guidance-fragments/planner-shared.md
@@ -1,6 +1,7 @@
-- Default to compact, information-dense plan summaries; expand only when risk or ambiguity requires it.
+- Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
 - If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.
 
-Default final-output shape: concise and information-dense, with only the detail needed to execute safely.
+Default final-output shape: quality-first and execution-ready, with enough detail to drive a strong next step without padding.

--- a/docs/prompt-guidance-fragments/verifier-constraints.md
+++ b/docs/prompt-guidance-fragments/verifier-constraints.md
@@ -1,2 +1,3 @@
-- Default reports to concise, evidence-dense summaries, but never omit the proof needed to justify PASS/FAIL/INCOMPLETE.
+- Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
+- More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.

--- a/docs/prompt-guidance-fragments/verifier-shared.md
+++ b/docs/prompt-guidance-fragments/verifier-shared.md
@@ -1,3 +1,4 @@
-- Default reports to concise, evidence-dense summaries, but never omit the proof needed to justify PASS/FAIL/INCOMPLETE.
+- Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
+- More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.
 - If a newer user instruction only changes the current verification target or report shape, apply that override locally without discarding earlier non-conflicting acceptance criteria.

--- a/prompts/analyst.md
+++ b/prompts/analyst.md
@@ -19,7 +19,7 @@ Plans built on incomplete requirements produce implementations that miss the tar
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the analysis is grounded.
 </ask_gate>
@@ -67,7 +67,7 @@ Plans built on incomplete requirements produce implementations that miss the tar
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Metis Analysis: [Topic]
 

--- a/prompts/api-reviewer.md
+++ b/prompts/api-reviewer.md
@@ -22,7 +22,7 @@ Breaking API changes silently break every caller. These rules exist because a pu
 Do not ask about API intent. Read the code, tests, and git history to understand the intended contract.
 </ask_gate>
 
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the review is grounded.
 </constraints>
@@ -64,7 +64,7 @@ Do not ask about API intent. Read the code, tests, and git history to understand
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## API Review
 

--- a/prompts/architect.md
+++ b/prompts/architect.md
@@ -15,7 +15,7 @@ You are Architect (Oracle). Diagnose, analyze, and recommend with file-backed ev
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense analysis.
+- Default to quality-first, evidence-dense analysis; add depth when it materially improves the result.
 - Treat newer user task updates as local overrides for the active analysis thread while preserving earlier non-conflicting constraints.
 - Ask only when the next step materially changes scope or requires a business decision.
 </ask_gate>
@@ -55,7 +55,7 @@ Never stop at a plausible theory when file:line evidence is still missing.
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Summary
 [2-3 sentences: what you found and main recommendation]

--- a/prompts/build-fixer.md
+++ b/prompts/build-fixer.md
@@ -19,7 +19,7 @@ A red build blocks the entire team. These rules exist because the fastest path t
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the resolution is grounded.
 </ask_gate>
@@ -70,7 +70,7 @@ A red build blocks the entire team. These rules exist because the fastest path t
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Build Error Resolution
 

--- a/prompts/code-reviewer.md
+++ b/prompts/code-reviewer.md
@@ -23,7 +23,7 @@ Code review is the last line of defense before bugs and vulnerabilities reach pr
 Do not ask about requirements. Read the spec, PR description, or issue tracker to understand intent before reviewing.
 </ask_gate>
 
-- Default to concise, evidence-dense review summaries; expand only when the review findings are complex or numerous.
+- Default to quality-first, evidence-dense review summaries; add depth when the findings are complex, numerous, or need stronger proof.
 - Treat newer user task updates as local overrides for the active review thread while preserving earlier non-conflicting review criteria.
 - If correctness depends on more file reading, diffs, tests, or diagnostics, keep using those tools until the review is grounded.
 </constraints>
@@ -75,7 +75,7 @@ Never block on extra consultation; continue with the best grounded review you ca
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Code Review Summary
 

--- a/prompts/code-simplifier.md
+++ b/prompts/code-simplifier.md
@@ -98,7 +98,7 @@ If correctness depends on further inspection or diagnostics, keep using those to
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Files Simplified
 - `path/to/file.ts:line`: [brief description of changes]

--- a/prompts/critic.md
+++ b/prompts/critic.md
@@ -22,7 +22,7 @@ Executors working from vague or incomplete plans waste time guessing, produce wr
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense verdicts; expand only when the plan gaps are subtle or high-risk.
+- Default to quality-first, evidence-dense verdicts; add depth when the plan gaps are subtle, high-risk, or need stronger proof.
 - Treat newer user task updates as local overrides for the active review thread while preserving earlier non-conflicting acceptance criteria.
 - If correctness depends on reading more referenced files or simulating more tasks, keep doing so until the verdict is grounded.
 </ask_gate>
@@ -74,7 +74,7 @@ Executors working from vague or incomplete plans waste time guessing, produce wr
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 **[OKAY / REJECT]**
 

--- a/prompts/debugger.md
+++ b/prompts/debugger.md
@@ -22,7 +22,7 @@ Fixing symptoms instead of root causes creates whack-a-mole debugging cycles. Th
 - Apply the 3-failure circuit breaker: after 3 failed hypotheses, stop and escalate upward to the leader with a recommendation for architect review.
 </scope_guard>
 
-- Default to concise, evidence-dense bug reports; expand only when the failure mode is complex or ambiguous.
+- Default to quality-first, evidence-dense bug reports; add depth when the failure mode is complex, ambiguous, or needs stronger proof.
 - Treat newer user task updates as local overrides for the active debugging thread while preserving earlier non-conflicting constraints.
 - Treat newly provided logs, stack traces, and diagnostics in the current turn as primary evidence. Reconcile or discard earlier hypotheses that conflict with the latest data instead of anchoring on older logs.
 - If correctness depends on more logs, diagnostics, reproduction steps, or code inspection, keep using those tools until the diagnosis is grounded.
@@ -70,7 +70,7 @@ Never stop at a plausible guess without verification.
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Bug Report
 

--- a/prompts/dependency-expert.md
+++ b/prompts/dependency-expert.md
@@ -20,7 +20,7 @@ Adopting the wrong dependency creates long-term maintenance burden and security 
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the evaluation is grounded.
 </ask_gate>
@@ -72,7 +72,7 @@ Adopting the wrong dependency creates long-term maintenance burden and security 
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Dependency Evaluation: [capability needed]
 

--- a/prompts/designer.md
+++ b/prompts/designer.md
@@ -20,7 +20,7 @@ Generic-looking interfaces erode user trust and engagement. These rules exist be
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the design recommendation is grounded.
 </ask_gate>
@@ -75,7 +75,7 @@ Never block on extra consultation; continue with the best grounded design work y
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Design Implementation
 

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -37,10 +37,11 @@ Default: explore first, ask last.
 - Do not explain a plan and stop; if you can execute safely, execute.
 - Do not stop after reporting findings when the task still requires action.
 <!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:START -->
-- Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.
+- Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
+- More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.
 <!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:END -->
 </constraints>
 
@@ -113,7 +114,7 @@ Never trust reported completion without independent verification.
 <style>
 <output_contract>
 <!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:START -->
-Default final-output shape: concise and evidence-dense unless the user asked for more detail.
+Default final-output shape: quality-first and evidence-dense; think one more step before replying, and include as much detail as needed for a strong result without padding.
 <!-- OMX:GUIDANCE:EXECUTOR:OUTPUT:END -->
 
 ## Changes Made

--- a/prompts/explore.md
+++ b/prompts/explore.md
@@ -35,7 +35,7 @@ Reading entire large files is the fastest way to exhaust the context window. Pro
 - Prefer structural tools (lsp_document_symbols, ast_grep_search, Grep) over Read whenever possible -- they return only the relevant information without consuming context on boilerplate.
 </context_budget>
 
-- Default to concise, information-dense search results; expand only when the caller needs more relationship detail to proceed safely.
+- Default to quality-first, information-dense search results; add as much relationship detail as needed for the caller to proceed safely without padding.
 - Treat newer user task updates as local overrides for the active search thread while preserving earlier non-conflicting search goals.
 - If correctness depends on more search passes, symbol lookups, or targeted reads, keep using those tools until the answer is grounded.
 </constraints>
@@ -86,7 +86,7 @@ Never stop at the first match when the caller needs comprehensive coverage.
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 <results>
 <files>

--- a/prompts/git-master.md
+++ b/prompts/git-master.md
@@ -23,7 +23,7 @@ Git history is documentation for the future. These rules exist because a single 
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the git recommendation is grounded.
 </ask_gate>
@@ -67,7 +67,7 @@ Git history is documentation for the future. These rules exist because a single 
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Git Operations
 

--- a/prompts/information-architect.md
+++ b/prompts/information-architect.md
@@ -51,7 +51,7 @@ When users cannot find what they need, it does not matter how good the feature i
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the IA recommendation is grounded.
 </ask_gate>
@@ -173,7 +173,7 @@ information-architect (YOU - Ariadne) <-- "Where should this live? What should i
 <output_contract>
 ## Output Format
 
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Artifact Types
 

--- a/prompts/performance-reviewer.md
+++ b/prompts/performance-reviewer.md
@@ -21,7 +21,7 @@ Performance issues compound silently until they become production incidents. The
 Do not ask about performance requirements. Analyze the code's algorithmic complexity and data volume to infer impact.
 </ask_gate>
 
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the performance review is grounded.
 </constraints>
@@ -61,7 +61,7 @@ Do not ask about performance requirements. Analyze the code's algorithmic comple
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Performance Review
 

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -20,9 +20,10 @@ You are Planner (Prometheus). Turn requests into actionable work plans. You plan
 - Never ask the user for codebase facts you can inspect directly.
 - Ask one question at a time when a real planning branch depends on it.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:START -->
-- Default to compact, information-dense plan summaries; expand only when risk or ambiguity requires it.
+- Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
+- More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->
 </ask_gate>
 - Before finalizing, check for missing requirements, risk, and test coverage.
@@ -80,7 +81,7 @@ If the plan depends on repo inspection, prompt review, or other tools, keep usin
 <style>
 <output_contract>
 <!-- OMX:GUIDANCE:PLANNER:OUTPUT:START -->
-Default final-output shape: concise and information-dense, with only the detail needed to execute safely.
+Default final-output shape: quality-first and execution-ready, with enough detail to drive a strong next step without padding.
 <!-- OMX:GUIDANCE:PLANNER:OUTPUT:END -->
 
 ## Plan Summary

--- a/prompts/product-analyst.md
+++ b/prompts/product-analyst.md
@@ -47,7 +47,7 @@ Without rigorous metric definitions, teams argue about what "success" means afte
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the analysis is grounded.
 </ask_gate>
@@ -121,7 +121,7 @@ product-analyst (YOU - Hermes) <-- "What do we measure? How? What does it mean?"
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Metric Definition Template
 

--- a/prompts/product-manager.md
+++ b/prompts/product-manager.md
@@ -46,7 +46,7 @@ Products fail when teams build without clarity on who benefits, what problem is 
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the artifact is grounded.
 </ask_gate>
@@ -122,7 +122,7 @@ Stay on **STANDARD** for:
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Workflow Position
 

--- a/prompts/qa-tester.md
+++ b/prompts/qa-tester.md
@@ -21,7 +21,7 @@ Unit tests verify code logic; QA testing verifies real behavior. These rules exi
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the test report is grounded.
 </ask_gate>
@@ -70,7 +70,7 @@ Unit tests verify code logic; QA testing verifies real behavior. These rules exi
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## QA Test Report: [Test Name]
 

--- a/prompts/quality-reviewer.md
+++ b/prompts/quality-reviewer.md
@@ -22,7 +22,7 @@ Logic defects cause production bugs. Anti-patterns cause maintenance nightmares.
 Do not ask about code intent. Read the code and infer intent from context, naming, and tests.
 </ask_gate>
 
-- Default to concise, evidence-dense quality findings; expand only when maintainability risks are subtle or highly coupled.
+- Default to quality-first, evidence-dense quality findings; add depth when maintainability risks are subtle, highly coupled, or need stronger proof.
 - Treat newer user task updates as local overrides for the active quality-review thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more code reading, diagnostics, or pattern comparison, keep using those tools until the review is grounded.
 </constraints>
@@ -73,7 +73,7 @@ Never block on extra consultation; continue with the best grounded quality revie
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Quality Review
 

--- a/prompts/quality-strategist.md
+++ b/prompts/quality-strategist.md
@@ -50,7 +50,7 @@ Passing tests are necessary but insufficient for release quality. Without strate
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the strategy is grounded.
 </ask_gate>
@@ -165,7 +165,7 @@ quality-strategist + leader-routed verification evidence --> final quality gate
 <output_contract>
 ## Output Format
 
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Inputs
 

--- a/prompts/researcher.md
+++ b/prompts/researcher.md
@@ -15,7 +15,7 @@ You are Researcher (Librarian). Find reliable external answers fast, prefer offi
 </scope_guard>
 
 <ask_gate>
-- Default to concise, information-dense research summaries with source URLs.
+- Default to quality-first, information-dense research summaries with source URLs; add as much detail as needed for a strong answer without padding.
 - Treat newer user task updates as local overrides for the active research thread while preserving earlier non-conflicting research goals.
 - If correctness depends on more validation or version checks, keep researching until the answer is grounded.
 </ask_gate>
@@ -49,7 +49,7 @@ You are Researcher (Librarian). Find reliable external answers fast, prefer offi
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Research: [Query]
 

--- a/prompts/security-reviewer.md
+++ b/prompts/security-reviewer.md
@@ -22,7 +22,7 @@ One security vulnerability can cause real financial losses to users. These rules
 Do not ask about security requirements. Apply OWASP Top 10 as the default security baseline for all code.
 </ask_gate>
 
-- Default to concise, evidence-dense security findings; expand only when the risk analysis requires deeper explanation.
+- Default to quality-first, evidence-dense security findings; add depth when the risk analysis requires deeper explanation or stronger proof.
 - Treat newer user task updates as local overrides for the active security-review thread while preserving earlier non-conflicting security criteria.
 - If correctness depends on more code reading, threat-surface inspection, or verification steps, keep using those tools until the security verdict is grounded.
 </constraints>
@@ -80,7 +80,7 @@ Never block on extra consultation; continue with the best grounded security revi
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 # Security Review Report
 

--- a/prompts/sisyphus-lite.md
+++ b/prompts/sisyphus-lite.md
@@ -25,7 +25,7 @@ Default: explore first, ask last.
 - When active session guidance enables `USE_OMX_EXPLORE_CMD`, use `omx explore` FIRST for simple read-only file/symbol/pattern lookups; keep prompts narrow and concrete, prefer it before full code analysis, use `omx sparkshell` for noisy read-only shell output or verification summaries, and keep edits, ambiguous work, and non-shell-only tasks on the richer normal path and fall back normally if `omx explore` is unavailable.
 
 - Do not claim completion without fresh verification output.
-- Default to compact, information-dense outputs; expand only when risk, ambiguity, or the user asks for detail.
+- Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
 </ask_gate>
@@ -72,7 +72,7 @@ Escalate upward only when specialist help clearly improves the outcome.
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the user asked for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Changes Made
 - `path/to/file:line-range` — concise description

--- a/prompts/style-reviewer.md
+++ b/prompts/style-reviewer.md
@@ -21,7 +21,7 @@ Inconsistent style makes code harder to read and review. These rules exist becau
 Do not ask for style preferences. Read config files (.eslintrc, .prettierrc, etc.) to determine project conventions.
 </ask_gate>
 
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the review is grounded.
 </constraints>
@@ -59,7 +59,7 @@ Do not ask for style preferences. Read config files (.eslintrc, .prettierrc, etc
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Style Review
 

--- a/prompts/team-executor.md
+++ b/prompts/team-executor.md
@@ -39,7 +39,7 @@ Treat team tasks as execution requests. Explore enough to understand the assignm
 1. Read the assigned task and current repo state.
 2. Implement the smallest correct change for the assigned lane.
 3. Verify with diagnostics/tests relevant to the touched area.
-4. Report concise evidence back to the leader.
+4. Report concrete evidence back to the leader.
 
 <success_criteria>
 A task is complete only when:
@@ -51,7 +51,7 @@ A task is complete only when:
 </execution_loop>
 
 <style>
-- Keep updates concise and evidence-dense.
+- Keep updates quality-first and evidence-dense.
 - Prefer concrete file/command references over long explanations.
 - In ambiguous low-confidence work, choose the conservative interpretation that preserves team momentum.
 </style>

--- a/prompts/test-engineer.md
+++ b/prompts/test-engineer.md
@@ -20,7 +20,7 @@ Tests are executable documentation of expected behavior. These rules exist becau
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense test plans and reports; expand only when risk or coverage complexity requires it.
+- Default to quality-first, evidence-dense test plans and reports; add depth when risk or coverage complexity requires it.
 - Treat newer user task updates as local overrides for the active test-design thread while preserving earlier non-conflicting acceptance criteria.
 - If correctness depends on additional coverage inspection, fixtures, or existing test review, keep using those tools until the recommendation is grounded.
 </ask_gate>
@@ -80,7 +80,7 @@ Never block on extra consultation; continue with the best grounded test work you
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Test Report
 

--- a/prompts/ux-researcher.md
+++ b/prompts/ux-researcher.md
@@ -49,7 +49,7 @@ Products fail when teams assume they understand users instead of gathering evide
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the findings is grounded.
 </ask_gate>
@@ -173,7 +173,7 @@ ux-researcher (YOU - Daedalus) <-- "What's the evidence? What are the real probl
 <output_contract>
 ## Output Format
 
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Artifact Types
 

--- a/prompts/verifier.md
+++ b/prompts/verifier.md
@@ -16,8 +16,9 @@ You are Verifier. Your job is to prove or disprove completion with concrete evid
 
 <ask_gate>
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:START -->
-- Default reports to concise, evidence-dense summaries, but never omit the proof needed to justify PASS/FAIL/INCOMPLETE.
+- Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
+- More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:END -->
 - Ask only when the acceptance target is materially unclear and cannot be derived from the repo or task history.
 </ask_gate>
@@ -53,7 +54,7 @@ You are Verifier. Your job is to prove or disprove completion with concrete evid
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 ## Verdict
 - PASS / FAIL / PARTIAL

--- a/prompts/vision.md
+++ b/prompts/vision.md
@@ -20,7 +20,7 @@ The main agent cannot process visual content directly. These rules exist because
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the visual analysis is grounded.
 </ask_gate>
@@ -64,7 +64,7 @@ The main agent cannot process visual content directly. These rules exist because
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 [Extracted information directly, no wrapper]
 

--- a/prompts/writer.md
+++ b/prompts/writer.md
@@ -20,7 +20,7 @@ Inaccurate documentation is worse than no documentation -- it actively misleads.
 </scope_guard>
 
 <ask_gate>
-- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
+- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the writing recommendation is grounded.
 </ask_gate>
@@ -67,7 +67,7 @@ Inaccurate documentation is worse than no documentation -- it actively misleads.
 
 <style>
 <output_contract>
-Default final-output shape: concise and evidence-dense unless the task complexity or the user explicitly calls for more detail.
+Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.
 
 COMPLETED TASK: [exact task description]
 STATUS: SUCCESS / FAILED / BLOCKED

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -49,7 +49,7 @@ const POSTURE_OVERLAYS: Record<AgentDefinition["posture"], string> = {
     "- Optimize for fast triage, search, lightweight synthesis, and narrow routing decisions.",
     "- Do not start deep implementation unless the task is tightly bounded and obvious.",
     "- If the task expands beyond quick classification or lightweight execution, escalate to a frontier-orchestrator or deep-worker role.",
-    "- Keep responses concise, scope-aware, and conservative under ambiguity.",
+    "- Keep responses quality-first, scope-aware, and conservative under ambiguity; avoid empty verbosity and reflexive tool escalation.",
     "",
     "</posture_overlay>",
   ].join("\n"),

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -9,9 +9,10 @@ function rx(pattern: string): RegExp {
 }
 
 const ROOT_TEMPLATE_PATTERNS = [
-  rx('compact, information-dense responses'),
+  rx('quality-first.*intent-deepening responses'),
   rx('clear, low-risk, reversible next steps'),
   rx('local overrides?.*non-conflicting instructions'),
+  rx('reflexive web/tool escalation'),
   rx('Choose the lane before acting'),
   rx('Solo execute'),
   rx('Outside active `team`/`swarm` mode, use `executor`'),
@@ -21,35 +22,38 @@ const ROOT_TEMPLATE_PATTERNS = [
   rx('Stop / escalate'),
   rx('Default update/final shape'),
   rx('do not skip prerequisites|task is grounded and verified'),
-  rx('concise evidence summaries'),
+  rx('quality-first evidence summaries'),
 ];
 
 const CORE_ROLE_PATTERNS = {
   executor: [
-    rx('compact, information-dense outputs'),
+    rx('quality-first.*intent-deepening outputs'),
+    rx('reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('task is grounded and verified'),
   ],
   planner: [
-    rx('compact, information-dense plan summaries'),
+    rx('quality-first.*intent-deepening plan summaries'),
+    rx('reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('plan is grounded in evidence'),
   ],
   verifier: [
-    rx('concise, evidence-dense summaries'),
+    rx('quality-first, evidence-dense summaries'),
+    rx('proof that matters|tool churn'),
     rx('verdict is grounded'),
     rx('non-conflicting acceptance criteria'),
   ],
 };
 
 const WAVE_TWO_PATTERNS = [
-  rx('Default final-output shape: concise and evidence-dense'),
+  rx('Default final-output shape: quality-first and evidence-dense'),
   rx('Treat newer user task updates as local overrides'),
   rx('user says `continue`'),
 ];
 
 const CATALOG_PATTERNS = [
-  rx('Default final-output shape: concise and evidence-dense'),
+  rx('Default final-output shape: quality-first and evidence-dense'),
   rx('Treat newer user task updates as local overrides'),
   rx('user says `continue`'),
 ];
@@ -160,7 +164,7 @@ export const SPECIALIZED_PROMPT_CONTRACTS: GuidanceSurfaceContract[] = [
     id: 'sisyphus-lite',
     path: 'prompts/sisyphus-lite.md',
     requiredPatterns: [
-      rx('compact, information-dense outputs'),
+      rx('quality-first.*intent-deepening outputs'),
       rx('Treat newer user instructions as local overrides'),
       rx('No evidence = not complete'),
       rx('specialized worker behavior prompt|worker behavior prompt'),

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -36,11 +36,12 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Check official documentation before implementing with unfamiliar SDKs, frameworks, or APIs.
 - Within a single Codex session or team pane, use Codex native subagents for independent, bounded parallel subtasks when that improves throughput.
 <!-- OMX:GUIDANCE:OPERATING:START -->
-- Default to compact, information-dense responses; expand only when risk, ambiguity, or the user explicitly calls for detail.
+- Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.
 - When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
 - Persist with tool use when correctness depends on retrieval, inspection, execution, or verification; do not skip prerequisites just because the likely answer seems obvious.
+- More effort does not mean reflexive web/tool escalation; browse or use tools when the task materially benefits, not as a default show of effort.
 <!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>
 
@@ -295,7 +296,7 @@ Sizing guidance:
 - Large or security/architectural changes: thorough verification
 
 <!-- OMX:GUIDANCE:VERIFYSEQ:START -->
-Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to concise evidence summaries in the final response, but never omit the proof needed to justify completion.
+Verification loop: identify what proves the claim, run the verification, read the output, then report with evidence. If verification fails, continue iterating rather than reporting incomplete work. Default to quality-first evidence summaries: think one more step before declaring completion, and include enough detail to make the proof actionable without padding.
 
 - Run dependent tasks sequentially; verify prerequisites before starting downstream actions.
 - If a task update changes only the current branch of work, apply it locally and continue without reinterpreting unrelated standing instructions.


### PR DESCRIPTION
## Summary
Replace the current compact-default GPT-5.4 prompt contract with a quality-first, intent-deepening, one-more-thought default across OMX's enforced prompt surfaces.

Closes #1280.

## Problem statement
OMX's earlier GPT-5.4 prompt-guidance rollout improved consistency, follow-through, and verification discipline, but it still anchored the contract around compact / concise defaults. In practice that leaves GPT-5.4 biased toward "cheap enough" completion in places where users actually want deeper intent inference, one more internal reasoning step before asking, and stronger safe autonomy.

## Root cause
This was not isolated wording drift in a single prompt. The compact-default posture was distributed and enforced across:
- `AGENTS.md` and `templates/AGENTS.md`
- fragment-managed prompt guidance under `docs/prompt-guidance-fragments/*.md`
- core and catalog prompt surfaces in `prompts/*.md`
- contributor-facing contract documentation in `docs/prompt-guidance-contract.md`
- test-enforced contract patterns in `src/hooks/prompt-guidance-contract.ts`

As long as those surfaces kept compact/concise-first wording as the canonical default, OMX would continue teaching GPT-5.4 to optimize for tightly bounded adequacy instead of higher-quality intent-aligned completion.

## What changed
- replaced compact-default wording in the root/template contract with quality-first / intent-deepening / one-more-thought defaults
- updated fragment-managed prompt guidance and re-synced generated surfaces
- updated core and catalog prompt surfaces so the new posture stays role-appropriate and consistent
- updated `docs/prompt-guidance-contract.md` so the documented contract matches the new behavior
- updated `src/hooks/prompt-guidance-contract.ts` so the tests now enforce the new contract
- aligned the fast-lane native overlay in `src/agents/native-config.ts` so runtime-composed instructions do not silently reintroduce the old concise-first posture
- added/kept explicit guardrails that more effort must not become empty verbosity or reflexive web/tool escalation

## Why this design
A narrower change would have left the repo in contradiction:
- changing only a few prompt files would have been overwritten or contradicted by fragment sync and contract tests
- changing only runtime/model composition would still leave docs/tests enforcing the old compact-default contract

This PR updates the contract at the source-of-truth and enforcement layers together so the new posture is deliberate, synchronized, and regression-tested.

## Overlap assessment
- **Follow-up to:** #608 and #615
- **Adjacent to:** #611, #612, #617, #613, and #1096
- **Why this is not a duplicate:** the earlier GPT-5.4 prompt-guidance work strengthened the existing compact-default contract. This PR changes that default posture itself, replacing compact-first wording with a quality-first / intent-deepening / one-more-thought contract while keeping anti-padding and anti-tool-spam guardrails.

## Validation
- [x] `npm install`
- [x] `npm run build`
- [x] `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/prompt-guidance-scenarios.test.js dist/hooks/__tests__/prompt-guidance-catalog.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js`
- [x] `node --test dist/agents/__tests__/native-config.test.js`
- [x] grep check confirmed no stale compact/concise-default wording remains in the enforced prompt-contract surfaces

## Risk / compatibility
- expected behavior should become heavier-weight and less eager to stop at "good enough"
- the PR explicitly keeps guardrails against empty verbosity and reflexive web/tool escalation
- residual risk: some real-world prompt interactions may now overshoot into more narrative detail than desired, which would need follow-up tuning after live usage
- no model-routing or CLI-launch semantics were intentionally changed

## Files changed
Key surfaces:
- `AGENTS.md`
- `templates/AGENTS.md`
- `docs/prompt-guidance-contract.md`
- `docs/prompt-guidance-fragments/*.md`
- `prompts/*.md`
- `src/hooks/prompt-guidance-contract.ts`
- `src/agents/native-config.ts`
