### PR TITLE
Clean duplicate 0.12.0 team/runtime seams

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,6 +44,10 @@ import {
   getStateDir,
   listModeStateFilesWithScopePreference,
 } from "../mcp/state-paths.js";
+import {
+  hasModelInstructionsOverride,
+  MODEL_INSTRUCTIONS_FILE_KEY,
+} from "../utils/model-instructions.js";
 import { maybeCheckAndPromptUpdate } from "./update.js";
 import { maybePromptGithubStar } from "./star-prompt.js";
 import {
@@ -189,7 +193,6 @@ Options:
 `;
 
 const REASONING_KEY = "model_reasoning_effort";
-const MODEL_INSTRUCTIONS_FILE_KEY = "model_instructions_file";
 const TEAM_WORKER_LAUNCH_ARGS_ENV = "OMX_TEAM_WORKER_LAUNCH_ARGS";
 const TEAM_INHERIT_LEADER_FLAGS_ENV = "OMX_TEAM_INHERIT_LEADER_FLAGS";
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = "OMX_BYPASS_DEFAULT_SYSTEM_PROMPT";
@@ -1086,32 +1089,6 @@ export function resolveWorkerSparkModel(
     }
   }
   return undefined;
-}
-
-function isModelInstructionsOverride(value: string): boolean {
-  return new RegExp(`^${MODEL_INSTRUCTIONS_FILE_KEY}\\s*=`).test(value.trim());
-}
-
-function hasModelInstructionsOverride(args: string[]): boolean {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
-      const maybeValue = args[i + 1];
-      if (
-        typeof maybeValue === "string" &&
-        isModelInstructionsOverride(maybeValue)
-      ) {
-        return true;
-      }
-      continue;
-    }
-
-    if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) {
-      const inlineValue = arg.slice(`${LONG_CONFIG_FLAG}=`.length);
-      if (isModelInstructionsOverride(inlineValue)) return true;
-    }
-  }
-  return false;
 }
 
 function shouldBypassDefaultSystemPrompt(env: NodeJS.ProcessEnv): boolean {

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -569,6 +569,19 @@ function buildDispatchAttemptEvidence(result, fallback = {}) {
   };
 }
 
+async function appendDispatchResultTelemetry(logsDir, teamName, request, result, reason) {
+  await appendDeliveryTelemetry(logsDir, {
+    event: 'dispatch_result',
+    team: teamName,
+    request_id: request.request_id,
+    message_id: request.message_id || null,
+    to_worker: request.to_worker,
+    transport: 'send-keys',
+    result,
+    reason,
+  });
+}
+
 export async function drainPendingTeamDispatch({
   cwd,
   stateDir = resolveBridgeStateDir(cwd),
@@ -650,16 +663,13 @@ export async function drainPendingTeamDispatch({
               readiness_evidence: null,
               pane_current_command: null,
             });
-            await appendDeliveryTelemetry(logsDir, {
-              event: 'dispatch_result',
-              team: teamName,
-              request_id: request.request_id,
-              message_id: request.message_id || null,
-              to_worker: request.to_worker,
-              transport: 'send-keys',
-              result: 'deferred',
-              reason: LEADER_PANE_MISSING_DEFERRED_REASON,
-            });
+            await appendDispatchResultTelemetry(
+              logsDir,
+              teamName,
+              request,
+              'deferred',
+              LEADER_PANE_MISSING_DEFERRED_REASON,
+            );
             // On the legacy fallback lane, requests.json still carries the queue
             // state for this deferred request; this event stays a progress
             // artifact for hook/watcher readers.
@@ -731,16 +741,7 @@ export async function drainPendingTeamDispatch({
               reason: result.reason,
               ...buildDispatchAttemptEvidence(result),
             });
-            await appendDeliveryTelemetry(logsDir, {
-              event: 'dispatch_result',
-              team: teamName,
-              request_id: request.request_id,
-              message_id: request.message_id || null,
-              to_worker: request.to_worker,
-              transport: 'send-keys',
-              result: 'retry',
-              reason: result.reason,
-            });
+            await appendDispatchResultTelemetry(logsDir, teamName, request, 'retry', result.reason);
             await emitOperationalHookEvent(cwd, 'retry-needed', {
               team: teamName,
               worker: request.to_worker,
@@ -769,16 +770,7 @@ export async function drainPendingTeamDispatch({
               reason: request.last_reason,
               ...buildDispatchAttemptEvidence(result),
             });
-            await appendDeliveryTelemetry(logsDir, {
-              event: 'dispatch_result',
-              team: teamName,
-              request_id: request.request_id,
-              message_id: request.message_id || null,
-              to_worker: request.to_worker,
-              transport: 'send-keys',
-              result: 'failed',
-              reason: request.last_reason,
-            });
+            await appendDispatchResultTelemetry(logsDir, teamName, request, 'failed', request.last_reason);
             await emitOperationalHookEvent(cwd, 'failed', {
               team: teamName,
               worker: request.to_worker,
@@ -812,16 +804,7 @@ export async function drainPendingTeamDispatch({
             reason: result.reason,
             ...buildDispatchAttemptEvidence(result),
           });
-          await appendDeliveryTelemetry(logsDir, {
-            event: 'dispatch_result',
-            team: teamName,
-            request_id: request.request_id,
-            message_id: request.message_id || null,
-            to_worker: request.to_worker,
-            transport: 'send-keys',
-            result: 'notified',
-            reason: result.reason,
-          });
+          await appendDispatchResultTelemetry(logsDir, teamName, request, 'notified', result.reason);
         } else {
           request.status = 'failed';
           request.failed_at = nowIso;
@@ -839,16 +822,7 @@ export async function drainPendingTeamDispatch({
             reason: result.reason,
             ...buildDispatchAttemptEvidence(result),
           });
-          await appendDeliveryTelemetry(logsDir, {
-            event: 'dispatch_result',
-            team: teamName,
-            request_id: request.request_id,
-            message_id: request.message_id || null,
-            to_worker: request.to_worker,
-            transport: 'send-keys',
-            result: 'failed',
-            reason: result.reason,
-          });
+          await appendDispatchResultTelemetry(logsDir, teamName, request, 'failed', result.reason);
           await emitOperationalHookEvent(cwd, result.reason === LEADER_PANE_MISSING_DEFERRED_REASON ? 'handoff-needed' : 'failed', {
             team: teamName,
             worker: request.to_worker,

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -180,6 +180,55 @@ export async function isLeaderStale(stateDir, thresholdMs, nowMs) {
   return isLeaderRuntimeStale(stateDir, thresholdMs, nowMs);
 }
 
+function recordLeaderNudgeState(
+  nudgeState,
+  teamName,
+  nowIso,
+  newestId,
+  prevMsgId,
+  nudgeReason,
+  orchestrationIntent,
+  shouldSendAllIdleNudge,
+  workerCount,
+) {
+  nudgeState.last_nudged_by_team[teamName] = {
+    at: nowIso,
+    last_message_id: newestId || prevMsgId || '',
+    reason: nudgeReason,
+    orchestration_intent: orchestrationIntent,
+  };
+  if (shouldSendAllIdleNudge) {
+    nudgeState.last_idle_nudged_by_team[teamName] = {
+      at: nowIso,
+      worker_count: workerCount,
+      orchestration_intent: orchestrationIntent,
+    };
+  }
+}
+
+async function appendLeaderNudgeDeliveryLog(
+  logsDir,
+  source,
+  teamName,
+  transport,
+  result,
+  reason,
+  orchestrationIntent,
+  error,
+) {
+  await appendTeamDeliveryLog(logsDir, {
+    event: 'nudge_triggered',
+    source,
+    team: teamName,
+    to_worker: 'leader-fixed',
+    transport,
+    result,
+    reason,
+    orchestration_intent: orchestrationIntent,
+    ...(error ? { error } : {}),
+  }).catch(() => {});
+}
+
 function resolveTerminalAtFromPhaseDoc(parsed, fallbackIso) {
   const transitions = Array.isArray(parsed && parsed.transitions) ? parsed.transitions : [];
   for (let idx = transitions.length - 1; idx >= 0; idx -= 1) {
@@ -816,19 +865,17 @@ export async function maybeNudgeTeamLeader({
     const markedText = `${capped} ${DEFAULT_MARKER}`;
 
     if (!tmuxTarget) {
-      nudgeState.last_nudged_by_team[teamName] = {
-        at: nowIso,
-        last_message_id: newestId || prevMsgId || '',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-      };
-      if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = {
-          at: nowIso,
-          worker_count: workerNames.length,
-          orchestration_intent: orchestrationIntent,
-        };
-      }
+      recordLeaderNudgeState(
+        nudgeState,
+        teamName,
+        nowIso,
+        newestId,
+        prevMsgId,
+        nudgeReason,
+        orchestrationIntent,
+        shouldSendAllIdleNudge,
+        workerNames.length,
+      );
       await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
@@ -849,16 +896,15 @@ export async function maybeNudgeTeamLeader({
           source_type: 'leader_nudge',
         });
       } catch { /* ignore */ }
-      await appendTeamDeliveryLog(logsDir, {
-        event: 'nudge_triggered',
+      await appendLeaderNudgeDeliveryLog(
+        logsDir,
         source,
-        team: teamName,
-        to_worker: 'leader-fixed',
-        transport: 'none',
-        result: 'deferred',
-        reason: LEADER_PANE_MISSING_NO_INJECTION_REASON,
-        orchestration_intent: orchestrationIntent,
-      }).catch(() => {});
+        teamName,
+        'none',
+        'deferred',
+        LEADER_PANE_MISSING_NO_INJECTION_REASON,
+        orchestrationIntent,
+      );
       continue;
     }
 
@@ -874,19 +920,17 @@ export async function maybeNudgeTeamLeader({
       const deferredReason = paneGuard.reason === 'pane_running_shell'
         ? LEADER_PANE_SHELL_NO_INJECTION_REASON
         : paneGuard.reason;
-      nudgeState.last_nudged_by_team[teamName] = {
-        at: nowIso,
-        last_message_id: newestId || prevMsgId || '',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-      };
-      if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = {
-          at: nowIso,
-          worker_count: workerNames.length,
-          orchestration_intent: orchestrationIntent,
-        };
-      }
+      recordLeaderNudgeState(
+        nudgeState,
+        teamName,
+        nowIso,
+        newestId,
+        prevMsgId,
+        nudgeReason,
+        orchestrationIntent,
+        shouldSendAllIdleNudge,
+        workerNames.length,
+      );
       await emitLeaderNudgeDeferredEvent(cwd, teamName, deferredReason, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
@@ -912,16 +956,7 @@ export async function maybeNudgeTeamLeader({
           source_type: 'leader_nudge',
         });
       } catch { /* ignore */ }
-      await appendTeamDeliveryLog(logsDir, {
-        event: 'nudge_triggered',
-        source,
-        team: teamName,
-        to_worker: 'leader-fixed',
-        transport: 'none',
-        result: 'deferred',
-        reason: deferredReason,
-        orchestration_intent: orchestrationIntent,
-      }).catch(() => {});
+      await appendLeaderNudgeDeliveryLog(logsDir, source, teamName, 'none', 'deferred', deferredReason, orchestrationIntent);
       continue;
     }
 
@@ -935,19 +970,17 @@ export async function maybeNudgeTeamLeader({
       if (!sendResult.ok) {
         throw new Error(sendResult.error || sendResult.reason);
       }
-      nudgeState.last_nudged_by_team[teamName] = {
-        at: nowIso,
-        last_message_id: newestId || prevMsgId || '',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-      };
-      if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = {
-          at: nowIso,
-          worker_count: workerNames.length,
-          orchestration_intent: orchestrationIntent,
-        };
-      }
+      recordLeaderNudgeState(
+        nudgeState,
+        teamName,
+        nowIso,
+        newestId,
+        prevMsgId,
+        nudgeReason,
+        orchestrationIntent,
+        shouldSendAllIdleNudge,
+        workerNames.length,
+      );
 
       await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
 
@@ -966,16 +999,7 @@ export async function maybeNudgeTeamLeader({
           missing_signal_workers: progressSnapshot.missingSignalWorkers,
         });
       } catch { /* ignore */ }
-      await appendTeamDeliveryLog(logsDir, {
-        event: 'nudge_triggered',
-        source,
-        team: teamName,
-        to_worker: 'leader-fixed',
-        transport: 'send-keys',
-        result: 'sent',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-      }).catch(() => {});
+      await appendLeaderNudgeDeliveryLog(logsDir, source, teamName, 'send-keys', 'sent', nudgeReason, orchestrationIntent);
     } catch (err) {
       try {
         await logTmuxHookEvent(logsDir, {
@@ -988,17 +1012,16 @@ export async function maybeNudgeTeamLeader({
           error: safeString(err && err.message ? err.message : err),
         });
       } catch { /* ignore */ }
-      await appendTeamDeliveryLog(logsDir, {
-        event: 'nudge_triggered',
+      await appendLeaderNudgeDeliveryLog(
+        logsDir,
         source,
-        team: teamName,
-        to_worker: 'leader-fixed',
-        transport: 'send-keys',
-        result: 'failed',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-        error: safeString(err && err.message ? err.message : err),
-      }).catch(() => {});
+        teamName,
+        'send-keys',
+        'failed',
+        nudgeReason,
+        orchestrationIntent,
+        safeString(err && err.message ? err.message : err),
+      );
     }
   }
 

--- a/src/team/contracts.ts
+++ b/src/team/contracts.ts
@@ -25,7 +25,6 @@ export function canTransitionTeamTaskStatus(from: TeamTaskStatus, to: TeamTaskSt
 export const TEAM_DISPATCH_REQUEST_STATUSES = ['pending', 'notified', 'delivered', 'failed'] as const;
 export type TeamDispatchRequestStatus = (typeof TEAM_DISPATCH_REQUEST_STATUSES)[number];
 
-export const TEAM_TERMINAL_DISPATCH_REQUEST_STATUSES: ReadonlySet<TeamDispatchRequestStatus> = new Set(['delivered', 'failed']);
 export const TEAM_DISPATCH_REQUEST_STATUS_TRANSITIONS: Readonly<Record<TeamDispatchRequestStatus, readonly TeamDispatchRequestStatus[]>> = {
   pending: ['notified', 'failed'],
   notified: ['delivered', 'failed'],
@@ -35,10 +34,6 @@ export const TEAM_DISPATCH_REQUEST_STATUS_TRANSITIONS: Readonly<Record<TeamDispa
 
 export function isTeamDispatchRequestStatus(status: unknown): status is TeamDispatchRequestStatus {
   return TEAM_DISPATCH_REQUEST_STATUSES.includes(status as TeamDispatchRequestStatus);
-}
-
-export function isTerminalTeamDispatchRequestStatus(status: TeamDispatchRequestStatus): boolean {
-  return TEAM_TERMINAL_DISPATCH_REQUEST_STATUSES.has(status);
 }
 
 export function canTransitionTeamDispatchRequestStatus(from: TeamDispatchRequestStatus, to: TeamDispatchRequestStatus): boolean {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2584,19 +2584,6 @@ export async function assignTask(
 }
 
 /**
- * Reassign a task from one worker to another.
- */
-export async function reassignTask(
-  teamName: string,
-  taskId: string,
-  _fromWorker: string,
-  toWorker: string,
-  cwd: string,
-): Promise<void> {
-  await assignTask(teamName, toWorker, taskId, cwd);
-}
-
-/**
  * Graceful shutdown: send shutdown inbox to all workers, wait, force kill, cleanup.
  */
 export async function shutdownTeam(teamName: string, cwd: string, options: ShutdownOptions = {}): Promise<TeamShutdownSummary> {
@@ -3403,11 +3390,19 @@ async function finalizeHookPreferredMailboxDispatch(params: {
     timeoutMs: dispatchPolicy.dispatch_ack_timeout_ms,
     pollMs: 50,
   });
-  if (receipt && (receipt.status === 'notified' || receipt.status === 'delivered')) {
-    await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-    const outcome = { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: requestId, message_id: messageId } as const;
+  const returnOutcome = async (outcome: DispatchOutcome): Promise<DispatchOutcome> => {
     await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
     return outcome;
+  };
+  if (receipt && (receipt.status === 'notified' || receipt.status === 'delivered')) {
+    await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
+    return returnOutcome({
+      ok: true,
+      transport: 'hook',
+      reason: `hook_receipt_${receipt.status}`,
+      request_id: requestId,
+      message_id: messageId,
+    } as const);
   }
 
   const fallback: DispatchOutcome = fallbackNotify
@@ -3426,15 +3421,13 @@ async function finalizeHookPreferredMailboxDispatch(params: {
         { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
         cwd,
       ).catch(() => {});
-      const outcome = {
+      return returnOutcome({
         ok: true,
         transport: fallback.transport,
         reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
         request_id: requestId,
         message_id: messageId,
-      } as const;
-      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-      return outcome;
+      } as const);
     }
     await transitionDispatchRequest(
       teamName,
@@ -3444,15 +3437,13 @@ async function finalizeHookPreferredMailboxDispatch(params: {
       { message_id: messageId, last_reason: `fallback_attempted_but_unconfirmed:${fallback.reason}` },
       cwd,
     ).catch(() => {});
-    const outcome = {
+    return returnOutcome({
       ok: false,
       transport: fallback.transport,
       reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
       request_id: requestId,
       message_id: messageId,
-    } as const;
-    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-    return outcome;
+    } as const);
   }
 
   if (fallback.ok) {
@@ -3463,15 +3454,13 @@ async function finalizeHookPreferredMailboxDispatch(params: {
         messageId,
         cwd,
       });
-      const outcome = {
+      return returnOutcome({
         ok: true,
         transport: fallback.transport,
         reason: 'leader_pane_missing_mailbox_persisted',
         request_id: requestId,
         message_id: messageId,
-      } as const;
-      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-      return outcome;
+      } as const);
     }
 
     await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
@@ -3491,15 +3480,13 @@ async function finalizeHookPreferredMailboxDispatch(params: {
         cwd,
       ).catch(() => {});
     }
-    const outcome = {
+    return returnOutcome({
       ok: true,
       transport: fallback.transport,
       reason: `hook_timeout_fallback_confirmed:${fallback.reason}`,
       request_id: requestId,
       message_id: messageId,
-    } as const;
-    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-    return outcome;
+    } as const);
   }
 
   const current = await readDispatchRequest(teamName, requestId, cwd);
@@ -3513,15 +3500,13 @@ async function finalizeHookPreferredMailboxDispatch(params: {
       cwd,
     ).catch(() => {});
   }
-  const outcome = {
+  return returnOutcome({
     ok: false,
     transport: fallback.transport,
     reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
     request_id: requestId,
     message_id: messageId,
-  } as const;
-  await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-  return outcome;
+  } as const);
 }
 
 async function notifyLeaderAsync(config: TeamConfig, message: string, cwd: string): Promise<DispatchOutcome> {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -3,7 +3,7 @@ import { join, dirname, resolve, sep } from 'path';
 import { existsSync } from 'fs';
 import { randomUUID } from 'crypto';
 import { omxStateDir } from '../utils/paths.js';
-import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
+import { isTerminalPhase } from './orchestrator.js';
 import {
   computeTaskReadiness as computeTaskReadinessImpl,
   claimTask as claimTaskImpl,
@@ -58,251 +58,82 @@ import {
   WORKER_NAME_SAFE_PATTERN,
   TASK_ID_SAFE_PATTERN,
   TEAM_TASK_STATUSES,
-  type TeamWorkerIntegrationStatus,
   canTransitionTeamTaskStatus,
   isTerminalTeamTaskStatus,
   type TeamTaskStatus,
-  type TeamEventType,
 } from './contracts.js';
-import type { TeamReminderIntent } from './reminder-intents.js';
-import type { WorktreeMode } from './worktree.js';
+import { ABSOLUTE_MAX_WORKERS, DEFAULT_MAX_WORKERS } from './state/types.js';
+import type {
+  ClaimTaskResult,
+  PermissionsSnapshot,
+  ReclaimTaskResult,
+  ReleaseTaskClaimResult,
+  ShutdownAck,
+  TaskApprovalRecord,
+  TaskReadiness,
+  TeamConfig,
+  TeamDispatchRequest,
+  TeamDispatchRequestInput,
+  TeamDispatchRequestKind,
+  TeamDispatchTransportPreference,
+  TeamEvent,
+  TeamGovernance,
+  TeamLeader,
+  TeamMailbox,
+  TeamMailboxMessage,
+  TeamManifestV2,
+  TeamMonitorSnapshotState,
+  TeamPhaseState,
+  TeamPolicy,
+  TeamSummary,
+  TeamSummaryPerformance,
+  TeamTask,
+  TeamTaskClaim,
+  TeamTaskV2,
+  TeamWorkerIntegrationState,
+  TeamWorkspaceMetadata,
+  TransitionTaskResult,
+  WorkerHeartbeat,
+  WorkerInfo,
+  WorkerStatus,
+} from './state/types.js';
 
 export type { TeamDispatchRequestStatus, TeamWorkerIntegrationStatus } from './contracts.js';
-
-export interface TeamConfig {
-  name: string;
-  task: string;
-  agent_type: string;
-  worker_launch_mode: 'interactive' | 'prompt';
-  lifecycle_profile: 'default';
-  worker_count: number;
-  max_workers: number; // default 20, configurable up to 20
-  workers: WorkerInfo[];
-  created_at: string;
-  tmux_session: string; // "omx-team-{name}"
-  next_task_id: number;
-  leader_cwd?: string;
-  team_state_root?: string;
-  workspace_mode?: 'single' | 'worktree';
-  worktree_mode?: WorktreeMode;
-  /** Leader's own tmux pane ID — must never be killed during worker cleanup. */
-  leader_pane_id: string | null;
-  /** HUD pane spawned below the leader column — excluded from worker pane cleanup. */
-  hud_pane_id: string | null;
-  /** Registered HUD resize hook name used for window-size reconciliation. */
-  resize_hook_name: string | null;
-  /** Registered HUD resize hook target in "<session>:<window>" form. */
-  resize_hook_target: string | null;
-  /** Monotonic counter for worker index assignment during scaling. */
-  next_worker_index?: number;
-}
-
-export interface WorkerInfo {
-  name: string; // "worker-1"
-  index: number; // tmux window index (1-based)
-  role: string; // agent type
-  worker_cli?: 'codex' | 'claude' | 'gemini';
-  assigned_tasks: string[]; // task IDs
-  pid?: number;
-  pane_id?: string;
-  working_dir?: string;
-  worktree_repo_root?: string;
-  worktree_path?: string;
-  worktree_branch?: string;
-  worktree_detached?: boolean;
-  worktree_created?: boolean;
-  team_state_root?: string;
-}
-
-export interface WorkerHeartbeat {
-  pid: number;
-  last_turn_at: string;
-  turn_count: number;
-  alive: boolean;
-}
-
-export interface WorkerStatus {
-  state: 'idle' | 'working' | 'blocked' | 'done' | 'failed' | 'draining' | 'unknown';
-  current_task_id?: string;
-  reason?: string;
-  updated_at: string;
-}
-
-export interface TeamTask {
-  id: string;
-  subject: string;
-  description: string;
-  status: 'pending' | 'blocked' | 'in_progress' | 'completed' | 'failed';
-  requires_code_change?: boolean;
-  role?: string; // agent role for this task (e.g., 'executor', 'test-engineer', 'designer')
-  owner?: string; // worker name
-  result?: string; // completion summary
-  error?: string; // failure reason
-  blocked_by?: string[]; // task IDs
-  depends_on?: string[]; // task IDs
-  version?: number;
-  claim?: TeamTaskClaim;
-  created_at: string;
-  completed_at?: string;
-}
-
-export interface TeamTaskClaim {
-  owner: string;
-  token: string;
-  leased_until: string;
-}
-
-export interface TeamTaskV2 extends TeamTask {
-  version: number;
-}
-
-export interface TeamLeader {
-  session_id: string;
-  thread_id?: string;
-  worker_id: string;
-  role: string;
-}
-
-export interface TeamPolicy {
-  display_mode: 'split_pane' | 'auto';
-  worker_launch_mode: 'interactive' | 'prompt';
-  dispatch_mode: 'hook_preferred_with_fallback' | 'transport_direct';
-  dispatch_ack_timeout_ms: number;
-}
-
-/**
- * Lifecycle/workflow guardrails persisted alongside the manifest, but kept
- * separate from transport/runtime policy so each layer has a single owner.
- */
-export interface TeamGovernance {
-  delegation_only: boolean;
-  plan_approval_required: boolean;
-  nested_teams_allowed: boolean;
-  one_team_per_leader_session: boolean;
-  cleanup_requires_all_workers_inactive: boolean;
-}
-
-export type TeamDispatchRequestKind = 'inbox' | 'mailbox' | 'nudge';
-export type TeamDispatchTransportPreference = 'hook_preferred_with_fallback' | 'transport_direct' | 'prompt_stdin';
-
-export interface TeamDispatchRequest {
-  request_id: string;
-  kind: TeamDispatchRequestKind;
-  team_name: string;
-  to_worker: string;
-  worker_index?: number;
-  pane_id?: string;
-  trigger_message: string;
-  intent?: TeamReminderIntent;
-  message_id?: string;
-  inbox_correlation_key?: string;
-  transport_preference: TeamDispatchTransportPreference;
-  fallback_allowed: boolean;
-  status: TeamDispatchRequestStatus;
-  attempt_count: number;
-  created_at: string;
-  updated_at: string;
-  notified_at?: string;
-  delivered_at?: string;
-  failed_at?: string;
-  last_reason?: string;
-}
-
-export interface TeamDispatchRequestInput {
-  kind: TeamDispatchRequestKind;
-  to_worker: string;
-  worker_index?: number;
-  pane_id?: string;
-  trigger_message: string;
-  intent?: TeamReminderIntent;
-  message_id?: string;
-  inbox_correlation_key?: string;
-  transport_preference?: TeamDispatchTransportPreference;
-  fallback_allowed?: boolean;
-  last_reason?: string;
-}
-
-export interface PermissionsSnapshot {
-  approval_mode: string;
-  sandbox_mode: string;
-  network_access: boolean;
-}
-
-export interface TeamManifestV2 {
-  schema_version: 2;
-  name: string;
-  task: string;
-  leader: TeamLeader;
-  policy: TeamPolicy;
-  governance: TeamGovernance;
-  lifecycle_profile: 'default';
-  permissions_snapshot: PermissionsSnapshot;
-  tmux_session: string;
-  worker_count: number;
-  workers: WorkerInfo[];
-  next_task_id: number;
-  created_at: string;
-  leader_cwd?: string;
-  team_state_root?: string;
-  workspace_mode?: 'single' | 'worktree';
-  worktree_mode?: WorktreeMode;
-  leader_pane_id: string | null;
-  hud_pane_id: string | null;
-  resize_hook_name: string | null;
-  resize_hook_target: string | null;
-  /** Monotonic counter for worker index assignment during scaling. */
-  next_worker_index?: number;
-}
-
-export interface TeamWorkspaceMetadata {
-  leader_cwd?: string;
-  team_state_root?: string;
-  workspace_mode?: 'single' | 'worktree';
-  worktree_mode?: WorktreeMode;
-}
-
-export interface TeamEvent {
-  event_id: string;
-  team: string;
-  type: TeamEventType;
-  worker: string;
-  task_id?: string;
-  message_id?: string | null;
-  reason?: string;
-  intent?: TeamReminderIntent;
-  state?: WorkerStatus['state'];
-  prev_state?: WorkerStatus['state'];
-  worker_count?: number;
-  to_worker?: string;
-  source_type?: string;
-  metadata?: Record<string, unknown>;
-  created_at: string;
-  [key: string]: unknown;
-}
-
-export interface TeamMailboxMessage {
-  message_id: string;
-  from_worker: string;
-  to_worker: string;
-  body: string;
-  created_at: string;
-  notified_at?: string;
-  delivered_at?: string;
-}
-
-export interface TeamMailbox {
-  worker: string;
-  messages: TeamMailboxMessage[];
-}
-
-export interface TaskApprovalRecord {
-  task_id: string;
-  required: boolean;
-  status: 'pending' | 'approved' | 'rejected';
-  reviewer: string;
-  decision_reason: string;
-  decided_at: string;
-}
+export { ABSOLUTE_MAX_WORKERS, DEFAULT_MAX_WORKERS } from './state/types.js';
+export type {
+  ClaimTaskResult,
+  PermissionsSnapshot,
+  ReclaimTaskResult,
+  ReleaseTaskClaimResult,
+  ShutdownAck,
+  TaskApprovalRecord,
+  TaskReadiness,
+  TeamConfig,
+  TeamDispatchRequest,
+  TeamDispatchRequestInput,
+  TeamDispatchRequestKind,
+  TeamDispatchTransportPreference,
+  TeamEvent,
+  TeamGovernance,
+  TeamLeader,
+  TeamMailbox,
+  TeamMailboxMessage,
+  TeamManifestV2,
+  TeamMonitorSnapshotState,
+  TeamPhaseState,
+  TeamPolicy,
+  TeamSummary,
+  TeamSummaryPerformance,
+  TeamTask,
+  TeamTaskClaim,
+  TeamTaskV2,
+  TeamWorkerIntegrationState,
+  TeamWorkspaceMetadata,
+  TransitionTaskResult,
+  WorkerHeartbeat,
+  WorkerInfo,
+  WorkerStatus,
+} from './state/types.js';
 
 let renameForAtomicWrite: typeof rename = rename;
 
@@ -313,52 +144,7 @@ export function setWriteAtomicRenameForTests(fn: typeof rename): void {
 export function resetWriteAtomicRenameForTests(): void {
   renameForAtomicWrite = rename;
 }
-export type TaskReadiness =
-  | { ready: true }
-  | { ready: false; reason: 'blocked_dependency'; dependencies: string[] };
 
-export type ClaimTaskResult =
-  | { ok: true; task: TeamTaskV2; claimToken: string }
-  | { ok: false; error: 'claim_conflict' | 'blocked_dependency' | 'task_not_found' | 'already_terminal' | 'worker_not_found'; dependencies?: string[] };
-
-export type TransitionTaskResult =
-  | { ok: true; task: TeamTaskV2 }
-  | { ok: false; error: 'claim_conflict' | 'invalid_transition' | 'task_not_found' | 'already_terminal' | 'lease_expired' };
-
-export type ReleaseTaskClaimResult =
-  | { ok: true; task: TeamTaskV2 }
-  | { ok: false; error: 'claim_conflict' | 'task_not_found' | 'already_terminal' | 'lease_expired' };
-
-export type ReclaimTaskResult =
-  | { ok: true; task: TeamTaskV2; reclaimed: boolean }
-  | { ok: false; error: 'claim_conflict' | 'task_not_found' | 'already_terminal' | 'lease_active' };
-
-export interface TeamSummary {
-  teamName: string;
-  workerCount: number;
-  tasks: {
-    total: number;
-    pending: number;
-    blocked: number;
-    in_progress: number;
-    completed: number;
-    failed: number;
-  };
-  workers: Array<{ name: string; alive: boolean; lastTurnAt: string | null; turnsWithoutProgress: number }>;
-  nonReportingWorkers: string[];
-  performance?: TeamSummaryPerformance;
-}
-
-export interface TeamSummaryPerformance {
-  total_ms: number;
-  tasks_loaded_ms: number;
-  workers_polled_ms: number;
-  task_count: number;
-  worker_count: number;
-}
-
-export const DEFAULT_MAX_WORKERS = 20;
-export const ABSOLUTE_MAX_WORKERS = 20;
 const LOCK_STALE_MS = 5 * 60 * 1000;
 // Hook-preferred delivery can wait for the fallback watcher tick plus tmux
 // injection verification; keep the default ack budget above that steady-state
@@ -1744,12 +1530,6 @@ export async function getTeamSummary(teamName: string, cwd: string): Promise<Tea
 
 // === Shutdown control ===
 
-export interface ShutdownAck {
-  status: 'accept' | 'reject';
-  reason?: string;
-  updated_at?: string;
-}
-
 export async function writeShutdownRequest(
   teamName: string,
   workerName: string,
@@ -1781,47 +1561,6 @@ export async function readShutdownAck(
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
     return null;
   }
-}
-
-// === Monitor snapshot ===
-
-export interface TeamWorkerIntegrationState {
-  last_seen_head?: string;
-  last_integrated_head?: string;
-  last_leader_head?: string;
-  last_rebased_leader_head?: string;
-  status?: TeamWorkerIntegrationStatus;
-  conflict_commit?: string;
-  conflict_files?: string[];
-  updated_at?: string;
-}
-
-export interface TeamMonitorSnapshotState {
-  taskStatusById: Record<string, string>;
-  workerAliveByName: Record<string, boolean>;
-  workerStateByName: Record<string, string>;
-  workerTurnCountByName: Record<string, number>;
-  workerTaskIdByName: Record<string, string>;
-  mailboxNotifiedByMessageId: Record<string, string>;
-  /** Task IDs for which a task_completed event has already been emitted (from any path). */
-  completedEventTaskIds: Record<string, boolean>;
-  integrationByWorker?: Record<string, TeamWorkerIntegrationState>;
-  /** Optional timing telemetry from the most recent monitorTeam poll. */
-  monitorTimings?: {
-    list_tasks_ms: number;
-    worker_scan_ms: number;
-    mailbox_delivery_ms: number;
-    total_ms: number;
-    updated_at: string;
-  };
-}
-
-export interface TeamPhaseState {
-  current_phase: TeamPhase | TerminalPhase;
-  max_fix_attempts: number;
-  current_fix_attempt: number;
-  transitions: Array<{ from: string; to: string; at: string; reason?: string }>;
-  updated_at: string;
 }
 
 export type TeamLeaderDecisionState = 'still_actionable' | 'done_waiting_on_leader' | 'stuck_waiting_on_leader';

--- a/src/team/state/bridge-command.ts
+++ b/src/team/state/bridge-command.ts
@@ -1,0 +1,11 @@
+import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type RuntimeCommand } from '../../runtime/bridge.js';
+
+export function executeBridgeCommand(cwd: string, command: RuntimeCommand): boolean {
+  if (!isBridgeEnabled()) return false;
+  try {
+    getDefaultBridge(resolveBridgeStateDir(cwd)).execCommand(command);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type DispatchRecord, type RuntimeCommand } from '../../runtime/bridge.js';
+import { type DispatchRecord } from '../../runtime/bridge.js';
 import { appendTeamDeliveryLogForCwd } from '../delivery-log.js';
 import { isTeamReminderIntent, type TeamReminderIntent } from '../reminder-intents.js';
 import {
@@ -7,46 +7,13 @@ import {
   isTeamDispatchRequestStatus,
   type TeamDispatchRequestStatus,
 } from '../contracts.js';
-
-export type TeamDispatchRequestKind = 'inbox' | 'mailbox' | 'nudge';
-export type TeamDispatchTransportPreference = 'hook_preferred_with_fallback' | 'transport_direct' | 'prompt_stdin';
-
-export interface TeamDispatchRequest {
-  request_id: string;
-  kind: TeamDispatchRequestKind;
-  team_name: string;
-  to_worker: string;
-  worker_index?: number;
-  pane_id?: string;
-  trigger_message: string;
-  intent?: TeamReminderIntent;
-  message_id?: string;
-  inbox_correlation_key?: string;
-  transport_preference: TeamDispatchTransportPreference;
-  fallback_allowed: boolean;
-  status: TeamDispatchRequestStatus;
-  attempt_count: number;
-  created_at: string;
-  updated_at: string;
-  notified_at?: string;
-  delivered_at?: string;
-  failed_at?: string;
-  last_reason?: string;
-}
-
-export interface TeamDispatchRequestInput {
-  kind: TeamDispatchRequestKind;
-  to_worker: string;
-  worker_index?: number;
-  pane_id?: string;
-  trigger_message: string;
-  intent?: TeamReminderIntent;
-  message_id?: string;
-  inbox_correlation_key?: string;
-  transport_preference?: TeamDispatchTransportPreference;
-  fallback_allowed?: boolean;
-  last_reason?: string;
-}
+import { executeBridgeCommand } from './bridge-command.js';
+import type {
+  TeamDispatchRequest,
+  TeamDispatchRequestInput,
+  TeamDispatchRequestKind,
+  TeamDispatchTransportPreference,
+} from './types.js';
 
 interface DispatchDeps {
   teamName: string;
@@ -161,16 +128,6 @@ function buildDispatchMetadata(teamName: string, requestInput: TeamDispatchReque
     transport_preference: requestInput.transport_preference,
     fallback_allowed: requestInput.fallback_allowed,
   };
-}
-
-function executeBridgeCommand(cwd: string, command: RuntimeCommand): boolean {
-  if (!isBridgeEnabled()) return false;
-  try {
-    getDefaultBridge(resolveBridgeStateDir(cwd)).execCommand(command);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function coerceMetadataValue<T extends string | number | boolean>(

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -1,21 +1,8 @@
 import { randomUUID } from 'crypto';
-import { getDefaultBridge, isBridgeEnabled, resolveBridgeStateDir, type MailboxRecord, type RuntimeCommand } from '../../runtime/bridge.js';
+import { type MailboxRecord } from '../../runtime/bridge.js';
 import { appendTeamDeliveryLogForCwd } from '../delivery-log.js';
-
-export interface TeamMailboxMessage {
-  message_id: string;
-  from_worker: string;
-  to_worker: string;
-  body: string;
-  created_at: string;
-  notified_at?: string;
-  delivered_at?: string;
-}
-
-export interface TeamMailbox {
-  worker: string;
-  messages: TeamMailboxMessage[];
-}
+import { executeBridgeCommand } from './bridge-command.js';
+import type { TeamMailbox, TeamMailboxMessage } from './types.js';
 
 interface MailboxDeps {
   teamName: string;
@@ -36,16 +23,6 @@ interface MailboxDeps {
     cwd: string,
   ) => Promise<unknown>;
   readTeamConfig: (teamName: string, cwd: string) => Promise<{ workers: Array<{ name: string }> } | null>;
-}
-
-function executeBridgeCommand(cwd: string, command: RuntimeCommand): boolean {
-  if (!isBridgeEnabled()) return false;
-  try {
-    getDefaultBridge(resolveBridgeStateDir(cwd)).execCommand(command);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export function normalizeBridgeMailboxMessage(record: MailboxRecord): TeamMailboxMessage {

--- a/src/team/state/monitor.ts
+++ b/src/team/state/monitor.ts
@@ -2,71 +2,17 @@ import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { performance } from 'perf_hooks';
 import { isTeamWorkerIntegrationStatus, type TeamWorkerIntegrationStatus } from '../contracts.js';
-
-export interface TeamSummary {
-  teamName: string;
-  workerCount: number;
-  tasks: {
-    total: number;
-    pending: number;
-    blocked: number;
-    in_progress: number;
-    completed: number;
-    failed: number;
-  };
-  workers: Array<{ name: string; alive: boolean; lastTurnAt: string | null; turnsWithoutProgress: number }>;
-  nonReportingWorkers: string[];
-  performance?: TeamSummaryPerformance;
-}
-
-export interface TeamSummaryPerformance {
-  total_ms: number;
-  tasks_loaded_ms: number;
-  workers_polled_ms: number;
-  task_count: number;
-  worker_count: number;
-}
+import type {
+  TeamMonitorSnapshotState,
+  TeamPhaseState,
+  TeamSummary,
+  TeamSummaryPerformance,
+  TeamWorkerIntegrationState,
+} from './types.js';
 
 interface TeamSummarySnapshot {
   workerTurnCountByName: Record<string, number>;
   workerTaskByName: Record<string, string>;
-}
-
-export interface TeamWorkerIntegrationState {
-  last_seen_head?: string;
-  last_integrated_head?: string;
-  last_leader_head?: string;
-  last_rebased_leader_head?: string;
-  status?: TeamWorkerIntegrationStatus;
-  conflict_commit?: string;
-  conflict_files?: string[];
-  updated_at?: string;
-}
-
-export interface TeamMonitorSnapshotState {
-  taskStatusById: Record<string, string>;
-  workerAliveByName: Record<string, boolean>;
-  workerStateByName: Record<string, string>;
-  workerTurnCountByName: Record<string, number>;
-  workerTaskIdByName: Record<string, string>;
-  mailboxNotifiedByMessageId: Record<string, string>;
-  completedEventTaskIds: Record<string, boolean>;
-  integrationByWorker?: Record<string, TeamWorkerIntegrationState>;
-  monitorTimings?: {
-    list_tasks_ms: number;
-    worker_scan_ms: number;
-    mailbox_delivery_ms: number;
-    total_ms: number;
-    updated_at: string;
-  };
-}
-
-export interface TeamPhaseState {
-  current_phase: string;
-  max_fix_attempts: number;
-  current_fix_attempt: number;
-  transitions: Array<{ from: string; to: string; at: string; reason?: string }>;
-  updated_at: string;
 }
 
 interface MonitorDeps {

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -1,5 +1,10 @@
 import type { TeamPhase, TerminalPhase } from '../orchestrator.js';
-import type { TeamDispatchRequestStatus, TeamEventType, TeamTaskStatus } from '../contracts.js';
+import type {
+  TeamDispatchRequestStatus,
+  TeamEventType,
+  TeamTaskStatus,
+  TeamWorkerIntegrationStatus,
+} from '../contracts.js';
 import type { TeamReminderIntent } from '../reminder-intents.js';
 import type { WorktreeMode } from '../worktree.js';
 
@@ -282,6 +287,17 @@ export interface ShutdownAck {
   updated_at?: string;
 }
 
+export interface TeamWorkerIntegrationState {
+  last_seen_head?: string;
+  last_integrated_head?: string;
+  last_leader_head?: string;
+  last_rebased_leader_head?: string;
+  status?: TeamWorkerIntegrationStatus;
+  conflict_commit?: string;
+  conflict_files?: string[];
+  updated_at?: string;
+}
+
 export interface TeamMonitorSnapshotState {
   taskStatusById: Record<string, string>;
   workerAliveByName: Record<string, boolean>;
@@ -290,6 +306,7 @@ export interface TeamMonitorSnapshotState {
   workerTaskIdByName: Record<string, string>;
   mailboxNotifiedByMessageId: Record<string, string>;
   completedEventTaskIds: Record<string, boolean>;
+  integrationByWorker?: Record<string, TeamWorkerIntegrationState>;
   monitorTimings?: {
     list_tasks_ms: number;
     worker_scan_ms: number;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -6,7 +6,6 @@ import {
   CODEX_BYPASS_FLAG,
   MADMAX_FLAG,
   CONFIG_FLAG,
-  LONG_CONFIG_FLAG,
   MODEL_FLAG,
 } from '../cli/constants.js';
 import {
@@ -19,6 +18,7 @@ import {
   paneLooksReady as sharedPaneLooksReady,
 } from '../scripts/tmux-hook-engine.js';
 import { readActiveProviderEnvOverrides } from '../config/models.js';
+import { hasModelInstructionsOverride, MODEL_INSTRUCTIONS_FILE_KEY } from '../utils/model-instructions.js';
 import { sleep, sleepSync } from '../utils/sleep.js';
 import { classifySpawnError, resolveCommandPathForPlatform, spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { resolveOmxEntryPath } from '../utils/paths.js';
@@ -42,7 +42,6 @@ export interface TeamSession {
 }
 
 const INJECTION_MARKER = '[OMX_TMUX_INJECT]';
-const MODEL_INSTRUCTIONS_FILE_KEY = 'model_instructions_file';
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = 'OMX_BYPASS_DEFAULT_SYSTEM_PROMPT';
 const OMX_MODEL_INSTRUCTIONS_FILE_ENV = 'OMX_MODEL_INSTRUCTIONS_FILE';
 const OMX_TEAM_WORKER_CLI_ENV = 'OMX_TEAM_WORKER_CLI';
@@ -469,28 +468,6 @@ function buildWorkerLaunchSpec(shellPath: string | undefined): WorkerLaunchSpec 
 
 function escapeTomlString(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-}
-
-function isModelInstructionsOverride(value: string): boolean {
-  return new RegExp(`^${MODEL_INSTRUCTIONS_FILE_KEY}\\s*=`).test(value.trim());
-}
-
-function hasModelInstructionsOverride(args: string[]): boolean {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
-      const maybeValue = args[i + 1];
-      if (typeof maybeValue === 'string' && isModelInstructionsOverride(maybeValue)) {
-        return true;
-      }
-      continue;
-    }
-    if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) {
-      const inlineValue = arg.slice(`${LONG_CONFIG_FLAG}=`.length);
-      if (isModelInstructionsOverride(inlineValue)) return true;
-    }
-  }
-  return false;
 }
 
 function normalizeTeamWorkerCliMode(raw: string | undefined, sourceEnv: string = OMX_TEAM_WORKER_CLI_ENV): TeamWorkerCliMode {
@@ -1652,15 +1629,6 @@ export async function teardownWorkerPanes(
   }
 
   return summary;
-}
-
-export async function killWorkerPanes(
-  paneIds: string[],
-  leaderPaneId: string,
-  graceMs: number = 2000,
-  hudPaneId?: string,
-): Promise<PaneTeardownSummary> {
-  return teardownWorkerPanes(paneIds, { leaderPaneId, hudPaneId: hudPaneId ?? null, graceMs });
 }
 
 // Kill entire tmux session. Tolerates already-dead sessions.

--- a/src/utils/model-instructions.ts
+++ b/src/utils/model-instructions.ts
@@ -1,0 +1,26 @@
+import { CONFIG_FLAG, LONG_CONFIG_FLAG } from '../cli/constants.js';
+
+export const MODEL_INSTRUCTIONS_FILE_KEY = 'model_instructions_file';
+
+export function isModelInstructionsOverride(value: string): boolean {
+  return new RegExp(`^${MODEL_INSTRUCTIONS_FILE_KEY}\\s*=`).test(value.trim());
+}
+
+export function hasModelInstructionsOverride(args: string[]): boolean {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
+      const maybeValue = args[i + 1];
+      if (typeof maybeValue === 'string' && isModelInstructionsOverride(maybeValue)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) {
+      const inlineValue = arg.slice(`${LONG_CONFIG_FLAG}=`.length);
+      if (isModelInstructionsOverride(inlineValue)) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Clean up duplicated helper/type seams introduced during the 0.12.0 release so the team/runtime and notify-hook codepaths stay easier to maintain without changing behavior.

## Changes

- centralize shared model-instructions parsing and bridge-command helpers
- remove dead wrappers/unused exports in team runtime/contracts/tmux-session
- continue consolidating shared team-state types into `src/team/state/types.ts`
- reduce repeated notify-hook telemetry/nudge bookkeeping without changing emitted behavior

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- None
