### PR TITLE
Fix notify-fallback once-mode log spam and add rotation

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -249,6 +249,70 @@ describe('notify-fallback watcher', () => {
       assert.equal(turnLines.length, 1);
       assert.match(turnLines[0], new RegExp(freshTurn));
       assert.doesNotMatch(turnLines[0], new RegExp(staleTurn));
+
+      const fallbackLog = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const fallbackEntries = await readJsonLines(fallbackLog);
+      assert.deepEqual(fallbackEntries.map((entry) => entry.type), ['fallback_notify']);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+      await rm(rolloutPath, { force: true });
+    }
+  });
+
+  it('rotates notify-fallback logs when the size cap is exceeded', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-once-rotate-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-home-'));
+    const sid = randomUUID();
+    const sessionDir = todaySessionDir(tempHome);
+    const rolloutPath = join(sessionDir, `rollout-test-fallback-rotate-${sid}.jsonl`);
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+
+      const threadId = `thread-${sid}`;
+      const turnIds = ['first', 'second', 'third'].map((label) => `turn-${label}-${sid}`);
+      const nowIso = new Date(Date.now() + 2_000).toISOString();
+      const lines = [
+        {
+          timestamp: nowIso,
+          type: 'session_meta',
+          payload: { id: threadId, cwd: wd },
+        },
+        ...turnIds.map((turnId) => ({
+          timestamp: nowIso,
+          type: 'event_msg',
+          payload: {
+            type: 'task_complete',
+            turn_id: turnId,
+            last_agent_message: `message for ${turnId}`,
+          },
+        })),
+      ];
+      await writeFile(rolloutPath, `${lines.map(v => JSON.stringify(v)).join('\n')}\n`);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50', '--log-max-bytes', '1'],
+        { encoding: 'utf-8', env: buildCleanNotifyEnv({ HOME: tempHome }) }
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const fallbackLog = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const rotatedLog = `${fallbackLog}.1`;
+      const currentEntries = await readJsonLines(fallbackLog);
+      const rotatedEntries = await readJsonLines(rotatedLog);
+
+      assert.equal(currentEntries.length, 1);
+      assert.equal(rotatedEntries.length, 1);
+      assert.equal(currentEntries[0]?.turn_id, turnIds[2]);
+      assert.equal(rotatedEntries[0]?.turn_id, turnIds[1]);
+      assert.deepEqual(currentEntries.map((entry) => entry.type), ['fallback_notify']);
+      assert.deepEqual(rotatedEntries.map((entry) => entry.type), ['fallback_notify']);
     } finally {
       await rm(wd, { recursive: true, force: true });
       await rm(tempHome, { recursive: true, force: true });
@@ -879,7 +943,7 @@ describe('notify-fallback watcher', () => {
       assert.equal(watcherState.leader_nudge?.precomputed_leader_stale, false);
 
       const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
-      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const logEntries = await readJsonLines(logPath);
       const nudgeEvent = logEntries.find((entry: { type?: string }) => entry.type === 'leader_nudge_tick');
       assert.equal(nudgeEvent, undefined);
     } finally {
@@ -1460,7 +1524,7 @@ exit 0
       assert.equal(watcherState.dispatch_drain?.last_result?.processed, 0);
 
       const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
-      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const logEntries = await readJsonLines(logPath);
       const drainEvent = logEntries.find((entry: { type?: string }) => entry.type === 'dispatch_drain_tick');
       assert.equal(drainEvent, undefined);
     } finally {

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync } from 'fs';
-import { appendFile, mkdir, open, readFile, readdir, rename, stat, unlink, writeFile } from 'fs/promises';
+import { appendFile, mkdir, open, readFile, readdir, rename, rm, stat, unlink, writeFile } from 'fs/promises';
 import { spawnSync } from 'child_process';
 import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
@@ -110,6 +110,13 @@ const stateDir = join(omxDir, 'state');
 const statePath = join(stateDir, 'notify-fallback-state.json');
 const pidFilePath = resolve(argValue('--pid-file', join(stateDir, 'notify-fallback.pid')));
 const logPath = join(logsDir, `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+const logRotatePath = `${logPath}.1`;
+const logLockPath = `${logPath}.lock`;
+const defaultMaxLogBytes = 10 * 1024 * 1024;
+const maxLogBytes = Math.max(
+  0,
+  asNumber(argValue('--log-max-bytes', process.env.OMX_NOTIFY_FALLBACK_LOG_MAX_BYTES || String(defaultMaxLogBytes)), defaultMaxLogBytes),
+);
 const ralphSteerTimestampPath = join(stateDir, 'ralph-last-steer-at');
 const ralphSteerLockPath = join(stateDir, 'ralph-continue-steer.lock');
 const watcherOwnerToken = `${process.pid}-${startedAt}-${Math.random().toString(36).slice(2, 10)}`;
@@ -117,6 +124,7 @@ const RALPH_CONTINUE_TEXT = 'Ralph loop active continue';
 const RALPH_CONTINUE_CADENCE_MS = 60_000;
 const RALPH_STEER_LOCK_STALE_MS = 30_000;
 const RALPH_TERMINAL_PHASES = new Set(['complete', 'failed', 'cancelled']);
+const QUIET_ONCE_EVENT_TYPES = new Set(['watcher_start', 'watcher_once_complete']);
 
 interface WatcherFileMeta {
   threadId: string;
@@ -311,8 +319,57 @@ let adaptivePollState: AdaptivePollState = {
   last_activity_at: null,
   last_activity_reason: 'init',
 };
-function eventLog(event: Record<string, unknown>): Promise<void> {
-  return appendFile(logPath, `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`).catch(() => {});
+
+function shouldSuppressEventLog(event: Record<string, unknown>): boolean {
+  const eventType = safeString(event.type).trim();
+  return runOnce && QUIET_ONCE_EVENT_TYPES.has(eventType);
+}
+
+async function acquireLogLock(timeoutMs = 1000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await mkdir(logLockPath, { recursive: false });
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException | null)?.code !== 'EEXIST') return false;
+      const lockStat = await stat(logLockPath).catch(() => null);
+      if (lockStat && Date.now() - lockStat.mtimeMs > 5000) {
+        await rm(logLockPath, { recursive: true, force: true }).catch(() => {});
+        continue;
+      }
+      await sleep(10);
+    }
+  }
+  return false;
+}
+
+async function releaseLogLock(): Promise<void> {
+  await rm(logLockPath, { recursive: true, force: true }).catch(() => {});
+}
+
+async function rotateLogIfNeeded(nextEntryBytes: number): Promise<void> {
+  if (maxLogBytes <= 0) return;
+  const currentStat = await stat(logPath).catch(() => null);
+  if (!currentStat || currentStat.size + nextEntryBytes <= maxLogBytes) return;
+  await unlink(logRotatePath).catch(() => {});
+  await rename(logPath, logRotatePath).catch(() => {});
+}
+
+async function eventLog(event: Record<string, unknown>): Promise<void> {
+  if (shouldSuppressEventLog(event)) return;
+  const line = `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`;
+  await mkdir(dirname(logPath), { recursive: true }).catch(() => {});
+  const locked = await acquireLogLock();
+  if (!locked) return;
+  try {
+    await rotateLogIfNeeded(Buffer.byteLength(line));
+    await appendFile(logPath, line);
+  } catch {
+    // best effort only
+  } finally {
+    await releaseLogLock();
+  }
 }
 
 function shouldLogLeaderNudgeTick(reason: string): boolean {
@@ -1669,8 +1726,8 @@ async function main(): Promise<void> {
       notify_script: notifyScript,
       authority_only: authorityOnly,
       poll_ms: pollMs,
-    effective_poll_ms: adaptivePollState.current_ms,
-    idle_max_poll_ms: idleMaxPollMs,
+      effective_poll_ms: adaptivePollState.current_ms,
+      idle_max_poll_ms: idleMaxPollMs,
       once: runOnce,
       parent_pid: parentPid,
       pid_file: runOnce ? null : pidFilePath,


### PR DESCRIPTION
## Summary
- suppress routine `watcher_start` and `watcher_once_complete` log entries in `--once` mode
- rotate `notify-fallback-*.jsonl` to `.1` when a size cap is exceeded
- add focused watcher regressions for no-spam once mode and size-based rotation

## Testing
- npm run build
- node --test dist/hooks/__tests__/notify-fallback-watcher.test.js
- npx biome lint src/scripts/notify-fallback-watcher.ts src/hooks/__tests__/notify-fallback-watcher.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json