### PR TITLE
Fix stale stop-hook deep-interview state gating

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1622,7 +1622,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("returns Stop continuation output when deep-interview mode state is active without a scoped skill state", async () => {
+  it("suppresses native auto-nudge when root deep-interview mode state is active without an explicit session", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-deep-interview-mode-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1637,9 +1637,37 @@ describe("codex native hook dispatch", () => {
         {
           hook_event_name: "Stop",
           cwd,
-          session_id: "sess-stop-auto-mode",
-          thread_id: "thread-stop-auto-mode",
           turn_id: "turn-stop-auto-mode-1",
+          last_assistant_message: "Would you like me to continue with the next step?",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not suppress native auto-nudge from stale root deep-interview mode state when the explicit session-scoped mode state is absent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-stale-root-mode-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-stale-root-mode",
+          thread_id: "thread-stop-auto-stale-root-mode",
+          turn_id: "turn-stop-auto-stale-root-mode-1",
           last_assistant_message: "Would you like me to continue with the next step?",
         },
         { cwd },
@@ -1648,10 +1676,10 @@ describe("codex native hook dispatch", () => {
       assert.equal(result.omxEventName, "stop");
       assert.deepEqual(result.outputJson, {
         decision: "block",
-        reason:
-          "OMX skill deep-interview is still active (phase: intent-first); continue until the current deep-interview workflow reaches a terminal state.",
-        stopReason: "skill_deep-interview_intent-first",
-        systemMessage: "OMX skill deep-interview is still active (phase: intent-first).",
+        reason: "yes, proceed",
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -1676,6 +1704,48 @@ describe("codex native hook dispatch", () => {
           session_id: "sess-stop-auto-stale-root-skill",
           thread_id: "thread-stop-auto-stale-root-skill",
           turn_id: "turn-stop-auto-stale-root-skill-1",
+          last_assistant_message: "Would you like me to continue with the next step?",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "yes, proceed",
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not suppress native auto-nudge from stale root deep-interview input lock when the explicit session-scoped canonical skill state is absent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-stale-root-lock-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        input_lock: {
+          active: true,
+          scope: "deep-interview-auto-approval",
+          blocked_inputs: ["yes", "proceed"],
+          message: "Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.",
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-stale-root-lock",
+          thread_id: "thread-stop-auto-stale-root-lock",
+          turn_id: "turn-stop-auto-stale-root-lock-1",
           last_assistant_message: "Would you like me to continue with the next step?",
         },
         { cwd },

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3,7 +3,6 @@ import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join, resolve } from "path";
 import { readModeState, updateModeState } from "../modes/base.js";
-import { getReadScopedStateDirs } from "../mcp/state-paths.js";
 import {
   listActiveSkills,
   readVisibleSkillActiveState,
@@ -18,7 +17,7 @@ import {
   writeTeamLeaderAttention,
   writeTeamPhase,
 } from "../team/state.js";
-import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
+import { omxNotepadPath, omxProjectMemoryPath, omxStateDir } from "../utils/paths.js";
 import {
   detectPrimaryKeyword,
   recordSkillActivation,
@@ -26,8 +25,6 @@ import {
 } from "../hooks/keyword-detector.js";
 import {
   detectStallPattern,
-  isDeepInterviewInputLockActive,
-  isDeepInterviewStateActive,
   loadAutoNudgeConfig,
   normalizeAutoNudgeSignatureText,
 } from "./notify-hook/auto-nudge.js";
@@ -164,19 +161,6 @@ async function readJsonIfExists(path: string): Promise<Record<string, unknown> |
   } catch {
     return null;
   }
-}
-
-async function readScopedJsonState(
-  fileName: string,
-  cwd: string,
-  sessionId?: string,
-): Promise<Record<string, unknown> | null> {
-  const dirs = await getReadScopedStateDirs(cwd, sessionId);
-  for (const dir of dirs) {
-    const candidate = await readJsonIfExists(join(dir, fileName));
-    if (candidate) return candidate;
-  }
-  return null;
 }
 
 function isNonTerminalPhase(value: unknown): boolean {
@@ -633,14 +617,39 @@ function readPayloadTurnId(payload: CodexHookPayload): string {
 
 async function isDeepInterviewSuppressedForStop(
   cwd: string,
-  stateDir: string,
   sessionId: string,
   threadId: string,
 ): Promise<boolean> {
-  if (await isDeepInterviewStateActive(stateDir)) return true;
-  if (await isDeepInterviewInputLockActive(stateDir)) return true;
+  const scopedModeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId);
+  if (scopedModeState?.active === true) return true;
+
+  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+  const deepInterviewEntry = canonicalState
+    ? listActiveSkills(canonicalState).find((entry) => (
+      entry.skill === "deep-interview"
+      && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+    ))
+    : null;
+  if (
+    deepInterviewEntry
+    && safeObject(canonicalState?.input_lock).active === true
+  ) {
+    return true;
+  }
 
   return (await readBlockingSkillForStop(cwd, sessionId, threadId, "deep-interview")) !== null;
+}
+
+async function readStopSessionPinnedState(
+  fileName: string,
+  cwd: string,
+  sessionId: string,
+): Promise<Record<string, unknown> | null> {
+  const stateDir = omxStateDir(cwd);
+  const statePath = sessionId
+    ? join(stateDir, "sessions", sessionId, fileName)
+    : join(stateDir, fileName);
+  return readJsonIfExists(statePath);
 }
 
 function matchesSkillStopContext(
@@ -671,7 +680,7 @@ async function readBlockingSkillForStop(
     : [...SKILL_STOP_BLOCKERS];
 
   for (const skill of candidateSkills) {
-    const modeState = await readScopedJsonState(`${skill}-state.json`, cwd, sessionId);
+    const modeState = await readStopSessionPinnedState(`${skill}-state.json`, cwd, sessionId);
     if (!modeState || modeState.active !== true) continue;
 
     const phase = formatPhase(
@@ -1004,7 +1013,7 @@ async function buildStopHookOutput(
       if (!stopHookActive && skillOutput) return skillOutput;
     }
 
-    const deepInterviewActive = await isDeepInterviewSuppressedForStop(cwd, stateDir, sessionId, threadId);
+    const deepInterviewActive = await isDeepInterviewSuppressedForStop(cwd, sessionId, threadId);
     const lastAssistantMessage = safeString(
       payload.last_assistant_message ?? payload.lastAssistantMessage,
     );


### PR DESCRIPTION
## Summary

Stop native-hook deep-interview suppression was still reading stale root mode/input-lock state after skill-state canonicalization. This could block or suppress Stop for the wrong session even when canonical session-scoped state showed no active workflow.

## Changes

- pin deep-interview Stop suppression checks to session-scoped mode state when a session id is provided
- keep canonical skill visibility checks session-aware instead of using raw root notify-hook helpers
- add regressions for stale root deep-interview mode and input-lock false positives while preserving root-only behavior without an explicit session

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
