### PR TITLE
Fix postLaunch MCP orphan cleanup gap

### DIFF
--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -130,6 +130,23 @@ describe('findCleanupCandidates', () => {
       },
     ]);
   });
+
+  it('always preserves ppid=1 orphan candidates even if pid 1 matches a protected ancestor predicate', () => {
+    const reparentedProcesses: ProcessEntry[] = [
+      { pid: 1, ppid: 0, command: 'codex' },
+      { pid: 701, ppid: 700, command: 'node /repo/bin/omx.js' },
+      { pid: 840, ppid: 1, command: 'node /tmp/reparented/dist/mcp/state-server.js' },
+    ];
+
+    assert.deepEqual(findLaunchSafeCleanupCandidates(reparentedProcesses, 701), [
+      {
+        pid: 840,
+        ppid: 1,
+        command: 'node /tmp/reparented/dist/mcp/state-server.js',
+        reason: 'ppid=1',
+      },
+    ]);
+  });
 });
 
 describe('listOmxProcesses', () => {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -39,6 +39,7 @@ import {
   shouldEnableNotifyFallbackWatcher,
   reapStaleNotifyFallbackWatcher,
   cleanupLaunchOrphanedMcpProcesses,
+  reapPostLaunchOrphanedMcpProcesses,
   resolveBackgroundHelperLaunchMode,
   shouldDetachBackgroundHelper,
   resolveNotifyFallbackWatcherScript,
@@ -359,6 +360,50 @@ describe("cleanupLaunchOrphanedMcpProcesses", () => {
       false,
       "launch-safe cleanup must preserve OMX MCP processes still attached to another live OMX launch tree",
     );
+  });
+});
+
+describe("reapPostLaunchOrphanedMcpProcesses", () => {
+  it("logs postLaunch reaped MCP orphans and keeps cleanup non-fatal", async () => {
+    const info: string[] = [];
+    const warnings: string[] = [];
+    const errors: string[] = [];
+
+    await reapPostLaunchOrphanedMcpProcesses({
+      cleanup: async () => ({
+        dryRun: false,
+        candidates: [],
+        terminatedCount: 2,
+        forceKilledCount: 0,
+        failedPids: [810],
+      }),
+      writeInfo: (line) => info.push(line),
+      writeWarn: (line) => warnings.push(line),
+      writeError: (line) => errors.push(line),
+    });
+
+    assert.deepEqual(errors, []);
+    assert.match(
+      info.join("\n"),
+      /postLaunch: reaped 2 orphaned OMX MCP process/,
+    );
+    assert.match(
+      warnings.join("\n"),
+      /postLaunch: failed to reap 1 orphaned OMX MCP process/,
+    );
+  });
+
+  it("writes a non-fatal postLaunch cleanup error when the cleanup step throws", async () => {
+    const errors: string[] = [];
+
+    await reapPostLaunchOrphanedMcpProcesses({
+      cleanup: async () => {
+        throw new Error("boom");
+      },
+      writeError: (line) => errors.push(line),
+    });
+
+    assert.match(errors.join("\n"), /postLaunch MCP cleanup failed: Error: boom/);
   });
 });
 

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -217,9 +217,13 @@ export function findLaunchSafeCleanupCandidates(
     processes.map((processEntry) => [processEntry.pid, processEntry] as const),
   );
 
-  return findCleanupCandidates(processes, currentPid)
-    .filter((candidate) => !hasAncestorMatching(processByPid, candidate.pid, isCodexSessionProcess))
-    .filter((candidate) => !hasAncestorMatching(processByPid, candidate.pid, isOmxLaunchProcess));
+  return findCleanupCandidates(processes, currentPid).filter((candidate) => {
+    if (candidate.ppid <= 1) return true;
+    return (
+      !hasAncestorMatching(processByPid, candidate.pid, isCodexSessionProcess) &&
+      !hasAncestorMatching(processByPid, candidate.pid, isOmxLaunchProcess)
+    );
+  });
 }
 
 function defaultIsPidAlive(pid: number): boolean {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1917,6 +1917,39 @@ export async function cleanupLaunchOrphanedMcpProcesses(
   });
 }
 
+interface PostLaunchCleanupDependencies {
+  cleanup?: () => Promise<CleanupResult>;
+  writeInfo?: (line: string) => void;
+  writeWarn?: (line: string) => void;
+  writeError?: (line: string) => void;
+}
+
+export async function reapPostLaunchOrphanedMcpProcesses(
+  dependencies: PostLaunchCleanupDependencies = {},
+): Promise<void> {
+  const cleanup = dependencies.cleanup ?? cleanupLaunchOrphanedMcpProcesses;
+  const writeInfo = dependencies.writeInfo ?? console.log;
+  const writeWarn = dependencies.writeWarn ?? console.warn;
+  const writeError =
+    dependencies.writeError ?? ((line: string) => process.stderr.write(line));
+
+  try {
+    const result = await cleanup();
+    if (result.terminatedCount > 0) {
+      writeInfo(
+        `[omx] postLaunch: reaped ${result.terminatedCount} orphaned OMX MCP process(es).`,
+      );
+    }
+    if (result.failedPids.length > 0) {
+      writeWarn(
+        `[omx] postLaunch: failed to reap ${result.failedPids.length} orphaned OMX MCP process(es); continuing cleanup.`,
+      );
+    }
+  } catch (err) {
+    writeError(`[cli/index] postLaunch MCP cleanup failed: ${err}\n`);
+  }
+}
+
 /**
  * preLaunch: Prepare environment before Codex starts.
  * 1. Best-effort launch-safe orphan cleanup for detached OMX MCP processes
@@ -2446,6 +2479,9 @@ async function postLaunch(
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
     // Non-fatal
   }
+
+  // 0. Reap MCP orphans left behind by the session that just exited.
+  await reapPostLaunchOrphanedMcpProcesses();
 
   // 0. Flush fallback watcher once to reduce race with fast codex exit.
   try {


### PR DESCRIPTION
## Summary\n- reap orphaned OMX MCP processes during postLaunch so the just-finished session does not leave leaked servers behind\n- make launch-safe cleanup explicitly keep  orphan candidates eligible while still protecting live Codex/OMX launch trees\n- add targeted regression coverage for both the explicit orphan rule and the postLaunch cleanup path\n\n## Testing\n- npm run build\n- npx biome lint src/cli/cleanup.ts src/cli/index.ts src/cli/__tests__/cleanup.test.ts src/cli/__tests__/index.test.ts\n- node --test dist/cli/__tests__/cleanup.test.js dist/cli/__tests__/index.test.js\n\nFixes #1342