### PR TITLE
Keep tmux HUD self-healing aligned with active sessions

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -80,6 +80,14 @@ import { getPackageRoot } from "../utils/package.js";
 import { codexConfigPath, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
 import { repairConfigIfNeeded } from "../config/generator.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
+import {
+  createHudWatchPane as createSharedHudWatchPane,
+  killTmuxPane as killSharedTmuxPane,
+  listCurrentWindowHudPaneIds,
+  parsePaneIdFromTmuxOutput,
+} from "../hud/tmux.js";
+
+export { parseTmuxPaneSnapshot, isHudWatchPane, findHudWatchPaneIds } from "../hud/tmux.js";
 
 rememberOmxLaunchContext();
 import {
@@ -566,51 +574,9 @@ function runCodexBlocking(
   }
 }
 
-interface TmuxPaneSnapshot {
-  paneId: string;
-  currentCommand: string;
-  startCommand: string;
-}
-
 export interface DetachedSessionTmuxStep {
   name: string;
   args: string[];
-}
-
-export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
-  return output
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const [paneId = "", currentCommand = "", ...startCommandParts] =
-        line.split("\t");
-      return {
-        paneId: paneId.trim(),
-        currentCommand: currentCommand.trim(),
-        startCommand: startCommandParts.join("\t").trim(),
-      };
-    })
-    .filter((pane) => pane.paneId.startsWith("%"));
-}
-
-export function isHudWatchPane(pane: TmuxPaneSnapshot): boolean {
-  const command = `${pane.startCommand} ${pane.currentCommand}`.toLowerCase();
-  return (
-    /\bhud\b/.test(command) &&
-    /--watch\b/.test(command) &&
-    (/\bomx(?:\.js)?\b/.test(command) || /\bnode\b/.test(command))
-  );
-}
-
-export function findHudWatchPaneIds(
-  panes: TmuxPaneSnapshot[],
-  currentPaneId?: string,
-): string[] {
-  return panes
-    .filter((pane) => pane.paneId !== currentPaneId)
-    .filter((pane) => isHudWatchPane(pane))
-    .map((pane) => pane.paneId);
 }
 
 export function buildHudPaneCleanupTargets(
@@ -1423,8 +1389,12 @@ export function buildTmuxSessionName(cwd: string, sessionId: string): string {
   const branch = tryReadGitValue(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (branch) branchToken = sanitizeTmuxToken(branch);
   const sessionToken = sanitizeTmuxToken(sessionId.replace(/^omx-/, ""));
-  const name = `omx-${dirToken}-${branchToken}-${sessionToken}`;
-  return name.length > 120 ? name.slice(0, 120) : name;
+  const prefix = `omx-${dirToken}-${branchToken}`;
+  const name = `${prefix}-${sessionToken}`;
+  if (name.length <= 120) return name;
+  const prefixBudget = Math.max(4, 120 - sessionToken.length - 1);
+  const trimmedPrefix = prefix.slice(0, prefixBudget).replace(/-+$/g, "");
+  return `${trimmedPrefix}-${sessionToken}`.slice(0, 120);
 }
 
 export function buildDetachedTmuxSessionName(
@@ -1432,11 +1402,6 @@ export function buildDetachedTmuxSessionName(
   sessionId: string,
 ): string {
   return buildTmuxSessionName(cwd, sessionId);
-}
-
-function parsePaneIdFromTmuxOutput(rawOutput: string): string | null {
-  const paneId = rawOutput.split("\n")[0]?.trim() || "";
-  return paneId.startsWith("%") ? paneId : null;
 }
 
 function parseWindowIndexFromTmuxOutput(rawOutput: string): string | null {
@@ -2500,16 +2465,7 @@ function runCodex(
 
 function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): string[] {
   try {
-    const output = execFileSync(
-      "tmux",
-      [
-        "list-panes",
-        "-F",
-        "#{pane_id}\t#{pane_current_command}\t#{pane_start_command}",
-      ],
-      { encoding: "utf-8" },
-    );
-    return findHudWatchPaneIds(parseTmuxPaneSnapshot(output), currentPaneId);
+    return listCurrentWindowHudPaneIds(currentPaneId);
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
     return [];
@@ -2517,30 +2473,13 @@ function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): string[] {
 }
 
 function createHudWatchPane(cwd: string, hudCmd: string): string | null {
-  const output = execFileSync(
-    "tmux",
-    [
-      "split-window",
-      "-v",
-      "-l",
-      String(HUD_TMUX_HEIGHT_LINES),
-      "-d",
-      "-c",
-      cwd,
-      "-P",
-      "-F",
-      "#{pane_id}",
-      hudCmd,
-    ],
-    { encoding: "utf-8" },
-  );
-  return parsePaneIdFromTmuxOutput(output);
+  return createSharedHudWatchPane(cwd, hudCmd, { heightLines: HUD_TMUX_HEIGHT_LINES });
 }
 
 function killTmuxPane(paneId: string): void {
   if (!paneId.startsWith("%")) return;
   try {
-    execFileSync("tmux", ["kill-pane", "-t", paneId], { stdio: "ignore" });
+    killSharedTmuxPane(paneId);
   } catch (err) {
     process.stderr.write(`[cli/index] operation failed: ${err}\n`);
     // Pane may already be gone; ignore.

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { reconcileHudForPromptSubmit } from '../reconcile.js';
+
+describe('reconcileHudForPromptSubmit', () => {
+  it('skips reconciliation outside tmux', async () => {
+    const result = await reconcileHudForPromptSubmit('/tmp', {
+      env: {},
+    });
+    assert.equal(result.status, 'skipped_not_tmux');
+    assert.equal(result.paneId, null);
+  });
+
+  it('recreates a missing HUD in tmux', async () => {
+    const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; fullWidth?: boolean } }> = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      readCurrentWindowSize: () => ({ width: 80, height: 24 }),
+      createHudWatchPane: (cwd, cmd, options) => {
+        created.push({ cwd, cmd, options });
+        return '%9';
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      readHudConfig: async () => ({ preset: 'focused', git: { display: 'branch' } }),
+      readAllState: async () => ({
+        version: null,
+        gitBranch: 'main',
+        ralph: null,
+        ultrawork: null,
+        autopilot: null,
+        ralplan: null,
+        deepInterview: null,
+        autoresearch: null,
+        ultraqa: null,
+        team: null,
+        metrics: null,
+        hudNotify: null,
+        session: null,
+      }),
+      resolveOmxEntryPath: () => '/repo/dist/index.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%9');
+    assert.equal(created.length, 1);
+    assert.equal(created[0]?.options?.heightLines, 1);
+    assert.equal(resized.length, 1);
+  });
+
+  it('kills duplicate HUD panes and recreates one full-width pane', async () => {
+    const killed: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
+        { paneId: '%3', currentCommand: 'node', startCommand: 'node omx hud --watch' },
+        { paneId: '%4', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      readCurrentWindowSize: () => ({ width: 32, height: 24 }),
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        assert.equal(options?.fullWidth, true);
+        return '%9';
+      },
+      resizeTmuxPane: () => true,
+      readHudConfig: async () => ({ preset: 'focused', git: { display: 'branch' } }),
+      readAllState: async () => ({
+        version: null,
+        gitBranch: 'feature/some-branch',
+        ralph: { active: true, iteration: 3, max_iterations: 10 },
+        ultrawork: null,
+        autopilot: null,
+        ralplan: null,
+        deepInterview: null,
+        autoresearch: null,
+        ultraqa: null,
+        team: null,
+        metrics: null,
+        hudNotify: null,
+        session: null,
+      }),
+      resolveOmxEntryPath: () => '/repo/dist/index.js',
+    });
+
+    assert.equal(result.status, 'replaced_duplicates');
+    assert.deepEqual(killed, ['%2', '%3']);
+  });
+
+  it('resizes an existing single HUD pane instead of recreating it', async () => {
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
+      ],
+      readCurrentWindowSize: () => ({ width: 24, height: 24 }),
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      readHudConfig: async () => ({ preset: 'focused', git: { display: 'branch' } }),
+      readAllState: async () => ({
+        version: null,
+        gitBranch: 'feature/some-branch',
+        ralph: { active: true, iteration: 3, max_iterations: 10 },
+        ultrawork: { active: true },
+        autopilot: { active: true, current_phase: 'planning' },
+        ralplan: { active: true, current_phase: 'review' },
+        deepInterview: null,
+        autoresearch: null,
+        ultraqa: null,
+        team: null,
+        metrics: null,
+        hudNotify: null,
+        session: null,
+      }),
+      resolveOmxEntryPath: () => '/repo/dist/index.js',
+    });
+
+    assert.equal(result.status, 'resized');
+    assert.equal(resized.length, 1);
+    assert.equal(resized[0]?.paneId, '%2');
+    assert.ok((resized[0]?.heightLines ?? 0) >= 2);
+  });
+});

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -599,6 +599,51 @@ describe('renderHud – separator', () => {
   });
 });
 
+describe('renderHud – wrapping', () => {
+  it('wraps long HUD output across multiple lines when width is constrained', () => {
+    const ctx = {
+      ...emptyCtx(),
+      gitBranch: 'feature/very-long-branch-name',
+      ralph: { active: true, iteration: 3, max_iterations: 10 },
+      ultrawork: { active: true },
+      metrics: { session_turns: 12, total_turns: 12, last_activity: new Date().toISOString() },
+      session: { session_id: 'sess-wrap-1', started_at: new Date().toISOString() },
+      hudNotify: { last_turn_at: new Date().toISOString(), turn_count: 12 },
+    };
+    const result = stripSgr(renderHud(ctx, 'focused', { maxWidth: 32, maxLines: 5 }));
+    assert.ok(result.includes('\n'));
+    assert.ok(result.split('\n').length <= 5);
+  });
+
+  it('caps wrapped HUD output at the requested max line count', () => {
+    const ctx = {
+      ...emptyCtx(),
+      gitBranch: 'feature/very-long-branch-name',
+      ralph: { active: true, iteration: 3, max_iterations: 10 },
+      ultrawork: { active: true },
+      autopilot: { active: true, current_phase: 'planning' },
+      ralplan: { active: true, current_phase: 'review' },
+      deepInterview: { active: true, current_phase: 'intent-first' },
+      autoresearch: { active: true, current_phase: 'running' },
+      ultraqa: { active: true, current_phase: 'diagnose' },
+      team: { active: true, agent_count: 3 },
+      metrics: {
+        session_turns: 12,
+        total_turns: 12,
+        last_activity: new Date().toISOString(),
+        session_total_tokens: 10_000,
+        five_hour_limit_pct: 80,
+        weekly_limit_pct: 40,
+      },
+      session: { session_id: 'sess-wrap-2', started_at: new Date().toISOString() },
+      hudNotify: { last_turn_at: new Date().toISOString(), turn_count: 12 },
+    };
+    const result = stripSgr(renderHud(ctx, 'full', { maxWidth: 22, maxLines: 3 }));
+    assert.equal(result.split('\n').length, 3);
+    assert.ok(result.includes('…'));
+  });
+});
+
 // ── Sanitization ─────────────────────────────────────────────────────────────
 
 describe('renderHud – sanitization', () => {

--- a/src/hud/constants.ts
+++ b/src/hud/constants.ts
@@ -1,3 +1,4 @@
 export const HUD_TMUX_HEIGHT_LINES = 2;
 export const HUD_TMUX_TEAM_HEIGHT_LINES = 3;
+export const HUD_TMUX_MAX_HEIGHT_LINES = 5;
 export const HUD_RESIZE_RECONCILE_DELAY_SECONDS = 2;

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -13,7 +13,7 @@ import { execFileSync } from 'child_process';
 import { readAllState, readHudConfig } from './state.js';
 import { renderHud } from './render.js';
 import type { HudFlags, HudPreset, HudRenderContext, ResolvedHudConfig } from './types.js';
-import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
+import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MAX_HEIGHT_LINES } from './constants.js';
 import { sleep } from '../utils/sleep.js';
 import { runHudAuthorityTick } from './authority.js';
 import { resolveOmxEntryPath } from '../utils/paths.js';
@@ -61,7 +61,7 @@ interface RunWatchModeDependencies {
   env: NodeJS.ProcessEnv;
   readAllStateFn: (cwd: string, config?: ResolvedHudConfig) => Promise<HudRenderContext>;
   readHudConfigFn: (cwd: string) => Promise<ResolvedHudConfig>;
-  renderHudFn: (ctx: HudRenderContext, preset: HudPreset) => string;
+  renderHudFn: (ctx: HudRenderContext, preset: HudPreset, options?: { maxWidth?: number; maxLines?: number }) => string;
   runAuthorityTickFn: (options: { cwd: string }) => Promise<void>;
   writeStdout: (text: string) => void;
   writeStderr: (text: string) => void;
@@ -139,7 +139,10 @@ export async function runWatchMode(
       const config = await dependencies.readHudConfigFn(cwd);
       const ctx = await dependencies.readAllStateFn(cwd, config);
       const preset = flags.preset ?? config.preset;
-      const line = dependencies.renderHudFn(ctx, preset);
+      const line = dependencies.renderHudFn(ctx, preset, {
+        maxWidth: process.stdout.columns ?? undefined,
+        maxLines: HUD_TMUX_MAX_HEIGHT_LINES,
+      });
       dependencies.writeStdout(line + '\x1b[K\n\x1b[J');
       await dependencies.runAuthorityTickFn({ cwd });
     } catch (error) {
@@ -208,7 +211,10 @@ async function renderOnce(cwd: string, flags: HudFlags): Promise<void> {
     return;
   }
 
-  console.log(renderHud(ctx, preset));
+  console.log(renderHud(ctx, preset, {
+    maxWidth: process.stdout.columns ?? undefined,
+    maxLines: HUD_TMUX_MAX_HEIGHT_LINES,
+  }));
 }
 
 export async function hudCommand(args: string[]): Promise<void> {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -1,0 +1,156 @@
+import { readAllState, readHudConfig } from './state.js';
+import { renderHud, countRenderedHudLines } from './render.js';
+import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MAX_HEIGHT_LINES } from './constants.js';
+import {
+  buildHudWatchCommand,
+  createHudWatchPane,
+  findHudWatchPaneIds,
+  isHudWatchPane,
+  killTmuxPane,
+  listCurrentWindowPanes,
+  readCurrentWindowSize,
+  resizeTmuxPane,
+  type TmuxPaneSnapshot,
+} from './tmux.js';
+import { resolveOmxEntryPath } from '../utils/paths.js';
+
+export interface ReconcileHudForPromptSubmitResult {
+  status:
+    | 'skipped_not_tmux'
+    | 'skipped_no_entry'
+    | 'resized'
+    | 'recreated'
+    | 'replaced_duplicates'
+    | 'failed';
+  paneId: string | null;
+  desiredHeight: number | null;
+  duplicateCount: number;
+}
+
+export interface ReconcileHudForPromptSubmitDeps {
+  env?: NodeJS.ProcessEnv;
+  listCurrentWindowPanes?: () => TmuxPaneSnapshot[];
+  readCurrentWindowSize?: () => { width: number | null; height: number | null };
+  createHudWatchPane?: (
+    cwd: string,
+    hudCmd: string,
+    options?: { heightLines?: number; fullWidth?: boolean },
+  ) => string | null;
+  killTmuxPane?: (paneId: string) => boolean;
+  resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;
+  readHudConfig?: typeof readHudConfig;
+  readAllState?: typeof readAllState;
+  renderHud?: typeof renderHud;
+  resolveOmxEntryPath?: typeof resolveOmxEntryPath;
+}
+
+function resolveHudMaxLines(windowHeight: number | null): number {
+  if (!Number.isFinite(windowHeight) || !windowHeight || windowHeight <= 0) {
+    return HUD_TMUX_MAX_HEIGHT_LINES;
+  }
+  return Math.max(1, Math.min(HUD_TMUX_MAX_HEIGHT_LINES, Math.floor(windowHeight - 1)));
+}
+
+async function resolveDesiredHudHeight(
+  cwd: string,
+  width: number | null,
+  height: number | null,
+  deps: ReconcileHudForPromptSubmitDeps,
+): Promise<number> {
+  const maxLines = resolveHudMaxLines(height);
+  try {
+    const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
+    const readAllStateFn = deps.readAllState ?? readAllState;
+    const renderHudFn = deps.renderHud ?? renderHud;
+    const config = await readHudConfigFn(cwd);
+    const ctx = await readAllStateFn(cwd, config);
+    const frame = renderHudFn(ctx, config.preset, {
+      maxWidth: width ?? undefined,
+      maxLines,
+    });
+    return Math.max(1, Math.min(maxLines, countRenderedHudLines(frame)));
+  } catch {
+    return Math.min(Math.max(1, maxLines), HUD_TMUX_HEIGHT_LINES);
+  }
+}
+
+export async function reconcileHudForPromptSubmit(
+  cwd: string,
+  deps: ReconcileHudForPromptSubmitDeps = {},
+): Promise<ReconcileHudForPromptSubmitResult> {
+  const env = deps.env ?? process.env;
+  if (!env.TMUX) {
+    return {
+      status: 'skipped_not_tmux',
+      paneId: null,
+      desiredHeight: null,
+      duplicateCount: 0,
+    };
+  }
+
+  const resolveOmxEntryPathFn = deps.resolveOmxEntryPath ?? resolveOmxEntryPath;
+  const omxBin = resolveOmxEntryPathFn();
+  if (!omxBin) {
+    return {
+      status: 'skipped_no_entry',
+      paneId: null,
+      desiredHeight: null,
+      duplicateCount: 0,
+    };
+  }
+
+  const listPanes = deps.listCurrentWindowPanes ?? (() => listCurrentWindowPanes());
+  const readSize = deps.readCurrentWindowSize ?? (() => readCurrentWindowSize());
+  const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
+  const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
+  const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
+
+  const panes = listPanes();
+  const currentPaneId = env.TMUX_PANE?.trim();
+  const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId);
+  const duplicateCount = Math.max(0, hudPaneIds.length - 1);
+  const nonHudPaneCount = panes.filter((pane) => !isHudWatchPane(pane)).length;
+  const { width, height } = readSize();
+  const desiredHeight = await resolveDesiredHudHeight(cwd, width, height, deps);
+
+  const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
+  const hudConfig = await readHudConfigFn(cwd).catch(() => null);
+  const preset = hudConfig?.preset;
+  const hudCmd = buildHudWatchCommand(omxBin, preset);
+
+  if (hudPaneIds.length === 1) {
+    const resized = resizePane(hudPaneIds[0], desiredHeight);
+    return {
+      status: resized ? 'resized' : 'failed',
+      paneId: hudPaneIds[0],
+      desiredHeight,
+      duplicateCount,
+    };
+  }
+
+  for (const paneId of hudPaneIds) {
+    killPane(paneId);
+  }
+
+  const paneId = createPane(cwd, hudCmd, {
+    heightLines: desiredHeight,
+    fullWidth: nonHudPaneCount > 1,
+  });
+  if (!paneId) {
+    return {
+      status: 'failed',
+      paneId: null,
+      desiredHeight,
+      duplicateCount,
+    };
+  }
+
+  resizePane(paneId, desiredHeight);
+
+  return {
+    status: hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated',
+    paneId,
+    desiredHeight,
+    duplicateCount,
+  };
+}

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -6,12 +6,27 @@
 
 import type { HudRenderContext, HudPreset } from './types.js';
 import { green, yellow, cyan, dim, bold, getRalphColor, isColorEnabled, RESET } from './colors.js';
+import { HUD_TMUX_MAX_HEIGHT_LINES } from './constants.js';
 
 const SEP = dim(' | ');
 const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f-\u009f]/g;
+const ANSI_SGR_RE = /\x1b\[[0-9;]*m/g;
+
+export interface RenderHudOptions {
+  maxWidth?: number;
+  maxLines?: number;
+}
 
 function sanitizeDynamicText(value: string): string {
   return value.replace(CONTROL_CHARS_RE, '');
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_SGR_RE, '');
+}
+
+function visibleLength(value: string): number {
+  return stripAnsi(value).length;
 }
 
 function formatTokenCount(value: number): string {
@@ -230,12 +245,89 @@ function getElements(preset: HudPreset): ElementRenderer[] {
   }
 }
 
+function ellipsizeSegment(segment: string, maxWidth: number): string {
+  if (!Number.isFinite(maxWidth) || maxWidth <= 0) return '';
+  if (visibleLength(segment) <= maxWidth) return segment;
+
+  const plain = stripAnsi(segment);
+  if (plain.length <= maxWidth) return plain;
+  if (maxWidth <= 1) return '…';
+  if (maxWidth <= 4) return `${plain.slice(0, Math.max(0, maxWidth - 1))}…`;
+
+  const head = Math.max(1, Math.ceil((maxWidth - 1) / 2));
+  const tail = Math.max(1, Math.floor((maxWidth - 1) / 2));
+  return `${plain.slice(0, head)}…${plain.slice(-tail)}`;
+}
+
+function wrapHudParts(
+  label: string,
+  parts: string[],
+  options: RenderHudOptions,
+): string {
+  const maxWidth = Number.isFinite(options.maxWidth) && (options.maxWidth ?? 0) > 0
+    ? Math.max(12, Math.floor(options.maxWidth ?? 0))
+    : Infinity;
+  const maxLines = Number.isFinite(options.maxLines) && (options.maxLines ?? 0) > 0
+    ? Math.max(1, Math.floor(options.maxLines ?? 0))
+    : HUD_TMUX_MAX_HEIGHT_LINES;
+
+  if (!Number.isFinite(maxWidth)) {
+    return `${label} ${parts.join(SEP)}`;
+  }
+
+  const lines: string[] = [];
+  const indent = ' '.repeat(Math.max(0, visibleLength(label) + 1));
+  let currentLine = label;
+  let hasContent = false;
+
+  const pushLine = () => {
+    lines.push(currentLine);
+    currentLine = indent;
+    hasContent = false;
+  };
+
+  for (const part of parts) {
+    const linePrefix = hasContent ? indent : `${label} `;
+    const available = Math.max(1, maxWidth - visibleLength(linePrefix));
+    const segment = ellipsizeSegment(part, available);
+    const separator = hasContent ? SEP : ' ';
+    const candidate = `${currentLine}${separator}${segment}`;
+    if (visibleLength(candidate) <= maxWidth) {
+      currentLine = candidate;
+      hasContent = true;
+      continue;
+    }
+
+    if (lines.length + 1 < maxLines) {
+      pushLine();
+      currentLine = `${currentLine}${segment}`;
+      hasContent = true;
+      continue;
+    }
+
+    const overflow = dim('…');
+    const overflowCandidate = `${currentLine}${hasContent ? SEP : ' '}${overflow}`;
+    currentLine = visibleLength(overflowCandidate) <= maxWidth
+      ? overflowCandidate
+      : ellipsizeSegment(currentLine, maxWidth - 1) + '…';
+    hasContent = true;
+    break;
+  }
+
+  lines.push(currentLine);
+  return lines.join('\n');
+}
+
 // ============================================================================
 // Main Render
 // ============================================================================
 
 /** Render the HUD statusline from context and preset */
-export function renderHud(ctx: HudRenderContext, preset: HudPreset): string {
+export function renderHud(
+  ctx: HudRenderContext,
+  preset: HudPreset,
+  options: RenderHudOptions = {},
+): string {
   const elements = getElements(preset);
   const parts = elements
     .map(fn => fn(ctx))
@@ -245,8 +337,12 @@ export function renderHud(ctx: HudRenderContext, preset: HudPreset): string {
   const label = bold(`[OMX${ver}]`);
 
   if (parts.length === 0) {
-    return label + ' ' + dim('No active modes.');
+    return wrapHudParts(label, [dim('No active modes.')], options);
   }
 
-  return label + ' ' + parts.join(SEP);
+  return wrapHudParts(label, parts, options);
+}
+
+export function countRenderedHudLines(text: string): number {
+  return text.replace(/\r/g, '').split('\n').length;
 }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1,0 +1,168 @@
+import { execFileSync } from 'child_process';
+import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
+
+export interface TmuxPaneSnapshot {
+  paneId: string;
+  currentCommand: string;
+  startCommand: string;
+}
+
+type TmuxExecSync = (args: string[]) => string;
+
+function defaultExecTmuxSync(args: string[]): string {
+  return execFileSync('tmux', args, { encoding: 'utf-8' });
+}
+
+export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [paneId = '', currentCommand = '', ...startCommandParts] = line.split('\t');
+      return {
+        paneId: paneId.trim(),
+        currentCommand: currentCommand.trim(),
+        startCommand: startCommandParts.join('\t').trim(),
+      };
+    })
+    .filter((pane) => pane.paneId.startsWith('%'));
+}
+
+export function isHudWatchPane(pane: TmuxPaneSnapshot): boolean {
+  const command = `${pane.startCommand} ${pane.currentCommand}`.toLowerCase();
+  return (
+    /\bhud\b/.test(command)
+    && /--watch\b/.test(command)
+    && (/\bomx(?:\.js)?\b/.test(command) || /\bnode\b/.test(command))
+  );
+}
+
+export function findHudWatchPaneIds(
+  panes: TmuxPaneSnapshot[],
+  currentPaneId?: string,
+): string[] {
+  return panes
+    .filter((pane) => pane.paneId !== currentPaneId)
+    .filter((pane) => isHudWatchPane(pane))
+    .map((pane) => pane.paneId);
+}
+
+export function parsePaneIdFromTmuxOutput(rawOutput: string): string | null {
+  const paneId = rawOutput.split('\n')[0]?.trim() || '';
+  return paneId.startsWith('%') ? paneId : null;
+}
+
+export function shellEscapeSingle(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function buildHudWatchCommand(omxBin: string, preset?: string): string {
+  const safePreset = preset === 'minimal' || preset === 'focused' || preset === 'full'
+    ? ` --preset=${preset}`
+    : '';
+  return `node ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
+}
+
+export function listCurrentWindowPanes(
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): TmuxPaneSnapshot[] {
+  try {
+    return parseTmuxPaneSnapshot(
+      execTmuxSync([
+        'list-panes',
+        '-F',
+        '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
+      ]),
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function listCurrentWindowHudPaneIds(
+  currentPaneId?: string,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): string[] {
+  return findHudWatchPaneIds(listCurrentWindowPanes(execTmuxSync), currentPaneId);
+}
+
+export function readCurrentWindowSize(
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): { width: number | null; height: number | null } {
+  try {
+    const raw = execTmuxSync(['display-message', '-p', '#{window_width}\t#{window_height}']);
+    const [widthRaw = '', heightRaw = ''] = raw.split('\t');
+    const width = Number.parseInt(widthRaw.trim(), 10);
+    const height = Number.parseInt(heightRaw.trim(), 10);
+    return {
+      width: Number.isFinite(width) && width > 0 ? width : null,
+      height: Number.isFinite(height) && height > 0 ? height : null,
+    };
+  } catch {
+    return { width: null, height: null };
+  }
+}
+
+export function createHudWatchPane(
+  cwd: string,
+  hudCmd: string,
+  options: {
+    heightLines?: number;
+    fullWidth?: boolean;
+  } = {},
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): string | null {
+  const heightLines = Number.isFinite(options.heightLines) && (options.heightLines ?? 0) > 0
+    ? Math.floor(options.heightLines ?? HUD_TMUX_HEIGHT_LINES)
+    : HUD_TMUX_HEIGHT_LINES;
+  const args = [
+    'split-window',
+    '-v',
+    ...(options.fullWidth ? ['-f'] : []),
+    '-l',
+    String(heightLines),
+    '-d',
+    '-c',
+    cwd,
+    '-P',
+    '-F',
+    '#{pane_id}',
+    hudCmd,
+  ];
+  try {
+    return parsePaneIdFromTmuxOutput(execTmuxSync(args));
+  } catch {
+    return null;
+  }
+}
+
+export function killTmuxPane(
+  paneId: string,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  if (!paneId.startsWith('%')) return false;
+  try {
+    execTmuxSync(['kill-pane', '-t', paneId]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resizeTmuxPane(
+  paneId: string,
+  heightLines: number,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  if (!paneId.startsWith('%')) return false;
+  const height = Number.isFinite(heightLines) && heightLines > 0
+    ? Math.floor(heightLines)
+    : HUD_TMUX_HEIGHT_LINES;
+  try {
+    execTmuxSync(['resize-pane', '-t', paneId, '-y', String(height)]);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
@@ -257,6 +257,76 @@ describe("codex native hook dispatch", () => {
       assert.equal(state.active, true);
       assert.equal(state.current_phase, "starting");
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("runs prompt-submit HUD reconciliation as a best-effort tmux-only side effect", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reconcile-"));
+    const originalTmux = process.env.TMUX;
+    const originalTmuxPane = process.env.TMUX_PANE;
+    const originalPath = process.env.PATH;
+    try {
+      process.env.TMUX = "1";
+      process.env.TMUX_PANE = "%1";
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "hud-config.json"),
+        JSON.stringify({ preset: "focused", git: { display: "branch" } }, null, 2),
+      );
+
+      const binDir = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reconcile-bin-"));
+      const tmuxLog = join(cwd, "tmux.log");
+      await writeFile(
+        join(binDir, "tmux"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> ${JSON.stringify(tmuxLog)}
+case "$1" in
+  list-panes)
+    printf '%%1\\tcodex\\tcodex\\n'
+    ;;
+  display-message)
+    printf '80\\t24\\n'
+    ;;
+  split-window)
+    printf '%%9\\n'
+    ;;
+  resize-pane)
+    ;;
+esac
+`,
+      );
+      await chmod(join(binDir, "tmux"), 0o755);
+      process.env.PATH = `${binDir}:${originalPath}`;
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-hud-1",
+          prompt: "$ralplan prepare plan",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      const tmuxCalls = await readFile(tmuxLog, "utf-8");
+      assert.match(tmuxCalls, /list-panes/);
+      assert.match(tmuxCalls, /split-window/);
+      assert.match(tmuxCalls, /resize-pane -t %9 -y 1/);
+    } finally {
+      if (originalTmux === undefined) {
+        delete process.env.TMUX;
+      } else {
+        process.env.TMUX = originalTmux;
+      }
+      if (originalTmuxPane === undefined) {
+        delete process.env.TMUX_PANE;
+      } else {
+        process.env.TMUX_PANE = originalTmuxPane;
+      }
+      process.env.PATH = originalPath;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -42,6 +42,7 @@ import {
 import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { writeSessionStart } from "../hooks/session.js";
+import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -1082,6 +1083,7 @@ export async function dispatchCodexNativeHook(
         turnId,
       });
     }
+    await reconcileHudForPromptSubmit(cwd).catch(() => {});
   }
 
   if (omxEventName) {

--- a/src/scripts/notify-hook/operational-events.ts
+++ b/src/scripts/notify-hook/operational-events.ts
@@ -70,8 +70,12 @@ function buildTmuxSessionName(cwd: any, sessionId: any): string {
   const branch = gitValue(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
   const branchToken = branch ? sanitizeTmuxToken(branch) : 'detached';
   const sessionToken = sanitizeTmuxToken(safeString(sessionId).replace(/^omx-/, ''));
-  const name = `omx-${dirToken}-${branchToken}-${sessionToken}`;
-  return name.length > 120 ? name.slice(0, 120) : name;
+  const prefix = `omx-${dirToken}-${branchToken}`;
+  const name = `${prefix}-${sessionToken}`;
+  if (name.length <= 120) return name;
+  const prefixBudget = Math.max(4, 120 - sessionToken.length - 1);
+  const trimmedPrefix = prefix.slice(0, prefixBudget).replace(/-+$/g, '');
+  return `${trimmedPrefix}-${sessionToken}`.slice(0, 120);
 }
 
 export function resolveOperationalSessionName(cwd: any, sessionId = '', sessionName = ''): string | undefined {


### PR DESCRIPTION
## Summary

Make tmux HUD recovery happen at natural interaction points instead of polling. This reuses shared tmux HUD helpers so `UserPromptSubmit` can recreate or resize a missing HUD, while the HUD renderer stays compact (max 5 lines) with smarter wrapping on short screens.

## Changes

- extract shared tmux HUD pane parsing/create/resize helpers
- run best-effort HUD reconcile on `UserPromptSubmit` for tmux sessions
- bound HUD rendering to compact multi-line output with wrapping/ellipsis
- preserve session-id suffixes when trimming derived tmux session names
- add regression coverage for prompt-submit HUD healing and wrapped HUD rendering

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
