### PR TITLE
Fix false-positive native Stop blocking from stale blocker skill state

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -893,7 +893,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("returns Stop continuation output for active ralplan skill without active subagents", async () => {
+  it("returns Stop continuation output for active ralplan skill with matching active mode state and without active subagents", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-skill-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -903,6 +903,10 @@ describe("codex native hook dispatch", () => {
         active: true,
         skill: "ralplan",
         phase: "planning",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-stop-skill", "ralplan-state.json"), {
+        active: true,
+        current_phase: "planning",
       });
 
       const result = await dispatchCodexNativeHook(
@@ -927,6 +931,41 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("does not block on stale ralplan skill-active state when the matching mode state is absent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-skill-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-stale-skill"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-stale-skill" });
+      await writeJson(join(stateDir, "sessions", "sess-stop-stale-skill", "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: "sess-stop-stale-skill",
+        active_skills: [{
+          skill: "ralplan",
+          phase: "planning",
+          active: true,
+          session_id: "sess-stop-stale-skill",
+        }],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-stale-skill",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block on active ralplan skill when subagents are still active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-skill-subagent-"));
     try {
@@ -937,6 +976,10 @@ describe("codex native hook dispatch", () => {
         active: true,
         skill: "ralplan",
         phase: "planning",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-stop-skill-subagent", "ralplan-state.json"), {
+        active: true,
+        current_phase: "planning",
       });
       await writeJson(join(stateDir, "subagent-tracking.json"), {
         schemaVersion: 1,
@@ -981,7 +1024,35 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("returns Stop continuation output for active deep-interview skill without active subagents", async () => {
+  it("does not block on stale root ralplan skill when the explicit session-scoped canonical skill state is absent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-root-skill-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-stale-root-skill",
+          thread_id: "thread-stop-stale-root-skill",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns Stop continuation output for active deep-interview skill with matching active mode state and without active subagents", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -991,6 +1062,10 @@ describe("codex native hook dispatch", () => {
         active: true,
         skill: "deep-interview",
         phase: "planning",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-stop-deep-interview", "deep-interview-state.json"), {
+        active: true,
+        current_phase: "planning",
       });
 
       const result = await dispatchCodexNativeHook(
@@ -1238,6 +1313,10 @@ describe("codex native hook dispatch", () => {
           message: "Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.",
         },
       });
+      await writeJson(join(stateDir, "sessions", "sess-stop-auto-lock", "deep-interview-state.json"), {
+        active: true,
+        current_phase: "planning",
+      });
 
       const result = await dispatchCodexNativeHook(
         {
@@ -1296,7 +1375,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("suppresses native auto-nudge when deep-interview mode state is active without a scoped skill state", async () => {
+  it("returns Stop continuation output when deep-interview mode state is active without a scoped skill state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-deep-interview-mode-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1320,7 +1399,49 @@ describe("codex native hook dispatch", () => {
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX skill deep-interview is still active (phase: intent-first); continue until the current deep-interview workflow reaches a terminal state.",
+        stopReason: "skill_deep-interview_intent-first",
+        systemMessage: "OMX skill deep-interview is still active (phase: intent-first).",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not suppress native auto-nudge from stale root deep-interview skill state when the explicit session-scoped canonical skill state is absent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-stale-root-skill-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-stale-root-skill",
+          thread_id: "thread-stop-auto-stale-root-skill",
+          turn_id: "turn-stop-auto-stale-root-skill-1",
+          last_assistant_message: "Would you like me to continue with the next step?",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "yes, proceed",
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4,6 +4,10 @@ import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join, resolve } from "path";
 import { readModeState } from "../modes/base.js";
 import { getReadScopedStateDirs } from "../mcp/state-paths.js";
+import {
+  listActiveSkills,
+  readVisibleSkillActiveState,
+} from "../state/skill-active.js";
 import { readSubagentSessionSummary } from "../subagents/tracker.js";
 import { resolveCanonicalTeamStateRoot } from "../team/state-root.js";
 import { readTeamManifestV2, readTeamPhase } from "../team/state.js";
@@ -623,20 +627,73 @@ async function isDeepInterviewSuppressedForStop(
   cwd: string,
   stateDir: string,
   sessionId: string,
+  threadId: string,
 ): Promise<boolean> {
   if (await isDeepInterviewStateActive(stateDir)) return true;
   if (await isDeepInterviewInputLockActive(stateDir)) return true;
 
-  const scopedModeState = sessionId
-    ? await readScopedJsonState("deep-interview-state.json", cwd, sessionId)
-    : null;
-  if (scopedModeState?.active === true) return true;
+  return (await readBlockingSkillForStop(cwd, sessionId, threadId, "deep-interview")) !== null;
+}
 
-  const scopedSkillState = sessionId
-    ? await readScopedJsonState("skill-active-state.json", cwd, sessionId)
-    : null;
-  if (!scopedSkillState || scopedSkillState.active !== true) return false;
-  return safeString(scopedSkillState.skill).trim() === "deep-interview";
+function matchesSkillStopContext(
+  entry: { session_id?: string; thread_id?: string },
+  state: { session_id?: string; thread_id?: string },
+  sessionId: string,
+  threadId: string,
+): boolean {
+  const entrySessionId = safeString(entry.session_id ?? state.session_id).trim();
+  const entryThreadId = safeString(entry.thread_id ?? state.thread_id).trim();
+  if (sessionId && entrySessionId && entrySessionId !== sessionId) return false;
+  if (sessionId && !entrySessionId && threadId && entryThreadId && entryThreadId !== threadId) {
+    return false;
+  }
+  return true;
+}
+
+async function readBlockingSkillForStop(
+  cwd: string,
+  sessionId: string,
+  threadId: string,
+  requiredSkill?: string,
+): Promise<{ skill: string; phase: string } | null> {
+  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+  const visibleEntries = canonicalState ? listActiveSkills(canonicalState) : [];
+  const candidateSkills = requiredSkill
+    ? [requiredSkill]
+    : [...SKILL_STOP_BLOCKERS];
+
+  for (const skill of candidateSkills) {
+    const modeState = await readScopedJsonState(`${skill}-state.json`, cwd, sessionId);
+    if (!modeState || modeState.active !== true) continue;
+
+    const phase = formatPhase(
+      modeState.current_phase,
+      formatPhase(
+        visibleEntries.find((entry) => entry.skill === skill)?.phase,
+        "planning",
+      ),
+    );
+    if (TERMINAL_MODE_PHASES.has(phase.toLowerCase()) || phase === "completing") {
+      continue;
+    }
+
+    if (!canonicalState) {
+      return { skill, phase };
+    }
+
+    const blocker = visibleEntries.find((entry) => (
+      entry.skill === skill
+      && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+    ));
+    if (!blocker) continue;
+
+    return {
+      skill,
+      phase: formatPhase(modeState.current_phase ?? blocker.phase ?? canonicalState.phase, "planning"),
+    };
+  }
+
+  return null;
 }
 
 function buildRepeatableStopSignature(
@@ -766,17 +823,8 @@ async function buildSkillStopOutput(
   sessionId: string,
   threadId: string,
 ): Promise<Record<string, unknown> | null> {
-  const state = await readScopedJsonState("skill-active-state.json", cwd, sessionId);
-  if (!state || state.active !== true) return null;
-  const stateSessionId = safeString(state.session_id).trim();
-  const stateThreadId = safeString(state.thread_id).trim();
-  if (sessionId && stateSessionId && stateSessionId !== sessionId) return null;
-  if (sessionId && !stateSessionId && threadId && stateThreadId && stateThreadId !== threadId) {
-    return null;
-  }
-  const skill = safeString(state.skill).trim();
-  const phase = formatPhase(state.phase, "planning");
-  if (!SKILL_STOP_BLOCKERS.has(skill) || phase === "completing") return null;
+  const blocker = await readBlockingSkillForStop(cwd, sessionId, threadId);
+  if (!blocker) return null;
 
   const subagentSummary = await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
   if (subagentSummary && subagentSummary.activeSubagentThreadIds.length > 0) {
@@ -785,9 +833,9 @@ async function buildSkillStopOutput(
 
   return {
     decision: "block",
-    reason: `OMX skill ${skill} is still active (phase: ${phase}); continue until the current ${skill} workflow reaches a terminal state.`,
-    stopReason: `skill_${skill}_${phase}`,
-    systemMessage: `OMX skill ${skill} is still active (phase: ${phase}).`,
+    reason: `OMX skill ${blocker.skill} is still active (phase: ${blocker.phase}); continue until the current ${blocker.skill} workflow reaches a terminal state.`,
+    stopReason: `skill_${blocker.skill}_${blocker.phase}`,
+    systemMessage: `OMX skill ${blocker.skill} is still active (phase: ${blocker.phase}).`,
   };
 }
 
@@ -844,7 +892,7 @@ async function buildStopHookOutput(
       if (!stopHookActive && skillOutput) return skillOutput;
     }
 
-    const deepInterviewActive = await isDeepInterviewSuppressedForStop(cwd, stateDir, sessionId);
+    const deepInterviewActive = await isDeepInterviewSuppressedForStop(cwd, stateDir, sessionId, threadId);
     const lastAssistantMessage = safeString(
       payload.last_assistant_message ?? payload.lastAssistantMessage,
     );


### PR DESCRIPTION
## Summary\n- require a matching non-terminal mode state before native Stop blocks on blocker skill-active entries\n- keep session/thread-aware canonical skill matching for deep-interview/ralplan stop handling\n- add regression coverage for stale session/root blocker skill leftovers and preserve active-workflow blocking\n\n## Verification\n- npm install\n- npm run build\n- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/agents-overlay.test.js dist/hud/__tests__/state.test.js\n- npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts\n- lsp diagnostics clean on changed files