### PR TITLE
fix(team): restore orchestration semantics without leaking intent tags

### DIFF
--- a/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-all-workers-idle.test.ts
@@ -695,13 +695,17 @@ exit 0
       assert.ok(existsSync(eventsPath), 'events.ndjson should exist after notification');
       const content = await readFile(eventsPath, 'utf-8');
       const events = content.trim().split('\n').map(line => JSON.parse(line));
-      const idleEvent = events.find((e: { type: string }) => e.type === 'all_workers_idle');
+      const idleEvent = events.find((e: { type: string; orchestration_intent?: string }) => e.type === 'all_workers_idle');
       assert.ok(idleEvent, 'should have an all_workers_idle event');
       assert.equal(idleEvent.team, teamName);
       assert.equal(idleEvent.worker, 'worker-1');
       assert.equal(idleEvent.worker_count, 2);
+      assert.equal(idleEvent.orchestration_intent, 'done-review-or-shutdown');
       assert.ok(idleEvent.event_id, 'event should have an event_id');
       assert.ok(idleEvent.created_at, 'event should have a created_at timestamp');
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /\[OMX_INTENT:/);
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -239,6 +239,14 @@ describe('notify-hook/auto-nudge – detectStallPattern', () => {
     assert.equal(detectStallPattern(text, DEFAULT_STALL_PATTERNS), false);
   });
 
+  it('ignores orchestration intent tags when normalizing stall text', async () => {
+    const { normalizeAutoNudgeSignatureText } = await loadModule('notify-hook/auto-nudge.js');
+    assert.equal(
+      normalizeAutoNudgeSignatureText('Team alpha: 1 msg(s) for leader. [OMX_INTENT:pending-mailbox-review]'),
+      'team alpha 1 msg s for leader',
+    );
+  });
+
   it('focuses detection on the last few lines (hotZone)', async () => {
     const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
     // Stall phrase only in the last line — should detect
@@ -412,6 +420,37 @@ describe('notify-hook/auto-nudge – blocked deep-interview auto approvals', () 
       latestUserInput: 'abort',
       lastMessage: 'Stopping now.',
     }), 'abort');
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// orchestration-intent.js – team reminder taxonomy
+// ---------------------------------------------------------------------------
+describe('notify-hook/orchestration-intent – taxonomy helpers', () => {
+  it('appends and strips orchestration intent tags', async () => {
+    const { appendOrchestrationIntentTag, stripOrchestrationIntentTags } = await loadModule('notify-hook/orchestration-intent.js');
+    const tagged = appendOrchestrationIntentTag('Team alpha: 1 msg(s) for leader.', 'pending-mailbox-review');
+    assert.equal(tagged, 'Team alpha: 1 msg(s) for leader. [OMX_INTENT:pending-mailbox-review]');
+    assert.equal(stripOrchestrationIntentTags(tagged).trim(), 'Team alpha: 1 msg(s) for leader.');
+  });
+
+  it('maps leader reminder reasons to stable orchestration intents', async () => {
+    const { resolveLeaderNudgeIntent } = await loadModule('notify-hook/orchestration-intent.js');
+    assert.equal(resolveLeaderNudgeIntent({ nudgeReason: 'new_mailbox_message' }), 'pending-mailbox-review');
+    assert.equal(resolveLeaderNudgeIntent({ nudgeReason: 'ack_without_start_evidence' }), 'followup-relaunch');
+    assert.equal(resolveLeaderNudgeIntent({ nudgeReason: 'stuck_waiting_on_leader' }), 'stalled-unblock');
+    assert.equal(resolveLeaderNudgeIntent({ nudgeReason: 'all_workers_idle', leaderActionState: 'done_waiting_on_leader' }), 'done-review-or-shutdown');
+    assert.equal(resolveLeaderNudgeIntent({ nudgeReason: 'all_workers_idle', leaderActionState: 'still_actionable' }), 'followup-reuse');
+  });
+
+  it('maps worker-state reminders to stable orchestration intents', async () => {
+    const { resolveAllWorkersIdleIntent, resolveWorkerIdleIntent } = await loadModule('notify-hook/orchestration-intent.js');
+    assert.equal(resolveAllWorkersIdleIntent('done_waiting_on_leader'), 'done-review-or-shutdown');
+    assert.equal(resolveAllWorkersIdleIntent('stuck_waiting_on_leader'), 'stalled-unblock');
+    assert.equal(resolveAllWorkersIdleIntent('still_actionable'), 'followup-reuse');
+    assert.equal(resolveWorkerIdleIntent('idle'), 'followup-reuse');
+    assert.equal(resolveWorkerIdleIntent('done'), 'done-review-or-shutdown');
   });
 });
 

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -355,6 +355,7 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /send-keys/);
       assert.match(tmuxLog, /-t %99/, 'should target leader pane when present');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'should emit all-workers-idle nudge');
+      assert.doesNotMatch(tmuxLog, /\[OMX_INTENT:/, 'should keep orchestration intent out of injected display text');
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
       const submitMatches = tmuxLog.match(/send-keys -t %99 C-m/g) || [];
       assert.equal(submitMatches.length, 2, 'leader nudge should submit with isolated double C-m');
@@ -364,9 +365,10 @@ describe('notify-hook team leader nudge', () => {
       assert.ok(existsSync(eventsPath), 'events.ndjson should exist');
       const eventsContent = await readFile(eventsPath, 'utf-8');
       const events = eventsContent.trim().split('\n').map(line => JSON.parse(line));
-      const nudgeEvent = events.find((e: { type: string }) => e.type === 'team_leader_nudge');
+      const nudgeEvent = events.find((e: { type: string; orchestration_intent?: string }) => e.type === 'team_leader_nudge');
       assert.ok(nudgeEvent, 'should have team_leader_nudge event');
       assert.equal(nudgeEvent.reason, 'done_waiting_on_leader');
+      assert.equal(nudgeEvent.orchestration_intent, 'done-review-or-shutdown');
     });
   });
 
@@ -849,12 +851,14 @@ exit 0
       assert.match(tmuxLog, /no start evidence/);
       assert.match(tmuxLog, /status: unknown/);
       assert.match(tmuxLog, /Next: check worker-1 msg\/output, confirm task in omx team status ack-missing-start/);
+      assert.doesNotMatch(tmuxLog, /\[OMX_INTENT:/);
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
-      const nudgeEvent = events.find((e: { type?: string; reason?: string }) =>
+      const nudgeEvent = events.find((e: { type?: string; reason?: string; orchestration_intent?: string }) =>
         e.type === 'team_leader_nudge' && e.reason === 'ack_without_start_evidence');
       assert.ok(nudgeEvent, 'should emit an ack_without_start_evidence leader nudge');
+      assert.equal(nudgeEvent.orchestration_intent, 'followup-relaunch');
     });
   });
 
@@ -934,7 +938,7 @@ exit 0
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
-      const nudgeEvent = events.find((e: { type?: string }) => e.type === 'team_leader_nudge');
+      const nudgeEvent = events.find((e: { type?: string; reason?: string; orchestration_intent?: string }) => e.type === 'team_leader_nudge');
       assert.equal(nudgeEvent?.reason, 'new_mailbox_message');
     });
   });
@@ -1709,12 +1713,14 @@ exit 0
       assert.match(tmuxLog, /Team stalled-progress: leader stale, no progress 3m\./);
       assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
       assert.doesNotMatch(tmuxLog, /keep polling/);
+      assert.doesNotMatch(tmuxLog, /\[OMX_INTENT:/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/);
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
       const nudgeEvent = events.find((e: { type?: string }) => e.type === 'team_leader_nudge');
       assert.equal(nudgeEvent?.reason, 'stuck_waiting_on_leader');
+      assert.equal(nudgeEvent?.orchestration_intent, 'stalled-unblock');
     });
   });
 
@@ -2401,12 +2407,13 @@ exit 0
       assert.ok(existsSync(eventsPath), 'events.ndjson should exist after nudge');
       const eventsContent = await readFile(eventsPath, 'utf-8');
       const events = eventsContent.trim().split('\n').map(line => JSON.parse(line));
-      const nudgeEvent = events.find((e: { type: string }) => e.type === 'team_leader_nudge');
+      const nudgeEvent = events.find((e: { type: string; orchestration_intent?: string }) => e.type === 'team_leader_nudge');
       assert.ok(nudgeEvent, 'should have a team_leader_nudge event');
       assert.equal(nudgeEvent.team, teamName);
       assert.equal(nudgeEvent.worker, 'leader-fixed');
       assert.ok(nudgeEvent.reason, 'event should have a reason');
       assert.notEqual(nudgeEvent.reason, 'leader_pane_missing_no_injection');
+      assert.ok(nudgeEvent.orchestration_intent, 'event should record an orchestration intent');
     });
   });
 
@@ -2474,12 +2481,14 @@ exit 0
       assert.equal(deferred.source_type, 'leader_nudge');
       assert.equal(deferred.tmux_session, 'devsess:0');
       assert.equal(deferred.leader_pane_id, null);
+      assert.equal(deferred.orchestration_intent, 'pending-mailbox-review');
       assert.equal(deferred.tmux_injection_attempted, false);
 
       const nudgeStatePath = join(stateDir, 'team-leader-nudge.json');
       assert.ok(existsSync(nudgeStatePath), 'nudge state should still advance on deferred leader visibility');
       const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       assert.ok(nudgeState.last_nudged_by_team?.[teamName]?.at);
+      assert.equal(nudgeState.last_nudged_by_team?.[teamName]?.orchestration_intent, 'pending-mailbox-review');
     });
   });
 
@@ -2536,6 +2545,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       const sends = tmuxLog.match(/send-keys -t %98 -l \[OMX\] All 2 workers idle/g) || [];
       assert.equal(sends.length, 1, 'cooldown should keep repeated all-workers-idle leader nudges bounded');
+      assert.doesNotMatch(tmuxLog, /\[OMX_INTENT:/);
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-worker-idle.test.ts
+++ b/src/hooks/__tests__/notify-hook-worker-idle.test.ts
@@ -696,15 +696,19 @@ exit 0
       assert.ok(existsSync(eventsPath), 'events.ndjson should exist');
       const content = await readFile(eventsPath, 'utf-8');
       const events = content.trim().split('\n').map(line => JSON.parse(line));
-      const workerIdleEvent = events.find((e: { type: string }) => e.type === 'worker_idle');
+      const workerIdleEvent = events.find((e: { type: string; orchestration_intent?: string }) => e.type === 'worker_idle');
       assert.ok(workerIdleEvent, 'should have a worker_idle event');
       assert.equal(workerIdleEvent.team, teamName);
       assert.equal(workerIdleEvent.worker, 'worker-1');
       assert.equal(workerIdleEvent.prev_state, 'working');
       assert.equal(workerIdleEvent.task_id, 'task-99');
       assert.equal(workerIdleEvent.reason, 'finished');
+      assert.equal(workerIdleEvent.orchestration_intent, 'followup-reuse');
       assert.ok(workerIdleEvent.event_id, 'event should have an event_id');
       assert.ok(workerIdleEvent.created_at, 'event should have a created_at');
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /\[OMX_INTENT:/);
     });
   });
 

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -12,6 +12,7 @@ import { readJsonIfExists, getScopedStateDirsForCurrentSession, readdir } from '
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
+import { stripOrchestrationIntentTags } from './orchestration-intent.js';
 import { buildCapturePaneArgv, DEFAULT_MARKER, tmuxHookExplicitlyDisablesInjection } from '../tmux-hook-engine.js';
 import {
   isManagedOmxSession,
@@ -282,7 +283,7 @@ const SEMANTIC_STALL_PROMPT_PATTERNS = [
 ];
 
 function normalizeStallDetectionText(text) {
-  return safeString(text)
+  return stripOrchestrationIntentTags(safeString(text))
     .replace(/\r\n?/g, '\n')
     .split('\n')
     .filter((line) => !line.includes(DEFAULT_MARKER))

--- a/src/scripts/notify-hook/orchestration-intent.ts
+++ b/src/scripts/notify-hook/orchestration-intent.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+
+import { safeString } from './utils.js';
+
+export const TEAM_ORCHESTRATION_INTENTS = [
+  'followup-reuse',
+  'followup-relaunch',
+  'stalled-unblock',
+  'done-review-or-shutdown',
+  'pending-mailbox-review',
+] as const;
+
+export const ORCHESTRATION_INTENT_TAG_PREFIX = '[OMX_INTENT:';
+
+const ORCHESTRATION_INTENT_TAG_RE = /\s*\[OMX_INTENT:[a-z0-9-]+\]/gi;
+
+export function buildOrchestrationIntentTag(intent) {
+  const normalizedIntent = safeString(intent).trim();
+  return normalizedIntent ? `${ORCHESTRATION_INTENT_TAG_PREFIX}${normalizedIntent}]` : '';
+}
+
+export function appendOrchestrationIntentTag(text, intent) {
+  const normalizedText = safeString(text).trim();
+  const tag = buildOrchestrationIntentTag(intent);
+  if (!tag) return normalizedText;
+  return normalizedText ? `${normalizedText} ${tag}` : tag;
+}
+
+export function stripOrchestrationIntentTags(text) {
+  return safeString(text).replace(ORCHESTRATION_INTENT_TAG_RE, '');
+}
+
+export function classifyLeaderActionState({
+  allWorkersIdle = false,
+  workerPanesAlive = false,
+  taskCounts = {},
+  teamProgressStalled = false,
+} = {}) {
+  const pending = Number.isFinite(taskCounts.pending) ? taskCounts.pending : 0;
+  const blocked = Number.isFinite(taskCounts.blocked) ? taskCounts.blocked : 0;
+  const inProgress = Number.isFinite(taskCounts.in_progress) ? taskCounts.in_progress : 0;
+  const tasksComplete = pending === 0 && blocked === 0 && inProgress === 0;
+  const pendingFollowUpTasks = allWorkersIdle && pending > 0 && blocked === 0 && inProgress === 0;
+  const blockedWaitingOnLeader = allWorkersIdle && blocked > 0 && pending === 0 && inProgress === 0;
+  const terminalWaitingOnLeader = allWorkersIdle && tasksComplete && workerPanesAlive;
+  const stalledWaitingOnLeader = blockedWaitingOnLeader || teamProgressStalled;
+
+  if (terminalWaitingOnLeader) return 'done_waiting_on_leader';
+  if (stalledWaitingOnLeader) return 'stuck_waiting_on_leader';
+  if (pendingFollowUpTasks) return 'still_actionable';
+  return 'still_actionable';
+}
+
+export function resolveAllWorkersIdleIntent(leaderActionState = 'still_actionable') {
+  if (leaderActionState === 'done_waiting_on_leader') return 'done-review-or-shutdown';
+  if (leaderActionState === 'stuck_waiting_on_leader') return 'stalled-unblock';
+  return 'followup-reuse';
+}
+
+export function resolveLeaderNudgeIntent({ nudgeReason = '', leaderActionState = 'still_actionable' } = {}) {
+  switch (safeString(nudgeReason).trim()) {
+    case 'new_mailbox_message':
+    case 'stale_leader_with_messages':
+      return 'pending-mailbox-review';
+    case 'ack_without_start_evidence':
+      return 'followup-relaunch';
+    case 'stuck_waiting_on_leader':
+    case 'stale_leader_panes_alive':
+      return 'stalled-unblock';
+    case 'done_waiting_on_leader':
+      return 'done-review-or-shutdown';
+    case 'all_workers_idle':
+    default:
+      return resolveAllWorkersIdleIntent(leaderActionState);
+  }
+}
+
+export function resolveWorkerIdleIntent(currentState = 'idle') {
+  return safeString(currentState).trim() === 'done'
+    ? 'done-review-or-shutdown'
+    : 'followup-reuse';
+}

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -12,6 +12,10 @@ import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
+import {
+  classifyLeaderActionState,
+  resolveLeaderNudgeIntent,
+} from './orchestration-intent.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
@@ -80,27 +84,6 @@ function buildMailboxCheckReminder(teamName) {
 
 function buildWorkerStartEvidenceReminder(teamName, workerName) {
   return `Next: check ${workerName} msg/output, confirm task in omx team status ${teamName}, then reassign/nudge.`;
-}
-
-function classifyLeaderActionState({
-  allWorkersIdle = false,
-  workerPanesAlive = false,
-  taskCounts = {},
-  teamProgressStalled = false,
-} = {}) {
-  const pending = Number.isFinite(taskCounts.pending) ? taskCounts.pending : 0;
-  const blocked = Number.isFinite(taskCounts.blocked) ? taskCounts.blocked : 0;
-  const inProgress = Number.isFinite(taskCounts.in_progress) ? taskCounts.in_progress : 0;
-  const tasksComplete = pending === 0 && blocked === 0 && inProgress === 0;
-  const pendingFollowUpTasks = allWorkersIdle && pending > 0 && blocked === 0 && inProgress === 0;
-  const blockedWaitingOnLeader = allWorkersIdle && blocked > 0 && pending === 0 && inProgress === 0;
-  const terminalWaitingOnLeader = allWorkersIdle && tasksComplete && workerPanesAlive;
-  const stalledWaitingOnLeader = blockedWaitingOnLeader || teamProgressStalled;
-
-  if (terminalWaitingOnLeader) return 'done_waiting_on_leader';
-  if (stalledWaitingOnLeader) return 'stuck_waiting_on_leader';
-  if (pendingFollowUpTasks) return 'still_actionable';
-  return 'still_actionable';
 }
 
 function buildLeaderActionGuidance(teamName) {
@@ -476,7 +459,7 @@ async function getAckWithoutStartEvidence(stateDir, teamName, msg) {
   };
 }
 
-export async function emitTeamNudgeEvent(cwd, teamName, reason, nowIso) {
+export async function emitTeamNudgeEvent(cwd, teamName, reason, orchestrationIntent, nowIso) {
   const eventsDir = join(cwd, '.omx', 'state', 'team', teamName, 'events');
   const eventsPath = join(eventsDir, 'events.ndjson');
   try {
@@ -487,6 +470,7 @@ export async function emitTeamNudgeEvent(cwd, teamName, reason, nowIso) {
       type: 'team_leader_nudge',
       worker: 'leader-fixed',
       reason,
+      orchestration_intent: orchestrationIntent,
       created_at: nowIso,
     };
     await appendFile(eventsPath, JSON.stringify(event) + '\n');
@@ -495,7 +479,7 @@ export async function emitTeamNudgeEvent(cwd, teamName, reason, nowIso) {
   }
 }
 
-async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmuxSession = '', leaderPaneId = '', paneCurrentCommand = '', sourceType = 'leader_nudge' } = {}) {
+async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, orchestrationIntent, nowIso, { tmuxSession = '', leaderPaneId = '', paneCurrentCommand = '', sourceType = 'leader_nudge' } = {}) {
   const eventsDir = join(cwd, '.omx', 'state', 'team', teamName, 'events');
   const eventsPath = join(eventsDir, 'events.ndjson');
   try {
@@ -510,6 +494,7 @@ async function emitLeaderNudgeDeferredEvent(cwd, teamName, reason, nowIso, { tmu
       created_at: nowIso,
       tmux_session: tmuxSession || null,
       leader_pane_id: leaderPaneId || null,
+      orchestration_intent: orchestrationIntent,
       tmux_injection_attempted: false,
       pane_current_command: paneCurrentCommand || null,
       source_type: sourceType,
@@ -761,15 +746,25 @@ export async function maybeNudgeTeamLeader({
     } else {
       continue;
     }
+    const orchestrationIntent = resolveLeaderNudgeIntent({ nudgeReason, leaderActionState });
     const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
     const markedText = `${capped} ${DEFAULT_MARKER}`;
 
     if (!tmuxTarget) {
-      nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '', reason: nudgeReason };
+      nudgeState.last_nudged_by_team[teamName] = {
+        at: nowIso,
+        last_message_id: newestId || prevMsgId || '',
+        reason: nudgeReason,
+        orchestration_intent: orchestrationIntent,
+      };
       if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = { at: nowIso, worker_count: workerNames.length };
+        nudgeState.last_idle_nudged_by_team[teamName] = {
+          at: nowIso,
+          worker_count: workerNames.length,
+          orchestration_intent: orchestrationIntent,
+        };
       }
-      await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, nowIso, {
+      await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
         sourceType: 'leader_nudge',
@@ -784,6 +779,7 @@ export async function maybeNudgeTeamLeader({
           reason: LEADER_PANE_MISSING_NO_INJECTION_REASON,
           leader_pane_id: leaderPaneId || null,
           tmux_session: tmuxSession || null,
+          orchestration_intent: orchestrationIntent,
           tmux_injection_attempted: false,
           source_type: 'leader_nudge',
         });
@@ -796,6 +792,7 @@ export async function maybeNudgeTeamLeader({
         transport: 'none',
         result: 'deferred',
         reason: LEADER_PANE_MISSING_NO_INJECTION_REASON,
+        orchestration_intent: orchestrationIntent,
       }).catch(() => {});
       continue;
     }
@@ -812,11 +809,20 @@ export async function maybeNudgeTeamLeader({
       const deferredReason = paneGuard.reason === 'pane_running_shell'
         ? LEADER_PANE_SHELL_NO_INJECTION_REASON
         : paneGuard.reason;
-      nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '', reason: nudgeReason };
+      nudgeState.last_nudged_by_team[teamName] = {
+        at: nowIso,
+        last_message_id: newestId || prevMsgId || '',
+        reason: nudgeReason,
+        orchestration_intent: orchestrationIntent,
+      };
       if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = { at: nowIso, worker_count: workerNames.length };
+        nudgeState.last_idle_nudged_by_team[teamName] = {
+          at: nowIso,
+          worker_count: workerNames.length,
+          orchestration_intent: orchestrationIntent,
+        };
       }
-      await emitLeaderNudgeDeferredEvent(cwd, teamName, deferredReason, nowIso, {
+      await emitLeaderNudgeDeferredEvent(cwd, teamName, deferredReason, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
         paneCurrentCommand: paneGuard.paneCurrentCommand,
@@ -834,6 +840,7 @@ export async function maybeNudgeTeamLeader({
           tmux_session: tmuxSession || null,
           tmux_injection_attempted: false,
           pane_target: tmuxTarget,
+          orchestration_intent: orchestrationIntent,
           readiness_evidence: paneGuard.readinessEvidence || null,
           pane_current_command: paneGuard.paneCurrentCommand || null,
           injection_skip_reason: paneGuard.reason,
@@ -848,6 +855,7 @@ export async function maybeNudgeTeamLeader({
         transport: 'none',
         result: 'deferred',
         reason: deferredReason,
+        orchestration_intent: orchestrationIntent,
       }).catch(() => {});
       continue;
     }
@@ -862,12 +870,21 @@ export async function maybeNudgeTeamLeader({
       if (!sendResult.ok) {
         throw new Error(sendResult.error || sendResult.reason);
       }
-      nudgeState.last_nudged_by_team[teamName] = { at: nowIso, last_message_id: newestId || prevMsgId || '', reason: nudgeReason };
+      nudgeState.last_nudged_by_team[teamName] = {
+        at: nowIso,
+        last_message_id: newestId || prevMsgId || '',
+        reason: nudgeReason,
+        orchestration_intent: orchestrationIntent,
+      };
       if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = { at: nowIso, worker_count: workerNames.length };
+        nudgeState.last_idle_nudged_by_team[teamName] = {
+          at: nowIso,
+          worker_count: workerNames.length,
+          orchestration_intent: orchestrationIntent,
+        };
       }
 
-      await emitTeamNudgeEvent(cwd, teamName, nudgeReason, nowIso);
+      await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
 
       try {
         await logTmuxHookEvent(logsDir, {
@@ -876,6 +893,7 @@ export async function maybeNudgeTeamLeader({
           team: teamName,
           tmux_target: tmuxTarget,
           reason: nudgeReason,
+          orchestration_intent: orchestrationIntent,
           pane_count: paneStatus.paneCount,
           leader_stale: leaderStale,
           message_count: messages.length,
@@ -891,6 +909,7 @@ export async function maybeNudgeTeamLeader({
         transport: 'send-keys',
         result: 'sent',
         reason: nudgeReason,
+        orchestration_intent: orchestrationIntent,
       }).catch(() => {});
     } catch (err) {
       try {
@@ -900,6 +919,7 @@ export async function maybeNudgeTeamLeader({
           team: teamName,
           tmux_target: tmuxTarget,
           reason: nudgeReason,
+          orchestration_intent: orchestrationIntent,
           error: safeString(err && err.message ? err.message : err),
         });
       } catch { /* ignore */ }
@@ -911,6 +931,7 @@ export async function maybeNudgeTeamLeader({
         transport: 'send-keys',
         result: 'failed',
         reason: nudgeReason,
+        orchestration_intent: orchestrationIntent,
         error: safeString(err && err.message ? err.message : err),
       }).catch(() => {});
     }

--- a/src/scripts/notify-hook/team-worker.ts
+++ b/src/scripts/notify-hook/team-worker.ts
@@ -3,7 +3,7 @@
  * Team worker: heartbeat, idle detection, and leader notification.
  */
 
-import { readFile, writeFile, mkdir, appendFile, rename, stat } from 'fs/promises';
+import { readFile, writeFile, mkdir, appendFile, rename, stat, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, resolve as resolvePath } from 'path';
 import { asNumber, safeString, isTerminalPhase } from './utils.js';
@@ -11,6 +11,11 @@ import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
+import {
+  classifyLeaderActionState,
+  resolveAllWorkersIdleIntent,
+  resolveWorkerIdleIntent,
+} from './orchestration-intent.js';
 import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 
@@ -258,6 +263,31 @@ export async function readTeamWorkersForIdleCheck(stateDir, teamName) {
   }
 }
 
+async function readTeamTaskCounts(stateDir, teamName) {
+  const tasksDir = join(stateDir, 'team', teamName, 'tasks');
+  const taskCounts = { pending: 0, blocked: 0, in_progress: 0, completed: 0, failed: 0 };
+  if (!existsSync(tasksDir)) return taskCounts;
+
+  try {
+    const taskFiles = (await readdir(tasksDir))
+      .filter((entry) => /^task-\d+\.json$/.test(entry))
+      .sort();
+    for (const entry of taskFiles) {
+      try {
+        const parsed = JSON.parse(await readFile(join(tasksDir, entry), 'utf-8'));
+        const status = safeString(parsed?.status || 'pending').trim() || 'pending';
+        if (Object.hasOwn(taskCounts, status)) taskCounts[status] += 1;
+      } catch {
+        // ignore malformed task files
+      }
+    }
+  } catch {
+    return taskCounts;
+  }
+
+  return taskCounts;
+}
+
 async function resolveCanonicalLeaderPaneId(_tmuxSession, leaderPaneId) {
   const normalizedLeaderPaneId = safeString(leaderPaneId).trim();
   if (normalizedLeaderPaneId) {
@@ -295,6 +325,7 @@ async function emitLeaderPaneMissingDeferred({
   reason = 'leader_pane_missing_no_injection',
   paneCurrentCommand = '',
   sourceType = 'unknown',
+  orchestrationIntent = '',
 }) {
   const nowIso = new Date().toISOString();
   await logTmuxHookEvent(logsDir, {
@@ -306,6 +337,7 @@ async function emitLeaderPaneMissingDeferred({
     reason,
     leader_pane_id: leaderPaneId || null,
     tmux_session: tmuxSession || null,
+    orchestration_intent: orchestrationIntent || null,
     tmux_injection_attempted: false,
     pane_current_command: paneCurrentCommand || null,
     source_type: sourceType,
@@ -324,6 +356,7 @@ async function emitLeaderPaneMissingDeferred({
     created_at: nowIso,
     leader_pane_id: leaderPaneId || null,
     tmux_session: tmuxSession || null,
+    orchestration_intent: orchestrationIntent || null,
     tmux_injection_attempted: false,
     pane_current_command: paneCurrentCommand || null,
     source_type: sourceType,
@@ -393,12 +426,21 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   );
   if (!allIdle) return;
 
+  const taskCounts = await readTeamTaskCounts(stateDir, teamName);
+  const leaderActionState = classifyLeaderActionState({
+    allWorkersIdle: allIdle,
+    workerPanesAlive: snapshots.length > 0,
+    taskCounts,
+  });
+  const orchestrationIntent = resolveAllWorkersIdleIntent(leaderActionState);
+
   if (!canonicalLeaderPaneId) {
     const nextIdleState = {
       ...idleState,
       last_notified_at_ms: nowMs,
       last_notified_at: nowIso,
       worker_count: workers.length,
+      orchestration_intent: orchestrationIntent,
       delivery: 'deferred',
     };
     await writeFile(idleStatePath, JSON.stringify(nextIdleState, null, 2)).catch(() => {});
@@ -410,6 +452,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       sourceType: 'all_workers_idle',
       tmuxSession,
       leaderPaneId: canonicalLeaderPaneId,
+      orchestrationIntent,
     });
     return;
   }
@@ -425,6 +468,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       last_notified_at_ms: nowMs,
       last_notified_at: nowIso,
       worker_count: N,
+      orchestration_intent: orchestrationIntent,
       delivery: 'deferred_shell',
       pane_current_command: paneGuard.paneCurrentCommand || null,
     };
@@ -439,6 +483,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       sourceType: 'all_workers_idle',
       tmuxSession,
       leaderPaneId: canonicalLeaderPaneId,
+      orchestrationIntent,
     });
     return;
   }
@@ -457,6 +502,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       last_notified_at_ms: nowMs,
       last_notified_at: nowIso,
       worker_count: N,
+      orchestration_intent: orchestrationIntent,
     };
     await writeFile(idleStatePath, JSON.stringify(nextIdleState, null, 2)).catch(() => {});
 
@@ -470,6 +516,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
         type: 'all_workers_idle',
         worker: workerName,
         worker_count: N,
+        orchestration_intent: orchestrationIntent,
         created_at: nowIso,
       };
       await appendFile(eventsPath, JSON.stringify(event) + '\n');
@@ -482,6 +529,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       tmux_target: tmuxTarget,
       worker: workerName,
       worker_count: N,
+      orchestration_intent: orchestrationIntent,
     });
   } catch (err) {
     await logTmuxHookEvent(logsDir, {
@@ -490,6 +538,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       team: teamName,
       tmux_target: tmuxTarget,
       worker: workerName,
+      orchestration_intent: orchestrationIntent,
       error: err instanceof Error ? err.message : safeString(err),
     }).catch(() => {});
   }
@@ -557,6 +606,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
   if (currentState !== 'idle' && currentState !== 'done') return;
   if (!statusFresh) return;
   if (prevState === 'idle' || prevState === 'done') return;
+  const orchestrationIntent = resolveWorkerIdleIntent(currentState);
 
   const heartbeat = await readWorkerHeartbeatSnapshot(stateDir, teamName, workerName, nowMs);
   if (!heartbeat.fresh) return;
@@ -588,6 +638,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       sourceType: 'worker_idle',
       tmuxSession,
       leaderPaneId: canonicalLeaderPaneId,
+      orchestrationIntent,
     });
     return;
   }
@@ -600,6 +651,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
         last_notified_at_ms: nowMs,
         last_notified_at: nowIso,
         prev_state: prevState,
+        orchestration_intent: orchestrationIntent,
         delivery: 'deferred_shell',
         pane_current_command: paneGuard.paneCurrentCommand || null,
       }, null, 2));
@@ -615,6 +667,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       sourceType: 'worker_idle',
       tmuxSession,
       leaderPaneId: canonicalLeaderPaneId,
+      orchestrationIntent,
     });
     return;
   }
@@ -643,6 +696,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
         last_notified_at_ms: nowMs,
         last_notified_at: nowIso,
         prev_state: prevState,
+        orchestration_intent: orchestrationIntent,
       }, null, 2));
       await rename(tmpPath, cooldownPath);
     } catch { /* best effort */ }
@@ -660,6 +714,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
         prev_state: prevState,
         task_id: currentTaskId || null,
         reason: currentReason || null,
+        orchestration_intent: orchestrationIntent,
         created_at: nowIso,
       };
       await appendFile(eventsPath, JSON.stringify(event) + '\n');
@@ -673,6 +728,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       worker: workerName,
       prev_state: prevState,
       task_id: currentTaskId || null,
+      orchestration_intent: orchestrationIntent,
     });
   } catch (err) {
     await logTmuxHookEvent(logsDir, {
@@ -681,6 +737,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       team: teamName,
       tmux_target: tmuxTarget,
       worker: workerName,
+      orchestration_intent: orchestrationIntent,
       error: err instanceof Error ? err.message : safeString(err),
     }).catch(() => {});
   }

--- a/src/team/__tests__/mcp-comm.test.ts
+++ b/src/team/__tests__/mcp-comm.test.ts
@@ -39,6 +39,7 @@ describe('mcp-comm', () => {
         workerIndex: 1,
         inbox: '# hi',
         triggerMessage: 'trigger',
+        intent: 'followup-relaunch',
         cwd,
         notify: async () => {
           events.push('notify');
@@ -52,6 +53,8 @@ describe('mcp-comm', () => {
       assert.equal(outcome.transport, 'tmux_send_keys');
       assert.ok(outcome.request_id);
       assert.deepEqual(events, ['notify']);
+      const requests = await listDispatchRequests('alpha', cwd, { kind: 'inbox' });
+      assert.equal(requests[0]?.intent, 'followup-relaunch');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -69,6 +72,7 @@ describe('mcp-comm', () => {
         toWorkerIndex: 2,
         body: 'hello',
         triggerMessage: 'check mailbox',
+        intent: 'pending-mailbox-review',
         cwd,
         notify: async () => ({ ok: true, transport: 'tmux_send_keys', reason: 'sent' }),
       });
@@ -83,6 +87,7 @@ describe('mcp-comm', () => {
       const requests = await listDispatchRequests('alpha', cwd, { kind: 'mailbox' });
       assert.equal(requests.length, 1);
       assert.equal(requests[0]?.message_id, mailbox[0]?.message_id);
+      assert.equal(requests[0]?.intent, 'pending-mailbox-review');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -386,6 +386,7 @@ exit 1
           kind: 'inbox',
           to_worker: 'worker-1',
           trigger_message: 'ping',
+          intent: 'followup-relaunch',
         },
         cwd,
       );
@@ -396,8 +397,9 @@ exit 1
       const jsonStart = queueLine.indexOf('{');
       const stateDirFlag = queueLine.lastIndexOf(' --state-dir=');
       const jsonPayload = stateDirFlag > jsonStart ? queueLine.slice(jsonStart, stateDirFlag) : queueLine.slice(jsonStart);
-      const payload = JSON.parse(jsonPayload) as { request_id: string };
+      const payload = JSON.parse(jsonPayload) as { request_id: string; metadata?: { intent?: string } };
       assert.equal(payload.request_id, queued.request.request_id);
+      assert.equal(payload.metadata?.intent, 'followup-relaunch');
     } finally {
       if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
       else delete process.env.OMX_RUNTIME_BINARY;
@@ -416,6 +418,7 @@ exit 1
           to_worker: 'worker-1',
           message_id: 'msg-1',
           trigger_message: 'check mailbox',
+          intent: 'pending-mailbox-review',
         },
         cwd,
       );
@@ -443,6 +446,7 @@ exit 1
       const listed = await listDispatchRequests('team-dispatch', cwd);
       assert.equal(listed.length, 1);
       assert.equal(listed[0]?.message_id, 'msg-1');
+      assert.equal(listed[0]?.intent, 'pending-mailbox-review');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -17,8 +17,11 @@ import {
   generateTaskAssignmentInbox,
   generateShutdownInbox,
   generateTriggerMessage,
+  buildTriggerDirective,
   generateMailboxTriggerMessage,
+  buildMailboxTriggerDirective,
   generateLeaderMailboxTriggerMessage,
+  buildLeaderMailboxTriggerDirective,
 } from "../worker-bootstrap.js";
 import { composeRoleInstructionsForRole } from "../../agents/native-config.js";
 import type { TeamTask } from "../state.js";
@@ -444,6 +447,13 @@ describe("worker bootstrap", () => {
     assert.match(message, /next feasible task/i);
   });
 
+  it("buildTriggerDirective keeps human text separate from orchestration intent", () => {
+    const directive = buildTriggerDirective("worker-9", "team-path");
+    assert.equal(directive.intent, "followup-relaunch");
+    assert.match(directive.text, /\.omx\/state\/team\/team-path\/workers\/worker-9\/inbox\.md/);
+    assert.doesNotMatch(directive.text, /OMX_INTENT/);
+  });
+
   it("generateTriggerMessage uses provided state-root reference for worktree workers", () => {
     const message = generateTriggerMessage(
       "worker-9",
@@ -481,6 +491,13 @@ describe("worker bootstrap", () => {
     assert.match(message, /concrete progress/i);
     assert.match(message, /continue assigned work/i);
     assert.match(message, /next feasible task/i);
+  });
+
+  it("buildMailboxTriggerDirective keeps mailbox review intent out of display text", () => {
+    const directive = buildMailboxTriggerDirective("worker-2", "team-mail", 3);
+    assert.equal(directive.intent, "pending-mailbox-review");
+    assert.match(directive.text, /3 new message/);
+    assert.doesNotMatch(directive.text, /OMX_INTENT/);
   });
 
   it("generateMailboxTriggerMessage uses provided state-root reference for worktree workers", () => {
@@ -522,6 +539,13 @@ describe("worker bootstrap", () => {
     assert.match(message, /worker-2 sent a new message/);
     assert.match(message, /Review it and decide the next concrete step/);
     assert.doesNotMatch(message, /\bReply\b/i);
+  });
+
+  it("buildLeaderMailboxTriggerDirective records leader mailbox-review intent separately", () => {
+    const directive = buildLeaderMailboxTriggerDirective("team-mail", "worker-2");
+    assert.equal(directive.intent, "pending-mailbox-review");
+    assert.match(directive.text, /worker-2 sent a new message/);
+    assert.doesNotMatch(directive.text, /OMX_INTENT/);
   });
 
   it("generateLeaderMailboxTriggerMessage uses provided state-root reference for worktree leaders", () => {

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -16,7 +16,7 @@ import { readTeamEvents, waitForTeamEvent } from './state/events.js';
 import { queueDirectMailboxMessage } from './mcp-comm.js';
 import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
-import { generateLeaderMailboxTriggerMessage, generateMailboxTriggerMessage } from './worker-bootstrap.js';
+import { buildLeaderMailboxTriggerDirective, buildMailboxTriggerDirective } from './worker-bootstrap.js';
 import {
   teamBroadcast as broadcastMessage,
   teamListMailbox as listMailboxMessages,
@@ -248,6 +248,12 @@ function summarizeEvent(event: TeamEvent | null): Record<string, unknown> | null
     task_id: event.task_id ?? null,
     created_at: event.created_at,
     reason: event.reason ?? null,
+    intent:
+      typeof event.intent === 'string'
+        ? event.intent
+        : typeof (event as Record<string, unknown>).orchestration_intent === 'string'
+          ? (event as Record<string, unknown>).orchestration_intent
+          : null,
     state: event.state ?? null,
     prev_state: event.prev_state ?? null,
     source_type: event.source_type ?? null,
@@ -547,9 +553,9 @@ export async function executeTeamApiOperation(
           return { ok: false, operation, error: { code: 'worker_not_found', message: `Worker ${toWorker} not found in team ${teamName}` } };
         }
 
-        const triggerMessage = toWorker === 'leader-fixed'
-          ? generateLeaderMailboxTriggerMessage(teamName, fromWorker)
-          : generateMailboxTriggerMessage(toWorker, teamName, 1);
+        const triggerDirective = toWorker === 'leader-fixed'
+          ? buildLeaderMailboxTriggerDirective(teamName, fromWorker)
+          : buildMailboxTriggerDirective(toWorker, teamName, 1);
 
         const livePaneId = toWorker === 'leader-fixed'
           ? config.leader_pane_id ?? undefined
@@ -568,7 +574,8 @@ export async function executeTeamApiOperation(
             toWorkerIndex: recipient?.index,
             toPaneId: livePaneId,
             body,
-            triggerMessage,
+            triggerMessage: triggerDirective.text,
+            intent: triggerDirective.intent,
             cwd,
             transportPreference: 'hook_preferred_with_fallback',
             fallbackAllowed: true,

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -11,6 +11,7 @@ import {
   type TeamDispatchRequestInput,
 } from './team-ops.js';
 import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
+import type { TeamReminderIntent } from './reminder-intents.js';
 
 export interface TeamNotifierTarget {
   workerName: string;
@@ -72,9 +73,10 @@ async function logDispatchOutcome(params: {
   toWorker: string;
   dispatchKind: 'inbox' | 'mailbox';
   outcome: DispatchOutcome;
+  intent?: TeamReminderIntent;
   transportPreference?: TeamDispatchRequestInput['transport_preference'];
 }): Promise<void> {
-  const { cwd, teamName, source, requestId, messageId, toWorker, dispatchKind, outcome, transportPreference } = params;
+  const { cwd, teamName, source, requestId, messageId, toWorker, dispatchKind, outcome, intent, transportPreference } = params;
   const result = outcome.ok
     ? (outcome.reason === 'queued_for_hook_dispatch' ? 'queued' : 'ok')
     : 'failed';
@@ -86,6 +88,7 @@ async function logDispatchOutcome(params: {
     message_id: messageId,
     to_worker: toWorker,
     dispatch_kind: dispatchKind,
+    intent,
     transport_preference: transportPreference,
     transport: outcome.transport,
     result,
@@ -151,6 +154,7 @@ interface QueueInboxParams {
   paneId?: string;
   inbox: string;
   triggerMessage: string;
+  intent?: TeamReminderIntent;
   cwd: string;
   transportPreference?: TeamDispatchRequestInput['transport_preference'];
   fallbackAllowed?: boolean;
@@ -168,6 +172,7 @@ export async function queueInboxInstruction(params: QueueInboxParams): Promise<D
       worker_index: params.workerIndex,
       pane_id: params.paneId,
       trigger_message: params.triggerMessage,
+      intent: params.intent,
       transport_preference: params.transportPreference,
       fallback_allowed: params.fallbackAllowed,
       inbox_correlation_key: params.inboxCorrelationKey,
@@ -219,6 +224,7 @@ export async function queueInboxInstruction(params: QueueInboxParams): Promise<D
     toWorker: params.workerName,
     dispatchKind: 'inbox',
     outcome,
+    intent: params.intent,
     transportPreference: params.transportPreference,
   });
 
@@ -233,6 +239,7 @@ interface QueueDirectMessageParams {
   toPaneId?: string;
   body: string;
   triggerMessage: string;
+  intent?: TeamReminderIntent;
   cwd: string;
   transportPreference?: TeamDispatchRequestInput['transport_preference'];
   fallbackAllowed?: boolean;
@@ -257,6 +264,7 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
       toWorker: params.toWorker,
       dispatchKind: 'mailbox',
       outcome,
+      intent: params.intent,
       transportPreference: params.transportPreference,
     });
     return outcome;
@@ -269,6 +277,7 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
       worker_index: params.toWorkerIndex,
       pane_id: params.toPaneId,
       trigger_message: params.triggerMessage,
+      intent: params.intent,
       message_id: message.message_id,
       transport_preference: params.transportPreference,
       fallback_allowed: params.fallbackAllowed,
@@ -317,6 +326,7 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
       toWorker: params.toWorker,
       dispatchKind: 'mailbox',
       outcome,
+      intent: params.intent,
       transportPreference: params.transportPreference,
     });
     return outcome;
@@ -347,6 +357,7 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
     toWorker: params.toWorker,
     dispatchKind: 'mailbox',
     outcome,
+    intent: params.intent,
     transportPreference: params.transportPreference,
   });
   return outcome;
@@ -359,6 +370,7 @@ interface QueueBroadcastParams {
   body: string;
   cwd: string;
   triggerFor: (workerName: string) => string;
+  intentFor?: (workerName: string) => TeamReminderIntent;
   transportPreference?: TeamDispatchRequestInput['transport_preference'];
   fallbackAllowed?: boolean;
   notify: TeamNotifier;
@@ -381,6 +393,7 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
         worker_index: recipient.workerIndex,
         pane_id: recipient.paneId,
         trigger_message: params.triggerFor(recipient.workerName),
+        intent: params.intentFor?.(recipient.workerName),
         message_id: message.message_id,
         transport_preference: params.transportPreference,
         fallback_allowed: params.fallbackAllowed,
@@ -444,6 +457,7 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
       toWorker: recipient.workerName,
       dispatchKind: 'mailbox',
       outcome,
+      intent: params.intentFor?.(recipient.workerName),
       transportPreference: params.transportPreference,
     });
   }

--- a/src/team/reminder-intents.ts
+++ b/src/team/reminder-intents.ts
@@ -1,0 +1,48 @@
+export const TEAM_REMINDER_INTENTS = [
+  'followup-reuse',
+  'followup-relaunch',
+  'stalled-unblock',
+  'done-review-or-shutdown',
+  'pending-mailbox-review',
+] as const;
+
+export type TeamReminderIntent = typeof TEAM_REMINDER_INTENTS[number];
+
+export interface TeamReminderDirective {
+  text: string;
+  intent: TeamReminderIntent;
+}
+
+export function isTeamReminderIntent(value: unknown): value is TeamReminderIntent {
+  return typeof value === 'string' && TEAM_REMINDER_INTENTS.includes(value as TeamReminderIntent);
+}
+
+export function resolveLeaderNudgeIntent(
+  reason: string,
+  options: { leaderActionState?: string } = {},
+): TeamReminderIntent {
+  const leaderActionState = typeof options.leaderActionState === 'string'
+    ? options.leaderActionState
+    : 'still_actionable';
+
+  switch (reason) {
+    case 'new_mailbox_message':
+    case 'stale_leader_with_messages':
+      return 'pending-mailbox-review';
+    case 'ack_without_start_evidence':
+    case 'stuck_waiting_on_leader':
+      return 'stalled-unblock';
+    case 'done_waiting_on_leader':
+      return 'done-review-or-shutdown';
+    case 'all_workers_idle':
+      if (leaderActionState === 'done_waiting_on_leader') return 'done-review-or-shutdown';
+      if (leaderActionState === 'stuck_waiting_on_leader') return 'stalled-unblock';
+      return 'followup-relaunch';
+    case 'stale_leader_panes_alive':
+      return 'followup-reuse';
+    default:
+      if (leaderActionState === 'done_waiting_on_leader') return 'done-review-or-shutdown';
+      if (leaderActionState === 'stuck_waiting_on_leader') return 'stalled-unblock';
+      return 'followup-reuse';
+  }
+}

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -74,6 +74,7 @@ import {
   type TeamWorkerIntegrationState,
   type TeamGovernance,
   type TeamPolicy,
+  type TeamDispatchRequest,
 } from './team-ops.js';
 import {
   queueInboxInstruction,
@@ -83,6 +84,7 @@ import {
   type DispatchOutcome,
 } from './mcp-comm.js';
 import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
+import type { TeamReminderIntent } from './reminder-intents.js';
 import {
   generateWorkerOverlay,
   writeTeamWorkerInstructionsFile,
@@ -92,9 +94,9 @@ import {
   generateInitialInbox,
   generateTaskAssignmentInbox,
   generateShutdownInbox,
-  generateTriggerMessage,
-  generateMailboxTriggerMessage,
-  generateLeaderMailboxTriggerMessage,
+  buildTriggerDirective,
+  buildMailboxTriggerDirective,
+  buildLeaderMailboxTriggerDirective,
   writeWorkerRoleInstructionsFile,
 } from './worker-bootstrap.js';
 import { loadRolePrompt } from './role-router.js';
@@ -273,10 +275,11 @@ async function logRuntimeDispatchOutcome(params: {
   workerName: string;
   requestId?: string;
   messageId?: string;
+  intent?: TeamDispatchRequest['intent'];
   outcome: DispatchOutcome;
   source?: string;
 }): Promise<void> {
-  const { cwd, teamName, workerName, requestId, messageId, outcome, source = 'team.runtime' } = params;
+  const { cwd, teamName, workerName, requestId, messageId, intent, outcome, source = 'team.runtime' } = params;
   await appendTeamDeliveryLogForCwd(cwd, {
     event: 'dispatch_result',
     source,
@@ -284,6 +287,7 @@ async function logRuntimeDispatchOutcome(params: {
     request_id: requestId,
     message_id: messageId,
     to_worker: workerName,
+    intent,
     transport: outcome.transport,
     result: outcome.ok ? 'confirmed' : 'failed',
     reason: outcome.reason,
@@ -1837,6 +1841,7 @@ export async function startTeam(
       instructionsFilePath: string;
       inbox: string;
       trigger: string;
+      triggerIntent: TeamReminderIntent;
       initialPrompt?: string;
       workerLaunchArgs: string[];
       workerCli: TeamWorkerCli;
@@ -1887,11 +1892,12 @@ export async function startTeam(
         rolePromptContent: rawRolePromptContent ?? undefined,
         worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
       });
-      const trigger = generateTriggerMessage(
+      const triggerDirective = buildTriggerDirective(
         workerName,
         sanitized,
         resolveInstructionStateRoot(workerWorkspace.worktreePath),
       );
+      const trigger = triggerDirective.text;
       const initialPrompt = workerCliPlan[i - 1] === 'gemini' ? trigger : undefined;
       if (initialPrompt) {
         await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
@@ -1905,6 +1911,7 @@ export async function startTeam(
         instructionsFilePath,
         inbox,
         trigger,
+        triggerIntent: triggerDirective.intent,
         initialPrompt,
         workerLaunchArgs,
         workerCli: workerCliPlan[i - 1],
@@ -1979,13 +1986,14 @@ export async function startTeam(
       if (!bootstrapPlan) {
         throw new Error(`missing bootstrap plan for worker-${i}`);
       }
-      const { workerName, paneId, workerTasks, workerRole, inbox, trigger, initialPrompt } = {
+      const { workerName, paneId, workerTasks, workerRole, inbox, trigger, triggerIntent, initialPrompt } = {
         workerName: bootstrapPlan.workerName,
         paneId: workerPaneIds[i - 1],
         workerTasks: bootstrapPlan.workerTasks,
         workerRole: bootstrapPlan.workerRole,
         inbox: bootstrapPlan.inbox,
         trigger: bootstrapPlan.trigger,
+        triggerIntent: bootstrapPlan.triggerIntent,
         initialPrompt: bootstrapPlan.initialPrompt,
       };
       const workerWorkspace = bootstrapPlan.workerWorkspace;
@@ -2060,6 +2068,7 @@ export async function startTeam(
             workerCli: workerCliPlan[i - 1],
             inbox,
             triggerMessage: trigger,
+            intent: triggerIntent,
             cwd: leaderCwd,
             dispatchPolicy,
             inboxCorrelationKey: `startup:${workerName}`,
@@ -2509,6 +2518,11 @@ export async function assignTask(
     const maxAssignRetries = 2;
     const assignRetryDelayS = 2;
     let outcome: DispatchOutcome = { ok: false, transport: 'none', reason: 'not_attempted' };
+    const triggerDirective = buildTriggerDirective(
+      workerName,
+      sanitized,
+      resolveInstructionStateRoot(workerInfo.worktree_path),
+    );
     for (let attempt = 1; attempt <= maxAssignRetries; attempt++) {
       outcome = await dispatchCriticalInboxInstruction({
         teamName: sanitized,
@@ -2517,11 +2531,8 @@ export async function assignTask(
         workerIndex: workerInfo.index,
         paneId: workerInfo.pane_id,
         inbox,
-        triggerMessage: generateTriggerMessage(
-          workerName,
-          sanitized,
-          resolveInstructionStateRoot(workerInfo.worktree_path),
-        ),
+        triggerMessage: triggerDirective.text,
+        intent: triggerDirective.intent,
         cwd,
         dispatchPolicy,
         inboxCorrelationKey: `assign:${taskId}:${workerName}`,
@@ -2658,6 +2669,11 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       const requestedAt = new Date().toISOString();
       await writeShutdownRequest(sanitized, w.name, 'leader-fixed', cwd);
       shutdownRequestTimes.set(w.name, requestedAt);
+      const triggerDirective = buildTriggerDirective(
+        w.name,
+        sanitized,
+        resolveInstructionStateRoot(w.worktree_path),
+      );
       await dispatchCriticalInboxInstruction({
         teamName: sanitized,
         config,
@@ -2665,11 +2681,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         workerIndex: w.index,
         paneId: w.pane_id,
         inbox: generateShutdownInbox(sanitized, w.name),
-        triggerMessage: generateTriggerMessage(
-          w.name,
-          sanitized,
-          resolveInstructionStateRoot(w.worktree_path),
-        ),
+        triggerMessage: triggerDirective.text,
+        intent: triggerDirective.intent,
         cwd,
         dispatchPolicy,
         inboxCorrelationKey: `shutdown:${w.name}`,
@@ -3169,6 +3182,7 @@ async function dispatchCriticalInboxInstruction(params: {
   workerCli?: TeamWorkerCli;
   inbox: string;
   triggerMessage: string;
+  intent?: TeamReminderIntent;
   cwd: string;
   dispatchPolicy: TeamPolicy;
   inboxCorrelationKey: string;
@@ -3183,6 +3197,7 @@ async function dispatchCriticalInboxInstruction(params: {
     workerCli,
     inbox,
     triggerMessage,
+    intent,
     cwd,
     dispatchPolicy,
     inboxCorrelationKey,
@@ -3197,6 +3212,7 @@ async function dispatchCriticalInboxInstruction(params: {
       paneId,
       inbox,
       triggerMessage,
+      intent,
       cwd,
       transportPreference: 'prompt_stdin',
       fallbackAllowed: false,
@@ -3213,6 +3229,7 @@ async function dispatchCriticalInboxInstruction(params: {
       paneId,
       inbox,
       triggerMessage,
+      intent,
       cwd,
       transportPreference: 'transport_direct',
       fallbackAllowed: false,
@@ -3228,6 +3245,7 @@ async function dispatchCriticalInboxInstruction(params: {
     paneId,
     inbox,
     triggerMessage,
+    intent,
     cwd,
     transportPreference: 'hook_preferred_with_fallback',
     fallbackAllowed: true,
@@ -3361,6 +3379,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   paneId?: string;
   messageId: string;
   triggerMessage: string;
+  intent?: TeamDispatchRequest['intent'];
   config: TeamConfig;
   dispatchPolicy: TeamPolicy;
   cwd: string;
@@ -3374,6 +3393,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
     paneId,
     messageId,
     triggerMessage,
+    intent,
     config,
     dispatchPolicy,
     cwd,
@@ -3386,7 +3406,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   if (receipt && (receipt.status === 'notified' || receipt.status === 'delivered')) {
     await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
     const outcome = { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: requestId, message_id: messageId } as const;
-    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
     return outcome;
   }
 
@@ -3413,7 +3433,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
         request_id: requestId,
         message_id: messageId,
       } as const;
-      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
       return outcome;
     }
     await transitionDispatchRequest(
@@ -3431,7 +3451,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
       request_id: requestId,
       message_id: messageId,
     } as const;
-    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
     return outcome;
   }
 
@@ -3450,7 +3470,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
         request_id: requestId,
         message_id: messageId,
       } as const;
-      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
       return outcome;
     }
 
@@ -3478,7 +3498,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
       request_id: requestId,
       message_id: messageId,
     } as const;
-    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
     return outcome;
   }
 
@@ -3500,7 +3520,7 @@ async function finalizeHookPreferredMailboxDispatch(params: {
     request_id: requestId,
     message_id: messageId,
   } as const;
-  await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, outcome });
+  await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
   return outcome;
 }
 
@@ -3611,7 +3631,7 @@ async function dispatchPendingMailboxMessage(params: {
   cwd: string;
 }): Promise<DispatchOutcome> {
   const { teamName, workerName, workerInfo, messageId, config, dispatchPolicy, cwd } = params;
-  const triggerMessage = generateMailboxTriggerMessage(
+  const triggerDirective = buildMailboxTriggerDirective(
     workerName,
     teamName,
     1,
@@ -3625,7 +3645,8 @@ async function dispatchPendingMailboxMessage(params: {
       to_worker: workerName,
       worker_index: workerInfo.index,
       pane_id: workerInfo.pane_id,
-      trigger_message: triggerMessage,
+      trigger_message: triggerDirective.text,
+      intent: triggerDirective.intent,
       message_id: messageId,
       transport_preference: transportPreference,
       fallback_allowed: transportPreference === 'hook_preferred_with_fallback',
@@ -3648,14 +3669,15 @@ async function dispatchPendingMailboxMessage(params: {
       workerIndex: workerInfo.index,
       paneId: workerInfo.pane_id,
       messageId,
-      triggerMessage,
+      triggerMessage: triggerDirective.text,
+      intent: triggerDirective.intent,
       config,
       dispatchPolicy,
       cwd,
     });
   }
 
-  const direct = await notifyWorkerOutcome(config, workerInfo.index, triggerMessage, workerInfo.pane_id);
+  const direct = await notifyWorkerOutcome(config, workerInfo.index, triggerDirective.text, workerInfo.pane_id);
   const outcome: DispatchOutcome = { ...direct, request_id: queued.request.request_id, message_id: messageId };
   if (outcome.ok) {
     await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
@@ -3686,6 +3708,7 @@ async function finalizeQueuedMailboxDispatch(params: {
   paneId?: string;
   messageId?: string;
   triggerMessage: string;
+  intent?: TeamDispatchRequest['intent'];
   config: TeamConfig;
   dispatchPolicy: TeamPolicy;
   cwd: string;
@@ -3700,6 +3723,7 @@ async function finalizeQueuedMailboxDispatch(params: {
     paneId,
     messageId,
     triggerMessage,
+    intent,
     config,
     dispatchPolicy,
     cwd,
@@ -3724,6 +3748,7 @@ async function finalizeQueuedMailboxDispatch(params: {
     paneId,
     messageId,
     triggerMessage,
+    intent,
     config,
     dispatchPolicy,
     cwd,
@@ -3740,7 +3765,7 @@ async function sendLeaderMailboxMessage(params: {
   cwd: string;
 }): Promise<DispatchOutcome> {
   const { teamName, fromWorker, body, config, dispatchPolicy, cwd } = params;
-  const triggerMessage = generateLeaderMailboxTriggerMessage(teamName, fromWorker);
+  const triggerDirective = buildLeaderMailboxTriggerDirective(teamName, fromWorker);
   const transportPreference = resolveLeaderMailboxTransportPreference(dispatchPolicy);
   const queuedOutcome = await queueDirectMailboxMessage({
     teamName,
@@ -3748,7 +3773,8 @@ async function sendLeaderMailboxMessage(params: {
     toWorker: 'leader-fixed',
     toPaneId: config.leader_pane_id ?? undefined,
     body,
-    triggerMessage,
+    triggerMessage: triggerDirective.text,
+    intent: triggerDirective.intent,
     cwd,
     transportPreference,
     fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
@@ -3784,6 +3810,7 @@ async function sendLeaderMailboxMessage(params: {
       workerName: 'leader-fixed',
       requestId: deferredOutcome.request_id,
       messageId: deferredOutcome.message_id,
+      intent: triggerDirective.intent,
       outcome: deferredOutcome,
     });
     return deferredOutcome;
@@ -3797,11 +3824,12 @@ async function sendLeaderMailboxMessage(params: {
     workerName: 'leader-fixed',
     paneId: config.leader_pane_id ?? undefined,
     messageId: queuedOutcome.message_id,
-    triggerMessage,
+    triggerMessage: triggerDirective.text,
+    intent: triggerDirective.intent,
     config,
     dispatchPolicy,
     cwd,
-    fallbackNotify: async () => await notifyLeaderAsync(config, triggerMessage, cwd),
+    fallbackNotify: async () => await notifyLeaderAsync(config, triggerDirective.text, cwd),
   });
 }
 
@@ -3818,7 +3846,7 @@ async function sendRecipientMailboxMessage(params: {
   const recipient = config.workers.find((worker) => worker.name === toWorker);
   if (!recipient) throw new Error(`Worker ${toWorker} not found in team`);
 
-  const triggerMessage = generateMailboxTriggerMessage(
+  const triggerDirective = buildMailboxTriggerDirective(
     toWorker,
     teamName,
     1,
@@ -3832,7 +3860,8 @@ async function sendRecipientMailboxMessage(params: {
     toWorkerIndex: recipient.index,
     toPaneId: recipient.pane_id,
     body,
-    triggerMessage,
+    triggerMessage: triggerDirective.text,
+    intent: triggerDirective.intent,
     cwd,
     transportPreference,
     fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
@@ -3851,7 +3880,8 @@ async function sendRecipientMailboxMessage(params: {
     workerIndex: recipient.index,
     paneId: recipient.pane_id,
     messageId: queuedOutcome.message_id,
-    triggerMessage,
+    triggerMessage: triggerDirective.text,
+    intent: triggerDirective.intent,
     config,
     dispatchPolicy,
     cwd,
@@ -3880,6 +3910,12 @@ async function finalizeBroadcastMailboxOutcomes(params: {
       finalizedOutcomes.push({ ...outcome, ok: false, reason: 'missing_worker_index' });
       continue;
     }
+    const triggerDirective = buildMailboxTriggerDirective(
+      target.name,
+      teamName,
+      1,
+      resolveInstructionStateRoot(target.worktree_path),
+    );
     finalizedOutcomes.push(await finalizeQueuedMailboxDispatch({
       queuedOutcome: outcome,
       transportPreference,
@@ -3888,12 +3924,8 @@ async function finalizeBroadcastMailboxOutcomes(params: {
       workerIndex: target.index,
       paneId: target.pane_id,
       messageId: outcome.message_id,
-      triggerMessage: generateMailboxTriggerMessage(
-        target.name,
-        teamName,
-        1,
-        resolveInstructionStateRoot(target.worktree_path),
-      ),
+      triggerMessage: triggerDirective.text,
+      intent: triggerDirective.intent,
       config,
       dispatchPolicy,
       cwd,
@@ -3961,12 +3993,13 @@ export async function broadcastWorkerMessage(
     recipients: config.workers.map((w) => ({ workerName: w.name, workerIndex: w.index, paneId: w.pane_id })),
     body,
     cwd,
-    triggerFor: (workerName) => generateMailboxTriggerMessage(
+    triggerFor: (workerName) => buildMailboxTriggerDirective(
       workerName,
       sanitized,
       1,
       resolveInstructionStateRoot(config.workers.find((worker) => worker.name === workerName)?.worktree_path),
-    ),
+    ).text,
+    intentFor: () => 'pending-mailbox-review',
     transportPreference,
     fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
     notify: async (target, message) =>

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -51,7 +51,7 @@ import {
 } from './mcp-comm.js';
 import {
   generateInitialInbox,
-  generateTriggerMessage,
+  buildTriggerDirective,
   writeWorkerRoleInstructionsFile,
   writeWorkerWorktreeRootAgentsFile,
   removeWorkerWorktreeRootAgentsFile,
@@ -468,7 +468,7 @@ export async function scaleUp(
         worktreeRootAgentsCanonical: Boolean(workerWorkspace?.worktreePath),
       });
 
-      const trigger = generateTriggerMessage(
+      const triggerDirective = buildTriggerDirective(
         workerName,
         sanitized,
         resolveInstructionStateRoot(workerInfo.worktree_path),
@@ -479,7 +479,8 @@ export async function scaleUp(
         workerIndex,
         paneId,
         inbox,
-        triggerMessage: trigger,
+        triggerMessage: triggerDirective.text,
+        intent: triggerDirective.intent,
         cwd: leaderCwd,
         transportPreference: dispatchPolicy.dispatch_mode,
         fallbackAllowed: true,
@@ -500,7 +501,7 @@ export async function scaleUp(
         if (receipt && (receipt.status === 'notified' || receipt.status === 'delivered')) {
           outcome = { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: queued.request_id };
         } else {
-          const fallback = await notifyWorkerPaneOutcome(sessionName, workerIndex, trigger, paneId, workerCliPlan[i]);
+          const fallback = await notifyWorkerPaneOutcome(sessionName, workerIndex, triggerDirective.text, paneId, workerCliPlan[i]);
           if (receipt?.status === 'failed') {
             if (fallback.ok) {
               await transitionDispatchRequest(
@@ -580,7 +581,7 @@ export async function scaleUp(
       // Retry dispatch once if a trust prompt is blocking the worker pane (fixes #393).
       if (!outcome.ok && dismissTrustPromptIfPresent(sessionName, workerIndex, paneId)) {
         waitForWorkerReady(sessionName, workerIndex, readyTimeoutMs, paneId);
-        const retry = await notifyWorkerPaneOutcome(sessionName, workerIndex, trigger, paneId, workerCliPlan[i]);
+        const retry = await notifyWorkerPaneOutcome(sessionName, workerIndex, triggerDirective.text, paneId, workerCliPlan[i]);
         if (retry.ok) {
           outcome = retry;
         }

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -64,6 +64,7 @@ import {
   type TeamTaskStatus,
   type TeamEventType,
 } from './contracts.js';
+import type { TeamReminderIntent } from './reminder-intents.js';
 import type { WorktreeMode } from './worktree.js';
 
 export type { TeamDispatchRequestStatus, TeamWorkerIntegrationStatus } from './contracts.js';
@@ -192,6 +193,7 @@ export interface TeamDispatchRequest {
   worker_index?: number;
   pane_id?: string;
   trigger_message: string;
+  intent?: TeamReminderIntent;
   message_id?: string;
   inbox_correlation_key?: string;
   transport_preference: TeamDispatchTransportPreference;
@@ -212,6 +214,7 @@ export interface TeamDispatchRequestInput {
   worker_index?: number;
   pane_id?: string;
   trigger_message: string;
+  intent?: TeamReminderIntent;
   message_id?: string;
   inbox_correlation_key?: string;
   transport_preference?: TeamDispatchTransportPreference;
@@ -266,6 +269,7 @@ export interface TeamEvent {
   task_id?: string;
   message_id?: string | null;
   reason?: string;
+  intent?: TeamReminderIntent;
   state?: WorkerStatus['state'];
   prev_state?: WorkerStatus['state'];
   worker_count?: number;
@@ -1476,6 +1480,7 @@ function serializeDispatchRequestToBridgeRecord(request: TeamDispatchRequest): D
       worker_index: request.worker_index,
       pane_id: request.pane_id,
       trigger_message: request.trigger_message,
+      intent: request.intent,
       message_id: request.message_id,
       inbox_correlation_key: request.inbox_correlation_key,
       transport_preference: request.transport_preference,

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type DispatchRecord, type RuntimeCommand } from '../../runtime/bridge.js';
 import { appendTeamDeliveryLogForCwd } from '../delivery-log.js';
+import { isTeamReminderIntent, type TeamReminderIntent } from '../reminder-intents.js';
 import {
   canTransitionTeamDispatchRequestStatus,
   isTeamDispatchRequestStatus,
@@ -18,6 +19,7 @@ export interface TeamDispatchRequest {
   worker_index?: number;
   pane_id?: string;
   trigger_message: string;
+  intent?: TeamReminderIntent;
   message_id?: string;
   inbox_correlation_key?: string;
   transport_preference: TeamDispatchTransportPreference;
@@ -38,6 +40,7 @@ export interface TeamDispatchRequestInput {
   worker_index?: number;
   pane_id?: string;
   trigger_message: string;
+  intent?: TeamReminderIntent;
   message_id?: string;
   inbox_correlation_key?: string;
   transport_preference?: TeamDispatchTransportPreference;
@@ -104,6 +107,7 @@ export function normalizeDispatchRequest(
     worker_index: typeof raw.worker_index === 'number' ? raw.worker_index : undefined,
     pane_id: typeof raw.pane_id === 'string' && raw.pane_id !== '' ? raw.pane_id : undefined,
     trigger_message: raw.trigger_message,
+    intent: isTeamReminderIntent(raw.intent) ? raw.intent : undefined,
     message_id: typeof raw.message_id === 'string' && raw.message_id !== '' ? raw.message_id : undefined,
     inbox_correlation_key:
       typeof raw.inbox_correlation_key === 'string' && raw.inbox_correlation_key !== '' ? raw.inbox_correlation_key : undefined,
@@ -151,6 +155,7 @@ function buildDispatchMetadata(teamName: string, requestInput: TeamDispatchReque
     worker_index: requestInput.worker_index,
     pane_id: requestInput.pane_id,
     trigger_message: requestInput.trigger_message,
+    intent: requestInput.intent,
     message_id: requestInput.message_id,
     inbox_correlation_key: requestInput.inbox_correlation_key,
     transport_preference: requestInput.transport_preference,
@@ -200,6 +205,7 @@ export function normalizeBridgeDispatchRecord(
         typeof metadata.trigger_message === 'string' && metadata.trigger_message.trim() !== ''
           ? metadata.trigger_message
           : record.reason ?? record.request_id,
+      intent: isTeamReminderIntent(metadata.intent) ? metadata.intent : undefined,
       message_id: typeof metadata.message_id === 'string' && metadata.message_id !== '' ? metadata.message_id : undefined,
       inbox_correlation_key:
         typeof metadata.inbox_correlation_key === 'string' && metadata.inbox_correlation_key !== ''
@@ -282,6 +288,7 @@ export async function enqueueDispatchRequest(
       message_id: queued.request.message_id,
       to_worker: queued.request.to_worker,
       dispatch_kind: queued.request.kind,
+      intent: queued.request.intent,
       transport: queued.request.transport_preference,
       result: 'queued',
       storage: queued.queuedTransport,

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -1,5 +1,6 @@
 import type { TeamPhase, TerminalPhase } from '../orchestrator.js';
 import type { TeamDispatchRequestStatus, TeamEventType, TeamTaskStatus } from '../contracts.js';
+import type { TeamReminderIntent } from '../reminder-intents.js';
 import type { WorktreeMode } from '../worktree.js';
 
 export interface TeamConfig {
@@ -121,6 +122,7 @@ export interface TeamDispatchRequest {
   worker_index?: number;
   pane_id?: string;
   trigger_message: string;
+  intent?: TeamReminderIntent;
   message_id?: string;
   inbox_correlation_key?: string;
   transport_preference: TeamDispatchTransportPreference;
@@ -141,6 +143,7 @@ export interface TeamDispatchRequestInput {
   worker_index?: number;
   pane_id?: string;
   trigger_message: string;
+  intent?: TeamReminderIntent;
   message_id?: string;
   inbox_correlation_key?: string;
   transport_preference?: TeamDispatchTransportPreference;
@@ -194,6 +197,7 @@ export interface TeamEvent {
   task_id?: string;
   message_id?: string | null;
   reason?: string;
+  intent?: TeamReminderIntent;
   state?: WorkerStatus['state'];
   prev_state?: WorkerStatus['state'];
   worker_count?: number;

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -9,6 +9,7 @@ import {
 } from "../verification/verifier.js";
 import { codexHome, listInstalledSkillDirectories } from "../utils/paths.js";
 import { sleep } from "../utils/sleep.js";
+import type { TeamReminderDirective } from "./reminder-intents.js";
 
 const TEAM_OVERLAY_START = "<!-- OMX:TEAM:WORKER:START -->";
 const TEAM_OVERLAY_END = "<!-- OMX:TEAM:WORKER:END -->";
@@ -810,6 +811,14 @@ export function generateTriggerMessage(
   teamName: string,
   teamStateRoot: string = ".omx/state",
 ): string {
+  return buildTriggerDirective(workerName, teamName, teamStateRoot).text;
+}
+
+export function buildTriggerDirective(
+  workerName: string,
+  teamName: string,
+  teamStateRoot: string = ".omx/state",
+): TeamReminderDirective {
   const inboxPath = buildInstructionPath(
     teamStateRoot,
     "team",
@@ -819,9 +828,15 @@ export function generateTriggerMessage(
     "inbox.md",
   );
   if (teamStateRoot !== ".omx/state") {
-    return `Read ${inboxPath}, work now, report progress, continue assigned work or next feasible task.`;
+    return {
+      intent: "followup-relaunch",
+      text: `Read ${inboxPath}, work now, report progress, continue assigned work or next feasible task.`,
+    };
   }
-  return `Read ${inboxPath}, start work now, report concrete progress, then continue assigned work or next feasible task.`;
+  return {
+    intent: "followup-relaunch",
+    text: `Read ${inboxPath}, start work now, report concrete progress, then continue assigned work or next feasible task.`,
+  };
 }
 
 /**
@@ -834,6 +849,15 @@ export function generateMailboxTriggerMessage(
   count: number,
   teamStateRoot: string = ".omx/state",
 ): string {
+  return buildMailboxTriggerDirective(workerName, teamName, count, teamStateRoot).text;
+}
+
+export function buildMailboxTriggerDirective(
+  workerName: string,
+  teamName: string,
+  count: number,
+  teamStateRoot: string = ".omx/state",
+): TeamReminderDirective {
   const n = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : 1;
   const mailboxPath = buildInstructionPath(
     teamStateRoot,
@@ -843,9 +867,15 @@ export function generateMailboxTriggerMessage(
     workerName + ".json",
   );
   if (teamStateRoot !== ".omx/state") {
-    return `${n} new msg(s): read ${mailboxPath}, act, report progress, continue assigned work or next feasible task.`;
+    return {
+      intent: "pending-mailbox-review",
+      text: `${n} new msg(s): read ${mailboxPath}, act, report progress, continue assigned work or next feasible task.`,
+    };
   }
-  return `You have ${n} new message(s). Read ${mailboxPath}, act now, reply with concrete progress, then continue assigned work or next feasible task.`;
+  return {
+    intent: "pending-mailbox-review",
+    text: `You have ${n} new message(s). Read ${mailboxPath}, act now, reply with concrete progress, then continue assigned work or next feasible task.`,
+  };
 }
 
 export function generateLeaderMailboxTriggerMessage(
@@ -853,6 +883,14 @@ export function generateLeaderMailboxTriggerMessage(
   fromWorker: string,
   teamStateRoot: string = ".omx/state",
 ): string {
+  return buildLeaderMailboxTriggerDirective(teamName, fromWorker, teamStateRoot).text;
+}
+
+export function buildLeaderMailboxTriggerDirective(
+  teamName: string,
+  fromWorker: string,
+  teamStateRoot: string = ".omx/state",
+): TeamReminderDirective {
   const mailboxPath = buildInstructionPath(
     teamStateRoot,
     "team",
@@ -861,7 +899,13 @@ export function generateLeaderMailboxTriggerMessage(
     "leader-fixed.json",
   );
   if (teamStateRoot !== ".omx/state") {
-    return `Read ${mailboxPath}; new msg from ${fromWorker}. Review it; decide next step.`;
+    return {
+      intent: "pending-mailbox-review",
+      text: `Read ${mailboxPath}; new msg from ${fromWorker}. Review it; decide next step.`,
+    };
   }
-  return `Read ${mailboxPath}; ${fromWorker} sent a new message. Review it and decide the next concrete step.`;
+  return {
+    intent: "pending-mailbox-review",
+    text: `Read ${mailboxPath}; ${fromWorker} sent a new message. Review it and decide the next concrete step.`,
+  };
 }


### PR DESCRIPTION
## Summary
- separate internal orchestration intent semantics from neutral human-facing reminder wording
- thread orchestration intent through current reminder generation and state recording without leaking raw intent tags into pane text
- add focused coverage so reminder text stays neutral while intent semantics remain testable and structured

## Verification
- npm test -- --run src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts src/hooks/__tests__/notify-hook-worker-idle.test.ts
- npm run build

## Contributor credit
Co-authored-by: HaD0Yun <102889891+HaD0Yun@users.noreply.github.com>
