### PR TITLE
feat: add Telegram topic (message_thread_id) support

### DIFF
--- a/src/notifications/__tests__/config.test.ts
+++ b/src/notifications/__tests__/config.test.ts
@@ -174,6 +174,20 @@ describe('buildConfigFromEnv', () => {
     });
   });
 
+  it('builds telegram config with message_thread_id from env var', () => {
+    process.env.OMX_TELEGRAM_BOT_TOKEN = '123:abc';
+    process.env.OMX_TELEGRAM_CHAT_ID = '999';
+    process.env.OMX_TELEGRAM_MESSAGE_THREAD_ID = '42';
+    const config = buildConfigFromEnv();
+    assert.ok(config);
+    assert.deepEqual(config.telegram, {
+      enabled: true,
+      botToken: '123:abc',
+      chatId: '999',
+      messageThreadId: 42,
+    });
+  });
+
   it('builds slack config from env var', () => {
     process.env.OMX_SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/test';
     const config = buildConfigFromEnv();
@@ -271,5 +285,36 @@ describe('getReplyListenerPlatformConfig', () => {
     assert.equal(platformConfig.telegramBotToken, 'tg-token');
     assert.equal(platformConfig.discordEnabled, false);
     assert.equal(platformConfig.discordBotToken, undefined);
+  });
+
+  it('returns messageThreadId for enabled telegram channel', () => {
+    const config = {
+      enabled: true,
+      telegram: {
+        enabled: true,
+        botToken: 'tg-token',
+        chatId: 'tg-chat',
+        messageThreadId: 42,
+      },
+    };
+
+    const platformConfig = getReplyListenerPlatformConfig(config);
+    assert.equal(platformConfig.telegramEnabled, true);
+    assert.equal(platformConfig.telegramMessageThreadId, 42);
+  });
+
+  it('returns undefined messageThreadId when not set', () => {
+    const config = {
+      enabled: true,
+      telegram: {
+        enabled: true,
+        botToken: 'tg-token',
+        chatId: 'tg-chat',
+      },
+    };
+
+    const platformConfig = getReplyListenerPlatformConfig(config);
+    assert.equal(platformConfig.telegramEnabled, true);
+    assert.equal(platformConfig.telegramMessageThreadId, undefined);
   });
 });

--- a/src/notifications/__tests__/dispatcher.test.ts
+++ b/src/notifications/__tests__/dispatcher.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   sendDiscord,
   sendDiscordBot,
+  sendTelegram,
   sendSlack,
   sendWebhook,
   dispatchNotifications,
@@ -107,6 +108,45 @@ describe('sendDiscordBot', () => {
     const result = await sendDiscordBot(config, basePayload);
     assert.equal(result.success, false);
     assert.ok(result.error?.includes('Missing botToken or channelId'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendTelegram
+// ---------------------------------------------------------------------------
+
+describe('sendTelegram', () => {
+  it('returns error when not enabled', async () => {
+    const config: TelegramNotificationConfig = {
+      enabled: false,
+      botToken: '123:abc',
+      chatId: '999',
+    };
+    const result = await sendTelegram(config, basePayload);
+    assert.equal(result.success, false);
+    assert.equal(result.platform, 'telegram');
+    assert.ok(result.error?.includes('Not configured'));
+  });
+
+  it('returns error when botToken is empty', async () => {
+    const config: TelegramNotificationConfig = {
+      enabled: true,
+      botToken: '',
+      chatId: '999',
+    };
+    const result = await sendTelegram(config, basePayload);
+    assert.equal(result.success, false);
+  });
+
+  it('returns error for invalid bot token format', async () => {
+    const config: TelegramNotificationConfig = {
+      enabled: true,
+      botToken: 'invalid-format',
+      chatId: '999',
+    };
+    const result = await sendTelegram(config, basePayload);
+    assert.equal(result.success, false);
+    assert.equal(result.error, 'Invalid bot token format');
   });
 });
 

--- a/src/notifications/config.ts
+++ b/src/notifications/config.ts
@@ -59,6 +59,9 @@ function migrateStopHookCallbacks(
       enabled: true,
       botToken: (telegram.botToken as string) || "",
       chatId: (telegram.chatId as string) || "",
+      ...(telegram.messageThreadId != null && {
+        messageThreadId: Number(telegram.messageThreadId),
+      }),
     };
     config.telegram = telegramConfig;
   }
@@ -153,10 +156,14 @@ export function buildConfigFromEnv(): FullNotificationConfig | null {
     process.env.OMX_TELEGRAM_NOTIFIER_CHAT_ID ||
     process.env.OMX_TELEGRAM_NOTIFIER_UID;
   if (telegramToken && telegramChatId) {
+    const telegramMessageThreadId = process.env.OMX_TELEGRAM_MESSAGE_THREAD_ID;
     config.telegram = {
       enabled: true,
       botToken: telegramToken,
       chatId: telegramChatId,
+      ...(telegramMessageThreadId && {
+        messageThreadId: Number(telegramMessageThreadId),
+      }),
     };
     hasAnyPlatform = true;
   }
@@ -615,6 +622,7 @@ export function getReplyListenerPlatformConfig(
   telegramEnabled: boolean;
   telegramBotToken?: string;
   telegramChatId?: string;
+  telegramMessageThreadId?: number;
   discordEnabled: boolean;
   discordBotToken?: string;
   discordChannelId?: string;
@@ -645,6 +653,7 @@ export function getReplyListenerPlatformConfig(
     telegramEnabled,
     telegramBotToken: telegramEnabled ? telegramConfig?.botToken : undefined,
     telegramChatId: telegramEnabled ? telegramConfig?.chatId : undefined,
+    telegramMessageThreadId: telegramEnabled ? telegramConfig?.messageThreadId : undefined,
     discordEnabled,
     discordBotToken: discordEnabled ? discordBotConfig?.botToken : undefined,
     discordChannelId: discordEnabled ? discordBotConfig?.channelId : undefined,

--- a/src/notifications/dispatcher.ts
+++ b/src/notifications/dispatcher.ts
@@ -232,11 +232,15 @@ export async function sendTelegram(
   }
 
   try {
-    const body = JSON.stringify({
+    const bodyObj: Record<string, unknown> = {
       chat_id: config.chatId,
       text: payload.message,
       parse_mode: config.parseMode || "Markdown",
-    });
+    };
+    if (config.messageThreadId != null) {
+      bodyObj.message_thread_id = config.messageThreadId;
+    }
+    const body = JSON.stringify(bodyObj);
 
     const result = await new Promise<NotificationResult>((resolve) => {
       const req = httpsRequest(

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -85,6 +85,7 @@ export interface ReplyListenerDaemonConfig extends ReplyConfig {
   telegramEnabled?: boolean;
   telegramBotToken?: string;
   telegramChatId?: string;
+  telegramMessageThreadId?: number;
   discordEnabled?: boolean;
   discordBotToken?: string;
   discordChannelId?: string;
@@ -722,11 +723,15 @@ export async function pollTelegramOnce(
         state.messagesInjected++;
         const acknowledgement = formatReplyAcknowledgement(captureReplyAcknowledgementSummaryImpl(mapping.tmuxPaneId));
         try {
-          const replyBody = JSON.stringify({
+          const replyBodyObj: Record<string, unknown> = {
             chat_id: config.telegramChatId,
             text: acknowledgement,
             reply_to_message_id: msg.message_id,
-          });
+          };
+          if (config.telegramMessageThreadId != null) {
+            replyBodyObj.message_thread_id = config.telegramMessageThreadId;
+          }
+          const replyBody = JSON.stringify(replyBodyObj);
 
           await new Promise<void>((resolve) => {
             const replyReq = httpsRequestImpl(

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -63,6 +63,8 @@ export interface TelegramNotificationConfig {
   chatId: string;
   /** Parse mode: Markdown or HTML (default: Markdown) */
   parseMode?: "Markdown" | "HTML";
+  /** Message thread ID for sending to a specific topic in a supergroup */
+  messageThreadId?: number;
 }
 
 /** Slack platform configuration */


### PR DESCRIPTION
Add optional `messageThreadId` field to TelegramNotificationConfig.
When configured, `message_thread_id` is included in the Telegram
sendMessage API payload, allowing notifications to target a specific
topic/thread within a supergroup.

Supports configuration via:
- JSON config: `notifications.telegram.messageThreadId`
- Environment variable: `OMX_TELEGRAM_MESSAGE_THREAD_ID`

Also propagated to reply-listener acknowledgement messages.