### PR TITLE
fix(hud): stop prompt-submit autosizing while keeping recovery

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
 
 function runOmx(
   cwd: string,
@@ -183,7 +184,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(tmuxLog, /tmux:new-session .* -s /);
-      assert.match(tmuxLog, /tmux:split-window -v -l 2 .* -t /);
+      assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES} .* -t `));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -20,7 +20,6 @@ describe('reconcileHudForPromptSubmit', () => {
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
       ],
-      readCurrentWindowSize: () => ({ width: 80, height: 24 }),
       createHudWatchPane: (cwd, cmd, options) => {
         created.push({ cwd, cmd, options });
         return '%9';
@@ -29,30 +28,15 @@ describe('reconcileHudForPromptSubmit', () => {
         resized.push({ paneId, heightLines });
         return true;
       },
-      readHudConfig: async () => ({ preset: 'focused', git: { display: 'branch' } }),
-      readAllState: async () => ({
-        version: null,
-        gitBranch: 'main',
-        ralph: null,
-        ultrawork: null,
-        autopilot: null,
-        ralplan: null,
-        deepInterview: null,
-        autoresearch: null,
-        ultraqa: null,
-        team: null,
-        metrics: null,
-        hudNotify: null,
-        session: null,
-      }),
       resolveOmxEntryPath: () => '/repo/dist/index.js',
     });
 
     assert.equal(result.status, 'recreated');
     assert.equal(result.paneId, '%9');
     assert.equal(created.length, 1);
-    assert.equal(created[0]?.options?.heightLines, 1);
+    assert.equal(created[0]?.options?.heightLines, 3);
     assert.equal(resized.length, 1);
+    assert.equal(resized[0]?.heightLines, 3);
   });
 
   it('kills duplicate HUD panes and recreates one full-width pane', async () => {
@@ -66,32 +50,16 @@ describe('reconcileHudForPromptSubmit', () => {
         { paneId: '%3', currentCommand: 'node', startCommand: 'node omx hud --watch' },
         { paneId: '%4', currentCommand: 'codex', startCommand: 'codex' },
       ],
-      readCurrentWindowSize: () => ({ width: 32, height: 24 }),
       killTmuxPane: (paneId) => {
         killed.push(paneId);
         return true;
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
         assert.equal(options?.fullWidth, true);
+        assert.equal(options?.heightLines, 3);
         return '%9';
       },
       resizeTmuxPane: () => true,
-      readHudConfig: async () => ({ preset: 'focused', git: { display: 'branch' } }),
-      readAllState: async () => ({
-        version: null,
-        gitBranch: 'feature/some-branch',
-        ralph: { active: true, iteration: 3, max_iterations: 10 },
-        ultrawork: null,
-        autopilot: null,
-        ralplan: null,
-        deepInterview: null,
-        autoresearch: null,
-        ultraqa: null,
-        team: null,
-        metrics: null,
-        hudNotify: null,
-        session: null,
-      }),
       resolveOmxEntryPath: () => '/repo/dist/index.js',
     });
 
@@ -107,33 +75,16 @@ describe('reconcileHudForPromptSubmit', () => {
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
         { paneId: '%2', currentCommand: 'node', startCommand: 'node omx hud --watch' },
       ],
-      readCurrentWindowSize: () => ({ width: 24, height: 24 }),
       resizeTmuxPane: (paneId, heightLines) => {
         resized.push({ paneId, heightLines });
         return true;
       },
-      readHudConfig: async () => ({ preset: 'focused', git: { display: 'branch' } }),
-      readAllState: async () => ({
-        version: null,
-        gitBranch: 'feature/some-branch',
-        ralph: { active: true, iteration: 3, max_iterations: 10 },
-        ultrawork: { active: true },
-        autopilot: { active: true, current_phase: 'planning' },
-        ralplan: { active: true, current_phase: 'review' },
-        deepInterview: null,
-        autoresearch: null,
-        ultraqa: null,
-        team: null,
-        metrics: null,
-        hudNotify: null,
-        session: null,
-      }),
       resolveOmxEntryPath: () => '/repo/dist/index.js',
     });
 
     assert.equal(result.status, 'resized');
     assert.equal(resized.length, 1);
     assert.equal(resized[0]?.paneId, '%2');
-    assert.ok((resized[0]?.heightLines ?? 0) >= 2);
+    assert.equal(resized[0]?.heightLines, 3);
   });
 });

--- a/src/hud/constants.ts
+++ b/src/hud/constants.ts
@@ -1,4 +1,4 @@
-export const HUD_TMUX_HEIGHT_LINES = 2;
+export const HUD_TMUX_HEIGHT_LINES = 3;
 export const HUD_TMUX_TEAM_HEIGHT_LINES = 3;
 export const HUD_TMUX_MAX_HEIGHT_LINES = 5;
 export const HUD_RESIZE_RECONCILE_DELAY_SECONDS = 2;

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -1,6 +1,5 @@
-import { readAllState, readHudConfig } from './state.js';
-import { renderHud, countRenderedHudLines } from './render.js';
-import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MAX_HEIGHT_LINES } from './constants.js';
+import { readHudConfig } from './state.js';
+import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import {
   buildHudWatchCommand,
   createHudWatchPane,
@@ -8,7 +7,6 @@ import {
   isHudWatchPane,
   killTmuxPane,
   listCurrentWindowPanes,
-  readCurrentWindowSize,
   resizeTmuxPane,
   type TmuxPaneSnapshot,
 } from './tmux.js';
@@ -30,7 +28,6 @@ export interface ReconcileHudForPromptSubmitResult {
 export interface ReconcileHudForPromptSubmitDeps {
   env?: NodeJS.ProcessEnv;
   listCurrentWindowPanes?: () => TmuxPaneSnapshot[];
-  readCurrentWindowSize?: () => { width: number | null; height: number | null };
   createHudWatchPane?: (
     cwd: string,
     hudCmd: string,
@@ -39,39 +36,7 @@ export interface ReconcileHudForPromptSubmitDeps {
   killTmuxPane?: (paneId: string) => boolean;
   resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;
   readHudConfig?: typeof readHudConfig;
-  readAllState?: typeof readAllState;
-  renderHud?: typeof renderHud;
   resolveOmxEntryPath?: typeof resolveOmxEntryPath;
-}
-
-function resolveHudMaxLines(windowHeight: number | null): number {
-  if (!Number.isFinite(windowHeight) || !windowHeight || windowHeight <= 0) {
-    return HUD_TMUX_MAX_HEIGHT_LINES;
-  }
-  return Math.max(1, Math.min(HUD_TMUX_MAX_HEIGHT_LINES, Math.floor(windowHeight - 1)));
-}
-
-async function resolveDesiredHudHeight(
-  cwd: string,
-  width: number | null,
-  height: number | null,
-  deps: ReconcileHudForPromptSubmitDeps,
-): Promise<number> {
-  const maxLines = resolveHudMaxLines(height);
-  try {
-    const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
-    const readAllStateFn = deps.readAllState ?? readAllState;
-    const renderHudFn = deps.renderHud ?? renderHud;
-    const config = await readHudConfigFn(cwd);
-    const ctx = await readAllStateFn(cwd, config);
-    const frame = renderHudFn(ctx, config.preset, {
-      maxWidth: width ?? undefined,
-      maxLines,
-    });
-    return Math.max(1, Math.min(maxLines, countRenderedHudLines(frame)));
-  } catch {
-    return Math.min(Math.max(1, maxLines), HUD_TMUX_HEIGHT_LINES);
-  }
 }
 
 export async function reconcileHudForPromptSubmit(
@@ -100,7 +65,6 @@ export async function reconcileHudForPromptSubmit(
   }
 
   const listPanes = deps.listCurrentWindowPanes ?? (() => listCurrentWindowPanes());
-  const readSize = deps.readCurrentWindowSize ?? (() => readCurrentWindowSize());
   const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
   const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
@@ -110,8 +74,7 @@ export async function reconcileHudForPromptSubmit(
   const hudPaneIds = findHudWatchPaneIds(panes, currentPaneId);
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);
   const nonHudPaneCount = panes.filter((pane) => !isHudWatchPane(pane)).length;
-  const { width, height } = readSize();
-  const desiredHeight = await resolveDesiredHudHeight(cwd, width, height, deps);
+  const desiredHeight = HUD_TMUX_HEIGHT_LINES;
 
   const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
   const hudConfig = await readHudConfigFn(cwd).catch(() => null);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -364,7 +364,7 @@ esac
       const tmuxCalls = await readFile(tmuxLog, "utf-8");
       assert.match(tmuxCalls, /list-panes/);
       assert.match(tmuxCalls, /split-window/);
-      assert.match(tmuxCalls, /resize-pane -t %9 -y 1/);
+      assert.match(tmuxCalls, /resize-pane -t %9 -y 3/);
     } finally {
       if (originalTmux === undefined) {
         delete process.env.TMUX;


### PR DESCRIPTION
## Summary\n- keep the prompt-submit HUD auto-recovery hook in place\n- revert the render-driven/dynamic prompt-submit resize behavior so reconciliation always uses the shared 3-line HUD height\n- update HUD regression tests and detached launch fallback expectations to match the fixed-height behavior\n\n## Verification\n- npm run build\n- node --test dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/hud-tmux-injection.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/index.test.js\n- npm run lint\n- npm run check:no-unused\n- npm test\n\n## Notes\n- intentionally merging without waiting on CI because the full local suite passed in this worktree\n