### PR TITLE
Canonicalize HUD skill state and suppress stale root fallback

### DIFF
--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -366,6 +366,35 @@ describe("resolveSessionOrchestrationMode", () => {
     const mode = await resolveSessionOrchestrationMode(tempDir, sessionId);
     assert.equal(mode, "team");
   });
+
+  it("active mode summary follows canonical session skill state instead of stale root mode files", async () => {
+    const sessionId = "sess-active-summary";
+    const rootStateDir = join(tempDir, ".omx", "state");
+    const sessionDir = join(rootStateDir, "sessions", sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(rootStateDir, "ralph-state.json"),
+      JSON.stringify({ active: true, iteration: 9, max_iterations: 10, current_phase: "stale-root" }),
+    );
+    await writeFile(
+      join(sessionDir, "skill-active-state.json"),
+      JSON.stringify({
+        active: true,
+        skill: "team",
+        phase: "running",
+        session_id: sessionId,
+        active_skills: [{ skill: "team", phase: "running", active: true, session_id: sessionId }],
+      }),
+    );
+    await writeFile(
+      join(sessionDir, "team-state.json"),
+      JSON.stringify({ active: true, team_name: "delta" }),
+    );
+
+    const overlay = await generateOverlay(tempDir, sessionId);
+    assert.ok(overlay.includes("- team: phase: running"));
+    assert.equal(overlay.includes("ralph"), false);
+  });
 });
 
 describe("applyOverlay + stripOverlay roundtrip", () => {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -7,11 +7,11 @@ import {
   detectKeywords,
   detectPrimaryKeyword,
   recordSkillActivation,
-  SKILL_ACTIVE_STATE_FILE,
   DEEP_INTERVIEW_STATE_FILE,
   DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS,
   DEEP_INTERVIEW_INPUT_LOCK_MESSAGE,
 } from '../keyword-detector.js';
+import { SKILL_ACTIVE_STATE_FILE } from '../../state/skill-active.js';
 import { isUnderspecifiedForExecution, applyRalplanGate } from '../keyword-detector.js';
 import { KEYWORD_TRIGGER_DEFINITIONS } from '../keyword-registry.js';
 
@@ -226,6 +226,16 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(result.skill, 'autopilot');
       assert.equal(result.phase, 'planning');
       assert.equal(result.active, true);
+      assert.deepEqual(result.active_skills, [{
+        skill: 'autopilot',
+        phase: 'planning',
+        active: true,
+        activated_at: '2026-02-25T00:00:00.000Z',
+        updated_at: '2026-02-25T00:00:00.000Z',
+        session_id: 'sess-1',
+        thread_id: 'thread-1',
+        turn_id: 'turn-1',
+      }]);
       assert.equal(result.initialized_mode, 'autopilot');
       assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-1/autopilot-state.json');
 
@@ -233,12 +243,28 @@ describe('keyword detector skill-active-state lifecycle', () => {
         skill: string;
         phase: string;
         active: boolean;
+        active_skills?: Array<{ skill: string; session_id?: string }>;
         initialized_mode?: string;
       };
       assert.equal(persisted.skill, 'autopilot');
       assert.equal(persisted.phase, 'planning');
       assert.equal(persisted.active, true);
+      assert.deepEqual(persisted.active_skills, [{
+        skill: 'autopilot',
+        phase: 'planning',
+        active: true,
+        activated_at: '2026-02-25T00:00:00.000Z',
+        updated_at: '2026-02-25T00:00:00.000Z',
+        session_id: 'sess-1',
+        thread_id: 'thread-1',
+        turn_id: 'turn-1',
+      }]);
       assert.equal(persisted.initialized_mode, 'autopilot');
+
+      const sessionScopedSkillState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-1', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; session_id?: string }> };
+      assert.deepEqual(sessionScopedSkillState.active_skills, persisted.active_skills);
 
       const modeState = JSON.parse(await readFile(join(stateDir, 'sessions', 'sess-1', 'autopilot-state.json'), 'utf-8')) as {
         mode: string;

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -34,8 +34,12 @@ import {
   listModeStateFilesWithScopePreference,
 } from "../mcp/state-paths.js";
 import { generateCodebaseMap } from "./codebase-map.js";
-import { SKILL_ACTIVE_STATE_FILE } from "./keyword-detector.js";
 import { buildExploreRoutingGuidance } from "./explore-routing.js";
+import {
+  SKILL_ACTIVE_STATE_FILE,
+  listActiveSkills,
+  readVisibleSkillActiveState,
+} from "../state/skill-active.js";
 
 const START_MARKER = "<!-- OMX:RUNTIME:START -->";
 const END_MARKER = "<!-- OMX:RUNTIME:END -->";
@@ -198,6 +202,11 @@ async function readActiveModes(
   sessionId?: string,
 ): Promise<string> {
   const refs = await listModeStateFilesWithScopePreference(cwd, sessionId);
+  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+  const canonicalSkills = new Map(
+    listActiveSkills(canonicalState).map((entry) => [entry.skill, entry] as const),
+  );
+  const useCompatibilityFallback = canonicalState == null;
 
   const preferredByMode = new Map<
     string,
@@ -208,10 +217,18 @@ async function readActiveModes(
   }
 
   const modes: string[] = [];
+  const emittedCanonicalSkills = new Set<string>();
   for (const ref of [...preferredByMode.values()].sort((a, b) =>
     a.mode.localeCompare(b.mode),
   )) {
     try {
+      if (
+        !useCompatibilityFallback &&
+        ref.mode !== "autoresearch" &&
+        !canonicalSkills.has(ref.mode)
+      ) {
+        continue;
+      }
       const data = JSON.parse(await readFile(ref.path, "utf-8"));
       if (!data.active) continue;
       const details: string[] = [];
@@ -219,10 +236,22 @@ async function readActiveModes(
         details.push(
           `iteration ${data.iteration}/${data.max_iterations || "?"}`,
         );
-      if (data.current_phase) details.push(`phase: ${data.current_phase}`);
+      const canonicalPhase = canonicalSkills.get(ref.mode)?.phase;
+      const phase = data.current_phase || canonicalPhase;
+      if (phase) details.push(`phase: ${phase}`);
       modes.push(`- ${ref.mode}: ${details.join(", ") || "active"}`);
+      emittedCanonicalSkills.add(ref.mode);
     } catch {
       // Skip malformed mode state files.
+    }
+  }
+
+  if (!useCompatibilityFallback) {
+    for (const [skill, entry] of [...canonicalSkills.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+      if (emittedCanonicalSkills.has(skill)) continue;
+      const details: string[] = [];
+      if (entry.phase) details.push(`phase: ${entry.phase}`);
+      modes.push(`- ${skill}: ${details.join(", ") || "active"}`);
     }
   }
 

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -17,6 +17,11 @@ import { classifyTaskSize, isHeavyMode, type TaskSizeResult, type TaskSizeThresh
 import { isApprovedExecutionFollowupShortcut, type FollowupMode } from '../team/followup-planner.js';
 import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
 import { KEYWORD_TRIGGER_DEFINITIONS, compareKeywordMatches } from './keyword-registry.js';
+import {
+  SKILL_ACTIVE_STATE_FILE,
+  writeSkillActiveStateCopies,
+  type SkillActiveEntry,
+} from '../state/skill-active.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -53,8 +58,10 @@ export interface SkillActiveState {
   thread_id?: string;
   turn_id?: string;
   input_lock?: DeepInterviewInputLock;
+  active_skills?: SkillActiveEntry[];
   initialized_mode?: string;
   initialized_state_path?: string;
+  [key: string]: unknown;
 }
 
 export interface RecordSkillActivationInput {
@@ -66,7 +73,6 @@ export interface RecordSkillActivationInput {
   nowIso?: string;
 }
 
-export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
 export const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
 export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'] as const;
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
@@ -132,6 +138,20 @@ async function readExistingSkillState(statePath: string): Promise<SkillActiveSta
   } catch {
     return null;
   }
+}
+
+function buildActiveSkills(state: SkillActiveState): SkillActiveEntry[] | undefined {
+  if (!state.active) return undefined;
+  return [{
+    skill: state.skill,
+    phase: state.phase,
+    active: true,
+    activated_at: state.activated_at,
+    updated_at: state.updated_at,
+    session_id: state.session_id,
+    thread_id: state.thread_id,
+    turn_id: state.turn_id,
+  }];
 }
 
 async function readExistingDeepInterviewState(statePath: string): Promise<DeepInterviewModeState | null> {
@@ -422,11 +442,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       session_id: input.sessionId ?? previous?.session_id,
       thread_id: input.threadId ?? previous?.thread_id,
       turn_id: input.turnId ?? previous?.turn_id,
+      active_skills: [],
       ...(previous?.input_lock ? { input_lock: releaseDeepInterviewInputLock(previous.input_lock, nowIso, 'abort') } : {}),
     };
 
     try {
-      await writeFile(statePath, JSON.stringify(state, null, 2));
+      await writeSkillActiveStateCopies(dirname(dirname(input.stateDir)), state, input.sessionId);
       await persistDeepInterviewModeState(input.stateDir, state, nowIso, previous, input);
     } catch (error) {
       console.warn('[omx] warning: failed to persist keyword activation state', error);
@@ -454,12 +475,23 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     session_id: input.sessionId,
     thread_id: input.threadId,
     turn_id: input.turnId,
+    active_skills: [{
+      skill: match.skill,
+      phase: 'planning',
+      active: true,
+      activated_at: sameSkill && sameKeyword ? previous?.activated_at : nowIso,
+      updated_at: nowIso,
+      session_id: input.sessionId,
+      thread_id: input.threadId,
+      turn_id: input.turnId,
+    }],
     ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
   };
 
   try {
     const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous);
-    await writeFile(statePath, JSON.stringify(nextState, null, 2));
+    nextState.active_skills = buildActiveSkills(nextState);
+    await writeSkillActiveStateCopies(dirname(dirname(input.stateDir)), nextState, input.sessionId);
     await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
     return nextState;
   } catch (error) {

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -104,6 +104,13 @@ describe('renderHud – ralph', () => {
     assert.ok(result.includes('ralph:3/10'));
   });
 
+  it('falls back to a bare label when Ralph counters are unavailable', () => {
+    const ctx = { ...emptyCtx(), ralph: { active: true } };
+    const result = stripSgr(renderHud(ctx, 'focused'));
+    assert.ok(result.includes('ralph'));
+    assert.equal(result.includes('ralph:'), false);
+  });
+
   it('omits ralph when null', () => {
     const result = renderHud(emptyCtx(), 'focused');
     assert.ok(!result.includes('ralph'));

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -6,6 +6,7 @@ import { basename, join, relative } from 'node:path';
 import {
   buildGitBranchLabel,
   readGitBranch,
+  readAllState,
   readRalphState,
   readRalplanState,
   readDeepInterviewState,
@@ -317,6 +318,64 @@ describe('additional HUD mode state readers', () => {
     await withTempRepo('omx-hud-ultraqa-', async (cwd) => {
       await writeModeState(cwd, 'ultraqa', { active: true, current_phase: 'diagnose' });
       assert.deepEqual(await readUltraqaState(cwd), { active: true, current_phase: 'diagnose' });
+    });
+  });
+});
+
+describe('readAllState canonical skill precedence', () => {
+  it('does not surface stale session mode detail when canonical skill state is inactive in legacy shape', async () => {
+    await withTempRepo('omx-hud-canonical-inactive-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-canonical-off';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: false,
+        skill: 'ralph',
+        phase: 'completing',
+        session_id: sessionId,
+      }));
+      await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        iteration: 2,
+        max_iterations: 5,
+        current_phase: 'executing',
+      }));
+
+      const state = await readAllState(cwd);
+      assert.equal(state.ralph, null);
+    });
+  });
+
+  it('uses canonical session skill state to suppress stale root fallback while preserving session detail', async () => {
+    await withTempRepo('omx-hud-canonical-session-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-current';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(rootStateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        iteration: 9,
+        max_iterations: 10,
+        current_phase: 'stale-root',
+      }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        session_id: sessionId,
+        active_skills: [{ skill: 'team', phase: 'running', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'alpha',
+      }));
+
+      const state = await readAllState(cwd);
+      assert.equal(state.ralph, null);
+      assert.deepEqual(state.team, { active: true, team_name: 'alpha', current_phase: 'running' });
     });
   });
 });

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -44,9 +44,14 @@ function renderGitBranch(ctx: HudRenderContext): string | null {
 function renderRalph(ctx: HudRenderContext): string | null {
   if (!ctx.ralph) return null;
   const { iteration, max_iterations } = ctx.ralph;
-  if (!isColorEnabled()) return `ralph:${iteration}/${max_iterations}`;
-  const color = getRalphColor(iteration, max_iterations);
-  return `${color}ralph:${iteration}/${max_iterations}${RESET}`;
+  if (!Number.isFinite(iteration) || !Number.isFinite(max_iterations)) {
+    return yellow('ralph');
+  }
+  const safeIteration = iteration as number;
+  const safeMaxIterations = max_iterations as number;
+  if (!isColorEnabled()) return `ralph:${safeIteration}/${safeMaxIterations}`;
+  const color = getRalphColor(safeIteration, safeMaxIterations);
+  return `${color}ralph:${safeIteration}/${safeMaxIterations}${RESET}`;
 }
 
 function renderUltrawork(ctx: HudRenderContext): string | null {

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -14,6 +14,7 @@ import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
 import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import type {
   RalphStateForHud,
   UltraworkStateForHud,
@@ -48,6 +49,23 @@ async function readScopedModeState<T>(cwd: string, mode: string): Promise<T | nu
     const state = await readJsonFile<T>(candidate);
     if (state) return state;
   }
+  return null;
+}
+
+async function readSessionAwareModeState<T>(cwd: string, mode: string): Promise<T | null> {
+  const candidates = await getReadScopedStatePaths(mode, cwd);
+  const session = await readSessionState(cwd);
+
+  if (session?.session_id) {
+    if (candidates.length === 0) return null;
+    return readJsonFile<T>(candidates[0]);
+  }
+
+  for (const candidate of candidates) {
+    const state = await readJsonFile<T>(candidate);
+    if (state) return state;
+  }
+
   return null;
 }
 
@@ -317,25 +335,91 @@ export function buildGitBranchLabel(
   return repoLabel ? `${repoLabel}/${branch}` : branch;
 }
 
+function canonicalPhaseForSkill(
+  canonicalSkills: Map<string, { phase?: string }>,
+  skill: string,
+): string | undefined {
+  return canonicalSkills.get(skill)?.phase;
+}
+
+function mergePhase<T extends { active?: boolean; current_phase?: string }>(
+  detail: T | null,
+  canonicalPhase?: string,
+): T | null {
+  if (detail?.active === true) {
+    if (!canonicalPhase || detail.current_phase) return detail;
+    return { ...detail, current_phase: canonicalPhase };
+  }
+  if (!canonicalPhase) return null;
+  return { active: true, current_phase: canonicalPhase } as T;
+}
+
 /** Read all state files and build the full render context */
 export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFAULT_HUD_CONFIG): Promise<HudRenderContext> {
   const version = readVersion();
   const gitBranch = buildGitBranchLabel(cwd, config);
+  const [metrics, hudNotify, session] = await Promise.all([
+    readMetrics(cwd),
+    readHudNotifyState(cwd),
+    readSessionState(cwd),
+  ]);
+  const canonicalSkillState = await readVisibleSkillActiveState(cwd, session?.session_id);
+  const canonicalSkills = new Map(
+    listActiveSkills(canonicalSkillState).map((entry) => [entry.skill, entry] as const),
+  );
+  const useCompatibilityFallback = canonicalSkillState == null;
 
-  const [ralph, ultrawork, autopilot, ralplan, deepInterview, autoresearch, ultraqa, team, metrics, hudNotify, session] =
-    await Promise.all([
-      readRalphState(cwd),
-      readUltraworkState(cwd),
-      readAutopilotState(cwd),
-      readRalplanState(cwd),
-      readDeepInterviewState(cwd),
-      readAutoresearchState(cwd),
-      readUltraqaState(cwd),
-      readTeamState(cwd),
-      readMetrics(cwd),
-      readHudNotifyState(cwd),
-      readSessionState(cwd),
-    ]);
+  const [
+    ralphDetail,
+    ultraworkDetail,
+    autopilotDetail,
+    ralplanDetail,
+    deepInterviewDetail,
+    autoresearchDetail,
+    ultraqaDetail,
+    teamDetail,
+  ] = await Promise.all([
+    readSessionAwareModeState<RalphStateForHud>(cwd, 'ralph'),
+    readSessionAwareModeState<UltraworkStateForHud>(cwd, 'ultrawork'),
+    readSessionAwareModeState<AutopilotStateForHud>(cwd, 'autopilot'),
+    readSessionAwareModeState<RalplanStateForHud>(cwd, 'ralplan'),
+    readSessionAwareModeState<DeepInterviewRawState>(cwd, 'deep-interview'),
+    readSessionAwareModeState<AutoresearchStateForHud>(cwd, 'autoresearch'),
+    readSessionAwareModeState<UltraqaStateForHud>(cwd, 'ultraqa'),
+    readSessionAwareModeState<TeamStateForHud>(cwd, 'team'),
+  ]);
+
+  const ralph = canonicalSkills.has('ralph') || useCompatibilityFallback
+    ? (ralphDetail?.active === true ? mergePhase(ralphDetail, canonicalPhaseForSkill(canonicalSkills, 'ralph')) : null)
+    : null;
+  const ultrawork = canonicalSkills.has('ultrawork') || useCompatibilityFallback
+    ? mergePhase(ultraworkDetail?.active === true ? ultraworkDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultrawork'))
+    : null;
+  const autopilot = canonicalSkills.has('autopilot') || useCompatibilityFallback
+    ? mergePhase(autopilotDetail?.active === true ? autopilotDetail : null, canonicalPhaseForSkill(canonicalSkills, 'autopilot'))
+    : null;
+  const ralplan = canonicalSkills.has('ralplan') || useCompatibilityFallback
+    ? mergePhase(ralplanDetail?.active === true ? ralplanDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ralplan'))
+    : null;
+  const deepInterview = canonicalSkills.has('deep-interview') || useCompatibilityFallback
+    ? (() => {
+      const merged = mergePhase(
+        deepInterviewDetail?.active === true ? {
+          ...deepInterviewDetail,
+          input_lock_active: deepInterviewDetail.input_lock_active ?? deepInterviewDetail.input_lock?.active === true,
+        } : null,
+        canonicalPhaseForSkill(canonicalSkills, 'deep-interview'),
+      );
+      return merged;
+    })()
+    : null;
+  const ultraqa = canonicalSkills.has('ultraqa') || useCompatibilityFallback
+    ? mergePhase(ultraqaDetail?.active === true ? ultraqaDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultraqa'))
+    : null;
+  const team = canonicalSkills.has('team') || useCompatibilityFallback
+    ? mergePhase(teamDetail?.active === true ? teamDetail : null, canonicalPhaseForSkill(canonicalSkills, 'team'))
+    : null;
+  const autoresearch = autoresearchDetail?.active === true ? autoresearchDetail : null;
 
   // When the Rust runtime bridge is enabled, prefer Rust-authored snapshot
   // for authority/backlog/readiness display over JS-inferred state.

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -5,8 +5,8 @@
 /** Ralph loop state for HUD display */
 export interface RalphStateForHud {
   active: boolean;
-  iteration: number;
-  max_iterations: number;
+  iteration?: number;
+  max_iterations?: number;
 }
 
 /** Ultrawork state for HUD display */

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -252,4 +252,101 @@ describe('state-server directory initialization', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('syncs canonical skill-active state for tracked mode writes and clears', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-canonical-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-sync',
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            max_iterations: 3,
+            current_phase: 'executing',
+          },
+        },
+      });
+
+      const canonicalPath = join(wd, '.omx', 'state', 'sessions', 'sess-sync', 'skill-active-state.json');
+      const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active_skills?: Array<{ skill: string; session_id?: string; activated_at?: string; updated_at?: string }>;
+      };
+      assert.deepEqual(canonical.active_skills, [{
+        skill: 'ralph',
+        phase: 'executing',
+        active: true,
+        activated_at: canonical.active_skills?.[0]?.activated_at,
+        updated_at: canonical.active_skills?.[0]?.updated_at,
+        session_id: 'sess-sync',
+      }]);
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-sync',
+            mode: 'ralph',
+          },
+        },
+      });
+
+      const clearedCanonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active: boolean;
+        active_skills?: unknown[];
+      };
+      assert.equal(clearedCanonical.active, false);
+      assert.deepEqual(clearedCanonical.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes tracked workflows from canonical skill-active state on all_sessions clear', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-canonical-clear-all-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+            all_sessions: true,
+          },
+        },
+      });
+
+      const canonicalPath = join(wd, '.omx', 'state', 'skill-active-state.json');
+      const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active: boolean;
+        active_skills?: unknown[];
+      };
+      assert.equal(canonical.active, false);
+      assert.deepEqual(canonical.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -31,6 +31,12 @@ import {
 } from "./state-paths.js";
 import { withModeRuntimeContext } from "../state/mode-state-context.js";
 import {
+	SKILL_ACTIVE_STATE_MODE,
+	readSkillActiveState,
+	syncCanonicalSkillStateForMode,
+	writeSkillActiveStateCopies,
+} from "../state/skill-active.js";
+import {
 	RALPH_PHASES,
 	validateAndNormalizeRalphState,
 } from "../ralph/contract.js";
@@ -49,6 +55,7 @@ const SUPPORTED_MODES = [
 	"ultraqa",
 	"ralplan",
 	"deep-interview",
+	"skill-active",
 ] as const;
 
 const STATE_TOOL_NAMES = new Set([
@@ -388,6 +395,21 @@ export async function handleStateToolCall(request: {
 						isError: true,
 					};
 				}
+				if (mode === SKILL_ACTIVE_STATE_MODE) {
+					const state = await readSkillActiveState(path);
+					if (state) {
+						await writeSkillActiveStateCopies(cwd, state, effectiveSessionId);
+					}
+				} else {
+					const data = JSON.parse(await readFile(path, "utf-8")) as Record<string, unknown>;
+					await syncCanonicalSkillStateForMode({
+						cwd,
+						mode,
+						active: data.active === true,
+						currentPhase: typeof data.current_phase === "string" ? data.current_phase : undefined,
+						sessionId: effectiveSessionId,
+					});
+				}
 				return {
 					content: [
 						{
@@ -408,6 +430,14 @@ export async function handleStateToolCall(request: {
 					if (existsSync(path)) {
 						await unlink(path);
 					}
+					if (mode !== SKILL_ACTIVE_STATE_MODE) {
+						await syncCanonicalSkillStateForMode({
+							cwd,
+							mode,
+							active: false,
+							sessionId: effectiveSessionId,
+						});
+					}
 					return {
 						content: [
 							{
@@ -424,6 +454,13 @@ export async function handleStateToolCall(request: {
 					if (!existsSync(path)) continue;
 					await unlink(path);
 					removedPaths.push(path);
+				}
+				if (mode !== SKILL_ACTIVE_STATE_MODE) {
+					await syncCanonicalSkillStateForMode({
+						cwd,
+						mode,
+						active: false,
+					});
 				}
 
 				return {
@@ -454,6 +491,7 @@ export async function handleStateToolCall(request: {
 					for (const f of files) {
 						if (!f.endsWith("-state.json")) continue;
 						const mode = f.replace("-state.json", "");
+						if (mode === SKILL_ACTIVE_STATE_MODE) continue;
 						if (seenModes.has(mode)) continue;
 						seenModes.add(mode);
 						try {

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  listActiveSkills,
+  readVisibleSkillActiveState,
+  syncCanonicalSkillStateForMode,
+  writeSkillActiveStateCopies,
+} from '../skill-active.js';
+
+async function withTempRepo(prefix: string, run: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('skill-active state helpers', () => {
+  it('prefers session-scoped canonical state over root state', async () => {
+    await withTempRepo('omx-skill-active-session-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeSkillActiveStateCopies(cwd, {
+        active: true,
+        skill: 'ralph',
+        phase: 'executing',
+        active_skills: [{ skill: 'ralph', phase: 'executing', active: true }],
+      });
+      await writeSkillActiveStateCopies(cwd, {
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        session_id: 'sess-1',
+        active_skills: [{ skill: 'team', phase: 'running', active: true, session_id: 'sess-1' }],
+      }, 'sess-1');
+
+      const state = await readVisibleSkillActiveState(cwd, 'sess-1');
+      assert.ok(state);
+      assert.equal(state?.skill, 'team');
+      const [entry] = listActiveSkills(state);
+      assert.ok(entry);
+      assert.equal(entry.skill, 'team');
+      assert.equal(entry.phase, 'running');
+      assert.equal(entry.active, true);
+      assert.equal(entry.session_id, 'sess-1');
+    });
+  });
+
+  it('drops stale entries from other sessions when syncing canonical state for the current session', async () => {
+    await withTempRepo('omx-skill-active-filter-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeSkillActiveStateCopies(cwd, {
+        active: true,
+        skill: 'deep-interview',
+        phase: 'intent-first',
+        session_id: 'old-session',
+        active_skills: [{ skill: 'deep-interview', phase: 'intent-first', active: true, session_id: 'old-session' }],
+      });
+
+      await syncCanonicalSkillStateForMode({
+        cwd,
+        mode: 'ralph',
+        active: true,
+        currentPhase: 'executing',
+        sessionId: 'new-session',
+        nowIso: '2026-04-08T00:00:00.000Z',
+      });
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'new-session');
+      assert.ok(sessionState);
+      const [entry] = listActiveSkills(sessionState);
+      assert.ok(entry);
+      assert.equal(entry.skill, 'ralph');
+      assert.equal(entry.phase, 'executing');
+      assert.equal(entry.active, true);
+      assert.equal(entry.activated_at, '2026-04-08T00:00:00.000Z');
+      assert.equal(entry.updated_at, '2026-04-08T00:00:00.000Z');
+      assert.equal(entry.session_id, 'new-session');
+
+      const rootState = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'skill-active-state.json'), 'utf-8')) as {
+        active_skills?: Array<{ skill: string; session_id?: string }>;
+      };
+      assert.deepEqual(rootState.active_skills, [{
+        skill: 'ralph',
+        phase: 'executing',
+        active: true,
+        activated_at: '2026-04-08T00:00:00.000Z',
+        updated_at: '2026-04-08T00:00:00.000Z',
+        session_id: 'new-session',
+      }]);
+    });
+  });
+});

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -1,0 +1,254 @@
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { omxStateDir } from '../utils/paths.js';
+
+export const SKILL_ACTIVE_STATE_MODE = 'skill-active';
+export const SKILL_ACTIVE_STATE_FILE = `${SKILL_ACTIVE_STATE_MODE}-state.json`;
+
+export const CANONICAL_WORKFLOW_SKILLS = [
+  'autopilot',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
+  'ralplan',
+  'deep-interview',
+] as const;
+
+export type CanonicalWorkflowSkill = (typeof CANONICAL_WORKFLOW_SKILLS)[number];
+
+export interface SkillActiveEntry {
+  skill: string;
+  phase?: string;
+  active?: boolean;
+  activated_at?: string;
+  updated_at?: string;
+  session_id?: string;
+  thread_id?: string;
+  turn_id?: string;
+}
+
+export interface SkillActiveStateLike {
+  version?: number;
+  active?: boolean;
+  skill?: string;
+  keyword?: string;
+  phase?: string;
+  activated_at?: string;
+  updated_at?: string;
+  source?: string;
+  session_id?: string;
+  thread_id?: string;
+  turn_id?: string;
+  initialized_mode?: string;
+  initialized_state_path?: string;
+  input_lock?: unknown;
+  active_skills?: SkillActiveEntry[];
+  [key: string]: unknown;
+}
+
+export interface SyncCanonicalSkillStateOptions {
+  cwd: string;
+  mode: string;
+  active: boolean;
+  currentPhase?: string;
+  sessionId?: string;
+  threadId?: string;
+  turnId?: string;
+  nowIso?: string;
+  source?: string;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function filterEntriesForSession(
+  entries: SkillActiveEntry[],
+  sessionId?: string,
+): SkillActiveEntry[] {
+  const normalizedSessionId = safeString(sessionId).trim();
+  if (!normalizedSessionId) return entries;
+  return entries.filter((entry) => safeString(entry.session_id).trim() === normalizedSessionId);
+}
+
+function normalizeSkillActiveEntry(raw: unknown): SkillActiveEntry | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const skill = safeString((raw as Record<string, unknown>).skill).trim();
+  if (!skill) return null;
+
+  return {
+    ...raw as Record<string, unknown>,
+    skill,
+    phase: safeString((raw as Record<string, unknown>).phase).trim() || undefined,
+    active: (raw as Record<string, unknown>).active !== false,
+    activated_at: safeString((raw as Record<string, unknown>).activated_at).trim() || undefined,
+    updated_at: safeString((raw as Record<string, unknown>).updated_at).trim() || undefined,
+    session_id: safeString((raw as Record<string, unknown>).session_id).trim() || undefined,
+    thread_id: safeString((raw as Record<string, unknown>).thread_id).trim() || undefined,
+    turn_id: safeString((raw as Record<string, unknown>).turn_id).trim() || undefined,
+  };
+}
+
+export function listActiveSkills(raw: unknown): SkillActiveEntry[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const state = raw as SkillActiveStateLike;
+  const deduped = new Map<string, SkillActiveEntry>();
+
+  if (Array.isArray(state.active_skills)) {
+    for (const candidate of state.active_skills) {
+      const normalized = normalizeSkillActiveEntry(candidate);
+      if (!normalized || normalized.active === false) continue;
+      deduped.set(normalized.skill, normalized);
+    }
+  }
+
+  const topLevelSkill = safeString(state.skill).trim();
+  if (deduped.size === 0 && state.active === true && topLevelSkill) {
+    deduped.set(topLevelSkill, {
+      skill: topLevelSkill,
+      phase: safeString(state.phase).trim() || undefined,
+      active: true,
+      activated_at: safeString(state.activated_at).trim() || undefined,
+      updated_at: safeString(state.updated_at).trim() || undefined,
+      session_id: safeString(state.session_id).trim() || undefined,
+      thread_id: safeString(state.thread_id).trim() || undefined,
+      turn_id: safeString(state.turn_id).trim() || undefined,
+    });
+  }
+
+  return [...deduped.values()];
+}
+
+export function normalizeSkillActiveState(raw: unknown): SkillActiveStateLike | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const state = raw as SkillActiveStateLike;
+  const activeSkills = listActiveSkills(state);
+  const primary = activeSkills.find((entry) => entry.skill === safeString(state.skill).trim()) ?? activeSkills[0];
+  const skill = safeString(state.skill).trim() || primary?.skill || '';
+  if (!skill && activeSkills.length === 0) return null;
+
+  return {
+    ...state,
+    version: typeof state.version === 'number' ? state.version : 1,
+    active: typeof state.active === 'boolean' ? state.active : activeSkills.length > 0,
+    skill,
+    keyword: safeString(state.keyword).trim(),
+    phase: safeString(state.phase).trim() || primary?.phase || '',
+    activated_at: safeString(state.activated_at).trim() || primary?.activated_at || '',
+    updated_at: safeString(state.updated_at).trim() || primary?.updated_at || '',
+    source: safeString(state.source).trim() || undefined,
+    session_id: safeString(state.session_id).trim() || primary?.session_id || undefined,
+    thread_id: safeString(state.thread_id).trim() || primary?.thread_id || undefined,
+    turn_id: safeString(state.turn_id).trim() || primary?.turn_id || undefined,
+    active_skills: activeSkills.length > 0 ? activeSkills : undefined,
+  };
+}
+
+export function getSkillActiveStatePaths(cwd: string, sessionId?: string): {
+  rootPath: string;
+  sessionPath?: string;
+} {
+  const rootPath = join(omxStateDir(cwd), SKILL_ACTIVE_STATE_FILE);
+  const normalizedSession = safeString(sessionId).trim();
+  if (!normalizedSession) return { rootPath };
+  return {
+    rootPath,
+    sessionPath: join(omxStateDir(cwd), 'sessions', normalizedSession, SKILL_ACTIVE_STATE_FILE),
+  };
+}
+
+export async function readSkillActiveState(path: string): Promise<SkillActiveStateLike | null> {
+  try {
+    return normalizeSkillActiveState(JSON.parse(await readFile(path, 'utf-8')));
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSkillActiveStateCopies(
+  cwd: string,
+  state: SkillActiveStateLike,
+  sessionId?: string,
+): Promise<void> {
+  const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+  const payload = JSON.stringify(state, null, 2);
+
+  await mkdir(dirname(rootPath), { recursive: true });
+  await writeFile(rootPath, payload);
+
+  if (sessionPath) {
+    await mkdir(dirname(sessionPath), { recursive: true });
+    await writeFile(sessionPath, payload);
+  }
+}
+
+export async function readVisibleSkillActiveState(cwd: string, sessionId?: string): Promise<SkillActiveStateLike | null> {
+  const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+  if (sessionPath && existsSync(sessionPath)) {
+    return readSkillActiveState(sessionPath);
+  }
+  if (sessionPath) return null;
+  if (!existsSync(rootPath)) return null;
+  return readSkillActiveState(rootPath);
+}
+
+export function tracksCanonicalWorkflowSkill(mode: string): mode is CanonicalWorkflowSkill {
+  return (CANONICAL_WORKFLOW_SKILLS as readonly string[]).includes(mode);
+}
+
+export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkillStateOptions): Promise<void> {
+  const {
+    cwd,
+    mode,
+    active,
+    currentPhase,
+    sessionId,
+    threadId,
+    turnId,
+    nowIso = new Date().toISOString(),
+    source = 'state-server',
+  } = options;
+
+  if (!tracksCanonicalWorkflowSkill(mode)) return;
+
+  const { rootPath } = getSkillActiveStatePaths(cwd, sessionId);
+  const existing = await readSkillActiveState(rootPath);
+  if (!existing && !active) return;
+
+  const entries = filterEntriesForSession(listActiveSkills(existing ?? {}), sessionId);
+  const filtered = entries.filter((entry) => entry.skill !== mode);
+  if (active) {
+    filtered.push({
+      skill: mode,
+      phase: safeString(currentPhase).trim() || undefined,
+      active: true,
+      activated_at: entries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
+      updated_at: nowIso,
+      session_id: safeString(sessionId).trim() || undefined,
+      thread_id: safeString(threadId).trim() || undefined,
+      turn_id: safeString(turnId).trim() || undefined,
+    });
+  }
+
+  const currentPrimary = safeString(existing?.skill).trim();
+  const primaryEntry = filtered.find((entry) => entry.skill === currentPrimary) ?? filtered[0];
+  const nextState: SkillActiveStateLike = {
+    ...(existing ?? {}),
+    version: 1,
+    active: filtered.length > 0,
+    skill: primaryEntry?.skill || currentPrimary || mode,
+    keyword: safeString(existing?.keyword).trim(),
+    phase: primaryEntry?.phase || safeString(currentPhase).trim() || safeString(existing?.phase).trim(),
+    activated_at: primaryEntry?.activated_at || safeString(existing?.activated_at).trim() || nowIso,
+    updated_at: nowIso,
+    source: safeString(existing?.source).trim() || source,
+    session_id: safeString(sessionId).trim() || safeString(existing?.session_id).trim() || undefined,
+    thread_id: safeString(threadId).trim() || safeString(existing?.thread_id).trim() || undefined,
+    turn_id: safeString(turnId).trim() || safeString(existing?.turn_id).trim() || undefined,
+    active_skills: filtered.length > 0 ? filtered : [],
+  };
+
+  await writeSkillActiveStateCopies(cwd, nextState, sessionId);
+}


### PR DESCRIPTION
## Summary
- make `skill-active-state.json` the canonical visible workflow source for HUD and overlay summaries
- sync canonical skill state through MCP mode writes/clears and preserve session-scoped copies for compatibility
- add regression coverage for stale root suppression, multi-skill canonical state, and unchanged consumer behavior

## Verification
- npm run build
- npm run lint -- src/hooks/agents-overlay.ts src/hooks/keyword-detector.ts src/hud/render.ts src/hud/state.ts src/hud/types.ts src/mcp/state-server.ts src/state/skill-active.ts src/hooks/__tests__/agents-overlay.test.ts src/hooks/__tests__/keyword-detector.test.ts src/hud/__tests__/render.test.ts src/hud/__tests__/state.test.ts src/mcp/__tests__/state-server.test.ts src/state/__tests__/skill-active.test.ts
- node --test dist/state/__tests__/skill-active.test.js dist/hud/__tests__/state.test.js dist/hud/__tests__/render.test.js dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/agents-overlay.test.js dist/mcp/__tests__/state-server.test.js
- npm test
- npx tsc --noEmit --pretty false --project tsconfig.json
