### PR TITLE
Add native Bash PreToolUse/PostToolUse guidance

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -25,8 +25,8 @@ For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of sourc
 | --- | --- | --- | --- | --- |
 | `session-start` | `SessionStart` | `session-start` | native | Native adapter refreshes session bookkeeping, restores startup developer context, and ensures `.omx/` is gitignored at the repo root |
 | `keyword-detector` | `UserPromptSubmit` | `keyword-detector` | native | Persists skill activation state and can add prompt-side developer context |
-| `pre-tool-use` | `PreToolUse` (`Bash`) | `pre-tool-use` | native-partial | Current native scope is Bash-only |
-| `post-tool-use` | `PostToolUse` (`Bash`) | `post-tool-use` | native-partial | Current native scope is Bash-only |
+| `pre-tool-use` | `PreToolUse` (`Bash`) | `pre-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior is a narrow destructive-command caution via `systemMessage` |
+| `post-tool-use` | `PostToolUse` (`Bash`) | `post-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior covers command-not-found / permission-denied / missing-path guidance and informative non-zero-output review |
 | Ralph/persistence stop handling | `Stop` | `stop` | native-partial | Native adapter uses the documented native Stop continuation contract (`decision: "block"` + `reason`) for active Ralph runs and avoids re-blocking once `stop_hook_active` is set |
 | Autopilot continuation | `Stop` | `stop` | native-partial | Native adapter continues non-terminal autopilot sessions from active session/root mode state |
 | Ultrawork continuation | `Stop` | `stop` | native-partial | Native adapter continues non-terminal ultrawork sessions from active session/root mode state |

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -202,6 +202,166 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("returns a destructive-command caution on PreToolUse for rm -rf dist", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-danger-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-danger",
+          tool_input: { command: "rm -rf dist" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.deepEqual(result.outputJson, {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+        },
+        systemMessage:
+          "Destructive Bash command detected (`rm -rf dist`). Confirm the target and expected side effects before running it.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("stays silent on PreToolUse for neutral pwd", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-neutral-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-neutral",
+          tool_input: { command: "pwd" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns PostToolUse remediation guidance for command-not-found output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-failure-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-fail",
+          tool_input: { command: "foo --version" },
+          tool_response: "{\"exit_code\":127,\"stdout\":\"\",\"stderr\":\"bash: foo: command not found\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "The Bash output indicates a command/setup failure that should be fixed before retrying.",
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext:
+            "Bash reported `command not found`, `permission denied`, or a missing file/path. Verify the command, dependency installation, PATH, file permissions, and referenced paths before retrying.",
+        },
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats stderr-only informative non-zero output as reviewable instead of a generic failure", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-informative-stderr-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-useful-stderr",
+          tool_input: { command: "gh pr checks" },
+          tool_response: "{\"exit_code\":8,\"stdout\":\"\",\"stderr\":\"build pending\\nlint pass\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "The Bash command returned a non-zero exit code but produced useful output that should be reviewed before retrying.",
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext:
+            "The Bash output appears informative despite the non-zero exit code. Review and report the output before retrying instead of assuming the command simply failed.",
+        },
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats non-zero gh pr checks style output as informative instead of a generic failure", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-informative-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-useful",
+          tool_input: { command: "gh pr checks" },
+          tool_response: "{\"exit_code\":8,\"stdout\":\"build\\tpending\\t2m\\nlint\\tpass\\t18s\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "The Bash command returned a non-zero exit code but produced useful output that should be reviewed before retrying.",
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext:
+            "The Bash output appears informative despite the non-zero exit code. Review and report the output before retrying instead of assuming the command simply failed.",
+        },
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("stays silent on neutral successful PostToolUse output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-neutral-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-ok",
+          tool_input: { command: "pwd" },
+          tool_response: "{\"exit_code\":0,\"stdout\":\"/repo\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns Stop continuation output while Autopilot is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-autopilot-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -18,6 +18,10 @@ import {
   loadAutoNudgeConfig,
 } from "./notify-hook/auto-nudge.js";
 import {
+  buildNativePostToolUseOutput,
+  buildNativePreToolUseOutput,
+} from "./codex-native-pre-post.js";
+import {
   buildNativeHookEvent,
 } from "../hooks/extensibility/events.js";
 import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
@@ -629,6 +633,10 @@ export async function dispatchCodexNativeHook(
         },
       };
     }
+  } else if (hookEventName === "PreToolUse") {
+    outputJson = buildNativePreToolUseOutput(payload);
+  } else if (hookEventName === "PostToolUse") {
+    outputJson = buildNativePostToolUseOutput(payload);
   } else if (hookEventName === "Stop") {
     outputJson = await buildStopHookOutput(payload, cwd, stateDir);
   }

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1,0 +1,161 @@
+type CodexHookPayload = Record<string, unknown>;
+
+export interface NormalizedPreToolUsePayload {
+  toolName: string;
+  toolUseId: string;
+  command: string;
+  normalizedCommand: string;
+  isBash: boolean;
+}
+
+export interface NormalizedPostToolUsePayload {
+  toolName: string;
+  toolUseId: string;
+  command: string;
+  normalizedCommand: string;
+  isBash: boolean;
+  rawToolResponse: unknown;
+  parsedToolResponse: Record<string, unknown> | null;
+  exitCode: number | null;
+  stdoutText: string;
+  stderrText: string;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function safeInteger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isInteger(parsed)) return parsed;
+  }
+  return null;
+}
+
+function safeObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function tryParseJsonString(value: unknown): Record<string, unknown> | null {
+  const text = safeString(value).trim();
+  if (!text) return null;
+  try {
+    return safeObject(JSON.parse(text));
+  } catch {
+    return null;
+  }
+}
+
+function readCommand(payload: CodexHookPayload): string {
+  const toolInput = safeObject(payload.tool_input);
+  return safeString(toolInput?.command).trim();
+}
+
+export function normalizePreToolUsePayload(
+  payload: CodexHookPayload,
+): NormalizedPreToolUsePayload {
+  const toolName = safeString(payload.tool_name).trim();
+  const command = readCommand(payload);
+  return {
+    toolName,
+    toolUseId: safeString(payload.tool_use_id).trim(),
+    command,
+    normalizedCommand: command,
+    isBash: toolName === "Bash",
+  };
+}
+
+export function normalizePostToolUsePayload(
+  payload: CodexHookPayload,
+): NormalizedPostToolUsePayload {
+  const toolName = safeString(payload.tool_name).trim();
+  const command = readCommand(payload);
+  const rawToolResponse = payload.tool_response;
+  const parsedToolResponse = tryParseJsonString(rawToolResponse) ?? safeObject(rawToolResponse);
+  const exitCode = safeInteger(parsedToolResponse?.exit_code)
+    ?? safeInteger(parsedToolResponse?.exitCode)
+    ?? null;
+  const rawText = safeString(rawToolResponse).trim();
+  const stdoutText = safeString(parsedToolResponse?.stdout).trim() || rawText;
+  const stderrText = safeString(parsedToolResponse?.stderr).trim();
+
+  return {
+    toolName,
+    toolUseId: safeString(payload.tool_use_id).trim(),
+    command,
+    normalizedCommand: command,
+    isBash: toolName === "Bash",
+    rawToolResponse,
+    parsedToolResponse,
+    exitCode,
+    stdoutText,
+    stderrText,
+  };
+}
+
+function matchesDestructiveFixture(command: string): boolean {
+  return /^\s*rm\s+-rf\s+dist(?:\s|$)/.test(command);
+}
+
+export function buildNativePreToolUseOutput(
+  payload: CodexHookPayload,
+): Record<string, unknown> | null {
+  const normalized = normalizePreToolUsePayload(payload);
+  if (!normalized.isBash) return null;
+  if (!matchesDestructiveFixture(normalized.normalizedCommand)) return null;
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+    },
+    systemMessage:
+      "Destructive Bash command detected (`rm -rf dist`). Confirm the target and expected side effects before running it.",
+  };
+}
+
+function containsHardFailure(text: string): boolean {
+  return /command not found|permission denied|no such file or directory/i.test(text);
+}
+
+export function buildNativePostToolUseOutput(
+  payload: CodexHookPayload,
+): Record<string, unknown> | null {
+  const normalized = normalizePostToolUsePayload(payload);
+  if (!normalized.isBash) return null;
+
+  const combined = `${normalized.stderrText}\n${normalized.stdoutText}`.trim();
+  if (containsHardFailure(combined)) {
+    return {
+      decision: "block",
+      reason: "The Bash output indicates a command/setup failure that should be fixed before retrying.",
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext:
+          "Bash reported `command not found`, `permission denied`, or a missing file/path. Verify the command, dependency installation, PATH, file permissions, and referenced paths before retrying.",
+      },
+    };
+  }
+
+  if (
+    normalized.exitCode !== null
+    && normalized.exitCode !== 0
+    && combined.length > 0
+    && !containsHardFailure(combined)
+  ) {
+    return {
+      decision: "block",
+      reason: "The Bash command returned a non-zero exit code but produced useful output that should be reviewed before retrying.",
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext:
+          "The Bash output appears informative despite the non-zero exit code. Review and report the output before retrying instead of assuming the command simply failed.",
+      },
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a thin first-party native Bash pre/post helper layer
- implement a narrow native `PreToolUse` caution path for destructive Bash commands
- implement native `PostToolUse` guidance for command/setup failures and informative non-zero output
- document the exact native pre/post scope and keep broader OMC behavior fallback-only

## Verification
- `npm run build`
- `npx biome lint src/scripts/codex-native-hook.ts src/scripts/codex-native-pre-post.ts src/scripts/__tests__/codex-native-hook.test.ts docs/codex-native-hooks.md`
- `npx tsc --noEmit --project tsconfig.json`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`
- `npm test`

## Notes
- base PR already merged to `dev`: #1314
