### PR TITLE
test: add orchestration actionability regression guard

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -168,3 +168,13 @@ To achieve 100% hook parity, these changes need to be contributed to Codex CLI:
 4. Add hook context injection (hook stdout -> system message)
 
 RFC tracking: TBD
+
+## Orchestration pressure / actionability regression guard
+
+Leader nudge regressions are not only about whether a nudge fires, but whether the emitted guidance remains actionable. The regression suite in `src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts` now treats these as observable proxies:
+
+- idle + completed work -> shutdown/reconcile guidance
+- idle + pending follow-up -> reuse-team guidance
+- stalled worker progress -> inspect status and unblock/reassign guidance
+
+These cases must stay semantically distinct and must not collapse into generic "keep polling" wording.

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -98,6 +98,15 @@ function runNotifyHook(
   });
 }
 
+function extractInjectedTmuxPayload(tmuxLog: string): string {
+  const literalLine = tmuxLog
+    .split('\n')
+    .find((line) => line.includes('send-keys') && line.includes(' -l '));
+  assert.ok(literalLine, 'expected tmux log to include a literal send-keys payload');
+  const marker = ' -l ';
+  return literalLine.slice(literalLine.indexOf(marker) + marker.length);
+}
+
 describe('notify-hook leader-side authority handoff', () => {
   it('does not inject leader nudge from notify-hook when team is active and stale', async () => {
     await withTempWorkingDir(async (cwd) => {
@@ -2325,4 +2334,180 @@ exit 0
       assert.equal(nudgeEvent.reason, 'stale_leader_with_messages');
     });
   });
+  it('preserves distinct next-action guidance across idle, follow-up, and stall states', async () => {
+    const runScenario = async (
+      scenario: 'idle-shutdown' | 'idle-followup' | 'stalled',
+      teamName: string,
+      leaderPaneId: string,
+    ): Promise<string> => {
+      let payload = '';
+      await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const tasksDir = join(teamDir, 'tasks');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const nowIso = new Date().toISOString();
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(workersDir, { recursive: true });
+      await mkdir(tasksDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: teamName + ':0',
+        leader_pane_id: leaderPaneId,
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10', role: 'executor' },
+          { name: 'worker-2', index: 2, pane_id: '%11', role: 'executor' },
+        ],
+      });
+
+      if (scenario === 'stalled') {
+        await writeJson(join(stateDir, 'hud-state.json'), {
+          last_turn_at: nowIso,
+          turn_count: 4,
+        });
+        await mkdir(join(workersDir, 'worker-1'), { recursive: true });
+        await writeJson(join(tasksDir, 'task-1.json'), {
+          id: '1',
+          subject: 'Investigate stall',
+          description: 'worker-1 owns the active task',
+          status: 'in_progress',
+          owner: 'worker-1',
+          created_at: nowIso,
+        });
+        await writeJson(join(tasksDir, 'task-2.json'), {
+          id: '2',
+          subject: 'Follow-up',
+          description: 'still pending',
+          status: 'pending',
+          created_at: nowIso,
+        });
+        await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+          state: 'working',
+          current_task_id: '1',
+          updated_at: nowIso,
+        });
+        await writeJson(join(workersDir, 'worker-1', 'heartbeat.json'), {
+          last_turn_at: nowIso,
+          turn_count: 2,
+          alive: true,
+        });
+        const stalledSignature = JSON.stringify({
+          tasks: [
+            { id: '1', owner: 'worker-1', status: 'in_progress' },
+            { id: '2', owner: '', status: 'pending' },
+          ],
+          workers: [
+            {
+              worker: 'worker-1',
+              state: 'working',
+              current_task_id: '1',
+              status_missing: false,
+              turn_count: 2,
+              heartbeat_missing: false,
+            },
+            {
+              worker: 'worker-2',
+              state: 'unknown',
+              current_task_id: '',
+              status_missing: true,
+              turn_count: null,
+              heartbeat_missing: true,
+            },
+          ],
+        });
+        await writeJson(join(stateDir, 'team-leader-nudge.json'), {
+          last_nudged_by_team: {
+            [teamName]: {
+              at: new Date(Date.now() - 5_000).toISOString(),
+              last_message_id: '',
+              reason: 'new_mailbox_message',
+            },
+          },
+          progress_by_team: {
+            [teamName]: {
+              signature: stalledSignature,
+              last_progress_at: new Date(Date.now() - 180_000).toISOString(),
+            },
+          },
+        });
+      } else {
+        await writeJson(join(stateDir, 'hud-state.json'), {
+          last_turn_at: nowIso,
+          turn_count: 1,
+        });
+        for (const worker of ['worker-1', 'worker-2']) {
+          await mkdir(join(workersDir, worker), { recursive: true });
+          await writeJson(join(workersDir, worker, 'status.json'), {
+            state: 'idle',
+            updated_at: nowIso,
+          });
+        }
+        if (scenario === 'idle-shutdown') {
+          await writeJson(join(tasksDir, 'task-1.json'), {
+            id: '1',
+            subject: 'Done',
+            description: 'completed work item',
+            status: 'completed',
+            owner: 'worker-1',
+            created_at: nowIso,
+          });
+        } else {
+          await writeJson(join(tasksDir, 'task-2.json'), {
+            id: '2',
+            subject: 'Follow-up',
+            description: 'queued follow-up task',
+            status: 'pending',
+            created_at: nowIso,
+          });
+        }
+      }
+
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345', '%11 12346']));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, scenario === 'stalled'
+        ? {
+            OMX_TEAM_PROGRESS_STALL_MS: '60000',
+            OMX_TEAM_LEADER_NUDGE_MS: '30000',
+            OMX_TEAM_LEADER_STALE_MS: '60000',
+          }
+        : {});
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      payload = extractInjectedTmuxPayload(tmuxLog);
+    });
+      return payload;
+    }
+
+    const shutdownPayload = await runScenario('idle-shutdown', 'actionability-shutdown', '%71');
+    const followupPayload = await runScenario('idle-followup', 'actionability-followup', '%72');
+    const stalledPayload = await runScenario('stalled', 'actionability-stalled', '%73');
+
+    assert.ok(shutdownPayload.includes('Next: decide whether to reconcile/merge results or gracefully shut down: omx team shutdown')); 
+    assert.match(followupPayload, /Next: assign the next follow-up task to this idle team/);
+    assert.ok(stalledPayload.includes('Next: omx team status actionability-stalled; read worker messages; unblock/reassign or shutdown.')); 
+
+    assert.notEqual(shutdownPayload, followupPayload);
+    assert.notEqual(shutdownPayload, stalledPayload);
+    assert.notEqual(followupPayload, stalledPayload);
+
+    for (const payload of [shutdownPayload, followupPayload, stalledPayload]) {
+      assert.doesNotMatch(payload, /keep polling/);
+    }
+  });
+
 });

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -11,6 +11,7 @@ import {
   readDeepInterviewState,
   readAutoresearchState,
   readUltraqaState,
+  resolveGitMetadataForTesting,
 } from '../state.js';
 
 function gitRunnerFromMap(map: Record<string, string | Error>) {
@@ -65,6 +66,46 @@ describe('readGitBranch', () => {
   });
 });
 
+describe('resolveGitMetadataForTesting', () => {
+  it('resolves standard .git directories as repo top-level', async () => {
+    await withTempRepo('omx-hud-gitdir-', async (cwd) => {
+      await mkdir(join(cwd, '.git'), { recursive: true });
+
+      assert.deepEqual(resolveGitMetadataForTesting(cwd), {
+        gitDir: join(cwd, '.git'),
+        topLevel: cwd,
+      });
+    });
+  });
+
+  it('resolves git worktree .git files and preserves repo top-level', async () => {
+    await withTempRepo('omx-hud-worktree-', async (cwd) => {
+      const actualGitDir = join(cwd, '..', 'main-repo', '.git', 'worktrees', 'feature-x');
+      await mkdir(actualGitDir, { recursive: true });
+      await writeFile(join(cwd, '.git'), 'gitdir: ../main-repo/.git/worktrees/feature-x\n');
+
+      assert.deepEqual(resolveGitMetadataForTesting(cwd), {
+        gitDir: actualGitDir,
+        topLevel: cwd,
+      });
+    });
+  });
+
+  it('supports nested cwd inside a worktree checkout', async () => {
+    await withTempRepo('omx-hud-worktree-nested-', async (cwd) => {
+      const actualGitDir = join(cwd, '..', 'main-repo', '.git', 'worktrees', 'feature-y');
+      const nested = join(cwd, 'packages', 'hud');
+      await mkdir(actualGitDir, { recursive: true });
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(cwd, '.git'), 'gitdir: ../main-repo/.git/worktrees/feature-y\n');
+
+      assert.deepEqual(resolveGitMetadataForTesting(nested), {
+        gitDir: actualGitDir,
+        topLevel: cwd,
+      });
+    });
+  });
+});
 describe('buildGitBranchLabel', () => {
   it('keeps the branch when origin lookup fails', () => {
     const gitRunner = gitRunnerFromMap({

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -7,7 +7,7 @@
 import { readFile } from 'fs/promises';
 import { readFileSync, statSync } from 'fs';
 import { execSync } from 'child_process';
-import { join, dirname, basename } from 'path';
+import { join, dirname, basename, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { omxStateDir } from '../utils/paths.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
@@ -175,17 +175,45 @@ export function readVersion(): string | null {
 
 export type GitRunner = (cwd: string, args: string[]) => string | null;
 
+interface GitMetadata {
+  gitDir: string;
+  topLevel: string;
+}
+
+function resolveGitMetadataFromCandidate(dir: string): GitMetadata | null {
+  const candidate = join(dir, '.git');
+
+  try {
+    if (statSync(candidate).isDirectory()) {
+      return { gitDir: candidate, topLevel: dir };
+    }
+  } catch {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(candidate, 'utf-8').trim();
+    const match = content.match(/^gitdir:\s*(.+)$/im);
+    if (!match) return null;
+
+    return {
+      gitDir: resolve(dir, match[1].trim()),
+      topLevel: dir,
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Find the .git directory by walking up from `startCwd`.
- * Returns the path to the `.git` directory, or null if not found.
+ * Find git metadata by walking up from `startCwd`.
+ * Supports both `.git/` directories and git worktree `.git` files.
  */
-function findGitDir(startCwd: string): string | null {
+function findGitMetadata(startCwd: string): GitMetadata | null {
   let dir = startCwd;
   for (;;) {
-    const candidate = join(dir, '.git');
-    try {
-      if (statSync(candidate).isDirectory()) return candidate;
-    } catch { /* not found, walk up */ }
+    const metadata = resolveGitMetadataFromCandidate(dir);
+    if (metadata) return metadata;
     const parent = dirname(dir);
     if (parent === dir) return null;
     dir = parent;
@@ -213,8 +241,9 @@ function readGitFile(gitDir: string, ...parts: string[]): string | null {
 function runGit(cwd: string, args: string[]): string | null {
   if (process.platform === 'win32') {
     try {
-      const gitDir = findGitDir(cwd);
-      if (gitDir) {
+      const gitMetadata = findGitMetadata(cwd);
+      if (gitMetadata) {
+        const { gitDir, topLevel } = gitMetadata;
         const cmd = args.join(' ');
 
         if (cmd === 'rev-parse --abbrev-ref HEAD') {
@@ -248,7 +277,7 @@ function runGit(cwd: string, args: string[]): string | null {
         }
 
         if (cmd === 'rev-parse --show-toplevel') {
-          return dirname(gitDir);
+          return topLevel;
         }
       }
     } catch { /* fall through to execSync */ }
@@ -340,6 +369,10 @@ export function buildGitBranchLabel(
 
   const repoLabel = resolveRepoLabel(cwd, config, gitRunner);
   return repoLabel ? `${repoLabel}/${branch}` : branch;
+}
+
+export function resolveGitMetadataForTesting(startCwd: string): GitMetadata | null {
+  return findGitMetadata(startCwd);
 }
 
 /** Read all state files and build the full render context */


### PR DESCRIPTION
$## Summary\n- add an orchestration-pressure regression test that compares idle-shutdown, idle-follow-up, and stalled-team leader nudges\n- assert that each state preserves a distinct next action instead of collapsing into generic wording\n- document the actionability proxies in COVERAGE.md\n\nCloses #1299