### PR TITLE
Fix native Stop repeat-fire behavior and team guidance

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -31,10 +31,10 @@ For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of sourc
 | Autopilot continuation | `Stop` | `stop` | native-partial | Native adapter continues non-terminal autopilot sessions from active session/root mode state |
 | Ultrawork continuation | `Stop` | `stop` | native-partial | Native adapter continues non-terminal ultrawork sessions from active session/root mode state |
 | UltraQA continuation | `Stop` | `stop` | native-partial | Native adapter continues non-terminal ultraqa sessions from active session/root mode state |
-| Team-phase continuation | `Stop` | `stop` | native-partial | Native adapter treats per-team `phase.json` as canonical when deciding whether a current-session team run is still non-terminal |
+| Team-phase continuation | `Stop` | `stop` | native-partial | Native adapter treats per-team `phase.json` as canonical when deciding whether a current-session team run is still non-terminal and can re-block on later fresh Stop replies while keeping leader guidance explicit about rewriting system-generated worker auto-checkpoint commits into Lore-format final history |
 | `ralplan` skill-state continuation | `Stop` | `stop` | native-partial | Native adapter can block on active `skill-active-state.json` for `ralplan`, unless active subagents are already the real in-flight owners |
 | `deep-interview` skill-state continuation | `Stop` | `stop` | native-partial | Native adapter can block on active `skill-active-state.json` for `deep-interview`, unless active subagents are already the real in-flight owners |
-| auto-nudge continuation | `Stop` | `stop` | native-partial | Native adapter continues turns that end in a permission/stall prompt, unless the Stop hook already continued once |
+| auto-nudge continuation | `Stop` | `stop` | native-partial | Native adapter continues turns that end in a permission/stall prompt, can re-fire for later fresh replies, and suppresses auto-nudge while interview / deep-interview state is active |
 | `ask-user-question` | none | runtime-only | runtime-fallback | No distinct Codex native hook today |
 | `PostToolUseFailure` | none | runtime-only | runtime-fallback | Fold into runtime/fallback handling until native support exists |
 | non-Bash tool interception | none | runtime-only | runtime-fallback | Current Codex native tool hooks expose Bash only |

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -18,6 +18,9 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+const TEAM_STOP_COMMIT_GUIDANCE =
+  " If system-generated worker auto-checkpoint commits exist, rewrite them into Lore-format final commits before merge/finalization.";
+
 describe("codex native hook config", () => {
   it("builds the expected managed hooks.json shape", () => {
     const config = buildManagedCodexHooksConfig("/tmp/omx");
@@ -480,7 +483,7 @@ describe("codex native hook dispatch", () => {
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "OMX team pipeline is still active (review-team) at phase team-verify; continue coordinating until the team reaches a terminal phase.",
+          `OMX team pipeline is still active (review-team) at phase team-verify; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
         stopReason: "team_team-verify",
         systemMessage: "OMX team pipeline is still active at phase team-verify.",
       });
@@ -515,7 +518,56 @@ describe("codex native hook dispatch", () => {
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "OMX team pipeline is still active (canonical-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.",
+          `OMX team pipeline is still active (canonical-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("re-fires canonical-team Stop output for a later fresh Stop reply when coarse mode state is missing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-canonical-refire-"));
+    try {
+      await initTeamState(
+        "canonical-team-refire",
+        "canonical stop fallback refire",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-canonical-refire" },
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-canonical-refire",
+          thread_id: "thread-stop-team-canonical-refire",
+          turn_id: "turn-stop-team-canonical-refire-1",
+        },
+        { cwd },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-canonical-refire",
+          thread_id: "thread-stop-team-canonical-refire",
+          turn_id: "turn-stop-team-canonical-refire-2",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          `OMX team pipeline is still active (canonical-team-refire) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
         stopReason: "team_team-exec",
         systemMessage: "OMX team pipeline is still active at phase team-exec.",
       });
@@ -595,7 +647,7 @@ describe("codex native hook dispatch", () => {
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "OMX team pipeline is still active (legacy-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.",
+          `OMX team pipeline is still active (legacy-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
         stopReason: "team_team-exec",
         systemMessage: "OMX team pipeline is still active at phase team-exec.",
       });
@@ -634,7 +686,7 @@ describe("codex native hook dispatch", () => {
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "OMX team pipeline is still active (canonical-root-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.",
+          `OMX team pipeline is still active (canonical-root-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
         stopReason: "team_team-exec",
         systemMessage: "OMX team pipeline is still active at phase team-exec.",
       });
@@ -678,7 +730,7 @@ describe("codex native hook dispatch", () => {
       assert.deepEqual(result.outputJson, {
         decision: "block",
         reason:
-          "OMX team pipeline is still active (env-root-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.",
+          `OMX team pipeline is still active (env-root-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
         stopReason: "team_team-exec",
         systemMessage: "OMX team pipeline is still active at phase team-exec.",
       });
@@ -905,17 +957,31 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("does not auto-nudge again when Stop already continued once", async () => {
+  it("suppresses duplicate native auto-nudge replays for the same Stop reply", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-once-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-once",
+          thread_id: "thread-stop-auto",
+          turn_id: "turn-stop-auto-1",
+          last_assistant_message: "Would you like me to continue?",
+        },
+        { cwd },
+      );
 
       const result = await dispatchCodexNativeHook(
         {
           hook_event_name: "Stop",
           cwd,
           session_id: "sess-stop-auto-once",
+          thread_id: "thread-stop-auto",
+          turn_id: "turn-stop-auto-1",
           stop_hook_active: true,
           last_assistant_message: "Would you like me to continue?",
         },
@@ -924,6 +990,210 @@ describe("codex native hook dispatch", () => {
 
       assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("re-fires native auto-nudge for a later fresh Stop reply even when stop_hook_active is true", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-refire-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-refire",
+          thread_id: "thread-stop-auto-refire",
+          turn_id: "turn-stop-auto-refire-1",
+          last_assistant_message: "Would you like me to continue?",
+        },
+        { cwd },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-refire",
+          thread_id: "thread-stop-auto-refire",
+          turn_id: "turn-stop-auto-refire-2",
+          stop_hook_active: true,
+          last_assistant_message: "If you want, I can keep going and finish the cleanup.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "yes, proceed",
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses native auto-nudge when only the deep-interview input lock is active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-deep-interview-lock-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-auto-lock"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-auto-lock" });
+      await writeJson(join(stateDir, "sessions", "sess-stop-auto-lock", "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        input_lock: {
+          active: true,
+          scope: "deep-interview-auto-approval",
+          blocked_inputs: ["yes", "proceed"],
+          message: "Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.",
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-lock",
+          thread_id: "thread-stop-auto-lock",
+          turn_id: "turn-stop-auto-lock-1",
+          last_assistant_message: "Would you like me to continue with the next step?",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX skill deep-interview is still active (phase: planning); continue until the current deep-interview workflow reaches a terminal state.",
+        stopReason: "skill_deep-interview_planning",
+        systemMessage: "OMX skill deep-interview is still active (phase: planning).",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses native auto-nudge re-fire while session-scoped deep-interview state is still active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-deep-interview-state-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-auto-interview"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-auto-interview" });
+      await writeJson(join(stateDir, "sessions", "sess-stop-auto-interview", "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-interview",
+          thread_id: "thread-stop-auto-interview",
+          turn_id: "turn-stop-auto-interview-2",
+          stop_hook_active: true,
+          last_assistant_message: "If you want, I can keep going from here.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses native auto-nudge when deep-interview mode state is active without a scoped skill state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-deep-interview-mode-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-mode",
+          thread_id: "thread-stop-auto-mode",
+          turn_id: "turn-stop-auto-mode-1",
+          last_assistant_message: "Would you like me to continue with the next step?",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("re-fires team Stop output for a later fresh Stop reply while the team is still active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-refire-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "team-state.json"), {
+        active: true,
+        current_phase: "team-exec",
+        team_name: "review-team",
+      });
+      await writeJson(join(stateDir, "team", "review-team", "phase.json"), {
+        current_phase: "team-verify",
+        max_fix_attempts: 3,
+        current_fix_attempt: 0,
+        transitions: [],
+        updated_at: new Date().toISOString(),
+      });
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-refire",
+          thread_id: "thread-stop-team-refire",
+          turn_id: "turn-stop-team-refire-1",
+        },
+        { cwd },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-refire",
+          thread_id: "thread-stop-team-refire",
+          turn_id: "turn-stop-team-refire-2",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          `OMX team pipeline is still active (review-team) at phase team-verify; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
+        stopReason: "team_team-verify",
+        systemMessage: "OMX team pipeline is still active at phase team-verify.",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -15,8 +15,10 @@ import {
 } from "../hooks/keyword-detector.js";
 import {
   detectStallPattern,
+  isDeepInterviewInputLockActive,
   isDeepInterviewStateActive,
   loadAutoNudgeConfig,
+  normalizeAutoNudgeSignatureText,
 } from "./notify-hook/auto-nudge.js";
 import {
   buildNativePostToolUseOutput,
@@ -53,6 +55,7 @@ export interface NativeHookDispatchResult {
 const TERMINAL_RALPH_PHASES = new Set(["complete", "failed", "cancelled"]);
 const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
 const SKILL_STOP_BLOCKERS = new Set(["ralplan", "deep-interview"]);
+const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
 
 function safeString(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -469,13 +472,143 @@ async function buildTeamStopOutput(cwd: string): Promise<Record<string, unknown>
   const coarsePhase = teamState.current_phase;
   const canonicalPhase = teamName ? (await readTeamPhase(teamName, cwd))?.current_phase ?? coarsePhase : coarsePhase;
   if (!isNonTerminalPhase(canonicalPhase)) return null;
-  const phase = formatPhase(canonicalPhase);
+  return buildTeamStopOutputForPhase(teamName, formatPhase(canonicalPhase));
+}
+
+function buildTeamStopReason(teamName: string, phase: string): string {
+  const teamContext = teamName ? ` (${teamName})` : "";
+  return `OMX team pipeline is still active${teamContext} at phase ${phase}; continue coordinating until the team reaches a terminal phase. If system-generated worker auto-checkpoint commits exist, rewrite them into Lore-format final commits before merge/finalization.`;
+}
+
+function buildTeamStopOutputForPhase(teamName: string, phase: string): Record<string, unknown> {
   return {
     decision: "block",
-    reason: `OMX team pipeline is still active${teamName ? ` (${teamName})` : ""} at phase ${phase}; continue coordinating until the team reaches a terminal phase.`,
+    reason: buildTeamStopReason(teamName, phase),
     stopReason: `team_${phase}`,
     systemMessage: `OMX team pipeline is still active at phase ${phase}.`,
   };
+}
+
+function readPayloadSessionId(payload: CodexHookPayload): string {
+  return safeString(payload.session_id ?? payload.sessionId).trim();
+}
+
+function readPayloadThreadId(payload: CodexHookPayload): string {
+  return safeString(payload.thread_id ?? payload.threadId).trim();
+}
+
+function readPayloadTurnId(payload: CodexHookPayload): string {
+  return safeString(payload.turn_id ?? payload.turnId).trim();
+}
+
+async function isDeepInterviewSuppressedForStop(
+  cwd: string,
+  stateDir: string,
+  sessionId: string,
+): Promise<boolean> {
+  if (await isDeepInterviewStateActive(stateDir)) return true;
+  if (await isDeepInterviewInputLockActive(stateDir)) return true;
+
+  const scopedModeState = sessionId
+    ? await readScopedJsonState("deep-interview-state.json", cwd, sessionId)
+    : null;
+  if (scopedModeState?.active === true) return true;
+
+  const scopedSkillState = sessionId
+    ? await readScopedJsonState("skill-active-state.json", cwd, sessionId)
+    : null;
+  if (!scopedSkillState || scopedSkillState.active !== true) return false;
+  return safeString(scopedSkillState.skill).trim() === "deep-interview";
+}
+
+function buildRepeatableStopSignature(
+  payload: CodexHookPayload,
+  kind: string,
+  detail = "",
+): string {
+  const sessionId = readPayloadSessionId(payload) || "no-session";
+  const threadId = readPayloadThreadId(payload) || "no-thread";
+  const turnId = readPayloadTurnId(payload);
+  const normalizedDetail = normalizeAutoNudgeSignatureText(detail) || safeString(detail).trim().toLowerCase();
+  const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim() || "no-transcript";
+  const lastAssistantMessage = normalizeAutoNudgeSignatureText(
+    payload.last_assistant_message ?? payload.lastAssistantMessage,
+  ) || "no-message";
+  if (turnId) {
+    return [
+      kind,
+      sessionId,
+      threadId,
+      turnId,
+      transcriptPath,
+      lastAssistantMessage,
+      normalizedDetail || "no-detail",
+    ].join("|");
+  }
+  return [
+    kind,
+    sessionId,
+    threadId,
+    transcriptPath,
+    lastAssistantMessage,
+    normalizedDetail || "no-detail",
+  ].join("|");
+}
+
+async function readNativeStopState(stateDir: string): Promise<Record<string, unknown>> {
+  return await readJsonIfExists(join(stateDir, NATIVE_STOP_STATE_FILE)) ?? {};
+}
+
+function readNativeStopSessionKey(payload: CodexHookPayload): string {
+  return readPayloadSessionId(payload) || readPayloadThreadId(payload) || "global";
+}
+
+function readPreviousNativeStopSignature(
+  state: Record<string, unknown>,
+  sessionKey: string,
+): string {
+  const sessions = safeObject(state.sessions);
+  const sessionState = safeObject(sessions[sessionKey]);
+  return safeString(sessionState.last_signature).trim();
+}
+
+async function persistNativeStopSignature(
+  stateDir: string,
+  payload: CodexHookPayload,
+  signature: string,
+): Promise<void> {
+  if (!signature) return;
+  const state = await readNativeStopState(stateDir);
+  const sessions = safeObject(state.sessions);
+  const sessionKey = readNativeStopSessionKey(payload);
+  sessions[sessionKey] = {
+    ...safeObject(sessions[sessionKey]),
+    last_signature: signature,
+    updated_at: new Date().toISOString(),
+  };
+  await writeFile(join(stateDir, NATIVE_STOP_STATE_FILE), JSON.stringify({
+    ...state,
+    sessions,
+  }, null, 2));
+}
+
+async function maybeReturnRepeatableStopOutput(
+  payload: CodexHookPayload,
+  stateDir: string,
+  signature: string,
+  output: Record<string, unknown> | null,
+): Promise<Record<string, unknown> | null> {
+  if (!output) return null;
+  const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
+  if (stopHookActive) {
+    const state = await readNativeStopState(stateDir);
+    const previousSignature = readPreviousNativeStopSignature(state, readNativeStopSessionKey(payload));
+    if (!signature || previousSignature === signature) {
+      return null;
+    }
+  }
+  await persistNativeStopSignature(stateDir, payload, signature);
+  return output;
 }
 
 async function findCanonicalActiveTeamForSession(
@@ -542,7 +675,7 @@ async function buildStopHookOutput(
     return null;
   }
 
-  const sessionId = safeString(payload.session_id ?? payload.sessionId).trim();
+  const sessionId = readPayloadSessionId(payload);
   const ralphState = await readActiveRalphState(stateDir);
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
   if (!ralphState) {
@@ -556,42 +689,55 @@ async function buildStopHookOutput(
     if (!stopHookActive && ultraqaOutput) return ultraqaOutput;
 
     const teamOutput = await buildTeamStopOutput(cwd);
-    if (!stopHookActive && teamOutput) return teamOutput;
+    if (teamOutput) {
+      const teamSignature = buildRepeatableStopSignature(payload, "team-stop", safeString(teamOutput.stopReason));
+      return await maybeReturnRepeatableStopOutput(payload, stateDir, teamSignature, teamOutput);
+    }
 
     if (sessionId) {
       const canonicalTeam = await findCanonicalActiveTeamForSession(cwd, sessionId);
-      if (!stopHookActive && canonicalTeam) {
-        return {
-          decision: "block",
-          reason: `OMX team pipeline is still active (${canonicalTeam.teamName}) at phase ${canonicalTeam.phase}; continue coordinating until the team reaches a terminal phase.`,
-          stopReason: `team_${canonicalTeam.phase}`,
-          systemMessage: `OMX team pipeline is still active at phase ${canonicalTeam.phase}.`,
-        };
+      if (canonicalTeam) {
+        const canonicalTeamOutput = buildTeamStopOutputForPhase(
+          canonicalTeam.teamName,
+          canonicalTeam.phase,
+        );
+        const canonicalTeamSignature = buildRepeatableStopSignature(payload, "team-stop", `${canonicalTeam.teamName}|${canonicalTeam.phase}`);
+        const repeatedCanonicalTeamOutput = await maybeReturnRepeatableStopOutput(
+          payload,
+          stateDir,
+          canonicalTeamSignature,
+          canonicalTeamOutput,
+        );
+        if (repeatedCanonicalTeamOutput) return repeatedCanonicalTeamOutput;
       }
 
       const skillOutput = await buildSkillStopOutput(cwd, sessionId);
       if (!stopHookActive && skillOutput) return skillOutput;
     }
 
-    const deepInterviewActive = await isDeepInterviewStateActive(stateDir);
+    const deepInterviewActive = await isDeepInterviewSuppressedForStop(cwd, stateDir, sessionId);
     const lastAssistantMessage = safeString(
       payload.last_assistant_message ?? payload.lastAssistantMessage,
     );
     const autoNudgeConfig = await loadAutoNudgeConfig();
 
     if (
-      !stopHookActive
-      && !deepInterviewActive
+      !deepInterviewActive
       && autoNudgeConfig.enabled
       && detectStallPattern(lastAssistantMessage, autoNudgeConfig.patterns)
     ) {
-      return {
-        decision: "block",
-        reason: autoNudgeConfig.response,
-        stopReason: "auto_nudge",
-        systemMessage:
-          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
-      };
+      return await maybeReturnRepeatableStopOutput(
+        payload,
+        stateDir,
+        buildRepeatableStopSignature(payload, "auto-nudge", lastAssistantMessage),
+        {
+          decision: "block",
+          reason: autoNudgeConfig.response,
+          stopReason: "auto_nudge",
+          systemMessage:
+            "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+        },
+      );
     }
 
     return null;


### PR DESCRIPTION
## Summary
- allow native Stop to re-fire for later fresh stall-style replies instead of staying globally one-shot
- extend the same repeatable Stop behavior to team-native Stop handling
- suppress native Stop auto-nudge while interview / deep-interview state is active
- clarify native team Stop guidance so leaders rewrite system-generated worker auto-checkpoint commits into Lore-format final commits

## Problem
Native Stop was suppressing later fresh continuation decisions after the first auto-continue because `stop_hook_active` acted like a global one-shot guard. In practice, that left later `if you want` / permission-style replies unhandled. The same area also surfaced a deep-interview misbehavior where native Stop auto-nudge could interfere with interview mode.

## What changed
- replaced one-shot Stop suppression with signature-based duplicate suppression for same-reply replays
- persisted last native Stop signature so later fresh replies can re-block while duplicates still stay silent
- updated team Stop reason text to include Lore-format rewrite guidance for operational auto-checkpoint commits
- added regression coverage for:
  - same-reply native auto-nudge suppression
  - fresh native auto-nudge re-fire
  - deep-interview input-lock suppression
  - deep-interview mode-state suppression
  - team Stop re-fire
  - canonical-team fallback re-fire
- updated native hooks docs to reflect the new Stop semantics

## Verification
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint -- src/scripts/__tests__/codex-native-hook.test.ts`
- `npm run check:no-unused`
- LSP diagnostics on changed files: 0 errors

## Risks / follow-ups
- fresh-repeat behavior still depends on signature uniqueness; if `turn_id` is absent and normalized message text is identical, a legitimate fresh reply could still be suppressed
- this PR does not change tmux/notify-hook fallback semantics beyond documentation scope
