### PR TITLE
Add Cursor runtime provider support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Thanks for contributing.
 
 ## Development setup
 
+Provider note: OMX defaults to Codex runtime. To test Cursor runtime paths, set
+`OMX_RUNTIME_PROVIDER=cursor` before running commands.
+
 - Node.js >= 20
 - npm
 
@@ -51,8 +54,8 @@ unset OMX_TEAM_WORKER OMX_TEAM_STATE_ROOT OMX_TEAM_LEADER_CWD OMX_TEAM_WORKER_CL
 ## Project structure
 
 - `src/` -- TypeScript source (CLI, config, agents, MCP servers, hooks, modes, team, verification)
-- `prompts/` -- 30 agent prompt markdown files (installed to `~/.codex/prompts/`)
-- `skills/` -- 39 skill directories with `SKILL.md` (installed to `~/.codex/skills/`)
+- `prompts/` -- agent prompt markdown files (installed under provider home, e.g. `~/.codex/prompts/` or `~/.cursor/prompts/`)
+- `skills/` -- skill directories with `SKILL.md` (installed under provider home, e.g. `~/.codex/skills/` or `~/.cursor/skills/`)
 - `templates/` -- `AGENTS.md` orchestration brain template
 
 ### Adding a new agent prompt

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 **Docs:** [Getting Started](./docs/getting-started.html) · [Agents](./docs/agents.html) · [Skills](./docs/skills.html) · [Integrations](./docs/integrations.html) · [Demo](./DEMO.md) · [OpenClaw guide](./docs/openclaw-integration.md)
 **Community:** [Discord](https://discord.gg/PUwSMR9XNk) — shared OMX/community server for oh-my-codex and related tooling.
 
-OMX is a workflow layer for [OpenAI Codex CLI](https://github.com/openai/codex).
+OMX is a workflow layer for [OpenAI Codex CLI](https://github.com/openai/codex), with
+incremental Cursor CLI runtime support via provider switching.
 
 It keeps Codex as the execution engine and makes it easier to:
 - start a stronger Codex session by default
@@ -84,6 +85,7 @@ If you want plain Codex with no extra workflow layer, you probably do not need O
 
 - Node.js 20+
 - Codex CLI installed: `npm install -g @openai/codex`
+- Optional Cursor CLI runtime path: set `OMX_RUNTIME_PROVIDER=cursor` and ensure `cursor` is on `PATH`
 - Codex auth configured
 - `tmux` on macOS/Linux if you later want the durable team runtime
 - `psmux` on native Windows if you later want Windows team mode
@@ -161,7 +163,7 @@ omx team shutdown <team-name>
 ### Setup, doctor, and HUD
 
 These are operator/support surfaces:
-- `omx setup` installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and OMX-managed native Codex hooks in `.codex/hooks.json`
+- `omx setup` installs prompts, skills, AGENTS scaffolding, runtime config (`.codex` or `.cursor` by provider), and OMX-managed native runtime hooks (`hooks.json`)
 - `omx doctor` verifies the install when something seems wrong
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow
 

--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -9,6 +9,8 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const CODEX_BIN_ENV: &str = "OMX_EXPLORE_CODEX_BIN";
+const CURSOR_BIN_ENV: &str = "OMX_EXPLORE_CURSOR_BIN";
+const RUNTIME_PROVIDER_ENV: &str = "OMX_RUNTIME_PROVIDER";
 const HARNESS_ROOT_ENV: &str = "OMX_EXPLORE_ROOT";
 const INTERNAL_DIRECT_WRAPPER_FLAG: &str = "--internal-allowlist-direct";
 const INTERNAL_SHELL_WRAPPER_FLAG: &str = "--internal-allowlist-shell";
@@ -250,6 +252,30 @@ fn resolve_codex_launch() -> CodexLaunch {
 }
 
 fn resolve_codex_binary() -> String {
+    let provider = env::var(RUNTIME_PROVIDER_ENV)
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .unwrap_or_else(|| "codex".to_string());
+    let preferred_env = if provider == "cursor" {
+        CURSOR_BIN_ENV
+    } else {
+        CODEX_BIN_ENV
+    };
+
+    if let Some(value) = env::var(preferred_env)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        if value.contains(std::path::MAIN_SEPARATOR) {
+            return value;
+        }
+        if let Some(path) = resolve_host_command(&value) {
+            return path.display().to_string();
+        }
+        return value;
+    }
+
     if let Some(value) = env::var(CODEX_BIN_ENV)
         .ok()
         .map(|value| value.trim().to_string())
@@ -264,6 +290,11 @@ fn resolve_codex_binary() -> String {
         return value;
     }
 
+    if provider == "cursor" {
+        return resolve_host_command("cursor")
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "cursor".to_string());
+    }
     resolve_host_command("codex")
         .map(|path| path.display().to_string())
         .unwrap_or_else(|| "codex".to_string())
@@ -330,7 +361,7 @@ fn discover_codex_support_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
         let home = PathBuf::from(home);
-        for relative in [".omx", ".codex"] {
+        for relative in [".omx", ".codex", ".cursor"] {
             let dir = home.join(relative);
             if dir.is_dir() {
                 dirs.push(dir);
@@ -984,12 +1015,13 @@ mod tests {
     }
 
     #[test]
-    fn discover_codex_support_dirs_includes_home_omx_and_codex_when_present() {
+    fn discover_codex_support_dirs_includes_home_omx_codex_cursor_when_present() {
         let _guard = env_lock();
         let root = temp_allowlist_dir().expect("temp root");
         let home_dir = root.path.join("home");
         create_dir_all(home_dir.join(".omx")).expect("create .omx");
         create_dir_all(home_dir.join(".codex")).expect("create .codex");
+        create_dir_all(home_dir.join(".cursor")).expect("create .cursor");
         let original_home = env::var_os("HOME");
         unsafe {
             env::set_var("HOME", &home_dir);
@@ -1001,7 +1033,14 @@ mod tests {
             Some(value) => unsafe { env::set_var("HOME", value) },
             None => unsafe { env::remove_var("HOME") },
         }
-        assert_eq!(dirs, vec![home_dir.join(".omx"), home_dir.join(".codex")]);
+        assert_eq!(
+            dirs,
+            vec![
+                home_dir.join(".omx"),
+                home_dir.join(".codex"),
+                home_dir.join(".cursor")
+            ]
+        );
     }
 
     #[test]

--- a/crates/omx-sparkshell/src/codex_bridge.rs
+++ b/crates/omx-sparkshell/src/codex_bridge.rs
@@ -10,6 +10,19 @@ use std::time::{Duration, Instant};
 pub const DEFAULT_SUMMARY_TIMEOUT_MS: u64 = 60_000;
 pub const DEFAULT_SPARK_MODEL: &str = "gpt-5.3-codex-spark";
 pub const DEFAULT_FRONTIER_MODEL: &str = "gpt-5.4";
+const RUNTIME_PROVIDER_ENV: &str = "OMX_RUNTIME_PROVIDER";
+
+fn resolve_runtime_command() -> &'static str {
+    let provider = env::var(RUNTIME_PROVIDER_ENV)
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .unwrap_or_else(|| "codex".to_string());
+    if provider == "cursor" {
+        "cursor"
+    } else {
+        "codex"
+    }
+}
 
 pub fn resolve_model() -> String {
     env::var("OMX_SPARKSHELL_MODEL")
@@ -117,7 +130,8 @@ fn run_codex_exec(
     model: &str,
     timeout_ms: u64,
 ) -> Result<(String, String, bool), SparkshellError> {
-    let mut child = Command::new("codex")
+    let runtime_command = resolve_runtime_command();
+    let mut child = Command::new(runtime_command)
         .arg("exec")
         .arg("--model")
         .arg(model)
@@ -137,15 +151,15 @@ fn run_codex_exec(
     let mut stdin = child
         .stdin
         .take()
-        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open codex stdin".to_string()))?;
+        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open runtime stdin".to_string()))?;
     let mut stdout = child
         .stdout
         .take()
-        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open codex stdout".to_string()))?;
+        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open runtime stdout".to_string()))?;
     let mut stderr = child
         .stderr
         .take()
-        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open codex stderr".to_string()))?;
+        .ok_or_else(|| SparkshellError::SummaryBridge("failed to open runtime stderr".to_string()))?;
 
     let prompt_owned = prompt.to_string();
     let stdin_writer = thread::spawn(move || stdin.write_all(prompt_owned.as_bytes()));
@@ -179,10 +193,10 @@ fn run_codex_exec(
     let _ = stdin_writer.join();
     let stdout_bytes = stdout_reader
         .join()
-        .map_err(|_| SparkshellError::SummaryBridge("failed reading codex stdout".to_string()))?;
+        .map_err(|_| SparkshellError::SummaryBridge("failed reading runtime stdout".to_string()))?;
     let stderr_bytes = stderr_reader
         .join()
-        .map_err(|_| SparkshellError::SummaryBridge("failed reading codex stderr".to_string()))?;
+        .map_err(|_| SparkshellError::SummaryBridge("failed reading runtime stderr".to_string()))?;
 
     Ok((
         String::from_utf8_lossy(&stdout_bytes).into_owned(),

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -345,7 +345,11 @@ describe("buildNotifyFallbackWatcherEnv", () => {
   it("enables watcher authority and propagates CODEX_HOME override when requested", () => {
     const env = buildNotifyFallbackWatcherEnv(
       { HOME: "/tmp/home", OMX_HUD_AUTHORITY: "0", TMUX: "sock,1,0", TMUX_PANE: "%2" },
-      { codexHomeOverride: "/tmp/codex-home", enableAuthority: true },
+      {
+        runtimeHomeOverride: "/tmp/codex-home",
+        runtimeHomeEnvVar: "CODEX_HOME",
+        enableAuthority: true,
+      },
     );
     assert.equal(env.OMX_HUD_AUTHORITY, "1");
     assert.equal(env.CODEX_HOME, "/tmp/codex-home");
@@ -1107,6 +1111,7 @@ describe("detached tmux new-session sequencing", () => {
       "'node' '/tmp/omx.js' 'hud' '--watch'",
       null,
       undefined,
+      undefined,
       null,
       false,
       "sess-detached-managed",
@@ -1133,6 +1138,7 @@ describe("detached tmux new-session sequencing", () => {
       hudCmd,
       "--model gpt-5",
       "C:/codex-home",
+      "CODEX_HOME",
       null,
       true,
     );

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -24,9 +24,20 @@ import {
   listAutoresearchDeepInterviewResultPaths,
   resolveAutoresearchDeepInterviewResult,
 } from './autoresearch-intake.js';
-import { CODEX_BYPASS_FLAG, MADMAX_FLAG } from './constants.js';
+import {
+  CODEX_BYPASS_FLAG,
+  CONFIG_FLAG,
+  LONG_CONFIG_FLAG,
+  MADMAX_FLAG,
+} from './constants.js';
 import { restoreStandaloneHudPane, enableMouseScrolling } from '../team/tmux-session.js';
 import { resolveOmxEntryPath } from '../utils/paths.js';
+import {
+  resolveRuntimeCommand,
+  resolveRuntimeLeadingArgs,
+  resolveRuntimeProvider,
+  type RuntimeProvider,
+} from '../runtime/provider.js';
 
 export const AUTORESEARCH_HELP = `omx autoresearch - Launch OMX autoresearch with thin-supervisor parity semantics
 
@@ -148,10 +159,51 @@ export function normalizeAutoresearchCodexArgs(codexArgs: readonly string[]): st
   return normalized;
 }
 
-function runAutoresearchTurn(worktreePath: string, instructionsFile: string, codexArgs: string[]): void {
+export function normalizeAutoresearchLaunchArgs(
+  provider: RuntimeProvider,
+  rawArgs: readonly string[],
+): string[] {
+  if (provider === 'codex') {
+    return normalizeAutoresearchCodexArgs(rawArgs);
+  }
+  // Cursor path: strip Codex-only flags.
+  const sanitized: string[] = [];
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    if (arg === CODEX_BYPASS_FLAG || arg === MADMAX_FLAG) continue;
+    if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) continue;
+    sanitized.push(arg);
+  }
+  return sanitized;
+}
+
+function buildRuntimeExecArgs(
+  provider: RuntimeProvider,
+  rawArgs: string[],
+): string[] {
+  const execSubcommand = String(
+    process.env.OMX_RUNTIME_EXEC_SUBCOMMAND ?? 'exec',
+  ).trim();
+  return [execSubcommand, ...normalizeAutoresearchLaunchArgs(provider, rawArgs), '-'];
+}
+
+function runAutoresearchTurn(
+  provider: RuntimeProvider,
+  worktreePath: string,
+  instructionsFile: string,
+  codexArgs: string[],
+): void {
   const prompt = readFileSync(instructionsFile, 'utf-8');
-  const launchArgs = ['exec', ...normalizeAutoresearchCodexArgs(codexArgs), '-'];
-  const result = spawnSync('codex', launchArgs, {
+  const launchArgs = [
+    ...resolveRuntimeLeadingArgs(provider),
+    ...buildRuntimeExecArgs(provider, codexArgs),
+  ];
+  const runtimeCommand = resolveRuntimeCommand(provider);
+  const result = spawnSync(runtimeCommand, launchArgs, {
     cwd: worktreePath,
     stdio: ['pipe', 'inherit', 'inherit'],
     input: prompt,
@@ -165,7 +217,9 @@ function runAutoresearchTurn(worktreePath: string, instructionsFile: string, cod
   }
   if (result.status !== 0) {
     process.exitCode = typeof result.status === 'number' ? result.status : 1;
-    throw new Error(`autoresearch_codex_exec_failed:${result.status ?? 'unknown'}`);
+    throw new Error(
+      `autoresearch_${provider}_exec_failed:${result.status ?? 'unknown'}`,
+    );
   }
 }
 
@@ -233,6 +287,7 @@ export function parseAutoresearchArgs(args: readonly string[]): ParsedAutoresear
 }
 
 async function runAutoresearchLoop(
+  provider: RuntimeProvider,
   codexArgs: string[],
   runtime: {
     instructionsFile: string;
@@ -248,7 +303,12 @@ async function runAutoresearchLoop(
 
   try {
     while (true) {
-      runAutoresearchTurn(runtime.worktreePath, runtime.instructionsFile, codexArgs);
+      runAutoresearchTurn(
+        provider,
+        runtime.worktreePath,
+        runtime.instructionsFile,
+        codexArgs,
+      );
 
       const contract = await loadAutoresearchMissionContract(missionDir);
       const { run_id: runId } = JSON.parse(readFileSync(runtime.manifestFile, 'utf-8')) as { run_id: string };
@@ -359,6 +419,7 @@ function launchAutoresearchInSplitPane(args: {
 }
 
 async function executeAutoresearchMissionRun(missionDir: string, codexArgs: string[]): Promise<void> {
+  const runtimeProvider = resolveRuntimeProvider(process.env);
   const contract = await loadAutoresearchMissionContract(missionDir);
   await assertModeStartAllowed('autoresearch', contract.repoRoot);
   const runTag = buildAutoresearchRunTag();
@@ -375,7 +436,12 @@ async function executeAutoresearchMissionRun(missionDir: string, codexArgs: stri
 
   const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, ensured.worktreePath);
   const runtime = await prepareAutoresearchRuntime(worktreeContract, contract.repoRoot, ensured.worktreePath, { runTag });
-  await runAutoresearchLoop(codexArgs, runtime, worktreeContract.missionDir);
+  await runAutoresearchLoop(
+    runtimeProvider,
+    codexArgs,
+    runtime,
+    worktreeContract.missionDir,
+  );
 }
 
 export async function autoresearchCommand(args: string[]): Promise<void> {
@@ -423,11 +489,17 @@ export async function autoresearchCommand(args: string[]): Promise<void> {
   }
 
   if (parsed.runId) {
+    const runtimeProvider = resolveRuntimeProvider(process.env);
     const repoRoot = resolveRepoRoot(process.cwd());
     await assertModeStartAllowed('autoresearch', repoRoot);
     const manifest = await loadAutoresearchRunManifest(repoRoot, parsed.runId);
     const runtime = await resumeAutoresearchRuntime(repoRoot, parsed.runId);
-    await runAutoresearchLoop(parsed.codexArgs, runtime, manifest.mission_dir);
+    await runAutoresearchLoop(
+      runtimeProvider,
+      parsed.codexArgs,
+      runtime,
+      manifest.mission_dir,
+    );
     return;
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -78,6 +78,14 @@ import { getPackageRoot } from "../utils/package.js";
 import { codexConfigPath, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
 import { repairConfigIfNeeded } from "../config/generator.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
+import {
+  resolveProjectRuntimeHome,
+  resolveRuntimeCommand,
+  resolveRuntimeLeadingArgs,
+  resolveRuntimeHomeEnvVar,
+  resolveRuntimeProvider,
+  type RuntimeProvider,
+} from "../runtime/provider.js";
 
 rememberOmxLaunchContext();
 import {
@@ -312,16 +320,28 @@ export function readPersistedSetupPreferences(
   return undefined;
 }
 
+export function resolveRuntimeHomeForLaunch(
+  provider: RuntimeProvider,
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const runtimeHomeEnvVar = resolveRuntimeHomeEnvVar(provider);
+  const runtimeHomeOverride = env[runtimeHomeEnvVar];
+  if (runtimeHomeOverride && runtimeHomeOverride.trim() !== "") {
+    return runtimeHomeOverride;
+  }
+  const persistedScope = readPersistedSetupScope(cwd);
+  if (persistedScope === "project") {
+    return resolveProjectRuntimeHome(provider, cwd);
+  }
+  return undefined;
+}
+
 export function resolveCodexHomeForLaunch(
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-  if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
-  const persistedScope = readPersistedSetupScope(cwd);
-  if (persistedScope === "project") {
-    return join(cwd, ".codex");
-  }
-  return undefined;
+  return resolveRuntimeHomeForLaunch("codex", cwd, env);
 }
 
 export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {
@@ -473,15 +493,18 @@ export function classifyCodexExecFailure(
   };
 }
 
-function runCodexBlocking(
+function runProviderBlocking(
+  provider: RuntimeProvider,
   cwd: string,
   launchArgs: string[],
-  codexEnv: NodeJS.ProcessEnv,
+  runtimeEnv: NodeJS.ProcessEnv,
 ): void {
-  const { result } = spawnPlatformCommandSync("codex", launchArgs, {
+  const runtimeCommand = resolveRuntimeCommand(provider);
+  const runtimeArgs = [...resolveRuntimeLeadingArgs(provider), ...launchArgs];
+  const { result } = spawnPlatformCommandSync(runtimeCommand, runtimeArgs, {
     cwd,
     stdio: "inherit",
-    env: codexEnv,
+    env: runtimeEnv,
     encoding: "utf-8",
   });
 
@@ -490,14 +513,16 @@ function runCodexBlocking(
     const kind = classifySpawnError(errno);
     if (kind === "missing") {
       console.error(
-        "[omx] failed to launch codex: executable not found in PATH",
+        `[omx] failed to launch ${runtimeCommand}: executable not found in PATH`,
       );
     } else if (kind === "blocked") {
       console.error(
-        `[omx] failed to launch codex: executable is present but blocked in the current environment (${errno.code || "blocked"})`,
+        `[omx] failed to launch ${runtimeCommand}: executable is present but blocked in the current environment (${errno.code || "blocked"})`,
       );
     } else {
-      console.error(`[omx] failed to launch codex: ${errno.message}`);
+      console.error(
+        `[omx] failed to launch ${runtimeCommand}: ${errno.message}`,
+      );
     }
     throw result.error;
   }
@@ -508,7 +533,7 @@ function runCodexBlocking(
         ? result.status
         : resolveSignalExitCode(result.signal);
     if (result.signal) {
-      console.error(`[omx] codex exited due to signal ${result.signal}`);
+      console.error(`[omx] ${runtimeCommand} exited due to signal ${result.signal}`);
     }
   }
 }
@@ -808,6 +833,7 @@ async function reasoningCommand(args: string[]): Promise<void> {
 }
 
 export async function launchWithHud(args: string[]): Promise<void> {
+  const runtimeProvider = resolveRuntimeProvider(process.env);
   if (isNativeWindows()) {
     const { result } = spawnPlatformCommandSync("tmux", ["-V"], {
       encoding: "utf-8",
@@ -842,7 +868,11 @@ export async function launchWithHud(args: string[]): Promise<void> {
     parsedWorktree.remainingArgs,
     process.env,
   );
-  const codexHomeOverride = resolveCodexHomeForLaunch(launchCwd, process.env);
+  const runtimeHomeOverride = resolveRuntimeHomeForLaunch(
+    runtimeProvider,
+    launchCwd,
+    process.env,
+  );
   const launchPolicy = resolveCodexLaunchPolicy(
     process.env,
     process.platform,
@@ -852,7 +882,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
   const enableNotifyFallbackAuthority = launchPolicy === "direct";
   const workerSparkModel = resolveWorkerSparkModel(
     notifyTempResult.passthroughArgs,
-    codexHomeOverride,
+    runtimeHomeOverride,
   );
   const normalizedArgs = normalizeCodexLaunchArgs(
     notifyTempResult.passthroughArgs,
@@ -903,7 +933,13 @@ export async function launchWithHud(args: string[]): Promise<void> {
 
   // ── Phase 1: preLaunch ──────────────────────────────────────────────────
   try {
-    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, enableNotifyFallbackAuthority);
+    await preLaunch(
+      cwd,
+      sessionId,
+      notifyTempResult.contract,
+      runtimeHomeOverride,
+      enableNotifyFallbackAuthority,
+    );
   } catch (err) {
     // preLaunch errors must NOT prevent Codex from starting
     console.error(
@@ -917,27 +953,38 @@ export async function launchWithHud(args: string[]): Promise<void> {
       ? serializeNotifyTempContract(notifyTempResult.contract)
       : null;
     runCodex(
+      runtimeProvider,
       cwd,
       normalizedArgs,
       sessionId,
       workerSparkModel,
-      codexHomeOverride,
+      runtimeHomeOverride,
       notifyTempContractRaw,
     );
   } finally {
     // ── Phase 3: postLaunch ─────────────────────────────────────────────
-    await postLaunch(cwd, sessionId, codexHomeOverride, enableNotifyFallbackAuthority);
+    await postLaunch(
+      cwd,
+      sessionId,
+      runtimeHomeOverride,
+      enableNotifyFallbackAuthority,
+    );
   }
 }
 
 export async function execWithOverlay(args: string[]): Promise<void> {
+  const runtimeProvider = resolveRuntimeProvider(process.env);
   const launchCwd = process.cwd();
   const parsedWorktree = parseWorktreeMode(args);
   const notifyTempResult = resolveNotifyTempContract(
     parsedWorktree.remainingArgs,
     process.env,
   );
-  const codexHomeOverride = resolveCodexHomeForLaunch(launchCwd, process.env);
+  const runtimeHomeOverride = resolveRuntimeHomeForLaunch(
+    runtimeProvider,
+    launchCwd,
+    process.env,
+  );
   const normalizedArgs = normalizeCodexLaunchArgs(
     notifyTempResult.passthroughArgs,
   );
@@ -982,7 +1029,13 @@ export async function execWithOverlay(args: string[]): Promise<void> {
   }
 
   try {
-    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, true);
+    await preLaunch(
+      cwd,
+      sessionId,
+      notifyTempResult.contract,
+      runtimeHomeOverride,
+      true,
+    );
   } catch (err) {
     console.error(
       `[omx] preLaunch warning: ${err instanceof Error ? err.message : err}`,
@@ -993,24 +1046,28 @@ export async function execWithOverlay(args: string[]): Promise<void> {
     const notifyTempContractRaw = notifyTempResult.contract.active
       ? serializeNotifyTempContract(notifyTempResult.contract)
       : null;
-    const codexArgs = injectModelInstructionsBypassArgs(
-      cwd,
-      ["exec", ...normalizedArgs],
-      process.env,
-      sessionModelInstructionsPath(cwd, sessionId),
+    const codexArgs = sanitizeLaunchArgsForRuntimeProvider(
+      runtimeProvider,
+      injectModelInstructionsBypassArgs(
+        cwd,
+        ["exec", ...normalizedArgs],
+        process.env,
+        sessionModelInstructionsPath(cwd, sessionId),
+      ),
     );
-    const codexEnvBase = codexHomeOverride
-      ? { ...process.env, CODEX_HOME: codexHomeOverride }
+    const runtimeHomeEnvVar = resolveRuntimeHomeEnvVar(runtimeProvider);
+    const runtimeEnvBase = runtimeHomeOverride
+      ? { ...process.env, [runtimeHomeEnvVar]: runtimeHomeOverride }
       : process.env;
-    const codexEnv = notifyTempContractRaw
+    const runtimeEnv = notifyTempContractRaw
       ? {
-          ...codexEnvBase,
+          ...runtimeEnvBase,
           [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw,
         }
-      : codexEnvBase;
-    runCodexBlocking(cwd, codexArgs, codexEnv);
+      : runtimeEnvBase;
+    runProviderBlocking(runtimeProvider, cwd, codexArgs, runtimeEnv);
   } finally {
-    await postLaunch(cwd, sessionId, codexHomeOverride, true);
+    await postLaunch(cwd, sessionId, runtimeHomeOverride, true);
   }
 }
 
@@ -1069,6 +1126,30 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
   }
 
   return normalized;
+}
+
+function sanitizeLaunchArgsForRuntimeProvider(
+  provider: RuntimeProvider,
+  args: string[],
+): string[] {
+  if (provider !== "cursor") return [...args];
+
+  const sanitized: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === CODEX_BYPASS_FLAG || arg === MADMAX_FLAG) {
+      continue;
+    }
+    if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) {
+      continue;
+    }
+    sanitized.push(arg);
+  }
+  return sanitized;
 }
 
 /**
@@ -1647,7 +1728,8 @@ export function buildDetachedSessionBootstrapSteps(
   codexCmd: string,
   hudCmd: string,
   workerLaunchArgs: string | null,
-  codexHomeOverride?: string,
+  runtimeHomeOverride?: string,
+  runtimeHomeEnvVar: string = "CODEX_HOME",
   notifyTempContractRaw?: string | null,
   nativeWindows = false,
   sessionId?: string,
@@ -1669,7 +1751,9 @@ export function buildDetachedSessionBootstrapSteps(
       ? ["-e", `${TEAM_WORKER_LAUNCH_ARGS_ENV}=${workerLaunchArgs}`]
       : []),
     ...(sessionId ? ["-e", `OMX_SESSION_ID=${sessionId}`] : []),
-    ...(codexHomeOverride ? ["-e", `CODEX_HOME=${codexHomeOverride}`] : []),
+    ...(runtimeHomeOverride
+      ? ["-e", `${runtimeHomeEnvVar}=${runtimeHomeOverride}`]
+      : []),
     ...(notifyTempContractRaw
       ? ["-e", `${OMX_NOTIFY_TEMP_CONTRACT_ENV}=${notifyTempContractRaw}`]
       : []),
@@ -1831,7 +1915,8 @@ export function buildNotifyTempStartupMessages(
 export function buildNotifyFallbackWatcherEnv(
   env: NodeJS.ProcessEnv = process.env,
   options: {
-    codexHomeOverride?: string;
+    runtimeHomeOverride?: string;
+    runtimeHomeEnvVar?: string;
     enableAuthority?: boolean;
     sessionId?: string;
   } = {},
@@ -1841,7 +1926,9 @@ export function buildNotifyFallbackWatcherEnv(
   delete nextEnv.TMUX_PANE;
   return {
     ...nextEnv,
-    ...(options.codexHomeOverride ? { CODEX_HOME: options.codexHomeOverride } : {}),
+    ...(options.runtimeHomeOverride
+      ? { [options.runtimeHomeEnvVar ?? "CODEX_HOME"]: options.runtimeHomeOverride }
+      : {}),
     ...(options.sessionId ? { OMX_SESSION_ID: options.sessionId } : {}),
     OMX_HUD_AUTHORITY: options.enableAuthority ? "1" : "0",
   };
@@ -1882,7 +1969,7 @@ async function preLaunch(
   cwd: string,
   sessionId: string,
   notifyTempContract?: NotifyTempContract,
-  codexHomeOverride?: string,
+  runtimeHomeOverride?: string,
   enableNotifyFallbackAuthority: boolean = false,
 ): Promise<void> {
   // 1. Best-effort launch-safe orphan cleanup
@@ -1924,7 +2011,12 @@ ${launchAppendix}`
 
   // 4. Start notify fallback watcher (best effort)
   try {
-    await startNotifyFallbackWatcher(cwd, { codexHomeOverride, enableAuthority: enableNotifyFallbackAuthority, sessionId });
+    await startNotifyFallbackWatcher(cwd, {
+      runtimeHomeOverride,
+      runtimeHomeEnvVar: resolveRuntimeHomeEnvVar(resolveRuntimeProvider(process.env)),
+      enableAuthority: enableNotifyFallbackAuthority,
+      sessionId,
+    });
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
     // Non-fatal
@@ -1991,18 +2083,22 @@ ${launchAppendix}`
  * All 3 paths (new tmux, existing tmux, no tmux) block via execSync/execFileSync.
  */
 function runCodex(
+  runtimeProvider: RuntimeProvider,
   cwd: string,
   args: string[],
   sessionId: string,
   workerDefaultModel?: string,
-  codexHomeOverride?: string,
+  runtimeHomeOverride?: string,
   notifyTempContractRaw?: string | null,
 ): void {
-  const launchArgs = injectModelInstructionsBypassArgs(
-    cwd,
-    args,
-    process.env,
-    sessionModelInstructionsPath(cwd, sessionId),
+  const launchArgs = sanitizeLaunchArgsForRuntimeProvider(
+    runtimeProvider,
+    injectModelInstructionsBypassArgs(
+      cwd,
+      args,
+      process.env,
+      sessionModelInstructionsPath(cwd, sessionId),
+    ),
   );
   const nativeWindows = isNativeWindows();
   const omxBin = resolveOmxEntryPath();
@@ -2019,16 +2115,20 @@ function runCodex(
     inheritLeaderFlags,
     workerDefaultModel,
   );
-  const codexBaseEnv = codexHomeOverride
-    ? { ...process.env, CODEX_HOME: codexHomeOverride }
+  const runtimeHomeEnvVar = resolveRuntimeHomeEnvVar(runtimeProvider);
+  const runtimeBaseEnv = runtimeHomeOverride
+    ? { ...process.env, [runtimeHomeEnvVar]: runtimeHomeOverride }
     : process.env;
-  const codexEnvWithSession = { ...codexBaseEnv, OMX_SESSION_ID: sessionId };
-  const codexEnv = workerLaunchArgs
-    ? { ...codexEnvWithSession, [TEAM_WORKER_LAUNCH_ARGS_ENV]: workerLaunchArgs }
-    : codexEnvWithSession;
-  const codexEnvWithNotify = notifyTempContractRaw
-    ? { ...codexEnv, [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw }
-    : codexEnv;
+  const runtimeEnvWithSession = { ...runtimeBaseEnv, OMX_SESSION_ID: sessionId };
+  const runtimeEnv = workerLaunchArgs
+    ? {
+        ...runtimeEnvWithSession,
+        [TEAM_WORKER_LAUNCH_ARGS_ENV]: workerLaunchArgs,
+      }
+    : runtimeEnvWithSession;
+  const runtimeEnvWithNotify = notifyTempContractRaw
+    ? { ...runtimeEnv, [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw }
+    : runtimeEnv;
 
   const launchPolicy = resolveCodexLaunchPolicy(
     process.env,
@@ -2038,7 +2138,7 @@ function runCodex(
   );
 
   if (isCodexVersionRequest(launchArgs)) {
-    runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+    runProviderBlocking(runtimeProvider, cwd, launchArgs, runtimeEnvWithNotify);
     return;
   }
 
@@ -2088,7 +2188,7 @@ function runCodex(
 
     try {
       withTmuxExtendedKeys(cwd, () => {
-        runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+        runProviderBlocking(runtimeProvider, cwd, launchArgs, runtimeEnvWithNotify);
       });
     } finally {
       const cleanupPaneIds = buildHudPaneCleanupTargets(
@@ -2103,12 +2203,14 @@ function runCodex(
   } else if (launchPolicy === "direct") {
     // Detached HUD sessions require tmux. Skip the bootstrap entirely when the
     // binary is unavailable so direct launches do not emit noisy ENOENT logs.
-    runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+    runProviderBlocking(runtimeProvider, cwd, launchArgs, runtimeEnvWithNotify);
   } else {
     // Not in tmux: create a new tmux session with codex + HUD pane
-    const codexCmd = buildTmuxPaneCommand("codex", launchArgs);
+    const runtimeCommand = resolveRuntimeCommand(runtimeProvider);
+    const runtimeArgs = [...resolveRuntimeLeadingArgs(runtimeProvider), ...launchArgs];
+    const codexCmd = buildTmuxPaneCommand(runtimeCommand, runtimeArgs);
     const detachedWindowsCodexCmd = nativeWindows
-      ? buildWindowsPromptCommand("codex", launchArgs)
+      ? buildWindowsPromptCommand(runtimeCommand, runtimeArgs)
       : null;
     const sessionName = buildDetachedTmuxSessionName(cwd, sessionId);
     let createdDetachedSession = false;
@@ -2122,7 +2224,8 @@ function runCodex(
         codexCmd,
         hudCmd,
         workerLaunchArgs,
-        codexHomeOverride,
+        runtimeHomeOverride,
+        runtimeHomeEnvVar,
         notifyTempContractRaw,
         nativeWindows,
         sessionId,
@@ -2223,7 +2326,7 @@ function runCodex(
         }
       }
       // tmux not available or failed, just run codex directly
-      runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+      runProviderBlocking(runtimeProvider, cwd, launchArgs, runtimeEnvWithNotify);
     }
   }
 }
@@ -2381,7 +2484,7 @@ function scheduleDetachedWindowsCodexLaunch(
 async function postLaunch(
   cwd: string,
   sessionId: string,
-  codexHomeOverride?: string,
+  runtimeHomeOverride?: string,
   enableNotifyFallbackAuthority: boolean = false,
 ): Promise<void> {
   // Capture session start time before cleanup (writeSessionEnd deletes session.json)
@@ -2396,7 +2499,12 @@ async function postLaunch(
 
   // 0. Flush fallback watcher once to reduce race with fast codex exit.
   try {
-    await flushNotifyFallbackOnce(cwd, { codexHomeOverride, enableAuthority: enableNotifyFallbackAuthority, sessionId });
+    await flushNotifyFallbackOnce(cwd, {
+      runtimeHomeOverride,
+      runtimeHomeEnvVar: resolveRuntimeHomeEnvVar(resolveRuntimeProvider(process.env)),
+      enableAuthority: enableNotifyFallbackAuthority,
+      sessionId,
+    });
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
     // Non-fatal
@@ -2722,7 +2830,12 @@ function tryKillPid(pid: number, signal: NodeJS.Signals = "SIGTERM"): boolean {
 
 async function startNotifyFallbackWatcher(
   cwd: string,
-  options: { codexHomeOverride?: string; enableAuthority?: boolean; sessionId?: string } = {},
+  options: {
+    runtimeHomeOverride?: string;
+    runtimeHomeEnvVar?: string;
+    enableAuthority?: boolean;
+    sessionId?: string;
+  } = {},
 ): Promise<void> {
   const { mkdir, writeFile } = await import("fs/promises");
   const pidPath = notifyFallbackPidPath(cwd);
@@ -2747,7 +2860,8 @@ async function startNotifyFallbackWatcher(
     },
   );
   const watcherEnv = buildNotifyFallbackWatcherEnv(process.env, {
-    codexHomeOverride: options.codexHomeOverride,
+    runtimeHomeOverride: options.runtimeHomeOverride,
+    runtimeHomeEnvVar: options.runtimeHomeEnvVar,
     enableAuthority: options.enableAuthority === true,
     sessionId: options.sessionId,
   });
@@ -2939,7 +3053,12 @@ async function stopHookDerivedWatcher(cwd: string): Promise<void> {
 
 async function flushNotifyFallbackOnce(
   cwd: string,
-  options: { codexHomeOverride?: string; enableAuthority?: boolean; sessionId?: string } = {},
+  options: {
+    runtimeHomeOverride?: string;
+    runtimeHomeEnvVar?: string;
+    enableAuthority?: boolean;
+    sessionId?: string;
+  } = {},
 ): Promise<void> {
   if (!shouldEnableNotifyFallbackWatcher(process.env, process.platform)) return;
   const { spawnSync } = await import("child_process");
@@ -2956,7 +3075,8 @@ async function flushNotifyFallbackOnce(
       timeout: 3000,
       windowsHide: true,
       env: buildNotifyFallbackWatcherEnv(process.env, {
-        codexHomeOverride: options.codexHomeOverride,
+        runtimeHomeOverride: options.runtimeHomeOverride,
+        runtimeHomeEnvVar: options.runtimeHomeEnvVar,
         enableAuthority: options.enableAuthority === true,
         sessionId: options.sessionId,
       }),

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -19,17 +19,21 @@ import { createInterface } from "readline/promises";
 import { homedir } from "os";
 import {
   codexHome,
+  cursorHome,
   codexConfigPath,
+  runtimeConfigPath,
   codexPromptsDir,
   codexAgentsDir,
   userSkillsDir,
+  runtimeAgentsDir,
+  runtimePromptsDir,
   omxStateDir,
   detectLegacySkillRootOverlap,
   omxPlansDir,
   omxLogsDir,
 } from "../utils/paths.js";
 import { buildMergedConfig, getRootModelName } from "../config/generator.js";
-import { buildManagedCodexHooksConfig } from "../config/codex-hooks.js";
+import { buildManagedRuntimeHooksConfig } from "../config/codex-hooks.js";
 import {
   getLegacyUnifiedMcpRegistryCandidate,
   getUnifiedMcpRegistryCandidates,
@@ -53,6 +57,7 @@ import {
   upsertAgentsModelTable,
 } from "../utils/agents-model-table.js";
 import { spawnPlatformCommandSync } from "../utils/platform-command.js";
+import { resolveRuntimeProvider } from "../runtime/provider.js";
 
 interface SetupOptions {
   codexVersionProbe?: () => string | null;
@@ -382,8 +387,13 @@ export function resolveScopeDirectories(
   scope: SetupScope,
   projectRoot: string,
 ): ScopeDirectories {
+  const runtimeProvider = resolveRuntimeProvider(process.env);
+  const projectRuntimeDir =
+    runtimeProvider === "cursor"
+      ? join(projectRoot, ".cursor")
+      : join(projectRoot, ".codex");
   if (scope === "project") {
-    const codexHomeDir = join(projectRoot, ".codex");
+    const codexHomeDir = projectRuntimeDir;
     return {
       codexConfigFile: join(codexHomeDir, "config.toml"),
       codexHomeDir,
@@ -391,6 +401,16 @@ export function resolveScopeDirectories(
       nativeAgentsDir: join(codexHomeDir, "agents"),
       promptsDir: join(codexHomeDir, "prompts"),
       skillsDir: join(codexHomeDir, "skills"),
+    };
+  }
+  if (runtimeProvider === "cursor") {
+    return {
+      codexConfigFile: runtimeConfigPath("cursor"),
+      codexHomeDir: cursorHome(),
+      codexHooksFile: join(cursorHome(), "hooks.json"),
+      nativeAgentsDir: runtimeAgentsDir("cursor"),
+      promptsDir: runtimePromptsDir("cursor"),
+      skillsDir: userSkillsDir(),
     };
   }
   return {
@@ -837,7 +857,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
 
   const hooksConfig = JSON.stringify(
-    buildManagedCodexHooksConfig(pkgRoot),
+    buildManagedRuntimeHooksConfig(pkgRoot, resolveRuntimeProvider(process.env)),
     null,
     2,
   ) + "\n";
@@ -850,7 +870,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     `native hooks ${scopeDirs.codexHooksFile}`,
   );
   console.log(
-    `  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
+    `  Native runtime hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
   );
 
   // Step 5.5: Verify team CLI interop surface is available.

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
+import { resolveRuntimeProvider, type RuntimeProvider } from "../runtime/provider.js";
 
-export interface ManagedCodexHooksConfig {
+export interface ManagedRuntimeHooksConfig {
   hooks: {
     SessionStart: Array<Record<string, unknown>>;
     PreToolUse: Array<Record<string, unknown>>;
@@ -30,8 +31,18 @@ function buildCommandHook(
   };
 }
 
-export function buildManagedCodexHooksConfig(pkgRoot: string): ManagedCodexHooksConfig {
-  const hookScript = join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
+function resolveHookScriptName(provider: RuntimeProvider): string {
+  // Cursor currently reuses the same native bridge semantics as codex.
+  // Keep a dedicated resolver so provider-specific hook scripts can be added
+  // later without touching setup call sites.
+  return provider === "cursor" ? "codex-native-hook.js" : "codex-native-hook.js";
+}
+
+export function buildManagedRuntimeHooksConfig(
+  pkgRoot: string,
+  provider: RuntimeProvider = resolveRuntimeProvider(),
+): ManagedRuntimeHooksConfig {
+  const hookScript = join(pkgRoot, "dist", "scripts", resolveHookScriptName(provider));
   const command = `node "${hookScript}"`;
 
   return {
@@ -66,4 +77,12 @@ export function buildManagedCodexHooksConfig(pkgRoot: string): ManagedCodexHooks
       ],
     },
   };
+}
+
+export type ManagedCodexHooksConfig = ManagedRuntimeHooksConfig;
+
+export function buildManagedCodexHooksConfig(
+  pkgRoot: string,
+): ManagedCodexHooksConfig {
+  return buildManagedRuntimeHooksConfig(pkgRoot, "codex");
 }

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -16,6 +16,7 @@ import { join } from "path";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
+import { resolveRuntimeProvider } from "../runtime/provider.js";
 
 interface MergeOptions {
   includeTui?: boolean;
@@ -172,6 +173,8 @@ export function stripOmxTopLevelKeys(config: string): string {
 // ---------------------------------------------------------------------------
 
 function upsertFeatureFlags(config: string): string {
+  const runtimeProvider = resolveRuntimeProvider(process.env);
+  const runtimeHooksKey = runtimeProvider === "cursor" ? "cursor_hooks" : "codex_hooks";
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
@@ -184,6 +187,7 @@ function upsertFeatureFlags(config: string): string {
       "multi_agent = true",
       "child_agents_md = true",
       "codex_hooks = true",
+      ...(runtimeHooksKey === "cursor_hooks" ? ["cursor_hooks = true"] : []),
       "",
     ].join("\n");
     if (base.length === 0) {
@@ -211,6 +215,7 @@ function upsertFeatureFlags(config: string): string {
   let multiAgentIdx = -1;
   let childAgentsIdx = -1;
   let codexHooksIdx = -1;
+  let cursorHooksIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
     if (/^\s*multi_agent\s*=/.test(lines[i])) {
       multiAgentIdx = i;
@@ -218,6 +223,8 @@ function upsertFeatureFlags(config: string): string {
       childAgentsIdx = i;
     } else if (/^\s*codex_hooks\s*=/.test(lines[i])) {
       codexHooksIdx = i;
+    } else if (/^\s*cursor_hooks\s*=/.test(lines[i])) {
+      cursorHooksIdx = i;
     }
   }
 
@@ -239,6 +246,14 @@ function upsertFeatureFlags(config: string): string {
     lines[codexHooksIdx] = "codex_hooks = true";
   } else {
     lines.splice(sectionEnd, 0, "codex_hooks = true");
+    sectionEnd += 1;
+  }
+  if (runtimeHooksKey === "cursor_hooks") {
+    if (cursorHooksIdx >= 0) {
+      lines[cursorHooksIdx] = "cursor_hooks = true";
+    } else {
+      lines.splice(sectionEnd, 0, "cursor_hooks = true");
+    }
   }
 
   return lines.join("\n");
@@ -353,7 +368,13 @@ export function stripOmxFeatureFlags(config: string): string {
     }
   }
 
-  const omxFlags = ["multi_agent", "child_agents_md", "codex_hooks", "collab"];
+  const omxFlags = [
+    "multi_agent",
+    "child_agents_md",
+    "codex_hooks",
+    "cursor_hooks",
+    "collab",
+  ];
   const filtered: string[] = [];
   for (let i = 0; i < lines.length; i++) {
     if (i > featuresStart && i < sectionEnd) {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -22,7 +22,8 @@
 import { parse as parseToml } from '@iarna/toml';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { codexConfigPath, codexHome } from '../utils/paths.js';
+import { codexConfigPath, codexHome, runtimeConfigPath, runtimeHome } from '../utils/paths.js';
+import { resolveRuntimeProvider, type RuntimeProvider } from '../runtime/provider.js';
 
 export interface ModelsConfig {
   [mode: string]: string | undefined;
@@ -37,7 +38,7 @@ interface OmxConfigFile {
   models?: ModelsConfig;
 }
 
-interface CodexConfigFile {
+interface RuntimeConfigFile {
   model_provider?: unknown;
   model_providers?: Record<string, unknown>;
 }
@@ -59,15 +60,18 @@ function readOmxConfigFile(codexHomeOverride?: string): OmxConfigFile | null {
   }
 }
 
-function readCodexConfigFile(codexHomeOverride?: string): CodexConfigFile | null {
-  const configPath = codexHomeOverride
-    ? join(codexHomeOverride, 'config.toml')
-    : codexConfigPath();
+function readRuntimeConfigFile(
+  provider: RuntimeProvider,
+  runtimeHomeOverride?: string,
+): RuntimeConfigFile | null {
+  const configPath = runtimeHomeOverride
+    ? join(runtimeHomeOverride, 'config.toml')
+    : runtimeConfigPath(provider);
   if (!existsSync(configPath)) return null;
   try {
     const raw = parseToml(readFileSync(configPath, 'utf-8'));
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
-    return raw as CodexConfigFile;
+    return raw as RuntimeConfigFile;
   } catch {
     return null;
   }
@@ -126,9 +130,10 @@ export function readConfiguredEnvOverrides(codexHomeOverride?: string): NodeJS.P
 
 export function readActiveProviderEnvOverrides(
   env: NodeJS.ProcessEnv = process.env,
-  codexHomeOverride?: string,
+  runtimeHomeOverride?: string,
+  provider: RuntimeProvider = resolveRuntimeProvider(),
 ): NodeJS.ProcessEnv {
-  const config = readCodexConfigFile(codexHomeOverride);
+  const config = readRuntimeConfigFile(provider, runtimeHomeOverride);
   if (!config) return {};
 
   const activeProvider = normalizeConfiguredValue(config.model_provider);
@@ -184,6 +189,20 @@ export function getEnvConfiguredSparkDefaultModel(
 export function getMainDefaultModel(codexHomeOverride?: string): string {
   return getEnvConfiguredMainDefaultModel(process.env, codexHomeOverride)
     ?? DEFAULT_FRONTIER_MODEL;
+}
+
+export function getRuntimeConfigPathCompat(
+  provider: RuntimeProvider = resolveRuntimeProvider(),
+): string {
+  if (provider === 'codex') return codexConfigPath();
+  return runtimeConfigPath(provider);
+}
+
+export function getRuntimeHomeCompat(
+  provider: RuntimeProvider = resolveRuntimeProvider(),
+): string {
+  if (provider === 'codex') return codexHome();
+  return runtimeHome(provider);
 }
 
 /**

--- a/src/notifications/__tests__/tmux-detector.test.ts
+++ b/src/notifications/__tests__/tmux-detector.test.ts
@@ -18,6 +18,11 @@ describe('analyzePaneContent', () => {
     assert.ok(result.confidence >= 0.5);
   });
 
+  it('detects "cursor" keyword', () => {
+    const result = analyzePaneContent('cursor agent running');
+    assert.equal(result.hasCodex, true);
+  });
+
   it('detects "omx" keyword', () => {
     const result = analyzePaneContent('omx session started');
     assert.equal(result.hasCodex, true);

--- a/src/notifications/tmux-detector.ts
+++ b/src/notifications/tmux-detector.ts
@@ -47,6 +47,7 @@ export function analyzePaneContent(content: string): PaneAnalysis {
 
   const hasCodex =
     lower.includes('codex') ||
+    lower.includes('cursor') ||
     lower.includes('omx') ||
     lower.includes('oh-my-codex') ||
     lower.includes('openai');

--- a/src/runtime/__tests__/provider.test.ts
+++ b/src/runtime/__tests__/provider.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveRuntimeProvider,
+  resolveRuntimeCommand,
+  resolveRuntimeLeadingArgs,
+  resolveRuntimeHomeEnvVar,
+  resolveProjectRuntimeHome,
+} from "../provider.js";
+
+describe("runtime provider", () => {
+  it("defaults to codex", () => {
+    assert.equal(resolveRuntimeProvider({}), "codex");
+  });
+
+  it("supports explicit cursor provider", () => {
+    assert.equal(resolveRuntimeProvider({ OMX_RUNTIME_PROVIDER: "cursor" }), "cursor");
+    assert.equal(resolveRuntimeCommand("cursor"), "agent");
+    assert.deepEqual(resolveRuntimeLeadingArgs("cursor"), []);
+    assert.equal(resolveRuntimeHomeEnvVar("cursor"), "CURSOR_HOME");
+  });
+
+  it("resolves project runtime home by provider", () => {
+    assert.equal(resolveProjectRuntimeHome("codex", "/repo"), "/repo/.codex");
+    assert.equal(resolveProjectRuntimeHome("cursor", "/repo"), "/repo/.cursor");
+  });
+});

--- a/src/runtime/provider.ts
+++ b/src/runtime/provider.ts
@@ -1,0 +1,43 @@
+import { join } from "path";
+
+export type RuntimeProvider = "codex" | "cursor";
+
+export const OMX_RUNTIME_PROVIDER_ENV = "OMX_RUNTIME_PROVIDER";
+export const OMX_PROVIDER_ENV = "OMX_PROVIDER";
+export const CODEX_HOME_ENV = "CODEX_HOME";
+export const CURSOR_HOME_ENV = "CURSOR_HOME";
+
+function normalizeProviderName(raw: string | undefined): RuntimeProvider | null {
+  const value = String(raw ?? "").trim().toLowerCase();
+  if (value === "codex" || value === "cursor") return value;
+  return null;
+}
+
+export function resolveRuntimeProvider(
+  env: NodeJS.ProcessEnv = process.env,
+): RuntimeProvider {
+  return (
+    normalizeProviderName(env[OMX_RUNTIME_PROVIDER_ENV]) ??
+    normalizeProviderName(env[OMX_PROVIDER_ENV]) ??
+    "codex"
+  );
+}
+
+export function resolveRuntimeCommand(provider: RuntimeProvider): string {
+  return provider === "cursor" ? "agent" : "codex";
+}
+
+export function resolveRuntimeLeadingArgs(provider: RuntimeProvider): string[] {
+  return [];
+}
+
+export function resolveRuntimeHomeEnvVar(provider: RuntimeProvider): string {
+  return provider === "cursor" ? CURSOR_HOME_ENV : CODEX_HOME_ENV;
+}
+
+export function resolveProjectRuntimeHome(
+  provider: RuntimeProvider,
+  cwd: string,
+): string {
+  return join(cwd, provider === "cursor" ? ".cursor" : ".codex");
+}

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -260,7 +260,7 @@ function looksLikeShellCommand(command: string): boolean {
 
 function looksLikeCodexCommand(command: string): boolean {
   if (/codex-native-hook(?:\.js)?/i.test(command)) return false;
-  return /\bcodex(?:\.js)?\b/i.test(command);
+  return /\b(?:codex|cursor)(?:\.js)?\b/i.test(command);
 }
 
 export function resolveSessionOwnerPidFromAncestry(

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -183,15 +183,15 @@ export function isPaneRunningShell(paneCurrentCommand: any): boolean {
   return SHELL_COMMANDS.has(base);
 }
 
-// Codex agent commands — do NOT include 'claude' (that's Claude Code CLI, a different tool)
-const AGENT_COMMANDS = new Set(['node', 'codex', 'npx']);
+// Agent commands (Codex/Cursor wrappers) — do NOT include 'claude'
+const AGENT_COMMANDS = new Set(['node', 'codex', 'cursor', 'npx']);
 
 function isHudStartCommand(startCommand: string): boolean {
   return /\bomx\b.*\bhud\b.*--watch/i.test(startCommand);
 }
 
 /**
- * Canonical codex pane resolver. Finds the tmux pane running a codex/claude agent.
+ * Canonical agent pane resolver. Finds the tmux pane running a codex/cursor agent.
  *
  * Resolution order:
  * 1. TMUX_PANE env var — but only if the pane looks like a real agent pane, not HUD
@@ -218,7 +218,7 @@ export function resolveCodexPane(): string {
     }
     if (!SHELL_COMMANDS.has(base)) {
       // Not a shell and not a known agent (e.g. claude CLI) — fall through to
-      // session scan so we can still reject HUD or locate a codex pane.
+      // session scan so we can still reject HUD or locate an agent pane.
     }
   } catch {
     // Fall through to session scan instead of guessing.
@@ -241,7 +241,7 @@ export function resolveCodexPane(): string {
       const paneId = parts[0];
       const startCmd = (parts[2] || '').toLowerCase();
       if (!paneId) continue;
-      if (startCmd.includes('codex') && !isHudStartCommand(startCmd)) {
+      if ((startCmd.includes('codex') || startCmd.includes('cursor')) && !isHudStartCommand(startCmd)) {
         return paneId;
       }
     }
@@ -307,8 +307,10 @@ export function paneShowsCodexViewport(captured: any): boolean {
   if (lines.length === 0) return false;
   if (paneIsBootstrapping(lines)) return false;
 
-  const hasCodexBanner = lines.some((line) => /\bOpenAI Codex\b/i.test(line));
-  if (!hasCodexBanner) return false;
+  const hasAgentBanner = lines.some(
+    (line) => /\bOpenAI Codex\b/i.test(line) || /\bCursor\b/i.test(line),
+  );
+  if (!hasAgentBanner) return false;
 
   return lines.some((line) => /(?:^|\s)(?:model|directory):/i.test(line));
 }

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -25,7 +25,7 @@ describe('runtime-cli helpers', () => {
     );
     assert.throws(
       () => runtimeCli.normalizeAgentTypes(['codex', 'invalid'], 2),
-      /Expected codex\\|claude\\|gemini/,
+      /Expected codex\\|cursor\\|claude\\|gemini/,
     );
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1147,10 +1147,18 @@ describe('team worker CLI helpers', () => {
     assert.equal(resolveTeamWorkerCli(['--model', 'gemini-2.0-pro'], {}), 'gemini');
     assert.equal(resolveTeamWorkerCli(['--model', 'gpt-5'], {}), 'codex');
     assert.equal(resolveTeamWorkerCli([], {}), 'codex');
+    assert.equal(
+      resolveTeamWorkerCli([], { OMX_RUNTIME_PROVIDER: 'cursor' }),
+      'cursor',
+    );
   });
 
   it('resolveTeamWorkerCli accepts explicit gemini override', () => {
     assert.equal(resolveTeamWorkerCli([], { OMX_TEAM_WORKER_CLI: 'gemini' }), 'gemini');
+  });
+
+  it('resolveTeamWorkerCli accepts explicit cursor override', () => {
+    assert.equal(resolveTeamWorkerCli([], { OMX_TEAM_WORKER_CLI: 'cursor' }), 'cursor');
   });
 
   it('resolveTeamWorkerCliPlan accepts gemini in CLI map', () => {
@@ -1161,6 +1169,14 @@ describe('team worker CLI helpers', () => {
   it('translateWorkerLaunchArgsForCli preserves args for codex', () => {
     const args = ['--model', 'gpt-5', '-c', 'model_reasoning_effort="xhigh"'];
     assert.deepEqual(translateWorkerLaunchArgsForCli('codex', args), args);
+  });
+
+  it('translateWorkerLaunchArgsForCli strips codex-only bypass flags for cursor', () => {
+    const args = ['--model', 'gpt-5', '--dangerously-bypass-approvals-and-sandbox', '--madmax'];
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('cursor', args),
+      ['--model', 'gpt-5'],
+    );
   });
 
   it('translateWorkerLaunchArgsForCli returns only skip-permissions for claude', () => {
@@ -1286,6 +1302,13 @@ describe('team worker CLI helpers', () => {
 
   it('buildWorkerSubmitPlan preserves queue-first behavior for busy codex workers', () => {
     const plan = buildWorkerSubmitPlan('auto', 'codex', true, true);
+    assert.equal(plan.queueFirstRound, true);
+    assert.equal(plan.submitKeyPressesPerRound, 2);
+    assert.equal(plan.allowAdaptiveRetry, true);
+  });
+
+  it('buildWorkerSubmitPlan treats cursor workers as codex-like submit flow', () => {
+    const plan = buildWorkerSubmitPlan('auto', 'cursor', true, true);
     assert.equal(plan.queueFirstRound, true);
     assert.equal(plan.submitKeyPressesPerRound, 2);
     assert.equal(plan.allowAdaptiveRetry, true);

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -5,6 +5,7 @@ import {
   getSparkDefaultModel,
   getStandardDefaultModel,
 } from '../config/models.js';
+import { resolveRuntimeProvider, type RuntimeProvider } from '../runtime/provider.js';
 
 const MADMAX_FLAG = '--madmax';
 const CODEX_BYPASS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
@@ -133,11 +134,12 @@ export function normalizeTeamWorkerLaunchArgs(
   args: string[],
   preferredModel?: string,
   preferredReasoning?: TeamReasoningEffort,
+  provider: RuntimeProvider = resolveRuntimeProvider(process.env),
 ): string[] {
   const parsed = parseTeamWorkerLaunchArgs(args);
   const normalized = [...parsed.passthrough];
 
-  if (parsed.wantsBypass) normalized.push(CODEX_BYPASS_FLAG);
+  if (provider === 'codex' && parsed.wantsBypass) normalized.push(CODEX_BYPASS_FLAG);
 
   const selectedReasoning = parsed.reasoningOverride
     ?? (normalizeOptionalReasoning(preferredReasoning)
@@ -152,6 +154,7 @@ export function normalizeTeamWorkerLaunchArgs(
 }
 
 export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgsOptions): string[] {
+  const provider = resolveRuntimeProvider(process.env);
   const envArgs = splitWorkerLaunchArgs(options.existingRaw);
   const inheritedArgs = options.inheritedArgs ?? [];
   const allArgs = [...envArgs, ...inheritedArgs];
@@ -160,7 +163,12 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
   const inheritedModel = normalizeOptionalModel(parseTeamWorkerLaunchArgs(inheritedArgs).modelOverride);
   const fallbackModel = normalizeOptionalModel(options.fallbackModel);
   const selectedModel = envModel ?? inheritedModel ?? fallbackModel;
-  return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning);
+  return normalizeTeamWorkerLaunchArgs(
+    allArgs,
+    selectedModel,
+    options.preferredReasoning,
+    provider,
+  );
 }
 
 export function resolveAgentReasoningEffort(agentType?: string): TeamReasoningEffort | undefined {

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -23,7 +23,7 @@ interface CliInput {
   pollIntervalMs?: number;
 }
 
-type TeamWorkerProvider = 'codex' | 'claude' | 'gemini';
+type TeamWorkerProvider = 'codex' | 'cursor' | 'claude' | 'gemini';
 
 interface TaskResult {
   taskId: string;
@@ -124,9 +124,9 @@ export function collectTaskResults(stateRoot: string, teamName: string): TaskRes
 
 export function normalizeAgentTypes(raw: string[], workerCount: number): TeamWorkerProvider[] {
   const providers = raw.map((entry) => String(entry || '').trim().toLowerCase());
-  const invalid = providers.filter((entry) => entry !== 'codex' && entry !== 'claude' && entry !== 'gemini');
+  const invalid = providers.filter((entry) => entry !== 'codex' && entry !== 'cursor' && entry !== 'claude' && entry !== 'gemini');
   if (invalid.length > 0) {
-    throw new Error(`Invalid agentTypes entries: ${invalid.join(', ')}. Expected codex|claude|gemini.`);
+    throw new Error(`Invalid agentTypes entries: ${invalid.join(', ')}. Expected codex|cursor|claude|gemini.`);
   }
   if (providers.length !== 1 && providers.length !== workerCount) {
     throw new Error(`agentTypes length must be 1 or ${workerCount}; received ${providers.length}.`);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1584,7 +1584,7 @@ function spawnPromptWorker(
   workerCwd: string,
   launchArgs: string[],
   workerEnv: Record<string, string>,
-  workerCli: 'codex' | 'claude' | 'gemini',
+  workerCli: 'codex' | 'cursor' | 'claude' | 'gemini',
   initialPrompt?: string,
 ): ChildProcessByStdio<Writable, null, null> {
   const processSpec = buildWorkerProcessLaunchSpec(
@@ -1657,7 +1657,7 @@ export function resolveWorkerLaunchArgsFromEnv(
 function resolveEffectiveWorkerCliForStartupLog(
   resolvedLaunchArgs: string[],
   env: NodeJS.ProcessEnv,
-): 'codex' | 'claude' | 'gemini' {
+): 'codex' | 'cursor' | 'claude' | 'gemini' {
   const rawCliMap = String(env.OMX_TEAM_WORKER_CLI_MAP ?? '').trim();
   if (rawCliMap !== '') {
     const entries = rawCliMap
@@ -1669,13 +1669,15 @@ function resolveEffectiveWorkerCliForStartupLog(
         ...env,
         OMX_TEAM_WORKER_CLI: 'auto',
       });
-      const resolvedMap = entries.map((entry): 'codex' | 'claude' | 'gemini' | null => {
+      const resolvedMap = entries.map((entry): 'codex' | 'cursor' | 'claude' | 'gemini' | null => {
         if (entry === 'auto') return autoCli;
-        if (entry === 'codex' || entry === 'claude' || entry === 'gemini') return entry;
+        if (entry === 'codex' || entry === 'cursor' || entry === 'claude' || entry === 'gemini') return entry;
         return null;
       });
+      if (resolvedMap.every((entry) => entry === 'cursor')) return 'cursor';
       if (resolvedMap.every((entry) => entry === 'claude')) return 'claude';
       if (resolvedMap.every((entry) => entry === 'gemini')) return 'gemini';
+      if (resolvedMap.some((entry) => entry === 'cursor')) return 'cursor';
       if (resolvedMap.some((entry) => entry === 'codex')) return 'codex';
     }
   }

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -58,7 +58,8 @@ import {
 } from './worker-bootstrap.js';
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
-import { codexPromptsDir } from '../utils/paths.js';
+import { codexPromptsDir, runtimePromptsDir } from '../utils/paths.js';
+import { resolveRuntimeProvider } from '../runtime/provider.js';
 import {
   parseTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchArgs,
@@ -169,7 +170,7 @@ async function notifyWorkerPaneOutcome(
   workerIndex: number,
   message: string,
   paneId?: string,
-  workerCli?: 'codex' | 'claude' | 'gemini',
+  workerCli?: 'codex' | 'cursor' | 'claude' | 'gemini',
 ): Promise<DispatchOutcome> {
   try {
     await sendToWorker(sessionName, workerIndex, message, paneId, workerCli);
@@ -351,7 +352,8 @@ export async function scaleUp(
       const workerCwd = workerWorkspace ? workerWorkspace.worktreePath : leaderCwd;
 
       // Build startup command and create tmux pane
-      const rawRolePromptContent = await loadRolePrompt(workerRole, join(leaderCwd, '.codex', 'prompts'))
+      const runtimeProvider = resolveRuntimeProvider(env);
+      const rawRolePromptContent = await loadRolePrompt(workerRole, runtimePromptsDir(runtimeProvider))
         ?? await loadRolePrompt(workerRole, codexPromptsDir());
       const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
       const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(env, workerRole, preferredReasoning);

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -101,7 +101,7 @@ export interface WorkerInfo {
   name: string; // "worker-1"
   index: number; // tmux window index (1-based)
   role: string; // agent type
-  worker_cli?: 'codex' | 'claude' | 'gemini';
+  worker_cli?: 'codex' | 'cursor' | 'claude' | 'gemini';
   assigned_tasks: string[]; // task IDs
   pid?: number;
   pane_id?: string;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -30,7 +30,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude' | 'gemini';
+  worker_cli?: 'codex' | 'cursor' | 'claude' | 'gemini';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -22,6 +22,7 @@ import { readActiveProviderEnvOverrides } from '../config/models.js';
 import { sleep, sleepSync } from '../utils/sleep.js';
 import { classifySpawnError, resolveCommandPathForPlatform, spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { resolveOmxEntryPath } from '../utils/paths.js';
+import { resolveRuntimeProvider } from '../runtime/provider.js';
 
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
@@ -56,7 +57,7 @@ const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
 const OMX_LEADER_NODE_PATH_ENV = 'OMX_LEADER_NODE_PATH';
 const OMX_LEADER_CLI_PATH_ENV = 'OMX_LEADER_CLI_PATH';
 
-export type TeamWorkerCli = 'codex' | 'claude' | 'gemini';
+export type TeamWorkerCli = 'codex' | 'cursor' | 'claude' | 'gemini';
 type TeamWorkerCliMode = 'auto' | TeamWorkerCli;
 export type TeamWorkerLaunchMode = 'interactive' | 'prompt';
 
@@ -496,8 +497,8 @@ function hasModelInstructionsOverride(args: string[]): boolean {
 function normalizeTeamWorkerCliMode(raw: string | undefined, sourceEnv: string = OMX_TEAM_WORKER_CLI_ENV): TeamWorkerCliMode {
   const normalized = String(raw ?? 'auto').trim().toLowerCase();
   if (normalized === '' || normalized === 'auto') return 'auto';
-  if (normalized === 'codex' || normalized === 'claude' || normalized === 'gemini') return normalized;
-  throw new Error(`Invalid ${sourceEnv} value "${raw}". Expected: auto, codex, claude, gemini`);
+  if (normalized === 'codex' || normalized === 'cursor' || normalized === 'claude' || normalized === 'gemini') return normalized;
+  throw new Error(`Invalid ${sourceEnv} value "${raw}". Expected: auto, codex, cursor, claude, gemini`);
 }
 
 export function resolveTeamWorkerLaunchMode(
@@ -532,14 +533,19 @@ function extractModelOverride(args: string[]): string | null {
 export function resolveTeamWorkerCli(launchArgs: string[] = [], env: NodeJS.ProcessEnv = process.env): TeamWorkerCli {
   const mode = normalizeTeamWorkerCliMode(env[OMX_TEAM_WORKER_CLI_ENV]);
   if (mode !== 'auto') return mode;
-  return resolveTeamWorkerCliFromLaunchArgs(launchArgs);
+  return resolveTeamWorkerCliFromLaunchArgs(launchArgs, env);
 }
 
-function resolveTeamWorkerCliFromLaunchArgs(launchArgs: string[] = []): TeamWorkerCli {
+function resolveTeamWorkerCliFromLaunchArgs(
+  launchArgs: string[] = [],
+  env: NodeJS.ProcessEnv = process.env,
+): TeamWorkerCli {
   const model = extractModelOverride(launchArgs);
+  if (model && /cursor/i.test(model)) return 'cursor';
   if (model && /claude/i.test(model)) return 'claude';
   if (model && /gemini/i.test(model)) return 'gemini';
-  return 'codex';
+  const defaultProvider = resolveRuntimeProvider(env);
+  return defaultProvider === 'cursor' ? 'cursor' : 'codex';
 }
 
 export function resolveTeamWorkerCliPlan(
@@ -553,7 +559,8 @@ export function resolveTeamWorkerCliPlan(
 
   const rawMap = String(env[OMX_TEAM_WORKER_CLI_MAP_ENV] ?? '').trim();
   const fallback = (): TeamWorkerCli => resolveTeamWorkerCli(launchArgs, env);
-  const fallbackAutoFromArgs = (): TeamWorkerCli => resolveTeamWorkerCliFromLaunchArgs(launchArgs);
+  const fallbackAutoFromArgs = (): TeamWorkerCli =>
+    resolveTeamWorkerCliFromLaunchArgs(launchArgs, env);
 
   if (rawMap === '') {
     const cli = fallback();
@@ -567,7 +574,7 @@ export function resolveTeamWorkerCliPlan(
   if (entries.length === 0 || entries.every((part) => part.length === 0)) {
     throw new Error(
       `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} value "${env[OMX_TEAM_WORKER_CLI_MAP_ENV]}". `
-        + `Expected comma-separated values: auto|codex|claude|gemini.`,
+        + `Expected comma-separated values: auto|codex|cursor|claude|gemini.`,
     );
   }
   if (entries.some((part) => part.length === 0)) {
@@ -592,6 +599,9 @@ export function resolveTeamWorkerCliPlan(
 
 export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: string[], initialPrompt?: string): string[] {
   if (workerCli === 'codex') return [...args];
+  if (workerCli === 'cursor') {
+    return args.filter((arg) => arg !== CODEX_BYPASS_FLAG && arg !== MADMAX_FLAG);
+  }
   if (workerCli === 'gemini') {
     const model = extractModelOverride(args);
     const geminiModel = model && /gemini/i.test(model) ? model : null;
@@ -614,6 +624,11 @@ function commandExists(binary: string): boolean {
     return classifySpawnError(result.error as NodeJS.ErrnoException) !== 'missing';
   }
   return true;
+}
+
+function resolveWorkerCliBinary(workerCli: TeamWorkerCli): string {
+  if (workerCli === 'cursor') return 'agent';
+  return workerCli;
 }
 
 /**
@@ -644,10 +659,11 @@ export function assertTeamWorkerCliBinaryAvailable(
   workerCli: TeamWorkerCli,
   existsImpl: (binary: string) => boolean = commandExists,
 ): void {
-  if (existsImpl(workerCli)) return;
+  const binary = resolveWorkerCliBinary(workerCli);
+  if (existsImpl(binary)) return;
   throw new Error(
-    `Selected team worker CLI "${workerCli}" is not available on PATH. `
-      + `Install "${workerCli}" or set ${OMX_TEAM_WORKER_CLI_ENV}=codex|claude|gemini.`,
+    `Selected team worker CLI "${workerCli}" (${binary}) is not available on PATH. `
+      + `Install "${workerCli}" or set ${OMX_TEAM_WORKER_CLI_ENV}=codex|cursor|claude|gemini.`,
   );
 }
 
@@ -725,15 +741,16 @@ export function buildWorkerProcessLaunchSpec(
     ? (isAbsolute(workerCodexHomeOverride) ? workerCodexHomeOverride : resolve(cwd, workerCodexHomeOverride))
     : undefined;
 
-  const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);
+  const resolvedCliPath = resolveAbsoluteBinaryPath(resolveWorkerCliBinary(workerCli));
   const workerEnv: Record<string, string> = {
     OMX_TEAM_WORKER: `${teamName}/worker-${workerIndex}`,
     [OMX_LEADER_NODE_PATH_ENV]: resolveLeaderNodePath(),
     [OMX_LEADER_CLI_PATH_ENV]: resolvedCliPath,
-    ...(workerCli === 'codex'
+    ...((workerCli === 'codex' || workerCli === 'cursor')
       ? readActiveProviderEnvOverrides(
           effectiveEnv,
           providerLookupCodexHome,
+          workerCli === 'cursor' ? 'cursor' : 'codex',
         )
       : {}),
   };
@@ -1160,7 +1177,7 @@ function resolveWorkerCliFromMapForSend(
   if (!selectedRaw) return null;
   try {
     const mode = normalizeTeamWorkerCliMode(selectedRaw, OMX_TEAM_WORKER_CLI_MAP_ENV);
-    return mode === 'auto' ? resolveTeamWorkerCliFromLaunchArgs(launchArgs) : mode;
+    return mode === 'auto' ? resolveTeamWorkerCliFromLaunchArgs(launchArgs, env) : mode;
   } catch {
     return null;
   }
@@ -1191,12 +1208,13 @@ export function buildWorkerSubmitPlan(
   allowAdaptiveRetry: boolean,
 ): WorkerSubmitPlan {
   const queueRequested = strategy === 'queue' || (strategy === 'auto' && paneBusyAtStart);
+  const isCodexLikeCli = workerCli === 'codex' || workerCli === 'cursor';
   return {
     shouldInterrupt: strategy === 'interrupt',
-    queueFirstRound: workerCli === 'codex' && queueRequested,
+    queueFirstRound: isCodexLikeCli && queueRequested,
     rounds: 6,
     submitKeyPressesPerRound: workerCli === 'claude' ? 1 : 2,
-    allowAdaptiveRetry: workerCli === 'codex' && allowAdaptiveRetry,
+    allowAdaptiveRetry: isCodexLikeCli && allowAdaptiveRetry,
   };
 }
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -9,10 +9,26 @@ import { readdir, readFile, realpath } from "fs/promises";
 import { dirname, isAbsolute, join, resolve } from "path";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
+import {
+  resolveRuntimeHomeEnvVar,
+  type RuntimeProvider,
+} from "../runtime/provider.js";
 
 /** Codex CLI home directory (~/.codex/) */
 export function codexHome(): string {
   return process.env.CODEX_HOME || join(homedir(), ".codex");
+}
+
+/** Cursor CLI home directory (~/.cursor/) */
+export function cursorHome(): string {
+  return process.env.CURSOR_HOME || join(homedir(), ".cursor");
+}
+
+/** Runtime home directory for the selected provider. */
+export function runtimeHome(provider: RuntimeProvider): string {
+  const envKey = resolveRuntimeHomeEnvVar(provider);
+  const fallbackDir = provider === "cursor" ? ".cursor" : ".codex";
+  return process.env[envKey] || join(homedir(), fallbackDir);
 }
 
 export const OMX_ENTRY_PATH_ENV = "OMX_ENTRY_PATH";
@@ -76,14 +92,30 @@ export function codexConfigPath(): string {
   return join(codexHome(), "config.toml");
 }
 
+/** Runtime config file path (~/.codex/config.toml or ~/.cursor/config.toml) */
+export function runtimeConfigPath(provider: RuntimeProvider): string {
+  return join(runtimeHome(provider), "config.toml");
+}
+
 /** Codex prompts directory (~/.codex/prompts/) */
 export function codexPromptsDir(): string {
   return join(codexHome(), "prompts");
 }
 
+export function runtimePromptsDir(provider: RuntimeProvider): string {
+  return join(runtimeHome(provider), "prompts");
+}
+
 /** Codex native agents directory (~/.codex/agents/) */
 export function codexAgentsDir(codexHomeDir?: string): string {
   return join(codexHomeDir || codexHome(), "agents");
+}
+
+export function runtimeAgentsDir(
+  provider: RuntimeProvider,
+  runtimeHomeDir?: string,
+): string {
+  return join(runtimeHomeDir || runtimeHome(provider), "agents");
 }
 
 /** Project-level Codex native agents directory (.codex/agents/) */

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -25,6 +25,7 @@ const WINDOWS_EXTENSION_PRIORITY = ['.exe', '.com', '.cmd', '.bat', '.ps1'];
 const NODE_HOSTED_SCRIPT_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
 const WINDOWS_NODE_HOSTED_COMMANDS: Record<string, string[]> = {
   codex: ['node_modules', '@openai', 'codex', 'bin', 'codex.js'],
+  cursor: ['node_modules', '@cursor', 'cli', 'bin', 'cursor.js'],
 };
 
 function existsFileSync(path: string): boolean {


### PR DESCRIPTION
## Summary
- add a runtime provider abstraction so OMX can launch through Codex or Cursor
- make CLI launch paths, hooks/config handling, team tmux workers, and Rust bridges provider-aware
- include compatibility handling for Cursor CLI argument differences and add regression tests/docs updates

## Test plan
- [x] npm run build
- [x] npm install -g .
- [x] OMX_RUNTIME_PROVIDER=cursor omx launch --help
- [x] cursor-agent --help (validate CLI flag semantics like `-c/--cloud`)

Made with [Cursor](https://cursor.com)