### PR TITLE
Add Homebrew formula and tap bootstrap

### DIFF
--- a/Formula/oh-my-codex.rb
+++ b/Formula/oh-my-codex.rb
@@ -1,0 +1,18 @@
+class OhMyCodex < Formula
+  desc "Multi-agent orchestration layer for OpenAI Codex CLI"
+  homepage "https://github.com/Yeachan-Heo/oh-my-codex"
+  url "https://registry.npmjs.org/oh-my-codex/-/oh-my-codex-0.11.13.tgz"
+  sha256 "ab6defdacac3f0eea704f024aa9c18ab43b351bf55e14618d9317ea866b71c94"
+  license "MIT"
+
+  depends_on "node@22"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/omx --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ omx setup
 omx --madmax --high
 ```
 
+Or install via Homebrew (macOS):
+
+```bash
+brew tap Yeachan-Heo/oh-my-codex https://github.com/Yeachan-Heo/oh-my-codex.git
+brew install oh-my-codex
+omx setup
+omx --madmax --high
+```
+
+See [docs/homebrew.md](docs/homebrew.md) for upgrade and maintenance details.
+
 Then work normally inside Codex:
 
 ```text

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,0 +1,49 @@
+# Homebrew Installation
+
+oh-my-codex can be installed via Homebrew using the repository as a tap.
+
+## Install
+
+    brew tap Yeachan-Heo/oh-my-codex https://github.com/Yeachan-Heo/oh-my-codex.git
+    brew install oh-my-codex
+
+## Upgrade
+
+    brew update
+    brew upgrade oh-my-codex
+
+## Uninstall
+
+    brew uninstall oh-my-codex
+    brew untap Yeachan-Heo/oh-my-codex
+
+---
+
+## Maintenance
+
+The formula lives at `Formula/oh-my-codex.rb`. On each npm release,
+two fields need updating:
+
+| Field    | Source                          |
+|----------|---------------------------------|
+| `url`    | `npm view oh-my-codex dist.tarball` |
+| `sha256` | `curl -sL <tarball-url> \| shasum -a 256` |
+
+### Manual update
+
+    URL=$(npm view oh-my-codex dist.tarball)
+    SHA=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
+    sed -i '' "s|url \".*\"|url \"$URL\"|" Formula/oh-my-codex.rb
+    sed -i '' "s|sha256 \".*\"|sha256 \"$SHA\"|" Formula/oh-my-codex.rb
+
+### CI automation (optional)
+
+A GitHub Action triggered on release tags can run the update above and
+open a PR automatically. See `brew bump-formula-pr` for Homebrew's
+built-in tooling.
+
+### Testing locally
+
+    brew install --build-from-source ./Formula/oh-my-codex.rb
+    brew test oh-my-codex
+    omx --version


### PR DESCRIPTION
## Summary

There's no Homebrew install path for oh-my-codex. Users on macOS who prefer Homebrew over npm have no option. This was raised in a prior issue, where the maintainer asked for a narrow PR that adds the formula and documents the maintenance surface.

## Changes

- Add `Formula/oh-my-codex.rb` — standard Node formula using the npm tarball, depends on `node@22`, installs and links the `omx` binary
- Add `docs/homebrew.md` — tap/install/upgrade/uninstall instructions, maintenance surface docs (what to update per release, manual and CI update paths, local testing steps)
- Add Homebrew install option to README alongside existing npm instructions

## Validation

- [x] `brew install` from local tap succeeds
- [x] `omx --version` returns correct version from Homebrew-installed binary
- [x] `brew test` passes
- [x] No conflict with nvm-managed Node (Homebrew's `node@22` is keg-only)
- [ ] `npm run build`
- [ ] `npm test`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README, docs/homebrew.md)
- [x] Backward-compatibility impact considered — no existing behavior changed

## Related

Addresses maintainer feedback on Homebrew formula request (issue was closed with guidance to submit a narrow PR).