### PR TITLE
fix(team): keep leader pane alive on Windows split-pane shutdown

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -32,6 +32,7 @@ import {
   sendWorkerMessage,
   applyCreatedInteractiveSessionToConfig,
   resolveWorkerLaunchArgsFromEnv,
+  shouldPrekillInteractiveShutdownProcessTrees,
   waitForWorkerStartupEvidence,
   waitForClaudeStartupEvidence,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
@@ -191,6 +192,33 @@ async function withMockTmuxFixture<T>(
     }
 
     await rm(fakeBinDir, { recursive: true, force: true });
+  }
+}
+
+async function withNativeWindowsPlatform<T>(run: () => Promise<T>): Promise<T> {
+  const prevMsystem = process.env.MSYSTEM;
+  const prevOstype = process.env.OSTYPE;
+  const prevWsl = process.env.WSL_DISTRO_NAME;
+  const prevWslInterop = process.env.WSL_INTEROP;
+  const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  try {
+    delete process.env.MSYSTEM;
+    delete process.env.OSTYPE;
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.WSL_INTEROP;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    return await run();
+  } finally {
+    if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
+    if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
+    else delete process.env.MSYSTEM;
+    if (typeof prevOstype === 'string') process.env.OSTYPE = prevOstype;
+    else delete process.env.OSTYPE;
+    if (typeof prevWsl === 'string') process.env.WSL_DISTRO_NAME = prevWsl;
+    else delete process.env.WSL_DISTRO_NAME;
+    if (typeof prevWslInterop === 'string') process.env.WSL_INTEROP = prevWslInterop;
+    else delete process.env.WSL_INTEROP;
   }
 }
 
@@ -647,6 +675,15 @@ sleep 5
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('skips interactive worker process-tree prekill on native Windows split-pane sessions', async () => {
+    await withNativeWindowsPlatform(async () => {
+      assert.equal(shouldPrekillInteractiveShutdownProcessTrees('leader:0'), false);
+      assert.equal(shouldPrekillInteractiveShutdownProcessTrees('omx-team-alpha'), true);
+    });
+
+    assert.equal(shouldPrekillInteractiveShutdownProcessTrees('leader:0'), true);
   });
 
   it('startTeam accepts native Windows tmux clients even when TMUX env vars are absent', async () => {
@@ -3341,6 +3378,85 @@ esac
           assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
         },
       );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam skips prekill and keeps the leader pane alive on native Windows split-pane shutdown', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-win32-split-'));
+    try {
+      await withNativeWindowsPlatform(async () => {
+        await withMockTmuxFixture(
+          {
+            dirPrefix: 'omx-runtime-shutdown-win32-split-bin-',
+            tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tpwsh\\tpwsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tcodex\\n%%14\\tcodex\\tcodex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          },
+          async ({ tmuxLogPath }) => {
+            await initTeamState('team-shutdown-win32-split', 'shutdown win32 split test', 'executor', 2, cwd);
+            const config = await readTeamConfig('team-shutdown-win32-split', cwd);
+            assert.ok(config);
+            if (!config) return;
+            config.tmux_session = 'leader:0';
+            config.leader_pane_id = '%11';
+            config.hud_pane_id = '%12';
+            config.workers[0]!.pane_id = '%13';
+            config.workers[1]!.pane_id = '%14';
+            await saveTeamConfig(config, cwd);
+
+            await shutdownTeam('team-shutdown-win32-split', cwd, { force: true });
+
+            const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-win32-split');
+            assert.equal(existsSync(teamRoot), false);
+            assert.equal(await readMonitorSnapshot('team-shutdown-win32-split', cwd), null);
+
+            const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+            assert.doesNotMatch(tmuxLog, /list-panes -t %13 -F #\{pane_pid\}/);
+            assert.doesNotMatch(tmuxLog, /list-panes -t %14 -F #\{pane_pid\}/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+            assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
+            assert.match(tmuxLog, /kill-pane -t %12/);
+            assert.match(tmuxLog, /kill-pane -t %13/);
+            assert.match(tmuxLog, /kill-pane -t %14/);
+            assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+            assert.match(tmuxLog, new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+            assert.match(tmuxLog, /select-pane -t %11/);
+          },
+        );
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -17,6 +17,7 @@ import {
   type TeamSession,
   waitForWorkerReady,
   dismissTrustPromptIfPresent,
+  isNativeWindows,
   sleepFractionalSeconds,
   sendToWorker,
   sendToWorkerStdin,
@@ -267,6 +268,12 @@ function collectShutdownPaneIds(params: {
   }
 
   return [...paneIds];
+}
+
+export function shouldPrekillInteractiveShutdownProcessTrees(sessionName: string): boolean {
+  // Native Windows + split-pane psmux sessions can expose overlapping
+  // ancestry around the leader client; rely on pane-targeted teardown there.
+  return !(isNativeWindows() && sessionName.includes(':'));
 }
 
 async function logRuntimeDispatchOutcome(params: {
@@ -2744,11 +2751,13 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   if (config.worker_launch_mode === 'interactive') {
     const livePaneIds = listPaneIds(sessionName);
     let shutdownPaneIds = collectShutdownPaneIds({ config, livePaneIds });
-    const workerPanePids = shutdownPaneIds
-      .map((paneId) => getWorkerPanePid(sessionName, 1, paneId))
-      .filter((pid): pid is number => typeof pid === 'number' && Number.isFinite(pid) && pid > 0);
-    for (const panePid of workerPanePids) {
-      await terminateTrackedProcessTree(panePid);
+    if (shouldPrekillInteractiveShutdownProcessTrees(sessionName)) {
+      const workerPanePids = shutdownPaneIds
+        .map((paneId) => getWorkerPanePid(sessionName, 1, paneId))
+        .filter((pid): pid is number => typeof pid === 'number' && Number.isFinite(pid) && pid > 0);
+      for (const panePid of workerPanePids) {
+        await terminateTrackedProcessTree(panePid);
+      }
     }
 
     let resizeHookWarning: string | null = null;


### PR DESCRIPTION
## Summary

Native Windows + psmux split-pane shutdown could run worker process-tree prekill before pane-targeted teardown, which can overlap the leader client and terminate the leader pane mid-cleanup. That interruption left stale active team state behind and could trigger `leader_session_conflict` on the next team start.

## Changes

- skip interactive worker process-tree prekill for native Windows split-pane tmux targets
- keep pane-targeted HUD/worker teardown intact so shutdown still reaches clean `status: missing` cleanup
- add regression coverage for the prekill decision helper and the Windows split-pane shutdown flow

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1353
