### PR TITLE
Make tmux auto-nudges read like execution guidance instead of approval shortcuts

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -493,7 +493,7 @@ describe('notify-fallback watcher', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
       assert.doesNotMatch(tmuxLog, /Ralph loop active continue/);
       assert.doesNotMatch(tmuxLog, /Team dispatch-team:/);
-      assert.doesNotMatch(tmuxLog, /yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, /continue from current state \[OMX_TMUX_INJECT\]/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -675,7 +675,7 @@ describe('notify-fallback watcher', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8');
-      assert.match(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.match(tmuxLog, /send-keys -t %42 -l continue from current state \[OMX_TMUX_INJECT\]/);
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
@@ -727,7 +727,7 @@ describe('notify-fallback watcher', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l continue from current state \[OMX_TMUX_INJECT\]/);
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
@@ -786,7 +786,7 @@ describe('notify-fallback watcher', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l continue from current state \[OMX_TMUX_INJECT\]/);
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -145,7 +145,7 @@ describe('notify-hook auto-nudge', () => {
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/);
 
       const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 0);
@@ -183,7 +183,7 @@ describe('notify-hook auto-nudge', () => {
 
       assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should send nudge response with injection marker');
+      assert.match(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/, 'should send nudge response with injection marker');
       // Codex CLI needs C-m sent twice with a delay for reliable submission
       const cmMatches = tmuxLog.match(/send-keys -t %99 C-m/g);
       assert.ok(cmMatches && cmMatches.length >= 2, `should send C-m twice, got ${cmMatches?.length ?? 0}`);
@@ -224,7 +224,7 @@ describe('notify-hook auto-nudge', () => {
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /capture-pane/, 'should have tried capture-pane');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should send nudge via capture-pane fallback with marker');
+      assert.match(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/, 'should send nudge via capture-pane fallback with marker');
     });
   });
 
@@ -324,7 +324,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -t %99 -p #S/, 'should anchor off the active mode pane');
-      assert.match(tmuxLog, /send-keys -t %100 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should upgrade anchored shell pane to sibling codex pane');
+      assert.match(tmuxLog, /send-keys -t %100 -l continue from current state \[OMX_TMUX_INJECT\]/, 'should upgrade anchored shell pane to sibling codex pane');
     });
   });
 
@@ -357,7 +357,7 @@ exit 0
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'team-worker context should still send auto-nudge');
+      assert.match(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/, 'team-worker context should still send auto-nudge');
 
       const nudgeStatePath = join(workerStateRoot, 'auto-nudge-state.json');
       assert.ok(existsSync(nudgeStatePath), 'worker state root should receive auto-nudge state');
@@ -392,7 +392,7 @@ exit 0
 
       if (existsSync(tmuxLogPath)) {
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-        assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should NOT send nudge');
+        assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l continue from current state/, 'should NOT send nudge');
       }
     });
   });
@@ -459,7 +459,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -t %99 -p #\{pane_current_command\}/);
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'shell pane should not receive auto-nudge injection');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/, 'shell pane should not receive auto-nudge injection');
     });
   });
 
@@ -557,7 +557,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p #S/);
       assert.match(tmuxLog, /display-message -t %99 -p #\{pane_current_command\}/);
-      assert.match(tmuxLog, /send-keys -t %100 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.match(tmuxLog, /send-keys -t %100 -l continue from current state \[OMX_TMUX_INJECT\]/);
     });
   });
 
@@ -589,7 +589,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p #S/);
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'current implementation still injects in this copy-mode fixture');
+      assert.match(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/, 'current implementation still injects in this copy-mode fixture');
     });
   });
 
@@ -634,7 +634,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p #S/);
       assert.doesNotMatch(tmuxLog, /capture-pane -t %99/, 'current canonical pane path no longer requires capture-pane here');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'current implementation still injects in this busy-pane fixture');
+      assert.match(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/, 'current implementation still injects in this busy-pane fixture');
     });
   });
 
@@ -707,7 +707,7 @@ exit 0
       assert.equal(second.status, 0, `second hook failed: ${second.stderr || second.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 1);
+      assert.equal((tmuxLog.match(/send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/g) || []).length, 1);
 
       const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1);
@@ -749,7 +749,7 @@ exit 0
       assert.equal(second.status, 0, `second hook failed: ${second.stderr || second.stdout}`);
 
       let tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 1);
+      assert.equal((tmuxLog.match(/send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/g) || []).length, 1);
 
       const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
       const nudgeStateBeforeThird = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
@@ -765,7 +765,7 @@ exit 0
       assert.equal(third.status, 0, `third hook failed: ${third.stderr || third.stdout}`);
 
       tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 2);
+      assert.equal((tmuxLog.match(/send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/g) || []).length, 2);
 
       const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 2);
@@ -910,7 +910,7 @@ exit 0
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/);
     });
   });
 
@@ -1320,7 +1320,7 @@ exit 0
       assert.equal(result2.status, 0);
 
       const log2 = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(log2, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'custom pattern should trigger nudge with marker');
+      assert.match(log2, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/, 'custom pattern should trigger nudge with marker');
     });
   });
 
@@ -1353,7 +1353,7 @@ exit 0
 
       assert.ok(existsSync(tmuxLogPath), 'tmux should be called with defaults');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should nudge with default config and marker');
+      assert.match(tmuxLog, /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/, 'should nudge with default config and marker');
     });
   });
 
@@ -1388,7 +1388,7 @@ exit 0
 
       if (existsSync(tmuxLogPath)) {
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-        assert.doesNotMatch(tmuxLog, /send-keys.*-l yes, proceed/, 'should not nudge without pane');
+        assert.doesNotMatch(tmuxLog, /send-keys.*-l continue from current state/, 'should not nudge without pane');
       }
     });
   });

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -235,7 +235,7 @@ describe('notify-hook/auto-nudge – detectStallPattern', () => {
 
   it('ignores prior OMX injection lines so injected text cannot self-trigger detection', async () => {
     const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
-    const text = 'Completed the change.\nyes, proceed [OMX_TMUX_INJECT]\nkeep going [OMX_TMUX_INJECT]';
+    const text = 'Completed the change.\ncontinue from current state [OMX_TMUX_INJECT]\nkeep going [OMX_TMUX_INJECT]';
     assert.equal(detectStallPattern(text, DEFAULT_STALL_PATTERNS), false);
   });
 
@@ -263,7 +263,7 @@ describe('notify-hook/auto-nudge – normalizeAutoNudgeConfig', () => {
     const cfg = normalizeAutoNudgeConfig(null);
     assert.equal(cfg.enabled, true);
     assert.deepEqual(cfg.patterns, DEFAULT_STALL_PATTERNS);
-    assert.equal(cfg.response, 'yes, proceed');
+    assert.equal(cfg.response, 'continue from current state');
     assert.equal(cfg.delaySec, 3);
     assert.equal(cfg.ttlMs, 30_000);
   });
@@ -283,7 +283,7 @@ describe('notify-hook/auto-nudge – normalizeAutoNudgeConfig', () => {
   it('falls back to defaults for empty response string', async () => {
     const { normalizeAutoNudgeConfig } = await loadModule('notify-hook/auto-nudge.js');
     const cfg = normalizeAutoNudgeConfig({ response: '   ' });
-    assert.equal(cfg.response, 'yes, proceed');
+    assert.equal(cfg.response, 'continue from current state');
   });
 
   it('accepts valid delaySec', async () => {
@@ -357,7 +357,7 @@ describe('notify-hook/auto-nudge – inferSkillPhaseFromText', () => {
 describe('notify-hook/auto-nudge – blocked deep-interview auto approvals', () => {
   it('normalizes injected approval text before matching blocked inputs', async () => {
     const { normalizeBlockedAutoApprovalInput } = await loadModule('notify-hook/auto-nudge.js');
-    assert.equal(normalizeBlockedAutoApprovalInput(' yes, proceed [OMX_TMUX_INJECT] '), 'yes proceed');
+    assert.equal(normalizeBlockedAutoApprovalInput(' continue from current state [OMX_TMUX_INJECT] '), 'continue from current state');
   });
 
   it('matches each blocked approval keyword or phrase', async () => {
@@ -369,7 +369,7 @@ describe('notify-hook/auto-nudge – blocked deep-interview auto approvals', () 
 
   it('blocks combined yes/proceed injection text', async () => {
     const { isBlockedAutoApprovalInput } = await loadModule('notify-hook/auto-nudge.js');
-    assert.equal(isBlockedAutoApprovalInput('yes, proceed'), true);
+    assert.equal(isBlockedAutoApprovalInput('continue from current state'), true);
   });
 
   it('treats actionable "Next I should ..." replies like continuation approval', async () => {

--- a/src/hooks/__tests__/notify-hook-regression-205.test.ts
+++ b/src/hooks/__tests__/notify-hook-regression-205.test.ts
@@ -221,7 +221,7 @@ describe('regression-205: notify-hook records pending stall state on "if you wan
       const tmuxLog = await readFile(tmuxLogPath, 'utf8');
       assert.doesNotMatch(
         tmuxLog,
-        /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/,
+        /send-keys -t %99 -l continue from current state \[OMX_TMUX_INJECT\]/,
         'default notify-hook path should not inject before the real stall window elapses',
       );
 

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -16,7 +16,7 @@ import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPa
 import { buildCapturePaneArgv, DEFAULT_MARKER } from '../tmux-hook-engine.js';
 
 export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
-export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'];
+export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'continue from current state', 'ok', 'sure', 'go ahead', 'next i should'];
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
 const DEEP_INTERVIEW_ERROR_PATTERNS = [' error', ' failed', ' failure', ' exception', 'unable to continue', 'cannot continue', 'could not continue'];
 const DEEP_INTERVIEW_ABORT_PATTERNS = ['aborted', 'cancelled', 'canceled'];
@@ -316,7 +316,7 @@ export function normalizeAutoNudgeConfig(raw) {
     return {
       enabled: true,
       patterns: DEFAULT_STALL_PATTERNS,
-      response: 'yes, proceed',
+      response: 'continue from current state',
       delaySec: 3,
       stallMs: 5000,
       ttlMs: DEFAULT_AUTO_NUDGE_TTL_MS,
@@ -329,7 +329,7 @@ export function normalizeAutoNudgeConfig(raw) {
       : DEFAULT_STALL_PATTERNS,
     response: typeof raw.response === 'string' && raw.response.trim() !== ''
       ? raw.response
-      : 'yes, proceed',
+      : 'continue from current state',
     delaySec: typeof raw.delaySec === 'number' && raw.delaySec >= 0 && raw.delaySec <= 60
       ? raw.delaySec
       : 3,


### PR DESCRIPTION
## Summary
This changes OMX’s default tmux auto-nudge wording from `yes, proceed` to `continue from current state`.

## Why
The old phrase looked like a human approval shortcut even though it was actually OMX-generated tmux control text. The new wording better communicates that the message is a continuation nudge, not a user approval.

## What changed
- Updated the default auto-nudge response text
- Updated deep-interview blocked auto-approval handling to recognize the new phrase
- Updated notify-hook/fallback watcher/regression tests to match the new default wording

## Impact
- No change to the tmux injection marker behavior
- No change to the overall auto-nudge flow
- Deep-interview safety behavior remains intact
- The injected text is simply less confusing

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-modules.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-regression-205.test.js`

Result: **129 tests passed**
