### PR TITLE
Make postLaunch mode cleanup recover transient JSON shutdown races

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -40,6 +40,7 @@ import {
   reapStaleNotifyFallbackWatcher,
   cleanupLaunchOrphanedMcpProcesses,
   reapPostLaunchOrphanedMcpProcesses,
+  cleanupPostLaunchModeStateFiles,
   resolveBackgroundHelperLaunchMode,
   shouldDetachBackgroundHelper,
   resolveNotifyFallbackWatcherScript,
@@ -404,6 +405,125 @@ describe("reapPostLaunchOrphanedMcpProcesses", () => {
     });
 
     assert.match(errors.join("\n"), /postLaunch MCP cleanup failed: Error: boom/);
+  });
+});
+
+describe("cleanupPostLaunchModeStateFiles", () => {
+  it("repairs empty or truncated mode state files and still cancels valid siblings", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-mode-cleanup-"));
+    const sessionId = "sess-postlaunch-cleanup";
+    const stateDir = join(wd, ".omx", "state");
+    const sessionStateDir = join(stateDir, "sessions", sessionId);
+    const partialState = '{\n  "active": true,\n  "mode": "ralph",\n';
+    const warnings: string[] = [];
+
+    await mkdir(sessionStateDir, { recursive: true });
+    await writeFile(
+      join(stateDir, "autopilot-state.json"),
+      JSON.stringify({ active: true, mode: "autopilot" }, null, 2),
+      "utf-8",
+    );
+    await writeFile(join(stateDir, "deep-interview-state.json"), "", "utf-8");
+    await writeFile(join(sessionStateDir, "ralph-state.json"), partialState, "utf-8");
+
+    await cleanupPostLaunchModeStateFiles(wd, sessionId, {
+      writeWarn: (line) => warnings.push(line),
+    });
+
+    const autopilot = JSON.parse(
+      await readFile(join(stateDir, "autopilot-state.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    const deepInterview = JSON.parse(
+      await readFile(join(stateDir, "deep-interview-state.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    const ralph = JSON.parse(
+      await readFile(join(sessionStateDir, "ralph-state.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    assert.equal(autopilot.active, false);
+    assert.equal(typeof autopilot.completed_at, "string");
+    assert.equal(deepInterview.active, false);
+    assert.equal(deepInterview.mode, "deep-interview");
+    assert.equal(deepInterview.current_phase, "cancelled");
+    assert.equal(typeof deepInterview.completed_at, "string");
+    assert.equal(typeof deepInterview.last_turn_at, "string");
+    assert.equal(ralph.active, false);
+    assert.equal(ralph.mode, "ralph");
+    assert.equal(ralph.current_phase, "cancelled");
+    assert.equal(typeof ralph.completed_at, "string");
+    assert.equal(typeof ralph.last_turn_at, "string");
+    assert.deepEqual(warnings, []);
+  });
+
+  it("retries a transient parse failure before cancelling the rewritten mode state", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-mode-retry-"));
+    const sessionId = "sess-postlaunch-retry";
+    const stateDir = join(wd, ".omx", "state");
+    const statePath = join(stateDir, "ralph-state.json");
+    const writes: Array<{ path: string; content: string }> = [];
+    const validState = JSON.stringify({ active: true, mode: "ralph" }, null, 2);
+    let reads = 0;
+
+    await mkdir(stateDir, { recursive: true });
+
+    const mockReaddir = (async (dir: unknown, _options: unknown) => (
+      String(dir) === stateDir ? ["ralph-state.json"] : []
+    )) as unknown as typeof fsReaddir;
+    const mockReadFile = (async (path: unknown, _options: unknown) => {
+        assert.equal(String(path), statePath);
+        reads += 1;
+        return reads === 1
+          ? '{\n  "active": true,\n  "mode": "ralph"'
+          : validState;
+      }) as unknown as typeof readFile;
+    const mockWriteFile = (async (path: unknown, content: unknown, _options: unknown) => {
+        writes.push({ path: String(path), content: String(content) });
+      }) as unknown as typeof writeFile;
+
+    const dependencies: Parameters<typeof cleanupPostLaunchModeStateFiles>[2] = {
+      readdir: mockReaddir,
+      readFile: mockReadFile,
+      writeFile: mockWriteFile,
+      sleep: async () => {},
+      now: () => new Date("2026-04-07T00:00:00.000Z"),
+    };
+
+    await cleanupPostLaunchModeStateFiles(wd, sessionId, dependencies);
+
+    assert.equal(reads, 2);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0]?.path, statePath);
+    const persisted = JSON.parse(writes[0]?.content ?? "{}") as Record<string, unknown>;
+    assert.equal(persisted.active, false);
+    assert.equal(persisted.completed_at, "2026-04-07T00:00:00.000Z");
+  });
+
+  it("warns on structurally complete malformed JSON without aborting sibling cleanup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-mode-malformed-"));
+    const sessionId = "sess-postlaunch-malformed";
+    const stateDir = join(wd, ".omx", "state");
+    const warnings: string[] = [];
+    const malformedState = '{\n  "active": true,\n}\n';
+
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(join(stateDir, "ralph-state.json"), malformedState, "utf-8");
+    await writeFile(
+      join(stateDir, "ultrawork-state.json"),
+      JSON.stringify({ active: true, mode: "ultrawork" }, null, 2),
+      "utf-8",
+    );
+
+    await cleanupPostLaunchModeStateFiles(wd, sessionId, {
+      writeWarn: (line) => warnings.push(line),
+    });
+
+    const ultrawork = JSON.parse(
+      await readFile(join(stateDir, "ultrawork-state.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    assert.equal(ultrawork.active, false);
+    assert.equal(typeof ultrawork.completed_at, "string");
+    assert.equal(await readFile(join(stateDir, "ralph-state.json"), "utf-8"), malformedState);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0] ?? "", /skipped malformed mode state .*ralph-state\.json/);
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1925,6 +1925,162 @@ interface PostLaunchCleanupDependencies {
   writeError?: (line: string) => void;
 }
 
+interface PostLaunchModeCleanupDependencies {
+  readdir?: typeof import("fs/promises").readdir;
+  readFile?: typeof import("fs/promises").readFile;
+  writeFile?: typeof import("fs/promises").writeFile;
+  sleep?: (ms: number) => Promise<void>;
+  writeWarn?: (line: string) => void;
+  now?: () => Date;
+}
+
+type PostLaunchModeStateReadResult =
+  | { kind: "ok"; state: Record<string, unknown> }
+  | { kind: "missing" | "recoverable" }
+  | { kind: "malformed"; message: string };
+
+const POST_LAUNCH_MODE_STATE_RETRY_DELAY_MS = 10;
+const POST_LAUNCH_MODE_STATE_MAX_READ_ATTEMPTS = 2;
+
+function isLikelyTransientModeStateParseFailure(raw: string, err: unknown): boolean {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return true;
+  if (!(err instanceof SyntaxError)) return false;
+  if (!trimmed.startsWith("{") || trimmed.endsWith("}")) return false;
+  return (
+    /Unexpected end of JSON input/.test(err.message) ||
+    /Unterminated string in JSON/.test(err.message) ||
+    /Expected double-quoted property name in JSON/.test(err.message) ||
+    /Expected property name or '}' in JSON/.test(err.message) ||
+    /Expected ':' after property name in JSON/.test(err.message) ||
+    /Expected ',' or '}' after property value in JSON/.test(err.message)
+  );
+}
+
+async function readPostLaunchModeStateFile(
+  path: string,
+  dependencies: Pick<PostLaunchModeCleanupDependencies, "readFile" | "sleep"> = {},
+): Promise<PostLaunchModeStateReadResult> {
+  const readFile =
+    dependencies.readFile ?? (await import("fs/promises")).readFile;
+  const sleep =
+    dependencies.sleep
+    ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  for (let attempt = 1; attempt <= POST_LAUNCH_MODE_STATE_MAX_READ_ATTEMPTS; attempt += 1) {
+    try {
+      const raw = await readFile(path, "utf-8");
+      const trimmed = raw.trim();
+      if (trimmed.length === 0) {
+        if (attempt < POST_LAUNCH_MODE_STATE_MAX_READ_ATTEMPTS) {
+          await sleep(POST_LAUNCH_MODE_STATE_RETRY_DELAY_MS);
+          continue;
+        }
+        return { kind: "recoverable" };
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw) as unknown;
+      } catch (err) {
+        if (isLikelyTransientModeStateParseFailure(raw, err)) {
+          if (attempt < POST_LAUNCH_MODE_STATE_MAX_READ_ATTEMPTS) {
+            await sleep(POST_LAUNCH_MODE_STATE_RETRY_DELAY_MS);
+            continue;
+          }
+          return { kind: "recoverable" };
+        }
+        return {
+          kind: "malformed",
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+        return { kind: "malformed", message: "mode state must be a JSON object" };
+      }
+      return { kind: "ok", state: parsed as Record<string, unknown> };
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      if (error?.code === "ENOENT") return { kind: "missing" };
+      return {
+        kind: "malformed",
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  return { kind: "recoverable" };
+}
+
+function buildRecoveredPostLaunchModeState(
+  mode: string,
+  completedAt: string,
+): Record<string, unknown> {
+  return {
+    active: false,
+    mode,
+    current_phase: "cancelled",
+    completed_at: completedAt,
+    last_turn_at: completedAt,
+  };
+}
+
+export async function cleanupPostLaunchModeStateFiles(
+  cwd: string,
+  sessionId: string,
+  dependencies: PostLaunchModeCleanupDependencies = {},
+): Promise<void> {
+  const readdir =
+    dependencies.readdir ?? (await import("fs/promises")).readdir;
+  const writeFile =
+    dependencies.writeFile ?? (await import("fs/promises")).writeFile;
+  const writeWarn = dependencies.writeWarn ?? console.warn;
+  const now = dependencies.now ?? (() => new Date());
+  const scopedDirs = [getBaseStateDir(cwd), getStateDir(cwd, sessionId)];
+
+  for (const stateDir of scopedDirs) {
+    const files = await readdir(stateDir).catch(() => [] as string[]);
+    for (const file of files) {
+      if (!file.endsWith("-state.json") || file === "session.json") continue;
+      const path = join(stateDir, file);
+      const mode = file.slice(0, -"-state.json".length);
+      const result = await readPostLaunchModeStateFile(path, dependencies);
+      if (result.kind !== "ok") {
+        if (result.kind === "recoverable") {
+          try {
+            const completedAt = now().toISOString();
+            await writeFile(
+              path,
+              JSON.stringify(buildRecoveredPostLaunchModeState(mode, completedAt), null, 2),
+            );
+          } catch (err) {
+            writeWarn(
+              `[omx] postLaunch: failed to recover mode state ${path}: ${err instanceof Error ? err.message : err}`,
+            );
+          }
+        } else if (result.kind === "malformed") {
+          writeWarn(
+            `[omx] postLaunch: skipped malformed mode state ${path}: ${result.message}`,
+          );
+        }
+        continue;
+      }
+      if (result.state.active !== true) continue;
+
+      try {
+        result.state.active = false;
+        result.state.completed_at = now().toISOString();
+        await writeFile(path, JSON.stringify(result.state, null, 2));
+      } catch (err) {
+        writeWarn(
+          `[omx] postLaunch: failed to update mode state ${path}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+  }
+}
+
 export async function reapPostLaunchOrphanedMcpProcesses(
   dependencies: PostLaunchCleanupDependencies = {},
 ): Promise<void> {
@@ -2536,22 +2692,7 @@ async function postLaunch(
 
   // 3. Cancel any still-active modes
   try {
-    const { readdir, writeFile, readFile } = await import("fs/promises");
-    const scopedDirs = [getBaseStateDir(cwd), getStateDir(cwd, sessionId)];
-    for (const stateDir of scopedDirs) {
-      const files = await readdir(stateDir).catch(() => [] as string[]);
-      for (const file of files) {
-        if (!file.endsWith("-state.json") || file === "session.json") continue;
-        const path = join(stateDir, file);
-        const content = await readFile(path, "utf-8");
-        const state = JSON.parse(content);
-        if (state.active) {
-          state.active = false;
-          state.completed_at = new Date().toISOString();
-          await writeFile(path, JSON.stringify(state, null, 2));
-        }
-      }
-    }
+    await cleanupPostLaunchModeStateFiles(cwd, sessionId);
   } catch (err) {
     console.error(
       `[omx] postLaunch: mode cleanup failed: ${err instanceof Error ? err.message : err}`,


### PR DESCRIPTION
## Summary
- repair empty or structurally unclosed mode-state JSON during postLaunch cleanup by rewriting a minimal inactive terminal record
- keep structurally closed malformed JSON as warned-but-untouched corruption so shutdown does not mask broader state bugs
- add focused regression coverage for repair, retry, and malformed-json boundaries in postLaunch cleanup

## Testing
- npm run build
- node --test dist/cli/__tests__/index.test.js
- npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts
- git diff --check

Closes #1359