### PR TITLE
Default OMX leader launches to direct mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Launch OMX the recommended way:
 omx --madmax --high
 ```
 
+This starts the interactive leader session directly by default.
+If you explicitly want the leader session in tmux, use:
+
+```bash
+omx --tmux --madmax --high
+```
+
 Then try the canonical workflow:
 
 ```text

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -13,6 +13,7 @@ import {
   resolveCliInvocation,
   commandOwnsLocalHelp,
   resolveCodexLaunchPolicy,
+  resolveLeaderLaunchPolicyOverride,
   classifyCodexExecFailure,
   resolveSignalExitCode,
   parseTmuxPaneSnapshot,
@@ -200,6 +201,28 @@ describe("normalizeCodexLaunchArgs", () => {
       "--model",
       "gpt-5",
     ]);
+  });
+
+  it("strips --tmux from leader codex args", () => {
+    assert.deepEqual(normalizeCodexLaunchArgs(["--tmux", "--yolo"]), [
+      "--yolo",
+    ]);
+  });
+});
+
+describe("resolveLeaderLaunchPolicyOverride", () => {
+  it("detects explicit detached tmux launch requests", () => {
+    assert.equal(
+      resolveLeaderLaunchPolicyOverride(["--tmux", "--model", "gpt-5"]),
+      "detached-tmux",
+    );
+  });
+
+  it("returns undefined when no explicit policy override is present", () => {
+    assert.equal(
+      resolveLeaderLaunchPolicyOverride(["--model", "gpt-5"]),
+      undefined,
+    );
   });
 });
 
@@ -873,10 +896,10 @@ describe("project launch scope helpers", () => {
 });
 
 describe("resolveCodexLaunchPolicy", () => {
-  it("uses detached tmux on macOS when outside tmux and tmux is available", () => {
+  it("uses direct launch on macOS when outside tmux even if tmux is available", () => {
     assert.equal(
       resolveCodexLaunchPolicy({}, "darwin", true, false, true, true),
-      "detached-tmux",
+      "direct",
     );
   });
 
@@ -903,10 +926,10 @@ describe("resolveCodexLaunchPolicy", () => {
     );
   });
 
-  it("uses detached tmux on non-macOS hosts when outside tmux and tmux is available", () => {
+  it("uses direct launch on non-macOS hosts when outside tmux even if tmux is available", () => {
     assert.equal(
       resolveCodexLaunchPolicy({}, "linux", true, false, true, true),
-      "detached-tmux",
+      "direct",
     );
   });
 
@@ -923,6 +946,21 @@ describe("resolveCodexLaunchPolicy", () => {
         false,
         true,
         true,
+      ),
+      "direct",
+    );
+  });
+
+  it("honors explicit detached tmux launch requests when tmux is available", () => {
+    assert.equal(
+      resolveCodexLaunchPolicy(
+        {},
+        "linux",
+        true,
+        false,
+        true,
+        true,
+        "detached-tmux",
       ),
       "detached-tmux",
     );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -169,6 +169,7 @@ Options:
   --madmax-spark  spark model for workers + bypass approvals for leader and workers
                 (shorthand for: --spark --madmax)
   --notify-temp  Enable temporary notification routing for this run/session only
+  --tmux         Launch the interactive leader session in detached tmux
   --discord      Select Discord provider for temporary notification mode
   --slack        Select Slack provider for temporary notification mode
   --telegram     Select Telegram provider for temporary notification mode
@@ -388,6 +389,15 @@ export function commandOwnsLocalHelp(command: CliCommand): boolean {
 
 export type CodexLaunchPolicy = "inside-tmux" | "detached-tmux" | "direct";
 
+export function resolveLeaderLaunchPolicyOverride(
+  args: string[],
+): CodexLaunchPolicy | undefined {
+  for (const arg of args) {
+    if (arg === "--tmux") return "detached-tmux";
+  }
+  return undefined;
+}
+
 export function resolveCodexLaunchPolicy(
   env: NodeJS.ProcessEnv = process.env,
   _platform: NodeJS.Platform = process.platform,
@@ -395,11 +405,14 @@ export function resolveCodexLaunchPolicy(
   nativeWindows: boolean = isNativeWindows(),
   stdinIsTTY: boolean = Boolean(process.stdin.isTTY),
   stdoutIsTTY: boolean = Boolean(process.stdout.isTTY),
+  explicitPolicy?: CodexLaunchPolicy,
 ): CodexLaunchPolicy {
   if (env.TMUX) return "inside-tmux";
+  if (explicitPolicy === "detached-tmux") return tmuxAvailable ? "detached-tmux" : "direct";
+  if (explicitPolicy === "direct") return "direct";
   if (nativeWindows) return "direct";
   if (!stdinIsTTY || !stdoutIsTTY) return "direct";
-  return tmuxAvailable ? "detached-tmux" : "direct";
+  return "direct";
 }
 
 type ExecFileSyncFailure = NodeJS.ErrnoException & {
@@ -842,12 +855,18 @@ export async function launchWithHud(args: string[]): Promise<void> {
     parsedWorktree.remainingArgs,
     process.env,
   );
+  const explicitLaunchPolicy = resolveLeaderLaunchPolicyOverride(
+    notifyTempResult.passthroughArgs,
+  );
   const codexHomeOverride = resolveCodexHomeForLaunch(launchCwd, process.env);
   const launchPolicy = resolveCodexLaunchPolicy(
     process.env,
     process.platform,
     undefined,
     isNativeWindows(),
+    undefined,
+    undefined,
+    explicitLaunchPolicy,
   );
   const enableNotifyFallbackAuthority = launchPolicy === "direct";
   const workerSparkModel = resolveWorkerSparkModel(
@@ -923,6 +942,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
       workerSparkModel,
       codexHomeOverride,
       notifyTempContractRaw,
+      explicitLaunchPolicy,
     );
   } finally {
     // ── Phase 3: postLaunch ─────────────────────────────────────────────
@@ -1022,6 +1042,10 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
   let reasoningMode: ReasoningMode | null = null;
 
   for (const arg of parsed.remainingArgs) {
+    if (arg === "--tmux") {
+      continue;
+    }
+
     if (arg === MADMAX_FLAG) {
       wantsBypass = true;
       continue;
@@ -1997,6 +2021,7 @@ function runCodex(
   workerDefaultModel?: string,
   codexHomeOverride?: string,
   notifyTempContractRaw?: string | null,
+  explicitLaunchPolicy?: CodexLaunchPolicy,
 ): void {
   const launchArgs = injectModelInstructionsBypassArgs(
     cwd,
@@ -2035,6 +2060,9 @@ function runCodex(
     process.platform,
     undefined,
     nativeWindows,
+    undefined,
+    undefined,
+    explicitLaunchPolicy,
   );
 
   if (isCodexVersionRequest(launchArgs)) {


### PR DESCRIPTION
Fixes #1331 
## Summary

  - default interactive OMX leader launches now use direct mode instead of detached tmux
  - add an explicit --tmux opt-in for users who still want detached tmux leader sessions
  - keep tmux as the default for workflows that actually depend on tmux orchestration, including omx team and other
    existing tmux-backed runtime behavior

  ## Changes

  - added resolveLeaderLaunchPolicyOverride() and threaded explicit leader launch policy through the interactive
    launch path
  - changed resolveCodexLaunchPolicy() so outside-tmux interactive leader launches default to direct
  - stripped --tmux from leader Codex args so the flag remains OMX-only
  - preserved existing inside-tmux behavior
  - preserved tmux-backed defaults for team and other tmux-required orchestration paths
  - updated CLI help and README quick-start guidance to document the new leader default and the explicit tmux
    override
  - expanded CLI tests to cover direct default behavior, inside-tmux behavior, and explicit detached tmux opt-in

  ## Testing

  - npm run build
  - node --test dist/cli/__tests__/index.test.js
  - npm test
    Launch-policy-related CLI coverage passed. The repo still has unrelated pre-existing failures in other suites
    such as ask, autoresearch, explore, native-assets, session-search, and notify-fallback watcher.