### PR TITLE
fix(team): preserve team state until explicit shutdown

### DIFF
--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -162,6 +162,118 @@ describe('runtime-cli helpers', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('preserves team state when building terminal output for completed teams', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-preserve-complete-'));
+    try {
+      await initTeamState('runtime-cli-preserve-complete', 'task', 'executor', 1, cwd);
+      await createTask('runtime-cli-preserve-complete', {
+        subject: 'done task',
+        description: 'already complete',
+        status: 'completed',
+        owner: 'worker-1',
+        result: 'PASS: complete without shutdown',
+      }, cwd);
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'runtime-cli-preserve-complete');
+      assert.equal(existsSync(teamRoot), true);
+
+      const runtimeCli = await loadRuntimeCliModule();
+      const result = runtimeCli.buildTerminalCliResult(
+        runtimeCli.resolveRuntimeCliStateRoot(cwd),
+        'runtime-cli-preserve-complete',
+        'complete',
+        1,
+        Date.now() - 1_000,
+      );
+
+      assert.equal(existsSync(teamRoot), true);
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.output.status, 'completed');
+      assert.equal(result.output.teamName, 'runtime-cli-preserve-complete');
+      assert.deepEqual(result.output.taskResults, [{
+        taskId: '1',
+        status: 'completed',
+        summary: 'PASS: complete without shutdown',
+      }]);
+      assert.match(result.notice, /preserving team state/i);
+      assert.match(result.notice, /omx team shutdown runtime-cli-preserve-complete/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves team state when building terminal output for failed teams', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-preserve-failed-'));
+    try {
+      await initTeamState('runtime-cli-preserve-failed', 'task', 'executor', 1, cwd);
+      await createTask('runtime-cli-preserve-failed', {
+        subject: 'failed task',
+        description: 'needs postmortem',
+        status: 'failed',
+        owner: 'worker-1',
+        result: 'FAIL: worker crashed',
+      }, cwd);
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'runtime-cli-preserve-failed');
+      assert.equal(existsSync(teamRoot), true);
+
+      const runtimeCli = await loadRuntimeCliModule();
+      const result = runtimeCli.buildTerminalCliResult(
+        runtimeCli.resolveRuntimeCliStateRoot(cwd),
+        'runtime-cli-preserve-failed',
+        'failed',
+        1,
+        Date.now() - 1_000,
+      );
+
+      assert.equal(existsSync(teamRoot), true);
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.output.status, 'failed');
+      assert.equal(result.output.teamName, 'runtime-cli-preserve-failed');
+      assert.deepEqual(result.output.taskResults, [{
+        taskId: '1',
+        status: 'failed',
+        summary: 'FAIL: worker crashed',
+      }]);
+      assert.match(result.notice, /preserving team state/i);
+      assert.match(result.notice, /omx team shutdown runtime-cli-preserve-failed/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports cancelled terminal phases without deleting team state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-preserve-cancelled-'));
+    try {
+      await initTeamState('runtime-cli-preserve-cancelled', 'task', 'executor', 1, cwd);
+      await createTask('runtime-cli-preserve-cancelled', {
+        subject: 'cancelled task',
+        description: 'team stopped for inspection',
+        status: 'blocked',
+      }, cwd);
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'runtime-cli-preserve-cancelled');
+      assert.equal(existsSync(teamRoot), true);
+
+      const runtimeCli = await loadRuntimeCliModule();
+      const result = runtimeCli.buildTerminalCliResult(
+        runtimeCli.resolveRuntimeCliStateRoot(cwd),
+        'runtime-cli-preserve-cancelled',
+        'cancelled',
+        1,
+        Date.now() - 1_000,
+      );
+
+      assert.equal(existsSync(teamRoot), true);
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.output.status, 'failed');
+      assert.match(result.notice, /phase=cancelled/);
+      assert.match(result.notice, /omx team shutdown runtime-cli-preserve-cancelled/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -39,6 +39,14 @@ interface CliOutput {
   workerCount: number;
 }
 
+export type TerminalPhaseResult = 'complete' | 'failed' | 'cancelled';
+
+export interface TerminalCliResult {
+  output: CliOutput;
+  exitCode: number;
+  notice: string;
+}
+
 export interface LivePaneState {
   paneIds: string[];
   leaderPaneId: string;
@@ -122,6 +130,39 @@ export function collectTaskResults(stateRoot: string, teamName: string): TaskRes
   }
 }
 
+export function buildCliOutput(
+  stateRoot: string,
+  teamName: string,
+  status: 'completed' | 'failed',
+  workerCount: number,
+  startTimeMs: number,
+): CliOutput {
+  const taskResults = collectTaskResults(stateRoot, teamName);
+  const duration = (Date.now() - startTimeMs) / 1000;
+  return {
+    status,
+    teamName,
+    taskResults,
+    duration,
+    workerCount,
+  };
+}
+
+export function buildTerminalCliResult(
+  stateRoot: string,
+  teamName: string,
+  phase: TerminalPhaseResult,
+  workerCount: number,
+  startTimeMs: number,
+): TerminalCliResult {
+  const status = phase === 'complete' ? 'completed' : 'failed';
+  return {
+    output: buildCliOutput(stateRoot, teamName, status, workerCount, startTimeMs),
+    exitCode: status === 'completed' ? 0 : 1,
+    notice: `[runtime-cli] phase=${phase} reached terminal state; preserving team state for inspection. Run "omx team shutdown ${teamName}" when explicit cleanup is desired.\n`,
+  };
+}
+
 export function normalizeAgentTypes(raw: string[], workerCount: number): TeamWorkerProvider[] {
   const providers = raw.map((entry) => String(entry || '').trim().toLowerCase());
   const invalid = providers.filter((entry) => entry !== 'codex' && entry !== 'claude' && entry !== 'gemini');
@@ -178,18 +219,11 @@ async function main(): Promise<void> {
   let finalStatus: 'completed' | 'failed' = 'failed';
   let pollActive = true;
 
-  function exitCodeFor(status: 'completed' | 'failed'): number {
-    return status === 'completed' ? 0 : 1;
-  }
-
   async function doShutdown(status: 'completed' | 'failed'): Promise<void> {
     pollActive = false;
     finalStatus = status;
 
-    // 1. Collect task results
-    const taskResults = collectTaskResults(stateRoot, teamName);
-
-    // 2. Shutdown team
+    // 1. Shutdown team
     let shutdownSummary: TeamShutdownSummary | null = null;
     if (runtime) {
       try {
@@ -209,20 +243,22 @@ async function main(): Promise<void> {
       process.stderr.write(`[runtime-cli] commit_hygiene_context_md=${shutdownSummary.commitHygieneArtifacts.markdownPath}\n`);
     }
 
-    const duration = (Date.now() - startTime) / 1000;
-    const output: CliOutput = {
-      status: finalStatus,
-      teamName,
-      taskResults,
-      duration,
-      workerCount,
-    };
+    const output = buildCliOutput(stateRoot, teamName, finalStatus, workerCount, startTime);
 
-    // 3. Write result to stdout
+    // 2. Write result to stdout
     process.stdout.write(JSON.stringify(output) + '\n');
 
-    // 4. Exit
-    process.exit(exitCodeFor(status));
+    // 3. Exit
+    process.exit(status === 'completed' ? 0 : 1);
+  }
+
+  function exitWithoutShutdown(phase: TerminalPhaseResult): void {
+    pollActive = false;
+    finalStatus = phase === 'complete' ? 'completed' : 'failed';
+    const result = buildTerminalCliResult(stateRoot, teamName, phase, workerCount, startTime);
+    process.stderr.write(result.notice);
+    process.stdout.write(JSON.stringify(result.output) + '\n');
+    process.exit(result.exitCode);
   }
 
   // Register signal handlers before poll loop
@@ -318,11 +354,11 @@ async function main(): Promise<void> {
 
     // Check completion
     if (snap.phase === 'complete') {
-      await doShutdown('completed');
+      exitWithoutShutdown('complete');
       return;
     }
     if (snap.phase === 'failed' || snap.phase === 'cancelled') {
-      await doShutdown('failed');
+      exitWithoutShutdown(snap.phase);
       return;
     }
 
@@ -338,7 +374,9 @@ async function main(): Promise<void> {
 
     if (deadWorkerFailure || fixingWithNoWorkers) {
       process.stderr.write(`[runtime-cli] Failure detected: deadWorkerFailure=${deadWorkerFailure} fixingWithNoWorkers=${fixingWithNoWorkers}\n`);
-      await doShutdown('failed');
+      // Monitor-detected failure is still not an explicit shutdown request.
+      // Preserve team state for inspection and let the leader decide when to clean up.
+      exitWithoutShutdown('failed');
       return;
     }
   }


### PR DESCRIPTION
## Summary
- keep runtime-cli terminal monitor exits on a preserve-state path instead of implicit shutdown cleanup
- reuse shared terminal output builders for explicit shutdown vs inspect-first terminal exits
- add focused runtime-cli regression coverage for complete, failed, and cancelled preserved-state outputs

## Testing
- npm run build
- npx biome lint src/team/runtime-cli.ts src/team/__tests__/runtime-cli.test.ts
- node --test dist/team/__tests__/runtime-cli.test.js

## Risk
- full tmux/prompt end-to-end dead-worker failure cleanup remains unverified in this PR; helper and focused runtime-cli coverage are green
