### PR TITLE
Prevent duplicate native-hook continuation from unknown $tokens and stale Ralph state

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -36,6 +36,13 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.deepEqual(matches.map((m) => m.skill), ['team']);
   });
 
+  it('does not fall back to implicit keyword detection when an unknown $token is present', () => {
+    const matches = detectKeywords('$maer-thinking 다시 설명해봐 keep going');
+    assert.deepEqual(matches, []);
+    const primary = detectPrimaryKeyword('$maer-thinking 다시 설명해봐 keep going');
+    assert.equal(primary, null);
+  });
+
   it('does not auto-detect keywords for explicit /prompts invocation without $skills', () => {
     const matches = detectKeywords('/prompts:architect analyze this issue');
     assert.deepEqual(matches, []);

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -345,6 +345,10 @@ function hasExplicitPromptsInvocation(text: string): boolean {
   return /(?:^|\s)\/prompts:[\w.-]+(?=[\s.,!?;:]|$)/i.test(text);
 }
 
+function hasExplicitSkillLikeInvocation(text: string): boolean {
+  return /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/i.test(text);
+}
+
 function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
   const results: KeywordMatch[] = [];
   const regex = /(?:^|[^\w])\$([a-z][a-z0-9-]*)\b/gi;
@@ -395,6 +399,9 @@ function hasIntentContextForKeyword(text: string, keyword: string): boolean {
 export function detectKeywords(text: string): KeywordMatch[] {
   const explicit = extractExplicitSkillInvocations(text);
   if (hasExplicitPromptsInvocation(text) && explicit.length === 0) {
+    return [];
+  }
+  if (explicit.length === 0 && hasExplicitSkillLikeInvocation(text)) {
     return [];
   }
   if (explicit.length > 0) {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -225,6 +225,31 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("does not emit UserPromptSubmit routing context for unknown $tokens", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-unknown-token-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-unknown-1",
+          thread_id: "thread-unknown-1",
+          turn_id: "turn-unknown-1",
+          prompt: "$maer-thinking 다시 설명해봐",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState, null);
+      assert.equal(result.outputJson, null);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "skill-active-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("nudges $team prompt-submit routing toward omx team runtime usage", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-"));
     try {
@@ -1396,6 +1421,35 @@ describe("codex native hook dispatch", () => {
         systemMessage:
           "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
       });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block Stop from stale session-scoped Ralph state that belongs to another session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-session-ralph-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await mkdir(join(stateDir, "sessions", "sess-stale"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current" });
+      await writeJson(join(stateDir, "sessions", "sess-stale", "ralph-state.json"), {
+        active: true,
+        current_phase: "starting",
+        session_id: "sess-stale",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -190,26 +190,28 @@ function formatPhase(value: unknown, fallback = "active"): string {
 }
 
 async function readActiveRalphState(stateDir: string): Promise<Record<string, unknown> | null> {
+  const sessionInfo = await readJsonIfExists(join(stateDir, "session.json"));
+  const currentOmxSessionId = safeString(sessionInfo?.session_id).trim();
+  if (currentOmxSessionId) {
+    const sessionScoped = await readJsonIfExists(
+      join(stateDir, "sessions", currentOmxSessionId, "ralph-state.json"),
+    );
+    if (
+      sessionScoped?.active === true
+      && !TERMINAL_RALPH_PHASES.has(
+        safeString(sessionScoped.current_phase).trim().toLowerCase(),
+      )
+    ) {
+      return sessionScoped;
+    }
+  }
+
   const direct = await readJsonIfExists(join(stateDir, "ralph-state.json"));
   if (direct?.active === true && !TERMINAL_RALPH_PHASES.has(safeString(direct.current_phase).trim().toLowerCase())) {
     return direct;
   }
 
-  const sessionInfo = await readJsonIfExists(join(stateDir, "session.json"));
-  const currentOmxSessionId = safeString(sessionInfo?.session_id).trim();
-  if (!currentOmxSessionId) return null;
-
-  const sessionScoped = await readJsonIfExists(
-    join(stateDir, "sessions", currentOmxSessionId, "ralph-state.json"),
-  );
-  if (
-    sessionScoped?.active === true
-    && !TERMINAL_RALPH_PHASES.has(
-      safeString(sessionScoped.current_phase).trim().toLowerCase(),
-    )
-  ) {
-    return sessionScoped;
-  }
+  if (currentOmxSessionId) return null;
 
   const sessionsRoot = join(stateDir, "sessions");
   if (!existsSync(sessionsRoot)) return null;


### PR DESCRIPTION
## Summary
This PR prevents a duplicate native-hook continuation path where an unknown `$token` could still trigger implicit keyword routing and Stop could then block on stale Ralph state from another session.

## Problem statement
A user could submit a prompt like `$maer-thinking 다시 설명해봐` and receive more than one continuation-style response:
- UserPromptSubmit could inject OMX routing context because implicit keyword detection still ran after an unrecognized `$...` token.
- Stop could then block completion with an active Ralph message if it found a stale session-scoped Ralph file that belonged to a different session.

The result is a doubled/contradictory UX even though the user did not intentionally activate a real OMX workflow.

## Root cause
There were two independent bugs that compounded:
1. `detectKeywords()` only treated recognized explicit `$skill` tokens as authoritative. If the prompt contained an unknown `$token`, implicit keyword fallback still ran and could match phrases like `keep going` or pasted `Ralph` text.
2. `readActiveRalphState()` preferred scanning every session-scoped Ralph file even when `session.json` identified a different current session and that current session had no active Ralph state.

## What changed
- added an explicit skill-like guard so unknown `$...` invocations suppress implicit keyword fallback instead of being treated like ordinary prose
- made Ralph Stop gating session-authoritative: check the current session-scoped Ralph file first, then root fallback, and only scan every session when no current session id exists
- added focused regressions for both the unknown `$token` prompt-submit case and the stale foreign-session Ralph Stop case

## Why this design
This keeps the fix narrow and behavioral:
- it preserves valid explicit `$skill` routing
- it preserves real active-session Ralph blocking
- it avoids mutating or deleting stale session files as a side effect
- it treats session ownership as the correct boundary for Stop gating

## Overlap assessment
- related issue: #1399
- related PR: #1380 (`Fix stale stop-hook deep-interview state gating`)
- classification: adjacent but distinct
- rationale: #1380 fixed stale deep-interview suppression. This PR fixes the Ralph/session equivalent plus the separate UserPromptSubmit unknown-token fallback bug.

## Validation
- `npm run build`
- `node --test --test-reporter=spec dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js`

## Risk / compatibility
- low risk / narrow scope
- no intended behavior change for recognized explicit skills
- no intended behavior change for real active Ralph sessions
- not tested yet against a live Codex App session with real hook payloads; focused automated regressions cover the reproduced logic paths

## Files changed
- `src/hooks/keyword-detector.ts`
- `src/hooks/__tests__/keyword-detector.test.ts`
- `src/scripts/codex-native-hook.ts`
- `src/scripts/__tests__/codex-native-hook.test.ts`
