### PR TITLE
Reduce native subagent OMX MCP startup churn

### DIFF
--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -86,6 +86,64 @@ describe("agents/native-config", () => {
     assert.doesNotMatch(tunedToml, /exact gpt-5\.4-mini model/);
   });
 
+  it("disables leader-oriented OMX MCP servers for generated native subagents only when present in config", () => {
+    const agent: AgentDefinition = {
+      name: "planner",
+      description: "Project planner",
+      reasoningEffort: "medium",
+      posture: "frontier-orchestrator",
+      modelClass: "frontier",
+      routingRole: "leader",
+      tools: "analysis",
+      category: "build",
+    };
+
+    const prompt = "Instruction line";
+    const toml = generateAgentToml(agent, prompt, {
+      configTomlContent: `
+[mcp_servers.omx_state]
+command = "node"
+
+[mcp_servers.omx_code_intel]
+command = "node"
+
+[mcp_servers.omx_trace]
+command = "node"
+
+[mcp_servers.chrome-mcp]
+url = "http://127.0.0.1:12306/mcp"
+`,
+    });
+
+    assert.match(toml, /\[mcp_servers\.omx_state\]\nenabled = false/);
+    assert.match(toml, /\[mcp_servers\.omx_trace\]\nenabled = false/);
+    assert.doesNotMatch(toml, /\[mcp_servers\.omx_code_intel\]\nenabled = false/);
+    assert.doesNotMatch(toml, /\[mcp_servers\.chrome-mcp\]\nenabled = false/);
+  });
+
+  it("does not inject OMX MCP disable blocks when the current config has no matching OMX servers", () => {
+    const agent: AgentDefinition = {
+      name: "planner",
+      description: "Project planner",
+      reasoningEffort: "medium",
+      posture: "frontier-orchestrator",
+      modelClass: "frontier",
+      routingRole: "leader",
+      tools: "analysis",
+      category: "build",
+    };
+
+    const prompt = "Instruction line";
+    const toml = generateAgentToml(agent, prompt, {
+      configTomlContent: `
+[mcp_servers.chrome-mcp]
+url = "http://127.0.0.1:12306/mcp"
+`,
+    });
+
+    assert.doesNotMatch(toml, /\[mcp_servers\.omx_/);
+  });
+
   it("installs only agents with prompt files and skips existing files without force", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-native-config-"));
     const promptsDir = join(root, "prompts");

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -6,6 +6,7 @@
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
+import { parse as parseToml } from "@iarna/toml";
 import { AGENT_DEFINITIONS, AgentDefinition } from "./definitions.js";
 import {
   getEnvConfiguredStandardDefaultModel,
@@ -103,6 +104,7 @@ export interface GeneratedNativeAgentConfig {
   developerInstructions?: string;
   model?: string;
   reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+  disabledMcpServers?: string[];
 }
 
 interface AgentModelResolutionOptions {
@@ -117,6 +119,13 @@ interface RoleInstructionMetadata {
   modelClass: AgentDefinition["modelClass"];
   routingRole: AgentDefinition["routingRole"];
 }
+
+const LEADER_ONLY_OMX_MCP_SERVERS = [
+  "omx_state",
+  "omx_memory",
+  "omx_trace",
+  "omx_team_run",
+] as const;
 
 function readConfigTomlContent(
   codexHomeOverride?: string,
@@ -284,8 +293,55 @@ export function generateStandaloneAgentToml(
     lines.push('developer_instructions = """', escapedInstructions, '"""');
   }
 
+  const disabledMcpServers = (config.disabledMcpServers ?? []).filter(Boolean);
+  if (disabledMcpServers.length > 0) {
+    lines.push(
+      "",
+      "# Disable leader-oriented OMX MCP servers for native subagents.",
+      "# These servers are session-scoped helpers; spawning them again in each",
+      "# subagent adds startup churn and can surface misleading MCP startup UI.",
+    );
+    for (const serverName of disabledMcpServers) {
+      lines.push(
+        `[mcp_servers.${escapeTomlBasicString(serverName)}]`,
+        "enabled = false",
+        "",
+      );
+    }
+  }
+
   lines.push("");
   return lines.join("\n");
+}
+
+function resolveConfigTomlContent(
+  options: AgentModelResolutionOptions = {},
+): string {
+  return readConfigTomlContent(
+    options.codexHomeOverride,
+    options.configTomlContent,
+  );
+}
+
+function resolveDisabledOmxMcpServers(
+  options: AgentModelResolutionOptions = {},
+): string[] {
+  const configTomlContent = resolveConfigTomlContent(options);
+  if (configTomlContent.trim().length === 0) {
+    return [];
+  }
+
+  try {
+    const parsed = parseToml(configTomlContent) as {
+      mcp_servers?: Record<string, unknown>;
+    };
+    const configuredServers = parsed?.mcp_servers ?? {};
+    return LEADER_ONLY_OMX_MCP_SERVERS.filter((serverName) =>
+      Object.prototype.hasOwnProperty.call(configuredServers, serverName),
+    );
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -296,13 +352,16 @@ export function generateAgentToml(
   promptContent: string,
   options: AgentModelResolutionOptions = {},
 ): string {
-  const resolvedModel = resolveAgentModel(agent, options);
+  const configTomlContent = resolveConfigTomlContent(options);
+  const optionsWithConfig = { ...options, configTomlContent };
+  const resolvedModel = resolveAgentModel(agent, optionsWithConfig);
   return generateStandaloneAgentToml({
     name: agent.name,
     description: agent.description,
     developerInstructions: composeRoleInstructions(promptContent, agent, resolvedModel),
     model: resolvedModel,
     reasoningEffort: agent.reasoningEffort,
+    disabledMcpServers: resolveDisabledOmxMcpServers(optionsWithConfig),
   });
 }
 


### PR DESCRIPTION
## Summary
- make generated native agent role files disable leader-oriented OMX MCP servers only when those servers exist in the current config
- keep omx_code_intel untouched so coding-focused subagents still retain code-intel support
- add regression tests covering conditional injection and no-op behavior when OMX MCP entries are absent

## Why
Native Codex subagents inherit full Codex config, so they can redundantly start OMX session-scoped MCP servers (state, memory, trace, team-run). In practice this can create extra startup churn and misleading `Starting MCP servers` UI even when the subagent is already running.

## Testing
- npm run build
- npm run check:no-unused
- node --test dist/agents/__tests__/native-config.test.js