### PR TITLE
fix: detect and clean stale team worktrees at startTeam() time (#1354)

### DIFF
--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -6,13 +6,33 @@
  * Spawned by OMX team orchestration entrypoints when a background team run starts.
  */
 
+import { createInterface } from 'readline';
 import { readdirSync, readFileSync } from 'fs';
 import { writeFile, rename } from 'fs/promises';
 import { join } from 'path';
 import { startTeam, monitorTeam, shutdownTeam } from './runtime.js';
-import type { TeamRuntime, TeamShutdownSummary } from './runtime.js';
+import type { TeamRuntime, TeamShutdownSummary, StaleTeamSummary } from './runtime.js';
 import { teamReadConfig as readTeamConfig } from './team-ops.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
+
+async function promptStaleCleanup(summary: StaleTeamSummary): Promise<boolean> {
+  process.stderr.write(
+    `\n[omx] Stale artifacts from previous team "${summary.teamName}":\n` +
+    `  Worktrees: ${summary.worktreePaths.join(', ')}\n` +
+    `  State dir: ${summary.statePath}\n` +
+    (summary.hasDirtyWorktrees
+      ? '  ⚠ Some worktrees have uncommitted changes that will be lost.\n'
+      : '') +
+    '  Clean up and continue? [y/N] ',
+  );
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise<boolean>((res) => {
+    rl.question('', (answer) => {
+      rl.close();
+      res(answer.trim().toLowerCase() === 'y');
+    });
+  });
+}
 
 interface CliInput {
   teamName: string;
@@ -255,6 +275,7 @@ async function main(): Promise<void> {
         workerCount,
         tasks,
         cwd,
+        { confirmStaleCleanup: promptStaleCleanup },
       );
     } finally {
       if (typeof previousCliMap === 'string') process.env.OMX_TEAM_WORKER_CLI_MAP = previousCliMap;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -129,7 +129,9 @@ import {
   assertCleanLeaderWorkspaceForWorkerWorktrees,
   ensureWorktree,
   isGitRepository,
+  isWorktreeDirty,
   planWorktreeTarget,
+  removeWorktreeForce,
   rollbackProvisionedWorktrees,
   type EnsureWorktreeResult,
   type WorktreeMode,
@@ -1056,8 +1058,16 @@ async function prepareWorkerWorktreeShutdownReports(config: TeamConfig, leaderCw
   return reports
 }
 
+export interface StaleTeamSummary {
+  teamName: string;
+  worktreePaths: string[];
+  statePath: string;
+  hasDirtyWorktrees: boolean;
+}
+
 export interface TeamStartOptions {
   worktreeMode?: WorktreeMode;
+  confirmStaleCleanup?: (summary: StaleTeamSummary) => Promise<boolean>;
 }
 
 interface ShutdownGateCounts {
@@ -1729,6 +1739,8 @@ export async function startTeam(
   for (let i = 1; i <= workerCount; i++) {
     workerWorkspaceByName.set(`worker-${i}`, { cwd: leaderCwd });
   }
+
+  await detectAndCleanStaleTeam(sanitized, leaderCwd, workerCount, options.confirmStaleCleanup);
 
   if (activeWorktreeMode) {
     assertCleanLeaderWorkspaceForWorkerWorktrees(leaderCwd);
@@ -2990,6 +3002,62 @@ async function findActiveTeams(cwd: string, leaderSessionId: string): Promise<st
     if (sessions.has(tmuxSession)) active.push(teamName);
   }
   return active;
+}
+
+async function detectAndCleanStaleTeam(
+  teamName: string,
+  leaderCwd: string,
+  workerCount: number,
+  confirmFn?: (summary: StaleTeamSummary) => Promise<boolean>,
+): Promise<void> {
+  const stateDir = join(leaderCwd, '.omx', 'state', 'team', teamName);
+  if (!existsSync(stateDir)) return;
+
+  const sessions = new Set(listTeamSessions());
+  if (sessions.has(`omx-team-${teamName}`)) return;
+
+  const repoRootResult = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: leaderCwd, encoding: 'utf-8', windowsHide: true,
+  });
+  if (repoRootResult.status !== 0) return;
+  const repoRoot = repoRootResult.stdout.trim();
+
+  const worktreePaths: string[] = [];
+  for (let i = 1; i <= workerCount; i++) {
+    const wtPath = join(repoRoot, '.omx', 'team', teamName, 'worktrees', `worker-${i}`);
+    if (existsSync(wtPath)) worktreePaths.push(wtPath);
+  }
+
+  if (worktreePaths.length === 0) {
+    await cleanupTeamState(teamName, leaderCwd);
+    return;
+  }
+
+  const hasDirtyWorktrees = worktreePaths.some((p) => {
+    try { return isWorktreeDirty(p); } catch { return false; }
+  });
+
+  const summary: StaleTeamSummary = { teamName, worktreePaths, statePath: stateDir, hasDirtyWorktrees };
+
+  if (!confirmFn) {
+    throw new Error(
+      `stale_team_artifacts:${teamName}:${worktreePaths.length}_worktrees:` +
+      'pass_confirmStaleCleanup_or_manually_remove',
+    );
+  }
+
+  const confirmed = await confirmFn(summary);
+  if (!confirmed) {
+    throw new Error(
+      `stale_team_cleanup_declined:${teamName}:` +
+      'manually_remove_worktrees_and_state_before_retrying',
+    );
+  }
+
+  for (const wtPath of worktreePaths) {
+    await removeWorktreeForce(repoRoot, wtPath);
+  }
+  await cleanupTeamState(teamName, leaderCwd);
 }
 
 async function resolveLeaderSessionId(cwd: string): Promise<string> {

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -110,7 +110,7 @@ function branchExists(repoRoot: string, branchName: string): boolean {
   return result.status === 0;
 }
 
-function isWorktreeDirty(worktreePath: string): boolean {
+export function isWorktreeDirty(worktreePath: string): boolean {
   const result = spawnSync('git', ['status', '--porcelain'], {
     cwd: worktreePath,
     encoding: 'utf-8',
@@ -485,4 +485,11 @@ export async function rollbackProvisionedWorktrees(
   if (errors.length > 0) {
     throw new Error(`worktree_rollback_failed:${errors.join(' | ')}`);
   }
+}
+
+export async function removeWorktreeForce(repoRoot: string, worktreePath: string): Promise<void> {
+  await execFilePromise('git', ['worktree', 'remove', '--force', worktreePath], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+  });
 }


### PR DESCRIPTION
## Summary

Detect and clean stale worktrees from a previous `$team` run before starting a new one, so the next `omx team` no longer fails with `worktree_dirty` errors caused by leftover artifacts from a prior session.

## Changes

* export `isWorktreeDirty` in `src/team/worktree.ts` so `detectAndCleanStaleTeam()` in runtime.ts can check whether stale worktrees have uncommitted changes before removing them
* add `removeWorktreeForce()` in `src/team/worktree.ts` — thin async wrapper around `git worktree remove --force`, needed because the existing `rollbackProvisionedWorktrees` only removes worktrees created in the current run (`result.created === true`), not worktrees from a prior run
* add `StaleTeamSummary` interface and optional `confirmStaleCleanup` callback to `TeamStartOptions` in `src/team/runtime.ts` — callback pattern keeps runtime.ts testable and UI-agnostic; callers control how to prompt
* add `detectAndCleanStaleTeam()` private function in `src/team/runtime.ts`:
  * checks if `.omx/state/team/{teamName}/` exists (early return if no prior run)
  * checks if tmux session `omx-team-{teamName}` is alive via `listTeamSessions()` (early return if team is still running)
  * enumerates expected worktree paths, filters by `existsSync`
  * if no worktrees found, silently cleans state dir via `cleanupTeamState()` (no data loss risk, no prompt needed)
  * checks `isWorktreeDirty()` on each surviving worktree to populate `hasDirtyWorktrees` in the summary
  * if no callback provided, throws `stale_team_artifacts:{teamName}` with guidance
  * if user declines cleanup, throws `stale_team_cleanup_declined:{teamName}`
  * if confirmed, removes each worktree via `removeWorktreeForce()` then cleans state via `cleanupTeamState()`
* wire `detectAndCleanStaleTeam()` into `startTeam()` after `sanitizeTeamName` and before the worktree provisioning loop, so stale dirty worktrees are cleaned before they trigger `worktree_dirty` errors
* add `promptStaleCleanup()` in `src/team/runtime-cli.ts` — interactive stderr prompt that prints the stale summary (worktree paths, state dir, dirty warning) and asks `[y/N]`; default is deny; wired into the `startTeam()` call as the `confirmStaleCleanup` callback

## Validation

* `npx tsc --noEmit` — full type check, passed clean
* `npm run lint` — Biome across 421 files, passed clean
* `npm run build` — compiled successfully
* `npm run test:node` — 2986 tests, 2970 pass, 16 fail; the 16 failures are pre-existing (confirmed by `git stash` → rebuild → same 16 failures → `git stash pop`)

## Checklist

* PR is focused and avoids unrelated changes
* three files modified: `src/team/worktree.ts`, `src/team/runtime.ts`, `src/team/runtime-cli.ts`
* backward-compatibility impact: none — `confirmStaleCleanup` is optional; existing callers that don't pass it get a thrown error with guidance instead of silent cleanup
* pre-existing test failures documented and confirmed unrelated via git stash round-trip

## Related

Closes #1354

–

Co-Authored-By: Claude Opus 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)