### PR TITLE
refactor: route the state CLI through omx consistently

### DIFF
--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -28,6 +28,7 @@ describe('nested help routing', () => {
     [['autoresearch', '--help'], /Usage:[\s\S]*omx autoresearch <mission-dir>/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
+    [['state', '--help'], /Usage:\s*omx state <read\|write\|clear\|list-active\|get-status>/i],
     [['tmux-hook', '--help'], /Usage:\s*\n\s*omx tmux-hook init/i],
     [['ralph', '--help'], /omx ralph - Launch Codex with ralph persistence mode active/i],
   ] satisfies Array<[string[], RegExp]>) {
@@ -43,4 +44,16 @@ describe('nested help routing', () => {
       }
     });
   }
+
+  it('routes `omx state read` through the top-level CLI', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-state-route-'));
+    try {
+      const result = runOmx(cwd, ['state', 'read', '--input', '{"mode":"ralph"}', '--json']);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout.trim(), /^\{"exists":false,"mode":"ralph"\}$/);
+      assert.doesNotMatch(result.stdout, /Unknown command: state/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/state.test.ts
+++ b/src/cli/__tests__/state.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { stateCommand } from '../state.js';
+
+describe('stateCommand', () => {
+  it('prints help for empty args', async () => {
+    const out: string[] = [];
+    await stateCommand([], {
+      stdout: (line) => out.push(line),
+      stderr: () => undefined,
+    });
+    assert.match(out.join('\n'), /Usage: omx state/);
+  });
+
+  it('emits a frozen compact JSON envelope when --json is set', async () => {
+    const out: string[] = [];
+    await stateCommand(['read', '--input', '{"mode":"ralph"}', '--json'], {
+      stdout: (line) => out.push(line),
+      stderr: () => undefined,
+      execute: async () => ({ payload: { exists: false, mode: 'ralph' } }),
+    });
+    assert.deepEqual(out, ['{"exists":false,"mode":"ralph"}']);
+  });
+
+  it('writes errors to stderr and sets exitCode', async () => {
+    const err: string[] = [];
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = undefined;
+      await stateCommand(['clear', '--input', '{"mode":"ralph"}', '--json'], {
+        stdout: () => undefined,
+        stderr: (line) => err.push(line),
+        execute: async () => ({ payload: { error: 'boom' }, isError: true }),
+      });
+      assert.equal(process.exitCode, 1);
+      assert.deepEqual(err, ['{"error":"boom"}']);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it('rejects malformed --input JSON', async () => {
+    await assert.rejects(
+      stateCommand(['read', '--input', '{bad-json'], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      }),
+      /valid JSON/i,
+    );
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import { hudCommand } from "../hud/index.js";
 import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
 import { askCommand } from "./ask.js";
+import { stateCommand } from "./state.js";
 import {
   cleanupCommand,
   cleanupOmxMcpProcesses,
@@ -147,6 +148,7 @@ Usage:
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
   omx hooks     Manage hook plugins (init|status|validate|test)
   omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
+  omx state     Read/write/list OMX mode state via CLI parity surface
   omx sparkshell <command> [args...]
   omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]
                 Run native sparkshell sidecar for direct command execution or explicit tmux-pane summarization
@@ -246,6 +248,7 @@ type CliCommand =
   | "tmux-hook"
   | "hooks"
   | "hud"
+  | "state"
   | "status"
   | "cancel"
   | "help"
@@ -262,6 +265,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "exec",
   "hooks",
   "hud",
+  "state",
   "ralph",
   "resume",
   "session",
@@ -643,6 +647,7 @@ export async function main(args: string[]): Promise<void> {
     "tmux-hook",
     "hooks",
     "hud",
+    "state",
     "status",
     "cancel",
     "help",
@@ -735,6 +740,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "hud":
         await hudCommand(args.slice(1));
+        break;
+      case "state":
+        await stateCommand(args.slice(1));
         break;
       case "tmux-hook":
         await tmuxHookCommand(args.slice(1));

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -1,0 +1,87 @@
+import { executeStateOperation, type StateOperationName } from '../state/operations.js';
+
+const STATE_HELP = `Usage: omx state <read|write|clear|list-active|get-status> [--input <json>] [--json]\n\nExamples:\n  omx state read --input '{"mode":"ralph"}' --json\n  omx state write --input '{"mode":"ralph","active":true,"current_phase":"executing"}' --json\n  omx state clear --input '{"mode":"ralph","all_sessions":true}' --json\n  omx state list-active --json\n  omx state get-status --input '{"mode":"ralph"}' --json`;
+
+const STATE_OPERATION_MAP: Record<string, StateOperationName> = {
+  read: 'state_read',
+  write: 'state_write',
+  clear: 'state_clear',
+  'list-active': 'state_list_active',
+  'get-status': 'state_get_status',
+};
+
+export interface StateCommandDependencies {
+  stdout?: (line: string) => void;
+  stderr?: (line: string) => void;
+  execute?: typeof executeStateOperation;
+}
+
+function parseStateInput(input: string | undefined): Record<string, unknown> {
+  if (!input) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch (error) {
+    throw new Error(`--input must be valid JSON: ${(error as Error).message}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('--input must decode to a JSON object');
+  }
+  return { ...(parsed as Record<string, unknown>) };
+}
+
+export async function stateCommand(
+  args: string[],
+  deps: StateCommandDependencies = {},
+): Promise<void> {
+  const stdout = deps.stdout ?? ((line: string) => console.log(line));
+  const stderr = deps.stderr ?? ((line: string) => console.error(line));
+  const execute = deps.execute ?? executeStateOperation;
+
+  const subcommand = args[0];
+  if (!subcommand || subcommand === '--help' || subcommand === '-h' || subcommand === 'help') {
+    stdout(STATE_HELP);
+    return;
+  }
+
+  const operation = STATE_OPERATION_MAP[subcommand];
+  if (!operation) {
+    throw new Error(`Unknown state subcommand: ${subcommand}\n${STATE_HELP}`);
+  }
+
+  let inputValue: string | undefined;
+  let json = false;
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+    if (arg === '--input') {
+      const next = args[index + 1];
+      if (!next) {
+        throw new Error('Missing JSON value after --input');
+      }
+      inputValue = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--input=')) {
+      inputValue = arg.slice('--input='.length);
+      continue;
+    }
+    throw new Error(`Unknown state argument: ${arg}`);
+  }
+
+  const input = parseStateInput(inputValue);
+  const result = await execute(operation, input);
+  const body = JSON.stringify(result.payload, null, json ? 0 : 2);
+
+  if (result.isError) {
+    stderr(body);
+    process.exitCode = 1;
+    return;
+  }
+
+  stdout(body);
+}

--- a/src/state/__tests__/operations-ralph-phase.test.ts
+++ b/src/state/__tests__/operations-ralph-phase.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { executeStateOperation } from '../operations.js';
+
+describe('state operations Ralph phase contract', () => {
+  it('normalizes legacy Ralph phase aliases on state_write', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-phase-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        active: true,
+        current_phase: 'execution',
+        started_at: '2026-02-22T00:00:00.000Z',
+      });
+      assert.equal(response.isError, undefined);
+
+      const file = join(wd, '.omx', 'state', 'ralph-state.json');
+      const state = JSON.parse(await readFile(file, 'utf-8'));
+      assert.equal(state.current_phase, 'executing');
+      assert.equal(state.ralph_phase_normalized_from, 'execution');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unknown Ralph phases on state_write', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-phase-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        active: true,
+        current_phase: 'bananas',
+      });
+      assert.equal(response.isError, true);
+      const body = response.payload as { error?: string };
+      assert.match(body.error || '', /Invalid Ralph phase|must be one of/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects terminal Ralph phase when active=true', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-phase-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        active: true,
+        current_phase: 'complete',
+      });
+      assert.equal(response.isError, true);
+      const body = response.payload as { error?: string };
+      assert.match(body.error || '', /terminal Ralph phases require active=false/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects fractional iteration values for Ralph state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-phase-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        active: true,
+        current_phase: 'executing',
+        iteration: 0.25,
+        max_iterations: 10.5,
+      });
+      assert.equal(response.isError, true);
+      const body = response.payload as { error?: string };
+      assert.match(body.error || '', /finite integer/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1,0 +1,212 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { executeStateOperation } from '../operations.js';
+
+async function withAmbientTmuxEnv<T>(env: NodeJS.ProcessEnv, run: () => Promise<T>): Promise<T> {
+  const previousTmux = process.env.TMUX;
+  const previousTmuxPane = process.env.TMUX_PANE;
+  const previousPath = process.env.PATH;
+
+  if (typeof env.TMUX === 'string') process.env.TMUX = env.TMUX;
+  else delete process.env.TMUX;
+  if (typeof env.TMUX_PANE === 'string') process.env.TMUX_PANE = env.TMUX_PANE;
+  else delete process.env.TMUX_PANE;
+  if (typeof env.PATH === 'string') process.env.PATH = env.PATH;
+  else if ('PATH' in env) delete process.env.PATH;
+
+  try {
+    return await run();
+  } finally {
+    if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+    else delete process.env.TMUX;
+    if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+    else delete process.env.TMUX_PANE;
+    if (typeof previousPath === 'string') process.env.PATH = previousPath;
+    else delete process.env.PATH;
+  }
+}
+
+async function createFakeTmuxBin(wd: string): Promise<string> {
+  const fakeBin = join(wd, 'bin');
+  await mkdir(fakeBin, { recursive: true });
+  const tmuxPath = join(fakeBin, 'tmux');
+  await writeFile(
+    tmuxPath,
+    `#!/usr/bin/env bash
+set -eu
+cmd="\${1:-}"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ -z "$target" && "$format" == "#{pane_id}" ]]; then
+    echo "%777"
+    exit 0
+  fi
+  if [[ -z "$target" && "$format" == "#S" ]]; then
+    echo "maintainer-default"
+    exit 0
+  fi
+  if [[ "$target" == "%777" && "$format" == "#{pane_id}" ]]; then
+    echo "%777"
+    exit 0
+  fi
+  if [[ "$target" == "%777" && "$format" == "#S" ]]; then
+    echo "maintainer-default"
+    exit 0
+  fi
+fi
+if [[ "$cmd" == "list-sessions" ]]; then
+  echo "maintainer-default"
+  exit 0
+fi
+exit 1
+`,
+  );
+  await chmod(tmuxPath, 0o755);
+  return fakeBin;
+}
+
+describe('state operations directory initialization', () => {
+  it('creates .omx/state for state operations without setup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-test-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+      assert.equal(existsSync(stateDir), false);
+      assert.equal(existsSync(tmuxHookConfig), false);
+
+      const response = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+
+      assert.equal(existsSync(stateDir), true);
+      assert.equal(existsSync(tmuxHookConfig), true);
+      assert.deepEqual(response.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('bootstraps tmux-hook from the current tmux pane when available', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-live-'));
+    try {
+      const tmuxHookConfig = join(wd, '.omx', 'tmux-hook.json');
+      const fakeBin = await createFakeTmuxBin(wd);
+
+      await withAmbientTmuxEnv(
+        {
+          TMUX: '/tmp/maintainer-default,123,0',
+          TMUX_PANE: '%777',
+          PATH: `${fakeBin}:${process.env.PATH || ''}`,
+        },
+        async () => {
+          const response = await executeStateOperation('state_list_active', {
+            workingDirectory: wd,
+          });
+          assert.deepEqual(response.payload, { active_modes: [] });
+        },
+      );
+
+      const tmuxConfig = JSON.parse(await readFile(tmuxHookConfig, 'utf-8')) as {
+        target?: { type?: string; value?: string };
+      };
+      assert.deepEqual(tmuxConfig.target, { type: 'pane', value: '%777' });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('writes and reads deep-interview state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-readwrite-'));
+    try {
+      const writeResponse = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'deep-interview',
+        active: true,
+        current_phase: 'deep-interview',
+        state: {
+          current_focus: 'intent',
+          threshold: 0.2,
+        },
+      });
+
+      assert.equal(writeResponse.isError, undefined);
+      assert.deepEqual(writeResponse.payload, {
+        success: true,
+        mode: 'deep-interview',
+        path: join(wd, '.omx', 'state', 'deep-interview-state.json'),
+      });
+
+      const readResponse = await executeStateOperation('state_read', {
+        workingDirectory: wd,
+        mode: 'deep-interview',
+      });
+
+      assert.equal(readResponse.isError, undefined);
+      const readBody = readResponse.payload as Record<string, unknown>;
+      assert.equal(readBody.active, true);
+      assert.equal(readBody.current_phase, 'deep-interview');
+      assert.equal(readBody.current_focus, 'intent');
+      assert.equal(readBody.threshold, 0.2);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('creates session-scoped state directory when session_id is provided', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-session-'));
+    try {
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', 'sess1');
+      assert.equal(existsSync(sessionDir), false);
+
+      const response = await executeStateOperation('state_get_status', {
+        workingDirectory: wd,
+        session_id: 'sess1',
+      });
+
+      assert.equal(existsSync(sessionDir), true);
+      assert.deepEqual(response.payload, { statuses: {} });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes concurrent state_write calls per mode file and preserves merged fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-concurrency-'));
+    try {
+      const writes = Array.from({ length: 16 }, (_, i) =>
+        executeStateOperation('state_write', {
+          workingDirectory: wd,
+          mode: 'team',
+          state: { [`k${i}`]: i },
+        }),
+      );
+
+      const responses = await Promise.all(writes);
+      for (const response of responses) {
+        assert.equal(response.isError, undefined);
+      }
+
+      const filePath = join(wd, '.omx', 'state', 'team-state.json');
+      const state = JSON.parse(await readFile(filePath, 'utf-8')) as Record<string, unknown>;
+      for (let i = 0; i < 16; i++) {
+        assert.equal(state[`k${i}`], i);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/state/__tests__/path-traversal.test.ts
+++ b/src/state/__tests__/path-traversal.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { executeStateOperation } from '../operations.js';
+
+describe('state CLI path traversal prevention', () => {
+  it('rejects invalid workingDirectory inputs containing NUL bytes', async () => {
+    const resp = await executeStateOperation('state_read', {
+      mode: 'team',
+      workingDirectory: 'bad\0path',
+    });
+    assert.equal(resp.isError, true);
+    const body = resp.payload as { error?: string };
+    assert.match(body.error || '', /NUL byte/);
+  });
+
+  it('rejects traversal in mode for state_write', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-traversal-'));
+    try {
+      const resp = await executeStateOperation('state_write', {
+        mode: '../../outside',
+        state: { active: true },
+        workingDirectory: wd,
+      });
+      assert.equal(resp.isError, true);
+      const body = resp.payload as { error?: string };
+      assert.ok(typeof body.error === 'string' && body.error.length > 0);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unsupported mode names for state_read', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-traversal-'));
+    try {
+      const resp = await executeStateOperation('state_read', {
+        mode: 'custom_mode',
+        workingDirectory: wd,
+      });
+      assert.equal(resp.isError, true);
+      const body = resp.payload as { error?: string };
+      assert.ok(typeof body.error === 'string' && body.error.includes('mode must be one of'));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -1,0 +1,296 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { withModeRuntimeContext } from './mode-state-context.js';
+import {
+  getAllScopedStatePaths,
+  getReadScopedStateDirs,
+  getReadScopedStatePaths,
+  getStateDir,
+  getStatePath,
+  resolveStateScope,
+  resolveWorkingDirectoryForState,
+  validateSessionId,
+  validateStateModeSegment,
+} from '../mcp/state-paths.js';
+import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
+import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
+
+export const SUPPORTED_STATE_READ_MODES = [
+  'autopilot',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
+  'ralplan',
+  'deep-interview',
+] as const;
+
+export type SupportedStateReadMode = (typeof SUPPORTED_STATE_READ_MODES)[number];
+export type StateOperationName =
+  | 'state_read'
+  | 'state_write'
+  | 'state_clear'
+  | 'state_list_active'
+  | 'state_get_status';
+
+export interface StateOperationResponse {
+  payload: unknown;
+  isError?: boolean;
+}
+
+const stateWriteQueues = new Map<string, Promise<void>>();
+
+async function withStateWriteLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const tail = stateWriteQueues.get(path) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = tail.finally(() => gate);
+  stateWriteQueues.set(path, queued);
+
+  await tail.catch(() => {});
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (stateWriteQueues.get(path) === queued) {
+      stateWriteQueues.delete(path);
+    }
+  }
+}
+
+async function writeAtomicFile(path: string, data: string): Promise<void> {
+  const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  await writeFile(tmpPath, data, 'utf-8');
+  try {
+    await rename(tmpPath, path);
+  } catch (error) {
+    await unlink(tmpPath).catch(() => {});
+    throw error;
+  }
+}
+
+function readModeSupportsStrictValidation(mode: string): mode is SupportedStateReadMode {
+  return SUPPORTED_STATE_READ_MODES.includes(mode as SupportedStateReadMode);
+}
+
+function validateStrictReadableMode(mode: unknown): string {
+  const normalized = validateStateModeSegment(mode);
+  if (!readModeSupportsStrictValidation(normalized)) {
+    throw new Error(`mode must be one of: ${SUPPORTED_STATE_READ_MODES.join(', ')}`);
+  }
+  return normalized;
+}
+
+async function initializeStateEnvironment(cwd: string, effectiveSessionId?: string): Promise<void> {
+  await mkdir(getStateDir(cwd), { recursive: true });
+  if (effectiveSessionId) {
+    await mkdir(getStateDir(cwd, effectiveSessionId), { recursive: true });
+  }
+  const { ensureTmuxHookInitialized } = await import('../cli/tmux-hook.js');
+  await ensureTmuxHookInitialized(cwd);
+}
+
+export async function listStateStatuses(
+  cwd: string,
+  explicitSessionId?: string,
+  mode?: string,
+): Promise<Record<string, unknown>> {
+  const stateDirs = await getReadScopedStateDirs(cwd, explicitSessionId);
+  const statuses: Record<string, unknown> = {};
+  const seenModes = new Set<string>();
+
+  for (const stateDir of stateDirs) {
+    if (!existsSync(stateDir)) continue;
+    const files = await readdir(stateDir);
+    for (const file of files) {
+      if (!file.endsWith('-state.json')) continue;
+      const currentMode = file.replace('-state.json', '');
+      if (mode && currentMode !== mode) continue;
+      if (seenModes.has(currentMode)) continue;
+      seenModes.add(currentMode);
+      try {
+        const data = JSON.parse(await readFile(join(stateDir, file), 'utf-8'));
+        statuses[currentMode] = {
+          active: data.active,
+          phase: data.current_phase,
+          path: join(stateDir, file),
+          data,
+        };
+      } catch {
+        statuses[currentMode] = { error: 'malformed state file' };
+      }
+    }
+  }
+
+  return statuses;
+}
+
+
+export async function listActiveStateModes(
+  workingDirectory?: string,
+  explicitSessionId?: string,
+): Promise<string[]> {
+  const cwd = resolveWorkingDirectoryForState(workingDirectory);
+  const sessionId = validateSessionId(explicitSessionId);
+  const statuses = await listStateStatuses(cwd, sessionId);
+  return Object.entries(statuses)
+    .filter(([, status]) => Boolean((status as { active?: unknown }).active))
+    .map(([mode]) => mode);
+}
+
+export async function executeStateOperation(
+  name: StateOperationName,
+  rawArgs: Record<string, unknown> = {},
+): Promise<StateOperationResponse> {
+  let cwd: string;
+  let explicitSessionId: string | undefined;
+
+  try {
+    cwd = resolveWorkingDirectoryForState(rawArgs.workingDirectory as string | undefined);
+    explicitSessionId = validateSessionId(rawArgs.session_id);
+  } catch (error) {
+    return {
+      payload: { error: (error as Error).message },
+      isError: true,
+    };
+  }
+
+  try {
+    const stateScope = await resolveStateScope(cwd, explicitSessionId);
+    const effectiveSessionId = stateScope.sessionId;
+    await initializeStateEnvironment(cwd, effectiveSessionId);
+
+    switch (name) {
+      case 'state_read': {
+        const mode = validateStrictReadableMode(rawArgs.mode);
+        const paths = await getReadScopedStatePaths(mode, cwd, explicitSessionId);
+        const path = paths.find((candidate) => existsSync(candidate));
+        if (!path) {
+          return { payload: { exists: false, mode } };
+        }
+        const data = JSON.parse(await readFile(path, 'utf-8'));
+        return { payload: data };
+      }
+
+      case 'state_write': {
+        const mode = validateStateModeSegment(rawArgs.mode);
+        const path = getStatePath(mode, cwd, effectiveSessionId);
+        const {
+          mode: _mode,
+          workingDirectory: _workingDirectory,
+          session_id: _sessionId,
+          state: customState,
+          ...fields
+        } = rawArgs;
+        let validationError: string | null = null;
+
+        await withStateWriteLock(path, async () => {
+          let existing: Record<string, unknown> = {};
+          if (existsSync(path)) {
+            try {
+              existing = JSON.parse(await readFile(path, 'utf-8'));
+            } catch (error) {
+              process.stderr.write(`[state] Failed to parse state file: ${error}\n`);
+            }
+          }
+
+          const mergedRaw = {
+            ...existing,
+            ...fields,
+            ...((customState as Record<string, unknown>) || {}),
+          } as Record<string, unknown>;
+
+          if (
+            mode === 'ralph' &&
+            effectiveSessionId &&
+            typeof mergedRaw.owner_omx_session_id !== 'string'
+          ) {
+            mergedRaw.owner_omx_session_id = effectiveSessionId;
+          }
+
+          if (mode === 'ralph') {
+            const originalPhase = mergedRaw.current_phase;
+            const validation = validateAndNormalizeRalphState(mergedRaw);
+            if (!validation.ok || !validation.state) {
+              validationError = validation.error || `ralph.current_phase must be one of: ${RALPH_PHASES.join(', ')}`;
+              return;
+            }
+            if (
+              typeof originalPhase === 'string' &&
+              typeof validation.state.current_phase === 'string' &&
+              validation.state.current_phase !== originalPhase
+            ) {
+              validation.state.ralph_phase_normalized_from = originalPhase;
+            }
+            Object.assign(mergedRaw, validation.state);
+            await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
+          }
+
+          const merged = withModeRuntimeContext(existing, mergedRaw);
+          await writeAtomicFile(path, JSON.stringify(merged, null, 2));
+        });
+
+        if (validationError) {
+          return {
+            payload: { error: validationError },
+            isError: true,
+          };
+        }
+
+        return { payload: { success: true, mode, path } };
+      }
+
+      case 'state_clear': {
+        const mode = validateStateModeSegment(rawArgs.mode);
+        const allSessions = rawArgs.all_sessions === true;
+
+        if (!allSessions) {
+          const path = getStatePath(mode, cwd, effectiveSessionId);
+          if (existsSync(path)) {
+            await unlink(path);
+          }
+          return { payload: { cleared: true, mode, path } };
+        }
+
+        const removedPaths: string[] = [];
+        const paths = await getAllScopedStatePaths(mode, cwd);
+        for (const path of paths) {
+          if (!existsSync(path)) continue;
+          await unlink(path);
+          removedPaths.push(path);
+        }
+
+        return {
+          payload: {
+            cleared: true,
+            mode,
+            all_sessions: true,
+            removed: removedPaths.length,
+            paths: removedPaths,
+            warning: 'all_sessions clears global and session-scoped state files',
+          },
+        };
+      }
+
+      case 'state_list_active': {
+        const activeModes = await listActiveStateModes(cwd, explicitSessionId);
+        return { payload: { active_modes: activeModes } };
+      }
+
+      case 'state_get_status': {
+        const mode = typeof rawArgs.mode === 'string' ? rawArgs.mode.trim() : undefined;
+        const statuses = await listStateStatuses(cwd, explicitSessionId, mode || undefined);
+        return { payload: { statuses } };
+      }
+    }
+  } catch (error) {
+    return {
+      payload: { error: (error as Error).message },
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- land the extracted `omx state` CLI surface with top-level routing/help coverage
- fix the Node 25 exit-code regression test reset and add a direct `omx state read` integration check
- remove duplicated active-mode filtering in the shared state operations path

## Verification
- npm run build
- npx tsc --noEmit --pretty false
- npx biome lint src/cli/index.ts src/cli/state.ts src/cli/__tests__/state.test.ts src/cli/__tests__/nested-help-routing.test.ts src/state/operations.ts src/state/__tests__/operations.test.ts src/state/__tests__/operations-ralph-phase.test.ts src/state/__tests__/path-traversal.test.ts
- node --test dist/cli/__tests__/state.test.js dist/cli/__tests__/nested-help-routing.test.js dist/state/__tests__/operations.test.js dist/state/__tests__/operations-ralph-phase.test.js dist/state/__tests__/path-traversal.test.js
- node dist/cli/omx.js state read --input '{"mode":"ralph"}' --json