### PR TITLE
Harden MCP transport-death fallback and CLI parity

### DIFF
--- a/src/cli/__tests__/mcp-parity.test.ts
+++ b/src/cli/__tests__/mcp-parity.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { mcpParityCommand } from "../mcp-parity.js";
+
+const originalLog = console.log;
+
+afterEach(() => {
+  console.log = originalLog;
+  process.exitCode = undefined;
+});
+
+function captureLogs(): string[] {
+  const logs: string[] = [];
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((arg) => String(arg)).join(" "));
+  };
+  return logs;
+}
+
+describe("mcpParityCommand", () => {
+  it("supports state write/read parity via CLI", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-state-"));
+    const logs = captureLogs();
+
+    try {
+      await mcpParityCommand("state", [
+        "state_write",
+        "--input",
+        JSON.stringify({ mode: "ralph", active: true, current_phase: "executing", workingDirectory: cwd }),
+        "--json",
+      ]);
+      const writeResult = JSON.parse(logs.pop() || "{}") as { path?: string };
+      assert.match(writeResult.path ?? "", /ralph-state\.json$/);
+
+      await mcpParityCommand("state", [
+        "state_read",
+        "--input",
+        JSON.stringify({ mode: "ralph", workingDirectory: cwd }),
+        "--json",
+      ]);
+      const readResult = JSON.parse(logs.pop() || "{}") as { active?: boolean; current_phase?: string };
+      assert.equal(readResult.active, true);
+      assert.equal(readResult.current_phase, "executing");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("supports notepad and project-memory parity via CLI", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-memory-"));
+    const logs = captureLogs();
+
+    try {
+      await mcpParityCommand("notepad", [
+        "notepad_write_working",
+        "--input",
+        JSON.stringify({ content: "Investigating MCP transport death", workingDirectory: cwd }),
+        "--json",
+      ]);
+      const notepadWrite = JSON.parse(logs.pop() || "{}") as { success?: boolean };
+      assert.equal(notepadWrite.success, true);
+
+      await mcpParityCommand("notepad", [
+        "notepad_read",
+        "--input",
+        JSON.stringify({ workingDirectory: cwd }),
+        "--json",
+      ]);
+      const notepadRead = JSON.parse(logs.pop() || "{}") as { content?: string };
+      assert.match(notepadRead.content ?? "", /Investigating MCP transport death/);
+
+      await mcpParityCommand("project-memory", [
+        "project_memory_add_note",
+        "--input",
+        JSON.stringify({ category: "architecture", content: "CLI parity exists for transport fallback", workingDirectory: cwd }),
+        "--json",
+      ]);
+      const addNote = JSON.parse(logs.pop() || "{}") as { success?: boolean; noteCount?: number };
+      assert.equal(addNote.success, true);
+      assert.equal(addNote.noteCount, 1);
+
+      await mcpParityCommand("project-memory", [
+        "project_memory_read",
+        "--input",
+        JSON.stringify({ workingDirectory: cwd }),
+        "--json",
+      ]);
+      const memoryRead = JSON.parse(logs.pop() || "{}") as { notes?: Array<{ content?: string }> };
+      assert.equal(memoryRead.notes?.length, 1);
+      assert.equal(memoryRead.notes?.[0]?.content, "CLI parity exists for transport fallback");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("supports trace summary parity via CLI", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-trace-"));
+    const logs = captureLogs();
+
+    try {
+      const logsDir = join(cwd, ".omx", "logs");
+      await mkdir(logsDir, { recursive: true });
+      await writeFile(
+        join(logsDir, "turns-2026-04-08.jsonl"),
+        `${JSON.stringify({ timestamp: "2026-04-08T13:00:00.000Z", type: "assistant" })}\n`,
+      );
+
+      await mcpParityCommand("trace", [
+        "trace_summary",
+        "--input",
+        JSON.stringify({ workingDirectory: cwd }),
+        "--json",
+      ]);
+      const summary = JSON.parse(logs.pop() || "{}") as {
+        turns?: { total?: number; byType?: Record<string, number> };
+      };
+      assert.equal(summary.turns?.total, 1);
+      assert.equal(summary.turns?.byType?.assistant, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import { agentsInitCommand } from "./agents-init.js";
 import { agentsCommand } from "./agents.js";
 import { sessionCommand } from "./session-search.js";
 import { autoresearchCommand } from "./autoresearch.js";
+import { mcpParityCommand } from "./mcp-parity.js";
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -149,6 +150,12 @@ Usage:
   omx hooks     Manage hook plugins (init|status|validate|test)
   omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
   omx state     Read/write/list OMX mode state via CLI parity surface
+  omx notepad   CLI parity for OMX notepad MCP tools
+  omx project-memory
+                CLI parity for OMX project-memory MCP tools
+  omx trace     CLI parity for OMX trace MCP tools
+  omx code-intel
+                CLI parity for OMX code-intel MCP tools
   omx sparkshell <command> [args...]
   omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]
                 Run native sparkshell sidecar for direct command execution or explicit tmux-pane summarization
@@ -743,6 +750,18 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "state":
         await stateCommand(args.slice(1));
+        break;
+      case "notepad":
+        await mcpParityCommand("notepad", args.slice(1));
+        break;
+      case "project-memory":
+        await mcpParityCommand("project-memory", args.slice(1));
+        break;
+      case "trace":
+        await mcpParityCommand("trace", args.slice(1));
+        break;
+      case "code-intel":
+        await mcpParityCommand("code-intel", args.slice(1));
         break;
       case "tmux-hook":
         await tmuxHookCommand(args.slice(1));

--- a/src/cli/mcp-parity.ts
+++ b/src/cli/mcp-parity.ts
@@ -1,0 +1,327 @@
+import process from "node:process";
+
+type ToolSchema = {
+  name: string;
+  description?: string;
+};
+
+type ToolHandlerResult = {
+  content?: Array<{ type?: string; text?: string }>;
+  isError?: boolean;
+};
+
+type ToolHandler = (request: {
+  params: { name: string; arguments?: Record<string, unknown> };
+}) => Promise<ToolHandlerResult>;
+
+interface McpCliDescriptor {
+  commandName: string;
+  title: string;
+  tools: ToolSchema[];
+  aliases?: Record<string, string>;
+  handle: ToolHandler;
+}
+
+interface ParsedMcpCliArgs {
+  toolName: string | null;
+  input: Record<string, unknown>;
+  json: boolean;
+  help: boolean;
+}
+
+type DescriptorLoader = () => Promise<McpCliDescriptor>;
+type McpParityCommandName = "state" | "notepad" | "project-memory" | "trace" | "code-intel";
+
+export type McpParityExecutionResult =
+  | { ok: true; help: string }
+  | { ok: true; data: unknown }
+  | { ok: false; error: unknown };
+
+async function importWithAutoStartDisabled<T>(
+  envName: string,
+  importer: () => Promise<T>,
+): Promise<T> {
+  const previous = process.env[envName];
+  process.env[envName] = "1";
+  try {
+    return await importer();
+  } finally {
+    if (typeof previous === "string") process.env[envName] = previous;
+    else delete process.env[envName];
+  }
+}
+
+function buildDescriptorHelp(descriptor: McpCliDescriptor): string {
+  const toolLines = descriptor.tools
+    .map((tool) => `  - ${tool.name}${tool.description ? ` — ${tool.description}` : ""}`)
+    .join("\n");
+
+  return [
+    `Usage: omx ${descriptor.commandName} <tool-name> [--input <json>] [--json]`,
+    "",
+    descriptor.title,
+    "",
+    "Available tools:",
+    toolLines,
+    "",
+    "Examples:",
+    `  omx ${descriptor.commandName} ${descriptor.tools[0]?.name ?? "<tool>"} --input '{}' --json`,
+  ].join("\n");
+}
+
+function parseInputJson(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("input JSON must decode to an object");
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    throw new Error(
+      `Invalid --input JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export function parseMcpCliArgs(args: string[]): ParsedMcpCliArgs {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
+    return { toolName: null, input: {}, json: false, help: true };
+  }
+
+  const [toolName, ...rest] = args;
+  let input: Record<string, unknown> = {};
+  let json = false;
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (token === "--json") {
+      json = true;
+      continue;
+    }
+    if (token === "--input") {
+      const next = rest[i + 1];
+      if (!next) throw new Error("Missing value for --input");
+      input = parseInputJson(next);
+      i += 1;
+      continue;
+    }
+    if (token === "--help" || token === "-h" || token === "help") {
+      return { toolName: null, input: {}, json: false, help: true };
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return { toolName, input, json, help: false };
+}
+
+function extractPayload(result: ToolHandlerResult): unknown {
+  const text = result.content
+    ?.filter((entry) => entry.type === "text" && typeof entry.text === "string")
+    .map((entry) => entry.text as string)
+    .join("\n")
+    .trim() ?? "";
+
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function executeDescriptorCommand(
+  args: string[],
+  loadDescriptor: DescriptorLoader,
+): Promise<McpParityExecutionResult> {
+  const descriptor = await loadDescriptor();
+  const parsed = parseMcpCliArgs(args);
+  if (parsed.help || !parsed.toolName) {
+    return { ok: true, help: buildDescriptorHelp(descriptor) };
+  }
+
+  const toolName = descriptor.aliases?.[parsed.toolName] ?? parsed.toolName;
+  const allowedTools = new Set(descriptor.tools.map((tool) => tool.name));
+  if (!allowedTools.has(toolName)) {
+    throw new Error(
+      `Unknown ${descriptor.commandName} tool: ${parsed.toolName}\n${buildDescriptorHelp(descriptor)}`,
+    );
+  }
+
+  const result = await descriptor.handle({
+    params: {
+      name: toolName,
+      arguments: parsed.input,
+    },
+  });
+  const payload = extractPayload(result);
+  return result.isError
+    ? { ok: false, error: payload }
+    : { ok: true, data: payload };
+}
+
+async function runDescriptorCommand(
+  args: string[],
+  loadDescriptor: DescriptorLoader,
+): Promise<void> {
+  const parsed = parseMcpCliArgs(args);
+  const result = await executeDescriptorCommand(args, loadDescriptor);
+  if ("help" in result) {
+    globalThis.console.log(result.help);
+    return;
+  }
+  if (parsed.json) {
+    globalThis.console.log(JSON.stringify("data" in result ? result.data : result.error));
+  } else if ("data" in result && typeof result.data === "string") {
+    globalThis.console.log(result.data);
+  } else if ("error" in result && typeof result.error === "string") {
+    globalThis.console.log(result.error);
+  } else {
+    globalThis.console.log(JSON.stringify("data" in result ? result.data : result.error, null, 2));
+  }
+  if (!result.ok) process.exitCode = 1;
+}
+
+async function loadStateDescriptor(): Promise<McpCliDescriptor> {
+  const { buildStateServerTools, handleStateToolCall } = await importWithAutoStartDisabled(
+    "OMX_STATE_SERVER_DISABLE_AUTO_START",
+    async () => await import("../mcp/state-server.js"),
+  );
+  return {
+    commandName: "state",
+    title: "CLI parity surface for OMX state MCP tools.",
+    tools: buildStateServerTools().map(({ name, description }) => ({ name, description })),
+    aliases: {
+      read: "state_read",
+      write: "state_write",
+      clear: "state_clear",
+      "list-active": "state_list_active",
+      "get-status": "state_get_status",
+    },
+    handle: handleStateToolCall,
+  };
+}
+
+async function loadMemoryDescriptor(
+  commandName: "notepad" | "project-memory",
+  prefix: "notepad_" | "project_memory_",
+  title: string,
+): Promise<McpCliDescriptor> {
+  const { buildMemoryServerTools, handleMemoryToolCall } = await importWithAutoStartDisabled(
+    "OMX_MEMORY_SERVER_DISABLE_AUTO_START",
+    async () => await import("../mcp/memory-server.js"),
+  );
+  return {
+    commandName,
+    title,
+    tools: buildMemoryServerTools()
+      .filter((tool) => tool.name.startsWith(prefix))
+      .map(({ name, description }) => ({ name, description })),
+    aliases: commandName === "notepad"
+      ? {
+        read: "notepad_read",
+        "write-priority": "notepad_write_priority",
+        "write-working": "notepad_write_working",
+        "write-manual": "notepad_write_manual",
+        prune: "notepad_prune",
+        stats: "notepad_stats",
+      }
+      : {
+        read: "project_memory_read",
+        write: "project_memory_write",
+        "add-note": "project_memory_add_note",
+        "add-directive": "project_memory_add_directive",
+      },
+    handle: handleMemoryToolCall,
+  };
+}
+
+async function loadTraceDescriptor(): Promise<McpCliDescriptor> {
+  const { buildTraceServerTools, handleTraceToolCall } = await importWithAutoStartDisabled(
+    "OMX_TRACE_SERVER_DISABLE_AUTO_START",
+    async () => await import("../mcp/trace-server.js"),
+  );
+  return {
+    commandName: "trace",
+    title: "CLI parity surface for OMX trace MCP tools.",
+    tools: buildTraceServerTools().map(({ name, description }) => ({ name, description })),
+    aliases: {
+      timeline: "trace_timeline",
+      summary: "trace_summary",
+    },
+    handle: handleTraceToolCall,
+  };
+}
+
+async function loadCodeIntelDescriptor(): Promise<McpCliDescriptor> {
+  const { buildCodeIntelServerTools, handleCodeIntelToolCall } = await importWithAutoStartDisabled(
+    "OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START",
+    async () => await import("../mcp/code-intel-server.js"),
+  );
+  return {
+    commandName: "code-intel",
+    title: "CLI parity surface for OMX code-intel MCP tools.",
+    tools: buildCodeIntelServerTools().map(({ name, description }) => ({ name, description })),
+    handle: handleCodeIntelToolCall,
+  };
+}
+
+export async function mcpParityCommand(
+  commandName: McpParityCommandName,
+  args: string[],
+): Promise<void> {
+  switch (commandName) {
+    case "state":
+      await runDescriptorCommand(args, loadStateDescriptor);
+      return;
+    case "notepad":
+      await runDescriptorCommand(
+        args,
+        async () => await loadMemoryDescriptor("notepad", "notepad_", "CLI parity surface for OMX notepad MCP tools."),
+      );
+      return;
+    case "project-memory":
+      await runDescriptorCommand(
+        args,
+        async () => await loadMemoryDescriptor(
+          "project-memory",
+          "project_memory_",
+          "CLI parity surface for OMX project-memory MCP tools.",
+        ),
+      );
+      return;
+    case "trace":
+      await runDescriptorCommand(args, loadTraceDescriptor);
+      return;
+    case "code-intel":
+      await runDescriptorCommand(args, loadCodeIntelDescriptor);
+      return;
+  }
+}
+
+export async function executeMcpParityCommand(
+  commandName: McpParityCommandName,
+  args: string[],
+): Promise<McpParityExecutionResult> {
+  switch (commandName) {
+    case "state":
+      return await executeDescriptorCommand(args, loadStateDescriptor);
+    case "notepad":
+      return await executeDescriptorCommand(
+        args,
+        async () => await loadMemoryDescriptor("notepad", "notepad_", "CLI parity surface for OMX notepad MCP tools."),
+      );
+    case "project-memory":
+      return await executeDescriptorCommand(
+        args,
+        async () => await loadMemoryDescriptor(
+          "project-memory",
+          "project_memory_",
+          "CLI parity surface for OMX project-memory MCP tools.",
+        ),
+      );
+    case "trace":
+      return await executeDescriptorCommand(args, loadTraceDescriptor);
+    case "code-intel":
+      return await executeDescriptorCommand(args, loadCodeIntelDescriptor);
+  }
+}

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -50,8 +50,7 @@ export function buildManagedCodexHooksConfig(pkgRoot: string): ManagedCodexHooks
       ],
       PostToolUse: [
         buildCommandHook(command, {
-          matcher: "Bash",
-          statusMessage: "Running OMX Bash review",
+          statusMessage: "Running OMX tool review",
         }),
       ],
       UserPromptSubmit: [

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -10,6 +10,7 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
 };
 
 const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
+const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
 
 interface StdioLifecycleServer {
   connect(transport: StdioServerTransport): Promise<unknown>;
@@ -36,12 +37,20 @@ export function autoStartStdioMcpServer(
 
   const transport = new StdioServerTransport();
   let shuttingDown = false;
+  const lifecycleDebugEnabled = env[LIFECYCLE_DEBUG_ENV] === '1';
 
-  const shutdown = async () => {
+  const logLifecycle = (message: string, error?: unknown) => {
+    if (!lifecycleDebugEnabled) return;
+    const detail = error ? ` ${error instanceof Error ? error.message : String(error)}` : '';
+    process.stderr.write(`[omx-${serverName}-server] ${message}${detail}\n`);
+  };
+
+  const shutdown = async (reason: string) => {
     if (shuttingDown) {
       return;
     }
     shuttingDown = true;
+    logLifecycle(`transport shutdown: ${reason}`);
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
     process.off('SIGTERM', handleSigterm);
@@ -55,16 +64,16 @@ export function autoStartStdioMcpServer(
   };
 
   const handleStdinEnd = () => {
-    void shutdown();
+    void shutdown('stdin_end');
   };
   const handleStdinClose = () => {
-    void shutdown();
+    void shutdown('stdin_close');
   };
   const handleSigterm = () => {
-    void shutdown();
+    void shutdown('sigterm');
   };
   const handleSigint = () => {
-    void shutdown();
+    void shutdown('sigint');
   };
 
   process.stdin.once('end', handleStdinEnd);
@@ -74,10 +83,11 @@ export function autoStartStdioMcpServer(
 
   // Funnel transport/client disconnects through the same idempotent shutdown path.
   transport.onclose = () => {
-    void shutdown();
+    void shutdown('transport_close');
   };
 
   server.connect(transport).catch((error) => {
+    logLifecycle('server.connect failed', error);
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
     process.off('SIGTERM', handleSigterm);

--- a/src/mcp/code-intel-server.ts
+++ b/src/mcp/code-intel-server.ts
@@ -320,8 +320,8 @@ const server = new Server(
   { capabilities: { tools: {} } }
 );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
+export function buildCodeIntelServerTools() {
+  return [
     {
       name: 'lsp_diagnostics',
       description: 'Get diagnostics (errors, warnings) for a file. Uses tsc --noEmit for TypeScript projects.',
@@ -440,10 +440,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['pattern', 'replacement', 'language'],
       },
     },
-  ],
+  ];
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: buildCodeIntelServerTools(),
 }));
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+export async function handleCodeIntelToolCall(request: {
+  params: { name: string; arguments?: Record<string, unknown> };
+}) {
   const { name, arguments: args } = request.params;
   const a = (args || {}) as Record<string, unknown>;
 
@@ -666,6 +672,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     default:
       return { content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }], isError: true };
   }
-});
+}
+
+server.setRequestHandler(CallToolRequestSchema, handleCodeIntelToolCall);
 
 autoStartStdioMcpServer('code_intel', server);

--- a/src/mcp/memory-server.ts
+++ b/src/mcp/memory-server.ts
@@ -38,8 +38,8 @@ const server = new Server(
   { capabilities: { tools: {} } }
 );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
+export function buildMemoryServerTools() {
+  return [
     // Project Memory tools
     {
       name: 'project_memory_read',
@@ -161,10 +161,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         },
       },
     },
-  ],
+  ];
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: buildMemoryServerTools(),
 }));
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+export async function handleMemoryToolCall(request: {
+  params: { name: string; arguments?: Record<string, unknown> };
+}) {
   const { name, arguments: args } = request.params;
   const a = (args || {}) as Record<string, unknown>;
   let wd: string;
@@ -412,7 +418,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     default:
       return { content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }], isError: true };
   }
-});
+}
+
+server.setRequestHandler(CallToolRequestSchema, handleMemoryToolCall);
 
 function text(data: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };

--- a/src/mcp/trace-server.ts
+++ b/src/mcp/trace-server.ts
@@ -206,8 +206,8 @@ const server = new Server(
   { capabilities: { tools: {} } }
 );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
+export function buildTraceServerTools() {
+  return [
     {
       name: 'trace_timeline',
       description: 'Show chronological agent flow trace timeline. Displays turns, mode transitions, and agent activity in time order.',
@@ -234,10 +234,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         },
       },
     },
-  ],
+  ];
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: buildTraceServerTools(),
 }));
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+export async function handleTraceToolCall(request: {
+  params: { name: string; arguments?: Record<string, unknown> };
+}) {
   const { name, arguments: args } = request.params;
   const a = (args || {}) as Record<string, unknown>;
   let wd: string;
@@ -331,6 +337,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     default:
       return { content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }], isError: true };
   }
-});
+}
+
+server.setRequestHandler(CallToolRequestSchema, handleTraceToolCall);
 
 autoStartStdioMcpServer('trace', server);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6,7 +6,11 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import { buildManagedCodexHooksConfig } from "../../config/codex-hooks.js";
-import { initTeamState } from "../../team/state.js";
+import {
+  initTeamState,
+  readTeamLeaderAttention,
+  readTeamPhase,
+} from "../../team/state.js";
 import {
   dispatchCodexNativeHook,
   mapCodexHookEventToOmxEvent,
@@ -41,6 +45,17 @@ describe("codex native hook config", () => {
       String(preToolUse.hooks?.[0]?.command || ""),
       /codex-native-hook\.js"?$/,
     );
+
+    const postToolUse = config.hooks.PostToolUse[0] as {
+      matcher?: string;
+      hooks?: Array<Record<string, unknown>>;
+    };
+    assert.equal(postToolUse.matcher, undefined);
+    assert.match(
+      String(postToolUse.hooks?.[0]?.command || ""),
+      /codex-native-hook\.js"?$/,
+    );
+    assert.equal(postToolUse.hooks?.[0]?.statusMessage, "Running OMX tool review");
 
     const stop = config.hooks.Stop[0] as {
       hooks?: Array<Record<string, unknown>>;
@@ -324,6 +339,123 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("returns PostToolUse MCP transport fallback guidance for clear MCP transport death", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-transport-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-mcp-transport",
+          tool_input: { mode: "team", active: true },
+          tool_response: "{\"error\":\"MCP transport closed\",\"details\":\"stdio pipe closed before response\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      const output = result.outputJson as {
+        decision?: string;
+        reason?: string;
+        hookSpecificOutput?: { additionalContext?: string };
+      } | null;
+      assert.equal(output?.decision, "block");
+      assert.equal(
+        output?.reason,
+        "The MCP tool appears to have lost its transport/server connection. Preserve state, debug the transport failure, and use OMX CLI/file-backed fallbacks instead of retrying blindly.",
+      );
+      const additionalContext = String(
+        output?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(
+        additionalContext,
+        /omx state state_write --input/,
+      );
+      assert.match(
+        additionalContext,
+        /plain Node stdio processes/i,
+      );
+      assert.match(
+        additionalContext,
+        /read-stall-state/,
+      );
+      assert.match(
+        additionalContext,
+        /OMX_MCP_TRANSPORT_DEBUG=1/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not classify non-transport MCP failures as transport death", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-nontransport-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-mcp-nontransport",
+          tool_input: { active: true },
+          tool_response: "{\"error\":\"validation failed\",\"details\":\"mode is required\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("marks active team state failed on MCP transport death without deleting team state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-mcp-transport-"));
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(cwd);
+      await initTeamState(
+        "transport-team",
+        "task",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-transport" },
+      );
+      await writeJson(join(cwd, ".omx", "state", "team-state.json"), {
+        active: true,
+        team_name: "transport-team",
+        current_phase: "team-exec",
+      });
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          session_id: "sess-transport",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-mcp-transport-team",
+          tool_input: { mode: "team", active: true },
+          tool_response: "{\"error\":\"MCP transport closed\",\"details\":\"stdio pipe closed before response\"}",
+        },
+        { cwd },
+      );
+
+      const phase = await readTeamPhase("transport-team", cwd);
+      const attention = await readTeamLeaderAttention("transport-team", cwd);
+      assert.equal(phase?.current_phase, "failed");
+      assert.equal(attention?.leader_attention_reason, "mcp_transport_dead");
+      assert.equal(attention?.leader_attention_pending, true);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "team", "transport-team")), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("treats stderr-only informative non-zero output as reviewable instead of a generic failure", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-informative-stderr-"));
     try {
@@ -384,6 +516,67 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("returns MCP transport-death guidance and preserves failed team state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-dead-"));
+    try {
+      await initTeamState(
+        "mcp-transport-dead-team",
+        "transport failure fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-mcp-dead" },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          session_id: "sess-mcp-dead",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-mcp-dead",
+          tool_response: JSON.stringify({
+            error: "transport closed",
+            message: "MCP server disconnected",
+          }),
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason || ""), /lost its transport\/server connection/);
+      const hookSpecificOutput = result.outputJson?.hookSpecificOutput as {
+        hookEventName?: string;
+        additionalContext?: string;
+      } | undefined;
+      assert.equal(hookSpecificOutput?.hookEventName, "PostToolUse");
+      assert.match(
+        String(hookSpecificOutput?.additionalContext || ""),
+        /Retry via CLI parity with `omx state state_write --input '\{\}' --json`\./,
+      );
+      assert.match(
+        String(hookSpecificOutput?.additionalContext || ""),
+        /omx team api read-stall-state/,
+      );
+
+      const phase = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "team", "mcp-transport-dead-team", "phase.json"), "utf-8"),
+      ) as { current_phase?: string; transitions?: Array<{ reason?: string }> };
+      assert.equal(phase.current_phase, "failed");
+      assert.equal(phase.transitions?.at(-1)?.reason, "mcp_transport_dead");
+
+      const attention = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "team", "mcp-transport-dead-team", "leader-attention.json"), "utf-8"),
+      ) as { leader_attention_reason?: string; attention_reasons?: string[] };
+      assert.equal(attention.leader_attention_reason, "mcp_transport_dead");
+      assert.ok(attention.attention_reasons?.includes("mcp_transport_dead"));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("stays silent on neutral successful PostToolUse output", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-neutral-"));
     try {
@@ -401,6 +594,60 @@ describe("codex native hook dispatch", () => {
 
       assert.equal(result.omxEventName, "post-tool-use");
       assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns CLI fallback guidance and preserves failed team state on clear MCP transport death", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-transport-"));
+    try {
+      await initTeamState(
+        "transport-team",
+        "transport failure fallback",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-mcp-transport" },
+      );
+      await writeJson(join(cwd, ".omx", "state", "team-state.json"), {
+        active: true,
+        team_name: "transport-team",
+        current_phase: "team-exec",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          session_id: "sess-stop-mcp-transport",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-mcp-fail",
+          tool_input: { mode: "team", active: true },
+          tool_response: JSON.stringify({
+            error: "MCP transport closed unexpectedly",
+            exit_code: 1,
+          }),
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "The MCP tool appears to have lost its transport/server connection. Preserve state, debug the transport failure, and use OMX CLI/file-backed fallbacks instead of retrying blindly.",
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext:
+            "Clear MCP transport-death signal detected. Preserve current team/runtime state. Retry via CLI parity with `omx state state_write --input '{\"mode\":\"team\",\"active\":true}' --json`. OMX MCP servers are plain Node stdio processes, so they still shut down when stdin/transport closes. If this happened during team runtime, inspect first with `omx team status <team>` or `omx team api read-stall-state --input '{\"team_name\":\"<team>\"}' --json`, and only force cleanup after capturing needed state. For root-cause debugging, rerun with `OMX_MCP_TRANSPORT_DEBUG=1` to log why the stdio transport closed.",
+        },
+      });
+
+      const phase = await readTeamPhase("transport-team", cwd);
+      const attention = await readTeamLeaderAttention("transport-team", cwd);
+      assert.equal(phase?.current_phase, "failed");
+      assert.equal(attention?.leader_attention_reason, "mcp_transport_dead");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2,11 +2,18 @@ import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join, resolve } from "path";
-import { readModeState } from "../modes/base.js";
+import { readModeState, updateModeState } from "../modes/base.js";
 import { getReadScopedStateDirs } from "../mcp/state-paths.js";
 import { readSubagentSessionSummary } from "../subagents/tracker.js";
 import { resolveCanonicalTeamStateRoot } from "../team/state-root.js";
-import { readTeamManifestV2, readTeamPhase } from "../team/state.js";
+import {
+  appendTeamEvent,
+  readTeamLeaderAttention,
+  readTeamManifestV2,
+  readTeamPhase,
+  writeTeamLeaderAttention,
+  writeTeamPhase,
+} from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
 import {
   detectPrimaryKeyword,
@@ -23,6 +30,7 @@ import {
 import {
   buildNativePostToolUseOutput,
   buildNativePreToolUseOutput,
+  detectMcpTransportFailure,
 } from "./codex-native-pre-post.js";
 import {
   buildNativeHookEvent,
@@ -791,6 +799,110 @@ async function buildSkillStopOutput(
   };
 }
 
+async function findActiveTeamForTransportFailure(
+  cwd: string,
+  sessionId: string,
+): Promise<{ teamName: string; phase: string } | null> {
+  const teamState = await readModeState("team", cwd);
+  if (teamState?.active === true) {
+    const teamName = safeString(teamState.team_name).trim();
+    const coarsePhase = formatPhase(teamState.current_phase);
+    if (teamName) {
+      const canonicalPhase = (await readTeamPhase(teamName, cwd))?.current_phase ?? coarsePhase;
+      if (isNonTerminalPhase(canonicalPhase)) {
+        return { teamName, phase: formatPhase(canonicalPhase) };
+      }
+    }
+  }
+
+  return await findCanonicalActiveTeamForSession(cwd, sessionId);
+}
+
+async function markTeamTransportFailure(
+  cwd: string,
+  payload: CodexHookPayload,
+): Promise<void> {
+  const sessionId = readPayloadSessionId(payload);
+  const activeTeam = await findActiveTeamForTransportFailure(cwd, sessionId);
+  if (!activeTeam) return;
+
+  const nowIso = new Date().toISOString();
+  const existingPhase = await readTeamPhase(activeTeam.teamName, cwd);
+  const currentPhase = existingPhase?.current_phase ?? activeTeam.phase;
+  if (!isNonTerminalPhase(currentPhase)) return;
+
+  await writeTeamPhase(
+    activeTeam.teamName,
+    {
+      current_phase: "failed",
+      max_fix_attempts: existingPhase?.max_fix_attempts ?? 3,
+      current_fix_attempt: existingPhase?.current_fix_attempt ?? 0,
+      transitions: [
+        ...(existingPhase?.transitions ?? []),
+        {
+          from: formatPhase(currentPhase),
+          to: "failed",
+          at: nowIso,
+          reason: "mcp_transport_dead",
+        },
+      ],
+      updated_at: nowIso,
+    },
+    cwd,
+  );
+
+  const existingAttention = await readTeamLeaderAttention(activeTeam.teamName, cwd);
+  await writeTeamLeaderAttention(
+    activeTeam.teamName,
+    {
+      team_name: activeTeam.teamName,
+      updated_at: nowIso,
+      source: "notify_hook",
+      leader_decision_state: existingAttention?.leader_decision_state ?? "still_actionable",
+      leader_attention_pending: true,
+      leader_attention_reason: "mcp_transport_dead",
+      attention_reasons: [
+        ...new Set([...(existingAttention?.attention_reasons ?? []), "mcp_transport_dead"]),
+      ],
+      leader_stale: existingAttention?.leader_stale ?? false,
+      leader_session_active: existingAttention?.leader_session_active ?? true,
+      leader_session_id: existingAttention?.leader_session_id ?? (sessionId || null),
+      leader_session_stopped_at: existingAttention?.leader_session_stopped_at ?? null,
+      unread_leader_message_count: existingAttention?.unread_leader_message_count ?? 0,
+      work_remaining: existingAttention?.work_remaining ?? true,
+      stalled_for_ms: existingAttention?.stalled_for_ms ?? null,
+    },
+    cwd,
+  );
+
+  await appendTeamEvent(
+    activeTeam.teamName,
+    {
+      type: "leader_attention",
+      worker: "leader-fixed",
+      reason: "mcp_transport_dead",
+      metadata: {
+        phase_before: formatPhase(currentPhase),
+      },
+    },
+    cwd,
+  ).catch(() => {});
+
+  try {
+    await updateModeState(
+      "team",
+      {
+        current_phase: "failed",
+        error: "mcp_transport_dead",
+        last_turn_at: nowIso,
+      },
+      cwd,
+    );
+  } catch {
+    // Canonical team state already carries the preserved failure for coarse-state-missing sessions.
+  }
+}
+
 async function buildStopHookOutput(
   payload: CodexHookPayload,
   cwd: string,
@@ -954,6 +1066,9 @@ export async function dispatchCodexNativeHook(
   } else if (hookEventName === "PreToolUse") {
     outputJson = buildNativePreToolUseOutput(payload);
   } else if (hookEventName === "PostToolUse") {
+    if (detectMcpTransportFailure(payload)) {
+      await markTeamTransportFailure(cwd, payload);
+    }
     outputJson = buildNativePostToolUseOutput(payload);
   } else if (hookEventName === "Stop") {
     outputJson = await buildStopHookOutput(payload, cwd, stateDir);

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -21,6 +21,11 @@ export interface NormalizedPostToolUsePayload {
   stderrText: string;
 }
 
+export interface McpTransportFailureSignal {
+  toolName: string;
+  summary: string;
+}
+
 function safeString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
@@ -101,6 +106,88 @@ function matchesDestructiveFixture(command: string): boolean {
   return /^\s*rm\s+-rf\s+dist(?:\s|$)/.test(command);
 }
 
+function isMcpLikeToolName(toolName: string): boolean {
+  return /^(mcp__|omx_(?:state|memory|trace|code_intel)\b|state_|project_memory_|notepad_|trace_)/i.test(toolName);
+}
+
+const MCP_TRANSPORT_FAILURE_PATTERNS = [
+  /transport (?:closed|error|failed)/i,
+  /server disconnected/i,
+  /connection (?:closed|reset|lost)/i,
+  /\beconnreset\b/i,
+  /\bepipe\b/i,
+  /broken pipe/i,
+  /stream ended unexpectedly/i,
+  /stdio .*closed/i,
+  /pipe closed/i,
+  /mcp(?: server)? .*closed/i,
+];
+
+type OmxParityCommand =
+  | "state"
+  | "notepad"
+  | "project-memory"
+  | "trace"
+  | "code-intel";
+
+export function detectMcpTransportFailure(
+  payload: CodexHookPayload,
+): McpTransportFailureSignal | null {
+  const normalized = normalizePostToolUsePayload(payload);
+  const combined = [
+    normalized.stderrText,
+    normalized.stdoutText,
+    safeString(normalized.parsedToolResponse?.error),
+    safeString(normalized.parsedToolResponse?.message),
+    safeString(normalized.parsedToolResponse?.details),
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+
+  const mcpContextDetected = isMcpLikeToolName(normalized.toolName)
+    || /\bmcp\b/i.test(combined)
+    || /\bomx-(?:state|memory|trace|code-intel)-server\b/i.test(combined);
+  if (!mcpContextDetected) return null;
+  if (!combined) return null;
+  if (!MCP_TRANSPORT_FAILURE_PATTERNS.some((pattern) => pattern.test(combined))) {
+    return null;
+  }
+
+  return {
+    toolName: normalized.toolName,
+    summary: combined,
+  };
+}
+
+function resolveOmxParityTarget(toolName: string): { command: OmxParityCommand; tool: string } | null {
+  const match = toolName.match(/^mcp__omx_(state|memory|trace|code_intel)__([a-z0-9_]+)$/i);
+  if (!match) return null;
+
+  const [, server, tool] = match;
+  if (server === "state") return { command: "state", tool };
+  if (server === "trace") return { command: "trace", tool };
+  if (server === "code_intel") return { command: "code-intel", tool };
+  if (server === "memory" && tool.startsWith("notepad_")) {
+    return { command: "notepad", tool };
+  }
+  if (server === "memory" && tool.startsWith("project_memory_")) {
+    return { command: "project-memory", tool };
+  }
+  return null;
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function buildOmxParityFallbackCommand(payload: CodexHookPayload, toolName: string): string | null {
+  const target = resolveOmxParityTarget(toolName);
+  if (!target) return null;
+  const input = safeObject(payload.tool_input) ?? {};
+  return `omx ${target.command} ${target.tool} --input ${shellSingleQuote(JSON.stringify(input))} --json`;
+}
+
 export function buildNativePreToolUseOutput(
   payload: CodexHookPayload,
 ): Record<string, unknown> | null {
@@ -124,6 +211,23 @@ function containsHardFailure(text: string): boolean {
 export function buildNativePostToolUseOutput(
   payload: CodexHookPayload,
 ): Record<string, unknown> | null {
+  const mcpTransportFailure = detectMcpTransportFailure(payload);
+  if (mcpTransportFailure) {
+    const fallbackCommand = buildOmxParityFallbackCommand(payload, mcpTransportFailure.toolName);
+    const fallbackText = fallbackCommand
+      ? `Retry via CLI parity with \`${fallbackCommand}\`.`
+      : "Retry via the matching OMX CLI parity surface instead of retrying the MCP transport blindly.";
+    return {
+      decision: "block",
+      reason: "The MCP tool appears to have lost its transport/server connection. Preserve state, debug the transport failure, and use OMX CLI/file-backed fallbacks instead of retrying blindly.",
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext:
+          `Clear MCP transport-death signal detected. Preserve current team/runtime state. ${fallbackText} OMX MCP servers are plain Node stdio processes, so they still shut down when stdin/transport closes. If this happened during team runtime, inspect first with \`omx team status <team>\` or \`omx team api read-stall-state --input '{"team_name":"<team>"}' --json\`, and only force cleanup after capturing needed state. For root-cause debugging, rerun with \`OMX_MCP_TRANSPORT_DEBUG=1\` to log why the stdio transport closed.`,
+      },
+    };
+  }
+
   const normalized = normalizePostToolUsePayload(payload);
   if (!normalized.isBash) return null;
 

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -198,6 +198,7 @@ describe('runtime-cli helpers', () => {
       }]);
       assert.match(result.notice, /preserving team state/i);
       assert.match(result.notice, /omx team shutdown runtime-cli-preserve-complete/);
+      assert.match(result.notice, /omx team api read-stall-state/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -237,6 +238,7 @@ describe('runtime-cli helpers', () => {
         summary: 'FAIL: worker crashed',
       }]);
       assert.match(result.notice, /preserving team state/i);
+      assert.match(result.notice, /omx team api read-stall-state/);
       assert.match(result.notice, /omx team shutdown runtime-cli-preserve-failed/);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -159,7 +159,10 @@ export function buildTerminalCliResult(
   return {
     output: buildCliOutput(stateRoot, teamName, status, workerCount, startTimeMs),
     exitCode: status === 'completed' ? 0 : 1,
-    notice: `[runtime-cli] phase=${phase} reached terminal state; preserving team state for inspection. Run "omx team shutdown ${teamName}" when explicit cleanup is desired.\n`,
+    notice:
+      `[runtime-cli] phase=${phase} reached terminal state; preserving team state for inspection. `
+      + `Inspect with "omx team status ${teamName} --json" or "omx team api read-stall-state --input '{\"team_name\":\"${teamName}\"}' --json". `
+      + `Run "omx team shutdown ${teamName}" (or --force after state capture) when explicit cleanup is desired.\n`,
   };
 }
 


### PR DESCRIPTION
## Summary
- add CLI parity commands for OMX MCP-backed state, notepad/project-memory, trace, and code-intel flows
- classify clear MCP transport-death in PostToolUse and steer recovery through OMX CLI/file-backed fallbacks
- preserve and explicitly fail active team runtime state on transport death instead of letting cleanup/recovery stall ambiguously

## Why
During team runtime, MCP transport death could strand state in a never-cleanup / unclear recovery situation. This change keeps the fallback narrow to clear transport death, preserves debuggable team state, and gives the model explicit CLI parity paths when MCP is unavailable.

## What changed
- wired top-level CLI parity entrypoints:
  - `omx state`
  - `omx notepad`
  - `omx project-memory`
  - `omx trace`
  - `omx code-intel`
- reused existing MCP handlers for parity instead of duplicating implementations
- expanded managed `PostToolUse` hook coverage beyond Bash-only matching
- added clear MCP transport-death detection and targeted fallback guidance in native hook post-processing
- marked active team state failed-but-preserved on transport death and improved failed runtime inspection guidance
- added optional MCP lifecycle debug logging with `OMX_MCP_TRANSPORT_DEBUG=1`
- added regression tests for CLI parity, hook behavior, bootstrap lifecycle, and failed-team guidance

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/mcp-parity.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/team/__tests__/runtime-cli.test.js dist/mcp/__tests__/bootstrap.test.js`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js`
- `npm run lint`
- `npm run check:no-unused`

## Risks / follow-ups
- transport-death detection is heuristic and may need signature tuning if live Codex/MCP error text differs
- no live end-to-end reproduction of the original transport death was captured in this PR; diagnostics were improved to help that follow-up
