### PR TITLE
fix: reconcile active subagents before Ralph fallback self-steer

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1717,6 +1717,91 @@ exit 0
     }
   });
 
+  it('suppresses Ralph continue steer while tracked native subagents are still active', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-subagents-active-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const stateDir = join(wd, '.omx', 'state');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const statePath = join(stateDir, 'notify-fallback-state.json');
+    const omxSessionId = 'sess-current';
+    const codexSessionId = 'codex-session-1';
+    try {
+      await mkdir(join(stateDir, 'sessions', omxSessionId), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeSessionStart(wd, omxSessionId);
+      await writeFile(join(stateDir, 'sessions', omxSessionId, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        tmux_pane_id: '%42',
+        owner_omx_session_id: omxSessionId,
+        owner_codex_session_id: codexSessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_progress_at: new Date(Date.now() - 61_000).toISOString(),
+      }, null, 2));
+      await writeFile(statePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+      await writeFile(join(stateDir, 'subagent-tracking.json'), JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [codexSessionId]: {
+            session_id: codexSessionId,
+            leader_thread_id: 'leader-thread',
+            updated_at: new Date(Date.now() - 15_000).toISOString(),
+            threads: {
+              'leader-thread': {
+                thread_id: 'leader-thread',
+                kind: 'leader',
+                first_seen_at: new Date(Date.now() - 30_000).toISOString(),
+                last_seen_at: new Date(Date.now() - 15_000).toISOString(),
+                turn_count: 1,
+                mode: 'ralph',
+              },
+              'sub-thread-1': {
+                thread_id: 'sub-thread-1',
+                kind: 'subagent',
+                first_seen_at: new Date(Date.now() - 30_000).toISOString(),
+                last_seen_at: new Date(Date.now() - 15_000).toISOString(),
+                turn_count: 1,
+                mode: 'ralph',
+              },
+            },
+          },
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const env = {
+        ...buildCleanNotifyEnv(),
+        PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+      };
+
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'active native subagents should block fallback continue steer');
+
+      const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'subagents_active');
+      assert.equal(watcherState.ralph_continue_steer?.subagent_session_id, codexSessionId);
+      assert.deepEqual(watcherState.ralph_continue_steer?.active_subagent_thread_ids, ['sub-thread-1']);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when Ralph hud progress is missing or invalid', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-progress-guard-'));
     const fakeBinDir = join(wd, 'fake-bin');

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -25,6 +25,10 @@ import {
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 import { isTerminalPhase } from './notify-hook/utils.js';
 import { isSessionStale, readSessionState } from '../hooks/session.js';
+import {
+  DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS,
+  readSubagentSessionSummary,
+} from '../subagents/tracker.js';
 
 function argValue(name: string, fallback = ''): string {
   const idx = process.argv.indexOf(name);
@@ -135,6 +139,8 @@ interface RalphContinueSteerState {
   pane_id: string;
   pane_current_command: string;
   current_phase: string;
+  subagent_session_id: string;
+  active_subagent_thread_ids: string[];
   shared_timestamp_path: string;
   shared_last_sent_at: string;
   singleton_lock_path: string;
@@ -260,6 +266,8 @@ let lastRalphContinueSteer: RalphContinueSteerState = {
   pane_id: '',
   pane_current_command: '',
   current_phase: '',
+  subagent_session_id: '',
+  active_subagent_thread_ids: [],
   shared_timestamp_path: ralphSteerTimestampPath,
   shared_last_sent_at: '',
   singleton_lock_path: ralphSteerLockPath,
@@ -373,6 +381,10 @@ function normalizeRalphContinueSteerState(raw: Record<string, unknown> | null | 
     pane_id: safeString(raw.pane_id),
     pane_current_command: safeString(raw.pane_current_command),
     current_phase: safeString(raw.current_phase),
+    subagent_session_id: safeString(raw.subagent_session_id),
+    active_subagent_thread_ids: Array.isArray(raw.active_subagent_thread_ids)
+      ? raw.active_subagent_thread_ids.map((value) => safeString(value).trim()).filter(Boolean)
+      : [],
     shared_timestamp_path: safeString(raw.shared_timestamp_path) || ralphSteerTimestampPath,
     shared_last_sent_at: safeString(raw.shared_last_sent_at),
     singleton_lock_path: safeString(raw.singleton_lock_path) || ralphSteerLockPath,
@@ -656,29 +668,51 @@ interface RalphProgressGateResult {
   allow: boolean;
   reason: string;
   progress_at: string;
+  subagent_session_id?: string;
+  active_subagent_thread_ids?: string[];
 }
 
-async function readRalphProgressGate(now: number): Promise<RalphProgressGateResult> {
+async function readRalphProgressGate(
+  activeRalphState: Record<string, unknown> | null,
+  now: number,
+): Promise<RalphProgressGateResult> {
+  const subagentSessionId = safeString(activeRalphState?.owner_codex_session_id).trim();
+  if (subagentSessionId) {
+    const summary = await readSubagentSessionSummary(cwd, subagentSessionId, {
+      now: new Date(now),
+      activeWindowMs: DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS,
+    });
+    if ((summary?.activeSubagentThreadIds.length ?? 0) > 0) {
+      return {
+        allow: false,
+        reason: 'subagents_active',
+        progress_at: '',
+        subagent_session_id: subagentSessionId,
+        active_subagent_thread_ids: summary?.activeSubagentThreadIds ?? [],
+      };
+    }
+  }
+
   const hudState = await readJsonObject(join(stateDir, 'hud-state.json'));
   if (!hudState || typeof hudState !== 'object') {
-    return { allow: false, reason: 'progress_missing', progress_at: '' };
+    return { allow: false, reason: 'progress_missing', progress_at: '', subagent_session_id: subagentSessionId };
   }
 
   const progressAt = safeString(hudState.last_progress_at).trim();
   if (!progressAt) {
-    return { allow: false, reason: 'progress_missing', progress_at: '' };
+    return { allow: false, reason: 'progress_missing', progress_at: '', subagent_session_id: subagentSessionId };
   }
 
   const progressMs = parseIsoMillis(progressAt);
   if (progressMs === null) {
-    return { allow: false, reason: 'progress_invalid', progress_at: progressAt };
+    return { allow: false, reason: 'progress_invalid', progress_at: progressAt, subagent_session_id: subagentSessionId };
   }
 
   if (now - progressMs < RALPH_CONTINUE_CADENCE_MS) {
-    return { allow: false, reason: 'progress_fresh', progress_at: progressAt };
+    return { allow: false, reason: 'progress_fresh', progress_at: progressAt, subagent_session_id: subagentSessionId };
   }
 
-  return { allow: true, reason: 'progress_stale', progress_at: progressAt };
+  return { allow: true, reason: 'progress_stale', progress_at: progressAt, subagent_session_id: subagentSessionId };
 }
 
 function shouldSkipRalphContinue(now: number, candidateIso: string, startupIso: string): { skip: boolean; reason: string; anchorMs: number; anchorIso: string } {
@@ -851,6 +885,8 @@ async function runRalphContinueSteerTick(): Promise<void> {
     state_path: activeRalph.path,
     pane_id: activePaneId,
     pane_current_command: '',
+    subagent_session_id: safeString(activeRalph.state?.owner_codex_session_id).trim(),
+    active_subagent_thread_ids: [],
     shared_timestamp_path: ralphSteerTimestampPath,
     singleton_lock_path: ralphSteerLockPath,
   };
@@ -884,9 +920,11 @@ async function runRalphContinueSteerTick(): Promise<void> {
       return { sent: false, skipped: true };
     }
 
-    const progressGate = await readRalphProgressGate(Date.now());
+    const progressGate = await readRalphProgressGate(activeRalph.state, Date.now());
     if (!progressGate.allow) {
       lastRalphContinueSteer.last_reason = progressGate.reason;
+      lastRalphContinueSteer.subagent_session_id = progressGate.subagent_session_id ?? lastRalphContinueSteer.subagent_session_id;
+      lastRalphContinueSteer.active_subagent_thread_ids = progressGate.active_subagent_thread_ids ?? [];
       return { sent: false, skipped: true };
     }
 


### PR DESCRIPTION
## Summary
- stop Ralph fallback continue-steer when the owning Codex session still has active tracked native subagents
- reconcile the fallback watcher against `owner_codex_session_id` before parent self-work proceeds
- add a regression test for the stale-progress + active-subagent handoff case

## Root cause
The parent/subagent coordination hole was in `src/scripts/notify-fallback-watcher.ts`: the Ralph fallback path only checked stale HUD progress/cooldowns before injecting `Ralph loop active continue` into the parent pane. Native subagent activity was tracked in `.omx/state/subagent-tracking.json`, but that ledger was never consulted on the fallback/self-steer path, so the parent could drift into duplicated or downgraded work while a spawned subagent was still active.

## Testing
- npm ci
- npm run build
- node --test dist/subagents/__tests__/tracker.test.js
- node --test dist/hooks/__tests__/notify-fallback-watcher.test.js

Closes #1266
