### PR TITLE
docs: narrow deep-interview readiness split

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -43,7 +43,7 @@ If no flag is provided, use **Standard**.
 - Ask ONE question per round (never batch)
 - Ask about intent and boundaries before implementation detail
 - Target the weakest clarity dimension each round after applying the stage-priority rules below
-- When a key term is overloaded, shifts meaning, or mixes multiple categories, spend the round normalizing that term explicitly before scoring it as clear
+- Define key terms when they are used inconsistently; state the normalization before scoring them as clear
 - Treat every answer as a claim to pressure-test before moving on: the next question should usually demand evidence or examples, expose a hidden assumption, force a tradeoff or boundary, or reframe root cause vs symptom
 - Do not rotate to a new clarity dimension just for coverage when the current answer is still vague; stay on the same thread until one layer deeper, one assumption clearer, or one boundary tighter
 - Before crystallizing, complete at least one explicit pressure pass that revisits an earlier answer with a deeper, assumption-focused, or tradeoff-focused follow-up
@@ -54,10 +54,10 @@ If no flag is provided, use **Standard**.
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
 - In Codex CLI, prefer `request_user_input` when available; if unavailable, fall back to concise plain-text one-question turns
 - Re-score ambiguity after each answer and show progress transparently
-- Treat the weighted ambiguity score as an epistemic readiness signal, not the whole truth: final readiness also requires deontic authority clarity and robustness checks
+- Treat the weighted ambiguity score as epistemic only; final readiness also requires deontic clarity and a completed pressure pass
 - Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning
 - Do not crystallize or hand off while `Non-goals` or `Decision Boundaries` remain unresolved, even if the weighted ambiguity threshold is met
-- If ontology or consistency fails, label the failure (`categorical`, `empirical`, `authority/deontic`, or `logical inconsistency`), state the minimal repair, and keep the workflow narrow rather than broadening into a rewrite
+- If ontology fails, label it (`categorical` or `empirical`), give a concrete counterexample, and state the minimal repair. If logic fails, state the inconsistency or `salvage by trivialization` explicitly
 - Treat early exit as a safety valve, not the default success path
 - Persist mode state for resume safety (`state_write` / `state_read`)
 </Execution_Policy>
@@ -129,13 +129,13 @@ Target the lowest-scoring dimension, but respect stage priority:
 - **Stage 2 — Feasibility:** Constraints, Success Criteria
 - **Stage 3 — Brownfield grounding:** Context Clarity (brownfield only)
 
-If a key term (`scope`, `done`, `success`, `authority`, etc.) is being used loosely, inconsistently, or across multiple categories, use the next round to normalize that term before returning to ordinary scoring.
+If a key term (`scope`, `done`, `success`, `authority`, etc.) is being used inconsistently, use the next round to define it and state the normalization before returning to ordinary scoring.
 
 Follow-up pressure ladder after each answer:
 1. Ask for a concrete example, counterexample, or evidence signal behind the latest claim
 2. Probe the hidden assumption, dependency, or belief that makes the claim true
 3. Force a boundary or tradeoff: what would you explicitly not do, defer, or reject?
-4. Separate mixed kinds before accepting the answer as clear: epistemic uncertainty, deontic authority, operational feasibility, and evaluative success should not be collapsed into one answer
+4. Separate modalities before accepting the answer as clear: epistemic uncertainty, deontic authority, operational feasibility, and evaluative success should not be collapsed into one answer
 5. If the answer still describes symptoms, reframe toward essence / root cause before moving on
 
 Prefer staying on the same thread for multiple rounds when it has the highest leverage. Breadth without pressure is not progress.
@@ -166,16 +166,17 @@ Greenfield: `ambiguity = 1 - (intent × 0.30 + outcome × 0.25 + scope × 0.20 +
 
 Brownfield: `ambiguity = 1 - (intent × 0.25 + outcome × 0.20 + scope × 0.20 + constraints × 0.15 + success × 0.10 + context × 0.10)`
 
-Interpret the weighted ambiguity score as an epistemic clarity heuristic. It should not overrule deontic authority failures or robustness failures.
+Treat the weighted ambiguity score as epistemic only. It should not overrule deontic failures or robustness failures.
 
 Readiness gate:
-- Split readiness explicitly across: **Epistemic** (`ambiguity` threshold), **Deontic** (`Non-goals`, `Decision Boundaries`, approval boundaries), and **Robustness** (pressure pass, consistency, anti-trivialization)
+- Split readiness explicitly across: **Epistemic** (`ambiguity` threshold), **Deontic** (`Non-goals`, `Decision Boundaries`), and **Robustness** (pressure pass)
 - `Non-goals` must be explicit
 - `Decision Boundaries` must be explicit
 - A pressure pass must be complete: at least one earlier answer has been revisited with an evidence, assumption, or tradeoff follow-up
 - Run a lightweight consistency pass across intent, scope, non-goals, decision boundaries, and acceptance criteria before crystallizing
 - If clarity improved only by becoming more generic, treat that as `salvage by trivialization` and continue interviewing
-- If ontology fails, label the failure (`categorical`, `empirical`, `authority/deontic`, or `logical inconsistency`), state the minimal repair, and re-score only after the repaired framing is explicit
+- If ontology fails, label it (`categorical` or `empirical`), give a concrete counterexample, state the minimal repair, and re-score only after the repaired framing is explicit
+- If logic fails, state the inconsistency or `salvage by trivialization` explicitly before moving on
 - If any readiness lane is unresolved, continue interviewing even when weighted ambiguity is below threshold
 
 ### 2d) Report progress
@@ -196,7 +197,7 @@ Use each mode once when applicable. These are normal escalation tools, not rare 
 
 - **Contrarian** (round 2+ or immediately when an answer rests on an untested assumption): challenge core assumptions
 - **Simplifier** (round 4+ or when scope expands faster than outcome clarity): probe minimal viable scope
-- **Ontologist** (round 5+ and ambiguity > 0.25, or when the user keeps describing symptoms): ask for essence-level reframing and check for category mistakes or epistemic/deontic/operational collapse
+- **Ontologist** (round 5+ and ambiguity > 0.25, or when the user keeps describing symptoms): validate ontology first, checking for category mistake or conflict with real examples before accepting the framing
 
 Track used modes in state to prevent repetition.
 
@@ -214,8 +215,8 @@ Spec should include:
 - Metadata (profile, rounds, final ambiguity, threshold, context type)
 - Context snapshot reference/path (for ralplan/team reuse)
 - Clarity breakdown table
-- Key term normalizations (only when terms were overloaded, shifted, or mixed across categories)
-- Readiness split summary: **Epistemic** (`ambiguity` signal), **Deontic** (authority / confirmation boundaries), **Robustness** (pressure pass, consistency, anti-trivialization)
+- Key term normalizations
+- Readiness split summary: **Epistemic**, **Deontic**, **Robustness**
 - Intent (why the user wants this)
 - Desired Outcome
 - In-Scope
@@ -225,11 +226,11 @@ Spec should include:
 - Testable acceptance criteria
 - Assumptions exposed + resolutions
 - Pressure-pass findings (which answer was revisited, and what changed)
-- Consistency findings across intent / scope / non-goals / decision boundaries / acceptance criteria
-- Anti-trivialization findings (`salvage by trivialization` or explicit note that no such collapse was detected)
-- Failure labels + minimal repairs (when ontology, authority, or consistency failed during the interview)
-- Modal summary: Known / unknown, Allowed without confirmation / requires confirmation, Feasible now / blocked, Must-have / nice-to-have
-- Established facts vs open hypotheses
+- Consistency findings
+- `Salvage by trivialization` findings
+- Failure labels + minimal repair
+- Modality summary
+- Established claims vs hypotheses
 - Brownfield evidence vs inference notes for any repository-grounded confirmation questions
 - Technical context findings
 - Full or condensed transcript

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -57,9 +57,9 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /Desired Outcome/i);
 		assert.match(deepInterviewSkill, /Out-of-Scope \/ Non-goals/i);
 		assert.match(deepInterviewSkill, /Decision Boundaries/i);
-		assert.match(deepInterviewSkill, /epistemic readiness signal/i);
-		assert.match(deepInterviewSkill, /deontic authority clarity/i);
-		assert.match(deepInterviewSkill, /robustness checks/i);
+		assert.match(deepInterviewSkill, /Treat the weighted ambiguity score as epistemic only/i);
+		assert.match(deepInterviewSkill, /deontic clarity/i);
+		assert.match(deepInterviewSkill, /completed pressure pass/i);
 		assert.match(deepInterviewSkill, /Reduce user effort/i);
 		assert.match(deepInterviewSkill, /must be explicit/i);
 		assert.match(deepInterviewSkill, /pressure pass/i);
@@ -128,7 +128,7 @@ describe("deep-interview Ouroboros contract", () => {
 		);
 		assert.match(
 			deepInterviewSkill,
-			/category mistakes or epistemic\/deontic\/operational collapse/i,
+			/validate ontology first, checking for category mistake or conflict with real examples/i,
 		);
 		assert.match(
 			deepInterviewSkill,
@@ -139,7 +139,7 @@ describe("deep-interview Ouroboros contract", () => {
 	it("keeps ambiguity terminology while splitting readiness and artifact checks more explicitly", () => {
 		assert.match(
 			deepInterviewSkill,
-			/Interpret the weighted ambiguity score as an epistemic clarity heuristic/i,
+			/Treat the weighted ambiguity score as epistemic only/i,
 		);
 		assert.match(
 			deepInterviewSkill,
@@ -147,7 +147,7 @@ describe("deep-interview Ouroboros contract", () => {
 		);
 		assert.match(
 			deepInterviewSkill,
-			/Key term normalizations \(only when terms were overloaded, shifted, or mixed across categories\)/i,
+			/Define key terms when they are used inconsistently; state the normalization/i,
 		);
 		assert.match(
 			deepInterviewSkill,
@@ -155,11 +155,11 @@ describe("deep-interview Ouroboros contract", () => {
 		);
 		assert.match(
 			deepInterviewSkill,
-			/Failure labels \+ minimal repairs/i,
+			/label it \(`categorical` or `empirical`\), give a concrete counterexample, and state the minimal repair/i,
 		);
 		assert.match(
 			deepInterviewSkill,
-			/Modal summary: Known \/ unknown, Allowed without confirmation \/ requires confirmation, Feasible now \/ blocked, Must-have \/ nice-to-have/i,
+			/Modality summary/i,
 		);
 	});
 


### PR DESCRIPTION
## Summary

Narrow, contract-focused follow-up to #1318.

This keeps the existing `deep-interview` workflow shape and user-facing ambiguity terminology, but makes the internal readiness contract more explicit by:

- clarifying that the weighted ambiguity score is an epistemic signal rather than the whole readiness truth,
- splitting readiness language across epistemic / deontic / robustness lanes,
- adding lightweight normalization / consistency / anti-trivialization checks,
- and extending the contract test so the change stays reviewable.

## Changes

- update `skills/deep-interview/SKILL.md` to:
  - keep `ambiguity` as the external term,
  - describe readiness as split across epistemic, deontic, and robustness checks,
  - add key-term normalization guidance,
  - add lightweight consistency + `salvage by trivialization` checks,
  - make Ontologist mode explicitly check for category mistakes / epistemic-deontic-operational collapse,
  - add compact artifact requirements for readiness split, modal summary, and minimal-repair/failure-label output
- extend `src/hooks/__tests__/deep-interview-contract.test.ts` to lock the new contract language

## Validation

- [x] `npm run build`
- [ ] `npm test` *(currently fails in unrelated existing `dist/team` tests: `startTeam preserves routed task roles into team state and worker launch args`, and `claimTask owner write failure cleans up claim lock without orphan lock dir`)*
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npm run lint`
- [x] `node --test dist/hooks/__tests__/deep-interview-contract.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1318
