### PR TITLE
fix: propagate persist errors in omx-runtime exec subcommand

### DIFF
--- a/crates/omx-runtime/src/main.rs
+++ b/crates/omx-runtime/src/main.rs
@@ -86,7 +86,9 @@ fn run() -> Result<(), String> {
             }
 
             if state_dir.is_some() {
-                engine.persist().map_err(|e| format!("persist failed: {e}"))?;
+                engine
+                    .persist()
+                    .map_err(|e| format!("persist failed: {e}"))?;
                 engine
                     .write_compatibility_view()
                     .map_err(|e| format!("compatibility view failed: {e}"))?;


### PR DESCRIPTION
Internal replacement for #1295 because the original PR head is on a contributor fork and the required rustfmt follow-up could not be pushed there from this environment.\n\nScope kept identical to the original fix, plus rustfmt alignment so CI can proceed.\n\nRefs: #1295