### PR TITLE
Keep team status JSON clean for delivered leader mail

### DIFF
--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -1240,6 +1240,15 @@ exit 1
       const compat = JSON.parse(await readFile(compatPath, 'utf8')) as { records: Array<{ message_id: string; body: string }> };
       const compatRecord = compat.records.find((entry) => entry.message_id === message.message_id);
       assert.ok(compatRecord);
+
+      const runtimeLogBefore = await readFile(runtimeLogPath, 'utf8');
+      const deliveredCallsBefore = runtimeLogBefore.split('MarkMailboxDelivered').length - 1;
+      const deliveredAgain = await markMessageDelivered('team-mailbox-bridge-authority', 'worker-2', message.message_id, cwd);
+      assert.equal(deliveredAgain, true, 'already-delivered bridge message should be treated as delivered');
+      const runtimeLogAfter = await readFile(runtimeLogPath, 'utf8');
+      const deliveredCallsAfter = runtimeLogAfter.split('MarkMailboxDelivered').length - 1;
+      assert.equal(deliveredCallsAfter, deliveredCallsBefore, 'idempotent delivered calls should not invoke bridge a second time');
+
       compatRecord!.body = '';
       await writeFile(compatPath, JSON.stringify(compat, null, 2));
 

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -187,6 +187,11 @@ export async function markMessageDelivered(
   messageId: string,
   deps: MailboxDeps,
 ): Promise<boolean> {
+  const existingMailbox = await deps.readMailbox(deps.teamName, workerName, deps.cwd);
+  const existingMessage = existingMailbox.messages.find((message) => message.message_id === messageId);
+  if (!existingMessage) return false;
+  if (existingMessage.delivered_at) return true;
+
   if (executeBridgeCommand(deps.cwd, { command: 'MarkMailboxDelivered', message_id: messageId })) {
     const updated = await deps.withMailboxLock(deps.teamName, workerName, deps.cwd, async () => {
       const mailbox = await deps.readMailbox(deps.teamName, workerName, deps.cwd);


### PR DESCRIPTION
## Summary
- short-circuit mailbox delivery when the message is already marked delivered
- add a regression test that verifies the bridge is not called twice

## Verification
- npm run build
- node --test dist/team/__tests__/state.test.js
- npx biome lint src/team/state/mailbox.ts src/team/__tests__/state.test.ts

## Notes
- team verification lane completed with PASS and no blocking findings