### PR TITLE
Fix worker-state reminders being gated by leader pane state

### DIFF
--- a/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
@@ -295,6 +295,98 @@ exit 0
     });
   });
 
+  it('injects all-workers-idle notification even while the leader pane has an active task', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'busy-leader-all-idle';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(workersDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'busy-all-idle:0',
+        leader_pane_id: '%182',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+          { name: 'worker-2', index: 2, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      for (const worker of ['worker-1', 'worker-2']) {
+        await mkdir(join(workersDir, worker), { recursive: true });
+        await writeJson(join(workersDir, worker, 'status.json'), {
+          state: 'idle',
+          updated_at: new Date().toISOString(),
+        });
+      }
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%182" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%182" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  printf "• Running tests (1m 05s • esc to interrupt)\\n"
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /capture-pane/, 'busy-pane reminders should still inspect pane state');
+      assert.match(tmuxLog, /send-keys -t %182/, 'all-workers-idle reminder should still inject into a busy leader pane');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      if (existsSync(eventsPath)) {
+        const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+        const deferred = events.find((entry: { type?: string; reason?: string }) =>
+          entry.type === 'leader_notification_deferred' && entry.reason === 'pane_has_active_task');
+        assert.equal(deferred, undefined, 'busy leader panes must not suppress all-workers-idle reminders');
+      }
+    });
+  });
+
   it('targets leader pane id when leader_pane_id is present', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -278,6 +278,98 @@ exit 0
     });
   });
 
+  it('injects worker-idle notification even while the leader pane has an active task', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'busy-leader-worker-idle';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'busy-worker-idle:0',
+        leader_pane_id: '%81',
+        workers: [
+          { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        ],
+      });
+
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        current_task_id: 'task-42',
+        reason: 'task complete',
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'prev-notify-state.json'), {
+        state: 'working',
+        updated_at: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%81" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%81" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  printf "• Running tests (2m 10s • esc to interrupt)\\n"
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHookAsWorker(cwd, fakeBinDir, `${teamName}/worker-1`);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /capture-pane/, 'busy-pane reminders should still inspect pane state');
+      assert.match(tmuxLog, /send-keys -t %81/, 'worker-state transition reminder should still inject into a busy leader pane');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      if (existsSync(eventsPath)) {
+        const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+        const deferred = events.find((entry: { type?: string; reason?: string }) =>
+          entry.type === 'leader_notification_deferred' && entry.reason === 'pane_has_active_task');
+        assert.equal(deferred, undefined, 'busy leader panes must not suppress worker-state transition reminders');
+      }
+    });
+  });
+
   it('does not fire when worker was already idle (idle->idle)', async () => {
     await withTempWorkingDir(async (cwd) => {
       const stateDir = join(cwd, '.omx', 'state');

--- a/src/scripts/notify-hook/team-worker.ts
+++ b/src/scripts/notify-hook/team-worker.ts
@@ -9,7 +9,7 @@ import { join, resolve as resolvePath } from 'path';
 import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
-import { checkPaneReadyForTeamSendKeys, sendPaneInput } from './team-tmux-guard.js';
+import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
@@ -273,6 +273,18 @@ async function resolveCanonicalLeaderPaneId(_tmuxSession, leaderPaneId) {
   return '';
 }
 
+async function checkLeaderPaneReadyForWorkerStateReminder(paneTarget) {
+  return evaluatePaneInjectionReadiness(paneTarget, {
+    skipIfScrolling: true,
+    // Worker-state reminders are their own trigger path. They should still
+    // queue into a live Codex pane even while the leader is busy or not
+    // visibly input-ready; only shell/copy-mode style safety guards remain.
+    requireRunningAgent: true,
+    requireReady: false,
+    requireIdle: false,
+  });
+}
+
 async function emitLeaderPaneMissingDeferred({
   stateDir,
   logsDir,
@@ -406,7 +418,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   const nextAction = `Next: run omx team status ${teamName}, read unread worker messages, then decide whether to assign the next concrete task, reconcile results, or shut the team down.`;
   const message = `[OMX] All ${N} worker${N === 1 ? '' : 's'} idle. ${nextAction} ${DEFAULT_MARKER}`;
   const tmuxTarget = canonicalLeaderPaneId;
-  const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
+  const paneGuard = await checkLeaderPaneReadyForWorkerStateReminder(tmuxTarget);
   if (!paneGuard.ok) {
     const nextIdleState = {
       ...idleState,
@@ -580,7 +592,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
     return;
   }
   const tmuxTarget = canonicalLeaderPaneId;
-  const paneGuard = await checkPaneReadyForTeamSendKeys(tmuxTarget);
+  const paneGuard = await checkLeaderPaneReadyForWorkerStateReminder(tmuxTarget);
   if (!paneGuard.ok) {
     try {
       const tmpPath = cooldownPath + '.tmp.' + process.pid;


### PR DESCRIPTION
## Summary

Worker idle and all-workers-idle reminders were still using the strict team send-keys pane guard, so a busy live leader pane could suppress worker-state-change reminders by looking active or not-ready. This change keeps worker-state-triggered reminders independent from leader-pane-state heuristics while preserving the existing shell/copy-mode safety checks.

## Changes

- switch worker-state reminder injection to a live-Codex queueing guard that does not require the leader pane to look idle or input-ready
- keep shell/copy-mode blocking intact for worker idle and all-workers-idle reminder paths
- add regression coverage for busy leader panes on both per-worker idle and all-workers-idle transitions

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/hooks/__tests__/notify-hook-worker-idle.test.js dist/hooks/__tests__/notify-hook-all-workers-idle.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
- [x] `npx biome lint src/scripts/notify-hook/team-worker.ts src/hooks/__tests__/notify-hook-worker-idle.test.ts src/hooks/__tests__/notify-hook-all-workers-idle.test.ts`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1292
