### PR TITLE
fix: stop repeated yes proceed auto-nudges on non-turn hook payloads

### DIFF
--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -1105,6 +1105,55 @@ exit 0
     });
   });
 
+  it('ignores non-turn-complete payloads so the same stalled reply cannot re-nudge without a new Codex boundary', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const lastMessage = 'If you want, I can keep going from here.';
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const first = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        type: 'agent-turn-complete',
+        'turn-id': 'turn-complete-1',
+        'last-assistant-message': lastMessage,
+      });
+      assert.equal(first.status, 0, `first hook failed: ${first.stderr || first.stdout}`);
+
+      const second = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        type: 'function_call_output',
+        'turn-id': 'function-call-output-1',
+        'last-assistant-message': lastMessage,
+      });
+      assert.equal(second.status, 0, `second hook failed: ${second.stderr || second.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 1);
+
+      const hudState = JSON.parse(await readFile(join(stateDir, 'hud-state.json'), 'utf-8'));
+      assert.equal(hudState.turn_count, 1);
+
+      const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
+      assert.equal(nudgeState.nudgeCount, 1);
+      assert.match(nudgeState.lastSignature, /^hud:1\|.*\|stall:proceed_intent$/);
+    });
+  });
+
   it('uses custom response from config', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -145,6 +145,11 @@ function buildIdleNotificationFingerprint(payload: Record<string, unknown>): str
   });
 }
 
+function isTurnCompletePayload(payload: Record<string, unknown>): boolean {
+  const type = safeString(payload.type || '').trim().toLowerCase();
+  return type === '' || type === 'agent-turn-complete' || type === 'turn-complete';
+}
+
 async function main() {
   const rawPayload = process.argv[process.argv.length - 1];
   if (!rawPayload || rawPayload.startsWith('-')) {
@@ -163,6 +168,7 @@ async function main() {
   const payloadThreadId = safeString(payload['thread-id'] || payload.thread_id || '');
   const inputMessages = normalizeInputMessages(payload);
   const latestUserInput = safeString(inputMessages.length > 0 ? inputMessages[inputMessages.length - 1] : '');
+  const isTurnComplete = isTurnCompletePayload(payload);
 
   // Team worker detection via environment variable
   const teamWorkerEnv = process.env.OMX_TEAM_WORKER; // e.g., "fix-ts/worker-1"
@@ -238,6 +244,10 @@ async function main() {
 
   const logFile = join(logsDir, `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
   await appendFile(logFile, JSON.stringify(logEntry) + '\n').catch(() => {});
+
+  if (!isTurnComplete) {
+    return;
+  }
 
   // Reconcile Ralph ownership for same-Codex-session continuation before
   // lifecycle counters or injection read the active scope.


### PR DESCRIPTION
## Summary
- reproduce #1286 by driving a stalled `agent-turn-complete` reply followed by a non-turn-complete `function_call_output` payload carrying the same assistant text
- stop `notify-hook` post-turn state mutation/nudge paths unless the payload is an actual turn-complete boundary
- add regression coverage proving the same stalled reply cannot inject a second `yes, proceed` without a new Codex response

## Root cause
`notify-hook` was treating every hook payload like a completed assistant turn. On Linux, a stalled reply could be followed by another hook payload (for example `function_call_output`) with the same `last-assistant-message`. That second payload still updated `hud-state.json` (`turn_count`, `last_turn_at`) and then re-ran `maybeAutoNudge()`. Because the auto-nudge signature is HUD-based (`hud:<turn_count>|<last_turn_at>|...`), the signature changed without any new Codex response boundary, so OMX injected `yes, proceed` again into the active tmux pane.

## Repro used
1. Build the repo
2. Run `dist/scripts/notify-hook.js` with an `agent-turn-complete` payload whose assistant text is `If you want, I can keep going from here.`
3. Run it again with `type=function_call_output` and the same assistant text
4. Before this fix, tmux saw 2 `send-keys -t %99 -l yes, proceed [OMX_TMUX_INJECT]` writes and HUD `turn_count` advanced to 2; after the fix both stay at 1

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-auto-nudge.test.js`
- `node --test dist/hooks/__tests__/notify-fallback-watcher.test.js`
- `node --test dist/hooks/__tests__/notify-hook-session-scope.test.js`
- `npx biome lint src/scripts/notify-hook.ts src/hooks/__tests__/notify-hook-auto-nudge.test.ts`

Closes #1286
