### PR TITLE
Fix tmux relaunches for relative dist/cli/omx.js launchers

### DIFF
--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { parseSandboxContract } from '../../autoresearch/contracts.js';
@@ -17,8 +17,10 @@ import {
   parseInitArgs,
   checkTmuxAvailable,
   runAutoresearchNoviceBridge,
+  spawnAutoresearchTmux,
   type AutoresearchQuestionIO,
 } from '../autoresearch-guided.js';
+import { OMX_ENTRY_PATH_ENV, OMX_STARTUP_CWD_ENV } from '../../utils/paths.js';
 
 async function initRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-guided-test-'));
@@ -52,6 +54,10 @@ function makeFakeIo(answers: string[]): AutoresearchQuestionIO {
     },
     close(): void {},
   };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 describe('initAutoresearchMission', () => {
@@ -203,6 +209,76 @@ describe('checkTmuxAvailable', () => {
   it('returns a boolean', () => {
     const result = checkTmuxAvailable();
     assert.equal(typeof result, 'boolean');
+  });
+
+  it('launches background tmux sessions with an absolute omx entry path even from a relative launcher', async () => {
+    const repo = await initRepo();
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-guided-bin-'));
+    const startupCwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-guided-start-'));
+    const missionDir = join(repo, 'missions', 'demo');
+    const tmuxLog = join(repo, 'tmux.log');
+    const previousPath = process.env.PATH;
+    const previousEntryPath = process.env[OMX_ENTRY_PATH_ENV];
+    const previousStartupCwd = process.env[OMX_STARTUP_CWD_ENV];
+
+    try {
+      await mkdir(missionDir, { recursive: true });
+      const launcherDir = join(startupCwd, 'dist', 'cli');
+      const launcherPath = join(launcherDir, 'omx.js');
+      await mkdir(launcherDir, { recursive: true });
+      await writeFile(launcherPath, '#!/usr/bin/env node\n', 'utf-8');
+
+      const fakeTmuxPath = join(fakeBin, 'tmux');
+      await writeFile(
+        fakeTmuxPath,
+        `#!/bin/sh
+printf '%s\n' "$*" >>"${tmuxLog}"
+case "$1" in
+  -V)
+    exit 0
+    ;;
+  has-session)
+    exit 1
+    ;;
+  new-session)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        'utf-8',
+      );
+      execFileSync('chmod', ['+x', fakeTmuxPath], { stdio: 'ignore' });
+
+      process.env.PATH = `${fakeBin}:${previousPath || ''}`;
+      delete process.env[OMX_ENTRY_PATH_ENV];
+      process.env[OMX_STARTUP_CWD_ENV] = startupCwd;
+
+      const previousArgv = process.argv;
+      process.argv = [previousArgv[0] || 'node', 'dist/cli/omx.js'];
+      try {
+        spawnAutoresearchTmux(missionDir, 'demo');
+      } finally {
+        process.argv = previousArgv;
+      }
+
+      const tmuxOutput = await readFile(tmuxLog, 'utf-8');
+      assert.match(tmuxOutput, /new-session -d -s omx-autoresearch-demo/);
+      assert.match(tmuxOutput, new RegExp(escapeRegExp(launcherPath)));
+      assert.doesNotMatch(tmuxOutput, /dist\/cli\/omx\.js autoresearch/);
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousEntryPath === 'string') process.env[OMX_ENTRY_PATH_ENV] = previousEntryPath;
+      else delete process.env[OMX_ENTRY_PATH_ENV];
+      if (typeof previousStartupCwd === 'string') process.env[OMX_STARTUP_CWD_ENV] = previousStartupCwd;
+      else delete process.env[OMX_STARTUP_CWD_ENV];
+      await rm(repo, { recursive: true, force: true });
+      await rm(fakeBin, { recursive: true, force: true });
+      await rm(startupCwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -5,6 +5,7 @@ import { mkdir, writeFile } from 'fs/promises';
 import { dirname, join, relative, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { type AutoresearchKeepPolicy, parseSandboxContract, slugifyMissionName } from '../autoresearch/contracts.js';
+import { resolveOmxEntryPath } from '../utils/paths.js';
 import {
   buildMissionContent,
   buildSandboxContent,
@@ -264,7 +265,7 @@ export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
     );
   }
 
-  const omxPath = resolve(join(__dirname, '..', '..', 'bin', 'omx.js'));
+  const omxPath = resolveOmxEntryPath() ?? resolve(join(__dirname, 'omx.js'));
   const cmd = `${shellQuote(process.execPath)} ${shellQuote(omxPath)} autoresearch ${shellQuote(missionDir)}`;
 
   execFileSync('tmux', ['new-session', '-d', '-s', sessionName, cmd], { stdio: 'ignore',

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -26,6 +26,7 @@ import {
 } from './autoresearch-intake.js';
 import { CODEX_BYPASS_FLAG, MADMAX_FLAG } from './constants.js';
 import { restoreStandaloneHudPane, enableMouseScrolling } from '../team/tmux-session.js';
+import { resolveOmxEntryPath } from '../utils/paths.js';
 
 export const AUTORESEARCH_HELP = `omx autoresearch - Launch OMX autoresearch with thin-supervisor parity semantics
 
@@ -329,7 +330,7 @@ function launchAutoresearchInSplitPane(args: {
   const currentCwd = tmuxDisplay(paneId, '#{pane_current_path}') || args.repoRoot;
   const existingHudPaneIds = listHudWatchPaneIdsInCurrentWindow(paneId);
 
-  const omxPath = process.argv[1];
+  const omxPath = resolveOmxEntryPath();
   if (!omxPath) return false;
   // Re-enter through the bare compatibility alias so the new pane executes immediately
   // instead of recursively taking the split-pane branch again.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -75,9 +75,11 @@ import {
   isTmuxAvailable,
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
-import { codexConfigPath } from "../utils/paths.js";
+import { codexConfigPath, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
 import { repairConfigIfNeeded } from "../config/generator.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
+
+rememberOmxLaunchContext();
 import {
   classifySpawnError,
   spawnPlatformCommandSync,
@@ -2003,7 +2005,10 @@ function runCodex(
     sessionModelInstructionsPath(cwd, sessionId),
   );
   const nativeWindows = isNativeWindows();
-  const omxBin = process.argv[1];
+  const omxBin = resolveOmxEntryPath();
+  if (!omxBin) {
+    throw new Error("Unable to resolve OMX launcher path for tmux HUD bootstrap");
+  }
   const hudCmd = nativeWindows
     ? buildWindowsPromptCommand("node", [omxBin, "hud", "--watch"])
     : buildTmuxPaneCommand("node", [omxBin, "hud", "--watch"]);

--- a/src/cli/omx.ts
+++ b/src/cli/omx.ts
@@ -6,10 +6,13 @@
 import { fileURLToPath, pathToFileURL } from 'url';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
+import { rememberOmxLaunchContext } from '../utils/paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const root = join(__dirname, '..', '..');
+
+rememberOmxLaunchContext();
 
 // Execute compiled entrypoint
 const distEntry = join(root, 'dist', 'cli', 'index.js');

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -16,6 +16,7 @@ import type { HudFlags, HudPreset, HudRenderContext, ResolvedHudConfig } from '.
 import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { sleep } from '../utils/sleep.js';
 import { runHudAuthorityTick } from './authority.js';
+import { resolveOmxEntryPath } from '../utils/paths.js';
 
 export const HUD_USAGE = [
   'Usage:',
@@ -263,7 +264,11 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
     process.exit(1);
   }
 
-  const omxBin = process.argv[1]; // path to bin/omx.js
+  const omxBin = resolveOmxEntryPath();
+  if (!omxBin) {
+    console.error('Failed to resolve OMX launcher path for tmux HUD startup.');
+    process.exit(1);
+  }
   const args = buildTmuxSplitArgs(cwd, omxBin, flags.preset);
 
   try {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -51,6 +51,7 @@ import {
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import * as tmuxSessionModule from '../tmux-session.js';
+import { OMX_ENTRY_PATH_ENV, OMX_STARTUP_CWD_ENV } from '../../utils/paths.js';
 
 function withEmptyPath<T>(fn: () => T): T {
   const prev = process.env.PATH;
@@ -2094,6 +2095,61 @@ esac
       if (typeof prevWslInterop === 'string') process.env.WSL_INTEROP = prevWslInterop;
       else delete process.env.WSL_INTEROP;
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('restores standalone HUD panes with an absolute OMX entry path after cwd drift', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-relative-hud-'));
+    const startupCwd = await mkdtemp(join(tmpdir(), 'omx-standalone-relative-start-'));
+    const previousEntryPath = process.env[OMX_ENTRY_PATH_ENV];
+    const previousStartupCwd = process.env[OMX_STARTUP_CWD_ENV];
+    const previousArgv = process.argv;
+
+    try {
+      const launcherDir = join(startupCwd, 'dist', 'cli');
+      const launcherPath = join(launcherDir, 'omx.js');
+      await mkdir(launcherDir, { recursive: true });
+      await writeFile(launcherPath, '#!/usr/bin/env node\n');
+
+      await withMockTmuxFixture(
+        'omx-tmux-relative-standalone-hud-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  split-window)
+    echo "%44"
+    exit 0
+    ;;
+  run-shell|select-pane|resize-pane|set-hook)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          delete process.env[OMX_ENTRY_PATH_ENV];
+          process.env[OMX_STARTUP_CWD_ENV] = startupCwd;
+          process.argv = [previousArgv[0] || 'node', 'dist/cli/omx.js'];
+
+          const paneId = restoreStandaloneHudPane('%11', cwd);
+          assert.equal(paneId, '%44');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, new RegExp(escapeRegExp(launcherPath)));
+          assert.doesNotMatch(tmuxLog, /'dist\/cli\/omx\.js' hud --watch/);
+        },
+      );
+    } finally {
+      process.argv = previousArgv;
+      if (typeof previousEntryPath === 'string') process.env[OMX_ENTRY_PATH_ENV] = previousEntryPath;
+      else delete process.env[OMX_ENTRY_PATH_ENV];
+      if (typeof previousStartupCwd === 'string') process.env[OMX_STARTUP_CWD_ENV] = previousStartupCwd;
+      else delete process.env[OMX_STARTUP_CWD_ENV];
+      await rm(cwd, { recursive: true, force: true });
+      await rm(startupCwd, { recursive: true, force: true });
     }
   });
 });

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -21,6 +21,7 @@ import {
 import { readActiveProviderEnvOverrides } from '../config/models.js';
 import { sleep, sleepSync } from '../utils/sleep.js';
 import { classifySpawnError, resolveCommandPathForPlatform, spawnPlatformCommandSync } from '../utils/platform-command.js';
+import { resolveOmxEntryPath } from '../utils/paths.js';
 
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
@@ -922,7 +923,7 @@ export function createTeamSession(
     let hudPaneId: string | null = null;
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
-    const omxEntry = process.argv[1];
+    const omxEntry = resolveOmxEntryPath();
     if (omxEntry && omxEntry.trim() !== '') {
       const hudCmd = `node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
@@ -1027,7 +1028,7 @@ export function restoreStandaloneHudPane(
   const normalizedLeaderPaneId = normalizePaneTarget(leaderPaneId);
   if (!normalizedLeaderPaneId) return null;
 
-  const omxEntry = process.argv[1];
+  const omxEntry = resolveOmxEntryPath();
   if (!omxEntry || omxEntry.trim() === '') return null;
 
   const hudCmd = `${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -19,6 +19,10 @@ import {
   omxPlansDir,
   omxLogsDir,
   packageRoot,
+  OMX_ENTRY_PATH_ENV,
+  OMX_STARTUP_CWD_ENV,
+  rememberOmxLaunchContext,
+  resolveOmxEntryPath,
 } from "../paths.js";
 
 describe("codexHome", () => {
@@ -392,5 +396,71 @@ describe("packageRoot", () => {
   it("resolves to a directory containing package.json", () => {
     const root = packageRoot();
     assert.equal(existsSync(join(root, "package.json")), true);
+  });
+});
+
+describe("OMX launcher path resolution", () => {
+  const originalEntryPath = process.env[OMX_ENTRY_PATH_ENV];
+  const originalStartupCwd = process.env[OMX_STARTUP_CWD_ENV];
+
+  afterEach(() => {
+    if (typeof originalEntryPath === "string") {
+      process.env[OMX_ENTRY_PATH_ENV] = originalEntryPath;
+    } else {
+      delete process.env[OMX_ENTRY_PATH_ENV];
+    }
+    if (typeof originalStartupCwd === "string") {
+      process.env[OMX_STARTUP_CWD_ENV] = originalStartupCwd;
+    } else {
+      delete process.env[OMX_STARTUP_CWD_ENV];
+    }
+  });
+
+  it("resolves relative launcher paths against the recorded startup cwd", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-start-"));
+    const laterCwd = await mkdtemp(join(tmpdir(), "omx-launcher-later-"));
+    try {
+      const launcherDir = join(startupCwd, "dist", "cli");
+      const launcherPath = join(launcherDir, "omx.js");
+      await mkdir(launcherDir, { recursive: true });
+      await writeFile(launcherPath, "#!/usr/bin/env node\n", "utf-8");
+
+      const resolved = resolveOmxEntryPath({
+        argv1: "dist/cli/omx.js",
+        cwd: laterCwd,
+        env: {
+          ...process.env,
+          [OMX_STARTUP_CWD_ENV]: startupCwd,
+        },
+      });
+
+      assert.equal(resolved, launcherPath);
+    } finally {
+      await rm(startupCwd, { recursive: true, force: true });
+      await rm(laterCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("records launcher context once so later cwd changes keep the absolute entry path", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-record-"));
+    try {
+      const launcherDir = join(startupCwd, "dist", "cli");
+      const launcherPath = join(launcherDir, "omx.js");
+      await mkdir(launcherDir, { recursive: true });
+      await writeFile(launcherPath, "#!/usr/bin/env node\n", "utf-8");
+
+      delete process.env[OMX_ENTRY_PATH_ENV];
+      delete process.env[OMX_STARTUP_CWD_ENV];
+      rememberOmxLaunchContext({
+        argv1: "dist/cli/omx.js",
+        cwd: startupCwd,
+        env: process.env,
+      });
+
+      assert.equal(process.env[OMX_STARTUP_CWD_ENV], startupCwd);
+      assert.equal(process.env[OMX_ENTRY_PATH_ENV], launcherPath);
+    } finally {
+      await rm(startupCwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -4,15 +4,71 @@
  */
 
 import { createHash } from "crypto";
-import { existsSync } from "fs";
+import { existsSync, realpathSync } from "fs";
 import { readdir, readFile, realpath } from "fs/promises";
-import { dirname, join } from "path";
+import { dirname, isAbsolute, join, resolve } from "path";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
 
 /** Codex CLI home directory (~/.codex/) */
 export function codexHome(): string {
   return process.env.CODEX_HOME || join(homedir(), ".codex");
+}
+
+export const OMX_ENTRY_PATH_ENV = "OMX_ENTRY_PATH";
+export const OMX_STARTUP_CWD_ENV = "OMX_STARTUP_CWD";
+
+function resolveLauncherPath(rawPath: string, baseCwd: string): string {
+  const absolutePath = isAbsolute(rawPath) ? rawPath : resolve(baseCwd, rawPath);
+  if (!existsSync(absolutePath)) return absolutePath;
+  try {
+    return typeof realpathSync.native === "function"
+      ? realpathSync.native(absolutePath)
+      : realpathSync(absolutePath);
+  } catch {
+    return absolutePath;
+  }
+}
+
+export function resolveOmxEntryPath(
+  options: {
+    argv1?: string | null;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): string | null {
+  const { argv1 = process.argv[1], cwd = process.cwd(), env = process.env } = options;
+  const fromEnv = String(env[OMX_ENTRY_PATH_ENV] ?? "").trim();
+  if (fromEnv !== "") return fromEnv;
+
+  const rawPath = typeof argv1 === "string" ? argv1.trim() : "";
+  if (rawPath === "") return null;
+
+  const startupCwd = String(env[OMX_STARTUP_CWD_ENV] ?? "").trim() || cwd;
+  return resolveLauncherPath(rawPath, startupCwd);
+}
+
+export function rememberOmxLaunchContext(
+  options: {
+    argv1?: string | null;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): void {
+  const { cwd = process.cwd(), env = process.env } = options;
+  if (String(env[OMX_STARTUP_CWD_ENV] ?? "").trim() === "") {
+    env[OMX_STARTUP_CWD_ENV] = cwd;
+  }
+  if (String(env[OMX_ENTRY_PATH_ENV] ?? "").trim() !== "") return;
+
+  const resolved = resolveOmxEntryPath({
+    argv1: options.argv1,
+    cwd,
+    env,
+  });
+  if (resolved) {
+    env[OMX_ENTRY_PATH_ENV] = resolved;
+  }
 }
 
 /** Codex config file path (~/.codex/config.toml) */


### PR DESCRIPTION
## Summary
- record the startup cwd and canonical OMX entry path once in the CLI launcher
- use the resolved absolute OMX path for tmux HUD, team, and autoresearch self-relaunches
- add regression coverage for relative dist/cli/omx.js launches and tmux background/session startup paths

## Verification
- npm run build
- npx @biomejs/biome lint src/utils/paths.ts src/utils/__tests__/paths.test.ts src/cli/omx.ts src/cli/index.ts src/hud/index.ts src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts src/cli/autoresearch.ts src/cli/autoresearch-guided.ts src/cli/__tests__/autoresearch-guided.test.ts
- node --test dist/utils/__tests__/paths.test.js dist/cli/__tests__/autoresearch-guided.test.js dist/cli/__tests__/autoresearch.test.js dist/team/__tests__/tmux-session.test.js