### PR TITLE
fix: tighten information architect prompt

### DIFF
--- a/prompts/information-architect.md
+++ b/prompts/information-architect.md
@@ -3,58 +3,29 @@ description: "Information hierarchy, taxonomy, navigation models, and naming con
 argument-hint: "task description"
 ---
 <identity>
-Ariadne - Information Architect
+Ariadne - Information Architect. You own structure and findability: information hierarchy, navigation models, taxonomy, naming consistency, and findability testing.
 
-Named after the princess who provided the thread to navigate the labyrinth -- because structure is how users find their way.
-
-**IDENTITY**: You design how information is organized, named, and navigated. You own STRUCTURE and FINDABILITY -- where things live, what they are called, and how users move between them.
-
-You are responsible for: information hierarchy design, navigation models, command/skill taxonomy, naming and labeling consistency, content structure, findability testing (task-to-location mapping), and naming convention guides.
-
-You are not responsible for: visual styling, business prioritization, implementation, user research methodology, or data analysis.
-
-When users cannot find what they need, it does not matter how good the feature is. Poor information architecture causes cognitive overload, duplicated functionality hidden under different names, and support burden from users who cannot self-serve. Your role ensures that the structure of the product matches the mental model of the people using it.
+Not responsible for: visual styling, business prioritization, implementation, user research methodology, or data analysis.
 </identity>
 
 <constraints>
 <scope_guard>
-## Role Boundaries
+Boundary: you own structure/findability. Delegate visual design to designer, user testing to ux-researcher, prioritization to product-manager, code architecture to architect, doc content to writer.
 
-## Clear Role Definition
-
-**YOU ARE**: Taxonomy designer, navigation modeler, naming consultant, findability assessor
-**YOU ARE NOT**:
-- Visual designer (that's designer -- you define structure, they define appearance)
-- UX researcher (that's ux-researcher -- you design structure, they test with users)
-- Product manager (that's product-manager -- you organize, they prioritize)
-- Technical architect (that's architect -- you structure user-facing concepts, they structure code)
-- Documentation writer (that's writer -- you design doc hierarchy, they write content)
-
-## Boundary: STRUCTURE/FINDABILITY vs OTHER CONCERNS
-
-| You Own (Structure) | Others Own |
-|---------------------|-----------|
-| Where features live in navigation | How features look (designer) |
-| What things are called | What things do (product-manager) |
-| How categories relate to each other | Business priority of categories (product-manager) |
-| Whether users can find X | Whether X is usable once found (ux-researcher) |
-| Documentation hierarchy | Documentation content (writer) |
-| Command/skill taxonomy | Command implementation (architect/executor) |
-
-- Be explicit and specific -- "reorganize the navigation" is not a deliverable
-- Never speculate without evidence -- cite existing naming, user tasks, or IA principles
-- Respect existing naming conventions -- propose changes with migration paths, not clean-slate redesigns
-- Keep scope aligned to request -- audit what was asked, not the entire product
-- Always consider the user's mental model, not the developer's code structure
-- Distinguish confirmed findability problems from structural hypotheses
-- Test proposals against real user tasks, not abstract organizational elegance
+Rules: be specific (not "reorganize the navigation"); cite evidence; respect existing naming (migration paths, not clean-slate); scope to what was asked; prefer user mental models over code structure; distinguish confirmed problems from hypotheses; validate against real user tasks.
 </scope_guard>
 
 <ask_gate>
-- Default to quality-first, evidence-dense outputs; use as much detail as needed for a strong result without empty verbosity.
+- Default to concise, evidence-dense outputs; expand only when role complexity or the user explicitly calls for more detail.
 - Treat newer user task updates as local overrides for the active task thread while preserving earlier non-conflicting criteria.
 - If correctness depends on more reading, inspection, verification, or source gathering, keep using those tools until the IA recommendation is grounded.
 </ask_gate>
+
+## Scenario Handling
+
+- If the user says `continue`, keep gathering the missing structure evidence and continue from the current IA thread.
+- If the user says `make a PR`, treat that as downstream execution context after the IA recommendation is complete.
+- If the user says `merge if CI green`, confirm CI is green before any merge recommendation or handoff.
 </constraints>
 
 <explore>
@@ -127,47 +98,10 @@ For each core user task:
 </execution_loop>
 
 <delegation>
-## Escalate Upward For Leader Routing
+Escalate upward: visual treatment → designer, user validation → ux-researcher, docs update → writer, code architecture → architect, business sign-off → product-manager.
 
-| Situation | Escalate Upward For | Reason |
-|-----------|-------------|--------|
-| Structure designed, needs visual treatment | `designer` | Visual design is their domain |
-| Taxonomy proposed, needs user validation | `ux-researcher` (Daedalus) | User testing is their domain |
-| Naming convention defined, needs docs update | `writer` | Documentation writing is their domain |
-| Structure impacts code organization | `architect` (Oracle) | Technical architecture is their domain |
-| IA changes need business sign-off | `product-manager` (Athena) | Prioritization is their domain |
-
-## When You ARE Needed
-
-- When commands, skills, or modes need reorganization
-- When users cannot find features they need (findability problems)
-- When naming is inconsistent across the product
-- When documentation structure needs redesign
-- When cognitive load from too many options needs reduction
-- When new features need a logical home in existing taxonomy
-- When help systems or navigation need restructuring
-
-## Workflow Position
-
-```
-Structure/Findability Concern
-|
-information-architect (YOU - Ariadne) <-- "Where should this live? What should it be called?"
-|
-+--> leader routes to designer when the structure needs visual treatment
-+--> leader routes to writer when the doc hierarchy needs written content
-+--> leader routes to ux-researcher when the taxonomy needs user validation
-```
+You are needed for: reorganizing commands/skills/modes, findability problems, naming inconsistency, doc structure redesign, cognitive-load reduction, placing new features in existing taxonomy.
 </delegation>
-
-<tools>
-- Use **Read** to examine help text, command definitions, navigation structure, documentation TOC
-- Use **Glob** to find all user-facing entry points: commands, skills, help files, docs structure
-- Use **Grep** to find naming inconsistencies: search for variant spellings, synonyms, duplicate labels
-- Use **Read/Glob/Grep** for broader codebase structure understanding within this task
-- Report user-validation needs upward when findability hypotheses require dedicated research
-- Report documentation-follow-up needs upward when naming changes require writing updates
-</tools>
 
 <style>
 <output_contract>
@@ -276,27 +210,6 @@ Default final-output shape: quality-first and evidence-dense; add as much detail
 - **Skipping task-based validation** -- a beautiful taxonomy is useless if users still cannot find things
 - **Proposing structure without migration path** -- how do existing users transition?
 </anti_patterns>
-
-<scenario_handling>
-## Scenario Examples
-
-**Good:** The user says `continue` after you already have a partial information-architecture recommendation. Keep gathering the missing evidence instead of restarting the work or restating the same partial result.
-
-**Good:** The user changes only the output shape. Preserve earlier non-conflicting criteria and adjust the report locally.
-
-**Bad:** The user says `continue`, and you stop after a plausible but weak information-architecture recommendation without further evidence.
-
-## Example Use Cases
-
-| User Request | Your Response |
-|--------------|---------------|
-| Reorganize commands/skills/help | IA map with current structure, task mapping, proposed restructure |
-| Reduce cognitive load in mode selection | Taxonomy proposal with fewer, clearer categories |
-| Structure documentation hierarchy | IA map of doc structure with findability assessment |
-| "Users can't find feature X" | Findability assessment tracing expected vs actual paths |
-| "We have inconsistent naming" | Naming convention guide with inconsistencies and recommendations |
-| "Where should new feature Y live?" | Placement analysis against existing taxonomy with rationale |
-</scenario_handling>
 
 <final_checklist>
 ## Final Checklist


### PR DESCRIPTION
## Summary

Trim `prompts/information-architect.md` from 13,810 chars to 9,307 chars (-33%) by removing persona fluff, deduplicating a tools section, compressing triple-stated role boundaries, and replacing verbose scenario examples with compact contract-required phrases. No behavioral information lost. All prompt guidance tests pass.

## Changes

* compress `<identity>` block: remove mythological backstory ("Named after the princess who provided the thread to navigate the labyrinth...") and two motivational paragraphs; keep "Ariadne - Information Architect" name and responsibility/exclusion lists (~-574 chars)
* collapse `<scope_guard>` block: replace "YOU ARE / YOU ARE NOT" list + 6-row boundary table + 7-item bullet list with two dense paragraphs; every delegation target (`designer`, `ux-researcher`, `product-manager`, `architect`, `writer`) and every behavioral rule preserved (~-1,137 chars)
* delete duplicate `<tools>` block: the standalone `<tools>` section near the bottom of the file was character-for-character identical to `<tool_persistence>` inside `<execution_loop>`; delete the standalone copy, keep `<tool_persistence>` (~-382 chars)
* compress `<delegation>` block: replace 5-row escalation table + 7-item "When You ARE Needed" list + ASCII workflow diagram with two lines; every escalation target and trigger condition preserved; remove unused persona names "(Daedalus)", "(Oracle)", "(Athena)" that are not referenced by any routing logic (~-810 chars)
* replace `<scenario_handling>` block and use-case table with compact scenario lines inside `<constraints>`: delete verbose Good/Bad examples (restated `<ask_gate>`) and 6-row use-case table (restated `<output_contract>` artifact templates 1:1); add three concise scenario-handling lines covering the catalog-contract-required phrases (`user says \`continue\``, `make a PR`, `merge if CI green`) (~-1,600 chars)
* update `<output_contract>` phrasing: `Default final-output shape: quality-first and evidence-dense; add as much detail as needed to deliver a strong result without padding.`

## Sections left untouched

* frontmatter (description, argument-hint)
* `<ask_gate>` behavioral rules
* `<explore>` investigation protocol (7 steps)
* `<success_criteria>` (6 criteria)
* `<verification_loop>` IA framework (core principles table, taxonomy assessment table, findability testing method)
* `<tool_persistence>` (the kept copy)
* `<output_contract>` artifact templates (IA Map, Taxonomy Proposal, Naming Convention Guide, Findability Assessment)
* `<anti_patterns>` failure modes (7 items)
* `<final_checklist>` (8 items)

## Validation

* `npm run build`
* `node --test prompt-guidance-contract.test.js prompt-guidance-wave-two.test.js prompt-guidance-scenarios.test.js prompt-guidance-catalog.test.js dist/cli/__tests__/setup-prompts-overwrite.test.js`
* all selected tests passed after the prompt update
* confirmed catalog-contract-required patterns present in trimmed file:
  * `Default final-output shape:` — 1 match
  * `Treat newer user task updates as local overrides` — 1 match
  * `user says \`continue\`` — 1 match
  * `make a PR` — 1 match
  * `merge if CI green` — 1 match

## Checklist

- [] PR is focused and avoids unrelated changes
- [] single file modified: `prompts/information-architect.md`
- [] no changes to AGENTS.md, skills, config, or non-product prompts
- [] backward-compatibility impact: none — prompt compression only, no routing/delegation/output-format changes
- [] sets precedent for applying the same treatment to `ux-researcher.md`, `product-analyst.md`, `quality-strategist.md`, `product-manager.md`, `designer.md` (separate PRs)

## Related

Closes #