### PR TITLE
Clean up team shutdown contract for clean worktrees and explicit failed-task confirmation

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -176,6 +176,12 @@ describe('teamCommand shutdown --force parsing', () => {
     const force = teamArgs.includes('--force');
     assert.equal(force, true);
   });
+
+  it('parses --confirm-issues from shutdown args', () => {
+    const teamArgs = ['shutdown', 'my-team', '--confirm-issues'];
+    const confirmIssues = teamArgs.includes('--confirm-issues');
+    assert.equal(confirmIssues, true);
+  });
 });
 
 describe('teamCommand api', () => {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -128,7 +128,7 @@ Usage: omx team [N:agent-type] "<task description>"
        omx team status <team-name> [--json] [--tail-lines <100-1000>]
        omx team await <team-name> [--timeout-ms <ms>] [--after-event-id <id>] [--json]
        omx team resume <team-name>
-       omx team shutdown <team-name> [--force]
+       omx team shutdown <team-name> [--force] [--confirm-issues]
        omx team api <operation> [--input <json>] [--json]
        omx team api --help
 
@@ -199,7 +199,7 @@ const TEAM_API_OPERATION_OPTIONAL_FIELDS: Partial<Record<TeamApiOperation, strin
   'create-task': ['owner', 'blocked_by', 'requires_code_change'],
   'update-task': ['subject', 'description', 'blocked_by', 'requires_code_change'],
   'claim-task': ['expected_version'],
-  'cleanup': ['force'],
+  'cleanup': ['force', 'confirm_issues'],
   'transition-task-status': ['result', 'error'],
   'read-shutdown-ack': ['min_updated_at'],
   'write-worker-identity': [
@@ -216,7 +216,7 @@ const TEAM_API_OPERATION_NOTES: Partial<Record<TeamApiOperation, string>> = {
   'update-task': 'Only non-lifecycle task metadata can be updated.',
   'release-task-claim': 'Use this only for rollback/requeue to pending (not for completion).',
   'transition-task-status': 'Lifecycle flow is claim-safe and typically transitions in_progress -> completed|failed.',
-  'cleanup': 'Uses the runtime shutdown contract; use orphan-cleanup only for known orphan recovery.',
+  'cleanup': 'Uses the runtime shutdown contract; add confirm_issues=true when failed tasks are acknowledged and shutdown should still proceed.',
   'orphan-cleanup': 'Destructive escape hatch for known orphan recovery. Bypasses shutdown orchestration.',
   'read-events': 'Events are returned in canonical form; worker_idle log entries normalize to type worker_state_changed with source_type worker_idle. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics (wakeable events now include merge conflicts and per-signal stale alerts).',
   'await-event': 'Waits for the next matching event and returns status=timeout when no matching event arrives before timeout_ms. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics (wakeable events now include merge conflicts and per-signal stale alerts).',
@@ -1525,9 +1525,10 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
 
   if (subcommand === 'shutdown') {
     const name = teamArgs[1];
-    if (!name) throw new Error('Usage: omx team shutdown <team-name> [--force]');
+    if (!name) throw new Error('Usage: omx team shutdown <team-name> [--force] [--confirm-issues]');
     const force = teamArgs.includes('--force');
-    const summary = await shutdownTeam(name, cwd, { force });
+    const confirmIssues = teamArgs.includes('--confirm-issues');
+    const summary = await shutdownTeam(name, cwd, { force, confirmIssues });
     await updateModeState('team', {
       active: false,
       current_phase: 'cancelled',

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -1829,7 +1829,7 @@ describe('executeTeamApiOperation: cleanup', () => {
     assert.equal(result.ok, false);
   });
 
-  it('routes cleanup through the shutdown gate for failed tasks on normal teams', async () => {
+  it('requires confirm_issues for failed-task cleanup on normal teams', async () => {
     const { cwd, cleanup } = await setupTeam('cleanup-gate');
     try {
       await createTask('cleanup-gate', {
@@ -1843,13 +1843,36 @@ describe('executeTeamApiOperation: cleanup', () => {
       }, cwd);
       assert.equal(result.ok, false);
       if (!result.ok) {
-        assert.match(result.error.message, /shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/);
+        assert.match(result.error.message, /shutdown_confirm_issues_required:failed=1/);
       }
 
       const summary = await executeTeamApiOperation('get-summary', {
         team_name: 'cleanup-gate',
       }, cwd);
       assert.equal(summary.ok, true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('allows cleanup with confirm_issues when failed tasks remain', async () => {
+    const { cwd, cleanup } = await setupTeam('cleanup-confirm-issues');
+    try {
+      await createTask('cleanup-confirm-issues', {
+        subject: 'failed task',
+        description: 'requires explicit confirmation',
+        status: 'failed',
+      }, cwd);
+
+      const result = await executeTeamApiOperation('cleanup', {
+        team_name: 'cleanup-confirm-issues',
+        confirm_issues: true,
+      }, cwd);
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.data.team_name, 'cleanup-confirm-issues');
+        assert.equal(result.data.cleanup_mode, 'shutdown');
+      }
     } finally {
       await cleanup();
     }

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -134,6 +134,35 @@ describe('runtime-cli helpers', () => {
     }
   });
 
+  it('does not auto-force failed-task shutdown without explicit issue confirmation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-confirm-issues-'));
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      await initTeamState('shutdown-confirm-required', 'task', 'executor', 1, cwd);
+      await createTask('shutdown-confirm-required', {
+        subject: 'failed task',
+        description: 'requires confirmation',
+        status: 'failed',
+      }, cwd);
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'shutdown-confirm-required');
+      assert.equal(existsSync(teamRoot), true);
+
+      const runtimeCli = await loadRuntimeCliModule();
+      await assert.rejects(
+        () => runtimeCli.shutdownWithForceFallback('shutdown-confirm-required', cwd),
+        /shutdown_confirm_issues_required:failed=1/,
+      );
+
+      assert.equal(existsSync(teamRoot), true);
+    } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('does not auto-shutdown merely because monitorTeam reaches complete', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-complete-'));
     const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -58,6 +58,25 @@ async function addWorktree(repo: string, branchName: string, pathPrefix: string)
   return worktreePath;
 }
 
+async function attachDirtyWorkerRepo(teamName: string, cwd: string, repoName: string): Promise<void> {
+  const repo = join(cwd, repoName);
+  await mkdir(repo, { recursive: true });
+  execFileSync('git', ['init'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo, stdio: 'ignore' });
+  await writeFile(join(repo, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd: repo, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd: repo, stdio: 'ignore' });
+  await writeFile(join(repo, 'DIRTY.txt'), 'dirty\n', 'utf-8');
+
+  const config = await readTeamConfig(teamName, cwd);
+  assert.ok(config, 'team config should exist');
+  if (!config) throw new Error('missing config');
+  config.workers[0]!.worktree_repo_root = repo;
+  config.workers[0]!.worktree_path = repo;
+  await saveTeamConfig(config, cwd);
+}
+
 
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
   return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
@@ -3029,6 +3048,34 @@ exec "${realGit}" "$@"
     }
   });
 
+  it('shutdownTeam clean fast path ignores worker shutdown ack files', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-clean-fast-'));
+    try {
+      await initTeamState('team-shutdown-clean-fast', 'shutdown clean fast path test', 'executor', 1, cwd);
+      const ackPath = join(
+        cwd,
+        '.omx',
+        'state',
+        'team',
+        'team-shutdown-clean-fast',
+        'workers',
+        'worker-1',
+        'shutdown-ack.json',
+      );
+      await writeFile(
+        ackPath,
+        JSON.stringify({ status: 'reject', reason: 'stale ack', updated_at: '9999-01-01T00:00:00.000Z' }),
+      );
+
+      await shutdownTeam('team-shutdown-clean-fast', cwd);
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-clean-fast');
+      assert.equal(existsSync(teamRoot), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('shutdownTeam blocks when pending tasks remain (shutdown gate)', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-'));
     try {
@@ -3106,7 +3153,7 @@ exec "${realGit}" "$@"
     }
   });
 
-  it('shutdownTeam blocks when failed tasks remain (completion gate)', async () => {
+  it('shutdownTeam requires explicit issue confirmation when failed tasks remain', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-failed-'));
     try {
       await initTeamState('team-shutdown-gate-failed', 'shutdown gate failed test', 'executor', 1, cwd);
@@ -3118,7 +3165,7 @@ exec "${realGit}" "$@"
 
       await assert.rejects(
         () => shutdownTeam('team-shutdown-gate-failed', cwd),
-        /shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/,
+        /shutdown_confirm_issues_required:failed=1:rerun=omx team shutdown team-shutdown-gate-failed --confirm-issues/,
       );
 
       const teamRoot = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed');
@@ -3267,6 +3314,7 @@ esac
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     try {
       await initTeamState('team-reject', 'shutdown reject test', 'executor', 1, cwd);
+      await attachDirtyWorkerRepo('team-reject', cwd, 'team-reject-repo');
       const ackPath = join(
         cwd,
         '.omx',
@@ -3292,6 +3340,7 @@ esac
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
     try {
       await initTeamState('team-ack-evt', 'shutdown ack event test', 'executor', 1, cwd);
+      await attachDirtyWorkerRepo('team-ack-evt', cwd, 'team-ack-evt-repo');
       const ackPath = join(
         cwd,
         '.omx',
@@ -3406,6 +3455,39 @@ esac
 
       await shutdownTeam('team-stale-ack', cwd);
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-stale-ack');
+      assert.equal(existsSync(teamRoot), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam confirmIssues=true allows failed-task shutdown without worker ack handshake', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-confirm-issues-'));
+    try {
+      await initTeamState('team-confirm-issues', 'shutdown confirm issues test', 'executor', 1, cwd);
+      await createTask(
+        'team-confirm-issues',
+        { subject: 'failed', description: 'd', status: 'failed' },
+        cwd,
+      );
+      const ackPath = join(
+        cwd,
+        '.omx',
+        'state',
+        'team',
+        'team-confirm-issues',
+        'workers',
+        'worker-1',
+        'shutdown-ack.json',
+      );
+      await writeFile(
+        ackPath,
+        JSON.stringify({ status: 'reject', reason: 'should be ignored', updated_at: '9999-01-01T00:00:00.000Z' }),
+      );
+
+      await shutdownTeam('team-confirm-issues', cwd, { confirmIssues: true });
+
+      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-confirm-issues');
       assert.equal(existsSync(teamRoot), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -3749,7 +3831,7 @@ esac
     }
   });
 
-  it('shutdownTeam still throws on failed tasks', async () => {
+  it('shutdownTeam still requires confirm-issues on failed tasks', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-normal-gate-'));
     try {
       await initTeamState('team-normal-gate', 'normal gate test', 'executor', 1, cwd);
@@ -3761,7 +3843,7 @@ esac
 
       await assert.rejects(
         () => shutdownTeam('team-normal-gate', cwd),
-        /shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/,
+        /shutdown_confirm_issues_required:failed=1/,
       );
 
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-normal-gate');

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -1086,7 +1086,8 @@ export async function executeTeamApiOperation(
         const teamName = String(args.team_name || '').trim();
         if (!teamName) return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name is required' } };
         const force = args.force === true;
-        await shutdownTeam(teamName, cwd, { force });
+        const confirmIssues = args.confirm_issues === true || args.confirmIssues === true;
+        await shutdownTeam(teamName, cwd, { force, confirmIssues });
         return { ok: true, operation, data: { team_name: teamName, cleanup_mode: 'shutdown' } };
       }
       case 'orphan-cleanup': {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -245,6 +245,7 @@ export interface TeamRuntime {
 
 interface ShutdownOptions {
   force?: boolean;
+  confirmIssues?: boolean;
 }
 
 export interface TeamShutdownSummary {
@@ -1104,6 +1105,60 @@ interface ShutdownGateCounts {
   completed: number;
   failed: number;
   allowed: boolean;
+}
+
+interface ShutdownClassification {
+  gate: ShutdownGateCounts;
+  dirtyWorkers: string[];
+  requiresIssueConfirmation: boolean;
+  useCleanFastPath: boolean;
+}
+
+function listDirtyShutdownWorkers(config: TeamConfig): string[] {
+  const dirtyWorkers: string[] = [];
+  for (const worker of config.workers) {
+    if (!worker.worktree_repo_root || !worker.worktree_path || !existsSync(worker.worktree_path)) continue;
+    const worktreePath = resolve(worker.worktree_path);
+    const repoRoot = resolve(worker.worktree_repo_root);
+    const status = runGitCommand(repoRoot, ['status', '--porcelain'], worktreePath);
+    if (!status.ok || status.stdout.trim().length > 0) {
+      dirtyWorkers.push(worker.name);
+    }
+  }
+  return dirtyWorkers;
+}
+
+async function classifyShutdown(params: {
+  teamName: string;
+  cwd: string;
+  config: TeamConfig;
+  governance: TeamGovernance;
+  confirmIssues: boolean;
+}): Promise<ShutdownClassification> {
+  const { teamName, cwd, config, governance, confirmIssues } = params;
+  const allTasks = await listTasks(teamName, cwd);
+  const gate: ShutdownGateCounts = {
+    total: allTasks.length,
+    pending: allTasks.filter((t) => t.status === 'pending').length,
+    blocked: allTasks.filter((t) => t.status === 'blocked').length,
+    in_progress: allTasks.filter((t) => t.status === 'in_progress').length,
+    completed: allTasks.filter((t) => t.status === 'completed').length,
+    failed: allTasks.filter((t) => t.status === 'failed').length,
+    allowed: false,
+  };
+
+  const dirtyWorkers = listDirtyShutdownWorkers(config);
+  const hasBlockingBacklog = gate.pending > 0 || gate.blocked > 0 || gate.in_progress > 0;
+  const requiresIssueConfirmation = gate.failed > 0 && dirtyWorkers.length === 0 && !confirmIssues;
+  gate.allowed = governance.cleanup_requires_all_workers_inactive !== true
+    || (!hasBlockingBacklog && !requiresIssueConfirmation);
+
+  return {
+    gate,
+    dirtyWorkers,
+    requiresIssueConfirmation,
+    useCleanFastPath: dirtyWorkers.length === 0 && !hasBlockingBacklog && (gate.failed === 0 || confirmIssues),
+  };
 }
 
 function resolveEffectiveTeamWorktreeMode(
@@ -2633,6 +2688,8 @@ export async function reassignTask(
  */
 export async function shutdownTeam(teamName: string, cwd: string, options: ShutdownOptions = {}): Promise<TeamShutdownSummary> {
   const force = options.force === true;
+  const confirmIssues = options.confirmIssues === true;
+  let skipWorkerAcks = false;
   const sanitized = sanitizeTeamName(teamName);
   const config = await readTeamConfig(sanitized, cwd);
   if (!config) {
@@ -2653,34 +2710,37 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   );
 
   if (!force) {
-    const allTasks = await listTasks(sanitized, cwd);
-    const gate: ShutdownGateCounts = {
-      total: allTasks.length,
-      pending: allTasks.filter((t) => t.status === 'pending').length,
-      blocked: allTasks.filter((t) => t.status === 'blocked').length,
-      in_progress: allTasks.filter((t) => t.status === 'in_progress').length,
-      completed: allTasks.filter((t) => t.status === 'completed').length,
-      failed: allTasks.filter((t) => t.status === 'failed').length,
-      allowed: false,
-    };
-    gate.allowed = governance.cleanup_requires_all_workers_inactive !== true
-      || (gate.pending === 0 && gate.blocked === 0 && gate.in_progress === 0 && gate.failed === 0);
+    const classification = await classifyShutdown({
+      teamName: sanitized,
+      cwd,
+      config,
+      governance,
+      confirmIssues,
+    });
+    const { gate, dirtyWorkers, requiresIssueConfirmation, useCleanFastPath } = classification;
 
     await appendTeamEvent(
       sanitized,
       {
         type: 'shutdown_gate',
         worker: 'leader-fixed',
-        reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed} cleanup_requires_all_workers_inactive=${governance.cleanup_requires_all_workers_inactive}`,
+        reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed} cleanup_requires_all_workers_inactive=${governance.cleanup_requires_all_workers_inactive} dirty_workers=${dirtyWorkers.join('|') || 'none'} confirm_issues=${confirmIssues} clean_fast_path=${useCleanFastPath}`,
       },
       cwd,
     ).catch(() => {});
 
     if (!gate.allowed) {
+      if (requiresIssueConfirmation) {
+        throw new Error(
+          `shutdown_confirm_issues_required:failed=${gate.failed}:rerun=omx team shutdown ${sanitized} --confirm-issues`,
+        );
+      }
       throw new Error(
         `shutdown_gate_blocked:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
       );
     }
+
+    skipWorkerAcks = useCleanFastPath;
   }
 
   if (force) {
@@ -2695,79 +2755,81 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
   const shutdownRequestTimes = new Map<string, string>();
 
-  // 1. Send shutdown inbox to each worker
-  for (const w of config.workers) {
-    try {
-      const requestedAt = new Date().toISOString();
-      await writeShutdownRequest(sanitized, w.name, 'leader-fixed', cwd);
-      shutdownRequestTimes.set(w.name, requestedAt);
-      const triggerDirective = buildTriggerDirective(
-        w.name,
-        sanitized,
-        resolveInstructionStateRoot(w.worktree_path),
-      );
-      await dispatchCriticalInboxInstruction({
-        teamName: sanitized,
-        config,
-        workerName: w.name,
-        workerIndex: w.index,
-        paneId: w.pane_id,
-        inbox: generateShutdownInbox(sanitized, w.name),
-        triggerMessage: triggerDirective.text,
-        intent: triggerDirective.intent,
-        cwd,
-        dispatchPolicy,
-        inboxCorrelationKey: `shutdown:${w.name}`,
-      });
-    } catch (err) {
-      process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    }
-  }
-
-  // 2. Wait up to 15s for workers to exit and collect acks
-  const deadline = Date.now() + 15_000;
-  const rejected: Array<{ worker: string; reason: string }> = [];
-  const ackedWorkers = new Set<string>();
-  while (Date.now() < deadline) {
+  if (!skipWorkerAcks) {
+    // 1. Send shutdown inbox to each worker
     for (const w of config.workers) {
-      const ack = await readShutdownAck(sanitized, w.name, cwd, shutdownRequestTimes.get(w.name));
-      if (ack && !ackedWorkers.has(w.name)) {
-        ackedWorkers.add(w.name);
-        await appendTeamEvent(sanitized, {
-          type: 'shutdown_ack',
-          worker: w.name,
-          reason: ack.status === 'reject' ? `reject:${ack.reason || 'no_reason'}` : 'accept',
-        }, cwd);
+      try {
+        const requestedAt = new Date().toISOString();
+        await writeShutdownRequest(sanitized, w.name, 'leader-fixed', cwd);
+        shutdownRequestTimes.set(w.name, requestedAt);
+        const triggerDirective = buildTriggerDirective(
+          w.name,
+          sanitized,
+          resolveInstructionStateRoot(w.worktree_path),
+        );
+        await dispatchCriticalInboxInstruction({
+          teamName: sanitized,
+          config,
+          workerName: w.name,
+          workerIndex: w.index,
+          paneId: w.pane_id,
+          inbox: generateShutdownInbox(sanitized, w.name),
+          triggerMessage: triggerDirective.text,
+          intent: triggerDirective.intent,
+          cwd,
+          dispatchPolicy,
+          inboxCorrelationKey: `shutdown:${w.name}`,
+        });
+      } catch (err) {
+        process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
       }
-      if (ack?.status === 'reject') {
-        if (!rejected.some((r) => r.worker === w.name)) {
-          rejected.push({ worker: w.name, reason: ack.reason || 'no_reason' });
+    }
+
+    // 2. Wait up to 15s for workers to exit and collect acks
+    const deadline = Date.now() + 15_000;
+    const rejected: Array<{ worker: string; reason: string }> = [];
+    const ackedWorkers = new Set<string>();
+    while (Date.now() < deadline) {
+      for (const w of config.workers) {
+        const ack = await readShutdownAck(sanitized, w.name, cwd, shutdownRequestTimes.get(w.name));
+        if (ack && !ackedWorkers.has(w.name)) {
+          ackedWorkers.add(w.name);
+          await appendTeamEvent(sanitized, {
+            type: 'shutdown_ack',
+            worker: w.name,
+            reason: ack.status === 'reject' ? `reject:${ack.reason || 'no_reason'}` : 'accept',
+          }, cwd);
+        }
+        if (ack?.status === 'reject') {
+          if (!rejected.some((r) => r.worker === w.name)) {
+            rejected.push({ worker: w.name, reason: ack.reason || 'no_reason' });
+          }
         }
       }
-    }
-    if (rejected.length > 0 && !force) {
-      const detail = rejected.map(r => `${r.worker}:${r.reason}`).join(',');
-      throw new Error(`shutdown_rejected:${detail}`);
+      if (rejected.length > 0 && !force) {
+        const detail = rejected.map(r => `${r.worker}:${r.reason}`).join(',');
+        throw new Error(`shutdown_rejected:${detail}`);
+      }
+
+      const anyAlive = config.workers.some((w) => (
+        config.worker_launch_mode === 'prompt'
+          ? isPromptWorkerAlive(config, w)
+          : isWorkerAlive(sessionName, w.index, w.pane_id)
+      ));
+      if (!anyAlive) break;
+      // Sleep 2s
+      await new Promise(resolve => setTimeout(resolve, 2000));
     }
 
-    const anyAlive = config.workers.some((w) => (
+    const anyAliveAfterWait = config.workers.some((w) => (
       config.worker_launch_mode === 'prompt'
         ? isPromptWorkerAlive(config, w)
         : isWorkerAlive(sessionName, w.index, w.pane_id)
     ));
-    if (!anyAlive) break;
-    // Sleep 2s
-    await new Promise(resolve => setTimeout(resolve, 2000));
-  }
-
-  const anyAliveAfterWait = config.workers.some((w) => (
-    config.worker_launch_mode === 'prompt'
-      ? isPromptWorkerAlive(config, w)
-      : isWorkerAlive(sessionName, w.index, w.pane_id)
-  ));
-  if (anyAliveAfterWait && !force) {
-    // Workers may have accepted shutdown but not exited (Codex TUI requires explicit exit).
-    // In this case, proceed to force kill panes (next step) rather than failing and leaving state around.
+    if (anyAliveAfterWait && !force) {
+      // Workers may have accepted shutdown but not exited (Codex TUI requires explicit exit).
+      // In this case, proceed to force kill panes (next step) rather than failing and leaving state around.
+    }
   }
 
   // 3. Force kill remaining workers


### PR DESCRIPTION
## Summary
This PR makes team shutdown behave more predictably in the clean case while preserving the existing dirty-worktree safety path.

### What changed
- adds a clean fast path in `shutdownTeam` that skips worker shutdown ack/reject handshakes when worker worktrees are clean and there is no pending/blocked/in-progress backlog
- adds explicit failed-task confirmation via `omx team shutdown <team> --confirm-issues` and API `confirm_issues` / `confirmIssues`
- preserves the existing dirty worker worktree shutdown flow, including checkpoint / merge / report behavior
- keeps governance override compatibility intact
- keeps runtime-cli terminal failure/cancelled force-clean behavior distinct from normal/manual shutdown

## Why
There was a contract mismatch:
- leader nudges treated a complete/idle team as ready for graceful shutdown
- runtime still required worker shutdown ack/reject handshakes
- failed-task shutdown semantics were not explicit enough for the normal/manual path

This PR narrows the fix to the shutdown entrypoints and their direct tests for a conservative merge.

## Behavior changes
### Clean worker worktrees
- normal shutdown no longer waits on worker ack/reject files
- stale reject acks no longer block the clean shutdown path

### Failed tasks
- plain `omx team shutdown <team>` now stops with actionable guidance
- rerun with `--confirm-issues` to proceed intentionally

### Dirty worker worktrees
- unchanged safety behavior
- dirty shutdown still uses the preservation/reporting path

## Files changed
- `src/team/runtime.ts`
- `src/cli/team.ts`
- `src/team/api-interop.ts`
- `src/team/__tests__/runtime.test.ts`
- `src/team/__tests__/runtime-cli.test.ts`
- `src/team/__tests__/api-interop.test.ts`
- `src/cli/__tests__/team.test.ts`

## Verification
- `npm run build`
- `npx biome lint src/team/runtime.ts src/team/runtime-cli.ts src/team/api-interop.ts src/cli/team.ts src/team/__tests__/runtime.test.ts src/team/__tests__/runtime-cli.test.ts src/team/__tests__/api-interop.test.ts src/cli/__tests__/team.test.ts`
- `node dist/scripts/run-test-files.js dist/team/__tests__/runtime.test.js dist/team/__tests__/runtime-cli.test.js dist/team/__tests__/api-interop.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/shutdown-fallback.test.js`

Result:
- **264 passed, 0 failed**

## Notes
- includes a small cleanup to remove duplicated `confirm-issues` predicate logic in shutdown classification
- CLI coverage for `--confirm-issues` is strongest at parse + downstream behavior levels; a future explicit end-to-end CLI invocation test could be added separately
