### PR TITLE
Resolve Windows prompt launch commands via platform command resolution

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1732,19 +1732,23 @@ describe("buildTmuxPaneCommand", () => {
 
 describe("buildWindowsPromptCommand", () => {
   it("encodes detached Windows commands for safe PowerShell prompt injection", () => {
-    const result = buildWindowsPromptCommand("codex", [
-      "--dangerously-bypass-approvals-and-sandbox",
-      "-c",
-      'model_reasoning_effort="high"',
-      "it's",
-    ]);
+    const result = buildWindowsPromptCommand(
+      "codex",
+      [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "-c",
+        'model_reasoning_effort="high"',
+        "it's",
+      ],
+      () => "C:\\Codex\\codex.cmd",
+    );
     const prefix = "powershell.exe -NoLogo -NoExit -EncodedCommand ";
     assert.ok(result.startsWith(prefix));
     const payload = result.slice(prefix.length);
     const decoded = Buffer.from(payload, "base64").toString("utf16le");
     assert.equal(
       decoded,
-      "$ErrorActionPreference = 'Stop'; & { & 'codex' '--dangerously-bypass-approvals-and-sandbox' '-c' 'model_reasoning_effort=\"high\"' 'it''s' }",
+      "$ErrorActionPreference = 'Stop'; & { & 'C:\\Codex\\codex.cmd' '--dangerously-bypass-approvals-and-sandbox' '-c' 'model_reasoning_effort=\"high\"' 'it''s' }",
     );
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -84,6 +84,7 @@ import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
 rememberOmxLaunchContext();
 import {
   classifySpawnError,
+  resolveCommandPathForPlatform,
   spawnPlatformCommandSync,
 } from "../utils/platform-command.js";
 import { buildHookEvent } from "../hooks/extensibility/events.js";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2562,10 +2562,13 @@ function isCodexVersionRequest(args: string[]): boolean {
 export function buildWindowsPromptCommand(
   command: string,
   args: string[],
+  resolveCommand: (command: string) => string = (candidate) =>
+    resolveCommandPathForPlatform(candidate) || candidate,
 ): string {
+  const resolvedCommand = resolveCommand(command);
   const invocation = [
     "&",
-    quotePowerShellArg(command),
+    quotePowerShellArg(resolvedCommand),
     ...args.map(quotePowerShellArg),
   ].join(" ");
   const wrappedCommand = [


### PR DESCRIPTION
Successor to #1389. This version carries forward the prior Windows prompt launch fix and addresses the compile-blocking review note.

Addressed feedback:
- kept the Windows prompt command-resolution change
- added the missing `resolveCommandPathForPlatform` import so the branch compiles cleanly

Branch tip commits:
- `187db1a` Resolve Windows prompt launches through the platform command path
- `d522033` Import the Windows prompt command resolver

Verification:
- addressed the concrete PR review finding about the missing import
