### PR TITLE
Restore state-aware leader next actions in notify-hook nudges

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -434,7 +434,7 @@ describe('notify-hook team leader nudge', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle\./);
       assert.match(tmuxLog, /Team idle-shutdown looks complete\./);
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: decide whether to reconcile\/merge results or gracefully shut down: omx team shutdown idle-shutdown\./);
       assert.doesNotMatch(tmuxLog, /keep polling/);
     });
   });
@@ -500,7 +500,7 @@ describe('notify-hook team leader nudge', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/);
       assert.match(tmuxLog, /Team idle-followup-reuse has idle workers ready\./);
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: assign the next follow-up task to this idle team\./);
       assert.doesNotMatch(tmuxLog, /launch a new team/);
     });
   });
@@ -566,7 +566,7 @@ describe('notify-hook team leader nudge', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/);
       assert.match(tmuxLog, /Team idle-followup-relaunch has follow-up work ready\./);
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: launch a new team for the next task set\./);
       assert.doesNotMatch(tmuxLog, /idle workers ready/);
     });
   });
@@ -934,7 +934,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.doesNotMatch(tmuxLog, /no start evidence/);
       assert.match(tmuxLog, /Team ack-with-start: 1 msg\(s\) for leader\./);
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: read messages; keep orchestrating; if done, gracefully shut down: omx team shutdown ack-with-start\./);
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
@@ -1591,7 +1591,7 @@ exit 0
       assert.match(tmuxLog, /send-keys/);
       assert.match(tmuxLog, /Team beta:/);
       assert.match(tmuxLog, /leader stale, \d+ worker pane\(s\) still active\./);
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: check messages; keep orchestrating; if done, gracefully shut down: omx team shutdown beta\./);
       assert.doesNotMatch(tmuxLog, /keep polling/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
     });
@@ -1711,7 +1711,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /Team stalled-progress: leader stale, no progress 3m\./);
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: omx team status stalled-progress; read worker messages; unblock\/reassign or shutdown\./);
       assert.doesNotMatch(tmuxLog, /keep polling/);
       assert.doesNotMatch(tmuxLog, /\[OMX_INTENT:/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/);
@@ -1839,7 +1839,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /Team stalled-before-stale: worker panes stalled, no progress 3m\./);
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: omx team status stalled-before-stale; read worker messages; unblock\/reassign or shutdown\./);
       assert.doesNotMatch(tmuxLog, /keep polling/);
       assert.doesNotMatch(tmuxLog, /leader stale/);
 
@@ -2189,7 +2189,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       const sends = tmuxLog.match(/send-keys -t %88 -l Team stalled-before-stale-bounded: worker panes stalled, no progress/g) || [];
       assert.equal(sends.length, 1, 'cooldown should keep repeated stalled-team nudges bounded');
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: omx team status stalled-before-stale-bounded; read worker messages; unblock\/reassign or shutdown\./);
     });
   });
 
@@ -2635,7 +2635,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /Team delta: leader stale, \d+ pane\(s\) active, 1 msg\(s\) pending\./);
-      assert.match(tmuxLog, /Read worker messages, then choose by worker status: continue, steer, or shut down if done\./);
+      assert.match(tmuxLog, /Next: read messages; keep orchestrating; if done, gracefully shut down: omx team shutdown delta\./);
       assert.doesNotMatch(tmuxLog, /keep polling/);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
 

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -70,23 +70,61 @@ export function resolveWorkerTurnStallThresholdMs() {
   return 30_000;
 }
 
-function buildLeaderDecisionReminder(teamName) {
-  return 'Read worker messages, then choose by worker status: continue, steer, or shut down if done.';
-}
-
 function buildStatusCheckReminder(teamName) {
-  return buildLeaderDecisionReminder(teamName);
+  return `Next: check messages; keep orchestrating; if done, gracefully shut down: omx team shutdown ${teamName}.`;
 }
 
 function buildMailboxCheckReminder(teamName) {
-  return buildLeaderDecisionReminder(teamName);
+  return `Next: read messages; keep orchestrating; if done, gracefully shut down: omx team shutdown ${teamName}.`;
 }
 
 function buildWorkerStartEvidenceReminder(teamName, workerName) {
   return `Next: check ${workerName} msg/output, confirm task in omx team status ${teamName}, then reassign/nudge.`;
 }
 
-function buildLeaderActionGuidance(teamName) {
+function classifyLeaderActionState({
+  allWorkersIdle = false,
+  workerPanesAlive = false,
+  taskCounts = {},
+  teamProgressStalled = false,
+} = {}) {
+  const pending = Number.isFinite(taskCounts.pending) ? taskCounts.pending : 0;
+  const blocked = Number.isFinite(taskCounts.blocked) ? taskCounts.blocked : 0;
+  const inProgress = Number.isFinite(taskCounts.in_progress) ? taskCounts.in_progress : 0;
+  const tasksComplete = pending === 0 && blocked === 0 && inProgress === 0;
+  const pendingFollowUpTasks = allWorkersIdle && pending > 0 && blocked === 0 && inProgress === 0;
+  const blockedWaitingOnLeader = allWorkersIdle && blocked > 0 && pending === 0 && inProgress === 0;
+  const terminalWaitingOnLeader = allWorkersIdle && tasksComplete && workerPanesAlive;
+  const stalledWaitingOnLeader = blockedWaitingOnLeader || teamProgressStalled;
+
+  if (terminalWaitingOnLeader) return 'done_waiting_on_leader';
+  if (stalledWaitingOnLeader) return 'stuck_waiting_on_leader';
+  if (pendingFollowUpTasks) return 'still_actionable';
+  return 'still_actionable';
+}
+
+function buildLeaderActionGuidance(teamName, {
+  allWorkersIdle = false,
+  workerPanesAlive = false,
+  taskCounts = {},
+  leaderActionState = 'still_actionable',
+} = {}) {
+  const pending = Number.isFinite(taskCounts.pending) ? taskCounts.pending : 0;
+  const blocked = Number.isFinite(taskCounts.blocked) ? taskCounts.blocked : 0;
+  const inProgress = Number.isFinite(taskCounts.in_progress) ? taskCounts.in_progress : 0;
+  const pendingFollowUpTasks = allWorkersIdle && pending > 0 && blocked === 0 && inProgress === 0;
+
+  if (pendingFollowUpTasks) {
+    return workerPanesAlive
+      ? 'Next: assign the next follow-up task to this idle team.'
+      : 'Next: launch a new team for the next task set.';
+  }
+  if (leaderActionState === 'done_waiting_on_leader') {
+    return `Next: decide whether to reconcile/merge results or gracefully shut down: omx team shutdown ${teamName}.`;
+  }
+  if (leaderActionState === 'stuck_waiting_on_leader') {
+    return `Next: omx team status ${teamName}; read worker messages; unblock/reassign or shutdown.`;
+  }
   return buildStatusCheckReminder(teamName);
 }
 


### PR DESCRIPTION
## Summary
- restore state-aware leader next-step guidance for all-idle reuse vs relaunch vs shutdown-review paths
- restore stronger default actions for stale mailbox and stalled-progress nudges
- update the focused notify-hook leader nudge assertions to lock the matrix back in

## Testing
- npm run build && node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js

Closes #1297