### PR TITLE
Fix  prompt routing and duplicate launch teardown

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -281,6 +281,74 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('seeds first-class root team state for team prompt-submit activation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$team coordinate the hotfix',
+        sessionId: 'sess-team',
+        nowIso: '2026-04-08T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'team');
+      assert.equal(result.initialized_mode, 'team');
+      assert.equal(result.initialized_state_path, '.omx/state/team-state.json');
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
+      ) as { mode: string; active: boolean; current_phase: string };
+      assert.equal(modeState.mode, 'team');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'starting');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves active team root state when $team is re-entered from prompt routing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-preserve-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'team',
+          current_phase: 'team-verify',
+          started_at: '2026-04-08T00:00:00.000Z',
+          updated_at: '2026-04-08T00:05:00.000Z',
+          team_name: 'review-team',
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$team continue the review lane',
+        sessionId: 'sess-team-preserve',
+        nowIso: '2026-04-08T00:10:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.initialized_mode, 'team');
+      assert.equal(result.initialized_state_path, '.omx/state/team-state.json');
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
+      ) as { mode: string; active: boolean; current_phase: string; team_name?: string };
+      assert.equal(modeState.mode, 'team');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'team-verify');
+      assert.equal(modeState.team_name, 'review-team');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('acquires a deep-interview input lock immediately on activation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -71,12 +71,13 @@ export const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
 export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'] as const;
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
 
-type StatefulSkillMode = 'deep-interview' | 'autopilot' | 'ralph' | 'ralplan' | 'ultrawork' | 'ultraqa';
+type StatefulSkillMode = 'deep-interview' | 'autopilot' | 'ralph' | 'ralplan' | 'ultrawork' | 'ultraqa' | 'team';
 
 interface StatefulSkillSeedConfig {
   mode: StatefulSkillMode;
   initialPhase: string;
   includeIteration?: boolean;
+  scope?: 'session' | 'root';
 }
 
 const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedConfig> = {
@@ -84,6 +85,7 @@ const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedCon
   autopilot: { mode: 'autopilot', initialPhase: 'planning' },
   ralph: { mode: 'ralph', initialPhase: 'starting', includeIteration: true },
   ralplan: { mode: 'ralplan', initialPhase: 'planning' },
+  team: { mode: 'team', initialPhase: 'starting', scope: 'root' },
   ultrawork: { mode: 'ultrawork', initialPhase: 'planning' },
   ultraqa: { mode: 'ultraqa', initialPhase: 'planning' },
 };
@@ -197,11 +199,16 @@ async function persistDeepInterviewModeState(
   await writeFile(statePath, JSON.stringify(nextState, null, 2));
 }
 
-function resolveSeedStateFilePath(stateDir: string, mode: StatefulSkillMode, sessionId?: string): {
+function resolveSeedStateFilePath(
+  stateDir: string,
+  mode: StatefulSkillMode,
+  sessionId?: string,
+  scope: 'session' | 'root' = 'session',
+): {
   absolutePath: string;
   relativePath: string;
 } {
-  if (sessionId?.trim()) {
+  if (scope !== 'root' && sessionId?.trim()) {
     return {
       absolutePath: join(stateDir, 'sessions', sessionId, `${mode}-state.json`),
       relativePath: `.omx/state/sessions/${sessionId}/${mode}-state.json`,
@@ -227,14 +234,22 @@ async function persistStatefulSkillSeedState(
     stateDir,
     config.mode,
     nextSkill.session_id,
+    config.scope,
   );
   const existingModeState = await readJsonStateIfExists(absolutePath);
   const sameActiveSkill = previousSkill?.skill === nextSkill.skill && previousSkill.active;
-  const preserveExistingModeState = sameActiveSkill
-    && safeString(existingModeState?.mode).trim() === config.mode
-    && safeString(existingModeState?.current_phase).trim() !== '';
+  const existingModeMatches = safeString(existingModeState?.mode).trim() === config.mode;
+  const existingPhase = safeString(existingModeState?.current_phase).trim();
+  const preserveExistingModeState = existingModeMatches
+    && existingPhase !== ''
+    && (
+      sameActiveSkill
+      || (config.mode === 'team' && existingModeState?.active === true)
+    );
   const startedAt = previousSkill?.skill === nextSkill.skill && previousSkill.active
     ? safeString(existingModeState?.started_at).trim() || previousSkill.activated_at || nowIso
+    : preserveExistingModeState
+      ? safeString(existingModeState?.started_at).trim() || nowIso
     : nowIso;
 
   const baseState: Record<string, unknown> = {
@@ -242,7 +257,7 @@ async function persistStatefulSkillSeedState(
     active: true,
     mode: config.mode,
     current_phase: preserveExistingModeState
-      ? safeString(existingModeState?.current_phase).trim() || config.initialPhase
+      ? existingPhase || config.initialPhase
       : config.initialPhase,
     started_at: startedAt,
     updated_at: nowIso,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -210,6 +210,42 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("nudges $team prompt-submit routing toward omx team runtime usage", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-team-1",
+          thread_id: "thread-team-1",
+          turn_id: "turn-team-1",
+          prompt: "$team ship this fix with verification",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "team");
+      assert.match(
+        JSON.stringify(result.outputJson),
+        /skill: team activated and initial state initialized at \.omx\/state\/team-state\.json; write subsequent updates via omx_state MCP\./,
+      );
+      assert.match(JSON.stringify(result.outputJson), /Use the durable OMX team runtime via `omx team \.\.\.`/);
+      assert.match(JSON.stringify(result.outputJson), /If you need help, run `omx team --help`\./);
+
+      const state = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "team-state.json"), "utf-8"),
+      ) as { mode?: string; active?: boolean; current_phase?: string };
+      assert.equal(state.mode, "team");
+      assert.equal(state.active, true);
+      assert.equal(state.current_phase, "starting");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns a destructive-command caution on PreToolUse for rm -rf dist", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-danger-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -429,6 +429,19 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
   const match = detectPrimaryKeyword(prompt);
   if (!match) return null;
 
+  if (match.skill === "team") {
+    const initializedStateMessage = skillState?.initialized_mode && skillState.initialized_state_path
+      ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
+      : null;
+    return [
+      `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`,
+      initializedStateMessage,
+      "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
+      "If you need help, run `omx team --help`.",
+      "Follow AGENTS.md routing and preserve ralplan/ralph execution gates.",
+    ].filter(Boolean).join(" ");
+  }
+
   if (skillState?.initialized_mode && skillState.initialized_state_path) {
     return [
       `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`,

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -649,6 +649,61 @@ sleep 5
     }
   });
 
+  it('startTeam rejects duplicate active same-name team state without mutating existing files', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-duplicate-team-'));
+    const prevSessionId = process.env.OMX_SESSION_ID;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    try {
+      process.env.OMX_SESSION_ID = 'sess-existing-team';
+      await initTeamState(
+        'dup-team',
+        'existing task',
+        'executor',
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: 'sess-existing-team' },
+      );
+      await createTask('dup-team', {
+        subject: 'existing subject',
+        description: 'existing description',
+        status: 'pending',
+      }, cwd);
+
+      const beforeConfig = await readTeamConfig('dup-team', cwd);
+      assert.ok(beforeConfig);
+
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_SESSION_ID = 'sess-second-team';
+
+      await assert.rejects(
+        () => withoutTeamWorkerEnv(() =>
+          startTeam(
+            'dup-team',
+            'replacement task',
+            'executor',
+            1,
+            [{ subject: 'new subject', description: 'new description', owner: 'worker-1' }],
+            cwd,
+          )),
+        /team_name_conflict: active team state already exists/,
+      );
+
+      const afterConfig = await readTeamConfig('dup-team', cwd);
+      const existingTask = await readTask('dup-team', '1', cwd);
+      assert.equal(afterConfig?.task, 'existing task');
+      assert.equal(afterConfig?.created_at, beforeConfig?.created_at);
+      assert.equal(existingTask?.subject, 'existing subject');
+      assert.equal(existingTask?.description, 'existing description');
+    } finally {
+      if (typeof prevSessionId === 'string') process.env.OMX_SESSION_ID = prevSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam accepts native Windows tmux clients even when TMUX env vars are absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-win32-no-env-'));
     const prevTmux = process.env.TMUX;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -102,7 +102,7 @@ import {
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
-import { type TeamPhase, type TerminalPhase } from './orchestrator.js';
+import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
   resolveTeamWorkerLaunchArgs,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
@@ -202,6 +202,35 @@ async function syncRootTeamModeStateOnTerminalPhase(
   } catch {
     // Best-effort compatibility sync only.
   }
+}
+
+async function assertTeamStartupIsNonDestructive(
+  teamName: string,
+  cwd: string,
+  leaderSessionId: string,
+): Promise<void> {
+  const activeTeams = await findActiveTeams(cwd, leaderSessionId);
+  if (activeTeams.length > 0) {
+    throw new Error(`leader_session_conflict: active team exists (${activeTeams.join(', ')})`);
+  }
+
+  const [existingConfig, existingManifest, existingPhase] = await Promise.all([
+    readTeamConfig(teamName, cwd),
+    readTeamManifestV2(teamName, cwd),
+    readTeamPhaseState(teamName, cwd),
+  ]);
+
+  if (!existingConfig && !existingManifest) return;
+
+  const currentPhase = existingPhase?.current_phase;
+  if (currentPhase && isTerminalPhase(currentPhase)) return;
+
+  const tmuxSession = existingConfig?.tmux_session ?? existingManifest?.tmux_session ?? `omx-team-${teamName}`;
+  const renderedPhase = currentPhase ?? 'team-exec';
+  throw new Error(
+    `team_name_conflict: active team state already exists for "${teamName}" (phase: ${renderedPhase}, tmux: ${tmuxSession}). `
+    + `Use "omx team status ${teamName}", "omx team resume ${teamName}", or "omx team shutdown ${teamName}" instead of launching a duplicate team.`,
+  );
 }
 
 /** Runtime handle returned by startTeam */
@@ -1698,6 +1727,10 @@ export async function startTeam(
   const leaderCwd = resolve(cwd);
   await assertNestedTeamAllowed(leaderCwd);
   const effectiveWorktreeMode = resolveEffectiveTeamWorktreeMode(leaderCwd, options.worktreeMode);
+  const sanitized = sanitizeTeamName(teamName);
+  const leaderSessionId = await resolveLeaderSessionId(leaderCwd);
+
+  await assertTeamStartupIsNonDestructive(sanitized, leaderCwd, leaderSessionId);
 
   const workerLaunchMode = resolveTeamWorkerLaunchMode(process.env);
   const displayMode = workerLaunchMode === 'interactive' ? 'split_pane' : 'auto';
@@ -1710,7 +1743,6 @@ export async function startTeam(
     }
   }
 
-  const sanitized = sanitizeTeamName(teamName);
   const teamStateRoot = resolveCanonicalTeamStateRoot(leaderCwd);
   const activeWorktreeMode: 'detached' | 'named' | null =
     effectiveWorktreeMode.enabled
@@ -1754,14 +1786,6 @@ export async function startTeam(
         });
       }
     }
-  }
-
-  const leaderSessionId = await resolveLeaderSessionId(leaderCwd);
-
-  // Topology guard: one active team per leader session/process context.
-  const activeTeams = await findActiveTeams(leaderCwd, leaderSessionId);
-  if (activeTeams.length > 0) {
-    throw new Error(`leader_session_conflict: active team exists (${activeTeams.join(', ')})`);
   }
 
   // 2. Team name is already sanitized above.


### PR DESCRIPTION
## Summary
- seed root `team-state.json` when `$team` is detected in `UserPromptSubmit`
- nudge `$team` routing toward `omx team ...` and `omx team --help`
- reject duplicate active same-name team launches before state mutation/worktree provisioning

## Testing
- `npm run build`
- `npx biome lint src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts src/team/runtime.ts src/team/__tests__/runtime.test.ts`
- `node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/team/__tests__/runtime.test.js`
