### PR TITLE
Prevent active team runs from slipping past stop and mode-state guards

### DIFF
--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -29,8 +29,9 @@ When user triggers `$team`, the agent must:
 1. Invoke OMX runtime directly with `omx team ...`
 2. Avoid replacing the flow with in-process `spawn_agent` fanout
 3. Verify startup and surface concrete state/pane evidence
-4. Keep team state alive until workers are terminal (unless explicit abort)
-5. Handle cleanup and stale-pane recovery when needed
+4. If active team mode state is missing, initialize/sync it from canonical team runtime state before proceeding
+5. Keep team state alive until workers are terminal (unless explicit abort)
+6. Handle cleanup and stale-pane recovery when needed
 
 If `omx team` is unavailable, stop with a hard error.
 
@@ -148,6 +149,8 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 7. Wait for worker readiness (`capture-pane` polling)
 8. Write per-worker `inbox.md` and trigger via `tmux send-keys`
 9. Return control to leader; follow-up uses `status` / `resume` / `shutdown`
+
+If coarse active team mode state is missing while canonical team runtime state exists, restore/sync the active team mode state before relying on hook/mode-aware behavior.
 
 Important:
 

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -4,6 +4,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
+import { readModeState } from '../../modes/base.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
 import {
   appendTeamEvent,
@@ -1527,6 +1528,129 @@ process.on('SIGTERM', () => process.exit(0));
     } finally {
       console.log = originalLog;
       process.stderr.write = originalStderrWrite;
+      process.chdir(previousCwd);
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('initializes and rehydrates active team mode state on start and resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-mode-state-'));
+    const binDir = join(wd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const previousCwd = process.cwd();
+    const previousPath = process.env.PATH;
+    const previousTmux = process.env.TMUX;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const teamTask = 'issue 771 rehydrate team mode state';
+    const teamName = parseTeamStartArgs(['1:executor', teamTask]).parsed.teamName;
+
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+setTimeout(() => process.exit(0), 3000);
+process.stdin.resume();
+process.on('SIGTERM', () => process.exit(0));
+`,
+    );
+    await chmod(fakeCodexPath, 0o755);
+
+    try {
+      process.chdir(wd);
+      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+      delete process.env.TMUX;
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_TEAM_WORKER_CLI = 'codex';
+
+      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+
+      const startedState = await readModeState('team', wd);
+      assert.equal(startedState?.active, true);
+      assert.equal(startedState?.team_name, teamName);
+      assert.equal(startedState?.current_phase, 'team-exec');
+
+      await rm(join(wd, '.omx', 'state', 'team-state.json'), { force: true });
+      assert.equal(await readModeState('team', wd), null);
+
+      await withoutTeamTestWorkerEnv(() => teamCommand(['resume', teamName]));
+
+      const resumedState = await readModeState('team', wd);
+      assert.equal(resumedState?.active, true);
+      assert.equal(resumedState?.team_name, teamName);
+      assert.equal(resumedState?.current_phase, 'team-exec');
+    } finally {
+      process.chdir(previousCwd);
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not resurrect active team mode state when canonical team phase is terminal on resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-mode-terminal-'));
+    const binDir = join(wd, 'bin');
+    const fakeCodexPath = join(binDir, 'codex');
+    const previousCwd = process.cwd();
+    const previousPath = process.env.PATH;
+    const previousTmux = process.env.TMUX;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const teamTask = 'issue 772 terminal team mode state';
+    const teamName = parseTeamStartArgs(['1:executor', teamTask]).parsed.teamName;
+
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      fakeCodexPath,
+      `#!/usr/bin/env node
+setTimeout(() => process.exit(0), 3000);
+process.stdin.resume();
+process.on('SIGTERM', () => process.exit(0));
+`,
+    );
+    await chmod(fakeCodexPath, 0o755);
+
+    try {
+      process.chdir(wd);
+      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+      delete process.env.TMUX;
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_TEAM_WORKER_CLI = 'codex';
+
+      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+      await writeFile(
+        join(wd, '.omx', 'state', 'team', teamName, 'phase.json'),
+        JSON.stringify({
+          current_phase: 'complete',
+          max_fix_attempts: 3,
+          current_fix_attempt: 0,
+          transitions: [],
+          updated_at: new Date().toISOString(),
+        }, null, 2),
+      );
+      await rm(join(wd, '.omx', 'state', 'team-state.json'), { force: true });
+
+      await withoutTeamTestWorkerEnv(() => teamCommand(['resume', teamName]));
+
+      const resumedState = await readModeState('team', wd);
+      assert.equal(resumedState?.active, false);
+      assert.equal(resumedState?.team_name, teamName);
+      assert.equal(resumedState?.current_phase, 'complete');
+    } finally {
       process.chdir(previousCwd);
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -22,7 +22,7 @@ import {
   executeTeamApiOperation,
   type TeamApiOperation,
 } from '../team/api-interop.js';
-import { teamReadConfig as readTeamConfig } from '../team/team-ops.js';
+import { teamReadConfig as readTeamConfig, teamReadPhase as readTeamPhase } from '../team/team-ops.js';
 import { recordLeaderRuntimeActivity } from '../team/leader-activity.js';
 import { readTeamPaneStatus } from '../team/pane-status.js';
 
@@ -118,6 +118,11 @@ const MIN_WORKER_COUNT = 1;
 const DEFAULT_SPARKSHELL_TAIL_LINES = 400;
 const MIN_SPARKSHELL_TAIL_LINES = 100;
 const MAX_SPARKSHELL_TAIL_LINES = 1000;
+
+function isTerminalModePhase(phase: string): boolean {
+  return ['complete', 'failed', 'cancelled'].includes(phase);
+}
+
 const TEAM_HELP = `
 Usage: omx team [N:agent-type] "<task description>"
        omx team status <team-name> [--json] [--tail-lines <100-1000>]
@@ -1190,31 +1195,40 @@ async function ensureTeamModeState(
     workerCount: parsed.workerCount,
     fallbackRole,
   });
+  const currentPhase = parsed.teamName
+    ? (await readTeamPhase(parsed.teamName, process.cwd()))?.current_phase ?? 'team-exec'
+    : 'team-exec';
+  const active = !isTerminalModePhase(currentPhase);
+  const completionStamp = active ? undefined : new Date().toISOString();
 
   const existing = await readModeState('team');
   if (existing?.active) {
     await updateModeState('team', {
+      active,
       task_description: parsed.task,
-      current_phase: 'team-exec',
+      current_phase: currentPhase,
       team_name: parsed.teamName,
       agent_count: parsed.workerCount,
       agent_types: roleDistribution,
       available_agent_types: availableAgentTypes,
       staffing_summary: staffingPlan.staffingSummary,
       staffing_allocations: staffingPlan.allocations,
+      completed_at: completionStamp,
     });
     return;
   }
 
   await startMode('team', parsed.task, 50);
   await updateModeState('team', {
-    current_phase: 'team-exec',
+    active,
+    current_phase: currentPhase,
     team_name: parsed.teamName,
     agent_count: parsed.workerCount,
     agent_types: roleDistribution,
     available_agent_types: availableAgentTypes,
     staffing_summary: staffingPlan.staffingSummary,
     staffing_allocations: staffingPlan.allocations,
+    completed_at: completionStamp,
   });
 
 }

--- a/src/hooks/__tests__/pre-context-gate-skills.test.ts
+++ b/src/hooks/__tests__/pre-context-gate-skills.test.ts
@@ -34,6 +34,7 @@ describe('pre-context gate guidance in planning/execution-heavy skills', () => {
     assert.match(teamSkill, /Pre-context Intake Gate/i);
     assert.match(teamSkill, /\.omx\/context\/\{slug\}-\{timestamp\}\.md/);
     assert.match(teamSkill, /\$deep-interview\s+--quick/i);
+    assert.match(teamSkill, /initialize\/sync it from canonical team runtime state before proceeding/i);
   });
 
   it('autopilot documents required pre-context intake before expansion', () => {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import { buildManagedCodexHooksConfig } from "../../config/codex-hooks.js";
+import { initTeamState } from "../../team/state.js";
 import {
   dispatchCodexNativeHook,
   mapCodexHookEventToOmxEvent,
@@ -484,6 +485,206 @@ describe("codex native hook dispatch", () => {
         systemMessage: "OMX team pipeline is still active at phase team-verify.",
       });
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns Stop continuation output from canonical team state when coarse mode state is missing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-canonical-"));
+    try {
+      await initTeamState(
+        "canonical-team",
+        "canonical stop fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-canonical" },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-canonical",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX team pipeline is still active (canonical-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.",
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block Stop from canonical team state alone when the canonical phase is terminal", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-terminal-"));
+    try {
+      await initTeamState(
+        "terminal-team",
+        "terminal stop fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-terminal" },
+      );
+      await writeJson(join(cwd, ".omx", "state", "team", "terminal-team", "phase.json"), {
+        current_phase: "complete",
+        max_fix_attempts: 3,
+        current_fix_attempt: 0,
+        transitions: [],
+        updated_at: new Date().toISOString(),
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-terminal",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns Stop continuation output from canonical team state when manifest session ownership is missing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-legacy-"));
+    try {
+      await initTeamState(
+        "legacy-team",
+        "legacy stop fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-legacy" },
+      );
+      const manifestPath = join(cwd, ".omx", "state", "team", "legacy-team", "manifest.v2.json");
+      const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as Record<string, unknown>;
+      await writeJson(manifestPath, {
+        ...manifest,
+        leader: {
+          ...(manifest.leader as Record<string, unknown> | undefined),
+          session_id: "",
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-legacy",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX team pipeline is still active (legacy-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.",
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("reads canonical Stop fallback team state from OMX_TEAM_STATE_ROOT when configured", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-root-"));
+    const sharedRoot = join(cwd, "shared-root");
+    const priorTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_TEAM_STATE_ROOT = "shared-root";
+      await initTeamState(
+        "canonical-root-team",
+        "canonical stop root fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-root", OMX_TEAM_STATE_ROOT: "shared-root" },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-root",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX team pipeline is still active (canonical-root-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.",
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
+      assert.equal(existsSync(join(sharedRoot, "team", "canonical-root-team", "phase.json")), true);
+    } finally {
+      if (typeof priorTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = priorTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns Stop continuation output from canonical team state rooted via OMX_TEAM_STATE_ROOT", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-env-root-"));
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_TEAM_STATE_ROOT = "shared-team-state";
+      await initTeamState(
+        "env-root-team",
+        "env root stop fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        {
+          ...process.env,
+          OMX_SESSION_ID: "sess-stop-team-env-root",
+          OMX_TEAM_STATE_ROOT: "shared-team-state",
+        },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-env-root",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX team pipeline is still active (env-root-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.",
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
+    } finally {
+      if (typeof previousTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -5,7 +5,8 @@ import { join } from "path";
 import { readModeState } from "../modes/base.js";
 import { getReadScopedStateDirs } from "../mcp/state-paths.js";
 import { readSubagentSessionSummary } from "../subagents/tracker.js";
-import { readTeamPhase } from "../team/state.js";
+import { resolveCanonicalTeamStateRoot } from "../team/state-root.js";
+import { readTeamManifestV2, readTeamPhase } from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
 import {
   detectPrimaryKeyword,
@@ -477,6 +478,38 @@ async function buildTeamStopOutput(cwd: string): Promise<Record<string, unknown>
   };
 }
 
+async function findCanonicalActiveTeamForSession(
+  cwd: string,
+  sessionId: string,
+): Promise<{ teamName: string; phase: string } | null> {
+  if (!sessionId.trim()) return null;
+  const teamsRoot = join(resolveCanonicalTeamStateRoot(cwd), "team");
+  if (!existsSync(teamsRoot)) return null;
+
+  const entries = await readdir(teamsRoot, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const teamName = entry.name.trim();
+    if (!teamName) continue;
+
+    const [manifest, phaseState] = await Promise.all([
+      readTeamManifestV2(teamName, cwd),
+      readTeamPhase(teamName, cwd),
+    ]);
+    if (!manifest || !phaseState) continue;
+    const ownerSessionId = (manifest.leader?.session_id ?? "").trim();
+    if (ownerSessionId && ownerSessionId !== sessionId.trim()) continue;
+    if (!isNonTerminalPhase(phaseState.current_phase)) continue;
+
+    return {
+      teamName,
+      phase: formatPhase(phaseState.current_phase),
+    };
+  }
+
+  return null;
+}
+
 async function buildSkillStopOutput(
   cwd: string,
   sessionId: string,
@@ -526,6 +559,16 @@ async function buildStopHookOutput(
     if (!stopHookActive && teamOutput) return teamOutput;
 
     if (sessionId) {
+      const canonicalTeam = await findCanonicalActiveTeamForSession(cwd, sessionId);
+      if (!stopHookActive && canonicalTeam) {
+        return {
+          decision: "block",
+          reason: `OMX team pipeline is still active (${canonicalTeam.teamName}) at phase ${canonicalTeam.phase}; continue coordinating until the team reaches a terminal phase.`,
+          stopReason: `team_${canonicalTeam.phase}`,
+          systemMessage: `OMX team pipeline is still active at phase ${canonicalTeam.phase}.`,
+        };
+      }
+
       const skillOutput = await buildSkillStopOutput(cwd, sessionId);
       if (!stopHookActive && skillOutput) return skillOutput;
     }


### PR DESCRIPTION
## Summary

Fix a team-state drift gap so active `omx team` runs remain visible to mode-aware flows even when coarse mode state goes missing.

## Changes

- sync/rehydrate active coarse `team` mode state on `omx team` start and resume
- make native `Stop` fall back to canonical non-terminal team state when coarse team mode state is missing
- document in the `team` skill that missing team mode state should be initialized/synced from canonical runtime state before proceeding
- add regression coverage for start/resume rehydration, canonical Stop fallback, terminal canonical phase behavior, and the skill guidance contract

## Validation

- [x] `npm run build`
- [ ] `npm test` *(still running in a separate session due suite length at PR creation time)*
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx biome lint skills/team/SKILL.md src/cli/team.ts src/scripts/codex-native-hook.ts src/cli/__tests__/team.test.ts src/scripts/__tests__/codex-native-hook.test.ts src/hooks/__tests__/pre-context-gate-skills.test.ts`
- [x] `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/team.test.js dist/hooks/__tests__/pre-context-gate-skills.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
