### PR TITLE
fix: preserve project cwd in detached tmux launches

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, realpath, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -1370,7 +1370,7 @@ describe("detached tmux new-session sequencing", () => {
     );
     const leaderCmd = steps[0]?.args.at(-1);
     assert.equal(typeof leaderCmd, "string");
-    assert.match(leaderCmd!, /^\/bin\/sh -lc '/);
+    assert.match(leaderCmd!, /^\/bin\/sh -c '/);
     assert.match(leaderCmd!, /acquireTmuxExtendedKeysLease/);
     assert.match(leaderCmd!, /omx_detached_session_cleanup\(\)/);
     assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0 INT TERM HUP/);
@@ -1382,6 +1382,7 @@ describe("detached tmux new-session sequencing", () => {
 
   it("detached leader command executes codex and cleanup without shell-quote breakage", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-"));
+    const effectiveCwd = await realpath(cwd);
     const fakeBin = join(cwd, "bin");
     const logPath = join(cwd, "leader.log");
 
@@ -1390,6 +1391,7 @@ describe("detached tmux new-session sequencing", () => {
       await writeFile(
         join(fakeBin, "codex"),
         `#!/bin/sh
+printf 'pwd:%s\\n' "$PWD" >> "${logPath}"
 printf 'codex:%s\\n' "$*" >> "${logPath}"
 exit 0
 `,
@@ -1432,7 +1434,7 @@ exit 0
       const leaderCmd = steps[0]?.args.at(-1);
       assert.equal(typeof leaderCmd, "string");
 
-      execFileSync("/bin/sh", ["-lc", leaderCmd!], {
+      execFileSync("/bin/sh", ["-c", leaderCmd!], {
         cwd,
         env: {
           ...process.env,
@@ -1443,6 +1445,10 @@ exit 0
       });
 
       const log = await readFile(logPath, "utf-8");
+      assert.match(
+        log,
+        new RegExp(`pwd:${effectiveCwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+      );
       assert.match(log, /codex:--dangerously-bypass-approvals-and-sandbox/);
       assert.match(log, /tmux:display-message -p #\{socket_path\}/);
       assert.match(log, /tmux:show-options -sv extended-keys/);
@@ -1694,8 +1700,8 @@ describe("buildTmuxPaneCommand", () => {
       "/usr/bin/zsh",
     );
     assert.ok(
-      result.startsWith("'/usr/bin/zsh' -lc "),
-      "should start with zsh login shell",
+      result.startsWith("'/usr/bin/zsh' -c "),
+      "should start with zsh shell wrapper",
     );
     assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");
     assert.ok(result.includes("exec "), "should exec the command");
@@ -1704,18 +1710,18 @@ describe("buildTmuxPaneCommand", () => {
   it("wraps command with bash profile sourcing for bash shell", () => {
     const result = buildTmuxPaneCommand("codex", [], "/bin/bash");
     assert.ok(
-      result.startsWith("'/bin/bash' -lc "),
-      "should start with bash login shell",
+      result.startsWith("'/bin/bash' -c "),
+      "should start with bash shell wrapper",
     );
     assert.ok(result.includes("source ~/.bashrc"), "should source .bashrc");
     assert.ok(result.includes("exec "), "should exec the command");
   });
 
-  it("skips rc sourcing for unknown shells but still uses login flag", () => {
+  it("skips rc sourcing for unknown shells but still preserves tmux cwd", () => {
     const result = buildTmuxPaneCommand("codex", [], "/bin/fish");
     assert.ok(
-      result.startsWith("'/bin/fish' -lc "),
-      "should start with fish login shell",
+      result.startsWith("'/bin/fish' -c "),
+      "should start with fish shell wrapper",
     );
     assert.ok(!result.includes("source"), "should not source any rc file");
     assert.ok(result.includes("exec "), "should exec the command");
@@ -1724,7 +1730,7 @@ describe("buildTmuxPaneCommand", () => {
   it("falls back to /bin/sh when shell path is empty", () => {
     const result = buildTmuxPaneCommand("codex", [], "");
     assert.ok(
-      result.startsWith("'/bin/sh' -lc "),
+      result.startsWith("'/bin/sh' -c "),
       "should fall back to /bin/sh",
     );
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1559,7 +1559,7 @@ function buildDetachedSessionLeaderCommand(
     "trap omx_detached_session_cleanup 0 INT TERM HUP;",
     codexCmd,
   ].join(" ");
-  return `/bin/sh -lc ${quoteShellArg(wrapped)}`;
+  return `/bin/sh -c ${quoteShellArg(wrapped)}`;
 }
 
 type TmuxExecSync = (file: string, args: readonly string[]) => string;
@@ -2550,8 +2550,8 @@ export function buildWindowsPromptCommand(
 
 /**
  * Wrap a command for tmux pane execution so the user's shell profile is
- * sourced.  Without this, tmux runs `default-shell -c "cmd"` which is
- * non-interactive/non-login and skips .zshrc / .bashrc.
+ * sourced without promoting the shell to a login shell, which can reset the
+ * working directory away from the tmux pane's `-c` target.
  */
 export function buildTmuxPaneCommand(
   command: string,
@@ -2569,7 +2569,7 @@ export function buildTmuxPaneCommand(
     shellPath && shellPath.trim() !== "" ? shellPath.trim() : "/bin/sh";
   const shellBin = ALLOWED_SHELLS.has(rawShell) ? rawShell : "/bin/sh";
   const inner = `${rcSource}exec ${bareCmd}`;
-  return `${quoteShellArg(shellBin)} -lc ${quoteShellArg(inner)}`;
+  return `${quoteShellArg(shellBin)} -c ${quoteShellArg(inner)}`;
 }
 
 function quoteShellArg(value: string): string {


### PR DESCRIPTION
## Summary

Detached tmux launches were wrapping both the leader cleanup shell and the pane command shell with `-lc`. On affected setups that login-shell hop could reset the process cwd away from the tmux pane's `-c` target, which made Codex start from an ancestor directory and surface trust prompts there.

This change switches those wrappers to `-c` while keeping explicit zsh/bash rc sourcing for pane commands.

Closes #1374.

## Verification

- `npm run build`
- `node --test dist/cli/__tests__/index.test.js`
- `npm run lint`

## Notes

- I also ran the broader `npm test` command, but the repo currently has unrelated baseline failures in `omx ask` and `omx autoresearch` tests that predate this fix.
