### PR TITLE
Fix #1302: skip code-intel tsc diagnostics without tsconfig

### DIFF
--- a/src/mcp/__tests__/code-intel-server.test.ts
+++ b/src/mcp/__tests__/code-intel-server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const REQUIRED_TOOLS = [
@@ -47,5 +48,38 @@ describe('mcp/code-intel-server module contract', () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/code-intel-server.ts'), 'utf8');
     assert.match(src, /if \(options\.replacement\) \{/);
     assert.match(src, /else \{\s*args\.push\('--json'\);/);
+  });
+
+  it('skips tsc diagnostics when the project has no tsconfig', async () => {
+    const previous = process.env.OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START;
+    process.env.OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START = '1';
+
+    const projectDir = await mkdtemp(join(tmpdir(), 'omx-code-intel-'));
+
+    try {
+      const { runTscDiagnostics } = await import(`../code-intel-server.js?ts=${Date.now()}`);
+      let called = false;
+
+      const result = await runTscDiagnostics(
+        '',
+        projectDir,
+        undefined,
+        async () => {
+          called = true;
+          throw new Error('tsc runner should not be called without a tsconfig');
+        },
+      );
+
+      assert.equal(called, false);
+      assert.deepEqual(result.diagnostics, []);
+      assert.equal(result.command, 'tsc skipped: no tsconfig found');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START;
+      } else {
+        process.env.OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START = previous;
+      }
+      await rm(projectDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/mcp/code-intel-server.ts
+++ b/src/mcp/code-intel-server.ts
@@ -82,18 +82,28 @@ async function findTsconfig(dir: string): Promise<string | null> {
   return null;
 }
 
-async function runTscDiagnostics(
+type ExecResult = { stdout: string; stderr: string };
+type ExecRunner = (
+  cmd: string,
+  args: string[],
+  options?: { cwd?: string; timeout?: number }
+) => Promise<ExecResult>;
+
+export async function runTscDiagnostics(
   target: string,
   projectDir: string,
-  severity?: string
+  severity?: string,
+  runCommand: ExecRunner = exec
 ): Promise<{ diagnostics: Diagnostic[]; command: string }> {
   const tsconfig = await findTsconfig(projectDir);
-  const args = ['--noEmit', '--pretty', 'false'];
-  if (tsconfig) {
-    args.push('--project', tsconfig);
+  if (!tsconfig) {
+    return { diagnostics: [], command: 'tsc skipped: no tsconfig found' };
   }
 
-  const { stdout, stderr } = await exec('npx', ['tsc', ...args], { cwd: projectDir, timeout: 60000 });
+  const args = ['--noEmit', '--pretty', 'false'];
+  args.push('--project', tsconfig);
+
+  const { stdout, stderr } = await runCommand('npx', ['tsc', ...args], { cwd: projectDir, timeout: 60000 });
   const output = stdout + '\n' + stderr;
   let diagnostics = parseTscOutput(output, projectDir);
 


### PR DESCRIPTION
## Summary\n- skip `runTscDiagnostics` before invoking `npx tsc` when no tsconfig is present\n- return empty diagnostics plus a skip command marker for non-TypeScript projects\n- add a focused regression test that proves the runner is never called without a tsconfig\n\n## Verification\n- npx tsc --pretty false\n- node --test dist/mcp/__tests__/code-intel-server.test.js\n- npx @biomejs/biome lint src/mcp/code-intel-server.ts src/mcp/__tests__/code-intel-server.test.ts\n- node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/server-lifecycle.test.js\n\nCloses #1302