### PR TITLE
Prevent setup from corrupting config.toml during notify cleanup

### DIFF
--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -791,7 +791,7 @@ describe("config generator idempotency (#384)", () => {
       '  "/tmp/legacy-notify-hook.js"',
       "]",
       "pre_commit_hooks = [",
-      '  "/Users/donovanyohan/.git-ai/bin/git-ai",',
+      '  "/Users/example/.git-ai/bin/git-ai",',
       '  "checkpoint",',
       '  "codex",',
       '  "--hook-input",',
@@ -808,8 +808,27 @@ describe("config generator idempotency (#384)", () => {
     assert.match(merged, /^notify = \["node", ".*notify-hook\.js"\]$/m);
     assert.doesNotMatch(merged, /legacy-notify-hook\.js/);
     assert.match(merged, /^pre_commit_hooks = \[$/m);
-    assert.match(merged, /\.git-ai\/bin\/git-ai/);
+    assert.match(merged, /\/Users\/example\/\.git-ai\/bin\/git-ai/);
     assert.doesNotMatch(merged, /^\s*"node",\s*$/m);
+    assert.doesNotThrow(() => TOML.parse(merged));
+  });
+
+  it("does not strip user-owned multiline arrays that happen to mention notify-hook paths", () => {
+    const existing = [
+      "pre_commit_hooks = [",
+      '  "node",',
+      '  "/tmp/custom-notify-hook.js",',
+      '  "--flag",',
+      "]",
+      "",
+    ].join("\n");
+
+    const merged = buildMergedConfig(existing, "/tmp/omx");
+
+    assert.match(merged, /^pre_commit_hooks = \[$/m);
+    assert.match(merged, /^\s*"node",$/m);
+    assert.match(merged, /^\s*"\/tmp\/custom-notify-hook\.js",$/m);
+    assert.match(merged, /^\s*"--flag",$/m);
     assert.doesNotThrow(() => TOML.parse(merged));
   });
 

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import TOML from "@iarna/toml";
 import { buildMergedConfig, mergeConfig, repairConfigIfNeeded } from "../generator.js";
 
 /** Count occurrences of a pattern in text */
@@ -781,6 +782,35 @@ describe("config generator idempotency (#384)", () => {
     assert.equal(count(merged, /^\[mcp_servers\.existing_server\]$/gm), 1);
     assert.match(merged, /command = "custom"/);
     assert.equal(count(merged, /^\[mcp_servers\.eslint\]$/gm), 1);
+  });
+
+  it("replaces legacy multiline notify arrays without leaving orphaned lines", () => {
+    const existing = [
+      "notify = [",
+      '  "node",',
+      '  "/tmp/legacy-notify-hook.js"',
+      "]",
+      "pre_commit_hooks = [",
+      '  "/Users/donovanyohan/.git-ai/bin/git-ai",',
+      '  "checkpoint",',
+      '  "codex",',
+      '  "--hook-input",',
+      "]",
+      'personality = "pragmatic"',
+      "",
+      "[notice]",
+      "hide_full_access_warning = true",
+      "",
+    ].join("\n");
+
+    const merged = buildMergedConfig(existing, "/tmp/omx");
+
+    assert.match(merged, /^notify = \["node", ".*notify-hook\.js"\]$/m);
+    assert.doesNotMatch(merged, /legacy-notify-hook\.js/);
+    assert.match(merged, /^pre_commit_hooks = \[$/m);
+    assert.match(merged, /\.git-ai\/bin\/git-ai/);
+    assert.doesNotMatch(merged, /^\s*"node",\s*$/m);
+    assert.doesNotThrow(() => TOML.parse(merged));
   });
 
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -149,15 +149,47 @@ function stripRootLevelKeys(config: string, keys: readonly string[]): string {
 }
 
 function stripOrphanedManagedNotify(config: string): string {
-  return config
-    .replace(
-      /^\s*notify\s*=\s*\["node",\s*".*notify-hook\.js"\]\s*$(\n)?/gm,
-      "",
-    )
-    .replace(
-      /\n?\s*"node"\s*,\s*\n\s*".*notify-hook\.js"\s*,?\s*\n\s*\]\s*(?=\n|$)/g,
-      "",
-    );
+  const lines = config.split(/\r?\n/);
+  const result: string[] = [];
+
+  const isNotifyPathLine = (line: string): boolean =>
+    /^\s*".*notify-hook\.js"\s*,?\s*$/.test(line);
+  const isNodeLine = (line: string): boolean => /^\s*"node"\s*,\s*$/.test(line);
+  const isClosingBracketLine = (line: string): boolean => /^\s*\]\s*$/.test(line);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (/^\s*notify\s*=\s*\["node",\s*".*notify-hook\.js"\]\s*$/.test(line)) {
+      continue;
+    }
+
+    if (
+      /^\s*notify\s*=\s*\[\s*$/.test(line) &&
+      isNodeLine(lines[i + 1] ?? "") &&
+      isNotifyPathLine(lines[i + 2] ?? "") &&
+      isClosingBracketLine(lines[i + 3] ?? "")
+    ) {
+      i += 3;
+      continue;
+    }
+
+    const previousNonEmpty = [...result].reverse().find((entry) => entry.trim() !== "");
+    const isStandaloneOrphanFragment =
+      isNodeLine(line) &&
+      isNotifyPathLine(lines[i + 1] ?? "") &&
+      isClosingBracketLine(lines[i + 2] ?? "") &&
+      !/=\s*\[\s*$/.test(previousNonEmpty ?? "");
+
+    if (isStandaloneOrphanFragment) {
+      i += 2;
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n");
 }
 
 function assertValidGeneratedConfig(config: string): void {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -13,6 +13,7 @@
 import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
+import { parse as parseToml } from "@iarna/toml";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
@@ -154,9 +155,18 @@ function stripOrphanedManagedNotify(config: string): string {
       "",
     )
     .replace(
-      /\n?\s*"node",\s*\n\s*".*notify-hook\.js",\s*\n\s*\]\s*(?=\n|$)/g,
+      /\n?\s*"node"\s*,\s*\n\s*".*notify-hook\.js"\s*,?\s*\n\s*\]\s*(?=\n|$)/g,
       "",
     );
+}
+
+function assertValidGeneratedConfig(config: string): void {
+  try {
+    parseToml(config);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Generated config.toml is invalid: ${message}`);
+  }
 }
 
 /**
@@ -850,7 +860,9 @@ export function buildMergedConfig(
     body = body ? `${body}\n\n${sharedRegistryBlock}` : sharedRegistryBlock;
   }
 
-  return topLines.join("\n") + "\n\n" + body + "\n" + tablesBlock;
+  const mergedConfig = topLines.join("\n") + "\n\n" + body + "\n" + tablesBlock;
+  assertValidGeneratedConfig(mergedConfig);
+  return mergedConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary

Prevent `omx setup` from writing an invalid `config.toml` when it repairs legacy multiline `notify` arrays. This broke Codex startup and sent users into a setup/doctor loop.

## Changes

- fix legacy multiline `notify` cleanup so the no-trailing-comma form is removed cleanly
- validate generated `config.toml` with the TOML parser before returning/writing it
- add regression coverage for legacy multiline `notify` cleanup alongside preserved user-owned top-level arrays like `pre_commit_hooks`

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [x] `omx doctor` (when setup/config behavior changes)

Notes:
- `npm run lint` passed locally.
- Targeted config/setup suites passed locally:
  - `node --test dist/config/__tests__/generator-idempotent.test.js dist/config/__tests__/generator-notify.test.js dist/cli/__tests__/doctor-invalid-config.test.js`
- Full `npm test` still reports unrelated local failures in existing `ask`, `autoresearch`, `explore`, `launch-fallback`, `team`, `paths`, and `notify-hook` areas, so that box is intentionally left unchecked.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- n/a
