### PR TITLE
Seed stateful prompt-submit state and harden native Stop flow

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -226,15 +226,56 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(result.skill, 'autopilot');
       assert.equal(result.phase, 'planning');
       assert.equal(result.active, true);
+      assert.equal(result.initialized_mode, 'autopilot');
+      assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-1/autopilot-state.json');
 
       const persisted = JSON.parse(await readFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), 'utf-8')) as {
         skill: string;
         phase: string;
         active: boolean;
+        initialized_mode?: string;
       };
       assert.equal(persisted.skill, 'autopilot');
       assert.equal(persisted.phase, 'planning');
       assert.equal(persisted.active, true);
+      assert.equal(persisted.initialized_mode, 'autopilot');
+
+      const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', 'sess-1', 'autopilot-state.json'), 'utf-8')) as {
+        mode: string;
+        active: boolean;
+        current_phase: string;
+      };
+      assert.equal(modeState.mode, 'autopilot');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'planning');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('seeds first-class state for ralplan prompt-submit activation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan tighten the plan',
+        sessionId: 'sess-ralplan',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ralplan');
+      assert.equal(result.initialized_mode, 'ralplan');
+      assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-ralplan/ralplan-state.json');
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-ralplan', 'ralplan-state.json'), 'utf-8'),
+      ) as { mode: string; active: boolean; current_phase: string };
+      assert.equal(modeState.mode, 'ralplan');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'planning');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -328,6 +369,25 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not seed non-stateful skill mode state on keyword activation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-non-stateful-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'please do a code review before merge',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'code-review');
+      assert.equal(result.initialized_mode, undefined);
+      assert.equal(result.initialized_state_path, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('emits a warning when skill-active-state persistence fails', async () => {
     const warnings: unknown[][] = [];
     mock.method(console, 'warn', (...args: unknown[]) => {
@@ -375,6 +435,111 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.ok(result);
       assert.equal(result.activated_at, '2026-02-25T00:00:00.000Z');
       assert.equal(result.updated_at, '2026-02-26T00:00:00.000Z');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves seeded mode progress for same-skill continuation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-seed-continuation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const statePath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(join(stateDir, 'sessions', 'sess-autopilot'), { recursive: true });
+      await writeFile(
+        statePath,
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: 'autopilot',
+          phase: 'planning',
+          activated_at: '2026-02-25T00:00:00.000Z',
+          updated_at: '2026-02-25T00:10:00.000Z',
+          source: 'keyword-detector',
+          session_id: 'sess-autopilot',
+        }),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-autopilot', 'autopilot-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'execution',
+          started_at: '2026-02-25T00:00:00.000Z',
+          updated_at: '2026-02-25T00:10:00.000Z',
+          session_id: 'sess-autopilot',
+          state: { context_snapshot_path: '.omx/context/existing.md' },
+        }),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'autopilot keep going',
+        sessionId: 'sess-autopilot',
+        nowIso: '2026-02-26T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-autopilot', 'autopilot-state.json'), 'utf-8'),
+      ) as { current_phase: string; started_at: string; state?: { context_snapshot_path?: string } };
+      assert.equal(modeState.current_phase, 'execution');
+      assert.equal(modeState.started_at, '2026-02-25T00:00:00.000Z');
+      assert.equal(modeState.state?.context_snapshot_path, '.omx/context/existing.md');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves Ralph iteration counters for same-skill continuation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralph-continuation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const statePath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        statePath,
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'ralph',
+          keyword: 'ralph',
+          phase: 'executing',
+          activated_at: '2026-02-25T00:00:00.000Z',
+          updated_at: '2026-02-25T00:10:00.000Z',
+          source: 'keyword-detector',
+        }),
+      );
+      await writeFile(
+        join(stateDir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'ralph',
+          current_phase: 'verifying',
+          started_at: '2026-02-25T00:00:00.000Z',
+          updated_at: '2026-02-25T00:10:00.000Z',
+          iteration: 3,
+          max_iterations: 10,
+        }),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'ralph keep going',
+        nowIso: '2026-02-26T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      const modeState = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8')) as {
+        current_phase: string;
+        iteration: number;
+        max_iterations: number;
+      };
+      assert.equal(modeState.current_phase, 'verifying');
+      assert.equal(modeState.iteration, 3);
+      assert.equal(modeState.max_iterations, 10);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -11,8 +11,8 @@
  * to an external hook handler.
  */
 
-import { readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { classifyTaskSize, isHeavyMode, type TaskSizeResult, type TaskSizeThresholds } from './task-size-detector.js';
 import { isApprovedExecutionFollowupShortcut, type FollowupMode } from '../team/followup-planner.js';
 import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
@@ -22,6 +22,10 @@ export interface KeywordMatch {
   keyword: string;
   skill: string;
   priority: number;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
 }
 
 export type SkillActivePhase = 'planning' | 'executing' | 'reviewing' | 'completing';
@@ -49,6 +53,8 @@ export interface SkillActiveState {
   thread_id?: string;
   turn_id?: string;
   input_lock?: DeepInterviewInputLock;
+  initialized_mode?: string;
+  initialized_state_path?: string;
 }
 
 export interface RecordSkillActivationInput {
@@ -64,6 +70,23 @@ export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
 export const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
 export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'] as const;
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
+
+type StatefulSkillMode = 'deep-interview' | 'autopilot' | 'ralph' | 'ralplan' | 'ultrawork' | 'ultraqa';
+
+interface StatefulSkillSeedConfig {
+  mode: StatefulSkillMode;
+  initialPhase: string;
+  includeIteration?: boolean;
+}
+
+const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedConfig> = {
+  'deep-interview': { mode: 'deep-interview', initialPhase: 'intent-first' },
+  autopilot: { mode: 'autopilot', initialPhase: 'planning' },
+  ralph: { mode: 'ralph', initialPhase: 'starting', includeIteration: true },
+  ralplan: { mode: 'ralplan', initialPhase: 'planning' },
+  ultrawork: { mode: 'ultrawork', initialPhase: 'planning' },
+  ultraqa: { mode: 'ultraqa', initialPhase: 'planning' },
+};
 
 interface DeepInterviewModeState {
   active: boolean;
@@ -120,6 +143,15 @@ async function readExistingDeepInterviewState(statePath: string): Promise<DeepIn
   }
 }
 
+async function readJsonStateIfExists(path: string): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await readFile(path, 'utf-8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
 async function persistDeepInterviewModeState(
   stateDir: string,
   nextSkill: SkillActiveState | null,
@@ -163,6 +195,75 @@ async function persistDeepInterviewModeState(
     ...(releasedInputLock ? { input_lock: releasedInputLock } : {}),
   };
   await writeFile(statePath, JSON.stringify(nextState, null, 2));
+}
+
+function resolveSeedStateFilePath(stateDir: string, mode: StatefulSkillMode, sessionId?: string): {
+  absolutePath: string;
+  relativePath: string;
+} {
+  if (sessionId?.trim()) {
+    return {
+      absolutePath: join(stateDir, 'sessions', sessionId, `${mode}-state.json`),
+      relativePath: `.omx/state/sessions/${sessionId}/${mode}-state.json`,
+    };
+  }
+
+  return {
+    absolutePath: join(stateDir, `${mode}-state.json`),
+    relativePath: `.omx/state/${mode}-state.json`,
+  };
+}
+
+async function persistStatefulSkillSeedState(
+  stateDir: string,
+  nextSkill: SkillActiveState,
+  nowIso: string,
+  previousSkill: SkillActiveState | null,
+): Promise<SkillActiveState> {
+  const config = STATEFUL_SKILL_SEED_CONFIG[nextSkill.skill as StatefulSkillMode];
+  if (!config) return nextSkill;
+
+  const { absolutePath, relativePath } = resolveSeedStateFilePath(
+    stateDir,
+    config.mode,
+    nextSkill.session_id,
+  );
+  const existingModeState = await readJsonStateIfExists(absolutePath);
+  const sameActiveSkill = previousSkill?.skill === nextSkill.skill && previousSkill.active;
+  const preserveExistingModeState = sameActiveSkill
+    && safeString(existingModeState?.mode).trim() === config.mode
+    && safeString(existingModeState?.current_phase).trim() !== '';
+  const startedAt = previousSkill?.skill === nextSkill.skill && previousSkill.active
+    ? safeString(existingModeState?.started_at).trim() || previousSkill.activated_at || nowIso
+    : nowIso;
+
+  const baseState: Record<string, unknown> = {
+    ...(preserveExistingModeState ? existingModeState : {}),
+    active: true,
+    mode: config.mode,
+    current_phase: preserveExistingModeState
+      ? safeString(existingModeState?.current_phase).trim() || config.initialPhase
+      : config.initialPhase,
+    started_at: startedAt,
+    updated_at: nowIso,
+    session_id: nextSkill.session_id || safeString(existingModeState?.session_id).trim() || undefined,
+    thread_id: nextSkill.thread_id || safeString(existingModeState?.thread_id).trim() || undefined,
+    turn_id: nextSkill.turn_id || safeString(existingModeState?.turn_id).trim() || undefined,
+  };
+
+  if (config.includeIteration) {
+    baseState.iteration = typeof existingModeState?.iteration === 'number' ? existingModeState.iteration : 0;
+    baseState.max_iterations = typeof existingModeState?.max_iterations === 'number' ? existingModeState.max_iterations : 50;
+  }
+
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, JSON.stringify(baseState, null, 2));
+
+  return {
+    ...nextSkill,
+    initialized_mode: config.mode,
+    initialized_state_path: relativePath,
+  };
 }
 
 function escapeRegex(text: string): string {
@@ -357,8 +458,10 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   };
 
   try {
-    await writeFile(statePath, JSON.stringify(state, null, 2));
-    await persistDeepInterviewModeState(input.stateDir, state, nowIso, previous, input);
+    const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous);
+    await writeFile(statePath, JSON.stringify(nextState, null, 2));
+    await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
+    return nextState;
   } catch (error) {
     console.warn('[omx] warning: failed to persist keyword activation state', error);
   }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -189,15 +189,19 @@ describe("codex native hook dispatch", () => {
       assert.equal(result.omxEventName, "keyword-detector");
       assert.equal(result.skillState?.skill, "ralplan");
       assert.ok(result.outputJson, "UserPromptSubmit should emit developer context");
+      assert.match(JSON.stringify(result.outputJson), /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
 
       const statePath = join(cwd, ".omx", "state", "skill-active-state.json");
       assert.equal(existsSync(statePath), true);
       const state = JSON.parse(await readFile(statePath, "utf-8")) as {
         skill?: string;
         active?: boolean;
+        initialized_mode?: string;
       };
       assert.equal(state.skill, "ralplan");
       assert.equal(state.active, true);
+      assert.equal(state.initialized_mode, "ralplan");
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-1", "ralplan-state.json")), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -485,6 +489,118 @@ describe("codex native hook dispatch", () => {
         systemMessage: "OMX team pipeline is still active at phase team-verify.",
       });
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Stop for a team worker with a non-terminal assigned task via native worker context", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-"));
+    const prevTeamWorker = process.env.OMX_TEAM_WORKER;
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const prevLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
+    try {
+      await initTeamState(
+        "worker-stop-team",
+        "worker stop fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-worker" },
+      );
+      const workerDir = join(cwd, ".omx", "state", "team", "worker-stop-team", "workers", "worker-1");
+      await writeJson(join(workerDir, "status.json"), {
+        state: "idle",
+        current_task_id: "1",
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(cwd, ".omx", "state", "team", "worker-stop-team", "tasks", "task-1.json"), {
+        id: "1",
+        subject: "hook task",
+        description: "finish hook task",
+        status: "in_progress",
+        owner: "worker-1",
+        created_at: new Date().toISOString(),
+      });
+
+      process.env.OMX_TEAM_WORKER = "worker-stop-team/worker-1";
+      process.env.OMX_TEAM_STATE_ROOT = join(cwd, ".omx", "state");
+      process.env.OMX_TEAM_LEADER_CWD = cwd;
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd: join(cwd, ".omx", "team", "worker-stop-team", "worktrees", "worker-1"),
+          session_id: "sess-stop-team-worker",
+        },
+        { cwd: join(cwd, ".omx", "team", "worker-stop-team", "worktrees", "worker-1") },
+      );
+
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX team worker worker-1 is still assigned non-terminal task 1 (in_progress); continue the current assigned task or report a concrete blocker before stopping.",
+        stopReason: "team_worker_worker-1_1_in_progress",
+        systemMessage: "OMX team worker worker-1 is still assigned task 1 (in_progress).",
+      });
+    } finally {
+      if (typeof prevTeamWorker === "string") process.env.OMX_TEAM_WORKER = prevTeamWorker;
+      else delete process.env.OMX_TEAM_WORKER;
+      if (typeof prevTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      if (typeof prevLeaderCwd === "string") process.env.OMX_TEAM_LEADER_CWD = prevLeaderCwd;
+      else delete process.env.OMX_TEAM_LEADER_CWD;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block Stop for a team worker when assigned task is terminal", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-worker-terminal-"));
+    const prevTeamWorker = process.env.OMX_TEAM_WORKER;
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      await initTeamState(
+        "worker-stop-team-terminal",
+        "worker stop terminal fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-team-worker-terminal" },
+      );
+      const workerDir = join(cwd, ".omx", "state", "team", "worker-stop-team-terminal", "workers", "worker-1");
+      await writeJson(join(workerDir, "status.json"), {
+        state: "done",
+        current_task_id: "1",
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(cwd, ".omx", "state", "team", "worker-stop-team-terminal", "tasks", "task-1.json"), {
+        id: "1",
+        subject: "hook task",
+        description: "finish hook task",
+        status: "completed",
+        owner: "worker-1",
+        created_at: new Date().toISOString(),
+      });
+
+      process.env.OMX_TEAM_WORKER = "worker-stop-team-terminal/worker-1";
+      process.env.OMX_TEAM_STATE_ROOT = join(cwd, ".omx", "state");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-team-worker-terminal",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (typeof prevTeamWorker === "string") process.env.OMX_TEAM_WORKER = prevTeamWorker;
+      else delete process.env.OMX_TEAM_WORKER;
+      if (typeof prevTeamStateRoot === "string") process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -805,6 +921,35 @@ describe("codex native hook dispatch", () => {
         stopReason: "skill_deep-interview_planning",
         systemMessage: "OMX skill deep-interview is still active (phase: planning).",
       });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores root skill-active fallback from a different thread when evaluating Stop", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-foreign-thread-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "",
+        thread_id: "other-thread",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-main",
+          thread_id: "main-thread",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
-import { join } from "path";
+import { join, resolve } from "path";
 import { readModeState } from "../modes/base.js";
 import { getReadScopedStateDirs } from "../mcp/state-paths.js";
 import { readSubagentSessionSummary } from "../subagents/tracker.js";
@@ -53,6 +53,7 @@ export interface NativeHookDispatchResult {
 const TERMINAL_RALPH_PHASES = new Set(["complete", "failed", "cancelled"]);
 const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
 const SKILL_STOP_BLOCKERS = new Set(["ralplan", "deep-interview"]);
+const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);
 
 function safeString(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -420,12 +421,116 @@ async function buildSessionStartContext(
   return sections.join("\n\n");
 }
 
-function buildAdditionalContextMessage(prompt: string): string | null {
+function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveState | null): string | null {
   if (!prompt) return null;
   const match = detectPrimaryKeyword(prompt);
   if (!match) return null;
 
+  if (skillState?.initialized_mode && skillState.initialized_state_path) {
+    return [
+      `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`,
+      `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
+      "Follow AGENTS.md routing and preserve ralplan/ralph execution gates.",
+    ].join(" ");
+  }
+
   return `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}. Follow AGENTS.md routing and preserve ralplan/ralph execution gates.`;
+}
+
+function parseTeamWorkerEnv(rawValue: string): { teamName: string; workerName: string } | null {
+  const match = /^([a-z0-9][a-z0-9-]{0,29})\/(worker-\d+)$/.exec(rawValue.trim());
+  if (!match) return null;
+  return {
+    teamName: match[1] || "",
+    workerName: match[2] || "",
+  };
+}
+
+async function readTeamStateRootFromJson(path: string): Promise<string | null> {
+  const parsed = await readJsonIfExists(path);
+  const value = safeString(parsed?.team_state_root).trim();
+  return value || null;
+}
+
+async function resolveTeamStateDirForWorkerContext(
+  cwd: string,
+  workerContext: { teamName: string; workerName: string },
+): Promise<string> {
+  const explicitStateRoot = safeString(process.env.OMX_TEAM_STATE_ROOT).trim();
+  if (explicitStateRoot) {
+    return resolve(cwd, explicitStateRoot);
+  }
+
+  const leaderCwd = safeString(process.env.OMX_TEAM_LEADER_CWD).trim();
+  const candidateStateDirs = [
+    ...(leaderCwd ? [join(resolve(leaderCwd), ".omx", "state")] : []),
+    join(cwd, ".omx", "state"),
+  ];
+
+  for (const candidateStateDir of candidateStateDirs) {
+    const teamRoot = join(candidateStateDir, "team", workerContext.teamName);
+    if (!existsSync(teamRoot)) continue;
+
+    const identityRoot = await readTeamStateRootFromJson(
+      join(teamRoot, "workers", workerContext.workerName, "identity.json"),
+    );
+    if (identityRoot) return resolve(cwd, identityRoot);
+
+    const manifestRoot = await readTeamStateRootFromJson(join(teamRoot, "manifest.v2.json"));
+    if (manifestRoot) return resolve(cwd, manifestRoot);
+
+    const configRoot = await readTeamStateRootFromJson(join(teamRoot, "config.json"));
+    if (configRoot) return resolve(cwd, configRoot);
+
+    return candidateStateDir;
+  }
+
+  return join(cwd, ".omx", "state");
+}
+
+async function buildTeamWorkerStopOutput(
+  cwd: string,
+): Promise<Record<string, unknown> | null> {
+  const workerContext = parseTeamWorkerEnv(safeString(process.env.OMX_TEAM_WORKER));
+  if (!workerContext) return null;
+
+  const stateDir = await resolveTeamStateDirForWorkerContext(cwd, workerContext);
+  const workerRoot = join(stateDir, "team", workerContext.teamName, "workers", workerContext.workerName);
+  const [identity, status] = await Promise.all([
+    readJsonIfExists(join(workerRoot, "identity.json")),
+    readJsonIfExists(join(workerRoot, "status.json")),
+  ]);
+
+  const candidateTaskIds = new Set<string>();
+  const currentTaskId = safeString(status?.current_task_id).trim();
+  if (currentTaskId) candidateTaskIds.add(currentTaskId);
+  const assignedTasks = Array.isArray(identity?.assigned_tasks) ? identity?.assigned_tasks : [];
+  for (const taskId of assignedTasks) {
+    const normalized = safeString(taskId).trim();
+    if (normalized) candidateTaskIds.add(normalized);
+  }
+
+  for (const taskId of candidateTaskIds) {
+    const task = await readJsonIfExists(
+      join(stateDir, "team", workerContext.teamName, "tasks", `task-${taskId}.json`),
+    );
+    const statusValue = safeString(task?.status).trim().toLowerCase();
+    if (!statusValue || TEAM_TERMINAL_TASK_STATUSES.has(statusValue)) continue;
+    return {
+      decision: "block",
+      reason:
+        `OMX team worker ${workerContext.workerName} is still assigned non-terminal task ${taskId} (${statusValue}); continue the current assigned task or report a concrete blocker before stopping.`,
+      stopReason: `team_worker_${workerContext.workerName}_${taskId}_${statusValue}`,
+      systemMessage:
+        `OMX team worker ${workerContext.workerName} is still assigned task ${taskId} (${statusValue}).`,
+    };
+  }
+
+  return null;
+}
+
+function hasTeamWorkerContext(): boolean {
+  return parseTeamWorkerEnv(safeString(process.env.OMX_TEAM_WORKER)) !== null;
 }
 
 function isStopExempt(payload: CodexHookPayload): boolean {
@@ -513,9 +618,16 @@ async function findCanonicalActiveTeamForSession(
 async function buildSkillStopOutput(
   cwd: string,
   sessionId: string,
+  threadId: string,
 ): Promise<Record<string, unknown> | null> {
   const state = await readScopedJsonState("skill-active-state.json", cwd, sessionId);
   if (!state || state.active !== true) return null;
+  const stateSessionId = safeString(state.session_id).trim();
+  const stateThreadId = safeString(state.thread_id).trim();
+  if (sessionId && stateSessionId && stateSessionId !== sessionId) return null;
+  if (sessionId && !stateSessionId && threadId && stateThreadId && stateThreadId !== threadId) {
+    return null;
+  }
   const skill = safeString(state.skill).trim();
   const phase = formatPhase(state.phase, "planning");
   if (!SKILL_STOP_BLOCKERS.has(skill) || phase === "completing") return null;
@@ -543,9 +655,13 @@ async function buildStopHookOutput(
   }
 
   const sessionId = safeString(payload.session_id ?? payload.sessionId).trim();
+  const threadId = safeString(payload.thread_id ?? payload.threadId).trim();
   const ralphState = await readActiveRalphState(stateDir);
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
   if (!ralphState) {
+    const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);
+    if (!stopHookActive && hasTeamWorkerContext()) return teamWorkerOutput;
+
     const autopilotOutput = await buildModeBasedStopOutput("autopilot", cwd);
     if (!stopHookActive && autopilotOutput) return autopilotOutput;
 
@@ -569,7 +685,7 @@ async function buildStopHookOutput(
         };
       }
 
-      const skillOutput = await buildSkillStopOutput(cwd, sessionId);
+      const skillOutput = await buildSkillStopOutput(cwd, sessionId, threadId);
       if (!stopHookActive && skillOutput) return skillOutput;
     }
 
@@ -667,7 +783,7 @@ export async function dispatchCodexNativeHook(
   if (hookEventName === "SessionStart" || hookEventName === "UserPromptSubmit") {
     const additionalContext = hookEventName === "SessionStart"
       ? await buildSessionStartContext(cwd, sessionId)
-      : buildAdditionalContextMessage(readPromptText(payload));
+      : buildAdditionalContextMessage(readPromptText(payload), skillState);
     if (additionalContext) {
       outputJson = {
         hookSpecificOutput: {


### PR DESCRIPTION
## Summary

Prompt-submit activation now seeds first-class stateful mode state immediately and tells the model which `omx_state` path to keep updating. Native `Stop` also blocks team workers with non-terminal assigned tasks without relying on tmux reminder injection, and it no longer leaks stale root `deep-interview` state across unrelated threads.

## Changes

- seed prompt-submit state for first-class stateful modes (`deep-interview`, `autopilot`, `ralph`, `ralplan`, `ultrawork`, `ultraqa`)
- persist `initialized_mode` / `initialized_state_path` on `skill-active-state.json`
- emit native `UserPromptSubmit` nudge pointing follow-up state writes to `omx_state` MCP
- block native `Stop` for team workers with non-terminal assigned tasks using worker-context team state resolution
- ignore foreign-thread root `skill-active` fallback during `Stop` evaluation
- preserve same-skill continuation progress so repeated prompts do not reset seeded mode phase/iteration
- add regression coverage for seeded state paths, non-stateful exclusions, continuation preservation, worker stop blocking, and foreign-thread stale-state protection

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (not run; no setup/config generation flow changed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
