### PR TITLE
Fix Linux tmux team startup handoff and shutdown state persistence

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1,1674 +1,2485 @@
-import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../team.js';
-import { readModeState } from '../../modes/base.js';
-import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
+import assert from "node:assert/strict";
 import {
-  appendTeamEvent,
-  createTask,
-  initTeamState,
-  updateWorkerHeartbeat,
-  writeMonitorSnapshot,
-  writeTaskApproval,
-  writeWorkerStatus,
-} from '../../team/state.js';
-
+	chmod,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { readModeState } from "../../modes/base.js";
+import {
+	appendTeamEvent,
+	createTask,
+	DEFAULT_MAX_WORKERS,
+	initTeamState,
+	updateWorkerHeartbeat,
+	writeMonitorSnapshot,
+	writeTaskApproval,
+	writeWorkerStatus,
+} from "../../team/state.js";
+import {
+	buildLeaderMonitoringHints,
+	parseTeamStartArgs,
+	teamCommand,
+} from "../team.js";
 
 function withoutTeamTestWorkerEnv<T>(fn: () => T): T {
-  const previousTeamWorker = process.env.OMX_TEAM_WORKER;
-  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
-  delete process.env.OMX_TEAM_WORKER;
-  delete process.env.OMX_TEAM_STATE_ROOT;
+	const previousTeamWorker = process.env.OMX_TEAM_WORKER;
+	const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+	delete process.env.OMX_TEAM_WORKER;
+	delete process.env.OMX_TEAM_STATE_ROOT;
 
-  let restoreImmediately = true;
-  const restore = () => {
-    if (typeof previousTeamWorker === 'string') process.env.OMX_TEAM_WORKER = previousTeamWorker;
-    else delete process.env.OMX_TEAM_WORKER;
+	let restoreImmediately = true;
+	const restore = () => {
+		if (typeof previousTeamWorker === "string")
+			process.env.OMX_TEAM_WORKER = previousTeamWorker;
+		else delete process.env.OMX_TEAM_WORKER;
 
-    if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
-    else delete process.env.OMX_TEAM_STATE_ROOT;
-  };
+		if (typeof previousTeamStateRoot === "string")
+			process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+		else delete process.env.OMX_TEAM_STATE_ROOT;
+	};
 
-  try {
-    const result = fn();
-    if (result instanceof Promise) {
-      restoreImmediately = false;
-      return result.finally(restore) as T;
-    }
-    return result;
-  } finally {
-    if (restoreImmediately) restore();
-  }
+	try {
+		const result = fn();
+		if (result instanceof Promise) {
+			restoreImmediately = false;
+			return result.finally(restore) as T;
+		}
+		return result;
+	} finally {
+		if (restoreImmediately) restore();
+	}
 }
 
-describe('parseTeamStartArgs', () => {
-  it('parses default team start args with automatic detached worktrees', () => {
-    const result = parseTeamStartArgs(['2:executor', 'build', 'feature']);
-    assert.deepEqual(result.worktreeMode, { enabled: true, detached: true, name: null });
-    assert.equal(result.parsed.workerCount, 2);
-    assert.equal(result.parsed.agentType, 'executor');
-    assert.equal(result.parsed.task, 'build feature');
-    assert.equal(result.parsed.teamName, 'build-feature');
-  });
+describe("parseTeamStartArgs", () => {
+	it("parses default team start args with automatic detached worktrees", () => {
+		const result = parseTeamStartArgs(["2:executor", "build", "feature"]);
+		assert.deepEqual(result.worktreeMode, {
+			enabled: true,
+			detached: true,
+			name: null,
+		});
+		assert.equal(result.parsed.workerCount, 2);
+		assert.equal(result.parsed.agentType, "executor");
+		assert.equal(result.parsed.task, "build feature");
+		assert.equal(result.parsed.teamName, "build-feature");
+	});
 
-  it('parses detached worktree mode and strips the flag', () => {
-    const result = parseTeamStartArgs(['--worktree', '3:debugger', 'fix', 'bug']);
-    assert.deepEqual(result.worktreeMode, { enabled: true, detached: true, name: null });
-    assert.equal(result.parsed.workerCount, 3);
-    assert.equal(result.parsed.agentType, 'debugger');
-    assert.equal(result.parsed.task, 'fix bug');
-    assert.equal(result.parsed.teamName, 'fix-bug');
-  });
+	it("parses detached worktree mode and strips the flag", () => {
+		const result = parseTeamStartArgs([
+			"--worktree",
+			"3:debugger",
+			"fix",
+			"bug",
+		]);
+		assert.deepEqual(result.worktreeMode, {
+			enabled: true,
+			detached: true,
+			name: null,
+		});
+		assert.equal(result.parsed.workerCount, 3);
+		assert.equal(result.parsed.agentType, "debugger");
+		assert.equal(result.parsed.task, "fix bug");
+		assert.equal(result.parsed.teamName, "fix-bug");
+	});
 
-  it('keeps explicit --worktree detached mode as a legacy-compatible override', () => {
-    const result = parseTeamStartArgs(['--worktree', '3:debugger', 'fix', 'bug']);
-    assert.deepEqual(result.worktreeMode, { enabled: true, detached: true, name: null });
-    assert.equal(result.parsed.workerCount, 3);
-    assert.equal(result.parsed.agentType, 'debugger');
-  });
+	it("keeps explicit --worktree detached mode as a legacy-compatible override", () => {
+		const result = parseTeamStartArgs([
+			"--worktree",
+			"3:debugger",
+			"fix",
+			"bug",
+		]);
+		assert.deepEqual(result.worktreeMode, {
+			enabled: true,
+			detached: true,
+			name: null,
+		});
+		assert.equal(result.parsed.workerCount, 3);
+		assert.equal(result.parsed.agentType, "debugger");
+	});
 
-  it('rejects deprecated omx team ralph syntax', () => {
-    assert.throws(
-      () => parseTeamStartArgs(['ralph', '--worktree=feature/demo', '4:executor', 'ship', 'it']),
-      /Deprecated usage: `omx team ralph \.\.\.` has been removed/,
-    );
-  });
+	it("rejects deprecated omx team ralph syntax", () => {
+		assert.throws(
+			() =>
+				parseTeamStartArgs([
+					"ralph",
+					"--worktree=feature/demo",
+					"4:executor",
+					"ship",
+					"it",
+				]),
+			/Deprecated usage: `omx team ralph \.\.\.` has been removed/,
+		);
+	});
 
-  it('accepts the maximum supported worker count', () => {
-    const result = parseTeamStartArgs([`${DEFAULT_MAX_WORKERS}:executor`, 'ship', 'it']);
-    assert.equal(result.parsed.workerCount, DEFAULT_MAX_WORKERS);
-  });
+	it("accepts the maximum supported worker count", () => {
+		const result = parseTeamStartArgs([
+			`${DEFAULT_MAX_WORKERS}:executor`,
+			"ship",
+			"it",
+		]);
+		assert.equal(result.parsed.workerCount, DEFAULT_MAX_WORKERS);
+	});
 
-  it('rejects worker count above the supported maximum', () => {
-    assert.throws(
-      () => parseTeamStartArgs([`${DEFAULT_MAX_WORKERS + 1}:executor`, 'ship', 'it']),
-      new RegExp(`Expected 1-${DEFAULT_MAX_WORKERS}`),
-    );
-  });
+	it("rejects worker count above the supported maximum", () => {
+		assert.throws(
+			() =>
+				parseTeamStartArgs([
+					`${DEFAULT_MAX_WORKERS + 1}:executor`,
+					"ship",
+					"it",
+				]),
+			new RegExp(`Expected 1-${DEFAULT_MAX_WORKERS}`),
+		);
+	});
 
-  it('reuses the approved team launch hint for a short English follow-up', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-en-'));
-    const previousCwd = process.cwd();
-    try {
-      process.chdir(wd);
-      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
-      await writeFile(
-        join(wd, '.omx', 'plans', 'prd-issue-831.md'),
-        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
-      );
-      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831.md'), '# Test spec\n');
+	it("reuses the approved team launch hint for a short English follow-up", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-followup-en-"));
+		const previousCwd = process.cwd();
+		try {
+			process.chdir(wd);
+			await mkdir(join(wd, ".omx", "plans"), { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "plans", "prd-issue-831.md"),
+				'# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
+			);
+			await writeFile(
+				join(wd, ".omx", "plans", "test-spec-issue-831.md"),
+				"# Test spec\n",
+			);
 
-      const result = parseTeamStartArgs(['team']);
-      assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
-      assert.equal(result.parsed.workerCount, 3);
-      assert.equal(result.parsed.agentType, 'executor');
-      assert.equal(result.parsed.explicitWorkerCount, true);
-    } finally {
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const result = parseTeamStartArgs(["team"]);
+			assert.equal(result.parsed.task, "Execute approved issue 831 plan");
+			assert.equal(result.parsed.workerCount, 3);
+			assert.equal(result.parsed.agentType, "executor");
+			assert.equal(result.parsed.explicitWorkerCount, true);
+		} finally {
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('reuses the approved team launch hint for a short Korean follow-up', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-ko-'));
-    const previousCwd = process.cwd();
-    try {
-      process.chdir(wd);
-      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
-      await writeFile(
-        join(wd, '.omx', 'plans', 'prd-issue-831.md'),
-        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
-      );
-      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831.md'), '# Test spec\n');
+	it("reuses the approved team launch hint for a short Korean follow-up", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-followup-ko-"));
+		const previousCwd = process.cwd();
+		try {
+			process.chdir(wd);
+			await mkdir(join(wd, ".omx", "plans"), { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "plans", "prd-issue-831.md"),
+				'# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
+			);
+			await writeFile(
+				join(wd, ".omx", "plans", "test-spec-issue-831.md"),
+				"# Test spec\n",
+			);
 
-      const result = parseTeamStartArgs(['team으로', '해줘']);
-      assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
-      assert.equal(result.parsed.workerCount, 3);
-    } finally {
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const result = parseTeamStartArgs(["team으로", "해줘"]);
+			assert.equal(result.parsed.task, "Execute approved issue 831 plan");
+			assert.equal(result.parsed.workerCount, 3);
+		} finally {
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('preserves explicit team staffing overrides while reusing the approved plan task', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-followup-override-'));
-    const previousCwd = process.cwd();
-    try {
-      process.chdir(wd);
-      await mkdir(join(wd, '.omx', 'plans'), { recursive: true });
-      await writeFile(
-        join(wd, '.omx', 'plans', 'prd-issue-831.md'),
-        '# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
-      );
-      await writeFile(join(wd, '.omx', 'plans', 'test-spec-issue-831.md'), '# Test spec\n');
+	it("preserves explicit team staffing overrides while reusing the approved plan task", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-followup-override-"));
+		const previousCwd = process.cwd();
+		try {
+			process.chdir(wd);
+			await mkdir(join(wd, ".omx", "plans"), { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "plans", "prd-issue-831.md"),
+				'# Approved plan\n\nLaunch via omx team 3:executor "Execute approved issue 831 plan"\n',
+			);
+			await writeFile(
+				join(wd, ".omx", "plans", "test-spec-issue-831.md"),
+				"# Test spec\n",
+			);
 
-      const result = parseTeamStartArgs(['2:debugger', 'team']);
-      assert.equal(result.parsed.task, 'Execute approved issue 831 plan');
-      assert.equal(result.parsed.workerCount, 2);
-      assert.equal(result.parsed.agentType, 'debugger');
-      assert.equal(result.parsed.explicitWorkerCount, true);
-      assert.equal(result.parsed.explicitAgentType, true);
-    } finally {
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const result = parseTeamStartArgs(["2:debugger", "team"]);
+			assert.equal(result.parsed.task, "Execute approved issue 831 plan");
+			assert.equal(result.parsed.workerCount, 2);
+			assert.equal(result.parsed.agentType, "debugger");
+			assert.equal(result.parsed.explicitWorkerCount, true);
+			assert.equal(result.parsed.explicitAgentType, true);
+		} finally {
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });
 
-describe('teamCommand shutdown --force parsing', () => {
-  it('parses --force flag from shutdown args', () => {
-    const teamArgs = ['shutdown', 'my-team', '--force'];
-    const force = teamArgs.includes('--force');
-    assert.equal(force, true);
-  });
+describe("teamCommand shutdown --force parsing", () => {
+	it("parses --force flag from shutdown args", () => {
+		const teamArgs = ["shutdown", "my-team", "--force"];
+		const force = teamArgs.includes("--force");
+		assert.equal(force, true);
+	});
 
-  it('does not set force when --force is absent', () => {
-    const teamArgs = ['shutdown', 'my-team'];
-    const force = teamArgs.includes('--force');
-    assert.equal(force, false);
-  });
+	it("does not set force when --force is absent", () => {
+		const teamArgs = ["shutdown", "my-team"];
+		const force = teamArgs.includes("--force");
+		assert.equal(force, false);
+	});
 
-  it('parses --force regardless of position after subcommand', () => {
-    const teamArgs = ['shutdown', '--force', 'my-team'];
-    const force = teamArgs.includes('--force');
-    assert.equal(force, true);
-  });
+	it("parses --force regardless of position after subcommand", () => {
+		const teamArgs = ["shutdown", "--force", "my-team"];
+		const force = teamArgs.includes("--force");
+		assert.equal(force, true);
+	});
+
+	it("persists cancelled team mode state on shutdown even when no team mode state existed beforehand", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-shutdown-mode-state-"));
+		const previousCwd = process.cwd();
+		const originalLog = console.log;
+		const originalWarn = console.warn;
+		const logs: string[] = [];
+		const warns: string[] = [];
+
+		try {
+			process.chdir(wd);
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "state", "session.json"),
+				JSON.stringify({ session_id: "sess-team-shutdown-state" }),
+			);
+			await initTeamState(
+				"team-shutdown-mode-state",
+				"persist cancelled team mode state after shutdown",
+				"executor",
+				1,
+				wd,
+			);
+
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			console.warn = (...args: unknown[]) =>
+				warns.push(args.map(String).join(" "));
+
+			await teamCommand(["shutdown", "team-shutdown-mode-state", "--force"]);
+
+			const state = await readModeState("team", wd);
+			assert.ok(state);
+			assert.equal(state?.active, false);
+			assert.equal(state?.current_phase, "cancelled");
+			assert.equal(state?.team_name, "team-shutdown-mode-state");
+			assert.equal(warns.length, 0);
+			assert.ok(
+				logs.some((line) =>
+					line.includes("Team shutdown complete: team-shutdown-mode-state"),
+				),
+			);
+		} finally {
+			console.log = originalLog;
+			console.warn = originalWarn;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });
 
-describe('teamCommand api', () => {
-  it('builds leader monitoring hints that keep team status visible while ON', () => {
-    const hints = buildLeaderMonitoringHints('My Team');
-    assert.equal(hints[0], 'leader_check: omx team status my-team');
-    assert.match(hints[1] ?? '', /while ON, keep checking state/);
-    assert.match(hints[1] ?? '', /sleep 30 && omx team status my-team/);
-  });
+describe("teamCommand api", () => {
+	it("builds leader monitoring hints that keep team status visible while ON", () => {
+		const hints = buildLeaderMonitoringHints("My Team");
+		assert.equal(hints[0], "leader_check: omx team status my-team");
+		assert.match(hints[1] ?? "", /while ON, keep checking state/);
+		assert.match(hints[1] ?? "", /sleep 30 && omx team status my-team/);
+	});
 
-  it('prints team-specific help for omx team --help', async () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['--help']);
-      assert.equal(logs.length, 1);
-      assert.match(logs[0] ?? '', /Usage: omx team \[N:agent-type\]/);
-      assert.match(logs[0] ?? '', /omx team api <operation>/);
-      assert.match(logs[0] ?? '', /dedicated worktrees automatically by default/);
-      assert.match(logs[0] ?? '', /--worktree is deprecated/);
-      assert.match(logs[0] ?? '', /native Codex subagents for small in-session fanout/);
-    } finally {
-      console.log = originalLog;
-    }
-  });
+	it("prints team-specific help for omx team --help", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await teamCommand(["--help"]);
+			assert.equal(logs.length, 1);
+			assert.match(logs[0] ?? "", /Usage: omx team \[N:agent-type\]/);
+			assert.match(logs[0] ?? "", /omx team api <operation>/);
+			assert.match(
+				logs[0] ?? "",
+				/dedicated worktrees automatically by default/,
+			);
+			assert.match(logs[0] ?? "", /--worktree is deprecated/);
+			assert.match(
+				logs[0] ?? "",
+				/native Codex subagents for small in-session fanout/,
+			);
+		} finally {
+			console.log = originalLog;
+		}
+	});
 
-  it('prints team-specific help for omx team help alias', async () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['help']);
-      assert.equal(logs.length, 1);
-      assert.match(logs[0] ?? '', /Usage: omx team \[N:agent-type\]/);
-      assert.match(logs[0] ?? '', /omx team api <operation>/);
-      assert.match(logs[0] ?? '', /dedicated worktrees automatically by default/);
-      assert.match(logs[0] ?? '', /--worktree is deprecated/);
-    } finally {
-      console.log = originalLog;
-    }
-  });
+	it("prints team-specific help for omx team help alias", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await teamCommand(["help"]);
+			assert.equal(logs.length, 1);
+			assert.match(logs[0] ?? "", /Usage: omx team \[N:agent-type\]/);
+			assert.match(logs[0] ?? "", /omx team api <operation>/);
+			assert.match(
+				logs[0] ?? "",
+				/dedicated worktrees automatically by default/,
+			);
+			assert.match(logs[0] ?? "", /--worktree is deprecated/);
+		} finally {
+			console.log = originalLog;
+		}
+	});
 
-  it('prints team-api-specific help for omx team api --help', async () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['api', '--help']);
-      assert.equal(logs.length, 1);
-      assert.match(logs[0] ?? '', /Usage: omx team api <operation>/);
-      assert.match(logs[0] ?? '', /send-message/);
-      assert.match(logs[0] ?? '', /transition-task-status/);
-      assert.match(logs[0] ?? '', /read-idle-state/);
-      assert.match(logs[0] ?? '', /read-stall-state/);
-    } finally {
-      console.log = originalLog;
-    }
-  });
+	it("prints team-api-specific help for omx team api --help", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await teamCommand(["api", "--help"]);
+			assert.equal(logs.length, 1);
+			assert.match(logs[0] ?? "", /Usage: omx team api <operation>/);
+			assert.match(logs[0] ?? "", /send-message/);
+			assert.match(logs[0] ?? "", /transition-task-status/);
+			assert.match(logs[0] ?? "", /read-idle-state/);
+			assert.match(logs[0] ?? "", /read-stall-state/);
+		} finally {
+			console.log = originalLog;
+		}
+	});
 
-  it('prints team-api-specific help for omx team api help alias', async () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['api', 'help']);
-      assert.equal(logs.length, 1);
-      assert.match(logs[0] ?? '', /Usage: omx team api <operation>/);
-      assert.match(logs[0] ?? '', /send-message/);
-      assert.match(logs[0] ?? '', /transition-task-status/);
-    } finally {
-      console.log = originalLog;
-    }
-  });
+	it("prints team-api-specific help for omx team api help alias", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await teamCommand(["api", "help"]);
+			assert.equal(logs.length, 1);
+			assert.match(logs[0] ?? "", /Usage: omx team api <operation>/);
+			assert.match(logs[0] ?? "", /send-message/);
+			assert.match(logs[0] ?? "", /transition-task-status/);
+		} finally {
+			console.log = originalLog;
+		}
+	});
 
-  it('prints operation-specific help for omx team api <operation> --help', async () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['api', 'send-message', '--help']);
-      assert.equal(logs.length, 1);
-      assert.match(logs[0] ?? '', /Usage: omx team api send-message --input <json> \[--json\]/);
-      assert.match(logs[0] ?? '', /Required input fields/);
-      assert.match(logs[0] ?? '', /from_worker/);
-      assert.match(logs[0] ?? '', /to_worker/);
-      assert.match(logs[0] ?? '', /body/);
-    } finally {
-      console.log = originalLog;
-    }
-  });
+	it("prints operation-specific help for omx team api <operation> --help", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await teamCommand(["api", "send-message", "--help"]);
+			assert.equal(logs.length, 1);
+			assert.match(
+				logs[0] ?? "",
+				/Usage: omx team api send-message --input <json> \[--json\]/,
+			);
+			assert.match(logs[0] ?? "", /Required input fields/);
+			assert.match(logs[0] ?? "", /from_worker/);
+			assert.match(logs[0] ?? "", /to_worker/);
+			assert.match(logs[0] ?? "", /body/);
+		} finally {
+			console.log = originalLog;
+		}
+	});
 
-  it('prints operation-specific help for omx team api <operation> help alias', async () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['api', 'claim-task', 'help']);
-      assert.equal(logs.length, 1);
-      assert.match(logs[0] ?? '', /Usage: omx team api claim-task --input <json> \[--json\]/);
-      assert.match(logs[0] ?? '', /expected_version/);
-    } finally {
-      console.log = originalLog;
-    }
-  });
+	it("prints operation-specific help for omx team api <operation> help alias", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await teamCommand(["api", "claim-task", "help"]);
+			assert.equal(logs.length, 1);
+			assert.match(
+				logs[0] ?? "",
+				/Usage: omx team api claim-task --input <json> \[--json\]/,
+			);
+			assert.match(logs[0] ?? "", /expected_version/);
+		} finally {
+			console.log = originalLog;
+		}
+	});
 
-  it('prints event query help for omx team api read-events help alias', async () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand(['api', 'read-events', 'help']);
-      assert.equal(logs.length, 1);
-      assert.match(logs[0] ?? '', /Usage: omx team api read-events --input <json> \[--json\]/);
-      assert.match(logs[0] ?? '', /after_event_id/);
-      assert.match(logs[0] ?? '', /wakeable_only/);
-      assert.match(logs[0] ?? '', /worker_idle/);
-    } finally {
-      console.log = originalLog;
-    }
-  });
+	it("prints event query help for omx team api read-events help alias", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await teamCommand(["api", "read-events", "help"]);
+			assert.equal(logs.length, 1);
+			assert.match(
+				logs[0] ?? "",
+				/Usage: omx team api read-events --input <json> \[--json\]/,
+			);
+			assert.match(logs[0] ?? "", /after_event_id/);
+			assert.match(logs[0] ?? "", /wakeable_only/);
+			assert.match(logs[0] ?? "", /worker_idle/);
+		} finally {
+			console.log = originalLog;
+		}
+	});
 
-  it('executes read-events via CLI api with canonical JSON results', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-read-events-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      await initTeamState('api-read-events', 'api event test', 'executor', 1, wd);
-      await appendTeamEvent('api-read-events', {
-        type: 'worker_idle',
-        worker: 'worker-1',
-        task_id: '1',
-        prev_state: 'working',
-      }, wd);
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+	it("executes read-events via CLI api with canonical JSON results", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-api-read-events-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			await initTeamState(
+				"api-read-events",
+				"api event test",
+				"executor",
+				1,
+				wd,
+			);
+			await appendTeamEvent(
+				"api-read-events",
+				{
+					type: "worker_idle",
+					worker: "worker-1",
+					task_id: "1",
+					prev_state: "working",
+				},
+				wd,
+			);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
-      await teamCommand([
-        'api',
-        'read-events',
-        '--input',
-        JSON.stringify({
-          team_name: 'api-read-events',
-          type: 'worker_idle',
-          worker: 'worker-1',
-          task_id: '1',
-        }),
-        '--json',
-      ]);
+			await teamCommand([
+				"api",
+				"read-events",
+				"--input",
+				JSON.stringify({
+					team_name: "api-read-events",
+					type: "worker_idle",
+					worker: "worker-1",
+					task_id: "1",
+				}),
+				"--json",
+			]);
 
-      assert.equal(logs.length, 1);
-      const envelope = JSON.parse(logs[0]) as {
-        command?: string;
-        ok?: boolean;
-        operation?: string;
-        data?: {
-          count?: number;
-          events?: Array<{ type?: string; source_type?: string; worker?: string; task_id?: string }>;
-        };
-      };
-      assert.equal(envelope.command, 'omx team api read-events');
-      assert.equal(envelope.ok, true);
-      assert.equal(envelope.operation, 'read-events');
-      assert.equal(envelope.data?.count, 1);
-      assert.equal(envelope.data?.events?.[0]?.type, 'worker_state_changed');
-      assert.equal(envelope.data?.events?.[0]?.source_type, 'worker_idle');
-      assert.equal(envelope.data?.events?.[0]?.worker, 'worker-1');
-      assert.equal(envelope.data?.events?.[0]?.task_id, '1');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			assert.equal(logs.length, 1);
+			const envelope = JSON.parse(logs[0]) as {
+				command?: string;
+				ok?: boolean;
+				operation?: string;
+				data?: {
+					count?: number;
+					events?: Array<{
+						type?: string;
+						source_type?: string;
+						worker?: string;
+						task_id?: string;
+					}>;
+				};
+			};
+			assert.equal(envelope.command, "omx team api read-events");
+			assert.equal(envelope.ok, true);
+			assert.equal(envelope.operation, "read-events");
+			assert.equal(envelope.data?.count, 1);
+			assert.equal(envelope.data?.events?.[0]?.type, "worker_state_changed");
+			assert.equal(envelope.data?.events?.[0]?.source_type, "worker_idle");
+			assert.equal(envelope.data?.events?.[0]?.worker, "worker-1");
+			assert.equal(envelope.data?.events?.[0]?.task_id, "1");
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('executes read-idle-state via CLI api with structured JSON results', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-read-idle-state-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      await initTeamState('api-read-idle', 'api idle state test', 'executor', 2, wd);
-      await writeMonitorSnapshot('api-read-idle', {
-        taskStatusById: {},
-        workerAliveByName: { 'worker-1': true, 'worker-2': true },
-        workerStateByName: { 'worker-1': 'idle', 'worker-2': 'working' },
-        workerTurnCountByName: { 'worker-1': 2, 'worker-2': 4 },
-        workerTaskIdByName: { 'worker-1': '', 'worker-2': '1' },
-        mailboxNotifiedByMessageId: {},
-        completedEventTaskIds: {},
-      }, wd);
-      await appendTeamEvent('api-read-idle', {
-        type: 'worker_idle',
-        worker: 'worker-1',
-        task_id: '1',
-        prev_state: 'working',
-      }, wd);
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+	it("executes read-idle-state via CLI api with structured JSON results", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-api-read-idle-state-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			await initTeamState(
+				"api-read-idle",
+				"api idle state test",
+				"executor",
+				2,
+				wd,
+			);
+			await writeMonitorSnapshot(
+				"api-read-idle",
+				{
+					taskStatusById: {},
+					workerAliveByName: { "worker-1": true, "worker-2": true },
+					workerStateByName: { "worker-1": "idle", "worker-2": "working" },
+					workerTurnCountByName: { "worker-1": 2, "worker-2": 4 },
+					workerTaskIdByName: { "worker-1": "", "worker-2": "1" },
+					mailboxNotifiedByMessageId: {},
+					completedEventTaskIds: {},
+				},
+				wd,
+			);
+			await appendTeamEvent(
+				"api-read-idle",
+				{
+					type: "worker_idle",
+					worker: "worker-1",
+					task_id: "1",
+					prev_state: "working",
+				},
+				wd,
+			);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
-      await teamCommand([
-        'api',
-        'read-idle-state',
-        '--input',
-        JSON.stringify({ team_name: 'api-read-idle' }),
-        '--json',
-      ]);
+			await teamCommand([
+				"api",
+				"read-idle-state",
+				"--input",
+				JSON.stringify({ team_name: "api-read-idle" }),
+				"--json",
+			]);
 
-      assert.equal(logs.length, 1);
-      const envelope = JSON.parse(logs[0]) as {
-        command?: string;
-        ok?: boolean;
-        operation?: string;
-        data?: {
-          all_workers_idle?: boolean;
-          idle_worker_count?: number;
-          idle_workers?: string[];
-          non_idle_workers?: string[];
-          last_idle_transition_by_worker?: Record<string, { source_type?: string } | null>;
-        };
-      };
-      assert.equal(envelope.command, 'omx team api read-idle-state');
-      assert.equal(envelope.ok, true);
-      assert.equal(envelope.operation, 'read-idle-state');
-      assert.equal(envelope.data?.all_workers_idle, false);
-      assert.equal(envelope.data?.idle_worker_count, 1);
-      assert.deepEqual(envelope.data?.idle_workers, ['worker-1']);
-      assert.deepEqual(envelope.data?.non_idle_workers, ['worker-2']);
-      assert.equal(envelope.data?.last_idle_transition_by_worker?.['worker-1']?.source_type, 'worker_idle');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			assert.equal(logs.length, 1);
+			const envelope = JSON.parse(logs[0]) as {
+				command?: string;
+				ok?: boolean;
+				operation?: string;
+				data?: {
+					all_workers_idle?: boolean;
+					idle_worker_count?: number;
+					idle_workers?: string[];
+					non_idle_workers?: string[];
+					last_idle_transition_by_worker?: Record<
+						string,
+						{ source_type?: string } | null
+					>;
+				};
+			};
+			assert.equal(envelope.command, "omx team api read-idle-state");
+			assert.equal(envelope.ok, true);
+			assert.equal(envelope.operation, "read-idle-state");
+			assert.equal(envelope.data?.all_workers_idle, false);
+			assert.equal(envelope.data?.idle_worker_count, 1);
+			assert.deepEqual(envelope.data?.idle_workers, ["worker-1"]);
+			assert.deepEqual(envelope.data?.non_idle_workers, ["worker-2"]);
+			assert.equal(
+				envelope.data?.last_idle_transition_by_worker?.["worker-1"]
+					?.source_type,
+				"worker_idle",
+			);
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('executes read-stall-state via CLI api with structured JSON results', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-read-stall-state-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      await initTeamState('api-read-stall', 'api stall state test', 'executor', 2, wd);
-      const task = await createTask('api-read-stall', {
-        subject: 'Pending work',
-        description: 'Needs leader attention',
-        status: 'pending',
-      }, wd);
-      await writeWorkerStatus('api-read-stall', 'worker-1', {
-        state: 'working',
-        current_task_id: task.id,
-        updated_at: '2026-03-10T10:00:00.000Z',
-      }, wd);
-      await writeWorkerStatus('api-read-stall', 'worker-2', {
-        state: 'idle',
-        updated_at: '2026-03-10T10:00:00.000Z',
-      }, wd);
-      await updateWorkerHeartbeat('api-read-stall', 'worker-1', {
-        alive: true,
-        pid: 201,
-        turn_count: 1,
-        last_turn_at: '2026-03-10T10:00:00.000Z',
-      }, wd);
-      await updateWorkerHeartbeat('api-read-stall', 'worker-2', {
-        alive: true,
-        pid: 202,
-        turn_count: 1,
-        last_turn_at: '2026-03-10T10:00:00.000Z',
-      }, wd);
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await teamCommand([
-        'api',
-        'get-summary',
-        '--input',
-        JSON.stringify({ team_name: 'api-read-stall' }),
-        '--json',
-      ]);
-      logs.length = 0;
+	it("executes read-stall-state via CLI api with structured JSON results", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-api-read-stall-state-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			await initTeamState(
+				"api-read-stall",
+				"api stall state test",
+				"executor",
+				2,
+				wd,
+			);
+			const task = await createTask(
+				"api-read-stall",
+				{
+					subject: "Pending work",
+					description: "Needs leader attention",
+					status: "pending",
+				},
+				wd,
+			);
+			await writeWorkerStatus(
+				"api-read-stall",
+				"worker-1",
+				{
+					state: "working",
+					current_task_id: task.id,
+					updated_at: "2026-03-10T10:00:00.000Z",
+				},
+				wd,
+			);
+			await writeWorkerStatus(
+				"api-read-stall",
+				"worker-2",
+				{
+					state: "idle",
+					updated_at: "2026-03-10T10:00:00.000Z",
+				},
+				wd,
+			);
+			await updateWorkerHeartbeat(
+				"api-read-stall",
+				"worker-1",
+				{
+					alive: true,
+					pid: 201,
+					turn_count: 1,
+					last_turn_at: "2026-03-10T10:00:00.000Z",
+				},
+				wd,
+			);
+			await updateWorkerHeartbeat(
+				"api-read-stall",
+				"worker-2",
+				{
+					alive: true,
+					pid: 202,
+					turn_count: 1,
+					last_turn_at: "2026-03-10T10:00:00.000Z",
+				},
+				wd,
+			);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await teamCommand([
+				"api",
+				"get-summary",
+				"--input",
+				JSON.stringify({ team_name: "api-read-stall" }),
+				"--json",
+			]);
+			logs.length = 0;
 
-      await updateWorkerHeartbeat('api-read-stall', 'worker-1', {
-        alive: true,
-        pid: 201,
-        turn_count: 8,
-        last_turn_at: '2026-03-10T10:05:00.000Z',
-      }, wd);
-      await writeMonitorSnapshot('api-read-stall', {
-        taskStatusById: { [task.id]: 'pending' },
-        workerAliveByName: { 'worker-1': true, 'worker-2': true },
-        workerStateByName: { 'worker-1': 'idle', 'worker-2': 'idle' },
-        workerTurnCountByName: { 'worker-1': 8, 'worker-2': 1 },
-        workerTaskIdByName: { 'worker-1': task.id, 'worker-2': '' },
-        mailboxNotifiedByMessageId: {},
-        completedEventTaskIds: {},
-      }, wd);
-      await writeFile(join(wd, '.omx', 'state', 'team', 'api-read-stall', 'leader-attention.json'), JSON.stringify({
-        team_name: 'api-read-stall',
-        updated_at: '2026-03-10T10:05:00.000Z',
-        source: 'native_stop',
-        leader_decision_state: 'still_actionable',
-        leader_attention_pending: true,
-        leader_attention_reason: 'leader_session_stopped',
-        attention_reasons: ['leader_session_stopped'],
-        leader_stale: false,
-        leader_session_active: false,
-        leader_session_id: 'leader-session-1',
-        leader_session_stopped_at: '2026-03-10T10:05:00.000Z',
-        unread_leader_message_count: 1,
-        work_remaining: true,
-        stalled_for_ms: null,
-      }, null, 2));
+			await updateWorkerHeartbeat(
+				"api-read-stall",
+				"worker-1",
+				{
+					alive: true,
+					pid: 201,
+					turn_count: 8,
+					last_turn_at: "2026-03-10T10:05:00.000Z",
+				},
+				wd,
+			);
+			await writeMonitorSnapshot(
+				"api-read-stall",
+				{
+					taskStatusById: { [task.id]: "pending" },
+					workerAliveByName: { "worker-1": true, "worker-2": true },
+					workerStateByName: { "worker-1": "idle", "worker-2": "idle" },
+					workerTurnCountByName: { "worker-1": 8, "worker-2": 1 },
+					workerTaskIdByName: { "worker-1": task.id, "worker-2": "" },
+					mailboxNotifiedByMessageId: {},
+					completedEventTaskIds: {},
+				},
+				wd,
+			);
+			await writeFile(
+				join(
+					wd,
+					".omx",
+					"state",
+					"team",
+					"api-read-stall",
+					"leader-attention.json",
+				),
+				JSON.stringify(
+					{
+						team_name: "api-read-stall",
+						updated_at: "2026-03-10T10:05:00.000Z",
+						source: "native_stop",
+						leader_decision_state: "still_actionable",
+						leader_attention_pending: true,
+						leader_attention_reason: "leader_session_stopped",
+						attention_reasons: ["leader_session_stopped"],
+						leader_stale: false,
+						leader_session_active: false,
+						leader_session_id: "leader-session-1",
+						leader_session_stopped_at: "2026-03-10T10:05:00.000Z",
+						unread_leader_message_count: 1,
+						work_remaining: true,
+						stalled_for_ms: null,
+					},
+					null,
+					2,
+				),
+			);
 
-      await teamCommand([
-        'api',
-        'read-stall-state',
-        '--input',
-        JSON.stringify({ team_name: 'api-read-stall' }),
-        '--json',
-      ]);
+			await teamCommand([
+				"api",
+				"read-stall-state",
+				"--input",
+				JSON.stringify({ team_name: "api-read-stall" }),
+				"--json",
+			]);
 
-      assert.equal(logs.length, 1);
-      const envelope = JSON.parse(logs[0]) as {
-        command?: string;
-        ok?: boolean;
-        operation?: string;
-        data?: {
-          team_stalled?: boolean;
-          leader_stale?: boolean;
-          stalled_workers?: string[];
-          reasons?: string[];
-        };
-      };
-      assert.equal(envelope.command, 'omx team api read-stall-state');
-      assert.equal(envelope.ok, true);
-      assert.equal(envelope.operation, 'read-stall-state');
-      assert.equal(envelope.data?.team_stalled, true);
-      assert.equal(envelope.data?.leader_stale, true);
-      assert.deepEqual(envelope.data?.stalled_workers, ['worker-1']);
-      assert.match((envelope.data?.reasons ?? []).join(' '), /leader_attention_pending:leader_session_stopped/);
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			assert.equal(logs.length, 1);
+			const envelope = JSON.parse(logs[0]) as {
+				command?: string;
+				ok?: boolean;
+				operation?: string;
+				data?: {
+					team_stalled?: boolean;
+					leader_stale?: boolean;
+					stalled_workers?: string[];
+					reasons?: string[];
+				};
+			};
+			assert.equal(envelope.command, "omx team api read-stall-state");
+			assert.equal(envelope.ok, true);
+			assert.equal(envelope.operation, "read-stall-state");
+			assert.equal(envelope.data?.team_stalled, true);
+			assert.equal(envelope.data?.leader_stale, true);
+			assert.deepEqual(envelope.data?.stalled_workers, ["worker-1"]);
+			assert.match(
+				(envelope.data?.reasons ?? []).join(" "),
+				/leader_attention_pending:leader_session_stopped/,
+			);
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('executes CLI interop operation with stable JSON envelope', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      await initTeamState('api-team', 'api test', 'executor', 1, wd);
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+	it("executes CLI interop operation with stable JSON envelope", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-api-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			await initTeamState("api-team", "api test", "executor", 1, wd);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
-      await teamCommand([
-        'api',
-        'send-message',
-        '--input',
-        JSON.stringify({
-          team_name: 'api-team',
-          from_worker: 'worker-1',
-          to_worker: 'leader-fixed',
-          body: 'ACK',
-        }),
-        '--json',
-      ]);
+			await teamCommand([
+				"api",
+				"send-message",
+				"--input",
+				JSON.stringify({
+					team_name: "api-team",
+					from_worker: "worker-1",
+					to_worker: "leader-fixed",
+					body: "ACK",
+				}),
+				"--json",
+			]);
 
-      assert.equal(logs.length, 1);
-      const envelope = JSON.parse(logs[0]) as {
-        schema_version?: string;
-        timestamp?: string;
-        command?: string;
-        ok?: boolean;
-        operation?: string;
-        data?: { message?: { body?: string } };
-      };
-      assert.equal(envelope.schema_version, '1.0');
-      assert.equal(typeof envelope.timestamp, 'string');
-      assert.equal(envelope.command, 'omx team api send-message');
-      assert.equal(envelope.ok, true);
-      assert.equal(envelope.operation, 'send-message');
-      assert.equal(envelope.data?.message?.body, 'ACK');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			assert.equal(logs.length, 1);
+			const envelope = JSON.parse(logs[0]) as {
+				schema_version?: string;
+				timestamp?: string;
+				command?: string;
+				ok?: boolean;
+				operation?: string;
+				data?: { message?: { body?: string } };
+			};
+			assert.equal(envelope.schema_version, "1.0");
+			assert.equal(typeof envelope.timestamp, "string");
+			assert.equal(envelope.command, "omx team api send-message");
+			assert.equal(envelope.ok, true);
+			assert.equal(envelope.operation, "send-message");
+			assert.equal(envelope.data?.message?.body, "ACK");
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('returns deterministic JSON errors for invalid api usage with --json', async () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      process.exitCode = 0;
-      await teamCommand(['api', 'unknown-operation', '--json']);
-      assert.equal(logs.length, 1);
-      const envelope = JSON.parse(logs[0]) as {
-        schema_version?: string;
-        timestamp?: string;
-        command?: string;
-        ok?: boolean;
-        operation?: string;
-        error?: { code?: string; message?: string };
-      };
-      assert.equal(envelope.schema_version, '1.0');
-      assert.equal(typeof envelope.timestamp, 'string');
-      assert.equal(envelope.command, 'omx team api');
-      assert.equal(envelope.ok, false);
-      assert.equal(envelope.operation, 'unknown');
-      assert.equal(envelope.error?.code, 'invalid_input');
-      assert.match(envelope.error?.message ?? '', /Usage: omx team api/);
-      assert.equal(process.exitCode, 1);
-    } finally {
-      console.log = originalLog;
-      process.exitCode = 0;
-    }
-  });
+	it("returns deterministic JSON errors for invalid api usage with --json", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			process.exitCode = 0;
+			await teamCommand(["api", "unknown-operation", "--json"]);
+			assert.equal(logs.length, 1);
+			const envelope = JSON.parse(logs[0]) as {
+				schema_version?: string;
+				timestamp?: string;
+				command?: string;
+				ok?: boolean;
+				operation?: string;
+				error?: { code?: string; message?: string };
+			};
+			assert.equal(envelope.schema_version, "1.0");
+			assert.equal(typeof envelope.timestamp, "string");
+			assert.equal(envelope.command, "omx team api");
+			assert.equal(envelope.ok, false);
+			assert.equal(envelope.operation, "unknown");
+			assert.equal(envelope.error?.code, "invalid_input");
+			assert.match(envelope.error?.message ?? "", /Usage: omx team api/);
+			assert.equal(process.exitCode, 1);
+		} finally {
+			console.log = originalLog;
+			process.exitCode = 0;
+		}
+	});
 
-  it('supports claim-safe lifecycle via CLI api (create -> claim -> transition)', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-lifecycle-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      await initTeamState('lifecycle-team', 'lifecycle test', 'executor', 1, wd);
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+	it("supports claim-safe lifecycle via CLI api (create -> claim -> transition)", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-api-lifecycle-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			await initTeamState(
+				"lifecycle-team",
+				"lifecycle test",
+				"executor",
+				1,
+				wd,
+			);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
-      await teamCommand([
-        'api',
-        'create-task',
-        '--input',
-        JSON.stringify({
-          team_name: 'lifecycle-team',
-          subject: 'Lifecycle task',
-          description: 'Created through CLI interop',
-        }),
-        '--json',
-      ]);
-      const created = JSON.parse(logs.at(-1) ?? '{}') as {
-        ok?: boolean;
-        data?: { task?: { id?: string } };
-      };
-      assert.equal(created.ok, true);
-      const taskId = created.data?.task?.id;
-      assert.equal(typeof taskId, 'string');
+			await teamCommand([
+				"api",
+				"create-task",
+				"--input",
+				JSON.stringify({
+					team_name: "lifecycle-team",
+					subject: "Lifecycle task",
+					description: "Created through CLI interop",
+				}),
+				"--json",
+			]);
+			const created = JSON.parse(logs.at(-1) ?? "{}") as {
+				ok?: boolean;
+				data?: { task?: { id?: string } };
+			};
+			assert.equal(created.ok, true);
+			const taskId = created.data?.task?.id;
+			assert.equal(typeof taskId, "string");
 
-      await teamCommand([
-        'api',
-        'claim-task',
-        '--input',
-        JSON.stringify({
-          team_name: 'lifecycle-team',
-          task_id: taskId,
-          worker: 'worker-1',
-          expected_version: 1,
-        }),
-        '--json',
-      ]);
-      const claimed = JSON.parse(logs.at(-1) ?? '{}') as {
-        ok?: boolean;
-        data?: { claimToken?: string };
-      };
-      assert.equal(claimed.ok, true);
-      const claimToken = claimed.data?.claimToken;
-      assert.equal(typeof claimToken, 'string');
+			await teamCommand([
+				"api",
+				"claim-task",
+				"--input",
+				JSON.stringify({
+					team_name: "lifecycle-team",
+					task_id: taskId,
+					worker: "worker-1",
+					expected_version: 1,
+				}),
+				"--json",
+			]);
+			const claimed = JSON.parse(logs.at(-1) ?? "{}") as {
+				ok?: boolean;
+				data?: { claimToken?: string };
+			};
+			assert.equal(claimed.ok, true);
+			const claimToken = claimed.data?.claimToken;
+			assert.equal(typeof claimToken, "string");
 
-      await teamCommand([
-        'api',
-        'transition-task-status',
-        '--input',
-        JSON.stringify({
-          team_name: 'lifecycle-team',
-          task_id: taskId,
-          from: 'in_progress',
-          to: 'completed',
-          claim_token: claimToken,
-        }),
-        '--json',
-      ]);
-      const transitioned = JSON.parse(logs.at(-1) ?? '{}') as {
-        ok?: boolean;
-        data?: { ok?: boolean; task?: { status?: string } };
-      };
-      assert.equal(transitioned.ok, true);
-      assert.equal(transitioned.data?.ok, true);
-      assert.equal(transitioned.data?.task?.status, 'completed');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			await teamCommand([
+				"api",
+				"transition-task-status",
+				"--input",
+				JSON.stringify({
+					team_name: "lifecycle-team",
+					task_id: taskId,
+					from: "in_progress",
+					to: "completed",
+					claim_token: claimToken,
+				}),
+				"--json",
+			]);
+			const transitioned = JSON.parse(logs.at(-1) ?? "{}") as {
+				ok?: boolean;
+				data?: { ok?: boolean; task?: { status?: string } };
+			};
+			assert.equal(transitioned.ok, true);
+			assert.equal(transitioned.data?.ok, true);
+			assert.equal(transitioned.data?.task?.status, "completed");
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
+	it("accepts new canonical event types via CLI api append-event", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-api-event-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			await initTeamState("event-team", "event test", "executor", 1, wd);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
-  it('accepts new canonical event types via CLI api append-event', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-api-event-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      await initTeamState('event-team', 'event test', 'executor', 1, wd);
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+			await teamCommand([
+				"api",
+				"append-event",
+				"--input",
+				JSON.stringify({
+					team_name: "event-team",
+					type: "leader_notification_deferred",
+					worker: "worker-1",
+					to_worker: "leader-fixed",
+					source_type: "worker_idle",
+					reason: "leader_pane_missing_no_injection",
+				}),
+				"--json",
+			]);
 
-      await teamCommand([
-        'api',
-        'append-event',
-        '--input',
-        JSON.stringify({
-          team_name: 'event-team',
-          type: 'leader_notification_deferred',
-          worker: 'worker-1',
-          to_worker: 'leader-fixed',
-          source_type: 'worker_idle',
-          reason: 'leader_pane_missing_no_injection',
-        }),
-        '--json',
-      ]);
-
-      const envelope = JSON.parse(logs.at(-1) ?? '{}') as {
-        ok?: boolean;
-        data?: { event?: { type?: string; to_worker?: string; reason?: string; source_type?: string } };
-      };
-      assert.equal(envelope.ok, true);
-      assert.equal(envelope.data?.event?.type, 'leader_notification_deferred');
-      assert.equal(envelope.data?.event?.to_worker, 'leader-fixed');
-      assert.equal(envelope.data?.event?.source_type, 'worker_idle');
-      assert.equal(envelope.data?.event?.reason, 'leader_pane_missing_no_injection');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const envelope = JSON.parse(logs.at(-1) ?? "{}") as {
+				ok?: boolean;
+				data?: {
+					event?: {
+						type?: string;
+						to_worker?: string;
+						reason?: string;
+						source_type?: string;
+					};
+				};
+			};
+			assert.equal(envelope.ok, true);
+			assert.equal(envelope.data?.event?.type, "leader_notification_deferred");
+			assert.equal(envelope.data?.event?.to_worker, "leader-fixed");
+			assert.equal(envelope.data?.event?.source_type, "worker_idle");
+			assert.equal(
+				envelope.data?.event?.reason,
+				"leader_pane_missing_no_injection",
+			);
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });
 
+describe("teamCommand status", () => {
+	it("prints pane ids and sparkshell hint when tmux panes are recorded", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-status-panes-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			const config = await withoutTeamTestWorkerEnv(() =>
+				initTeamState("pane-team", "inspect worker panes", "executor", 2, wd),
+			);
+			await withoutTeamTestWorkerEnv(() =>
+				createTask(
+					"pane-team",
+					{
+						subject: "Recover worker-1 progress",
+						description: "Inspect worker-1 pane",
+						status: "pending",
+						version: 3,
+						requires_code_change: true,
+						role: "debugger",
+						owner: "worker-1",
+					},
+					wd,
+				),
+			);
+			await withoutTeamTestWorkerEnv(() =>
+				createTask(
+					"pane-team",
+					{
+						subject: "Recover worker-2 progress",
+						description: "Inspect worker-2 pane",
+						status: "pending",
+						version: 4,
+						requires_code_change: false,
+						blocked_by: ["1"],
+						depends_on: ["1"],
+						role: "test-engineer",
+						owner: "worker-2",
+						result: "waiting on worker-1",
+						error: "blocked by dependency",
+					},
+					wd,
+				),
+			);
+			await writeFile(
+				join(wd, ".omx", "state", "team", "pane-team", "tasks", "task-1.json"),
+				`${JSON.stringify(
+					{
+						...(JSON.parse(
+							await readFile(
+								join(
+									wd,
+									".omx",
+									"state",
+									"team",
+									"pane-team",
+									"tasks",
+									"task-1.json",
+								),
+								"utf-8",
+							),
+						) as Record<string, unknown>),
+						created_at: "2026-03-10T23:55:00.000Z",
+						claim: {
+							owner: "worker-1",
+							token: "claim-token-1",
+							leased_until: "2026-03-11T00:10:00.000Z",
+						},
+					},
+					null,
+					2,
+				)}\n`,
+			);
+			await writeFile(
+				join(wd, ".omx", "state", "team", "pane-team", "tasks", "task-2.json"),
+				`${JSON.stringify(
+					{
+						...(JSON.parse(
+							await readFile(
+								join(
+									wd,
+									".omx",
+									"state",
+									"team",
+									"pane-team",
+									"tasks",
+									"task-2.json",
+								),
+								"utf-8",
+							),
+						) as Record<string, unknown>),
+						created_at: "2026-03-10T23:56:00.000Z",
+						completed_at: "2026-03-11T00:06:00.000Z",
+					},
+					null,
+					2,
+				)}\n`,
+			);
+			config.workers[0]!.worker_cli = "codex";
+			config.workers[1]!.worker_cli = "gemini";
+			config.workers[0]!.pid = 101;
+			config.workers[1]!.pid = 102;
+			config.workers[0]!.assigned_tasks = ["1"];
+			config.workers[1]!.assigned_tasks = ["2", "3"];
+			config.leader_pane_id = "%10";
+			config.hud_pane_id = "%11";
+			config.workers[0]!.pane_id = "%21";
+			config.workers[1]!.pane_id = "%22";
+			config.workers[0]!.working_dir = "/tmp/pane-team/worker-1";
+			config.workers[1]!.working_dir = "/tmp/pane-team/worker-2";
+			config.workers[0]!.worktree_repo_root = "/tmp/pane-team/repo";
+			config.workers[1]!.worktree_repo_root = "/tmp/pane-team/repo";
+			config.workers[0]!.team_state_root = "/tmp/pane-team/.omx/state";
+			config.workers[1]!.team_state_root = "/tmp/pane-team/.omx/state";
+			config.workers[0]!.worktree_path = "/tmp/pane-team/worktrees/worker-1";
+			config.workers[1]!.worktree_path = "/tmp/pane-team/worktrees/worker-2";
+			config.workers[0]!.worktree_branch = "feat/pane-team-worker-1";
+			config.workers[1]!.worktree_branch = "feat/pane-team-worker-2";
+			config.workers[0]!.worktree_detached = false;
+			config.workers[1]!.worktree_detached = true;
+			config.workers[0]!.worktree_created = true;
+			config.workers[1]!.worktree_created = false;
+			await writeWorkerStatus(
+				"pane-team",
+				"worker-1",
+				{
+					state: "working",
+					current_task_id: "1",
+					reason: "recovering progress",
+					updated_at: "2026-03-11T00:00:00.000Z",
+				},
+				wd,
+			);
+			await writeWorkerStatus(
+				"pane-team",
+				"worker-2",
+				{
+					state: "blocked",
+					current_task_id: "2",
+					reason: "waiting for dependency 1",
+					updated_at: "2026-03-11T00:00:00.000Z",
+				},
+				wd,
+			);
+			await updateWorkerHeartbeat(
+				"pane-team",
+				"worker-1",
+				{
+					pid: 101,
+					last_turn_at: "2026-03-11T00:01:00.000Z",
+					turn_count: 3,
+					alive: false,
+				},
+				wd,
+			);
+			await updateWorkerHeartbeat(
+				"pane-team",
+				"worker-2",
+				{
+					pid: 102,
+					last_turn_at: "2026-03-11T00:02:00.000Z",
+					turn_count: 4,
+					alive: false,
+				},
+				wd,
+			);
+			await writeTaskApproval(
+				"pane-team",
+				{
+					task_id: "1",
+					required: true,
+					status: "approved",
+					reviewer: "leader-fixed",
+					decision_reason: "Looks good",
+					decided_at: "2026-03-11T00:05:00.000Z",
+				},
+				wd,
+			);
+			const manifestPath = join(
+				wd,
+				".omx",
+				"state",
+				"team",
+				"pane-team",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as {
+				leader_pane_id?: string | null;
+				hud_pane_id?: string | null;
+				workers?: Array<{ pane_id?: string }>;
+			};
+			manifest.leader_pane_id = config.leader_pane_id;
+			manifest.hud_pane_id = config.hud_pane_id;
+			manifest.workers = config.workers.map((worker) => ({
+				...worker,
+				pane_id: worker.pane_id,
+			}));
+			await writeFile(
+				join(wd, ".omx", "state", "team", "pane-team", "config.json"),
+				`${JSON.stringify(config, null, 2)}\n`,
+			);
+			await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
-describe('teamCommand status', () => {
-  it('prints pane ids and sparkshell hint when tmux panes are recorded', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-panes-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      const config = await withoutTeamTestWorkerEnv(() => initTeamState('pane-team', 'inspect worker panes', 'executor', 2, wd));
-      await withoutTeamTestWorkerEnv(() => createTask('pane-team', {
-        subject: 'Recover worker-1 progress',
-        description: 'Inspect worker-1 pane',
-        status: 'pending',
-        version: 3,
-        requires_code_change: true,
-        role: 'debugger',
-        owner: 'worker-1',
-      }, wd));
-      await withoutTeamTestWorkerEnv(() => createTask('pane-team', {
-        subject: 'Recover worker-2 progress',
-        description: 'Inspect worker-2 pane',
-        status: 'pending',
-        version: 4,
-        requires_code_change: false,
-        blocked_by: ['1'],
-        depends_on: ['1'],
-        role: 'test-engineer',
-        owner: 'worker-2',
-        result: 'waiting on worker-1',
-        error: 'blocked by dependency',
-      }, wd));
-      await writeFile(
-        join(wd, '.omx', 'state', 'team', 'pane-team', 'tasks', 'task-1.json'),
-        `${JSON.stringify({
-          ...JSON.parse(await readFile(join(wd, '.omx', 'state', 'team', 'pane-team', 'tasks', 'task-1.json'), 'utf-8')) as Record<string, unknown>,
-          created_at: '2026-03-10T23:55:00.000Z',
-          claim: {
-            owner: 'worker-1',
-            token: 'claim-token-1',
-            leased_until: '2026-03-11T00:10:00.000Z',
-          },
-        }, null, 2)}\n`,
-      );
-      await writeFile(
-        join(wd, '.omx', 'state', 'team', 'pane-team', 'tasks', 'task-2.json'),
-        `${JSON.stringify({
-          ...JSON.parse(await readFile(join(wd, '.omx', 'state', 'team', 'pane-team', 'tasks', 'task-2.json'), 'utf-8')) as Record<string, unknown>,
-          created_at: '2026-03-10T23:56:00.000Z',
-          completed_at: '2026-03-11T00:06:00.000Z',
-        }, null, 2)}\n`,
-      );
-      config.workers[0]!.worker_cli = 'codex';
-      config.workers[1]!.worker_cli = 'gemini';
-      config.workers[0]!.pid = 101;
-      config.workers[1]!.pid = 102;
-      config.workers[0]!.assigned_tasks = ['1'];
-      config.workers[1]!.assigned_tasks = ['2', '3'];
-      config.leader_pane_id = '%10';
-      config.hud_pane_id = '%11';
-      config.workers[0]!.pane_id = '%21';
-      config.workers[1]!.pane_id = '%22';
-      config.workers[0]!.working_dir = '/tmp/pane-team/worker-1';
-      config.workers[1]!.working_dir = '/tmp/pane-team/worker-2';
-      config.workers[0]!.worktree_repo_root = '/tmp/pane-team/repo';
-      config.workers[1]!.worktree_repo_root = '/tmp/pane-team/repo';
-      config.workers[0]!.team_state_root = '/tmp/pane-team/.omx/state';
-      config.workers[1]!.team_state_root = '/tmp/pane-team/.omx/state';
-      config.workers[0]!.worktree_path = '/tmp/pane-team/worktrees/worker-1';
-      config.workers[1]!.worktree_path = '/tmp/pane-team/worktrees/worker-2';
-      config.workers[0]!.worktree_branch = 'feat/pane-team-worker-1';
-      config.workers[1]!.worktree_branch = 'feat/pane-team-worker-2';
-      config.workers[0]!.worktree_detached = false;
-      config.workers[1]!.worktree_detached = true;
-      config.workers[0]!.worktree_created = true;
-      config.workers[1]!.worktree_created = false;
-      await writeWorkerStatus('pane-team', 'worker-1', {
-        state: 'working',
-        current_task_id: '1',
-        reason: 'recovering progress',
-        updated_at: '2026-03-11T00:00:00.000Z',
-      }, wd);
-      await writeWorkerStatus('pane-team', 'worker-2', {
-        state: 'blocked',
-        current_task_id: '2',
-        reason: 'waiting for dependency 1',
-        updated_at: '2026-03-11T00:00:00.000Z',
-      }, wd);
-      await updateWorkerHeartbeat('pane-team', 'worker-1', {
-        pid: 101,
-        last_turn_at: '2026-03-11T00:01:00.000Z',
-        turn_count: 3,
-        alive: false,
-      }, wd);
-      await updateWorkerHeartbeat('pane-team', 'worker-2', {
-        pid: 102,
-        last_turn_at: '2026-03-11T00:02:00.000Z',
-        turn_count: 4,
-        alive: false,
-      }, wd);
-      await writeTaskApproval('pane-team', {
-        task_id: '1',
-        required: true,
-        status: 'approved',
-        reviewer: 'leader-fixed',
-        decision_reason: 'Looks good',
-        decided_at: '2026-03-11T00:05:00.000Z',
-      }, wd);
-      const manifestPath = join(wd, '.omx', 'state', 'team', 'pane-team', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
-        leader_pane_id?: string | null;
-        hud_pane_id?: string | null;
-        workers?: Array<{ pane_id?: string }>;
-      };
-      manifest.leader_pane_id = config.leader_pane_id;
-      manifest.hud_pane_id = config.hud_pane_id;
-      manifest.workers = config.workers.map((worker) => ({
-        ...worker,
-        pane_id: worker.pane_id,
-      }));
-      await writeFile(
-        join(wd, '.omx', 'state', 'team', 'pane-team', 'config.json'),
-        `${JSON.stringify(config, null, 2)}\n`,
-      );
-      await writeFile(
-        manifestPath,
-        `${JSON.stringify(manifest, null, 2)}\n`,
-      );
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["status", "pane-team"]),
+			);
 
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-team']));
+			const output = logs.join("\n");
+			assert.match(output, /panes: leader=%10 hud=%11/);
+			assert.match(output, /worker_panes: worker-1=%21 worker-2=%22/);
+			assert.match(
+				output,
+				/sparkshell_hint: omx sparkshell --tmux-pane <pane-id> --tail-lines 400/,
+			);
+			assert.match(
+				output,
+				/inspect_leader: omx sparkshell --tmux-pane %10 --tail-lines 400/,
+			);
+			assert.match(
+				output,
+				/inspect_hud: omx sparkshell --tmux-pane %11 --tail-lines 400/,
+			);
+			assert.match(
+				output,
+				/inspect_worker-1: omx sparkshell --tmux-pane %21 --tail-lines 400/,
+			);
+			assert.match(
+				output,
+				/inspect_worker-2: omx sparkshell --tmux-pane %22 --tail-lines 400/,
+			);
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-      const output = logs.join('\n');
-      assert.match(output, /panes: leader=%10 hud=%11/);
-      assert.match(output, /worker_panes: worker-1=%21 worker-2=%22/);
-      assert.match(output, /sparkshell_hint: omx sparkshell --tmux-pane <pane-id> --tail-lines 400/);
-      assert.match(output, /inspect_leader: omx sparkshell --tmux-pane %10 --tail-lines 400/);
-      assert.match(output, /inspect_hud: omx sparkshell --tmux-pane %11 --tail-lines 400/);
-      assert.match(output, /inspect_worker-1: omx sparkshell --tmux-pane %21 --tail-lines 400/);
-      assert.match(output, /inspect_worker-2: omx sparkshell --tmux-pane %22 --tail-lines 400/);
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+	it("returns pane ids and sparkshell hint in JSON mode", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-status-json-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			const config = await withoutTeamTestWorkerEnv(() =>
+				initTeamState(
+					"pane-json-team",
+					"inspect worker panes",
+					"executor",
+					1,
+					wd,
+				),
+			);
+			await withoutTeamTestWorkerEnv(() =>
+				createTask(
+					"pane-json-team",
+					{
+						subject: "Recover worker-1 progress",
+						description: "Inspect worker-1 pane",
+						status: "pending",
+						version: 7,
+						requires_code_change: true,
+						role: "debugger",
+						owner: "worker-1",
+					},
+					wd,
+				),
+			);
+			await writeFile(
+				join(
+					wd,
+					".omx",
+					"state",
+					"team",
+					"pane-json-team",
+					"tasks",
+					"task-1.json",
+				),
+				`${JSON.stringify(
+					{
+						...(JSON.parse(
+							await readFile(
+								join(
+									wd,
+									".omx",
+									"state",
+									"team",
+									"pane-json-team",
+									"tasks",
+									"task-1.json",
+								),
+								"utf-8",
+							),
+						) as Record<string, unknown>),
+						created_at: "2026-03-10T23:57:00.000Z",
+						claim: {
+							owner: "worker-1",
+							token: "claim-token-1",
+							leased_until: "2026-03-11T00:11:00.000Z",
+						},
+					},
+					null,
+					2,
+				)}\n`,
+			);
+			config.workers[0]!.worker_cli = "claude";
+			config.workers[0]!.pid = 201;
+			config.workers[0]!.assigned_tasks = ["1", "extra-2"];
+			config.leader_pane_id = "%30";
+			config.hud_pane_id = "%31";
+			config.workers[0]!.pane_id = "%41";
+			config.workers[0]!.working_dir = "/tmp/pane-json-team/worker-1";
+			config.workers[0]!.worktree_repo_root = "/tmp/pane-json-team/repo";
+			config.workers[0]!.team_state_root = "/tmp/pane-json-team/.omx/state";
+			config.workers[0]!.worktree_path =
+				"/tmp/pane-json-team/worktrees/worker-1";
+			config.workers[0]!.worktree_branch = "feat/pane-json-team-worker-1";
+			config.workers[0]!.worktree_detached = false;
+			config.workers[0]!.worktree_created = true;
+			await writeWorkerStatus(
+				"pane-json-team",
+				"worker-1",
+				{
+					state: "working",
+					current_task_id: "1",
+					reason: "recovering progress",
+					updated_at: "2026-03-11T00:00:00.000Z",
+				},
+				wd,
+			);
+			await updateWorkerHeartbeat(
+				"pane-json-team",
+				"worker-1",
+				{
+					pid: 201,
+					last_turn_at: "2026-03-11T00:03:00.000Z",
+					turn_count: 5,
+					alive: false,
+				},
+				wd,
+			);
+			await writeTaskApproval(
+				"pane-json-team",
+				{
+					task_id: "1",
+					required: true,
+					status: "approved",
+					reviewer: "leader-fixed",
+					decision_reason: "Looks good",
+					decided_at: "2026-03-11T00:05:00.000Z",
+				},
+				wd,
+			);
+			const manifestPath = join(
+				wd,
+				".omx",
+				"state",
+				"team",
+				"pane-json-team",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as {
+				leader_pane_id?: string | null;
+				hud_pane_id?: string | null;
+				workers?: Array<{ pane_id?: string }>;
+			};
+			manifest.leader_pane_id = config.leader_pane_id;
+			manifest.hud_pane_id = config.hud_pane_id;
+			manifest.workers = config.workers.map((worker) => ({
+				...worker,
+				pane_id: worker.pane_id,
+			}));
+			await writeFile(
+				join(wd, ".omx", "state", "team", "pane-json-team", "config.json"),
+				`${JSON.stringify(config, null, 2)}\n`,
+			);
+			await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
-  it('returns pane ids and sparkshell hint in JSON mode', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-json-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      const config = await withoutTeamTestWorkerEnv(() => initTeamState('pane-json-team', 'inspect worker panes', 'executor', 1, wd));
-      await withoutTeamTestWorkerEnv(() => createTask('pane-json-team', {
-        subject: 'Recover worker-1 progress',
-        description: 'Inspect worker-1 pane',
-        status: 'pending',
-        version: 7,
-        requires_code_change: true,
-        role: 'debugger',
-        owner: 'worker-1',
-      }, wd));
-      await writeFile(
-        join(wd, '.omx', 'state', 'team', 'pane-json-team', 'tasks', 'task-1.json'),
-        `${JSON.stringify({
-          ...JSON.parse(await readFile(join(wd, '.omx', 'state', 'team', 'pane-json-team', 'tasks', 'task-1.json'), 'utf-8')) as Record<string, unknown>,
-          created_at: '2026-03-10T23:57:00.000Z',
-          claim: {
-            owner: 'worker-1',
-            token: 'claim-token-1',
-            leased_until: '2026-03-11T00:11:00.000Z',
-          },
-        }, null, 2)}\n`,
-      );
-      config.workers[0]!.worker_cli = 'claude';
-      config.workers[0]!.pid = 201;
-      config.workers[0]!.assigned_tasks = ['1', 'extra-2'];
-      config.leader_pane_id = '%30';
-      config.hud_pane_id = '%31';
-      config.workers[0]!.pane_id = '%41';
-      config.workers[0]!.working_dir = '/tmp/pane-json-team/worker-1';
-      config.workers[0]!.worktree_repo_root = '/tmp/pane-json-team/repo';
-      config.workers[0]!.team_state_root = '/tmp/pane-json-team/.omx/state';
-      config.workers[0]!.worktree_path = '/tmp/pane-json-team/worktrees/worker-1';
-      config.workers[0]!.worktree_branch = 'feat/pane-json-team-worker-1';
-      config.workers[0]!.worktree_detached = false;
-      config.workers[0]!.worktree_created = true;
-      await writeWorkerStatus('pane-json-team', 'worker-1', {
-        state: 'working',
-        current_task_id: '1',
-        reason: 'recovering progress',
-        updated_at: '2026-03-11T00:00:00.000Z',
-      }, wd);
-      await updateWorkerHeartbeat('pane-json-team', 'worker-1', {
-        pid: 201,
-        last_turn_at: '2026-03-11T00:03:00.000Z',
-        turn_count: 5,
-        alive: false,
-      }, wd);
-      await writeTaskApproval('pane-json-team', {
-        task_id: '1',
-        required: true,
-        status: 'approved',
-        reviewer: 'leader-fixed',
-        decision_reason: 'Looks good',
-        decided_at: '2026-03-11T00:05:00.000Z',
-      }, wd);
-      const manifestPath = join(wd, '.omx', 'state', 'team', 'pane-json-team', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
-        leader_pane_id?: string | null;
-        hud_pane_id?: string | null;
-        workers?: Array<{ pane_id?: string }>;
-      };
-      manifest.leader_pane_id = config.leader_pane_id;
-      manifest.hud_pane_id = config.hud_pane_id;
-      manifest.workers = config.workers.map((worker) => ({
-        ...worker,
-        pane_id: worker.pane_id,
-      }));
-      await writeFile(
-        join(wd, '.omx', 'state', 'team', 'pane-json-team', 'config.json'),
-        `${JSON.stringify(config, null, 2)}\n`,
-      );
-      await writeFile(
-        manifestPath,
-        `${JSON.stringify(manifest, null, 2)}\n`,
-      );
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["status", "pane-json-team", "--json"]),
+			);
 
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-json-team', '--json']));
+			const payload = JSON.parse(logs.at(-1) ?? "{}") as {
+				schema_version?: string;
+				timestamp?: string;
+				command?: string;
+				team_name?: string;
+				status?: string;
+				dead_workers?: string[];
+				non_reporting_workers?: string[];
+				panes?: {
+					leader_pane_id?: string | null;
+					hud_pane_id?: string | null;
+					worker_panes?: Record<string, string>;
+					sparkshell_hint?: string | null;
+					sparkshell_commands?: Record<string, string>;
+					recommended_inspect_targets?: string[];
+					recommended_inspect_reasons?: Record<string, string>;
+					recommended_inspect_clis?: Record<string, string | null>;
+					recommended_inspect_roles?: Record<string, string | null>;
+					recommended_inspect_indexes?: Record<string, number | null>;
+					recommended_inspect_alive?: Record<string, boolean | null>;
+					recommended_inspect_turn_counts?: Record<string, number | null>;
+					recommended_inspect_turns_without_progress?: Record<
+						string,
+						number | null
+					>;
+					recommended_inspect_last_turn_at?: Record<string, string | null>;
+					recommended_inspect_status_updated_at?: Record<string, string | null>;
+					recommended_inspect_pids?: Record<string, number | null>;
+					recommended_inspect_worktree_paths?: Record<string, string | null>;
+					recommended_inspect_worktree_repo_roots?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_worktree_branches?: Record<string, string | null>;
+					recommended_inspect_worktree_detached?: Record<
+						string,
+						boolean | null
+					>;
+					recommended_inspect_worktree_created?: Record<string, boolean | null>;
+					recommended_inspect_team_state_roots?: Record<string, string | null>;
+					recommended_inspect_workdirs?: Record<string, string | null>;
+					recommended_inspect_assigned_tasks?: Record<string, string[]>;
+					recommended_inspect_task_statuses?: Record<string, string | null>;
+					recommended_inspect_task_results?: Record<string, string | null>;
+					recommended_inspect_task_errors?: Record<string, string | null>;
+					recommended_inspect_task_versions?: Record<string, number | null>;
+					recommended_inspect_task_created_at?: Record<string, string | null>;
+					recommended_inspect_task_completed_at?: Record<string, string | null>;
+					recommended_inspect_task_depends_on?: Record<string, string[]>;
+					recommended_inspect_task_claim_present?: Record<
+						string,
+						boolean | null
+					>;
+					recommended_inspect_task_claim_owners?: Record<string, string | null>;
+					recommended_inspect_task_claim_tokens?: Record<string, string | null>;
+					recommended_inspect_task_claim_leases?: Record<string, string | null>;
+					recommended_inspect_approval_required?: Record<
+						string,
+						boolean | null
+					>;
+					recommended_inspect_requires_code_change?: Record<
+						string,
+						boolean | null
+					>;
+					recommended_inspect_descriptions?: Record<string, string | null>;
+					recommended_inspect_blocked_by?: Record<string, string[]>;
+					recommended_inspect_task_roles?: Record<string, string | null>;
+					recommended_inspect_task_owners?: Record<string, string | null>;
+					recommended_inspect_approval_statuses?: Record<string, string | null>;
+					recommended_inspect_approval_reviewers?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_approval_reasons?: Record<string, string | null>;
+					recommended_inspect_approval_decided_at?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_approval_record_present?: Record<
+						string,
+						boolean | null
+					>;
+					recommended_inspect_states?: Record<string, string | null>;
+					recommended_inspect_state_reasons?: Record<string, string | null>;
+					recommended_inspect_tasks?: Record<string, string | null>;
+					recommended_inspect_subjects?: Record<string, string | null>;
+					recommended_inspect_task_paths?: Record<string, string | null>;
+					recommended_inspect_approval_paths?: Record<string, string | null>;
+					recommended_inspect_worker_state_dirs?: Record<string, string | null>;
+					recommended_inspect_worker_status_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_worker_heartbeat_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_worker_identity_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_worker_inbox_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_worker_mailbox_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_worker_shutdown_request_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_worker_shutdown_ack_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_team_dir_paths?: Record<string, string | null>;
+					recommended_inspect_team_config_paths?: Record<string, string | null>;
+					recommended_inspect_team_manifest_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_team_events_paths?: Record<string, string | null>;
+					recommended_inspect_team_dispatch_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_team_phase_paths?: Record<string, string | null>;
+					recommended_inspect_team_monitor_snapshot_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_team_summary_snapshot_paths?: Record<
+						string,
+						string | null
+					>;
+					recommended_inspect_panes?: Record<string, string | null>;
+					recommended_inspect_command?: string | null;
+					recommended_inspect_commands?: string[];
+					recommended_inspect_summary?: string | null;
+					recommended_inspect_items?: Array<{
+						target?: string;
+						pane_id?: string;
+						worker_cli?: string | null;
+						role?: string | null;
+						index?: number | null;
+						alive?: boolean | null;
+						turn_count?: number | null;
+						turns_without_progress?: number | null;
+						last_turn_at?: string | null;
+						status_updated_at?: string | null;
+						pid?: number | null;
+						worktree_repo_root?: string | null;
+						worktree_path?: string | null;
+						worktree_branch?: string | null;
+						worktree_detached?: boolean | null;
+						worktree_created?: boolean | null;
+						team_state_root?: string | null;
+						working_dir?: string | null;
+						assigned_tasks?: string[];
+						task_status?: string | null;
+						task_result?: string | null;
+						task_error?: string | null;
+						task_version?: number | null;
+						task_created_at?: string | null;
+						task_completed_at?: string | null;
+						task_depends_on?: string[];
+						task_claim_present?: boolean | null;
+						task_claim_owner?: string | null;
+						task_claim_token?: string | null;
+						task_claim_leased_until?: string | null;
+						approval_required?: boolean | null;
+						requires_code_change?: boolean | null;
+						task_description?: string | null;
+						blocked_by?: string[];
+						task_role?: string | null;
+						task_owner?: string | null;
+						approval_status?: string | null;
+						approval_reviewer?: string | null;
+						approval_reason?: string | null;
+						approval_decided_at?: string | null;
+						approval_record_present?: boolean | null;
+						reason?: string;
+						state?: string | null;
+						state_reason?: string | null;
+						task_id?: string | null;
+						task_subject?: string | null;
+						task_path?: string | null;
+						approval_path?: string | null;
+						worker_state_dir?: string | null;
+						worker_status_path?: string | null;
+						worker_heartbeat_path?: string | null;
+						worker_identity_path?: string | null;
+						worker_inbox_path?: string | null;
+						worker_mailbox_path?: string | null;
+						worker_shutdown_request_path?: string | null;
+						worker_shutdown_ack_path?: string | null;
+						team_dir_path?: string | null;
+						team_config_path?: string | null;
+						team_manifest_path?: string | null;
+						team_events_path?: string | null;
+						team_dispatch_path?: string | null;
+						team_phase_path?: string | null;
+						team_monitor_snapshot_path?: string | null;
+						team_summary_snapshot_path?: string | null;
+						command?: string;
+					}>;
+				};
+			};
+			assert.equal(payload.schema_version, "1.0");
+			assert.equal(typeof payload.timestamp, "string");
+			assert.equal(payload.command, "omx team status");
+			assert.equal(payload.team_name, "pane-json-team");
+			assert.equal(payload.status, "ok");
+			assert.deepEqual(payload.dead_workers, ["worker-1"]);
+			assert.deepEqual(payload.non_reporting_workers, []);
+			assert.deepEqual(payload.panes?.recommended_inspect_targets, [
+				"worker-1",
+			]);
+			assert.deepEqual(payload.panes?.recommended_inspect_reasons, {
+				"worker-1": "dead_worker",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_clis, {
+				"worker-1": "claude",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_roles, {
+				"worker-1": "executor",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_indexes, {
+				"worker-1": 1,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_alive, {
+				"worker-1": false,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_turn_counts, {
+				"worker-1": 5,
+			});
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_turns_without_progress,
+				{ "worker-1": 0 },
+			);
+			assert.deepEqual(payload.panes?.recommended_inspect_last_turn_at, {
+				"worker-1": "2026-03-11T00:03:00.000Z",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_status_updated_at, {
+				"worker-1": "2026-03-11T00:00:00.000Z",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_pids, {
+				"worker-1": 201,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_worktree_paths, {
+				"worker-1": "/tmp/pane-json-team/worktrees/worker-1",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_worktree_repo_roots, {
+				"worker-1": "/tmp/pane-json-team/repo",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_worktree_branches, {
+				"worker-1": "feat/pane-json-team-worker-1",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_worktree_detached, {
+				"worker-1": false,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_worktree_created, {
+				"worker-1": true,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_team_state_roots, {
+				"worker-1": "/tmp/pane-json-team/.omx/state",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_workdirs, {
+				"worker-1": "/tmp/pane-json-team/worker-1",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_assigned_tasks, {
+				"worker-1": ["1", "extra-2"],
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_statuses, {
+				"worker-1": "pending",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_results, {
+				"worker-1": null,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_errors, {
+				"worker-1": null,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_versions, {
+				"worker-1": 1,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_created_at, {
+				"worker-1": "2026-03-10T23:57:00.000Z",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_completed_at, {
+				"worker-1": null,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_depends_on, {
+				"worker-1": [],
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_claim_present, {
+				"worker-1": true,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_claim_owners, {
+				"worker-1": "worker-1",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_claim_tokens, {
+				"worker-1": "claim-token-1",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_claim_leases, {
+				"worker-1": "2026-03-11T00:11:00.000Z",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_approval_required, {
+				"worker-1": true,
+			});
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_requires_code_change,
+				{ "worker-1": true },
+			);
+			assert.deepEqual(payload.panes?.recommended_inspect_descriptions, {
+				"worker-1": "Inspect worker-1 pane",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_blocked_by, {
+				"worker-1": [],
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_roles, {
+				"worker-1": "debugger",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_owners, {
+				"worker-1": "worker-1",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_approval_statuses, {
+				"worker-1": "approved",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_approval_reviewers, {
+				"worker-1": "leader-fixed",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_approval_reasons, {
+				"worker-1": "Looks good",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_approval_decided_at, {
+				"worker-1": "2026-03-11T00:05:00.000Z",
+			});
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_approval_record_present,
+				{ "worker-1": true },
+			);
+			assert.deepEqual(payload.panes?.recommended_inspect_states, {
+				"worker-1": "working",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_state_reasons, {
+				"worker-1": "recovering progress",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_tasks, {
+				"worker-1": "1",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_subjects, {
+				"worker-1": "Recover worker-1 progress",
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_task_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/tasks/task-1.json`,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_approval_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/approvals/task-1.json`,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_worker_state_dirs, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/workers/worker-1`,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_worker_status_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/workers/worker-1/status.json`,
+			});
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_worker_heartbeat_paths,
+				{
+					"worker-1": `${wd}/.omx/state/team/pane-json-team/workers/worker-1/heartbeat.json`,
+				},
+			);
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_worker_identity_paths,
+				{
+					"worker-1": `${wd}/.omx/state/team/pane-json-team/workers/worker-1/identity.json`,
+				},
+			);
+			assert.deepEqual(payload.panes?.recommended_inspect_worker_inbox_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/workers/worker-1/inbox.md`,
+			});
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_worker_mailbox_paths,
+				{
+					"worker-1": `${wd}/.omx/state/team/pane-json-team/mailbox/worker-1.json`,
+				},
+			);
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_worker_shutdown_request_paths,
+				{
+					"worker-1": `${wd}/.omx/state/team/pane-json-team/workers/worker-1/shutdown-request.json`,
+				},
+			);
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_worker_shutdown_ack_paths,
+				{
+					"worker-1": `${wd}/.omx/state/team/pane-json-team/workers/worker-1/shutdown-ack.json`,
+				},
+			);
+			assert.deepEqual(payload.panes?.recommended_inspect_team_dir_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team`,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_team_config_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/config.json`,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_team_manifest_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/manifest.v2.json`,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_team_events_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/events/events.ndjson`,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_team_dispatch_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/dispatch/requests.json`,
+			});
+			assert.deepEqual(payload.panes?.recommended_inspect_team_phase_paths, {
+				"worker-1": `${wd}/.omx/state/team/pane-json-team/phase.json`,
+			});
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_team_monitor_snapshot_paths,
+				{
+					"worker-1": `${wd}/.omx/state/team/pane-json-team/monitor-snapshot.json`,
+				},
+			);
+			assert.deepEqual(
+				payload.panes?.recommended_inspect_team_summary_snapshot_paths,
+				{
+					"worker-1": `${wd}/.omx/state/team/pane-json-team/summary-snapshot.json`,
+				},
+			);
+			assert.deepEqual(payload.panes?.recommended_inspect_panes, {
+				"worker-1": "%41",
+			});
+			assert.equal(
+				payload.panes?.recommended_inspect_command,
+				"omx sparkshell --tmux-pane %41 --tail-lines 400",
+			);
+			assert.deepEqual(payload.panes?.recommended_inspect_commands, [
+				"omx sparkshell --tmux-pane %41 --tail-lines 400",
+			]);
+			assert.equal(
+				payload.panes?.recommended_inspect_summary,
+				"target=worker-1 pane=%41 cli=claude role=executor alive=false turn_count=5 turns_without_progress=0 reason=dead_worker state=working task=1 subject=Recover worker-1 progress command=omx sparkshell --tmux-pane %41 --tail-lines 400",
+			);
+			assert.deepEqual(payload.panes?.recommended_inspect_items, [
+				{
+					target: "worker-1",
+					pane_id: "%41",
+					worker_cli: "claude",
+					role: "executor",
+					index: 1,
+					alive: false,
+					turn_count: 5,
+					turns_without_progress: 0,
+					last_turn_at: "2026-03-11T00:03:00.000Z",
+					status_updated_at: "2026-03-11T00:00:00.000Z",
+					pid: 201,
+					worktree_repo_root: "/tmp/pane-json-team/repo",
+					worktree_path: "/tmp/pane-json-team/worktrees/worker-1",
+					worktree_branch: "feat/pane-json-team-worker-1",
+					worktree_detached: false,
+					worktree_created: true,
+					team_state_root: "/tmp/pane-json-team/.omx/state",
+					working_dir: "/tmp/pane-json-team/worker-1",
+					assigned_tasks: ["1", "extra-2"],
+					task_status: "pending",
+					task_result: null,
+					task_error: null,
+					task_version: 1,
+					task_created_at: "2026-03-10T23:57:00.000Z",
+					task_completed_at: null,
+					task_depends_on: [],
+					task_claim_present: true,
+					task_claim_owner: "worker-1",
+					task_claim_token: "claim-token-1",
+					task_claim_leased_until: "2026-03-11T00:11:00.000Z",
+					task_claim_lock_path: `${wd}/.omx/state/team/pane-json-team/claims/task-1.lock`,
+					approval_required: true,
+					requires_code_change: true,
+					task_description: "Inspect worker-1 pane",
+					blocked_by: [],
+					task_role: "debugger",
+					task_owner: "worker-1",
+					approval_status: "approved",
+					approval_reviewer: "leader-fixed",
+					approval_reason: "Looks good",
+					approval_decided_at: "2026-03-11T00:05:00.000Z",
+					approval_record_present: true,
+					reason: "dead_worker",
+					state: "working",
+					state_reason: "recovering progress",
+					task_id: "1",
+					task_subject: "Recover worker-1 progress",
+					task_path: `${wd}/.omx/state/team/pane-json-team/tasks/task-1.json`,
+					approval_path: `${wd}/.omx/state/team/pane-json-team/approvals/task-1.json`,
+					worker_state_dir: `${wd}/.omx/state/team/pane-json-team/workers/worker-1`,
+					worker_status_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/status.json`,
+					worker_heartbeat_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/heartbeat.json`,
+					worker_identity_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/identity.json`,
+					worker_inbox_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/inbox.md`,
+					worker_mailbox_path: `${wd}/.omx/state/team/pane-json-team/mailbox/worker-1.json`,
+					worker_shutdown_request_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/shutdown-request.json`,
+					worker_shutdown_ack_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/shutdown-ack.json`,
+					team_dir_path: `${wd}/.omx/state/team/pane-json-team`,
+					team_config_path: `${wd}/.omx/state/team/pane-json-team/config.json`,
+					team_manifest_path: `${wd}/.omx/state/team/pane-json-team/manifest.v2.json`,
+					team_events_path: `${wd}/.omx/state/team/pane-json-team/events/events.ndjson`,
+					team_dispatch_path: `${wd}/.omx/state/team/pane-json-team/dispatch/requests.json`,
+					team_phase_path: `${wd}/.omx/state/team/pane-json-team/phase.json`,
+					team_monitor_snapshot_path: `${wd}/.omx/state/team/pane-json-team/monitor-snapshot.json`,
+					team_summary_snapshot_path: `${wd}/.omx/state/team/pane-json-team/summary-snapshot.json`,
+					command: "omx sparkshell --tmux-pane %41 --tail-lines 400",
+				},
+			]);
+			assert.equal(payload.panes?.leader_pane_id, "%30");
+			assert.equal(payload.panes?.hud_pane_id, "%31");
+			assert.deepEqual(payload.panes?.worker_panes, { "worker-1": "%41" });
+			assert.equal(
+				payload.panes?.sparkshell_hint,
+				"omx sparkshell --tmux-pane <pane-id> --tail-lines 400",
+			);
+			assert.deepEqual(payload.panes?.sparkshell_commands, {
+				leader: "omx sparkshell --tmux-pane %30 --tail-lines 400",
+				hud: "omx sparkshell --tmux-pane %31 --tail-lines 400",
+				"worker-1": "omx sparkshell --tmux-pane %41 --tail-lines 400",
+			});
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-      const payload = JSON.parse(logs.at(-1) ?? '{}') as {
-        schema_version?: string;
-        timestamp?: string;
-        command?: string;
-        team_name?: string;
-        status?: string;
-        dead_workers?: string[];
-        non_reporting_workers?: string[];
-        panes?: {
-          leader_pane_id?: string | null;
-          hud_pane_id?: string | null;
-          worker_panes?: Record<string, string>;
-          sparkshell_hint?: string | null;
-          sparkshell_commands?: Record<string, string>;
-          recommended_inspect_targets?: string[];
-          recommended_inspect_reasons?: Record<string, string>;
-          recommended_inspect_clis?: Record<string, string | null>;
-          recommended_inspect_roles?: Record<string, string | null>;
-          recommended_inspect_indexes?: Record<string, number | null>;
-          recommended_inspect_alive?: Record<string, boolean | null>;
-          recommended_inspect_turn_counts?: Record<string, number | null>;
-          recommended_inspect_turns_without_progress?: Record<string, number | null>;
-          recommended_inspect_last_turn_at?: Record<string, string | null>;
-          recommended_inspect_status_updated_at?: Record<string, string | null>;
-          recommended_inspect_pids?: Record<string, number | null>;
-          recommended_inspect_worktree_paths?: Record<string, string | null>;
-          recommended_inspect_worktree_repo_roots?: Record<string, string | null>;
-          recommended_inspect_worktree_branches?: Record<string, string | null>;
-          recommended_inspect_worktree_detached?: Record<string, boolean | null>;
-          recommended_inspect_worktree_created?: Record<string, boolean | null>;
-          recommended_inspect_team_state_roots?: Record<string, string | null>;
-          recommended_inspect_workdirs?: Record<string, string | null>;
-          recommended_inspect_assigned_tasks?: Record<string, string[]>;
-          recommended_inspect_task_statuses?: Record<string, string | null>;
-          recommended_inspect_task_results?: Record<string, string | null>;
-          recommended_inspect_task_errors?: Record<string, string | null>;
-          recommended_inspect_task_versions?: Record<string, number | null>;
-          recommended_inspect_task_created_at?: Record<string, string | null>;
-          recommended_inspect_task_completed_at?: Record<string, string | null>;
-          recommended_inspect_task_depends_on?: Record<string, string[]>;
-          recommended_inspect_task_claim_present?: Record<string, boolean | null>;
-          recommended_inspect_task_claim_owners?: Record<string, string | null>;
-          recommended_inspect_task_claim_tokens?: Record<string, string | null>;
-          recommended_inspect_task_claim_leases?: Record<string, string | null>;
-          recommended_inspect_approval_required?: Record<string, boolean | null>;
-          recommended_inspect_requires_code_change?: Record<string, boolean | null>;
-          recommended_inspect_descriptions?: Record<string, string | null>;
-          recommended_inspect_blocked_by?: Record<string, string[]>;
-          recommended_inspect_task_roles?: Record<string, string | null>;
-          recommended_inspect_task_owners?: Record<string, string | null>;
-          recommended_inspect_approval_statuses?: Record<string, string | null>;
-          recommended_inspect_approval_reviewers?: Record<string, string | null>;
-          recommended_inspect_approval_reasons?: Record<string, string | null>;
-          recommended_inspect_approval_decided_at?: Record<string, string | null>;
-          recommended_inspect_approval_record_present?: Record<string, boolean | null>;
-          recommended_inspect_states?: Record<string, string | null>;
-          recommended_inspect_state_reasons?: Record<string, string | null>;
-          recommended_inspect_tasks?: Record<string, string | null>;
-          recommended_inspect_subjects?: Record<string, string | null>;
-          recommended_inspect_task_paths?: Record<string, string | null>;
-          recommended_inspect_approval_paths?: Record<string, string | null>;
-          recommended_inspect_worker_state_dirs?: Record<string, string | null>;
-          recommended_inspect_worker_status_paths?: Record<string, string | null>;
-          recommended_inspect_worker_heartbeat_paths?: Record<string, string | null>;
-          recommended_inspect_worker_identity_paths?: Record<string, string | null>;
-          recommended_inspect_worker_inbox_paths?: Record<string, string | null>;
-          recommended_inspect_worker_mailbox_paths?: Record<string, string | null>;
-          recommended_inspect_worker_shutdown_request_paths?: Record<string, string | null>;
-          recommended_inspect_worker_shutdown_ack_paths?: Record<string, string | null>;
-          recommended_inspect_team_dir_paths?: Record<string, string | null>;
-          recommended_inspect_team_config_paths?: Record<string, string | null>;
-          recommended_inspect_team_manifest_paths?: Record<string, string | null>;
-          recommended_inspect_team_events_paths?: Record<string, string | null>;
-          recommended_inspect_team_dispatch_paths?: Record<string, string | null>;
-          recommended_inspect_team_phase_paths?: Record<string, string | null>;
-          recommended_inspect_team_monitor_snapshot_paths?: Record<string, string | null>;
-          recommended_inspect_team_summary_snapshot_paths?: Record<string, string | null>;
-          recommended_inspect_panes?: Record<string, string | null>;
-          recommended_inspect_command?: string | null;
-          recommended_inspect_commands?: string[];
-          recommended_inspect_summary?: string | null;
-          recommended_inspect_items?: Array<{
-            target?: string;
-            pane_id?: string;
-            worker_cli?: string | null;
-            role?: string | null;
-            index?: number | null;
-            alive?: boolean | null;
-            turn_count?: number | null;
-            turns_without_progress?: number | null;
-            last_turn_at?: string | null;
-            status_updated_at?: string | null;
-            pid?: number | null;
-            worktree_repo_root?: string | null;
-            worktree_path?: string | null;
-            worktree_branch?: string | null;
-            worktree_detached?: boolean | null;
-            worktree_created?: boolean | null;
-            team_state_root?: string | null;
-            working_dir?: string | null;
-            assigned_tasks?: string[];
-            task_status?: string | null;
-            task_result?: string | null;
-            task_error?: string | null;
-            task_version?: number | null;
-            task_created_at?: string | null;
-            task_completed_at?: string | null;
-            task_depends_on?: string[];
-            task_claim_present?: boolean | null;
-            task_claim_owner?: string | null;
-            task_claim_token?: string | null;
-            task_claim_leased_until?: string | null;
-            approval_required?: boolean | null;
-            requires_code_change?: boolean | null;
-            task_description?: string | null;
-            blocked_by?: string[];
-            task_role?: string | null;
-            task_owner?: string | null;
-            approval_status?: string | null;
-            approval_reviewer?: string | null;
-            approval_reason?: string | null;
-            approval_decided_at?: string | null;
-            approval_record_present?: boolean | null;
-            reason?: string;
-            state?: string | null;
-            state_reason?: string | null;
-            task_id?: string | null;
-            task_subject?: string | null;
-            task_path?: string | null;
-            approval_path?: string | null;
-            worker_state_dir?: string | null;
-            worker_status_path?: string | null;
-            worker_heartbeat_path?: string | null;
-            worker_identity_path?: string | null;
-            worker_inbox_path?: string | null;
-            worker_mailbox_path?: string | null;
-            worker_shutdown_request_path?: string | null;
-            worker_shutdown_ack_path?: string | null;
-            team_dir_path?: string | null;
-            team_config_path?: string | null;
-            team_manifest_path?: string | null;
-            team_events_path?: string | null;
-            team_dispatch_path?: string | null;
-            team_phase_path?: string | null;
-            team_monitor_snapshot_path?: string | null;
-            team_summary_snapshot_path?: string | null;
-            command?: string;
-          }>;
-        };
-      };
-      assert.equal(payload.schema_version, '1.0');
-      assert.equal(typeof payload.timestamp, 'string');
-      assert.equal(payload.command, 'omx team status');
-      assert.equal(payload.team_name, 'pane-json-team');
-      assert.equal(payload.status, 'ok');
-      assert.deepEqual(payload.dead_workers, ['worker-1']);
-      assert.deepEqual(payload.non_reporting_workers, []);
-      assert.deepEqual(payload.panes?.recommended_inspect_targets, ['worker-1']);
-      assert.deepEqual(payload.panes?.recommended_inspect_reasons, { 'worker-1': 'dead_worker' });
-      assert.deepEqual(payload.panes?.recommended_inspect_clis, { 'worker-1': 'claude' });
-      assert.deepEqual(payload.panes?.recommended_inspect_roles, { 'worker-1': 'executor' });
-      assert.deepEqual(payload.panes?.recommended_inspect_indexes, { 'worker-1': 1 });
-      assert.deepEqual(payload.panes?.recommended_inspect_alive, { 'worker-1': false });
-      assert.deepEqual(payload.panes?.recommended_inspect_turn_counts, { 'worker-1': 5 });
-      assert.deepEqual(payload.panes?.recommended_inspect_turns_without_progress, { 'worker-1': 0 });
-      assert.deepEqual(payload.panes?.recommended_inspect_last_turn_at, { 'worker-1': '2026-03-11T00:03:00.000Z' });
-      assert.deepEqual(payload.panes?.recommended_inspect_status_updated_at, { 'worker-1': '2026-03-11T00:00:00.000Z' });
-      assert.deepEqual(payload.panes?.recommended_inspect_pids, { 'worker-1': 201 });
-      assert.deepEqual(payload.panes?.recommended_inspect_worktree_paths, { 'worker-1': '/tmp/pane-json-team/worktrees/worker-1' });
-      assert.deepEqual(payload.panes?.recommended_inspect_worktree_repo_roots, { 'worker-1': '/tmp/pane-json-team/repo' });
-      assert.deepEqual(payload.panes?.recommended_inspect_worktree_branches, { 'worker-1': 'feat/pane-json-team-worker-1' });
-      assert.deepEqual(payload.panes?.recommended_inspect_worktree_detached, { 'worker-1': false });
-      assert.deepEqual(payload.panes?.recommended_inspect_worktree_created, { 'worker-1': true });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_state_roots, { 'worker-1': '/tmp/pane-json-team/.omx/state' });
-      assert.deepEqual(payload.panes?.recommended_inspect_workdirs, { 'worker-1': '/tmp/pane-json-team/worker-1' });
-      assert.deepEqual(payload.panes?.recommended_inspect_assigned_tasks, { 'worker-1': ['1', 'extra-2'] });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_statuses, { 'worker-1': 'pending' });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_results, { 'worker-1': null });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_errors, { 'worker-1': null });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_versions, { 'worker-1': 1 });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_created_at, { 'worker-1': '2026-03-10T23:57:00.000Z' });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_completed_at, { 'worker-1': null });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_depends_on, { 'worker-1': [] });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_claim_present, { 'worker-1': true });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_claim_owners, { 'worker-1': 'worker-1' });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_claim_tokens, { 'worker-1': 'claim-token-1' });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_claim_leases, { 'worker-1': '2026-03-11T00:11:00.000Z' });
-      assert.deepEqual(payload.panes?.recommended_inspect_approval_required, { 'worker-1': true });
-      assert.deepEqual(payload.panes?.recommended_inspect_requires_code_change, { 'worker-1': true });
-      assert.deepEqual(payload.panes?.recommended_inspect_descriptions, { 'worker-1': 'Inspect worker-1 pane' });
-      assert.deepEqual(payload.panes?.recommended_inspect_blocked_by, { 'worker-1': [] });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_roles, { 'worker-1': 'debugger' });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_owners, { 'worker-1': 'worker-1' });
-      assert.deepEqual(payload.panes?.recommended_inspect_approval_statuses, { 'worker-1': 'approved' });
-      assert.deepEqual(payload.panes?.recommended_inspect_approval_reviewers, { 'worker-1': 'leader-fixed' });
-      assert.deepEqual(payload.panes?.recommended_inspect_approval_reasons, { 'worker-1': 'Looks good' });
-      assert.deepEqual(payload.panes?.recommended_inspect_approval_decided_at, { 'worker-1': '2026-03-11T00:05:00.000Z' });
-      assert.deepEqual(payload.panes?.recommended_inspect_approval_record_present, { 'worker-1': true });
-      assert.deepEqual(payload.panes?.recommended_inspect_states, { 'worker-1': 'working' });
-      assert.deepEqual(payload.panes?.recommended_inspect_state_reasons, { 'worker-1': 'recovering progress' });
-      assert.deepEqual(payload.panes?.recommended_inspect_tasks, { 'worker-1': '1' });
-      assert.deepEqual(payload.panes?.recommended_inspect_subjects, { 'worker-1': 'Recover worker-1 progress' });
-      assert.deepEqual(payload.panes?.recommended_inspect_task_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/tasks/task-1.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_approval_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/approvals/task-1.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_worker_state_dirs, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/workers/worker-1` });
-      assert.deepEqual(payload.panes?.recommended_inspect_worker_status_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/workers/worker-1/status.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_worker_heartbeat_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/workers/worker-1/heartbeat.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_worker_identity_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/workers/worker-1/identity.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_worker_inbox_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/workers/worker-1/inbox.md` });
-      assert.deepEqual(payload.panes?.recommended_inspect_worker_mailbox_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/mailbox/worker-1.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_worker_shutdown_request_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/workers/worker-1/shutdown-request.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_worker_shutdown_ack_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/workers/worker-1/shutdown-ack.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_dir_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team` });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_config_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/config.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_manifest_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/manifest.v2.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_events_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/events/events.ndjson` });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_dispatch_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/dispatch/requests.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_phase_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/phase.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_monitor_snapshot_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/monitor-snapshot.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_team_summary_snapshot_paths, { 'worker-1': `${wd}/.omx/state/team/pane-json-team/summary-snapshot.json` });
-      assert.deepEqual(payload.panes?.recommended_inspect_panes, { 'worker-1': '%41' });
-      assert.equal(payload.panes?.recommended_inspect_command, 'omx sparkshell --tmux-pane %41 --tail-lines 400');
-      assert.deepEqual(payload.panes?.recommended_inspect_commands, ['omx sparkshell --tmux-pane %41 --tail-lines 400']);
-      assert.equal(payload.panes?.recommended_inspect_summary, 'target=worker-1 pane=%41 cli=claude role=executor alive=false turn_count=5 turns_without_progress=0 reason=dead_worker state=working task=1 subject=Recover worker-1 progress command=omx sparkshell --tmux-pane %41 --tail-lines 400');
-      assert.deepEqual(payload.panes?.recommended_inspect_items, [{
-        target: 'worker-1',
-        pane_id: '%41',
-        worker_cli: 'claude',
-        role: 'executor',
-        index: 1,
-        alive: false,
-        turn_count: 5,
-        turns_without_progress: 0,
-        last_turn_at: '2026-03-11T00:03:00.000Z',
-        status_updated_at: '2026-03-11T00:00:00.000Z',
-        pid: 201,
-        worktree_repo_root: '/tmp/pane-json-team/repo',
-        worktree_path: '/tmp/pane-json-team/worktrees/worker-1',
-        worktree_branch: 'feat/pane-json-team-worker-1',
-        worktree_detached: false,
-        worktree_created: true,
-        team_state_root: '/tmp/pane-json-team/.omx/state',
-        working_dir: '/tmp/pane-json-team/worker-1',
-        assigned_tasks: ['1', 'extra-2'],
-        task_status: 'pending',
-        task_result: null,
-        task_error: null,
-        task_version: 1,
-        task_created_at: '2026-03-10T23:57:00.000Z',
-        task_completed_at: null,
-        task_depends_on: [],
-        task_claim_present: true,
-        task_claim_owner: 'worker-1',
-        task_claim_token: 'claim-token-1',
-        task_claim_leased_until: '2026-03-11T00:11:00.000Z',
-        task_claim_lock_path: `${wd}/.omx/state/team/pane-json-team/claims/task-1.lock`,
-        approval_required: true,
-        requires_code_change: true,
-        task_description: 'Inspect worker-1 pane',
-        blocked_by: [],
-        task_role: 'debugger',
-        task_owner: 'worker-1',
-        approval_status: 'approved',
-        approval_reviewer: 'leader-fixed',
-        approval_reason: 'Looks good',
-        approval_decided_at: '2026-03-11T00:05:00.000Z',
-        approval_record_present: true,
-        reason: 'dead_worker',
-        state: 'working',
-        state_reason: 'recovering progress',
-        task_id: '1',
-        task_subject: 'Recover worker-1 progress',
-        task_path: `${wd}/.omx/state/team/pane-json-team/tasks/task-1.json`,
-        approval_path: `${wd}/.omx/state/team/pane-json-team/approvals/task-1.json`,
-        worker_state_dir: `${wd}/.omx/state/team/pane-json-team/workers/worker-1`,
-        worker_status_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/status.json`,
-        worker_heartbeat_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/heartbeat.json`,
-        worker_identity_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/identity.json`,
-        worker_inbox_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/inbox.md`,
-        worker_mailbox_path: `${wd}/.omx/state/team/pane-json-team/mailbox/worker-1.json`,
-        worker_shutdown_request_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/shutdown-request.json`,
-        worker_shutdown_ack_path: `${wd}/.omx/state/team/pane-json-team/workers/worker-1/shutdown-ack.json`,
-        team_dir_path: `${wd}/.omx/state/team/pane-json-team`,
-        team_config_path: `${wd}/.omx/state/team/pane-json-team/config.json`,
-        team_manifest_path: `${wd}/.omx/state/team/pane-json-team/manifest.v2.json`,
-        team_events_path: `${wd}/.omx/state/team/pane-json-team/events/events.ndjson`,
-        team_dispatch_path: `${wd}/.omx/state/team/pane-json-team/dispatch/requests.json`,
-        team_phase_path: `${wd}/.omx/state/team/pane-json-team/phase.json`,
-        team_monitor_snapshot_path: `${wd}/.omx/state/team/pane-json-team/monitor-snapshot.json`,
-        team_summary_snapshot_path: `${wd}/.omx/state/team/pane-json-team/summary-snapshot.json`,
-        command: 'omx sparkshell --tmux-pane %41 --tail-lines 400',
-      }]);
-      assert.equal(payload.panes?.leader_pane_id, '%30');
-      assert.equal(payload.panes?.hud_pane_id, '%31');
-      assert.deepEqual(payload.panes?.worker_panes, { 'worker-1': '%41' });
-      assert.equal(payload.panes?.sparkshell_hint, 'omx sparkshell --tmux-pane <pane-id> --tail-lines 400');
-      assert.deepEqual(payload.panes?.sparkshell_commands, {
-        leader: 'omx sparkshell --tmux-pane %30 --tail-lines 400',
-        hud: 'omx sparkshell --tmux-pane %31 --tail-lines 400',
-        'worker-1': 'omx sparkshell --tmux-pane %41 --tail-lines 400',
-      });
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+	it("prints workspace_mode in text status output when present", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-status-workspace-mode-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			const config = await withoutTeamTestWorkerEnv(() =>
+				initTeamState(
+					"workspace-mode-team",
+					"inspect workspace mode",
+					"executor",
+					1,
+					wd,
+				),
+			);
+			config.workspace_mode = "worktree";
+			const teamDir = join(wd, ".omx", "state", "team", "workspace-mode-team");
+			const configPath = join(teamDir, "config.json");
+			const manifestPath = join(teamDir, "manifest.v2.json");
+			await mkdir(teamDir, { recursive: true });
+			await writeFile(configPath, JSON.stringify(config, null, 2));
+			const manifest = JSON.parse(
+				await readFile(manifestPath, "utf8"),
+			) as Record<string, unknown>;
+			manifest.workspace_mode = "worktree";
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["status", "workspace-mode-team"]),
+			);
 
-  it('prints workspace_mode in text status output when present', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-workspace-mode-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      const config = await withoutTeamTestWorkerEnv(() => initTeamState('workspace-mode-team', 'inspect workspace mode', 'executor', 1, wd));
-      config.workspace_mode = 'worktree';
-      const teamDir = join(wd, '.omx', 'state', 'team', 'workspace-mode-team');
-      const configPath = join(teamDir, 'config.json');
-      const manifestPath = join(teamDir, 'manifest.v2.json');
-      await mkdir(teamDir, { recursive: true });
-      await writeFile(configPath, JSON.stringify(config, null, 2));
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as Record<string, unknown>;
-      manifest.workspace_mode = 'worktree';
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+			assert.ok(logs.some((line) => /workspace_mode: worktree/.test(line)));
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'workspace-mode-team']));
+	it("returns workspace_mode in JSON status output when present", async () => {
+		const wd = await mkdtemp(
+			join(tmpdir(), "omx-team-status-json-workspace-mode-"),
+		);
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			const config = await withoutTeamTestWorkerEnv(() =>
+				initTeamState(
+					"workspace-mode-json-team",
+					"inspect workspace mode",
+					"executor",
+					1,
+					wd,
+				),
+			);
+			config.workspace_mode = "worktree";
+			const teamDir = join(
+				wd,
+				".omx",
+				"state",
+				"team",
+				"workspace-mode-json-team",
+			);
+			const configPath = join(teamDir, "config.json");
+			const manifestPath = join(teamDir, "manifest.v2.json");
+			await mkdir(teamDir, { recursive: true });
+			await writeFile(configPath, JSON.stringify(config, null, 2));
+			const manifest = JSON.parse(
+				await readFile(manifestPath, "utf8"),
+			) as Record<string, unknown>;
+			manifest.workspace_mode = "worktree";
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
-      assert.ok(logs.some((line) => /workspace_mode: worktree/.test(line)));
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["status", "workspace-mode-json-team", "--json"]),
+			);
 
-  it('returns workspace_mode in JSON status output when present', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-json-workspace-mode-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      const config = await withoutTeamTestWorkerEnv(() => initTeamState('workspace-mode-json-team', 'inspect workspace mode', 'executor', 1, wd));
-      config.workspace_mode = 'worktree';
-      const teamDir = join(wd, '.omx', 'state', 'team', 'workspace-mode-json-team');
-      const configPath = join(teamDir, 'config.json');
-      const manifestPath = join(teamDir, 'manifest.v2.json');
-      await mkdir(teamDir, { recursive: true });
-      await writeFile(configPath, JSON.stringify(config, null, 2));
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as Record<string, unknown>;
-      manifest.workspace_mode = 'worktree';
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+			const payload = JSON.parse(logs[0] ?? "{}") as {
+				workspace_mode?: string | null;
+				status?: string;
+			};
+			assert.equal(payload.status, "ok");
+			assert.equal(payload.workspace_mode, "worktree");
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'workspace-mode-json-team', '--json']));
+	it("returns a missing envelope in JSON mode when team state is absent", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-status-missing-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["status", "missing-team", "--json"]),
+			);
 
-      const payload = JSON.parse(logs[0] ?? '{}') as { workspace_mode?: string | null; status?: string };
-      assert.equal(payload.status, 'ok');
-      assert.equal(payload.workspace_mode, 'worktree');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const payload = JSON.parse(logs.at(-1) ?? "{}") as {
+				schema_version?: string;
+				timestamp?: string;
+				command?: string;
+				team_name?: string;
+				status?: string;
+			};
+			assert.equal(payload.schema_version, "1.0");
+			assert.equal(typeof payload.timestamp, "string");
+			assert.equal(payload.command, "omx team status");
+			assert.equal(payload.team_name, "missing-team");
+			assert.equal(payload.status, "missing");
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('returns a missing envelope in JSON mode when team state is absent', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-missing-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'missing-team', '--json']));
+	it("records leader runtime activity when team status is read", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-status-activity-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			await withoutTeamTestWorkerEnv(() =>
+				initTeamState("activity-team", "inspect activity", "executor", 1, wd),
+			);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
-      const payload = JSON.parse(logs.at(-1) ?? '{}') as {
-        schema_version?: string;
-        timestamp?: string;
-        command?: string;
-        team_name?: string;
-        status?: string;
-      };
-      assert.equal(payload.schema_version, '1.0');
-      assert.equal(typeof payload.timestamp, 'string');
-      assert.equal(payload.command, 'omx team status');
-      assert.equal(payload.team_name, 'missing-team');
-      assert.equal(payload.status, 'missing');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["status", "activity-team", "--json"]),
+			);
 
-  it('records leader runtime activity when team status is read', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-activity-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      await withoutTeamTestWorkerEnv(() => initTeamState('activity-team', 'inspect activity', 'executor', 1, wd));
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+			const activity = JSON.parse(
+				await readFile(
+					join(wd, ".omx", "state", "leader-runtime-activity.json"),
+					"utf-8",
+				),
+			) as {
+				last_activity_at?: string;
+				last_team_status_at?: string;
+				last_source?: string;
+				last_team_name?: string;
+			};
+			assert.equal(activity.last_source, "team_status");
+			assert.equal(activity.last_team_name, "activity-team");
+			assert.ok(
+				typeof activity.last_activity_at === "string" &&
+					activity.last_activity_at.length > 0,
+			);
+			assert.ok(
+				typeof activity.last_team_status_at === "string" &&
+					activity.last_team_status_at.length > 0,
+			);
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'activity-team', '--json']));
+	it("supports custom tail lines for generated sparkshell commands", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-status-tail-lines-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			const config = await withoutTeamTestWorkerEnv(() =>
+				initTeamState(
+					"pane-tail-team",
+					"inspect worker panes",
+					"executor",
+					1,
+					wd,
+				),
+			);
+			config.workers[0]!.pane_id = "%51";
+			const manifestPath = join(
+				wd,
+				".omx",
+				"state",
+				"team",
+				"pane-tail-team",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as {
+				workers?: Array<{ pane_id?: string }>;
+			};
+			manifest.workers = config.workers.map((worker) => ({
+				...worker,
+				pane_id: worker.pane_id,
+			}));
+			await writeFile(
+				join(wd, ".omx", "state", "team", "pane-tail-team", "config.json"),
+				`${JSON.stringify(config, null, 2)}\n`,
+			);
+			await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
-      const activity = JSON.parse(await readFile(join(wd, '.omx', 'state', 'leader-runtime-activity.json'), 'utf-8')) as {
-        last_activity_at?: string;
-        last_team_status_at?: string;
-        last_source?: string;
-        last_team_name?: string;
-      };
-      assert.equal(activity.last_source, 'team_status');
-      assert.equal(activity.last_team_name, 'activity-team');
-      assert.ok(typeof activity.last_activity_at === 'string' && activity.last_activity_at.length > 0);
-      assert.ok(typeof activity.last_team_status_at === 'string' && activity.last_team_status_at.length > 0);
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["status", "pane-tail-team", "--tail-lines", "600"]),
+			);
+			assert.match(
+				logs.join("\n"),
+				/inspect_worker-1: omx sparkshell --tmux-pane %51 --tail-lines 600/,
+			);
 
-  it('supports custom tail lines for generated sparkshell commands', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-tail-lines-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      const config = await withoutTeamTestWorkerEnv(() => initTeamState('pane-tail-team', 'inspect worker panes', 'executor', 1, wd));
-      config.workers[0]!.pane_id = '%51';
-      const manifestPath = join(wd, '.omx', 'state', 'team', 'pane-tail-team', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
-        workers?: Array<{ pane_id?: string }>;
-      };
-      manifest.workers = config.workers.map((worker) => ({
-        ...worker,
-        pane_id: worker.pane_id,
-      }));
-      await writeFile(
-        join(wd, '.omx', 'state', 'team', 'pane-tail-team', 'config.json'),
-        `${JSON.stringify(config, null, 2)}\n`,
-      );
-      await writeFile(
-        manifestPath,
-        `${JSON.stringify(manifest, null, 2)}\n`,
-      );
-
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-tail-team', '--tail-lines', '600']));
-      assert.match(logs.join('\n'), /inspect_worker-1: omx sparkshell --tmux-pane %51 --tail-lines 600/);
-
-      logs.length = 0;
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-tail-team', '--json', '--tail-lines=550']));
-      const payload = JSON.parse(logs.at(-1) ?? '{}') as {
-        tail_lines?: number;
-        panes?: { sparkshell_commands?: Record<string, string> };
-      };
-      assert.equal(payload.tail_lines, 550);
-      assert.equal(payload.panes?.sparkshell_commands?.['worker-1'], 'omx sparkshell --tmux-pane %51 --tail-lines 550');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			logs.length = 0;
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["status", "pane-tail-team", "--json", "--tail-lines=550"]),
+			);
+			const payload = JSON.parse(logs.at(-1) ?? "{}") as {
+				tail_lines?: number;
+				panes?: { sparkshell_commands?: Record<string, string> };
+			};
+			assert.equal(payload.tail_lines, 550);
+			assert.equal(
+				payload.panes?.sparkshell_commands?.["worker-1"],
+				"omx sparkshell --tmux-pane %51 --tail-lines 550",
+			);
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });
 
-describe('teamCommand await', () => {
-  it('returns next canonical event for a team in JSON mode', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-await-'));
-    const previousCwd = process.cwd();
-    const logs: string[] = [];
-    const originalLog = console.log;
-    try {
-      process.chdir(wd);
-      await initTeamState('await-team', 'await test', 'executor', 1, wd);
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+describe("teamCommand await", () => {
+	it("returns next canonical event for a team in JSON mode", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-await-"));
+		const previousCwd = process.cwd();
+		const logs: string[] = [];
+		const originalLog = console.log;
+		try {
+			process.chdir(wd);
+			await initTeamState("await-team", "await test", "executor", 1, wd);
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
 
-      const waitPromise = teamCommand(['await', 'await-team', '--json', '--timeout-ms', '500']);
-      setTimeout(() => {
-        void appendTeamEvent('await-team', {
-          type: 'worker_state_changed',
-          worker: 'worker-1',
-          state: 'blocked',
-          prev_state: 'working',
-          reason: 'needs_follow_up',
-        }, wd);
-      }, 50);
-      await waitPromise;
+			const waitPromise = teamCommand([
+				"await",
+				"await-team",
+				"--json",
+				"--timeout-ms",
+				"500",
+			]);
+			setTimeout(() => {
+				void appendTeamEvent(
+					"await-team",
+					{
+						type: "worker_state_changed",
+						worker: "worker-1",
+						state: "blocked",
+						prev_state: "working",
+						reason: "needs_follow_up",
+					},
+					wd,
+				);
+			}, 50);
+			await waitPromise;
 
-      const payload = JSON.parse(logs.at(-1) ?? '{}') as {
-        team_name?: string;
-        status?: string;
-        cursor?: string;
-        event?: { type?: string; state?: string; prev_state?: string; reason?: string } | null;
-      };
-      assert.equal(payload.team_name, 'await-team');
-      assert.equal(payload.status, 'event');
-      assert.equal(typeof payload.cursor, 'string');
-      assert.equal(payload.event?.type, 'worker_state_changed');
-      assert.equal(payload.event?.state, 'blocked');
-      assert.equal(payload.event?.prev_state, 'working');
-      assert.equal(payload.event?.reason, 'needs_follow_up');
-    } finally {
-      console.log = originalLog;
-      process.chdir(previousCwd);
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const payload = JSON.parse(logs.at(-1) ?? "{}") as {
+				team_name?: string;
+				status?: string;
+				cursor?: string;
+				event?: {
+					type?: string;
+					state?: string;
+					prev_state?: string;
+					reason?: string;
+				} | null;
+			};
+			assert.equal(payload.team_name, "await-team");
+			assert.equal(payload.status, "event");
+			assert.equal(typeof payload.cursor, "string");
+			assert.equal(payload.event?.type, "worker_state_changed");
+			assert.equal(payload.event?.state, "blocked");
+			assert.equal(payload.event?.prev_state, "working");
+			assert.equal(payload.event?.reason, "needs_follow_up");
+		} finally {
+			console.log = originalLog;
+			process.chdir(previousCwd);
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('returns a dead-worker event for the prompt-launch smoke path instead of timing out', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-await-prompt-dead-'));
-    const binDir = join(wd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    const previousCwd = process.cwd();
-    const previousPath = process.env.PATH;
-    const previousTmux = process.env.TMUX;
-    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const logs: string[] = [];
-    const stderr: string[] = [];
-    const originalLog = console.log;
-    const originalStderrWrite = process.stderr.write.bind(process.stderr);
-    const teamTask = 'issue 662 prompt dead worker smoke';
-    const teamName = parseTeamStartArgs(['1:executor', teamTask]).parsed.teamName;
+	it("returns a dead-worker event for the prompt-launch smoke path instead of timing out", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-await-prompt-dead-"));
+		const binDir = join(wd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const previousCwd = process.cwd();
+		const previousPath = process.env.PATH;
+		const previousTmux = process.env.TMUX;
+		const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const logs: string[] = [];
+		const stderr: string[] = [];
+		const originalLog = console.log;
+		const originalStderrWrite = process.stderr.write.bind(process.stderr);
+		const teamTask = "issue 662 prompt dead worker smoke";
+		const teamName = parseTeamStartArgs(["1:executor", teamTask]).parsed
+			.teamName;
 
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 setTimeout(() => process.exit(0), 150);
 process.stdin.resume();
 process.on('SIGTERM', () => process.exit(0));
 `,
-    );
-    await chmod(fakeCodexPath, 0o755);
+		);
+		await chmod(fakeCodexPath, 0o755);
 
-    try {
-      process.chdir(wd);
-      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
-      delete process.env.TMUX;
-      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-      process.env.OMX_TEAM_WORKER_CLI = 'codex';
-      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
-      process.stderr.write = ((chunk: string | Uint8Array) => {
-        stderr.push(String(chunk));
-        return true;
-      }) as typeof process.stderr.write;
+		try {
+			process.chdir(wd);
+			process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+			delete process.env.TMUX;
+			process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+			process.env.OMX_TEAM_WORKER_CLI = "codex";
+			console.log = (...args: unknown[]) =>
+				logs.push(args.map(String).join(" "));
+			process.stderr.write = ((chunk: string | Uint8Array) => {
+				stderr.push(String(chunk));
+				return true;
+			}) as typeof process.stderr.write;
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
-      await new Promise((resolve) => setTimeout(resolve, 500));
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["1:executor", teamTask]),
+			);
+			await new Promise((resolve) => setTimeout(resolve, 500));
 
-      logs.length = 0;
-      stderr.length = 0;
-      await withoutTeamTestWorkerEnv(() => teamCommand(['status', teamName]));
-      assert.match(logs.join('\n'), /phase=failed/);
-      assert.doesNotMatch(stderr.join('\n'), /ESRCH/);
+			logs.length = 0;
+			stderr.length = 0;
+			await withoutTeamTestWorkerEnv(() => teamCommand(["status", teamName]));
+			assert.match(logs.join("\n"), /phase=failed/);
+			assert.doesNotMatch(stderr.join("\n"), /ESRCH/);
 
-      logs.length = 0;
-      await withoutTeamTestWorkerEnv(() => teamCommand(['await', teamName, '--json', '--timeout-ms', '250']));
-      const payload = JSON.parse(logs.at(-1) ?? '{}') as {
-        team_name?: string;
-        status?: string;
-        event?: { type?: string; worker?: string; reason?: string | null } | null;
-      };
-      assert.equal(payload.team_name, teamName);
-      assert.equal(payload.status, 'event');
-      assert.equal(payload.event?.type, 'worker_stopped');
-      assert.equal(payload.event?.worker, 'worker-1');
-    } finally {
-      console.log = originalLog;
-      process.stderr.write = originalStderrWrite;
-      process.chdir(previousCwd);
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
-      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
-      else delete process.env.TMUX;
-      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			logs.length = 0;
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["await", teamName, "--json", "--timeout-ms", "250"]),
+			);
+			const payload = JSON.parse(logs.at(-1) ?? "{}") as {
+				team_name?: string;
+				status?: string;
+				event?: {
+					type?: string;
+					worker?: string;
+					reason?: string | null;
+				} | null;
+			};
+			assert.equal(payload.team_name, teamName);
+			assert.equal(payload.status, "event");
+			assert.equal(payload.event?.type, "worker_stopped");
+			assert.equal(payload.event?.worker, "worker-1");
+		} finally {
+			console.log = originalLog;
+			process.stderr.write = originalStderrWrite;
+			process.chdir(previousCwd);
+			if (typeof previousPath === "string") process.env.PATH = previousPath;
+			else delete process.env.PATH;
+			if (typeof previousTmux === "string") process.env.TMUX = previousTmux;
+			else delete process.env.TMUX;
+			if (typeof previousLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof previousWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('initializes and rehydrates active team mode state on start and resume', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-mode-state-'));
-    const binDir = join(wd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    const previousCwd = process.cwd();
-    const previousPath = process.env.PATH;
-    const previousTmux = process.env.TMUX;
-    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const teamTask = 'issue 771 rehydrate team mode state';
-    const teamName = parseTeamStartArgs(['1:executor', teamTask]).parsed.teamName;
+	it("initializes and rehydrates active team mode state on start and resume", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-mode-state-"));
+		const binDir = join(wd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const previousCwd = process.cwd();
+		const previousPath = process.env.PATH;
+		const previousTmux = process.env.TMUX;
+		const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const teamTask = "issue 771 rehydrate team mode state";
+		const teamName = parseTeamStartArgs(["1:executor", teamTask]).parsed
+			.teamName;
 
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 setTimeout(() => process.exit(0), 3000);
 process.stdin.resume();
 process.on('SIGTERM', () => process.exit(0));
 `,
-    );
-    await chmod(fakeCodexPath, 0o755);
+		);
+		await chmod(fakeCodexPath, 0o755);
 
-    try {
-      process.chdir(wd);
-      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
-      delete process.env.TMUX;
-      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-      process.env.OMX_TEAM_WORKER_CLI = 'codex';
+		try {
+			process.chdir(wd);
+			process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+			delete process.env.TMUX;
+			process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+			process.env.OMX_TEAM_WORKER_CLI = "codex";
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["1:executor", teamTask]),
+			);
 
-      const startedState = await readModeState('team', wd);
-      assert.equal(startedState?.active, true);
-      assert.equal(startedState?.team_name, teamName);
-      assert.equal(startedState?.current_phase, 'team-exec');
+			const startedState = await readModeState("team", wd);
+			assert.equal(startedState?.active, true);
+			assert.equal(startedState?.team_name, teamName);
+			assert.equal(startedState?.current_phase, "team-exec");
 
-      await rm(join(wd, '.omx', 'state', 'team-state.json'), { force: true });
-      assert.equal(await readModeState('team', wd), null);
+			await rm(join(wd, ".omx", "state", "team-state.json"), { force: true });
+			assert.equal(await readModeState("team", wd), null);
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['resume', teamName]));
+			await withoutTeamTestWorkerEnv(() => teamCommand(["resume", teamName]));
 
-      const resumedState = await readModeState('team', wd);
-      assert.equal(resumedState?.active, true);
-      assert.equal(resumedState?.team_name, teamName);
-      assert.equal(resumedState?.current_phase, 'team-exec');
-    } finally {
-      process.chdir(previousCwd);
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
-      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
-      else delete process.env.TMUX;
-      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const resumedState = await readModeState("team", wd);
+			assert.equal(resumedState?.active, true);
+			assert.equal(resumedState?.team_name, teamName);
+			assert.equal(resumedState?.current_phase, "team-exec");
+		} finally {
+			process.chdir(previousCwd);
+			if (typeof previousPath === "string") process.env.PATH = previousPath;
+			else delete process.env.PATH;
+			if (typeof previousTmux === "string") process.env.TMUX = previousTmux;
+			else delete process.env.TMUX;
+			if (typeof previousLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof previousWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('does not resurrect active team mode state when canonical team phase is terminal on resume', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-team-mode-terminal-'));
-    const binDir = join(wd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    const previousCwd = process.cwd();
-    const previousPath = process.env.PATH;
-    const previousTmux = process.env.TMUX;
-    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const teamTask = 'issue 772 terminal team mode state';
-    const teamName = parseTeamStartArgs(['1:executor', teamTask]).parsed.teamName;
+	it("does not resurrect active team mode state when canonical team phase is terminal on resume", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-mode-terminal-"));
+		const binDir = join(wd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const previousCwd = process.cwd();
+		const previousPath = process.env.PATH;
+		const previousTmux = process.env.TMUX;
+		const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const teamTask = "issue 772 terminal team mode state";
+		const teamName = parseTeamStartArgs(["1:executor", teamTask]).parsed
+			.teamName;
 
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 setTimeout(() => process.exit(0), 3000);
 process.stdin.resume();
 process.on('SIGTERM', () => process.exit(0));
 `,
-    );
-    await chmod(fakeCodexPath, 0o755);
+		);
+		await chmod(fakeCodexPath, 0o755);
 
-    try {
-      process.chdir(wd);
-      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
-      delete process.env.TMUX;
-      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-      process.env.OMX_TEAM_WORKER_CLI = 'codex';
+		try {
+			process.chdir(wd);
+			process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+			delete process.env.TMUX;
+			process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+			process.env.OMX_TEAM_WORKER_CLI = "codex";
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
-      await writeFile(
-        join(wd, '.omx', 'state', 'team', teamName, 'phase.json'),
-        JSON.stringify({
-          current_phase: 'complete',
-          max_fix_attempts: 3,
-          current_fix_attempt: 0,
-          transitions: [],
-          updated_at: new Date().toISOString(),
-        }, null, 2),
-      );
-      await rm(join(wd, '.omx', 'state', 'team-state.json'), { force: true });
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["1:executor", teamTask]),
+			);
+			await writeFile(
+				join(wd, ".omx", "state", "team", teamName, "phase.json"),
+				JSON.stringify(
+					{
+						current_phase: "complete",
+						max_fix_attempts: 3,
+						current_fix_attempt: 0,
+						transitions: [],
+						updated_at: new Date().toISOString(),
+					},
+					null,
+					2,
+				),
+			);
+			await rm(join(wd, ".omx", "state", "team-state.json"), { force: true });
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['resume', teamName]));
+			await withoutTeamTestWorkerEnv(() => teamCommand(["resume", teamName]));
 
-      const resumedState = await readModeState('team', wd);
-      assert.equal(resumedState?.active, false);
-      assert.equal(resumedState?.team_name, teamName);
-      assert.equal(resumedState?.current_phase, 'complete');
-    } finally {
-      process.chdir(previousCwd);
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
-      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
-      else delete process.env.TMUX;
-      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const resumedState = await readModeState("team", wd);
+			assert.equal(resumedState?.active, false);
+			assert.equal(resumedState?.team_name, teamName);
+			assert.equal(resumedState?.current_phase, "complete");
+		} finally {
+			process.chdir(previousCwd);
+			if (typeof previousPath === "string") process.env.PATH = previousPath;
+			else delete process.env.PATH;
+			if (typeof previousTmux === "string") process.env.TMUX = previousTmux;
+			else delete process.env.TMUX;
+			if (typeof previousLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof previousWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('rejects legacy omx team ralph launches at command entry', async () => {
-    await assert.rejects(
-      () => withoutTeamTestWorkerEnv(() => teamCommand(['ralph', '1:executor', 'issue 742 linked ralph launch'])),
-      /Deprecated usage: `omx team ralph \.\.\.` has been removed/,
-    );
-  });
+	it("recreates a cancelled team mode state on shutdown when startup left no root team-state file", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-team-shutdown-mode-state-"));
+		const binDir = join(wd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const previousCwd = process.cwd();
+		const previousPath = process.env.PATH;
+		const previousTmux = process.env.TMUX;
+		const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const teamTask = "issue 1373 shutdown mode state";
+		const teamName = parseTeamStartArgs(["1:executor", teamTask]).parsed
+			.teamName;
 
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
+setTimeout(() => process.exit(0), 3000);
+process.stdin.resume();
+process.on('SIGTERM', () => process.exit(0));
+`,
+		);
+		await chmod(fakeCodexPath, 0o755);
+
+		try {
+			process.chdir(wd);
+			process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+			delete process.env.TMUX;
+			process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+			process.env.OMX_TEAM_WORKER_CLI = "codex";
+
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["1:executor", teamTask]),
+			);
+
+			await rm(join(wd, ".omx", "state", "team-state.json"), { force: true });
+			assert.equal(await readModeState("team", wd), null);
+
+			await withoutTeamTestWorkerEnv(() =>
+				teamCommand(["shutdown", teamName, "--force"]),
+			);
+
+			const shutdownState = await readModeState("team", wd);
+			assert.equal(shutdownState?.active, false);
+			assert.equal(shutdownState?.current_phase, "cancelled");
+			assert.equal(shutdownState?.team_name, teamName);
+			assert.equal(shutdownState?.task_description, teamTask);
+		} finally {
+			process.chdir(previousCwd);
+			if (typeof previousPath === "string") process.env.PATH = previousPath;
+			else delete process.env.PATH;
+			if (typeof previousTmux === "string") process.env.TMUX = previousTmux;
+			else delete process.env.TMUX;
+			if (typeof previousLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof previousWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects legacy omx team ralph launches at command entry", async () => {
+		await assert.rejects(
+			() =>
+				withoutTeamTestWorkerEnv(() =>
+					teamCommand(["ralph", "1:executor", "issue 742 linked ralph launch"]),
+				),
+			/Deprecated usage: `omx team ralph \.\.\.` has been removed/,
+		);
+	});
 });

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,117 +1,137 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { updateModeState, startMode, readModeState } from '../modes/base.js';
-import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
-import { DEFAULT_MAX_WORKERS } from '../team/state.js';
-import { sanitizeTeamName } from '../team/tmux-session.js';
-import { readTeamEvents, waitForTeamEvent } from '../team/state/events.js';
-import type { TeamEvent } from '../team/state.js';
-import { parseWorktreeMode, type WorktreeMode } from '../team/worktree.js';
-import { classifyTaskSize } from '../hooks/task-size-detector.js';
-import { readApprovedExecutionLaunchHint } from '../planning/artifacts.js';
-import { routeTaskToRole } from '../team/role-router.js';
-import { allocateTasksToWorkers } from '../team/allocation-policy.js';
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { classifyTaskSize } from "../hooks/task-size-detector.js";
+import { readModeState, startMode, updateModeState } from "../modes/base.js";
+import { readApprovedExecutionLaunchHint } from "../planning/artifacts.js";
+import { allocateTasksToWorkers } from "../team/allocation-policy.js";
 import {
-  buildFollowupStaffingPlan,
-  resolveAvailableAgentTypes,
-  type FollowupStaffingPlan,
-} from '../team/followup-planner.js';
+	executeTeamApiOperation,
+	resolveTeamApiOperation,
+	TEAM_API_OPERATIONS,
+	type TeamApiOperation,
+} from "../team/api-interop.js";
 import {
-  TEAM_API_OPERATIONS,
-  resolveTeamApiOperation,
-  executeTeamApiOperation,
-  type TeamApiOperation,
-} from '../team/api-interop.js';
-import { teamReadConfig as readTeamConfig, teamReadPhase as readTeamPhase } from '../team/team-ops.js';
-import { recordLeaderRuntimeActivity } from '../team/leader-activity.js';
-import { readTeamPaneStatus } from '../team/pane-status.js';
+	buildFollowupStaffingPlan,
+	type FollowupStaffingPlan,
+	resolveAvailableAgentTypes,
+} from "../team/followup-planner.js";
+import { recordLeaderRuntimeActivity } from "../team/leader-activity.js";
+import { readTeamPaneStatus } from "../team/pane-status.js";
+import { routeTaskToRole } from "../team/role-router.js";
+import {
+	monitorTeam,
+	resumeTeam,
+	shutdownTeam,
+	startTeam,
+	type TeamRuntime,
+	type TeamSnapshot,
+} from "../team/runtime.js";
+import { readTeamEvents, waitForTeamEvent } from "../team/state/events.js";
+import type { TeamEvent } from "../team/state.js";
+import { DEFAULT_MAX_WORKERS } from "../team/state.js";
+import {
+	teamReadConfig as readTeamConfig,
+	teamReadPhase as readTeamPhase,
+} from "../team/team-ops.js";
+import { sanitizeTeamName } from "../team/tmux-session.js";
+import { parseWorktreeMode, type WorktreeMode } from "../team/worktree.js";
 
 interface TeamCliOptions {
-  verbose?: boolean;
+	verbose?: boolean;
 }
 
 interface ParsedTeamArgs {
-  workerCount: number;
-  agentType: string;
-  explicitAgentType: boolean;
-  explicitWorkerCount: boolean;
-  task: string;
-  teamName: string;
+	workerCount: number;
+	agentType: string;
+	explicitAgentType: boolean;
+	explicitWorkerCount: boolean;
+	task: string;
+	teamName: string;
 }
 
-
 interface TeamFollowupContext {
-  task: string;
-  workerCount: number;
-  explicitWorkerCount: boolean;
-  agentType?: string;
-  explicitAgentType?: boolean;
+	task: string;
+	workerCount: number;
+	explicitWorkerCount: boolean;
+	agentType?: string;
+	explicitAgentType?: boolean;
 }
 
 function readPersistedTeamFollowupState(cwd: string): {
-  task?: string;
-  task_description?: string;
-  workerCount?: number;
-  agent_count?: number;
-  agentType?: string;
-  agent_types?: string;
-  linkedRalph?: boolean;
+	task?: string;
+	task_description?: string;
+	workerCount?: number;
+	agent_count?: number;
+	agentType?: string;
+	agent_types?: string;
+	linkedRalph?: boolean;
 } | null {
-  const path = join(cwd, '.omx', 'state', 'team-state.json');
-  if (!existsSync(path)) return null;
-  try {
-    return JSON.parse(readFileSync(path, 'utf-8')) as {
-      task?: string;
-      workerCount?: number;
-      agentType?: string;
-      linkedRalph?: boolean;
-      task_description?: string;
-      agent_count?: number;
-      agent_types?: string;
-    };
-  } catch {
-    return null;
-  }
+	const path = join(cwd, ".omx", "state", "team-state.json");
+	if (!existsSync(path)) return null;
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as {
+			task?: string;
+			workerCount?: number;
+			agentType?: string;
+			linkedRalph?: boolean;
+			task_description?: string;
+			agent_count?: number;
+			agent_types?: string;
+		};
+	} catch {
+		return null;
+	}
 }
 
-function resolveApprovedTeamFollowupContext(cwd: string, task: string): TeamFollowupContext | null {
-  const normalizedTask = task.trim();
-  if (!normalizedTask) return null;
+function resolveApprovedTeamFollowupContext(
+	cwd: string,
+	task: string,
+): TeamFollowupContext | null {
+	const normalizedTask = task.trim();
+	if (!normalizedTask) return null;
 
-  const existingTeamState = readPersistedTeamFollowupState(cwd);
-  const shortFollowup = ['team', 'team으로 해줘', 'team으로 해주세요'].includes(normalizedTask);
-  if (!shortFollowup) return null;
+	const existingTeamState = readPersistedTeamFollowupState(cwd);
+	const shortFollowup = ["team", "team으로 해줘", "team으로 해주세요"].includes(
+		normalizedTask,
+	);
+	if (!shortFollowup) return null;
 
-  const approvedHint = readApprovedExecutionLaunchHint(cwd, 'team');
-  if (!approvedHint) return null;
+	const approvedHint = readApprovedExecutionLaunchHint(cwd, "team");
+	if (!approvedHint) return null;
 
-  const persistedTask = typeof existingTeamState?.task_description === 'string'
-    ? existingTeamState.task_description
-    : typeof existingTeamState?.task === 'string'
-      ? existingTeamState.task
-      : null;
-  const persistedWorkerCount = typeof existingTeamState?.agent_count === 'number'
-    ? existingTeamState.agent_count
-    : typeof existingTeamState?.workerCount === 'number'
-      ? existingTeamState.workerCount
-      : null;
-  if (persistedTask && persistedWorkerCount && persistedTask.trim() === approvedHint.task.trim()) {
-    return {
-      task: persistedTask,
-      workerCount: persistedWorkerCount,
-      explicitWorkerCount: true,
-      agentType: approvedHint.agentType,
-      explicitAgentType: approvedHint.agentType != null,
-    };
-  }
+	const persistedTask =
+		typeof existingTeamState?.task_description === "string"
+			? existingTeamState.task_description
+			: typeof existingTeamState?.task === "string"
+				? existingTeamState.task
+				: null;
+	const persistedWorkerCount =
+		typeof existingTeamState?.agent_count === "number"
+			? existingTeamState.agent_count
+			: typeof existingTeamState?.workerCount === "number"
+				? existingTeamState.workerCount
+				: null;
+	if (
+		persistedTask &&
+		persistedWorkerCount &&
+		persistedTask.trim() === approvedHint.task.trim()
+	) {
+		return {
+			task: persistedTask,
+			workerCount: persistedWorkerCount,
+			explicitWorkerCount: true,
+			agentType: approvedHint.agentType,
+			explicitAgentType: approvedHint.agentType != null,
+		};
+	}
 
-  return {
-    task: approvedHint.task,
-    workerCount: approvedHint.workerCount ?? 3,
-    explicitWorkerCount: approvedHint.workerCount != null,
-    agentType: approvedHint.agentType,
-    explicitAgentType: approvedHint.agentType != null,
-  };
+	return {
+		task: approvedHint.task,
+		workerCount: approvedHint.workerCount ?? 3,
+		explicitWorkerCount: approvedHint.workerCount != null,
+		agentType: approvedHint.agentType,
+		explicitAgentType: approvedHint.agentType != null,
+	};
 }
 
 const MIN_WORKER_COUNT = 1;
@@ -120,7 +140,7 @@ const MIN_SPARKSHELL_TAIL_LINES = 100;
 const MAX_SPARKSHELL_TAIL_LINES = 1000;
 
 function isTerminalModePhase(phase: string): boolean {
-  return ['complete', 'failed', 'cancelled'].includes(phase);
+	return ["complete", "failed", "cancelled"].includes(phase);
 }
 
 const TEAM_HELP = `
@@ -150,156 +170,255 @@ Usage: omx team api <operation> [--input <json>] [--json]
        omx team api <operation> --help
 
 Supported operations:
-  ${TEAM_API_OPERATIONS.join('\n  ')}
+  ${TEAM_API_OPERATIONS.join("\n  ")}
 
 Examples:
   omx team api list-tasks --input '{"team_name":"my-team"}' --json
   omx team api claim-task --input '{"team_name":"my-team","task_id":"1","worker":"worker-1","expected_version":1}' --json
 `;
 
-const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+const HELP_TOKENS = new Set(["--help", "-h", "help"]);
 
 const TEAM_API_OPERATION_REQUIRED_FIELDS: Record<TeamApiOperation, string[]> = {
-  'send-message': ['team_name', 'from_worker', 'to_worker', 'body'],
-  'broadcast': ['team_name', 'from_worker', 'body'],
-  'mailbox-list': ['team_name', 'worker'],
-  'mailbox-mark-delivered': ['team_name', 'worker', 'message_id'],
-  'mailbox-mark-notified': ['team_name', 'worker', 'message_id'],
-  'create-task': ['team_name', 'subject', 'description'],
-  'read-task': ['team_name', 'task_id'],
-  'list-tasks': ['team_name'],
-  'update-task': ['team_name', 'task_id'],
-  'claim-task': ['team_name', 'task_id', 'worker'],
-  'transition-task-status': ['team_name', 'task_id', 'from', 'to', 'claim_token'],
-  'release-task-claim': ['team_name', 'task_id', 'claim_token', 'worker'],
-  'read-config': ['team_name'],
-  'read-manifest': ['team_name'],
-  'read-worker-status': ['team_name', 'worker'],
-  'read-worker-heartbeat': ['team_name', 'worker'],
-  'update-worker-heartbeat': ['team_name', 'worker', 'pid', 'turn_count', 'alive'],
-  'write-worker-inbox': ['team_name', 'worker', 'content'],
-  'write-worker-identity': ['team_name', 'worker', 'index', 'role'],
-  'append-event': ['team_name', 'type', 'worker'],
-  'read-events': ['team_name'],
-  'await-event': ['team_name'],
-  'read-idle-state': ['team_name'],
-  'read-stall-state': ['team_name'],
-  'get-summary': ['team_name'],
-  'cleanup': ['team_name'],
-  'orphan-cleanup': ['team_name'],
-  'write-shutdown-request': ['team_name', 'worker', 'requested_by'],
-  'read-shutdown-ack': ['team_name', 'worker'],
-  'read-monitor-snapshot': ['team_name'],
-  'write-monitor-snapshot': ['team_name', 'snapshot'],
-  'read-task-approval': ['team_name', 'task_id'],
-  'write-task-approval': ['team_name', 'task_id', 'status', 'reviewer', 'decision_reason'],
+	"send-message": ["team_name", "from_worker", "to_worker", "body"],
+	broadcast: ["team_name", "from_worker", "body"],
+	"mailbox-list": ["team_name", "worker"],
+	"mailbox-mark-delivered": ["team_name", "worker", "message_id"],
+	"mailbox-mark-notified": ["team_name", "worker", "message_id"],
+	"create-task": ["team_name", "subject", "description"],
+	"read-task": ["team_name", "task_id"],
+	"list-tasks": ["team_name"],
+	"update-task": ["team_name", "task_id"],
+	"claim-task": ["team_name", "task_id", "worker"],
+	"transition-task-status": [
+		"team_name",
+		"task_id",
+		"from",
+		"to",
+		"claim_token",
+	],
+	"release-task-claim": ["team_name", "task_id", "claim_token", "worker"],
+	"read-config": ["team_name"],
+	"read-manifest": ["team_name"],
+	"read-worker-status": ["team_name", "worker"],
+	"read-worker-heartbeat": ["team_name", "worker"],
+	"update-worker-heartbeat": [
+		"team_name",
+		"worker",
+		"pid",
+		"turn_count",
+		"alive",
+	],
+	"write-worker-inbox": ["team_name", "worker", "content"],
+	"write-worker-identity": ["team_name", "worker", "index", "role"],
+	"append-event": ["team_name", "type", "worker"],
+	"read-events": ["team_name"],
+	"await-event": ["team_name"],
+	"read-idle-state": ["team_name"],
+	"read-stall-state": ["team_name"],
+	"get-summary": ["team_name"],
+	cleanup: ["team_name"],
+	"orphan-cleanup": ["team_name"],
+	"write-shutdown-request": ["team_name", "worker", "requested_by"],
+	"read-shutdown-ack": ["team_name", "worker"],
+	"read-monitor-snapshot": ["team_name"],
+	"write-monitor-snapshot": ["team_name", "snapshot"],
+	"read-task-approval": ["team_name", "task_id"],
+	"write-task-approval": [
+		"team_name",
+		"task_id",
+		"status",
+		"reviewer",
+		"decision_reason",
+	],
 };
 
-const TEAM_API_OPERATION_OPTIONAL_FIELDS: Partial<Record<TeamApiOperation, string[]>> = {
-  'create-task': ['owner', 'blocked_by', 'requires_code_change'],
-  'update-task': ['subject', 'description', 'blocked_by', 'requires_code_change'],
-  'claim-task': ['expected_version'],
-  'cleanup': ['force'],
-  'transition-task-status': ['result', 'error'],
-  'read-shutdown-ack': ['min_updated_at'],
-  'write-worker-identity': [
-    'assigned_tasks', 'pid', 'pane_id', 'working_dir',
-    'worktree_path', 'worktree_branch', 'worktree_detached', 'team_state_root',
-  ],
-  'append-event': ['task_id', 'message_id', 'reason', 'state', 'prev_state', 'to_worker', 'worker_count', 'source_type', 'metadata'],
-  'read-events': ['after_event_id', 'wakeable_only', 'type', 'worker', 'task_id'],
-  'await-event': ['after_event_id', 'timeout_ms', 'poll_ms', 'wakeable_only', 'type', 'worker', 'task_id'],
-  'write-task-approval': ['required'],
+const TEAM_API_OPERATION_OPTIONAL_FIELDS: Partial<
+	Record<TeamApiOperation, string[]>
+> = {
+	"create-task": ["owner", "blocked_by", "requires_code_change"],
+	"update-task": [
+		"subject",
+		"description",
+		"blocked_by",
+		"requires_code_change",
+	],
+	"claim-task": ["expected_version"],
+	cleanup: ["force"],
+	"transition-task-status": ["result", "error"],
+	"read-shutdown-ack": ["min_updated_at"],
+	"write-worker-identity": [
+		"assigned_tasks",
+		"pid",
+		"pane_id",
+		"working_dir",
+		"worktree_path",
+		"worktree_branch",
+		"worktree_detached",
+		"team_state_root",
+	],
+	"append-event": [
+		"task_id",
+		"message_id",
+		"reason",
+		"state",
+		"prev_state",
+		"to_worker",
+		"worker_count",
+		"source_type",
+		"metadata",
+	],
+	"read-events": [
+		"after_event_id",
+		"wakeable_only",
+		"type",
+		"worker",
+		"task_id",
+	],
+	"await-event": [
+		"after_event_id",
+		"timeout_ms",
+		"poll_ms",
+		"wakeable_only",
+		"type",
+		"worker",
+		"task_id",
+	],
+	"write-task-approval": ["required"],
 };
 
 const TEAM_API_OPERATION_NOTES: Partial<Record<TeamApiOperation, string>> = {
-  'update-task': 'Only non-lifecycle task metadata can be updated.',
-  'release-task-claim': 'Use this only for rollback/requeue to pending (not for completion).',
-  'transition-task-status': 'Lifecycle flow is claim-safe and typically transitions in_progress -> completed|failed.',
-  'cleanup': 'Uses the runtime shutdown contract; use orphan-cleanup only for known orphan recovery.',
-  'orphan-cleanup': 'Destructive escape hatch for known orphan recovery. Bypasses shutdown orchestration.',
-  'read-events': 'Events are returned in canonical form; worker_idle log entries normalize to type worker_state_changed with source_type worker_idle. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics (wakeable events now include merge conflicts and per-signal stale alerts).',
-  'await-event': 'Waits for the next matching event and returns status=timeout when no matching event arrives before timeout_ms. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics (wakeable events now include merge conflicts and per-signal stale alerts).',
-  'read-idle-state': 'Builds a structured idle summary from the existing monitor snapshot, team summary, and recent events.',
-  'read-stall-state': 'Builds a structured stall summary from the existing monitor snapshot, team summary, and recent events.',
+	"update-task": "Only non-lifecycle task metadata can be updated.",
+	"release-task-claim":
+		"Use this only for rollback/requeue to pending (not for completion).",
+	"transition-task-status":
+		"Lifecycle flow is claim-safe and typically transitions in_progress -> completed|failed.",
+	cleanup:
+		"Uses the runtime shutdown contract; use orphan-cleanup only for known orphan recovery.",
+	"orphan-cleanup":
+		"Destructive escape hatch for known orphan recovery. Bypasses shutdown orchestration.",
+	"read-events":
+		"Events are returned in canonical form; worker_idle log entries normalize to type worker_state_changed with source_type worker_idle. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics (wakeable events now include merge conflicts and per-signal stale alerts).",
+	"await-event":
+		"Waits for the next matching event and returns status=timeout when no matching event arrives before timeout_ms. wakeable_only defaults to false; set wakeable_only=true to mirror omx team await semantics (wakeable events now include merge conflicts and per-signal stale alerts).",
+	"read-idle-state":
+		"Builds a structured idle summary from the existing monitor snapshot, team summary, and recent events.",
+	"read-stall-state":
+		"Builds a structured stall summary from the existing monitor snapshot, team summary, and recent events.",
 };
 
 function sampleValueForTeamApiField(field: string): unknown {
-  switch (field) {
-    case 'team_name': return 'my-team';
-    case 'from_worker': return 'worker-1';
-    case 'to_worker': return 'leader-fixed';
-    case 'worker': return 'worker-1';
-    case 'body': return 'ACK';
-    case 'subject': return 'Demo task';
-    case 'description': return 'Created through CLI interop';
-    case 'task_id': return '1';
-    case 'message_id': return 'msg-123';
-    case 'from': return 'in_progress';
-    case 'to': return 'completed';
-    case 'claim_token': return 'claim-token';
-    case 'result': return 'Verification:\nPASS - example';
-    case 'error': return 'Verification failed';
-    case 'expected_version': return 1;
-    case 'pid': return 12345;
-    case 'turn_count': return 12;
-    case 'alive': return true;
-    case 'content': return '# Inbox update\nProceed with task 2.';
-    case 'index': return 1;
-    case 'role': return 'executor';
-    case 'assigned_tasks': return ['1', '2'];
-    case 'type': return 'task_completed';
-    case 'metadata':
-      return {
-        summary: 'worker diff report',
-        worktree_path: '/tmp/team/worktrees/worker-1',
-        diff_path: '/tmp/team/worktrees/worker-1/.omx/diff.md',
-        full_diff_available: true,
-      };
-    case 'requested_by': return 'leader-fixed';
-    case 'after_event_id': return 'evt-123';
-    case 'wakeable_only': return true;
-    case 'timeout_ms': return 500;
-    case 'poll_ms': return 100;
-    case 'min_updated_at': return '2026-03-04T00:00:00.000Z';
-    case 'snapshot':
-      return {
-        taskStatusById: { '1': 'completed' },
-        workerAliveByName: { 'worker-1': true },
-        workerStateByName: { 'worker-1': 'idle' },
-        workerTurnCountByName: { 'worker-1': 12 },
-        workerTaskIdByName: { 'worker-1': '1' },
-        mailboxNotifiedByMessageId: {},
-        completedEventTaskIds: { '1': true },
-      };
-    case 'status': return 'approved';
-    case 'reviewer': return 'leader-fixed';
-    case 'decision_reason': return 'approved in demo';
-    case 'required': return true;
-    default: return `<${field}>`;
-  }
+	switch (field) {
+		case "team_name":
+			return "my-team";
+		case "from_worker":
+			return "worker-1";
+		case "to_worker":
+			return "leader-fixed";
+		case "worker":
+			return "worker-1";
+		case "body":
+			return "ACK";
+		case "subject":
+			return "Demo task";
+		case "description":
+			return "Created through CLI interop";
+		case "task_id":
+			return "1";
+		case "message_id":
+			return "msg-123";
+		case "from":
+			return "in_progress";
+		case "to":
+			return "completed";
+		case "claim_token":
+			return "claim-token";
+		case "result":
+			return "Verification:\nPASS - example";
+		case "error":
+			return "Verification failed";
+		case "expected_version":
+			return 1;
+		case "pid":
+			return 12345;
+		case "turn_count":
+			return 12;
+		case "alive":
+			return true;
+		case "content":
+			return "# Inbox update\nProceed with task 2.";
+		case "index":
+			return 1;
+		case "role":
+			return "executor";
+		case "assigned_tasks":
+			return ["1", "2"];
+		case "type":
+			return "task_completed";
+		case "metadata":
+			return {
+				summary: "worker diff report",
+				worktree_path: "/tmp/team/worktrees/worker-1",
+				diff_path: "/tmp/team/worktrees/worker-1/.omx/diff.md",
+				full_diff_available: true,
+			};
+		case "requested_by":
+			return "leader-fixed";
+		case "after_event_id":
+			return "evt-123";
+		case "wakeable_only":
+			return true;
+		case "timeout_ms":
+			return 500;
+		case "poll_ms":
+			return 100;
+		case "min_updated_at":
+			return "2026-03-04T00:00:00.000Z";
+		case "snapshot":
+			return {
+				taskStatusById: { "1": "completed" },
+				workerAliveByName: { "worker-1": true },
+				workerStateByName: { "worker-1": "idle" },
+				workerTurnCountByName: { "worker-1": 12 },
+				workerTaskIdByName: { "worker-1": "1" },
+				mailboxNotifiedByMessageId: {},
+				completedEventTaskIds: { "1": true },
+			};
+		case "status":
+			return "approved";
+		case "reviewer":
+			return "leader-fixed";
+		case "decision_reason":
+			return "approved in demo";
+		case "required":
+			return true;
+		default:
+			return `<${field}>`;
+	}
 }
 
 function buildTeamApiOperationHelp(operation: TeamApiOperation): string {
-  const requiredFields = TEAM_API_OPERATION_REQUIRED_FIELDS[operation] ?? [];
-  const optionalFields = TEAM_API_OPERATION_OPTIONAL_FIELDS[operation] ?? [];
-  const sampleInput: Record<string, unknown> = {};
+	const requiredFields = TEAM_API_OPERATION_REQUIRED_FIELDS[operation] ?? [];
+	const optionalFields = TEAM_API_OPERATION_OPTIONAL_FIELDS[operation] ?? [];
+	const sampleInput: Record<string, unknown> = {};
 
-  for (const field of requiredFields) {
-    sampleInput[field] = sampleValueForTeamApiField(field);
-  }
-  const sampleInputJson = JSON.stringify(sampleInput);
-  const required = requiredFields.length > 0
-    ? requiredFields.map((field) => `  - ${field}`).join('\n')
-    : '  (none)';
-  const optional = optionalFields.length > 0
-    ? `\nOptional input fields:\n${optionalFields.map((field) => `  - ${field}`).join('\n')}\n`
-    : '\n';
-  const note = TEAM_API_OPERATION_NOTES[operation]
-    ? `\nNote:\n  ${TEAM_API_OPERATION_NOTES[operation]}\n`
-    : '';
+	for (const field of requiredFields) {
+		sampleInput[field] = sampleValueForTeamApiField(field);
+	}
+	const sampleInputJson = JSON.stringify(sampleInput);
+	const required =
+		requiredFields.length > 0
+			? requiredFields.map((field) => `  - ${field}`).join("\n")
+			: "  (none)";
+	const optional =
+		optionalFields.length > 0
+			? `\nOptional input fields:\n${optionalFields.map((field) => `  - ${field}`).join("\n")}\n`
+			: "\n";
+	const note = TEAM_API_OPERATION_NOTES[operation]
+		? `\nNote:\n  ${TEAM_API_OPERATION_NOTES[operation]}\n`
+		: "";
 
-  return `
+	return `
 Usage: omx team api ${operation} --input <json> [--json]
 
 Required input fields:
@@ -309,609 +428,931 @@ ${required}${optional}${note}Example:
 }
 
 function buildJsonBase(): { schema_version: string; timestamp: string } {
-  return {
-    schema_version: '1.0',
-    timestamp: new Date().toISOString(),
-  };
+	return {
+		schema_version: "1.0",
+		timestamp: new Date().toISOString(),
+	};
 }
 
 function parseStatusTailLines(args: string[]): number {
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === '--tail-lines') {
-      const next = args[index + 1];
-      const parsed = Number.parseInt(next || '', 10);
-      if (!Number.isFinite(parsed) || parsed < MIN_SPARKSHELL_TAIL_LINES || parsed > MAX_SPARKSHELL_TAIL_LINES) {
-        throw new Error(`Usage: omx team status <team-name> [--json] [--tail-lines <${MIN_SPARKSHELL_TAIL_LINES}-${MAX_SPARKSHELL_TAIL_LINES}>]`);
-      }
-      return parsed;
-    }
-    if (token.startsWith('--tail-lines=')) {
-      const parsed = Number.parseInt(token.slice('--tail-lines='.length), 10);
-      if (!Number.isFinite(parsed) || parsed < MIN_SPARKSHELL_TAIL_LINES || parsed > MAX_SPARKSHELL_TAIL_LINES) {
-        throw new Error(`Usage: omx team status <team-name> [--json] [--tail-lines <${MIN_SPARKSHELL_TAIL_LINES}-${MAX_SPARKSHELL_TAIL_LINES}>]`);
-      }
-      return parsed;
-    }
-  }
-  return DEFAULT_SPARKSHELL_TAIL_LINES;
+	for (let index = 0; index < args.length; index += 1) {
+		const token = args[index];
+		if (token === "--tail-lines") {
+			const next = args[index + 1];
+			const parsed = Number.parseInt(next || "", 10);
+			if (
+				!Number.isFinite(parsed) ||
+				parsed < MIN_SPARKSHELL_TAIL_LINES ||
+				parsed > MAX_SPARKSHELL_TAIL_LINES
+			) {
+				throw new Error(
+					`Usage: omx team status <team-name> [--json] [--tail-lines <${MIN_SPARKSHELL_TAIL_LINES}-${MAX_SPARKSHELL_TAIL_LINES}>]`,
+				);
+			}
+			return parsed;
+		}
+		if (token.startsWith("--tail-lines=")) {
+			const parsed = Number.parseInt(token.slice("--tail-lines=".length), 10);
+			if (
+				!Number.isFinite(parsed) ||
+				parsed < MIN_SPARKSHELL_TAIL_LINES ||
+				parsed > MAX_SPARKSHELL_TAIL_LINES
+			) {
+				throw new Error(
+					`Usage: omx team status <team-name> [--json] [--tail-lines <${MIN_SPARKSHELL_TAIL_LINES}-${MAX_SPARKSHELL_TAIL_LINES}>]`,
+				);
+			}
+			return parsed;
+		}
+	}
+	return DEFAULT_SPARKSHELL_TAIL_LINES;
 }
 
 export interface ParsedTeamStartArgs {
-  parsed: ParsedTeamArgs;
-  worktreeMode: WorktreeMode;
+	parsed: ParsedTeamArgs;
+	worktreeMode: WorktreeMode;
 }
 
 function resolveDefaultTeamWorktreeMode(mode: WorktreeMode): WorktreeMode {
-  if (mode.enabled) return mode;
-  return { enabled: true, detached: true, name: null };
+	if (mode.enabled) return mode;
+	return { enabled: true, detached: true, name: null };
 }
 
 function parseTeamApiArgs(args: string[]): {
-  operation: TeamApiOperation;
-  input: Record<string, unknown>;
-  json: boolean;
+	operation: TeamApiOperation;
+	input: Record<string, unknown>;
+	json: boolean;
 } {
-  const operation = resolveTeamApiOperation(args[0] || '');
-  if (!operation) {
-    throw new Error(`Usage: omx team api <operation> [--input <json>] [--json]\nSupported operations: ${TEAM_API_OPERATIONS.join(', ')}`);
-  }
-  let input: Record<string, unknown> = {};
-  let json = false;
-  for (let i = 1; i < args.length; i += 1) {
-    const token = args[i];
-    if (token === '--json') {
-      json = true;
-      continue;
-    }
-    if (token === '--input') {
-      const next = args[i + 1];
-      if (!next) throw new Error('Missing value after --input');
-      try {
-        const parsed = JSON.parse(next) as unknown;
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          throw new Error('input must be a JSON object');
-        }
-        input = parsed as Record<string, unknown>;
-      } catch (error) {
-        throw new Error(`Invalid --input JSON: ${error instanceof Error ? error.message : String(error)}`);
-      }
-      i += 1;
-      continue;
-    }
-    if (token.startsWith('--input=')) {
-      const raw = token.slice('--input='.length);
-      try {
-        const parsed = JSON.parse(raw) as unknown;
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          throw new Error('input must be a JSON object');
-        }
-        input = parsed as Record<string, unknown>;
-      } catch (error) {
-        throw new Error(`Invalid --input JSON: ${error instanceof Error ? error.message : String(error)}`);
-      }
-      continue;
-    }
-    throw new Error(`Unknown argument for "omx team api": ${token}`);
-  }
-  return { operation, input, json };
+	const operation = resolveTeamApiOperation(args[0] || "");
+	if (!operation) {
+		throw new Error(
+			`Usage: omx team api <operation> [--input <json>] [--json]\nSupported operations: ${TEAM_API_OPERATIONS.join(", ")}`,
+		);
+	}
+	let input: Record<string, unknown> = {};
+	let json = false;
+	for (let i = 1; i < args.length; i += 1) {
+		const token = args[i];
+		if (token === "--json") {
+			json = true;
+			continue;
+		}
+		if (token === "--input") {
+			const next = args[i + 1];
+			if (!next) throw new Error("Missing value after --input");
+			try {
+				const parsed = JSON.parse(next) as unknown;
+				if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+					throw new Error("input must be a JSON object");
+				}
+				input = parsed as Record<string, unknown>;
+			} catch (error) {
+				throw new Error(
+					`Invalid --input JSON: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+			i += 1;
+			continue;
+		}
+		if (token.startsWith("--input=")) {
+			const raw = token.slice("--input=".length);
+			try {
+				const parsed = JSON.parse(raw) as unknown;
+				if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+					throw new Error("input must be a JSON object");
+				}
+				input = parsed as Record<string, unknown>;
+			} catch (error) {
+				throw new Error(
+					`Invalid --input JSON: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+			continue;
+		}
+		throw new Error(`Unknown argument for "omx team api": ${token}`);
+	}
+	return { operation, input, json };
 }
 
 function slugifyTask(task: string): string {
-  return task
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 30) || 'team-task';
+	return (
+		task
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^-|-$/g, "")
+			.slice(0, 30) || "team-task"
+	);
 }
 
 function snapshotHasDeadWorkerStall(snapshot: TeamSnapshot): boolean {
-  return snapshot.deadWorkers.length > 0 && (snapshot.tasks.pending + snapshot.tasks.in_progress) > 0;
+	return (
+		snapshot.deadWorkers.length > 0 &&
+		snapshot.tasks.pending + snapshot.tasks.in_progress > 0
+	);
 }
 
-function buildDeadWorkerAwaitEvent(teamName: string, snapshot: TeamSnapshot): TeamEvent | null {
-  const deadWorker = snapshot.workers.find((worker) => worker.alive === false);
-  if (!deadWorker) return null;
-  return {
-    event_id: `snapshot-${Date.now()}`,
-    team: sanitizeTeamName(teamName),
-    type: 'worker_stopped',
-    worker: deadWorker.name,
-    task_id: deadWorker.status.current_task_id,
-    message_id: null,
-    reason: deadWorker.status.reason ?? 'dead_worker_detected_during_await',
-    created_at: deadWorker.status.updated_at || new Date().toISOString(),
-    source_type: 'await_snapshot',
-  };
+function buildDeadWorkerAwaitEvent(
+	teamName: string,
+	snapshot: TeamSnapshot,
+): TeamEvent | null {
+	const deadWorker = snapshot.workers.find((worker) => worker.alive === false);
+	if (!deadWorker) return null;
+	return {
+		event_id: `snapshot-${Date.now()}`,
+		team: sanitizeTeamName(teamName),
+		type: "worker_stopped",
+		worker: deadWorker.name,
+		task_id: deadWorker.status.current_task_id,
+		message_id: null,
+		reason: deadWorker.status.reason ?? "dead_worker_detected_during_await",
+		created_at: deadWorker.status.updated_at || new Date().toISOString(),
+		source_type: "await_snapshot",
+	};
 }
-
 
 function renderTeamPaneStatus(
-  paneStatus: Awaited<ReturnType<typeof readTeamPaneStatus>>,
+	paneStatus: Awaited<ReturnType<typeof readTeamPaneStatus>>,
 ): void {
-  if (paneStatus.leader_pane_id || paneStatus.hud_pane_id) {
-    console.log(`panes: leader=${paneStatus.leader_pane_id || '-'} hud=${paneStatus.hud_pane_id || '-'}`);
-  }
+	if (paneStatus.leader_pane_id || paneStatus.hud_pane_id) {
+		console.log(
+			`panes: leader=${paneStatus.leader_pane_id || "-"} hud=${paneStatus.hud_pane_id || "-"}`,
+		);
+	}
 
-  const workerPanePairs = Object.entries(paneStatus.worker_panes).map(([workerName, paneId]) => `${workerName}=${paneId}`);
-  if (workerPanePairs.length > 0) {
-    console.log(`worker_panes: ${workerPanePairs.join(' ')}`);
-  }
+	const workerPanePairs = Object.entries(paneStatus.worker_panes).map(
+		([workerName, paneId]) => `${workerName}=${paneId}`,
+	);
+	if (workerPanePairs.length > 0) {
+		console.log(`worker_panes: ${workerPanePairs.join(" ")}`);
+	}
 
-  if (paneStatus.sparkshell_hint) {
-    console.log('sparkshell_hint: omx sparkshell --tmux-pane <pane-id> --tail-lines 400');
-  }
+	if (paneStatus.sparkshell_hint) {
+		console.log(
+			"sparkshell_hint: omx sparkshell --tmux-pane <pane-id> --tail-lines 400",
+		);
+	}
 
-  if (paneStatus.recommended_inspect_targets.length > 0) {
-    console.log(`recommended_inspect_targets: ${paneStatus.recommended_inspect_targets.join(' ')}`);
-  }
-  for (const [target, reason] of Object.entries(paneStatus.recommended_inspect_reasons)) {
-    console.log(`inspect_reason_${target}: ${reason}`);
-  }
-  for (const [target, workerCli] of Object.entries(paneStatus.recommended_inspect_clis)) {
-    if (workerCli) {
-      console.log(`inspect_cli_${target}: ${workerCli}`);
-    }
-  }
-  for (const [target, role] of Object.entries(paneStatus.recommended_inspect_roles)) {
-    if (role) {
-      console.log(`inspect_role_${target}: ${role}`);
-    }
-  }
-  for (const [target, index] of Object.entries(paneStatus.recommended_inspect_indexes)) {
-    if (typeof index === 'number') {
-      console.log(`inspect_index_${target}: ${index}`);
-    }
-  }
-  for (const [target, alive] of Object.entries(paneStatus.recommended_inspect_alive)) {
-    if (typeof alive === 'boolean') {
-      console.log(`inspect_alive_${target}: ${alive}`);
-    }
-  }
-  for (const [target, turnCount] of Object.entries(paneStatus.recommended_inspect_turn_counts)) {
-    if (typeof turnCount === 'number') {
-      console.log(`inspect_turn_count_${target}: ${turnCount}`);
-    }
-  }
-  for (const [target, turnsWithoutProgress] of Object.entries(paneStatus.recommended_inspect_turns_without_progress)) {
-    if (typeof turnsWithoutProgress === 'number') {
-      console.log(`inspect_turns_without_progress_${target}: ${turnsWithoutProgress}`);
-    }
-  }
-  for (const [target, lastTurnAt] of Object.entries(paneStatus.recommended_inspect_last_turn_at)) {
-    if (lastTurnAt) {
-      console.log(`inspect_last_turn_at_${target}: ${lastTurnAt}`);
-    }
-  }
-  for (const [target, statusUpdatedAt] of Object.entries(paneStatus.recommended_inspect_status_updated_at)) {
-    if (statusUpdatedAt) {
-      console.log(`inspect_status_updated_at_${target}: ${statusUpdatedAt}`);
-    }
-  }
-  for (const [target, pid] of Object.entries(paneStatus.recommended_inspect_pids)) {
-    if (typeof pid === 'number') {
-      console.log(`inspect_pid_${target}: ${pid}`);
-    }
-  }
-  for (const [target, worktreePath] of Object.entries(paneStatus.recommended_inspect_worktree_paths)) {
-    if (worktreePath) {
-      console.log(`inspect_worktree_path_${target}: ${worktreePath}`);
-    }
-  }
-  for (const [target, worktreeRepoRoot] of Object.entries(paneStatus.recommended_inspect_worktree_repo_roots)) {
-    if (worktreeRepoRoot) {
-      console.log(`inspect_worktree_repo_root_${target}: ${worktreeRepoRoot}`);
-    }
-  }
-  for (const [target, worktreeBranch] of Object.entries(paneStatus.recommended_inspect_worktree_branches)) {
-    if (worktreeBranch) {
-      console.log(`inspect_worktree_branch_${target}: ${worktreeBranch}`);
-    }
-  }
-  for (const [target, worktreeDetached] of Object.entries(paneStatus.recommended_inspect_worktree_detached)) {
-    if (typeof worktreeDetached === 'boolean') {
-      console.log(`inspect_worktree_detached_${target}: ${worktreeDetached}`);
-    }
-  }
-  for (const [target, worktreeCreated] of Object.entries(paneStatus.recommended_inspect_worktree_created)) {
-    if (typeof worktreeCreated === 'boolean') {
-      console.log(`inspect_worktree_created_${target}: ${worktreeCreated}`);
-    }
-  }
-  for (const [target, teamStateRoot] of Object.entries(paneStatus.recommended_inspect_team_state_roots)) {
-    if (teamStateRoot) {
-      console.log(`inspect_team_state_root_${target}: ${teamStateRoot}`);
-    }
-  }
-  for (const [target, workdir] of Object.entries(paneStatus.recommended_inspect_workdirs)) {
-    if (workdir) {
-      console.log(`inspect_workdir_${target}: ${workdir}`);
-    }
-  }
-  for (const [target, assignedTasks] of Object.entries(paneStatus.recommended_inspect_assigned_tasks)) {
-    if (assignedTasks.length > 0) {
-      console.log(`inspect_assigned_tasks_${target}: ${assignedTasks.join(' ')}`);
-    }
-  }
-  for (const [target, taskStatus] of Object.entries(paneStatus.recommended_inspect_task_statuses)) {
-    if (taskStatus) {
-      console.log(`inspect_task_status_${target}: ${taskStatus}`);
-    }
-  }
-  for (const [target, taskResult] of Object.entries(paneStatus.recommended_inspect_task_results)) {
-    if (taskResult) {
-      console.log(`inspect_task_result_${target}: ${taskResult}`);
-    }
-  }
-  for (const [target, taskError] of Object.entries(paneStatus.recommended_inspect_task_errors)) {
-    if (taskError) {
-      console.log(`inspect_task_error_${target}: ${taskError}`);
-    }
-  }
-  for (const [target, taskVersion] of Object.entries(paneStatus.recommended_inspect_task_versions)) {
-    if (typeof taskVersion === 'number') {
-      console.log(`inspect_task_version_${target}: ${taskVersion}`);
-    }
-  }
-  for (const [target, taskCreatedAt] of Object.entries(paneStatus.recommended_inspect_task_created_at)) {
-    if (taskCreatedAt) {
-      console.log(`inspect_task_created_at_${target}: ${taskCreatedAt}`);
-    }
-  }
-  for (const [target, taskCompletedAt] of Object.entries(paneStatus.recommended_inspect_task_completed_at)) {
-    if (taskCompletedAt) {
-      console.log(`inspect_task_completed_at_${target}: ${taskCompletedAt}`);
-    }
-  }
-  for (const [target, taskDependsOn] of Object.entries(paneStatus.recommended_inspect_task_depends_on)) {
-    if (taskDependsOn.length > 0) {
-      console.log(`inspect_task_depends_on_${target}: ${taskDependsOn.join(' ')}`);
-    }
-  }
-  for (const [target, taskClaimPresent] of Object.entries(paneStatus.recommended_inspect_task_claim_present)) {
-    if (typeof taskClaimPresent === 'boolean') {
-      console.log(`inspect_task_claim_present_${target}: ${taskClaimPresent}`);
-    }
-  }
-  for (const [target, taskClaimOwner] of Object.entries(paneStatus.recommended_inspect_task_claim_owners)) {
-    if (taskClaimOwner) {
-      console.log(`inspect_task_claim_owner_${target}: ${taskClaimOwner}`);
-    }
-  }
-  for (const [target, taskClaimToken] of Object.entries(paneStatus.recommended_inspect_task_claim_tokens)) {
-    if (taskClaimToken) {
-      console.log(`inspect_task_claim_token_${target}: ${taskClaimToken}`);
-    }
-  }
-  for (const [target, taskClaimLease] of Object.entries(paneStatus.recommended_inspect_task_claim_leases)) {
-    if (taskClaimLease) {
-      console.log(`inspect_task_claim_leased_until_${target}: ${taskClaimLease}`);
-    }
-  }
-  for (const [target, taskClaimLockPath] of Object.entries(paneStatus.recommended_inspect_task_claim_lock_paths)) {
-    if (taskClaimLockPath) {
-      console.log(`inspect_task_claim_lock_path_${target}: ${taskClaimLockPath}`);
-    }
-  }
-  for (const [target, approvalRequired] of Object.entries(paneStatus.recommended_inspect_approval_required)) {
-    if (typeof approvalRequired === 'boolean') {
-      console.log(`inspect_approval_required_${target}: ${approvalRequired}`);
-    }
-  }
-  for (const [target, requiresCodeChange] of Object.entries(paneStatus.recommended_inspect_requires_code_change)) {
-    if (typeof requiresCodeChange === 'boolean') {
-      console.log(`inspect_requires_code_change_${target}: ${requiresCodeChange}`);
-    }
-  }
-  for (const [target, description] of Object.entries(paneStatus.recommended_inspect_descriptions)) {
-    if (description) {
-      console.log(`inspect_description_${target}: ${description}`);
-    }
-  }
-  for (const [target, blockedBy] of Object.entries(paneStatus.recommended_inspect_blocked_by)) {
-    if (blockedBy.length > 0) {
-      console.log(`inspect_blocked_by_${target}: ${blockedBy.join(' ')}`);
-    }
-  }
-  for (const [target, taskRole] of Object.entries(paneStatus.recommended_inspect_task_roles)) {
-    if (taskRole) {
-      console.log(`inspect_task_role_${target}: ${taskRole}`);
-    }
-  }
-  for (const [target, taskOwner] of Object.entries(paneStatus.recommended_inspect_task_owners)) {
-    if (taskOwner) {
-      console.log(`inspect_task_owner_${target}: ${taskOwner}`);
-    }
-  }
-  for (const [target, approvalStatus] of Object.entries(paneStatus.recommended_inspect_approval_statuses)) {
-    if (approvalStatus) {
-      console.log(`inspect_approval_status_${target}: ${approvalStatus}`);
-    }
-  }
-  for (const [target, approvalReviewer] of Object.entries(paneStatus.recommended_inspect_approval_reviewers)) {
-    if (approvalReviewer) {
-      console.log(`inspect_approval_reviewer_${target}: ${approvalReviewer}`);
-    }
-  }
-  for (const [target, approvalReason] of Object.entries(paneStatus.recommended_inspect_approval_reasons)) {
-    if (approvalReason) {
-      console.log(`inspect_approval_reason_${target}: ${approvalReason}`);
-    }
-  }
-  for (const [target, approvalDecidedAt] of Object.entries(paneStatus.recommended_inspect_approval_decided_at)) {
-    if (approvalDecidedAt) {
-      console.log(`inspect_approval_decided_at_${target}: ${approvalDecidedAt}`);
-    }
-  }
-  for (const [target, approvalRecordPresent] of Object.entries(paneStatus.recommended_inspect_approval_record_present)) {
-    if (typeof approvalRecordPresent === 'boolean') {
-      console.log(`inspect_approval_record_present_${target}: ${approvalRecordPresent}`);
-    }
-  }
-  for (const [target, state] of Object.entries(paneStatus.recommended_inspect_states)) {
-    if (state) {
-      console.log(`inspect_state_${target}: ${state}`);
-    }
-  }
-  for (const [target, stateReason] of Object.entries(paneStatus.recommended_inspect_state_reasons)) {
-    if (stateReason) {
-      console.log(`inspect_state_reason_${target}: ${stateReason}`);
-    }
-  }
-  for (const [target, taskId] of Object.entries(paneStatus.recommended_inspect_tasks)) {
-    if (taskId) {
-      console.log(`inspect_task_${target}: ${taskId}`);
-    }
-  }
-  for (const [target, subject] of Object.entries(paneStatus.recommended_inspect_subjects)) {
-    if (subject) {
-      console.log(`inspect_subject_${target}: ${subject}`);
-    }
-  }
-  for (const [target, taskPath] of Object.entries(paneStatus.recommended_inspect_task_paths)) {
-    if (taskPath) {
-      console.log(`inspect_task_path_${target}: ${taskPath}`);
-    }
-  }
-  for (const [target, approvalPath] of Object.entries(paneStatus.recommended_inspect_approval_paths)) {
-    if (approvalPath) {
-      console.log(`inspect_approval_path_${target}: ${approvalPath}`);
-    }
-  }
-  for (const [target, workerStateDir] of Object.entries(paneStatus.recommended_inspect_worker_state_dirs)) {
-    if (workerStateDir) {
-      console.log(`inspect_worker_state_dir_${target}: ${workerStateDir}`);
-    }
-  }
-  for (const [target, workerStatusPath] of Object.entries(paneStatus.recommended_inspect_worker_status_paths)) {
-    if (workerStatusPath) {
-      console.log(`inspect_worker_status_path_${target}: ${workerStatusPath}`);
-    }
-  }
-  for (const [target, workerHeartbeatPath] of Object.entries(paneStatus.recommended_inspect_worker_heartbeat_paths)) {
-    if (workerHeartbeatPath) {
-      console.log(`inspect_worker_heartbeat_path_${target}: ${workerHeartbeatPath}`);
-    }
-  }
-  for (const [target, workerIdentityPath] of Object.entries(paneStatus.recommended_inspect_worker_identity_paths)) {
-    if (workerIdentityPath) {
-      console.log(`inspect_worker_identity_path_${target}: ${workerIdentityPath}`);
-    }
-  }
-  for (const [target, workerInboxPath] of Object.entries(paneStatus.recommended_inspect_worker_inbox_paths)) {
-    if (workerInboxPath) {
-      console.log(`inspect_worker_inbox_path_${target}: ${workerInboxPath}`);
-    }
-  }
-  for (const [target, workerMailboxPath] of Object.entries(paneStatus.recommended_inspect_worker_mailbox_paths)) {
-    if (workerMailboxPath) {
-      console.log(`inspect_worker_mailbox_path_${target}: ${workerMailboxPath}`);
-    }
-  }
-  for (const [target, workerShutdownRequestPath] of Object.entries(paneStatus.recommended_inspect_worker_shutdown_request_paths)) {
-    if (workerShutdownRequestPath) {
-      console.log(`inspect_worker_shutdown_request_path_${target}: ${workerShutdownRequestPath}`);
-    }
-  }
-  for (const [target, workerShutdownAckPath] of Object.entries(paneStatus.recommended_inspect_worker_shutdown_ack_paths)) {
-    if (workerShutdownAckPath) {
-      console.log(`inspect_worker_shutdown_ack_path_${target}: ${workerShutdownAckPath}`);
-    }
-  }
-  for (const [target, teamDirPath] of Object.entries(paneStatus.recommended_inspect_team_dir_paths)) {
-    if (teamDirPath) {
-      console.log(`inspect_team_dir_path_${target}: ${teamDirPath}`);
-    }
-  }
-  for (const [target, teamConfigPath] of Object.entries(paneStatus.recommended_inspect_team_config_paths)) {
-    if (teamConfigPath) {
-      console.log(`inspect_team_config_path_${target}: ${teamConfigPath}`);
-    }
-  }
-  for (const [target, teamManifestPath] of Object.entries(paneStatus.recommended_inspect_team_manifest_paths)) {
-    if (teamManifestPath) {
-      console.log(`inspect_team_manifest_path_${target}: ${teamManifestPath}`);
-    }
-  }
-  for (const [target, teamEventsPath] of Object.entries(paneStatus.recommended_inspect_team_events_paths)) {
-    if (teamEventsPath) {
-      console.log(`inspect_team_events_path_${target}: ${teamEventsPath}`);
-    }
-  }
-  for (const [target, teamDispatchPath] of Object.entries(paneStatus.recommended_inspect_team_dispatch_paths)) {
-    if (teamDispatchPath) {
-      console.log(`inspect_team_dispatch_path_${target}: ${teamDispatchPath}`);
-    }
-  }
-  for (const [target, teamPhasePath] of Object.entries(paneStatus.recommended_inspect_team_phase_paths)) {
-    if (teamPhasePath) {
-      console.log(`inspect_team_phase_path_${target}: ${teamPhasePath}`);
-    }
-  }
-  for (const [target, teamMonitorSnapshotPath] of Object.entries(paneStatus.recommended_inspect_team_monitor_snapshot_paths)) {
-    if (teamMonitorSnapshotPath) {
-      console.log(`inspect_team_monitor_snapshot_path_${target}: ${teamMonitorSnapshotPath}`);
-    }
-  }
-  for (const [target, teamSummarySnapshotPath] of Object.entries(paneStatus.recommended_inspect_team_summary_snapshot_paths)) {
-    if (teamSummarySnapshotPath) {
-      console.log(`inspect_team_summary_snapshot_path_${target}: ${teamSummarySnapshotPath}`);
-    }
-  }
-  for (const [target, paneId] of Object.entries(paneStatus.recommended_inspect_panes)) {
-    if (paneId) {
-      console.log(`inspect_pane_${target}: ${paneId}`);
-    }
-  }
-  if (paneStatus.recommended_inspect_command) {
-    console.log(`inspect_next: ${paneStatus.recommended_inspect_command}`);
-  }
-  if (paneStatus.recommended_inspect_summary) {
-    console.log(`inspect_summary: ${paneStatus.recommended_inspect_summary}`);
-  }
-  for (const [index, command] of paneStatus.recommended_inspect_commands.entries()) {
-    console.log(`inspect_priority_${index + 1}: ${command}`);
-  }
-  for (const [index, item] of paneStatus.recommended_inspect_items.entries()) {
-    const panePart = item.pane_id ? ` pane=${item.pane_id}` : '';
-    const cliPart = item.worker_cli ? ` cli=${item.worker_cli}` : '';
-    const rolePart = item.role ? ` role=${item.role}` : '';
-    const indexPart = typeof item.index === 'number' ? ` index=${item.index}` : '';
-    const alivePart = typeof item.alive === 'boolean' ? ` alive=${item.alive}` : '';
-    const turnCountPart = typeof item.turn_count === 'number' ? ` turn_count=${item.turn_count}` : '';
-    const turnsWithoutProgressPart = typeof item.turns_without_progress === 'number'
-      ? ` turns_without_progress=${item.turns_without_progress}`
-      : '';
-    const lastTurnPart = item.last_turn_at ? ` last_turn_at=${item.last_turn_at}` : '';
-    const statusUpdatedPart = item.status_updated_at ? ` status_updated_at=${item.status_updated_at}` : '';
-    const pidPart = typeof item.pid === 'number' ? ` pid=${item.pid}` : '';
-    const worktreeRepoRootPart = item.worktree_repo_root ? ` worktree_repo_root=${item.worktree_repo_root}` : '';
-    const worktreePathPart = item.worktree_path ? ` worktree_path=${item.worktree_path}` : '';
-    const worktreeBranchPart = item.worktree_branch ? ` worktree_branch=${item.worktree_branch}` : '';
-    const worktreeDetachedPart = typeof item.worktree_detached === 'boolean'
-      ? ` worktree_detached=${item.worktree_detached}`
-      : '';
-    const worktreeCreatedPart = typeof item.worktree_created === 'boolean'
-      ? ` worktree_created=${item.worktree_created}`
-      : '';
-    const teamStateRootPart = item.team_state_root ? ` team_state_root=${item.team_state_root}` : '';
-    const workdirPart = item.working_dir ? ` workdir=${item.working_dir}` : '';
-    const assignedTasksPart = item.assigned_tasks.length > 0 ? ` assigned_tasks=${item.assigned_tasks.join(',')}` : '';
-    const taskStatusPart = item.task_status ? ` task_status=${item.task_status}` : '';
-    const taskResultPart = item.task_result ? ` task_result=${item.task_result}` : '';
-    const taskErrorPart = item.task_error ? ` task_error=${item.task_error}` : '';
-    const taskVersionPart = typeof item.task_version === 'number' ? ` task_version=${item.task_version}` : '';
-    const taskCreatedAtPart = item.task_created_at ? ` task_created_at=${item.task_created_at}` : '';
-    const taskCompletedAtPart = item.task_completed_at ? ` task_completed_at=${item.task_completed_at}` : '';
-    const taskDependsOnPart = item.task_depends_on.length > 0 ? ` task_depends_on=${item.task_depends_on.join(',')}` : '';
-    const taskClaimPresentPart = typeof item.task_claim_present === 'boolean'
-      ? ` task_claim_present=${item.task_claim_present}`
-      : '';
-    const taskClaimOwnerPart = item.task_claim_owner ? ` task_claim_owner=${item.task_claim_owner}` : '';
-    const taskClaimTokenPart = item.task_claim_token ? ` task_claim_token=${item.task_claim_token}` : '';
-    const taskClaimLeasePart = item.task_claim_leased_until ? ` task_claim_leased_until=${item.task_claim_leased_until}` : '';
-    const taskClaimLockPathPart = item.task_claim_lock_path ? ` task_claim_lock_path=${item.task_claim_lock_path}` : '';
-    const approvalRequiredPart = typeof item.approval_required === 'boolean' ? ` approval_required=${item.approval_required}` : '';
-    const requiresCodeChangePart = typeof item.requires_code_change === 'boolean'
-      ? ` requires_code_change=${item.requires_code_change}`
-      : '';
-    const taskDescriptionPart = item.task_description ? ` description=${item.task_description}` : '';
-    const blockedByPart = item.blocked_by.length > 0 ? ` blocked_by=${item.blocked_by.join(',')}` : '';
-    const taskRolePart = item.task_role ? ` task_role=${item.task_role}` : '';
-    const taskOwnerPart = item.task_owner ? ` task_owner=${item.task_owner}` : '';
-    const approvalStatusPart = item.approval_status ? ` approval_status=${item.approval_status}` : '';
-    const approvalReviewerPart = item.approval_reviewer ? ` approval_reviewer=${item.approval_reviewer}` : '';
-    const approvalReasonPart = item.approval_reason ? ` approval_reason=${item.approval_reason}` : '';
-    const approvalDecidedAtPart = item.approval_decided_at ? ` approval_decided_at=${item.approval_decided_at}` : '';
-    const approvalRecordPresentPart = typeof item.approval_record_present === 'boolean'
-      ? ` approval_record_present=${item.approval_record_present}`
-      : '';
-    const statePart = item.state ? ` state=${item.state}` : '';
-    const stateReasonPart = item.state_reason ? ` state_reason=${item.state_reason}` : '';
-    const taskPart = item.task_id ? ` task=${item.task_id}` : '';
-    const subjectPart = item.task_subject ? ` subject=${item.task_subject}` : '';
-    const taskPathPart = item.task_path ? ` task_path=${item.task_path}` : '';
-    const approvalPathPart = item.approval_path ? ` approval_path=${item.approval_path}` : '';
-    const workerStateDirPart = item.worker_state_dir ? ` worker_state_dir=${item.worker_state_dir}` : '';
-    const workerStatusPathPart = item.worker_status_path ? ` worker_status_path=${item.worker_status_path}` : '';
-    const workerHeartbeatPathPart = item.worker_heartbeat_path ? ` worker_heartbeat_path=${item.worker_heartbeat_path}` : '';
-    const workerIdentityPathPart = item.worker_identity_path ? ` worker_identity_path=${item.worker_identity_path}` : '';
-    const workerInboxPathPart = item.worker_inbox_path ? ` worker_inbox_path=${item.worker_inbox_path}` : '';
-    const workerMailboxPathPart = item.worker_mailbox_path ? ` worker_mailbox_path=${item.worker_mailbox_path}` : '';
-    const workerShutdownRequestPathPart = item.worker_shutdown_request_path ? ` worker_shutdown_request_path=${item.worker_shutdown_request_path}` : '';
-    const workerShutdownAckPathPart = item.worker_shutdown_ack_path ? ` worker_shutdown_ack_path=${item.worker_shutdown_ack_path}` : '';
-    const teamDirPathPart = item.team_dir_path ? ` team_dir_path=${item.team_dir_path}` : '';
-    const teamConfigPathPart = item.team_config_path ? ` team_config_path=${item.team_config_path}` : '';
-    const teamManifestPathPart = item.team_manifest_path ? ` team_manifest_path=${item.team_manifest_path}` : '';
-    const teamEventsPathPart = item.team_events_path ? ` team_events_path=${item.team_events_path}` : '';
-    const teamDispatchPathPart = item.team_dispatch_path ? ` team_dispatch_path=${item.team_dispatch_path}` : '';
-    const teamPhasePathPart = item.team_phase_path ? ` team_phase_path=${item.team_phase_path}` : '';
-    const teamMonitorSnapshotPathPart = item.team_monitor_snapshot_path ? ` team_monitor_snapshot_path=${item.team_monitor_snapshot_path}` : '';
-    const teamSummarySnapshotPathPart = item.team_summary_snapshot_path ? ` team_summary_snapshot_path=${item.team_summary_snapshot_path}` : '';
-    console.log(`inspect_item_${index + 1}: target=${item.target}${panePart}${cliPart}${rolePart}${indexPart}${alivePart}${turnCountPart}${turnsWithoutProgressPart}${lastTurnPart}${statusUpdatedPart}${pidPart}${worktreeRepoRootPart}${worktreePathPart}${worktreeBranchPart}${worktreeDetachedPart}${worktreeCreatedPart}${teamStateRootPart}${workdirPart}${assignedTasksPart}${taskStatusPart}${taskResultPart}${taskErrorPart}${taskVersionPart}${taskCreatedAtPart}${taskCompletedAtPart}${taskDependsOnPart}${taskClaimPresentPart}${taskClaimOwnerPart}${taskClaimTokenPart}${taskClaimLeasePart}${taskClaimLockPathPart}${approvalRequiredPart}${requiresCodeChangePart}${taskDescriptionPart}${blockedByPart}${taskRolePart}${taskOwnerPart}${approvalStatusPart}${approvalReviewerPart}${approvalReasonPart}${approvalDecidedAtPart}${approvalRecordPresentPart}${stateReasonPart}${taskPart}${subjectPart}${taskPathPart}${approvalPathPart}${workerStateDirPart}${workerStatusPathPart}${workerHeartbeatPathPart}${workerIdentityPathPart}${workerInboxPathPart}${workerMailboxPathPart}${workerShutdownRequestPathPart}${workerShutdownAckPathPart}${teamDirPathPart}${teamConfigPathPart}${teamManifestPathPart}${teamEventsPathPart}${teamDispatchPathPart}${teamPhasePathPart}${teamMonitorSnapshotPathPart}${teamSummarySnapshotPathPart} reason=${item.reason}${statePart} command=${item.command}`);
-  }
+	if (paneStatus.recommended_inspect_targets.length > 0) {
+		console.log(
+			`recommended_inspect_targets: ${paneStatus.recommended_inspect_targets.join(" ")}`,
+		);
+	}
+	for (const [target, reason] of Object.entries(
+		paneStatus.recommended_inspect_reasons,
+	)) {
+		console.log(`inspect_reason_${target}: ${reason}`);
+	}
+	for (const [target, workerCli] of Object.entries(
+		paneStatus.recommended_inspect_clis,
+	)) {
+		if (workerCli) {
+			console.log(`inspect_cli_${target}: ${workerCli}`);
+		}
+	}
+	for (const [target, role] of Object.entries(
+		paneStatus.recommended_inspect_roles,
+	)) {
+		if (role) {
+			console.log(`inspect_role_${target}: ${role}`);
+		}
+	}
+	for (const [target, index] of Object.entries(
+		paneStatus.recommended_inspect_indexes,
+	)) {
+		if (typeof index === "number") {
+			console.log(`inspect_index_${target}: ${index}`);
+		}
+	}
+	for (const [target, alive] of Object.entries(
+		paneStatus.recommended_inspect_alive,
+	)) {
+		if (typeof alive === "boolean") {
+			console.log(`inspect_alive_${target}: ${alive}`);
+		}
+	}
+	for (const [target, turnCount] of Object.entries(
+		paneStatus.recommended_inspect_turn_counts,
+	)) {
+		if (typeof turnCount === "number") {
+			console.log(`inspect_turn_count_${target}: ${turnCount}`);
+		}
+	}
+	for (const [target, turnsWithoutProgress] of Object.entries(
+		paneStatus.recommended_inspect_turns_without_progress,
+	)) {
+		if (typeof turnsWithoutProgress === "number") {
+			console.log(
+				`inspect_turns_without_progress_${target}: ${turnsWithoutProgress}`,
+			);
+		}
+	}
+	for (const [target, lastTurnAt] of Object.entries(
+		paneStatus.recommended_inspect_last_turn_at,
+	)) {
+		if (lastTurnAt) {
+			console.log(`inspect_last_turn_at_${target}: ${lastTurnAt}`);
+		}
+	}
+	for (const [target, statusUpdatedAt] of Object.entries(
+		paneStatus.recommended_inspect_status_updated_at,
+	)) {
+		if (statusUpdatedAt) {
+			console.log(`inspect_status_updated_at_${target}: ${statusUpdatedAt}`);
+		}
+	}
+	for (const [target, pid] of Object.entries(
+		paneStatus.recommended_inspect_pids,
+	)) {
+		if (typeof pid === "number") {
+			console.log(`inspect_pid_${target}: ${pid}`);
+		}
+	}
+	for (const [target, worktreePath] of Object.entries(
+		paneStatus.recommended_inspect_worktree_paths,
+	)) {
+		if (worktreePath) {
+			console.log(`inspect_worktree_path_${target}: ${worktreePath}`);
+		}
+	}
+	for (const [target, worktreeRepoRoot] of Object.entries(
+		paneStatus.recommended_inspect_worktree_repo_roots,
+	)) {
+		if (worktreeRepoRoot) {
+			console.log(`inspect_worktree_repo_root_${target}: ${worktreeRepoRoot}`);
+		}
+	}
+	for (const [target, worktreeBranch] of Object.entries(
+		paneStatus.recommended_inspect_worktree_branches,
+	)) {
+		if (worktreeBranch) {
+			console.log(`inspect_worktree_branch_${target}: ${worktreeBranch}`);
+		}
+	}
+	for (const [target, worktreeDetached] of Object.entries(
+		paneStatus.recommended_inspect_worktree_detached,
+	)) {
+		if (typeof worktreeDetached === "boolean") {
+			console.log(`inspect_worktree_detached_${target}: ${worktreeDetached}`);
+		}
+	}
+	for (const [target, worktreeCreated] of Object.entries(
+		paneStatus.recommended_inspect_worktree_created,
+	)) {
+		if (typeof worktreeCreated === "boolean") {
+			console.log(`inspect_worktree_created_${target}: ${worktreeCreated}`);
+		}
+	}
+	for (const [target, teamStateRoot] of Object.entries(
+		paneStatus.recommended_inspect_team_state_roots,
+	)) {
+		if (teamStateRoot) {
+			console.log(`inspect_team_state_root_${target}: ${teamStateRoot}`);
+		}
+	}
+	for (const [target, workdir] of Object.entries(
+		paneStatus.recommended_inspect_workdirs,
+	)) {
+		if (workdir) {
+			console.log(`inspect_workdir_${target}: ${workdir}`);
+		}
+	}
+	for (const [target, assignedTasks] of Object.entries(
+		paneStatus.recommended_inspect_assigned_tasks,
+	)) {
+		if (assignedTasks.length > 0) {
+			console.log(
+				`inspect_assigned_tasks_${target}: ${assignedTasks.join(" ")}`,
+			);
+		}
+	}
+	for (const [target, taskStatus] of Object.entries(
+		paneStatus.recommended_inspect_task_statuses,
+	)) {
+		if (taskStatus) {
+			console.log(`inspect_task_status_${target}: ${taskStatus}`);
+		}
+	}
+	for (const [target, taskResult] of Object.entries(
+		paneStatus.recommended_inspect_task_results,
+	)) {
+		if (taskResult) {
+			console.log(`inspect_task_result_${target}: ${taskResult}`);
+		}
+	}
+	for (const [target, taskError] of Object.entries(
+		paneStatus.recommended_inspect_task_errors,
+	)) {
+		if (taskError) {
+			console.log(`inspect_task_error_${target}: ${taskError}`);
+		}
+	}
+	for (const [target, taskVersion] of Object.entries(
+		paneStatus.recommended_inspect_task_versions,
+	)) {
+		if (typeof taskVersion === "number") {
+			console.log(`inspect_task_version_${target}: ${taskVersion}`);
+		}
+	}
+	for (const [target, taskCreatedAt] of Object.entries(
+		paneStatus.recommended_inspect_task_created_at,
+	)) {
+		if (taskCreatedAt) {
+			console.log(`inspect_task_created_at_${target}: ${taskCreatedAt}`);
+		}
+	}
+	for (const [target, taskCompletedAt] of Object.entries(
+		paneStatus.recommended_inspect_task_completed_at,
+	)) {
+		if (taskCompletedAt) {
+			console.log(`inspect_task_completed_at_${target}: ${taskCompletedAt}`);
+		}
+	}
+	for (const [target, taskDependsOn] of Object.entries(
+		paneStatus.recommended_inspect_task_depends_on,
+	)) {
+		if (taskDependsOn.length > 0) {
+			console.log(
+				`inspect_task_depends_on_${target}: ${taskDependsOn.join(" ")}`,
+			);
+		}
+	}
+	for (const [target, taskClaimPresent] of Object.entries(
+		paneStatus.recommended_inspect_task_claim_present,
+	)) {
+		if (typeof taskClaimPresent === "boolean") {
+			console.log(`inspect_task_claim_present_${target}: ${taskClaimPresent}`);
+		}
+	}
+	for (const [target, taskClaimOwner] of Object.entries(
+		paneStatus.recommended_inspect_task_claim_owners,
+	)) {
+		if (taskClaimOwner) {
+			console.log(`inspect_task_claim_owner_${target}: ${taskClaimOwner}`);
+		}
+	}
+	for (const [target, taskClaimToken] of Object.entries(
+		paneStatus.recommended_inspect_task_claim_tokens,
+	)) {
+		if (taskClaimToken) {
+			console.log(`inspect_task_claim_token_${target}: ${taskClaimToken}`);
+		}
+	}
+	for (const [target, taskClaimLease] of Object.entries(
+		paneStatus.recommended_inspect_task_claim_leases,
+	)) {
+		if (taskClaimLease) {
+			console.log(
+				`inspect_task_claim_leased_until_${target}: ${taskClaimLease}`,
+			);
+		}
+	}
+	for (const [target, taskClaimLockPath] of Object.entries(
+		paneStatus.recommended_inspect_task_claim_lock_paths,
+	)) {
+		if (taskClaimLockPath) {
+			console.log(
+				`inspect_task_claim_lock_path_${target}: ${taskClaimLockPath}`,
+			);
+		}
+	}
+	for (const [target, approvalRequired] of Object.entries(
+		paneStatus.recommended_inspect_approval_required,
+	)) {
+		if (typeof approvalRequired === "boolean") {
+			console.log(`inspect_approval_required_${target}: ${approvalRequired}`);
+		}
+	}
+	for (const [target, requiresCodeChange] of Object.entries(
+		paneStatus.recommended_inspect_requires_code_change,
+	)) {
+		if (typeof requiresCodeChange === "boolean") {
+			console.log(
+				`inspect_requires_code_change_${target}: ${requiresCodeChange}`,
+			);
+		}
+	}
+	for (const [target, description] of Object.entries(
+		paneStatus.recommended_inspect_descriptions,
+	)) {
+		if (description) {
+			console.log(`inspect_description_${target}: ${description}`);
+		}
+	}
+	for (const [target, blockedBy] of Object.entries(
+		paneStatus.recommended_inspect_blocked_by,
+	)) {
+		if (blockedBy.length > 0) {
+			console.log(`inspect_blocked_by_${target}: ${blockedBy.join(" ")}`);
+		}
+	}
+	for (const [target, taskRole] of Object.entries(
+		paneStatus.recommended_inspect_task_roles,
+	)) {
+		if (taskRole) {
+			console.log(`inspect_task_role_${target}: ${taskRole}`);
+		}
+	}
+	for (const [target, taskOwner] of Object.entries(
+		paneStatus.recommended_inspect_task_owners,
+	)) {
+		if (taskOwner) {
+			console.log(`inspect_task_owner_${target}: ${taskOwner}`);
+		}
+	}
+	for (const [target, approvalStatus] of Object.entries(
+		paneStatus.recommended_inspect_approval_statuses,
+	)) {
+		if (approvalStatus) {
+			console.log(`inspect_approval_status_${target}: ${approvalStatus}`);
+		}
+	}
+	for (const [target, approvalReviewer] of Object.entries(
+		paneStatus.recommended_inspect_approval_reviewers,
+	)) {
+		if (approvalReviewer) {
+			console.log(`inspect_approval_reviewer_${target}: ${approvalReviewer}`);
+		}
+	}
+	for (const [target, approvalReason] of Object.entries(
+		paneStatus.recommended_inspect_approval_reasons,
+	)) {
+		if (approvalReason) {
+			console.log(`inspect_approval_reason_${target}: ${approvalReason}`);
+		}
+	}
+	for (const [target, approvalDecidedAt] of Object.entries(
+		paneStatus.recommended_inspect_approval_decided_at,
+	)) {
+		if (approvalDecidedAt) {
+			console.log(
+				`inspect_approval_decided_at_${target}: ${approvalDecidedAt}`,
+			);
+		}
+	}
+	for (const [target, approvalRecordPresent] of Object.entries(
+		paneStatus.recommended_inspect_approval_record_present,
+	)) {
+		if (typeof approvalRecordPresent === "boolean") {
+			console.log(
+				`inspect_approval_record_present_${target}: ${approvalRecordPresent}`,
+			);
+		}
+	}
+	for (const [target, state] of Object.entries(
+		paneStatus.recommended_inspect_states,
+	)) {
+		if (state) {
+			console.log(`inspect_state_${target}: ${state}`);
+		}
+	}
+	for (const [target, stateReason] of Object.entries(
+		paneStatus.recommended_inspect_state_reasons,
+	)) {
+		if (stateReason) {
+			console.log(`inspect_state_reason_${target}: ${stateReason}`);
+		}
+	}
+	for (const [target, taskId] of Object.entries(
+		paneStatus.recommended_inspect_tasks,
+	)) {
+		if (taskId) {
+			console.log(`inspect_task_${target}: ${taskId}`);
+		}
+	}
+	for (const [target, subject] of Object.entries(
+		paneStatus.recommended_inspect_subjects,
+	)) {
+		if (subject) {
+			console.log(`inspect_subject_${target}: ${subject}`);
+		}
+	}
+	for (const [target, taskPath] of Object.entries(
+		paneStatus.recommended_inspect_task_paths,
+	)) {
+		if (taskPath) {
+			console.log(`inspect_task_path_${target}: ${taskPath}`);
+		}
+	}
+	for (const [target, approvalPath] of Object.entries(
+		paneStatus.recommended_inspect_approval_paths,
+	)) {
+		if (approvalPath) {
+			console.log(`inspect_approval_path_${target}: ${approvalPath}`);
+		}
+	}
+	for (const [target, workerStateDir] of Object.entries(
+		paneStatus.recommended_inspect_worker_state_dirs,
+	)) {
+		if (workerStateDir) {
+			console.log(`inspect_worker_state_dir_${target}: ${workerStateDir}`);
+		}
+	}
+	for (const [target, workerStatusPath] of Object.entries(
+		paneStatus.recommended_inspect_worker_status_paths,
+	)) {
+		if (workerStatusPath) {
+			console.log(`inspect_worker_status_path_${target}: ${workerStatusPath}`);
+		}
+	}
+	for (const [target, workerHeartbeatPath] of Object.entries(
+		paneStatus.recommended_inspect_worker_heartbeat_paths,
+	)) {
+		if (workerHeartbeatPath) {
+			console.log(
+				`inspect_worker_heartbeat_path_${target}: ${workerHeartbeatPath}`,
+			);
+		}
+	}
+	for (const [target, workerIdentityPath] of Object.entries(
+		paneStatus.recommended_inspect_worker_identity_paths,
+	)) {
+		if (workerIdentityPath) {
+			console.log(
+				`inspect_worker_identity_path_${target}: ${workerIdentityPath}`,
+			);
+		}
+	}
+	for (const [target, workerInboxPath] of Object.entries(
+		paneStatus.recommended_inspect_worker_inbox_paths,
+	)) {
+		if (workerInboxPath) {
+			console.log(`inspect_worker_inbox_path_${target}: ${workerInboxPath}`);
+		}
+	}
+	for (const [target, workerMailboxPath] of Object.entries(
+		paneStatus.recommended_inspect_worker_mailbox_paths,
+	)) {
+		if (workerMailboxPath) {
+			console.log(
+				`inspect_worker_mailbox_path_${target}: ${workerMailboxPath}`,
+			);
+		}
+	}
+	for (const [target, workerShutdownRequestPath] of Object.entries(
+		paneStatus.recommended_inspect_worker_shutdown_request_paths,
+	)) {
+		if (workerShutdownRequestPath) {
+			console.log(
+				`inspect_worker_shutdown_request_path_${target}: ${workerShutdownRequestPath}`,
+			);
+		}
+	}
+	for (const [target, workerShutdownAckPath] of Object.entries(
+		paneStatus.recommended_inspect_worker_shutdown_ack_paths,
+	)) {
+		if (workerShutdownAckPath) {
+			console.log(
+				`inspect_worker_shutdown_ack_path_${target}: ${workerShutdownAckPath}`,
+			);
+		}
+	}
+	for (const [target, teamDirPath] of Object.entries(
+		paneStatus.recommended_inspect_team_dir_paths,
+	)) {
+		if (teamDirPath) {
+			console.log(`inspect_team_dir_path_${target}: ${teamDirPath}`);
+		}
+	}
+	for (const [target, teamConfigPath] of Object.entries(
+		paneStatus.recommended_inspect_team_config_paths,
+	)) {
+		if (teamConfigPath) {
+			console.log(`inspect_team_config_path_${target}: ${teamConfigPath}`);
+		}
+	}
+	for (const [target, teamManifestPath] of Object.entries(
+		paneStatus.recommended_inspect_team_manifest_paths,
+	)) {
+		if (teamManifestPath) {
+			console.log(`inspect_team_manifest_path_${target}: ${teamManifestPath}`);
+		}
+	}
+	for (const [target, teamEventsPath] of Object.entries(
+		paneStatus.recommended_inspect_team_events_paths,
+	)) {
+		if (teamEventsPath) {
+			console.log(`inspect_team_events_path_${target}: ${teamEventsPath}`);
+		}
+	}
+	for (const [target, teamDispatchPath] of Object.entries(
+		paneStatus.recommended_inspect_team_dispatch_paths,
+	)) {
+		if (teamDispatchPath) {
+			console.log(`inspect_team_dispatch_path_${target}: ${teamDispatchPath}`);
+		}
+	}
+	for (const [target, teamPhasePath] of Object.entries(
+		paneStatus.recommended_inspect_team_phase_paths,
+	)) {
+		if (teamPhasePath) {
+			console.log(`inspect_team_phase_path_${target}: ${teamPhasePath}`);
+		}
+	}
+	for (const [target, teamMonitorSnapshotPath] of Object.entries(
+		paneStatus.recommended_inspect_team_monitor_snapshot_paths,
+	)) {
+		if (teamMonitorSnapshotPath) {
+			console.log(
+				`inspect_team_monitor_snapshot_path_${target}: ${teamMonitorSnapshotPath}`,
+			);
+		}
+	}
+	for (const [target, teamSummarySnapshotPath] of Object.entries(
+		paneStatus.recommended_inspect_team_summary_snapshot_paths,
+	)) {
+		if (teamSummarySnapshotPath) {
+			console.log(
+				`inspect_team_summary_snapshot_path_${target}: ${teamSummarySnapshotPath}`,
+			);
+		}
+	}
+	for (const [target, paneId] of Object.entries(
+		paneStatus.recommended_inspect_panes,
+	)) {
+		if (paneId) {
+			console.log(`inspect_pane_${target}: ${paneId}`);
+		}
+	}
+	if (paneStatus.recommended_inspect_command) {
+		console.log(`inspect_next: ${paneStatus.recommended_inspect_command}`);
+	}
+	if (paneStatus.recommended_inspect_summary) {
+		console.log(`inspect_summary: ${paneStatus.recommended_inspect_summary}`);
+	}
+	for (const [
+		index,
+		command,
+	] of paneStatus.recommended_inspect_commands.entries()) {
+		console.log(`inspect_priority_${index + 1}: ${command}`);
+	}
+	for (const [index, item] of paneStatus.recommended_inspect_items.entries()) {
+		const panePart = item.pane_id ? ` pane=${item.pane_id}` : "";
+		const cliPart = item.worker_cli ? ` cli=${item.worker_cli}` : "";
+		const rolePart = item.role ? ` role=${item.role}` : "";
+		const indexPart =
+			typeof item.index === "number" ? ` index=${item.index}` : "";
+		const alivePart =
+			typeof item.alive === "boolean" ? ` alive=${item.alive}` : "";
+		const turnCountPart =
+			typeof item.turn_count === "number"
+				? ` turn_count=${item.turn_count}`
+				: "";
+		const turnsWithoutProgressPart =
+			typeof item.turns_without_progress === "number"
+				? ` turns_without_progress=${item.turns_without_progress}`
+				: "";
+		const lastTurnPart = item.last_turn_at
+			? ` last_turn_at=${item.last_turn_at}`
+			: "";
+		const statusUpdatedPart = item.status_updated_at
+			? ` status_updated_at=${item.status_updated_at}`
+			: "";
+		const pidPart = typeof item.pid === "number" ? ` pid=${item.pid}` : "";
+		const worktreeRepoRootPart = item.worktree_repo_root
+			? ` worktree_repo_root=${item.worktree_repo_root}`
+			: "";
+		const worktreePathPart = item.worktree_path
+			? ` worktree_path=${item.worktree_path}`
+			: "";
+		const worktreeBranchPart = item.worktree_branch
+			? ` worktree_branch=${item.worktree_branch}`
+			: "";
+		const worktreeDetachedPart =
+			typeof item.worktree_detached === "boolean"
+				? ` worktree_detached=${item.worktree_detached}`
+				: "";
+		const worktreeCreatedPart =
+			typeof item.worktree_created === "boolean"
+				? ` worktree_created=${item.worktree_created}`
+				: "";
+		const teamStateRootPart = item.team_state_root
+			? ` team_state_root=${item.team_state_root}`
+			: "";
+		const workdirPart = item.working_dir ? ` workdir=${item.working_dir}` : "";
+		const assignedTasksPart =
+			item.assigned_tasks.length > 0
+				? ` assigned_tasks=${item.assigned_tasks.join(",")}`
+				: "";
+		const taskStatusPart = item.task_status
+			? ` task_status=${item.task_status}`
+			: "";
+		const taskResultPart = item.task_result
+			? ` task_result=${item.task_result}`
+			: "";
+		const taskErrorPart = item.task_error
+			? ` task_error=${item.task_error}`
+			: "";
+		const taskVersionPart =
+			typeof item.task_version === "number"
+				? ` task_version=${item.task_version}`
+				: "";
+		const taskCreatedAtPart = item.task_created_at
+			? ` task_created_at=${item.task_created_at}`
+			: "";
+		const taskCompletedAtPart = item.task_completed_at
+			? ` task_completed_at=${item.task_completed_at}`
+			: "";
+		const taskDependsOnPart =
+			item.task_depends_on.length > 0
+				? ` task_depends_on=${item.task_depends_on.join(",")}`
+				: "";
+		const taskClaimPresentPart =
+			typeof item.task_claim_present === "boolean"
+				? ` task_claim_present=${item.task_claim_present}`
+				: "";
+		const taskClaimOwnerPart = item.task_claim_owner
+			? ` task_claim_owner=${item.task_claim_owner}`
+			: "";
+		const taskClaimTokenPart = item.task_claim_token
+			? ` task_claim_token=${item.task_claim_token}`
+			: "";
+		const taskClaimLeasePart = item.task_claim_leased_until
+			? ` task_claim_leased_until=${item.task_claim_leased_until}`
+			: "";
+		const taskClaimLockPathPart = item.task_claim_lock_path
+			? ` task_claim_lock_path=${item.task_claim_lock_path}`
+			: "";
+		const approvalRequiredPart =
+			typeof item.approval_required === "boolean"
+				? ` approval_required=${item.approval_required}`
+				: "";
+		const requiresCodeChangePart =
+			typeof item.requires_code_change === "boolean"
+				? ` requires_code_change=${item.requires_code_change}`
+				: "";
+		const taskDescriptionPart = item.task_description
+			? ` description=${item.task_description}`
+			: "";
+		const blockedByPart =
+			item.blocked_by.length > 0
+				? ` blocked_by=${item.blocked_by.join(",")}`
+				: "";
+		const taskRolePart = item.task_role ? ` task_role=${item.task_role}` : "";
+		const taskOwnerPart = item.task_owner
+			? ` task_owner=${item.task_owner}`
+			: "";
+		const approvalStatusPart = item.approval_status
+			? ` approval_status=${item.approval_status}`
+			: "";
+		const approvalReviewerPart = item.approval_reviewer
+			? ` approval_reviewer=${item.approval_reviewer}`
+			: "";
+		const approvalReasonPart = item.approval_reason
+			? ` approval_reason=${item.approval_reason}`
+			: "";
+		const approvalDecidedAtPart = item.approval_decided_at
+			? ` approval_decided_at=${item.approval_decided_at}`
+			: "";
+		const approvalRecordPresentPart =
+			typeof item.approval_record_present === "boolean"
+				? ` approval_record_present=${item.approval_record_present}`
+				: "";
+		const statePart = item.state ? ` state=${item.state}` : "";
+		const stateReasonPart = item.state_reason
+			? ` state_reason=${item.state_reason}`
+			: "";
+		const taskPart = item.task_id ? ` task=${item.task_id}` : "";
+		const subjectPart = item.task_subject
+			? ` subject=${item.task_subject}`
+			: "";
+		const taskPathPart = item.task_path ? ` task_path=${item.task_path}` : "";
+		const approvalPathPart = item.approval_path
+			? ` approval_path=${item.approval_path}`
+			: "";
+		const workerStateDirPart = item.worker_state_dir
+			? ` worker_state_dir=${item.worker_state_dir}`
+			: "";
+		const workerStatusPathPart = item.worker_status_path
+			? ` worker_status_path=${item.worker_status_path}`
+			: "";
+		const workerHeartbeatPathPart = item.worker_heartbeat_path
+			? ` worker_heartbeat_path=${item.worker_heartbeat_path}`
+			: "";
+		const workerIdentityPathPart = item.worker_identity_path
+			? ` worker_identity_path=${item.worker_identity_path}`
+			: "";
+		const workerInboxPathPart = item.worker_inbox_path
+			? ` worker_inbox_path=${item.worker_inbox_path}`
+			: "";
+		const workerMailboxPathPart = item.worker_mailbox_path
+			? ` worker_mailbox_path=${item.worker_mailbox_path}`
+			: "";
+		const workerShutdownRequestPathPart = item.worker_shutdown_request_path
+			? ` worker_shutdown_request_path=${item.worker_shutdown_request_path}`
+			: "";
+		const workerShutdownAckPathPart = item.worker_shutdown_ack_path
+			? ` worker_shutdown_ack_path=${item.worker_shutdown_ack_path}`
+			: "";
+		const teamDirPathPart = item.team_dir_path
+			? ` team_dir_path=${item.team_dir_path}`
+			: "";
+		const teamConfigPathPart = item.team_config_path
+			? ` team_config_path=${item.team_config_path}`
+			: "";
+		const teamManifestPathPart = item.team_manifest_path
+			? ` team_manifest_path=${item.team_manifest_path}`
+			: "";
+		const teamEventsPathPart = item.team_events_path
+			? ` team_events_path=${item.team_events_path}`
+			: "";
+		const teamDispatchPathPart = item.team_dispatch_path
+			? ` team_dispatch_path=${item.team_dispatch_path}`
+			: "";
+		const teamPhasePathPart = item.team_phase_path
+			? ` team_phase_path=${item.team_phase_path}`
+			: "";
+		const teamMonitorSnapshotPathPart = item.team_monitor_snapshot_path
+			? ` team_monitor_snapshot_path=${item.team_monitor_snapshot_path}`
+			: "";
+		const teamSummarySnapshotPathPart = item.team_summary_snapshot_path
+			? ` team_summary_snapshot_path=${item.team_summary_snapshot_path}`
+			: "";
+		console.log(
+			`inspect_item_${index + 1}: target=${item.target}${panePart}${cliPart}${rolePart}${indexPart}${alivePart}${turnCountPart}${turnsWithoutProgressPart}${lastTurnPart}${statusUpdatedPart}${pidPart}${worktreeRepoRootPart}${worktreePathPart}${worktreeBranchPart}${worktreeDetachedPart}${worktreeCreatedPart}${teamStateRootPart}${workdirPart}${assignedTasksPart}${taskStatusPart}${taskResultPart}${taskErrorPart}${taskVersionPart}${taskCreatedAtPart}${taskCompletedAtPart}${taskDependsOnPart}${taskClaimPresentPart}${taskClaimOwnerPart}${taskClaimTokenPart}${taskClaimLeasePart}${taskClaimLockPathPart}${approvalRequiredPart}${requiresCodeChangePart}${taskDescriptionPart}${blockedByPart}${taskRolePart}${taskOwnerPart}${approvalStatusPart}${approvalReviewerPart}${approvalReasonPart}${approvalDecidedAtPart}${approvalRecordPresentPart}${stateReasonPart}${taskPart}${subjectPart}${taskPathPart}${approvalPathPart}${workerStateDirPart}${workerStatusPathPart}${workerHeartbeatPathPart}${workerIdentityPathPart}${workerInboxPathPart}${workerMailboxPathPart}${workerShutdownRequestPathPart}${workerShutdownAckPathPart}${teamDirPathPart}${teamConfigPathPart}${teamManifestPathPart}${teamEventsPathPart}${teamDispatchPathPart}${teamPhasePathPart}${teamMonitorSnapshotPathPart}${teamSummarySnapshotPathPart} reason=${item.reason}${statePart} command=${item.command}`,
+		);
+	}
 
-  for (const [target, command] of Object.entries(paneStatus.sparkshell_commands)) {
-    console.log(`inspect_${target}: ${command}`);
-  }
+	for (const [target, command] of Object.entries(
+		paneStatus.sparkshell_commands,
+	)) {
+		console.log(`inspect_${target}: ${command}`);
+	}
 }
 
-function parseTeamArgs(args: string[], cwd: string = process.cwd()): ParsedTeamArgs {
-  const tokens = [...args];
-  let workerCount = 3;
-  let agentType = 'executor';
-  let explicitAgentType = false;
-  let explicitWorkerCount = false;
+function parseTeamArgs(
+	args: string[],
+	cwd: string = process.cwd(),
+): ParsedTeamArgs {
+	const tokens = [...args];
+	let workerCount = 3;
+	let agentType = "executor";
+	let explicitAgentType = false;
+	let explicitWorkerCount = false;
 
-  if (tokens[0]?.toLowerCase() === 'ralph') {
-    throw new Error('Deprecated usage: `omx team ralph ...` has been removed. Use `omx team ...` or run `omx ralph ...` separately.');
-  }
+	if (tokens[0]?.toLowerCase() === "ralph") {
+		throw new Error(
+			"Deprecated usage: `omx team ralph ...` has been removed. Use `omx team ...` or run `omx ralph ...` separately.",
+		);
+	}
 
-  const first = tokens[0] || '';
-  const match = first.match(/^(\d+)(?::([a-z][a-z0-9-]*))?$/i);
-  if (match) {
-    const count = Number.parseInt(match[1], 10);
-    if (!Number.isFinite(count) || count < MIN_WORKER_COUNT || count > DEFAULT_MAX_WORKERS) {
-      throw new Error(`Invalid worker count "${match[1]}". Expected ${MIN_WORKER_COUNT}-${DEFAULT_MAX_WORKERS}.`);
-    }
-    workerCount = count;
-    explicitWorkerCount = true;
-    if (match[2]) {
-      agentType = match[2];
-      explicitAgentType = true;
-    }
-    tokens.shift();
-  }
+	const first = tokens[0] || "";
+	const match = first.match(/^(\d+)(?::([a-z][a-z0-9-]*))?$/i);
+	if (match) {
+		const count = Number.parseInt(match[1], 10);
+		if (
+			!Number.isFinite(count) ||
+			count < MIN_WORKER_COUNT ||
+			count > DEFAULT_MAX_WORKERS
+		) {
+			throw new Error(
+				`Invalid worker count "${match[1]}". Expected ${MIN_WORKER_COUNT}-${DEFAULT_MAX_WORKERS}.`,
+			);
+		}
+		workerCount = count;
+		explicitWorkerCount = true;
+		if (match[2]) {
+			agentType = match[2];
+			explicitAgentType = true;
+		}
+		tokens.shift();
+	}
 
-  const task = tokens.join(' ').trim();
-  if (!task) {
-    throw new Error('Usage: omx team [N:agent-type] "<task description>"');
-  }
+	const task = tokens.join(" ").trim();
+	if (!task) {
+		throw new Error('Usage: omx team [N:agent-type] "<task description>"');
+	}
 
-  const followupContext = resolveApprovedTeamFollowupContext(cwd, task);
-  const effectiveTask = followupContext?.task ?? task;
-  if (followupContext) {
-    if (!explicitWorkerCount) {
-      workerCount = followupContext.workerCount;
-      explicitWorkerCount = followupContext.explicitWorkerCount;
-    }
-    if (!explicitAgentType && followupContext.agentType) {
-      agentType = followupContext.agentType;
-      explicitAgentType = followupContext.explicitAgentType === true;
-    }
-  }
+	const followupContext = resolveApprovedTeamFollowupContext(cwd, task);
+	const effectiveTask = followupContext?.task ?? task;
+	if (followupContext) {
+		if (!explicitWorkerCount) {
+			workerCount = followupContext.workerCount;
+			explicitWorkerCount = followupContext.explicitWorkerCount;
+		}
+		if (!explicitAgentType && followupContext.agentType) {
+			agentType = followupContext.agentType;
+			explicitAgentType = followupContext.explicitAgentType === true;
+		}
+	}
 
-  const teamName = sanitizeTeamName(slugifyTask(effectiveTask));
-  return { workerCount, agentType, explicitAgentType, explicitWorkerCount, task: effectiveTask, teamName };
+	const teamName = sanitizeTeamName(slugifyTask(effectiveTask));
+	return {
+		workerCount,
+		agentType,
+		explicitAgentType,
+		explicitWorkerCount,
+		task: effectiveTask,
+		teamName,
+	};
 }
 
 export function parseTeamStartArgs(args: string[]): ParsedTeamStartArgs {
-  const parsedWorktree = parseWorktreeMode(args);
-  return {
-    parsed: parseTeamArgs(parsedWorktree.remainingArgs),
-    worktreeMode: resolveDefaultTeamWorktreeMode(parsedWorktree.mode),
-  };
+	const parsedWorktree = parseWorktreeMode(args);
+	return {
+		parsed: parseTeamArgs(parsedWorktree.remainingArgs),
+		worktreeMode: resolveDefaultTeamWorktreeMode(parsedWorktree.mode),
+	};
 }
 
 /**
@@ -925,654 +1366,900 @@ export function parseTeamStartArgs(args: string[]): ParsedTeamStartArgs {
  * When the user specifies an explicit agent-type (e.g., `3:executor`), all tasks
  * get that role (backward compat). Otherwise, heuristic routing assigns roles.
  */
-type DecompositionStrategy = 'numbered' | 'bulleted' | 'conjunction' | 'atomic';
+type DecompositionStrategy = "numbered" | "bulleted" | "conjunction" | "atomic";
 
 interface DecompositionCandidate {
-  subject: string;
-  description: string;
+	subject: string;
+	description: string;
 }
 
 interface DecompositionPlan {
-  strategy: DecompositionStrategy;
-  subtasks: DecompositionCandidate[];
+	strategy: DecompositionStrategy;
+	subtasks: DecompositionCandidate[];
 }
 
 export interface TeamExecutionPlan {
-  workerCount: number;
-  tasks: Array<{ subject: string; description: string; owner: string; role?: string }>;
+	workerCount: number;
+	tasks: Array<{
+		subject: string;
+		description: string;
+		owner: string;
+		role?: string;
+	}>;
 }
 
-function resolveImplicitTeamFallbackRole(agentType: string, explicitAgentType: boolean): string {
-  return !explicitAgentType && agentType === 'executor' ? 'team-executor' : agentType;
+function resolveImplicitTeamFallbackRole(
+	agentType: string,
+	explicitAgentType: boolean,
+): string {
+	return !explicitAgentType && agentType === "executor"
+		? "team-executor"
+		: agentType;
 }
 
 function looksLikeLowConfidenceAnalysisTask(task: string): boolean {
-  const normalized = task.trim();
-  return ANALYSIS_TASK_PREFIX.test(normalized)
-    && (ANALYSIS_DELIVERABLE_SIGNAL.test(normalized)
-      || countWords(normalized) > 18
-      || CONTEXTUAL_DECOMPOSITION_CLAUSE.test(normalized));
+	const normalized = task.trim();
+	return (
+		ANALYSIS_TASK_PREFIX.test(normalized) &&
+		(ANALYSIS_DELIVERABLE_SIGNAL.test(normalized) ||
+			countWords(normalized) > 18 ||
+			CONTEXTUAL_DECOMPOSITION_CLAUSE.test(normalized))
+	);
 }
 
 function resolveTeamFanoutLimit(
-  task: string,
-  requestedWorkerCount: number,
-  explicitAgentType: boolean,
-  explicitWorkerCount: boolean,
-  plan: DecompositionPlan,
+	task: string,
+	requestedWorkerCount: number,
+	explicitAgentType: boolean,
+	explicitWorkerCount: boolean,
+	plan: DecompositionPlan,
 ): number {
-  if (requestedWorkerCount <= 1 || explicitAgentType || explicitWorkerCount || plan.strategy === 'numbered' || plan.strategy === 'bulleted') {
-    return requestedWorkerCount;
-  }
+	if (
+		requestedWorkerCount <= 1 ||
+		explicitAgentType ||
+		explicitWorkerCount ||
+		plan.strategy === "numbered" ||
+		plan.strategy === "bulleted"
+	) {
+		return requestedWorkerCount;
+	}
 
-  const size = classifyTaskSize(task).size;
-  if (plan.strategy === 'atomic') {
-    if (looksLikeLowConfidenceAnalysisTask(task)) {
-      return 1;
-    }
+	const size = classifyTaskSize(task).size;
+	if (plan.strategy === "atomic") {
+		if (looksLikeLowConfidenceAnalysisTask(task)) {
+			return 1;
+		}
 
-    if (size === 'small') {
-      const proseHeavyAtomicTask = countWords(task) > 18 || CONTEXTUAL_DECOMPOSITION_CLAUSE.test(task);
-      if (!proseHeavyAtomicTask) return 1;
-    }
+		if (size === "small") {
+			const proseHeavyAtomicTask =
+				countWords(task) > 18 || CONTEXTUAL_DECOMPOSITION_CLAUSE.test(task);
+			if (!proseHeavyAtomicTask) return 1;
+		}
 
-    if (!hasAtomicParallelizationSignals(task, size)) {
-      return 1;
-    }
-  }
+		if (!hasAtomicParallelizationSignals(task, size)) {
+			return 1;
+		}
+	}
 
-  if (plan.strategy === 'conjunction' && size !== 'large') {
-    return Math.min(requestedWorkerCount, Math.max(2, plan.subtasks.length));
-  }
+	if (plan.strategy === "conjunction" && size !== "large") {
+		return Math.min(requestedWorkerCount, Math.max(2, plan.subtasks.length));
+	}
 
-  return requestedWorkerCount;
+	return requestedWorkerCount;
 }
 
 export function buildTeamExecutionPlan(
-  task: string,
-  workerCount: number,
-  agentType: string,
-  explicitAgentType: boolean,
-  explicitWorkerCount = false,
+	task: string,
+	workerCount: number,
+	agentType: string,
+	explicitAgentType: boolean,
+	explicitWorkerCount = false,
 ): TeamExecutionPlan {
-  const plan = splitTaskString(task);
-  const effectiveWorkerCount = resolveTeamFanoutLimit(
-    task,
-    workerCount,
-    explicitAgentType,
-    explicitWorkerCount,
-    plan,
-  );
-  const fallbackRole = resolveImplicitTeamFallbackRole(agentType, explicitAgentType);
+	const plan = splitTaskString(task);
+	const effectiveWorkerCount = resolveTeamFanoutLimit(
+		task,
+		workerCount,
+		explicitAgentType,
+		explicitWorkerCount,
+		plan,
+	);
+	const fallbackRole = resolveImplicitTeamFallbackRole(
+		agentType,
+		explicitAgentType,
+	);
 
-  let subtasks = plan.subtasks;
-  const usedAspectSubtasks = subtasks.length <= 1 && effectiveWorkerCount > 1;
-  if (subtasks.length <= 1 && effectiveWorkerCount > 1) {
-    subtasks = createAspectSubtasks(task, effectiveWorkerCount);
-  }
+	let subtasks = plan.subtasks;
+	const usedAspectSubtasks = subtasks.length <= 1 && effectiveWorkerCount > 1;
+	if (subtasks.length <= 1 && effectiveWorkerCount > 1) {
+		subtasks = createAspectSubtasks(task, effectiveWorkerCount);
+	}
 
-  const tasksWithRoles = subtasks.map((st) => {
-    if (explicitAgentType) {
-      return { ...st, role: agentType };
-    }
-    const result = routeTaskToRole(st.subject, st.description, 'team-exec', fallbackRole);
-    return { ...st, role: result.role };
-  });
+	const tasksWithRoles = subtasks.map((st) => {
+		if (explicitAgentType) {
+			return { ...st, role: agentType };
+		}
+		const result = routeTaskToRole(
+			st.subject,
+			st.description,
+			"team-exec",
+			fallbackRole,
+		);
+		return { ...st, role: result.role };
+	});
 
-  const normalizedRoles = new Set(tasksWithRoles.map((task) => (task.role ?? '').trim()));
-  const tasks = usedAspectSubtasks && tasksWithRoles.length > 1 && normalizedRoles.size <= 1
-    ? tasksWithRoles.map((task, index) => ({
-      ...task,
-      owner: `worker-${(index % effectiveWorkerCount) + 1}`,
-    }))
-    : distributeTasksToWorkers(
-      tasksWithRoles,
-      effectiveWorkerCount,
-      explicitAgentType ? agentType : undefined,
-    );
+	const normalizedRoles = new Set(
+		tasksWithRoles.map((task) => (task.role ?? "").trim()),
+	);
+	const tasks =
+		usedAspectSubtasks && tasksWithRoles.length > 1 && normalizedRoles.size <= 1
+			? tasksWithRoles.map((task, index) => ({
+					...task,
+					owner: `worker-${(index % effectiveWorkerCount) + 1}`,
+				}))
+			: distributeTasksToWorkers(
+					tasksWithRoles,
+					effectiveWorkerCount,
+					explicitAgentType ? agentType : undefined,
+				);
 
-  return {
-    workerCount: effectiveWorkerCount,
-    tasks,
-  };
+	return {
+		workerCount: effectiveWorkerCount,
+		tasks,
+	};
 }
 
 export function decomposeTaskString(
-  task: string,
-  workerCount: number,
-  agentType: string,
-  explicitAgentType: boolean,
-  explicitWorkerCount = false,
-): Array<{ subject: string; description: string; owner: string; role?: string }> {
-  return buildTeamExecutionPlan(task, workerCount, agentType, explicitAgentType, explicitWorkerCount).tasks;
+	task: string,
+	workerCount: number,
+	agentType: string,
+	explicitAgentType: boolean,
+	explicitWorkerCount = false,
+): Array<{
+	subject: string;
+	description: string;
+	owner: string;
+	role?: string;
+}> {
+	return buildTeamExecutionPlan(
+		task,
+		workerCount,
+		agentType,
+		explicitAgentType,
+		explicitWorkerCount,
+	).tasks;
 }
 
-const ACTIONABLE_TASK_PREFIX = /^(?:add|analy(?:se|ze)|audit|benchmark|build|clean(?:\s+up)?|create|debug|design|document|draft|fix|implement|improve|investigate|migrate|optimi(?:s|z)e|profile|refactor|repair|research|review|ship|summari(?:s|z)e|test|update|validate|verify|write)\b/i;
+const ACTIONABLE_TASK_PREFIX =
+	/^(?:add|analy(?:se|ze)|audit|benchmark|build|clean(?:\s+up)?|create|debug|design|document|draft|fix|implement|improve|investigate|migrate|optimi(?:s|z)e|profile|refactor|repair|research|review|ship|summari(?:s|z)e|test|update|validate|verify|write)\b/i;
 const TASK_LABEL_PREFIX = /^(?:task|step|phase|part)\s+[\w-]+(?:\s+[\w-]+)?$/i;
-const ANALYSIS_TASK_PREFIX = /^(?:analy(?:se|ze)|audit|assess|evaluate|explore|investigate|research|review|study|summari(?:s|z)e)\b/i;
-const ANALYSIS_DELIVERABLE_SIGNAL = /\b(?:actionable recommendations?|evidence(?: pointers?)?|findings?|issue|operator|report|root cause|summary|user impact|write-?up)\b/i;
-const CONTEXTUAL_DECOMPOSITION_CLAUSE = /\b(?:focusing on|focus on|including|covers?|covering|with|while|without|ensuring|suitable for|root cause|user impact|evidence pointers|actionable recommendations)\b/i;
+const ANALYSIS_TASK_PREFIX =
+	/^(?:analy(?:se|ze)|audit|assess|evaluate|explore|investigate|research|review|study|summari(?:s|z)e)\b/i;
+const ANALYSIS_DELIVERABLE_SIGNAL =
+	/\b(?:actionable recommendations?|evidence(?: pointers?)?|findings?|issue|operator|report|root cause|summary|user impact|write-?up)\b/i;
+const CONTEXTUAL_DECOMPOSITION_CLAUSE =
+	/\b(?:focusing on|focus on|including|covers?|covering|with|while|without|ensuring|suitable for|root cause|user impact|evidence pointers|actionable recommendations)\b/i;
 const BULLET_LINE_PATTERN = /^(?:[-*•]|(?:\[\s?[xX]?\]))\s+(.+)$/;
-const FILE_REFERENCE_PATTERN = /(?:^|[\s`'"])([A-Za-z0-9_./-]+\.[A-Za-z0-9]+)(?=$|[\s`'",;:])/g;
+const FILE_REFERENCE_PATTERN =
+	/(?:^|[\s`'"])([A-Za-z0-9_./-]+\.[A-Za-z0-9]+)(?=$|[\s`'",;:])/g;
 const CODE_SYMBOL_PATTERN = /[`'][A-Za-z_][A-Za-z0-9_.-]*[`']/g;
-const PARALLELIZATION_SIGNAL = /\b(?:acceptance criteria|cross[\s-]cutting|independent|in parallel|separately|verification|verify|tests?|docs?|documentation|benchmarks?|migration|rollout)\b/i;
+const PARALLELIZATION_SIGNAL =
+	/\b(?:acceptance criteria|cross[\s-]cutting|independent|in parallel|separately|verification|verify|tests?|docs?|documentation|benchmarks?|migration|rollout)\b/i;
 
 function countWords(text: string): number {
-  return text.trim().split(/\s+/).filter(Boolean).length;
+	return text.trim().split(/\s+/).filter(Boolean).length;
 }
 
 function countDistinctMatches(text: string, pattern: RegExp): number {
-  const matches = new Set<string>();
-  for (const match of text.matchAll(new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`))) {
-    const value = (match[1] ?? match[0] ?? '').trim().toLowerCase();
-    if (value) matches.add(value);
-  }
-  return matches.size;
+	const matches = new Set<string>();
+	for (const match of text.matchAll(
+		new RegExp(
+			pattern.source,
+			pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+		),
+	)) {
+		const value = (match[1] ?? match[0] ?? "").trim().toLowerCase();
+		if (value) matches.add(value);
+	}
+	return matches.size;
 }
 
-function hasAtomicParallelizationSignals(task: string, size: ReturnType<typeof classifyTaskSize>['size']): boolean {
-  const fileRefCount = countDistinctMatches(task, FILE_REFERENCE_PATTERN);
-  const symbolRefCount = countDistinctMatches(task, CODE_SYMBOL_PATTERN);
-  if (fileRefCount >= 2) return true;
-  if (fileRefCount >= 1 && symbolRefCount >= 1) return true;
-  if (PARALLELIZATION_SIGNAL.test(task) && size === 'large') return true;
-  return size === 'large' && countWords(task) >= 24;
+function hasAtomicParallelizationSignals(
+	task: string,
+	size: ReturnType<typeof classifyTaskSize>["size"],
+): boolean {
+	const fileRefCount = countDistinctMatches(task, FILE_REFERENCE_PATTERN);
+	const symbolRefCount = countDistinctMatches(task, CODE_SYMBOL_PATTERN);
+	if (fileRefCount >= 2) return true;
+	if (fileRefCount >= 1 && symbolRefCount >= 1) return true;
+	if (PARALLELIZATION_SIGNAL.test(task) && size === "large") return true;
+	return size === "large" && countWords(task) >= 24;
 }
 
 function looksLikeStandaloneWeakSubtask(part: string): boolean {
-  const normalized = part.trim().replace(/^[*-]\s*/, '');
-  return ACTIONABLE_TASK_PREFIX.test(normalized) || TASK_LABEL_PREFIX.test(normalized);
+	const normalized = part.trim().replace(/^[*-]\s*/, "");
+	return (
+		ACTIONABLE_TASK_PREFIX.test(normalized) ||
+		TASK_LABEL_PREFIX.test(normalized)
+	);
 }
 
 function canSafelySplitWeakTaskList(task: string, parts: string[]): boolean {
-  if (parts.length < 2) return false;
-  if (countWords(task) > 18) return false;
-  if (CONTEXTUAL_DECOMPOSITION_CLAUSE.test(task)) return false;
-  return parts.every((part) => countWords(part) <= 8 && looksLikeStandaloneWeakSubtask(part));
+	if (parts.length < 2) return false;
+	if (countWords(task) > 18) return false;
+	if (CONTEXTUAL_DECOMPOSITION_CLAUSE.test(task)) return false;
+	return parts.every(
+		(part) => countWords(part) <= 8 && looksLikeStandaloneWeakSubtask(part),
+	);
 }
 
 /** Split a task string into sub-tasks using numbered lists or conservative delimiters. */
 function splitTaskString(task: string): DecompositionPlan {
-  // Try numbered list: "1. foo 2. bar 3. baz" or "1) foo 2) bar"
-  const numberedPattern = /(?:^|\s)(\d+)[.)]\s+/g;
-  const numberedMatches = [...task.matchAll(numberedPattern)];
-  if (numberedMatches.length >= 2) {
-    const parts: Array<{ subject: string; description: string }> = [];
-    for (let i = 0; i < numberedMatches.length; i++) {
-      const prefixLen = numberedMatches[i][0].length;
-      const contentStart = numberedMatches[i].index! + prefixLen;
-      const end = i + 1 < numberedMatches.length ? numberedMatches[i + 1].index! : task.length;
-      const text = task.slice(contentStart, end).trim();
-      if (text) {
-        parts.push({ subject: text.slice(0, 80), description: text });
-      }
-    }
-    if (parts.length >= 2) return { strategy: 'numbered', subtasks: parts };
-  }
+	// Try numbered list: "1. foo 2. bar 3. baz" or "1) foo 2) bar"
+	const numberedPattern = /(?:^|\s)(\d+)[.)]\s+/g;
+	const numberedMatches = [...task.matchAll(numberedPattern)];
+	if (numberedMatches.length >= 2) {
+		const parts: Array<{ subject: string; description: string }> = [];
+		for (let i = 0; i < numberedMatches.length; i++) {
+			const prefixLen = numberedMatches[i][0].length;
+			const contentStart = numberedMatches[i].index! + prefixLen;
+			const end =
+				i + 1 < numberedMatches.length
+					? numberedMatches[i + 1].index!
+					: task.length;
+			const text = task.slice(contentStart, end).trim();
+			if (text) {
+				parts.push({ subject: text.slice(0, 80), description: text });
+			}
+		}
+		if (parts.length >= 2) return { strategy: "numbered", subtasks: parts };
+	}
 
-  const bulletParts = task
-    .split(/\r?\n+/)
-    .map((line) => line.trim())
-    .map((line) => line.match(BULLET_LINE_PATTERN)?.[1]?.trim() ?? '')
-    .filter((line) => line.length > 0);
-  if (bulletParts.length >= 2) {
-    return {
-      strategy: 'bulleted',
-      subtasks: bulletParts.map((part) => ({ subject: part.slice(0, 80), description: part })),
-    };
-  }
+	const bulletParts = task
+		.split(/\r?\n+/)
+		.map((line) => line.trim())
+		.map((line) => line.match(BULLET_LINE_PATTERN)?.[1]?.trim() ?? "")
+		.filter((line) => line.length > 0);
+	if (bulletParts.length >= 2) {
+		return {
+			strategy: "bulleted",
+			subtasks: bulletParts.map((part) => ({
+				subject: part.slice(0, 80),
+				description: part,
+			})),
+		};
+	}
 
-  const strongParts = task.split(/;\s+/).map(s => s.trim()).filter(s => s.length > 0);
-  if (strongParts.length >= 2) {
-    return {
-      strategy: 'conjunction',
-      subtasks: strongParts.map((part) => ({ subject: part.slice(0, 80), description: part })),
-    };
-  }
+	const strongParts = task
+		.split(/;\s+/)
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+	if (strongParts.length >= 2) {
+		return {
+			strategy: "conjunction",
+			subtasks: strongParts.map((part) => ({
+				subject: part.slice(0, 80),
+				description: part,
+			})),
+		};
+	}
 
-  // Commas / "and" only split when the overall input already looks like a flat task list.
-  const weakParts = task.split(/(?:,\s+and\s+|,\s+|\s+and\s+)/i).map(s => s.trim()).filter(s => s.length > 0);
-  if (canSafelySplitWeakTaskList(task, weakParts)) {
-    return {
-      strategy: 'conjunction',
-      subtasks: weakParts.map((part) => ({ subject: part.slice(0, 80), description: part })),
-    };
-  }
+	// Commas / "and" only split when the overall input already looks like a flat task list.
+	const weakParts = task
+		.split(/(?:,\s+and\s+|,\s+|\s+and\s+)/i)
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+	if (canSafelySplitWeakTaskList(task, weakParts)) {
+		return {
+			strategy: "conjunction",
+			subtasks: weakParts.map((part) => ({
+				subject: part.slice(0, 80),
+				description: part,
+			})),
+		};
+	}
 
-  return {
-    strategy: 'atomic',
-    subtasks: [{ subject: task.slice(0, 80), description: task }],
-  };
+	return {
+		strategy: "atomic",
+		subtasks: [{ subject: task.slice(0, 80), description: task }],
+	};
 }
 
 /** Create aspect-scoped sub-tasks for an atomic task that can't be split. */
 function createAspectSubtasks(
-  task: string,
-  workerCount: number,
+	task: string,
+	workerCount: number,
 ): Array<{ subject: string; description: string }> {
-  const aspects = [
-    { subject: `Implement: ${task}`.slice(0, 80), description: `Implement the core functionality for: ${task}` },
-    { subject: `Test: ${task}`.slice(0, 80), description: `Write tests and verify: ${task}` },
-    { subject: `Review and document: ${task}`.slice(0, 80), description: `Review code quality and update documentation for: ${task}` },
-  ];
+	const aspects = [
+		{
+			subject: `Implement: ${task}`.slice(0, 80),
+			description: `Implement the core functionality for: ${task}`,
+		},
+		{
+			subject: `Test: ${task}`.slice(0, 80),
+			description: `Write tests and verify: ${task}`,
+		},
+		{
+			subject: `Review and document: ${task}`.slice(0, 80),
+			description: `Review code quality and update documentation for: ${task}`,
+		},
+	];
 
-  // Return up to workerCount aspects, repeating implementation for extra workers
-  const result = aspects.slice(0, workerCount);
-  while (result.length < workerCount) {
-    const idx = result.length - aspects.length;
-    result.push({
-      subject: `Additional work (${idx + 1}): ${task}`.slice(0, 80),
-      description: `Continue implementation work on: ${task}`,
-    });
-  }
-  return result;
+	// Return up to workerCount aspects, repeating implementation for extra workers
+	const result = aspects.slice(0, workerCount);
+	while (result.length < workerCount) {
+		const idx = result.length - aspects.length;
+		result.push({
+			subject: `Additional work (${idx + 1}): ${task}`.slice(0, 80),
+			description: `Continue implementation work on: ${task}`,
+		});
+	}
+	return result;
 }
 
 /** Distribute tasks across workers using an inspectable allocation policy. */
 function distributeTasksToWorkers(
-  tasks: Array<{ subject: string; description: string; role?: string; blocked_by?: string[] }>,
-  workerCount: number,
-  workerRole?: string,
-): Array<{ subject: string; description: string; owner: string; role?: string }> {
-  const workers = Array.from({ length: workerCount }, (_, index) => ({
-    name: `worker-${index + 1}`,
-    role: workerRole,
-  }));
-  return allocateTasksToWorkers(tasks, workers).map(({ allocation_reason: _allocationReason, ...task }) => task);
+	tasks: Array<{
+		subject: string;
+		description: string;
+		role?: string;
+		blocked_by?: string[];
+	}>,
+	workerCount: number,
+	workerRole?: string,
+): Array<{
+	subject: string;
+	description: string;
+	owner: string;
+	role?: string;
+}> {
+	const workers = Array.from({ length: workerCount }, (_, index) => ({
+		name: `worker-${index + 1}`,
+		role: workerRole,
+	}));
+	return allocateTasksToWorkers(tasks, workers).map(
+		({ allocation_reason: _allocationReason, ...task }) => task,
+	);
 }
 
 async function ensureTeamModeState(
-  parsed: ParsedTeamArgs,
-  tasks?: Array<{ role?: string }>,
+	parsed: ParsedTeamArgs,
+	tasks?: Array<{ role?: string }>,
 ): Promise<void> {
-  const fallbackRole = resolveImplicitTeamFallbackRole(parsed.agentType, parsed.explicitAgentType);
-  const roleDistribution = tasks && tasks.length > 0
-    ? [...new Set(tasks.map(t => t.role ?? parsed.agentType))].join(',')
-    : parsed.agentType;
+	const fallbackRole = resolveImplicitTeamFallbackRole(
+		parsed.agentType,
+		parsed.explicitAgentType,
+	);
+	const roleDistribution =
+		tasks && tasks.length > 0
+			? [...new Set(tasks.map((t) => t.role ?? parsed.agentType))].join(",")
+			: parsed.agentType;
 
-  const availableAgentTypes = await resolveAvailableAgentTypes(process.cwd());
-  const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
-    workerCount: parsed.workerCount,
-    fallbackRole,
-  });
-  const currentPhase = parsed.teamName
-    ? (await readTeamPhase(parsed.teamName, process.cwd()))?.current_phase ?? 'team-exec'
-    : 'team-exec';
-  const active = !isTerminalModePhase(currentPhase);
-  const completionStamp = active ? undefined : new Date().toISOString();
+	const availableAgentTypes = await resolveAvailableAgentTypes(process.cwd());
+	const staffingPlan = buildFollowupStaffingPlan(
+		"team",
+		parsed.task,
+		availableAgentTypes,
+		{
+			workerCount: parsed.workerCount,
+			fallbackRole,
+		},
+	);
+	const currentPhase = parsed.teamName
+		? ((await readTeamPhase(parsed.teamName, process.cwd()))?.current_phase ??
+			"team-exec")
+		: "team-exec";
+	const active = !isTerminalModePhase(currentPhase);
+	const completionStamp = active ? undefined : new Date().toISOString();
 
-  const existing = await readModeState('team');
-  if (existing?.active) {
-    await updateModeState('team', {
-      active,
-      task_description: parsed.task,
-      current_phase: currentPhase,
-      team_name: parsed.teamName,
-      agent_count: parsed.workerCount,
-      agent_types: roleDistribution,
-      available_agent_types: availableAgentTypes,
-      staffing_summary: staffingPlan.staffingSummary,
-      staffing_allocations: staffingPlan.allocations,
-      completed_at: completionStamp,
-    });
-    return;
-  }
+	const existing = await readModeState("team");
+	if (existing?.active) {
+		await updateModeState("team", {
+			active,
+			task_description: parsed.task,
+			current_phase: currentPhase,
+			team_name: parsed.teamName,
+			agent_count: parsed.workerCount,
+			agent_types: roleDistribution,
+			available_agent_types: availableAgentTypes,
+			staffing_summary: staffingPlan.staffingSummary,
+			staffing_allocations: staffingPlan.allocations,
+			completed_at: completionStamp,
+		});
+		return;
+	}
 
-  await startMode('team', parsed.task, 50);
-  await updateModeState('team', {
-    active,
-    current_phase: currentPhase,
-    team_name: parsed.teamName,
-    agent_count: parsed.workerCount,
-    agent_types: roleDistribution,
-    available_agent_types: availableAgentTypes,
-    staffing_summary: staffingPlan.staffingSummary,
-    staffing_allocations: staffingPlan.allocations,
-    completed_at: completionStamp,
-  });
-
+	await startMode("team", parsed.task, 50);
+	await updateModeState("team", {
+		active,
+		current_phase: currentPhase,
+		team_name: parsed.teamName,
+		agent_count: parsed.workerCount,
+		agent_types: roleDistribution,
+		available_agent_types: availableAgentTypes,
+		staffing_summary: staffingPlan.staffingSummary,
+		staffing_allocations: staffingPlan.allocations,
+		completed_at: completionStamp,
+	});
 }
 
+async function persistTeamShutdownModeState(
+	teamName: string,
+	cwd: string,
+	configSnapshot?: {
+		task: string;
+		workerCount: number;
+		agentType: string;
+	} | null,
+): Promise<void> {
+	const existing = await readModeState("team", cwd);
+	if (!existing) {
+		if (configSnapshot) {
+			await ensureTeamModeState({
+				task: configSnapshot.task,
+				workerCount: configSnapshot.workerCount,
+				agentType: configSnapshot.agentType,
+				explicitAgentType: false,
+				explicitWorkerCount: false,
+				teamName,
+			});
+		} else {
+			await startMode("team", `shutdown team ${teamName}`, 50, cwd);
+		}
+	}
 
-async function renderStartSummary(runtime: TeamRuntime, staffingPlan?: FollowupStaffingPlan): Promise<void> {
-  console.log(`Team started: ${runtime.teamName}`);
-  console.log(`tmux target: ${runtime.sessionName}`);
-  console.log(`workers: ${runtime.config.worker_count}`);
-  console.log(`agent_type: ${runtime.config.agent_type}`);
-  if (runtime.config.workspace_mode) {
-    console.log(`workspace_mode: ${runtime.config.workspace_mode}`);
-  }
-  if (staffingPlan) {
-    console.log(`available_agent_types: ${staffingPlan.rosterSummary}`);
-    console.log(`staffing_plan: ${staffingPlan.staffingSummary}`);
-  }
+	await updateModeState(
+		"team",
+		{
+			active: false,
+			current_phase: "cancelled",
+			completed_at: new Date().toISOString(),
+			team_name: teamName,
+			...(configSnapshot
+				? {
+						task_description: configSnapshot.task,
+						agent_count: configSnapshot.workerCount,
+						agent_types: configSnapshot.agentType,
+					}
+				: {}),
+		},
+		cwd,
+	);
+}
 
-  const snapshot = await monitorTeam(runtime.teamName, runtime.cwd);
-  if (!snapshot) {
-    console.log('warning: team snapshot unavailable immediately after startup');
-    return;
-  }
-  console.log(`tasks: total=${snapshot.tasks.total} pending=${snapshot.tasks.pending} blocked=${snapshot.tasks.blocked} in_progress=${snapshot.tasks.in_progress} completed=${snapshot.tasks.completed} failed=${snapshot.tasks.failed}`);
-  if (snapshot.performance) {
-    console.log(
-      `monitor_perf_ms: total=${snapshot.performance.total_ms} list=${snapshot.performance.list_tasks_ms} workers=${snapshot.performance.worker_scan_ms} mailbox=${snapshot.performance.mailbox_delivery_ms}`
-    );
-  }
-  for (const hint of buildLeaderMonitoringHints(runtime.teamName)) {
-    console.log(hint);
-  }
+async function renderStartSummary(
+	runtime: TeamRuntime,
+	staffingPlan?: FollowupStaffingPlan,
+): Promise<void> {
+	console.log(`Team started: ${runtime.teamName}`);
+	console.log(`tmux target: ${runtime.sessionName}`);
+	console.log(`workers: ${runtime.config.worker_count}`);
+	console.log(`agent_type: ${runtime.config.agent_type}`);
+	if (runtime.config.workspace_mode) {
+		console.log(`workspace_mode: ${runtime.config.workspace_mode}`);
+	}
+	if (staffingPlan) {
+		console.log(`available_agent_types: ${staffingPlan.rosterSummary}`);
+		console.log(`staffing_plan: ${staffingPlan.staffingSummary}`);
+	}
+
+	const snapshot = await monitorTeam(runtime.teamName, runtime.cwd);
+	if (!snapshot) {
+		console.log("warning: team snapshot unavailable immediately after startup");
+		return;
+	}
+	console.log(
+		`tasks: total=${snapshot.tasks.total} pending=${snapshot.tasks.pending} blocked=${snapshot.tasks.blocked} in_progress=${snapshot.tasks.in_progress} completed=${snapshot.tasks.completed} failed=${snapshot.tasks.failed}`,
+	);
+	if (snapshot.performance) {
+		console.log(
+			`monitor_perf_ms: total=${snapshot.performance.total_ms} list=${snapshot.performance.list_tasks_ms} workers=${snapshot.performance.worker_scan_ms} mailbox=${snapshot.performance.mailbox_delivery_ms}`,
+		);
+	}
+	for (const hint of buildLeaderMonitoringHints(runtime.teamName)) {
+		console.log(hint);
+	}
 }
 
 export function buildLeaderMonitoringHints(teamName: string): string[] {
-  const sanitized = sanitizeTeamName(teamName);
-  return [
-    `leader_check: omx team status ${sanitized}`,
-    `leader_loop_hint: while ON, keep checking state (example: sleep 30 && omx team status ${sanitized})`,
-  ];
+	const sanitized = sanitizeTeamName(teamName);
+	return [
+		`leader_check: omx team status ${sanitized}`,
+		`leader_loop_hint: while ON, keep checking state (example: sleep 30 && omx team status ${sanitized})`,
+	];
 }
 
-export async function teamCommand(args: string[], _options: TeamCliOptions = {}): Promise<void> {
-  const cwd = process.cwd();
-  const parsedWorktree = parseWorktreeMode(args);
-  const worktreeMode = resolveDefaultTeamWorktreeMode(parsedWorktree.mode);
-  const teamArgs = parsedWorktree.remainingArgs;
-  const [subcommandRaw] = teamArgs;
-  const subcommand = (subcommandRaw || '').toLowerCase();
+export async function teamCommand(
+	args: string[],
+	_options: TeamCliOptions = {},
+): Promise<void> {
+	const cwd = process.cwd();
+	const parsedWorktree = parseWorktreeMode(args);
+	const worktreeMode = resolveDefaultTeamWorktreeMode(parsedWorktree.mode);
+	const teamArgs = parsedWorktree.remainingArgs;
+	const [subcommandRaw] = teamArgs;
+	const subcommand = (subcommandRaw || "").toLowerCase();
 
-  if (HELP_TOKENS.has(subcommand)) {
-    console.log(TEAM_HELP.trim());
-    return;
-  }
+	if (HELP_TOKENS.has(subcommand)) {
+		console.log(TEAM_HELP.trim());
+		return;
+	}
 
-  if (subcommand === 'api') {
-    const apiSubcommand = (teamArgs[1] || '').toLowerCase();
-    if (HELP_TOKENS.has(apiSubcommand)) {
-      const operationFromHelpAlias = resolveTeamApiOperation((teamArgs[2] || '').toLowerCase());
-      if (operationFromHelpAlias) {
-        console.log(buildTeamApiOperationHelp(operationFromHelpAlias));
-        return;
-      }
-      console.log(TEAM_API_HELP.trim());
-      return;
-    }
-    const operation = resolveTeamApiOperation(apiSubcommand);
-    if (operation) {
-      const trailing = teamArgs.slice(2).map((token) => token.toLowerCase());
-      if (trailing.some((token) => HELP_TOKENS.has(token))) {
-        console.log(buildTeamApiOperationHelp(operation));
-        return;
-      }
-    }
-    const wantsJson = teamArgs.includes('--json');
-    const jsonBase = buildJsonBase();
-    let parsedApi: ReturnType<typeof parseTeamApiArgs>;
-    try {
-      parsedApi = parseTeamApiArgs(teamArgs.slice(1));
-    } catch (error) {
-      if (wantsJson) {
-        console.log(JSON.stringify({
-          ...jsonBase,
-          ok: false,
-          command: 'omx team api',
-          operation: 'unknown',
-          error: {
-            code: 'invalid_input',
-            message: error instanceof Error ? error.message : String(error),
-          },
-        }));
-        process.exitCode = 1;
-        return;
-      }
-      throw error;
-    }
-    const envelope = await executeTeamApiOperation(parsedApi.operation, parsedApi.input, cwd);
-    if (parsedApi.json) {
-      console.log(JSON.stringify({
-        ...jsonBase,
-        command: `omx team api ${parsedApi.operation}`,
-        ...envelope,
-      }));
-      if (!envelope.ok) process.exitCode = 1;
-      return;
-    }
-    if (envelope.ok) {
-      console.log(`ok operation=${envelope.operation}`);
-      console.log(JSON.stringify(envelope.data, null, 2));
-      return;
-    }
-    console.error(`error operation=${envelope.operation} code=${envelope.error.code}: ${envelope.error.message}`);
-    process.exitCode = 1;
-    return;
-  }
+	if (subcommand === "api") {
+		const apiSubcommand = (teamArgs[1] || "").toLowerCase();
+		if (HELP_TOKENS.has(apiSubcommand)) {
+			const operationFromHelpAlias = resolveTeamApiOperation(
+				(teamArgs[2] || "").toLowerCase(),
+			);
+			if (operationFromHelpAlias) {
+				console.log(buildTeamApiOperationHelp(operationFromHelpAlias));
+				return;
+			}
+			console.log(TEAM_API_HELP.trim());
+			return;
+		}
+		const operation = resolveTeamApiOperation(apiSubcommand);
+		if (operation) {
+			const trailing = teamArgs.slice(2).map((token) => token.toLowerCase());
+			if (trailing.some((token) => HELP_TOKENS.has(token))) {
+				console.log(buildTeamApiOperationHelp(operation));
+				return;
+			}
+		}
+		const wantsJson = teamArgs.includes("--json");
+		const jsonBase = buildJsonBase();
+		let parsedApi: ReturnType<typeof parseTeamApiArgs>;
+		try {
+			parsedApi = parseTeamApiArgs(teamArgs.slice(1));
+		} catch (error) {
+			if (wantsJson) {
+				console.log(
+					JSON.stringify({
+						...jsonBase,
+						ok: false,
+						command: "omx team api",
+						operation: "unknown",
+						error: {
+							code: "invalid_input",
+							message: error instanceof Error ? error.message : String(error),
+						},
+					}),
+				);
+				process.exitCode = 1;
+				return;
+			}
+			throw error;
+		}
+		const envelope = await executeTeamApiOperation(
+			parsedApi.operation,
+			parsedApi.input,
+			cwd,
+		);
+		if (parsedApi.json) {
+			console.log(
+				JSON.stringify({
+					...jsonBase,
+					command: `omx team api ${parsedApi.operation}`,
+					...envelope,
+				}),
+			);
+			if (!envelope.ok) process.exitCode = 1;
+			return;
+		}
+		if (envelope.ok) {
+			console.log(`ok operation=${envelope.operation}`);
+			console.log(JSON.stringify(envelope.data, null, 2));
+			return;
+		}
+		console.error(
+			`error operation=${envelope.operation} code=${envelope.error.code}: ${envelope.error.message}`,
+		);
+		process.exitCode = 1;
+		return;
+	}
 
-  if (subcommand === 'status') {
-    const name = teamArgs[1];
-    const wantsJson = teamArgs.includes('--json');
-    if (!name) throw new Error('Usage: omx team status <team-name> [--json]');
-    await recordLeaderRuntimeActivity(cwd, 'team_status', name);
-    const snapshot = await monitorTeam(name, cwd);
-    if (!snapshot) {
-      if (wantsJson) {
-        console.log(JSON.stringify({
-          ...buildJsonBase(),
-          command: 'omx team status',
-          team_name: name,
-          status: 'missing',
-        }));
-        return;
-      }
-      console.log(`No team state found for ${name}`);
-      return;
-    }
-    const tailLines = parseStatusTailLines(teamArgs.slice(2));
-    const config = await readTeamConfig(name, cwd);
-    const paneStatus = await readTeamPaneStatus(config, cwd, snapshot, tailLines);
-    if (wantsJson) {
-      console.log(JSON.stringify({
-        ...buildJsonBase(),
-        command: 'omx team status',
-        team_name: snapshot.teamName,
-        status: 'ok',
-        tail_lines: tailLines,
-        phase: snapshot.phase,
-        workspace_mode: config?.workspace_mode ?? null,
-        dead_workers: snapshot.deadWorkers,
-        non_reporting_workers: snapshot.nonReportingWorkers,
-        workers: {
-          total: snapshot.workers.length,
-          dead: snapshot.deadWorkers.length,
-          non_reporting: snapshot.nonReportingWorkers.length,
-        },
-        tasks: {
-          total: snapshot.tasks.total,
-          pending: snapshot.tasks.pending,
-          blocked: snapshot.tasks.blocked,
-          in_progress: snapshot.tasks.in_progress,
-          completed: snapshot.tasks.completed,
-          failed: snapshot.tasks.failed,
-        },
-        performance: snapshot.performance ?? null,
-        panes: paneStatus,
-      }));
-      return;
-    }
-    console.log(`team=${snapshot.teamName} phase=${snapshot.phase}`);
-    if (config?.workspace_mode) {
-      console.log(`workspace_mode: ${config.workspace_mode}`);
-    }
-    console.log(`workers: total=${snapshot.workers.length} dead=${snapshot.deadWorkers.length} non_reporting=${snapshot.nonReportingWorkers.length}`);
-    if (snapshot.deadWorkers.length > 0) {
-      console.log(`dead_workers: ${snapshot.deadWorkers.join(' ')}`);
-    }
-    if (snapshot.nonReportingWorkers.length > 0) {
-      console.log(`non_reporting_workers: ${snapshot.nonReportingWorkers.join(' ')}`);
-    }
-    console.log(`tasks: total=${snapshot.tasks.total} pending=${snapshot.tasks.pending} blocked=${snapshot.tasks.blocked} in_progress=${snapshot.tasks.in_progress} completed=${snapshot.tasks.completed} failed=${snapshot.tasks.failed}`);
-    if (snapshot.performance) {
-      console.log(
-        `monitor_perf_ms: total=${snapshot.performance.total_ms} list=${snapshot.performance.list_tasks_ms} workers=${snapshot.performance.worker_scan_ms} mailbox=${snapshot.performance.mailbox_delivery_ms}`
-      );
-    }
-    renderTeamPaneStatus(paneStatus);
-    return;
-  }
+	if (subcommand === "status") {
+		const name = teamArgs[1];
+		const wantsJson = teamArgs.includes("--json");
+		if (!name) throw new Error("Usage: omx team status <team-name> [--json]");
+		await recordLeaderRuntimeActivity(cwd, "team_status", name);
+		const snapshot = await monitorTeam(name, cwd);
+		if (!snapshot) {
+			if (wantsJson) {
+				console.log(
+					JSON.stringify({
+						...buildJsonBase(),
+						command: "omx team status",
+						team_name: name,
+						status: "missing",
+					}),
+				);
+				return;
+			}
+			console.log(`No team state found for ${name}`);
+			return;
+		}
+		const tailLines = parseStatusTailLines(teamArgs.slice(2));
+		const config = await readTeamConfig(name, cwd);
+		const paneStatus = await readTeamPaneStatus(
+			config,
+			cwd,
+			snapshot,
+			tailLines,
+		);
+		if (wantsJson) {
+			console.log(
+				JSON.stringify({
+					...buildJsonBase(),
+					command: "omx team status",
+					team_name: snapshot.teamName,
+					status: "ok",
+					tail_lines: tailLines,
+					phase: snapshot.phase,
+					workspace_mode: config?.workspace_mode ?? null,
+					dead_workers: snapshot.deadWorkers,
+					non_reporting_workers: snapshot.nonReportingWorkers,
+					workers: {
+						total: snapshot.workers.length,
+						dead: snapshot.deadWorkers.length,
+						non_reporting: snapshot.nonReportingWorkers.length,
+					},
+					tasks: {
+						total: snapshot.tasks.total,
+						pending: snapshot.tasks.pending,
+						blocked: snapshot.tasks.blocked,
+						in_progress: snapshot.tasks.in_progress,
+						completed: snapshot.tasks.completed,
+						failed: snapshot.tasks.failed,
+					},
+					performance: snapshot.performance ?? null,
+					panes: paneStatus,
+				}),
+			);
+			return;
+		}
+		console.log(`team=${snapshot.teamName} phase=${snapshot.phase}`);
+		if (config?.workspace_mode) {
+			console.log(`workspace_mode: ${config.workspace_mode}`);
+		}
+		console.log(
+			`workers: total=${snapshot.workers.length} dead=${snapshot.deadWorkers.length} non_reporting=${snapshot.nonReportingWorkers.length}`,
+		);
+		if (snapshot.deadWorkers.length > 0) {
+			console.log(`dead_workers: ${snapshot.deadWorkers.join(" ")}`);
+		}
+		if (snapshot.nonReportingWorkers.length > 0) {
+			console.log(
+				`non_reporting_workers: ${snapshot.nonReportingWorkers.join(" ")}`,
+			);
+		}
+		console.log(
+			`tasks: total=${snapshot.tasks.total} pending=${snapshot.tasks.pending} blocked=${snapshot.tasks.blocked} in_progress=${snapshot.tasks.in_progress} completed=${snapshot.tasks.completed} failed=${snapshot.tasks.failed}`,
+		);
+		if (snapshot.performance) {
+			console.log(
+				`monitor_perf_ms: total=${snapshot.performance.total_ms} list=${snapshot.performance.list_tasks_ms} workers=${snapshot.performance.worker_scan_ms} mailbox=${snapshot.performance.mailbox_delivery_ms}`,
+			);
+		}
+		renderTeamPaneStatus(paneStatus);
+		return;
+	}
 
-  if (subcommand === 'await') {
-    const name = teamArgs[1];
-    if (!name) throw new Error('Usage: omx team await <team-name> [--timeout-ms <ms>] [--after-event-id <id>] [--json]');
-    const wantsJson = teamArgs.includes('--json');
-    const timeoutIdx = teamArgs.indexOf('--timeout-ms');
-    const afterIdx = teamArgs.indexOf('--after-event-id');
-    const timeoutMs = timeoutIdx >= 0 && teamArgs[timeoutIdx + 1]
-      ? Math.max(1, Number.parseInt(teamArgs[timeoutIdx + 1]!, 10) || 0)
-      : 30_000;
-    const afterEventId = afterIdx >= 0 ? (teamArgs[afterIdx + 1] || '') : '';
-    const config = await readTeamConfig(name, cwd);
-    if (!config) {
-      if (wantsJson) {
-        console.log(JSON.stringify({ team_name: name, status: 'missing', cursor: afterEventId || '', event: null }));
-      } else {
-        console.log(`No team state found for ${name}`);
-      }
-      return;
-    }
+	if (subcommand === "await") {
+		const name = teamArgs[1];
+		if (!name)
+			throw new Error(
+				"Usage: omx team await <team-name> [--timeout-ms <ms>] [--after-event-id <id>] [--json]",
+			);
+		const wantsJson = teamArgs.includes("--json");
+		const timeoutIdx = teamArgs.indexOf("--timeout-ms");
+		const afterIdx = teamArgs.indexOf("--after-event-id");
+		const timeoutMs =
+			timeoutIdx >= 0 && teamArgs[timeoutIdx + 1]
+				? Math.max(1, Number.parseInt(teamArgs[timeoutIdx + 1]!, 10) || 0)
+				: 30_000;
+		const afterEventId = afterIdx >= 0 ? teamArgs[afterIdx + 1] || "" : "";
+		const config = await readTeamConfig(name, cwd);
+		if (!config) {
+			if (wantsJson) {
+				console.log(
+					JSON.stringify({
+						team_name: name,
+						status: "missing",
+						cursor: afterEventId || "",
+						event: null,
+					}),
+				);
+			} else {
+				console.log(`No team state found for ${name}`);
+			}
+			return;
+		}
 
-    const baselineCursor = afterEventId || (await readTeamEvents(name, cwd, { wakeableOnly: true }).then((events) => events.at(-1)?.event_id ?? ''));
-    const snapshot = await monitorTeam(name, cwd);
-    const immediateEvent = await readTeamEvents(name, cwd, {
-      afterEventId: baselineCursor || undefined,
-      wakeableOnly: true,
-    }).then((events) => events[0]);
+		const baselineCursor =
+			afterEventId ||
+			(await readTeamEvents(name, cwd, { wakeableOnly: true }).then(
+				(events) => events.at(-1)?.event_id ?? "",
+			));
+		const snapshot = await monitorTeam(name, cwd);
+		const immediateEvent = await readTeamEvents(name, cwd, {
+			afterEventId: baselineCursor || undefined,
+			wakeableOnly: true,
+		}).then((events) => events[0]);
 
-    const result =
-      immediateEvent
-        ? { status: 'event' as const, cursor: immediateEvent.event_id, event: immediateEvent }
-        : snapshot && snapshotHasDeadWorkerStall(snapshot)
-          ? await readTeamEvents(name, cwd, { wakeableOnly: true }).then((events) => {
-            const latestWakeableEvent = events.at(-1);
-            if (latestWakeableEvent) {
-              return {
-                status: 'event' as const,
-                cursor: latestWakeableEvent.event_id,
-                event: latestWakeableEvent,
-              };
-            }
-            const fallbackEvent = buildDeadWorkerAwaitEvent(name, snapshot);
-            return fallbackEvent
-              ? { status: 'event' as const, cursor: baselineCursor, event: fallbackEvent }
-              : { status: 'timeout' as const, cursor: baselineCursor };
-          })
-          : await waitForTeamEvent(name, cwd, {
-            afterEventId: baselineCursor || undefined,
-            timeoutMs,
-            pollMs: 100,
-            wakeableOnly: true,
-          });
+		const result = immediateEvent
+			? {
+					status: "event" as const,
+					cursor: immediateEvent.event_id,
+					event: immediateEvent,
+				}
+			: snapshot && snapshotHasDeadWorkerStall(snapshot)
+				? await readTeamEvents(name, cwd, { wakeableOnly: true }).then(
+						(events) => {
+							const latestWakeableEvent = events.at(-1);
+							if (latestWakeableEvent) {
+								return {
+									status: "event" as const,
+									cursor: latestWakeableEvent.event_id,
+									event: latestWakeableEvent,
+								};
+							}
+							const fallbackEvent = buildDeadWorkerAwaitEvent(name, snapshot);
+							return fallbackEvent
+								? {
+										status: "event" as const,
+										cursor: baselineCursor,
+										event: fallbackEvent,
+									}
+								: { status: "timeout" as const, cursor: baselineCursor };
+						},
+					)
+				: await waitForTeamEvent(name, cwd, {
+						afterEventId: baselineCursor || undefined,
+						timeoutMs,
+						pollMs: 100,
+						wakeableOnly: true,
+					});
 
-    if (wantsJson) {
-      console.log(JSON.stringify({
-        team_name: sanitizeTeamName(name),
-        status: result.status,
-        cursor: result.cursor,
-        event: result.event ?? null,
-      }));
-      return;
-    }
+		if (wantsJson) {
+			console.log(
+				JSON.stringify({
+					team_name: sanitizeTeamName(name),
+					status: result.status,
+					cursor: result.cursor,
+					event: result.event ?? null,
+				}),
+			);
+			return;
+		}
 
-    if (result.status === 'timeout') {
-      console.log(`No new event for ${name} before timeout (${timeoutMs}ms).`);
-      return;
-    }
+		if (result.status === "timeout") {
+			console.log(`No new event for ${name} before timeout (${timeoutMs}ms).`);
+			return;
+		}
 
-    const event = result.event!;
-    const context = [
-      `team=${name}`,
-      `event=${event.type}`,
-      `worker=${event.worker}`,
-      event.state ? `state=${event.state}` : '',
-      event.prev_state ? `prev=${event.prev_state}` : '',
-      event.task_id ? `task=${event.task_id}` : '',
-      `cursor=${result.cursor}`,
-    ].filter(Boolean).join(' ');
-    console.log(context);
-    return;
-  }
+		const event = result.event!;
+		const context = [
+			`team=${name}`,
+			`event=${event.type}`,
+			`worker=${event.worker}`,
+			event.state ? `state=${event.state}` : "",
+			event.prev_state ? `prev=${event.prev_state}` : "",
+			event.task_id ? `task=${event.task_id}` : "",
+			`cursor=${result.cursor}`,
+		]
+			.filter(Boolean)
+			.join(" ");
+		console.log(context);
+		return;
+	}
 
-  if (subcommand === 'resume') {
-    const name = teamArgs[1];
-    if (!name) throw new Error('Usage: omx team resume <team-name>');
-    const runtime = await resumeTeam(name, cwd);
-    if (!runtime) {
-      console.log(`No resumable team found for ${name}`);
-      return;
-    }
-    await ensureTeamModeState({
-      task: runtime.config.task,
-      workerCount: runtime.config.worker_count,
-      agentType: runtime.config.agent_type,
-      explicitAgentType: false,
-      explicitWorkerCount: false,
-      teamName: runtime.teamName,
-    });
-    const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
-    const staffingPlan = buildFollowupStaffingPlan('team', runtime.config.task, availableAgentTypes, {
-      workerCount: runtime.config.worker_count,
-      fallbackRole: resolveImplicitTeamFallbackRole(runtime.config.agent_type, false),
-    });
-    await renderStartSummary(runtime, staffingPlan);
-    return;
-  }
+	if (subcommand === "resume") {
+		const name = teamArgs[1];
+		if (!name) throw new Error("Usage: omx team resume <team-name>");
+		const runtime = await resumeTeam(name, cwd);
+		if (!runtime) {
+			console.log(`No resumable team found for ${name}`);
+			return;
+		}
+		await ensureTeamModeState({
+			task: runtime.config.task,
+			workerCount: runtime.config.worker_count,
+			agentType: runtime.config.agent_type,
+			explicitAgentType: false,
+			explicitWorkerCount: false,
+			teamName: runtime.teamName,
+		});
+		const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
+		const staffingPlan = buildFollowupStaffingPlan(
+			"team",
+			runtime.config.task,
+			availableAgentTypes,
+			{
+				workerCount: runtime.config.worker_count,
+				fallbackRole: resolveImplicitTeamFallbackRole(
+					runtime.config.agent_type,
+					false,
+				),
+			},
+		);
+		await renderStartSummary(runtime, staffingPlan);
+		return;
+	}
 
-  if (subcommand === 'shutdown') {
-    const name = teamArgs[1];
-    if (!name) throw new Error('Usage: omx team shutdown <team-name> [--force]');
-    const force = teamArgs.includes('--force');
-    const summary = await shutdownTeam(name, cwd, { force });
-    await updateModeState('team', {
-      active: false,
-      current_phase: 'cancelled',
-      completed_at: new Date().toISOString(),
-    }).catch((error: unknown) => {
-      console.warn('[omx] warning: failed to persist team mode shutdown state', {
-        team: name,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
-    console.log(`Team shutdown complete: ${name}`);
-    if (summary.commitHygieneArtifacts) {
-      console.log(`commit_hygiene_context_json: ${summary.commitHygieneArtifacts.jsonPath}`);
-      console.log(`commit_hygiene_context_md: ${summary.commitHygieneArtifacts.markdownPath}`);
-    }
-    return;
-  }
+	if (subcommand === "shutdown") {
+		const name = teamArgs[1];
+		if (!name)
+			throw new Error("Usage: omx team shutdown <team-name> [--force]");
+		const force = teamArgs.includes("--force");
+		const configBeforeShutdown = await readTeamConfig(name, cwd);
+		const summary = await shutdownTeam(name, cwd, { force });
+		await persistTeamShutdownModeState(
+			name,
+			cwd,
+			configBeforeShutdown
+				? {
+						task: configBeforeShutdown.task,
+						workerCount: configBeforeShutdown.worker_count,
+						agentType: configBeforeShutdown.agent_type,
+					}
+				: null,
+		).catch((error: unknown) => {
+			console.warn(
+				"[omx] warning: failed to persist team mode shutdown state",
+				{
+					team: name,
+					error: error instanceof Error ? error.message : String(error),
+				},
+			);
+		});
+		console.log(`Team shutdown complete: ${name}`);
+		if (summary.commitHygieneArtifacts) {
+			console.log(
+				`commit_hygiene_context_json: ${summary.commitHygieneArtifacts.jsonPath}`,
+			);
+			console.log(
+				`commit_hygiene_context_md: ${summary.commitHygieneArtifacts.markdownPath}`,
+			);
+		}
+		return;
+	}
 
-  const parsed = parseTeamArgs(teamArgs, cwd);
-  const executionPlan = buildTeamExecutionPlan(
-    parsed.task,
-    parsed.workerCount,
-    parsed.agentType,
-    parsed.explicitAgentType,
-    parsed.explicitWorkerCount,
-  );
-  const tasks = executionPlan.tasks;
-  const effectiveParsed = executionPlan.workerCount === parsed.workerCount
-    ? parsed
-    : { ...parsed, workerCount: executionPlan.workerCount };
-  const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
-  const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
-    workerCount: executionPlan.workerCount,
-    fallbackRole: resolveImplicitTeamFallbackRole(parsed.agentType, parsed.explicitAgentType),
-  });
-  const runtime = await startTeam(
-    parsed.teamName,
-    parsed.task,
-    parsed.agentType,
-    executionPlan.workerCount,
-    tasks,
-    cwd,
-    { worktreeMode },
-  );
+	const parsed = parseTeamArgs(teamArgs, cwd);
+	const executionPlan = buildTeamExecutionPlan(
+		parsed.task,
+		parsed.workerCount,
+		parsed.agentType,
+		parsed.explicitAgentType,
+		parsed.explicitWorkerCount,
+	);
+	const tasks = executionPlan.tasks;
+	const effectiveParsed =
+		executionPlan.workerCount === parsed.workerCount
+			? parsed
+			: { ...parsed, workerCount: executionPlan.workerCount };
+	const availableAgentTypes = await resolveAvailableAgentTypes(cwd);
+	const staffingPlan = buildFollowupStaffingPlan(
+		"team",
+		parsed.task,
+		availableAgentTypes,
+		{
+			workerCount: executionPlan.workerCount,
+			fallbackRole: resolveImplicitTeamFallbackRole(
+				parsed.agentType,
+				parsed.explicitAgentType,
+			),
+		},
+	);
+	const runtime = await startTeam(
+		parsed.teamName,
+		parsed.task,
+		parsed.agentType,
+		executionPlan.workerCount,
+		tasks,
+		cwd,
+		{ worktreeMode },
+	);
 
-  await ensureTeamModeState(effectiveParsed, tasks);
-  await renderStartSummary(runtime, staffingPlan);
+	await ensureTeamModeState(effectiveParsed, tasks);
+	await renderStartSummary(runtime, staffingPlan);
 }

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1633,21 +1633,21 @@ process.on('SIGTERM', () => process.exit(0));
 			join(process.cwd(), "src", "team", "runtime.ts"),
 			"utf-8",
 		);
-		const applyIndex = source.indexOf(
-			"applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);",
+		const applyMatch = source.match(
+			/applyCreatedInteractiveSessionToConfig\(\s*config,\s*createdSession,\s*workerPaneIds,\s*\);/m,
 		);
-		const saveIndex = source.indexOf(
-			"await saveTeamConfig(config, leaderCwd);",
-			applyIndex,
-		);
-		const readyIndex = source.indexOf(
-			"const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);",
-			saveIndex,
+		const saveMatch = source.match(/await saveTeamConfig\(config, leaderCwd\);/m);
+		const readyMatch = source.match(
+			/const ready = waitForWorkerReady\(/m,
 		);
 
-		assert.notEqual(applyIndex, -1);
-		assert.notEqual(saveIndex, -1);
-		assert.notEqual(readyIndex, -1);
+		const applyIndex = applyMatch?.index ?? -1;
+		const saveIndex = saveMatch?.index ?? -1;
+		const readyIndex = readyMatch?.index ?? -1;
+
+		assert.notEqual(applyMatch, null);
+		assert.notEqual(saveMatch, null);
+		assert.notEqual(readyMatch, null);
 		assert.equal(applyIndex < saveIndex, true);
 		assert.equal(saveIndex < readyIndex, true);
 	});

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1,766 +1,1183 @@
-import { afterEach, beforeEach, describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { execFileSync, spawn } from 'child_process';
-import { mkdtemp, rm, writeFile, readFile, mkdir, chmod } from 'fs/promises';
-import { join } from 'path';
-import { tmpdir } from 'os';
-import { existsSync } from 'fs';
-import { HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { execFileSync, spawn } from "child_process";
+import { existsSync } from "fs";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { HUD_TMUX_TEAM_HEIGHT_LINES } from "../../hud/constants.js";
+import { resolveTeamLowComplexityDefaultModel } from "../model-contract.js";
 import {
-  initTeamState,
-  createTask,
-  writeWorkerIdentity,
-  readTeamConfig,
-  saveTeamConfig,
-  listMailboxMessages,
-  listDispatchRequests,
-  transitionDispatchRequest,
-  updateWorkerHeartbeat,
-  writeAtomic,
-  readTask,
-  readMonitorSnapshot,
-  claimTask,
-  transitionTaskStatus,
-  writeWorkerStatus,
-} from '../state.js';
+	applyCreatedInteractiveSessionToConfig,
+	assignTask,
+	monitorTeam,
+	resolveWorkerLaunchArgsFromEnv,
+	resumeTeam,
+	sendWorkerMessage,
+	shouldPrekillInteractiveShutdownProcessTrees,
+	shutdownTeam,
+	startTeam,
+	TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+	type TeamRuntime,
+	waitForClaudeStartupEvidence,
+	waitForWorkerStartupEvidence,
+} from "../runtime.js";
+import { readTeamEvents } from "../state/events.js";
 import {
-  monitorTeam,
-  shutdownTeam,
-  resumeTeam,
-  startTeam,
-  assignTask,
-  sendWorkerMessage,
-  applyCreatedInteractiveSessionToConfig,
-  resolveWorkerLaunchArgsFromEnv,
-  shouldPrekillInteractiveShutdownProcessTrees,
-  waitForWorkerStartupEvidence,
-  waitForClaudeStartupEvidence,
-  TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
-  type TeamRuntime,
-} from '../runtime.js';
-import { resolveTeamLowComplexityDefaultModel } from '../model-contract.js';
-import { readTeamEvents } from '../state/events.js';
+	claimTask,
+	createTask,
+	initTeamState,
+	listDispatchRequests,
+	listMailboxMessages,
+	readMonitorSnapshot,
+	readTask,
+	readTeamConfig,
+	saveTeamConfig,
+	transitionDispatchRequest,
+	transitionTaskStatus,
+	updateWorkerHeartbeat,
+	writeAtomic,
+	writeWorkerIdentity,
+	writeWorkerStatus,
+} from "../state.js";
 
 async function initRepo(): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-repo-'));
-  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
-  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
-  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
-  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
-  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
-  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
-  return cwd;
+	const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-worktree-repo-"));
+	execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+	execFileSync("git", ["config", "user.email", "test@example.com"], {
+		cwd,
+		stdio: "ignore",
+	});
+	execFileSync("git", ["config", "user.name", "Test User"], {
+		cwd,
+		stdio: "ignore",
+	});
+	await writeFile(join(cwd, "README.md"), "hello\n", "utf-8");
+	execFileSync("git", ["add", "README.md"], { cwd, stdio: "ignore" });
+	execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
+	return cwd;
 }
 
-async function addWorktree(repo: string, branchName: string, pathPrefix: string): Promise<string> {
-  const worktreePath = await mkdtemp(join(tmpdir(), pathPrefix));
-  execFileSync('git', ['worktree', 'add', '-b', branchName, worktreePath, 'HEAD'], { cwd: repo, stdio: 'ignore' });
-  return worktreePath;
+async function addWorktree(
+	repo: string,
+	branchName: string,
+	pathPrefix: string,
+): Promise<string> {
+	const worktreePath = await mkdtemp(join(tmpdir(), pathPrefix));
+	execFileSync(
+		"git",
+		["worktree", "add", "-b", branchName, worktreePath, "HEAD"],
+		{ cwd: repo, stdio: "ignore" },
+	);
+	return worktreePath;
 }
-
 
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
-  return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
+	return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
 }
 
-async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
-  const path = join(cwd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
-  const raw = await readFile(path, 'utf-8').catch(() => '');
-  return raw
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as Record<string, unknown>);
+async function readTeamDeliveryLog(
+	cwd: string,
+): Promise<Array<Record<string, unknown>>> {
+	const path = join(
+		cwd,
+		".omx",
+		"logs",
+		`team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`,
+	);
+	const raw = await readFile(path, "utf-8").catch(() => "");
+	return raw
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
 function withEmptyPath<T>(fn: () => T): T {
-  const prev = process.env.PATH;
-  process.env.PATH = '';
-  let restoreImmediately = true;
-  try {
-    const result = fn();
-    if (result instanceof Promise) {
-      restoreImmediately = false;
-      return result.finally(() => {
-        if (typeof prev === 'string') process.env.PATH = prev;
-        else delete process.env.PATH;
-      }) as T;
-    }
-    return result;
-  } finally {
-    if (restoreImmediately) {
-      if (typeof prev === 'string') process.env.PATH = prev;
-      else delete process.env.PATH;
-    }
-  }
+	const prev = process.env.PATH;
+	process.env.PATH = "";
+	let restoreImmediately = true;
+	try {
+		const result = fn();
+		if (result instanceof Promise) {
+			restoreImmediately = false;
+			return result.finally(() => {
+				if (typeof prev === "string") process.env.PATH = prev;
+				else delete process.env.PATH;
+			}) as T;
+		}
+		return result;
+	} finally {
+		if (restoreImmediately) {
+			if (typeof prev === "string") process.env.PATH = prev;
+			else delete process.env.PATH;
+		}
+	}
 }
 
 function withoutTeamWorkerEnv<T>(fn: () => T): T {
-  const prev = process.env.OMX_TEAM_WORKER;
-  delete process.env.OMX_TEAM_WORKER;
-  let restoreImmediately = true;
-  try {
-    const result = fn();
-    if (result instanceof Promise) {
-      restoreImmediately = false;
-      return result.finally(() => {
-        if (typeof prev === 'string') process.env.OMX_TEAM_WORKER = prev;
-        else delete process.env.OMX_TEAM_WORKER;
-      }) as T;
-    }
-    return result;
-  } finally {
-    if (restoreImmediately) {
-      if (typeof prev === 'string') process.env.OMX_TEAM_WORKER = prev;
-      else delete process.env.OMX_TEAM_WORKER;
-    }
-  }
+	const prev = process.env.OMX_TEAM_WORKER;
+	delete process.env.OMX_TEAM_WORKER;
+	let restoreImmediately = true;
+	try {
+		const result = fn();
+		if (result instanceof Promise) {
+			restoreImmediately = false;
+			return result.finally(() => {
+				if (typeof prev === "string") process.env.OMX_TEAM_WORKER = prev;
+				else delete process.env.OMX_TEAM_WORKER;
+			}) as T;
+		}
+		return result;
+	} finally {
+		if (restoreImmediately) {
+			if (typeof prev === "string") process.env.OMX_TEAM_WORKER = prev;
+			else delete process.env.OMX_TEAM_WORKER;
+		}
+	}
 }
 
 async function waitForFileText(
-  filePath: string,
-  matcher: (content: string) => boolean,
-  timeoutMs: number = 3_000,
+	filePath: string,
+	matcher: (content: string) => boolean,
+	timeoutMs: number = 3_000,
 ): Promise<string> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (existsSync(filePath)) {
-      const content = await readFile(filePath, 'utf-8');
-      if (matcher(content)) return content;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-  throw new Error(`timed out waiting for ${filePath}`);
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (existsSync(filePath)) {
+			const content = await readFile(filePath, "utf-8");
+			if (matcher(content)) return content;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error(`timed out waiting for ${filePath}`);
 }
 
 type MockBinarySpec = {
-  name: string;
-  content: string;
+	name: string;
+	content: string;
 };
 
-
 function teamStateTestPath(cwd: string, ...parts: string[]): string {
-  const stateRoot = process.env.OMX_TEAM_STATE_ROOT ?? join(cwd, '.omx', 'state');
-  return join(stateRoot, ...parts);
+	const stateRoot =
+		process.env.OMX_TEAM_STATE_ROOT ?? join(cwd, ".omx", "state");
+	return join(stateRoot, ...parts);
 }
 
 async function withMockTmuxFixture<T>(
-  options: {
-    dirPrefix: string;
-    tmuxScript: (tmuxLogPath: string) => string;
-    binaries?: MockBinarySpec[];
-    env?: Record<string, string | undefined>;
-  },
-  run: (ctx: { fakeBinDir: string; tmuxLogPath: string }) => Promise<T>,
+	options: {
+		dirPrefix: string;
+		tmuxScript: (tmuxLogPath: string) => string;
+		binaries?: MockBinarySpec[];
+		env?: Record<string, string | undefined>;
+	},
+	run: (ctx: { fakeBinDir: string; tmuxLogPath: string }) => Promise<T>,
 ): Promise<T> {
-  const fakeBinDir = await mkdtemp(join(tmpdir(), options.dirPrefix));
-  const tmuxLogPath = join(fakeBinDir, 'tmux.log');
-  const tmuxStubPath = join(fakeBinDir, 'tmux');
-  const previousPath = process.env.PATH;
-  const previousEnv = new Map<string, string | undefined>();
-  const envOverrides = {
-    OMX_TEAM_STATE_ROOT: undefined,
-    ...(options.env ?? {}),
-  };
+	const fakeBinDir = await mkdtemp(join(tmpdir(), options.dirPrefix));
+	const tmuxLogPath = join(fakeBinDir, "tmux.log");
+	const tmuxStubPath = join(fakeBinDir, "tmux");
+	const previousPath = process.env.PATH;
+	const previousEnv = new Map<string, string | undefined>();
+	const envOverrides = {
+		OMX_TEAM_STATE_ROOT: undefined,
+		...(options.env ?? {}),
+	};
 
-  try {
-    await writeFile(tmuxStubPath, options.tmuxScript(tmuxLogPath));
-    await chmod(tmuxStubPath, 0o755);
+	try {
+		await writeFile(tmuxStubPath, options.tmuxScript(tmuxLogPath));
+		await chmod(tmuxStubPath, 0o755);
 
-    for (const binary of options.binaries ?? []) {
-      const binaryPath = join(fakeBinDir, binary.name);
-      await writeFile(binaryPath, binary.content);
-      await chmod(binaryPath, 0o755);
-    }
+		for (const binary of options.binaries ?? []) {
+			const binaryPath = join(fakeBinDir, binary.name);
+			await writeFile(binaryPath, binary.content);
+			await chmod(binaryPath, 0o755);
+		}
 
-    process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+		process.env.PATH = `${fakeBinDir}:${previousPath ?? ""}`;
 
-    for (const [key, value] of Object.entries(envOverrides)) {
-      previousEnv.set(key, process.env[key]);
-      if (typeof value === 'string') process.env[key] = value;
-      else delete process.env[key];
-    }
+		for (const [key, value] of Object.entries(envOverrides)) {
+			previousEnv.set(key, process.env[key]);
+			if (typeof value === "string") process.env[key] = value;
+			else delete process.env[key];
+		}
 
-    return await run({ fakeBinDir, tmuxLogPath });
-  } finally {
-    if (typeof previousPath === 'string') process.env.PATH = previousPath;
-    else delete process.env.PATH;
+		return await run({ fakeBinDir, tmuxLogPath });
+	} finally {
+		if (typeof previousPath === "string") process.env.PATH = previousPath;
+		else delete process.env.PATH;
 
-    for (const [key, value] of previousEnv) {
-      if (typeof value === 'string') process.env[key] = value;
-      else delete process.env[key];
-    }
+		for (const [key, value] of previousEnv) {
+			if (typeof value === "string") process.env[key] = value;
+			else delete process.env[key];
+		}
 
-    await rm(fakeBinDir, { recursive: true, force: true });
-  }
+		await rm(fakeBinDir, { recursive: true, force: true });
+	}
 }
 
 async function withNativeWindowsPlatform<T>(run: () => Promise<T>): Promise<T> {
-  const prevMsystem = process.env.MSYSTEM;
-  const prevOstype = process.env.OSTYPE;
-  const prevWsl = process.env.WSL_DISTRO_NAME;
-  const prevWslInterop = process.env.WSL_INTEROP;
-  const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+	const prevMsystem = process.env.MSYSTEM;
+	const prevOstype = process.env.OSTYPE;
+	const prevWsl = process.env.WSL_DISTRO_NAME;
+	const prevWslInterop = process.env.WSL_INTEROP;
+	const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
-  try {
-    delete process.env.MSYSTEM;
-    delete process.env.OSTYPE;
-    delete process.env.WSL_DISTRO_NAME;
-    delete process.env.WSL_INTEROP;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    return await run();
-  } finally {
-    if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
-    if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
-    else delete process.env.MSYSTEM;
-    if (typeof prevOstype === 'string') process.env.OSTYPE = prevOstype;
-    else delete process.env.OSTYPE;
-    if (typeof prevWsl === 'string') process.env.WSL_DISTRO_NAME = prevWsl;
-    else delete process.env.WSL_DISTRO_NAME;
-    if (typeof prevWslInterop === 'string') process.env.WSL_INTEROP = prevWslInterop;
-    else delete process.env.WSL_INTEROP;
-  }
+	try {
+		delete process.env.MSYSTEM;
+		delete process.env.OSTYPE;
+		delete process.env.WSL_DISTRO_NAME;
+		delete process.env.WSL_INTEROP;
+		Object.defineProperty(process, "platform", {
+			value: "win32",
+			configurable: true,
+		});
+		return await run();
+	} finally {
+		if (origPlatform) Object.defineProperty(process, "platform", origPlatform);
+		if (typeof prevMsystem === "string") process.env.MSYSTEM = prevMsystem;
+		else delete process.env.MSYSTEM;
+		if (typeof prevOstype === "string") process.env.OSTYPE = prevOstype;
+		else delete process.env.OSTYPE;
+		if (typeof prevWsl === "string") process.env.WSL_DISTRO_NAME = prevWsl;
+		else delete process.env.WSL_DISTRO_NAME;
+		if (typeof prevWslInterop === "string")
+			process.env.WSL_INTEROP = prevWslInterop;
+		else delete process.env.WSL_INTEROP;
+	}
 }
 
 const ORIGINAL_OMX_TEAM_STATE_ROOT = process.env.OMX_TEAM_STATE_ROOT;
 
 beforeEach(() => {
-  delete process.env.OMX_TEAM_STATE_ROOT;
+	delete process.env.OMX_TEAM_STATE_ROOT;
 });
 
 afterEach(() => {
-  if (typeof ORIGINAL_OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = ORIGINAL_OMX_TEAM_STATE_ROOT;
-  else delete process.env.OMX_TEAM_STATE_ROOT;
+	if (typeof ORIGINAL_OMX_TEAM_STATE_ROOT === "string")
+		process.env.OMX_TEAM_STATE_ROOT = ORIGINAL_OMX_TEAM_STATE_ROOT;
+	else delete process.env.OMX_TEAM_STATE_ROOT;
 });
 
-describe('runtime', () => {
-  it('resolveWorkerLaunchArgsFromEnv injects low-complexity default model when missing', () => {
-    const args = resolveWorkerLaunchArgsFromEnv(
-      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-      'explore',
-    );
-    assert.deepEqual(args, ['--no-alt-screen', '--model', expectedLowComplexityModel()]);
-  });
+describe("runtime", () => {
+	it("resolveWorkerLaunchArgsFromEnv injects low-complexity default model when missing", () => {
+		const args = resolveWorkerLaunchArgsFromEnv(
+			{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+			"explore",
+		);
+		assert.deepEqual(args, [
+			"--no-alt-screen",
+			"--model",
+			expectedLowComplexityModel(),
+		]);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv reads low-complexity model from config when present', async () => {
-    const previousCodexHome = process.env.CODEX_HOME;
-    const tempCodexHome = await mkdtemp(join(tmpdir(), 'omx-codex-home-'));
-    await writeFile(
-      join(tempCodexHome, '.omx-config.json'),
-      JSON.stringify({ models: { team_low_complexity: 'gpt-4.1-mini' } }),
-    );
-    process.env.CODEX_HOME = tempCodexHome;
-    try {
-      const args = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'explore',
-      );
-      assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-4.1-mini']);
-    } finally {
-      if (typeof previousCodexHome === 'string') process.env.CODEX_HOME = previousCodexHome;
-      else delete process.env.CODEX_HOME;
-      await rm(tempCodexHome, { recursive: true, force: true });
-    }
-  });
+	it("resolveWorkerLaunchArgsFromEnv reads low-complexity model from config when present", async () => {
+		const previousCodexHome = process.env.CODEX_HOME;
+		const tempCodexHome = await mkdtemp(join(tmpdir(), "omx-codex-home-"));
+		await writeFile(
+			join(tempCodexHome, ".omx-config.json"),
+			JSON.stringify({ models: { team_low_complexity: "gpt-4.1-mini" } }),
+		);
+		process.env.CODEX_HOME = tempCodexHome;
+		try {
+			const args = resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+				"explore",
+			);
+			assert.deepEqual(args, ["--no-alt-screen", "--model", "gpt-4.1-mini"]);
+		} finally {
+			if (typeof previousCodexHome === "string")
+				process.env.CODEX_HOME = previousCodexHome;
+			else delete process.env.CODEX_HOME;
+			await rm(tempCodexHome, { recursive: true, force: true });
+		}
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv injects the frontier default model for executor workers', () => {
-    const args = resolveWorkerLaunchArgsFromEnv(
-      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-      'executor',
-    );
-    assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-5.4']);
-  });
+	it("resolveWorkerLaunchArgsFromEnv injects the frontier default model for executor workers", () => {
+		const args = resolveWorkerLaunchArgsFromEnv(
+			{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+			"executor",
+		);
+		assert.deepEqual(args, ["--no-alt-screen", "--model", "gpt-5.4"]);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv treats *-low aliases as low complexity', () => {
-    const args = resolveWorkerLaunchArgsFromEnv(
-      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-      'executor-low',
-    );
-    assert.deepEqual(args, ['--no-alt-screen', '--model', expectedLowComplexityModel()]);
-  });
+	it("resolveWorkerLaunchArgsFromEnv treats *-low aliases as low complexity", () => {
+		const args = resolveWorkerLaunchArgsFromEnv(
+			{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+			"executor-low",
+		);
+		assert.deepEqual(args, [
+			"--no-alt-screen",
+			"--model",
+			expectedLowComplexityModel(),
+		]);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv preserves explicit model in either syntax', () => {
-    assert.deepEqual(
-      resolveWorkerLaunchArgsFromEnv({ OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gpt-5' }, 'explore'),
-      ['--model', 'gpt-5'],
-    );
-    assert.deepEqual(
-      resolveWorkerLaunchArgsFromEnv({ OMX_TEAM_WORKER_LAUNCH_ARGS: '--model=gpt-5.3' }, 'explore'),
-      ['--model', 'gpt-5.3'],
-    );
-  });
+	it("resolveWorkerLaunchArgsFromEnv preserves explicit model in either syntax", () => {
+		assert.deepEqual(
+			resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--model gpt-5" },
+				"explore",
+			),
+			["--model", "gpt-5"],
+		);
+		assert.deepEqual(
+			resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--model=gpt-5.3" },
+				"explore",
+			),
+			["--model", "gpt-5.3"],
+		);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv uses inherited leader model for all agent types', () => {
-    const args = resolveWorkerLaunchArgsFromEnv(
-      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-      'executor',
-      'gpt-4.1',
-    );
-    assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-4.1']);
-  });
+	it("resolveWorkerLaunchArgsFromEnv uses inherited leader model for all agent types", () => {
+		const args = resolveWorkerLaunchArgsFromEnv(
+			{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+			"executor",
+			"gpt-4.1",
+		);
+		assert.deepEqual(args, ["--no-alt-screen", "--model", "gpt-4.1"]);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv uses inherited leader model over low-complexity default', () => {
-    const args = resolveWorkerLaunchArgsFromEnv(
-      { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-      'explore',
-      'gpt-4.1',
-    );
-    assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-4.1']);
-  });
+	it("resolveWorkerLaunchArgsFromEnv uses inherited leader model over low-complexity default", () => {
+		const args = resolveWorkerLaunchArgsFromEnv(
+			{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+			"explore",
+			"gpt-4.1",
+		);
+		assert.deepEqual(args, ["--no-alt-screen", "--model", "gpt-4.1"]);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv prefers explicit env model over inherited leader model', () => {
-    assert.deepEqual(
-      resolveWorkerLaunchArgsFromEnv({ OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gpt-5' }, 'explore', 'gpt-4.1'),
-      ['--model', 'gpt-5'],
-    );
-  });
+	it("resolveWorkerLaunchArgsFromEnv prefers explicit env model over inherited leader model", () => {
+		assert.deepEqual(
+			resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--model gpt-5" },
+				"explore",
+				"gpt-4.1",
+			),
+			["--model", "gpt-5"],
+		);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv injects teammate reasoning and logs source=role-default', () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
-    try {
-      const lowArgs = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'executor',
-        undefined,
-        'low',
-        'codex',
-      );
-      const highArgs = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'executor',
-        undefined,
-        'high',
-        'codex',
-      );
-      assert.deepEqual(lowArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"', '--model', 'gpt-5.4']);
-      assert.deepEqual(highArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', 'gpt-5.4']);
-    } finally {
-      console.log = originalLog;
-    }
-    assert.ok(logs.some((line) => line.includes('thinking_level=low') && line.includes('source=role-default')));
-    assert.ok(logs.some((line) => line.includes('thinking_level=high') && line.includes('source=role-default')));
-  });
+	it("resolveWorkerLaunchArgsFromEnv injects teammate reasoning and logs source=role-default", () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			const lowArgs = resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+				"executor",
+				undefined,
+				"low",
+				"codex",
+			);
+			const highArgs = resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+				"executor",
+				undefined,
+				"high",
+				"codex",
+			);
+			assert.deepEqual(lowArgs, [
+				"--no-alt-screen",
+				"-c",
+				'model_reasoning_effort="low"',
+				"--model",
+				"gpt-5.4",
+			]);
+			assert.deepEqual(highArgs, [
+				"--no-alt-screen",
+				"-c",
+				'model_reasoning_effort="high"',
+				"--model",
+				"gpt-5.4",
+			]);
+		} finally {
+			console.log = originalLog;
+		}
+		assert.ok(
+			logs.some(
+				(line) =>
+					line.includes("thinking_level=low") &&
+					line.includes("source=role-default"),
+			),
+		);
+		assert.ok(
+			logs.some(
+				(line) =>
+					line.includes("thinking_level=high") &&
+					line.includes("source=role-default"),
+			),
+		);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv preserves explicit reasoning and logs source=explicit', () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
-    try {
-      const args = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '-c model_reasoning_effort=\"high\" --no-alt-screen' },
-        'explore',
-      );
-      assert.deepEqual(
-        args,
-        ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', expectedLowComplexityModel()],
-      );
-    } finally {
-      console.log = originalLog;
-    }
-    assert.ok(logs.some((line) => line.includes('thinking_level=high') && line.includes('source=explicit')));
-  });
+	it("resolveWorkerLaunchArgsFromEnv preserves explicit reasoning and logs source=explicit", () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			const args = resolveWorkerLaunchArgsFromEnv(
+				{
+					OMX_TEAM_WORKER_LAUNCH_ARGS:
+						'-c model_reasoning_effort=\"high\" --no-alt-screen',
+				},
+				"explore",
+			);
+			assert.deepEqual(args, [
+				"--no-alt-screen",
+				"-c",
+				'model_reasoning_effort="high"',
+				"--model",
+				expectedLowComplexityModel(),
+			]);
+		} finally {
+			console.log = originalLog;
+		}
+		assert.ok(
+			logs.some(
+				(line) =>
+					line.includes("thinking_level=high") &&
+					line.includes("source=explicit"),
+			),
+		);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv logs model=claude without thinking_level for claude CLI', () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
-    try {
-      const args = resolveWorkerLaunchArgsFromEnv(
-        {
-          OMX_TEAM_WORKER_CLI: 'claude',
-          OMX_TEAM_WORKER_LAUNCH_ARGS: '-c model_reasoning_effort="high" --no-alt-screen',
-        },
-        'explore',
-      );
-      assert.deepEqual(
-        args,
-        ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', expectedLowComplexityModel()],
-      );
-    } finally {
-      console.log = originalLog;
-    }
-    const startupLog = logs.find((line) => line.includes('worker startup resolution:'));
-    assert.ok(startupLog);
-    assert.match(startupLog, /model=claude/);
-    assert.match(startupLog, /source=local-settings/);
-    assert.doesNotMatch(startupLog, /thinking_level=/);
-  });
+	it("resolveWorkerLaunchArgsFromEnv logs model=claude without thinking_level for claude CLI", () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			const args = resolveWorkerLaunchArgsFromEnv(
+				{
+					OMX_TEAM_WORKER_CLI: "claude",
+					OMX_TEAM_WORKER_LAUNCH_ARGS:
+						'-c model_reasoning_effort="high" --no-alt-screen',
+				},
+				"explore",
+			);
+			assert.deepEqual(args, [
+				"--no-alt-screen",
+				"-c",
+				'model_reasoning_effort="high"',
+				"--model",
+				expectedLowComplexityModel(),
+			]);
+		} finally {
+			console.log = originalLog;
+		}
+		const startupLog = logs.find((line) =>
+			line.includes("worker startup resolution:"),
+		);
+		assert.ok(startupLog);
+		assert.match(startupLog, /model=claude/);
+		assert.match(startupLog, /source=local-settings/);
+		assert.doesNotMatch(startupLog, /thinking_level=/);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv logs model=gemini without thinking_level for gemini CLI', () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
-    try {
-      const args = resolveWorkerLaunchArgsFromEnv(
-        {
-          OMX_TEAM_WORKER_CLI: 'gemini',
-          OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gemini-2.0-pro',
-        },
-        'executor',
-      );
-      assert.deepEqual(args, ['--model', 'gemini-2.0-pro']);
-    } finally {
-      console.log = originalLog;
-    }
-    const startupLog = logs.find((line) => line.includes('worker startup resolution:'));
-    assert.ok(startupLog);
-    assert.match(startupLog, /model=gemini/);
-    assert.match(startupLog, /source=local-settings/);
-    assert.doesNotMatch(startupLog, /thinking_level=/);
-  });
+	it("resolveWorkerLaunchArgsFromEnv logs model=gemini without thinking_level for gemini CLI", () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			const args = resolveWorkerLaunchArgsFromEnv(
+				{
+					OMX_TEAM_WORKER_CLI: "gemini",
+					OMX_TEAM_WORKER_LAUNCH_ARGS: "--model gemini-2.0-pro",
+				},
+				"executor",
+			);
+			assert.deepEqual(args, ["--model", "gemini-2.0-pro"]);
+		} finally {
+			console.log = originalLog;
+		}
+		const startupLog = logs.find((line) =>
+			line.includes("worker startup resolution:"),
+		);
+		assert.ok(startupLog);
+		assert.match(startupLog, /model=gemini/);
+		assert.match(startupLog, /source=local-settings/);
+		assert.doesNotMatch(startupLog, /thinking_level=/);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv keeps codex thinking_level logging for mixed CLI maps', () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
-    try {
-      const args = resolveWorkerLaunchArgsFromEnv(
-        {
-          OMX_TEAM_WORKER_CLI_MAP: 'codex,claude',
-          OMX_TEAM_WORKER_LAUNCH_ARGS: '-c model_reasoning_effort="high" --model claude-3-7-sonnet',
-        },
-        'executor',
-      );
-      assert.deepEqual(args, ['-c', 'model_reasoning_effort="high"', '--model', 'claude-3-7-sonnet']);
-    } finally {
-      console.log = originalLog;
-    }
-    assert.ok(logs.some((line) => line.includes('thinking_level=high') && line.includes('source=explicit')));
-  });
+	it("resolveWorkerLaunchArgsFromEnv keeps codex thinking_level logging for mixed CLI maps", () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			const args = resolveWorkerLaunchArgsFromEnv(
+				{
+					OMX_TEAM_WORKER_CLI_MAP: "codex,claude",
+					OMX_TEAM_WORKER_LAUNCH_ARGS:
+						'-c model_reasoning_effort="high" --model claude-3-7-sonnet',
+				},
+				"executor",
+			);
+			assert.deepEqual(args, [
+				"-c",
+				'model_reasoning_effort="high"',
+				"--model",
+				"claude-3-7-sonnet",
+			]);
+		} finally {
+			console.log = originalLog;
+		}
+		assert.ok(
+			logs.some(
+				(line) =>
+					line.includes("thinking_level=high") &&
+					line.includes("source=explicit"),
+			),
+		);
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv keeps claude and gemini startup logs free of thinking_level during teammate allocation', () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
-    try {
-      const codexArgs = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'executor',
-        undefined,
-        'high',
-        'codex',
-      );
-      const claudeArgs = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen --model claude-3-7-sonnet' },
-        'executor',
-        undefined,
-        'low',
-        'claude',
-      );
-      const geminiArgs = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--model gemini-2.0-pro' },
-        'executor',
-        undefined,
-        'low',
-        'gemini',
-      );
-      assert.deepEqual(codexArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', 'gpt-5.4']);
-      assert.deepEqual(claudeArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"', '--model', 'claude-3-7-sonnet']);
-      assert.deepEqual(geminiArgs, ['-c', 'model_reasoning_effort="low"', '--model', 'gemini-2.0-pro']);
-    } finally {
-      console.log = originalLog;
-    }
-    const codexLog = logs.find((line) => line.includes('thinking_level=high'));
-    const claudeLog = logs.find((line) => line.includes('model=claude'));
-    const geminiLog = logs.find((line) => line.includes('model=gemini'));
-    assert.ok(codexLog);
-    assert.ok(claudeLog);
-    assert.ok(geminiLog);
-    assert.doesNotMatch(claudeLog ?? '', /thinking_level=/);
-    assert.doesNotMatch(geminiLog ?? '', /thinking_level=/);
-  });
+	it("resolveWorkerLaunchArgsFromEnv keeps claude and gemini startup logs free of thinking_level during teammate allocation", () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			const codexArgs = resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+				"executor",
+				undefined,
+				"high",
+				"codex",
+			);
+			const claudeArgs = resolveWorkerLaunchArgsFromEnv(
+				{
+					OMX_TEAM_WORKER_LAUNCH_ARGS:
+						"--no-alt-screen --model claude-3-7-sonnet",
+				},
+				"executor",
+				undefined,
+				"low",
+				"claude",
+			);
+			const geminiArgs = resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--model gemini-2.0-pro" },
+				"executor",
+				undefined,
+				"low",
+				"gemini",
+			);
+			assert.deepEqual(codexArgs, [
+				"--no-alt-screen",
+				"-c",
+				'model_reasoning_effort="high"',
+				"--model",
+				"gpt-5.4",
+			]);
+			assert.deepEqual(claudeArgs, [
+				"--no-alt-screen",
+				"-c",
+				'model_reasoning_effort="low"',
+				"--model",
+				"claude-3-7-sonnet",
+			]);
+			assert.deepEqual(geminiArgs, [
+				"-c",
+				'model_reasoning_effort="low"',
+				"--model",
+				"gemini-2.0-pro",
+			]);
+		} finally {
+			console.log = originalLog;
+		}
+		const codexLog = logs.find((line) => line.includes("thinking_level=high"));
+		const claudeLog = logs.find((line) => line.includes("model=claude"));
+		const geminiLog = logs.find((line) => line.includes("model=gemini"));
+		assert.ok(codexLog);
+		assert.ok(claudeLog);
+		assert.ok(geminiLog);
+		assert.doesNotMatch(claudeLog ?? "", /thinking_level=/);
+		assert.doesNotMatch(geminiLog ?? "", /thinking_level=/);
+	});
 
-  it('waitForClaudeStartupEvidence requires first-start ACK/task progress before startup dispatch is treated as settled', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-claude-startup-'));
-    try {
-      await initTeamState('claude-startup', 'startup evidence test', 'executor', 1, cwd);
+	it("waitForClaudeStartupEvidence requires first-start ACK/task progress before startup dispatch is treated as settled", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-claude-startup-"));
+		try {
+			await initTeamState(
+				"claude-startup",
+				"startup evidence test",
+				"executor",
+				1,
+				cwd,
+			);
 
-      const none = await waitForClaudeStartupEvidence({
-        teamName: 'claude-startup',
-        workerName: 'worker-1',
-        cwd,
-        timeoutMs: 25,
-        pollMs: 5,
-      });
-      assert.equal(none, 'none');
+			const none = await waitForClaudeStartupEvidence({
+				teamName: "claude-startup",
+				workerName: "worker-1",
+				cwd,
+				timeoutMs: 25,
+				pollMs: 5,
+			});
+			assert.equal(none, "none");
 
-      await sendWorkerMessage('claude-startup', 'worker-1', 'leader-fixed', 'ACK', cwd);
-      const ack = await waitForClaudeStartupEvidence({
-        teamName: 'claude-startup',
-        workerName: 'worker-1',
-        cwd,
-        timeoutMs: 25,
-        pollMs: 5,
-      });
-      assert.equal(ack, 'leader_ack');
+			await sendWorkerMessage(
+				"claude-startup",
+				"worker-1",
+				"leader-fixed",
+				"ACK",
+				cwd,
+			);
+			const ack = await waitForClaudeStartupEvidence({
+				teamName: "claude-startup",
+				workerName: "worker-1",
+				cwd,
+				timeoutMs: 25,
+				pollMs: 5,
+			});
+			assert.equal(ack, "leader_ack");
 
-      await writeAtomic(
-        join(cwd, '.omx', 'state', 'team', 'claude-startup', 'workers', 'worker-1', 'status.json'),
-        JSON.stringify({
-          state: 'working',
-          current_task_id: 'task-1',
-          updated_at: new Date().toISOString(),
-        }, null, 2),
-      );
-      const taskClaim = await waitForClaudeStartupEvidence({
-        teamName: 'claude-startup',
-        workerName: 'worker-1',
-        cwd,
-        timeoutMs: 25,
-        pollMs: 5,
-      });
-      assert.equal(taskClaim, 'task_claim');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await writeAtomic(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					"claude-startup",
+					"workers",
+					"worker-1",
+					"status.json",
+				),
+				JSON.stringify(
+					{
+						state: "working",
+						current_task_id: "task-1",
+						updated_at: new Date().toISOString(),
+					},
+					null,
+					2,
+				),
+			);
+			const taskClaim = await waitForClaudeStartupEvidence({
+				teamName: "claude-startup",
+				workerName: "worker-1",
+				cwd,
+				timeoutMs: 25,
+				pollMs: 5,
+			});
+			assert.equal(taskClaim, "task_claim");
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('waitForWorkerStartupEvidence ignores Codex ACK-only startup replies until work is claimed', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-startup-'));
-    try {
-      await initTeamState('codex-startup', 'startup evidence test', 'executor', 1, cwd);
+	it("waitForWorkerStartupEvidence ignores Codex ACK-only startup replies until work is claimed", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-codex-startup-"));
+		try {
+			await initTeamState(
+				"codex-startup",
+				"startup evidence test",
+				"executor",
+				1,
+				cwd,
+			);
 
-      await sendWorkerMessage('codex-startup', 'worker-1', 'leader-fixed', 'ACK', cwd);
-      const ackOnly = await waitForWorkerStartupEvidence({
-        teamName: 'codex-startup',
-        workerName: 'worker-1',
-        workerCli: 'codex',
-        cwd,
-        timeoutMs: 25,
-        pollMs: 5,
-      });
-      assert.equal(ackOnly, 'none');
+			await sendWorkerMessage(
+				"codex-startup",
+				"worker-1",
+				"leader-fixed",
+				"ACK",
+				cwd,
+			);
+			const ackOnly = await waitForWorkerStartupEvidence({
+				teamName: "codex-startup",
+				workerName: "worker-1",
+				workerCli: "codex",
+				cwd,
+				timeoutMs: 25,
+				pollMs: 5,
+			});
+			assert.equal(ackOnly, "none");
 
-      await writeAtomic(
-        join(cwd, '.omx', 'state', 'team', 'codex-startup', 'workers', 'worker-1', 'status.json'),
-        JSON.stringify({
-          state: 'working',
-          current_task_id: 'task-1',
-          updated_at: new Date().toISOString(),
-        }, null, 2),
-      );
-      const taskClaim = await waitForWorkerStartupEvidence({
-        teamName: 'codex-startup',
-        workerName: 'worker-1',
-        workerCli: 'codex',
-        cwd,
-        timeoutMs: 25,
-        pollMs: 5,
-      });
-      assert.equal(taskClaim, 'task_claim');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await writeAtomic(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					"codex-startup",
+					"workers",
+					"worker-1",
+					"status.json",
+				),
+				JSON.stringify(
+					{
+						state: "working",
+						current_task_id: "task-1",
+						updated_at: new Date().toISOString(),
+					},
+					null,
+					2,
+				),
+			);
+			const taskClaim = await waitForWorkerStartupEvidence({
+				teamName: "codex-startup",
+				workerName: "worker-1",
+				workerCli: "codex",
+				cwd,
+				timeoutMs: 25,
+				pollMs: 5,
+			});
+			assert.equal(taskClaim, "task_claim");
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('resolveWorkerLaunchArgsFromEnv logs source=none/default-none when thinking is not explicit', () => {
-    const logs: string[] = [];
-    const originalLog = console.log;
-    console.log = (...args: unknown[]) => { logs.push(args.join(' ')); };
-    try {
-      const args = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
-        'explore',
-      );
-      assert.deepEqual(args, ['--no-alt-screen', '--model', expectedLowComplexityModel()]);
-    } finally {
-      console.log = originalLog;
-    }
-    assert.ok(logs.some((line) => line.includes('thinking_level=none') && line.includes('source=none/default-none')));
-  });
+	it("startTeam rejects interactive startup when tmux fallback never produces worker startup evidence", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-startup-no-evidence-"),
+		);
+		const prevTmux = process.env.TMUX;
+		const prevTmuxPane = process.env.TMUX_PANE;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+		let receiptFailer: NodeJS.Timeout | null = null;
 
-  it('startTeam rejects nested team invocation inside worker context', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    const prev = process.env.OMX_TEAM_WORKER;
-    process.env.OMX_TEAM_WORKER = 'alpha/worker-1';
-    try {
-      await assert.rejects(
-        () => startTeam('nested-a', 'task', 'executor', 1, [{ subject: 's', description: 'd' }], cwd),
-        /nested_team_disallowed/,
-      );
-    } finally {
-      if (typeof prev === 'string') process.env.OMX_TEAM_WORKER = prev;
-      else delete process.env.OMX_TEAM_WORKER;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-startup-no-evidence-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%1\\tzsh\\tzsh\\n"
+        exit 0
+        ;;
+      *"#{pane_pid}"*)
+        echo "4321"
+        exit 0
+        ;;
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "0 4321"
+        exit 0
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    printf 'OpenAI Codex\\n> '
+    exit 0
+    ;;
+  send-keys|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|kill-pane|kill-session)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+					binaries: [
+						{
+							name: "codex",
+							content: "#!/bin/sh\nsleep 30\n",
+						},
+					],
+				},
+				async ({ tmuxLogPath }) => {
+					process.env.TMUX = "leader-session";
+					process.env.TMUX_PANE = "%1";
+					process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "interactive";
+					process.env.OMX_TEAM_WORKER_CLI = "codex";
+					process.env.OMX_TEAM_SKIP_READY_WAIT = "1";
 
-  it('startTeam allows nested team invocation when parent governance enables it', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-nested-allow-'));
-    const binDir = join(cwd, 'bin');
-    const fakeGeminiPath = join(binDir, 'gemini');
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeGeminiPath,
-      `#!/usr/bin/env bash
+					receiptFailer = setInterval(() => {
+						void (async () => {
+							const requests = await listDispatchRequests(
+								"team-startup-no-evidence",
+								cwd,
+								{ kind: "inbox" },
+							).catch(() => []);
+							for (const request of requests) {
+								if (request.status !== "pending") continue;
+								await transitionDispatchRequest(
+									"team-startup-no-evidence",
+									request.request_id,
+									"pending",
+									"failed",
+									{ last_reason: "test_failed_receipt" },
+									cwd,
+								).catch(() => {});
+							}
+						})();
+					}, 20);
+
+					await assert.rejects(
+						() =>
+							withoutTeamWorkerEnv(() =>
+								startTeam(
+									"team-startup-no-evidence",
+									"interactive startup must observe worker evidence",
+									"executor",
+									1,
+									[{ subject: "s", description: "d", owner: "worker-1" }],
+									cwd,
+								),
+							),
+						/worker_notify_failed/,
+					);
+
+					if (receiptFailer) {
+						clearInterval(receiptFailer);
+						receiptFailer = null;
+					}
+
+					assert.equal(
+						await readTeamConfig("team-startup-no-evidence", cwd),
+						null,
+					);
+
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+					assert.match(tmuxLog, /send-keys -t %2 -l --/);
+				},
+			);
+		} finally {
+			if (receiptFailer) clearInterval(receiptFailer);
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevTmuxPane === "string")
+				process.env.TMUX_PANE = prevTmuxPane;
+			else delete process.env.TMUX_PANE;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevSkipReadyWait === "string")
+				process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
+			else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("resolveWorkerLaunchArgsFromEnv logs source=none/default-none when thinking is not explicit", () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			const args = resolveWorkerLaunchArgsFromEnv(
+				{ OMX_TEAM_WORKER_LAUNCH_ARGS: "--no-alt-screen" },
+				"explore",
+			);
+			assert.deepEqual(args, [
+				"--no-alt-screen",
+				"--model",
+				expectedLowComplexityModel(),
+			]);
+		} finally {
+			console.log = originalLog;
+		}
+		assert.ok(
+			logs.some(
+				(line) =>
+					line.includes("thinking_level=none") &&
+					line.includes("source=none/default-none"),
+			),
+		);
+	});
+
+	it("startTeam rejects nested team invocation inside worker context", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		const prev = process.env.OMX_TEAM_WORKER;
+		process.env.OMX_TEAM_WORKER = "alpha/worker-1";
+		try {
+			await assert.rejects(
+				() =>
+					startTeam(
+						"nested-a",
+						"task",
+						"executor",
+						1,
+						[{ subject: "s", description: "d" }],
+						cwd,
+					),
+				/nested_team_disallowed/,
+			);
+		} finally {
+			if (typeof prev === "string") process.env.OMX_TEAM_WORKER = prev;
+			else delete process.env.OMX_TEAM_WORKER;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("startTeam allows nested team invocation when parent governance enables it", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-nested-allow-"));
+		const binDir = join(cwd, "bin");
+		const fakeGeminiPath = join(binDir, "gemini");
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeGeminiPath,
+			`#!/usr/bin/env bash
 sleep 5
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    await initTeamState('parent-team', 'parent', 'executor', 1, cwd);
-    const parentManifestPath = join(cwd, '.omx', 'state', 'team', 'parent-team', 'manifest.v2.json');
-    const parentManifest = JSON.parse(await readFile(parentManifestPath, 'utf-8')) as any;
-    parentManifest.governance = { ...(parentManifest.governance || {}), nested_teams_allowed: true };
-    await writeFile(parentManifestPath, JSON.stringify(parentManifest, null, 2));
+		await initTeamState("parent-team", "parent", "executor", 1, cwd);
+		const parentManifestPath = join(
+			cwd,
+			".omx",
+			"state",
+			"team",
+			"parent-team",
+			"manifest.v2.json",
+		);
+		const parentManifest = JSON.parse(
+			await readFile(parentManifestPath, "utf-8"),
+		) as any;
+		parentManifest.governance = {
+			...(parentManifest.governance || {}),
+			nested_teams_allowed: true,
+		};
+		await writeFile(
+			parentManifestPath,
+			JSON.stringify(parentManifest, null, 2),
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevWorker = process.env.OMX_TEAM_WORKER;
-    const prevStateRoot = process.env.OMX_TEAM_STATE_ROOT;
-    const prevLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevWorker = process.env.OMX_TEAM_WORKER;
+		const prevStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+		const prevLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER = 'parent-team/worker-1';
-    process.env.OMX_TEAM_STATE_ROOT = join(cwd, '.omx', 'state');
-    process.env.OMX_TEAM_LEADER_CWD = cwd;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER = "parent-team/worker-1";
+		process.env.OMX_TEAM_STATE_ROOT = join(cwd, ".omx", "state");
+		process.env.OMX_TEAM_LEADER_CWD = cwd;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "gemini";
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await startTeam(
-        'nested-allowed',
-        'nested task',
-        'explore',
-        1,
-        [{ subject: 's', description: 'd', owner: 'worker-1' }],
-        cwd,
-      );
-      assert.equal(runtime.teamName, 'nested-allowed');
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
-    } finally {
-      const runtimeToShutdown = runtime as TeamRuntime | null;
-      if (runtimeToShutdown) {
-        await shutdownTeam(runtimeToShutdown.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevWorker === 'string') process.env.OMX_TEAM_WORKER = prevWorker;
-      else delete process.env.OMX_TEAM_WORKER;
-      if (typeof prevStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevStateRoot;
-      else delete process.env.OMX_TEAM_STATE_ROOT;
-      if (typeof prevLeaderCwd === 'string') process.env.OMX_TEAM_LEADER_CWD = prevLeaderCwd;
-      else delete process.env.OMX_TEAM_LEADER_CWD;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await startTeam(
+				"nested-allowed",
+				"nested task",
+				"explore",
+				1,
+				[{ subject: "s", description: "d", owner: "worker-1" }],
+				cwd,
+			);
+			assert.equal(runtime.teamName, "nested-allowed");
+			await shutdownTeam(runtime.teamName, cwd, { force: true });
+			runtime = null;
+		} finally {
+			const runtimeToShutdown = runtime as TeamRuntime | null;
+			if (runtimeToShutdown) {
+				await shutdownTeam(runtimeToShutdown.teamName, cwd, {
+					force: true,
+				}).catch(() => {});
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevWorker === "string")
+				process.env.OMX_TEAM_WORKER = prevWorker;
+			else delete process.env.OMX_TEAM_WORKER;
+			if (typeof prevStateRoot === "string")
+				process.env.OMX_TEAM_STATE_ROOT = prevStateRoot;
+			else delete process.env.OMX_TEAM_STATE_ROOT;
+			if (typeof prevLeaderCwd === "string")
+				process.env.OMX_TEAM_LEADER_CWD = prevLeaderCwd;
+			else delete process.env.OMX_TEAM_LEADER_CWD;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam throws when tmux is not available', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    try {
-      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
-      await assert.rejects(
-        () => withoutTeamWorkerEnv(() =>
-          withEmptyPath(() =>
-            startTeam('team-a', 'task', 'executor', 1, [{ subject: 's', description: 'd' }], cwd),
-          )),
-        /requires tmux/i,
-      );
-    } finally {
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("startTeam throws when tmux is not available", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		try {
+			process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "interactive";
+			await assert.rejects(
+				() =>
+					withoutTeamWorkerEnv(() =>
+						withEmptyPath(() =>
+							startTeam(
+								"team-a",
+								"task",
+								"executor",
+								1,
+								[{ subject: "s", description: "d" }],
+								cwd,
+							),
+						),
+					),
+				/requires tmux/i,
+			);
+		} finally {
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam rejects duplicate active same-name team state without mutating existing files', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-duplicate-team-'));
-    const prevSessionId = process.env.OMX_SESSION_ID;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    try {
-      process.env.OMX_SESSION_ID = 'sess-existing-team';
-      await initTeamState(
-        'dup-team',
-        'existing task',
-        'executor',
-        1,
-        cwd,
-        undefined,
-        { ...process.env, OMX_SESSION_ID: 'sess-existing-team' },
-      );
-      await createTask('dup-team', {
-        subject: 'existing subject',
-        description: 'existing description',
-        status: 'pending',
-      }, cwd);
+	it("startTeam rejects duplicate active same-name team state without mutating existing files", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-duplicate-team-"));
+		const prevSessionId = process.env.OMX_SESSION_ID;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		try {
+			process.env.OMX_SESSION_ID = "sess-existing-team";
+			await initTeamState(
+				"dup-team",
+				"existing task",
+				"executor",
+				1,
+				cwd,
+				undefined,
+				{ ...process.env, OMX_SESSION_ID: "sess-existing-team" },
+			);
+			await createTask(
+				"dup-team",
+				{
+					subject: "existing subject",
+					description: "existing description",
+					status: "pending",
+				},
+				cwd,
+			);
 
-      const beforeConfig = await readTeamConfig('dup-team', cwd);
-      assert.ok(beforeConfig);
+			const beforeConfig = await readTeamConfig("dup-team", cwd);
+			assert.ok(beforeConfig);
 
-      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-      process.env.OMX_SESSION_ID = 'sess-second-team';
+			process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+			process.env.OMX_SESSION_ID = "sess-second-team";
 
-      await assert.rejects(
-        () => withoutTeamWorkerEnv(() =>
-          startTeam(
-            'dup-team',
-            'replacement task',
-            'executor',
-            1,
-            [{ subject: 'new subject', description: 'new description', owner: 'worker-1' }],
-            cwd,
-          )),
-        /team_name_conflict: active team state already exists/,
-      );
+			await assert.rejects(
+				() =>
+					withoutTeamWorkerEnv(() =>
+						startTeam(
+							"dup-team",
+							"replacement task",
+							"executor",
+							1,
+							[
+								{
+									subject: "new subject",
+									description: "new description",
+									owner: "worker-1",
+								},
+							],
+							cwd,
+						),
+					),
+				/team_name_conflict: active team state already exists/,
+			);
 
-      const afterConfig = await readTeamConfig('dup-team', cwd);
-      const existingTask = await readTask('dup-team', '1', cwd);
-      assert.equal(afterConfig?.task, 'existing task');
-      assert.equal(afterConfig?.created_at, beforeConfig?.created_at);
-      assert.equal(existingTask?.subject, 'existing subject');
-      assert.equal(existingTask?.description, 'existing description');
-    } finally {
-      if (typeof prevSessionId === 'string') process.env.OMX_SESSION_ID = prevSessionId;
-      else delete process.env.OMX_SESSION_ID;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			const afterConfig = await readTeamConfig("dup-team", cwd);
+			const existingTask = await readTask("dup-team", "1", cwd);
+			assert.equal(afterConfig?.task, "existing task");
+			assert.equal(afterConfig?.created_at, beforeConfig?.created_at);
+			assert.equal(existingTask?.subject, "existing subject");
+			assert.equal(existingTask?.description, "existing description");
+		} finally {
+			if (typeof prevSessionId === "string")
+				process.env.OMX_SESSION_ID = prevSessionId;
+			else delete process.env.OMX_SESSION_ID;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('skips interactive worker process-tree prekill on native Windows split-pane sessions', async () => {
-    await withNativeWindowsPlatform(async () => {
-      assert.equal(shouldPrekillInteractiveShutdownProcessTrees('leader:0'), false);
-      assert.equal(shouldPrekillInteractiveShutdownProcessTrees('omx-team-alpha'), true);
-    });
+	it("skips interactive worker process-tree prekill on native Windows split-pane sessions", async () => {
+		await withNativeWindowsPlatform(async () => {
+			assert.equal(
+				shouldPrekillInteractiveShutdownProcessTrees("leader:0"),
+				false,
+			);
+			assert.equal(
+				shouldPrekillInteractiveShutdownProcessTrees("omx-team-alpha"),
+				true,
+			);
+		});
 
-    assert.equal(shouldPrekillInteractiveShutdownProcessTrees('leader:0'), true);
-  });
+		assert.equal(
+			shouldPrekillInteractiveShutdownProcessTrees("leader:0"),
+			true,
+		);
+	});
 
-  it('startTeam accepts native Windows tmux clients even when TMUX env vars are absent', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-win32-no-env-'));
-    const prevTmux = process.env.TMUX;
-    const prevTmuxPane = process.env.TMUX_PANE;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
-    const prevMsystem = process.env.MSYSTEM;
-    const prevOstype = process.env.OSTYPE;
-    const prevWsl = process.env.WSL_DISTRO_NAME;
-    const prevWslInterop = process.env.WSL_INTEROP;
-    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-    let runtime: TeamRuntime | null = null;
-    let teamNameForCleanup: string | null = null;
+	it("startTeam accepts native Windows tmux clients even when TMUX env vars are absent", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-win32-no-env-"));
+		const prevTmux = process.env.TMUX;
+		const prevTmuxPane = process.env.TMUX_PANE;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+		const prevMsystem = process.env.MSYSTEM;
+		const prevOstype = process.env.OSTYPE;
+		const prevWsl = process.env.WSL_DISTRO_NAME;
+		const prevWslInterop = process.env.WSL_INTEROP;
+		const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+		let runtime: TeamRuntime | null = null;
+		let teamNameForCleanup: string | null = null;
 
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-win32-no-env-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-win32-no-env-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
@@ -802,115 +1219,145 @@ case "\${1:-}" in
     ;;
 esac
 `,
-          binaries: [{
-            name: 'gemini',
-            content: '#!/bin/sh\nexit 0\n',
-          }],
-        },
-        async ({ tmuxLogPath }) => {
-          delete process.env.TMUX;
-          delete process.env.TMUX_PANE;
-          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
-          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
-          process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
-          delete process.env.MSYSTEM;
-          delete process.env.OSTYPE;
-          delete process.env.WSL_DISTRO_NAME;
-          delete process.env.WSL_INTEROP;
-          Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+					binaries: [
+						{
+							name: "gemini",
+							content: "#!/bin/sh\nexit 0\n",
+						},
+					],
+				},
+				async ({ tmuxLogPath }) => {
+					delete process.env.TMUX;
+					delete process.env.TMUX_PANE;
+					process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "interactive";
+					process.env.OMX_TEAM_WORKER_CLI = "gemini";
+					process.env.OMX_TEAM_SKIP_READY_WAIT = "1";
+					delete process.env.MSYSTEM;
+					delete process.env.OSTYPE;
+					delete process.env.WSL_DISTRO_NAME;
+					delete process.env.WSL_INTEROP;
+					Object.defineProperty(process, "platform", {
+						value: "win32",
+						configurable: true,
+					});
 
-          runtime = await withoutTeamWorkerEnv(() =>
-            startTeam(
-              'team-win32-no-env',
-              'native windows current-client detection',
-              'executor',
-              1,
-              [{ subject: 's', description: 'd', owner: 'worker-1' }],
-              cwd,
-            ));
-          teamNameForCleanup = runtime.teamName;
-          assert.equal(runtime.config.tmux_session, 'leader:0');
-          assert.equal(runtime.config.leader_pane_id, '%1');
-          assert.equal(runtime.config.hud_pane_id, '%3');
+					runtime = await withoutTeamWorkerEnv(() =>
+						startTeam(
+							"team-win32-no-env",
+							"native windows current-client detection",
+							"executor",
+							1,
+							[{ subject: "s", description: "d", owner: "worker-1" }],
+							cwd,
+						),
+					);
+					teamNameForCleanup = runtime.teamName;
+					assert.equal(runtime.config.tmux_session, "leader:0");
+					assert.equal(runtime.config.leader_pane_id, "%1");
+					assert.equal(runtime.config.hud_pane_id, "%3");
 
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /display-message -p #S:#I #{pane_id}/);
-          assert.match(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+					assert.match(tmuxLog, /display-message -p #S:#I #{pane_id}/);
+					assert.match(
+						tmuxLog,
+						new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`),
+					);
 
-          if (teamNameForCleanup) {
-            await shutdownTeam(teamNameForCleanup, cwd, { force: true });
-          }
-          runtime = null;
-        },
-      );
-    } finally {
-      if (teamNameForCleanup) {
-        await shutdownTeam(teamNameForCleanup, cwd, { force: true }).catch(() => {});
-      }
-      if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
-      else delete process.env.TMUX_PANE;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
-      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
-      if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
-      else delete process.env.MSYSTEM;
-      if (typeof prevOstype === 'string') process.env.OSTYPE = prevOstype;
-      else delete process.env.OSTYPE;
-      if (typeof prevWsl === 'string') process.env.WSL_DISTRO_NAME = prevWsl;
-      else delete process.env.WSL_DISTRO_NAME;
-      if (typeof prevWslInterop === 'string') process.env.WSL_INTEROP = prevWslInterop;
-      else delete process.env.WSL_INTEROP;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					if (teamNameForCleanup) {
+						await shutdownTeam(teamNameForCleanup, cwd, { force: true });
+					}
+					runtime = null;
+				},
+			);
+		} finally {
+			if (teamNameForCleanup) {
+				await shutdownTeam(teamNameForCleanup, cwd, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (origPlatform)
+				Object.defineProperty(process, "platform", origPlatform);
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevTmuxPane === "string")
+				process.env.TMUX_PANE = prevTmuxPane;
+			else delete process.env.TMUX_PANE;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevSkipReadyWait === "string")
+				process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
+			else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+			if (typeof prevMsystem === "string") process.env.MSYSTEM = prevMsystem;
+			else delete process.env.MSYSTEM;
+			if (typeof prevOstype === "string") process.env.OSTYPE = prevOstype;
+			else delete process.env.OSTYPE;
+			if (typeof prevWsl === "string") process.env.WSL_DISTRO_NAME = prevWsl;
+			else delete process.env.WSL_DISTRO_NAME;
+			if (typeof prevWslInterop === "string")
+				process.env.WSL_INTEROP = prevWslInterop;
+			else delete process.env.WSL_INTEROP;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('applyCreatedInteractiveSessionToConfig persists worker pane ids before readiness waits', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-pane-persist-race-'));
-    try {
-      const config = await initTeamState('team-pane-persist-race', 'persist pane ids before readiness wait', 'executor', 2, cwd);
-      const workerPaneIds = Array.from({ length: 2 }, () => undefined as string | undefined);
-      applyCreatedInteractiveSessionToConfig(config, {
-        name: 'leader:0',
-        workerCount: 2,
-        cwd,
-        workerPaneIds: ['%2', '%3'],
-        leaderPaneId: '%1',
-        hudPaneId: '%4',
-        resizeHookName: 'resize-hook',
-        resizeHookTarget: 'leader:0',
-      }, workerPaneIds);
+	it("applyCreatedInteractiveSessionToConfig persists worker pane ids before readiness waits", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-pane-persist-race-"));
+		try {
+			const config = await initTeamState(
+				"team-pane-persist-race",
+				"persist pane ids before readiness wait",
+				"executor",
+				2,
+				cwd,
+			);
+			const workerPaneIds = Array.from(
+				{ length: 2 },
+				() => undefined as string | undefined,
+			);
+			applyCreatedInteractiveSessionToConfig(
+				config,
+				{
+					name: "leader:0",
+					workerCount: 2,
+					cwd,
+					workerPaneIds: ["%2", "%3"],
+					leaderPaneId: "%1",
+					hudPaneId: "%4",
+					resizeHookName: "resize-hook",
+					resizeHookTarget: "leader:0",
+				},
+				workerPaneIds,
+			);
 
-      assert.equal(config.tmux_session, 'leader:0');
-      assert.equal(config.leader_pane_id, '%1');
-      assert.equal(config.hud_pane_id, '%4');
-      assert.deepEqual(workerPaneIds, ['%2', '%3']);
-      assert.equal(config.workers[0]?.pane_id, '%2');
-      assert.equal(config.workers[1]?.pane_id, '%3');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			assert.equal(config.tmux_session, "leader:0");
+			assert.equal(config.leader_pane_id, "%1");
+			assert.equal(config.hud_pane_id, "%4");
+			assert.deepEqual(workerPaneIds, ["%2", "%3"]);
+			assert.equal(config.workers[0]?.pane_id, "%2");
+			assert.equal(config.workers[1]?.pane_id, "%3");
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam captures interactive worker pid from the resolved pane id', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-pane-pid-'));
-    const prevTmux = process.env.TMUX;
-    const prevTmuxPane = process.env.TMUX_PANE;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
-    let runtime: TeamRuntime | null = null;
+	it("startTeam captures interactive worker pid from the resolved pane id", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-pane-pid-"));
+		const prevTmux = process.env.TMUX;
+		const prevTmuxPane = process.env.TMUX_PANE;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+		let runtime: TeamRuntime | null = null;
 
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-pane-pid-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-pane-pid-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
@@ -971,287 +1418,510 @@ case "\${1:-}" in
     ;;
 esac
 `,
-          binaries: [{ name: 'codex', content: '#!/bin/sh\nexit 0\n' }],
-        },
-        async () => {
-          delete process.env.TMUX;
-          process.env.TMUX_PANE = '%1';
-          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
-          process.env.OMX_TEAM_WORKER_CLI = 'codex';
-          process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+					binaries: [{ name: "gemini", content: "#!/bin/sh\nexit 0\n" }],
+				},
+				async () => {
+					delete process.env.TMUX;
+					process.env.TMUX_PANE = "%1";
+					process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "interactive";
+					process.env.OMX_TEAM_WORKER_CLI = "gemini";
+					process.env.OMX_TEAM_SKIP_READY_WAIT = "1";
 
-          runtime = await withoutTeamWorkerEnv(() =>
-            startTeam(
-              'team-pane-pid',
-              'interactive pane pid capture',
-              'executor',
-              1,
-              [{ subject: 's', description: 'd', owner: 'worker-1' }],
-              cwd,
-            ));
+					runtime = await withoutTeamWorkerEnv(() =>
+						startTeam(
+							"team-pane-pid",
+							"interactive pane pid capture",
+							"executor",
+							1,
+							[{ subject: "s", description: "d", owner: "worker-1" }],
+							cwd,
+						),
+					);
 
-          assert.equal(runtime.config.workers[0]?.pane_id, '%2');
-          assert.equal(runtime.config.workers[0]?.pid, 2222);
+					assert.equal(runtime.config.workers[0]?.pane_id, "%2");
+					assert.equal(runtime.config.workers[0]?.pid, 2222);
 
-          const identityPath = join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'identity.json');
-          const identity = JSON.parse(await readFile(identityPath, 'utf-8')) as { pid?: number; pane_id?: string };
-          assert.equal(identity.pane_id, '%2');
-          assert.equal(identity.pid, 2222);
-        },
-      );
-    } finally {
-      const runtimeToShutdown = runtime as TeamRuntime | null;
-      if (runtimeToShutdown) {
-        await shutdownTeam(runtimeToShutdown.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
-      else delete process.env.TMUX_PANE;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
-      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					const identityPath = join(
+						cwd,
+						".omx",
+						"state",
+						"team",
+						runtime.teamName,
+						"workers",
+						"worker-1",
+						"identity.json",
+					);
+					const identity = JSON.parse(
+						await readFile(identityPath, "utf-8"),
+					) as { pid?: number; pane_id?: string };
+					assert.equal(identity.pane_id, "%2");
+					assert.equal(identity.pid, 2222);
+				},
+			);
+		} finally {
+			const runtimeToShutdown = runtime as TeamRuntime | null;
+			if (runtimeToShutdown) {
+				await shutdownTeam(runtimeToShutdown.teamName, cwd, {
+					force: true,
+				}).catch(() => {});
+			}
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevTmuxPane === "string")
+				process.env.TMUX_PANE = prevTmuxPane;
+			else delete process.env.TMUX_PANE;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevSkipReadyWait === "string")
+				process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
+			else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam saves interactive pane ids before readiness waits in source order', async () => {
-    const source = await readFile(join(process.cwd(), 'src', 'team', 'runtime.ts'), 'utf-8');
-    const applyIndex = source.indexOf('applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);');
-    const saveIndex = source.indexOf('await saveTeamConfig(config, leaderCwd);', applyIndex);
-    const readyIndex = source.indexOf('const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);', saveIndex);
+	it("startTeam rejects interactive startup when fallback delivery never produces startup evidence", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-no-startup-evidence-"),
+		);
+		const previousTmux = process.env.TMUX;
+		const previousTmuxPane = process.env.TMUX_PANE;
+		const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+		const previousStartupEvidenceTimeout =
+			process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
 
-    assert.notEqual(applyIndex, -1);
-    assert.notEqual(saveIndex, -1);
-    assert.notEqual(readyIndex, -1);
-    assert.equal(applyIndex < saveIndex, true);
-    assert.equal(saveIndex < readyIndex, true);
-  });
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-no-startup-evidence-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "0 4242"
+        ;;
+      *"pane_current_command"* )
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *"#{pane_pid}"*)
+        echo "4242"
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session|resize-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+					binaries: [
+						{
+							name: "codex",
+							content: `#!/usr/bin/env node
+process.stdin.resume();
+setTimeout(() => process.exit(0), 30000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+						},
+					],
+				},
+				async () => {
+					delete process.env.TMUX;
+					process.env.TMUX_PANE = "%1";
+					process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "interactive";
+					process.env.OMX_TEAM_WORKER_CLI = "codex";
+					process.env.OMX_TEAM_SKIP_READY_WAIT = "1";
+					process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = "500";
 
-  it('startTeam rejects dirty leader workspace before provisioning worker worktrees', async () => {
-    const repo = await initRepo();
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    await writeFile(join(repo, 'README.md'), 'dirty\n', 'utf-8');
-    await writeFile(join(repo, 'notes.txt'), 'local only\n', 'utf-8');
-    try {
-      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-      await assert.rejects(
-        () => withoutTeamWorkerEnv(() =>
-          startTeam(
-            'team-dirty-preflight',
-            'reject dirty leader workspace',
-            'executor',
-            1,
-            [{ subject: 's', description: 'd', owner: 'worker-1' }],
-            repo,
-            { worktreeMode: { enabled: true, detached: true, name: null } },
-          )),
-        /leader_workspace_dirty_for_worktrees:.*M README\.md.*\?\? notes\.txt.*commit_or_stash_before_omx_team/s,
-      );
+					await assert.rejects(
+						() =>
+							withoutTeamWorkerEnv(() =>
+								startTeam(
+									"team-no-startup-evidence",
+									"interactive startup should fail without claim evidence",
+									"executor",
+									1,
+									[{ subject: "s", description: "d", owner: "worker-1" }],
+									cwd,
+								),
+							),
+						/worker_notify_failed:worker-1/,
+					);
 
-      const listedWorktrees = execFileSync('git', ['worktree', 'list', '--porcelain'], {
-        cwd: repo,
-        encoding: 'utf-8',
-      });
-      assert.doesNotMatch(listedWorktrees, /team-team-dirty-preflight-worker-1/);
-      assert.equal(existsSync(join(repo, '.omx', 'state', 'team', 'team-dirty-preflight')), false);
-    } finally {
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
+					assert.equal(
+						existsSync(
+							join(cwd, ".omx", "state", "team", "team-no-startup-evidence"),
+						),
+						false,
+					);
+					assert.equal(
+						existsSync(join(cwd, ".omx", "team", "team-no-startup-evidence")),
+						false,
+					);
+				},
+			);
+		} finally {
+			if (typeof previousTmux === "string") process.env.TMUX = previousTmux;
+			else delete process.env.TMUX;
+			if (typeof previousTmuxPane === "string")
+				process.env.TMUX_PANE = previousTmuxPane;
+			else delete process.env.TMUX_PANE;
+			if (typeof previousLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof previousWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof previousSkipReadyWait === "string")
+				process.env.OMX_TEAM_SKIP_READY_WAIT = previousSkipReadyWait;
+			else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+			if (typeof previousStartupEvidenceTimeout === "string") {
+				process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS =
+					previousStartupEvidenceTimeout;
+			} else {
+				delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+			}
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam launches gemini workers with startup prompt and no default model passthrough', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-gemini-'));
-    const binDir = join(cwd, 'bin');
-    const fakeGeminiPath = join(binDir, 'gemini');
-    const capturePath = join(cwd, 'gemini-argv.json');
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeGeminiPath,
-      `#!/usr/bin/env bash
+	it("startTeam saves interactive pane ids before readiness waits in source order", async () => {
+		const source = await readFile(
+			join(process.cwd(), "src", "team", "runtime.ts"),
+			"utf-8",
+		);
+		const applyIndex = source.indexOf(
+			"applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);",
+		);
+		const saveIndex = source.indexOf(
+			"await saveTeamConfig(config, leaderCwd);",
+			applyIndex,
+		);
+		const readyIndex = source.indexOf(
+			"const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);",
+			saveIndex,
+		);
+
+		assert.notEqual(applyIndex, -1);
+		assert.notEqual(saveIndex, -1);
+		assert.notEqual(readyIndex, -1);
+		assert.equal(applyIndex < saveIndex, true);
+		assert.equal(saveIndex < readyIndex, true);
+	});
+
+	it("startTeam rejects dirty leader workspace before provisioning worker worktrees", async () => {
+		const repo = await initRepo();
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		await writeFile(join(repo, "README.md"), "dirty\n", "utf-8");
+		await writeFile(join(repo, "notes.txt"), "local only\n", "utf-8");
+		try {
+			process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+			await assert.rejects(
+				() =>
+					withoutTeamWorkerEnv(() =>
+						startTeam(
+							"team-dirty-preflight",
+							"reject dirty leader workspace",
+							"executor",
+							1,
+							[{ subject: "s", description: "d", owner: "worker-1" }],
+							repo,
+							{ worktreeMode: { enabled: true, detached: true, name: null } },
+						),
+					),
+				/leader_workspace_dirty_for_worktrees:.*M README\.md.*\?\? notes\.txt.*commit_or_stash_before_omx_team/s,
+			);
+
+			const listedWorktrees = execFileSync(
+				"git",
+				["worktree", "list", "--porcelain"],
+				{
+					cwd: repo,
+					encoding: "utf-8",
+				},
+			);
+			assert.doesNotMatch(
+				listedWorktrees,
+				/team-team-dirty-preflight-worker-1/,
+			);
+			assert.equal(
+				existsSync(join(repo, ".omx", "state", "team", "team-dirty-preflight")),
+				false,
+			);
+		} finally {
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("startTeam launches gemini workers with startup prompt and no default model passthrough", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-gemini-"));
+		const binDir = join(cwd, "bin");
+		const fakeGeminiPath = join(binDir, "gemini");
+		const capturePath = join(cwd, "gemini-argv.json");
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeGeminiPath,
+			`#!/usr/bin/env bash
 printf '%s\n' "$@" > "$OMX_GEMINI_ARGV_CAPTURE_PATH"
 sleep 5
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-    const prevCapture = process.env.OMX_GEMINI_ARGV_CAPTURE_PATH;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+		const prevCapture = process.env.OMX_GEMINI_ARGV_CAPTURE_PATH;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'gemini';
-    process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.3-codex-spark';
-    process.env.OMX_GEMINI_ARGV_CAPTURE_PATH = capturePath;
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "gemini";
+		process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = "--model gpt-5.3-codex-spark";
+		process.env.OMX_GEMINI_ARGV_CAPTURE_PATH = capturePath;
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-gemini-prompt',
-          'gemini prompt-mode team bootstrap',
-          'explore',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-gemini-prompt",
+					"gemini prompt-mode team bootstrap",
+					"explore",
+					1,
+					[{ subject: "s", description: "d", owner: "worker-1" }],
+					cwd,
+				),
+			);
 
-      assert.equal(runtime.config.worker_launch_mode, 'prompt');
-      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
+			assert.equal(runtime.config.worker_launch_mode, "prompt");
+			assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
 
-      const expectedArgv = [
-        '--approval-mode',
-        'yolo',
-        '-i',
-        'Read .omx/state/team/team-gemini-prompt/workers/worker-1/inbox.md, start work now, report concrete progress, then continue assigned work or next feasible task.',
-      ];
-      let argv: string[] | null = null;
-      for (let attempt = 0; attempt < 50; attempt += 1) {
-        if (existsSync(capturePath)) {
-          const captured = (await readFile(capturePath, 'utf-8')).trim().split('\n').filter(Boolean);
-          if (captured.length >= expectedArgv.length) {
-            argv = captured;
-            break;
-          }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      assert.ok(argv, 'gemini argv capture file should be written');
-      assert.deepEqual(argv, expectedArgv);
+			const expectedArgv = [
+				"--approval-mode",
+				"yolo",
+				"-i",
+				"Read .omx/state/team/team-gemini-prompt/workers/worker-1/inbox.md, start work now, report concrete progress, then continue assigned work or next feasible task.",
+			];
+			let argv: string[] | null = null;
+			for (let attempt = 0; attempt < 50; attempt += 1) {
+				if (existsSync(capturePath)) {
+					const captured = (await readFile(capturePath, "utf-8"))
+						.trim()
+						.split("\n")
+						.filter(Boolean);
+					if (captured.length >= expectedArgv.length) {
+						argv = captured;
+						break;
+					}
+				}
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
+			assert.ok(argv, "gemini argv capture file should be written");
+			assert.deepEqual(argv, expectedArgv);
 
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-      if (typeof prevCapture === 'string') process.env.OMX_GEMINI_ARGV_CAPTURE_PATH = prevCapture;
-      else delete process.env.OMX_GEMINI_ARGV_CAPTURE_PATH;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam(runtime.teamName, cwd, { force: true });
+			runtime = null;
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevLaunchArgs === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+			if (typeof prevCapture === "string")
+				process.env.OMX_GEMINI_ARGV_CAPTURE_PATH = prevCapture;
+			else delete process.env.OMX_GEMINI_ARGV_CAPTURE_PATH;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam preserves explicit codex launch args while forcing bypass in prompt mode', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-explicit-launch-'));
-    const binDir = join(cwd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    const capturePath = join(cwd, 'codex-argv.json');
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("startTeam preserves explicit codex launch args while forcing bypass in prompt mode", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-codex-explicit-launch-"),
+		);
+		const binDir = join(cwd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const capturePath = join(cwd, "codex-argv.json");
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 const fs = require('fs');
 fs.writeFileSync(process.env.OMX_CODEX_ARGV_CAPTURE_PATH, JSON.stringify(process.argv.slice(2), null, 2));
 process.stdin.resume();
 setTimeout(() => process.exit(0), 5000);
 process.on('SIGTERM', () => process.exit(0));
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-    const prevCapture = process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+		const prevCapture = process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
-    process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.3-codex-spark -c model_reasoning_effort="low"';
-    process.env.OMX_CODEX_ARGV_CAPTURE_PATH = capturePath;
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
+		process.env.OMX_TEAM_WORKER_LAUNCH_ARGS =
+			'--model gpt-5.3-codex-spark -c model_reasoning_effort="low"';
+		process.env.OMX_CODEX_ARGV_CAPTURE_PATH = capturePath;
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-codex-explicit-launch',
-          'codex prompt-mode team bootstrap',
-          'explore',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-codex-explicit-launch",
+					"codex prompt-mode team bootstrap",
+					"explore",
+					1,
+					[{ subject: "s", description: "d", owner: "worker-1" }],
+					cwd,
+				),
+			);
 
-      assert.equal(runtime.config.worker_launch_mode, 'prompt');
-      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
+			assert.equal(runtime.config.worker_launch_mode, "prompt");
+			assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
 
-      let argv: string[] | null = null;
-      for (let attempt = 0; attempt < 50; attempt += 1) {
-        if (existsSync(capturePath)) {
-          argv = JSON.parse(await readFile(capturePath, 'utf-8')) as string[];
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      assert.ok(argv, 'codex argv capture file should be written');
-      assert.equal(argv.includes('--dangerously-bypass-approvals-and-sandbox'), true);
-      assert.equal(argv.filter((arg) => arg === '--dangerously-bypass-approvals-and-sandbox').length, 1);
-      assert.equal(argv.includes('--model'), true);
-      assert.equal(argv[argv.indexOf('--model') + 1], 'gpt-5.3-codex-spark');
-      assert.equal(argv.includes('-c'), true);
-      assert.equal(argv.includes('model_reasoning_effort="low"'), true);
-      assert.equal(argv.some((arg) => arg.includes('model_instructions_file=')), true);
+			let argv: string[] | null = null;
+			for (let attempt = 0; attempt < 50; attempt += 1) {
+				if (existsSync(capturePath)) {
+					argv = JSON.parse(await readFile(capturePath, "utf-8")) as string[];
+					break;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
+			assert.ok(argv, "codex argv capture file should be written");
+			assert.equal(
+				argv.includes("--dangerously-bypass-approvals-and-sandbox"),
+				true,
+			);
+			assert.equal(
+				argv.filter(
+					(arg) => arg === "--dangerously-bypass-approvals-and-sandbox",
+				).length,
+				1,
+			);
+			assert.equal(argv.includes("--model"), true);
+			assert.equal(argv[argv.indexOf("--model") + 1], "gpt-5.3-codex-spark");
+			assert.equal(argv.includes("-c"), true);
+			assert.equal(argv.includes('model_reasoning_effort="low"'), true);
+			assert.equal(
+				argv.some((arg) => arg.includes("model_instructions_file=")),
+				true,
+			);
 
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-      if (typeof prevCapture === 'string') process.env.OMX_CODEX_ARGV_CAPTURE_PATH = prevCapture;
-      else delete process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam(runtime.teamName, cwd, { force: true });
+			runtime = null;
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevLaunchArgs === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+			if (typeof prevCapture === "string")
+				process.env.OMX_CODEX_ARGV_CAPTURE_PATH = prevCapture;
+			else delete process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-
-  it('startTeam preserves routed task roles into team state and worker launch args', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-role-routing-'));
-    const binDir = join(cwd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    const captureDir = join(cwd, 'captures');
-    const promptsDir = join(cwd, '.codex', 'prompts');
-    await mkdir(binDir, { recursive: true });
-    await mkdir(captureDir, { recursive: true });
-    await mkdir(promptsDir, { recursive: true });
-    await writeFile(join(promptsDir, 'test-engineer.md'), '<identity>Test Engineer</identity>');
-    await writeFile(join(promptsDir, 'writer.md'), '<identity>You are Writer.</identity>');
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("startTeam preserves routed task roles into team state and worker launch args", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-role-routing-"));
+		const binDir = join(cwd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const captureDir = join(cwd, "captures");
+		const promptsDir = join(cwd, ".codex", "prompts");
+		await mkdir(binDir, { recursive: true });
+		await mkdir(captureDir, { recursive: true });
+		await mkdir(promptsDir, { recursive: true });
+		await writeFile(
+			join(promptsDir, "test-engineer.md"),
+			"<identity>Test Engineer</identity>",
+		);
+		await writeFile(
+			join(promptsDir, "writer.md"),
+			"<identity>You are Writer.</identity>",
+		);
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
 const worker = String(process.env.OMX_TEAM_WORKER || 'unknown').replace(/[^a-zA-Z0-9_-]+/g, '__');
@@ -1261,116 +1931,180 @@ process.stdin.resume();
 setTimeout(() => process.exit(0), 5000);
 process.on('SIGTERM', () => process.exit(0));
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
-    process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
+		process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-role-routing',
-          'heuristic routing handoff',
-          'executor',
-          2,
-          [
-            { subject: 'test routing report only', description: 'test routing report only', owner: 'worker-1', role: 'test-engineer' },
-            { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
-          ],
-          cwd,
-        ));
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-role-routing",
+					"heuristic routing handoff",
+					"executor",
+					2,
+					[
+						{
+							subject: "test routing report only",
+							description: "test routing report only",
+							owner: "worker-1",
+							role: "test-engineer",
+						},
+						{
+							subject: "document routing report only",
+							description: "document routing report only",
+							owner: "worker-2",
+							role: "writer",
+						},
+					],
+					cwd,
+				),
+			);
 
-      assert.equal(runtime.config.worker_launch_mode, 'prompt');
-      assert.equal(runtime.config.workers[0]?.role, 'test-engineer');
-      assert.equal(runtime.config.workers[1]?.role, 'writer');
+			assert.equal(runtime.config.worker_launch_mode, "prompt");
+			assert.equal(runtime.config.workers[0]?.role, "test-engineer");
+			assert.equal(runtime.config.workers[1]?.role, "writer");
 
-      const config = await readTeamConfig(runtime.teamName, cwd);
-      assert.equal(config?.workers[0]?.role, 'test-engineer');
-      assert.equal(config?.workers[1]?.role, 'writer');
+			const config = await readTeamConfig(runtime.teamName, cwd);
+			assert.equal(config?.workers[0]?.role, "test-engineer");
+			assert.equal(config?.workers[1]?.role, "writer");
 
-      const task1 = await readTask(runtime.teamName, '1', cwd);
-      const task2 = await readTask(runtime.teamName, '2', cwd);
-      assert.equal(task1?.role, 'test-engineer');
-      assert.equal(task2?.role, 'writer');
+			const task1 = await readTask(runtime.teamName, "1", cwd);
+			const task2 = await readTask(runtime.teamName, "2", cwd);
+			assert.equal(task1?.role, "test-engineer");
+			assert.equal(task2?.role, "writer");
 
-      const worker1Instructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'AGENTS.md'), 'utf-8');
-      const worker2Instructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-2', 'AGENTS.md'), 'utf-8');
-      assert.match(worker1Instructions, /You are operating as the \*\*test-engineer\*\* role/);
-      assert.match(worker1Instructions, /Test Engineer/);
-      assert.doesNotMatch(worker1Instructions, /exact gpt-5\.4-mini model/);
-      assert.match(worker2Instructions, /You are operating as the \*\*writer\*\* role/);
-      assert.match(worker2Instructions, /You are Writer\./);
-      assert.match(worker2Instructions, /exact gpt-5\.4-mini model/);
-      assert.match(worker2Instructions, /strict execution order: inspect -> plan -> act -> verify/);
+			const worker1Instructions = await readFile(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					runtime.teamName,
+					"workers",
+					"worker-1",
+					"AGENTS.md",
+				),
+				"utf-8",
+			);
+			const worker2Instructions = await readFile(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					runtime.teamName,
+					"workers",
+					"worker-2",
+					"AGENTS.md",
+				),
+				"utf-8",
+			);
+			assert.match(
+				worker1Instructions,
+				/You are operating as the \*\*test-engineer\*\* role/,
+			);
+			assert.match(worker1Instructions, /Test Engineer/);
+			assert.doesNotMatch(worker1Instructions, /exact gpt-5\.4-mini model/);
+			assert.match(
+				worker2Instructions,
+				/You are operating as the \*\*writer\*\* role/,
+			);
+			assert.match(worker2Instructions, /You are Writer\./);
+			assert.match(worker2Instructions, /exact gpt-5\.4-mini model/);
+			assert.match(
+				worker2Instructions,
+				/strict execution order: inspect -> plan -> act -> verify/,
+			);
 
-      let worker1Args: string[] | null = null;
-      let worker2Args: string[] | null = null;
-      for (let attempt = 0; attempt < 50; attempt += 1) {
-        const worker1Path = join(captureDir, 'team-role-routing__worker-1.json');
-        const worker2Path = join(captureDir, 'team-role-routing__worker-2.json');
-        if (existsSync(worker1Path) && existsSync(worker2Path)) {
-          worker1Args = JSON.parse(await readFile(worker1Path, 'utf-8')).argv;
-          worker2Args = JSON.parse(await readFile(worker2Path, 'utf-8')).argv;
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
+			let worker1Args: string[] | null = null;
+			let worker2Args: string[] | null = null;
+			for (let attempt = 0; attempt < 50; attempt += 1) {
+				const worker1Path = join(
+					captureDir,
+					"team-role-routing__worker-1.json",
+				);
+				const worker2Path = join(
+					captureDir,
+					"team-role-routing__worker-2.json",
+				);
+				if (existsSync(worker1Path) && existsSync(worker2Path)) {
+					worker1Args = JSON.parse(await readFile(worker1Path, "utf-8")).argv;
+					worker2Args = JSON.parse(await readFile(worker2Path, "utf-8")).argv;
+					break;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
 
-      assert.ok(worker1Args, 'worker-1 argv capture file should be written');
-      assert.ok(worker2Args, 'worker-2 argv capture file should be written');
-      const worker1Joined = worker1Args!.join(' ');
-      const worker2Joined = worker2Args!.join(' ');
-      assert.match(worker1Joined, /model_reasoning_effort="medium"/);
-      assert.match(worker1Joined, /model_instructions_file=.*worker-1\/AGENTS\.md/);
-      assert.match(worker1Joined, /--model gpt-5\.4/);
-      assert.match(worker2Joined, /model_reasoning_effort="high"/);
-      assert.match(worker2Joined, /model_instructions_file=.*worker-2\/AGENTS\.md/);
-      assert.match(worker2Joined, /--model gpt-5\.4-mini/);
+			assert.ok(worker1Args, "worker-1 argv capture file should be written");
+			assert.ok(worker2Args, "worker-2 argv capture file should be written");
+			const worker1Joined = worker1Args!.join(" ");
+			const worker2Joined = worker2Args!.join(" ");
+			assert.match(worker1Joined, /model_reasoning_effort="medium"/);
+			assert.match(
+				worker1Joined,
+				/model_instructions_file=.*worker-1\/AGENTS\.md/,
+			);
+			assert.match(worker1Joined, /--model gpt-5\.4/);
+			assert.match(worker2Joined, /model_reasoning_effort="high"/);
+			assert.match(
+				worker2Joined,
+				/model_instructions_file=.*worker-2\/AGENTS\.md/,
+			);
+			assert.match(worker2Joined, /--model gpt-5\.4-mini/);
 
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
-      else delete process.env.OMX_ARGV_CAPTURE_DIR;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam(runtime.teamName, cwd, { force: true });
+			runtime = null;
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevCaptureDir === "string")
+				process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
+			else delete process.env.OMX_ARGV_CAPTURE_DIR;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam does not apply mini guidance for exact-match negatives like gpt-5.4-mini-tuned', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-mini-tuned-'));
-    const binDir = join(cwd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    const captureDir = join(cwd, 'captures');
-    const promptsDir = join(cwd, '.codex', 'prompts');
-    await mkdir(binDir, { recursive: true });
-    await mkdir(captureDir, { recursive: true });
-    await mkdir(promptsDir, { recursive: true });
-    await writeFile(join(promptsDir, 'writer.md'), '<identity>You are Writer.</identity>');
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("startTeam does not apply mini guidance for exact-match negatives like gpt-5.4-mini-tuned", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-mini-tuned-"));
+		const binDir = join(cwd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const captureDir = join(cwd, "captures");
+		const promptsDir = join(cwd, ".codex", "prompts");
+		await mkdir(binDir, { recursive: true });
+		await mkdir(captureDir, { recursive: true });
+		await mkdir(promptsDir, { recursive: true });
+		await writeFile(
+			join(promptsDir, "writer.md"),
+			"<identity>You are Writer.</identity>",
+		);
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
 const worker = String(process.env.OMX_TEAM_WORKER || 'unknown').replace(/[^a-zA-Z0-9_-]+/g, '__');
@@ -1380,151 +2114,189 @@ process.stdin.resume();
 setTimeout(() => process.exit(0), 5000);
 process.on('SIGTERM', () => process.exit(0));
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
-    const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevCaptureDir = process.env.OMX_ARGV_CAPTURE_DIR;
+		const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
-    process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
-    process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.4-mini-tuned';
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
+		process.env.OMX_ARGV_CAPTURE_DIR = captureDir;
+		process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = "--model gpt-5.4-mini-tuned";
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-mini-tuned-routing',
-          'mini tuned routing handoff',
-          'executor',
-          1,
-          [
-            { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-1', role: 'writer' },
-          ],
-          cwd,
-        ));
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-mini-tuned-routing",
+					"mini tuned routing handoff",
+					"executor",
+					1,
+					[
+						{
+							subject: "document routing report only",
+							description: "document routing report only",
+							owner: "worker-1",
+							role: "writer",
+						},
+					],
+					cwd,
+				),
+			);
 
-      const workerInstructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'AGENTS.md'), 'utf-8');
-      assert.match(workerInstructions, /You are operating as the \*\*writer\*\* role/);
-      assert.match(workerInstructions, /You are Writer\./);
-      assert.doesNotMatch(workerInstructions, /exact gpt-5\.4-mini model/);
-      assert.doesNotMatch(workerInstructions, /strict execution order: inspect -> plan -> act -> verify/);
-      assert.match(workerInstructions, /resolved_model: gpt-5\.4-mini-tuned/);
+			const workerInstructions = await readFile(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					runtime.teamName,
+					"workers",
+					"worker-1",
+					"AGENTS.md",
+				),
+				"utf-8",
+			);
+			assert.match(
+				workerInstructions,
+				/You are operating as the \*\*writer\*\* role/,
+			);
+			assert.match(workerInstructions, /You are Writer\./);
+			assert.doesNotMatch(workerInstructions, /exact gpt-5\.4-mini model/);
+			assert.doesNotMatch(
+				workerInstructions,
+				/strict execution order: inspect -> plan -> act -> verify/,
+			);
+			assert.match(workerInstructions, /resolved_model: gpt-5\.4-mini-tuned/);
 
-      let workerArgs: string[] | null = null;
-      for (let attempt = 0; attempt < 50; attempt += 1) {
-        const workerPath = join(captureDir, 'team-mini-tuned-routing__worker-1.json');
-        if (existsSync(workerPath)) {
-          workerArgs = JSON.parse(await readFile(workerPath, 'utf-8')).argv;
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
+			let workerArgs: string[] | null = null;
+			for (let attempt = 0; attempt < 50; attempt += 1) {
+				const workerPath = join(
+					captureDir,
+					"team-mini-tuned-routing__worker-1.json",
+				);
+				if (existsSync(workerPath)) {
+					workerArgs = JSON.parse(await readFile(workerPath, "utf-8")).argv;
+					break;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
 
-      assert.ok(workerArgs, 'worker argv capture file should be written');
-      const workerJoined = workerArgs!.join(' ');
-      assert.match(workerJoined, /--model gpt-5\.4-mini-tuned/);
+			assert.ok(workerArgs, "worker argv capture file should be written");
+			const workerJoined = workerArgs!.join(" ");
+			assert.match(workerJoined, /--model gpt-5\.4-mini-tuned/);
 
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevCaptureDir === 'string') process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
-      else delete process.env.OMX_ARGV_CAPTURE_DIR;
-      if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam(runtime.teamName, cwd, { force: true });
+			runtime = null;
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevCaptureDir === "string")
+				process.env.OMX_ARGV_CAPTURE_DIR = prevCaptureDir;
+			else delete process.env.OMX_ARGV_CAPTURE_DIR;
+			if (typeof prevLaunchArgs === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam supports prompt launch mode without tmux and pipes trigger text via stdin', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-'));
-    const binDir = join(cwd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("startTeam supports prompt launch mode without tmux and pipes trigger text via stdin", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-prompt-"));
+		const binDir = join(cwd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 process.stdin.resume();
 setTimeout(() => process.exit(0), 5000);
 process.on('SIGTERM', () => process.exit(0));
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-prompt',
-          'prompt-mode team bootstrap',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-prompt",
+					"prompt-mode team bootstrap",
+					"executor",
+					1,
+					[{ subject: "s", description: "d", owner: "worker-1" }],
+					cwd,
+				),
+			);
 
-      assert.equal(runtime.config.worker_launch_mode, 'prompt');
-      assert.equal(runtime.config.leader_pane_id, null);
-      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
+			assert.equal(runtime.config.worker_launch_mode, "prompt");
+			assert.equal(runtime.config.leader_pane_id, null);
+			assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
 
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam(runtime.teamName, cwd, { force: true });
+			runtime = null;
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam relaunch re-creates HUD pane and re-registers reconcile hooks after shutdown', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-relaunch-hud-'));
-    const previousTmux = process.env.TMUX;
-    const previousTmuxPane = process.env.TMUX_PANE;
-    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    let runtime: TeamRuntime | null = null;
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-relaunch-hud-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("startTeam relaunch re-creates HUD pane and re-registers reconcile hooks after shutdown", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-relaunch-hud-"));
+		const previousTmux = process.env.TMUX;
+		const previousTmuxPane = process.env.TMUX_PANE;
+		const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		let runtime: TeamRuntime | null = null;
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-relaunch-hud-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
@@ -1579,88 +2351,137 @@ case "\${1:-}" in
     ;;
 esac
 `,
-          binaries: [{
-            name: 'gemini',
-            content: `#!/bin/sh
+					binaries: [
+						{
+							name: "gemini",
+							content: `#!/bin/sh
 exit 0
 `,
-          }],
-        },
-        async ({ tmuxLogPath }) => {
-          process.env.TMUX = 'leader-session,stub,0';
-          process.env.TMUX_PANE = '%1';
-          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
-          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+						},
+					],
+				},
+				async ({ tmuxLogPath }) => {
+					process.env.TMUX = "leader-session,stub,0";
+					process.env.TMUX_PANE = "%1";
+					process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "interactive";
+					process.env.OMX_TEAM_WORKER_CLI = "gemini";
 
-          runtime = await withoutTeamWorkerEnv(() =>
-            startTeam(
-              'team-rerun-hud',
-              'rerun hud restore',
-              'explore',
-              1,
-              [{ subject: 'restore hud', description: 'restore hud', owner: 'worker-1' }],
-              cwd,
-            ));
-          assert.equal(runtime.config.hud_pane_id, '%3');
-          assert.ok(runtime.config.resize_hook_name);
+					runtime = await withoutTeamWorkerEnv(() =>
+						startTeam(
+							"team-rerun-hud",
+							"rerun hud restore",
+							"explore",
+							1,
+							[
+								{
+									subject: "restore hud",
+									description: "restore hud",
+									owner: "worker-1",
+								},
+							],
+							cwd,
+						),
+					);
+					assert.equal(runtime.config.hud_pane_id, "%3");
+					assert.ok(runtime.config.resize_hook_name);
 
-          await shutdownTeam(runtime.teamName, cwd, { force: true });
-          runtime = null;
+					await shutdownTeam(runtime.teamName, cwd, { force: true });
+					runtime = null;
 
-          runtime = await withoutTeamWorkerEnv(() =>
-            startTeam(
-              'team-rerun-hud',
-              'rerun hud restore',
-              'explore',
-              1,
-              [{ subject: 'restore hud again', description: 'restore hud again', owner: 'worker-1' }],
-              cwd,
-            ));
-          assert.equal(runtime.config.hud_pane_id, '%3');
-          assert.ok(runtime.config.resize_hook_name);
+					runtime = await withoutTeamWorkerEnv(() =>
+						startTeam(
+							"team-rerun-hud",
+							"rerun hud restore",
+							"explore",
+							1,
+							[
+								{
+									subject: "restore hud again",
+									description: "restore hud again",
+									owner: "worker-1",
+								},
+							],
+							cwd,
+						),
+					);
+					assert.equal(runtime.config.hud_pane_id, "%3");
+					assert.ok(runtime.config.resize_hook_name);
 
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          const teamHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`, 'g');
-          const standaloneHudSplitRe = new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
-          assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 1);
-          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
-          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
-          assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
-          assert.match(tmuxLog, /kill-pane -t %3/);
-        },
-      );
-    } finally {
-      const runtimeToShutdown = runtime as TeamRuntime | null;
-      if (runtimeToShutdown) {
-        await shutdownTeam(runtimeToShutdown.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
-      else delete process.env.TMUX;
-      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
-      else delete process.env.TMUX_PANE;
-      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+					const teamHudSplitRe = new RegExp(
+						`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`,
+						"g",
+					);
+					const standaloneHudSplitRe = new RegExp(
+						`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`,
+						"g",
+					);
+					assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 2);
+					assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 1);
+					assert.equal(
+						tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)
+							?.length ?? 0,
+						2,
+					);
+					assert.equal(
+						tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)
+							?.length ?? 0,
+						2,
+					);
+					assert.equal(
+						tmuxLog.match(
+							/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g,
+						)?.length ?? 0,
+						3,
+					);
+					assert.equal(
+						tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)
+							?.length ?? 0,
+						3,
+					);
+					assert.ok(
+						(tmuxLog.match(/select-layout -t leader:0 main-vertical/g)
+							?.length ?? 0) >= 2,
+					);
+					assert.match(tmuxLog, /kill-pane -t %3/);
+				},
+			);
+		} finally {
+			const runtimeToShutdown = runtime as TeamRuntime | null;
+			if (runtimeToShutdown) {
+				await shutdownTeam(runtimeToShutdown.teamName, cwd, {
+					force: true,
+				}).catch(() => {});
+			}
+			if (typeof previousTmux === "string") process.env.TMUX = previousTmux;
+			else delete process.env.TMUX;
+			if (typeof previousTmuxPane === "string")
+				process.env.TMUX_PANE = previousTmuxPane;
+			else delete process.env.TMUX_PANE;
+			if (typeof previousLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof previousWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('startTeam routes detached worktree worker inbox and mailbox triggers through leader-root state references', async () => {
-    const repo = await initRepo();
-    const toolingDir = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-tools-'));
-    const binDir = join(toolingDir, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    const logDir = join(toolingDir, 'worker-logs');
-    const stdinLogPath = join(logDir, 'stdin.log');
-    const envLogPath = join(logDir, 'env.json');
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("startTeam routes detached worktree worker inbox and mailbox triggers through leader-root state references", async () => {
+		const repo = await initRepo();
+		const toolingDir = await mkdtemp(
+			join(tmpdir(), "omx-runtime-worktree-tools-"),
+		);
+		const binDir = join(toolingDir, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const logDir = join(toolingDir, "worker-logs");
+		const stdinLogPath = join(logDir, "stdin.log");
+		const envLogPath = join(logDir, "env.json");
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
 const logDir = process.env.OMX_TEST_LOG_DIR;
@@ -1677,173 +2498,211 @@ process.stdin.resume();
 setInterval(() => {}, 1000);
 process.on('SIGTERM', () => process.exit(0));
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevLogDir = process.env.OMX_TEST_LOG_DIR;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevLogDir = process.env.OMX_TEST_LOG_DIR;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
-    process.env.OMX_TEST_LOG_DIR = logDir;
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
+		process.env.OMX_TEST_LOG_DIR = logDir;
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-paths',
-          'detached worktree path resolution',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-detached-worktree-paths",
+					"detached worktree path resolution",
+					"executor",
+					1,
+					[{ subject: "s", description: "d", owner: "worker-1" }],
+					repo,
+					{ worktreeMode: { enabled: true, detached: true, name: null } },
+				),
+			);
 
-      const workerPath = runtime.config.workers[0]?.worktree_path;
-      assert.ok(workerPath, 'detached worker should have a worktree path');
-      assert.notEqual(workerPath, repo);
-      const workerAgents = await readFile(join(workerPath as string, 'AGENTS.md'), 'utf-8');
-      assert.match(workerAgents, /Team Worker Runtime Instructions/);
-      assert.match(workerAgents, /team-detached-worktree-paths/);
+			const workerPath = runtime.config.workers[0]?.worktree_path;
+			assert.ok(workerPath, "detached worker should have a worktree path");
+			assert.notEqual(workerPath, repo);
+			const workerAgents = await readFile(
+				join(workerPath as string, "AGENTS.md"),
+				"utf-8",
+			);
+			assert.match(workerAgents, /Team Worker Runtime Instructions/);
+			assert.match(workerAgents, /team-detached-worktree-paths/);
 
-      const startupLog = await waitForFileText(
-        stdinLogPath,
-        (content) => content.includes('/workers/worker-1/inbox.md'),
-      );
-      assert.match(
-        startupLog,
-        /\$OMX_TEAM_STATE_ROOT\/team\/team-detached-worktree-paths\/workers\/worker-1\/inbox\.md/,
-      );
-      assert.doesNotMatch(
-        startupLog,
-        /Read \.omx\/state\/team\/team-detached-worktree-paths\/workers\/worker-1\/inbox\.md/,
-      );
+			const startupLog = await waitForFileText(stdinLogPath, (content) =>
+				content.includes("/workers/worker-1/inbox.md"),
+			);
+			assert.match(
+				startupLog,
+				/\$OMX_TEAM_STATE_ROOT\/team\/team-detached-worktree-paths\/workers\/worker-1\/inbox\.md/,
+			);
+			assert.doesNotMatch(
+				startupLog,
+				/Read \.omx\/state\/team\/team-detached-worktree-paths\/workers\/worker-1\/inbox\.md/,
+			);
 
-      const envLog = JSON.parse(await waitForFileText(envLogPath, (content) => content.includes('teamStateRoot'))) as {
-        cwd: string;
-        teamStateRoot: string;
-        worker: string;
-      };
-      assert.equal(envLog.cwd, workerPath);
-      assert.equal(envLog.teamStateRoot, join(repo, '.omx', 'state'));
-      assert.equal(envLog.worker, 'team-detached-worktree-paths/worker-1');
-      const rootAgents = await readFile(join(workerPath, 'AGENTS.md'), 'utf-8');
-      assert.match(rootAgents, /Team Worker Runtime Instructions/);
-      assert.match(rootAgents, /Inbox path: .*team-detached-worktree-paths\/workers\/worker-1\/inbox\.md/);
+			const envLog = JSON.parse(
+				await waitForFileText(envLogPath, (content) =>
+					content.includes("teamStateRoot"),
+				),
+			) as {
+				cwd: string;
+				teamStateRoot: string;
+				worker: string;
+			};
+			assert.equal(envLog.cwd, workerPath);
+			assert.equal(envLog.teamStateRoot, join(repo, ".omx", "state"));
+			assert.equal(envLog.worker, "team-detached-worktree-paths/worker-1");
+			const rootAgents = await readFile(join(workerPath, "AGENTS.md"), "utf-8");
+			assert.match(rootAgents, /Team Worker Runtime Instructions/);
+			assert.match(
+				rootAgents,
+				/Inbox path: .*team-detached-worktree-paths\/workers\/worker-1\/inbox\.md/,
+			);
 
-      await sendWorkerMessage(runtime.teamName, 'leader-fixed', 'worker-1', 'follow-up', repo);
-      const mailboxLog = await waitForFileText(
-        stdinLogPath,
-        (content) => content.includes('/mailbox/worker-1.json'),
-      );
-      assert.match(
-        mailboxLog,
-        /\$OMX_TEAM_STATE_ROOT\/team\/team-detached-worktree-paths\/mailbox\/worker-1\.json/,
-      );
+			await sendWorkerMessage(
+				runtime.teamName,
+				"leader-fixed",
+				"worker-1",
+				"follow-up",
+				repo,
+			);
+			const mailboxLog = await waitForFileText(stdinLogPath, (content) =>
+				content.includes("/mailbox/worker-1.json"),
+			);
+			assert.match(
+				mailboxLog,
+				/\$OMX_TEAM_STATE_ROOT\/team\/team-detached-worktree-paths\/mailbox\/worker-1\.json/,
+			);
 
-      await shutdownTeam(runtime.teamName, repo, { force: true });
-      runtime = null;
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, repo, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevLogDir === 'string') process.env.OMX_TEST_LOG_DIR = prevLogDir;
-      else delete process.env.OMX_TEST_LOG_DIR;
-      await rm(toolingDir, { recursive: true, force: true });
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam(runtime.teamName, repo, { force: true });
+			runtime = null;
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, repo, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevLogDir === "string")
+				process.env.OMX_TEST_LOG_DIR = prevLogDir;
+			else delete process.env.OMX_TEST_LOG_DIR;
+			await rm(toolingDir, { recursive: true, force: true });
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam removes team-created detached worktrees on normal shutdown', async () => {
-    const repo = await initRepo();
-    const toolingDir = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-tools-'));
-    const binDir = join(toolingDir, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("shutdownTeam removes team-created detached worktrees on normal shutdown", async () => {
+		const repo = await initRepo();
+		const toolingDir = await mkdtemp(
+			join(tmpdir(), "omx-runtime-worktree-tools-"),
+		);
+		const binDir = join(toolingDir, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 process.stdin.resume();
 setTimeout(() => process.exit(0), 5000);
 process.on('SIGTERM', () => process.exit(0));
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-shutdown',
-          'detached worktree shutdown cleanup',
-          'executor',
-          1,
-          [],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-detached-worktree-shutdown",
+					"detached worktree shutdown cleanup",
+					"executor",
+					1,
+					[],
+					repo,
+					{ worktreeMode: { enabled: true, detached: true, name: null } },
+				),
+			);
 
-      const worktreePath = runtime.config.workers[0]?.worktree_path;
-      assert.ok(worktreePath, 'worker worktree path should be persisted');
-      assert.equal(runtime.config.workers[0]?.worktree_created, true);
-      assert.equal(existsSync(worktreePath as string), true);
-      assert.equal(existsSync(join(worktreePath as string, 'AGENTS.md')), true);
+			const worktreePath = runtime.config.workers[0]?.worktree_path;
+			assert.ok(worktreePath, "worker worktree path should be persisted");
+			assert.equal(runtime.config.workers[0]?.worktree_created, true);
+			assert.equal(existsSync(worktreePath as string), true);
+			assert.equal(existsSync(join(worktreePath as string, "AGENTS.md")), true);
 
-      await shutdownTeam(runtime.teamName, repo);
-      runtime = null;
+			await shutdownTeam(runtime.teamName, repo);
+			runtime = null;
 
-      assert.equal(existsSync(worktreePath as string), false);
-      assert.equal(existsSync(join(repo, '.omx', 'state', 'team', 'team-detached-worktree-shutdown')), false);
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, repo, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      await rm(toolingDir, { recursive: true, force: true });
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
+			assert.equal(existsSync(worktreePath as string), false);
+			assert.equal(
+				existsSync(
+					join(
+						repo,
+						".omx",
+						"state",
+						"team",
+						"team-detached-worktree-shutdown",
+					),
+				),
+				false,
+			);
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, repo, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(toolingDir, { recursive: true, force: true });
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
 
-  it('resumeTeam preserves detached worktree metadata for live prompt workers', async () => {
-    const repo = await initRepo();
-    const binDir = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-bin-'));
-    const fakeCodexPath = join(binDir, 'codex');
-    const logDir = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-logs-'));
-    const envLogPath = join(logDir, 'env.json');
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("resumeTeam preserves detached worktree metadata for live prompt workers", async () => {
+		const repo = await initRepo();
+		const binDir = await mkdtemp(join(tmpdir(), "omx-runtime-prompt-bin-"));
+		const fakeCodexPath = join(binDir, "codex");
+		const logDir = await mkdtemp(join(tmpdir(), "omx-runtime-prompt-logs-"));
+		const envLogPath = join(logDir, "env.json");
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
 const logDir = process.env.OMX_TEST_LOG_DIR;
@@ -1857,172 +2716,202 @@ process.stdin.resume();
 setInterval(() => {}, 1000);
 process.on('SIGTERM', () => process.exit(0));
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevLogDir = process.env.OMX_TEST_LOG_DIR;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevLogDir = process.env.OMX_TEST_LOG_DIR;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
-    process.env.OMX_TEST_LOG_DIR = logDir;
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
+		process.env.OMX_TEST_LOG_DIR = logDir;
 
-    let runtime: TeamRuntime | null = null;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-resume-metadata',
-          'detached worktree resume metadata',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+		let runtime: TeamRuntime | null = null;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-detached-worktree-resume-metadata",
+					"detached worktree resume metadata",
+					"executor",
+					1,
+					[{ subject: "s", description: "d", owner: "worker-1" }],
+					repo,
+					{ worktreeMode: { enabled: true, detached: true, name: null } },
+				),
+			);
 
-      const originalWorker = runtime.config.workers[0];
-      const originalWorktreePath = originalWorker?.worktree_path;
-      assert.ok(originalWorktreePath, 'worker worktree path should be persisted before resume');
-      assert.equal(originalWorker?.worktree_created, true);
+			const originalWorker = runtime.config.workers[0];
+			const originalWorktreePath = originalWorker?.worktree_path;
+			assert.ok(
+				originalWorktreePath,
+				"worker worktree path should be persisted before resume",
+			);
+			assert.equal(originalWorker?.worktree_created, true);
 
-      const envLog = JSON.parse(await waitForFileText(envLogPath, (content) => content.includes('teamStateRoot'))) as {
-        cwd: string;
-        teamStateRoot: string;
-        worker: string;
-      };
-      assert.equal(envLog.cwd, originalWorktreePath);
-      assert.equal(envLog.teamStateRoot, join(repo, '.omx', 'state'));
+			const envLog = JSON.parse(
+				await waitForFileText(envLogPath, (content) =>
+					content.includes("teamStateRoot"),
+				),
+			) as {
+				cwd: string;
+				teamStateRoot: string;
+				worker: string;
+			};
+			assert.equal(envLog.cwd, originalWorktreePath);
+			assert.equal(envLog.teamStateRoot, join(repo, ".omx", "state"));
 
-      const resumed = await resumeTeam(runtime.teamName, repo);
-      assert.ok(resumed, 'resumeTeam should reuse live prompt workers');
-      assert.equal(resumed?.config.workers[0]?.worktree_path, originalWorktreePath);
-      assert.equal(resumed?.config.workers[0]?.worktree_created, true);
-      assert.equal(resumed?.config.workers[0]?.team_state_root, join(repo, '.omx', 'state'));
+			const resumed = await resumeTeam(runtime.teamName, repo);
+			assert.ok(resumed, "resumeTeam should reuse live prompt workers");
+			assert.equal(
+				resumed?.config.workers[0]?.worktree_path,
+				originalWorktreePath,
+			);
+			assert.equal(resumed?.config.workers[0]?.worktree_created, true);
+			assert.equal(
+				resumed?.config.workers[0]?.team_state_root,
+				join(repo, ".omx", "state"),
+			);
 
-      const identityPath = join(
-        repo,
-        '.omx',
-        'state',
-        'team',
-        runtime.teamName,
-        'workers',
-        'worker-1',
-        'identity.json',
-      );
-      const identity = JSON.parse(await readFile(identityPath, 'utf-8')) as {
-        worktree_path?: string;
-        worktree_created?: boolean;
-        team_state_root?: string;
-      };
-      assert.equal(identity.worktree_path, originalWorktreePath);
-      assert.equal(identity.worktree_created, true);
-      assert.equal(identity.team_state_root, join(repo, '.omx', 'state'));
+			const identityPath = join(
+				repo,
+				".omx",
+				"state",
+				"team",
+				runtime.teamName,
+				"workers",
+				"worker-1",
+				"identity.json",
+			);
+			const identity = JSON.parse(await readFile(identityPath, "utf-8")) as {
+				worktree_path?: string;
+				worktree_created?: boolean;
+				team_state_root?: string;
+			};
+			assert.equal(identity.worktree_path, originalWorktreePath);
+			assert.equal(identity.worktree_created, true);
+			assert.equal(identity.team_state_root, join(repo, ".omx", "state"));
 
-      await shutdownTeam(runtime.teamName, repo, { force: true });
-      runtime = null;
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, repo, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevLogDir === 'string') process.env.OMX_TEST_LOG_DIR = prevLogDir;
-      else delete process.env.OMX_TEST_LOG_DIR;
-      await rm(binDir, { recursive: true, force: true });
-      await rm(logDir, { recursive: true, force: true });
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam(runtime.teamName, repo, { force: true });
+			runtime = null;
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, repo, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevLogDir === "string")
+				process.env.OMX_TEST_LOG_DIR = prevLogDir;
+			else delete process.env.OMX_TEST_LOG_DIR;
+			await rm(binDir, { recursive: true, force: true });
+			await rm(logDir, { recursive: true, force: true });
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam force-kills prompt workers that ignore SIGTERM', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-stubborn-'));
-    const binDir = join(cwd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("shutdownTeam force-kills prompt workers that ignore SIGTERM", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-prompt-stubborn-"));
+		const binDir = join(cwd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 process.stdin.resume();
 setInterval(() => {}, 1000);
 process.on('SIGTERM', () => {
   // Intentionally ignore SIGTERM so runtime teardown must escalate.
 });
 `,
-      { mode: 0o755 },
-    );
+			{ mode: 0o755 },
+		);
 
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
 
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
 
-    let runtime: TeamRuntime | null = null;
-    let workerPid = 0;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-prompt-stubborn',
-          'prompt-mode stubborn worker teardown',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
-      workerPid = runtime.config.workers[0]?.pid ?? 0;
-      assert.ok(workerPid > 0, 'prompt worker PID should be captured');
+		let runtime: TeamRuntime | null = null;
+		let workerPid = 0;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-prompt-stubborn",
+					"prompt-mode stubborn worker teardown",
+					"executor",
+					1,
+					[{ subject: "s", description: "d", owner: "worker-1" }],
+					cwd,
+				),
+			);
+			workerPid = runtime.config.workers[0]?.pid ?? 0;
+			assert.ok(workerPid > 0, "prompt worker PID should be captured");
 
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
+			await shutdownTeam(runtime.teamName, cwd, { force: true });
+			runtime = null;
 
-      let alive = false;
-      try {
-        process.kill(workerPid, 0);
-        alive = true;
-      } catch {
-        alive = false;
-      }
-      assert.equal(alive, false, `worker pid ${workerPid} should be terminated after shutdown`);
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			let alive = false;
+			try {
+				process.kill(workerPid, 0);
+				alive = true;
+			} catch {
+				alive = false;
+			}
+			assert.equal(
+				alive,
+				false,
+				`worker pid ${workerPid} should be terminated after shutdown`,
+			);
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam reaps detached prompt-worker descendants', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-descendants-'));
-    const binDir = join(cwd, 'bin');
-    const fakeCodexPath = join(binDir, 'codex');
-    const helperPidPath = join(cwd, 'helper.pid');
-    await mkdir(binDir, { recursive: true });
-    await writeFile(
-      fakeCodexPath,
-      `#!/usr/bin/env node
+	it("shutdownTeam reaps detached prompt-worker descendants", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-prompt-descendants-"),
+		);
+		const binDir = join(cwd, "bin");
+		const fakeCodexPath = join(binDir, "codex");
+		const helperPidPath = join(cwd, "helper.pid");
+		await mkdir(binDir, { recursive: true });
+		await writeFile(
+			fakeCodexPath,
+			`#!/usr/bin/env node
 const { spawn } = require('child_process');
 const { writeFileSync } = require('fs');
 const helper = spawn(process.execPath, ['-e', \`
@@ -2035,1171 +2924,2089 @@ process.stdin.resume();
 setInterval(() => {}, 1000);
 process.on('SIGTERM', () => process.exit(0));
 `,
-      { mode: 0o755 },
-    );
-
-    const prevPath = process.env.PATH;
-    const prevTmux = process.env.TMUX;
-    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
-    const prevHelperPidPath = process.env.OMX_HELPER_PID_PATH;
-
-    process.env.PATH = `${binDir}:${prevPath ?? ''}`;
-    delete process.env.TMUX;
-    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
-    process.env.OMX_TEAM_WORKER_CLI = 'codex';
-    process.env.OMX_HELPER_PID_PATH = helperPidPath;
-
-    let runtime: TeamRuntime | null = null;
-    let helperPid = 0;
-    try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-prompt-descendants',
-          'prompt-mode detached descendant teardown',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
-
-      for (let attempt = 0; attempt < 40; attempt += 1) {
-        if (existsSync(helperPidPath)) break;
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      helperPid = Number((await readFile(helperPidPath, 'utf-8')).trim());
-      assert.ok(helperPid > 0, 'detached helper pid should be captured');
-
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
-
-      let alive = false;
-      try {
-        process.kill(helperPid, 0);
-        alive = true;
-      } catch {
-        alive = false;
-      }
-      assert.equal(alive, false, `detached helper pid ${helperPid} should be terminated after shutdown`);
-    } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
-      if (helperPid > 0) {
-        try {
-          process.kill(helperPid, 'SIGKILL');
-        } catch {}
-      }
-      if (typeof prevPath === 'string') process.env.PATH = prevPath;
-      else delete process.env.PATH;
-      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
-      else delete process.env.TMUX;
-      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
-      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
-      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
-      else delete process.env.OMX_TEAM_WORKER_CLI;
-      if (typeof prevHelperPidPath === 'string') process.env.OMX_HELPER_PID_PATH = prevHelperPidPath;
-      else delete process.env.OMX_HELPER_PID_PATH;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam returns null for non-existent team', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      const snapshot = await monitorTeam('missing-team', cwd);
-      assert.equal(snapshot, null);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam returns correct task counts from state files', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-counts', 'monitor task counts', 'executor', 2, cwd);
-
-      const t1 = await createTask('team-counts', { subject: 'p', description: 'd', status: 'pending' }, cwd);
-      const t2 = await createTask('team-counts', { subject: 'ip', description: 'd', status: 'in_progress', owner: 'worker-1' }, cwd);
-      await createTask('team-counts', { subject: 'c', description: 'd', status: 'completed' }, cwd);
-      await createTask('team-counts', { subject: 'f', description: 'd', status: 'failed' }, cwd);
-
-      await updateWorkerHeartbeat(
-        'team-counts',
-        'worker-1',
-        { pid: 111, last_turn_at: new Date().toISOString(), turn_count: 7, alive: true },
-        cwd,
-      );
-
-      const statusPath = join(
-        cwd,
-        '.omx',
-        'state',
-        'team',
-        'team-counts',
-        'workers',
-        'worker-1',
-        'status.json',
-      );
-      await writeAtomic(
-        statusPath,
-        JSON.stringify(
-          {
-            state: 'working',
-            current_task_id: t2.id,
-            updated_at: new Date().toISOString(),
-          },
-          null,
-          2,
-        ),
-      );
-
-      const snapshot = await monitorTeam('team-counts', cwd);
-      assert.ok(snapshot);
-      assert.equal(snapshot?.tasks.total, 4);
-      assert.equal(snapshot?.tasks.pending, 1);
-      assert.equal(snapshot?.tasks.in_progress, 1);
-      assert.equal(snapshot?.tasks.completed, 1);
-      assert.equal(snapshot?.tasks.failed, 1);
-      assert.equal(snapshot?.allTasksTerminal, false);
-      assert.equal(snapshot?.phase, 'team-exec');
-
-      const worker1 = snapshot?.workers.find((w) => w.name === 'worker-1');
-      assert.ok(worker1);
-      assert.equal(worker1?.turnsWithoutProgress, 0);
-
-      const reassignHint = snapshot?.recommendations.some((r) => r.includes(`task-${t2.id}`));
-      assert.equal(typeof reassignHint, 'boolean');
-      void t1;
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam surfaces reclaimed work pickup attempts when an idle worker is available', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-reassign-reclaimed-'));
-    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
-    delete process.env.OMX_TEAM_STATE_ROOT;
-    let sleeper1: ReturnType<typeof spawn> | null = null;
-    let sleeper2: ReturnType<typeof spawn> | null = null;
-    try {
-      await initTeamState('team-runtime-reassign', 'reassign reclaimed test', 'executor', 2, cwd);
-      const task = await createTask('team-runtime-reassign', { subject: 'write docs', description: 'document feature', status: 'pending', role: 'writer' }, cwd);
-      const claim = await claimTask('team-runtime-reassign', task.id, 'worker-1', null, cwd);
-      assert.ok(claim.ok);
-      if (!claim.ok) throw new Error('claim failed');
-
-      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-runtime-reassign', 'tasks', `task-${task.id}.json`);
-      const current = JSON.parse(await readFile(taskPath, 'utf-8')) as any;
-      current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
-      await writeAtomic(taskPath, JSON.stringify(current, null, 2));
-
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-runtime-reassign', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
-      sleeper1 = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore', detached: false });
-      sleeper2 = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore', detached: false });
-      manifest.policy = { ...(manifest.policy || {}), worker_launch_mode: 'prompt' };
-      manifest.workers[0].role = 'executor';
-      manifest.workers[1].role = 'writer';
-      manifest.workers[0].pid = sleeper1.pid;
-      manifest.workers[1].pid = sleeper2.pid;
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-
-      await writeAtomic(
-        join(cwd, '.omx', 'state', 'team', 'team-runtime-reassign', 'workers', 'worker-1', 'status.json'),
-        JSON.stringify({ state: 'working', current_task_id: task.id, updated_at: new Date().toISOString() }, null, 2),
-      );
-      await writeAtomic(
-        join(cwd, '.omx', 'state', 'team', 'team-runtime-reassign', 'workers', 'worker-2', 'status.json'),
-        JSON.stringify({ state: 'idle', updated_at: new Date().toISOString() }, null, 2),
-      );
-
-      const snapshot = await monitorTeam('team-runtime-reassign', cwd);
-      assert.ok(snapshot);
-      const reread = await readTask('team-runtime-reassign', task.id, cwd);
-      assert.equal(reread?.status, 'pending');
-      assert.equal(reread?.owner, undefined);
-      assert.equal(snapshot?.recommendations.some((r) => r.includes(`Unable to assign task-${task.id} to worker-2: worker_notify_failed`)), true);
-    } finally {
-      try { if (sleeper1?.pid) process.kill(sleeper1.pid, 'SIGKILL'); } catch {}
-      try { if (sleeper2?.pid) process.kill(sleeper2.pid, 'SIGKILL'); } catch {}
-      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
-      else delete process.env.OMX_TEAM_STATE_ROOT;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam reclaims expired task claims and surfaces the recovery in recommendations', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-reclaim-'));
-    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
-    delete process.env.OMX_TEAM_STATE_ROOT;
-    try {
-      await initTeamState('team-runtime-reclaim', 'reclaim test', 'executor', 2, cwd);
-      const t = await createTask('team-runtime-reclaim', { subject: 'task', description: 'd', status: 'pending' }, cwd);
-      const claim = await claimTask('team-runtime-reclaim', t.id, 'worker-1', null, cwd);
-      assert.ok(claim.ok);
-      if (!claim.ok) throw new Error('claim failed');
-
-      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-runtime-reclaim', 'tasks', `task-${t.id}.json`);
-      const current = JSON.parse(await readFile(taskPath, 'utf-8')) as any;
-      current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
-      await writeAtomic(taskPath, JSON.stringify(current, null, 2));
-
-      const snapshot = await monitorTeam('team-runtime-reclaim', cwd);
-      assert.ok(snapshot);
-      const reread = await readTask('team-runtime-reclaim', t.id, cwd);
-      assert.equal(reread?.status, 'pending');
-      assert.equal(reread?.claim, undefined);
-      assert.equal(snapshot?.recommendations.some((r) => r.includes(`task-${t.id}`) && r.includes('Reclaimed expired claim')), true);
-    } finally {
-      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
-      else delete process.env.OMX_TEAM_STATE_ROOT;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam keeps phase in team-verify when completed code tasks lack verification evidence', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-verify-gate-'));
-    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
-    delete process.env.OMX_TEAM_STATE_ROOT;
-    try {
-      await initTeamState('team-verify-gate', 'verification gate test', 'executor', 1, cwd);
-      const task = await createTask(
-        'team-verify-gate',
-        {
-          subject: 'code change',
-          description: 'implement feature',
-          status: 'completed',
-          owner: 'worker-1',
-          requires_code_change: true,
-        },
-        cwd,
-      );
-
-      const first = await monitorTeam('team-verify-gate', cwd);
-      assert.ok(first);
-      assert.equal(first?.phase, 'team-verify');
-      assert.equal(
-        first?.recommendations.some((r) => r.includes(`task-${task.id}`) && r.includes('Verification evidence missing')),
-        true,
-      );
-
-      const taskPath = join(cwd, '.omx', 'state', 'team', 'team-verify-gate', 'tasks', `task-${task.id}.json`);
-      const fromDisk = JSON.parse(await readFile(taskPath, 'utf-8')) as Record<string, unknown>;
-      fromDisk.result = [
-        'Summary: done',
-        'Verification:',
-        '- PASS build: `npm run build`',
-        '- PASS tests: `node --test dist/foo.test.js`',
-      ].join('\n');
-      await writeAtomic(taskPath, JSON.stringify(fromDisk, null, 2));
-
-      const second = await monitorTeam('team-verify-gate', cwd);
-      assert.ok(second);
-      assert.equal(second?.phase, 'complete');
-    } finally {
-      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
-      else delete process.env.OMX_TEAM_STATE_ROOT;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-
-
-  it('monitorTeam deactivates root team-state.json when the local phase becomes terminal', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-root-team-state-'));
-    try {
-      await initTeamState('team-root-sync', 'root sync test', 'executor', 1, cwd);
-      await createTask(
-        'team-root-sync',
-        {
-          subject: 'code change',
-          description: 'implement feature',
-          status: 'completed',
-          owner: 'worker-1',
-          requires_code_change: false,
-        },
-        cwd,
-      );
-      const rootStatePath = join(cwd, '.omx', 'state', 'team-state.json');
-      await writeFile(rootStatePath, JSON.stringify({
-        active: true,
-        current_phase: 'team-exec',
-        team_name: 'team-root-sync',
-      }, null, 2));
-
-      const snapshot = await monitorTeam('team-root-sync', cwd);
-      assert.ok(snapshot);
-      assert.equal(snapshot?.phase, 'complete');
-
-      const rootState = JSON.parse(await readFile(rootStatePath, 'utf-8')) as Record<string, unknown>;
-      assert.equal(rootState.active, false);
-      assert.equal(rootState.current_phase, 'complete');
-      assert.ok(typeof rootState.completed_at === 'string' && rootState.completed_at.length > 0);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-
-  it('monitorTeam emits worker_state_changed, worker_idle, and task_completed events based on transitions', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-events', 'monitor event test', 'executor', 1, cwd);
-      const t = await createTask('team-events', { subject: 'a', description: 'd', status: 'pending' }, cwd);
-
-      // First monitor creates baseline snapshot.
-      await monitorTeam('team-events', cwd);
-
-      // Transition task to completed and worker status to idle.
-      await writeAtomic(
-        join(cwd, '.omx', 'state', 'team', 'team-events', 'tasks', `task-${t.id}.json`),
-        JSON.stringify({ ...t, status: 'completed', owner: 'worker-1' }, null, 2),
-      );
-      await writeAtomic(
-        join(cwd, '.omx', 'state', 'team', 'team-events', 'workers', 'worker-1', 'status.json'),
-        JSON.stringify({ state: 'idle', updated_at: new Date().toISOString() }, null, 2),
-      );
-
-      await monitorTeam('team-events', cwd);
-
-      const eventsPath = join(cwd, '.omx', 'state', 'team', 'team-events', 'events', 'events.ndjson');
-      const content = await readFile(eventsPath, 'utf-8');
-      assert.match(content, /\"type\":\"task_completed\"/);
-      assert.match(content, /\"type\":\"worker_state_changed\"/);
-      assert.match(content, /\"type\":\"worker_idle\"/);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam persists integration ledger and cherry-picks unseen worker HEADs once', async () => {
-    const repo = await initRepo();
-    let workerPath = '';
-    try {
-      workerPath = await addWorktree(repo, 'worker-1-branch', 'omx-runtime-worker-1-wt-');
-      await writeFile(join(workerPath, 'worker.txt'), 'from worker\n', 'utf-8');
-      execFileSync('git', ['add', 'worker.txt'], { cwd: workerPath, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker change'], { cwd: workerPath, stdio: 'ignore' });
-      const workerHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: workerPath, encoding: 'utf-8' }).trim();
-
-      await initTeamState('team-integration-ledger', 'integration ledger test', 'executor', 1, repo);
-      const cfg = await readTeamConfig('team-integration-ledger', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing team config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: workerPath,
-        worktree_branch: 'worker-1-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      await monitorTeam('team-integration-ledger', repo);
-      const firstSnapshot = await readMonitorSnapshot('team-integration-ledger', repo);
-      assert.equal(firstSnapshot?.integrationByWorker?.['worker-1']?.last_seen_head, workerHead);
-      assert.equal(typeof firstSnapshot?.integrationByWorker?.['worker-1']?.last_integrated_head, 'string');
-      // Status is 'idle' after successful merge/rebase, or 'integrated' if rebase was skipped
-      const status = firstSnapshot?.integrationByWorker?.['worker-1']?.status;
-      assert.ok(status === 'idle' || status === 'integrated', `expected idle or integrated, got ${status}`);
-
-      // Worker is cleanly ahead of leader → hybrid strategy uses merge (not cherry-pick)
-      // Verify merge commit on leader (2 parents) and worker content landed
-      const leaderHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-      const commitObj = execFileSync('git', ['cat-file', '-p', leaderHead], { cwd: repo, encoding: 'utf-8' });
-      const parentLines = commitObj.split('\n').filter((l: string) => l.startsWith('parent '));
-      assert.equal(parentLines.length, 2, 'hybrid merge should produce merge commit for clean-ahead worker');
-      assert.equal(await readFile(join(repo, 'worker.txt'), 'utf-8'), 'from worker\n');
-
-      await monitorTeam('team-integration-ledger', repo);
-      const secondSnapshot = await readMonitorSnapshot('team-integration-ledger', repo);
-      assert.equal(typeof secondSnapshot?.integrationByWorker?.['worker-1']?.last_seen_head, 'string');
-      assert.equal(typeof secondSnapshot?.integrationByWorker?.['worker-1']?.last_integrated_head, 'string');
-
-      // Hybrid merge emits merge events (or cherry-pick for backward compat)
-      const events = await readTeamEvents('team-integration-ledger', repo, { wakeableOnly: false });
-      const integrationEvents = events.filter((e) =>
-        (e.type as string) === 'worker_merge_applied' || e.type === 'worker_cherry_pick_applied');
-      assert.ok(integrationEvents.length >= 1, 'should have at least one integration event (merge or cherry-pick)');
-      const leaderMailbox = await listMailboxMessages('team-integration-ledger', 'leader-fixed', repo);
-      assert.equal(leaderMailbox.some((message) => /INTEGRATED:/.test(message.body)), true);
-    } finally {
-      if (workerPath) {
-        await rm(workerPath, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam auto-commits dirty worker worktree before integration', async () => {
-    const repo = await initRepo();
-    let workerPath = '';
-    try {
-      workerPath = await addWorktree(repo, 'wk1-ac-branch', 'omx-runtime-wk1-auto-commit-');
-
-      // Add uncommitted file (dirty worktree — no git commit)
-      await writeFile(join(workerPath, 'dirty.txt'), 'uncommitted content\n', 'utf-8');
-
-      await initTeamState('team-auto-commit', 'auto-commit test', 'executor', 1, repo);
-      const cfg = await readTeamConfig('team-auto-commit', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: workerPath,
-        worktree_branch: 'wk1-ac-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      await monitorTeam('team-auto-commit', repo);
-
-      // Verify worktree is no longer dirty (auto-commit was made)
-      const status = execFileSync('git', ['status', '--porcelain'], { cwd: workerPath, encoding: 'utf-8' }).trim();
-      assert.equal(status, '', 'worktree should be clean after auto-commit');
-
-      // Verify the commit message matches the auto-checkpoint pattern
-      const log = execFileSync('git', ['log', '-1', '--format=%s'], { cwd: workerPath, encoding: 'utf-8' }).trim();
-      assert.match(log, /omx\(team\): auto-checkpoint worker-1 \[1\]/, 'commit message should match auto-checkpoint pattern');
-
-      // Verify worker's changes are integrated into leader
-      const snapshot = await readMonitorSnapshot('team-auto-commit', repo);
-      assert.ok(snapshot?.integrationByWorker?.['worker-1']?.last_integrated_head, 'auto-committed changes should be integrated');
-
-      const ledgerPath = join(repo, '.omx', 'reports', 'team-commit-hygiene', 'team-auto-commit.ledger.json');
-      assert.equal(existsSync(ledgerPath), true, 'commit hygiene ledger should be written for runtime operational commits');
-      const ledger = JSON.parse(await readFile(ledgerPath, 'utf-8')) as {
-        entries: Array<{ operation: string; operational_commit?: string | null }>;
-      };
-      assert.equal(ledger.entries.some((entry) => entry.operation === 'auto_checkpoint'), true);
-      assert.equal(ledger.entries.some((entry) => entry.operation === 'integration_merge'), true);
-    } finally {
-      if (workerPath) {
-        await rm(workerPath, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam uses merge for worker cleanly ahead of leader (hybrid merge path)', async () => {
-    const repo = await initRepo();
-    let workerPath = '';
-    try {
-      workerPath = await addWorktree(repo, 'wk1-merge-branch', 'omx-runtime-wk1-merge-clean-');
-
-      // Commit only in worker (worker is cleanly ahead of leader)
-      await writeFile(join(workerPath, 'feature.txt'), 'new feature\n', 'utf-8');
-      execFileSync('git', ['add', 'feature.txt'], { cwd: workerPath, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker feature'], { cwd: workerPath, stdio: 'ignore' });
-
-      const leaderHeadBefore = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-
-      await initTeamState('team-merge-clean', 'merge clean test', 'executor', 1, repo);
-      const cfg = await readTeamConfig('team-merge-clean', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: workerPath,
-        worktree_branch: 'wk1-merge-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      await monitorTeam('team-merge-clean', repo);
-
-      // Verify worker content is on leader
-      const content = await readFile(join(repo, 'feature.txt'), 'utf-8');
-      assert.equal(content, 'new feature\n');
-
-      // Verify merge commit (2 parents) — hybrid strategy uses merge for clean-ahead worker
-      const leaderHeadAfter = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-      assert.notEqual(leaderHeadAfter, leaderHeadBefore, 'leader HEAD should advance');
-      const commitObj = execFileSync('git', ['cat-file', '-p', leaderHeadAfter], { cwd: repo, encoding: 'utf-8' });
-      const parentCount = commitObj.split('\n').filter((l: string) => l.startsWith('parent ')).length;
-      assert.equal(parentCount, 2, 'merge commit should have 2 parents');
-    } finally {
-      if (workerPath) {
-        await rm(workerPath, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam integrates detached worker worktree by commit sha instead of merging leader HEAD into itself', async () => {
-    const repo = await initRepo();
-    let workerPath = '';
-    try {
-      workerPath = await addWorktree(repo, 'wk1-detached-merge-branch', 'omx-runtime-wk1-detached-merge-');
-
-      await writeFile(join(workerPath, 'detached-feature.txt'), 'detached worker feature\n', 'utf-8');
-      execFileSync('git', ['add', 'detached-feature.txt'], { cwd: workerPath, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'detached worker feature'], { cwd: workerPath, stdio: 'ignore' });
-      execFileSync('git', ['checkout', '--detach', 'HEAD'], { cwd: workerPath, stdio: 'ignore' });
-
-      const workerHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: workerPath, encoding: 'utf-8' }).trim();
-      const detachedName = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: workerPath, encoding: 'utf-8' }).trim();
-      assert.equal(detachedName, 'HEAD');
-
-      const leaderHeadBefore = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-
-      await initTeamState('team-merge-detached', 'merge detached head test', 'executor', 1, repo);
-      const cfg = await readTeamConfig('team-merge-detached', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: workerPath,
-        worktree_branch: undefined,
-        worktree_detached: true,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      await monitorTeam('team-merge-detached', repo);
-
-      const leaderHeadAfter = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-      assert.notEqual(leaderHeadAfter, leaderHeadBefore, 'leader HEAD should advance for detached worker integration');
-      assert.equal(await readFile(join(repo, 'detached-feature.txt'), 'utf-8'), 'detached worker feature\n');
-
-      const commitObj = execFileSync('git', ['cat-file', '-p', leaderHeadAfter], { cwd: repo, encoding: 'utf-8' });
-      const parentCount = commitObj.split('\n').filter((l: string) => l.startsWith('parent ')).length;
-      assert.equal(parentCount, 2, 'detached worker integration should still produce a merge commit');
-
-      const workerMerged = execFileSync('git', ['merge-base', '--is-ancestor', workerHead, 'HEAD'], { cwd: repo, encoding: 'utf-8' });
-      assert.equal(workerMerged.length >= 0, true);
-
-      const leaderMailbox = await listMailboxMessages('team-merge-detached', 'leader-fixed', repo);
-      assert.equal(
-        leaderMailbox.some((message) =>
-          message.body.includes(`INTEGRATED: merged worker-1 (${workerHead.slice(0, 12)})`)
-          && message.body.includes(leaderHeadAfter.slice(0, 12))),
-        true,
-      );
-
-      const ledgerPath = join(repo, '.omx', 'reports', 'team-commit-hygiene', 'team-merge-detached.ledger.json');
-      const ledger = JSON.parse(await readFile(ledgerPath, 'utf-8')) as {
-        entries: Array<{
-          operation: string;
-          status: string;
-          source_commit?: string;
-          leader_head_before?: string;
-          leader_head_after?: string;
-        }>;
-      };
-      assert.equal(
-        ledger.entries.some((entry) =>
-          entry.operation === 'integration_merge'
-          && entry.status === 'applied'
-          && entry.source_commit === workerHead
-          && entry.leader_head_before !== entry.leader_head_after),
-        true,
-      );
-    } finally {
-      if (workerPath) {
-        await rm(workerPath, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam does not emit INTEGRATED when merge reports success but leader HEAD never advances', async () => {
-    const repo = await initRepo();
-    let workerPath = '';
-    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-fake-git-'));
-    const previousPath = process.env.PATH;
-    const previousFakeMode = process.env.OMX_FAKE_GIT_SUCCESS_NOOP;
-    try {
-      workerPath = await addWorktree(repo, 'wk1-merge-noadvance-branch', 'omx-runtime-wk1-merge-noadvance-');
-      await writeFile(join(workerPath, 'feature.txt'), 'new feature\n', 'utf-8');
-      execFileSync('git', ['add', 'feature.txt'], { cwd: workerPath, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker feature'], { cwd: workerPath, stdio: 'ignore' });
-
-      await initTeamState('team-merge-noadvance', 'merge no advance test', 'executor', 1, repo);
-      const cfg = await readTeamConfig('team-merge-noadvance', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: workerPath,
-        worktree_branch: 'wk1-merge-noadvance-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      const realGit = execFileSync('bash', ['-lc', 'command -v git'], { encoding: 'utf-8' }).trim();
-      await writeFile(
-        join(fakeBinDir, 'git'),
-        `#!/usr/bin/env bash
+			{ mode: 0o755 },
+		);
+
+		const prevPath = process.env.PATH;
+		const prevTmux = process.env.TMUX;
+		const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+		const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+		const prevHelperPidPath = process.env.OMX_HELPER_PID_PATH;
+
+		process.env.PATH = `${binDir}:${prevPath ?? ""}`;
+		delete process.env.TMUX;
+		process.env.OMX_TEAM_WORKER_LAUNCH_MODE = "prompt";
+		process.env.OMX_TEAM_WORKER_CLI = "codex";
+		process.env.OMX_HELPER_PID_PATH = helperPidPath;
+
+		let runtime: TeamRuntime | null = null;
+		let helperPid = 0;
+		try {
+			runtime = await withoutTeamWorkerEnv(() =>
+				startTeam(
+					"team-prompt-descendants",
+					"prompt-mode detached descendant teardown",
+					"executor",
+					1,
+					[{ subject: "s", description: "d", owner: "worker-1" }],
+					cwd,
+				),
+			);
+
+			for (let attempt = 0; attempt < 40; attempt += 1) {
+				if (existsSync(helperPidPath)) break;
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
+			helperPid = Number((await readFile(helperPidPath, "utf-8")).trim());
+			assert.ok(helperPid > 0, "detached helper pid should be captured");
+
+			await shutdownTeam(runtime.teamName, cwd, { force: true });
+			runtime = null;
+
+			let alive = false;
+			try {
+				process.kill(helperPid, 0);
+				alive = true;
+			} catch {
+				alive = false;
+			}
+			assert.equal(
+				alive,
+				false,
+				`detached helper pid ${helperPid} should be terminated after shutdown`,
+			);
+		} finally {
+			if (runtime) {
+				await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(
+					() => {},
+				);
+			}
+			if (helperPid > 0) {
+				try {
+					process.kill(helperPid, "SIGKILL");
+				} catch {}
+			}
+			if (typeof prevPath === "string") process.env.PATH = prevPath;
+			else delete process.env.PATH;
+			if (typeof prevTmux === "string") process.env.TMUX = prevTmux;
+			else delete process.env.TMUX;
+			if (typeof prevLaunchMode === "string")
+				process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+			else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+			if (typeof prevWorkerCli === "string")
+				process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+			else delete process.env.OMX_TEAM_WORKER_CLI;
+			if (typeof prevHelperPidPath === "string")
+				process.env.OMX_HELPER_PID_PATH = prevHelperPidPath;
+			else delete process.env.OMX_HELPER_PID_PATH;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam returns null for non-existent team", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			const snapshot = await monitorTeam("missing-team", cwd);
+			assert.equal(snapshot, null);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam returns correct task counts from state files", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-counts",
+				"monitor task counts",
+				"executor",
+				2,
+				cwd,
+			);
+
+			const t1 = await createTask(
+				"team-counts",
+				{ subject: "p", description: "d", status: "pending" },
+				cwd,
+			);
+			const t2 = await createTask(
+				"team-counts",
+				{
+					subject: "ip",
+					description: "d",
+					status: "in_progress",
+					owner: "worker-1",
+				},
+				cwd,
+			);
+			await createTask(
+				"team-counts",
+				{ subject: "c", description: "d", status: "completed" },
+				cwd,
+			);
+			await createTask(
+				"team-counts",
+				{ subject: "f", description: "d", status: "failed" },
+				cwd,
+			);
+
+			await updateWorkerHeartbeat(
+				"team-counts",
+				"worker-1",
+				{
+					pid: 111,
+					last_turn_at: new Date().toISOString(),
+					turn_count: 7,
+					alive: true,
+				},
+				cwd,
+			);
+
+			const statusPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-counts",
+				"workers",
+				"worker-1",
+				"status.json",
+			);
+			await writeAtomic(
+				statusPath,
+				JSON.stringify(
+					{
+						state: "working",
+						current_task_id: t2.id,
+						updated_at: new Date().toISOString(),
+					},
+					null,
+					2,
+				),
+			);
+
+			const snapshot = await monitorTeam("team-counts", cwd);
+			assert.ok(snapshot);
+			assert.equal(snapshot?.tasks.total, 4);
+			assert.equal(snapshot?.tasks.pending, 1);
+			assert.equal(snapshot?.tasks.in_progress, 1);
+			assert.equal(snapshot?.tasks.completed, 1);
+			assert.equal(snapshot?.tasks.failed, 1);
+			assert.equal(snapshot?.allTasksTerminal, false);
+			assert.equal(snapshot?.phase, "team-exec");
+
+			const worker1 = snapshot?.workers.find((w) => w.name === "worker-1");
+			assert.ok(worker1);
+			assert.equal(worker1?.turnsWithoutProgress, 0);
+
+			const reassignHint = snapshot?.recommendations.some((r) =>
+				r.includes(`task-${t2.id}`),
+			);
+			assert.equal(typeof reassignHint, "boolean");
+			void t1;
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam surfaces reclaimed work pickup attempts when an idle worker is available", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-reassign-reclaimed-"),
+		);
+		const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+		delete process.env.OMX_TEAM_STATE_ROOT;
+		let sleeper1: ReturnType<typeof spawn> | null = null;
+		let sleeper2: ReturnType<typeof spawn> | null = null;
+		try {
+			await initTeamState(
+				"team-runtime-reassign",
+				"reassign reclaimed test",
+				"executor",
+				2,
+				cwd,
+			);
+			const task = await createTask(
+				"team-runtime-reassign",
+				{
+					subject: "write docs",
+					description: "document feature",
+					status: "pending",
+					role: "writer",
+				},
+				cwd,
+			);
+			const claim = await claimTask(
+				"team-runtime-reassign",
+				task.id,
+				"worker-1",
+				null,
+				cwd,
+			);
+			assert.ok(claim.ok);
+			if (!claim.ok) throw new Error("claim failed");
+
+			const taskPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-runtime-reassign",
+				"tasks",
+				`task-${task.id}.json`,
+			);
+			const current = JSON.parse(await readFile(taskPath, "utf-8")) as any;
+			current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
+			await writeAtomic(taskPath, JSON.stringify(current, null, 2));
+
+			const manifestPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-runtime-reassign",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as any;
+			sleeper1 = spawn(
+				process.execPath,
+				["-e", "setInterval(() => {}, 1000)"],
+				{ stdio: "ignore", detached: false },
+			);
+			sleeper2 = spawn(
+				process.execPath,
+				["-e", "setInterval(() => {}, 1000)"],
+				{ stdio: "ignore", detached: false },
+			);
+			manifest.policy = {
+				...(manifest.policy || {}),
+				worker_launch_mode: "prompt",
+			};
+			manifest.workers[0].role = "executor";
+			manifest.workers[1].role = "writer";
+			manifest.workers[0].pid = sleeper1.pid;
+			manifest.workers[1].pid = sleeper2.pid;
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+			await writeAtomic(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					"team-runtime-reassign",
+					"workers",
+					"worker-1",
+					"status.json",
+				),
+				JSON.stringify(
+					{
+						state: "working",
+						current_task_id: task.id,
+						updated_at: new Date().toISOString(),
+					},
+					null,
+					2,
+				),
+			);
+			await writeAtomic(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					"team-runtime-reassign",
+					"workers",
+					"worker-2",
+					"status.json",
+				),
+				JSON.stringify(
+					{ state: "idle", updated_at: new Date().toISOString() },
+					null,
+					2,
+				),
+			);
+
+			const snapshot = await monitorTeam("team-runtime-reassign", cwd);
+			assert.ok(snapshot);
+			const reread = await readTask("team-runtime-reassign", task.id, cwd);
+			assert.equal(reread?.status, "pending");
+			assert.equal(reread?.owner, undefined);
+			assert.equal(
+				snapshot?.recommendations.some((r) =>
+					r.includes(
+						`Unable to assign task-${task.id} to worker-2: worker_notify_failed`,
+					),
+				),
+				true,
+			);
+		} finally {
+			try {
+				if (sleeper1?.pid) process.kill(sleeper1.pid, "SIGKILL");
+			} catch {}
+			try {
+				if (sleeper2?.pid) process.kill(sleeper2.pid, "SIGKILL");
+			} catch {}
+			if (typeof prevTeamStateRoot === "string")
+				process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+			else delete process.env.OMX_TEAM_STATE_ROOT;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam reclaims expired task claims and surfaces the recovery in recommendations", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-reclaim-"));
+		const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+		delete process.env.OMX_TEAM_STATE_ROOT;
+		try {
+			await initTeamState(
+				"team-runtime-reclaim",
+				"reclaim test",
+				"executor",
+				2,
+				cwd,
+			);
+			const t = await createTask(
+				"team-runtime-reclaim",
+				{ subject: "task", description: "d", status: "pending" },
+				cwd,
+			);
+			const claim = await claimTask(
+				"team-runtime-reclaim",
+				t.id,
+				"worker-1",
+				null,
+				cwd,
+			);
+			assert.ok(claim.ok);
+			if (!claim.ok) throw new Error("claim failed");
+
+			const taskPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-runtime-reclaim",
+				"tasks",
+				`task-${t.id}.json`,
+			);
+			const current = JSON.parse(await readFile(taskPath, "utf-8")) as any;
+			current.claim.leased_until = new Date(Date.now() - 1000).toISOString();
+			await writeAtomic(taskPath, JSON.stringify(current, null, 2));
+
+			const snapshot = await monitorTeam("team-runtime-reclaim", cwd);
+			assert.ok(snapshot);
+			const reread = await readTask("team-runtime-reclaim", t.id, cwd);
+			assert.equal(reread?.status, "pending");
+			assert.equal(reread?.claim, undefined);
+			assert.equal(
+				snapshot?.recommendations.some(
+					(r) =>
+						r.includes(`task-${t.id}`) && r.includes("Reclaimed expired claim"),
+				),
+				true,
+			);
+		} finally {
+			if (typeof prevTeamStateRoot === "string")
+				process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+			else delete process.env.OMX_TEAM_STATE_ROOT;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam keeps phase in team-verify when completed code tasks lack verification evidence", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-verify-gate-"));
+		const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+		delete process.env.OMX_TEAM_STATE_ROOT;
+		try {
+			await initTeamState(
+				"team-verify-gate",
+				"verification gate test",
+				"executor",
+				1,
+				cwd,
+			);
+			const task = await createTask(
+				"team-verify-gate",
+				{
+					subject: "code change",
+					description: "implement feature",
+					status: "completed",
+					owner: "worker-1",
+					requires_code_change: true,
+				},
+				cwd,
+			);
+
+			const first = await monitorTeam("team-verify-gate", cwd);
+			assert.ok(first);
+			assert.equal(first?.phase, "team-verify");
+			assert.equal(
+				first?.recommendations.some(
+					(r) =>
+						r.includes(`task-${task.id}`) &&
+						r.includes("Verification evidence missing"),
+				),
+				true,
+			);
+
+			const taskPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-verify-gate",
+				"tasks",
+				`task-${task.id}.json`,
+			);
+			const fromDisk = JSON.parse(await readFile(taskPath, "utf-8")) as Record<
+				string,
+				unknown
+			>;
+			fromDisk.result = [
+				"Summary: done",
+				"Verification:",
+				"- PASS build: `npm run build`",
+				"- PASS tests: `node --test dist/foo.test.js`",
+			].join("\n");
+			await writeAtomic(taskPath, JSON.stringify(fromDisk, null, 2));
+
+			const second = await monitorTeam("team-verify-gate", cwd);
+			assert.ok(second);
+			assert.equal(second?.phase, "complete");
+		} finally {
+			if (typeof prevTeamStateRoot === "string")
+				process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+			else delete process.env.OMX_TEAM_STATE_ROOT;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam deactivates root team-state.json when the local phase becomes terminal", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-root-team-state-"));
+		try {
+			await initTeamState(
+				"team-root-sync",
+				"root sync test",
+				"executor",
+				1,
+				cwd,
+			);
+			await createTask(
+				"team-root-sync",
+				{
+					subject: "code change",
+					description: "implement feature",
+					status: "completed",
+					owner: "worker-1",
+					requires_code_change: false,
+				},
+				cwd,
+			);
+			const rootStatePath = join(cwd, ".omx", "state", "team-state.json");
+			await writeFile(
+				rootStatePath,
+				JSON.stringify(
+					{
+						active: true,
+						current_phase: "team-exec",
+						team_name: "team-root-sync",
+					},
+					null,
+					2,
+				),
+			);
+
+			const snapshot = await monitorTeam("team-root-sync", cwd);
+			assert.ok(snapshot);
+			assert.equal(snapshot?.phase, "complete");
+
+			const rootState = JSON.parse(
+				await readFile(rootStatePath, "utf-8"),
+			) as Record<string, unknown>;
+			assert.equal(rootState.active, false);
+			assert.equal(rootState.current_phase, "complete");
+			assert.ok(
+				typeof rootState.completed_at === "string" &&
+					rootState.completed_at.length > 0,
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam emits worker_state_changed, worker_idle, and task_completed events based on transitions", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-events",
+				"monitor event test",
+				"executor",
+				1,
+				cwd,
+			);
+			const t = await createTask(
+				"team-events",
+				{ subject: "a", description: "d", status: "pending" },
+				cwd,
+			);
+
+			// First monitor creates baseline snapshot.
+			await monitorTeam("team-events", cwd);
+
+			// Transition task to completed and worker status to idle.
+			await writeAtomic(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					"team-events",
+					"tasks",
+					`task-${t.id}.json`,
+				),
+				JSON.stringify(
+					{ ...t, status: "completed", owner: "worker-1" },
+					null,
+					2,
+				),
+			);
+			await writeAtomic(
+				join(
+					cwd,
+					".omx",
+					"state",
+					"team",
+					"team-events",
+					"workers",
+					"worker-1",
+					"status.json",
+				),
+				JSON.stringify(
+					{ state: "idle", updated_at: new Date().toISOString() },
+					null,
+					2,
+				),
+			);
+
+			await monitorTeam("team-events", cwd);
+
+			const eventsPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-events",
+				"events",
+				"events.ndjson",
+			);
+			const content = await readFile(eventsPath, "utf-8");
+			assert.match(content, /\"type\":\"task_completed\"/);
+			assert.match(content, /\"type\":\"worker_state_changed\"/);
+			assert.match(content, /\"type\":\"worker_idle\"/);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam persists integration ledger and cherry-picks unseen worker HEADs once", async () => {
+		const repo = await initRepo();
+		let workerPath = "";
+		try {
+			workerPath = await addWorktree(
+				repo,
+				"worker-1-branch",
+				"omx-runtime-worker-1-wt-",
+			);
+			await writeFile(join(workerPath, "worker.txt"), "from worker\n", "utf-8");
+			execFileSync("git", ["add", "worker.txt"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker change"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+			const workerHead = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: workerPath,
+				encoding: "utf-8",
+			}).trim();
+
+			await initTeamState(
+				"team-integration-ledger",
+				"integration ledger test",
+				"executor",
+				1,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-integration-ledger", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing team config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: workerPath,
+				worktree_branch: "worker-1-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			await monitorTeam("team-integration-ledger", repo);
+			const firstSnapshot = await readMonitorSnapshot(
+				"team-integration-ledger",
+				repo,
+			);
+			assert.equal(
+				firstSnapshot?.integrationByWorker?.["worker-1"]?.last_seen_head,
+				workerHead,
+			);
+			assert.equal(
+				typeof firstSnapshot?.integrationByWorker?.["worker-1"]
+					?.last_integrated_head,
+				"string",
+			);
+			// Status is 'idle' after successful merge/rebase, or 'integrated' if rebase was skipped
+			const status = firstSnapshot?.integrationByWorker?.["worker-1"]?.status;
+			assert.ok(
+				status === "idle" || status === "integrated",
+				`expected idle or integrated, got ${status}`,
+			);
+
+			// Worker is cleanly ahead of leader → hybrid strategy uses merge (not cherry-pick)
+			// Verify merge commit on leader (2 parents) and worker content landed
+			const leaderHead = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+			const commitObj = execFileSync("git", ["cat-file", "-p", leaderHead], {
+				cwd: repo,
+				encoding: "utf-8",
+			});
+			const parentLines = commitObj
+				.split("\n")
+				.filter((l: string) => l.startsWith("parent "));
+			assert.equal(
+				parentLines.length,
+				2,
+				"hybrid merge should produce merge commit for clean-ahead worker",
+			);
+			assert.equal(
+				await readFile(join(repo, "worker.txt"), "utf-8"),
+				"from worker\n",
+			);
+
+			await monitorTeam("team-integration-ledger", repo);
+			const secondSnapshot = await readMonitorSnapshot(
+				"team-integration-ledger",
+				repo,
+			);
+			assert.equal(
+				typeof secondSnapshot?.integrationByWorker?.["worker-1"]
+					?.last_seen_head,
+				"string",
+			);
+			assert.equal(
+				typeof secondSnapshot?.integrationByWorker?.["worker-1"]
+					?.last_integrated_head,
+				"string",
+			);
+
+			// Hybrid merge emits merge events (or cherry-pick for backward compat)
+			const events = await readTeamEvents("team-integration-ledger", repo, {
+				wakeableOnly: false,
+			});
+			const integrationEvents = events.filter(
+				(e) =>
+					(e.type as string) === "worker_merge_applied" ||
+					e.type === "worker_cherry_pick_applied",
+			);
+			assert.ok(
+				integrationEvents.length >= 1,
+				"should have at least one integration event (merge or cherry-pick)",
+			);
+			const leaderMailbox = await listMailboxMessages(
+				"team-integration-ledger",
+				"leader-fixed",
+				repo,
+			);
+			assert.equal(
+				leaderMailbox.some((message) => /INTEGRATED:/.test(message.body)),
+				true,
+			);
+		} finally {
+			if (workerPath) {
+				await rm(workerPath, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam auto-commits dirty worker worktree before integration", async () => {
+		const repo = await initRepo();
+		let workerPath = "";
+		try {
+			workerPath = await addWorktree(
+				repo,
+				"wk1-ac-branch",
+				"omx-runtime-wk1-auto-commit-",
+			);
+
+			// Add uncommitted file (dirty worktree — no git commit)
+			await writeFile(
+				join(workerPath, "dirty.txt"),
+				"uncommitted content\n",
+				"utf-8",
+			);
+
+			await initTeamState(
+				"team-auto-commit",
+				"auto-commit test",
+				"executor",
+				1,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-auto-commit", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: workerPath,
+				worktree_branch: "wk1-ac-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			await monitorTeam("team-auto-commit", repo);
+
+			// Verify worktree is no longer dirty (auto-commit was made)
+			const status = execFileSync("git", ["status", "--porcelain"], {
+				cwd: workerPath,
+				encoding: "utf-8",
+			}).trim();
+			assert.equal(status, "", "worktree should be clean after auto-commit");
+
+			// Verify the commit message matches the auto-checkpoint pattern
+			const log = execFileSync("git", ["log", "-1", "--format=%s"], {
+				cwd: workerPath,
+				encoding: "utf-8",
+			}).trim();
+			assert.match(
+				log,
+				/omx\(team\): auto-checkpoint worker-1 \[1\]/,
+				"commit message should match auto-checkpoint pattern",
+			);
+
+			// Verify worker's changes are integrated into leader
+			const snapshot = await readMonitorSnapshot("team-auto-commit", repo);
+			assert.ok(
+				snapshot?.integrationByWorker?.["worker-1"]?.last_integrated_head,
+				"auto-committed changes should be integrated",
+			);
+
+			const ledgerPath = join(
+				repo,
+				".omx",
+				"reports",
+				"team-commit-hygiene",
+				"team-auto-commit.ledger.json",
+			);
+			assert.equal(
+				existsSync(ledgerPath),
+				true,
+				"commit hygiene ledger should be written for runtime operational commits",
+			);
+			const ledger = JSON.parse(await readFile(ledgerPath, "utf-8")) as {
+				entries: Array<{
+					operation: string;
+					operational_commit?: string | null;
+				}>;
+			};
+			assert.equal(
+				ledger.entries.some((entry) => entry.operation === "auto_checkpoint"),
+				true,
+			);
+			assert.equal(
+				ledger.entries.some((entry) => entry.operation === "integration_merge"),
+				true,
+			);
+		} finally {
+			if (workerPath) {
+				await rm(workerPath, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam uses merge for worker cleanly ahead of leader (hybrid merge path)", async () => {
+		const repo = await initRepo();
+		let workerPath = "";
+		try {
+			workerPath = await addWorktree(
+				repo,
+				"wk1-merge-branch",
+				"omx-runtime-wk1-merge-clean-",
+			);
+
+			// Commit only in worker (worker is cleanly ahead of leader)
+			await writeFile(
+				join(workerPath, "feature.txt"),
+				"new feature\n",
+				"utf-8",
+			);
+			execFileSync("git", ["add", "feature.txt"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker feature"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+
+			const leaderHeadBefore = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+
+			await initTeamState(
+				"team-merge-clean",
+				"merge clean test",
+				"executor",
+				1,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-merge-clean", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: workerPath,
+				worktree_branch: "wk1-merge-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			await monitorTeam("team-merge-clean", repo);
+
+			// Verify worker content is on leader
+			const content = await readFile(join(repo, "feature.txt"), "utf-8");
+			assert.equal(content, "new feature\n");
+
+			// Verify merge commit (2 parents) — hybrid strategy uses merge for clean-ahead worker
+			const leaderHeadAfter = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+			assert.notEqual(
+				leaderHeadAfter,
+				leaderHeadBefore,
+				"leader HEAD should advance",
+			);
+			const commitObj = execFileSync(
+				"git",
+				["cat-file", "-p", leaderHeadAfter],
+				{ cwd: repo, encoding: "utf-8" },
+			);
+			const parentCount = commitObj
+				.split("\n")
+				.filter((l: string) => l.startsWith("parent ")).length;
+			assert.equal(parentCount, 2, "merge commit should have 2 parents");
+		} finally {
+			if (workerPath) {
+				await rm(workerPath, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam integrates detached worker worktree by commit sha instead of merging leader HEAD into itself", async () => {
+		const repo = await initRepo();
+		let workerPath = "";
+		try {
+			workerPath = await addWorktree(
+				repo,
+				"wk1-detached-merge-branch",
+				"omx-runtime-wk1-detached-merge-",
+			);
+
+			await writeFile(
+				join(workerPath, "detached-feature.txt"),
+				"detached worker feature\n",
+				"utf-8",
+			);
+			execFileSync("git", ["add", "detached-feature.txt"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "detached worker feature"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["checkout", "--detach", "HEAD"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+
+			const workerHead = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: workerPath,
+				encoding: "utf-8",
+			}).trim();
+			const detachedName = execFileSync(
+				"git",
+				["rev-parse", "--abbrev-ref", "HEAD"],
+				{ cwd: workerPath, encoding: "utf-8" },
+			).trim();
+			assert.equal(detachedName, "HEAD");
+
+			const leaderHeadBefore = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+
+			await initTeamState(
+				"team-merge-detached",
+				"merge detached head test",
+				"executor",
+				1,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-merge-detached", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: workerPath,
+				worktree_branch: undefined,
+				worktree_detached: true,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			await monitorTeam("team-merge-detached", repo);
+
+			const leaderHeadAfter = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+			assert.notEqual(
+				leaderHeadAfter,
+				leaderHeadBefore,
+				"leader HEAD should advance for detached worker integration",
+			);
+			assert.equal(
+				await readFile(join(repo, "detached-feature.txt"), "utf-8"),
+				"detached worker feature\n",
+			);
+
+			const commitObj = execFileSync(
+				"git",
+				["cat-file", "-p", leaderHeadAfter],
+				{ cwd: repo, encoding: "utf-8" },
+			);
+			const parentCount = commitObj
+				.split("\n")
+				.filter((l: string) => l.startsWith("parent ")).length;
+			assert.equal(
+				parentCount,
+				2,
+				"detached worker integration should still produce a merge commit",
+			);
+
+			const workerMerged = execFileSync(
+				"git",
+				["merge-base", "--is-ancestor", workerHead, "HEAD"],
+				{ cwd: repo, encoding: "utf-8" },
+			);
+			assert.equal(workerMerged.length >= 0, true);
+
+			const leaderMailbox = await listMailboxMessages(
+				"team-merge-detached",
+				"leader-fixed",
+				repo,
+			);
+			assert.equal(
+				leaderMailbox.some(
+					(message) =>
+						message.body.includes(
+							`INTEGRATED: merged worker-1 (${workerHead.slice(0, 12)})`,
+						) && message.body.includes(leaderHeadAfter.slice(0, 12)),
+				),
+				true,
+			);
+
+			const ledgerPath = join(
+				repo,
+				".omx",
+				"reports",
+				"team-commit-hygiene",
+				"team-merge-detached.ledger.json",
+			);
+			const ledger = JSON.parse(await readFile(ledgerPath, "utf-8")) as {
+				entries: Array<{
+					operation: string;
+					status: string;
+					source_commit?: string;
+					leader_head_before?: string;
+					leader_head_after?: string;
+				}>;
+			};
+			assert.equal(
+				ledger.entries.some(
+					(entry) =>
+						entry.operation === "integration_merge" &&
+						entry.status === "applied" &&
+						entry.source_commit === workerHead &&
+						entry.leader_head_before !== entry.leader_head_after,
+				),
+				true,
+			);
+		} finally {
+			if (workerPath) {
+				await rm(workerPath, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam does not emit INTEGRATED when merge reports success but leader HEAD never advances", async () => {
+		const repo = await initRepo();
+		let workerPath = "";
+		const fakeBinDir = await mkdtemp(join(tmpdir(), "omx-runtime-fake-git-"));
+		const previousPath = process.env.PATH;
+		const previousFakeMode = process.env.OMX_FAKE_GIT_SUCCESS_NOOP;
+		try {
+			workerPath = await addWorktree(
+				repo,
+				"wk1-merge-noadvance-branch",
+				"omx-runtime-wk1-merge-noadvance-",
+			);
+			await writeFile(
+				join(workerPath, "feature.txt"),
+				"new feature\n",
+				"utf-8",
+			);
+			execFileSync("git", ["add", "feature.txt"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker feature"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+
+			await initTeamState(
+				"team-merge-noadvance",
+				"merge no advance test",
+				"executor",
+				1,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-merge-noadvance", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: workerPath,
+				worktree_branch: "wk1-merge-noadvance-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			const realGit = execFileSync("bash", ["-lc", "command -v git"], {
+				encoding: "utf-8",
+			}).trim();
+			await writeFile(
+				join(fakeBinDir, "git"),
+				`#!/usr/bin/env bash
 set -euo pipefail
 if [[ "\${OMX_FAKE_GIT_SUCCESS_NOOP:-}" == "merge" && "\${1:-}" == "merge" ]]; then
   exit 0
 fi
 exec "${realGit}" "$@"
 `,
-        { mode: 0o755 },
-      );
-      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
-      process.env.OMX_FAKE_GIT_SUCCESS_NOOP = 'merge';
-
-      const leaderHeadBefore = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-      await monitorTeam('team-merge-noadvance', repo);
-      const leaderHeadAfter = execFileSync(realGit, ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-      assert.equal(leaderHeadAfter, leaderHeadBefore, 'leader HEAD should stay unchanged in regression setup');
-
-      const snapshot = await readMonitorSnapshot('team-merge-noadvance', repo);
-      assert.equal(snapshot?.integrationByWorker?.['worker-1']?.status, 'integration_failed');
-      assert.equal(snapshot?.integrationByWorker?.['worker-1']?.last_integrated_head, undefined);
-
-      const leaderMailbox = await listMailboxMessages('team-merge-noadvance', 'leader-fixed', repo);
-      assert.equal(leaderMailbox.some((message) => /INTEGRATED:/.test(message.body)), false);
-      assert.equal(leaderMailbox.some((message) => /INTEGRATION FAILED:/.test(message.body)), true);
-
-      const events = await readTeamEvents('team-merge-noadvance', repo, { wakeableOnly: false });
-      assert.equal(events.some((event) => event.type === 'worker_integration_failed'), true);
-    } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
-      if (typeof previousFakeMode === 'string') process.env.OMX_FAKE_GIT_SUCCESS_NOOP = previousFakeMode;
-      else delete process.env.OMX_FAKE_GIT_SUCCESS_NOOP;
-      await rm(fakeBinDir, { recursive: true, force: true });
-      if (workerPath) {
-        await rm(workerPath, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam uses cherry-pick for diverged worker (hybrid cherry-pick path)', async () => {
-    const repo = await initRepo();
-    let workerPath = '';
-    try {
-      workerPath = await addWorktree(repo, 'wk1-div-branch', 'omx-runtime-wk1-diverged-');
-
-      // Commit in worker
-      await writeFile(join(workerPath, 'worker-file.txt'), 'worker content\n', 'utf-8');
-      execFileSync('git', ['add', 'worker-file.txt'], { cwd: workerPath, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker diverge'], { cwd: workerPath, stdio: 'ignore' });
-
-      // Commit in leader (creates divergence)
-      await writeFile(join(repo, 'leader-file.txt'), 'leader content\n', 'utf-8');
-      execFileSync('git', ['add', 'leader-file.txt'], { cwd: repo, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'leader diverge'], { cwd: repo, stdio: 'ignore' });
-
-      await initTeamState('team-diverged', 'diverged test', 'executor', 1, repo);
-      const cfg = await readTeamConfig('team-diverged', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: workerPath,
-        worktree_branch: 'wk1-div-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      await monitorTeam('team-diverged', repo);
-
-      // Verify both contents are on leader
-      assert.equal(await readFile(join(repo, 'worker-file.txt'), 'utf-8'), 'worker content\n');
-      assert.equal(await readFile(join(repo, 'leader-file.txt'), 'utf-8'), 'leader content\n');
-
-      // Cherry-pick creates single-parent commits (not merge)
-      const leaderHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-      const commitObj = execFileSync('git', ['cat-file', '-p', leaderHead], { cwd: repo, encoding: 'utf-8' });
-      const parentCount = commitObj.split('\n').filter((l: string) => l.startsWith('parent ')).length;
-      assert.equal(parentCount, 1, 'cherry-pick should create single-parent commit');
-
-      const snapshot = await readMonitorSnapshot('team-diverged', repo);
-      assert.ok(snapshot?.integrationByWorker?.['worker-1']?.last_integrated_head);
-    } finally {
-      if (workerPath) {
-        await rm(workerPath, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam rebases idle workers after integration lands on leader (cross-worker rebase)', async () => {
-    const repo = await initRepo();
-    let worker1Path = '';
-    let worker2Path = '';
-    try {
-      worker1Path = await addWorktree(repo, 'wk1-xr-branch', 'omx-runtime-wk1-cross-rebase-');
-      worker2Path = await addWorktree(repo, 'wk2-xr-branch', 'omx-runtime-wk2-cross-rebase-');
-
-      // Worker-1 commits a change
-      await writeFile(join(worker1Path, 'w1.txt'), 'from worker 1\n', 'utf-8');
-      execFileSync('git', ['add', 'w1.txt'], { cwd: worker1Path, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker-1 change'], { cwd: worker1Path, stdio: 'ignore' });
-
-      // Worker-2 commits its own change (so rebase is meaningful)
-      await writeFile(join(worker2Path, 'w2.txt'), 'from worker 2\n', 'utf-8');
-      execFileSync('git', ['add', 'w2.txt'], { cwd: worker2Path, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker-2 change'], { cwd: worker2Path, stdio: 'ignore' });
-
-      await initTeamState('team-cross-rebase', 'cross rebase test', 'executor', 2, repo);
-      const cfg = await readTeamConfig('team-cross-rebase', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: worker1Path,
-        worktree_branch: 'wk1-xr-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      cfg.workers[1] = {
-        ...cfg.workers[1],
-        assigned_tasks: ['2'],
-        worktree_repo_root: repo,
-        worktree_path: worker2Path,
-        worktree_branch: 'wk2-xr-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      // Set worker-2 status to idle (eligible for rebase)
-      await writeWorkerStatus('team-cross-rebase', 'worker-2', { state: 'idle', updated_at: new Date().toISOString() }, repo);
-
-      await monitorTeam('team-cross-rebase', repo);
-
-      // Verify leader has worker-1's changes
-      assert.equal(await readFile(join(repo, 'w1.txt'), 'utf-8'), 'from worker 1\n');
-
-      // Verify worker-2 was rebased onto new leader HEAD
-      // After rebase, worker-2 should have both its own files AND worker-1's files (from leader)
-      assert.equal(existsSync(join(worker2Path, 'w1.txt')), true, 'worker-2 should have w1.txt after rebase onto leader');
-      assert.equal(existsSync(join(worker2Path, 'w2.txt')), true, 'worker-2 should still have its own w2.txt');
-
-      // Verify leader HEAD is ancestor of worker-2 branch (rebase succeeded)
-      const newLeaderHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
-      const mergeBase = execFileSync('git', ['merge-base', newLeaderHead, 'wk2-xr-branch'], { cwd: repo, encoding: 'utf-8' }).trim();
-      assert.equal(mergeBase, newLeaderHead, 'worker-2 should be rebased onto new leader HEAD');
-
-      const ledgerPath = join(repo, '.omx', 'reports', 'team-commit-hygiene', 'team-cross-rebase.ledger.json');
-      const ledger = JSON.parse(await readFile(ledgerPath, 'utf-8')) as {
-        entries: Array<{ operation: string; worker_name: string; status: string }>;
-      };
-      assert.equal(
-        ledger.entries.some((entry) => entry.operation === 'cross_rebase' && entry.worker_name === 'worker-2' && entry.status === 'applied'),
-        true,
-      );
-    } finally {
-      if (worker1Path) {
-        await rm(worker1Path, { recursive: true, force: true });
-      }
-      if (worker2Path) {
-        await rm(worker2Path, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam auto-resolves conflicts with -X theirs (worker wins on leader)', async () => {
-    const repo = await initRepo();
-    let workerPath = '';
-    try {
-      workerPath = await addWorktree(repo, 'wk1-cr-branch', 'omx-runtime-wk1-conflict-resolve-');
-
-      // Worker edits README.md (same file, different content → conflict)
-      await writeFile(join(workerPath, 'README.md'), 'worker version\n', 'utf-8');
-      execFileSync('git', ['add', 'README.md'], { cwd: workerPath, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker edits README'], { cwd: workerPath, stdio: 'ignore' });
-
-      // Leader also edits README.md (creates divergence + conflict)
-      await writeFile(join(repo, 'README.md'), 'leader version\n', 'utf-8');
-      execFileSync('git', ['add', 'README.md'], { cwd: repo, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'leader edits README'], { cwd: repo, stdio: 'ignore' });
-
-      await initTeamState('team-conflict-resolve', 'conflict resolution test', 'executor', 1, repo);
-      const cfg = await readTeamConfig('team-conflict-resolve', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: workerPath,
-        worktree_branch: 'wk1-cr-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      await monitorTeam('team-conflict-resolve', repo);
-
-      // Verify worker's version wins on leader (-X theirs = worker wins)
-      const leaderContent = await readFile(join(repo, 'README.md'), 'utf-8');
-      assert.equal(leaderContent, 'worker version\n', 'worker content should win with -X theirs');
-
-      // Verify integration was not blocked
-      const snapshot = await readMonitorSnapshot('team-conflict-resolve', repo);
-      assert.notEqual(snapshot?.integrationByWorker?.['worker-1']?.status, 'cherry_pick_conflict',
-        'integration should not be permanently blocked');
-
-      // Note: -X theirs resolves conflicts silently — git cherry-pick succeeds,
-      // so the integration report is only written when -X theirs itself fails (e.g. binary conflicts).
-      // The key assertion above is that worker content wins on leader.
-    } finally {
-      if (workerPath) {
-        await rm(workerPath, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam skips rebase for workers with "working" status (idle-only gating)', async () => {
-    const repo = await initRepo();
-    let worker1Path = '';
-    let worker2Path = '';
-    try {
-      worker1Path = await addWorktree(repo, 'wk1-gate-branch', 'omx-runtime-wk1-rebase-gate-');
-      worker2Path = await addWorktree(repo, 'wk2-gate-branch', 'omx-runtime-wk2-rebase-gate-');
-
-      // Worker-1 commits a change
-      await writeFile(join(worker1Path, 'w1.txt'), 'from worker 1\n', 'utf-8');
-      execFileSync('git', ['add', 'w1.txt'], { cwd: worker1Path, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker-1 change'], { cwd: worker1Path, stdio: 'ignore' });
-
-      // Record worker-2 HEAD before integration
-      const worker2HeadBefore = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worker2Path, encoding: 'utf-8' }).trim();
-
-      await initTeamState('team-rebase-gate', 'rebase gate test', 'executor', 2, repo);
-      const cfg = await readTeamConfig('team-rebase-gate', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: worker1Path,
-        worktree_branch: 'wk1-gate-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      cfg.workers[1] = {
-        ...cfg.workers[1],
-        assigned_tasks: ['2'],
-        worktree_repo_root: repo,
-        worktree_path: worker2Path,
-        worktree_branch: 'wk2-gate-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      // Set worker-2 status to "working" (NOT eligible for rebase)
-      await writeWorkerStatus('team-rebase-gate', 'worker-2', { state: 'working', updated_at: new Date().toISOString() }, repo);
-
-      await monitorTeam('team-rebase-gate', repo);
-
-      // Verify worker-2 HEAD is unchanged (NOT rebased)
-      const worker2HeadAfter = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worker2Path, encoding: 'utf-8' }).trim();
-      assert.equal(worker2HeadAfter, worker2HeadBefore, 'worker-2 should NOT be rebased when status is "working"');
-    } finally {
-      if (worker1Path) {
-        await rm(worker1Path, { recursive: true, force: true });
-      }
-      if (worker2Path) {
-        await rm(worker2Path, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('monitorTeam aborts failed rebase and leaves worktree in clean state', async () => {
-    const repo = await initRepo();
-    let worker1Path = '';
-    let worker2Path = '';
-    try {
-      // Add a file that will be subject to rename/rename conflict
-      await writeFile(join(repo, 'original.txt'), 'original content\n', 'utf-8');
-      execFileSync('git', ['add', 'original.txt'], { cwd: repo, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'add original.txt'], { cwd: repo, stdio: 'ignore' });
-
-      worker1Path = await addWorktree(repo, 'wk1-rf-branch', 'omx-runtime-wk1-rebase-fail-');
-      worker2Path = await addWorktree(repo, 'wk2-rf-branch', 'omx-runtime-wk2-rebase-fail-');
-
-      // Worker-1 renames original.txt → renamed-by-w1.txt (will be integrated to leader)
-      execFileSync('git', ['mv', 'original.txt', 'renamed-by-w1.txt'], { cwd: worker1Path, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker-1 renames original'], { cwd: worker1Path, stdio: 'ignore' });
-
-      // Worker-2 renames original.txt → renamed-by-w2.txt (will conflict on rebase)
-      execFileSync('git', ['mv', 'original.txt', 'renamed-by-w2.txt'], { cwd: worker2Path, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'worker-2 renames original'], { cwd: worker2Path, stdio: 'ignore' });
-
-      const worker2HeadBefore = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worker2Path, encoding: 'utf-8' }).trim();
-
-      await initTeamState('team-rebase-fail', 'rebase failure test', 'executor', 2, repo);
-      const cfg = await readTeamConfig('team-rebase-fail', repo);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing config');
-      cfg.leader_pane_id = '';
-      cfg.workers[0] = {
-        ...cfg.workers[0],
-        assigned_tasks: ['1'],
-        worktree_repo_root: repo,
-        worktree_path: worker1Path,
-        worktree_branch: 'wk1-rf-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      cfg.workers[1] = {
-        ...cfg.workers[1],
-        assigned_tasks: ['2'],
-        worktree_repo_root: repo,
-        worktree_path: worker2Path,
-        worktree_branch: 'wk2-rf-branch',
-        worktree_detached: false,
-        worktree_created: false,
-      };
-      await saveTeamConfig(cfg, repo);
-
-      // Set worker-2 status to idle (eligible for rebase attempt)
-      await writeWorkerStatus('team-rebase-fail', 'worker-2', { state: 'idle', updated_at: new Date().toISOString() }, repo);
-
-      await monitorTeam('team-rebase-fail', repo);
-
-      // Verify worker-1's changes landed on leader
-      assert.equal(existsSync(join(repo, 'renamed-by-w1.txt')), true, 'leader should have worker-1 renamed file');
-
-      // Verify worker-2 worktree is NOT in a broken rebase state (rebase --abort was called)
-      const worker2HeadAfter = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worker2Path, encoding: 'utf-8' }).trim();
-      assert.equal(worker2HeadAfter, worker2HeadBefore, 'worker-2 HEAD should revert to pre-rebase state after abort');
-      // Verify no rebase-in-progress markers
-      const gitStatusOutput = execFileSync('git', ['status'], { cwd: worker2Path, encoding: 'utf-8' });
-      assert.doesNotMatch(gitStatusOutput, /rebase in progress/, 'worktree should not have rebase in progress');
-
-      // Verify integration report logged the failure
-      const reportPath = join(repo, '.omx', 'state', 'team', 'team-rebase-fail', 'integration-report.md');
-      assert.equal(existsSync(reportPath), true, 'integration report should exist after rebase failure');
-      const report = await readFile(reportPath, 'utf-8');
-      assert.match(report, /rebase/, 'report should mention the rebase operation');
-    } finally {
-      if (worker1Path) {
-        await rm(worker1Path, { recursive: true, force: true });
-      }
-      if (worker2Path) {
-        await rm(worker2Path, { recursive: true, force: true });
-      }
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam cleans up state even when tmux session doesn\'t exist', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-shutdown', 'shutdown test', 'executor', 1, cwd);
-      await shutdownTeam('team-shutdown', cwd);
-
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown');
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam blocks when pending tasks remain (shutdown gate)', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-'));
-    try {
-      await initTeamState('team-shutdown-gate-pending', 'shutdown gate pending test', 'executor', 1, cwd);
-      await createTask(
-        'team-shutdown-gate-pending',
-        { subject: 'pending', description: 'd', status: 'pending' },
-        cwd,
-      );
-
-      await assert.rejects(
-        () => shutdownTeam('team-shutdown-gate-pending', cwd),
-        /shutdown_gate_blocked:pending=1,blocked=0,in_progress=0,failed=0/,
-      );
-
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-pending');
-      assert.equal(existsSync(teamRoot), true);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam honors governance cleanup override when active tasks remain', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-override-'));
-    try {
-      await initTeamState('team-shutdown-gate-override', 'shutdown gate override test', 'executor', 1, cwd);
-      await createTask(
-        'team-shutdown-gate-override',
-        { subject: 'pending', description: 'd', status: 'pending' },
-        cwd,
-      );
-
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-override', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
-      manifest.governance = {
-        ...(manifest.governance || {}),
-        cleanup_requires_all_workers_inactive: false,
-      };
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-
-      await shutdownTeam('team-shutdown-gate-override', cwd);
-
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-override');
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam honors legacy policy cleanup override after governance hydration', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-legacy-'));
-    try {
-      await initTeamState('team-shutdown-gate-legacy', 'shutdown gate legacy policy test', 'executor', 1, cwd);
-      await createTask(
-        'team-shutdown-gate-legacy',
-        { subject: 'pending', description: 'd', status: 'pending' },
-        cwd,
-      );
-
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-legacy', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
-      manifest.policy = {
-        ...(manifest.policy || {}),
-        cleanup_requires_all_workers_inactive: false,
-      };
-      delete manifest.governance;
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-
-      await shutdownTeam('team-shutdown-gate-legacy', cwd);
-
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-legacy');
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam blocks when failed tasks remain (completion gate)', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-failed-'));
-    try {
-      await initTeamState('team-shutdown-gate-failed', 'shutdown gate failed test', 'executor', 1, cwd);
-      await createTask(
-        'team-shutdown-gate-failed',
-        { subject: 'failed', description: 'd', status: 'failed' },
-        cwd,
-      );
-
-      await assert.rejects(
-        () => shutdownTeam('team-shutdown-gate-failed', cwd),
-        /shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/,
-      );
-
-      const teamRoot = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed');
-      assert.equal(existsSync(teamRoot), true);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam force=true bypasses shutdown gate and cleans up', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-force-'));
-    try {
-      await initTeamState('team-shutdown-gate-force', 'shutdown gate force test', 'executor', 1, cwd);
-      await createTask(
-        'team-shutdown-gate-force',
-        { subject: 'pending', description: 'd', status: 'pending' },
-        cwd,
-      );
-
-      await shutdownTeam('team-shutdown-gate-force', cwd, { force: true });
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-force');
-      // Verify the forced shutdown audit event was written before cleanup removed state
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam force=true emits shutdown_gate_forced audit event', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-forced-event-'));
-    try {
-      await initTeamState('team-gate-forced-event', 'forced event test', 'executor', 1, cwd);
-      await createTask(
-        'team-gate-forced-event',
-        { subject: 'pending', description: 'd', status: 'pending' },
-        cwd,
-      );
-
-      const eventsPath = join(cwd, '.omx', 'state', 'team', 'team-gate-forced-event', 'events', 'events.ndjson');
-      await shutdownTeam('team-gate-forced-event', cwd, { force: true });
-
-      // Events file may have been removed during cleanup; if it existed before cleanup
-      // the audit event was appended. Verify by checking that the team root is gone (cleanup ran).
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-gate-forced-event');
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam handles persisted resize hook metadata during cleanup', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-resize-meta-'));
-    try {
-      const configPath = join(cwd, '.omx', 'state', 'team', 'team-resize-meta', 'config.json');
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-resize-meta', 'manifest.v2.json');
-      await initTeamState('team-resize-meta', 'shutdown resize metadata', 'executor', 1, cwd);
-      const config = JSON.parse(await readFile(configPath, 'utf-8')) as Record<string, unknown>;
-      config.resize_hook_name = 'omx_resize_team_resize_meta_test';
-      config.resize_hook_target = 'omx-team-team-resize-meta:0';
-      await writeFile(configPath, JSON.stringify(config, null, 2));
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as Record<string, unknown>;
-      manifest.resize_hook_name = 'omx_resize_team_resize_meta_test';
-      manifest.resize_hook_target = 'omx-team-team-resize-meta:0';
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-
-      await shutdownTeam('team-resize-meta', cwd);
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-resize-meta');
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('shutdownTeam continues cleanup when resize hook unregister fails while session remains active', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-failed-'));
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-fake-tmux-',
-          env: { TMUX_TEST_LOG: undefined },
-          tmuxScript: () => `#!/bin/sh
+				{ mode: 0o755 },
+			);
+			process.env.PATH = `${fakeBinDir}:${previousPath ?? ""}`;
+			process.env.OMX_FAKE_GIT_SUCCESS_NOOP = "merge";
+
+			const leaderHeadBefore = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+			await monitorTeam("team-merge-noadvance", repo);
+			const leaderHeadAfter = execFileSync(realGit, ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+			assert.equal(
+				leaderHeadAfter,
+				leaderHeadBefore,
+				"leader HEAD should stay unchanged in regression setup",
+			);
+
+			const snapshot = await readMonitorSnapshot("team-merge-noadvance", repo);
+			assert.equal(
+				snapshot?.integrationByWorker?.["worker-1"]?.status,
+				"integration_failed",
+			);
+			assert.equal(
+				snapshot?.integrationByWorker?.["worker-1"]?.last_integrated_head,
+				undefined,
+			);
+
+			const leaderMailbox = await listMailboxMessages(
+				"team-merge-noadvance",
+				"leader-fixed",
+				repo,
+			);
+			assert.equal(
+				leaderMailbox.some((message) => /INTEGRATED:/.test(message.body)),
+				false,
+			);
+			assert.equal(
+				leaderMailbox.some((message) =>
+					/INTEGRATION FAILED:/.test(message.body),
+				),
+				true,
+			);
+
+			const events = await readTeamEvents("team-merge-noadvance", repo, {
+				wakeableOnly: false,
+			});
+			assert.equal(
+				events.some((event) => event.type === "worker_integration_failed"),
+				true,
+			);
+		} finally {
+			if (typeof previousPath === "string") process.env.PATH = previousPath;
+			else delete process.env.PATH;
+			if (typeof previousFakeMode === "string")
+				process.env.OMX_FAKE_GIT_SUCCESS_NOOP = previousFakeMode;
+			else delete process.env.OMX_FAKE_GIT_SUCCESS_NOOP;
+			await rm(fakeBinDir, { recursive: true, force: true });
+			if (workerPath) {
+				await rm(workerPath, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam uses cherry-pick for diverged worker (hybrid cherry-pick path)", async () => {
+		const repo = await initRepo();
+		let workerPath = "";
+		try {
+			workerPath = await addWorktree(
+				repo,
+				"wk1-div-branch",
+				"omx-runtime-wk1-diverged-",
+			);
+
+			// Commit in worker
+			await writeFile(
+				join(workerPath, "worker-file.txt"),
+				"worker content\n",
+				"utf-8",
+			);
+			execFileSync("git", ["add", "worker-file.txt"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker diverge"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+
+			// Commit in leader (creates divergence)
+			await writeFile(
+				join(repo, "leader-file.txt"),
+				"leader content\n",
+				"utf-8",
+			);
+			execFileSync("git", ["add", "leader-file.txt"], {
+				cwd: repo,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "leader diverge"], {
+				cwd: repo,
+				stdio: "ignore",
+			});
+
+			await initTeamState(
+				"team-diverged",
+				"diverged test",
+				"executor",
+				1,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-diverged", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: workerPath,
+				worktree_branch: "wk1-div-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			await monitorTeam("team-diverged", repo);
+
+			// Verify both contents are on leader
+			assert.equal(
+				await readFile(join(repo, "worker-file.txt"), "utf-8"),
+				"worker content\n",
+			);
+			assert.equal(
+				await readFile(join(repo, "leader-file.txt"), "utf-8"),
+				"leader content\n",
+			);
+
+			// Cherry-pick creates single-parent commits (not merge)
+			const leaderHead = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+			const commitObj = execFileSync("git", ["cat-file", "-p", leaderHead], {
+				cwd: repo,
+				encoding: "utf-8",
+			});
+			const parentCount = commitObj
+				.split("\n")
+				.filter((l: string) => l.startsWith("parent ")).length;
+			assert.equal(
+				parentCount,
+				1,
+				"cherry-pick should create single-parent commit",
+			);
+
+			const snapshot = await readMonitorSnapshot("team-diverged", repo);
+			assert.ok(
+				snapshot?.integrationByWorker?.["worker-1"]?.last_integrated_head,
+			);
+		} finally {
+			if (workerPath) {
+				await rm(workerPath, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam rebases idle workers after integration lands on leader (cross-worker rebase)", async () => {
+		const repo = await initRepo();
+		let worker1Path = "";
+		let worker2Path = "";
+		try {
+			worker1Path = await addWorktree(
+				repo,
+				"wk1-xr-branch",
+				"omx-runtime-wk1-cross-rebase-",
+			);
+			worker2Path = await addWorktree(
+				repo,
+				"wk2-xr-branch",
+				"omx-runtime-wk2-cross-rebase-",
+			);
+
+			// Worker-1 commits a change
+			await writeFile(join(worker1Path, "w1.txt"), "from worker 1\n", "utf-8");
+			execFileSync("git", ["add", "w1.txt"], {
+				cwd: worker1Path,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker-1 change"], {
+				cwd: worker1Path,
+				stdio: "ignore",
+			});
+
+			// Worker-2 commits its own change (so rebase is meaningful)
+			await writeFile(join(worker2Path, "w2.txt"), "from worker 2\n", "utf-8");
+			execFileSync("git", ["add", "w2.txt"], {
+				cwd: worker2Path,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker-2 change"], {
+				cwd: worker2Path,
+				stdio: "ignore",
+			});
+
+			await initTeamState(
+				"team-cross-rebase",
+				"cross rebase test",
+				"executor",
+				2,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-cross-rebase", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: worker1Path,
+				worktree_branch: "wk1-xr-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			cfg.workers[1] = {
+				...cfg.workers[1],
+				assigned_tasks: ["2"],
+				worktree_repo_root: repo,
+				worktree_path: worker2Path,
+				worktree_branch: "wk2-xr-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			// Set worker-2 status to idle (eligible for rebase)
+			await writeWorkerStatus(
+				"team-cross-rebase",
+				"worker-2",
+				{ state: "idle", updated_at: new Date().toISOString() },
+				repo,
+			);
+
+			await monitorTeam("team-cross-rebase", repo);
+
+			// Verify leader has worker-1's changes
+			assert.equal(
+				await readFile(join(repo, "w1.txt"), "utf-8"),
+				"from worker 1\n",
+			);
+
+			// Verify worker-2 was rebased onto new leader HEAD
+			// After rebase, worker-2 should have both its own files AND worker-1's files (from leader)
+			assert.equal(
+				existsSync(join(worker2Path, "w1.txt")),
+				true,
+				"worker-2 should have w1.txt after rebase onto leader",
+			);
+			assert.equal(
+				existsSync(join(worker2Path, "w2.txt")),
+				true,
+				"worker-2 should still have its own w2.txt",
+			);
+
+			// Verify leader HEAD is ancestor of worker-2 branch (rebase succeeded)
+			const newLeaderHead = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: repo,
+				encoding: "utf-8",
+			}).trim();
+			const mergeBase = execFileSync(
+				"git",
+				["merge-base", newLeaderHead, "wk2-xr-branch"],
+				{ cwd: repo, encoding: "utf-8" },
+			).trim();
+			assert.equal(
+				mergeBase,
+				newLeaderHead,
+				"worker-2 should be rebased onto new leader HEAD",
+			);
+
+			const ledgerPath = join(
+				repo,
+				".omx",
+				"reports",
+				"team-commit-hygiene",
+				"team-cross-rebase.ledger.json",
+			);
+			const ledger = JSON.parse(await readFile(ledgerPath, "utf-8")) as {
+				entries: Array<{
+					operation: string;
+					worker_name: string;
+					status: string;
+				}>;
+			};
+			assert.equal(
+				ledger.entries.some(
+					(entry) =>
+						entry.operation === "cross_rebase" &&
+						entry.worker_name === "worker-2" &&
+						entry.status === "applied",
+				),
+				true,
+			);
+		} finally {
+			if (worker1Path) {
+				await rm(worker1Path, { recursive: true, force: true });
+			}
+			if (worker2Path) {
+				await rm(worker2Path, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam auto-resolves conflicts with -X theirs (worker wins on leader)", async () => {
+		const repo = await initRepo();
+		let workerPath = "";
+		try {
+			workerPath = await addWorktree(
+				repo,
+				"wk1-cr-branch",
+				"omx-runtime-wk1-conflict-resolve-",
+			);
+
+			// Worker edits README.md (same file, different content → conflict)
+			await writeFile(
+				join(workerPath, "README.md"),
+				"worker version\n",
+				"utf-8",
+			);
+			execFileSync("git", ["add", "README.md"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker edits README"], {
+				cwd: workerPath,
+				stdio: "ignore",
+			});
+
+			// Leader also edits README.md (creates divergence + conflict)
+			await writeFile(join(repo, "README.md"), "leader version\n", "utf-8");
+			execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+			execFileSync("git", ["commit", "-m", "leader edits README"], {
+				cwd: repo,
+				stdio: "ignore",
+			});
+
+			await initTeamState(
+				"team-conflict-resolve",
+				"conflict resolution test",
+				"executor",
+				1,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-conflict-resolve", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: workerPath,
+				worktree_branch: "wk1-cr-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			await monitorTeam("team-conflict-resolve", repo);
+
+			// Verify worker's version wins on leader (-X theirs = worker wins)
+			const leaderContent = await readFile(join(repo, "README.md"), "utf-8");
+			assert.equal(
+				leaderContent,
+				"worker version\n",
+				"worker content should win with -X theirs",
+			);
+
+			// Verify integration was not blocked
+			const snapshot = await readMonitorSnapshot("team-conflict-resolve", repo);
+			assert.notEqual(
+				snapshot?.integrationByWorker?.["worker-1"]?.status,
+				"cherry_pick_conflict",
+				"integration should not be permanently blocked",
+			);
+
+			// Note: -X theirs resolves conflicts silently — git cherry-pick succeeds,
+			// so the integration report is only written when -X theirs itself fails (e.g. binary conflicts).
+			// The key assertion above is that worker content wins on leader.
+		} finally {
+			if (workerPath) {
+				await rm(workerPath, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it('monitorTeam skips rebase for workers with "working" status (idle-only gating)', async () => {
+		const repo = await initRepo();
+		let worker1Path = "";
+		let worker2Path = "";
+		try {
+			worker1Path = await addWorktree(
+				repo,
+				"wk1-gate-branch",
+				"omx-runtime-wk1-rebase-gate-",
+			);
+			worker2Path = await addWorktree(
+				repo,
+				"wk2-gate-branch",
+				"omx-runtime-wk2-rebase-gate-",
+			);
+
+			// Worker-1 commits a change
+			await writeFile(join(worker1Path, "w1.txt"), "from worker 1\n", "utf-8");
+			execFileSync("git", ["add", "w1.txt"], {
+				cwd: worker1Path,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker-1 change"], {
+				cwd: worker1Path,
+				stdio: "ignore",
+			});
+
+			// Record worker-2 HEAD before integration
+			const worker2HeadBefore = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: worker2Path,
+				encoding: "utf-8",
+			}).trim();
+
+			await initTeamState(
+				"team-rebase-gate",
+				"rebase gate test",
+				"executor",
+				2,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-rebase-gate", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: worker1Path,
+				worktree_branch: "wk1-gate-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			cfg.workers[1] = {
+				...cfg.workers[1],
+				assigned_tasks: ["2"],
+				worktree_repo_root: repo,
+				worktree_path: worker2Path,
+				worktree_branch: "wk2-gate-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			// Set worker-2 status to "working" (NOT eligible for rebase)
+			await writeWorkerStatus(
+				"team-rebase-gate",
+				"worker-2",
+				{ state: "working", updated_at: new Date().toISOString() },
+				repo,
+			);
+
+			await monitorTeam("team-rebase-gate", repo);
+
+			// Verify worker-2 HEAD is unchanged (NOT rebased)
+			const worker2HeadAfter = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: worker2Path,
+				encoding: "utf-8",
+			}).trim();
+			assert.equal(
+				worker2HeadAfter,
+				worker2HeadBefore,
+				'worker-2 should NOT be rebased when status is "working"',
+			);
+		} finally {
+			if (worker1Path) {
+				await rm(worker1Path, { recursive: true, force: true });
+			}
+			if (worker2Path) {
+				await rm(worker2Path, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("monitorTeam aborts failed rebase and leaves worktree in clean state", async () => {
+		const repo = await initRepo();
+		let worker1Path = "";
+		let worker2Path = "";
+		try {
+			// Add a file that will be subject to rename/rename conflict
+			await writeFile(
+				join(repo, "original.txt"),
+				"original content\n",
+				"utf-8",
+			);
+			execFileSync("git", ["add", "original.txt"], {
+				cwd: repo,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "add original.txt"], {
+				cwd: repo,
+				stdio: "ignore",
+			});
+
+			worker1Path = await addWorktree(
+				repo,
+				"wk1-rf-branch",
+				"omx-runtime-wk1-rebase-fail-",
+			);
+			worker2Path = await addWorktree(
+				repo,
+				"wk2-rf-branch",
+				"omx-runtime-wk2-rebase-fail-",
+			);
+
+			// Worker-1 renames original.txt → renamed-by-w1.txt (will be integrated to leader)
+			execFileSync("git", ["mv", "original.txt", "renamed-by-w1.txt"], {
+				cwd: worker1Path,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker-1 renames original"], {
+				cwd: worker1Path,
+				stdio: "ignore",
+			});
+
+			// Worker-2 renames original.txt → renamed-by-w2.txt (will conflict on rebase)
+			execFileSync("git", ["mv", "original.txt", "renamed-by-w2.txt"], {
+				cwd: worker2Path,
+				stdio: "ignore",
+			});
+			execFileSync("git", ["commit", "-m", "worker-2 renames original"], {
+				cwd: worker2Path,
+				stdio: "ignore",
+			});
+
+			const worker2HeadBefore = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: worker2Path,
+				encoding: "utf-8",
+			}).trim();
+
+			await initTeamState(
+				"team-rebase-fail",
+				"rebase failure test",
+				"executor",
+				2,
+				repo,
+			);
+			const cfg = await readTeamConfig("team-rebase-fail", repo);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing config");
+			cfg.leader_pane_id = "";
+			cfg.workers[0] = {
+				...cfg.workers[0],
+				assigned_tasks: ["1"],
+				worktree_repo_root: repo,
+				worktree_path: worker1Path,
+				worktree_branch: "wk1-rf-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			cfg.workers[1] = {
+				...cfg.workers[1],
+				assigned_tasks: ["2"],
+				worktree_repo_root: repo,
+				worktree_path: worker2Path,
+				worktree_branch: "wk2-rf-branch",
+				worktree_detached: false,
+				worktree_created: false,
+			};
+			await saveTeamConfig(cfg, repo);
+
+			// Set worker-2 status to idle (eligible for rebase attempt)
+			await writeWorkerStatus(
+				"team-rebase-fail",
+				"worker-2",
+				{ state: "idle", updated_at: new Date().toISOString() },
+				repo,
+			);
+
+			await monitorTeam("team-rebase-fail", repo);
+
+			// Verify worker-1's changes landed on leader
+			assert.equal(
+				existsSync(join(repo, "renamed-by-w1.txt")),
+				true,
+				"leader should have worker-1 renamed file",
+			);
+
+			// Verify worker-2 worktree is NOT in a broken rebase state (rebase --abort was called)
+			const worker2HeadAfter = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: worker2Path,
+				encoding: "utf-8",
+			}).trim();
+			assert.equal(
+				worker2HeadAfter,
+				worker2HeadBefore,
+				"worker-2 HEAD should revert to pre-rebase state after abort",
+			);
+			// Verify no rebase-in-progress markers
+			const gitStatusOutput = execFileSync("git", ["status"], {
+				cwd: worker2Path,
+				encoding: "utf-8",
+			});
+			assert.doesNotMatch(
+				gitStatusOutput,
+				/rebase in progress/,
+				"worktree should not have rebase in progress",
+			);
+
+			// Verify integration report logged the failure
+			const reportPath = join(
+				repo,
+				".omx",
+				"state",
+				"team",
+				"team-rebase-fail",
+				"integration-report.md",
+			);
+			assert.equal(
+				existsSync(reportPath),
+				true,
+				"integration report should exist after rebase failure",
+			);
+			const report = await readFile(reportPath, "utf-8");
+			assert.match(
+				report,
+				/rebase/,
+				"report should mention the rebase operation",
+			);
+		} finally {
+			if (worker1Path) {
+				await rm(worker1Path, { recursive: true, force: true });
+			}
+			if (worker2Path) {
+				await rm(worker2Path, { recursive: true, force: true });
+			}
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam cleans up state even when tmux session doesn't exist", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState("team-shutdown", "shutdown test", "executor", 1, cwd);
+			await shutdownTeam("team-shutdown", cwd);
+
+			const teamRoot = join(cwd, ".omx", "state", "team", "team-shutdown");
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam blocks when pending tasks remain (shutdown gate)", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-shutdown-gate-"));
+		try {
+			await initTeamState(
+				"team-shutdown-gate-pending",
+				"shutdown gate pending test",
+				"executor",
+				1,
+				cwd,
+			);
+			await createTask(
+				"team-shutdown-gate-pending",
+				{ subject: "pending", description: "d", status: "pending" },
+				cwd,
+			);
+
+			await assert.rejects(
+				() => shutdownTeam("team-shutdown-gate-pending", cwd),
+				/shutdown_gate_blocked:pending=1,blocked=0,in_progress=0,failed=0/,
+			);
+
+			const teamRoot = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-shutdown-gate-pending",
+			);
+			assert.equal(existsSync(teamRoot), true);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam honors governance cleanup override when active tasks remain", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-gate-override-"),
+		);
+		try {
+			await initTeamState(
+				"team-shutdown-gate-override",
+				"shutdown gate override test",
+				"executor",
+				1,
+				cwd,
+			);
+			await createTask(
+				"team-shutdown-gate-override",
+				{ subject: "pending", description: "d", status: "pending" },
+				cwd,
+			);
+
+			const manifestPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-shutdown-gate-override",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as any;
+			manifest.governance = {
+				...(manifest.governance || {}),
+				cleanup_requires_all_workers_inactive: false,
+			};
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+			await shutdownTeam("team-shutdown-gate-override", cwd);
+
+			const teamRoot = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-shutdown-gate-override",
+			);
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam honors legacy policy cleanup override after governance hydration", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-gate-legacy-"),
+		);
+		try {
+			await initTeamState(
+				"team-shutdown-gate-legacy",
+				"shutdown gate legacy policy test",
+				"executor",
+				1,
+				cwd,
+			);
+			await createTask(
+				"team-shutdown-gate-legacy",
+				{ subject: "pending", description: "d", status: "pending" },
+				cwd,
+			);
+
+			const manifestPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-shutdown-gate-legacy",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as any;
+			manifest.policy = {
+				...(manifest.policy || {}),
+				cleanup_requires_all_workers_inactive: false,
+			};
+			delete manifest.governance;
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+			await shutdownTeam("team-shutdown-gate-legacy", cwd);
+
+			const teamRoot = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-shutdown-gate-legacy",
+			);
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam blocks when failed tasks remain (completion gate)", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-gate-failed-"),
+		);
+		try {
+			await initTeamState(
+				"team-shutdown-gate-failed",
+				"shutdown gate failed test",
+				"executor",
+				1,
+				cwd,
+			);
+			await createTask(
+				"team-shutdown-gate-failed",
+				{ subject: "failed", description: "d", status: "failed" },
+				cwd,
+			);
+
+			await assert.rejects(
+				() => shutdownTeam("team-shutdown-gate-failed", cwd),
+				/shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/,
+			);
+
+			const teamRoot = teamStateTestPath(
+				cwd,
+				"team",
+				"team-shutdown-gate-failed",
+			);
+			assert.equal(existsSync(teamRoot), true);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam force=true bypasses shutdown gate and cleans up", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-gate-force-"),
+		);
+		try {
+			await initTeamState(
+				"team-shutdown-gate-force",
+				"shutdown gate force test",
+				"executor",
+				1,
+				cwd,
+			);
+			await createTask(
+				"team-shutdown-gate-force",
+				{ subject: "pending", description: "d", status: "pending" },
+				cwd,
+			);
+
+			await shutdownTeam("team-shutdown-gate-force", cwd, { force: true });
+			const teamRoot = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-shutdown-gate-force",
+			);
+			// Verify the forced shutdown audit event was written before cleanup removed state
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam force=true emits shutdown_gate_forced audit event", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-gate-forced-event-"),
+		);
+		try {
+			await initTeamState(
+				"team-gate-forced-event",
+				"forced event test",
+				"executor",
+				1,
+				cwd,
+			);
+			await createTask(
+				"team-gate-forced-event",
+				{ subject: "pending", description: "d", status: "pending" },
+				cwd,
+			);
+
+			const eventsPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-gate-forced-event",
+				"events",
+				"events.ndjson",
+			);
+			await shutdownTeam("team-gate-forced-event", cwd, { force: true });
+
+			// Events file may have been removed during cleanup; if it existed before cleanup
+			// the audit event was appended. Verify by checking that the team root is gone (cleanup ran).
+			const teamRoot = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-gate-forced-event",
+			);
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam handles persisted resize hook metadata during cleanup", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-resize-meta-"));
+		try {
+			const configPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-resize-meta",
+				"config.json",
+			);
+			const manifestPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-resize-meta",
+				"manifest.v2.json",
+			);
+			await initTeamState(
+				"team-resize-meta",
+				"shutdown resize metadata",
+				"executor",
+				1,
+				cwd,
+			);
+			const config = JSON.parse(await readFile(configPath, "utf-8")) as Record<
+				string,
+				unknown
+			>;
+			config.resize_hook_name = "omx_resize_team_resize_meta_test";
+			config.resize_hook_target = "omx-team-team-resize-meta:0";
+			await writeFile(configPath, JSON.stringify(config, null, 2));
+			const manifest = JSON.parse(
+				await readFile(manifestPath, "utf-8"),
+			) as Record<string, unknown>;
+			manifest.resize_hook_name = "omx_resize_team_resize_meta_test";
+			manifest.resize_hook_target = "omx-team-team-resize-meta:0";
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+			await shutdownTeam("team-resize-meta", cwd);
+			const teamRoot = join(cwd, ".omx", "state", "team", "team-resize-meta");
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("shutdownTeam continues cleanup when resize hook unregister fails while session remains active", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-gate-failed-"),
+		);
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-fake-tmux-",
+					env: { TMUX_TEST_LOG: undefined },
+					tmuxScript: () => `#!/bin/sh
 set -eu
 if [ -n "\${TMUX_TEST_LOG:-}" ]; then
   printf '%s\\n' "$*" >> "$TMUX_TEST_LOG"
@@ -3231,194 +5038,307 @@ case "$1" in
     ;;
 esac
 `,
-        },
-        async ({ tmuxLogPath }) => {
-          await initTeamState('team-shutdown-gate-failed', 'shutdown resize hook failure test', 'executor', 1, cwd);
-          const configPath = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed', 'config.json');
-          const manifestPath = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed', 'manifest.v2.json');
-          const config = JSON.parse(await readFile(configPath, 'utf-8')) as Record<string, unknown>;
-          config.tmux_session = 'omx-team-team-shutdown-gate-failed';
-          config.resize_hook_name = 'omx_resize_team_shutdown_gate_failed_test';
-          config.resize_hook_target = 'omx-team-team-shutdown-gate-failed:0';
-          await writeFile(configPath, JSON.stringify(config, null, 2));
-          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as Record<string, unknown>;
-          manifest.tmux_session = 'omx-team-team-shutdown-gate-failed';
-          manifest.resize_hook_name = 'omx_resize_team_shutdown_gate_failed_test';
-          manifest.resize_hook_target = 'omx-team-team-shutdown-gate-failed:0';
-          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-          process.env.TMUX_TEST_LOG = tmuxLogPath;
+				},
+				async ({ tmuxLogPath }) => {
+					await initTeamState(
+						"team-shutdown-gate-failed",
+						"shutdown resize hook failure test",
+						"executor",
+						1,
+						cwd,
+					);
+					const configPath = teamStateTestPath(
+						cwd,
+						"team",
+						"team-shutdown-gate-failed",
+						"config.json",
+					);
+					const manifestPath = teamStateTestPath(
+						cwd,
+						"team",
+						"team-shutdown-gate-failed",
+						"manifest.v2.json",
+					);
+					const config = JSON.parse(
+						await readFile(configPath, "utf-8"),
+					) as Record<string, unknown>;
+					config.tmux_session = "omx-team-team-shutdown-gate-failed";
+					config.resize_hook_name = "omx_resize_team_shutdown_gate_failed_test";
+					config.resize_hook_target = "omx-team-team-shutdown-gate-failed:0";
+					await writeFile(configPath, JSON.stringify(config, null, 2));
+					const manifest = JSON.parse(
+						await readFile(manifestPath, "utf-8"),
+					) as Record<string, unknown>;
+					manifest.tmux_session = "omx-team-team-shutdown-gate-failed";
+					manifest.resize_hook_name =
+						"omx_resize_team_shutdown_gate_failed_test";
+					manifest.resize_hook_target = "omx-team-team-shutdown-gate-failed:0";
+					await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+					process.env.TMUX_TEST_LOG = tmuxLogPath;
 
-          await shutdownTeam('team-shutdown-gate-failed', cwd);
+					await shutdownTeam("team-shutdown-gate-failed", cwd);
 
-          const teamRoot = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed');
-          assert.equal(existsSync(teamRoot), false);
+					const teamRoot = teamStateTestPath(
+						cwd,
+						"team",
+						"team-shutdown-gate-failed",
+					);
+					assert.equal(existsSync(teamRoot), false);
 
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/);
-          assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-gate-failed/);
-        },
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+					assert.match(
+						tmuxLog,
+						/set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/,
+					);
+					assert.match(
+						tmuxLog,
+						/kill-session -t omx-team-team-shutdown-gate-failed/,
+					);
+				},
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam returns rejection error when worker rejects shutdown and force is false', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-reject', 'shutdown reject test', 'executor', 1, cwd);
-      const ackPath = join(
-        cwd,
-        '.omx',
-        'state',
-        'team',
-        'team-reject',
-        'workers',
-        'worker-1',
-        'shutdown-ack.json',
-      );
-      await writeFile(
-        ackPath,
-        JSON.stringify({ status: 'reject', reason: 'still working', updated_at: '9999-01-01T00:00:00.000Z' }),
-      );
+	it("shutdownTeam returns rejection error when worker rejects shutdown and force is false", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-reject",
+				"shutdown reject test",
+				"executor",
+				1,
+				cwd,
+			);
+			const ackPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-reject",
+				"workers",
+				"worker-1",
+				"shutdown-ack.json",
+			);
+			await writeFile(
+				ackPath,
+				JSON.stringify({
+					status: "reject",
+					reason: "still working",
+					updated_at: "9999-01-01T00:00:00.000Z",
+				}),
+			);
 
-      await assert.rejects(() => shutdownTeam('team-reject', cwd), /shutdown_rejected:worker-1:still working/);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await assert.rejects(
+				() => shutdownTeam("team-reject", cwd),
+				/shutdown_rejected:worker-1:still working/,
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam emits shutdown_ack event when worker ack is received', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-ack-evt', 'shutdown ack event test', 'executor', 1, cwd);
-      const ackPath = join(
-        cwd,
-        '.omx',
-        'state',
-        'team',
-        'team-ack-evt',
-        'workers',
-        'worker-1',
-        'shutdown-ack.json',
-      );
-      await writeFile(
-        ackPath,
-        JSON.stringify({ status: 'reject', reason: 'busy', updated_at: '9999-01-01T00:00:00.000Z' }),
-      );
+	it("shutdownTeam emits shutdown_ack event when worker ack is received", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-ack-evt",
+				"shutdown ack event test",
+				"executor",
+				1,
+				cwd,
+			);
+			const ackPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-ack-evt",
+				"workers",
+				"worker-1",
+				"shutdown-ack.json",
+			);
+			await writeFile(
+				ackPath,
+				JSON.stringify({
+					status: "reject",
+					reason: "busy",
+					updated_at: "9999-01-01T00:00:00.000Z",
+				}),
+			);
 
-      await assert.rejects(() => shutdownTeam('team-ack-evt', cwd), /shutdown_rejected/);
+			await assert.rejects(
+				() => shutdownTeam("team-ack-evt", cwd),
+				/shutdown_rejected/,
+			);
 
-      // Verify that a shutdown_ack event was written to the event log
-      const eventLogPath = join(cwd, '.omx', 'state', 'team', 'team-ack-evt', 'events', 'events.ndjson');
-      assert.ok(existsSync(eventLogPath), 'event log should exist');
-      const raw = await readFile(eventLogPath, 'utf-8');
-      const events = raw.trim().split('\n').map(line => JSON.parse(line));
-      const ackEvents = events.filter((e: { type: string }) => e.type === 'shutdown_ack');
-      assert.equal(ackEvents.length, 1, 'should have exactly one shutdown_ack event');
-      assert.equal(ackEvents[0].worker, 'worker-1');
-      assert.equal(ackEvents[0].reason, 'reject:busy');
-      assert.equal(ackEvents[0].team, 'team-ack-evt');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			// Verify that a shutdown_ack event was written to the event log
+			const eventLogPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-ack-evt",
+				"events",
+				"events.ndjson",
+			);
+			assert.ok(existsSync(eventLogPath), "event log should exist");
+			const raw = await readFile(eventLogPath, "utf-8");
+			const events = raw
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line));
+			const ackEvents = events.filter(
+				(e: { type: string }) => e.type === "shutdown_ack",
+			);
+			assert.equal(
+				ackEvents.length,
+				1,
+				"should have exactly one shutdown_ack event",
+			);
+			assert.equal(ackEvents[0].worker, "worker-1");
+			assert.equal(ackEvents[0].reason, "reject:busy");
+			assert.equal(ackEvents[0].team, "team-ack-evt");
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam emits shutdown_ack event with accept reason for accepted acks', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-ack-accept', 'shutdown ack accept test', 'executor', 1, cwd);
-      const ackPath = join(
-        cwd,
-        '.omx',
-        'state',
-        'team',
-        'team-ack-accept',
-        'workers',
-        'worker-1',
-        'shutdown-ack.json',
-      );
-      await writeFile(
-        ackPath,
-        JSON.stringify({ status: 'accept', updated_at: '9999-01-01T00:00:00.000Z' }),
-      );
+	it("shutdownTeam emits shutdown_ack event with accept reason for accepted acks", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-ack-accept",
+				"shutdown ack accept test",
+				"executor",
+				1,
+				cwd,
+			);
+			const ackPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-ack-accept",
+				"workers",
+				"worker-1",
+				"shutdown-ack.json",
+			);
+			await writeFile(
+				ackPath,
+				JSON.stringify({
+					status: "accept",
+					updated_at: "9999-01-01T00:00:00.000Z",
+				}),
+			);
 
-      // Read the event log before cleanup destroys it
-      const eventLogPath = join(cwd, '.omx', 'state', 'team', 'team-ack-accept', 'events', 'events.ndjson');
+			// Read the event log before cleanup destroys it
+			const eventLogPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-ack-accept",
+				"events",
+				"events.ndjson",
+			);
 
-      await shutdownTeam('team-ack-accept', cwd);
+			await shutdownTeam("team-ack-accept", cwd);
 
-      // State is cleaned up, but we can verify the event was emitted by checking
-      // that cleanup succeeded (no error) -- the event was written before cleanup.
-      // For a more direct test, check that the team root was cleaned up.
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-ack-accept');
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			// State is cleaned up, but we can verify the event was emitted by checking
+			// that cleanup succeeded (no error) -- the event was written before cleanup.
+			// For a more direct test, check that the team root was cleaned up.
+			const teamRoot = join(cwd, ".omx", "state", "team", "team-ack-accept");
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam force=true ignores rejection and cleans up team state', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-force', 'shutdown force test', 'executor', 1, cwd);
-      const ackPath = join(
-        cwd,
-        '.omx',
-        'state',
-        'team',
-        'team-force',
-        'workers',
-        'worker-1',
-        'shutdown-ack.json',
-      );
-      await writeFile(
-        ackPath,
-        JSON.stringify({ status: 'reject', reason: 'still working', updated_at: '9999-01-01T00:00:00.000Z' }),
-      );
+	it("shutdownTeam force=true ignores rejection and cleans up team state", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-force",
+				"shutdown force test",
+				"executor",
+				1,
+				cwd,
+			);
+			const ackPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-force",
+				"workers",
+				"worker-1",
+				"shutdown-ack.json",
+			);
+			await writeFile(
+				ackPath,
+				JSON.stringify({
+					status: "reject",
+					reason: "still working",
+					updated_at: "9999-01-01T00:00:00.000Z",
+				}),
+			);
 
-      await shutdownTeam('team-force', cwd, { force: true });
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-force');
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam("team-force", cwd, { force: true });
+			const teamRoot = join(cwd, ".omx", "state", "team", "team-force");
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam ignores stale rejection ack from a prior request', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-stale-ack', 'shutdown stale ack test', 'executor', 1, cwd);
-      const ackPath = join(
-        cwd,
-        '.omx',
-        'state',
-        'team',
-        'team-stale-ack',
-        'workers',
-        'worker-1',
-        'shutdown-ack.json',
-      );
-      await writeFile(
-        ackPath,
-        JSON.stringify({ status: 'reject', reason: 'old ack', updated_at: '2000-01-01T00:00:00.000Z' }),
-      );
+	it("shutdownTeam ignores stale rejection ack from a prior request", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-stale-ack",
+				"shutdown stale ack test",
+				"executor",
+				1,
+				cwd,
+			);
+			const ackPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-stale-ack",
+				"workers",
+				"worker-1",
+				"shutdown-ack.json",
+			);
+			await writeFile(
+				ackPath,
+				JSON.stringify({
+					status: "reject",
+					reason: "old ack",
+					updated_at: "2000-01-01T00:00:00.000Z",
+				}),
+			);
 
-      await shutdownTeam('team-stale-ack', cwd);
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-stale-ack');
-      assert.equal(existsSync(teamRoot), false);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			await shutdownTeam("team-stale-ack", cwd);
+			const teamRoot = join(cwd, ".omx", "state", "team", "team-stale-ack");
+			assert.equal(existsSync(teamRoot), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam applies best-effort teardown even when worker pane is already dead', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-dead-pane-'));
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-shutdown-dead-pane-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("shutdownTeam applies best-effort teardown even when worker pane is already dead", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-dead-pane-"),
+		);
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-shutdown-dead-pane-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
@@ -3444,39 +5364,56 @@ case "$1" in
     ;;
 esac
 `,
-        },
-        async ({ tmuxLogPath }) => {
-          await initTeamState('team-shutdown-dead-pane', 'shutdown dead pane test', 'executor', 2, cwd);
-          const config = await readTeamConfig('team-shutdown-dead-pane', cwd);
-          assert.ok(config);
-          if (!config) return;
-          config.tmux_session = 'omx-team-team-shutdown-dead-pane';
-          config.workers[0]!.pane_id = '%404';
-          config.workers[1]!.pane_id = '%405';
-          await saveTeamConfig(config, cwd);
+				},
+				async ({ tmuxLogPath }) => {
+					await initTeamState(
+						"team-shutdown-dead-pane",
+						"shutdown dead pane test",
+						"executor",
+						2,
+						cwd,
+					);
+					const config = await readTeamConfig("team-shutdown-dead-pane", cwd);
+					assert.ok(config);
+					if (!config) return;
+					config.tmux_session = "omx-team-team-shutdown-dead-pane";
+					config.workers[0]!.pane_id = "%404";
+					config.workers[1]!.pane_id = "%405";
+					await saveTeamConfig(config, cwd);
 
-          await shutdownTeam('team-shutdown-dead-pane', cwd, { force: true });
-          const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-dead-pane');
-          assert.equal(existsSync(teamRoot), false);
+					await shutdownTeam("team-shutdown-dead-pane", cwd, { force: true });
+					const teamRoot = join(
+						cwd,
+						".omx",
+						"state",
+						"team",
+						"team-shutdown-dead-pane",
+					);
+					assert.equal(existsSync(teamRoot), false);
 
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /kill-pane -t %404/);
-          assert.match(tmuxLog, /kill-pane -t %405/);
-          assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-dead-pane/);
-        },
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+					assert.match(tmuxLog, /kill-pane -t %404/);
+					assert.match(tmuxLog, /kill-pane -t %405/);
+					assert.match(
+						tmuxLog,
+						/kill-session -t omx-team-team-shutdown-dead-pane/,
+					);
+				},
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam reconciles persisted worker panes with live tmux panes before teardown', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-pane-reconcile-'));
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-shutdown-pane-reconcile-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("shutdownTeam reconciles persisted worker panes with live tmux panes before teardown", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-pane-reconcile-"),
+		);
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-shutdown-pane-reconcile-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 restored_marker="${tmuxLogPath}.restored"
@@ -3530,43 +5467,61 @@ case "$1" in
     ;;
 esac
 `,
-        },
-        async ({ tmuxLogPath }) => {
-          await initTeamState('team-shutdown-pane-reconcile', 'shutdown pane reconcile test', 'executor', 2, cwd);
-          const config = await readTeamConfig('team-shutdown-pane-reconcile', cwd);
-          assert.ok(config);
-          if (!config) return;
-          config.tmux_session = 'leader:0';
-          config.leader_pane_id = '%11';
-          config.hud_pane_id = '%12';
-          config.workers[0]!.pane_id = '';
-          config.workers[1]!.pane_id = '%999';
-          await saveTeamConfig(config, cwd);
+				},
+				async ({ tmuxLogPath }) => {
+					await initTeamState(
+						"team-shutdown-pane-reconcile",
+						"shutdown pane reconcile test",
+						"executor",
+						2,
+						cwd,
+					);
+					const config = await readTeamConfig(
+						"team-shutdown-pane-reconcile",
+						cwd,
+					);
+					assert.ok(config);
+					if (!config) return;
+					config.tmux_session = "leader:0";
+					config.leader_pane_id = "%11";
+					config.hud_pane_id = "%12";
+					config.workers[0]!.pane_id = "";
+					config.workers[1]!.pane_id = "%999";
+					await saveTeamConfig(config, cwd);
 
-          await shutdownTeam('team-shutdown-pane-reconcile', cwd, { force: true });
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, /kill-pane -t %14/);
-          assert.match(tmuxLog, /kill-pane -t %999/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
-          assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
-        },
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					await shutdownTeam("team-shutdown-pane-reconcile", cwd, {
+						force: true,
+					});
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+					assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+					assert.match(tmuxLog, /kill-pane -t %12/);
+					assert.match(tmuxLog, /kill-pane -t %13/);
+					assert.match(tmuxLog, /kill-pane -t %14/);
+					assert.match(tmuxLog, /kill-pane -t %999/);
+					assert.match(
+						tmuxLog,
+						new RegExp(
+							`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`,
+						),
+					);
+					assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
+				},
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam skips prekill and keeps the leader pane alive on native Windows split-pane shutdown', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-win32-split-'));
-    try {
-      await withNativeWindowsPlatform(async () => {
-        await withMockTmuxFixture(
-          {
-            dirPrefix: 'omx-runtime-shutdown-win32-split-bin-',
-            tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("shutdownTeam skips prekill and keeps the leader pane alive on native Windows split-pane shutdown", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-win32-split-"),
+		);
+		try {
+			await withNativeWindowsPlatform(async () => {
+				await withMockTmuxFixture(
+					{
+						dirPrefix: "omx-runtime-shutdown-win32-split-bin-",
+						tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
@@ -3600,52 +5555,81 @@ case "$1" in
     ;;
 esac
 `,
-          },
-          async ({ tmuxLogPath }) => {
-            await initTeamState('team-shutdown-win32-split', 'shutdown win32 split test', 'executor', 2, cwd);
-            const config = await readTeamConfig('team-shutdown-win32-split', cwd);
-            assert.ok(config);
-            if (!config) return;
-            config.tmux_session = 'leader:0';
-            config.leader_pane_id = '%11';
-            config.hud_pane_id = '%12';
-            config.workers[0]!.pane_id = '%13';
-            config.workers[1]!.pane_id = '%14';
-            await saveTeamConfig(config, cwd);
+					},
+					async ({ tmuxLogPath }) => {
+						await initTeamState(
+							"team-shutdown-win32-split",
+							"shutdown win32 split test",
+							"executor",
+							2,
+							cwd,
+						);
+						const config = await readTeamConfig(
+							"team-shutdown-win32-split",
+							cwd,
+						);
+						assert.ok(config);
+						if (!config) return;
+						config.tmux_session = "leader:0";
+						config.leader_pane_id = "%11";
+						config.hud_pane_id = "%12";
+						config.workers[0]!.pane_id = "%13";
+						config.workers[1]!.pane_id = "%14";
+						await saveTeamConfig(config, cwd);
 
-            await shutdownTeam('team-shutdown-win32-split', cwd, { force: true });
+						await shutdownTeam("team-shutdown-win32-split", cwd, {
+							force: true,
+						});
 
-            const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-win32-split');
-            assert.equal(existsSync(teamRoot), false);
-            assert.equal(await readMonitorSnapshot('team-shutdown-win32-split', cwd), null);
+						const teamRoot = join(
+							cwd,
+							".omx",
+							"state",
+							"team",
+							"team-shutdown-win32-split",
+						);
+						assert.equal(existsSync(teamRoot), false);
+						assert.equal(
+							await readMonitorSnapshot("team-shutdown-win32-split", cwd),
+							null,
+						);
 
-            const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-            assert.doesNotMatch(tmuxLog, /list-panes -t %13 -F #\{pane_pid\}/);
-            assert.doesNotMatch(tmuxLog, /list-panes -t %14 -F #\{pane_pid\}/);
-            assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-            assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
-            assert.match(tmuxLog, /kill-pane -t %12/);
-            assert.match(tmuxLog, /kill-pane -t %13/);
-            assert.match(tmuxLog, /kill-pane -t %14/);
-            assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
-            assert.match(tmuxLog, new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
-            assert.match(tmuxLog, /select-pane -t %11/);
-          },
-        );
-      });
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+						const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+						assert.doesNotMatch(tmuxLog, /list-panes -t %13 -F #\{pane_pid\}/);
+						assert.doesNotMatch(tmuxLog, /list-panes -t %14 -F #\{pane_pid\}/);
+						assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+						assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
+						assert.match(tmuxLog, /kill-pane -t %12/);
+						assert.match(tmuxLog, /kill-pane -t %13/);
+						assert.match(tmuxLog, /kill-pane -t %14/);
+						assert.match(
+							tmuxLog,
+							new RegExp(
+								`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`,
+							),
+						);
+						assert.match(
+							tmuxLog,
+							new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`),
+						);
+						assert.match(tmuxLog, /select-pane -t %11/);
+					},
+				);
+			});
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-
-  it('shutdownTeam restores a standalone HUD pane after tearing down the team HUD', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-restore-hud-'));
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-shutdown-restore-hud-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("shutdownTeam restores a standalone HUD pane after tearing down the team HUD", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-restore-hud-"),
+		);
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-shutdown-restore-hud-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
@@ -3668,43 +5652,59 @@ case "$1" in
     ;;
 esac
 `,
-        },
-        async ({ tmuxLogPath }) => {
-          await initTeamState('team-shutdown-restore-hud', 'shutdown restore hud test', 'executor', 2, cwd);
-          const config = await readTeamConfig('team-shutdown-restore-hud', cwd);
-          assert.ok(config);
-          if (!config) return;
-          config.tmux_session = 'leader:0';
-          config.leader_pane_id = '%11';
-          config.hud_pane_id = '%12';
-          config.workers[0]!.pane_id = '%12';
-          config.workers[1]!.pane_id = '%13';
-          await saveTeamConfig(config, cwd);
+				},
+				async ({ tmuxLogPath }) => {
+					await initTeamState(
+						"team-shutdown-restore-hud",
+						"shutdown restore hud test",
+						"executor",
+						2,
+						cwd,
+					);
+					const config = await readTeamConfig("team-shutdown-restore-hud", cwd);
+					assert.ok(config);
+					if (!config) return;
+					config.tmux_session = "leader:0";
+					config.leader_pane_id = "%11";
+					config.hud_pane_id = "%12";
+					config.workers[0]!.pane_id = "%12";
+					config.workers[1]!.pane_id = "%13";
+					await saveTeamConfig(config, cwd);
 
-          await shutdownTeam('team-shutdown-restore-hud', cwd, { force: true });
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
-          assert.match(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/);
-          assert.match(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
-          assert.match(tmuxLog, /hud --watch/);
-          assert.match(tmuxLog, /select-pane -t %11/);
-        },
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					await shutdownTeam("team-shutdown-restore-hud", cwd, { force: true });
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+					assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+					assert.match(tmuxLog, /kill-pane -t %12/);
+					assert.match(tmuxLog, /kill-pane -t %13/);
+					assert.match(
+						tmuxLog,
+						new RegExp(
+							`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`,
+						),
+					);
+					assert.match(
+						tmuxLog,
+						/run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/,
+					);
+					assert.match(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
+					assert.match(tmuxLog, /hud --watch/);
+					assert.match(tmuxLog, /select-pane -t %11/);
+				},
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam preserves leader exclusion while tearing down the hud pane', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-exclusions-'));
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-shutdown-exclusions-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("shutdownTeam preserves leader exclusion while tearing down the hud pane", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-shutdown-exclusions-"),
+		);
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-shutdown-exclusions-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
@@ -3723,426 +5723,639 @@ case "$1" in
     ;;
 esac
 `,
-        },
-        async ({ tmuxLogPath }) => {
-          await initTeamState('team-shutdown-exclusions', 'shutdown exclusions test', 'executor', 3, cwd);
-          const config = await readTeamConfig('team-shutdown-exclusions', cwd);
-          assert.ok(config);
-          if (!config) return;
-          config.tmux_session = 'omx-team-team-shutdown-exclusions';
-          config.leader_pane_id = '%11';
-          config.hud_pane_id = '%12';
-          config.workers[0]!.pane_id = '%11';
-          config.workers[1]!.pane_id = '%12';
-          config.workers[2]!.pane_id = '%13';
-          await saveTeamConfig(config, cwd);
+				},
+				async ({ tmuxLogPath }) => {
+					await initTeamState(
+						"team-shutdown-exclusions",
+						"shutdown exclusions test",
+						"executor",
+						3,
+						cwd,
+					);
+					const config = await readTeamConfig("team-shutdown-exclusions", cwd);
+					assert.ok(config);
+					if (!config) return;
+					config.tmux_session = "omx-team-team-shutdown-exclusions";
+					config.leader_pane_id = "%11";
+					config.hud_pane_id = "%12";
+					config.workers[0]!.pane_id = "%11";
+					config.workers[1]!.pane_id = "%12";
+					config.workers[2]!.pane_id = "%13";
+					await saveTeamConfig(config, cwd);
 
-          await shutdownTeam('team-shutdown-exclusions', cwd, { force: true });
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
-        },
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					await shutdownTeam("team-shutdown-exclusions", cwd, { force: true });
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8");
+					assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+					assert.match(tmuxLog, /kill-pane -t %12/);
+					assert.match(tmuxLog, /kill-pane -t %13/);
+				},
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('shutdownTeam still throws on failed tasks', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-normal-gate-'));
-    try {
-      await initTeamState('team-normal-gate', 'normal gate test', 'executor', 1, cwd);
-      await createTask(
-        'team-normal-gate',
-        { subject: 'failed', description: 'd', status: 'failed' },
-        cwd,
-      );
+	it("shutdownTeam still throws on failed tasks", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-normal-gate-"));
+		try {
+			await initTeamState(
+				"team-normal-gate",
+				"normal gate test",
+				"executor",
+				1,
+				cwd,
+			);
+			await createTask(
+				"team-normal-gate",
+				{ subject: "failed", description: "d", status: "failed" },
+				cwd,
+			);
 
-      await assert.rejects(
-        () => shutdownTeam('team-normal-gate', cwd),
-        /shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/,
-      );
+			await assert.rejects(
+				() => shutdownTeam("team-normal-gate", cwd),
+				/shutdown_gate_blocked:pending=0,blocked=0,in_progress=0,failed=1/,
+			);
 
-      const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-normal-gate');
-      assert.equal(existsSync(teamRoot), true);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			const teamRoot = join(cwd, ".omx", "state", "team", "team-normal-gate");
+			assert.equal(existsSync(teamRoot), true);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
+	it("resumeTeam returns null for non-existent team", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			const runtime = await resumeTeam("missing-team", cwd);
+			assert.equal(runtime, null);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('resumeTeam returns null for non-existent team', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      const runtime = await resumeTeam('missing-team', cwd);
-      assert.equal(runtime, null);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("resumeTeam returns null for prompt teams when worker handles are missing after restart", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-prompt-resume-"));
+		const sleeper = spawn(
+			process.execPath,
+			["-e", "setInterval(() => {}, 1000)"],
+			{
+				stdio: "ignore",
+				detached: false,
+			},
+		);
+		let sleeperPid = sleeper.pid ?? 0;
+		const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+		const prevLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
+		delete process.env.OMX_TEAM_STATE_ROOT;
+		delete process.env.OMX_TEAM_LEADER_CWD;
 
-  it('resumeTeam returns null for prompt teams when worker handles are missing after restart', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-resume-'));
-    const sleeper = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
-      stdio: 'ignore',
-      detached: false,
-    });
-    let sleeperPid = sleeper.pid ?? 0;
-    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
-    const prevLeaderCwd = process.env.OMX_TEAM_LEADER_CWD;
-    delete process.env.OMX_TEAM_STATE_ROOT;
-    delete process.env.OMX_TEAM_LEADER_CWD;
+		try {
+			await initTeamState(
+				"team-prompt-resume",
+				"prompt resume test",
+				"executor",
+				1,
+				cwd,
+			);
+			const configPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-prompt-resume",
+				"config.json",
+			);
+			const config = JSON.parse(await readFile(configPath, "utf-8")) as any;
+			config.worker_launch_mode = "prompt";
+			config.tmux_session = "prompt-team-prompt-resume";
+			config.leader_pane_id = null;
+			config.hud_pane_id = null;
+			config.workers[0].pid = sleeperPid;
+			config.workers[0].pane_id = null;
+			await writeFile(configPath, JSON.stringify(config, null, 2));
 
-    try {
-      await initTeamState('team-prompt-resume', 'prompt resume test', 'executor', 1, cwd);
-      const configPath = join(cwd, '.omx', 'state', 'team', 'team-prompt-resume', 'config.json');
-      const config = JSON.parse(await readFile(configPath, 'utf-8')) as any;
-      config.worker_launch_mode = 'prompt';
-      config.tmux_session = 'prompt-team-prompt-resume';
-      config.leader_pane_id = null;
-      config.hud_pane_id = null;
-      config.workers[0].pid = sleeperPid;
-      config.workers[0].pane_id = null;
-      await writeFile(configPath, JSON.stringify(config, null, 2));
+			const runtime = await resumeTeam("team-prompt-resume", cwd);
+			assert.equal(runtime, null);
+		} finally {
+			if (sleeperPid > 0) {
+				try {
+					process.kill(sleeperPid, "SIGKILL");
+				} catch {
+					// already exited
+				}
+			}
+			if (typeof prevTeamStateRoot === "string")
+				process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+			else delete process.env.OMX_TEAM_STATE_ROOT;
+			if (typeof prevLeaderCwd === "string")
+				process.env.OMX_TEAM_LEADER_CWD = prevLeaderCwd;
+			else delete process.env.OMX_TEAM_LEADER_CWD;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      const runtime = await resumeTeam('team-prompt-resume', cwd);
-      assert.equal(runtime, null);
-    } finally {
-      if (sleeperPid > 0) {
-        try {
-          process.kill(sleeperPid, 'SIGKILL');
-        } catch {
-          // already exited
-        }
-      }
-      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
-      else delete process.env.OMX_TEAM_STATE_ROOT;
-      if (typeof prevLeaderCwd === 'string') process.env.OMX_TEAM_LEADER_CWD = prevLeaderCwd;
-      else delete process.env.OMX_TEAM_LEADER_CWD;
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("assignTask enforces delegation_only policy for leader-fixed worker", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-delegation",
+				"delegation policy test",
+				"executor",
+				1,
+				cwd,
+			);
+			const task = await createTask(
+				"team-delegation",
+				{
+					subject: "x",
+					description: "d",
+					status: "pending",
+					requires_code_change: false,
+				},
+				cwd,
+			);
 
-  it('assignTask enforces delegation_only policy for leader-fixed worker', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-delegation', 'delegation policy test', 'executor', 1, cwd);
-      const task = await createTask(
-        'team-delegation',
-        { subject: 'x', description: 'd', status: 'pending', requires_code_change: false },
-        cwd,
-      );
+			const manifestPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-delegation",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as any;
+			manifest.governance = {
+				...(manifest.governance || {}),
+				delegation_only: true,
+			};
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-delegation', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
-      manifest.governance = { ...(manifest.governance || {}), delegation_only: true };
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+			await assert.rejects(
+				() => assignTask("team-delegation", "leader-fixed", task.id, cwd),
+				/delegation_only_violation/,
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      await assert.rejects(
-        () => assignTask('team-delegation', 'leader-fixed', task.id, cwd),
-        /delegation_only_violation/,
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("assignTask does not claim task when worker does not exist", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-missing-worker",
+				"assignment test",
+				"executor",
+				1,
+				cwd,
+			);
+			const task = await createTask(
+				"team-missing-worker",
+				{
+					subject: "x",
+					description: "d",
+					status: "pending",
+					requires_code_change: false,
+				},
+				cwd,
+			);
 
-  it('assignTask does not claim task when worker does not exist', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-missing-worker', 'assignment test', 'executor', 1, cwd);
-      const task = await createTask(
-        'team-missing-worker',
-        { subject: 'x', description: 'd', status: 'pending', requires_code_change: false },
-        cwd,
-      );
+			await assert.rejects(
+				() => assignTask("team-missing-worker", "worker-404", task.id, cwd),
+				/Worker worker-404 not found in team/,
+			);
 
-      await assert.rejects(
-        () => assignTask('team-missing-worker', 'worker-404', task.id, cwd),
-        /Worker worker-404 not found in team/,
-      );
+			const reread = await readTask("team-missing-worker", task.id, cwd);
+			assert.equal(reread?.status, "pending");
+			assert.equal(reread?.owner, undefined);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      const reread = await readTask('team-missing-worker', task.id, cwd);
-      assert.equal(reread?.status, 'pending');
-      assert.equal(reread?.owner, undefined);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("assignTask rolls back claim when notification transport fails", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-notify-fail",
+				"assignment test",
+				"executor",
+				1,
+				cwd,
+			);
+			const task = await createTask(
+				"team-notify-fail",
+				{
+					subject: "x",
+					description: "d",
+					status: "pending",
+					requires_code_change: false,
+				},
+				cwd,
+			);
 
-  it('assignTask rolls back claim when notification transport fails', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-notify-fail', 'assignment test', 'executor', 1, cwd);
-      const task = await createTask(
-        'team-notify-fail',
-        { subject: 'x', description: 'd', status: 'pending', requires_code_change: false },
-        cwd,
-      );
+			// Force notification transport to fail by clearing PATH so tmux is unavailable.
+			await assert.rejects(
+				() =>
+					withEmptyPath(() =>
+						assignTask("team-notify-fail", "worker-1", task.id, cwd),
+					),
+				/worker_notify_failed/,
+			);
 
-      // Force notification transport to fail by clearing PATH so tmux is unavailable.
-      await assert.rejects(
-        () => withEmptyPath(() => assignTask('team-notify-fail', 'worker-1', task.id, cwd)),
-        /worker_notify_failed/,
-      );
+			const reread = await readTask("team-notify-fail", task.id, cwd);
+			assert.equal(reread?.status, "pending");
+			assert.equal(reread?.owner, undefined);
+			assert.equal(reread?.claim, undefined);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      const reread = await readTask('team-notify-fail', task.id, cwd);
-      assert.equal(reread?.status, 'pending');
-      assert.equal(reread?.owner, undefined);
-      assert.equal(reread?.claim, undefined);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("assignTask rolls back claim when inbox write fails after claim", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-inbox-fail",
+				"assignment test",
+				"executor",
+				1,
+				cwd,
+			);
+			const task = await createTask(
+				"team-inbox-fail",
+				{
+					subject: "x",
+					description: "d",
+					status: "pending",
+					requires_code_change: false,
+				},
+				cwd,
+			);
+			const workerDir = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-inbox-fail",
+				"workers",
+				"worker-1",
+			);
+			await rm(workerDir, { recursive: true, force: true });
+			// Force inbox write failure by turning the would-be directory into a file.
+			await writeFile(workerDir, "not-a-directory");
 
-  it('assignTask rolls back claim when inbox write fails after claim', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-inbox-fail', 'assignment test', 'executor', 1, cwd);
-      const task = await createTask(
-        'team-inbox-fail',
-        { subject: 'x', description: 'd', status: 'pending', requires_code_change: false },
-        cwd,
-      );
-      const workerDir = join(cwd, '.omx', 'state', 'team', 'team-inbox-fail', 'workers', 'worker-1');
-      await rm(workerDir, { recursive: true, force: true });
-      // Force inbox write failure by turning the would-be directory into a file.
-      await writeFile(workerDir, 'not-a-directory');
+			await assert.rejects(
+				() => assignTask("team-inbox-fail", "worker-1", task.id, cwd),
+				/worker_assignment_failed:/,
+			);
 
-      await assert.rejects(
-        () => assignTask('team-inbox-fail', 'worker-1', task.id, cwd),
-        /worker_assignment_failed:/,
-      );
+			const reread = await readTask("team-inbox-fail", task.id, cwd);
+			assert.equal(reread?.status, "pending");
+			assert.equal(reread?.owner, undefined);
+			assert.equal(reread?.claim, undefined);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      const reread = await readTask('team-inbox-fail', task.id, cwd);
-      assert.equal(reread?.status, 'pending');
-      assert.equal(reread?.owner, undefined);
-      assert.equal(reread?.claim, undefined);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("assignTask enforces plan approval for code-change tasks when required", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-approval",
+				"approval policy test",
+				"executor",
+				1,
+				cwd,
+			);
+			const task = await createTask(
+				"team-approval",
+				{
+					subject: "x",
+					description: "d",
+					status: "pending",
+					requires_code_change: true,
+				},
+				cwd,
+			);
 
-  it('assignTask enforces plan approval for code-change tasks when required', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-approval', 'approval policy test', 'executor', 1, cwd);
-      const task = await createTask(
-        'team-approval',
-        { subject: 'x', description: 'd', status: 'pending', requires_code_change: true },
-        cwd,
-      );
+			const manifestPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-approval",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as any;
+			manifest.governance = {
+				...(manifest.governance || {}),
+				plan_approval_required: true,
+			};
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-approval', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as any;
-      manifest.governance = { ...(manifest.governance || {}), plan_approval_required: true };
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+			await assert.rejects(
+				() => assignTask("team-approval", "worker-1", task.id, cwd),
+				/plan_approval_required/,
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      await assert.rejects(
-        () => assignTask('team-approval', 'worker-1', task.id, cwd),
-        /plan_approval_required/,
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("monitorTeam does not re-notify already-notified mailbox messages (issue #116)", async () => {
+		// Regression: deliverPendingMailboxMessages used to re-notify every 15 s via shouldRetry.
+		// After the fix it must NOT re-notify messages that already have notified_at set.
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-no-spam-"));
+		try {
+			await initTeamState("team-no-spam", "no spam test", "executor", 1, cwd);
 
-  it('monitorTeam does not re-notify already-notified mailbox messages (issue #116)', async () => {
-    // Regression: deliverPendingMailboxMessages used to re-notify every 15 s via shouldRetry.
-    // After the fix it must NOT re-notify messages that already have notified_at set.
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-no-spam-'));
-    try {
-      await initTeamState('team-no-spam', 'no spam test', 'executor', 1, cwd);
+			// Write a mailbox message that is already notified but not yet delivered.
+			const mailboxDir = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-no-spam",
+				"mailbox",
+			);
+			await mkdir(mailboxDir, { recursive: true });
+			const notifiedAt = new Date(Date.now() - 60_000).toISOString(); // 1 minute ago
+			await writeFile(
+				join(mailboxDir, "worker-1.json"),
+				JSON.stringify({
+					worker: "worker-1",
+					messages: [
+						{
+							message_id: "msg-already-notified",
+							from_worker: "leader-fixed",
+							to_worker: "worker-1",
+							body: "hello",
+							created_at: notifiedAt,
+							notified_at: notifiedAt, // already notified
+							// delivered_at intentionally absent — message is still pending
+						},
+					],
+				}),
+			);
 
-      // Write a mailbox message that is already notified but not yet delivered.
-      const mailboxDir = join(cwd, '.omx', 'state', 'team', 'team-no-spam', 'mailbox');
-      await mkdir(mailboxDir, { recursive: true });
-      const notifiedAt = new Date(Date.now() - 60_000).toISOString(); // 1 minute ago
-      await writeFile(join(mailboxDir, 'worker-1.json'), JSON.stringify({
-        worker: 'worker-1',
-        messages: [
-          {
-            message_id: 'msg-already-notified',
-            from_worker: 'leader-fixed',
-            to_worker: 'worker-1',
-            body: 'hello',
-            created_at: notifiedAt,
-            notified_at: notifiedAt, // already notified
-            // delivered_at intentionally absent — message is still pending
-          },
-        ],
-      }));
+			// First monitorTeam call — should see the message as already-notified (unnotified=[]).
+			const result1 = await monitorTeam("team-no-spam", cwd);
+			assert.ok(result1, "snapshot should exist");
 
-      // First monitorTeam call — should see the message as already-notified (unnotified=[]).
-      const result1 = await monitorTeam('team-no-spam', cwd);
-      assert.ok(result1, 'snapshot should exist');
+			// Read the monitor snapshot from disk to verify the notified map.
+			const diskSnap1 = await readMonitorSnapshot("team-no-spam", cwd);
+			assert.ok(diskSnap1, "disk snapshot should exist after first poll");
+			assert.ok(
+				diskSnap1.mailboxNotifiedByMessageId["msg-already-notified"],
+				"already-notified message must be preserved in snapshot after first poll",
+			);
 
-      // Read the monitor snapshot from disk to verify the notified map.
-      const diskSnap1 = await readMonitorSnapshot('team-no-spam', cwd);
-      assert.ok(diskSnap1, 'disk snapshot should exist after first poll');
-      assert.ok(
-        diskSnap1.mailboxNotifiedByMessageId['msg-already-notified'],
-        'already-notified message must be preserved in snapshot after first poll',
-      );
+			// Second monitorTeam call — previousNotifications now carries the timestamp.
+			// The message must again be treated as notified (no duplicate notification).
+			const result2 = await monitorTeam("team-no-spam", cwd);
+			assert.ok(result2, "second snapshot should exist");
+			const diskSnap2 = await readMonitorSnapshot("team-no-spam", cwd);
+			assert.ok(diskSnap2, "disk snapshot should exist after second poll");
+			assert.ok(
+				diskSnap2.mailboxNotifiedByMessageId["msg-already-notified"],
+				"already-notified message must remain in snapshot after second poll (no reset)",
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      // Second monitorTeam call — previousNotifications now carries the timestamp.
-      // The message must again be treated as notified (no duplicate notification).
-      const result2 = await monitorTeam('team-no-spam', cwd);
-      assert.ok(result2, 'second snapshot should exist');
-      const diskSnap2 = await readMonitorSnapshot('team-no-spam', cwd);
-      assert.ok(diskSnap2, 'disk snapshot should exist after second poll');
-      assert.ok(
-        diskSnap2.mailboxNotifiedByMessageId['msg-already-notified'],
-        'already-notified message must remain in snapshot after second poll (no reset)',
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("monitorTeam only notifies once per new message even without notified_at (issue #116)", async () => {
+		// Regression: messages delivered via team_send_message MCP have no notified_at.
+		// After the first successful poll that sets notified_at, subsequent polls must not re-notify.
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-new-msg-"));
+		try {
+			await initTeamState("team-new-msg", "new msg test", "executor", 1, cwd);
 
-  it('monitorTeam only notifies once per new message even without notified_at (issue #116)', async () => {
-    // Regression: messages delivered via team_send_message MCP have no notified_at.
-    // After the first successful poll that sets notified_at, subsequent polls must not re-notify.
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-new-msg-'));
-    try {
-      await initTeamState('team-new-msg', 'new msg test', 'executor', 1, cwd);
+			const mailboxDir = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-new-msg",
+				"mailbox",
+			);
+			await mkdir(mailboxDir, { recursive: true });
+			const createdAt = new Date().toISOString();
+			await writeFile(
+				join(mailboxDir, "worker-1.json"),
+				JSON.stringify({
+					worker: "worker-1",
+					messages: [
+						{
+							message_id: "msg-unnotified",
+							from_worker: "leader-fixed",
+							to_worker: "worker-1",
+							body: "task assignment",
+							created_at: createdAt,
+							// notified_at and delivered_at intentionally absent
+						},
+					],
+				}),
+			);
 
-      const mailboxDir = join(cwd, '.omx', 'state', 'team', 'team-new-msg', 'mailbox');
-      await mkdir(mailboxDir, { recursive: true });
-      const createdAt = new Date().toISOString();
-      await writeFile(join(mailboxDir, 'worker-1.json'), JSON.stringify({
-        worker: 'worker-1',
-        messages: [
-          {
-            message_id: 'msg-unnotified',
-            from_worker: 'leader-fixed',
-            to_worker: 'worker-1',
-            body: 'task assignment',
-            created_at: createdAt,
-            // notified_at and delivered_at intentionally absent
-          },
-        ],
-      }));
+			// First poll — unnotified=[msg-unnotified]. notifyWorker will fail (no tmux in tests)
+			// so markMessageNotified is not called and the snapshot has no entry for this message.
+			const result1 = await monitorTeam("team-new-msg", cwd);
+			assert.ok(result1);
+			const diskSnap1 = await readMonitorSnapshot("team-new-msg", cwd);
+			// Without tmux the notify fails, so no entry is expected in the first snapshot.
+			assert.ok(diskSnap1);
 
-      // First poll — unnotified=[msg-unnotified]. notifyWorker will fail (no tmux in tests)
-      // so markMessageNotified is not called and the snapshot has no entry for this message.
-      const result1 = await monitorTeam('team-new-msg', cwd);
-      assert.ok(result1);
-      const diskSnap1 = await readMonitorSnapshot('team-new-msg', cwd);
-      // Without tmux the notify fails, so no entry is expected in the first snapshot.
-      assert.ok(diskSnap1);
+			// Simulate a successful notification by manually setting notified_at on the message.
+			await writeFile(
+				join(mailboxDir, "worker-1.json"),
+				JSON.stringify({
+					worker: "worker-1",
+					messages: [
+						{
+							message_id: "msg-unnotified",
+							from_worker: "leader-fixed",
+							to_worker: "worker-1",
+							body: "task assignment",
+							created_at: createdAt,
+							notified_at: new Date().toISOString(),
+						},
+					],
+				}),
+			);
 
-      // Simulate a successful notification by manually setting notified_at on the message.
-      await writeFile(join(mailboxDir, 'worker-1.json'), JSON.stringify({
-        worker: 'worker-1',
-        messages: [
-          {
-            message_id: 'msg-unnotified',
-            from_worker: 'leader-fixed',
-            to_worker: 'worker-1',
-            body: 'task assignment',
-            created_at: createdAt,
-            notified_at: new Date().toISOString(),
-          },
-        ],
-      }));
+			// Second poll — message now has notified_at, so unnotified=[], no re-notification.
+			const result2 = await monitorTeam("team-new-msg", cwd);
+			assert.ok(result2);
+			const diskSnap2 = await readMonitorSnapshot("team-new-msg", cwd);
+			assert.ok(diskSnap2);
+			assert.ok(
+				diskSnap2.mailboxNotifiedByMessageId["msg-unnotified"],
+				"notified message must be captured in snapshot after second poll",
+			);
 
-      // Second poll — message now has notified_at, so unnotified=[], no re-notification.
-      const result2 = await monitorTeam('team-new-msg', cwd);
-      assert.ok(result2);
-      const diskSnap2 = await readMonitorSnapshot('team-new-msg', cwd);
-      assert.ok(diskSnap2);
-      assert.ok(
-        diskSnap2.mailboxNotifiedByMessageId['msg-unnotified'],
-        'notified message must be captured in snapshot after second poll',
-      );
+			// Third poll — previousNotifications carries the timestamp.
+			// unnotified=[] so no re-notification attempt, and snapshot still tracks it.
+			const result3 = await monitorTeam("team-new-msg", cwd);
+			assert.ok(result3);
+			const diskSnap3 = await readMonitorSnapshot("team-new-msg", cwd);
+			assert.ok(diskSnap3);
+			assert.ok(
+				diskSnap3.mailboxNotifiedByMessageId["msg-unnotified"],
+				"notified message must remain in snapshot on third poll (no duplicate notification)",
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      // Third poll — previousNotifications carries the timestamp.
-      // unnotified=[] so no re-notification attempt, and snapshot still tracks it.
-      const result3 = await monitorTeam('team-new-msg', cwd);
-      assert.ok(result3);
-      const diskSnap3 = await readMonitorSnapshot('team-new-msg', cwd);
-      assert.ok(diskSnap3);
-      assert.ok(
-        diskSnap3.mailboxNotifiedByMessageId['msg-unnotified'],
-        'notified message must remain in snapshot on third poll (no duplicate notification)',
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("monitorTeam does not emit duplicate task_completed when transitionTaskStatus completed the task first (issue #161)", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-no-dup-"));
+		try {
+			await initTeamState("team-no-dup", "dedup test", "executor", 1, cwd);
+			const t = await createTask(
+				"team-no-dup",
+				{ subject: "task", description: "d", status: "pending" },
+				cwd,
+			);
 
-  it('monitorTeam does not emit duplicate task_completed when transitionTaskStatus completed the task first (issue #161)', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-no-dup-'));
-    try {
-      await initTeamState('team-no-dup', 'dedup test', 'executor', 1, cwd);
-      const t = await createTask('team-no-dup', { subject: 'task', description: 'd', status: 'pending' }, cwd);
+			// Establish a baseline snapshot (task is pending).
+			await monitorTeam("team-no-dup", cwd);
 
-      // Establish a baseline snapshot (task is pending).
-      await monitorTeam('team-no-dup', cwd);
+			// Complete the task via the claim-safe path — this emits the first task_completed event
+			// and records the task ID in the monitor snapshot.
+			const claim = await claimTask("team-no-dup", t.id, "worker-1", null, cwd);
+			assert.ok(claim.ok);
+			if (!claim.ok) throw new Error("claim failed");
+			await transitionTaskStatus(
+				"team-no-dup",
+				t.id,
+				"in_progress",
+				"completed",
+				claim.claimToken,
+				cwd,
+			);
 
-      // Complete the task via the claim-safe path — this emits the first task_completed event
-      // and records the task ID in the monitor snapshot.
-      const claim = await claimTask('team-no-dup', t.id, 'worker-1', null, cwd);
-      assert.ok(claim.ok);
-      if (!claim.ok) throw new Error('claim failed');
-      await transitionTaskStatus('team-no-dup', t.id, 'in_progress', 'completed', claim.claimToken, cwd);
+			// Run monitorTeam again — it must NOT emit a second task_completed event.
+			await monitorTeam("team-no-dup", cwd);
 
-      // Run monitorTeam again — it must NOT emit a second task_completed event.
-      await monitorTeam('team-no-dup', cwd);
+			const eventsPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-no-dup",
+				"events",
+				"events.ndjson",
+			);
+			const content = await readFile(eventsPath, "utf-8");
+			const events = content
+				.trim()
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line));
+			const completedEvents = events.filter(
+				(e: { type: string }) => e.type === "task_completed",
+			);
+			assert.equal(
+				completedEvents.length,
+				1,
+				"should have exactly one task_completed event",
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      const eventsPath = join(cwd, '.omx', 'state', 'team', 'team-no-dup', 'events', 'events.ndjson');
-      const content = await readFile(eventsPath, 'utf-8');
-      const events = content.trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
-      const completedEvents = events.filter((e: { type: string }) => e.type === 'task_completed');
-      assert.equal(completedEvents.length, 1, 'should have exactly one task_completed event');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("sendWorkerMessage allows worker to message leader-fixed mailbox", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-leader-msg",
+				"leader mailbox test",
+				"executor",
+				2,
+				cwd,
+			);
+			await sendWorkerMessage(
+				"team-leader-msg",
+				"worker-1",
+				"leader-fixed",
+				"worker one ack",
+				cwd,
+			);
+			await sendWorkerMessage(
+				"team-leader-msg",
+				"worker-2",
+				"leader-fixed",
+				"worker two ack",
+				cwd,
+			);
 
-  it('sendWorkerMessage allows worker to message leader-fixed mailbox', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-leader-msg', 'leader mailbox test', 'executor', 2, cwd);
-      await sendWorkerMessage('team-leader-msg', 'worker-1', 'leader-fixed', 'worker one ack', cwd);
-      await sendWorkerMessage('team-leader-msg', 'worker-2', 'leader-fixed', 'worker two ack', cwd);
+			const messages = await listMailboxMessages(
+				"team-leader-msg",
+				"leader-fixed",
+				cwd,
+			);
+			assert.equal(messages.length, 2);
+			assert.equal(messages[0]?.from_worker, "worker-1");
+			assert.equal(messages[1]?.from_worker, "worker-2");
+			assert.equal(messages[0]?.to_worker, "leader-fixed");
+			assert.equal(messages[1]?.to_worker, "leader-fixed");
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      const messages = await listMailboxMessages('team-leader-msg', 'leader-fixed', cwd);
-      assert.equal(messages.length, 2);
-      assert.equal(messages[0]?.from_worker, 'worker-1');
-      assert.equal(messages[1]?.from_worker, 'worker-2');
-      assert.equal(messages[0]?.to_worker, 'leader-fixed');
-      assert.equal(messages[1]?.to_worker, 'leader-fixed');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("sendWorkerMessage dedupes identical undelivered leader-fixed messages", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-"));
+		try {
+			await initTeamState(
+				"team-leader-dedupe",
+				"leader mailbox dedupe test",
+				"executor",
+				1,
+				cwd,
+			);
+			await sendWorkerMessage(
+				"team-leader-dedupe",
+				"worker-1",
+				"leader-fixed",
+				"INTEGRATED: same-body",
+				cwd,
+			);
+			await sendWorkerMessage(
+				"team-leader-dedupe",
+				"worker-1",
+				"leader-fixed",
+				"INTEGRATED: same-body",
+				cwd,
+			);
 
-  it('sendWorkerMessage dedupes identical undelivered leader-fixed messages', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-'));
-    try {
-      await initTeamState('team-leader-dedupe', 'leader mailbox dedupe test', 'executor', 1, cwd);
-      await sendWorkerMessage('team-leader-dedupe', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
-      await sendWorkerMessage('team-leader-dedupe', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
+			const messages = await listMailboxMessages(
+				"team-leader-dedupe",
+				"leader-fixed",
+				cwd,
+			);
+			assert.equal(messages.length, 1);
+			assert.equal(messages[0]?.body, "INTEGRATED: same-body");
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-      const messages = await listMailboxMessages('team-leader-dedupe', 'leader-fixed', cwd);
-      assert.equal(messages.length, 1);
-      assert.equal(messages[0]?.body, 'INTEGRATED: same-body');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-
-  it('sendWorkerMessage keeps hook-preferred duplicate leader mailbox sends idempotent after notification', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-dedupe-notified-'));
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-leader-dedupe-notified-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("sendWorkerMessage keeps hook-preferred duplicate leader mailbox sends idempotent after notification", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-leader-dedupe-notified-"),
+		);
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-leader-dedupe-notified-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\n' "$$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
@@ -4154,44 +6367,88 @@ case "\${1:-}" in
     ;;
 esac
 `,
-        },
-        async () => {
-          await initTeamState('team-leader-dedupe-notified', 'leader mailbox dedupe notified test', 'executor', 1, cwd);
-          const cfg = await readTeamConfig('team-leader-dedupe-notified', cwd);
-          assert.ok(cfg);
-          if (!cfg) throw new Error('missing team config');
-          cfg.leader_pane_id = '%55';
-          await saveTeamConfig(cfg, cwd);
+				},
+				async () => {
+					await initTeamState(
+						"team-leader-dedupe-notified",
+						"leader mailbox dedupe notified test",
+						"executor",
+						1,
+						cwd,
+					);
+					const cfg = await readTeamConfig("team-leader-dedupe-notified", cwd);
+					assert.ok(cfg);
+					if (!cfg) throw new Error("missing team config");
+					cfg.leader_pane_id = "%55";
+					await saveTeamConfig(cfg, cwd);
 
-          const manifestPath = teamStateTestPath(cwd, 'team', 'team-leader-dedupe-notified', 'manifest.v2.json');
-          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
-          manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 100 };
-          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+					const manifestPath = teamStateTestPath(
+						cwd,
+						"team",
+						"team-leader-dedupe-notified",
+						"manifest.v2.json",
+					);
+					const manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+					manifest.policy = {
+						...(manifest.policy || {}),
+						dispatch_ack_timeout_ms: 100,
+					};
+					await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
-          await sendWorkerMessage('team-leader-dedupe-notified', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
-          await sendWorkerMessage('team-leader-dedupe-notified', 'worker-1', 'leader-fixed', 'INTEGRATED: same-body', cwd);
+					await sendWorkerMessage(
+						"team-leader-dedupe-notified",
+						"worker-1",
+						"leader-fixed",
+						"INTEGRATED: same-body",
+						cwd,
+					);
+					await sendWorkerMessage(
+						"team-leader-dedupe-notified",
+						"worker-1",
+						"leader-fixed",
+						"INTEGRATED: same-body",
+						cwd,
+					);
 
-          const messages = await listMailboxMessages('team-leader-dedupe-notified', 'leader-fixed', cwd);
-          const workerMessages = messages.filter((message) => message.from_worker === 'worker-1' && message.body === 'INTEGRATED: same-body');
-          assert.equal(workerMessages.length, 1);
-          assert.ok(workerMessages[0]?.notified_at);
+					const messages = await listMailboxMessages(
+						"team-leader-dedupe-notified",
+						"leader-fixed",
+						cwd,
+					);
+					const workerMessages = messages.filter(
+						(message) =>
+							message.from_worker === "worker-1" &&
+							message.body === "INTEGRATED: same-body",
+					);
+					assert.equal(workerMessages.length, 1);
+					assert.ok(workerMessages[0]?.notified_at);
 
-          const requests = await listDispatchRequests('team-leader-dedupe-notified', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
-          assert.ok(requests.some((request) => request.status === 'notified' && request.message_id === workerMessages[0]?.message_id));
-        },
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					const requests = await listDispatchRequests(
+						"team-leader-dedupe-notified",
+						cwd,
+						{ kind: "mailbox", to_worker: "leader-fixed" },
+					);
+					assert.ok(
+						requests.some(
+							(request) =>
+								request.status === "notified" &&
+								request.message_id === workerMessages[0]?.message_id,
+						),
+					);
+				},
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('sendWorkerMessage hook-preferred path persists leader mailbox guidance when leader pane exists', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-inject-'));
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-leader-inject-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("sendWorkerMessage hook-preferred path persists leader mailbox guidance when leader pane exists", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-leader-inject-"));
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-leader-inject-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
@@ -4203,63 +6460,111 @@ case "\${1:-}" in
     ;;
 esac
 `,
-        },
-        async ({ tmuxLogPath }) => {
-          await initTeamState('team-leader-inject', 'leader injection test', 'executor', 1, cwd);
-          const cfg = await readTeamConfig('team-leader-inject', cwd);
-          assert.ok(cfg);
-          if (!cfg) throw new Error('missing team config');
-          cfg.leader_pane_id = '%55';
-          cfg.team_state_root = '/tmp/custom-team-state-root';
-          await saveTeamConfig(cfg, cwd);
+				},
+				async ({ tmuxLogPath }) => {
+					await initTeamState(
+						"team-leader-inject",
+						"leader injection test",
+						"executor",
+						1,
+						cwd,
+					);
+					const cfg = await readTeamConfig("team-leader-inject", cwd);
+					assert.ok(cfg);
+					if (!cfg) throw new Error("missing team config");
+					cfg.leader_pane_id = "%55";
+					cfg.team_state_root = "/tmp/custom-team-state-root";
+					await saveTeamConfig(cfg, cwd);
 
-          const manifestPath = teamStateTestPath(cwd, 'team', 'team-leader-inject', 'manifest.v2.json');
-          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
-          manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 100 };
-          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+					const manifestPath = teamStateTestPath(
+						cwd,
+						"team",
+						"team-leader-inject",
+						"manifest.v2.json",
+					);
+					const manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+					manifest.policy = {
+						...(manifest.policy || {}),
+						dispatch_ack_timeout_ms: 100,
+					};
+					await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
-          await sendWorkerMessage('team-leader-inject', 'worker-1', 'leader-fixed', 'hello leader', cwd);
+					await sendWorkerMessage(
+						"team-leader-inject",
+						"worker-1",
+						"leader-fixed",
+						"hello leader",
+						cwd,
+					);
 
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-          assert.doesNotMatch(tmuxLog, /send-keys -t %55/, 'team runtime should not directly inject into leader pane');
+					const tmuxLog = await readFile(tmuxLogPath, "utf-8").catch(() => "");
+					assert.doesNotMatch(
+						tmuxLog,
+						/send-keys -t %55/,
+						"team runtime should not directly inject into leader pane",
+					);
 
-          const mailbox = await listMailboxMessages('team-leader-inject', 'leader-fixed', cwd);
-          assert.ok(mailbox.some((m: { notified_at?: string }) => typeof m.notified_at === 'string' && m.notified_at.length > 0));
-          assert.equal(mailbox[0]?.body, 'hello leader');
+					const mailbox = await listMailboxMessages(
+						"team-leader-inject",
+						"leader-fixed",
+						cwd,
+					);
+					assert.ok(
+						mailbox.some(
+							(m: { notified_at?: string }) =>
+								typeof m.notified_at === "string" && m.notified_at.length > 0,
+						),
+					);
+					assert.equal(mailbox[0]?.body, "hello leader");
 
-          const requests = await listDispatchRequests('team-leader-inject', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
-          const latest = requests[requests.length - 1];
-          assert.equal(latest?.status, 'notified');
-          assert.equal(latest?.last_reason, 'fallback_confirmed:leader_mailbox_notified');
-          assert.match(
-            latest?.trigger_message ?? '',
-            /Read \/tmp\/custom-team-state-root\/team\/team-leader-inject\/mailbox\/leader-fixed\.json; new msg from worker-1\./,
-          );
+					const requests = await listDispatchRequests(
+						"team-leader-inject",
+						cwd,
+						{ kind: "mailbox", to_worker: "leader-fixed" },
+					);
+					const latest = requests[requests.length - 1];
+					assert.equal(latest?.status, "notified");
+					assert.equal(
+						latest?.last_reason,
+						"fallback_confirmed:leader_mailbox_notified",
+					);
+					assert.match(
+						latest?.trigger_message ?? "",
+						/Read \/tmp\/custom-team-state-root\/team\/team-leader-inject\/mailbox\/leader-fixed\.json; new msg from worker-1\./,
+					);
 
-          const deliveryLog = await readTeamDeliveryLog(cwd);
-          const runtimeEntries = deliveryLog.filter((entry) =>
-            entry.event === 'dispatch_result'
-            && entry.source === 'team.runtime'
-            && entry.to_worker === 'leader-fixed'
-            && entry.transport === 'mailbox'
-            && entry.result === 'confirmed'
-            && typeof entry.reason === 'string'
-            && String(entry.reason).includes('leader_mailbox_notified'));
-          assert.equal(runtimeEntries.length, 1, 'leader hook-preferred confirmation should emit exactly one runtime dispatch_result entry');
-        },
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					const deliveryLog = await readTeamDeliveryLog(cwd);
+					const runtimeEntries = deliveryLog.filter(
+						(entry) =>
+							entry.event === "dispatch_result" &&
+							entry.source === "team.runtime" &&
+							entry.to_worker === "leader-fixed" &&
+							entry.transport === "mailbox" &&
+							entry.result === "confirmed" &&
+							typeof entry.reason === "string" &&
+							String(entry.reason).includes("leader_mailbox_notified"),
+					);
+					assert.equal(
+						runtimeEntries.length,
+						1,
+						"leader hook-preferred confirmation should emit exactly one runtime dispatch_result entry",
+					);
+				},
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('sendWorkerMessage keeps failed hook receipts failed when fallback mailbox persistence confirms delivery', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-failed-receipt-'));
-    try {
-      await withMockTmuxFixture(
-        {
-          dirPrefix: 'omx-runtime-leader-failed-receipt-bin-',
-          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+	it("sendWorkerMessage keeps failed hook receipts failed when fallback mailbox persistence confirms delivery", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-runtime-leader-failed-receipt-"),
+		);
+		try {
+			await withMockTmuxFixture(
+				{
+					dirPrefix: "omx-runtime-leader-failed-receipt-bin-",
+					tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
@@ -4271,122 +6576,240 @@ case "\${1:-}" in
     ;;
 esac
 `,
-        },
-        async () => {
-          await initTeamState('team-leader-failed-receipt', 'leader failed receipt fallback test', 'executor', 1, cwd);
-          const cfg = await readTeamConfig('team-leader-failed-receipt', cwd);
-          assert.ok(cfg);
-          if (!cfg) throw new Error('missing team config');
-          cfg.leader_pane_id = '%55';
-          await saveTeamConfig(cfg, cwd);
+				},
+				async () => {
+					await initTeamState(
+						"team-leader-failed-receipt",
+						"leader failed receipt fallback test",
+						"executor",
+						1,
+						cwd,
+					);
+					const cfg = await readTeamConfig("team-leader-failed-receipt", cwd);
+					assert.ok(cfg);
+					if (!cfg) throw new Error("missing team config");
+					cfg.leader_pane_id = "%55";
+					await saveTeamConfig(cfg, cwd);
 
-          const manifestPath = teamStateTestPath(cwd, 'team', 'team-leader-failed-receipt', 'manifest.v2.json');
-          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
-          manifest.policy = { ...(manifest.policy || {}), dispatch_ack_timeout_ms: 250 };
-          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+					const manifestPath = teamStateTestPath(
+						cwd,
+						"team",
+						"team-leader-failed-receipt",
+						"manifest.v2.json",
+					);
+					const manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+					manifest.policy = {
+						...(manifest.policy || {}),
+						dispatch_ack_timeout_ms: 250,
+					};
+					await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
-          const sendPromise = sendWorkerMessage('team-leader-failed-receipt', 'worker-1', 'leader-fixed', 'hello failed receipt', cwd);
+					const sendPromise = sendWorkerMessage(
+						"team-leader-failed-receipt",
+						"worker-1",
+						"leader-fixed",
+						"hello failed receipt",
+						cwd,
+					);
 
-          const deadline = Date.now() + 2_000;
-          let requestId: string | null = null;
-          while (Date.now() < deadline && !requestId) {
-            const requests = await listDispatchRequests('team-leader-failed-receipt', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
-            requestId = requests[requests.length - 1]?.request_id ?? null;
-            if (!requestId) await new Promise((resolve) => setTimeout(resolve, 20));
-          }
-          assert.ok(requestId, 'expected mailbox dispatch request to be queued');
-          if (!requestId) throw new Error('missing request id');
+					const deadline = Date.now() + 2_000;
+					let requestId: string | null = null;
+					while (Date.now() < deadline && !requestId) {
+						const requests = await listDispatchRequests(
+							"team-leader-failed-receipt",
+							cwd,
+							{ kind: "mailbox", to_worker: "leader-fixed" },
+						);
+						requestId = requests[requests.length - 1]?.request_id ?? null;
+						if (!requestId)
+							await new Promise((resolve) => setTimeout(resolve, 20));
+					}
+					assert.ok(
+						requestId,
+						"expected mailbox dispatch request to be queued",
+					);
+					if (!requestId) throw new Error("missing request id");
 
-          await transitionDispatchRequest(
-            'team-leader-failed-receipt',
-            requestId,
-            'pending',
-            'failed',
-            { last_reason: 'hook_failed:test_receipt' },
-            cwd,
-          );
+					await transitionDispatchRequest(
+						"team-leader-failed-receipt",
+						requestId,
+						"pending",
+						"failed",
+						{ last_reason: "hook_failed:test_receipt" },
+						cwd,
+					);
 
-          const outcome = await sendPromise;
-          assert.equal(outcome.ok, true);
-          assert.equal(outcome.reason, 'fallback_confirmed_after_failed_receipt:leader_mailbox_notified');
+					const outcome = await sendPromise;
+					assert.equal(outcome.ok, true);
+					assert.equal(
+						outcome.reason,
+						"fallback_confirmed_after_failed_receipt:leader_mailbox_notified",
+					);
 
-          const requests = await listDispatchRequests('team-leader-failed-receipt', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
-          const latest = requests[requests.length - 1];
-          assert.equal(latest?.request_id, requestId);
-          assert.equal(latest?.status, 'failed');
-          assert.equal(latest?.last_reason, 'fallback_confirmed_after_failed_receipt:leader_mailbox_notified');
+					const requests = await listDispatchRequests(
+						"team-leader-failed-receipt",
+						cwd,
+						{ kind: "mailbox", to_worker: "leader-fixed" },
+					);
+					const latest = requests[requests.length - 1];
+					assert.equal(latest?.request_id, requestId);
+					assert.equal(latest?.status, "failed");
+					assert.equal(
+						latest?.last_reason,
+						"fallback_confirmed_after_failed_receipt:leader_mailbox_notified",
+					);
 
-          const mailbox = await listMailboxMessages('team-leader-failed-receipt', 'leader-fixed', cwd);
-          assert.ok(mailbox[0]?.notified_at, 'fallback mailbox persistence should still mark notified_at');
-        },
-      );
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+					const mailbox = await listMailboxMessages(
+						"team-leader-failed-receipt",
+						"leader-fixed",
+						cwd,
+					);
+					assert.ok(
+						mailbox[0]?.notified_at,
+						"fallback mailbox persistence should still mark notified_at",
+					);
+				},
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('sendWorkerMessage hook-preferred path for leader waits for receipt then falls back to mailbox persistence', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-hook-'));
-    try {
-      await initTeamState('team-leader-hook', 'leader hook fallback test', 'executor', 1, cwd);
-      const cfg = await readTeamConfig('team-leader-hook', cwd);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing team config');
-      cfg.leader_pane_id = '';
-      await saveTeamConfig(cfg, cwd);
-      await sendWorkerMessage('team-leader-hook', 'worker-1', 'leader-fixed', 'hello leader', cwd);
+	it("sendWorkerMessage hook-preferred path for leader waits for receipt then falls back to mailbox persistence", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-leader-hook-"));
+		try {
+			await initTeamState(
+				"team-leader-hook",
+				"leader hook fallback test",
+				"executor",
+				1,
+				cwd,
+			);
+			const cfg = await readTeamConfig("team-leader-hook", cwd);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing team config");
+			cfg.leader_pane_id = "";
+			await saveTeamConfig(cfg, cwd);
+			await sendWorkerMessage(
+				"team-leader-hook",
+				"worker-1",
+				"leader-fixed",
+				"hello leader",
+				cwd,
+			);
 
-      const mailbox = await listMailboxMessages('team-leader-hook', 'leader-fixed', cwd);
-      assert.ok(mailbox.length >= 1, `expected at least 1 mailbox message, got ${mailbox.length}`);
-      const notifiedMsg = mailbox.find((m: { notified_at?: string }) => m.notified_at);
-      assert.equal(notifiedMsg, undefined, 'leader mailbox message should remain unnotified while pane is missing');
+			const mailbox = await listMailboxMessages(
+				"team-leader-hook",
+				"leader-fixed",
+				cwd,
+			);
+			assert.ok(
+				mailbox.length >= 1,
+				`expected at least 1 mailbox message, got ${mailbox.length}`,
+			);
+			const notifiedMsg = mailbox.find(
+				(m: { notified_at?: string }) => m.notified_at,
+			);
+			assert.equal(
+				notifiedMsg,
+				undefined,
+				"leader mailbox message should remain unnotified while pane is missing",
+			);
 
-      const requests = await listDispatchRequests('team-leader-hook', cwd, { kind: 'mailbox' });
-      assert.ok(requests.length >= 1, `expected at least 1 dispatch request, got ${requests.length}`);
-      const pending = requests.find((r: { status?: string; to_worker?: string }) =>
-        r.status === 'pending' && r.to_worker === 'leader-fixed');
-      assert.ok(pending, 'expected a pending leader-fixed dispatch request');
-      assert.equal(pending?.last_reason, 'leader_pane_missing_deferred');
+			const requests = await listDispatchRequests("team-leader-hook", cwd, {
+				kind: "mailbox",
+			});
+			assert.ok(
+				requests.length >= 1,
+				`expected at least 1 dispatch request, got ${requests.length}`,
+			);
+			const pending = requests.find(
+				(r: { status?: string; to_worker?: string }) =>
+					r.status === "pending" && r.to_worker === "leader-fixed",
+			);
+			assert.ok(pending, "expected a pending leader-fixed dispatch request");
+			assert.equal(pending?.last_reason, "leader_pane_missing_deferred");
 
-      const deliveryLog = await readTeamDeliveryLog(cwd);
-      const runtimeEntries = deliveryLog.filter((entry) =>
-        entry.event === 'dispatch_result'
-        && entry.source === 'team.runtime'
-        && entry.to_worker === 'leader-fixed'
-        && entry.transport === 'mailbox'
-        && entry.reason === 'leader_pane_missing_mailbox_persisted');
-      assert.equal(runtimeEntries.length, 1, 'leader missing-pane fallback should emit exactly one runtime dispatch_result entry');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			const deliveryLog = await readTeamDeliveryLog(cwd);
+			const runtimeEntries = deliveryLog.filter(
+				(entry) =>
+					entry.event === "dispatch_result" &&
+					entry.source === "team.runtime" &&
+					entry.to_worker === "leader-fixed" &&
+					entry.transport === "mailbox" &&
+					entry.reason === "leader_pane_missing_mailbox_persisted",
+			);
+			assert.equal(
+				runtimeEntries.length,
+				1,
+				"leader missing-pane fallback should emit exactly one runtime dispatch_result entry",
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it('sendWorkerMessage transport_direct keeps leader-fixed request pending when leader_pane_id missing', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-leader-direct-'));
-    try {
-      await initTeamState('team-leader-direct', 'leader direct transport test', 'executor', 1, cwd);
-      const cfg = await readTeamConfig('team-leader-direct', cwd);
-      assert.ok(cfg);
-      if (!cfg) throw new Error('missing team config');
-      cfg.leader_pane_id = '';
-      await saveTeamConfig(cfg, cwd);
+	it("sendWorkerMessage transport_direct keeps leader-fixed request pending when leader_pane_id missing", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-leader-direct-"));
+		try {
+			await initTeamState(
+				"team-leader-direct",
+				"leader direct transport test",
+				"executor",
+				1,
+				cwd,
+			);
+			const cfg = await readTeamConfig("team-leader-direct", cwd);
+			assert.ok(cfg);
+			if (!cfg) throw new Error("missing team config");
+			cfg.leader_pane_id = "";
+			await saveTeamConfig(cfg, cwd);
 
-      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-leader-direct', 'manifest.v2.json');
-      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
-      manifest.policy = { ...(manifest.policy || {}), dispatch_mode: 'transport_direct' };
-      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+			const manifestPath = join(
+				cwd,
+				".omx",
+				"state",
+				"team",
+				"team-leader-direct",
+				"manifest.v2.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+			manifest.policy = {
+				...(manifest.policy || {}),
+				dispatch_mode: "transport_direct",
+			};
+			await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
-      await sendWorkerMessage('team-leader-direct', 'worker-1', 'leader-fixed', 'hello leader direct', cwd);
+			await sendWorkerMessage(
+				"team-leader-direct",
+				"worker-1",
+				"leader-fixed",
+				"hello leader direct",
+				cwd,
+			);
 
-      const mailbox = await listMailboxMessages('team-leader-direct', 'leader-fixed', cwd);
-      assert.ok(mailbox.length >= 1, `expected at least 1 mailbox message, got ${mailbox.length}`);
-      const requests = await listDispatchRequests('team-leader-direct', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
-      assert.ok(requests.length >= 1, `expected at least 1 leader-fixed dispatch request, got ${requests.length}`);
-      const latest = requests[requests.length - 1];
-      assert.equal(latest?.status, 'pending');
-      assert.equal(latest?.last_reason, 'leader_pane_missing_deferred');
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+			const mailbox = await listMailboxMessages(
+				"team-leader-direct",
+				"leader-fixed",
+				cwd,
+			);
+			assert.ok(
+				mailbox.length >= 1,
+				`expected at least 1 mailbox message, got ${mailbox.length}`,
+			);
+			const requests = await listDispatchRequests("team-leader-direct", cwd, {
+				kind: "mailbox",
+				to_worker: "leader-fixed",
+			});
+			assert.ok(
+				requests.length >= 1,
+				`expected at least 1 leader-fixed dispatch request, got ${requests.length}`,
+			);
+			const latest = requests[requests.length - 1];
+			assert.equal(latest?.status, "pending");
+			assert.equal(latest?.last_reason, "leader_pane_missing_deferred");
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1,4062 +1,5251 @@
-import { join, resolve, dirname } from 'path';
-import { existsSync, appendFileSync, mkdirSync } from 'fs';
-import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
-import { performance } from 'perf_hooks';
-import { spawn, spawnSync, type ChildProcessByStdio } from 'child_process';
-import type { Writable } from 'stream';
+import { type ChildProcessByStdio, spawn, spawnSync } from "child_process";
+import { appendFileSync, existsSync, mkdirSync } from "fs";
+import { mkdir, readdir, readFile, writeFile } from "fs/promises";
+import { dirname, join, resolve } from "path";
+import { performance } from "perf_hooks";
+import type { Writable } from "stream";
+import { composeRoleInstructionsForRole } from "../agents/native-config.js";
+import { readModeState, updateModeState } from "../modes/base.js";
+import { getTeamTmuxSessions } from "../notifications/tmux.js";
+import { codexPromptsDir } from "../utils/paths.js";
+import { hasStructuredVerificationEvidence } from "../verification/verifier.js";
 import {
-  sanitizeTeamName,
-  isTmuxAvailable,
-  hasCurrentTmuxClientContext,
-  createTeamSession,
-  buildWorkerProcessLaunchSpec,
-  resolveTeamWorkerCli,
-  type TeamWorkerCli,
-  resolveTeamWorkerCliPlan,
-  resolveTeamWorkerLaunchMode,
-  type TeamSession,
-  waitForWorkerReady,
-  dismissTrustPromptIfPresent,
-  isNativeWindows,
-  sleepFractionalSeconds,
-  sendToWorker,
-  sendToWorkerStdin,
-  isWorkerAlive,
-  getWorkerPanePid,
-  killWorkerByPaneIdAsync,
-  restoreStandaloneHudPane,
-  teardownWorkerPanes,
-  unregisterResizeHook,
-  destroyTeamSession,
-  listPaneIds,
-  listTeamSessions,
-} from './tmux-session.js';
+	appendTeamCommitHygieneEntries,
+	buildTeamCommitHygieneContext,
+	type TeamCommitHygieneArtifactPaths,
+	type TeamOperationalCommitEntry,
+	writeTeamCommitHygieneContext,
+} from "./commit-hygiene.js";
+import { appendTeamDeliveryLogForCwd } from "./delivery-log.js";
 import {
-  teamInit as initTeamState,
-  DEFAULT_MAX_WORKERS,
-  teamReadConfig as readTeamConfig,
-  teamWriteWorkerIdentity as writeWorkerIdentity,
-  teamReadWorkerHeartbeat as readWorkerHeartbeat,
-  teamReadWorkerStatus as readWorkerStatus,
-  teamWriteWorkerInbox as writeWorkerInbox,
-  teamCreateTask as createStateTask,
-  teamReadTask as readTask,
-  teamListTasks as listTasks,
-  teamReadManifest as readTeamManifestV2,
-  teamNormalizeGovernance as normalizeTeamGovernance,
-  teamNormalizePolicy as normalizeTeamPolicy,
-  teamClaimTask as claimTask,
-  teamReleaseTaskClaim as releaseTaskClaim,
-  teamReclaimExpiredTaskClaim as reclaimExpiredTaskClaim,
-  teamAppendEvent as appendTeamEvent,
-  teamReadTaskApproval as readTaskApproval,
-  teamListMailbox as listMailboxMessages,
-  teamMarkMessageDelivered as markMessageDelivered,
-  teamMarkMessageNotified as markMessageNotified,
-  teamEnqueueDispatchRequest as enqueueDispatchRequest,
-  teamMarkDispatchRequestNotified as markDispatchRequestNotified,
-  teamTransitionDispatchRequest as transitionDispatchRequest,
-  teamReadDispatchRequest as readDispatchRequest,
-  teamCleanup as cleanupTeamState,
-  teamSaveConfig as saveTeamConfig,
-  teamWriteShutdownRequest as writeShutdownRequest,
-  teamReadShutdownAck as readShutdownAck,
-  teamReadMonitorSnapshot as readMonitorSnapshot,
-  teamWriteMonitorSnapshot as writeMonitorSnapshot,
-  teamReadPhase as readTeamPhaseState,
-  teamWritePhase as writeTeamPhaseState,
-  type TeamConfig,
-  type WorkerInfo,
-  type WorkerHeartbeat,
-  type WorkerStatus,
-  type TeamTask,
-  type TeamMonitorSnapshotState,
-  type TeamPhaseState,
-  type TeamWorkerIntegrationState,
-  type TeamGovernance,
-  type TeamPolicy,
-  type TeamDispatchRequest,
-} from './team-ops.js';
+	type DispatchOutcome,
+	queueBroadcastMailboxMessage,
+	queueDirectMailboxMessage,
+	queueInboxInstruction,
+	waitForDispatchReceipt,
+} from "./mcp-comm.js";
 import {
-  queueInboxInstruction,
-  queueDirectMailboxMessage,
-  queueBroadcastMailboxMessage,
-  waitForDispatchReceipt,
-  type DispatchOutcome,
-} from './mcp-comm.js';
-import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
-import type { TeamReminderIntent } from './reminder-intents.js';
+	parseTeamWorkerLaunchArgs,
+	resolveAgentDefaultModel,
+	resolveAgentReasoningEffort,
+	resolveTeamWorkerLaunchArgs,
+	splitWorkerLaunchArgs,
+	TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+	type TeamReasoningEffort,
+} from "./model-contract.js";
 import {
-  generateWorkerOverlay,
-  writeTeamWorkerInstructionsFile,
-  removeTeamWorkerInstructionsFile,
-  writeWorkerWorktreeRootAgentsFile,
-  removeWorkerWorktreeRootAgentsFile,
-  generateInitialInbox,
-  generateTaskAssignmentInbox,
-  generateShutdownInbox,
-  buildTriggerDirective,
-  buildMailboxTriggerDirective,
-  buildLeaderMailboxTriggerDirective,
-  writeWorkerRoleInstructionsFile,
-} from './worker-bootstrap.js';
-import { loadRolePrompt } from './role-router.js';
-import { composeRoleInstructionsForRole } from '../agents/native-config.js';
-import { codexPromptsDir } from '../utils/paths.js';
-import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
+	isTerminalPhase,
+	type TeamPhase,
+	type TerminalPhase,
+} from "./orchestrator.js";
 import {
-  resolveTeamWorkerLaunchArgs,
-  TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
-  parseTeamWorkerLaunchArgs,
-  splitWorkerLaunchArgs,
-  resolveAgentDefaultModel,
-  resolveAgentReasoningEffort,
-  type TeamReasoningEffort,
-} from './model-contract.js';
-import { resolveCanonicalTeamStateRoot } from './state-root.js';
-import { inferPhaseTargetFromTaskCounts, reconcilePhaseStateForMonitor } from './phase-controller.js';
-import { getTeamTmuxSessions } from '../notifications/tmux.js';
-import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
-import { buildRebalanceDecisions } from './rebalance-policy.js';
-import { readModeState, updateModeState } from '../modes/base.js';
+	inferPhaseTargetFromTaskCounts,
+	reconcilePhaseStateForMonitor,
+} from "./phase-controller.js";
+import { buildRebalanceDecisions } from "./rebalance-policy.js";
+import type { TeamReminderIntent } from "./reminder-intents.js";
+import { loadRolePrompt } from "./role-router.js";
+import { resolveCanonicalTeamStateRoot } from "./state-root.js";
 import {
-  appendTeamCommitHygieneEntries,
-  buildTeamCommitHygieneContext,
-  writeTeamCommitHygieneContext,
-  type TeamCommitHygieneArtifactPaths,
-  type TeamOperationalCommitEntry,
-} from './commit-hygiene.js';
+	teamAppendEvent as appendTeamEvent,
+	teamClaimTask as claimTask,
+	teamCleanup as cleanupTeamState,
+	teamCreateTask as createStateTask,
+	DEFAULT_MAX_WORKERS,
+	teamEnqueueDispatchRequest as enqueueDispatchRequest,
+	teamInit as initTeamState,
+	teamListMailbox as listMailboxMessages,
+	teamListTasks as listTasks,
+	teamMarkDispatchRequestNotified as markDispatchRequestNotified,
+	teamMarkMessageDelivered as markMessageDelivered,
+	teamMarkMessageNotified as markMessageNotified,
+	teamNormalizeGovernance as normalizeTeamGovernance,
+	teamNormalizePolicy as normalizeTeamPolicy,
+	teamReadDispatchRequest as readDispatchRequest,
+	teamReadMonitorSnapshot as readMonitorSnapshot,
+	teamReadShutdownAck as readShutdownAck,
+	teamReadTask as readTask,
+	teamReadTaskApproval as readTaskApproval,
+	teamReadConfig as readTeamConfig,
+	teamReadManifest as readTeamManifestV2,
+	teamReadPhase as readTeamPhaseState,
+	teamReadWorkerHeartbeat as readWorkerHeartbeat,
+	teamReadWorkerStatus as readWorkerStatus,
+	teamReclaimExpiredTaskClaim as reclaimExpiredTaskClaim,
+	teamReleaseTaskClaim as releaseTaskClaim,
+	teamSaveConfig as saveTeamConfig,
+	type TeamConfig,
+	type TeamDispatchRequest,
+	type TeamGovernance,
+	type TeamMonitorSnapshotState,
+	type TeamPhaseState,
+	type TeamPolicy,
+	type TeamTask,
+	type TeamWorkerIntegrationState,
+	teamTransitionDispatchRequest as transitionDispatchRequest,
+	type WorkerHeartbeat,
+	type WorkerInfo,
+	type WorkerStatus,
+	teamWriteMonitorSnapshot as writeMonitorSnapshot,
+	teamWriteShutdownRequest as writeShutdownRequest,
+	teamWritePhase as writeTeamPhaseState,
+	teamWriteWorkerIdentity as writeWorkerIdentity,
+	teamWriteWorkerInbox as writeWorkerInbox,
+} from "./team-ops.js";
 import {
-  assertCleanLeaderWorkspaceForWorkerWorktrees,
-  ensureWorktree,
-  isGitRepository,
-  planWorktreeTarget,
-  rollbackProvisionedWorktrees,
-  type EnsureWorktreeResult,
-  type WorktreeMode,
-} from './worktree.js';
+	buildWorkerProcessLaunchSpec,
+	createTeamSession,
+	destroyTeamSession,
+	dismissTrustPromptIfPresent,
+	getWorkerPanePid,
+	hasCurrentTmuxClientContext,
+	isNativeWindows,
+	isTmuxAvailable,
+	isWorkerAlive,
+	killWorkerByPaneIdAsync,
+	listPaneIds,
+	listTeamSessions,
+	resolveTeamWorkerCli,
+	resolveTeamWorkerCliPlan,
+	resolveTeamWorkerLaunchMode,
+	restoreStandaloneHudPane,
+	sanitizeTeamName,
+	sendToWorker,
+	sendToWorkerStdin,
+	sleepFractionalSeconds,
+	type TeamSession,
+	type TeamWorkerCli,
+	teardownWorkerPanes,
+	unregisterResizeHook,
+	waitForWorkerReady,
+} from "./tmux-session.js";
+import {
+	buildLeaderMailboxTriggerDirective,
+	buildMailboxTriggerDirective,
+	buildTriggerDirective,
+	generateInitialInbox,
+	generateShutdownInbox,
+	generateTaskAssignmentInbox,
+	generateWorkerOverlay,
+	removeTeamWorkerInstructionsFile,
+	removeWorkerWorktreeRootAgentsFile,
+	writeTeamWorkerInstructionsFile,
+	writeWorkerRoleInstructionsFile,
+	writeWorkerWorktreeRootAgentsFile,
+} from "./worker-bootstrap.js";
+import {
+	assertCleanLeaderWorkspaceForWorkerWorktrees,
+	type EnsureWorktreeResult,
+	ensureWorktree,
+	isGitRepository,
+	planWorktreeTarget,
+	rollbackProvisionedWorktrees,
+	type WorktreeMode,
+} from "./worktree.js";
 
 /** Snapshot of the team state at a point in time */
 export interface TeamSnapshot {
-  teamName: string;
-  phase: TeamPhase | TerminalPhase;
-  workers: Array<{
-    name: string;
-    alive: boolean;
-    status: WorkerStatus;
-    heartbeat: WorkerHeartbeat | null;
-    assignedTasks: string[];
-    turnsWithoutProgress: number;
-  }>;
-  tasks: {
-    total: number;
-    pending: number;
-    blocked: number;
-    in_progress: number;
-    completed: number;
-    failed: number;
-    items: TeamTask[];
-  };
-  allTasksTerminal: boolean;
-  deadWorkers: string[];
-  nonReportingWorkers: string[];
-  recommendations: string[];
-  performance?: {
-    list_tasks_ms: number;
-    worker_scan_ms: number;
-    mailbox_delivery_ms: number;
-    total_ms: number;
-    updated_at: string;
-  };
+	teamName: string;
+	phase: TeamPhase | TerminalPhase;
+	workers: Array<{
+		name: string;
+		alive: boolean;
+		status: WorkerStatus;
+		heartbeat: WorkerHeartbeat | null;
+		assignedTasks: string[];
+		turnsWithoutProgress: number;
+	}>;
+	tasks: {
+		total: number;
+		pending: number;
+		blocked: number;
+		in_progress: number;
+		completed: number;
+		failed: number;
+		items: TeamTask[];
+	};
+	allTasksTerminal: boolean;
+	deadWorkers: string[];
+	nonReportingWorkers: string[];
+	recommendations: string[];
+	performance?: {
+		list_tasks_ms: number;
+		worker_scan_ms: number;
+		mailbox_delivery_ms: number;
+		total_ms: number;
+		updated_at: string;
+	};
 }
 
 async function syncRootTeamModeStateOnTerminalPhase(
-  teamName: string,
-  phase: TeamPhase | TerminalPhase,
-  cwd: string,
+	teamName: string,
+	phase: TeamPhase | TerminalPhase,
+	cwd: string,
 ): Promise<void> {
-  if (phase !== 'complete' && phase !== 'failed' && phase !== 'cancelled') return;
+	if (phase !== "complete" && phase !== "failed" && phase !== "cancelled")
+		return;
 
-  try {
-    const teamState = await readModeState('team', cwd);
-    if (!teamState) return;
+	try {
+		const teamState = await readModeState("team", cwd);
+		if (!teamState) return;
 
-    const stateTeamName = typeof teamState.team_name === 'string' ? teamState.team_name.trim() : '';
-    if (stateTeamName && stateTeamName !== teamName) return;
+		const stateTeamName =
+			typeof teamState.team_name === "string" ? teamState.team_name.trim() : "";
+		if (stateTeamName && stateTeamName !== teamName) return;
 
-    const alreadySynced = teamState.active === false
-      && teamState.current_phase === phase
-      && typeof teamState.completed_at === 'string'
-      && teamState.completed_at.length > 0;
-    if (alreadySynced) return;
+		const alreadySynced =
+			teamState.active === false &&
+			teamState.current_phase === phase &&
+			typeof teamState.completed_at === "string" &&
+			teamState.completed_at.length > 0;
+		if (alreadySynced) return;
 
-    const updates: Record<string, unknown> = {
-      active: false,
-      current_phase: phase,
-      team_name: teamName,
-    };
-    if (typeof teamState.completed_at !== 'string' || !teamState.completed_at) {
-      updates.completed_at = new Date().toISOString();
-    }
+		const updates: Record<string, unknown> = {
+			active: false,
+			current_phase: phase,
+			team_name: teamName,
+		};
+		if (typeof teamState.completed_at !== "string" || !teamState.completed_at) {
+			updates.completed_at = new Date().toISOString();
+		}
 
-    await updateModeState('team', updates, cwd);
-  } catch {
-    // Best-effort compatibility sync only.
-  }
+		await updateModeState("team", updates, cwd);
+	} catch {
+		// Best-effort compatibility sync only.
+	}
 }
 
 async function assertTeamStartupIsNonDestructive(
-  teamName: string,
-  cwd: string,
-  leaderSessionId: string,
+	teamName: string,
+	cwd: string,
+	leaderSessionId: string,
 ): Promise<void> {
-  const activeTeams = await findActiveTeams(cwd, leaderSessionId);
-  if (activeTeams.length > 0) {
-    throw new Error(`leader_session_conflict: active team exists (${activeTeams.join(', ')})`);
-  }
+	const activeTeams = await findActiveTeams(cwd, leaderSessionId);
+	if (activeTeams.length > 0) {
+		throw new Error(
+			`leader_session_conflict: active team exists (${activeTeams.join(", ")})`,
+		);
+	}
 
-  const [existingConfig, existingManifest, existingPhase] = await Promise.all([
-    readTeamConfig(teamName, cwd),
-    readTeamManifestV2(teamName, cwd),
-    readTeamPhaseState(teamName, cwd),
-  ]);
+	const [existingConfig, existingManifest, existingPhase] = await Promise.all([
+		readTeamConfig(teamName, cwd),
+		readTeamManifestV2(teamName, cwd),
+		readTeamPhaseState(teamName, cwd),
+	]);
 
-  if (!existingConfig && !existingManifest) return;
+	if (!existingConfig && !existingManifest) return;
 
-  const currentPhase = existingPhase?.current_phase;
-  if (currentPhase && isTerminalPhase(currentPhase)) return;
+	const currentPhase = existingPhase?.current_phase;
+	if (currentPhase && isTerminalPhase(currentPhase)) return;
 
-  const tmuxSession = existingConfig?.tmux_session ?? existingManifest?.tmux_session ?? `omx-team-${teamName}`;
-  const renderedPhase = currentPhase ?? 'team-exec';
-  throw new Error(
-    `team_name_conflict: active team state already exists for "${teamName}" (phase: ${renderedPhase}, tmux: ${tmuxSession}). `
-    + `Use "omx team status ${teamName}", "omx team resume ${teamName}", or "omx team shutdown ${teamName}" instead of launching a duplicate team.`,
-  );
+	const tmuxSession =
+		existingConfig?.tmux_session ??
+		existingManifest?.tmux_session ??
+		`omx-team-${teamName}`;
+	const renderedPhase = currentPhase ?? "team-exec";
+	throw new Error(
+		`team_name_conflict: active team state already exists for "${teamName}" (phase: ${renderedPhase}, tmux: ${tmuxSession}). ` +
+			`Use "omx team status ${teamName}", "omx team resume ${teamName}", or "omx team shutdown ${teamName}" instead of launching a duplicate team.`,
+	);
 }
 
 /** Runtime handle returned by startTeam */
 export interface TeamRuntime {
-  teamName: string;
-  sanitizedName: string;
-  sessionName: string;
-  config: TeamConfig;
-  cwd: string;
+	teamName: string;
+	sanitizedName: string;
+	sessionName: string;
+	config: TeamConfig;
+	cwd: string;
 }
 
 interface ShutdownOptions {
-  force?: boolean;
+	force?: boolean;
 }
 
 export interface TeamShutdownSummary {
-  commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null;
+	commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null;
 }
 
 export function applyCreatedInteractiveSessionToConfig(
-  config: TeamConfig,
-  createdSession: TeamSession,
-  workerPaneIds: Array<string | undefined>,
+	config: TeamConfig,
+	createdSession: TeamSession,
+	workerPaneIds: Array<string | undefined>,
 ): void {
-  config.tmux_session = createdSession.name;
-  config.leader_pane_id = createdSession.leaderPaneId;
-  config.hud_pane_id = createdSession.hudPaneId;
-  config.resize_hook_name = createdSession.resizeHookName;
-  config.resize_hook_target = createdSession.resizeHookTarget;
-  for (let i = 0; i < createdSession.workerPaneIds.length; i++) {
-    const paneId = createdSession.workerPaneIds[i];
-    workerPaneIds[i] = paneId;
-    if (config.workers[i]) {
-      config.workers[i].pane_id = paneId;
-    }
-  }
+	config.tmux_session = createdSession.name;
+	config.leader_pane_id = createdSession.leaderPaneId;
+	config.hud_pane_id = createdSession.hudPaneId;
+	config.resize_hook_name = createdSession.resizeHookName;
+	config.resize_hook_target = createdSession.resizeHookTarget;
+	for (let i = 0; i < createdSession.workerPaneIds.length; i++) {
+		const paneId = createdSession.workerPaneIds[i];
+		workerPaneIds[i] = paneId;
+		if (config.workers[i]) {
+			config.workers[i].pane_id = paneId;
+		}
+	}
 }
 
 function collectShutdownPaneIds(params: {
-  config: TeamConfig;
-  livePaneIds?: string[];
-  restoredStandaloneHudPaneId?: string | null;
+	config: TeamConfig;
+	livePaneIds?: string[];
+	restoredStandaloneHudPaneId?: string | null;
 }): string[] {
-  const { config, livePaneIds = [], restoredStandaloneHudPaneId = null } = params;
-  const excludedPaneIds = new Set(
-    [
-      config.leader_pane_id,
-      config.hud_pane_id,
-      restoredStandaloneHudPaneId,
-    ].filter((paneId): paneId is string => typeof paneId === 'string' && paneId.trim().startsWith('%')),
-  );
+	const {
+		config,
+		livePaneIds = [],
+		restoredStandaloneHudPaneId = null,
+	} = params;
+	const excludedPaneIds = new Set(
+		[
+			config.leader_pane_id,
+			config.hud_pane_id,
+			restoredStandaloneHudPaneId,
+		].filter(
+			(paneId): paneId is string =>
+				typeof paneId === "string" && paneId.trim().startsWith("%"),
+		),
+	);
 
-  const paneIds = new Set<string>();
-  for (const paneId of [
-    ...config.workers.map((worker) => worker.pane_id),
-    ...livePaneIds,
-  ]) {
-    if (typeof paneId !== 'string') continue;
-    const normalized = paneId.trim();
-    if (!normalized.startsWith('%')) continue;
-    if (excludedPaneIds.has(normalized)) continue;
-    paneIds.add(normalized);
-  }
+	const paneIds = new Set<string>();
+	for (const paneId of [
+		...config.workers.map((worker) => worker.pane_id),
+		...livePaneIds,
+	]) {
+		if (typeof paneId !== "string") continue;
+		const normalized = paneId.trim();
+		if (!normalized.startsWith("%")) continue;
+		if (excludedPaneIds.has(normalized)) continue;
+		paneIds.add(normalized);
+	}
 
-  return [...paneIds];
+	return [...paneIds];
 }
 
-export function shouldPrekillInteractiveShutdownProcessTrees(sessionName: string): boolean {
-  // Native Windows + split-pane psmux sessions can expose overlapping
-  // ancestry around the leader client; rely on pane-targeted teardown there.
-  return !(isNativeWindows() && sessionName.includes(':'));
+export function shouldPrekillInteractiveShutdownProcessTrees(
+	sessionName: string,
+): boolean {
+	// Native Windows + split-pane psmux sessions can expose overlapping
+	// ancestry around the leader client; rely on pane-targeted teardown there.
+	return !(isNativeWindows() && sessionName.includes(":"));
 }
 
 async function logRuntimeDispatchOutcome(params: {
-  cwd: string;
-  teamName: string;
-  workerName: string;
-  requestId?: string;
-  messageId?: string;
-  intent?: TeamDispatchRequest['intent'];
-  outcome: DispatchOutcome;
-  source?: string;
+	cwd: string;
+	teamName: string;
+	workerName: string;
+	requestId?: string;
+	messageId?: string;
+	intent?: TeamDispatchRequest["intent"];
+	outcome: DispatchOutcome;
+	source?: string;
 }): Promise<void> {
-  const { cwd, teamName, workerName, requestId, messageId, intent, outcome, source = 'team.runtime' } = params;
-  await appendTeamDeliveryLogForCwd(cwd, {
-    event: 'dispatch_result',
-    source,
-    team: teamName,
-    request_id: requestId,
-    message_id: messageId,
-    to_worker: workerName,
-    intent,
-    transport: outcome.transport,
-    result: outcome.ok ? 'confirmed' : 'failed',
-    reason: outcome.reason,
-  });
+	const {
+		cwd,
+		teamName,
+		workerName,
+		requestId,
+		messageId,
+		intent,
+		outcome,
+		source = "team.runtime",
+	} = params;
+	await appendTeamDeliveryLogForCwd(cwd, {
+		event: "dispatch_result",
+		source,
+		team: teamName,
+		request_id: requestId,
+		message_id: messageId,
+		to_worker: workerName,
+		intent,
+		transport: outcome.transport,
+		result: outcome.ok ? "confirmed" : "failed",
+		reason: outcome.reason,
+	});
 }
 
-function collectProvisionedShutdownWorktrees(config: TeamConfig): EnsureWorktreeResult[] {
-  const seenWorktreePaths = new Set<string>();
-  const worktrees: EnsureWorktreeResult[] = [];
+function collectProvisionedShutdownWorktrees(
+	config: TeamConfig,
+): EnsureWorktreeResult[] {
+	const seenWorktreePaths = new Set<string>();
+	const worktrees: EnsureWorktreeResult[] = [];
 
-  for (const worker of config.workers) {
-    if (worker.worktree_created !== true) continue;
-    if (worker.worktree_detached !== true) continue;
-    if (!worker.worktree_repo_root || !worker.worktree_path) continue;
-    if (!existsSync(worker.worktree_path)) continue;
+	for (const worker of config.workers) {
+		if (worker.worktree_created !== true) continue;
+		if (worker.worktree_detached !== true) continue;
+		if (!worker.worktree_repo_root || !worker.worktree_path) continue;
+		if (!existsSync(worker.worktree_path)) continue;
 
-    const worktreePath = resolve(worker.worktree_path);
-    if (seenWorktreePaths.has(worktreePath)) continue;
-    seenWorktreePaths.add(worktreePath);
+		const worktreePath = resolve(worker.worktree_path);
+		if (seenWorktreePaths.has(worktreePath)) continue;
+		seenWorktreePaths.add(worktreePath);
 
-    worktrees.push({
-      enabled: true,
-      repoRoot: worker.worktree_repo_root,
-      worktreePath,
-      detached: true,
-      branchName: null,
-      created: true,
-      reused: false,
-      createdBranch: false,
-    });
-  }
+		worktrees.push({
+			enabled: true,
+			repoRoot: worker.worktree_repo_root,
+			worktreePath,
+			detached: true,
+			branchName: null,
+			created: true,
+			reused: false,
+			createdBranch: false,
+		});
+	}
 
-  return worktrees;
+	return worktrees;
 }
 
 interface CommandResult {
-  ok: boolean;
-  stdout: string;
-  stderr: string;
-  exitCode: number | null;
+	ok: boolean;
+	stdout: string;
+	stderr: string;
+	exitCode: number | null;
 }
 
 interface WorkerShutdownMergeReport {
-  workerName: string;
-  worktreePath: string;
-  reportPath: string;
-  sourceRef: string | null;
-  syntheticCommit: string | null;
-  diffText: string;
-  summaryText: string | null;
-  mergeOutcome: 'merged' | 'conflict' | 'noop' | 'skipped';
-  mergeDetail: string;
-  leaderHeadBefore: string | null;
-  leaderHeadAfter: string | null;
+	workerName: string;
+	worktreePath: string;
+	reportPath: string;
+	sourceRef: string | null;
+	syntheticCommit: string | null;
+	diffText: string;
+	summaryText: string | null;
+	mergeOutcome: "merged" | "conflict" | "noop" | "skipped";
+	mergeDetail: string;
+	leaderHeadBefore: string | null;
+	leaderHeadAfter: string | null;
 }
 
-function runCommand(command: string, args: string[], cwd: string): CommandResult {
-  const result = spawnSync(command, args, {
-    cwd,
-    encoding: 'utf-8',
-      windowsHide: true,
-    });
-  return {
-    ok: result.status === 0,
-    stdout: (result.stdout || '').trim(),
-    stderr: (result.stderr || '').trim(),
-    exitCode: result.status,
-  };
+function runCommand(
+	command: string,
+	args: string[],
+	cwd: string,
+): CommandResult {
+	const result = spawnSync(command, args, {
+		cwd,
+		encoding: "utf-8",
+		windowsHide: true,
+	});
+	return {
+		ok: result.status === 0,
+		stdout: (result.stdout || "").trim(),
+		stderr: (result.stderr || "").trim(),
+		exitCode: result.status,
+	};
 }
 
-function runGitCommand(repoRoot: string, args: string[], cwd: string = repoRoot): CommandResult {
-  return runCommand('git', args, cwd);
+function runGitCommand(
+	repoRoot: string,
+	args: string[],
+	cwd: string = repoRoot,
+): CommandResult {
+	return runCommand("git", args, cwd);
 }
 
 function getWorktreeDiffText(worktreePath: string): string {
-  const staged = runGitCommand(worktreePath, ['diff', '--cached', '--stat', '--patch'], worktreePath);
-  if (staged.ok && staged.stdout) return staged.stdout;
+	const staged = runGitCommand(
+		worktreePath,
+		["diff", "--cached", "--stat", "--patch"],
+		worktreePath,
+	);
+	if (staged.ok && staged.stdout) return staged.stdout;
 
-  const unstaged = runGitCommand(worktreePath, ['diff', '--stat', '--patch'], worktreePath);
-  if (unstaged.ok && unstaged.stdout) return unstaged.stdout;
+	const unstaged = runGitCommand(
+		worktreePath,
+		["diff", "--stat", "--patch"],
+		worktreePath,
+	);
+	if (unstaged.ok && unstaged.stdout) return unstaged.stdout;
 
-  const againstHead = runGitCommand(worktreePath, ['diff', 'HEAD', '--stat', '--patch'], worktreePath);
-  if (againstHead.ok && againstHead.stdout) return againstHead.stdout;
+	const againstHead = runGitCommand(
+		worktreePath,
+		["diff", "HEAD", "--stat", "--patch"],
+		worktreePath,
+	);
+	if (againstHead.ok && againstHead.stdout) return againstHead.stdout;
 
-  return '';
+	return "";
 }
 
-function summarizeWorktreeDiffWithSparkShell(worktreePath: string): string | null {
-  const shellCommand = `git diff --cached --stat --patch || git diff --stat --patch || git diff HEAD --stat --patch`;
-  const result = runCommand('omx', ['sparkshell', 'sh', '-lc', shellCommand], worktreePath);
-  if (!result.ok || !result.stdout) return null;
-  return result.stdout;
+function summarizeWorktreeDiffWithSparkShell(
+	worktreePath: string,
+): string | null {
+	const shellCommand = `git diff --cached --stat --patch || git diff --stat --patch || git diff HEAD --stat --patch`;
+	const result = runCommand(
+		"omx",
+		["sparkshell", "sh", "-lc", shellCommand],
+		worktreePath,
+	);
+	if (!result.ok || !result.stdout) return null;
+	return result.stdout;
 }
 
 function resolveWorkerHead(worktreePath: string): string | null {
-  const head = runGitCommand(worktreePath, ['rev-parse', 'HEAD'], worktreePath);
-  return head.ok && head.stdout ? head.stdout : null;
+	const head = runGitCommand(worktreePath, ["rev-parse", "HEAD"], worktreePath);
+	return head.ok && head.stdout ? head.stdout : null;
 }
 
 function resolveLeaderHead(repoRoot: string, leaderCwd: string): string | null {
-  const head = runGitCommand(repoRoot, ['rev-parse', 'HEAD'], leaderCwd);
-  return head.ok && head.stdout ? head.stdout : null;
+	const head = runGitCommand(repoRoot, ["rev-parse", "HEAD"], leaderCwd);
+	return head.ok && head.stdout ? head.stdout : null;
 }
 
-function listCommitRange(repoRoot: string, baseRef: string, headRef: string, cwd: string): string[] {
-  if (!baseRef || !headRef || baseRef === headRef) return [];
-  const range = runGitCommand(repoRoot, ['rev-list', '--reverse', `${baseRef}..${headRef}`], cwd);
-  if (!range.ok || !range.stdout) return [];
-  return range.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+function listCommitRange(
+	repoRoot: string,
+	baseRef: string,
+	headRef: string,
+	cwd: string,
+): string[] {
+	if (!baseRef || !headRef || baseRef === headRef) return [];
+	const range = runGitCommand(
+		repoRoot,
+		["rev-list", "--reverse", `${baseRef}..${headRef}`],
+		cwd,
+	);
+	if (!range.ok || !range.stdout) return [];
+	return range.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
 }
 
 function listConflictFiles(repoRoot: string, cwd: string): string[] {
-  const result = runGitCommand(repoRoot, ['diff', '--name-only', '--diff-filter=U'], cwd);
-  if (!result.ok || !result.stdout) return [];
-  return result.stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+	const result = runGitCommand(
+		repoRoot,
+		["diff", "--name-only", "--diff-filter=U"],
+		cwd,
+	);
+	if (!result.ok || !result.stdout) return [];
+	return result.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
 }
 
 async function appendIntegrationEvent(
-  teamName: string,
-  type: 'worker_cherry_pick_detected' | 'worker_cherry_pick_applied' | 'worker_cherry_pick_conflict' | 'worker_rebase_applied' | 'worker_rebase_conflict' | 'worker_auto_commit' | 'worker_merge_applied' | 'worker_merge_conflict' | 'worker_integration_failed' | 'worker_cross_rebase_applied' | 'worker_cross_rebase_conflict' | 'worker_cross_rebase_skipped',
-  worker: WorkerInfo,
-  metadata: Record<string, unknown>,
-  cwd: string,
+	teamName: string,
+	type:
+		| "worker_cherry_pick_detected"
+		| "worker_cherry_pick_applied"
+		| "worker_cherry_pick_conflict"
+		| "worker_rebase_applied"
+		| "worker_rebase_conflict"
+		| "worker_auto_commit"
+		| "worker_merge_applied"
+		| "worker_merge_conflict"
+		| "worker_integration_failed"
+		| "worker_cross_rebase_applied"
+		| "worker_cross_rebase_conflict"
+		| "worker_cross_rebase_skipped",
+	worker: WorkerInfo,
+	metadata: Record<string, unknown>,
+	cwd: string,
 ): Promise<void> {
-  await appendTeamEvent(teamName, {
-    type,
-    worker: worker.name,
-    task_id: worker.assigned_tasks[0],
-    reason: typeof metadata.summary === 'string' ? metadata.summary : undefined,
-    metadata,
-  }, cwd);
+	await appendTeamEvent(
+		teamName,
+		{
+			type,
+			worker: worker.name,
+			task_id: worker.assigned_tasks[0],
+			reason:
+				typeof metadata.summary === "string" ? metadata.summary : undefined,
+			metadata,
+		},
+		cwd,
+	);
 }
 
 async function sendIntegrationMessageToLeader(
-  teamName: string,
-  worker: WorkerInfo,
-  body: string,
-  cwd: string,
+	teamName: string,
+	worker: WorkerInfo,
+	body: string,
+	cwd: string,
 ): Promise<void> {
-  await sendWorkerMessage(teamName, worker.name, 'leader-fixed', body, cwd).catch(() => {});
+	await sendWorkerMessage(
+		teamName,
+		worker.name,
+		"leader-fixed",
+		body,
+		cwd,
+	).catch(() => {});
 }
 
-function leaderHeadAdvanced(before: string, after: string | null): after is string {
-  return typeof after === 'string' && after.length > 0 && after !== before;
+function leaderHeadAdvanced(
+	before: string,
+	after: string | null,
+): after is string {
+	return typeof after === "string" && after.length > 0 && after !== before;
 }
 
 async function recordIntegrationFailure(
-  teamName: string,
-  worker: WorkerInfo,
-  state: TeamWorkerIntegrationState,
-  details: {
-    operation: 'merge' | 'cherry-pick';
-    sourceCommit: string;
-    leaderHeadBefore: string;
-    leaderHeadAfter: string | null;
-    worktreePath: string;
-    strategy: '-X theirs';
-  },
-  cwd: string,
+	teamName: string,
+	worker: WorkerInfo,
+	state: TeamWorkerIntegrationState,
+	details: {
+		operation: "merge" | "cherry-pick";
+		sourceCommit: string;
+		leaderHeadBefore: string;
+		leaderHeadAfter: string | null;
+		worktreePath: string;
+		strategy: "-X theirs";
+	},
+	cwd: string,
 ): Promise<void> {
-  const leaderHeadAfter = details.leaderHeadAfter ?? details.leaderHeadBefore;
-  const sourceShort = details.sourceCommit.slice(0, 12);
-  const leaderShort = details.leaderHeadBefore.slice(0, 12);
-  state.last_leader_head = leaderHeadAfter;
-  state.status = 'integration_failed';
-  state.conflict_commit = details.sourceCommit;
-  state.conflict_files = undefined;
-  state.updated_at = new Date().toISOString();
-  await appendIntegrationEvent(teamName, 'worker_integration_failed', worker, {
-    worker_name: worker.name,
-    operation: details.operation,
-    source_commit: details.sourceCommit,
-    leader_head_before: details.leaderHeadBefore,
-    leader_head_after: leaderHeadAfter,
-    worktree_path: details.worktreePath,
-    summary: `${details.operation} for ${worker.name} reported success but leader HEAD did not advance`,
-  }, cwd);
-  appendIntegrationReport(teamName, {
-    workerName: worker.name,
-    operation: details.operation,
-    strategy: details.strategy,
-    files: [],
-    detail: `${details.operation} reported success for ${sourceShort}, but leader HEAD did not advance from ${leaderShort}; not marking worker as integrated.`,
-  }, cwd);
-  await sendIntegrationMessageToLeader(
-    teamName,
-    worker,
-    `INTEGRATION FAILED: ${details.operation} for ${worker.name} reported success, but leader HEAD stayed at ${leaderShort}. Not emitting INTEGRATED; retry or inspect leader branch state before continuing.`,
-    cwd,
-  );
+	const leaderHeadAfter = details.leaderHeadAfter ?? details.leaderHeadBefore;
+	const sourceShort = details.sourceCommit.slice(0, 12);
+	const leaderShort = details.leaderHeadBefore.slice(0, 12);
+	state.last_leader_head = leaderHeadAfter;
+	state.status = "integration_failed";
+	state.conflict_commit = details.sourceCommit;
+	state.conflict_files = undefined;
+	state.updated_at = new Date().toISOString();
+	await appendIntegrationEvent(
+		teamName,
+		"worker_integration_failed",
+		worker,
+		{
+			worker_name: worker.name,
+			operation: details.operation,
+			source_commit: details.sourceCommit,
+			leader_head_before: details.leaderHeadBefore,
+			leader_head_after: leaderHeadAfter,
+			worktree_path: details.worktreePath,
+			summary: `${details.operation} for ${worker.name} reported success but leader HEAD did not advance`,
+		},
+		cwd,
+	);
+	appendIntegrationReport(
+		teamName,
+		{
+			workerName: worker.name,
+			operation: details.operation,
+			strategy: details.strategy,
+			files: [],
+			detail: `${details.operation} reported success for ${sourceShort}, but leader HEAD did not advance from ${leaderShort}; not marking worker as integrated.`,
+		},
+		cwd,
+	);
+	await sendIntegrationMessageToLeader(
+		teamName,
+		worker,
+		`INTEGRATION FAILED: ${details.operation} for ${worker.name} reported success, but leader HEAD stayed at ${leaderShort}. Not emitting INTEGRATED; retry or inspect leader branch state before continuing.`,
+		cwd,
+	);
 }
 
-function autoCommitDirtyWorktree(
-  worker: WorkerInfo,
-): { committed: boolean; commitHash: string | null } {
-  const worktreePath = resolve(worker.worktree_path!);
-  const repoRoot = resolve(worker.worktree_repo_root!);
-  const status = runGitCommand(repoRoot, ['status', '--porcelain'], worktreePath);
-  if (!status.ok || !status.stdout.trim()) return { committed: false, commitHash: null };
+function autoCommitDirtyWorktree(worker: WorkerInfo): {
+	committed: boolean;
+	commitHash: string | null;
+} {
+	const worktreePath = resolve(worker.worktree_path!);
+	const repoRoot = resolve(worker.worktree_repo_root!);
+	const status = runGitCommand(
+		repoRoot,
+		["status", "--porcelain"],
+		worktreePath,
+	);
+	if (!status.ok || !status.stdout.trim())
+		return { committed: false, commitHash: null };
 
-  const taskId = worker.assigned_tasks[0] || 'unknown';
-  const addResult = runGitCommand(repoRoot, ['add', '-A'], worktreePath);
-  if (!addResult.ok) return { committed: false, commitHash: null };
+	const taskId = worker.assigned_tasks[0] || "unknown";
+	const addResult = runGitCommand(repoRoot, ["add", "-A"], worktreePath);
+	if (!addResult.ok) return { committed: false, commitHash: null };
 
-  const msg = `omx(team): auto-checkpoint ${worker.name} [${taskId}]`;
-  const commitResult = runGitCommand(repoRoot, ['commit', '--no-verify', '-m', msg], worktreePath);
-  if (!commitResult.ok) return { committed: false, commitHash: null };
+	const msg = `omx(team): auto-checkpoint ${worker.name} [${taskId}]`;
+	const commitResult = runGitCommand(
+		repoRoot,
+		["commit", "--no-verify", "-m", msg],
+		worktreePath,
+	);
+	if (!commitResult.ok) return { committed: false, commitHash: null };
 
-  const head = runGitCommand(repoRoot, ['rev-parse', 'HEAD'], worktreePath);
-  return { committed: true, commitHash: head.ok ? head.stdout : null };
+	const head = runGitCommand(repoRoot, ["rev-parse", "HEAD"], worktreePath);
+	return { committed: true, commitHash: head.ok ? head.stdout : null };
 }
 
 function appendIntegrationReport(
-  teamName: string,
-  entry: {
-    workerName: string;
-    operation: 'merge' | 'cherry-pick' | 'rebase';
-    strategy: '-X theirs' | '-X ours';
-    files: string[];
-    detail: string;
-  },
-  cwd: string,
+	teamName: string,
+	entry: {
+		workerName: string;
+		operation: "merge" | "cherry-pick" | "rebase";
+		strategy: "-X theirs" | "-X ours";
+		files: string[];
+		detail: string;
+	},
+	cwd: string,
 ): void {
-  const teamStateRoot = resolveCanonicalTeamStateRoot(cwd);
-  const reportPath = join(teamStateRoot, 'team', teamName, 'integration-report.md');
-  const dir = dirname(reportPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+	const teamStateRoot = resolveCanonicalTeamStateRoot(cwd);
+	const reportPath = join(
+		teamStateRoot,
+		"team",
+		teamName,
+		"integration-report.md",
+	);
+	const dir = dirname(reportPath);
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
-  const timestamp = new Date().toISOString();
-  const line = `- [${timestamp}] ${entry.workerName}: ${entry.operation} conflict auto-resolved (${entry.strategy}) on files: ${entry.files.join(', ') || 'unknown'}. ${entry.detail}\n`;
+	const timestamp = new Date().toISOString();
+	const line = `- [${timestamp}] ${entry.workerName}: ${entry.operation} conflict auto-resolved (${entry.strategy}) on files: ${entry.files.join(", ") || "unknown"}. ${entry.detail}\n`;
 
-  appendFileSync(reportPath, existsSync(reportPath) ? line : `# Integration Report\n\n${line}`);
+	appendFileSync(
+		reportPath,
+		existsSync(reportPath) ? line : `# Integration Report\n\n${line}`,
+	);
 }
 
-function resolveWorkerMergeRef(branchResult: CommandResult, workerHead: string): string {
-  const branchRef = branchResult.ok ? branchResult.stdout.trim() : '';
-  if (!branchRef || branchRef === 'HEAD') return workerHead;
-  return branchRef;
+function resolveWorkerMergeRef(
+	branchResult: CommandResult,
+	workerHead: string,
+): string {
+	const branchRef = branchResult.ok ? branchResult.stdout.trim() : "";
+	if (!branchRef || branchRef === "HEAD") return workerHead;
+	return branchRef;
 }
 
-function leaderContainsCommit(repoRoot: string, cwd: string, commit: string): boolean {
-  return runGitCommand(repoRoot, ['merge-base', '--is-ancestor', commit, 'HEAD'], cwd).ok;
+function leaderContainsCommit(
+	repoRoot: string,
+	cwd: string,
+	commit: string,
+): boolean {
+	return runGitCommand(
+		repoRoot,
+		["merge-base", "--is-ancestor", commit, "HEAD"],
+		cwd,
+	).ok;
 }
 
 async function integrateWorkerCommitsIntoLeader(params: {
-  teamName: string;
-  config: TeamConfig;
-  previous: TeamMonitorSnapshotState | null;
-  cwd: string;
+	teamName: string;
+	config: TeamConfig;
+	previous: TeamMonitorSnapshotState | null;
+	cwd: string;
 }): Promise<Record<string, TeamWorkerIntegrationState>> {
-  const { teamName, config, previous, cwd } = params;
-  const next: Record<string, TeamWorkerIntegrationState> = { ...(previous?.integrationByWorker ?? {}) };
-  const leaderHeadAtCycleStart = resolveLeaderHead(resolve(config.workers[0]?.worktree_repo_root ?? cwd), cwd);
-  const integratedWorkerNames = new Set<string>();
-  const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
-  const artifactCwd = config.leader_cwd ?? cwd;
+	const { teamName, config, previous, cwd } = params;
+	const next: Record<string, TeamWorkerIntegrationState> = {
+		...(previous?.integrationByWorker ?? {}),
+	};
+	const leaderHeadAtCycleStart = resolveLeaderHead(
+		resolve(config.workers[0]?.worktree_repo_root ?? cwd),
+		cwd,
+	);
+	const integratedWorkerNames = new Set<string>();
+	const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
+	const artifactCwd = config.leader_cwd ?? cwd;
 
-  // ── Phase A: Auto-commit dirty worktrees ──
-  for (const worker of config.workers) {
-    if (!worker.worktree_repo_root || !worker.worktree_path || !existsSync(worker.worktree_path)) continue;
-    const { committed, commitHash } = autoCommitDirtyWorktree(worker);
-    if (committed) {
-      await appendIntegrationEvent(teamName, 'worker_auto_commit', worker, {
-        worker_name: worker.name,
-        commit_hash: commitHash,
-        worktree_path: resolve(worker.worktree_path),
-        summary: `auto-committed dirty worktree for ${worker.name}`,
-      }, cwd);
-      commitHygieneEntries.push({
-        recorded_at: new Date().toISOString(),
-        operation: 'auto_checkpoint',
-        worker_name: worker.name,
-        task_id: worker.assigned_tasks[0],
-        status: 'applied',
-        operational_commit: commitHash,
-        worktree_path: resolve(worker.worktree_path),
-        detail: 'Dirty worker worktree checkpointed before runtime integration.',
-      });
-    }
-  }
+	// ── Phase A: Auto-commit dirty worktrees ──
+	for (const worker of config.workers) {
+		if (
+			!worker.worktree_repo_root ||
+			!worker.worktree_path ||
+			!existsSync(worker.worktree_path)
+		)
+			continue;
+		const { committed, commitHash } = autoCommitDirtyWorktree(worker);
+		if (committed) {
+			await appendIntegrationEvent(
+				teamName,
+				"worker_auto_commit",
+				worker,
+				{
+					worker_name: worker.name,
+					commit_hash: commitHash,
+					worktree_path: resolve(worker.worktree_path),
+					summary: `auto-committed dirty worktree for ${worker.name}`,
+				},
+				cwd,
+			);
+			commitHygieneEntries.push({
+				recorded_at: new Date().toISOString(),
+				operation: "auto_checkpoint",
+				worker_name: worker.name,
+				task_id: worker.assigned_tasks[0],
+				status: "applied",
+				operational_commit: commitHash,
+				worktree_path: resolve(worker.worktree_path),
+				detail:
+					"Dirty worker worktree checkpointed before runtime integration.",
+			});
+		}
+	}
 
-  // ── Phase B: Integrate worker commits to leader (hybrid strategy) ──
-  for (const worker of config.workers) {
-    if (!worker.worktree_repo_root || !worker.worktree_path || !existsSync(worker.worktree_path)) continue;
-    const repoRoot = resolve(worker.worktree_repo_root);
-    const worktreePath = resolve(worker.worktree_path);
-    const leaderHead = resolveLeaderHead(repoRoot, cwd);
-    const workerHead = resolveWorkerHead(worktreePath);
-    const previousState = next[worker.name] ?? {};
-    const state: TeamWorkerIntegrationState = { ...previousState, last_leader_head: leaderHead ?? previousState.last_leader_head };
-    if (!workerHead || !leaderHead) {
-      next[worker.name] = state;
-      continue;
-    }
+	// ── Phase B: Integrate worker commits to leader (hybrid strategy) ──
+	for (const worker of config.workers) {
+		if (
+			!worker.worktree_repo_root ||
+			!worker.worktree_path ||
+			!existsSync(worker.worktree_path)
+		)
+			continue;
+		const repoRoot = resolve(worker.worktree_repo_root);
+		const worktreePath = resolve(worker.worktree_path);
+		const leaderHead = resolveLeaderHead(repoRoot, cwd);
+		const workerHead = resolveWorkerHead(worktreePath);
+		const previousState = next[worker.name] ?? {};
+		const state: TeamWorkerIntegrationState = {
+			...previousState,
+			last_leader_head: leaderHead ?? previousState.last_leader_head,
+		};
+		if (!workerHead || !leaderHead) {
+			next[worker.name] = state;
+			continue;
+		}
 
-    state.last_seen_head = workerHead;
-    const alreadyMerged = runGitCommand(repoRoot, ['merge-base', '--is-ancestor', workerHead, 'HEAD'], cwd).ok;
-    if (alreadyMerged) {
-      state.last_integrated_head = workerHead;
-      state.status = 'idle';
-      state.updated_at = new Date().toISOString();
-      next[worker.name] = state;
-      continue;
-    }
+		state.last_seen_head = workerHead;
+		const alreadyMerged = runGitCommand(
+			repoRoot,
+			["merge-base", "--is-ancestor", workerHead, "HEAD"],
+			cwd,
+		).ok;
+		if (alreadyMerged) {
+			state.last_integrated_head = workerHead;
+			state.status = "idle";
+			state.updated_at = new Date().toISOString();
+			next[worker.name] = state;
+			continue;
+		}
 
-    // Determine if worker is cleanly ahead of leader (merge) or diverged (cherry-pick)
-    const workerIsAheadOfLeader = runGitCommand(repoRoot, ['merge-base', '--is-ancestor', leaderHead, workerHead], cwd).ok;
+		// Determine if worker is cleanly ahead of leader (merge) or diverged (cherry-pick)
+		const workerIsAheadOfLeader = runGitCommand(
+			repoRoot,
+			["merge-base", "--is-ancestor", leaderHead, workerHead],
+			cwd,
+		).ok;
 
-    if (workerIsAheadOfLeader) {
-      // Worker is cleanly ahead → merge --no-ff -X theirs
-      const workerBranch = runGitCommand(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD'], worktreePath);
-      const branchRef = resolveWorkerMergeRef(workerBranch, workerHead);
-      const merge = runGitCommand(repoRoot, ['merge', '--no-ff', '-X', 'theirs', '-m', `omx(team): merge ${worker.name}`, branchRef], cwd);
+		if (workerIsAheadOfLeader) {
+			// Worker is cleanly ahead → merge --no-ff -X theirs
+			const workerBranch = runGitCommand(
+				repoRoot,
+				["rev-parse", "--abbrev-ref", "HEAD"],
+				worktreePath,
+			);
+			const branchRef = resolveWorkerMergeRef(workerBranch, workerHead);
+			const merge = runGitCommand(
+				repoRoot,
+				[
+					"merge",
+					"--no-ff",
+					"-X",
+					"theirs",
+					"-m",
+					`omx(team): merge ${worker.name}`,
+					branchRef,
+				],
+				cwd,
+			);
 
-      if (merge.ok) {
-        const newLeaderHead = resolveLeaderHead(repoRoot, cwd) ?? leaderHead;
-        const workerIntegrated = leaderContainsCommit(repoRoot, cwd, workerHead);
-        if (!leaderHeadAdvanced(leaderHead, newLeaderHead)) {
-          await recordIntegrationFailure(teamName, worker, state, {
-            operation: 'merge',
-            sourceCommit: workerHead,
-            leaderHeadBefore: leaderHead,
-            leaderHeadAfter: newLeaderHead,
-            worktreePath,
-            strategy: '-X theirs',
-          }, cwd);
-        } else if (workerIntegrated) {
-          state.last_integrated_head = workerHead;
-          state.last_leader_head = newLeaderHead;
-          state.status = 'integrated';
-          state.conflict_commit = undefined;
-          state.conflict_files = undefined;
-          state.updated_at = new Date().toISOString();
-          integratedWorkerNames.add(worker.name);
-          await appendIntegrationEvent(teamName, 'worker_merge_applied', worker, {
-            worker_name: worker.name,
-            worker_head: workerHead,
-            leader_head_before: leaderHead,
-            leader_head_after: newLeaderHead,
-            worktree_path: worktreePath,
-            summary: `merged ${worker.name} into leader via --no-ff -X theirs`,
-          }, cwd);
-          await sendIntegrationMessageToLeader(teamName, worker, `INTEGRATED: merged ${worker.name} (${workerHead.slice(0, 12)}) into leader HEAD ${newLeaderHead.slice(0, 12)} via merge --no-ff.`, cwd);
-          commitHygieneEntries.push({
-            recorded_at: new Date().toISOString(),
-            operation: 'integration_merge',
-            worker_name: worker.name,
-            task_id: worker.assigned_tasks[0],
-            status: 'applied',
-            operational_commit: newLeaderHead,
-            source_commit: workerHead,
-            leader_head_before: leaderHead,
-            leader_head_after: newLeaderHead,
-            worktree_path: worktreePath,
-            detail: 'Leader created a runtime merge commit to integrate worker history.',
-          });
-        } else {
-          state.last_leader_head = newLeaderHead;
-          state.status = 'idle';
-          state.updated_at = new Date().toISOString();
-          appendIntegrationReport(teamName, {
-            workerName: worker.name,
-            operation: 'merge',
-            strategy: '-X theirs',
-            files: [],
-            detail: `merge reported success but leader HEAD did not advance cleanly (leader_before=${leaderHead.slice(0, 12)}, leader_after=${newLeaderHead.slice(0, 12)}, worker_integrated=${workerIntegrated}, merge_ref=${branchRef}).`,
-          }, cwd);
-          await sendIntegrationMessageToLeader(teamName, worker, `INTEGRATION NO-OP: merge for ${worker.name} using ${branchRef.slice(0, 12)} reported success but leader HEAD stayed ${newLeaderHead.slice(0, 12)}. Inspect ${worktreePath}.`, cwd);
-          commitHygieneEntries.push({
-            recorded_at: new Date().toISOString(),
-            operation: 'integration_merge',
-            worker_name: worker.name,
-            task_id: worker.assigned_tasks[0],
-            status: 'skipped',
-            operational_commit: newLeaderHead,
-            source_commit: workerHead,
-            leader_head_before: leaderHead,
-            leader_head_after: newLeaderHead,
-            worktree_path: worktreePath,
-            detail: 'Merge command reported success but leader HEAD did not advance or contain the worker commit; runtime refused to report false integration.',
-          });
-        }
-      } else {
-        // Merge failed even with -X theirs (e.g. binary conflict) — abort and log
-        const conflictFiles = listConflictFiles(repoRoot, cwd);
-        runGitCommand(repoRoot, ['merge', '--abort'], cwd);
-        state.status = 'cherry_pick_conflict';
-        state.conflict_commit = workerHead;
-        state.conflict_files = conflictFiles;
-        state.updated_at = new Date().toISOString();
-        await appendIntegrationEvent(teamName, 'worker_merge_conflict', worker, {
-          worker_name: worker.name,
-          worker_head: workerHead,
-          leader_head: leaderHead,
-          worktree_path: worktreePath,
-          conflict_files: conflictFiles,
-          stderr: merge.stderr || merge.stdout,
-          summary: `merge conflict for ${worker.name} (auto-resolve failed)`,
-        }, cwd);
-        appendIntegrationReport(teamName, {
-          workerName: worker.name,
-          operation: 'merge',
-          strategy: '-X theirs',
-          files: conflictFiles,
-          detail: `merge --no-ff -X theirs failed; aborted. stderr: ${(merge.stderr || '').slice(0, 200)}`,
-        }, cwd);
-        await sendIntegrationMessageToLeader(teamName, worker, `CONFLICT AUTO-RESOLVED FAILED: ${worker.name}'s merge resolved with -X theirs failed on files: ${conflictFiles.join(', ') || 'unknown'}. Consider steering ${worker.name} to review these areas.`, cwd);
-      }
-    } else {
-      // Diverged → cherry-pick individual commits with -X theirs
-      const baseline = state.last_integrated_head && runGitCommand(repoRoot, ['rev-parse', '--verify', state.last_integrated_head], worktreePath).ok
-        ? state.last_integrated_head
-        : leaderHead;
-      const commits = listCommitRange(repoRoot, baseline, workerHead, worktreePath);
-      if (commits.length === 0) {
-        next[worker.name] = state;
-        continue;
-      }
+			if (merge.ok) {
+				const newLeaderHead = resolveLeaderHead(repoRoot, cwd) ?? leaderHead;
+				const workerIntegrated = leaderContainsCommit(
+					repoRoot,
+					cwd,
+					workerHead,
+				);
+				if (!leaderHeadAdvanced(leaderHead, newLeaderHead)) {
+					await recordIntegrationFailure(
+						teamName,
+						worker,
+						state,
+						{
+							operation: "merge",
+							sourceCommit: workerHead,
+							leaderHeadBefore: leaderHead,
+							leaderHeadAfter: newLeaderHead,
+							worktreePath,
+							strategy: "-X theirs",
+						},
+						cwd,
+					);
+				} else if (workerIntegrated) {
+					state.last_integrated_head = workerHead;
+					state.last_leader_head = newLeaderHead;
+					state.status = "integrated";
+					state.conflict_commit = undefined;
+					state.conflict_files = undefined;
+					state.updated_at = new Date().toISOString();
+					integratedWorkerNames.add(worker.name);
+					await appendIntegrationEvent(
+						teamName,
+						"worker_merge_applied",
+						worker,
+						{
+							worker_name: worker.name,
+							worker_head: workerHead,
+							leader_head_before: leaderHead,
+							leader_head_after: newLeaderHead,
+							worktree_path: worktreePath,
+							summary: `merged ${worker.name} into leader via --no-ff -X theirs`,
+						},
+						cwd,
+					);
+					await sendIntegrationMessageToLeader(
+						teamName,
+						worker,
+						`INTEGRATED: merged ${worker.name} (${workerHead.slice(0, 12)}) into leader HEAD ${newLeaderHead.slice(0, 12)} via merge --no-ff.`,
+						cwd,
+					);
+					commitHygieneEntries.push({
+						recorded_at: new Date().toISOString(),
+						operation: "integration_merge",
+						worker_name: worker.name,
+						task_id: worker.assigned_tasks[0],
+						status: "applied",
+						operational_commit: newLeaderHead,
+						source_commit: workerHead,
+						leader_head_before: leaderHead,
+						leader_head_after: newLeaderHead,
+						worktree_path: worktreePath,
+						detail:
+							"Leader created a runtime merge commit to integrate worker history.",
+					});
+				} else {
+					state.last_leader_head = newLeaderHead;
+					state.status = "idle";
+					state.updated_at = new Date().toISOString();
+					appendIntegrationReport(
+						teamName,
+						{
+							workerName: worker.name,
+							operation: "merge",
+							strategy: "-X theirs",
+							files: [],
+							detail: `merge reported success but leader HEAD did not advance cleanly (leader_before=${leaderHead.slice(0, 12)}, leader_after=${newLeaderHead.slice(0, 12)}, worker_integrated=${workerIntegrated}, merge_ref=${branchRef}).`,
+						},
+						cwd,
+					);
+					await sendIntegrationMessageToLeader(
+						teamName,
+						worker,
+						`INTEGRATION NO-OP: merge for ${worker.name} using ${branchRef.slice(0, 12)} reported success but leader HEAD stayed ${newLeaderHead.slice(0, 12)}. Inspect ${worktreePath}.`,
+						cwd,
+					);
+					commitHygieneEntries.push({
+						recorded_at: new Date().toISOString(),
+						operation: "integration_merge",
+						worker_name: worker.name,
+						task_id: worker.assigned_tasks[0],
+						status: "skipped",
+						operational_commit: newLeaderHead,
+						source_commit: workerHead,
+						leader_head_before: leaderHead,
+						leader_head_after: newLeaderHead,
+						worktree_path: worktreePath,
+						detail:
+							"Merge command reported success but leader HEAD did not advance or contain the worker commit; runtime refused to report false integration.",
+					});
+				}
+			} else {
+				// Merge failed even with -X theirs (e.g. binary conflict) — abort and log
+				const conflictFiles = listConflictFiles(repoRoot, cwd);
+				runGitCommand(repoRoot, ["merge", "--abort"], cwd);
+				state.status = "cherry_pick_conflict";
+				state.conflict_commit = workerHead;
+				state.conflict_files = conflictFiles;
+				state.updated_at = new Date().toISOString();
+				await appendIntegrationEvent(
+					teamName,
+					"worker_merge_conflict",
+					worker,
+					{
+						worker_name: worker.name,
+						worker_head: workerHead,
+						leader_head: leaderHead,
+						worktree_path: worktreePath,
+						conflict_files: conflictFiles,
+						stderr: merge.stderr || merge.stdout,
+						summary: `merge conflict for ${worker.name} (auto-resolve failed)`,
+					},
+					cwd,
+				);
+				appendIntegrationReport(
+					teamName,
+					{
+						workerName: worker.name,
+						operation: "merge",
+						strategy: "-X theirs",
+						files: conflictFiles,
+						detail: `merge --no-ff -X theirs failed; aborted. stderr: ${(merge.stderr || "").slice(0, 200)}`,
+					},
+					cwd,
+				);
+				await sendIntegrationMessageToLeader(
+					teamName,
+					worker,
+					`CONFLICT AUTO-RESOLVED FAILED: ${worker.name}'s merge resolved with -X theirs failed on files: ${conflictFiles.join(", ") || "unknown"}. Consider steering ${worker.name} to review these areas.`,
+					cwd,
+				);
+			}
+		} else {
+			// Diverged → cherry-pick individual commits with -X theirs
+			const baseline =
+				state.last_integrated_head &&
+				runGitCommand(
+					repoRoot,
+					["rev-parse", "--verify", state.last_integrated_head],
+					worktreePath,
+				).ok
+					? state.last_integrated_head
+					: leaderHead;
+			const commits = listCommitRange(
+				repoRoot,
+				baseline,
+				workerHead,
+				worktreePath,
+			);
+			if (commits.length === 0) {
+				next[worker.name] = state;
+				continue;
+			}
 
-      let allPicked = true;
-      for (const commit of commits) {
-        await appendIntegrationEvent(teamName, 'worker_cherry_pick_detected', worker, {
-          worker_name: worker.name,
-          worker_head: workerHead,
-          commit,
-          leader_head: resolveLeaderHead(repoRoot, cwd),
-          worktree_path: worktreePath,
-          summary: `detected worker commit ${commit.slice(0, 12)}`,
-        }, cwd);
+			let allPicked = true;
+			for (const commit of commits) {
+				await appendIntegrationEvent(
+					teamName,
+					"worker_cherry_pick_detected",
+					worker,
+					{
+						worker_name: worker.name,
+						worker_head: workerHead,
+						commit,
+						leader_head: resolveLeaderHead(repoRoot, cwd),
+						worktree_path: worktreePath,
+						summary: `detected worker commit ${commit.slice(0, 12)}`,
+					},
+					cwd,
+				);
 
-        const pick = runGitCommand(repoRoot, ['cherry-pick', '--allow-empty', '-X', 'theirs', commit], cwd);
-        if (!pick.ok) {
-          // Even -X theirs failed (binary conflict etc.) — abort this commit, log, continue
-          const conflictFiles = listConflictFiles(repoRoot, cwd);
-          runGitCommand(repoRoot, ['cherry-pick', '--abort'], cwd);
-          state.status = 'cherry_pick_conflict';
-          state.conflict_commit = commit;
-          state.conflict_files = conflictFiles;
-          state.updated_at = new Date().toISOString();
-          await appendIntegrationEvent(teamName, 'worker_cherry_pick_conflict', worker, {
-            worker_name: worker.name,
-            commit,
-            leader_head: leaderHead,
-            worktree_path: worktreePath,
-            conflict_files: conflictFiles,
-            stderr: pick.stderr || pick.stdout,
-            summary: `cherry-pick conflict for ${worker.name} at ${commit.slice(0, 12)} (auto-resolve failed)`,
-          }, cwd);
-          appendIntegrationReport(teamName, {
-            workerName: worker.name,
-            operation: 'cherry-pick',
-            strategy: '-X theirs',
-            files: conflictFiles,
-            detail: `cherry-pick -X theirs ${commit.slice(0, 12)} failed; aborted. stderr: ${(pick.stderr || '').slice(0, 200)}`,
-          }, cwd);
-          await sendIntegrationMessageToLeader(teamName, worker, `CONFLICT AUTO-RESOLVED FAILED: ${worker.name}'s cherry-pick ${commit.slice(0, 12)} with -X theirs failed on files: ${conflictFiles.join(', ') || 'unknown'}. Consider steering ${worker.name} to review these areas.`, cwd);
-          allPicked = false;
-          break;
-        }
+				const pick = runGitCommand(
+					repoRoot,
+					["cherry-pick", "--allow-empty", "-X", "theirs", commit],
+					cwd,
+				);
+				if (!pick.ok) {
+					// Even -X theirs failed (binary conflict etc.) — abort this commit, log, continue
+					const conflictFiles = listConflictFiles(repoRoot, cwd);
+					runGitCommand(repoRoot, ["cherry-pick", "--abort"], cwd);
+					state.status = "cherry_pick_conflict";
+					state.conflict_commit = commit;
+					state.conflict_files = conflictFiles;
+					state.updated_at = new Date().toISOString();
+					await appendIntegrationEvent(
+						teamName,
+						"worker_cherry_pick_conflict",
+						worker,
+						{
+							worker_name: worker.name,
+							commit,
+							leader_head: leaderHead,
+							worktree_path: worktreePath,
+							conflict_files: conflictFiles,
+							stderr: pick.stderr || pick.stdout,
+							summary: `cherry-pick conflict for ${worker.name} at ${commit.slice(0, 12)} (auto-resolve failed)`,
+						},
+						cwd,
+					);
+					appendIntegrationReport(
+						teamName,
+						{
+							workerName: worker.name,
+							operation: "cherry-pick",
+							strategy: "-X theirs",
+							files: conflictFiles,
+							detail: `cherry-pick -X theirs ${commit.slice(0, 12)} failed; aborted. stderr: ${(pick.stderr || "").slice(0, 200)}`,
+						},
+						cwd,
+					);
+					await sendIntegrationMessageToLeader(
+						teamName,
+						worker,
+						`CONFLICT AUTO-RESOLVED FAILED: ${worker.name}'s cherry-pick ${commit.slice(0, 12)} with -X theirs failed on files: ${conflictFiles.join(", ") || "unknown"}. Consider steering ${worker.name} to review these areas.`,
+						cwd,
+					);
+					allPicked = false;
+					break;
+				}
 
-        const newLeaderHead = resolveLeaderHead(repoRoot, cwd) ?? leaderHead;
-        if (!leaderHeadAdvanced(leaderHead, newLeaderHead)) {
-          await recordIntegrationFailure(teamName, worker, state, {
-            operation: 'cherry-pick',
-            sourceCommit: commit,
-            leaderHeadBefore: leaderHead,
-            leaderHeadAfter: newLeaderHead,
-            worktreePath,
-            strategy: '-X theirs',
-          }, cwd);
-          allPicked = false;
-          break;
-        }
+				const newLeaderHead = resolveLeaderHead(repoRoot, cwd) ?? leaderHead;
+				if (!leaderHeadAdvanced(leaderHead, newLeaderHead)) {
+					await recordIntegrationFailure(
+						teamName,
+						worker,
+						state,
+						{
+							operation: "cherry-pick",
+							sourceCommit: commit,
+							leaderHeadBefore: leaderHead,
+							leaderHeadAfter: newLeaderHead,
+							worktreePath,
+							strategy: "-X theirs",
+						},
+						cwd,
+					);
+					allPicked = false;
+					break;
+				}
 
-        state.last_integrated_head = commit;
-        state.last_leader_head = newLeaderHead;
-        state.status = 'integrated';
-        state.conflict_commit = undefined;
-        state.conflict_files = undefined;
-        state.updated_at = new Date().toISOString();
-        await appendIntegrationEvent(teamName, 'worker_cherry_pick_applied', worker, {
-          worker_name: worker.name,
-          commit,
-          leader_head_before: leaderHead,
-          leader_head_after: newLeaderHead,
-          worktree_path: worktreePath,
-          summary: `cherry-picked ${commit.slice(0, 12)} from ${worker.name} with -X theirs`,
-        }, cwd);
-        await sendIntegrationMessageToLeader(teamName, worker, `INTEGRATED: cherry-picked ${commit.slice(0, 12)} from ${worker.name} into leader HEAD ${newLeaderHead.slice(0, 12)} (-X theirs).`, cwd);
-        commitHygieneEntries.push({
-          recorded_at: new Date().toISOString(),
-          operation: 'integration_cherry_pick',
-          worker_name: worker.name,
-          task_id: worker.assigned_tasks[0],
-          status: 'applied',
-          operational_commit: newLeaderHead,
-          source_commit: commit,
-          leader_head_before: leaderHead,
-          leader_head_after: newLeaderHead,
-          worktree_path: worktreePath,
-          detail: 'Leader created a runtime cherry-pick commit while integrating diverged worker history.',
-        });
-      }
+				state.last_integrated_head = commit;
+				state.last_leader_head = newLeaderHead;
+				state.status = "integrated";
+				state.conflict_commit = undefined;
+				state.conflict_files = undefined;
+				state.updated_at = new Date().toISOString();
+				await appendIntegrationEvent(
+					teamName,
+					"worker_cherry_pick_applied",
+					worker,
+					{
+						worker_name: worker.name,
+						commit,
+						leader_head_before: leaderHead,
+						leader_head_after: newLeaderHead,
+						worktree_path: worktreePath,
+						summary: `cherry-picked ${commit.slice(0, 12)} from ${worker.name} with -X theirs`,
+					},
+					cwd,
+				);
+				await sendIntegrationMessageToLeader(
+					teamName,
+					worker,
+					`INTEGRATED: cherry-picked ${commit.slice(0, 12)} from ${worker.name} into leader HEAD ${newLeaderHead.slice(0, 12)} (-X theirs).`,
+					cwd,
+				);
+				commitHygieneEntries.push({
+					recorded_at: new Date().toISOString(),
+					operation: "integration_cherry_pick",
+					worker_name: worker.name,
+					task_id: worker.assigned_tasks[0],
+					status: "applied",
+					operational_commit: newLeaderHead,
+					source_commit: commit,
+					leader_head_before: leaderHead,
+					leader_head_after: newLeaderHead,
+					worktree_path: worktreePath,
+					detail:
+						"Leader created a runtime cherry-pick commit while integrating diverged worker history.",
+				});
+			}
 
-      if (allPicked) {
-        integratedWorkerNames.add(worker.name);
-      }
-    }
+			if (allPicked) {
+				integratedWorkerNames.add(worker.name);
+			}
+		}
 
-    next[worker.name] = state;
-  }
+		next[worker.name] = state;
+	}
 
-  // ── Phase C: Cross-worker rebase (idle/done/failed workers onto new leader) ──
-  const newLeaderHead = resolveLeaderHead(resolve(config.workers[0]?.worktree_repo_root ?? cwd), cwd);
-  if (newLeaderHead && leaderHeadAtCycleStart && newLeaderHead !== leaderHeadAtCycleStart) {
-    for (const worker of config.workers) {
-      if (!worker.worktree_repo_root || !worker.worktree_path || !existsSync(worker.worktree_path)) continue;
-      // Note: do NOT skip integratedWorkerNames here — cherry-picked workers need
-      // rebase to pick up other workers' changes that landed on leader in the same cycle.
+	// ── Phase C: Cross-worker rebase (idle/done/failed workers onto new leader) ──
+	const newLeaderHead = resolveLeaderHead(
+		resolve(config.workers[0]?.worktree_repo_root ?? cwd),
+		cwd,
+	);
+	if (
+		newLeaderHead &&
+		leaderHeadAtCycleStart &&
+		newLeaderHead !== leaderHeadAtCycleStart
+	) {
+		for (const worker of config.workers) {
+			if (
+				!worker.worktree_repo_root ||
+				!worker.worktree_path ||
+				!existsSync(worker.worktree_path)
+			)
+				continue;
+			// Note: do NOT skip integratedWorkerNames here — cherry-picked workers need
+			// rebase to pick up other workers' changes that landed on leader in the same cycle.
 
-      const repoRoot = resolve(worker.worktree_repo_root);
-      const worktreePath = resolve(worker.worktree_path);
+			const repoRoot = resolve(worker.worktree_repo_root);
+			const worktreePath = resolve(worker.worktree_path);
 
-      // Only rebase idle/done/failed workers to avoid race conditions
-      const workerStatus = await readWorkerStatus(teamName, worker.name, cwd);
-      const rebaseEligibleStates = new Set(['idle', 'done', 'failed']);
-      if (!rebaseEligibleStates.has(workerStatus.state)) {
-        await appendIntegrationEvent(teamName, 'worker_cross_rebase_skipped', worker, {
-          worker_name: worker.name,
-          worker_state: workerStatus.state,
-          leader_head: newLeaderHead,
-          worktree_path: worktreePath,
-          summary: `skipped cross-rebase for ${worker.name} (state: ${workerStatus.state})`,
-        }, cwd);
-        continue;
-      }
+			// Only rebase idle/done/failed workers to avoid race conditions
+			const workerStatus = await readWorkerStatus(teamName, worker.name, cwd);
+			const rebaseEligibleStates = new Set(["idle", "done", "failed"]);
+			if (!rebaseEligibleStates.has(workerStatus.state)) {
+				await appendIntegrationEvent(
+					teamName,
+					"worker_cross_rebase_skipped",
+					worker,
+					{
+						worker_name: worker.name,
+						worker_state: workerStatus.state,
+						leader_head: newLeaderHead,
+						worktree_path: worktreePath,
+						summary: `skipped cross-rebase for ${worker.name} (state: ${workerStatus.state})`,
+					},
+					cwd,
+				);
+				continue;
+			}
 
-      // Skip if worktree is dirty (will auto-commit next cycle, then rebase)
-      const statusCheck = runGitCommand(repoRoot, ['status', '--porcelain'], worktreePath);
-      if (statusCheck.ok && statusCheck.stdout.trim()) {
-        await appendIntegrationEvent(teamName, 'worker_cross_rebase_skipped', worker, {
-          worker_name: worker.name,
-          reason: 'dirty_worktree',
-          leader_head: newLeaderHead,
-          worktree_path: worktreePath,
-          summary: `skipped cross-rebase for ${worker.name} (dirty worktree)`,
-        }, cwd);
-        continue;
-      }
+			// Skip if worktree is dirty (will auto-commit next cycle, then rebase)
+			const statusCheck = runGitCommand(
+				repoRoot,
+				["status", "--porcelain"],
+				worktreePath,
+			);
+			if (statusCheck.ok && statusCheck.stdout.trim()) {
+				await appendIntegrationEvent(
+					teamName,
+					"worker_cross_rebase_skipped",
+					worker,
+					{
+						worker_name: worker.name,
+						reason: "dirty_worktree",
+						leader_head: newLeaderHead,
+						worktree_path: worktreePath,
+						summary: `skipped cross-rebase for ${worker.name} (dirty worktree)`,
+					},
+					cwd,
+				);
+				continue;
+			}
 
-      // Rebase with -X ours (in rebase context, "ours" = upstream = leader wins)
-      const workerHeadBeforeRebase = resolveWorkerHead(worktreePath);
-      const rebase = runGitCommand(repoRoot, ['rebase', '-X', 'ours', newLeaderHead], worktreePath);
-      if (rebase.ok) {
-        const workerHeadAfterRebase = resolveWorkerHead(worktreePath);
-        const state = next[worker.name] ?? {};
-        state.last_rebased_leader_head = newLeaderHead;
-        state.status = 'idle';
-        state.conflict_commit = undefined;
-        state.conflict_files = undefined;
-        state.updated_at = new Date().toISOString();
-        next[worker.name] = state;
-        await appendIntegrationEvent(teamName, 'worker_cross_rebase_applied', worker, {
-          worker_name: worker.name,
-          leader_head: newLeaderHead,
-          worktree_path: worktreePath,
-          summary: `cross-rebased ${worker.name} onto ${newLeaderHead.slice(0, 12)} (-X ours)`,
-        }, cwd);
-        commitHygieneEntries.push({
-          recorded_at: new Date().toISOString(),
-          operation: 'cross_rebase',
-          worker_name: worker.name,
-          task_id: worker.assigned_tasks[0],
-          status: 'applied',
-          operational_commit: workerHeadAfterRebase,
-          leader_head_after: newLeaderHead,
-          worker_head_before: workerHeadBeforeRebase,
-          worker_head_after: workerHeadAfterRebase,
-          worktree_path: worktreePath,
-          detail: 'Runtime rebase rewrote worker history onto the updated leader head.',
-        });
-      } else {
-        // Rebase failed — abort to restore worktree, log for retry next cycle
-        const conflictFiles = listConflictFiles(repoRoot, worktreePath);
-        runGitCommand(repoRoot, ['rebase', '--abort'], worktreePath);
-        await appendIntegrationEvent(teamName, 'worker_cross_rebase_conflict', worker, {
-          worker_name: worker.name,
-          leader_head: newLeaderHead,
-          worktree_path: worktreePath,
-          conflict_files: conflictFiles,
-          stderr: rebase.stderr || rebase.stdout,
-          summary: `cross-rebase conflict for ${worker.name} onto ${newLeaderHead.slice(0, 12)} (aborted, will retry)`,
-        }, cwd);
-        appendIntegrationReport(teamName, {
-          workerName: worker.name,
-          operation: 'rebase',
-          strategy: '-X ours',
-          files: conflictFiles,
-          detail: `rebase -X ours onto ${newLeaderHead.slice(0, 12)} failed; aborted. Will retry next cycle.`,
-        }, cwd);
-        await sendIntegrationMessageToLeader(teamName, worker, `CONFLICT AUTO-RESOLVED FAILED: ${worker.name}'s rebase onto ${newLeaderHead.slice(0, 12)} with -X ours failed on files: ${conflictFiles.join(', ') || 'unknown'}. Consider steering ${worker.name} to review these areas.`, cwd);
-      }
-    }
-  }
+			// Rebase with -X ours (in rebase context, "ours" = upstream = leader wins)
+			const workerHeadBeforeRebase = resolveWorkerHead(worktreePath);
+			const rebase = runGitCommand(
+				repoRoot,
+				["rebase", "-X", "ours", newLeaderHead],
+				worktreePath,
+			);
+			if (rebase.ok) {
+				const workerHeadAfterRebase = resolveWorkerHead(worktreePath);
+				const state = next[worker.name] ?? {};
+				state.last_rebased_leader_head = newLeaderHead;
+				state.status = "idle";
+				state.conflict_commit = undefined;
+				state.conflict_files = undefined;
+				state.updated_at = new Date().toISOString();
+				next[worker.name] = state;
+				await appendIntegrationEvent(
+					teamName,
+					"worker_cross_rebase_applied",
+					worker,
+					{
+						worker_name: worker.name,
+						leader_head: newLeaderHead,
+						worktree_path: worktreePath,
+						summary: `cross-rebased ${worker.name} onto ${newLeaderHead.slice(0, 12)} (-X ours)`,
+					},
+					cwd,
+				);
+				commitHygieneEntries.push({
+					recorded_at: new Date().toISOString(),
+					operation: "cross_rebase",
+					worker_name: worker.name,
+					task_id: worker.assigned_tasks[0],
+					status: "applied",
+					operational_commit: workerHeadAfterRebase,
+					leader_head_after: newLeaderHead,
+					worker_head_before: workerHeadBeforeRebase,
+					worker_head_after: workerHeadAfterRebase,
+					worktree_path: worktreePath,
+					detail:
+						"Runtime rebase rewrote worker history onto the updated leader head.",
+				});
+			} else {
+				// Rebase failed — abort to restore worktree, log for retry next cycle
+				const conflictFiles = listConflictFiles(repoRoot, worktreePath);
+				runGitCommand(repoRoot, ["rebase", "--abort"], worktreePath);
+				await appendIntegrationEvent(
+					teamName,
+					"worker_cross_rebase_conflict",
+					worker,
+					{
+						worker_name: worker.name,
+						leader_head: newLeaderHead,
+						worktree_path: worktreePath,
+						conflict_files: conflictFiles,
+						stderr: rebase.stderr || rebase.stdout,
+						summary: `cross-rebase conflict for ${worker.name} onto ${newLeaderHead.slice(0, 12)} (aborted, will retry)`,
+					},
+					cwd,
+				);
+				appendIntegrationReport(
+					teamName,
+					{
+						workerName: worker.name,
+						operation: "rebase",
+						strategy: "-X ours",
+						files: conflictFiles,
+						detail: `rebase -X ours onto ${newLeaderHead.slice(0, 12)} failed; aborted. Will retry next cycle.`,
+					},
+					cwd,
+				);
+				await sendIntegrationMessageToLeader(
+					teamName,
+					worker,
+					`CONFLICT AUTO-RESOLVED FAILED: ${worker.name}'s rebase onto ${newLeaderHead.slice(0, 12)} with -X ours failed on files: ${conflictFiles.join(", ") || "unknown"}. Consider steering ${worker.name} to review these areas.`,
+					cwd,
+				);
+			}
+		}
+	}
 
-  if (commitHygieneEntries.length > 0) {
-    await appendTeamCommitHygieneEntries(teamName, commitHygieneEntries, artifactCwd)
-  }
+	if (commitHygieneEntries.length > 0) {
+		await appendTeamCommitHygieneEntries(
+			teamName,
+			commitHygieneEntries,
+			artifactCwd,
+		);
+	}
 
-  return next;
+	return next;
 }
 
 function renderWorktreeMergeReport(report: WorkerShutdownMergeReport): string {
-  const lines = [
-    `# Worker ${report.workerName} shutdown report`,
-    '',
-    `- worktree: ${report.worktreePath}`,
-    `- report_path: ${report.reportPath}`,
-    `- source_ref: ${report.sourceRef ?? 'none'}`,
-    `- synthetic_commit: ${report.syntheticCommit ?? 'none'}`,
-    `- merge_outcome: ${report.mergeOutcome}`,
-    `- merge_detail: ${report.mergeDetail}`,
-    `- leader_head_before: ${report.leaderHeadBefore ?? 'none'}`,
-    `- leader_head_after: ${report.leaderHeadAfter ?? 'none'}`,
-    '',
-    '## Summary',
-    report.summaryText ?? 'sparkshell summary unavailable; using raw diff fallback.',
-    '',
-    '## Diff',
-    report.diffText || '(no diff output)',
-    '',
-  ];
-  return lines.join('\n');
+	const lines = [
+		`# Worker ${report.workerName} shutdown report`,
+		"",
+		`- worktree: ${report.worktreePath}`,
+		`- report_path: ${report.reportPath}`,
+		`- source_ref: ${report.sourceRef ?? "none"}`,
+		`- synthetic_commit: ${report.syntheticCommit ?? "none"}`,
+		`- merge_outcome: ${report.mergeOutcome}`,
+		`- merge_detail: ${report.mergeDetail}`,
+		`- leader_head_before: ${report.leaderHeadBefore ?? "none"}`,
+		`- leader_head_after: ${report.leaderHeadAfter ?? "none"}`,
+		"",
+		"## Summary",
+		report.summaryText ??
+			"sparkshell summary unavailable; using raw diff fallback.",
+		"",
+		"## Diff",
+		report.diffText || "(no diff output)",
+		"",
+	];
+	return lines.join("\n");
 }
 
 async function prepareShutdownMergeReport(
-  worker: WorkerInfo,
-  leaderCwd: string,
+	worker: WorkerInfo,
+	leaderCwd: string,
 ): Promise<WorkerShutdownMergeReport | null> {
-  if (!worker.worktree_repo_root || !worker.worktree_path || !existsSync(worker.worktree_path)) {
-    return null;
-  }
+	if (
+		!worker.worktree_repo_root ||
+		!worker.worktree_path ||
+		!existsSync(worker.worktree_path)
+	) {
+		return null;
+	}
 
-  const worktreePath = resolve(worker.worktree_path);
-  const repoRoot = resolve(worker.worktree_repo_root);
-  const statusBefore = runGitCommand(repoRoot, ['status', '--porcelain'], worktreePath);
-  const hadChanges = statusBefore.ok && statusBefore.stdout.length > 0;
+	const worktreePath = resolve(worker.worktree_path);
+	const repoRoot = resolve(worker.worktree_repo_root);
+	const statusBefore = runGitCommand(
+		repoRoot,
+		["status", "--porcelain"],
+		worktreePath,
+	);
+	const hadChanges = statusBefore.ok && statusBefore.stdout.length > 0;
 
-  let syntheticCommit: string | null = null;
-  if (hadChanges) {
-    const addResult = runGitCommand(repoRoot, ['add', '-A'], worktreePath);
-    if (!addResult.ok) {
-      return {
-        workerName: worker.name,
-        worktreePath,
-        reportPath: join(worktreePath, '.omx', 'diff.md'),
-        sourceRef: null,
-        syntheticCommit: null,
-        diffText: getWorktreeDiffText(worktreePath),
-        summaryText: null,
-        mergeOutcome: 'skipped',
-        mergeDetail: addResult.stderr || 'git add -A failed',
-        leaderHeadBefore: resolveLeaderHead(repoRoot, leaderCwd),
-        leaderHeadAfter: resolveLeaderHead(repoRoot, leaderCwd),
-      };
-    }
-    const commitResult = runGitCommand(
-      repoRoot,
-      ['commit', '--no-verify', '-m', `omx(team): checkpoint ${worker.name} shutdown changes`],
-      worktreePath,
-    );
-    if (commitResult.ok) {
-      const revParse = runGitCommand(repoRoot, ['rev-parse', 'HEAD'], worktreePath);
-      syntheticCommit = revParse.ok && revParse.stdout ? revParse.stdout : null;
-    } else if (!/nothing to commit/i.test(commitResult.stderr)) {
-      return {
-        workerName: worker.name,
-        worktreePath,
-        reportPath: join(worktreePath, '.omx', 'diff.md'),
-        sourceRef: null,
-        syntheticCommit: null,
-        diffText: getWorktreeDiffText(worktreePath),
-        summaryText: null,
-        mergeOutcome: 'skipped',
-        mergeDetail: commitResult.stderr || 'git commit failed',
-        leaderHeadBefore: resolveLeaderHead(repoRoot, leaderCwd),
-        leaderHeadAfter: resolveLeaderHead(repoRoot, leaderCwd),
-      };
-    }
-  }
+	let syntheticCommit: string | null = null;
+	if (hadChanges) {
+		const addResult = runGitCommand(repoRoot, ["add", "-A"], worktreePath);
+		if (!addResult.ok) {
+			return {
+				workerName: worker.name,
+				worktreePath,
+				reportPath: join(worktreePath, ".omx", "diff.md"),
+				sourceRef: null,
+				syntheticCommit: null,
+				diffText: getWorktreeDiffText(worktreePath),
+				summaryText: null,
+				mergeOutcome: "skipped",
+				mergeDetail: addResult.stderr || "git add -A failed",
+				leaderHeadBefore: resolveLeaderHead(repoRoot, leaderCwd),
+				leaderHeadAfter: resolveLeaderHead(repoRoot, leaderCwd),
+			};
+		}
+		const commitResult = runGitCommand(
+			repoRoot,
+			[
+				"commit",
+				"--no-verify",
+				"-m",
+				`omx(team): checkpoint ${worker.name} shutdown changes`,
+			],
+			worktreePath,
+		);
+		if (commitResult.ok) {
+			const revParse = runGitCommand(
+				repoRoot,
+				["rev-parse", "HEAD"],
+				worktreePath,
+			);
+			syntheticCommit = revParse.ok && revParse.stdout ? revParse.stdout : null;
+		} else if (!/nothing to commit/i.test(commitResult.stderr)) {
+			return {
+				workerName: worker.name,
+				worktreePath,
+				reportPath: join(worktreePath, ".omx", "diff.md"),
+				sourceRef: null,
+				syntheticCommit: null,
+				diffText: getWorktreeDiffText(worktreePath),
+				summaryText: null,
+				mergeOutcome: "skipped",
+				mergeDetail: commitResult.stderr || "git commit failed",
+				leaderHeadBefore: resolveLeaderHead(repoRoot, leaderCwd),
+				leaderHeadAfter: resolveLeaderHead(repoRoot, leaderCwd),
+			};
+		}
+	}
 
-  const sourceRefResult = runGitCommand(repoRoot, ['rev-parse', 'HEAD'], worktreePath);
-  const sourceRef = sourceRefResult.ok && sourceRefResult.stdout ? sourceRefResult.stdout : null;
-  const diffText = getWorktreeDiffText(worktreePath);
-  const summaryText = summarizeWorktreeDiffWithSparkShell(worktreePath);
-  const reportPath = join(worktreePath, '.omx', 'diff.md');
-  const leaderHeadBefore = resolveLeaderHead(repoRoot, leaderCwd);
+	const sourceRefResult = runGitCommand(
+		repoRoot,
+		["rev-parse", "HEAD"],
+		worktreePath,
+	);
+	const sourceRef =
+		sourceRefResult.ok && sourceRefResult.stdout
+			? sourceRefResult.stdout
+			: null;
+	const diffText = getWorktreeDiffText(worktreePath);
+	const summaryText = summarizeWorktreeDiffWithSparkShell(worktreePath);
+	const reportPath = join(worktreePath, ".omx", "diff.md");
+	const leaderHeadBefore = resolveLeaderHead(repoRoot, leaderCwd);
 
-  let mergeOutcome: WorkerShutdownMergeReport['mergeOutcome'] = 'skipped';
-  let mergeDetail = 'worktree merge skipped';
-  let leaderHeadAfter = leaderHeadBefore;
-  if (sourceRef) {
-    const alreadyMerged = runGitCommand(repoRoot, ['merge-base', '--is-ancestor', sourceRef, 'HEAD'], leaderCwd);
-    if (alreadyMerged.ok) {
-      mergeOutcome = 'noop';
-      mergeDetail = 'source already reachable from leader HEAD';
-    } else {
-      const mergeResult = runGitCommand(repoRoot, ['merge', '--no-ff', '--no-edit', sourceRef], leaderCwd);
-      if (mergeResult.ok) {
-        mergeOutcome = 'merged';
-        mergeDetail = mergeResult.stdout || 'merged successfully';
-        leaderHeadAfter = resolveLeaderHead(repoRoot, leaderCwd) ?? leaderHeadBefore;
-      } else {
-        mergeOutcome = 'conflict';
-        mergeDetail = mergeResult.stderr || mergeResult.stdout || 'merge failed';
-        runGitCommand(repoRoot, ['merge', '--abort'], leaderCwd);
-        leaderHeadAfter = resolveLeaderHead(repoRoot, leaderCwd) ?? leaderHeadBefore;
-      }
-    }
-  }
+	let mergeOutcome: WorkerShutdownMergeReport["mergeOutcome"] = "skipped";
+	let mergeDetail = "worktree merge skipped";
+	let leaderHeadAfter = leaderHeadBefore;
+	if (sourceRef) {
+		const alreadyMerged = runGitCommand(
+			repoRoot,
+			["merge-base", "--is-ancestor", sourceRef, "HEAD"],
+			leaderCwd,
+		);
+		if (alreadyMerged.ok) {
+			mergeOutcome = "noop";
+			mergeDetail = "source already reachable from leader HEAD";
+		} else {
+			const mergeResult = runGitCommand(
+				repoRoot,
+				["merge", "--no-ff", "--no-edit", sourceRef],
+				leaderCwd,
+			);
+			if (mergeResult.ok) {
+				mergeOutcome = "merged";
+				mergeDetail = mergeResult.stdout || "merged successfully";
+				leaderHeadAfter =
+					resolveLeaderHead(repoRoot, leaderCwd) ?? leaderHeadBefore;
+			} else {
+				mergeOutcome = "conflict";
+				mergeDetail =
+					mergeResult.stderr || mergeResult.stdout || "merge failed";
+				runGitCommand(repoRoot, ["merge", "--abort"], leaderCwd);
+				leaderHeadAfter =
+					resolveLeaderHead(repoRoot, leaderCwd) ?? leaderHeadBefore;
+			}
+		}
+	}
 
-  const report: WorkerShutdownMergeReport = {
-    workerName: worker.name,
-    worktreePath,
-    reportPath,
-    sourceRef,
-    syntheticCommit,
-    diffText,
-    summaryText,
-    mergeOutcome,
-    mergeDetail,
-    leaderHeadBefore,
-    leaderHeadAfter,
-  };
+	const report: WorkerShutdownMergeReport = {
+		workerName: worker.name,
+		worktreePath,
+		reportPath,
+		sourceRef,
+		syntheticCommit,
+		diffText,
+		summaryText,
+		mergeOutcome,
+		mergeDetail,
+		leaderHeadBefore,
+		leaderHeadAfter,
+	};
 
-  await mkdir(join(worktreePath, '.omx'), { recursive: true });
-  await writeFile(reportPath, renderWorktreeMergeReport(report), 'utf-8');
-  process.stdout.write(`${renderWorktreeMergeReport(report)}\n`);
-  return report;
+	await mkdir(join(worktreePath, ".omx"), { recursive: true });
+	await writeFile(reportPath, renderWorktreeMergeReport(report), "utf-8");
+	process.stdout.write(`${renderWorktreeMergeReport(report)}\n`);
+	return report;
 }
 
-async function prepareWorkerWorktreeShutdownReports(config: TeamConfig, leaderCwd: string): Promise<WorkerShutdownMergeReport[]> {
-  const reports: WorkerShutdownMergeReport[] = []
-  for (const worker of config.workers) {
-    if (!worker.worktree_path || !worker.worktree_repo_root) continue;
-    try {
-      const report = await prepareShutdownMergeReport(worker, leaderCwd);
-      if (report) reports.push(report);
-    } catch (error) {
-      const worktreePath = resolve(worker.worktree_path);
-      const reportPath = join(worktreePath, '.omx', 'diff.md');
-      const fallback = [
-        `# Worker ${worker.name} shutdown report`,
-        '',
-        `- worktree: ${worktreePath}`,
-        `- report_path: ${reportPath}`,
-        '- merge_outcome: skipped',
-        `- merge_detail: ${String(error)}`,
-        '',
-      ].join('\n');
-      await mkdir(join(worktreePath, '.omx'), { recursive: true }).catch(() => {});
-      await writeFile(reportPath, fallback, 'utf-8').catch(() => {});
-      process.stdout.write(`${fallback}\n`);
-    }
-  }
-  return reports
+async function prepareWorkerWorktreeShutdownReports(
+	config: TeamConfig,
+	leaderCwd: string,
+): Promise<WorkerShutdownMergeReport[]> {
+	const reports: WorkerShutdownMergeReport[] = [];
+	for (const worker of config.workers) {
+		if (!worker.worktree_path || !worker.worktree_repo_root) continue;
+		try {
+			const report = await prepareShutdownMergeReport(worker, leaderCwd);
+			if (report) reports.push(report);
+		} catch (error) {
+			const worktreePath = resolve(worker.worktree_path);
+			const reportPath = join(worktreePath, ".omx", "diff.md");
+			const fallback = [
+				`# Worker ${worker.name} shutdown report`,
+				"",
+				`- worktree: ${worktreePath}`,
+				`- report_path: ${reportPath}`,
+				"- merge_outcome: skipped",
+				`- merge_detail: ${String(error)}`,
+				"",
+			].join("\n");
+			await mkdir(join(worktreePath, ".omx"), { recursive: true }).catch(
+				() => {},
+			);
+			await writeFile(reportPath, fallback, "utf-8").catch(() => {});
+			process.stdout.write(`${fallback}\n`);
+		}
+	}
+	return reports;
 }
 
 export interface TeamStartOptions {
-  worktreeMode?: WorktreeMode;
+	worktreeMode?: WorktreeMode;
 }
 
 interface ShutdownGateCounts {
-  total: number;
-  pending: number;
-  blocked: number;
-  in_progress: number;
-  completed: number;
-  failed: number;
-  allowed: boolean;
+	total: number;
+	pending: number;
+	blocked: number;
+	in_progress: number;
+	completed: number;
+	failed: number;
+	allowed: boolean;
 }
 
 function resolveEffectiveTeamWorktreeMode(
-  leaderCwd: string,
-  requestedMode: WorktreeMode | undefined,
+	leaderCwd: string,
+	requestedMode: WorktreeMode | undefined,
 ): WorktreeMode {
-  if (!isGitRepository(leaderCwd)) {
-    return { enabled: false };
-  }
+	if (!isGitRepository(leaderCwd)) {
+		return { enabled: false };
+	}
 
-  if (requestedMode?.enabled) return requestedMode;
+	if (requestedMode?.enabled) return requestedMode;
 
-  try {
-    const probe = planWorktreeTarget({
-      cwd: leaderCwd,
-      scope: 'team',
-      mode: { enabled: true, detached: true, name: null },
-      teamName: 'probe',
-      workerName: 'worker-1',
-    });
-    if (probe.enabled) {
-      return { enabled: true, detached: true, name: null };
-    }
-  } catch {
-    // Non-git directories should keep legacy single-workspace behavior.
-  }
+	try {
+		const probe = planWorktreeTarget({
+			cwd: leaderCwd,
+			scope: "team",
+			mode: { enabled: true, detached: true, name: null },
+			teamName: "probe",
+			workerName: "worker-1",
+		});
+		if (probe.enabled) {
+			return { enabled: true, detached: true, name: null };
+		}
+	} catch {
+		// Non-git directories should keep legacy single-workspace behavior.
+	}
 
-  return { enabled: false };
+	return { enabled: false };
 }
 
-const MODEL_INSTRUCTIONS_FILE_ENV = 'OMX_MODEL_INSTRUCTIONS_FILE';
-const TEAM_STATE_ROOT_ENV = 'OMX_TEAM_STATE_ROOT';
-const TEAM_LEADER_CWD_ENV = 'OMX_TEAM_LEADER_CWD';
-const WORKTREE_TRIGGER_STATE_ROOT = '$OMX_TEAM_STATE_ROOT';
+const MODEL_INSTRUCTIONS_FILE_ENV = "OMX_MODEL_INSTRUCTIONS_FILE";
+const TEAM_STATE_ROOT_ENV = "OMX_TEAM_STATE_ROOT";
+const TEAM_LEADER_CWD_ENV = "OMX_TEAM_LEADER_CWD";
+const WORKTREE_TRIGGER_STATE_ROOT = "$OMX_TEAM_STATE_ROOT";
 const STARTUP_EVIDENCE_TIMEOUT_MS = 2_000;
 const STARTUP_EVIDENCE_POLL_MS = 100;
+const STARTUP_EVIDENCE_LAUNCH_TIMEOUT_MS = 5_000;
 
 interface PromptWorkerHandle {
-  child: ChildProcessByStdio<Writable, null, null>;
-  pid: number;
-  processGroupId: number | null;
+	child: ChildProcessByStdio<Writable, null, null>;
+	pid: number;
+	processGroupId: number | null;
 }
 
 const promptWorkerRegistry = new Map<string, Map<string, PromptWorkerHandle>>();
-const previousModelInstructionsFileByTeam = new Map<string, string | undefined>();
+const previousModelInstructionsFileByTeam = new Map<
+	string,
+	string | undefined
+>();
 const PROMPT_WORKER_SIGTERM_WAIT_MS = 3_000;
 const PROMPT_WORKER_SIGKILL_WAIT_MS = 2_000;
 const PROMPT_WORKER_EXIT_POLL_MS = 100;
 
-function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
-  return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
+function resolveInstructionStateRoot(
+	worktreePath?: string | null,
+): string | undefined {
+	return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
 }
 
 function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
-  const raw = env.OMX_TEAM_READY_TIMEOUT_MS;
-  const parsed = Number.parseInt(String(raw ?? ''), 10);
-  if (Number.isFinite(parsed) && parsed >= 5_000) return parsed;
-  return 45_000;
+	const raw = env.OMX_TEAM_READY_TIMEOUT_MS;
+	const parsed = Number.parseInt(String(raw ?? ""), 10);
+	if (Number.isFinite(parsed) && parsed >= 5_000) return parsed;
+	return 45_000;
 }
 
-function parseTeamWorkerContext(raw: string | undefined): { teamName: string; workerName: string } | null {
-  if (typeof raw !== 'string' || raw.trim() === '') return null;
-  const [teamName, workerName] = raw.trim().split('/');
-  if (!teamName || !workerName) return null;
-  return { teamName, workerName };
+function resolveWorkerStartupEvidenceTimeoutMs(
+	env: NodeJS.ProcessEnv,
+	workerReadyTimeoutMs: number,
+): number {
+	const raw = Number.parseInt(
+		String(env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS ?? ""),
+		10,
+	);
+	if (Number.isFinite(raw) && raw >= 500) return raw;
+	return Math.max(
+		STARTUP_EVIDENCE_TIMEOUT_MS,
+		Math.min(workerReadyTimeoutMs, STARTUP_EVIDENCE_LAUNCH_TIMEOUT_MS),
+	);
+}
+
+function parseTeamWorkerContext(
+	raw: string | undefined,
+): { teamName: string; workerName: string } | null {
+	if (typeof raw !== "string" || raw.trim() === "") return null;
+	const [teamName, workerName] = raw.trim().split("/");
+	if (!teamName || !workerName) return null;
+	return { teamName, workerName };
 }
 
 function resolveManifestLookupCwds(cwd: string): string[] {
-  const candidates = new Set<string>([resolve(cwd)]);
-  const leaderCwd = process.env[TEAM_LEADER_CWD_ENV];
-  if (typeof leaderCwd === 'string' && leaderCwd.trim() !== '') {
-    candidates.add(resolve(leaderCwd));
-  }
+	const candidates = new Set<string>([resolve(cwd)]);
+	const leaderCwd = process.env[TEAM_LEADER_CWD_ENV];
+	if (typeof leaderCwd === "string" && leaderCwd.trim() !== "") {
+		candidates.add(resolve(leaderCwd));
+	}
 
-  const teamStateRoot = process.env[TEAM_STATE_ROOT_ENV];
-  if (typeof teamStateRoot === 'string' && teamStateRoot.trim() !== '') {
-    candidates.add(resolve(teamStateRoot, '..', '..'));
-  }
+	const teamStateRoot = process.env[TEAM_STATE_ROOT_ENV];
+	if (typeof teamStateRoot === "string" && teamStateRoot.trim() !== "") {
+		candidates.add(resolve(teamStateRoot, "..", ".."));
+	}
 
-  return [...candidates];
+	return [...candidates];
 }
 
 function resolveGovernancePolicy(
-  governance: TeamGovernance | null | undefined,
-  legacyPolicy?: Partial<TeamGovernance> | null | undefined,
+	governance: TeamGovernance | null | undefined,
+	legacyPolicy?: Partial<TeamGovernance> | null | undefined,
 ): TeamGovernance {
-  return normalizeTeamGovernance(governance, legacyPolicy);
+	return normalizeTeamGovernance(governance, legacyPolicy);
 }
 
 async function assertNestedTeamAllowed(cwd: string): Promise<void> {
-  const workerContext = parseTeamWorkerContext(process.env.OMX_TEAM_WORKER);
-  if (!workerContext) return;
+	const workerContext = parseTeamWorkerContext(process.env.OMX_TEAM_WORKER);
+	if (!workerContext) return;
 
-  for (const candidateCwd of resolveManifestLookupCwds(cwd)) {
-    const manifest = await readTeamManifestV2(workerContext.teamName, candidateCwd);
-    const governance = resolveGovernancePolicy(manifest?.governance);
-    if (governance.nested_teams_allowed) return;
-    if (manifest) break;
-  }
+	for (const candidateCwd of resolveManifestLookupCwds(cwd)) {
+		const manifest = await readTeamManifestV2(
+			workerContext.teamName,
+			candidateCwd,
+		);
+		const governance = resolveGovernancePolicy(manifest?.governance);
+		if (governance.nested_teams_allowed) return;
+		if (manifest) break;
+	}
 
-  throw new Error('nested_team_disallowed');
+	throw new Error("nested_team_disallowed");
 }
 
-type WorkerStartupEvidence = 'task_claim' | 'worker_progress' | 'leader_ack' | 'none';
+type WorkerStartupEvidence =
+	| "task_claim"
+	| "worker_progress"
+	| "leader_ack"
+	| "none";
 
 async function readWorkerStartupEvidence(
-  teamName: string,
-  workerName: string,
-  cwd: string,
+	teamName: string,
+	workerName: string,
+	cwd: string,
 ): Promise<WorkerStartupEvidence> {
-  const status = await readWorkerStatus(teamName, workerName, cwd);
-  if (typeof status.current_task_id === 'string' && status.current_task_id.trim() !== '') {
-    return 'task_claim';
-  }
-  if (status.state === 'working' || status.state === 'blocked' || status.state === 'done' || status.state === 'failed') {
-    return 'worker_progress';
-  }
-  const leaderMailbox = await listMailboxMessages(teamName, 'leader-fixed', cwd).catch(() => []);
-  if (leaderMailbox.some((message) => message?.from_worker === workerName)) {
-    return 'leader_ack';
-  }
-  return 'none';
+	const status = await readWorkerStatus(teamName, workerName, cwd);
+	if (
+		typeof status.current_task_id === "string" &&
+		status.current_task_id.trim() !== ""
+	) {
+		return "task_claim";
+	}
+	if (
+		status.state === "working" ||
+		status.state === "blocked" ||
+		status.state === "done" ||
+		status.state === "failed"
+	) {
+		return "worker_progress";
+	}
+	const leaderMailbox = await listMailboxMessages(
+		teamName,
+		"leader-fixed",
+		cwd,
+	).catch(() => []);
+	if (leaderMailbox.some((message) => message?.from_worker === workerName)) {
+		return "leader_ack";
+	}
+	return "none";
 }
 
 function doesStartupEvidenceSettle(
-  workerCli: TeamWorkerCli,
-  evidence: WorkerStartupEvidence,
+	workerCli: TeamWorkerCli,
+	evidence: WorkerStartupEvidence,
 ): boolean {
-  if (evidence === 'none') return false;
-  if (workerCli === 'codex' && evidence === 'leader_ack') return false;
-  return true;
+	if (evidence === "none") return false;
+	if (workerCli === "codex" && evidence === "leader_ack") return false;
+	return true;
 }
 
 export async function waitForWorkerStartupEvidence(params: {
-  teamName: string;
-  workerName: string;
-  workerCli: TeamWorkerCli;
-  cwd: string;
-  timeoutMs?: number;
-  pollMs?: number;
+	teamName: string;
+	workerName: string;
+	workerCli: TeamWorkerCli;
+	cwd: string;
+	timeoutMs?: number;
+	pollMs?: number;
 }): Promise<WorkerStartupEvidence> {
-  const timeoutMs = Math.max(0, Math.floor(params.timeoutMs ?? STARTUP_EVIDENCE_TIMEOUT_MS));
-  const pollMs = Math.max(25, Math.floor(params.pollMs ?? STARTUP_EVIDENCE_POLL_MS));
-  const deadline = Date.now() + timeoutMs;
+	const timeoutMs = Math.max(
+		0,
+		Math.floor(params.timeoutMs ?? STARTUP_EVIDENCE_TIMEOUT_MS),
+	);
+	const pollMs = Math.max(
+		25,
+		Math.floor(params.pollMs ?? STARTUP_EVIDENCE_POLL_MS),
+	);
+	const deadline = Date.now() + timeoutMs;
 
-  while (true) {
-    const evidence = await readWorkerStartupEvidence(params.teamName, params.workerName, params.cwd);
-    if (doesStartupEvidenceSettle(params.workerCli, evidence)) return evidence;
-    if (Date.now() >= deadline) return 'none';
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
+	while (true) {
+		const evidence = await readWorkerStartupEvidence(
+			params.teamName,
+			params.workerName,
+			params.cwd,
+		);
+		if (doesStartupEvidenceSettle(params.workerCli, evidence)) return evidence;
+		if (Date.now() >= deadline) return "none";
+		await new Promise((resolve) => setTimeout(resolve, pollMs));
+	}
 }
 
 export async function waitForClaudeStartupEvidence(params: {
-  teamName: string;
-  workerName: string;
-  cwd: string;
-  timeoutMs?: number;
-  pollMs?: number;
+	teamName: string;
+	workerName: string;
+	cwd: string;
+	timeoutMs?: number;
+	pollMs?: number;
 }): Promise<WorkerStartupEvidence> {
-  return await waitForWorkerStartupEvidence({ ...params, workerCli: 'claude' });
+	return await waitForWorkerStartupEvidence({ ...params, workerCli: "claude" });
 }
 
 function shouldSkipWorkerReadyWait(env: NodeJS.ProcessEnv): boolean {
-  return env.OMX_TEAM_SKIP_READY_WAIT === '1';
+	return env.OMX_TEAM_SKIP_READY_WAIT === "1";
 }
 
-function setTeamModelInstructionsFile(teamName: string, filePath: string): void {
-  if (!previousModelInstructionsFileByTeam.has(teamName)) {
-    previousModelInstructionsFileByTeam.set(teamName, process.env[MODEL_INSTRUCTIONS_FILE_ENV]);
-  }
-  process.env[MODEL_INSTRUCTIONS_FILE_ENV] = filePath;
+function setTeamModelInstructionsFile(
+	teamName: string,
+	filePath: string,
+): void {
+	if (!previousModelInstructionsFileByTeam.has(teamName)) {
+		previousModelInstructionsFileByTeam.set(
+			teamName,
+			process.env[MODEL_INSTRUCTIONS_FILE_ENV],
+		);
+	}
+	process.env[MODEL_INSTRUCTIONS_FILE_ENV] = filePath;
 }
 
 function restoreTeamModelInstructionsFile(teamName: string): void {
-  if (!previousModelInstructionsFileByTeam.has(teamName)) return;
+	if (!previousModelInstructionsFileByTeam.has(teamName)) return;
 
-  const previous = previousModelInstructionsFileByTeam.get(teamName);
-  previousModelInstructionsFileByTeam.delete(teamName);
+	const previous = previousModelInstructionsFileByTeam.get(teamName);
+	previousModelInstructionsFileByTeam.delete(teamName);
 
-  if (typeof previous === 'string') {
-    process.env[MODEL_INSTRUCTIONS_FILE_ENV] = previous;
-    return;
-  }
-  delete process.env[MODEL_INSTRUCTIONS_FILE_ENV];
+	if (typeof previous === "string") {
+		process.env[MODEL_INSTRUCTIONS_FILE_ENV] = previous;
+		return;
+	}
+	delete process.env[MODEL_INSTRUCTIONS_FILE_ENV];
 }
 
 function registerPromptWorkerHandle(
-  teamName: string,
-  workerName: string,
-  child: ChildProcessByStdio<Writable, null, null>,
+	teamName: string,
+	workerName: string,
+	child: ChildProcessByStdio<Writable, null, null>,
 ): void {
-  const { pid } = child;
-  if (!Number.isFinite(pid) || (pid ?? 0) < 1) {
-    throw new Error(`failed to spawn prompt worker process for ${workerName}`);
-  }
-  const processPid = pid as number;
-  const existingTeamHandles = promptWorkerRegistry.get(teamName) ?? new Map<string, PromptWorkerHandle>();
-  existingTeamHandles.set(workerName, {
-    child,
-    pid: processPid,
-    processGroupId: process.platform !== 'win32' ? processPid : null,
-  });
-  promptWorkerRegistry.set(teamName, existingTeamHandles);
+	const { pid } = child;
+	if (!Number.isFinite(pid) || (pid ?? 0) < 1) {
+		throw new Error(`failed to spawn prompt worker process for ${workerName}`);
+	}
+	const processPid = pid as number;
+	const existingTeamHandles =
+		promptWorkerRegistry.get(teamName) ?? new Map<string, PromptWorkerHandle>();
+	existingTeamHandles.set(workerName, {
+		child,
+		pid: processPid,
+		processGroupId: process.platform !== "win32" ? processPid : null,
+	});
+	promptWorkerRegistry.set(teamName, existingTeamHandles);
 
-  child.on('exit', () => {
-    const teamHandles = promptWorkerRegistry.get(teamName);
-    if (!teamHandles) return;
-    const handle = teamHandles.get(workerName);
-    if (handle?.processGroupId && isProcessGroupAlive(handle.processGroupId)) {
-      return;
-    }
-    teamHandles.delete(workerName);
-    if (teamHandles.size === 0) promptWorkerRegistry.delete(teamName);
-  });
+	child.on("exit", () => {
+		const teamHandles = promptWorkerRegistry.get(teamName);
+		if (!teamHandles) return;
+		const handle = teamHandles.get(workerName);
+		if (handle?.processGroupId && isProcessGroupAlive(handle.processGroupId)) {
+			return;
+		}
+		teamHandles.delete(workerName);
+		if (teamHandles.size === 0) promptWorkerRegistry.delete(teamName);
+	});
 }
 
-function getPromptWorkerHandle(teamName: string, workerName: string): PromptWorkerHandle | null {
-  return promptWorkerRegistry.get(teamName)?.get(workerName) ?? null;
+function getPromptWorkerHandle(
+	teamName: string,
+	workerName: string,
+): PromptWorkerHandle | null {
+	return promptWorkerRegistry.get(teamName)?.get(workerName) ?? null;
 }
 
 function removePromptWorkerHandle(teamName: string, workerName: string): void {
-  const teamHandles = promptWorkerRegistry.get(teamName);
-  if (!teamHandles) return;
-  teamHandles.delete(workerName);
-  if (teamHandles.size === 0) promptWorkerRegistry.delete(teamName);
+	const teamHandles = promptWorkerRegistry.get(teamName);
+	if (!teamHandles) return;
+	teamHandles.delete(workerName);
+	if (teamHandles.size === 0) promptWorkerRegistry.delete(teamName);
 }
 
 function isPidAlive(pid: number): boolean {
-  if (!Number.isFinite(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    return false;
-  }
+	if (!Number.isFinite(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ESRCH") return false;
+		process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+		return false;
+	}
 }
 
 function isProcessGroupAlive(processGroupId: number): boolean {
-  if (process.platform === 'win32') return false;
-  if (!Number.isFinite(processGroupId) || processGroupId <= 0) return false;
-  try {
-    process.kill(-processGroupId, 0);
-    return true;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false;
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    return false;
-  }
+	if (process.platform === "win32") return false;
+	if (!Number.isFinite(processGroupId) || processGroupId <= 0) return false;
+	try {
+		process.kill(-processGroupId, 0);
+		return true;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ESRCH") return false;
+		process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+		return false;
+	}
 }
 
 interface PromptWorkerTeardownResult {
-  terminated: boolean;
-  forcedKill: boolean;
-  pid: number | null;
-  error?: string;
+	terminated: boolean;
+	forcedKill: boolean;
+	pid: number | null;
+	error?: string;
 }
 
 interface ProcessTreeEntry {
-  pid: number;
-  ppid: number;
+	pid: number;
+	ppid: number;
 }
 
 function listProcessTreeEntries(): ProcessTreeEntry[] {
-  if (process.platform === 'win32') return [];
-  const result = spawnSync('ps', ['axww', '-o', 'pid=,ppid='], {
-    encoding: 'utf-8',
-    windowsHide: true,
-  });
-  if (result.status !== 0 || typeof result.stdout !== 'string') return [];
+	if (process.platform === "win32") return [];
+	const result = spawnSync("ps", ["axww", "-o", "pid=,ppid="], {
+		encoding: "utf-8",
+		windowsHide: true,
+	});
+	if (result.status !== 0 || typeof result.stdout !== "string") return [];
 
-  return result.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const match = line.match(/^(\d+)\s+(\d+)$/);
-      if (!match) return null;
-      const pid = Number.parseInt(match[1], 10);
-      const ppid = Number.parseInt(match[2], 10);
-      if (!Number.isFinite(pid) || pid <= 0) return null;
-      if (!Number.isFinite(ppid) || ppid < 0) return null;
-      return { pid, ppid } satisfies ProcessTreeEntry;
-    })
-    .filter((entry): entry is ProcessTreeEntry => entry !== null);
+	return result.stdout
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line) => {
+			const match = line.match(/^(\d+)\s+(\d+)$/);
+			if (!match) return null;
+			const pid = Number.parseInt(match[1], 10);
+			const ppid = Number.parseInt(match[2], 10);
+			if (!Number.isFinite(pid) || pid <= 0) return null;
+			if (!Number.isFinite(ppid) || ppid < 0) return null;
+			return { pid, ppid } satisfies ProcessTreeEntry;
+		})
+		.filter((entry): entry is ProcessTreeEntry => entry !== null);
 }
 
 function collectProcessTreePids(rootPid: number): number[] {
-  if (!Number.isFinite(rootPid) || rootPid <= 0) return [];
+	if (!Number.isFinite(rootPid) || rootPid <= 0) return [];
 
-  const childrenByPid = new Map<number, number[]>();
-  for (const entry of listProcessTreeEntries()) {
-    const siblings = childrenByPid.get(entry.ppid) ?? [];
-    siblings.push(entry.pid);
-    childrenByPid.set(entry.ppid, siblings);
-  }
+	const childrenByPid = new Map<number, number[]>();
+	for (const entry of listProcessTreeEntries()) {
+		const siblings = childrenByPid.get(entry.ppid) ?? [];
+		siblings.push(entry.pid);
+		childrenByPid.set(entry.ppid, siblings);
+	}
 
-  const ordered: number[] = [];
-  const stack = [rootPid];
-  const seen = new Set<number>();
-  while (stack.length > 0) {
-    const pid = stack.pop()!;
-    if (seen.has(pid)) continue;
-    seen.add(pid);
-    ordered.push(pid);
-    for (const childPid of childrenByPid.get(pid) ?? []) {
-      if (!seen.has(childPid)) stack.push(childPid);
-    }
-  }
+	const ordered: number[] = [];
+	const stack = [rootPid];
+	const seen = new Set<number>();
+	while (stack.length > 0) {
+		const pid = stack.pop()!;
+		if (seen.has(pid)) continue;
+		seen.add(pid);
+		ordered.push(pid);
+		for (const childPid of childrenByPid.get(pid) ?? []) {
+			if (!seen.has(childPid)) stack.push(childPid);
+		}
+	}
 
-  return ordered.reverse();
+	return ordered.reverse();
 }
 
-async function waitForTrackedPidsExit(pids: readonly number[], timeoutMs: number): Promise<boolean> {
-  const tracked = [...new Set(pids.filter((pid) => Number.isFinite(pid) && pid > 0))];
-  if (tracked.length === 0) return true;
+async function waitForTrackedPidsExit(
+	pids: readonly number[],
+	timeoutMs: number,
+): Promise<boolean> {
+	const tracked = [
+		...new Set(pids.filter((pid) => Number.isFinite(pid) && pid > 0)),
+	];
+	if (tracked.length === 0) return true;
 
-  const deadline = Date.now() + Math.max(0, timeoutMs);
-  while (Date.now() < deadline) {
-    if (tracked.every((pid) => !isPidAlive(pid))) return true;
-    await new Promise((resolve) => setTimeout(resolve, PROMPT_WORKER_EXIT_POLL_MS));
-  }
+	const deadline = Date.now() + Math.max(0, timeoutMs);
+	while (Date.now() < deadline) {
+		if (tracked.every((pid) => !isPidAlive(pid))) return true;
+		await new Promise((resolve) =>
+			setTimeout(resolve, PROMPT_WORKER_EXIT_POLL_MS),
+		);
+	}
 
-  return tracked.every((pid) => !isPidAlive(pid));
+	return tracked.every((pid) => !isPidAlive(pid));
 }
 
 async function terminateTrackedProcessTree(
-  rootPid: number,
-  processGroupId: number | null = null,
-  graceMs: number = PROMPT_WORKER_SIGTERM_WAIT_MS,
-  killWaitMs: number = PROMPT_WORKER_SIGKILL_WAIT_MS,
-): Promise<{ terminated: boolean; forcedKill: boolean; trackedPids: number[] }> {
-  if (processGroupId && process.platform !== 'win32') {
-    const trackedPids = collectProcessTreePids(rootPid);
-    try {
-      process.kill(-processGroupId, 'SIGTERM');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
-        process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-      }
-    }
-    for (const pid of trackedPids) {
-      if (pid === rootPid) continue;
-      try {
-        process.kill(pid, 'SIGTERM');
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
-          process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-        }
-      }
-    }
+	rootPid: number,
+	processGroupId: number | null = null,
+	graceMs: number = PROMPT_WORKER_SIGTERM_WAIT_MS,
+	killWaitMs: number = PROMPT_WORKER_SIGKILL_WAIT_MS,
+): Promise<{
+	terminated: boolean;
+	forcedKill: boolean;
+	trackedPids: number[];
+}> {
+	if (processGroupId && process.platform !== "win32") {
+		const trackedPids = collectProcessTreePids(rootPid);
+		try {
+			process.kill(-processGroupId, "SIGTERM");
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+				process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+			}
+		}
+		for (const pid of trackedPids) {
+			if (pid === rootPid) continue;
+			try {
+				process.kill(pid, "SIGTERM");
+			} catch (err) {
+				if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+					process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+				}
+			}
+		}
 
-    const groupDeadline = Date.now() + Math.max(0, graceMs);
-    while (Date.now() < groupDeadline) {
-      const groupAlive = isProcessGroupAlive(processGroupId);
-      const descendantsAlive = trackedPids.some((pid) => isPidAlive(pid));
-      if (!groupAlive && !descendantsAlive) {
-        return { terminated: true, forcedKill: false, trackedPids };
-      }
-      await new Promise((resolve) => setTimeout(resolve, PROMPT_WORKER_EXIT_POLL_MS));
-    }
+		const groupDeadline = Date.now() + Math.max(0, graceMs);
+		while (Date.now() < groupDeadline) {
+			const groupAlive = isProcessGroupAlive(processGroupId);
+			const descendantsAlive = trackedPids.some((pid) => isPidAlive(pid));
+			if (!groupAlive && !descendantsAlive) {
+				return { terminated: true, forcedKill: false, trackedPids };
+			}
+			await new Promise((resolve) =>
+				setTimeout(resolve, PROMPT_WORKER_EXIT_POLL_MS),
+			);
+		}
 
-    try {
-      process.kill(-processGroupId, 'SIGKILL');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
-        process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-      }
-    }
-    for (const pid of trackedPids) {
-      if (!isPidAlive(pid)) continue;
-      try {
-        process.kill(pid, 'SIGKILL');
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
-          process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-        }
-      }
-    }
+		try {
+			process.kill(-processGroupId, "SIGKILL");
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+				process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+			}
+		}
+		for (const pid of trackedPids) {
+			if (!isPidAlive(pid)) continue;
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch (err) {
+				if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+					process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+				}
+			}
+		}
 
-    const killDeadline = Date.now() + Math.max(0, killWaitMs);
-    while (Date.now() < killDeadline) {
-      const groupAlive = isProcessGroupAlive(processGroupId);
-      const descendantsAlive = trackedPids.some((pid) => isPidAlive(pid));
-      if (!groupAlive && !descendantsAlive) {
-        return { terminated: true, forcedKill: true, trackedPids };
-      }
-      await new Promise((resolve) => setTimeout(resolve, PROMPT_WORKER_EXIT_POLL_MS));
-    }
+		const killDeadline = Date.now() + Math.max(0, killWaitMs);
+		while (Date.now() < killDeadline) {
+			const groupAlive = isProcessGroupAlive(processGroupId);
+			const descendantsAlive = trackedPids.some((pid) => isPidAlive(pid));
+			if (!groupAlive && !descendantsAlive) {
+				return { terminated: true, forcedKill: true, trackedPids };
+			}
+			await new Promise((resolve) =>
+				setTimeout(resolve, PROMPT_WORKER_EXIT_POLL_MS),
+			);
+		}
 
-    return {
-      terminated: !isProcessGroupAlive(processGroupId) && trackedPids.every((pid) => !isPidAlive(pid)),
-      forcedKill: true,
-      trackedPids,
-    };
-  }
+		return {
+			terminated:
+				!isProcessGroupAlive(processGroupId) &&
+				trackedPids.every((pid) => !isPidAlive(pid)),
+			forcedKill: true,
+			trackedPids,
+		};
+	}
 
-  const trackedPids = collectProcessTreePids(rootPid);
-  if (trackedPids.length === 0) {
-    return {
-      terminated: !isPidAlive(rootPid),
-      forcedKill: false,
-      trackedPids: [],
-    };
-  }
+	const trackedPids = collectProcessTreePids(rootPid);
+	if (trackedPids.length === 0) {
+		return {
+			terminated: !isPidAlive(rootPid),
+			forcedKill: false,
+			trackedPids: [],
+		};
+	}
 
-  for (const pid of trackedPids) {
-    try {
-      process.kill(pid, 'SIGTERM');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
-        process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-      }
-    }
-  }
+	for (const pid of trackedPids) {
+		try {
+			process.kill(pid, "SIGTERM");
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+				process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+			}
+		}
+	}
 
-  if (await waitForTrackedPidsExit(trackedPids, graceMs)) {
-    return { terminated: true, forcedKill: false, trackedPids };
-  }
+	if (await waitForTrackedPidsExit(trackedPids, graceMs)) {
+		return { terminated: true, forcedKill: false, trackedPids };
+	}
 
-  for (const pid of trackedPids) {
-    if (!isPidAlive(pid)) continue;
-    try {
-      process.kill(pid, 'SIGKILL');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ESRCH') {
-        process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-      }
-    }
-  }
+	for (const pid of trackedPids) {
+		if (!isPidAlive(pid)) continue;
+		try {
+			process.kill(pid, "SIGKILL");
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ESRCH") {
+				process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+			}
+		}
+	}
 
-  return {
-    terminated: await waitForTrackedPidsExit(trackedPids, killWaitMs),
-    forcedKill: true,
-    trackedPids,
-  };
+	return {
+		terminated: await waitForTrackedPidsExit(trackedPids, killWaitMs),
+		forcedKill: true,
+		trackedPids,
+	};
 }
 
 async function teardownPromptWorker(
-  teamName: string,
-  workerName: string,
-  fallbackPid: number | undefined,
-  cwd: string,
-  context: 'startup_rollback' | 'shutdown',
+	teamName: string,
+	workerName: string,
+	fallbackPid: number | undefined,
+	cwd: string,
+	context: "startup_rollback" | "shutdown",
 ): Promise<PromptWorkerTeardownResult> {
-  const handle = getPromptWorkerHandle(teamName, workerName);
-  const handlePid = handle?.pid;
-  const processGroupId = handle?.processGroupId ?? null;
-  const pid = (typeof handlePid === 'number' && Number.isFinite(handlePid))
-    ? handlePid
-    : (Number.isFinite(fallbackPid) && (fallbackPid ?? 0) > 0 ? (fallbackPid as number) : null);
+	const handle = getPromptWorkerHandle(teamName, workerName);
+	const handlePid = handle?.pid;
+	const processGroupId = handle?.processGroupId ?? null;
+	const pid =
+		typeof handlePid === "number" && Number.isFinite(handlePid)
+			? handlePid
+			: Number.isFinite(fallbackPid) && (fallbackPid ?? 0) > 0
+				? (fallbackPid as number)
+				: null;
 
-  if (pid === null && processGroupId === null) {
-    removePromptWorkerHandle(teamName, workerName);
-    return { terminated: true, forcedKill: false, pid: null };
-  }
+	if (pid === null && processGroupId === null) {
+		removePromptWorkerHandle(teamName, workerName);
+		return { terminated: true, forcedKill: false, pid: null };
+	}
 
-  const teardown = await terminateTrackedProcessTree(pid ?? 0, processGroupId);
-  const processGone = processGroupId ? !isProcessGroupAlive(processGroupId) : !isPidAlive(pid!);
-  if (teardown.terminated && processGone) {
-    removePromptWorkerHandle(teamName, workerName);
-    return { terminated: true, forcedKill: teardown.forcedKill, pid };
-  }
+	const teardown = await terminateTrackedProcessTree(pid ?? 0, processGroupId);
+	const processGone = processGroupId
+		? !isProcessGroupAlive(processGroupId)
+		: !isPidAlive(pid!);
+	if (teardown.terminated && processGone) {
+		removePromptWorkerHandle(teamName, workerName);
+		return { terminated: true, forcedKill: teardown.forcedKill, pid };
+	}
 
-  await appendTeamEvent(
-    teamName,
-    {
-      type: 'worker_stopped',
-      worker: workerName,
-      reason: `prompt_force_kill:${context}:pid=${pid}`,
-    },
-    cwd,
-  ).catch(() => {});
-  if (!teardown.terminated) {
-    await appendTeamEvent(
-      teamName,
-      {
-        type: 'worker_stopped',
-        worker: workerName,
-        reason: `prompt_teardown_failed:${context}:pid=${pid}`,
-      },
-      cwd,
-    ).catch(() => {});
-    return {
-      terminated: false,
-      forcedKill: teardown.forcedKill,
-      pid,
-      error: 'still_alive_after_sigkill',
-    };
-  }
+	await appendTeamEvent(
+		teamName,
+		{
+			type: "worker_stopped",
+			worker: workerName,
+			reason: `prompt_force_kill:${context}:pid=${pid}`,
+		},
+		cwd,
+	).catch(() => {});
+	if (!teardown.terminated) {
+		await appendTeamEvent(
+			teamName,
+			{
+				type: "worker_stopped",
+				worker: workerName,
+				reason: `prompt_teardown_failed:${context}:pid=${pid}`,
+			},
+			cwd,
+		).catch(() => {});
+		return {
+			terminated: false,
+			forcedKill: teardown.forcedKill,
+			pid,
+			error: "still_alive_after_sigkill",
+		};
+	}
 
-  removePromptWorkerHandle(teamName, workerName);
-  return { terminated: true, forcedKill: teardown.forcedKill, pid };
+	removePromptWorkerHandle(teamName, workerName);
+	return { terminated: true, forcedKill: teardown.forcedKill, pid };
 }
 
 function isPromptWorkerAlive(config: TeamConfig, worker: WorkerInfo): boolean {
-  const handle = getPromptWorkerHandle(config.name, worker.name);
-  if (handle?.child.exitCode === null && !handle.child.killed) return true;
-  if (handle?.processGroupId && isProcessGroupAlive(handle.processGroupId)) return true;
-  if (process.platform !== 'win32' && isProcessGroupAlive(worker.pid as number)) return true;
-  return isPidAlive(worker.pid as number);
+	const handle = getPromptWorkerHandle(config.name, worker.name);
+	if (handle?.child.exitCode === null && !handle.child.killed) return true;
+	if (handle?.processGroupId && isProcessGroupAlive(handle.processGroupId))
+		return true;
+	if (process.platform !== "win32" && isProcessGroupAlive(worker.pid as number))
+		return true;
+	return isPidAlive(worker.pid as number);
 }
 
-export { TEAM_LOW_COMPLEXITY_DEFAULT_MODEL };
-
-export { resolveCanonicalTeamStateRoot };
+export { resolveCanonicalTeamStateRoot, TEAM_LOW_COMPLEXITY_DEFAULT_MODEL };
 
 function spawnPromptWorker(
-  teamName: string,
-  workerName: string,
-  workerIndex: number,
-  workerCwd: string,
-  launchArgs: string[],
-  workerEnv: Record<string, string>,
-  workerCli: 'codex' | 'claude' | 'gemini',
-  initialPrompt?: string,
+	teamName: string,
+	workerName: string,
+	workerIndex: number,
+	workerCwd: string,
+	launchArgs: string[],
+	workerEnv: Record<string, string>,
+	workerCli: "codex" | "claude" | "gemini",
+	initialPrompt?: string,
 ): ChildProcessByStdio<Writable, null, null> {
-  const processSpec = buildWorkerProcessLaunchSpec(
-    teamName,
-    workerIndex,
-    launchArgs,
-    workerCwd,
-    workerEnv,
-    workerCli,
-    initialPrompt,
-  );
-  const child = spawn(
-    processSpec.command,
-    processSpec.args,
-    {
-      cwd: workerCwd,
-      detached: process.platform !== 'win32',
-      env: { ...process.env, ...processSpec.env },
-      stdio: ['pipe', 'ignore', 'ignore'],
-    },
-  );
-  registerPromptWorkerHandle(teamName, workerName, child);
-  return child;
+	const processSpec = buildWorkerProcessLaunchSpec(
+		teamName,
+		workerIndex,
+		launchArgs,
+		workerCwd,
+		workerEnv,
+		workerCli,
+		initialPrompt,
+	);
+	const child = spawn(processSpec.command, processSpec.args, {
+		cwd: workerCwd,
+		detached: process.platform !== "win32",
+		env: { ...process.env, ...processSpec.env },
+		stdio: ["pipe", "ignore", "ignore"],
+	});
+	registerPromptWorkerHandle(teamName, workerName, child);
+	return child;
 }
 
 export function resolveWorkerLaunchArgsFromEnv(
-  env: NodeJS.ProcessEnv,
-  agentType: string,
-  inheritedLeaderModel?: string,
-  preferredReasoning?: TeamReasoningEffort,
-  workerCliOverride?: TeamWorkerCli,
+	env: NodeJS.ProcessEnv,
+	agentType: string,
+	inheritedLeaderModel?: string,
+	preferredReasoning?: TeamReasoningEffort,
+	workerCliOverride?: TeamWorkerCli,
 ): string[] {
-  const inheritedArgs = (typeof inheritedLeaderModel === 'string' && inheritedLeaderModel.trim() !== '')
-    ? ['--model', inheritedLeaderModel.trim()]
-    : [];
-  const fallbackModel = resolveAgentDefaultModel(agentType, env.CODEX_HOME);
+	const inheritedArgs =
+		typeof inheritedLeaderModel === "string" &&
+		inheritedLeaderModel.trim() !== ""
+			? ["--model", inheritedLeaderModel.trim()]
+			: [];
+	const fallbackModel = resolveAgentDefaultModel(agentType, env.CODEX_HOME);
 
-  // Detect if an explicit reasoning override exists before resolving (for log source labelling)
-  const preEnvArgs = splitWorkerLaunchArgs(env.OMX_TEAM_WORKER_LAUNCH_ARGS);
-  const preAllArgs = [...preEnvArgs, ...inheritedArgs];
-  const hasExplicitReasoning = parseTeamWorkerLaunchArgs(preAllArgs).reasoningOverride !== null;
+	// Detect if an explicit reasoning override exists before resolving (for log source labelling)
+	const preEnvArgs = splitWorkerLaunchArgs(env.OMX_TEAM_WORKER_LAUNCH_ARGS);
+	const preAllArgs = [...preEnvArgs, ...inheritedArgs];
+	const hasExplicitReasoning =
+		parseTeamWorkerLaunchArgs(preAllArgs).reasoningOverride !== null;
 
-  const resolved = resolveTeamWorkerLaunchArgs({
-    existingRaw: env.OMX_TEAM_WORKER_LAUNCH_ARGS,
-    inheritedArgs,
-    fallbackModel,
-    preferredReasoning,
-  });
+	const resolved = resolveTeamWorkerLaunchArgs({
+		existingRaw: env.OMX_TEAM_WORKER_LAUNCH_ARGS,
+		inheritedArgs,
+		fallbackModel,
+		preferredReasoning,
+	});
 
-  // Extract resolved model and thinking level from result args for startup log
-  const resolvedParsed = parseTeamWorkerLaunchArgs(resolved);
-  const resolvedModel = resolvedParsed.modelOverride ?? fallbackModel ?? 'default';
-  const reasoningMatch = resolvedParsed.reasoningOverride?.match(/model_reasoning_effort\s*=\s*"?(\w+)"?/);
-  const thinkingLevel = reasoningMatch?.[1] ?? 'none';
-  const source = hasExplicitReasoning
-    ? 'explicit'
-    : (preferredReasoning ? 'role-default' : 'none/default-none');
-  const effectiveWorkerCli = workerCliOverride ?? resolveEffectiveWorkerCliForStartupLog(resolved, env);
-  if (effectiveWorkerCli === 'claude') {
-    console.log('[omx:team] worker startup resolution: model=claude source=local-settings');
-  } else if (effectiveWorkerCli === 'gemini') {
-    console.log('[omx:team] worker startup resolution: model=gemini source=local-settings');
-  } else {
-    console.log(`[omx:team] worker startup resolution: model=${resolvedModel} thinking_level=${thinkingLevel} source=${source}`);
-  }
+	// Extract resolved model and thinking level from result args for startup log
+	const resolvedParsed = parseTeamWorkerLaunchArgs(resolved);
+	const resolvedModel =
+		resolvedParsed.modelOverride ?? fallbackModel ?? "default";
+	const reasoningMatch = resolvedParsed.reasoningOverride?.match(
+		/model_reasoning_effort\s*=\s*"?(\w+)"?/,
+	);
+	const thinkingLevel = reasoningMatch?.[1] ?? "none";
+	const source = hasExplicitReasoning
+		? "explicit"
+		: preferredReasoning
+			? "role-default"
+			: "none/default-none";
+	const effectiveWorkerCli =
+		workerCliOverride ?? resolveEffectiveWorkerCliForStartupLog(resolved, env);
+	if (effectiveWorkerCli === "claude") {
+		console.log(
+			"[omx:team] worker startup resolution: model=claude source=local-settings",
+		);
+	} else if (effectiveWorkerCli === "gemini") {
+		console.log(
+			"[omx:team] worker startup resolution: model=gemini source=local-settings",
+		);
+	} else {
+		console.log(
+			`[omx:team] worker startup resolution: model=${resolvedModel} thinking_level=${thinkingLevel} source=${source}`,
+		);
+	}
 
-  return resolved;
+	return resolved;
 }
 
 function resolveEffectiveWorkerCliForStartupLog(
-  resolvedLaunchArgs: string[],
-  env: NodeJS.ProcessEnv,
-): 'codex' | 'claude' | 'gemini' {
-  const rawCliMap = String(env.OMX_TEAM_WORKER_CLI_MAP ?? '').trim();
-  if (rawCliMap !== '') {
-    const entries = rawCliMap
-      .split(',')
-      .map((entry) => entry.trim().toLowerCase())
-      .filter((entry) => entry.length > 0);
-    if (entries.length > 0) {
-      const autoCli = resolveTeamWorkerCli(resolvedLaunchArgs, {
-        ...env,
-        OMX_TEAM_WORKER_CLI: 'auto',
-      });
-      const resolvedMap = entries.map((entry): 'codex' | 'claude' | 'gemini' | null => {
-        if (entry === 'auto') return autoCli;
-        if (entry === 'codex' || entry === 'claude' || entry === 'gemini') return entry;
-        return null;
-      });
-      if (resolvedMap.every((entry) => entry === 'claude')) return 'claude';
-      if (resolvedMap.every((entry) => entry === 'gemini')) return 'gemini';
-      if (resolvedMap.some((entry) => entry === 'codex')) return 'codex';
-    }
-  }
+	resolvedLaunchArgs: string[],
+	env: NodeJS.ProcessEnv,
+): "codex" | "claude" | "gemini" {
+	const rawCliMap = String(env.OMX_TEAM_WORKER_CLI_MAP ?? "").trim();
+	if (rawCliMap !== "") {
+		const entries = rawCliMap
+			.split(",")
+			.map((entry) => entry.trim().toLowerCase())
+			.filter((entry) => entry.length > 0);
+		if (entries.length > 0) {
+			const autoCli = resolveTeamWorkerCli(resolvedLaunchArgs, {
+				...env,
+				OMX_TEAM_WORKER_CLI: "auto",
+			});
+			const resolvedMap = entries.map(
+				(entry): "codex" | "claude" | "gemini" | null => {
+					if (entry === "auto") return autoCli;
+					if (entry === "codex" || entry === "claude" || entry === "gemini")
+						return entry;
+					return null;
+				},
+			);
+			if (resolvedMap.every((entry) => entry === "claude")) return "claude";
+			if (resolvedMap.every((entry) => entry === "gemini")) return "gemini";
+			if (resolvedMap.some((entry) => entry === "codex")) return "codex";
+		}
+	}
 
-  return resolveTeamWorkerCli(resolvedLaunchArgs, env);
+	return resolveTeamWorkerCli(resolvedLaunchArgs, env);
 }
 
 /**
  * Start a new team: init state, create tmux session, bootstrap workers.
  */
 export async function startTeam(
-  teamName: string,
-  task: string,
-  agentType: string,
-  workerCount: number,
-  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; role?: string }>,
-  cwd: string,
-  options: TeamStartOptions = {},
+	teamName: string,
+	task: string,
+	agentType: string,
+	workerCount: number,
+	tasks: Array<{
+		subject: string;
+		description: string;
+		owner?: string;
+		blocked_by?: string[];
+		role?: string;
+	}>,
+	cwd: string,
+	options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
-  const leaderCwd = resolve(cwd);
-  await assertNestedTeamAllowed(leaderCwd);
-  const effectiveWorktreeMode = resolveEffectiveTeamWorktreeMode(leaderCwd, options.worktreeMode);
-  const sanitized = sanitizeTeamName(teamName);
-  const leaderSessionId = await resolveLeaderSessionId(leaderCwd);
+	const leaderCwd = resolve(cwd);
+	await assertNestedTeamAllowed(leaderCwd);
+	const effectiveWorktreeMode = resolveEffectiveTeamWorktreeMode(
+		leaderCwd,
+		options.worktreeMode,
+	);
+	const sanitized = sanitizeTeamName(teamName);
+	const leaderSessionId = await resolveLeaderSessionId(leaderCwd);
 
-  await assertTeamStartupIsNonDestructive(sanitized, leaderCwd, leaderSessionId);
+	await assertTeamStartupIsNonDestructive(
+		sanitized,
+		leaderCwd,
+		leaderSessionId,
+	);
 
-  const workerLaunchMode = resolveTeamWorkerLaunchMode(process.env);
-  const displayMode = workerLaunchMode === 'interactive' ? 'split_pane' : 'auto';
-  if (workerLaunchMode === 'interactive') {
-    if (!isTmuxAvailable()) {
-      throw new Error('Team mode requires tmux. Install with: apt install tmux / brew install tmux');
-    }
-    if (!hasCurrentTmuxClientContext()) {
-      throw new Error('Team mode requires running inside tmux current leader pane');
-    }
-  }
+	const workerLaunchMode = resolveTeamWorkerLaunchMode(process.env);
+	const displayMode =
+		workerLaunchMode === "interactive" ? "split_pane" : "auto";
+	if (workerLaunchMode === "interactive") {
+		if (!isTmuxAvailable()) {
+			throw new Error(
+				"Team mode requires tmux. Install with: apt install tmux / brew install tmux",
+			);
+		}
+		if (!hasCurrentTmuxClientContext()) {
+			throw new Error(
+				"Team mode requires running inside tmux current leader pane",
+			);
+		}
+	}
 
-  const teamStateRoot = resolveCanonicalTeamStateRoot(leaderCwd);
-  const activeWorktreeMode: 'detached' | 'named' | null =
-    effectiveWorktreeMode.enabled
-      ? (effectiveWorktreeMode.detached ? 'detached' : 'named')
-      : null;
-  const workspaceMode: 'single' | 'worktree' = activeWorktreeMode ? 'worktree' : 'single';
-  const workerWorkspaceByName = new Map<string, {
-    cwd: string;
-    worktreeRepoRoot?: string;
-    worktreePath?: string;
-    worktreeBranch?: string;
-    worktreeDetached?: boolean;
-    worktreeCreated?: boolean;
-  }>();
-  const provisionedWorktrees: Array<EnsureWorktreeResult | { enabled: false }> = [];
-  for (let i = 1; i <= workerCount; i++) {
-    workerWorkspaceByName.set(`worker-${i}`, { cwd: leaderCwd });
-  }
+	const teamStateRoot = resolveCanonicalTeamStateRoot(leaderCwd);
+	const activeWorktreeMode: "detached" | "named" | null =
+		effectiveWorktreeMode.enabled
+			? effectiveWorktreeMode.detached
+				? "detached"
+				: "named"
+			: null;
+	const workspaceMode: "single" | "worktree" = activeWorktreeMode
+		? "worktree"
+		: "single";
+	const workerWorkspaceByName = new Map<
+		string,
+		{
+			cwd: string;
+			worktreeRepoRoot?: string;
+			worktreePath?: string;
+			worktreeBranch?: string;
+			worktreeDetached?: boolean;
+			worktreeCreated?: boolean;
+		}
+	>();
+	const provisionedWorktrees: Array<EnsureWorktreeResult | { enabled: false }> =
+		[];
+	for (let i = 1; i <= workerCount; i++) {
+		workerWorkspaceByName.set(`worker-${i}`, { cwd: leaderCwd });
+	}
 
-  if (activeWorktreeMode) {
-    assertCleanLeaderWorkspaceForWorkerWorktrees(leaderCwd);
-    for (let i = 1; i <= workerCount; i++) {
-      const workerName = `worker-${i}`;
-      const planned = planWorktreeTarget({
-        cwd: leaderCwd,
-        scope: 'team',
-        mode: effectiveWorktreeMode,
-        teamName: sanitized,
-        workerName,
-      });
-      const ensured = ensureWorktree(planned);
-      provisionedWorktrees.push(ensured);
-      if (ensured.enabled) {
-        workerWorkspaceByName.set(workerName, {
-          cwd: ensured.worktreePath,
-          worktreeRepoRoot: ensured.repoRoot,
-          worktreePath: ensured.worktreePath,
-          worktreeBranch: ensured.branchName ?? undefined,
-          worktreeDetached: ensured.detached,
-          worktreeCreated: ensured.created,
-        });
-      }
-    }
-  }
+	if (activeWorktreeMode) {
+		assertCleanLeaderWorkspaceForWorkerWorktrees(leaderCwd);
+		for (let i = 1; i <= workerCount; i++) {
+			const workerName = `worker-${i}`;
+			const planned = planWorktreeTarget({
+				cwd: leaderCwd,
+				scope: "team",
+				mode: effectiveWorktreeMode,
+				teamName: sanitized,
+				workerName,
+			});
+			const ensured = ensureWorktree(planned);
+			provisionedWorktrees.push(ensured);
+			if (ensured.enabled) {
+				workerWorkspaceByName.set(workerName, {
+					cwd: ensured.worktreePath,
+					worktreeRepoRoot: ensured.repoRoot,
+					worktreePath: ensured.worktreePath,
+					worktreeBranch: ensured.branchName ?? undefined,
+					worktreeDetached: ensured.detached,
+					worktreeCreated: ensured.created,
+				});
+			}
+		}
+	}
 
-  // 2. Team name is already sanitized above.
-  let sessionName = `omx-team-${sanitized}`;
-  const overlay = generateWorkerOverlay(sanitized);
-  let workerInstructionsPath: string | null = null;
-  let sessionCreated = false;
-  const createdWorkerPaneIds: string[] = [];
-  let createdLeaderPaneId: string | undefined;
-  let config: TeamConfig | null = null;
-  const sharedWorkerLaunchArgs = resolveTeamWorkerLaunchArgs({
-    existingRaw: process.env.OMX_TEAM_WORKER_LAUNCH_ARGS,
-    fallbackModel: resolveAgentDefaultModel(agentType, process.env.CODEX_HOME),
-  });
-  const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, sharedWorkerLaunchArgs, process.env);
-  const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(process.env);
-  const skipWorkerReadyWait = shouldSkipWorkerReadyWait(process.env);
+	// 2. Team name is already sanitized above.
+	let sessionName = `omx-team-${sanitized}`;
+	const overlay = generateWorkerOverlay(sanitized);
+	let workerInstructionsPath: string | null = null;
+	let sessionCreated = false;
+	const createdWorkerPaneIds: string[] = [];
+	let createdLeaderPaneId: string | undefined;
+	let config: TeamConfig | null = null;
+	const sharedWorkerLaunchArgs = resolveTeamWorkerLaunchArgs({
+		existingRaw: process.env.OMX_TEAM_WORKER_LAUNCH_ARGS,
+		fallbackModel: resolveAgentDefaultModel(agentType, process.env.CODEX_HOME),
+	});
+	const workerCliPlan = resolveTeamWorkerCliPlan(
+		workerCount,
+		sharedWorkerLaunchArgs,
+		process.env,
+	);
+	const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(process.env);
+	const workerStartupEvidenceTimeoutMs = resolveWorkerStartupEvidenceTimeoutMs(
+		process.env,
+		workerReadyTimeoutMs,
+	);
+	const skipWorkerReadyWait = shouldSkipWorkerReadyWait(process.env);
 
-  try {
-    // 3. Init state directory + config
-    config = await initTeamState(
-      sanitized,
-      task,
-      agentType,
-      workerCount,
-      leaderCwd,
-      DEFAULT_MAX_WORKERS,
-      { ...process.env, OMX_TEAM_DISPLAY_MODE: displayMode, OMX_TEAM_WORKER_LAUNCH_MODE: workerLaunchMode },
-      {
-        leader_cwd: leaderCwd,
-        team_state_root: teamStateRoot,
-        workspace_mode: workspaceMode,
-        worktree_mode: effectiveWorktreeMode,
-      },
-      'default',
-    );
-    if (!config) {
-      throw new Error('failed to initialize team config');
-    }
-    config.leader_cwd = leaderCwd;
-    config.team_state_root = teamStateRoot;
-    config.workspace_mode = workspaceMode;
-    config.worktree_mode = effectiveWorktreeMode;
+	try {
+		// 3. Init state directory + config
+		config = await initTeamState(
+			sanitized,
+			task,
+			agentType,
+			workerCount,
+			leaderCwd,
+			DEFAULT_MAX_WORKERS,
+			{
+				...process.env,
+				OMX_TEAM_DISPLAY_MODE: displayMode,
+				OMX_TEAM_WORKER_LAUNCH_MODE: workerLaunchMode,
+			},
+			{
+				leader_cwd: leaderCwd,
+				team_state_root: teamStateRoot,
+				workspace_mode: workspaceMode,
+				worktree_mode: effectiveWorktreeMode,
+			},
+			"default",
+		);
+		if (!config) {
+			throw new Error("failed to initialize team config");
+		}
+		config.leader_cwd = leaderCwd;
+		config.team_state_root = teamStateRoot;
+		config.workspace_mode = workspaceMode;
+		config.worktree_mode = effectiveWorktreeMode;
 
-    // 4. Create tasks
-    for (const t of tasks) {
-      await createStateTask(sanitized, {
-        subject: t.subject,
-        description: t.description,
-        status: 'pending',
-        owner: t.owner,
-        blocked_by: t.blocked_by,
-        role: t.role,
-      }, leaderCwd);
-    }
+		// 4. Create tasks
+		for (const t of tasks) {
+			await createStateTask(
+				sanitized,
+				{
+					subject: t.subject,
+					description: t.description,
+					status: "pending",
+					owner: t.owner,
+					blocked_by: t.blocked_by,
+					role: t.role,
+				},
+				leaderCwd,
+			);
+		}
 
-    // 5. Write team-scoped worker instructions file only for single-workspace mode.
-    if (workspaceMode !== 'worktree') {
-      workerInstructionsPath = await writeTeamWorkerInstructionsFile(sanitized, leaderCwd, overlay);
-      setTeamModelInstructionsFile(sanitized, workerInstructionsPath);
-    }
+		// 5. Write team-scoped worker instructions file only for single-workspace mode.
+		if (workspaceMode !== "worktree") {
+			workerInstructionsPath = await writeTeamWorkerInstructionsFile(
+				sanitized,
+				leaderCwd,
+				overlay,
+			);
+			setTeamModelInstructionsFile(sanitized, workerInstructionsPath);
+		}
 
-    const allTasks = await listTasks(sanitized, leaderCwd);
-    const workerBootstrapPlans = [] as Array<{
-      workerName: string;
-      workerWorkspace: {
-        cwd: string;
-        worktreeRepoRoot?: string;
-        worktreePath?: string;
-        worktreeBranch?: string;
-        worktreeDetached?: boolean;
-        worktreeCreated?: boolean;
-      };
-      workerTasks: TeamTask[];
-      workerRole: string;
-      rolePromptContent: string | null;
-      instructionsFilePath: string;
-      inbox: string;
-      trigger: string;
-      triggerIntent: TeamReminderIntent;
-      initialPrompt?: string;
-      workerLaunchArgs: string[];
-      workerCli: TeamWorkerCli;
-    }>;
+		const allTasks = await listTasks(sanitized, leaderCwd);
+		const workerBootstrapPlans = [] as Array<{
+			workerName: string;
+			workerWorkspace: {
+				cwd: string;
+				worktreeRepoRoot?: string;
+				worktreePath?: string;
+				worktreeBranch?: string;
+				worktreeDetached?: boolean;
+				worktreeCreated?: boolean;
+			};
+			workerTasks: TeamTask[];
+			workerRole: string;
+			rolePromptContent: string | null;
+			instructionsFilePath: string;
+			inbox: string;
+			trigger: string;
+			triggerIntent: TeamReminderIntent;
+			initialPrompt?: string;
+			workerLaunchArgs: string[];
+			workerCli: TeamWorkerCli;
+		}>;
 
-    for (let i = 1; i <= workerCount; i++) {
-      const workerName = `worker-${i}`;
-      const workerWorkspace = workerWorkspaceByName.get(workerName) ?? { cwd: leaderCwd };
-      const workerTasks = allTasks.filter(t => t.owner === workerName);
-      const taskRoles = workerTasks.map(t => t.role).filter(Boolean) as string[];
-      const uniqueTaskRoles = new Set(taskRoles);
-      const workerRole = taskRoles.length > 0 && uniqueTaskRoles.size === 1
-        ? taskRoles[0]
-        : agentType;
-      const rawRolePromptContent = await loadRolePrompt(workerRole, join(leaderCwd, '.codex', 'prompts'))
-        ?? await loadRolePrompt(workerRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(workerRole) ?? resolveAgentReasoningEffort(agentType);
-      const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
-        process.env,
-        workerRole,
-        undefined,
-        preferredReasoning,
-        workerCliPlan[i - 1],
-      );
-      const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
-      const rolePromptContent = rawRolePromptContent
-        ? composeRoleInstructionsForRole(workerRole, rawRolePromptContent, resolvedWorkerModel)
-        : null;
-      const workerWorktreePath = workerWorkspace.worktreePath ?? undefined;
-      const fallbackInstructionsPath = workerInstructionsPath ?? join(leaderCwd, 'AGENTS.md');
-      const instructionsFilePath = workerWorktreePath
-        ? await writeWorkerWorktreeRootAgentsFile({
-          teamName: sanitized,
-          workerName,
-          workerRole,
-          rolePromptContent: rolePromptContent ?? "",
-          teamStateRoot,
-          leaderCwd,
-          worktreePath: workerWorktreePath,
-        })
-        : rolePromptContent
-          ? await writeWorkerRoleInstructionsFile(sanitized, workerName, leaderCwd, fallbackInstructionsPath, workerRole, rolePromptContent)
-          : fallbackInstructionsPath;
-      const inbox = generateInitialInbox(workerName, sanitized, agentType, workerTasks, {
-        teamStateRoot,
-        leaderCwd,
-        workerRole,
-        rolePromptContent: rawRolePromptContent ?? undefined,
-        worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
-      });
-      const triggerDirective = buildTriggerDirective(
-        workerName,
-        sanitized,
-        resolveInstructionStateRoot(workerWorkspace.worktreePath),
-      );
-      const trigger = triggerDirective.text;
-      const initialPrompt = workerCliPlan[i - 1] === 'gemini' ? trigger : undefined;
-      if (initialPrompt) {
-        await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
-      }
-      workerBootstrapPlans.push({
-        workerName,
-        workerWorkspace,
-        workerTasks,
-        workerRole,
-        rolePromptContent,
-        instructionsFilePath,
-        inbox,
-        trigger,
-        triggerIntent: triggerDirective.intent,
-        initialPrompt,
-        workerLaunchArgs,
-        workerCli: workerCliPlan[i - 1],
-      });
-    }
+		for (let i = 1; i <= workerCount; i++) {
+			const workerName = `worker-${i}`;
+			const workerWorkspace = workerWorkspaceByName.get(workerName) ?? {
+				cwd: leaderCwd,
+			};
+			const workerTasks = allTasks.filter((t) => t.owner === workerName);
+			const taskRoles = workerTasks
+				.map((t) => t.role)
+				.filter(Boolean) as string[];
+			const uniqueTaskRoles = new Set(taskRoles);
+			const workerRole =
+				taskRoles.length > 0 && uniqueTaskRoles.size === 1
+					? taskRoles[0]
+					: agentType;
+			const rawRolePromptContent =
+				(await loadRolePrompt(
+					workerRole,
+					join(leaderCwd, ".codex", "prompts"),
+				)) ?? (await loadRolePrompt(workerRole, codexPromptsDir()));
+			const preferredReasoning =
+				resolveAgentReasoningEffort(workerRole) ??
+				resolveAgentReasoningEffort(agentType);
+			const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
+				process.env,
+				workerRole,
+				undefined,
+				preferredReasoning,
+				workerCliPlan[i - 1],
+			);
+			const resolvedWorkerModel =
+				parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
+			const rolePromptContent = rawRolePromptContent
+				? composeRoleInstructionsForRole(
+						workerRole,
+						rawRolePromptContent,
+						resolvedWorkerModel,
+					)
+				: null;
+			const workerWorktreePath = workerWorkspace.worktreePath ?? undefined;
+			const fallbackInstructionsPath =
+				workerInstructionsPath ?? join(leaderCwd, "AGENTS.md");
+			const instructionsFilePath = workerWorktreePath
+				? await writeWorkerWorktreeRootAgentsFile({
+						teamName: sanitized,
+						workerName,
+						workerRole,
+						rolePromptContent: rolePromptContent ?? "",
+						teamStateRoot,
+						leaderCwd,
+						worktreePath: workerWorktreePath,
+					})
+				: rolePromptContent
+					? await writeWorkerRoleInstructionsFile(
+							sanitized,
+							workerName,
+							leaderCwd,
+							fallbackInstructionsPath,
+							workerRole,
+							rolePromptContent,
+						)
+					: fallbackInstructionsPath;
+			const inbox = generateInitialInbox(
+				workerName,
+				sanitized,
+				agentType,
+				workerTasks,
+				{
+					teamStateRoot,
+					leaderCwd,
+					workerRole,
+					rolePromptContent: rawRolePromptContent ?? undefined,
+					worktreeRootAgentsCanonical: Boolean(workerWorkspace.worktreePath),
+				},
+			);
+			const triggerDirective = buildTriggerDirective(
+				workerName,
+				sanitized,
+				resolveInstructionStateRoot(workerWorkspace.worktreePath),
+			);
+			const trigger = triggerDirective.text;
+			const initialPrompt =
+				workerCliPlan[i - 1] === "gemini" ? trigger : undefined;
+			if (initialPrompt) {
+				await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
+			}
+			workerBootstrapPlans.push({
+				workerName,
+				workerWorkspace,
+				workerTasks,
+				workerRole,
+				rolePromptContent,
+				instructionsFilePath,
+				inbox,
+				trigger,
+				triggerIntent: triggerDirective.intent,
+				initialPrompt,
+				workerLaunchArgs,
+				workerCli: workerCliPlan[i - 1],
+			});
+		}
 
-    const workerStartups = workerBootstrapPlans.map((plan) => {
-      const env: Record<string, string> = {
-        [TEAM_STATE_ROOT_ENV]: teamStateRoot,
-        [TEAM_LEADER_CWD_ENV]: leaderCwd,
-        [MODEL_INSTRUCTIONS_FILE_ENV]: plan.instructionsFilePath,
-      };
-      if (plan.workerWorkspace.worktreePath) {
-        env.OMX_TEAM_WORKTREE_PATH = plan.workerWorkspace.worktreePath;
-      }
-      if (plan.workerWorkspace.worktreeBranch) {
-        env.OMX_TEAM_WORKTREE_BRANCH = plan.workerWorkspace.worktreeBranch;
-      }
-      if (typeof plan.workerWorkspace.worktreeDetached === 'boolean') {
-        env.OMX_TEAM_WORKTREE_DETACHED = plan.workerWorkspace.worktreeDetached ? '1' : '0';
-      }
-      return {
-        cwd: plan.workerWorkspace.cwd,
-        env,
-        initialPrompt: plan.initialPrompt,
-        launchArgs: plan.workerLaunchArgs,
-        workerCli: plan.workerCli,
-      };
-    });
+		const workerStartups = workerBootstrapPlans.map((plan) => {
+			const env: Record<string, string> = {
+				[TEAM_STATE_ROOT_ENV]: teamStateRoot,
+				[TEAM_LEADER_CWD_ENV]: leaderCwd,
+				[MODEL_INSTRUCTIONS_FILE_ENV]: plan.instructionsFilePath,
+			};
+			if (plan.workerWorkspace.worktreePath) {
+				env.OMX_TEAM_WORKTREE_PATH = plan.workerWorkspace.worktreePath;
+			}
+			if (plan.workerWorkspace.worktreeBranch) {
+				env.OMX_TEAM_WORKTREE_BRANCH = plan.workerWorkspace.worktreeBranch;
+			}
+			if (typeof plan.workerWorkspace.worktreeDetached === "boolean") {
+				env.OMX_TEAM_WORKTREE_DETACHED = plan.workerWorkspace.worktreeDetached
+					? "1"
+					: "0";
+			}
+			return {
+				cwd: plan.workerWorkspace.cwd,
+				env,
+				initialPrompt: plan.initialPrompt,
+				launchArgs: plan.workerLaunchArgs,
+				workerCli: plan.workerCli,
+			};
+		});
 
-    const workerPaneIds = Array.from({ length: workerCount }, () => undefined as string | undefined);
+		const workerPaneIds = Array.from(
+			{ length: workerCount },
+			() => undefined as string | undefined,
+		);
 
-    // 6. Create worker runtime (interactive tmux panes or prompt-mode child processes)
-    if (workerLaunchMode === 'interactive') {
-      const createdSession = createTeamSession(sanitized, workerCount, leaderCwd, sharedWorkerLaunchArgs, workerStartups);
-      sessionName = createdSession.name;
-      sessionCreated = true;
-      createdWorkerPaneIds.push(...createdSession.workerPaneIds);
-      createdLeaderPaneId = createdSession.leaderPaneId;
-      applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);
-    } else {
-      config.tmux_session = `prompt-${sanitized}`;
-      config.leader_pane_id = null;
-      config.hud_pane_id = null;
-      config.resize_hook_name = null;
-      config.resize_hook_target = null;
-      for (let i = 1; i <= workerCount; i++) {
-        const startup = workerStartups[i - 1] || {};
-        const workerName = `worker-${i}`;
-        const child = spawnPromptWorker(
-          sanitized,
-          workerName,
-          i,
-          startup.cwd || leaderCwd,
-          startup.launchArgs || sharedWorkerLaunchArgs,
-          startup.env || {},
-          startup.workerCli || workerCliPlan[i - 1],
-          startup.initialPrompt,
-        );
-        if (config.workers[i - 1]) {
-          config.workers[i - 1].pid = child.pid;
-        }
-      }
-    }
-    await saveTeamConfig(config, leaderCwd);
+		// 6. Create worker runtime (interactive tmux panes or prompt-mode child processes)
+		if (workerLaunchMode === "interactive") {
+			const createdSession = createTeamSession(
+				sanitized,
+				workerCount,
+				leaderCwd,
+				sharedWorkerLaunchArgs,
+				workerStartups,
+			);
+			sessionName = createdSession.name;
+			sessionCreated = true;
+			createdWorkerPaneIds.push(...createdSession.workerPaneIds);
+			createdLeaderPaneId = createdSession.leaderPaneId;
+			applyCreatedInteractiveSessionToConfig(
+				config,
+				createdSession,
+				workerPaneIds,
+			);
+		} else {
+			config.tmux_session = `prompt-${sanitized}`;
+			config.leader_pane_id = null;
+			config.hud_pane_id = null;
+			config.resize_hook_name = null;
+			config.resize_hook_target = null;
+			for (let i = 1; i <= workerCount; i++) {
+				const startup = workerStartups[i - 1] || {};
+				const workerName = `worker-${i}`;
+				const child = spawnPromptWorker(
+					sanitized,
+					workerName,
+					i,
+					startup.cwd || leaderCwd,
+					startup.launchArgs || sharedWorkerLaunchArgs,
+					startup.env || {},
+					startup.workerCli || workerCliPlan[i - 1],
+					startup.initialPrompt,
+				);
+				if (config.workers[i - 1]) {
+					config.workers[i - 1].pid = child.pid;
+				}
+			}
+		}
+		await saveTeamConfig(config, leaderCwd);
 
-    // 7. Wait for all workers to be ready (interactive mode), then bootstrap them
-    const manifest = await readTeamManifestV2(sanitized, leaderCwd);
-    const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, workerLaunchMode);
-    for (let i = 1; i <= workerCount; i++) {
-      const bootstrapPlan = workerBootstrapPlans[i - 1];
-      if (!bootstrapPlan) {
-        throw new Error(`missing bootstrap plan for worker-${i}`);
-      }
-      const { workerName, paneId, workerTasks, workerRole, inbox, trigger, triggerIntent, initialPrompt } = {
-        workerName: bootstrapPlan.workerName,
-        paneId: workerPaneIds[i - 1],
-        workerTasks: bootstrapPlan.workerTasks,
-        workerRole: bootstrapPlan.workerRole,
-        inbox: bootstrapPlan.inbox,
-        trigger: bootstrapPlan.trigger,
-        triggerIntent: bootstrapPlan.triggerIntent,
-        initialPrompt: bootstrapPlan.initialPrompt,
-      };
-      const workerWorkspace = bootstrapPlan.workerWorkspace;
+		// 7. Wait for all workers to be ready (interactive mode), then bootstrap them
+		const manifest = await readTeamManifestV2(sanitized, leaderCwd);
+		const dispatchPolicy = resolveDispatchPolicy(
+			manifest?.policy,
+			workerLaunchMode,
+		);
+		for (let i = 1; i <= workerCount; i++) {
+			const bootstrapPlan = workerBootstrapPlans[i - 1];
+			if (!bootstrapPlan) {
+				throw new Error(`missing bootstrap plan for worker-${i}`);
+			}
+			const {
+				workerName,
+				paneId,
+				workerTasks,
+				workerRole,
+				inbox,
+				trigger,
+				triggerIntent,
+				initialPrompt,
+			} = {
+				workerName: bootstrapPlan.workerName,
+				paneId: workerPaneIds[i - 1],
+				workerTasks: bootstrapPlan.workerTasks,
+				workerRole: bootstrapPlan.workerRole,
+				inbox: bootstrapPlan.inbox,
+				trigger: bootstrapPlan.trigger,
+				triggerIntent: bootstrapPlan.triggerIntent,
+				initialPrompt: bootstrapPlan.initialPrompt,
+			};
+			const workerWorkspace = bootstrapPlan.workerWorkspace;
 
-      if (workerTasks.map(t => t.role).filter(Boolean).length > 0 && new Set(workerTasks.map(t => t.role).filter(Boolean)).size > 1) {
-        console.log(`[omx:team] ${workerName}: mixed task roles [${[...new Set(workerTasks.map(t => t.role).filter(Boolean))].join(', ')}], falling back to ${agentType}`);
-      }
+			if (
+				workerTasks.map((t) => t.role).filter(Boolean).length > 0 &&
+				new Set(workerTasks.map((t) => t.role).filter(Boolean)).size > 1
+			) {
+				console.log(
+					`[omx:team] ${workerName}: mixed task roles [${[...new Set(workerTasks.map((t) => t.role).filter(Boolean))].join(", ")}], falling back to ${agentType}`,
+				);
+			}
 
-      // Write worker identity
-      const identity: WorkerInfo = {
-        name: workerName,
-        index: i,
-        role: workerRole,
-        worker_cli: workerCliPlan[i - 1],
-        assigned_tasks: workerTasks.map(t => t.id),
-        working_dir: workerWorkspace.cwd,
-        worktree_repo_root: workerWorkspace.worktreeRepoRoot,
-        worktree_path: workerWorkspace.worktreePath,
-        worktree_branch: workerWorkspace.worktreeBranch,
-        worktree_detached: workerWorkspace.worktreeDetached,
-        worktree_created: workerWorkspace.worktreeCreated,
-        team_state_root: teamStateRoot,
-      };
+			// Write worker identity
+			const identity: WorkerInfo = {
+				name: workerName,
+				index: i,
+				role: workerRole,
+				worker_cli: workerCliPlan[i - 1],
+				assigned_tasks: workerTasks.map((t) => t.id),
+				working_dir: workerWorkspace.cwd,
+				worktree_repo_root: workerWorkspace.worktreeRepoRoot,
+				worktree_path: workerWorkspace.worktreePath,
+				worktree_branch: workerWorkspace.worktreeBranch,
+				worktree_detached: workerWorkspace.worktreeDetached,
+				worktree_created: workerWorkspace.worktreeCreated,
+				team_state_root: teamStateRoot,
+			};
 
-      // Get pane PID and store it (interactive mode) or process PID (prompt mode)
-      if (workerLaunchMode === 'interactive') {
-        const panePid = getWorkerPanePid(sessionName, i, paneId);
-        if (panePid) identity.pid = panePid;
-      } else if (config.workers[i - 1]?.pid) {
-        identity.pid = config.workers[i - 1].pid;
-      }
-      if (paneId) identity.pane_id = paneId;
-      if (config.workers[i - 1]) {
-        config.workers[i - 1].pid = identity.pid;
-        config.workers[i - 1].pane_id = paneId;
-        config.workers[i - 1].role = workerRole;
-        config.workers[i - 1].worker_cli = workerCliPlan[i - 1];
-        config.workers[i - 1].working_dir = workerWorkspace.cwd;
-        config.workers[i - 1].worktree_repo_root = workerWorkspace.worktreeRepoRoot;
-        config.workers[i - 1].worktree_path = workerWorkspace.worktreePath;
-        config.workers[i - 1].worktree_branch = workerWorkspace.worktreeBranch;
-        config.workers[i - 1].worktree_detached = workerWorkspace.worktreeDetached;
-        config.workers[i - 1].worktree_created = workerWorkspace.worktreeCreated;
-        config.workers[i - 1].team_state_root = teamStateRoot;
-      }
+			// Get pane PID and store it (interactive mode) or process PID (prompt mode)
+			if (workerLaunchMode === "interactive") {
+				const panePid = getWorkerPanePid(sessionName, i, paneId);
+				if (panePid) identity.pid = panePid;
+			} else if (config.workers[i - 1]?.pid) {
+				identity.pid = config.workers[i - 1].pid;
+			}
+			if (paneId) identity.pane_id = paneId;
+			if (config.workers[i - 1]) {
+				config.workers[i - 1].pid = identity.pid;
+				config.workers[i - 1].pane_id = paneId;
+				config.workers[i - 1].role = workerRole;
+				config.workers[i - 1].worker_cli = workerCliPlan[i - 1];
+				config.workers[i - 1].working_dir = workerWorkspace.cwd;
+				config.workers[i - 1].worktree_repo_root =
+					workerWorkspace.worktreeRepoRoot;
+				config.workers[i - 1].worktree_path = workerWorkspace.worktreePath;
+				config.workers[i - 1].worktree_branch = workerWorkspace.worktreeBranch;
+				config.workers[i - 1].worktree_detached =
+					workerWorkspace.worktreeDetached;
+				config.workers[i - 1].worktree_created =
+					workerWorkspace.worktreeCreated;
+				config.workers[i - 1].team_state_root = teamStateRoot;
+			}
 
-      await writeWorkerIdentity(sanitized, workerName, identity, leaderCwd);
+			await writeWorkerIdentity(sanitized, workerName, identity, leaderCwd);
 
-      // Wait for worker readiness
-      if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt) {
-        const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);
-        if (!ready) {
-          throw new Error(`Worker ${workerName} did not become ready in tmux session ${sessionName}`);
-        }
-      }
+			// Wait for worker readiness
+			if (
+				workerLaunchMode === "interactive" &&
+				!skipWorkerReadyWait &&
+				!initialPrompt
+			) {
+				const ready = waitForWorkerReady(
+					sessionName,
+					i,
+					workerReadyTimeoutMs,
+					paneId,
+				);
+				if (!ready) {
+					throw new Error(
+						`Worker ${workerName} did not become ready in tmux session ${sessionName}`,
+					);
+				}
+			}
 
-      // Queue inbox via MCP/state then notify worker via tmux transport.
-      // Retry dispatch up to 3 times to handle Codex trust prompts that may
-      // block the worker pane during startup (fixes #393).
-      const maxStartupDispatchRetries = 3;
-      const startupRetryDelayS = 3;
-      let dispatchOutcome: DispatchOutcome = initialPrompt
-        ? { ok: true, transport: 'none', reason: 'startup_prompt_delivered_at_launch' }
-        : { ok: false, transport: 'none', reason: 'not_attempted' };
-      if (!initialPrompt) {
-        for (let attempt = 1; attempt <= maxStartupDispatchRetries; attempt++) {
-          dispatchOutcome = await dispatchCriticalInboxInstruction({
-            teamName: sanitized,
-            config: config!,
-            workerName,
-            workerIndex: i,
-            paneId,
-            workerCli: workerCliPlan[i - 1],
-            inbox,
-            triggerMessage: trigger,
-            intent: triggerIntent,
-            cwd: leaderCwd,
-            dispatchPolicy,
-            inboxCorrelationKey: `startup:${workerName}`,
-            requireWorkerStartupEvidence: true,
-          });
-          if (dispatchOutcome.ok) break;
-          if (attempt < maxStartupDispatchRetries) {
-            // Check for trust prompt blocking the worker and dismiss it before retry
-            if (workerLaunchMode === 'interactive') {
-              if (dismissTrustPromptIfPresent(sessionName, i, paneId)) {
-                waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);
-              } else {
-                sleepFractionalSeconds(startupRetryDelayS);
-              }
-            } else {
-              sleepFractionalSeconds(startupRetryDelayS);
-            }
-          }
-        }
-      }
-      if (!dispatchOutcome.ok) {
-        throw new Error(`worker_notify_failed:${workerName}`);
-      }
-    }
-    await saveTeamConfig(config, leaderCwd);
+			// Queue inbox via MCP/state then notify worker via tmux transport.
+			// Retry dispatch up to 3 times to handle Codex trust prompts that may
+			// block the worker pane during startup (fixes #393).
+			const maxStartupDispatchRetries = 3;
+			const startupRetryDelayS = 3;
+			let dispatchOutcome: DispatchOutcome = initialPrompt
+				? {
+						ok: true,
+						transport: "none",
+						reason: "startup_prompt_delivered_at_launch",
+					}
+				: { ok: false, transport: "none", reason: "not_attempted" };
+			if (!initialPrompt) {
+				for (let attempt = 1; attempt <= maxStartupDispatchRetries; attempt++) {
+					dispatchOutcome = await dispatchCriticalInboxInstruction({
+						teamName: sanitized,
+						config: config!,
+						workerName,
+						workerIndex: i,
+						paneId,
+						workerCli: workerCliPlan[i - 1],
+						inbox,
+						triggerMessage: trigger,
+						intent: triggerIntent,
+						cwd: leaderCwd,
+						dispatchPolicy,
+						inboxCorrelationKey: `startup:${workerName}`,
+						requireWorkerStartupEvidence: true,
+						startupEvidenceTimeoutMs: workerStartupEvidenceTimeoutMs,
+					});
+					if (dispatchOutcome.ok) break;
+					if (attempt < maxStartupDispatchRetries) {
+						// Check for trust prompt blocking the worker and dismiss it before retry
+						if (workerLaunchMode === "interactive") {
+							if (dismissTrustPromptIfPresent(sessionName, i, paneId)) {
+								waitForWorkerReady(
+									sessionName,
+									i,
+									workerReadyTimeoutMs,
+									paneId,
+								);
+							} else {
+								sleepFractionalSeconds(startupRetryDelayS);
+							}
+						} else {
+							sleepFractionalSeconds(startupRetryDelayS);
+						}
+					}
+				}
+			}
+			if (!dispatchOutcome.ok) {
+				throw new Error(`worker_notify_failed:${workerName}`);
+			}
+		}
+		await saveTeamConfig(config, leaderCwd);
 
-    return {
-      teamName: sanitized,
-      sanitizedName: sanitized,
-      sessionName,
-      config,
-      cwd: leaderCwd,
-    };
-  } catch (error) {
-    const rollbackErrors: string[] = [];
+		return {
+			teamName: sanitized,
+			sanitizedName: sanitized,
+			sessionName,
+			config,
+			cwd: leaderCwd,
+		};
+	} catch (error) {
+		const rollbackErrors: string[] = [];
 
-    if (sessionCreated) {
-      if (config?.resize_hook_name && config.resize_hook_target) {
-        try {
-          const unregistered = unregisterResizeHook(config.resize_hook_target, config.resize_hook_name);
-          if (!unregistered) {
-            rollbackErrors.push('unregisterResizeHook: returned false');
-          }
-        } catch (cleanupError) {
-          rollbackErrors.push(`unregisterResizeHook: ${String(cleanupError)}`);
-        }
-      }
+		if (sessionCreated) {
+			if (config?.resize_hook_name && config.resize_hook_target) {
+				try {
+					const unregistered = unregisterResizeHook(
+						config.resize_hook_target,
+						config.resize_hook_name,
+					);
+					if (!unregistered) {
+						rollbackErrors.push("unregisterResizeHook: returned false");
+					}
+				} catch (cleanupError) {
+					rollbackErrors.push(`unregisterResizeHook: ${String(cleanupError)}`);
+				}
+			}
 
-      if (config) {
-        config.resize_hook_name = null;
-        config.resize_hook_target = null;
-        try {
-          await saveTeamConfig(config, leaderCwd);
-        } catch (cleanupError) {
-          rollbackErrors.push(`saveTeamConfig(clear resize hook): ${String(cleanupError)}`);
-        }
-      }
+			if (config) {
+				config.resize_hook_name = null;
+				config.resize_hook_target = null;
+				try {
+					await saveTeamConfig(config, leaderCwd);
+				} catch (cleanupError) {
+					rollbackErrors.push(
+						`saveTeamConfig(clear resize hook): ${String(cleanupError)}`,
+					);
+				}
+			}
 
-      // In split-pane topology, we must not kill the entire tmux session; kill only created panes.
-      if (sessionName.includes(':')) {
-        for (const [index, paneId] of createdWorkerPaneIds.entries()) {
-          const panePid = getWorkerPanePid(sessionName, index + 1, paneId);
-          if (panePid) {
-            await terminateTrackedProcessTree(panePid);
-          }
-          try {
-            await killWorkerByPaneIdAsync(paneId, createdLeaderPaneId);
-          } catch (err) {
-            process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-          }
-        }
-        if (config?.hud_pane_id) {
-          try {
-            await killWorkerByPaneIdAsync(config.hud_pane_id, createdLeaderPaneId);
-          } catch (err) {
-            process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-          }
-        }
-      } else {
-        try {
-          destroyTeamSession(sessionName);
-        } catch (cleanupError) {
-          rollbackErrors.push(`destroyTeamSession: ${String(cleanupError)}`);
-        }
-      }
-    }
-    if (workerLaunchMode === 'prompt' && config) {
-      const promptTeardownFailures: string[] = [];
-      for (const worker of config.workers) {
-        const teardown = await teardownPromptWorker(
-          sanitized,
-          worker.name,
-          worker.pid as number | undefined,
-          leaderCwd,
-          'startup_rollback',
-        );
-        if (!teardown.terminated) {
-          promptTeardownFailures.push(`${worker.name}:${teardown.error || 'unknown_error'}`);
-        }
-      }
-      if (promptTeardownFailures.length > 0) {
-        rollbackErrors.push(`promptTeardown:${promptTeardownFailures.join(',')}`);
-      }
-    }
+			// In split-pane topology, we must not kill the entire tmux session; kill only created panes.
+			if (sessionName.includes(":")) {
+				for (const [index, paneId] of createdWorkerPaneIds.entries()) {
+					const panePid = getWorkerPanePid(sessionName, index + 1, paneId);
+					if (panePid) {
+						await terminateTrackedProcessTree(panePid);
+					}
+					try {
+						await killWorkerByPaneIdAsync(paneId, createdLeaderPaneId);
+					} catch (err) {
+						process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+					}
+				}
+				if (config?.hud_pane_id) {
+					try {
+						await killWorkerByPaneIdAsync(
+							config.hud_pane_id,
+							createdLeaderPaneId,
+						);
+					} catch (err) {
+						process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+					}
+				}
+			} else {
+				try {
+					destroyTeamSession(sessionName);
+				} catch (cleanupError) {
+					rollbackErrors.push(`destroyTeamSession: ${String(cleanupError)}`);
+				}
+			}
+		}
+		if (workerLaunchMode === "prompt" && config) {
+			const promptTeardownFailures: string[] = [];
+			for (const worker of config.workers) {
+				const teardown = await teardownPromptWorker(
+					sanitized,
+					worker.name,
+					worker.pid as number | undefined,
+					leaderCwd,
+					"startup_rollback",
+				);
+				if (!teardown.terminated) {
+					promptTeardownFailures.push(
+						`${worker.name}:${teardown.error || "unknown_error"}`,
+					);
+				}
+			}
+			if (promptTeardownFailures.length > 0) {
+				rollbackErrors.push(
+					`promptTeardown:${promptTeardownFailures.join(",")}`,
+				);
+			}
+		}
 
-    if (config) {
-      for (const worker of config.workers) {
-        if (!worker.worktree_path || !worker.team_state_root) continue;
-        try {
-          await removeWorkerWorktreeRootAgentsFile(
-            sanitized,
-            worker.name,
-            worker.team_state_root,
-            worker.worktree_path,
-          );
-        } catch (cleanupError) {
-          rollbackErrors.push(`removeWorkerWorktreeRootAgentsFile(${worker.name}): ${String(cleanupError)}`);
-        }
-      }
-    }
-    if (workerInstructionsPath) {
-      try {
-        await removeTeamWorkerInstructionsFile(sanitized, leaderCwd);
-      } catch (cleanupError) {
-        rollbackErrors.push(`removeTeamWorkerInstructionsFile: ${String(cleanupError)}`);
-      }
-    }
-    restoreTeamModelInstructionsFile(sanitized);
+		if (config) {
+			for (const worker of config.workers) {
+				if (!worker.worktree_path || !worker.team_state_root) continue;
+				try {
+					await removeWorkerWorktreeRootAgentsFile(
+						sanitized,
+						worker.name,
+						worker.team_state_root,
+						worker.worktree_path,
+					);
+				} catch (cleanupError) {
+					rollbackErrors.push(
+						`removeWorkerWorktreeRootAgentsFile(${worker.name}): ${String(cleanupError)}`,
+					);
+				}
+			}
+		}
+		if (workerInstructionsPath) {
+			try {
+				await removeTeamWorkerInstructionsFile(sanitized, leaderCwd);
+			} catch (cleanupError) {
+				rollbackErrors.push(
+					`removeTeamWorkerInstructionsFile: ${String(cleanupError)}`,
+				);
+			}
+		}
+		restoreTeamModelInstructionsFile(sanitized);
 
-    try {
-      await cleanupTeamState(sanitized, leaderCwd);
-    } catch (cleanupError) {
-      rollbackErrors.push(`cleanupTeamState: ${String(cleanupError)}`);
-    }
-    if (provisionedWorktrees.length > 0) {
-      try {
-        await rollbackProvisionedWorktrees(provisionedWorktrees, {
-          skipBranchDeletion: false,
-        });
-      } catch (cleanupError) {
-        rollbackErrors.push(`rollbackProvisionedWorktrees: ${String(cleanupError)}`);
-      }
-    }
+		try {
+			await cleanupTeamState(sanitized, leaderCwd);
+		} catch (cleanupError) {
+			rollbackErrors.push(`cleanupTeamState: ${String(cleanupError)}`);
+		}
+		if (provisionedWorktrees.length > 0) {
+			try {
+				await rollbackProvisionedWorktrees(provisionedWorktrees, {
+					skipBranchDeletion: false,
+				});
+			} catch (cleanupError) {
+				rollbackErrors.push(
+					`rollbackProvisionedWorktrees: ${String(cleanupError)}`,
+				);
+			}
+		}
 
-    if (rollbackErrors.length > 0) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`${message}; rollback encountered errors: ${rollbackErrors.join(' | ')}`);
-    }
+		if (rollbackErrors.length > 0) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(
+				`${message}; rollback encountered errors: ${rollbackErrors.join(" | ")}`,
+			);
+		}
 
-    throw error;
-  }
+		throw error;
+	}
 }
 
 /**
  * Monitor team state by polling files. Returns a snapshot.
  */
-export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSnapshot | null> {
-  const monitorStartMs = performance.now();
-  const sanitized = sanitizeTeamName(teamName);
-  const config = await readTeamConfig(sanitized, cwd);
-  if (!config) return null;
-  const manifest = await readTeamManifestV2(sanitized, cwd);
-  const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
-  const previousSnapshot = await readMonitorSnapshot(sanitized, cwd);
+export async function monitorTeam(
+	teamName: string,
+	cwd: string,
+): Promise<TeamSnapshot | null> {
+	const monitorStartMs = performance.now();
+	const sanitized = sanitizeTeamName(teamName);
+	const config = await readTeamConfig(sanitized, cwd);
+	if (!config) return null;
+	const manifest = await readTeamManifestV2(sanitized, cwd);
+	const dispatchPolicy = resolveDispatchPolicy(
+		manifest?.policy,
+		config.worker_launch_mode,
+	);
+	const previousSnapshot = await readMonitorSnapshot(sanitized, cwd);
 
-  const sessionName = config.tmux_session;
-  const listTasksStartMs = performance.now();
-  const allTasks = await listTasks(sanitized, cwd);
-  const listTasksMs = performance.now() - listTasksStartMs;
+	const sessionName = config.tmux_session;
+	const listTasksStartMs = performance.now();
+	const allTasks = await listTasks(sanitized, cwd);
+	const listTasksMs = performance.now() - listTasksStartMs;
 
-  const reclaimedTaskIds: string[] = [];
-  for (const task of allTasks) {
-    if (task.status !== 'in_progress' || !task.claim?.leased_until) continue;
-    if (new Date(task.claim.leased_until) > new Date()) continue;
-    const reclaimed = await reclaimExpiredTaskClaim(sanitized, task.id, cwd);
-    if (reclaimed.ok && reclaimed.reclaimed) reclaimedTaskIds.push(task.id);
-  }
-  let taskView = reclaimedTaskIds.length > 0 ? await listTasks(sanitized, cwd) : allTasks;
-  const taskById = new Map(taskView.map((task) => [task.id, task] as const));
-  const inProgressByOwner = new Map<string, TeamTask[]>();
-  for (const task of taskView) {
-    if (task.status !== 'in_progress' || !task.owner) continue;
-    const existing = inProgressByOwner.get(task.owner) || [];
-    existing.push(task);
-    inProgressByOwner.set(task.owner, existing);
-  }
+	const reclaimedTaskIds: string[] = [];
+	for (const task of allTasks) {
+		if (task.status !== "in_progress" || !task.claim?.leased_until) continue;
+		if (new Date(task.claim.leased_until) > new Date()) continue;
+		const reclaimed = await reclaimExpiredTaskClaim(sanitized, task.id, cwd);
+		if (reclaimed.ok && reclaimed.reclaimed) reclaimedTaskIds.push(task.id);
+	}
+	let taskView =
+		reclaimedTaskIds.length > 0 ? await listTasks(sanitized, cwd) : allTasks;
+	const taskById = new Map(taskView.map((task) => [task.id, task] as const));
+	const inProgressByOwner = new Map<string, TeamTask[]>();
+	for (const task of taskView) {
+		if (task.status !== "in_progress" || !task.owner) continue;
+		const existing = inProgressByOwner.get(task.owner) || [];
+		existing.push(task);
+		inProgressByOwner.set(task.owner, existing);
+	}
 
-  const workers: TeamSnapshot['workers'] = [];
-  const deadWorkers: string[] = [];
-  const nonReportingWorkers: string[] = [];
-  const recommendations: string[] = [];
+	const workers: TeamSnapshot["workers"] = [];
+	const deadWorkers: string[] = [];
+	const nonReportingWorkers: string[] = [];
+	const recommendations: string[] = [];
 
-  const workerScanStartMs = performance.now();
-  const workerSignals = await Promise.all(
-    config.workers.map(async (worker) => {
-      const alive = config.worker_launch_mode === 'prompt'
-        ? isPromptWorkerAlive(config, worker)
-        : isWorkerAlive(sessionName, worker.index, worker.pane_id);
-      const [status, heartbeat] = await Promise.all([
-        readWorkerStatus(sanitized, worker.name, cwd),
-        readWorkerHeartbeat(sanitized, worker.name, cwd),
-      ]);
-      return { worker, alive, status, heartbeat };
-    })
-  );
-  const workerScanMs = performance.now() - workerScanStartMs;
+	const workerScanStartMs = performance.now();
+	const workerSignals = await Promise.all(
+		config.workers.map(async (worker) => {
+			const alive =
+				config.worker_launch_mode === "prompt"
+					? isPromptWorkerAlive(config, worker)
+					: isWorkerAlive(sessionName, worker.index, worker.pane_id);
+			const [status, heartbeat] = await Promise.all([
+				readWorkerStatus(sanitized, worker.name, cwd),
+				readWorkerHeartbeat(sanitized, worker.name, cwd),
+			]);
+			return { worker, alive, status, heartbeat };
+		}),
+	);
+	const workerScanMs = performance.now() - workerScanStartMs;
 
-  for (const { worker: w, alive, status, heartbeat } of workerSignals) {
-    const currentTask = status.current_task_id ? taskById.get(status.current_task_id) ?? null : null;
-    const previousTurns = previousSnapshot ? (previousSnapshot.workerTurnCountByName[w.name] ?? 0) : null;
-    const previousTaskId = previousSnapshot?.workerTaskIdByName[w.name] ?? '';
-    const currentTaskId = status.current_task_id ?? '';
-    const turnsWithoutProgress =
-      heartbeat &&
-      previousTurns !== null &&
-      status.state === 'working' &&
-      currentTask &&
-      (currentTask.status === 'pending' || currentTask.status === 'in_progress') &&
-      currentTaskId !== '' &&
-      previousTaskId === currentTaskId
-        ? Math.max(0, heartbeat.turn_count - previousTurns)
-        : 0;
+	for (const { worker: w, alive, status, heartbeat } of workerSignals) {
+		const currentTask = status.current_task_id
+			? (taskById.get(status.current_task_id) ?? null)
+			: null;
+		const previousTurns = previousSnapshot
+			? (previousSnapshot.workerTurnCountByName[w.name] ?? 0)
+			: null;
+		const previousTaskId = previousSnapshot?.workerTaskIdByName[w.name] ?? "";
+		const currentTaskId = status.current_task_id ?? "";
+		const turnsWithoutProgress =
+			heartbeat &&
+			previousTurns !== null &&
+			status.state === "working" &&
+			currentTask &&
+			(currentTask.status === "pending" ||
+				currentTask.status === "in_progress") &&
+			currentTaskId !== "" &&
+			previousTaskId === currentTaskId
+				? Math.max(0, heartbeat.turn_count - previousTurns)
+				: 0;
 
-    workers.push({
-      name: w.name,
-      alive,
-      status,
-      heartbeat,
-      assignedTasks: w.assigned_tasks,
-      turnsWithoutProgress,
-    });
+		workers.push({
+			name: w.name,
+			alive,
+			status,
+			heartbeat,
+			assignedTasks: w.assigned_tasks,
+			turnsWithoutProgress,
+		});
 
-    if (!alive) {
-      deadWorkers.push(w.name);
-      // Find in-progress tasks owned by this dead worker
-      const deadWorkerTasks = inProgressByOwner.get(w.name) || [];
-      for (const t of deadWorkerTasks) {
-        recommendations.push(`Reassign task-${t.id} from dead ${w.name}`);
-      }
-    }
+		if (!alive) {
+			deadWorkers.push(w.name);
+			// Find in-progress tasks owned by this dead worker
+			const deadWorkerTasks = inProgressByOwner.get(w.name) || [];
+			for (const t of deadWorkerTasks) {
+				recommendations.push(`Reassign task-${t.id} from dead ${w.name}`);
+			}
+		}
 
-    if (alive && turnsWithoutProgress > 5) {
-      nonReportingWorkers.push(w.name);
-      recommendations.push(`Send reminder to non-reporting ${w.name}`);
-    }
-  }
+		if (alive && turnsWithoutProgress > 5) {
+			nonReportingWorkers.push(w.name);
+			recommendations.push(`Send reminder to non-reporting ${w.name}`);
+		}
+	}
 
-  for (const taskId of reclaimedTaskIds) {
-    recommendations.push(`Reclaimed expired claim for task-${taskId}`);
-  }
-  const rebalanceDecisions = buildRebalanceDecisions({
-    tasks: taskView,
-    workers: workers.map((worker) => ({
-      name: worker.name,
-      role: config.workers.find((entry) => entry.name === worker.name)?.role,
-      alive: worker.alive,
-      status: worker.status,
-    })),
-    reclaimedTaskIds,
-  });
+	for (const taskId of reclaimedTaskIds) {
+		recommendations.push(`Reclaimed expired claim for task-${taskId}`);
+	}
+	const rebalanceDecisions = buildRebalanceDecisions({
+		tasks: taskView,
+		workers: workers.map((worker) => ({
+			name: worker.name,
+			role: config.workers.find((entry) => entry.name === worker.name)?.role,
+			alive: worker.alive,
+			status: worker.status,
+		})),
+		reclaimedTaskIds,
+	});
 
-  let assignedDuringMonitor = false;
-  for (const decision of rebalanceDecisions) {
-    if (decision.type === 'assign' && decision.taskId && decision.workerName) {
-      try {
-        await assignTask(sanitized, decision.workerName, decision.taskId, cwd);
-        recommendations.push(`Assigned task-${decision.taskId} to ${decision.workerName}: ${decision.reason}`);
-        assignedDuringMonitor = true;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        recommendations.push(`Unable to assign task-${decision.taskId} to ${decision.workerName}: ${message}`);
-      }
-    } else {
-      recommendations.push(decision.reason);
-    }
-  }
+	let assignedDuringMonitor = false;
+	for (const decision of rebalanceDecisions) {
+		if (decision.type === "assign" && decision.taskId && decision.workerName) {
+			try {
+				await assignTask(sanitized, decision.workerName, decision.taskId, cwd);
+				recommendations.push(
+					`Assigned task-${decision.taskId} to ${decision.workerName}: ${decision.reason}`,
+				);
+				assignedDuringMonitor = true;
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				recommendations.push(
+					`Unable to assign task-${decision.taskId} to ${decision.workerName}: ${message}`,
+				);
+			}
+		} else {
+			recommendations.push(decision.reason);
+		}
+	}
 
-  if (assignedDuringMonitor) {
-    taskView = await listTasks(sanitized, cwd);
-  }
+	if (assignedDuringMonitor) {
+		taskView = await listTasks(sanitized, cwd);
+	}
 
-  // Count tasks
-  const taskCounts = {
-    total: taskView.length,
-    pending: taskView.filter(t => t.status === 'pending').length,
-    blocked: taskView.filter(t => t.status === 'blocked').length,
-    in_progress: taskView.filter(t => t.status === 'in_progress').length,
-    completed: taskView.filter(t => t.status === 'completed').length,
-    failed: taskView.filter(t => t.status === 'failed').length,
-  };
+	// Count tasks
+	const taskCounts = {
+		total: taskView.length,
+		pending: taskView.filter((t) => t.status === "pending").length,
+		blocked: taskView.filter((t) => t.status === "blocked").length,
+		in_progress: taskView.filter((t) => t.status === "in_progress").length,
+		completed: taskView.filter((t) => t.status === "completed").length,
+		failed: taskView.filter((t) => t.status === "failed").length,
+	};
 
-  const verificationPendingTasks = taskView.filter(
-    (task) => task.status === 'completed'
-      && task.requires_code_change === true
-      && !hasStructuredVerificationEvidence(task.result),
-  );
-  if (verificationPendingTasks.length > 0) {
-    for (const task of verificationPendingTasks) {
-      recommendations.push(`Verification evidence missing for task-${task.id}; require structured PASS/FAIL evidence before terminal success`);
-    }
-  }
+	const verificationPendingTasks = taskView.filter(
+		(task) =>
+			task.status === "completed" &&
+			task.requires_code_change === true &&
+			!hasStructuredVerificationEvidence(task.result),
+	);
+	if (verificationPendingTasks.length > 0) {
+		for (const task of verificationPendingTasks) {
+			recommendations.push(
+				`Verification evidence missing for task-${task.id}; require structured PASS/FAIL evidence before terminal success`,
+			);
+		}
+	}
 
-  const allTasksTerminal = taskCounts.pending === 0 && taskCounts.blocked === 0 && taskCounts.in_progress === 0;
-  const deadWorkerStall =
-    config.worker_launch_mode === 'prompt'
-    && config.workers.length > 0
-    && deadWorkers.length >= config.workers.length
-    && !allTasksTerminal;
+	const allTasksTerminal =
+		taskCounts.pending === 0 &&
+		taskCounts.blocked === 0 &&
+		taskCounts.in_progress === 0;
+	const deadWorkerStall =
+		config.worker_launch_mode === "prompt" &&
+		config.workers.length > 0 &&
+		deadWorkers.length >= config.workers.length &&
+		!allTasksTerminal;
 
-  const persistedPhase = await readTeamPhaseState(sanitized, cwd);
-  const targetPhase = deadWorkerStall
-    ? 'failed'
-    : inferPhaseTargetFromTaskCounts(taskCounts, {
-      verificationPending: verificationPendingTasks.length > 0,
-    });
-  const phaseState: TeamPhaseState = reconcilePhaseStateForMonitor(persistedPhase, targetPhase);
-  await writeTeamPhaseState(sanitized, phaseState, cwd);
-  const phase: TeamPhase | TerminalPhase = phaseState.current_phase;
-  await syncRootTeamModeStateOnTerminalPhase(sanitized, phase, cwd);
+	const persistedPhase = await readTeamPhaseState(sanitized, cwd);
+	const targetPhase = deadWorkerStall
+		? "failed"
+		: inferPhaseTargetFromTaskCounts(taskCounts, {
+				verificationPending: verificationPendingTasks.length > 0,
+			});
+	const phaseState: TeamPhaseState = reconcilePhaseStateForMonitor(
+		persistedPhase,
+		targetPhase,
+	);
+	await writeTeamPhaseState(sanitized, phaseState, cwd);
+	const phase: TeamPhase | TerminalPhase = phaseState.current_phase;
+	await syncRootTeamModeStateOnTerminalPhase(sanitized, phase, cwd);
 
-  if (deadWorkerStall) {
-    recommendations.push('All workers are dead while work remains; mark the team failed or restart with fresh workers.');
-  }
+	if (deadWorkerStall) {
+		recommendations.push(
+			"All workers are dead while work remains; mark the team failed or restart with fresh workers.",
+		);
+	}
 
-  await emitMonitorDerivedEvents(sanitized, taskView, workers, previousSnapshot, config.worker_launch_mode, cwd);
-  const integrationByWorker = await integrateWorkerCommitsIntoLeader({
-    teamName: sanitized,
-    config,
-    previous: previousSnapshot,
-    cwd,
-  });
-  const mailboxDeliveryStartMs = performance.now();
-  const mailboxNotifiedByMessageId = await deliverPendingMailboxMessages(
-    sanitized,
-    config,
-    workers,
-    previousSnapshot?.mailboxNotifiedByMessageId ?? {},
-    dispatchPolicy,
-    cwd
-  );
-  const mailboxDeliveryMs = performance.now() - mailboxDeliveryStartMs;
+	await emitMonitorDerivedEvents(
+		sanitized,
+		taskView,
+		workers,
+		previousSnapshot,
+		config.worker_launch_mode,
+		cwd,
+	);
+	const integrationByWorker = await integrateWorkerCommitsIntoLeader({
+		teamName: sanitized,
+		config,
+		previous: previousSnapshot,
+		cwd,
+	});
+	const mailboxDeliveryStartMs = performance.now();
+	const mailboxNotifiedByMessageId = await deliverPendingMailboxMessages(
+		sanitized,
+		config,
+		workers,
+		previousSnapshot?.mailboxNotifiedByMessageId ?? {},
+		dispatchPolicy,
+		cwd,
+	);
+	const mailboxDeliveryMs = performance.now() - mailboxDeliveryStartMs;
 
-  // Prune ephemeral status messages from leader mailbox (TTL: 60s)
-  try {
-    const leaderMailbox = await listMailboxMessages(sanitized, 'leader-fixed', cwd);
-    const now = Date.now();
-    for (const msg of leaderMailbox) {
-      if (msg.from_worker === 'system' && msg.created_at) {
-        const age = now - new Date(msg.created_at).getTime();
-        if (age > 60_000) {
-          await markMessageDelivered(sanitized, 'leader-fixed', msg.message_id, cwd);
-        }
-      }
-    }
-  } catch (err) {
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-  }
+	// Prune ephemeral status messages from leader mailbox (TTL: 60s)
+	try {
+		const leaderMailbox = await listMailboxMessages(
+			sanitized,
+			"leader-fixed",
+			cwd,
+		);
+		const now = Date.now();
+		for (const msg of leaderMailbox) {
+			if (msg.from_worker === "system" && msg.created_at) {
+				const age = now - new Date(msg.created_at).getTime();
+				if (age > 60_000) {
+					await markMessageDelivered(
+						sanitized,
+						"leader-fixed",
+						msg.message_id,
+						cwd,
+					);
+				}
+			}
+		}
+	} catch (err) {
+		process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+	}
 
-  const updatedAt = new Date().toISOString();
-  const totalMs = performance.now() - monitorStartMs;
-  await writeMonitorSnapshot(
-    sanitized,
-      {
-        taskStatusById: Object.fromEntries(taskView.map((t) => [t.id, t.status])),
-        workerAliveByName: Object.fromEntries(workers.map((w) => [w.name, w.alive])),
-        workerStateByName: Object.fromEntries(workers.map((w) => [w.name, w.status.state])),
-        workerTurnCountByName: Object.fromEntries(workers.map((w) => [w.name, w.heartbeat?.turn_count ?? 0])),
-        workerTaskIdByName: Object.fromEntries(workers.map((w) => [w.name, w.status.current_task_id ?? ''])),
-        mailboxNotifiedByMessageId,
-        completedEventTaskIds: previousSnapshot?.completedEventTaskIds ?? {},
-        integrationByWorker,
-        monitorTimings: {
-          list_tasks_ms: Number(listTasksMs.toFixed(2)),
-          worker_scan_ms: Number(workerScanMs.toFixed(2)),
-          mailbox_delivery_ms: Number(mailboxDeliveryMs.toFixed(2)),
-          total_ms: Number(totalMs.toFixed(2)),
-          updated_at: updatedAt,
-        },
-      },
-      cwd
-  );
+	const updatedAt = new Date().toISOString();
+	const totalMs = performance.now() - monitorStartMs;
+	await writeMonitorSnapshot(
+		sanitized,
+		{
+			taskStatusById: Object.fromEntries(taskView.map((t) => [t.id, t.status])),
+			workerAliveByName: Object.fromEntries(
+				workers.map((w) => [w.name, w.alive]),
+			),
+			workerStateByName: Object.fromEntries(
+				workers.map((w) => [w.name, w.status.state]),
+			),
+			workerTurnCountByName: Object.fromEntries(
+				workers.map((w) => [w.name, w.heartbeat?.turn_count ?? 0]),
+			),
+			workerTaskIdByName: Object.fromEntries(
+				workers.map((w) => [w.name, w.status.current_task_id ?? ""]),
+			),
+			mailboxNotifiedByMessageId,
+			completedEventTaskIds: previousSnapshot?.completedEventTaskIds ?? {},
+			integrationByWorker,
+			monitorTimings: {
+				list_tasks_ms: Number(listTasksMs.toFixed(2)),
+				worker_scan_ms: Number(workerScanMs.toFixed(2)),
+				mailbox_delivery_ms: Number(mailboxDeliveryMs.toFixed(2)),
+				total_ms: Number(totalMs.toFixed(2)),
+				updated_at: updatedAt,
+			},
+		},
+		cwd,
+	);
 
-  return {
-    teamName: sanitized,
-    phase,
-    workers,
-    tasks: {
-      ...taskCounts,
-      items: taskView,
-    },
-    allTasksTerminal,
-    deadWorkers,
-    nonReportingWorkers,
-    recommendations,
-    performance: {
-      list_tasks_ms: Number(listTasksMs.toFixed(2)),
-      worker_scan_ms: Number(workerScanMs.toFixed(2)),
-      mailbox_delivery_ms: Number(mailboxDeliveryMs.toFixed(2)),
-      total_ms: Number(totalMs.toFixed(2)),
-      updated_at: updatedAt,
-    },
-  };
+	return {
+		teamName: sanitized,
+		phase,
+		workers,
+		tasks: {
+			...taskCounts,
+			items: taskView,
+		},
+		allTasksTerminal,
+		deadWorkers,
+		nonReportingWorkers,
+		recommendations,
+		performance: {
+			list_tasks_ms: Number(listTasksMs.toFixed(2)),
+			worker_scan_ms: Number(workerScanMs.toFixed(2)),
+			mailbox_delivery_ms: Number(mailboxDeliveryMs.toFixed(2)),
+			total_ms: Number(totalMs.toFixed(2)),
+			updated_at: updatedAt,
+		},
+	};
 }
 
 /**
  * Assign a task to a worker by writing inbox and sending trigger.
  */
 export async function assignTask(
-  teamName: string,
-  workerName: string,
-  taskId: string,
-  cwd: string,
+	teamName: string,
+	workerName: string,
+	taskId: string,
+	cwd: string,
 ): Promise<void> {
-  const sanitized = sanitizeTeamName(teamName);
-  const task = await readTask(sanitized, taskId, cwd);
-  if (!task) throw new Error(`Task ${taskId} not found`);
-  const manifest = await readTeamManifestV2(sanitized, cwd);
-  const governance = resolveGovernancePolicy(manifest?.governance);
+	const sanitized = sanitizeTeamName(teamName);
+	const task = await readTask(sanitized, taskId, cwd);
+	if (!task) throw new Error(`Task ${taskId} not found`);
+	const manifest = await readTeamManifestV2(sanitized, cwd);
+	const governance = resolveGovernancePolicy(manifest?.governance);
 
-  if (governance.delegation_only && workerName === 'leader-fixed') {
-    throw new Error('delegation_only_violation');
-  }
+	if (governance.delegation_only && workerName === "leader-fixed") {
+		throw new Error("delegation_only_violation");
+	}
 
-  if (governance.plan_approval_required && task.requires_code_change === true) {
-    const approved = await isTaskApprovedForExecution(sanitized, taskId, cwd);
-    if (!approved) {
-      throw new Error('plan_approval_required');
-    }
-  }
-  const config = await readTeamConfig(sanitized, cwd);
-  if (!config) throw new Error(`Team ${sanitized} not found`);
-  const workerInfo = config.workers.find(w => w.name === workerName);
-  if (!workerInfo) throw new Error(`Worker ${workerName} not found in team`);
-  const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
+	if (governance.plan_approval_required && task.requires_code_change === true) {
+		const approved = await isTaskApprovedForExecution(sanitized, taskId, cwd);
+		if (!approved) {
+			throw new Error("plan_approval_required");
+		}
+	}
+	const config = await readTeamConfig(sanitized, cwd);
+	if (!config) throw new Error(`Team ${sanitized} not found`);
+	const workerInfo = config.workers.find((w) => w.name === workerName);
+	if (!workerInfo) throw new Error(`Worker ${workerName} not found in team`);
+	const dispatchPolicy = resolveDispatchPolicy(
+		manifest?.policy,
+		config.worker_launch_mode,
+	);
 
-  const claim = await claimTask(sanitized, taskId, workerName, task.version ?? 1, cwd);
-  if (!claim.ok) {
-    if (claim.error === 'blocked_dependency') {
-      throw new Error(`blocked_dependency:${(claim.dependencies ?? []).join(',')}`);
-    }
-    throw new Error(claim.error);
-  }
+	const claim = await claimTask(
+		sanitized,
+		taskId,
+		workerName,
+		task.version ?? 1,
+		cwd,
+	);
+	if (!claim.ok) {
+		if (claim.error === "blocked_dependency") {
+			throw new Error(
+				`blocked_dependency:${(claim.dependencies ?? []).join(",")}`,
+			);
+		}
+		throw new Error(claim.error);
+	}
 
-  try {
-    // Retry dispatch up to 2 times to handle trust prompts during assignment (fixes #393).
-    const inbox = generateTaskAssignmentInbox(workerName, sanitized, taskId, task.description);
-    const maxAssignRetries = 2;
-    const assignRetryDelayS = 2;
-    let outcome: DispatchOutcome = { ok: false, transport: 'none', reason: 'not_attempted' };
-    const triggerDirective = buildTriggerDirective(
-      workerName,
-      sanitized,
-      resolveInstructionStateRoot(workerInfo.worktree_path),
-    );
-    for (let attempt = 1; attempt <= maxAssignRetries; attempt++) {
-      outcome = await dispatchCriticalInboxInstruction({
-        teamName: sanitized,
-        config,
-        workerName,
-        workerIndex: workerInfo.index,
-        paneId: workerInfo.pane_id,
-        inbox,
-        triggerMessage: triggerDirective.text,
-        intent: triggerDirective.intent,
-        cwd,
-        dispatchPolicy,
-        inboxCorrelationKey: `assign:${taskId}:${workerName}`,
-      });
-      if (outcome.ok) break;
-      if (attempt < maxAssignRetries && config.worker_launch_mode === 'interactive' && config.tmux_session) {
-        if (dismissTrustPromptIfPresent(config.tmux_session, workerInfo.index, workerInfo.pane_id)) {
-          waitForWorkerReady(
-            config.tmux_session,
-            workerInfo.index,
-            resolveWorkerReadyTimeoutMs(process.env),
-            workerInfo.pane_id,
-          );
-        } else {
-          await new Promise<void>(r => setTimeout(r, assignRetryDelayS * 1000));
-        }
-      }
-    }
-    if (!outcome.ok) {
-      throw new Error('worker_notify_failed');
-    }
-  } catch (error) {
-    // Roll back claim to avoid stuck in_progress tasks on any post-claim dispatch failure.
-    const released = await releaseTaskClaim(sanitized, taskId, claim.claimToken, workerName, cwd);
+	try {
+		// Retry dispatch up to 2 times to handle trust prompts during assignment (fixes #393).
+		const inbox = generateTaskAssignmentInbox(
+			workerName,
+			sanitized,
+			taskId,
+			task.description,
+		);
+		const maxAssignRetries = 2;
+		const assignRetryDelayS = 2;
+		let outcome: DispatchOutcome = {
+			ok: false,
+			transport: "none",
+			reason: "not_attempted",
+		};
+		const triggerDirective = buildTriggerDirective(
+			workerName,
+			sanitized,
+			resolveInstructionStateRoot(workerInfo.worktree_path),
+		);
+		for (let attempt = 1; attempt <= maxAssignRetries; attempt++) {
+			outcome = await dispatchCriticalInboxInstruction({
+				teamName: sanitized,
+				config,
+				workerName,
+				workerIndex: workerInfo.index,
+				paneId: workerInfo.pane_id,
+				inbox,
+				triggerMessage: triggerDirective.text,
+				intent: triggerDirective.intent,
+				cwd,
+				dispatchPolicy,
+				inboxCorrelationKey: `assign:${taskId}:${workerName}`,
+			});
+			if (outcome.ok) break;
+			if (
+				attempt < maxAssignRetries &&
+				config.worker_launch_mode === "interactive" &&
+				config.tmux_session
+			) {
+				if (
+					dismissTrustPromptIfPresent(
+						config.tmux_session,
+						workerInfo.index,
+						workerInfo.pane_id,
+					)
+				) {
+					waitForWorkerReady(
+						config.tmux_session,
+						workerInfo.index,
+						resolveWorkerReadyTimeoutMs(process.env),
+						workerInfo.pane_id,
+					);
+				} else {
+					await new Promise<void>((r) =>
+						setTimeout(r, assignRetryDelayS * 1000),
+					);
+				}
+			}
+		}
+		if (!outcome.ok) {
+			throw new Error("worker_notify_failed");
+		}
+	} catch (error) {
+		// Roll back claim to avoid stuck in_progress tasks on any post-claim dispatch failure.
+		const released = await releaseTaskClaim(
+			sanitized,
+			taskId,
+			claim.claimToken,
+			workerName,
+			cwd,
+		);
 
-    const reason = error instanceof Error && error.message.trim() !== ''
-      ? error.message
-      : 'worker_assignment_failed';
+		const reason =
+			error instanceof Error && error.message.trim() !== ""
+				? error.message
+				: "worker_assignment_failed";
 
-    try {
-      await writeWorkerInbox(
-        sanitized,
-        workerName,
-        `# Assignment Cancelled\n\nTask ${taskId} was not dispatched due to ${reason}.\nDo not execute this task from prior inbox content.`,
-        cwd,
-      );
-    } catch (err) {
-      process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-      // best effort
-    }
+		try {
+			await writeWorkerInbox(
+				sanitized,
+				workerName,
+				`# Assignment Cancelled\n\nTask ${taskId} was not dispatched due to ${reason}.\nDo not execute this task from prior inbox content.`,
+				cwd,
+			);
+		} catch (err) {
+			process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+			// best effort
+		}
 
-    if (!released.ok) {
-      throw new Error(`${reason}:${released.error}`);
-    }
+		if (!released.ok) {
+			throw new Error(`${reason}:${released.error}`);
+		}
 
-    if (reason === 'worker_notify_failed') throw new Error('worker_notify_failed');
-    throw new Error(`worker_assignment_failed:${reason}`);
-  }
+		if (reason === "worker_notify_failed")
+			throw new Error("worker_notify_failed");
+		throw new Error(`worker_assignment_failed:${reason}`);
+	}
 }
 
 /**
  * Reassign a task from one worker to another.
  */
 export async function reassignTask(
-  teamName: string,
-  taskId: string,
-  _fromWorker: string,
-  toWorker: string,
-  cwd: string,
+	teamName: string,
+	taskId: string,
+	_fromWorker: string,
+	toWorker: string,
+	cwd: string,
 ): Promise<void> {
-  await assignTask(teamName, toWorker, taskId, cwd);
+	await assignTask(teamName, toWorker, taskId, cwd);
 }
 
 /**
  * Graceful shutdown: send shutdown inbox to all workers, wait, force kill, cleanup.
  */
-export async function shutdownTeam(teamName: string, cwd: string, options: ShutdownOptions = {}): Promise<TeamShutdownSummary> {
-  const force = options.force === true;
-  const sanitized = sanitizeTeamName(teamName);
-  const config = await readTeamConfig(sanitized, cwd);
-  if (!config) {
-    // No config -- just try to kill tmux session and clean up
-    try {
-      destroyTeamSession(`omx-team-${sanitized}`);
-    } catch (err) {
-      process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    }
-    await cleanupTeamState(sanitized, cwd);
-    restoreTeamModelInstructionsFile(sanitized);
-    return { commitHygieneArtifacts: null };
-  }
-  const manifest = await readTeamManifestV2(sanitized, cwd);
-  const governance = resolveGovernancePolicy(
-    manifest?.governance,
-    manifest?.policy as Partial<TeamGovernance> | undefined,
-  );
+export async function shutdownTeam(
+	teamName: string,
+	cwd: string,
+	options: ShutdownOptions = {},
+): Promise<TeamShutdownSummary> {
+	const force = options.force === true;
+	const sanitized = sanitizeTeamName(teamName);
+	const config = await readTeamConfig(sanitized, cwd);
+	if (!config) {
+		// No config -- just try to kill tmux session and clean up
+		try {
+			destroyTeamSession(`omx-team-${sanitized}`);
+		} catch (err) {
+			process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+		}
+		await cleanupTeamState(sanitized, cwd);
+		restoreTeamModelInstructionsFile(sanitized);
+		return { commitHygieneArtifacts: null };
+	}
+	const manifest = await readTeamManifestV2(sanitized, cwd);
+	const governance = resolveGovernancePolicy(
+		manifest?.governance,
+		manifest?.policy as Partial<TeamGovernance> | undefined,
+	);
 
-  if (!force) {
-    const allTasks = await listTasks(sanitized, cwd);
-    const gate: ShutdownGateCounts = {
-      total: allTasks.length,
-      pending: allTasks.filter((t) => t.status === 'pending').length,
-      blocked: allTasks.filter((t) => t.status === 'blocked').length,
-      in_progress: allTasks.filter((t) => t.status === 'in_progress').length,
-      completed: allTasks.filter((t) => t.status === 'completed').length,
-      failed: allTasks.filter((t) => t.status === 'failed').length,
-      allowed: false,
-    };
-    gate.allowed = governance.cleanup_requires_all_workers_inactive !== true
-      || (gate.pending === 0 && gate.blocked === 0 && gate.in_progress === 0 && gate.failed === 0);
+	if (!force) {
+		const allTasks = await listTasks(sanitized, cwd);
+		const gate: ShutdownGateCounts = {
+			total: allTasks.length,
+			pending: allTasks.filter((t) => t.status === "pending").length,
+			blocked: allTasks.filter((t) => t.status === "blocked").length,
+			in_progress: allTasks.filter((t) => t.status === "in_progress").length,
+			completed: allTasks.filter((t) => t.status === "completed").length,
+			failed: allTasks.filter((t) => t.status === "failed").length,
+			allowed: false,
+		};
+		gate.allowed =
+			governance.cleanup_requires_all_workers_inactive !== true ||
+			(gate.pending === 0 &&
+				gate.blocked === 0 &&
+				gate.in_progress === 0 &&
+				gate.failed === 0);
 
-    await appendTeamEvent(
-      sanitized,
-      {
-        type: 'shutdown_gate',
-        worker: 'leader-fixed',
-        reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed} cleanup_requires_all_workers_inactive=${governance.cleanup_requires_all_workers_inactive}`,
-      },
-      cwd,
-    ).catch(() => {});
+		await appendTeamEvent(
+			sanitized,
+			{
+				type: "shutdown_gate",
+				worker: "leader-fixed",
+				reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed} cleanup_requires_all_workers_inactive=${governance.cleanup_requires_all_workers_inactive}`,
+			},
+			cwd,
+		).catch(() => {});
 
-    if (!gate.allowed) {
-      throw new Error(
-        `shutdown_gate_blocked:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
-      );
-    }
-  }
+		if (!gate.allowed) {
+			throw new Error(
+				`shutdown_gate_blocked:pending=${gate.pending},blocked=${gate.blocked},in_progress=${gate.in_progress},failed=${gate.failed}`,
+			);
+		}
+	}
 
-  if (force) {
-    await appendTeamEvent(sanitized, {
-      type: 'shutdown_gate_forced',
-      worker: 'leader-fixed',
-      reason: 'force_bypass',
-    }, cwd).catch(() => {});
-  }
+	if (force) {
+		await appendTeamEvent(
+			sanitized,
+			{
+				type: "shutdown_gate_forced",
+				worker: "leader-fixed",
+				reason: "force_bypass",
+			},
+			cwd,
+		).catch(() => {});
+	}
 
-  const sessionName = config.tmux_session;
-  const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
-  const shutdownRequestTimes = new Map<string, string>();
+	const sessionName = config.tmux_session;
+	const dispatchPolicy = resolveDispatchPolicy(
+		manifest?.policy,
+		config.worker_launch_mode,
+	);
+	const shutdownRequestTimes = new Map<string, string>();
 
-  // 1. Send shutdown inbox to each worker
-  for (const w of config.workers) {
-    try {
-      const requestedAt = new Date().toISOString();
-      await writeShutdownRequest(sanitized, w.name, 'leader-fixed', cwd);
-      shutdownRequestTimes.set(w.name, requestedAt);
-      const triggerDirective = buildTriggerDirective(
-        w.name,
-        sanitized,
-        resolveInstructionStateRoot(w.worktree_path),
-      );
-      await dispatchCriticalInboxInstruction({
-        teamName: sanitized,
-        config,
-        workerName: w.name,
-        workerIndex: w.index,
-        paneId: w.pane_id,
-        inbox: generateShutdownInbox(sanitized, w.name),
-        triggerMessage: triggerDirective.text,
-        intent: triggerDirective.intent,
-        cwd,
-        dispatchPolicy,
-        inboxCorrelationKey: `shutdown:${w.name}`,
-      });
-    } catch (err) {
-      process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    }
-  }
+	// 1. Send shutdown inbox to each worker
+	for (const w of config.workers) {
+		try {
+			const requestedAt = new Date().toISOString();
+			await writeShutdownRequest(sanitized, w.name, "leader-fixed", cwd);
+			shutdownRequestTimes.set(w.name, requestedAt);
+			const triggerDirective = buildTriggerDirective(
+				w.name,
+				sanitized,
+				resolveInstructionStateRoot(w.worktree_path),
+			);
+			await dispatchCriticalInboxInstruction({
+				teamName: sanitized,
+				config,
+				workerName: w.name,
+				workerIndex: w.index,
+				paneId: w.pane_id,
+				inbox: generateShutdownInbox(sanitized, w.name),
+				triggerMessage: triggerDirective.text,
+				intent: triggerDirective.intent,
+				cwd,
+				dispatchPolicy,
+				inboxCorrelationKey: `shutdown:${w.name}`,
+			});
+		} catch (err) {
+			process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+		}
+	}
 
-  // 2. Wait up to 15s for workers to exit and collect acks
-  const deadline = Date.now() + 15_000;
-  const rejected: Array<{ worker: string; reason: string }> = [];
-  const ackedWorkers = new Set<string>();
-  while (Date.now() < deadline) {
-    for (const w of config.workers) {
-      const ack = await readShutdownAck(sanitized, w.name, cwd, shutdownRequestTimes.get(w.name));
-      if (ack && !ackedWorkers.has(w.name)) {
-        ackedWorkers.add(w.name);
-        await appendTeamEvent(sanitized, {
-          type: 'shutdown_ack',
-          worker: w.name,
-          reason: ack.status === 'reject' ? `reject:${ack.reason || 'no_reason'}` : 'accept',
-        }, cwd);
-      }
-      if (ack?.status === 'reject') {
-        if (!rejected.some((r) => r.worker === w.name)) {
-          rejected.push({ worker: w.name, reason: ack.reason || 'no_reason' });
-        }
-      }
-    }
-    if (rejected.length > 0 && !force) {
-      const detail = rejected.map(r => `${r.worker}:${r.reason}`).join(',');
-      throw new Error(`shutdown_rejected:${detail}`);
-    }
+	// 2. Wait up to 15s for workers to exit and collect acks
+	const deadline = Date.now() + 15_000;
+	const rejected: Array<{ worker: string; reason: string }> = [];
+	const ackedWorkers = new Set<string>();
+	while (Date.now() < deadline) {
+		for (const w of config.workers) {
+			const ack = await readShutdownAck(
+				sanitized,
+				w.name,
+				cwd,
+				shutdownRequestTimes.get(w.name),
+			);
+			if (ack && !ackedWorkers.has(w.name)) {
+				ackedWorkers.add(w.name);
+				await appendTeamEvent(
+					sanitized,
+					{
+						type: "shutdown_ack",
+						worker: w.name,
+						reason:
+							ack.status === "reject"
+								? `reject:${ack.reason || "no_reason"}`
+								: "accept",
+					},
+					cwd,
+				);
+			}
+			if (ack?.status === "reject") {
+				if (!rejected.some((r) => r.worker === w.name)) {
+					rejected.push({ worker: w.name, reason: ack.reason || "no_reason" });
+				}
+			}
+		}
+		if (rejected.length > 0 && !force) {
+			const detail = rejected.map((r) => `${r.worker}:${r.reason}`).join(",");
+			throw new Error(`shutdown_rejected:${detail}`);
+		}
 
-    const anyAlive = config.workers.some((w) => (
-      config.worker_launch_mode === 'prompt'
-        ? isPromptWorkerAlive(config, w)
-        : isWorkerAlive(sessionName, w.index, w.pane_id)
-    ));
-    if (!anyAlive) break;
-    // Sleep 2s
-    await new Promise(resolve => setTimeout(resolve, 2000));
-  }
+		const anyAlive = config.workers.some((w) =>
+			config.worker_launch_mode === "prompt"
+				? isPromptWorkerAlive(config, w)
+				: isWorkerAlive(sessionName, w.index, w.pane_id),
+		);
+		if (!anyAlive) break;
+		// Sleep 2s
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+	}
 
-  const anyAliveAfterWait = config.workers.some((w) => (
-    config.worker_launch_mode === 'prompt'
-      ? isPromptWorkerAlive(config, w)
-      : isWorkerAlive(sessionName, w.index, w.pane_id)
-  ));
-  if (anyAliveAfterWait && !force) {
-    // Workers may have accepted shutdown but not exited (Codex TUI requires explicit exit).
-    // In this case, proceed to force kill panes (next step) rather than failing and leaving state around.
-  }
+	const anyAliveAfterWait = config.workers.some((w) =>
+		config.worker_launch_mode === "prompt"
+			? isPromptWorkerAlive(config, w)
+			: isWorkerAlive(sessionName, w.index, w.pane_id),
+	);
+	if (anyAliveAfterWait && !force) {
+		// Workers may have accepted shutdown but not exited (Codex TUI requires explicit exit).
+		// In this case, proceed to force kill panes (next step) rather than failing and leaving state around.
+	}
 
-  // 3. Force kill remaining workers
-  const leaderPaneId = config.leader_pane_id;
-  const hudPaneId = config.hud_pane_id;
-  if (config.worker_launch_mode === 'interactive') {
-    const livePaneIds = listPaneIds(sessionName);
-    let shutdownPaneIds = collectShutdownPaneIds({ config, livePaneIds });
-    if (shouldPrekillInteractiveShutdownProcessTrees(sessionName)) {
-      const workerPanePids = shutdownPaneIds
-        .map((paneId) => getWorkerPanePid(sessionName, 1, paneId))
-        .filter((pid): pid is number => typeof pid === 'number' && Number.isFinite(pid) && pid > 0);
-      for (const panePid of workerPanePids) {
-        await terminateTrackedProcessTree(panePid);
-      }
-    }
+	// 3. Force kill remaining workers
+	const leaderPaneId = config.leader_pane_id;
+	const hudPaneId = config.hud_pane_id;
+	if (config.worker_launch_mode === "interactive") {
+		const livePaneIds = listPaneIds(sessionName);
+		let shutdownPaneIds = collectShutdownPaneIds({ config, livePaneIds });
+		if (shouldPrekillInteractiveShutdownProcessTrees(sessionName)) {
+			const workerPanePids = shutdownPaneIds
+				.map((paneId) => getWorkerPanePid(sessionName, 1, paneId))
+				.filter(
+					(pid): pid is number =>
+						typeof pid === "number" && Number.isFinite(pid) && pid > 0,
+				);
+			for (const panePid of workerPanePids) {
+				await terminateTrackedProcessTree(panePid);
+			}
+		}
 
-    let resizeHookWarning: string | null = null;
-    if (config.resize_hook_name && config.resize_hook_target) {
-      const resizeHookName = config.resize_hook_name;
-      const unregistered = unregisterResizeHook(config.resize_hook_target, resizeHookName);
-      if (!unregistered && isTmuxAvailable()) {
-        const baseSession = sessionName.split(':')[0];
-        const sessionStillActive = listTeamSessions().includes(baseSession);
-        if (sessionStillActive) {
-          resizeHookWarning = `failed to unregister resize hook ${resizeHookName}`;
-        }
-      }
-    }
-    config.resize_hook_name = null;
-    config.resize_hook_target = null;
-    await saveTeamConfig(config, cwd);
-    if (resizeHookWarning) {
-      console.warn(`[team shutdown] ${sanitized}: ${resizeHookWarning}; continuing teardown`);
-    }
-    let restoredHudPaneId: string | null = null;
-    if (hudPaneId) {
-      await killWorkerByPaneIdAsync(hudPaneId, leaderPaneId ?? undefined);
-      if (sessionName.includes(':')) {
-        restoredHudPaneId = restoreStandaloneHudPane(leaderPaneId, cwd);
-        if (!restoredHudPaneId) {
-          console.warn(`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`);
-        }
-      }
-    }
-    shutdownPaneIds = collectShutdownPaneIds({
-      config,
-      livePaneIds: listPaneIds(sessionName),
-      restoredStandaloneHudPaneId: restoredHudPaneId,
-    });
-    await teardownWorkerPanes(shutdownPaneIds, {
-      leaderPaneId,
-      hudPaneId: restoredHudPaneId ?? hudPaneId,
-    });
+		let resizeHookWarning: string | null = null;
+		if (config.resize_hook_name && config.resize_hook_target) {
+			const resizeHookName = config.resize_hook_name;
+			const unregistered = unregisterResizeHook(
+				config.resize_hook_target,
+				resizeHookName,
+			);
+			if (!unregistered && isTmuxAvailable()) {
+				const baseSession = sessionName.split(":")[0];
+				const sessionStillActive = listTeamSessions().includes(baseSession);
+				if (sessionStillActive) {
+					resizeHookWarning = `failed to unregister resize hook ${resizeHookName}`;
+				}
+			}
+		}
+		config.resize_hook_name = null;
+		config.resize_hook_target = null;
+		await saveTeamConfig(config, cwd);
+		if (resizeHookWarning) {
+			console.warn(
+				`[team shutdown] ${sanitized}: ${resizeHookWarning}; continuing teardown`,
+			);
+		}
+		let restoredHudPaneId: string | null = null;
+		if (hudPaneId) {
+			await killWorkerByPaneIdAsync(hudPaneId, leaderPaneId ?? undefined);
+			if (sessionName.includes(":")) {
+				restoredHudPaneId = restoreStandaloneHudPane(leaderPaneId, cwd);
+				if (!restoredHudPaneId) {
+					console.warn(
+						`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`,
+					);
+				}
+			}
+		}
+		shutdownPaneIds = collectShutdownPaneIds({
+			config,
+			livePaneIds: listPaneIds(sessionName),
+			restoredStandaloneHudPaneId: restoredHudPaneId,
+		});
+		await teardownWorkerPanes(shutdownPaneIds, {
+			leaderPaneId,
+			hudPaneId: restoredHudPaneId ?? hudPaneId,
+		});
 
-    // 4. Destroy tmux session
-    if (!sessionName.includes(':')) {
-      try {
-        destroyTeamSession(sessionName);
-      } catch (err) {
-        process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-      }
-    }
-  } else {
-    const promptTeardownFailures: string[] = [];
-    for (const w of config.workers) {
-      const teardown = await teardownPromptWorker(
-        sanitized,
-        w.name,
-        w.pid as number | undefined,
-        cwd,
-        'shutdown',
-      );
-      if (!teardown.terminated) {
-        promptTeardownFailures.push(`${w.name}:${teardown.error || 'unknown_error'}`);
-      }
-    }
-    if (promptTeardownFailures.length > 0) {
-      throw new Error(`shutdown_prompt_teardown_failed:${promptTeardownFailures.join(',')}`);
-    }
-  }
+		// 4. Destroy tmux session
+		if (!sessionName.includes(":")) {
+			try {
+				destroyTeamSession(sessionName);
+			} catch (err) {
+				process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+			}
+		}
+	} else {
+		const promptTeardownFailures: string[] = [];
+		for (const w of config.workers) {
+			const teardown = await teardownPromptWorker(
+				sanitized,
+				w.name,
+				w.pid as number | undefined,
+				cwd,
+				"shutdown",
+			);
+			if (!teardown.terminated) {
+				promptTeardownFailures.push(
+					`${w.name}:${teardown.error || "unknown_error"}`,
+				);
+			}
+		}
+		if (promptTeardownFailures.length > 0) {
+			throw new Error(
+				`shutdown_prompt_teardown_failed:${promptTeardownFailures.join(",")}`,
+			);
+		}
+	}
 
-  const shutdownReports = await prepareWorkerWorktreeShutdownReports(config, cwd);
+	const shutdownReports = await prepareWorkerWorktreeShutdownReports(
+		config,
+		cwd,
+	);
 
-  const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
-  for (const report of shutdownReports) {
-    const worker = config.workers.find((entry) => entry.name === report.workerName);
-    if (report.syntheticCommit) {
-      commitHygieneEntries.push({
-        recorded_at: new Date().toISOString(),
-        operation: 'shutdown_checkpoint',
-        worker_name: report.workerName,
-        task_id: worker?.assigned_tasks[0],
-        status: 'applied',
-        operational_commit: report.syntheticCommit,
-        source_commit: report.sourceRef,
-        worktree_path: report.worktreePath,
-        report_path: report.reportPath,
-        detail: 'Runtime created a shutdown checkpoint commit to preserve worker worktree changes.',
-      });
-    }
+	const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
+	for (const report of shutdownReports) {
+		const worker = config.workers.find(
+			(entry) => entry.name === report.workerName,
+		);
+		if (report.syntheticCommit) {
+			commitHygieneEntries.push({
+				recorded_at: new Date().toISOString(),
+				operation: "shutdown_checkpoint",
+				worker_name: report.workerName,
+				task_id: worker?.assigned_tasks[0],
+				status: "applied",
+				operational_commit: report.syntheticCommit,
+				source_commit: report.sourceRef,
+				worktree_path: report.worktreePath,
+				report_path: report.reportPath,
+				detail:
+					"Runtime created a shutdown checkpoint commit to preserve worker worktree changes.",
+			});
+		}
 
-    if (report.sourceRef && report.mergeOutcome !== 'skipped') {
-      commitHygieneEntries.push({
-        recorded_at: new Date().toISOString(),
-        operation: 'shutdown_merge',
-        worker_name: report.workerName,
-        task_id: worker?.assigned_tasks[0],
-        status: report.mergeOutcome === 'merged' ? 'applied' : report.mergeOutcome,
-        operational_commit: report.mergeOutcome === 'merged' ? report.leaderHeadAfter : null,
-        source_commit: report.sourceRef,
-        leader_head_before: report.leaderHeadBefore,
-        leader_head_after: report.leaderHeadAfter,
-        worktree_path: report.worktreePath,
-        report_path: report.reportPath,
-        detail: report.mergeDetail,
-      });
-    }
-  }
+		if (report.sourceRef && report.mergeOutcome !== "skipped") {
+			commitHygieneEntries.push({
+				recorded_at: new Date().toISOString(),
+				operation: "shutdown_merge",
+				worker_name: report.workerName,
+				task_id: worker?.assigned_tasks[0],
+				status:
+					report.mergeOutcome === "merged" ? "applied" : report.mergeOutcome,
+				operational_commit:
+					report.mergeOutcome === "merged" ? report.leaderHeadAfter : null,
+				source_commit: report.sourceRef,
+				leader_head_before: report.leaderHeadBefore,
+				leader_head_after: report.leaderHeadAfter,
+				worktree_path: report.worktreePath,
+				report_path: report.reportPath,
+				detail: report.mergeDetail,
+			});
+		}
+	}
 
-  const artifactCwd = config.leader_cwd ?? cwd;
-  const ledger = await appendTeamCommitHygieneEntries(sanitized, commitHygieneEntries, artifactCwd)
-  const taskView = await listTasks(sanitized, cwd).catch(() => [])
-  const commitHygieneContext = buildTeamCommitHygieneContext({
-    teamName: sanitized,
-    tasks: taskView,
-    ledger,
-  })
-  const commitHygieneArtifacts = await writeTeamCommitHygieneContext(sanitized, commitHygieneContext, artifactCwd)
+	const artifactCwd = config.leader_cwd ?? cwd;
+	const ledger = await appendTeamCommitHygieneEntries(
+		sanitized,
+		commitHygieneEntries,
+		artifactCwd,
+	);
+	const taskView = await listTasks(sanitized, cwd).catch(() => []);
+	const commitHygieneContext = buildTeamCommitHygieneContext({
+		teamName: sanitized,
+		tasks: taskView,
+		ledger,
+	});
+	const commitHygieneArtifacts = await writeTeamCommitHygieneContext(
+		sanitized,
+		commitHygieneContext,
+		artifactCwd,
+	);
 
-  // 5. Remove worker worktree-root instructions and team-scoped fallback instructions.
-  for (const worker of config.workers) {
-    if (!worker.worktree_path || !worker.team_state_root) continue;
-    try {
-      await removeWorkerWorktreeRootAgentsFile(
-        sanitized,
-        worker.name,
-        worker.team_state_root,
-        worker.worktree_path,
-      );
-    } catch (err) {
-      process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    }
-  }
-  try {
-    await removeTeamWorkerInstructionsFile(sanitized, cwd);
-  } catch (err) {
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-  }
-  restoreTeamModelInstructionsFile(sanitized);
+	// 5. Remove worker worktree-root instructions and team-scoped fallback instructions.
+	for (const worker of config.workers) {
+		if (!worker.worktree_path || !worker.team_state_root) continue;
+		try {
+			await removeWorkerWorktreeRootAgentsFile(
+				sanitized,
+				worker.name,
+				worker.team_state_root,
+				worker.worktree_path,
+			);
+		} catch (err) {
+			process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+		}
+	}
+	try {
+		await removeTeamWorkerInstructionsFile(sanitized, cwd);
+	} catch (err) {
+		process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+	}
+	restoreTeamModelInstructionsFile(sanitized);
 
-  const cleanupErrors: string[] = [];
-  const provisionedWorktrees = collectProvisionedShutdownWorktrees(config);
-  if (provisionedWorktrees.length > 0) {
-    try {
-      await rollbackProvisionedWorktrees(provisionedWorktrees, {
-        skipBranchDeletion: false,
-      });
-    } catch (err) {
-      cleanupErrors.push(`rollbackProvisionedWorktrees: ${String(err)}`);
-    }
-  }
+	const cleanupErrors: string[] = [];
+	const provisionedWorktrees = collectProvisionedShutdownWorktrees(config);
+	if (provisionedWorktrees.length > 0) {
+		try {
+			await rollbackProvisionedWorktrees(provisionedWorktrees, {
+				skipBranchDeletion: false,
+			});
+		} catch (err) {
+			cleanupErrors.push(`rollbackProvisionedWorktrees: ${String(err)}`);
+		}
+	}
 
-  // 7. Cleanup state
-  try {
-    await cleanupTeamState(sanitized, cwd);
-  } catch (err) {
-    cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
-  }
+	// 7. Cleanup state
+	try {
+		await cleanupTeamState(sanitized, cwd);
+	} catch (err) {
+		cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+	}
 
-  if (cleanupErrors.length > 0) {
-    throw new Error(cleanupErrors.join(' | '));
-  }
+	if (cleanupErrors.length > 0) {
+		throw new Error(cleanupErrors.join(" | "));
+	}
 
-  return { commitHygieneArtifacts }
+	return { commitHygieneArtifacts };
 }
 
 /**
  * Resume monitoring an existing team.
  */
-export async function resumeTeam(teamName: string, cwd: string): Promise<TeamRuntime | null> {
-  const sanitized = sanitizeTeamName(teamName);
-  const config = await readTeamConfig(sanitized, cwd);
-  if (!config) return null;
-  config.lifecycle_profile = 'default';
+export async function resumeTeam(
+	teamName: string,
+	cwd: string,
+): Promise<TeamRuntime | null> {
+	const sanitized = sanitizeTeamName(teamName);
+	const config = await readTeamConfig(sanitized, cwd);
+	if (!config) return null;
+	config.lifecycle_profile = "default";
 
-  if (config.worker_launch_mode === 'prompt') {
-    const hasLivePromptWorker = config.workers.some((worker) => isPromptWorkerAlive(config, worker));
-    if (!hasLivePromptWorker) return null;
+	if (config.worker_launch_mode === "prompt") {
+		const hasLivePromptWorker = config.workers.some((worker) =>
+			isPromptWorkerAlive(config, worker),
+		);
+		if (!hasLivePromptWorker) return null;
 
-    const missingHandles = config.workers
-      .filter((worker) => {
-        if (!Number.isFinite(worker.pid) || (worker.pid ?? 0) <= 0) return false;
-        return isPidAlive(worker.pid as number);
-      })
-      .filter((worker) => !getPromptWorkerHandle(sanitized, worker.name));
-    if (missingHandles.length > 0) {
-      const detail = missingHandles.map((worker) => `${worker.name}:${worker.pid ?? 'unknown'}`).join(',');
-      await appendTeamEvent(
-        sanitized,
-        {
-          type: 'worker_stopped',
-          worker: 'leader-fixed',
-          reason: `prompt_resume_unavailable:missing_handle:${detail}`,
-        },
-        cwd,
-      ).catch(() => {});
-      return null;
-    }
-  } else {
-    // Check if tmux session still exists
-    const baseSession = config.tmux_session.split(':')[0];
-    const teamSessions = getTeamTmuxSessions(sanitized);
-    if (!teamSessions.includes(baseSession)) return null;
-  }
+		const missingHandles = config.workers
+			.filter((worker) => {
+				if (!Number.isFinite(worker.pid) || (worker.pid ?? 0) <= 0)
+					return false;
+				return isPidAlive(worker.pid as number);
+			})
+			.filter((worker) => !getPromptWorkerHandle(sanitized, worker.name));
+		if (missingHandles.length > 0) {
+			const detail = missingHandles
+				.map((worker) => `${worker.name}:${worker.pid ?? "unknown"}`)
+				.join(",");
+			await appendTeamEvent(
+				sanitized,
+				{
+					type: "worker_stopped",
+					worker: "leader-fixed",
+					reason: `prompt_resume_unavailable:missing_handle:${detail}`,
+				},
+				cwd,
+			).catch(() => {});
+			return null;
+		}
+	} else {
+		// Check if tmux session still exists
+		const baseSession = config.tmux_session.split(":")[0];
+		const teamSessions = getTeamTmuxSessions(sanitized);
+		if (!teamSessions.includes(baseSession)) return null;
+	}
 
-  return {
-    teamName: sanitized,
-    sanitizedName: sanitized,
-    sessionName: config.tmux_session,
-    config,
-    cwd,
-  };
+	return {
+		teamName: sanitized,
+		sanitizedName: sanitized,
+		sessionName: config.tmux_session,
+		config,
+		cwd,
+	};
 }
 
-async function findActiveTeams(cwd: string, leaderSessionId: string): Promise<string[]> {
-  const root = join(cwd, '.omx', 'state', 'team');
-  if (!existsSync(root)) return [];
-  const sessions = new Set(listTeamSessions());
-  const entries = await readdir(root, { withFileTypes: true });
-  const active: string[] = [];
-  for (const e of entries) {
-    if (!e.isDirectory()) continue;
-    const teamName = e.name;
-    const cfg = await readTeamConfig(teamName, cwd);
-    const manifest = await readTeamManifestV2(teamName, cwd);
-    const governance = resolveGovernancePolicy(manifest?.governance);
-    if (governance.one_team_per_leader_session === false) continue;
-    const workerLaunchMode = cfg?.worker_launch_mode
-      ?? manifest?.policy?.worker_launch_mode
-      ?? 'interactive';
-    const tmuxSession = (manifest?.tmux_session || cfg?.tmux_session || `omx-team-${teamName}`).split(':')[0];
-    if (leaderSessionId) {
-      const ownerSessionId = manifest?.leader?.session_id?.trim() ?? '';
-      if (ownerSessionId && ownerSessionId !== leaderSessionId) continue;
-    }
-    if (workerLaunchMode === 'prompt') {
-      if ((cfg?.workers ?? []).some((worker) => isPromptWorkerAlive(cfg!, worker))) {
-        active.push(teamName);
-      }
-      continue;
-    }
-    if (sessions.has(tmuxSession)) active.push(teamName);
-  }
-  return active;
+async function findActiveTeams(
+	cwd: string,
+	leaderSessionId: string,
+): Promise<string[]> {
+	const root = join(cwd, ".omx", "state", "team");
+	if (!existsSync(root)) return [];
+	const sessions = new Set(listTeamSessions());
+	const entries = await readdir(root, { withFileTypes: true });
+	const active: string[] = [];
+	for (const e of entries) {
+		if (!e.isDirectory()) continue;
+		const teamName = e.name;
+		const cfg = await readTeamConfig(teamName, cwd);
+		const manifest = await readTeamManifestV2(teamName, cwd);
+		const governance = resolveGovernancePolicy(manifest?.governance);
+		if (governance.one_team_per_leader_session === false) continue;
+		const workerLaunchMode =
+			cfg?.worker_launch_mode ??
+			manifest?.policy?.worker_launch_mode ??
+			"interactive";
+		const tmuxSession = (
+			manifest?.tmux_session ||
+			cfg?.tmux_session ||
+			`omx-team-${teamName}`
+		).split(":")[0];
+		if (leaderSessionId) {
+			const ownerSessionId = manifest?.leader?.session_id?.trim() ?? "";
+			if (ownerSessionId && ownerSessionId !== leaderSessionId) continue;
+		}
+		if (workerLaunchMode === "prompt") {
+			if (
+				(cfg?.workers ?? []).some((worker) => isPromptWorkerAlive(cfg!, worker))
+			) {
+				active.push(teamName);
+			}
+			continue;
+		}
+		if (sessions.has(tmuxSession)) active.push(teamName);
+	}
+	return active;
 }
 
 async function resolveLeaderSessionId(cwd: string): Promise<string> {
-  const fromEnv = process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID || process.env.SESSION_ID;
-  if (fromEnv && fromEnv.trim() !== '') return fromEnv.trim();
+	const fromEnv =
+		process.env.OMX_SESSION_ID ||
+		process.env.CODEX_SESSION_ID ||
+		process.env.SESSION_ID;
+	if (fromEnv && fromEnv.trim() !== "") return fromEnv.trim();
 
-  const p = join(cwd, '.omx', 'state', 'session.json');
-  if (!existsSync(p)) return '';
-  try {
-    const raw = await readFile(p, 'utf-8');
-    const parsed = JSON.parse(raw) as { session_id?: unknown };
-    if (typeof parsed.session_id === 'string' && parsed.session_id.trim() !== '') return parsed.session_id.trim();
-  } catch (err) {
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    return '';
-  }
-  return '';
+	const p = join(cwd, ".omx", "state", "session.json");
+	if (!existsSync(p)) return "";
+	try {
+		const raw = await readFile(p, "utf-8");
+		const parsed = JSON.parse(raw) as { session_id?: unknown };
+		if (
+			typeof parsed.session_id === "string" &&
+			parsed.session_id.trim() !== ""
+		)
+			return parsed.session_id.trim();
+	} catch (err) {
+		process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+		return "";
+	}
+	return "";
 }
 
-async function isTaskApprovedForExecution(teamName: string, taskId: string, cwd: string): Promise<boolean> {
-  const record = await readTaskApproval(teamName, taskId, cwd);
-  return record?.status === 'approved';
+async function isTaskApprovedForExecution(
+	teamName: string,
+	taskId: string,
+	cwd: string,
+): Promise<boolean> {
+	const record = await readTaskApproval(teamName, taskId, cwd);
+	return record?.status === "approved";
 }
 
 async function emitMonitorDerivedEvents(
-  teamName: string,
-  tasks: TeamTask[],
-  workers: TeamSnapshot['workers'],
-  previous: TeamMonitorSnapshotState | null,
-  workerLaunchMode: TeamConfig['worker_launch_mode'],
-  cwd: string,
+	teamName: string,
+	tasks: TeamTask[],
+	workers: TeamSnapshot["workers"],
+	previous: TeamMonitorSnapshotState | null,
+	workerLaunchMode: TeamConfig["worker_launch_mode"],
+	cwd: string,
 ): Promise<void> {
-  for (const task of tasks) {
-    const prevStatus = previous?.taskStatusById[task.id];
-    if (prevStatus && prevStatus !== 'completed' && task.status === 'completed') {
-      // Skip if a task_completed event was already emitted by transitionTaskStatus (issue #161).
-      if (previous?.completedEventTaskIds?.[task.id]) continue;
-      await appendTeamEvent(
-        teamName,
-        {
-          type: 'task_completed',
-          worker: task.owner || 'unknown',
-          task_id: task.id,
-          message_id: null,
-          reason: undefined,
-        },
-        cwd
-      );
-    }
-  }
+	for (const task of tasks) {
+		const prevStatus = previous?.taskStatusById[task.id];
+		if (
+			prevStatus &&
+			prevStatus !== "completed" &&
+			task.status === "completed"
+		) {
+			// Skip if a task_completed event was already emitted by transitionTaskStatus (issue #161).
+			if (previous?.completedEventTaskIds?.[task.id]) continue;
+			await appendTeamEvent(
+				teamName,
+				{
+					type: "task_completed",
+					worker: task.owner || "unknown",
+					task_id: task.id,
+					message_id: null,
+					reason: undefined,
+				},
+				cwd,
+			);
+		}
+	}
 
-  for (const worker of workers) {
-    const prevAlive = previous?.workerAliveByName[worker.name];
-    const shouldEmitInitialPromptWorkerStop = workerLaunchMode === 'prompt' && prevAlive === undefined;
-    if ((prevAlive === true || shouldEmitInitialPromptWorkerStop) && worker.alive === false) {
-      await appendTeamEvent(
-        teamName,
-        {
-          type: 'worker_stopped',
-          worker: worker.name,
-          task_id: worker.status.current_task_id,
-          message_id: null,
-          reason: worker.status.reason,
-        },
-        cwd
-      );
-    }
+	for (const worker of workers) {
+		const prevAlive = previous?.workerAliveByName[worker.name];
+		const shouldEmitInitialPromptWorkerStop =
+			workerLaunchMode === "prompt" && prevAlive === undefined;
+		if (
+			(prevAlive === true || shouldEmitInitialPromptWorkerStop) &&
+			worker.alive === false
+		) {
+			await appendTeamEvent(
+				teamName,
+				{
+					type: "worker_stopped",
+					worker: worker.name,
+					task_id: worker.status.current_task_id,
+					message_id: null,
+					reason: worker.status.reason,
+				},
+				cwd,
+			);
+		}
 
-    const prevState = previous?.workerStateByName[worker.name];
-    if (prevState && prevState !== worker.status.state) {
-      await appendTeamEvent(
-        teamName,
-        {
-          type: 'worker_state_changed',
-          worker: worker.name,
-          task_id: worker.status.current_task_id,
-          message_id: null,
-          reason: worker.status.reason,
-          state: worker.status.state,
-          prev_state: prevState,
-        },
-        cwd
-      );
-    }
+		const prevState = previous?.workerStateByName[worker.name];
+		if (prevState && prevState !== worker.status.state) {
+			await appendTeamEvent(
+				teamName,
+				{
+					type: "worker_state_changed",
+					worker: worker.name,
+					task_id: worker.status.current_task_id,
+					message_id: null,
+					reason: worker.status.reason,
+					state: worker.status.state,
+					prev_state: prevState,
+				},
+				cwd,
+			);
+		}
 
-    if (prevState && prevState !== 'idle' && worker.status.state === 'idle') {
-      await appendTeamEvent(
-        teamName,
-        {
-          type: 'worker_idle',
-          worker: worker.name,
-          task_id: worker.status.current_task_id,
-          message_id: null,
-          reason: undefined,
-          prev_state: prevState,
-          state: 'idle',
-          source_type: 'worker_idle',
-        },
-        cwd
-      );
-    }
-  }
+		if (prevState && prevState !== "idle" && worker.status.state === "idle") {
+			await appendTeamEvent(
+				teamName,
+				{
+					type: "worker_idle",
+					worker: worker.name,
+					task_id: worker.status.current_task_id,
+					message_id: null,
+					reason: undefined,
+					prev_state: prevState,
+					state: "idle",
+					source_type: "worker_idle",
+				},
+				cwd,
+			);
+		}
+	}
 }
 
-async function notifyWorkerOutcome(config: TeamConfig, workerIndex: number, message: string, workerPaneId?: string): Promise<DispatchOutcome> {
-  const worker = config.workers.find((candidate) => candidate.index === workerIndex);
-  if (!worker) return { ok: false, transport: 'none', reason: 'worker_not_found' };
+async function notifyWorkerOutcome(
+	config: TeamConfig,
+	workerIndex: number,
+	message: string,
+	workerPaneId?: string,
+): Promise<DispatchOutcome> {
+	const worker = config.workers.find(
+		(candidate) => candidate.index === workerIndex,
+	);
+	if (!worker)
+		return { ok: false, transport: "none", reason: "worker_not_found" };
 
-  if (config.worker_launch_mode === 'prompt') {
-    const handle = getPromptWorkerHandle(config.name, worker.name);
-    if (!handle) return { ok: false, transport: 'prompt_stdin', reason: 'prompt_worker_handle_missing' };
-    try {
-      sendToWorkerStdin(handle.child.stdin, message);
-      return { ok: true, transport: 'prompt_stdin', reason: 'prompt_stdin_sent' };
-    } catch (error) {
-      return {
-        ok: false,
-        transport: 'prompt_stdin',
-        reason: `prompt_stdin_failed:${error instanceof Error ? error.message : String(error)}`,
-      };
-    }
-  }
+	if (config.worker_launch_mode === "prompt") {
+		const handle = getPromptWorkerHandle(config.name, worker.name);
+		if (!handle)
+			return {
+				ok: false,
+				transport: "prompt_stdin",
+				reason: "prompt_worker_handle_missing",
+			};
+		try {
+			sendToWorkerStdin(handle.child.stdin, message);
+			return {
+				ok: true,
+				transport: "prompt_stdin",
+				reason: "prompt_stdin_sent",
+			};
+		} catch (error) {
+			return {
+				ok: false,
+				transport: "prompt_stdin",
+				reason: `prompt_stdin_failed:${error instanceof Error ? error.message : String(error)}`,
+			};
+		}
+	}
 
-  if (!config.tmux_session || !isTmuxAvailable()) {
-    return { ok: false, transport: 'tmux_send_keys', reason: 'tmux_unavailable' };
-  }
-  try {
-    await sendToWorker(config.tmux_session, workerIndex, message, workerPaneId, worker.worker_cli);
-    return { ok: true, transport: 'tmux_send_keys', reason: 'tmux_send_keys_sent' };
-  } catch (error) {
-    return {
-      ok: false,
-      transport: 'tmux_send_keys',
-      reason: `tmux_send_keys_failed:${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
+	if (!config.tmux_session || !isTmuxAvailable()) {
+		return {
+			ok: false,
+			transport: "tmux_send_keys",
+			reason: "tmux_unavailable",
+		};
+	}
+	try {
+		await sendToWorker(
+			config.tmux_session,
+			workerIndex,
+			message,
+			workerPaneId,
+			worker.worker_cli,
+		);
+		return {
+			ok: true,
+			transport: "tmux_send_keys",
+			reason: "tmux_send_keys_sent",
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			transport: "tmux_send_keys",
+			reason: `tmux_send_keys_failed:${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
 }
 
 function resolveDispatchPolicy(
-  manifestPolicy: TeamPolicy | null | undefined,
-  workerLaunchMode: TeamConfig['worker_launch_mode'],
+	manifestPolicy: TeamPolicy | null | undefined,
+	workerLaunchMode: TeamConfig["worker_launch_mode"],
 ): TeamPolicy {
-  return normalizeTeamPolicy(manifestPolicy, {
-    display_mode: manifestPolicy?.display_mode === 'split_pane' ? 'split_pane' : 'auto',
-    worker_launch_mode: workerLaunchMode,
-  });
+	return normalizeTeamPolicy(manifestPolicy, {
+		display_mode:
+			manifestPolicy?.display_mode === "split_pane" ? "split_pane" : "auto",
+		worker_launch_mode: workerLaunchMode,
+	});
 }
 
 function isLeaderPaneMissingMailboxPersistedOutcome(params: {
-  workerName: string;
-  paneId?: string;
-  outcome: DispatchOutcome;
+	workerName: string;
+	paneId?: string;
+	outcome: DispatchOutcome;
 }): boolean {
-  const { workerName, paneId, outcome } = params;
-  return workerName === 'leader-fixed'
-    && !paneId
-    && outcome.ok
-    && outcome.reason === 'leader_pane_missing_mailbox_persisted';
+	const { workerName, paneId, outcome } = params;
+	return (
+		workerName === "leader-fixed" &&
+		!paneId &&
+		outcome.ok &&
+		outcome.reason === "leader_pane_missing_mailbox_persisted"
+	);
 }
 
 async function markDispatchRequestLeaderPaneMissingDeferred(params: {
-  teamName: string;
-  requestId: string;
-  messageId?: string;
-  cwd: string;
+	teamName: string;
+	requestId: string;
+	messageId?: string;
+	cwd: string;
 }): Promise<void> {
-  const { teamName, requestId, messageId, cwd } = params;
-  const current = await readDispatchRequest(teamName, requestId, cwd);
-  if (!current) return;
-  if (current.status !== 'pending') return;
+	const { teamName, requestId, messageId, cwd } = params;
+	const current = await readDispatchRequest(teamName, requestId, cwd);
+	if (!current) return;
+	if (current.status !== "pending") return;
 
-  await transitionDispatchRequest(
-    teamName,
-    requestId,
-    current.status,
-    current.status,
-    {
-      message_id: messageId ?? current.message_id,
-      last_reason: 'leader_pane_missing_deferred',
-    },
-    cwd,
-  ).catch(() => {});
+	await transitionDispatchRequest(
+		teamName,
+		requestId,
+		current.status,
+		current.status,
+		{
+			message_id: messageId ?? current.message_id,
+			last_reason: "leader_pane_missing_deferred",
+		},
+		cwd,
+	).catch(() => {});
+}
+
+async function waitForRequiredStartupEvidenceAfterDirectFallback(params: {
+	requireWorkerStartupEvidence?: boolean;
+	workerCli?: TeamWorkerCli;
+	teamName: string;
+	workerName: string;
+	cwd: string;
+	timeoutMs?: number;
+}): Promise<WorkerStartupEvidence> {
+	const {
+		requireWorkerStartupEvidence,
+		workerCli,
+		teamName,
+		workerName,
+		cwd,
+		timeoutMs,
+	} = params;
+	const requiresObservedStartupEvidence =
+		requireWorkerStartupEvidence === true &&
+		(workerCli === "claude" || workerCli === "codex");
+	if (!requiresObservedStartupEvidence || !workerCli) {
+		return "none";
+	}
+	return await waitForWorkerStartupEvidence({
+		teamName,
+		workerName,
+		workerCli,
+		cwd,
+		timeoutMs,
+	});
 }
 
 async function dispatchCriticalInboxInstruction(params: {
-  teamName: string;
-  config: TeamConfig;
-  workerName: string;
-  workerIndex: number;
-  paneId?: string;
-  workerCli?: TeamWorkerCli;
-  inbox: string;
-  triggerMessage: string;
-  intent?: TeamReminderIntent;
-  cwd: string;
-  dispatchPolicy: TeamPolicy;
-  inboxCorrelationKey: string;
-  requireWorkerStartupEvidence?: boolean;
+	teamName: string;
+	config: TeamConfig;
+	workerName: string;
+	workerIndex: number;
+	paneId?: string;
+	workerCli?: TeamWorkerCli;
+	inbox: string;
+	triggerMessage: string;
+	intent?: TeamReminderIntent;
+	cwd: string;
+	dispatchPolicy: TeamPolicy;
+	inboxCorrelationKey: string;
+	requireWorkerStartupEvidence?: boolean;
+	startupEvidenceTimeoutMs?: number;
 }): Promise<DispatchOutcome> {
-  const {
-    teamName,
-    config,
-    workerName,
-    workerIndex,
-    paneId,
-    workerCli,
-    inbox,
-    triggerMessage,
-    intent,
-    cwd,
-    dispatchPolicy,
-    inboxCorrelationKey,
-    requireWorkerStartupEvidence,
-  } = params;
+	const {
+		teamName,
+		config,
+		workerName,
+		workerIndex,
+		paneId,
+		workerCli,
+		inbox,
+		triggerMessage,
+		intent,
+		cwd,
+		dispatchPolicy,
+		inboxCorrelationKey,
+		requireWorkerStartupEvidence,
+		startupEvidenceTimeoutMs,
+	} = params;
 
-  if (config.worker_launch_mode === 'prompt') {
-    return await queueInboxInstruction({
-      teamName,
-      workerName,
-      workerIndex,
-      paneId,
-      inbox,
-      triggerMessage,
-      intent,
-      cwd,
-      transportPreference: 'prompt_stdin',
-      fallbackAllowed: false,
-      inboxCorrelationKey,
-      notify: (_target, message) => notifyWorkerOutcome(config, workerIndex, message, paneId),
-    });
-  }
+	if (config.worker_launch_mode === "prompt") {
+		return await queueInboxInstruction({
+			teamName,
+			workerName,
+			workerIndex,
+			paneId,
+			inbox,
+			triggerMessage,
+			intent,
+			cwd,
+			transportPreference: "prompt_stdin",
+			fallbackAllowed: false,
+			inboxCorrelationKey,
+			notify: (_target, message) =>
+				notifyWorkerOutcome(config, workerIndex, message, paneId),
+		});
+	}
 
-  if (dispatchPolicy.dispatch_mode === 'transport_direct') {
-    return await queueInboxInstruction({
-      teamName,
-      workerName,
-      workerIndex,
-      paneId,
-      inbox,
-      triggerMessage,
-      intent,
-      cwd,
-      transportPreference: 'transport_direct',
-      fallbackAllowed: false,
-      inboxCorrelationKey,
-      notify: (_target, message) => notifyWorkerOutcome(config, workerIndex, message, paneId),
-    });
-  }
+	if (dispatchPolicy.dispatch_mode === "transport_direct") {
+		return await queueInboxInstruction({
+			teamName,
+			workerName,
+			workerIndex,
+			paneId,
+			inbox,
+			triggerMessage,
+			intent,
+			cwd,
+			transportPreference: "transport_direct",
+			fallbackAllowed: false,
+			inboxCorrelationKey,
+			notify: (_target, message) =>
+				notifyWorkerOutcome(config, workerIndex, message, paneId),
+		});
+	}
 
-  const queued = await queueInboxInstruction({
-    teamName,
-    workerName,
-    workerIndex,
-    paneId,
-    inbox,
-    triggerMessage,
-    intent,
-    cwd,
-    transportPreference: 'hook_preferred_with_fallback',
-    fallbackAllowed: true,
-    inboxCorrelationKey,
-    notify: () => ({ ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }),
-  });
+	const queued = await queueInboxInstruction({
+		teamName,
+		workerName,
+		workerIndex,
+		paneId,
+		inbox,
+		triggerMessage,
+		intent,
+		cwd,
+		transportPreference: "hook_preferred_with_fallback",
+		fallbackAllowed: true,
+		inboxCorrelationKey,
+		notify: () => ({
+			ok: true,
+			transport: "hook",
+			reason: "queued_for_hook_dispatch",
+		}),
+	});
 
-  if (!queued.request_id) return { ...queued, ok: false, reason: 'dispatch_request_missing_id' };
+	if (!queued.request_id)
+		return { ...queued, ok: false, reason: "dispatch_request_missing_id" };
 
-  const receipt = await waitForDispatchReceipt(teamName, queued.request_id, cwd, {
-    timeoutMs: dispatchPolicy.dispatch_ack_timeout_ms,
-    pollMs: 50,
-  });
-  if (receipt?.status === 'delivered') {
-    return { ok: true, transport: 'hook', reason: 'hook_receipt_delivered', request_id: queued.request_id };
-  }
-  const requiresObservedStartupEvidence = requireWorkerStartupEvidence === true
-    && (workerCli === 'claude' || workerCli === 'codex');
-  let startupEvidence: WorkerStartupEvidence = 'none';
-  if (receipt?.status === 'notified') {
-    if (!requiresObservedStartupEvidence) {
-      return { ok: true, transport: 'hook', reason: 'hook_receipt_notified', request_id: queued.request_id };
-    }
-    startupEvidence = await waitForWorkerStartupEvidence({
-      teamName,
-      workerName,
-      workerCli,
-      cwd,
-    });
-    if (startupEvidence !== 'none') {
-      return {
-        ok: true,
-        transport: 'hook',
-        reason: `hook_receipt_notified_with_${startupEvidence}`,
-        request_id: queued.request_id,
-      };
-    }
-  }
-  if (receipt?.status === 'failed') {
-    const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
-    if (fallback.ok) {
-      await transitionDispatchRequest(
-        teamName,
-        queued.request_id,
-        'failed',
-        'failed',
-        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
-        cwd,
-      ).catch(() => {});
-      return {
-        ok: true,
-        transport: fallback.transport,
-        reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
-        request_id: queued.request_id,
-      };
-    }
-    await transitionDispatchRequest(
-      teamName,
-      queued.request_id,
-      receipt.status,
-      'failed',
-      { last_reason: `fallback_attempted_but_unconfirmed:${fallback.reason}` },
-      cwd,
-    ).catch(() => {});
-    return {
-      ok: false,
-      transport: fallback.transport,
-      reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
-      request_id: queued.request_id,
-    };
-  }
+	const receipt = await waitForDispatchReceipt(
+		teamName,
+		queued.request_id,
+		cwd,
+		{
+			timeoutMs: dispatchPolicy.dispatch_ack_timeout_ms,
+			pollMs: 50,
+		},
+	);
+	if (receipt?.status === "delivered") {
+		return {
+			ok: true,
+			transport: "hook",
+			reason: "hook_receipt_delivered",
+			request_id: queued.request_id,
+		};
+	}
+	const requiresObservedStartupEvidence =
+		requireWorkerStartupEvidence === true &&
+		(workerCli === "claude" || workerCli === "codex");
+	let startupEvidence: WorkerStartupEvidence = "none";
+	if (receipt?.status === "notified") {
+		if (!requiresObservedStartupEvidence) {
+			return {
+				ok: true,
+				transport: "hook",
+				reason: "hook_receipt_notified",
+				request_id: queued.request_id,
+			};
+		}
+		startupEvidence = await waitForWorkerStartupEvidence({
+			teamName,
+			workerName,
+			workerCli,
+			cwd,
+			timeoutMs: startupEvidenceTimeoutMs,
+		});
+		if (startupEvidence !== "none") {
+			return {
+				ok: true,
+				transport: "hook",
+				reason: `hook_receipt_notified_with_${startupEvidence}`,
+				request_id: queued.request_id,
+			};
+		}
+	}
+	if (receipt?.status === "failed") {
+		const fallback = await notifyWorkerOutcome(
+			config,
+			workerIndex,
+			triggerMessage,
+			paneId,
+		);
+		if (fallback.ok) {
+			const fallbackStartupEvidence =
+				await waitForRequiredStartupEvidenceAfterDirectFallback({
+					requireWorkerStartupEvidence,
+					workerCli,
+					teamName,
+					workerName,
+					cwd,
+					timeoutMs: startupEvidenceTimeoutMs,
+				});
+			if (
+				requiresObservedStartupEvidence &&
+				fallbackStartupEvidence === "none"
+			) {
+				await transitionDispatchRequest(
+					teamName,
+					queued.request_id,
+					"failed",
+					"failed",
+					{
+						last_reason: `${workerCli}_startup_no_evidence_after_fallback:${fallback.reason}`,
+					},
+					cwd,
+				).catch(() => {});
+				return {
+					ok: false,
+					transport: fallback.transport,
+					reason: `${workerCli}_startup_no_evidence_after_fallback:${fallback.reason}`,
+					request_id: queued.request_id,
+				};
+			}
+			await transitionDispatchRequest(
+				teamName,
+				queued.request_id,
+				"failed",
+				"failed",
+				{
+					last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
+				},
+				cwd,
+			).catch(() => {});
+			return {
+				ok: true,
+				transport: fallback.transport,
+				reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
+				request_id: queued.request_id,
+			};
+		}
+		await transitionDispatchRequest(
+			teamName,
+			queued.request_id,
+			receipt.status,
+			"failed",
+			{ last_reason: `fallback_attempted_but_unconfirmed:${fallback.reason}` },
+			cwd,
+		).catch(() => {});
+		return {
+			ok: false,
+			transport: fallback.transport,
+			reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
+			request_id: queued.request_id,
+		};
+	}
 
-  const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
-  const startupFallbackLabel = receipt?.status === 'notified' && requiresObservedStartupEvidence
-    ? `${workerCli}_startup_no_evidence`
-    : null;
-  const fallbackFailureReason = startupFallbackLabel
-    ? `${startupFallbackLabel}_fallback_failed:${fallback.reason}`
-    : `fallback_attempted_but_unconfirmed:${fallback.reason}`;
-  if (fallback.ok) {
-    const marked = await markDispatchRequestNotified(
-      teamName,
-      queued.request_id,
-      { last_reason: `fallback_confirmed:${fallback.reason}` },
-      cwd,
-    );
-    if (!marked) {
-      await transitionDispatchRequest(
-        teamName,
-        queued.request_id,
-        'failed',
-        'failed',
-        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
-        cwd,
-      ).catch(() => {});
-    }
-    return {
-      ok: true,
-      transport: fallback.transport,
-      reason: startupFallbackLabel
-        ? `${startupFallbackLabel}_fallback_confirmed:${fallback.reason}`
-        : `hook_timeout_fallback_confirmed:${fallback.reason}`,
-      request_id: queued.request_id,
-    };
-  }
+	const fallback = await notifyWorkerOutcome(
+		config,
+		workerIndex,
+		triggerMessage,
+		paneId,
+	);
+	const startupFallbackLabel =
+		receipt?.status === "notified" && requiresObservedStartupEvidence
+			? `${workerCli}_startup_no_evidence`
+			: null;
+	const fallbackFailureReason = startupFallbackLabel
+		? `${startupFallbackLabel}_fallback_failed:${fallback.reason}`
+		: `fallback_attempted_but_unconfirmed:${fallback.reason}`;
+	if (fallback.ok) {
+		const fallbackStartupEvidence =
+			await waitForRequiredStartupEvidenceAfterDirectFallback({
+				requireWorkerStartupEvidence,
+				workerCli,
+				teamName,
+				workerName,
+				cwd,
+				timeoutMs: startupEvidenceTimeoutMs,
+			});
+		if (requiresObservedStartupEvidence && fallbackStartupEvidence === "none") {
+			const current = await readDispatchRequest(
+				teamName,
+				queued.request_id,
+				cwd,
+			);
+			if (current && current.status !== "failed") {
+				await transitionDispatchRequest(
+					teamName,
+					queued.request_id,
+					current.status,
+					"failed",
+					{
+						last_reason: `${workerCli}_startup_no_evidence_after_fallback:${fallback.reason}`,
+					},
+					cwd,
+				).catch(() => {});
+			}
+			return {
+				ok: false,
+				transport: fallback.transport,
+				reason: `${workerCli}_startup_no_evidence_after_fallback:${fallback.reason}`,
+				request_id: queued.request_id,
+			};
+		}
+		const marked = await markDispatchRequestNotified(
+			teamName,
+			queued.request_id,
+			{ last_reason: `fallback_confirmed:${fallback.reason}` },
+			cwd,
+		);
+		if (!marked) {
+			await transitionDispatchRequest(
+				teamName,
+				queued.request_id,
+				"failed",
+				"failed",
+				{
+					last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
+				},
+				cwd,
+			).catch(() => {});
+		}
+		return {
+			ok: true,
+			transport: fallback.transport,
+			reason: startupFallbackLabel
+				? `${startupFallbackLabel}_fallback_confirmed:${fallback.reason}`
+				: `hook_timeout_fallback_confirmed:${fallback.reason}`,
+			request_id: queued.request_id,
+		};
+	}
 
-  const current = await readDispatchRequest(teamName, queued.request_id, cwd);
-  if (current && current.status !== 'failed') {
-    await transitionDispatchRequest(
-      teamName,
-      queued.request_id,
-      current.status,
-      'failed',
-      { last_reason: fallbackFailureReason },
-      cwd,
-    ).catch(() => {});
-  }
-  return {
-    ok: false,
-    transport: fallback.transport,
-    reason: fallbackFailureReason,
-    request_id: queued.request_id,
-  };
+	const current = await readDispatchRequest(teamName, queued.request_id, cwd);
+	if (current && current.status !== "failed") {
+		await transitionDispatchRequest(
+			teamName,
+			queued.request_id,
+			current.status,
+			"failed",
+			{ last_reason: fallbackFailureReason },
+			cwd,
+		).catch(() => {});
+	}
+	return {
+		ok: false,
+		transport: fallback.transport,
+		reason: fallbackFailureReason,
+		request_id: queued.request_id,
+	};
 }
 
 async function finalizeHookPreferredMailboxDispatch(params: {
-  teamName: string;
-  requestId: string;
-  workerName: string;
-  workerIndex?: number;
-  paneId?: string;
-  messageId: string;
-  triggerMessage: string;
-  intent?: TeamDispatchRequest['intent'];
-  config: TeamConfig;
-  dispatchPolicy: TeamPolicy;
-  cwd: string;
-  fallbackNotify?: () => DispatchOutcome | Promise<DispatchOutcome>;
+	teamName: string;
+	requestId: string;
+	workerName: string;
+	workerIndex?: number;
+	paneId?: string;
+	messageId: string;
+	triggerMessage: string;
+	intent?: TeamDispatchRequest["intent"];
+	config: TeamConfig;
+	dispatchPolicy: TeamPolicy;
+	cwd: string;
+	fallbackNotify?: () => DispatchOutcome | Promise<DispatchOutcome>;
 }): Promise<DispatchOutcome> {
-  const {
-    teamName,
-    requestId,
-    workerName,
-    workerIndex,
-    paneId,
-    messageId,
-    triggerMessage,
-    intent,
-    config,
-    dispatchPolicy,
-    cwd,
-    fallbackNotify,
-  } = params;
-  const receipt = await waitForDispatchReceipt(teamName, requestId, cwd, {
-    timeoutMs: dispatchPolicy.dispatch_ack_timeout_ms,
-    pollMs: 50,
-  });
-  if (receipt && (receipt.status === 'notified' || receipt.status === 'delivered')) {
-    await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-    const outcome = { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: requestId, message_id: messageId } as const;
-    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-    return outcome;
-  }
+	const {
+		teamName,
+		requestId,
+		workerName,
+		workerIndex,
+		paneId,
+		messageId,
+		triggerMessage,
+		intent,
+		config,
+		dispatchPolicy,
+		cwd,
+		fallbackNotify,
+	} = params;
+	const receipt = await waitForDispatchReceipt(teamName, requestId, cwd, {
+		timeoutMs: dispatchPolicy.dispatch_ack_timeout_ms,
+		pollMs: 50,
+	});
+	if (
+		receipt &&
+		(receipt.status === "notified" || receipt.status === "delivered")
+	) {
+		await markMessageNotified(teamName, workerName, messageId, cwd).catch(
+			() => false,
+		);
+		const outcome = {
+			ok: true,
+			transport: "hook",
+			reason: `hook_receipt_${receipt.status}`,
+			request_id: requestId,
+			message_id: messageId,
+		} as const;
+		await logRuntimeDispatchOutcome({
+			cwd,
+			teamName,
+			workerName,
+			requestId,
+			messageId,
+			intent,
+			outcome,
+		});
+		return outcome;
+	}
 
-  const fallback: DispatchOutcome = fallbackNotify
-    ? await fallbackNotify()
-    : (typeof workerIndex === 'number'
-      ? await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId)
-      : { ok: false, transport: 'none', reason: 'missing_worker_index' });
-  if (receipt?.status === 'failed') {
-    if (fallback.ok) {
-      await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-      await transitionDispatchRequest(
-        teamName,
-        requestId,
-        'failed',
-        'failed',
-        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
-        cwd,
-      ).catch(() => {});
-      const outcome = {
-        ok: true,
-        transport: fallback.transport,
-        reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
-        request_id: requestId,
-        message_id: messageId,
-      } as const;
-      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-      return outcome;
-    }
-    await transitionDispatchRequest(
-      teamName,
-      requestId,
-      'failed',
-      'failed',
-      { message_id: messageId, last_reason: `fallback_attempted_but_unconfirmed:${fallback.reason}` },
-      cwd,
-    ).catch(() => {});
-    const outcome = {
-      ok: false,
-      transport: fallback.transport,
-      reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
-      request_id: requestId,
-      message_id: messageId,
-    } as const;
-    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-    return outcome;
-  }
+	const fallback: DispatchOutcome = fallbackNotify
+		? await fallbackNotify()
+		: typeof workerIndex === "number"
+			? await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId)
+			: { ok: false, transport: "none", reason: "missing_worker_index" };
+	if (receipt?.status === "failed") {
+		if (fallback.ok) {
+			await markMessageNotified(teamName, workerName, messageId, cwd).catch(
+				() => false,
+			);
+			await transitionDispatchRequest(
+				teamName,
+				requestId,
+				"failed",
+				"failed",
+				{
+					message_id: messageId,
+					last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
+				},
+				cwd,
+			).catch(() => {});
+			const outcome = {
+				ok: true,
+				transport: fallback.transport,
+				reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
+				request_id: requestId,
+				message_id: messageId,
+			} as const;
+			await logRuntimeDispatchOutcome({
+				cwd,
+				teamName,
+				workerName,
+				requestId,
+				messageId,
+				intent,
+				outcome,
+			});
+			return outcome;
+		}
+		await transitionDispatchRequest(
+			teamName,
+			requestId,
+			"failed",
+			"failed",
+			{
+				message_id: messageId,
+				last_reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
+			},
+			cwd,
+		).catch(() => {});
+		const outcome = {
+			ok: false,
+			transport: fallback.transport,
+			reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
+			request_id: requestId,
+			message_id: messageId,
+		} as const;
+		await logRuntimeDispatchOutcome({
+			cwd,
+			teamName,
+			workerName,
+			requestId,
+			messageId,
+			intent,
+			outcome,
+		});
+		return outcome;
+	}
 
-  if (fallback.ok) {
-    if (isLeaderPaneMissingMailboxPersistedOutcome({ workerName, paneId, outcome: fallback })) {
-      await markDispatchRequestLeaderPaneMissingDeferred({
-        teamName,
-        requestId,
-        messageId,
-        cwd,
-      });
-      const outcome = {
-        ok: true,
-        transport: fallback.transport,
-        reason: 'leader_pane_missing_mailbox_persisted',
-        request_id: requestId,
-        message_id: messageId,
-      } as const;
-      await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-      return outcome;
-    }
+	if (fallback.ok) {
+		if (
+			isLeaderPaneMissingMailboxPersistedOutcome({
+				workerName,
+				paneId,
+				outcome: fallback,
+			})
+		) {
+			await markDispatchRequestLeaderPaneMissingDeferred({
+				teamName,
+				requestId,
+				messageId,
+				cwd,
+			});
+			const outcome = {
+				ok: true,
+				transport: fallback.transport,
+				reason: "leader_pane_missing_mailbox_persisted",
+				request_id: requestId,
+				message_id: messageId,
+			} as const;
+			await logRuntimeDispatchOutcome({
+				cwd,
+				teamName,
+				workerName,
+				requestId,
+				messageId,
+				intent,
+				outcome,
+			});
+			return outcome;
+		}
 
-    await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-    const marked = await markDispatchRequestNotified(
-      teamName,
-      requestId,
-      { message_id: messageId, last_reason: `fallback_confirmed:${fallback.reason}` },
-      cwd,
-    );
-    if (!marked) {
-      await transitionDispatchRequest(
-        teamName,
-        requestId,
-        'failed',
-        'failed',
-        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
-        cwd,
-      ).catch(() => {});
-    }
-    const outcome = {
-      ok: true,
-      transport: fallback.transport,
-      reason: `hook_timeout_fallback_confirmed:${fallback.reason}`,
-      request_id: requestId,
-      message_id: messageId,
-    } as const;
-    await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-    return outcome;
-  }
+		await markMessageNotified(teamName, workerName, messageId, cwd).catch(
+			() => false,
+		);
+		const marked = await markDispatchRequestNotified(
+			teamName,
+			requestId,
+			{
+				message_id: messageId,
+				last_reason: `fallback_confirmed:${fallback.reason}`,
+			},
+			cwd,
+		);
+		if (!marked) {
+			await transitionDispatchRequest(
+				teamName,
+				requestId,
+				"failed",
+				"failed",
+				{
+					message_id: messageId,
+					last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}`,
+				},
+				cwd,
+			).catch(() => {});
+		}
+		const outcome = {
+			ok: true,
+			transport: fallback.transport,
+			reason: `hook_timeout_fallback_confirmed:${fallback.reason}`,
+			request_id: requestId,
+			message_id: messageId,
+		} as const;
+		await logRuntimeDispatchOutcome({
+			cwd,
+			teamName,
+			workerName,
+			requestId,
+			messageId,
+			intent,
+			outcome,
+		});
+		return outcome;
+	}
 
-  const current = await readDispatchRequest(teamName, requestId, cwd);
-  if (current) {
-    await transitionDispatchRequest(
-      teamName,
-      requestId,
-      current.status,
-      'failed',
-      { message_id: messageId, last_reason: `fallback_attempted_but_unconfirmed:${fallback.reason}` },
-      cwd,
-    ).catch(() => {});
-  }
-  const outcome = {
-    ok: false,
-    transport: fallback.transport,
-    reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
-    request_id: requestId,
-    message_id: messageId,
-  } as const;
-  await logRuntimeDispatchOutcome({ cwd, teamName, workerName, requestId, messageId, intent, outcome });
-  return outcome;
+	const current = await readDispatchRequest(teamName, requestId, cwd);
+	if (current) {
+		await transitionDispatchRequest(
+			teamName,
+			requestId,
+			current.status,
+			"failed",
+			{
+				message_id: messageId,
+				last_reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
+			},
+			cwd,
+		).catch(() => {});
+	}
+	const outcome = {
+		ok: false,
+		transport: fallback.transport,
+		reason: `fallback_attempted_but_unconfirmed:${fallback.reason}`,
+		request_id: requestId,
+		message_id: messageId,
+	} as const;
+	await logRuntimeDispatchOutcome({
+		cwd,
+		teamName,
+		workerName,
+		requestId,
+		messageId,
+		intent,
+		outcome,
+	});
+	return outcome;
 }
 
-async function notifyLeaderAsync(config: TeamConfig, message: string, cwd: string): Promise<DispatchOutcome> {
-  // Canonical leader delivery is durable mailbox persistence plus HUD-owned
-  // authority processing. Team runtime must not directly inject into the
-  // leader pane from this fallback path.
-  const { notifyLeaderMailboxAsync } = await import('./tmux-session.js');
-  const persisted = await notifyLeaderMailboxAsync(config.name, 'system', message, cwd);
-  if (!persisted) {
-    return { ok: false, transport: 'mailbox', reason: 'leader_mailbox_notify_failed' };
-  }
-  if (!config.leader_pane_id) {
-    return { ok: true, transport: 'mailbox', reason: 'leader_pane_missing_mailbox_persisted' };
-  }
-  return { ok: true, transport: 'mailbox', reason: 'leader_mailbox_notified' };
+async function notifyLeaderAsync(
+	config: TeamConfig,
+	message: string,
+	cwd: string,
+): Promise<DispatchOutcome> {
+	// Canonical leader delivery is durable mailbox persistence plus HUD-owned
+	// authority processing. Team runtime must not directly inject into the
+	// leader pane from this fallback path.
+	const { notifyLeaderMailboxAsync } = await import("./tmux-session.js");
+	const persisted = await notifyLeaderMailboxAsync(
+		config.name,
+		"system",
+		message,
+		cwd,
+	);
+	if (!persisted) {
+		return {
+			ok: false,
+			transport: "mailbox",
+			reason: "leader_mailbox_notify_failed",
+		};
+	}
+	if (!config.leader_pane_id) {
+		return {
+			ok: true,
+			transport: "mailbox",
+			reason: "leader_pane_missing_mailbox_persisted",
+		};
+	}
+	return { ok: true, transport: "mailbox", reason: "leader_mailbox_notified" };
 }
 
 async function deliverPendingMailboxMessages(
-  teamName: string,
-  config: TeamConfig,
-  workers: TeamSnapshot['workers'],
-  previousNotifications: Record<string, string>,
-  dispatchPolicy: TeamPolicy,
-  cwd: string,
+	teamName: string,
+	config: TeamConfig,
+	workers: TeamSnapshot["workers"],
+	previousNotifications: Record<string, string>,
+	dispatchPolicy: TeamPolicy,
+	cwd: string,
 ): Promise<Record<string, string>> {
-  const nextNotifications: Record<string, string> = {};
-  const pendingIdsAcrossTeam = new Set<string>();
+	const nextNotifications: Record<string, string> = {};
+	const pendingIdsAcrossTeam = new Set<string>();
 
-  for (const worker of workers) {
-    const workerInfo = config.workers.find((w) => w.name === worker.name);
-    if (!workerInfo) continue;
-    const mailbox = await listMailboxMessages(teamName, worker.name, cwd);
-    const pending = mailbox.filter((m) => !m.delivered_at);
-    if (pending.length === 0) continue;
+	for (const worker of workers) {
+		const workerInfo = config.workers.find((w) => w.name === worker.name);
+		if (!workerInfo) continue;
+		const mailbox = await listMailboxMessages(teamName, worker.name, cwd);
+		const pending = mailbox.filter((m) => !m.delivered_at);
+		if (pending.length === 0) continue;
 
-    const pendingIds = pending.map((m) => m.message_id);
-    for (const id of pendingIds) pendingIdsAcrossTeam.add(id);
+		const pendingIds = pending.map((m) => m.message_id);
+		for (const id of pendingIds) pendingIdsAcrossTeam.add(id);
 
-    // Preserve already-tracked notification timestamps in the next snapshot.
-    for (const msg of pending) {
-      nextNotifications[msg.message_id] = msg.notified_at || previousNotifications[msg.message_id] || '';
-    }
+		// Preserve already-tracked notification timestamps in the next snapshot.
+		for (const msg of pending) {
+			nextNotifications[msg.message_id] =
+				msg.notified_at || previousNotifications[msg.message_id] || "";
+		}
 
-    // Only notify for messages that have never been successfully notified.
-    // Using a message-ID set prevents re-notification on every monitor poll
-    // (issue #116). A message is considered notified when either:
-    //   - notified_at is set in the mailbox file (persisted by markMessageNotified), or
-    //   - the message_id exists in previousNotifications from the last snapshot.
-    // Both checks use Boolean() so an empty-string value is treated as unnotified.
-    const unnotified = pending.filter(
-      (m) => !m.notified_at && !previousNotifications[m.message_id],
-    );
-    if (unnotified.length === 0) continue;
-    if (!worker.alive) continue;
+		// Only notify for messages that have never been successfully notified.
+		// Using a message-ID set prevents re-notification on every monitor poll
+		// (issue #116). A message is considered notified when either:
+		//   - notified_at is set in the mailbox file (persisted by markMessageNotified), or
+		//   - the message_id exists in previousNotifications from the last snapshot.
+		// Both checks use Boolean() so an empty-string value is treated as unnotified.
+		const unnotified = pending.filter(
+			(m) => !m.notified_at && !previousNotifications[m.message_id],
+		);
+		if (unnotified.length === 0) continue;
+		if (!worker.alive) continue;
 
-    for (const msg of unnotified) {
-      const outcome = await dispatchPendingMailboxMessage({
-        teamName,
-        workerName: worker.name,
-        workerInfo,
-        messageId: msg.message_id,
-        config,
-        dispatchPolicy,
-        cwd,
-      });
-      if (outcome.ok) {
-        nextNotifications[msg.message_id] = new Date().toISOString();
-      }
-    }
-  }
+		for (const msg of unnotified) {
+			const outcome = await dispatchPendingMailboxMessage({
+				teamName,
+				workerName: worker.name,
+				workerInfo,
+				messageId: msg.message_id,
+				config,
+				dispatchPolicy,
+				cwd,
+			});
+			if (outcome.ok) {
+				nextNotifications[msg.message_id] = new Date().toISOString();
+			}
+		}
+	}
 
-  const pruned: Record<string, string> = {};
-  for (const [messageId, ts] of Object.entries(nextNotifications)) {
-    if (pendingIdsAcrossTeam.has(messageId) && ts) pruned[messageId] = ts;
-  }
-  return pruned;
+	const pruned: Record<string, string> = {};
+	for (const [messageId, ts] of Object.entries(nextNotifications)) {
+		if (pendingIdsAcrossTeam.has(messageId) && ts) pruned[messageId] = ts;
+	}
+	return pruned;
 }
 
-type RuntimeMailboxTransportPreference = 'prompt_stdin' | 'transport_direct' | 'hook_preferred_with_fallback';
+type RuntimeMailboxTransportPreference =
+	| "prompt_stdin"
+	| "transport_direct"
+	| "hook_preferred_with_fallback";
 
 function resolveWorkerMailboxTransportPreference(
-  config: TeamConfig,
-  dispatchPolicy: TeamPolicy,
+	config: TeamConfig,
+	dispatchPolicy: TeamPolicy,
 ): RuntimeMailboxTransportPreference {
-  return config.worker_launch_mode === 'prompt'
-    ? 'prompt_stdin'
-    : (dispatchPolicy.dispatch_mode === 'transport_direct' ? 'transport_direct' : 'hook_preferred_with_fallback');
+	return config.worker_launch_mode === "prompt"
+		? "prompt_stdin"
+		: dispatchPolicy.dispatch_mode === "transport_direct"
+			? "transport_direct"
+			: "hook_preferred_with_fallback";
 }
 
 function resolveLeaderMailboxTransportPreference(
-  dispatchPolicy: TeamPolicy,
-): Exclude<RuntimeMailboxTransportPreference, 'prompt_stdin'> {
-  return dispatchPolicy.dispatch_mode === 'transport_direct' ? 'transport_direct' : 'hook_preferred_with_fallback';
+	dispatchPolicy: TeamPolicy,
+): Exclude<RuntimeMailboxTransportPreference, "prompt_stdin"> {
+	return dispatchPolicy.dispatch_mode === "transport_direct"
+		? "transport_direct"
+		: "hook_preferred_with_fallback";
 }
 
-function isExistingMailboxNotificationOutcome(outcome: DispatchOutcome): boolean {
-  return outcome.ok && outcome.reason === 'existing_message_already_notified';
+function isExistingMailboxNotificationOutcome(
+	outcome: DispatchOutcome,
+): boolean {
+	return outcome.ok && outcome.reason === "existing_message_already_notified";
 }
 
 async function dispatchPendingMailboxMessage(params: {
-  teamName: string;
-  workerName: string;
-  workerInfo: WorkerInfo;
-  messageId: string;
-  config: TeamConfig;
-  dispatchPolicy: TeamPolicy;
-  cwd: string;
+	teamName: string;
+	workerName: string;
+	workerInfo: WorkerInfo;
+	messageId: string;
+	config: TeamConfig;
+	dispatchPolicy: TeamPolicy;
+	cwd: string;
 }): Promise<DispatchOutcome> {
-  const { teamName, workerName, workerInfo, messageId, config, dispatchPolicy, cwd } = params;
-  const triggerDirective = buildMailboxTriggerDirective(
-    workerName,
-    teamName,
-    1,
-    resolveInstructionStateRoot(workerInfo.worktree_path),
-  );
-  const transportPreference = resolveWorkerMailboxTransportPreference(config, dispatchPolicy);
-  const queued = await enqueueDispatchRequest(
-    teamName,
-    {
-      kind: 'mailbox',
-      to_worker: workerName,
-      worker_index: workerInfo.index,
-      pane_id: workerInfo.pane_id,
-      trigger_message: triggerDirective.text,
-      intent: triggerDirective.intent,
-      message_id: messageId,
-      transport_preference: transportPreference,
-      fallback_allowed: transportPreference === 'hook_preferred_with_fallback',
-    },
-    cwd,
-  );
+	const {
+		teamName,
+		workerName,
+		workerInfo,
+		messageId,
+		config,
+		dispatchPolicy,
+		cwd,
+	} = params;
+	const triggerDirective = buildMailboxTriggerDirective(
+		workerName,
+		teamName,
+		1,
+		resolveInstructionStateRoot(workerInfo.worktree_path),
+	);
+	const transportPreference = resolveWorkerMailboxTransportPreference(
+		config,
+		dispatchPolicy,
+	);
+	const queued = await enqueueDispatchRequest(
+		teamName,
+		{
+			kind: "mailbox",
+			to_worker: workerName,
+			worker_index: workerInfo.index,
+			pane_id: workerInfo.pane_id,
+			trigger_message: triggerDirective.text,
+			intent: triggerDirective.intent,
+			message_id: messageId,
+			transport_preference: transportPreference,
+			fallback_allowed: transportPreference === "hook_preferred_with_fallback",
+		},
+		cwd,
+	);
 
-  if (transportPreference === 'hook_preferred_with_fallback') {
-    return await finalizeQueuedMailboxDispatch({
-      queuedOutcome: {
-        ok: true,
-        transport: 'hook',
-        reason: 'queued_for_hook_dispatch',
-        request_id: queued.request.request_id,
-        message_id: messageId,
-      },
-      transportPreference,
-      teamName,
-      workerName,
-      workerIndex: workerInfo.index,
-      paneId: workerInfo.pane_id,
-      messageId,
-      triggerMessage: triggerDirective.text,
-      intent: triggerDirective.intent,
-      config,
-      dispatchPolicy,
-      cwd,
-    });
-  }
+	if (transportPreference === "hook_preferred_with_fallback") {
+		return await finalizeQueuedMailboxDispatch({
+			queuedOutcome: {
+				ok: true,
+				transport: "hook",
+				reason: "queued_for_hook_dispatch",
+				request_id: queued.request.request_id,
+				message_id: messageId,
+			},
+			transportPreference,
+			teamName,
+			workerName,
+			workerIndex: workerInfo.index,
+			paneId: workerInfo.pane_id,
+			messageId,
+			triggerMessage: triggerDirective.text,
+			intent: triggerDirective.intent,
+			config,
+			dispatchPolicy,
+			cwd,
+		});
+	}
 
-  const direct = await notifyWorkerOutcome(config, workerInfo.index, triggerDirective.text, workerInfo.pane_id);
-  const outcome: DispatchOutcome = { ...direct, request_id: queued.request.request_id, message_id: messageId };
-  if (outcome.ok) {
-    await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-    await markDispatchRequestNotified(
-      teamName,
-      queued.request.request_id,
-      { message_id: messageId, last_reason: outcome.reason },
-      cwd,
-    ).catch(() => null);
-  }
-  await logRuntimeDispatchOutcome({
-    cwd,
-    teamName,
-    workerName,
-    requestId: queued.request.request_id,
-    messageId,
-    outcome,
-  });
-  return outcome;
+	const direct = await notifyWorkerOutcome(
+		config,
+		workerInfo.index,
+		triggerDirective.text,
+		workerInfo.pane_id,
+	);
+	const outcome: DispatchOutcome = {
+		...direct,
+		request_id: queued.request.request_id,
+		message_id: messageId,
+	};
+	if (outcome.ok) {
+		await markMessageNotified(teamName, workerName, messageId, cwd).catch(
+			() => false,
+		);
+		await markDispatchRequestNotified(
+			teamName,
+			queued.request.request_id,
+			{ message_id: messageId, last_reason: outcome.reason },
+			cwd,
+		).catch(() => null);
+	}
+	await logRuntimeDispatchOutcome({
+		cwd,
+		teamName,
+		workerName,
+		requestId: queued.request.request_id,
+		messageId,
+		outcome,
+	});
+	return outcome;
 }
 
 async function finalizeQueuedMailboxDispatch(params: {
-  queuedOutcome: DispatchOutcome;
-  transportPreference: RuntimeMailboxTransportPreference;
-  teamName: string;
-  workerName: string;
-  workerIndex?: number;
-  paneId?: string;
-  messageId?: string;
-  triggerMessage: string;
-  intent?: TeamDispatchRequest['intent'];
-  config: TeamConfig;
-  dispatchPolicy: TeamPolicy;
-  cwd: string;
-  fallbackNotify?: () => DispatchOutcome | Promise<DispatchOutcome>;
+	queuedOutcome: DispatchOutcome;
+	transportPreference: RuntimeMailboxTransportPreference;
+	teamName: string;
+	workerName: string;
+	workerIndex?: number;
+	paneId?: string;
+	messageId?: string;
+	triggerMessage: string;
+	intent?: TeamDispatchRequest["intent"];
+	config: TeamConfig;
+	dispatchPolicy: TeamPolicy;
+	cwd: string;
+	fallbackNotify?: () => DispatchOutcome | Promise<DispatchOutcome>;
 }): Promise<DispatchOutcome> {
-  const {
-    queuedOutcome,
-    transportPreference,
-    teamName,
-    workerName,
-    workerIndex,
-    paneId,
-    messageId,
-    triggerMessage,
-    intent,
-    config,
-    dispatchPolicy,
-    cwd,
-    fallbackNotify,
-  } = params;
+	const {
+		queuedOutcome,
+		transportPreference,
+		teamName,
+		workerName,
+		workerIndex,
+		paneId,
+		messageId,
+		triggerMessage,
+		intent,
+		config,
+		dispatchPolicy,
+		cwd,
+		fallbackNotify,
+	} = params;
 
-  if (transportPreference !== 'hook_preferred_with_fallback') {
-    return queuedOutcome;
-  }
-  if (isExistingMailboxNotificationOutcome(queuedOutcome)) {
-    return queuedOutcome;
-  }
-  if (!queuedOutcome.request_id || !messageId) {
-    return { ...queuedOutcome, ok: false, reason: 'dispatch_request_missing_id' };
-  }
+	if (transportPreference !== "hook_preferred_with_fallback") {
+		return queuedOutcome;
+	}
+	if (isExistingMailboxNotificationOutcome(queuedOutcome)) {
+		return queuedOutcome;
+	}
+	if (!queuedOutcome.request_id || !messageId) {
+		return {
+			...queuedOutcome,
+			ok: false,
+			reason: "dispatch_request_missing_id",
+		};
+	}
 
-  return await finalizeHookPreferredMailboxDispatch({
-    teamName,
-    requestId: queuedOutcome.request_id,
-    workerName,
-    workerIndex,
-    paneId,
-    messageId,
-    triggerMessage,
-    intent,
-    config,
-    dispatchPolicy,
-    cwd,
-    fallbackNotify,
-  });
+	return await finalizeHookPreferredMailboxDispatch({
+		teamName,
+		requestId: queuedOutcome.request_id,
+		workerName,
+		workerIndex,
+		paneId,
+		messageId,
+		triggerMessage,
+		intent,
+		config,
+		dispatchPolicy,
+		cwd,
+		fallbackNotify,
+	});
 }
 
 async function sendLeaderMailboxMessage(params: {
-  teamName: string;
-  fromWorker: string;
-  body: string;
-  config: TeamConfig;
-  dispatchPolicy: TeamPolicy;
-  cwd: string;
+	teamName: string;
+	fromWorker: string;
+	body: string;
+	config: TeamConfig;
+	dispatchPolicy: TeamPolicy;
+	cwd: string;
 }): Promise<DispatchOutcome> {
-  const { teamName, fromWorker, body, config, dispatchPolicy, cwd } = params;
-  const triggerDirective = buildLeaderMailboxTriggerDirective(
-    teamName,
-    fromWorker,
-    config.team_state_root || undefined,
-  );
-  const transportPreference = resolveLeaderMailboxTransportPreference(dispatchPolicy);
-  const queuedOutcome = await queueDirectMailboxMessage({
-    teamName,
-    fromWorker,
-    toWorker: 'leader-fixed',
-    toPaneId: config.leader_pane_id ?? undefined,
-    body,
-    triggerMessage: triggerDirective.text,
-    intent: triggerDirective.intent,
-    cwd,
-    transportPreference,
-    fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
-    notify: async (_target, message) => (
-      transportPreference === 'hook_preferred_with_fallback'
-        ? { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }
-        : await notifyLeaderAsync(config, message, cwd)
-    ),
-  });
+	const { teamName, fromWorker, body, config, dispatchPolicy, cwd } = params;
+	const triggerDirective = buildLeaderMailboxTriggerDirective(
+		teamName,
+		fromWorker,
+		config.team_state_root || undefined,
+	);
+	const transportPreference =
+		resolveLeaderMailboxTransportPreference(dispatchPolicy);
+	const queuedOutcome = await queueDirectMailboxMessage({
+		teamName,
+		fromWorker,
+		toWorker: "leader-fixed",
+		toPaneId: config.leader_pane_id ?? undefined,
+		body,
+		triggerMessage: triggerDirective.text,
+		intent: triggerDirective.intent,
+		cwd,
+		transportPreference,
+		fallbackAllowed: transportPreference === "hook_preferred_with_fallback",
+		notify: async (_target, message) =>
+			transportPreference === "hook_preferred_with_fallback"
+				? { ok: true, transport: "hook", reason: "queued_for_hook_dispatch" }
+				: await notifyLeaderAsync(config, message, cwd),
+	});
 
-  if (
-    !isExistingMailboxNotificationOutcome(queuedOutcome)
-    && transportPreference === 'hook_preferred_with_fallback'
-    && !config.leader_pane_id
-  ) {
-    if (queuedOutcome.request_id) {
-      await markDispatchRequestLeaderPaneMissingDeferred({
-        teamName,
-        requestId: queuedOutcome.request_id,
-        messageId: queuedOutcome.message_id,
-        cwd,
-      });
-    }
-    const deferredOutcome: DispatchOutcome = {
-      ...queuedOutcome,
-      ok: true,
-      transport: 'mailbox',
-      reason: 'leader_pane_missing_mailbox_persisted',
-    };
-    await logRuntimeDispatchOutcome({
-      cwd,
-      teamName,
-      workerName: 'leader-fixed',
-      requestId: deferredOutcome.request_id,
-      messageId: deferredOutcome.message_id,
-      intent: triggerDirective.intent,
-      outcome: deferredOutcome,
-    });
-    return deferredOutcome;
-  }
+	if (
+		!isExistingMailboxNotificationOutcome(queuedOutcome) &&
+		transportPreference === "hook_preferred_with_fallback" &&
+		!config.leader_pane_id
+	) {
+		if (queuedOutcome.request_id) {
+			await markDispatchRequestLeaderPaneMissingDeferred({
+				teamName,
+				requestId: queuedOutcome.request_id,
+				messageId: queuedOutcome.message_id,
+				cwd,
+			});
+		}
+		const deferredOutcome: DispatchOutcome = {
+			...queuedOutcome,
+			ok: true,
+			transport: "mailbox",
+			reason: "leader_pane_missing_mailbox_persisted",
+		};
+		await logRuntimeDispatchOutcome({
+			cwd,
+			teamName,
+			workerName: "leader-fixed",
+			requestId: deferredOutcome.request_id,
+			messageId: deferredOutcome.message_id,
+			intent: triggerDirective.intent,
+			outcome: deferredOutcome,
+		});
+		return deferredOutcome;
+	}
 
-  const canLeaderFallbackDirectly = Boolean(config.leader_pane_id) && isTmuxAvailable();
-  return await finalizeQueuedMailboxDispatch({
-    queuedOutcome,
-    transportPreference: canLeaderFallbackDirectly ? transportPreference : 'transport_direct',
-    teamName,
-    workerName: 'leader-fixed',
-    paneId: config.leader_pane_id ?? undefined,
-    messageId: queuedOutcome.message_id,
-    triggerMessage: triggerDirective.text,
-    intent: triggerDirective.intent,
-    config,
-    dispatchPolicy,
-    cwd,
-    fallbackNotify: async () => await notifyLeaderAsync(config, triggerDirective.text, cwd),
-  });
+	const canLeaderFallbackDirectly =
+		Boolean(config.leader_pane_id) && isTmuxAvailable();
+	return await finalizeQueuedMailboxDispatch({
+		queuedOutcome,
+		transportPreference: canLeaderFallbackDirectly
+			? transportPreference
+			: "transport_direct",
+		teamName,
+		workerName: "leader-fixed",
+		paneId: config.leader_pane_id ?? undefined,
+		messageId: queuedOutcome.message_id,
+		triggerMessage: triggerDirective.text,
+		intent: triggerDirective.intent,
+		config,
+		dispatchPolicy,
+		cwd,
+		fallbackNotify: async () =>
+			await notifyLeaderAsync(config, triggerDirective.text, cwd),
+	});
 }
 
 async function sendRecipientMailboxMessage(params: {
-  teamName: string;
-  fromWorker: string;
-  toWorker: string;
-  body: string;
-  config: TeamConfig;
-  dispatchPolicy: TeamPolicy;
-  cwd: string;
+	teamName: string;
+	fromWorker: string;
+	toWorker: string;
+	body: string;
+	config: TeamConfig;
+	dispatchPolicy: TeamPolicy;
+	cwd: string;
 }): Promise<DispatchOutcome> {
-  const { teamName, fromWorker, toWorker, body, config, dispatchPolicy, cwd } = params;
-  const recipient = config.workers.find((worker) => worker.name === toWorker);
-  if (!recipient) throw new Error(`Worker ${toWorker} not found in team`);
+	const { teamName, fromWorker, toWorker, body, config, dispatchPolicy, cwd } =
+		params;
+	const recipient = config.workers.find((worker) => worker.name === toWorker);
+	if (!recipient) throw new Error(`Worker ${toWorker} not found in team`);
 
-  const triggerDirective = buildMailboxTriggerDirective(
-    toWorker,
-    teamName,
-    1,
-    resolveInstructionStateRoot(recipient.worktree_path),
-  );
-  const transportPreference = resolveWorkerMailboxTransportPreference(config, dispatchPolicy);
-  const queuedOutcome = await queueDirectMailboxMessage({
-    teamName,
-    fromWorker,
-    toWorker,
-    toWorkerIndex: recipient.index,
-    toPaneId: recipient.pane_id,
-    body,
-    triggerMessage: triggerDirective.text,
-    intent: triggerDirective.intent,
-    cwd,
-    transportPreference,
-    fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
-    notify: async (_target, message) => (
-      transportPreference === 'hook_preferred_with_fallback'
-        ? { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }
-        : await notifyWorkerOutcome(config, recipient.index, message, recipient.pane_id)
-    ),
-  });
+	const triggerDirective = buildMailboxTriggerDirective(
+		toWorker,
+		teamName,
+		1,
+		resolveInstructionStateRoot(recipient.worktree_path),
+	);
+	const transportPreference = resolveWorkerMailboxTransportPreference(
+		config,
+		dispatchPolicy,
+	);
+	const queuedOutcome = await queueDirectMailboxMessage({
+		teamName,
+		fromWorker,
+		toWorker,
+		toWorkerIndex: recipient.index,
+		toPaneId: recipient.pane_id,
+		body,
+		triggerMessage: triggerDirective.text,
+		intent: triggerDirective.intent,
+		cwd,
+		transportPreference,
+		fallbackAllowed: transportPreference === "hook_preferred_with_fallback",
+		notify: async (_target, message) =>
+			transportPreference === "hook_preferred_with_fallback"
+				? { ok: true, transport: "hook", reason: "queued_for_hook_dispatch" }
+				: await notifyWorkerOutcome(
+						config,
+						recipient.index,
+						message,
+						recipient.pane_id,
+					),
+	});
 
-  return await finalizeQueuedMailboxDispatch({
-    queuedOutcome,
-    transportPreference,
-    teamName,
-    workerName: recipient.name,
-    workerIndex: recipient.index,
-    paneId: recipient.pane_id,
-    messageId: queuedOutcome.message_id,
-    triggerMessage: triggerDirective.text,
-    intent: triggerDirective.intent,
-    config,
-    dispatchPolicy,
-    cwd,
-  });
+	return await finalizeQueuedMailboxDispatch({
+		queuedOutcome,
+		transportPreference,
+		teamName,
+		workerName: recipient.name,
+		workerIndex: recipient.index,
+		paneId: recipient.pane_id,
+		messageId: queuedOutcome.message_id,
+		triggerMessage: triggerDirective.text,
+		intent: triggerDirective.intent,
+		config,
+		dispatchPolicy,
+		cwd,
+	});
 }
 
 async function finalizeBroadcastMailboxOutcomes(params: {
-  teamName: string;
-  outcomes: DispatchOutcome[];
-  transportPreference: RuntimeMailboxTransportPreference;
-  config: TeamConfig;
-  dispatchPolicy: TeamPolicy;
-  cwd: string;
+	teamName: string;
+	outcomes: DispatchOutcome[];
+	transportPreference: RuntimeMailboxTransportPreference;
+	config: TeamConfig;
+	dispatchPolicy: TeamPolicy;
+	cwd: string;
 }): Promise<DispatchOutcome[]> {
-  const { teamName, outcomes, transportPreference, config, dispatchPolicy, cwd } = params;
-  if (transportPreference !== 'hook_preferred_with_fallback') {
-    return outcomes;
-  }
+	const {
+		teamName,
+		outcomes,
+		transportPreference,
+		config,
+		dispatchPolicy,
+		cwd,
+	} = params;
+	if (transportPreference !== "hook_preferred_with_fallback") {
+		return outcomes;
+	}
 
-  const finalizedOutcomes: DispatchOutcome[] = [];
-  for (const outcome of outcomes) {
-    const target = outcome.to_worker
-      ? (config.workers.find((worker) => worker.name === outcome.to_worker) ?? null)
-      : null;
-    if (!target) {
-      finalizedOutcomes.push({ ...outcome, ok: false, reason: 'missing_worker_index' });
-      continue;
-    }
-    const triggerDirective = buildMailboxTriggerDirective(
-      target.name,
-      teamName,
-      1,
-      resolveInstructionStateRoot(target.worktree_path),
-    );
-    finalizedOutcomes.push(await finalizeQueuedMailboxDispatch({
-      queuedOutcome: outcome,
-      transportPreference,
-      teamName,
-      workerName: target.name,
-      workerIndex: target.index,
-      paneId: target.pane_id,
-      messageId: outcome.message_id,
-      triggerMessage: triggerDirective.text,
-      intent: triggerDirective.intent,
-      config,
-      dispatchPolicy,
-      cwd,
-    }));
-  }
+	const finalizedOutcomes: DispatchOutcome[] = [];
+	for (const outcome of outcomes) {
+		const target = outcome.to_worker
+			? (config.workers.find((worker) => worker.name === outcome.to_worker) ??
+				null)
+			: null;
+		if (!target) {
+			finalizedOutcomes.push({
+				...outcome,
+				ok: false,
+				reason: "missing_worker_index",
+			});
+			continue;
+		}
+		const triggerDirective = buildMailboxTriggerDirective(
+			target.name,
+			teamName,
+			1,
+			resolveInstructionStateRoot(target.worktree_path),
+		);
+		finalizedOutcomes.push(
+			await finalizeQueuedMailboxDispatch({
+				queuedOutcome: outcome,
+				transportPreference,
+				teamName,
+				workerName: target.name,
+				workerIndex: target.index,
+				paneId: target.pane_id,
+				messageId: outcome.message_id,
+				triggerMessage: triggerDirective.text,
+				intent: triggerDirective.intent,
+				config,
+				dispatchPolicy,
+				cwd,
+			}),
+		);
+	}
 
-  return finalizedOutcomes;
+	return finalizedOutcomes;
 }
 
 export async function sendWorkerMessage(
-  teamName: string,
-  fromWorker: string,
-  toWorker: string,
-  body: string,
-  cwd: string,
+	teamName: string,
+	fromWorker: string,
+	toWorker: string,
+	body: string,
+	cwd: string,
 ): Promise<DispatchOutcome> {
-  const sanitized = sanitizeTeamName(teamName);
-  const config = await readTeamConfig(sanitized, cwd);
-  if (!config) throw new Error(`Team ${sanitized} not found`);
-  const manifest = await readTeamManifestV2(sanitized, cwd);
-  const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
+	const sanitized = sanitizeTeamName(teamName);
+	const config = await readTeamConfig(sanitized, cwd);
+	if (!config) throw new Error(`Team ${sanitized} not found`);
+	const manifest = await readTeamManifestV2(sanitized, cwd);
+	const dispatchPolicy = resolveDispatchPolicy(
+		manifest?.policy,
+		config.worker_launch_mode,
+	);
 
-  if (toWorker === 'leader-fixed') {
-    const finalOutcome = await sendLeaderMailboxMessage({
-      teamName: sanitized,
-      fromWorker,
-      body,
-      config,
-      dispatchPolicy,
-      cwd,
-    });
-    if (!finalOutcome.ok) throw new Error(`mailbox_notify_failed:${finalOutcome.reason}`);
-    return finalOutcome;
-  }
+	if (toWorker === "leader-fixed") {
+		const finalOutcome = await sendLeaderMailboxMessage({
+			teamName: sanitized,
+			fromWorker,
+			body,
+			config,
+			dispatchPolicy,
+			cwd,
+		});
+		if (!finalOutcome.ok)
+			throw new Error(`mailbox_notify_failed:${finalOutcome.reason}`);
+		return finalOutcome;
+	}
 
-  const finalOutcome = await sendRecipientMailboxMessage({
-    teamName: sanitized,
-    fromWorker,
-    toWorker,
-    body,
-    config,
-    dispatchPolicy,
-    cwd,
-  });
-  if (!finalOutcome.ok) throw new Error(`mailbox_notify_failed:${finalOutcome.reason}`);
-  return finalOutcome;
+	const finalOutcome = await sendRecipientMailboxMessage({
+		teamName: sanitized,
+		fromWorker,
+		toWorker,
+		body,
+		config,
+		dispatchPolicy,
+		cwd,
+	});
+	if (!finalOutcome.ok)
+		throw new Error(`mailbox_notify_failed:${finalOutcome.reason}`);
+	return finalOutcome;
 }
 
 export async function broadcastWorkerMessage(
-  teamName: string,
-  fromWorker: string,
-  body: string,
-  cwd: string,
+	teamName: string,
+	fromWorker: string,
+	body: string,
+	cwd: string,
 ): Promise<void> {
-  const sanitized = sanitizeTeamName(teamName);
-  const config = await readTeamConfig(sanitized, cwd);
-  if (!config) throw new Error(`Team ${sanitized} not found`);
-  const manifest = await readTeamManifestV2(sanitized, cwd);
-  const dispatchPolicy = resolveDispatchPolicy(manifest?.policy, config.worker_launch_mode);
-  const transportPreference = resolveWorkerMailboxTransportPreference(config, dispatchPolicy);
+	const sanitized = sanitizeTeamName(teamName);
+	const config = await readTeamConfig(sanitized, cwd);
+	if (!config) throw new Error(`Team ${sanitized} not found`);
+	const manifest = await readTeamManifestV2(sanitized, cwd);
+	const dispatchPolicy = resolveDispatchPolicy(
+		manifest?.policy,
+		config.worker_launch_mode,
+	);
+	const transportPreference = resolveWorkerMailboxTransportPreference(
+		config,
+		dispatchPolicy,
+	);
 
-  const outcomes = await queueBroadcastMailboxMessage({
-    teamName: sanitized,
-    fromWorker,
-    recipients: config.workers.map((w) => ({ workerName: w.name, workerIndex: w.index, paneId: w.pane_id })),
-    body,
-    cwd,
-    triggerFor: (workerName) => buildMailboxTriggerDirective(
-      workerName,
-      sanitized,
-      1,
-      resolveInstructionStateRoot(config.workers.find((worker) => worker.name === workerName)?.worktree_path),
-    ).text,
-    intentFor: () => 'pending-mailbox-review',
-    transportPreference,
-    fallbackAllowed: transportPreference === 'hook_preferred_with_fallback',
-    notify: async (target, message) =>
-      transportPreference === 'hook_preferred_with_fallback'
-        ? { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' }
-        : (typeof target.workerIndex === 'number'
-        ? await notifyWorkerOutcome(config, target.workerIndex, message, target.paneId)
-        : { ok: false, transport: 'none', reason: 'missing_worker_index' }),
-  });
-  const results = await finalizeBroadcastMailboxOutcomes({
-    teamName: sanitized,
-    outcomes,
-    transportPreference,
-    config,
-    dispatchPolicy,
-    cwd,
-  });
-  if (results.some((result) => !result.ok)) {
-    const firstFailure = results.find((result) => !result.ok);
-    throw new Error(`mailbox_notify_failed:${firstFailure?.reason ?? 'unknown'}`);
-  }
+	const outcomes = await queueBroadcastMailboxMessage({
+		teamName: sanitized,
+		fromWorker,
+		recipients: config.workers.map((w) => ({
+			workerName: w.name,
+			workerIndex: w.index,
+			paneId: w.pane_id,
+		})),
+		body,
+		cwd,
+		triggerFor: (workerName) =>
+			buildMailboxTriggerDirective(
+				workerName,
+				sanitized,
+				1,
+				resolveInstructionStateRoot(
+					config.workers.find((worker) => worker.name === workerName)
+						?.worktree_path,
+				),
+			).text,
+		intentFor: () => "pending-mailbox-review",
+		transportPreference,
+		fallbackAllowed: transportPreference === "hook_preferred_with_fallback",
+		notify: async (target, message) =>
+			transportPreference === "hook_preferred_with_fallback"
+				? { ok: true, transport: "hook", reason: "queued_for_hook_dispatch" }
+				: typeof target.workerIndex === "number"
+					? await notifyWorkerOutcome(
+							config,
+							target.workerIndex,
+							message,
+							target.paneId,
+						)
+					: { ok: false, transport: "none", reason: "missing_worker_index" },
+	});
+	const results = await finalizeBroadcastMailboxOutcomes({
+		teamName: sanitized,
+		outcomes,
+		transportPreference,
+		config,
+		dispatchPolicy,
+		cwd,
+	});
+	if (results.some((result) => !result.ok)) {
+		const firstFailure = results.find((result) => !result.ok);
+		throw new Error(
+			`mailbox_notify_failed:${firstFailure?.reason ?? "unknown"}`,
+		);
+	}
 }


### PR DESCRIPTION
## Summary\n- require observed startup evidence after direct tmux fallback before interactive worker bootstrap is treated as successful\n- allow a slightly longer startup-evidence window during team launch so Codex/Claude workers can claim work before fallback is considered settled\n- persist cancelled team mode state during shutdown even when a wedged run never created team mode metadata\n- add regressions for startup false-success and shutdown mode-state persistence\n\n## Testing\n- npm run build\n- node --test --test-name-pattern "startTeam rejects interactive startup when tmux fallback never produces worker startup evidence|persists cancelled team mode state on shutdown even when no team mode state existed beforehand" dist/team/__tests__/runtime.test.js dist/cli/__tests__/team.test.js\n\nCloses #1373