### PR TITLE
Fix issue #1342: reap leaked MCP servers after launch exit

### DIFF
--- a/src/cli/__tests__/cleanup.test.ts
+++ b/src/cli/__tests__/cleanup.test.ts
@@ -130,6 +130,28 @@ describe('findCleanupCandidates', () => {
       },
     ]);
   });
+
+  it('always keeps ppid=1 candidates launch-safe even if pid 1 looks like a Codex ancestor', () => {
+    const pidOneCodexProcesses: ProcessEntry[] = [
+      { pid: 1, ppid: 0, command: 'codex' },
+      { pid: 700, ppid: 500, command: 'codex' },
+      { pid: 701, ppid: 700, command: 'node /repo/bin/omx.js cleanup --dry-run' },
+      {
+        pid: 800,
+        ppid: 1,
+        command: 'node /tmp/oh-my-codex/dist/mcp/memory-server.js',
+      },
+    ];
+
+    assert.deepEqual(findLaunchSafeCleanupCandidates(pidOneCodexProcesses, 701), [
+      {
+        pid: 800,
+        ppid: 1,
+        command: 'node /tmp/oh-my-codex/dist/mcp/memory-server.js',
+        reason: 'ppid=1',
+      },
+    ]);
+  });
 });
 
 describe('listOmxProcesses', () => {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -39,6 +39,7 @@ import {
   shouldEnableNotifyFallbackWatcher,
   reapStaleNotifyFallbackWatcher,
   cleanupLaunchOrphanedMcpProcesses,
+  reapPostLaunchOrphanedMcpProcesses,
   resolveBackgroundHelperLaunchMode,
   shouldDetachBackgroundHelper,
   resolveNotifyFallbackWatcherScript,
@@ -359,6 +360,71 @@ describe("cleanupLaunchOrphanedMcpProcesses", () => {
       false,
       "launch-safe cleanup must preserve OMX MCP processes still attached to another live OMX launch tree",
     );
+  });
+});
+
+describe("reapPostLaunchOrphanedMcpProcesses", () => {
+  it("reaps orphaned MCP processes after launch and reports successful cleanup", async () => {
+    const logs: string[] = [];
+    const warnings: string[] = [];
+    const errors: string[] = [];
+
+    await reapPostLaunchOrphanedMcpProcesses(
+      async () => ({
+        dryRun: false,
+        candidates: [],
+        terminatedCount: 2,
+        forceKilledCount: 0,
+        failedPids: [],
+      }),
+      (line) => logs.push(line),
+      (line) => warnings.push(line),
+      (line) => errors.push(line),
+    );
+
+    assert.deepEqual(logs, [
+      "[omx] postLaunch: reaped 2 orphaned OMX MCP process(es).",
+    ]);
+    assert.deepEqual(warnings, []);
+    assert.deepEqual(errors, []);
+  });
+
+  it("warns about failed post-launch cleanup attempts without throwing", async () => {
+    const warnings: string[] = [];
+
+    await reapPostLaunchOrphanedMcpProcesses(
+      async () => ({
+        dryRun: false,
+        candidates: [],
+        terminatedCount: 0,
+        forceKilledCount: 0,
+        failedPids: [800, 801],
+      }),
+      () => {},
+      (line) => warnings.push(line),
+      () => {},
+    );
+
+    assert.deepEqual(warnings, [
+      "[omx] postLaunch: failed to reap 2 orphaned OMX MCP process(es).",
+    ]);
+  });
+
+  it("swallows post-launch cleanup errors and reports them to stderr", async () => {
+    const errors: string[] = [];
+
+    await reapPostLaunchOrphanedMcpProcesses(
+      async () => {
+        throw new Error("boom");
+      },
+      () => {},
+      () => {},
+      (line) => errors.push(line),
+    );
+
+    assert.deepEqual(errors, [
+      "[cli/index] postLaunch MCP cleanup failed: Error: boom\n",
+    ]);
   });
 });
 

--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -217,9 +217,15 @@ export function findLaunchSafeCleanupCandidates(
     processes.map((processEntry) => [processEntry.pid, processEntry] as const),
   );
 
-  return findCleanupCandidates(processes, currentPid)
-    .filter((candidate) => !hasAncestorMatching(processByPid, candidate.pid, isCodexSessionProcess))
-    .filter((candidate) => !hasAncestorMatching(processByPid, candidate.pid, isOmxLaunchProcess));
+  return findCleanupCandidates(processes, currentPid).filter((candidate) => {
+    // Reparented MCP children are definitively orphaned even if PID 1 happens
+    // to look Codex-like in a synthetic or platform-specific process table.
+    if (candidate.ppid <= 1) return true;
+    return (
+      !hasAncestorMatching(processByPid, candidate.pid, isCodexSessionProcess)
+      && !hasAncestorMatching(processByPid, candidate.pid, isOmxLaunchProcess)
+    );
+  });
 }
 
 function defaultIsPidAlive(pid: number): boolean {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1917,6 +1917,30 @@ export async function cleanupLaunchOrphanedMcpProcesses(
   });
 }
 
+export async function reapPostLaunchOrphanedMcpProcesses(
+  cleanupOrphanedMcpProcesses: () => Promise<CleanupResult> = () =>
+    cleanupLaunchOrphanedMcpProcesses(),
+  logLine: (line: string) => void = (line) => console.log(line),
+  warnLine: (line: string) => void = (line) => console.warn(line),
+  writeError: (line: string) => void = (line) => process.stderr.write(line),
+): Promise<void> {
+  try {
+    const cleanup = await cleanupOrphanedMcpProcesses();
+    if (cleanup.terminatedCount > 0) {
+      logLine(
+        `[omx] postLaunch: reaped ${cleanup.terminatedCount} orphaned OMX MCP process(es).`,
+      );
+    }
+    if (cleanup.failedPids.length > 0) {
+      warnLine(
+        `[omx] postLaunch: failed to reap ${cleanup.failedPids.length} orphaned OMX MCP process(es).`,
+      );
+    }
+  } catch (err) {
+    writeError(`[cli/index] postLaunch MCP cleanup failed: ${err}\n`);
+  }
+}
+
 /**
  * preLaunch: Prepare environment before Codex starts.
  * 1. Best-effort launch-safe orphan cleanup for detached OMX MCP processes
@@ -2446,6 +2470,9 @@ async function postLaunch(
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
     // Non-fatal
   }
+
+  // 0. Reap orphaned MCP processes left behind by the ending session.
+  await reapPostLaunchOrphanedMcpProcesses();
 
   // 0. Flush fallback watcher once to reduce race with fast codex exit.
   try {


### PR DESCRIPTION
## Summary
- run launch-safe MCP orphan cleanup during `postLaunch()` so crash leftovers are reaped even if no later session starts
- make launch-safe candidate selection explicitly preserve `ppid <= 1` orphan cleanup before ancestor checks
- add regression coverage for the new post-launch cleanup helper and the explicit `ppid=1` launch-safe path

## Testing
- npm run build
- node --test dist/cli/__tests__/cleanup.test.js dist/cli/__tests__/index.test.js
- npx biome lint src/cli/cleanup.ts src/cli/index.ts src/cli/__tests__/cleanup.test.ts src/cli/__tests__/index.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json

Closes #1342
