### PR TITLE
Align 0.12.1 release metadata with the reviewed patch set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-04-07
+
+Patch release for team status JSON hygiene, interactive worker PID metadata integrity, and release-collateral alignment after `0.12.0`.
+
+### Fixed
+- **Machine-readable team status output** — leader mailbox pruning no longer re-issues duplicate delivered-message bridge calls, so `omx team status --json` stays parseable instead of leaking mailbox-delivery stderr noise.
+- **Interactive worker PID capture** — team startup now resolves worker PIDs from the actual pane id and persists them into worker metadata for diagnostics and cleanup.
+
+### Changed
+- **Release metadata sync** — Node/Cargo package metadata, changelog, release body, and `0.12.1` release/readiness docs are aligned for the patch cut.
+
+### Verified
+- `npm run build`
+- `node --test dist/team/__tests__/state.test.js`
+- `node --test --test-name-pattern="startTeam captures interactive worker pid from the resolved pane id" dist/team/__tests__/runtime.test.js`
+- `npx biome lint src/team/state/mailbox.ts src/team/__tests__/state.test.ts src/team/runtime.ts src/team/__tests__/runtime.test.ts`
+- `node --test dist/cli/__tests__/version-sync-contract.test.js`
+
 ## [0.12.0] - 2026-04-06
 
 Minor release for native Codex hook ownership, first-party Bash pre/post tool guidance, runtime/team delivery hardening, and workflow-doc refresh after `0.11.13`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.12.0"
+version = "0.12.1"
 
 edition = "2021"
 license = "MIT"

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,52 +1,39 @@
-# oh-my-codex v0.12.0
+# oh-my-codex v0.12.1
 
-**Minor release for native Codex hook ownership, first-party Bash pre/post guidance, runtime/team delivery hardening, and workflow-doc refresh**
+**Patch release for team status JSON hygiene, interactive worker PID metadata integrity, and release collateral alignment**
 
-`0.12.0` follows `0.11.13` with a broad minor-release train from `v0.11.13..v0.12.0`: it promotes native Codex hook ownership into the repo/runtime contract, ships first-party Bash `PreToolUse` / `PostToolUse` guidance, hardens team/runtime delivery and operator steering, and refreshes workflow/docs collateral for the modern OMX path.
+`0.12.1` follows `0.12.0` with a narrow patch train focused on the findings resolved during the release branch review: clean machine-readable team status output, correct interactive worker PID metadata, and synchronized `0.12.1` release collateral.
 
 ## Highlights
 
-- Native Codex hook ownership now lives in the repo/runtime contract for non-team OMX sessions.
-- First-party Bash `PreToolUse` / `PostToolUse` guidance is now supported and documented.
-- Team runtime delivery, mailbox handling, pane-status visibility, and next-action steering are more robust.
-- Windows/tmux launch reliability and worker supervision are improved.
-- Prompt/AGENTS guidance now emphasizes quality-first, verification-heavy execution.
-- Translated README/docs collateral is reorganized under `docs/readme/`, with added Ukrainian coverage and refreshed workflow docs.
-- Release metadata and collateral are aligned to `0.12.0`.
+- `omx team status --json` no longer risks stray mailbox-delivery stderr noise during stale leader-mail pruning.
+- Interactive team workers now record the PID of their actual tmux pane, not a pane-index approximation.
+- Release metadata and collateral are aligned to `0.12.1`.
 
 ## What’s Changed
 
 ### Fixes
-- harden repo-local native hook ownership, session-start continuity, and stop-state persistence
-- strengthen team/runtime delivery, mailbox, persist-error, and next-action steering behavior
-- preserve Windows/tmux launch reliability, shift-enter handling, and launcher command resolution
-- keep notification/reminder/session continuity paths more reliable during live operator workflows
+- avoid duplicate bridge `MarkMailboxDelivered` calls for already-delivered leader system mail
+- persist interactive worker PID metadata from the resolved pane id
 
 ### Changed
-- add first-party Bash `PreToolUse` / `PostToolUse` guidance for the native hook lane
-- refresh prompt/AGENTS defaults toward quality-first, evidence-backed execution
-- reorganize translated README/docs collateral under `docs/readme/` and extend Ukrainian docs coverage
-- bump release metadata from `0.11.13` to `0.12.0` across Node/Cargo workspace manifests, lockfiles, and release collateral
+- bump release metadata from `0.12.0` to `0.12.1` across Node/Cargo manifests, changelog, and release collateral
 
 ## Verification
 
-- `npm ci`
-- `node dist/cli/omx.js version`
-- `node --test dist/cli/__tests__/version-sync-contract.test.js`
-- `cargo test -p omx-runtime-core`
 - `npm run build`
-- `npm run lint`
-- `npm test`
-- `npm run smoke:packed-install`
-- `git diff --check origin/main...HEAD`
+- `node --test dist/team/__tests__/state.test.js`
+- `node --test --test-name-pattern="startTeam captures interactive worker pid from the resolved pane id" dist/team/__tests__/runtime.test.js`
+- `npx biome lint src/team/state/mailbox.ts src/team/__tests__/state.test.ts src/team/runtime.ts src/team/__tests__/runtime.test.ts`
+- `node --test dist/cli/__tests__/version-sync-contract.test.js`
 
 ## Remaining risk
 
-- This release verification is still a local release gate, not a full GitHub Actions matrix rerun.
-- The release train is intentionally broad, so post-release monitoring should keep an eye on native hook setup/uninstall behavior, stop-state continuity, team delivery/runtime behavior, and follow-up docs/readme refresh work.
+- This patch verification is still local and targeted; it is not a full GitHub Actions matrix rerun.
+- The release still touches live team/runtime surfaces, so post-release monitoring should watch team status output and interactive worker lifecycle telemetry.
 
 ## Contributors
 
 - [@Yeachan-Heo](https://github.com/Yeachan-Heo) (Bellman)
 
-**Full Changelog**: [`v0.11.13...v0.12.0`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.11.13...v0.12.0)
+**Full Changelog**: [`v0.12.0...v0.12.1`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.12.0...v0.12.1)

--- a/docs/qa/release-readiness-0.12.1.md
+++ b/docs/qa/release-readiness-0.12.1.md
@@ -1,0 +1,28 @@
+# Release Readiness Verdict - 0.12.1
+
+Date: **2026-04-07**
+Target version: **0.12.1**
+Comparison base: **`v0.12.0..HEAD`**
+Verdict: **GO** ✅
+
+`0.12.1` is a focused patch release that addresses the three findings from the `release/0.12.1` review pass: machine-readable team status output, interactive worker PID metadata, and release-collateral alignment.
+
+## Scope reviewed
+
+- team mailbox delivery idempotence during leader-mail pruning (`src/team/state/mailbox.ts`, `src/team/__tests__/state.test.ts`)
+- interactive worker PID capture and persistence (`src/team/runtime.ts`, `src/team/__tests__/runtime.test.ts`)
+- release metadata and collateral (`package.json`, `package-lock.json`, `Cargo.toml`, `CHANGELOG.md`, `RELEASE_BODY.md`, `docs/release-notes-0.12.1.md`)
+
+## Validation evidence
+
+| Check | Command | Result |
+|---|---|---|
+| Build | `npm run build` | PASS |
+| Mailbox delivery regression | `node --test dist/team/__tests__/state.test.js` | PASS |
+| Interactive PID regression | `node --test --test-name-pattern="startTeam captures interactive worker pid from the resolved pane id" dist/team/__tests__/runtime.test.js` | PASS |
+| Targeted lint | `npx biome lint src/team/state/mailbox.ts src/team/__tests__/state.test.ts src/team/runtime.ts src/team/__tests__/runtime.test.ts` | PASS |
+| Version sync contract | `node --test dist/cli/__tests__/version-sync-contract.test.js` | PASS |
+
+## Final verdict
+
+Release **0.12.1** is **ready for branch push and PR handoff**.

--- a/docs/release-notes-0.12.1.md
+++ b/docs/release-notes-0.12.1.md
@@ -1,0 +1,24 @@
+# Release notes — 0.12.1
+
+## Summary
+
+`0.12.1` is a patch release after `0.12.0` that closes the three findings surfaced in the release branch review: clean machine-readable team status output, correct interactive worker PID metadata, and synchronized `0.12.1` release collateral.
+
+## Included fixes and changes
+
+- leader mailbox pruning no longer replays duplicate delivered-message bridge calls, so `omx team status --json` stays parseable
+- interactive team worker metadata now records the PID from the resolved pane id and persists it into config/identity state
+- release metadata and collateral are aligned to `0.12.1` across Node, Cargo, changelog, release body, and release-readiness docs
+
+## Verification evidence
+
+- `npm run build` ✅
+- `node --test dist/team/__tests__/state.test.js` ✅
+- `node --test --test-name-pattern="startTeam captures interactive worker pid from the resolved pane id" dist/team/__tests__/runtime.test.js` ✅
+- `npx biome lint src/team/state/mailbox.ts src/team/__tests__/state.test.ts src/team/runtime.ts src/team/__tests__/runtime.test.ts` ✅
+- `node --test dist/cli/__tests__/version-sync-contract.test.js` ✅
+
+## Remaining risk
+
+- This is a targeted local patch verification pass, not a full CI matrix rerun.
+- Post-release monitoring should keep an eye on team status JSON output and interactive worker lifecycle telemetry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump Node/Cargo workspace metadata to 0.12.1
- add 0.12.1 release notes and readiness collateral
- refresh changelog and release body for the reviewed patch release

## Verification
- npm run build
- node --test dist/cli/__tests__/version-sync-contract.test.js
- node dist/cli/omx.js version
- git diff --check
