### PR TITLE
Resolve Windows prompt launch commands via platform command resolution

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1732,19 +1732,23 @@ describe("buildTmuxPaneCommand", () => {
 
 describe("buildWindowsPromptCommand", () => {
   it("encodes detached Windows commands for safe PowerShell prompt injection", () => {
-    const result = buildWindowsPromptCommand("codex", [
-      "--dangerously-bypass-approvals-and-sandbox",
-      "-c",
-      'model_reasoning_effort="high"',
-      "it's",
-    ]);
+    const result = buildWindowsPromptCommand(
+      "codex",
+      [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "-c",
+        'model_reasoning_effort="high"',
+        "it's",
+      ],
+      () => "C:\\Codex\\codex.cmd",
+    );
     const prefix = "powershell.exe -NoLogo -NoExit -EncodedCommand ";
     assert.ok(result.startsWith(prefix));
     const payload = result.slice(prefix.length);
     const decoded = Buffer.from(payload, "base64").toString("utf16le");
     assert.equal(
       decoded,
-      "$ErrorActionPreference = 'Stop'; & { & 'codex' '--dangerously-bypass-approvals-and-sandbox' '-c' 'model_reasoning_effort=\"high\"' 'it''s' }",
+      "$ErrorActionPreference = 'Stop'; & { & 'C:\\Codex\\codex.cmd' '--dangerously-bypass-approvals-and-sandbox' '-c' 'model_reasoning_effort=\"high\"' 'it''s' }",
     );
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2562,10 +2562,13 @@ function isCodexVersionRequest(args: string[]): boolean {
 export function buildWindowsPromptCommand(
   command: string,
   args: string[],
+  resolveCommand: (command: string) => string = (candidate) =>
+    resolveCommandPathForPlatform(candidate) || candidate,
 ): string {
+  const resolvedCommand = resolveCommand(command);
   const invocation = [
     "&",
-    quotePowerShellArg(command),
+    quotePowerShellArg(resolvedCommand),
     ...args.map(quotePowerShellArg),
   ].join(" ");
   const wrappedCommand = [


### PR DESCRIPTION
## Summary

This keeps detached launch helpers aligned on Windows by resolving the command path before encoding the PowerShell prompt wrapper.

After the recent launch-path tightening, tmux shell helpers could resolve launcher paths through the platform-command utilities, but `buildWindowsPromptCommand` still encoded the raw command token (`codex`, `node`, etc.) directly into the PowerShell wrapper. That left Windows detached prompt launches as a special-case weaker path.

## Changes

- thread a resolver through `buildWindowsPromptCommand`
- encode the resolved command path instead of the raw command token
- update the Windows prompt unit test to assert the encoded payload uses the resolved path

## Verification

- Diff review in clean `dev`-based worktree

## Commit

- `187db1a` Resolve Windows prompt launches through the platform command path

## Notes

I did not run the full build/test suite for this branch in the clean `dev` worktree because `dev` does not carry the flake packaging surface used by the packaged-install PR and this sandbox does not have the Node toolchain on PATH.
