### PR TITLE
Fix team shutdown pane reconciliation race

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -30,6 +30,7 @@ import {
   startTeam,
   assignTask,
   sendWorkerMessage,
+  applyCreatedInteractiveSessionToConfig,
   resolveWorkerLaunchArgsFromEnv,
   waitForWorkerStartupEvidence,
   waitForClaudeStartupEvidence,
@@ -775,6 +776,46 @@ esac
       else delete process.env.WSL_INTEROP;
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('applyCreatedInteractiveSessionToConfig persists worker pane ids before readiness waits', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-pane-persist-race-'));
+    try {
+      const config = await initTeamState('team-pane-persist-race', 'persist pane ids before readiness wait', 'executor', 2, cwd);
+      const workerPaneIds = Array.from({ length: 2 }, () => undefined as string | undefined);
+      applyCreatedInteractiveSessionToConfig(config, {
+        name: 'leader:0',
+        workerCount: 2,
+        cwd,
+        workerPaneIds: ['%2', '%3'],
+        leaderPaneId: '%1',
+        hudPaneId: '%4',
+        resizeHookName: 'resize-hook',
+        resizeHookTarget: 'leader:0',
+      }, workerPaneIds);
+
+      assert.equal(config.tmux_session, 'leader:0');
+      assert.equal(config.leader_pane_id, '%1');
+      assert.equal(config.hud_pane_id, '%4');
+      assert.deepEqual(workerPaneIds, ['%2', '%3']);
+      assert.equal(config.workers[0]?.pane_id, '%2');
+      assert.equal(config.workers[1]?.pane_id, '%3');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam saves interactive pane ids before readiness waits in source order', async () => {
+    const source = await readFile(join(process.cwd(), 'src', 'team', 'runtime.ts'), 'utf-8');
+    const applyIndex = source.indexOf('applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);');
+    const saveIndex = source.indexOf('await saveTeamConfig(config, leaderCwd);', applyIndex);
+    const readyIndex = source.indexOf('const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);', saveIndex);
+
+    assert.notEqual(applyIndex, -1);
+    assert.notEqual(saveIndex, -1);
+    assert.notEqual(readyIndex, -1);
+    assert.equal(applyIndex < saveIndex, true);
+    assert.equal(saveIndex < readyIndex, true);
   });
 
   it('startTeam rejects dirty leader workspace before provisioning worker worktrees', async () => {
@@ -3205,6 +3246,95 @@ esac
           assert.match(tmuxLog, /kill-pane -t %404/);
           assert.match(tmuxLog, /kill-pane -t %405/);
           assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-dead-pane/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam reconciles persisted worker panes with live tmux panes before teardown', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-pane-reconcile-'));
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-pane-reconcile-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+restored_marker="${tmuxLogPath}.restored"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-t leader:0 -F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t %13 -F #{pane_pid}"*)
+        echo "1013"
+        exit 0
+        ;;
+      *"-t %14 -F #{pane_pid}"*)
+        echo "1014"
+        exit 0
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tcodex\\n%%14\\tcodex\\tcodex\\n"
+        if [ -f "$restored_marker" ]; then
+          printf "%%44\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n"
+        fi
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    : > "$restored_marker"
+    printf '%%44\\n'
+    exit 0
+    ;;
+  kill-pane)
+    if [ "\${3:-}" = "%999" ]; then
+      echo "missing pane" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  kill-session|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState('team-shutdown-pane-reconcile', 'shutdown pane reconcile test', 'executor', 2, cwd);
+          const config = await readTeamConfig('team-shutdown-pane-reconcile', cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '';
+          config.workers[1]!.pane_id = '%999';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam('team-shutdown-pane-reconcile', cwd, { force: true });
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.match(tmuxLog, /kill-pane -t %14/);
+          assert.match(tmuxLog, /kill-pane -t %999/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
         },
       );
     } finally {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -14,6 +14,7 @@ import {
   type TeamWorkerCli,
   resolveTeamWorkerCliPlan,
   resolveTeamWorkerLaunchMode,
+  type TeamSession,
   waitForWorkerReady,
   dismissTrustPromptIfPresent,
   sleepFractionalSeconds,
@@ -26,6 +27,7 @@ import {
   teardownWorkerPanes,
   unregisterResizeHook,
   destroyTeamSession,
+  listPaneIds,
   listTeamSessions,
 } from './tmux-session.js';
 import {
@@ -215,6 +217,54 @@ interface ShutdownOptions {
 
 export interface TeamShutdownSummary {
   commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null;
+}
+
+export function applyCreatedInteractiveSessionToConfig(
+  config: TeamConfig,
+  createdSession: TeamSession,
+  workerPaneIds: Array<string | undefined>,
+): void {
+  config.tmux_session = createdSession.name;
+  config.leader_pane_id = createdSession.leaderPaneId;
+  config.hud_pane_id = createdSession.hudPaneId;
+  config.resize_hook_name = createdSession.resizeHookName;
+  config.resize_hook_target = createdSession.resizeHookTarget;
+  for (let i = 0; i < createdSession.workerPaneIds.length; i++) {
+    const paneId = createdSession.workerPaneIds[i];
+    workerPaneIds[i] = paneId;
+    if (config.workers[i]) {
+      config.workers[i].pane_id = paneId;
+    }
+  }
+}
+
+function collectShutdownPaneIds(params: {
+  config: TeamConfig;
+  livePaneIds?: string[];
+  restoredStandaloneHudPaneId?: string | null;
+}): string[] {
+  const { config, livePaneIds = [], restoredStandaloneHudPaneId = null } = params;
+  const excludedPaneIds = new Set(
+    [
+      config.leader_pane_id,
+      config.hud_pane_id,
+      restoredStandaloneHudPaneId,
+    ].filter((paneId): paneId is string => typeof paneId === 'string' && paneId.trim().startsWith('%')),
+  );
+
+  const paneIds = new Set<string>();
+  for (const paneId of [
+    ...config.workers.map((worker) => worker.pane_id),
+    ...livePaneIds,
+  ]) {
+    if (typeof paneId !== 'string') continue;
+    const normalized = paneId.trim();
+    if (!normalized.startsWith('%')) continue;
+    if (excludedPaneIds.has(normalized)) continue;
+    paneIds.add(normalized);
+  }
+
+  return [...paneIds];
 }
 
 async function logRuntimeDispatchOutcome(params: {
@@ -1894,14 +1944,7 @@ export async function startTeam(
       sessionCreated = true;
       createdWorkerPaneIds.push(...createdSession.workerPaneIds);
       createdLeaderPaneId = createdSession.leaderPaneId;
-      config.tmux_session = sessionName;
-      config.leader_pane_id = createdSession.leaderPaneId;
-      config.hud_pane_id = createdSession.hudPaneId;
-      config.resize_hook_name = createdSession.resizeHookName;
-      config.resize_hook_target = createdSession.resizeHookTarget;
-      for (let i = 0; i < createdSession.workerPaneIds.length; i++) {
-        workerPaneIds[i] = createdSession.workerPaneIds[i];
-      }
+      applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);
     } else {
       config.tmux_session = `prompt-${sanitized}`;
       config.leader_pane_id = null;
@@ -2686,8 +2729,10 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   const leaderPaneId = config.leader_pane_id;
   const hudPaneId = config.hud_pane_id;
   if (config.worker_launch_mode === 'interactive') {
-    const workerPanePids = config.workers
-      .map((w) => getWorkerPanePid(sessionName, w.index, w.pane_id))
+    const livePaneIds = listPaneIds(sessionName);
+    let shutdownPaneIds = collectShutdownPaneIds({ config, livePaneIds });
+    const workerPanePids = shutdownPaneIds
+      .map((paneId) => getWorkerPanePid(sessionName, 1, paneId))
       .filter((pid): pid is number => typeof pid === 'number' && Number.isFinite(pid) && pid > 0);
     for (const panePid of workerPanePids) {
       await terminateTrackedProcessTree(panePid);
@@ -2711,22 +2756,25 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     if (resizeHookWarning) {
       console.warn(`[team shutdown] ${sanitized}: ${resizeHookWarning}; continuing teardown`);
     }
-    const workerPaneIds = config.workers
-      .map((w) => w.pane_id)
-      .filter((paneId): paneId is string => typeof paneId === 'string' && paneId.trim().length > 0);
-    await teardownWorkerPanes(workerPaneIds, {
-      leaderPaneId,
-      hudPaneId,
-    });
+    let restoredHudPaneId: string | null = null;
     if (hudPaneId) {
       await killWorkerByPaneIdAsync(hudPaneId, leaderPaneId ?? undefined);
       if (sessionName.includes(':')) {
-        const restoredHudPaneId = restoreStandaloneHudPane(leaderPaneId, cwd);
+        restoredHudPaneId = restoreStandaloneHudPane(leaderPaneId, cwd);
         if (!restoredHudPaneId) {
           console.warn(`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`);
         }
       }
     }
+    shutdownPaneIds = collectShutdownPaneIds({
+      config,
+      livePaneIds: listPaneIds(sessionName),
+      restoredStandaloneHudPaneId: restoredHudPaneId,
+    });
+    await teardownWorkerPanes(shutdownPaneIds, {
+      leaderPaneId,
+      hudPaneId: restoredHudPaneId ?? hudPaneId,
+    });
 
     // 4. Destroy tmux session
     if (!sessionName.includes(':')) {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -165,6 +165,10 @@ function listPanes(target: string): TmuxPaneInfo[] {
     .filter((pane) => pane.paneId.startsWith('%'));
 }
 
+export function listPaneIds(target: string): string[] {
+  return listPanes(target).map((pane) => pane.paneId);
+}
+
 function isHudWatchPane(pane: TmuxPaneInfo): boolean {
   const start = pane.startCommand || '';
   return /\bomx\b.*\bhud\b.*--watch/i.test(start);


### PR DESCRIPTION
## Summary
- persist interactive worker pane ids onto team config immediately after tmux session creation
- reconcile shutdown teardown targets against the live tmux pane list and re-check after standalone HUD restore
- add regression coverage for early pane-id persistence ordering and shutdown reconciliation in attached tmux targets

## Testing
- npm run build
- node --test --test-concurrency=1 --test-name-pattern "applyCreatedInteractiveSessionToConfig persists worker pane ids before readiness waits|startTeam saves interactive pane ids before readiness waits in source order|shutdownTeam reconciles persisted worker panes with live tmux panes before teardown|shutdownTeam restores a standalone HUD pane after tearing down the team HUD|shutdownTeam preserves leader exclusion while tearing down the hud pane|shutdownTeam applies best-effort teardown even when worker pane is already dead" dist/team/__tests__/runtime.test.js
- npx biome lint src/team/runtime.ts src/team/tmux-session.ts src/team/__tests__/runtime.test.ts

Closes #1288.