### PR TITLE
fix: propagate persist errors in omx-runtime exec subcommand

### DIFF
--- a/crates/omx-runtime/src/main.rs
+++ b/crates/omx-runtime/src/main.rs
@@ -86,8 +86,10 @@ fn run() -> Result<(), String> {
             }
 
             if state_dir.is_some() {
-                let _ = engine.persist();
-                let _ = engine.write_compatibility_view();
+                engine.persist().map_err(|e| format!("persist failed: {e}"))?;
+                engine
+                    .write_compatibility_view()
+                    .map_err(|e| format!("compatibility view failed: {e}"))?;
             }
 
             println!(


### PR DESCRIPTION
## Summary

The `exec` subcommand in `crates/omx-runtime/src/main.rs` silently discards errors from `engine.persist()` and `engine.write_compatibility_view()` using `let _ = ...` (lines 89–90).

When disk I/O fails (full disk, permission denied, concurrent write conflict), the binary still prints the event JSON to stdout and exits with code 0. The TS bridge (`src/runtime/bridge.ts`) trusts this stdout, so it proceeds as if state was saved — but nothing was actually written to disk. This can cause **silent state loss**: dispatch records, mailbox messages, and authority leases vanish on the next `RuntimeEngine::load()`.

### What this PR does

Replaces:
```rust
let _ = engine.persist();
let _ = engine.write_compatibility_view();
```

With:
```rust
engine.persist().map_err(|e| format!("persist failed: {e}"))?;
engine.write_compatibility_view()
    .map_err(|e| format!("compatibility view failed: {e}"))?;
```

This is consistent with the existing `init` subcommand (line 102), which already propagates `persist()` errors via `.map_err(|e| e.to_string())?`.

### Why this is safe

- `run()` returns `Result<(), String>`, so the error propagates to `main()` → `eprintln!` → `process::exit(1)`
- The TS bridge's `run()` method catches non-zero exits and throws `Error("omx-runtime exec failed: <stderr>")`, so callers get an actionable error instead of stale state
- The event JSON is printed **after** persist (line 93), so on failure no misleading output reaches the bridge

## Test plan

- [x] `cargo check -p omx-runtime` — compiles cleanly
- [x] `cargo clippy -p omx-runtime -- -D warnings` — no warnings
- [x] `cargo test --workspace` — 151 tests passed, 0 failures
- [x] Integration test `exec_with_state_dir_persists` exercises the exact changed code path and passes
- [x] `npm run build` — TS build unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)