### PR TITLE
Release 0.12.4: harden shared-session shutdown coverage

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -1360,7 +1360,7 @@ describe("detached tmux new-session sequencing", () => {
     assert.equal(steps[1]?.args.at(-1), hudCmd);
   });
 
-  it("buildDetachedSessionBootstrapSteps kills detached tmux session on exit and interrupt", () => {
+  it("buildDetachedSessionBootstrapSteps kills detached tmux session on normal shell exit", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",
       "/tmp/project",
@@ -1373,8 +1373,9 @@ describe("detached tmux new-session sequencing", () => {
     assert.match(leaderCmd!, /^\/bin\/sh -lc '/);
     assert.match(leaderCmd!, /acquireTmuxExtendedKeysLease/);
     assert.match(leaderCmd!, /omx_detached_session_cleanup\(\)/);
-    assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0 INT TERM HUP/);
+    assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0;/);
     assert.match(leaderCmd!, /releaseTmuxExtendedKeysLease/);
+    assert.match(leaderCmd!, /if \[ "\$status" -lt 128 \]; then/);
     assert.match(leaderCmd!, /tmux kill-session -t/);
     assert.match(leaderCmd!, /"omx-demo"/);
     assert.match(leaderCmd!, /exit \$status/);
@@ -1449,6 +1450,81 @@ exit 0
       assert.match(log, /tmux:set-option -sq extended-keys always/);
       assert.match(log, /tmux:set-option -sq extended-keys off/);
       assert.match(log, /tmux:kill-session -t omx-demo/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("detached leader command preserves the detached tmux session on signal-derived exits", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-signal-"));
+    const fakeBin = join(cwd, "bin");
+    const logPath = join(cwd, "leader.log");
+
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, "codex"),
+        `#!/bin/sh
+printf 'codex:%s\\n' "$*" >> "${logPath}"
+exit 143
+`,
+      );
+      await chmod(join(fakeBin, "codex"), 0o755);
+      await writeFile(
+        join(fakeBin, "tmux"),
+        `#!/bin/sh
+printf 'tmux:%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message)
+    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\\n'
+    else
+      printf '0\\n'
+    fi
+    ;;
+  show-options)
+    printf 'off\\n'
+    ;;
+  set-option|kill-session)
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(join(fakeBin, "tmux"), 0o755);
+
+      const steps = buildDetachedSessionBootstrapSteps(
+        "omx-demo",
+        cwd,
+        buildTmuxPaneCommand(
+          "codex",
+          ["--dangerously-bypass-approvals-and-sandbox"],
+          "/bin/sh",
+        ),
+        "'node' '/tmp/omx.js' 'hud' '--watch'",
+        null,
+      );
+      const leaderCmd = steps[0]?.args.at(-1);
+      assert.equal(typeof leaderCmd, "string");
+
+      const result = spawnSync("/bin/sh", ["-lc", leaderCmd!], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          HOME: cwd,
+        },
+        encoding: "utf-8",
+      });
+
+      assert.equal(result.status, 143);
+      const log = await readFile(logPath, "utf-8");
+      assert.match(log, /codex:--dangerously-bypass-approvals-and-sandbox/);
+      assert.match(log, /tmux:display-message -p #\{socket_path\}/);
+      assert.match(log, /tmux:show-options -sv extended-keys/);
+      assert.match(log, /tmux:set-option -sq extended-keys always/);
+      assert.match(log, /tmux:set-option -sq extended-keys off/);
+      assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1,8 +1,12 @@
-import { describe, it } from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, it, type TestContext } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
 import { readModeState } from '../../modes/base.js';
 import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
@@ -10,12 +14,31 @@ import {
   appendTeamEvent,
   createTask,
   initTeamState,
+  readTeamConfig,
+  saveTeamConfig,
   updateWorkerHeartbeat,
   writeMonitorSnapshot,
   writeTaskApproval,
   writeWorkerStatus,
 } from '../../team/state.js';
+import { isRealTmuxAvailable, withTempTmuxSession, type TempTmuxSessionFixture } from '../../team/__tests__/tmux-test-fixture.js';
 
+const OMX_CLI_PATH = fileURLToPath(new URL('../omx.js', import.meta.url));
+const ORIGINAL_OMX_TEAM_WORKER = process.env.OMX_TEAM_WORKER;
+const ORIGINAL_OMX_TEAM_STATE_ROOT = process.env.OMX_TEAM_STATE_ROOT;
+
+beforeEach(() => {
+  delete process.env.OMX_TEAM_WORKER;
+  delete process.env.OMX_TEAM_STATE_ROOT;
+});
+
+afterEach(() => {
+  if (typeof ORIGINAL_OMX_TEAM_WORKER === 'string') process.env.OMX_TEAM_WORKER = ORIGINAL_OMX_TEAM_WORKER;
+  else delete process.env.OMX_TEAM_WORKER;
+
+  if (typeof ORIGINAL_OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = ORIGINAL_OMX_TEAM_STATE_ROOT;
+  else delete process.env.OMX_TEAM_STATE_ROOT;
+});
 
 function withoutTeamTestWorkerEnv<T>(fn: () => T): T {
   const previousTeamWorker = process.env.OMX_TEAM_WORKER;
@@ -42,6 +65,74 @@ function withoutTeamTestWorkerEnv<T>(fn: () => T): T {
   } finally {
     if (restoreImmediately) restore();
   }
+}
+
+async function runNodeCli(
+  args: string[],
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+  },
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [OMX_CLI_PATH, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+function skipUnlessTmux(t: TestContext): void {
+  if (!isRealTmuxAvailable()) {
+    t.skip('tmux is not available in this environment');
+  }
+}
+
+function runFixtureTmux(fixture: TempTmuxSessionFixture, args: string[]): string {
+  return execFileSync('tmux', args, {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      TMUX: fixture.env.TMUX,
+      TMUX_PANE: fixture.leaderPaneId,
+    },
+  }).trim();
+}
+
+function fixturePaneExists(fixture: TempTmuxSessionFixture, paneId: string): boolean {
+  try {
+    runFixtureTmux(fixture, ['display-message', '-p', '-t', paneId, '#{pane_id}']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForFileText(filePath: string, timeoutMs: number = 5_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(filePath)) {
+      const text = await readFile(filePath, 'utf-8');
+      if (text.trim() !== '') return text;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`timed out waiting for ${filePath}`);
 }
 
 describe('parseTeamStartArgs', () => {
@@ -181,6 +272,151 @@ describe('teamCommand shutdown --force parsing', () => {
     const teamArgs = ['shutdown', 'my-team', '--confirm-issues'];
     const confirmIssues = teamArgs.includes('--confirm-issues');
     assert.equal(confirmIssues, true);
+  });
+
+  it('keeps the shutdown CLI alive while tearing down a shared leader tmux session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-shared-cli-'));
+    const binDir = join(wd, 'bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const tmuxPath = join(binDir, 'tmux');
+    const previousPath = process.env.PATH;
+
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      tmuxPath,
+      `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tcodex\\n%%14\\tcodex\\tcodex\\n"
+        exit 0
+        ;;
+      *"-t leader:0 -F #{pane_id}"*)
+        printf "%%11\\n%%12\\n%%13\\n%%14\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  kill-pane)
+    # Shared-session runtime coverage should validate pane-targeted teardown
+    # only. Detached leader-wrapper signal behavior is covered separately in
+    # cli/index detached-session tests.
+    exit 0
+    ;;
+  resize-pane|select-pane|has-session|show-options|show-hooks|set-hook|set-option)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+    );
+    await chmod(tmuxPath, 0o755);
+
+    try {
+      await initTeamState('shared-shutdown-cli', 'shared shutdown cli test', 'executor', 2, wd);
+      const config = await readTeamConfig('shared-shutdown-cli', wd);
+      assert.ok(config);
+      if (!config) return;
+      config.tmux_session = 'leader:0';
+      config.leader_pane_id = '%11';
+      config.hud_pane_id = '%12';
+      config.workers[0]!.pane_id = '%13';
+      config.workers[1]!.pane_id = '%14';
+      await saveTeamConfig(config, wd);
+
+      const result = await runNodeCli(['team', 'shutdown', 'shared-shutdown-cli', '--force'], {
+        cwd: wd,
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${previousPath ?? ''}`,
+          OMX_TEAM_STATE_ROOT: join(wd, '.omx', 'state'),
+        },
+      });
+
+      assert.equal(result.signal, null, `shutdown CLI received signal ${result.signal ?? 'none'}\n${result.stderr}`);
+      assert.equal(result.code, 0, `shutdown CLI exit=${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+      assert.match(result.stdout, /Team shutdown complete: shared-shutdown-cli/);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'team', 'shared-shutdown-cli')), false);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /kill-pane -t %12/);
+      assert.match(tmuxLog, /kill-pane -t %13/);
+      assert.match(tmuxLog, /kill-pane -t %14/);
+      assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the shutdown command alive when executed inside the leader pane PTY', { concurrency: false }, async (t) => {
+    skipUnlessTmux(t);
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-shared-in-pane-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const teamName = 'shared-shutdown-in-pane';
+        const teamStateRoot = join(wd, '.omx', 'state');
+        const hudPaneId = runFixtureTmux(fixture, ['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.windowTarget, 'sleep 300']);
+        const workerPaneOne = runFixtureTmux(fixture, ['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.windowTarget, 'sleep 300']);
+        const workerPaneTwo = runFixtureTmux(fixture, ['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.windowTarget, 'sleep 300']);
+
+        await initTeamState(teamName, 'shared shutdown in-pane test', 'executor', 2, wd);
+        const config = await readTeamConfig(teamName, wd);
+        assert.ok(config);
+        if (!config) return;
+        config.tmux_session = fixture.windowTarget;
+        config.leader_pane_id = fixture.leaderPaneId;
+        config.hud_pane_id = hudPaneId;
+        config.workers[0]!.pane_id = workerPaneOne;
+        config.workers[1]!.pane_id = workerPaneTwo;
+        await saveTeamConfig(config, wd);
+
+        const result = await runNodeCli(['team', 'shutdown', teamName, '--force'], {
+          cwd: wd,
+          env: {
+            ...process.env,
+            OMX_AUTO_UPDATE: '0',
+            OMX_TEAM_STATE_ROOT: teamStateRoot,
+            TMUX: fixture.env.TMUX,
+            TMUX_PANE: fixture.leaderPaneId,
+          },
+        });
+
+        assert.equal(result.signal, null, `shutdown CLI received signal ${result.signal ?? 'none'}\n${result.stderr}`);
+        assert.equal(result.code, 0, `shutdown CLI exit=${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+        const stdout = result.stdout;
+        assert.match(stdout, new RegExp(`Team shutdown complete: ${teamName}`));
+        assert.equal(existsSync(join(teamStateRoot, 'team', teamName)), false);
+        assert.equal(fixturePaneExists(fixture, fixture.leaderPaneId), true, 'leader pane should remain alive');
+        // Exact HUD/worker-pane teardown is covered in runtime shutdown tests.
+        // This CLI test owns the stable operator contract: the command must not
+        // die by signal, it must exit 0, and explicit shutdown must remove team
+        // state while preserving leader survival in a real tmux client context.
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
   });
 });
 
@@ -422,9 +658,11 @@ describe('teamCommand api', () => {
   it('executes read-stall-state via CLI api with structured JSON results', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-read-stall-state-'));
     const previousCwd = process.cwd();
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     const logs: string[] = [];
     const originalLog = console.log;
     try {
+      delete process.env.OMX_TEAM_STATE_ROOT;
       process.chdir(wd);
       await initTeamState('api-read-stall', 'api stall state test', 'executor', 2, wd);
       const task = await createTask('api-read-stall', {
@@ -478,6 +716,7 @@ describe('teamCommand api', () => {
         mailboxNotifiedByMessageId: {},
         completedEventTaskIds: {},
       }, wd);
+      await mkdir(join(wd, '.omx', 'state', 'team', 'api-read-stall'), { recursive: true });
       await writeFile(join(wd, '.omx', 'state', 'team', 'api-read-stall', 'leader-attention.json'), JSON.stringify({
         team_name: 'api-read-stall',
         updated_at: '2026-03-10T10:05:00.000Z',
@@ -523,6 +762,8 @@ describe('teamCommand api', () => {
       assert.deepEqual(envelope.data?.stalled_workers, ['worker-1']);
       assert.match((envelope.data?.reasons ?? []).join(' '), /leader_attention_pending:leader_session_stopped/);
     } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       console.log = originalLog;
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -873,9 +1114,11 @@ describe('teamCommand status', () => {
   it('returns pane ids and sparkshell hint in JSON mode', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-json-'));
     const previousCwd = process.cwd();
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     const logs: string[] = [];
     const originalLog = console.log;
     try {
+      delete process.env.OMX_TEAM_STATE_ROOT;
       process.chdir(wd);
       const config = await withoutTeamTestWorkerEnv(() => initTeamState('pane-json-team', 'inspect worker panes', 'executor', 1, wd));
       await withoutTeamTestWorkerEnv(() => createTask('pane-json-team', {
@@ -1258,6 +1501,8 @@ describe('teamCommand status', () => {
         'worker-1': 'omx sparkshell --tmux-pane %41 --tail-lines 400',
       });
     } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       console.log = originalLog;
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1580,10 +1580,12 @@ function buildDetachedSessionLeaderCommand(
     "status=$?;",
     "trap - 0 INT TERM HUP;",
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
+    'if [ "$status" -lt 128 ]; then',
     `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
+    "fi;",
     "exit $status;",
     "};",
-    "trap omx_detached_session_cleanup 0 INT TERM HUP;",
+    "trap omx_detached_session_cleanup 0;",
     codexCmd,
   ].join(" ");
   return `/bin/sh -lc ${quoteShellArg(wrapped)}`;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4,7 +4,7 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import { buildManagedCodexHooksConfig } from "../../config/codex-hooks.js";
 import {
   initTeamState,
@@ -24,6 +24,31 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 
 const TEAM_STOP_COMMIT_GUIDANCE =
   " If system-generated worker auto-checkpoint commits exist, rewrite them into Lore-format final commits before merge/finalization.";
+
+const TEAM_ENV_KEYS = [
+  "OMX_TEAM_WORKER",
+  "OMX_TEAM_STATE_ROOT",
+  "OMX_TEAM_LEADER_CWD",
+] as const;
+
+const priorTeamEnv = new Map<(typeof TEAM_ENV_KEYS)[number], string | undefined>();
+
+beforeEach(() => {
+  priorTeamEnv.clear();
+  for (const key of TEAM_ENV_KEYS) {
+    priorTeamEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of TEAM_ENV_KEYS) {
+    const value = priorTeamEnv.get(key);
+    if (typeof value === "string") process.env[key] = value;
+    else delete process.env[key];
+  }
+  priorTeamEnv.clear();
+});
 
 describe("codex native hook config", () => {
   it("builds the expected managed hooks.json shape", () => {

--- a/src/team/__tests__/delivery-e2e-smoke.test.ts
+++ b/src/team/__tests__/delivery-e2e-smoke.test.ts
@@ -178,10 +178,16 @@ switch (command.command) {
 
 async function setupTeam(name: string, workerCount: number = 2): Promise<{ cwd: string; cleanup: () => Promise<void> }> {
   const cwd = await mkdtemp(join(tmpdir(), `omx-delivery-e2e-${name}-`));
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+  process.env.OMX_TEAM_STATE_ROOT = join(cwd, '.omx', 'state');
   await initTeamState(name, 'delivery smoke test', 'executor', workerCount, cwd);
   return {
     cwd,
-    cleanup: async () => await rm(cwd, { recursive: true, force: true }),
+    cleanup: async () => {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+    },
   };
 }
 

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -194,7 +194,9 @@ describe('runtime-cli helpers', () => {
 
   it('preserves team state when building terminal output for completed teams', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-preserve-complete-'));
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     try {
+      delete process.env.OMX_TEAM_STATE_ROOT;
       await initTeamState('runtime-cli-preserve-complete', 'task', 'executor', 1, cwd);
       await createTask('runtime-cli-preserve-complete', {
         subject: 'done task',
@@ -229,13 +231,17 @@ describe('runtime-cli helpers', () => {
       assert.match(result.notice, /omx team shutdown runtime-cli-preserve-complete/);
       assert.match(result.notice, /omx team api read-stall-state/);
     } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
   it('preserves team state when building terminal output for failed teams', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-preserve-failed-'));
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     try {
+      delete process.env.OMX_TEAM_STATE_ROOT;
       await initTeamState('runtime-cli-preserve-failed', 'task', 'executor', 1, cwd);
       await createTask('runtime-cli-preserve-failed', {
         subject: 'failed task',
@@ -270,13 +276,17 @@ describe('runtime-cli helpers', () => {
       assert.match(result.notice, /omx team api read-stall-state/);
       assert.match(result.notice, /omx team shutdown runtime-cli-preserve-failed/);
     } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
   it('reports cancelled terminal phases without deleting team state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-preserve-cancelled-'));
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     try {
+      delete process.env.OMX_TEAM_STATE_ROOT;
       await initTeamState('runtime-cli-preserve-cancelled', 'task', 'executor', 1, cwd);
       await createTask('runtime-cli-preserve-cancelled', {
         subject: 'cancelled task',
@@ -302,6 +312,8 @@ describe('runtime-cli helpers', () => {
       assert.match(result.notice, /phase=cancelled/);
       assert.match(result.notice, /omx team shutdown runtime-cli-preserve-cancelled/);
     } finally {
+      if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -757,7 +757,8 @@ sleep 5
       assert.equal(shouldPrekillInteractiveShutdownProcessTrees('omx-team-alpha'), true);
     });
 
-    assert.equal(shouldPrekillInteractiveShutdownProcessTrees('leader:0'), true);
+    assert.equal(shouldPrekillInteractiveShutdownProcessTrees('leader:0'), false);
+    assert.equal(shouldPrekillInteractiveShutdownProcessTrees('omx-team-alpha'), true);
   });
 
   it('startTeam accepts native Windows tmux clients even when TMUX env vars are absent', async () => {
@@ -3715,6 +3716,82 @@ esac
           },
         );
       });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam skips prekill and keeps the leader pane alive on shared-session shutdown', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-shared-session-'));
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-shared-session-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tcodex\\n%%14\\tcodex\\tcodex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState('team-shutdown-shared-session', 'shutdown shared session test', 'executor', 2, cwd);
+          const config = await readTeamConfig('team-shutdown-shared-session', cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          config.workers[1]!.pane_id = '%14';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam('team-shutdown-shared-session', cwd, { force: true });
+
+          const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-shared-session');
+          assert.equal(existsSync(teamRoot), false);
+          assert.equal(await readMonitorSnapshot('team-shutdown-shared-session', cwd), null);
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /list-panes -t %13 -F #\{pane_pid\}/);
+          assert.doesNotMatch(tmuxLog, /list-panes -t %14 -F #\{pane_pid\}/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.match(tmuxLog, /kill-pane -t %14/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.match(tmuxLog, /select-pane -t %11/);
+        },
+      );
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -301,9 +301,15 @@ function collectShutdownPaneIds(params: {
 }
 
 export function shouldPrekillInteractiveShutdownProcessTrees(sessionName: string): boolean {
-  // Native Windows + split-pane psmux sessions can expose overlapping
-  // ancestry around the leader client; rely on pane-targeted teardown there.
-  return !(isNativeWindows() && sessionName.includes(':'));
+  // Shared-window tmux sessions can expose overlapping ancestry around the
+  // invoking leader client. Rely on pane-targeted teardown there so shutdown
+  // does not signal the leader while tearing down worker panes.
+  if (sessionName.includes(':')) return false;
+
+  // Detached session teardown still benefits from process-tree prekill,
+  // including native Windows prompt-worker ancestry where pane-targeted
+  // teardown alone is insufficient.
+  return true;
 }
 
 async function logRuntimeDispatchOutcome(params: {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -17,7 +17,6 @@ import {
   type TeamSession,
   waitForWorkerReady,
   dismissTrustPromptIfPresent,
-  isNativeWindows,
   sleepFractionalSeconds,
   sendToWorker,
   sendToWorkerStdin,


### PR DESCRIPTION
## Summary
- harden shared-session shutdown behavior and coverage without speculating beyond the current repro
- add stronger CLI/runtime tests around leader-pane survival and explicit shutdown cleanup
- record that the original live `143` is not reproducible on current source and appears tied to an external runtime path

## Changes
- disable shared-session interactive prekill in `src/team/runtime.ts` while preserving detached-session behavior
- harden detached cleanup trap behavior in `src/cli/index.ts`
- expand shutdown regression coverage in:
  - `src/cli/__tests__/index.test.ts`
  - `src/cli/__tests__/team.test.ts`
  - `src/team/__tests__/runtime.test.ts`
- keep related shutdown/verification fixtures aligned in:
  - `src/team/__tests__/runtime-cli.test.ts`
  - `src/team/__tests__/delivery-e2e-smoke.test.ts`
  - `src/scripts/__tests__/codex-native-hook.test.ts`

## Verification
- `npm run build`
- `npm link && omx --version`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js dist/cli/__tests__/team.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/team/__tests__/delivery-e2e-smoke.test.js dist/team/__tests__/runtime-cli.test.js dist/team/__tests__/runtime.test.js`

## Notes / risk
- the original live shutdown `143` still appears to be tied to the external `/home/bellman/Workspace/oh-my-codex` runtime path rather than current branch source alone
- this PR keeps current-source coverage/hardening and avoids speculative extra patches beyond what is reproducible here
