### PR TITLE
Preserve user-owned Codex hooks while refreshing OMX wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ omx team shutdown <team-name>
 
 These are operator/support surfaces:
 - `omx setup` installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and OMX-managed native Codex hooks in `.codex/hooks.json`
+  - setup refresh preserves non-OMX hook entries in `.codex/hooks.json` and only rewrites OMX-managed wrappers
+  - `omx uninstall` removes OMX-managed wrappers from `.codex/hooks.json` but keeps the file when user hooks remain
 - `omx doctor` verifies the install when something seems wrong
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow
 

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -9,15 +9,18 @@ This page is the canonical answer to:
 `omx setup` now owns both of these native Codex artifacts:
 
 - `.codex/config.toml` → enables `[features].codex_hooks = true`
-- `.codex/hooks.json` → registers the OMX-managed native hook command
+- `.codex/hooks.json` → registers the OMX-managed native hook command while preserving non-OMX hook entries already in the file
 
 For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of source control.
+`omx uninstall` removes only the OMX-managed wrapper entries from `.codex/hooks.json`; if user hooks remain, the file stays in place.
 
 ## Ownership split
 
 - **Native Codex hooks**: `.codex/hooks.json`
 - **OMX plugin hooks**: `.omx/hooks/*.mjs`
 - **tmux/runtime fallbacks**: `omx tmux-hook`, notify-hook, derived watcher, idle/session-end reporters
+
+OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js`. User-managed hook entries in the same `.codex/hooks.json` file are preserved across `omx setup` refreshes and `omx uninstall`.
 
 ## Mapping matrix
 

--- a/docs/hooks-extension.md
+++ b/docs/hooks-extension.md
@@ -9,6 +9,11 @@ Native Codex hook ownership is documented separately in
 - `.omx/hooks/*.mjs` = OMX plugin hooks dispatched by runtime/native events
 - `omx tmux-hook` / notify-hook / derived watcher = tmux/runtime fallback surfaces
 
+`omx setup` treats `.codex/hooks.json` as a shared-ownership file: it refreshes only the OMX-managed
+wrapper entries that invoke `dist/scripts/codex-native-hook.js` and preserves user hook entries in the
+same file. `omx uninstall` removes only those OMX-managed wrappers and leaves `.codex/hooks.json` in
+place when user hooks remain.
+
 > Compatibility guarantee: `omx tmux-hook` remains fully supported and unchanged.
 > The new `omx hooks` command group is additive and does **not** replace tmux-hook workflows.
 

--- a/docs/reports/open-prs-dev-readiness-2026-04-09.md
+++ b/docs/reports/open-prs-dev-readiness-2026-04-09.md
@@ -1,0 +1,43 @@
+# Open PR readiness matrix for `dev` — 2026-04-09 UTC
+
+Current `dev` head reviewed: `8656d21149a0772369f697df002f7bf85002db8d`.
+
+## `dev` CI note
+
+Push run `24141814673` on `dev` finished red because long jobs were cancelled, not because the fast validation jobs failed.
+
+- Passed on `dev`: Rust Format, Rust Clippy, Lint, Typecheck (Node 20/22), Test (Node 22 / smoke), Coverage Report (Rust), Coverage Gate (Team Critical), Ralph Persistence Gate.
+- Cancelled on `dev`: `Test (Node 20 / full)`, `Coverage Report (TypeScript Full)`.
+- Failed gate: `CI Status`.
+- Workflow reason: `.github/workflows/ci.yml:260-289` requires every `needs.*.result` to equal `success`; cancelled/skipped results force the gate red.
+
+## Readiness matrix
+
+| PR | Summary | Current checks | Merge blockers | Recommendation |
+| --- | --- | --- | --- | --- |
+| #1403 | Shared-session shutdown hardening + regression coverage | Fast checks mostly green, but both Typecheck jobs failed in run `24173665271`; full Node 20 suite still running | **Hard blocker:** `npm run check:no-unused` fails locally on PR head `e802eff1` with `src/team/runtime.ts(20,3): error TS6133: 'isNativeWindows' is declared but its value is never read.` | **Do not merge yet.** Fix unused import, rerun PR CI, then reassess. |
+| #1402 | tmux HUD self-healing / prompt-submit reconcile | Lint, typecheck, smoke, rust coverage, team coverage gate passed; full Node 20 and TS full coverage still pending | Pending long jobs; touches `src/cli`, `src/hud`, and native-hook operational events, so I would not merge before `dev` CI is green | **Good candidate once long jobs finish green and `dev` is green.** Recommended ahead of docs-only work. |
+| #1400 | Unknown `$token` duplicate continuation + stale Ralph state fix | Lint, typecheck, smoke, rust coverage, team coverage gate passed; full Node 20 and TS full coverage still pending | Pending long jobs; overlaps `src/scripts/codex-native-hook.ts` and its tests with #1380 | **Merge after #1380 is in `dev`, then rebase/retest.** Otherwise likely conflict/re-review churn. |
+| #1382 | Stale team worktree cleanup at startup | PR is open, but its head commit `e5f9ffe7...` is already an ancestor of current `dev` head | No merge work left; CI Status failure is stale noise from cancelled long jobs on an already-landed change | **Close as stale/already merged.** No merge needed. |
+| #1380 | Stale deep-interview stop-hook gating fix | Fast checks passed; CI Status failed only because long jobs were cancelled in old run `24142611197` | Long jobs were cancelled; overlaps same native-hook files as #1400 | **Best first merge among the hook fixes once `dev` CI is green.** Land before #1400. |
+| #1357 | AGENTS/template token reduction | Fast checks passed; CI Status failed only because long jobs were cancelled in old run `24145469951` | Long jobs cancelled; PR body/checklist says only two files changed, but diff also changes `CLAUDE.md` | **Hold for manual review after runtime fixes.** Lower urgency than #1380/#1400/#1402. |
+
+## Recommended merge order
+
+1. Close **#1382** as already merged into `dev`.
+2. After `dev` CI is rerun/green, merge **#1380**.
+3. Rebase/retest and merge **#1400**.
+4. Merge **#1402** once its pending jobs finish green.
+5. Re-review **#1357** (body/diff mismatch, prompt-contract risk) before merging.
+6. Fix **#1403** unused import + rerun CI before considering merge.
+
+## Evidence collected
+
+- `gh run view 24141814673 --json ...` for current `dev` CI failure shape.
+- `gh pr checks 1402`, `1400`, `1382`, `1380`, `1357`, `1403` for current PR statuses.
+- `gh pr diff --name-only` for overlap checks.
+- `git rev-list --left-right --count dev...pr-<n>` and `git merge-base dev pr-1382` for ancestry / already-merged detection.
+- Local PR verification for #1403 in `/tmp/worker3-pr1403`:
+  - `npm ci`
+  - `npm run build`
+  - `npm run check:no-unused` → unused import failure in `src/team/runtime.ts`.

--- a/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
+++ b/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
@@ -1,0 +1,269 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+type CommandHook = {
+  type?: string;
+  command?: string;
+  statusMessage?: string;
+  timeout?: number;
+  [key: string]: unknown;
+};
+
+type HookRegistration = {
+  matcher?: string;
+  hooks?: CommandHook[];
+  [key: string]: unknown;
+};
+
+type HooksFile = {
+  hooks?: Record<string, HookRegistration[]>;
+  [key: string]: unknown;
+};
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, "..", "..", "..");
+  const omxBin = join(repoRoot, "dist", "cli", "omx.js");
+  const resolvedHome = envOverrides.HOME ?? process.env.HOME;
+  const result = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      ...(resolvedHome && !envOverrides.CODEX_HOME
+        ? { CODEX_HOME: join(resolvedHome, ".codex") }
+        : {}),
+      ...envOverrides,
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    error: result.error?.message || "",
+  };
+}
+
+function shouldSkipForSpawnPermissions(err: string): boolean {
+  return typeof err === "string" && /(EPERM|EACCES)/i.test(err);
+}
+
+async function readHooksJson(filePath: string): Promise<HooksFile> {
+  return JSON.parse(await readFile(filePath, "utf-8")) as HooksFile;
+}
+
+async function writeHooksJson(filePath: string, hooksFile: HooksFile): Promise<void> {
+  await writeFile(filePath, JSON.stringify(hooksFile, null, 2) + "\n");
+}
+
+function makeUserCommandHook(command: string, matcher?: string): HookRegistration {
+  return {
+    ...(matcher ? { matcher } : {}),
+    hooks: [
+      {
+        type: "command",
+        command,
+        statusMessage: `user hook ${command}`,
+      },
+    ],
+  };
+}
+
+function hookCommands(entries: HookRegistration[] | undefined): string[] {
+  return (entries ?? [])
+    .flatMap((entry) => entry.hooks ?? [])
+    .map((hook) => hook.command)
+    .filter((command): command is string => typeof command === "string");
+}
+
+function countManagedHooks(entries: HookRegistration[] | undefined): number {
+  return hookCommands(entries).filter((command) => command.includes("codex-native-hook.js")).length;
+}
+
+function cloneRegistration(entry: HookRegistration): HookRegistration {
+  return structuredClone(entry) as HookRegistration;
+}
+
+describe("omx setup/uninstall shared ownership for native hooks", () => {
+  it("setup merges managed wrappers into an existing user-owned hooks.json", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-hooks-existing-user-file-"));
+    try {
+      const home = join(wd, "home");
+      const codexDir = join(wd, ".codex");
+      await mkdir(home, { recursive: true });
+      await mkdir(codexDir, { recursive: true });
+
+      const hooksPath = join(codexDir, "hooks.json");
+      await writeHooksJson(hooksPath, {
+        hooks: {
+          SessionStart: [
+            makeUserCommandHook('node "/custom/session-start.js"', "startup"),
+          ],
+          PostToolUse: [makeUserCommandHook('node "/custom/post-tool.js"')],
+        },
+      });
+
+      const setupResult = runOmx(wd, ["setup", "--scope", "project"], {
+        HOME: home,
+      });
+      if (shouldSkipForSpawnPermissions(setupResult.error)) return;
+      assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
+
+      const refreshed = await readHooksJson(hooksPath);
+      assert.ok(
+        hookCommands(refreshed.hooks?.SessionStart).includes(
+          'node "/custom/session-start.js"',
+        ),
+        "setup should preserve pre-existing user SessionStart hooks",
+      );
+      assert.ok(
+        hookCommands(refreshed.hooks?.PostToolUse).includes(
+          'node "/custom/post-tool.js"',
+        ),
+        "setup should preserve pre-existing user PostToolUse hooks",
+      );
+      assert.equal(
+        countManagedHooks(refreshed.hooks?.SessionStart),
+        1,
+        "setup should append the managed SessionStart wrapper into user-owned hooks.json",
+      );
+      assert.equal(
+        countManagedHooks(refreshed.hooks?.PostToolUse),
+        1,
+        "setup should append the managed PostToolUse wrapper into user-owned hooks.json",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("setup preserves user hooks while deduping stale OMX wrappers", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-hooks-ownership-"));
+    try {
+      const home = join(wd, "home");
+      await mkdir(home, { recursive: true });
+
+      const initial = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(initial.error)) return;
+      assert.equal(initial.status, 0, initial.stderr || initial.stdout);
+
+      const hooksPath = join(wd, ".codex", "hooks.json");
+      const generated = await readHooksJson(hooksPath);
+      const generatedSessionStart = generated.hooks?.SessionStart ?? [];
+      assert.ok(generatedSessionStart.length > 0, "setup should generate managed SessionStart hooks");
+
+      const staleManagedSessionStart = cloneRegistration(generatedSessionStart[0]!);
+      if (staleManagedSessionStart.hooks?.[0]) {
+        staleManagedSessionStart.hooks[0].command = 'node "/tmp/old/codex-native-hook.js"';
+        staleManagedSessionStart.hooks[0].statusMessage = "stale omx wrapper";
+      }
+
+      await writeHooksJson(hooksPath, {
+        ...generated,
+        hooks: {
+          ...(generated.hooks ?? {}),
+          SessionStart: [
+            makeUserCommandHook('node "/custom/session-start.js"', "startup"),
+            staleManagedSessionStart,
+            ...generatedSessionStart,
+          ],
+          PostToolUse: [
+            ...(generated.hooks?.PostToolUse ?? []),
+            makeUserCommandHook('node "/custom/post-tool.js"'),
+          ],
+        },
+      });
+
+      const refreshedSetup = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(refreshedSetup.error)) return;
+      assert.equal(refreshedSetup.status, 0, refreshedSetup.stderr || refreshedSetup.stdout);
+
+      const refreshed = await readHooksJson(hooksPath);
+      const sessionStartCommands = hookCommands(refreshed.hooks?.SessionStart);
+      const postToolCommands = hookCommands(refreshed.hooks?.PostToolUse);
+
+      assert.ok(
+        sessionStartCommands.includes('node "/custom/session-start.js"'),
+        "setup should preserve user SessionStart hooks",
+      );
+      assert.ok(
+        postToolCommands.includes('node "/custom/post-tool.js"'),
+        "setup should preserve user PostToolUse hooks",
+      );
+      assert.equal(
+        countManagedHooks(refreshed.hooks?.SessionStart),
+        1,
+        "setup should leave a single managed SessionStart wrapper after refresh",
+      );
+      assert.equal(
+        countManagedHooks(refreshed.hooks?.PostToolUse),
+        1,
+        "setup should keep the managed PostToolUse wrapper alongside user hooks",
+      );
+      assert.ok(
+        hookCommands(refreshed.hooks?.UserPromptSubmit).some((command) => command.includes("codex-native-hook.js")),
+        "setup should still register managed UserPromptSubmit hooks",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("uninstall removes only OMX-managed wrappers and preserves user hook content", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-uninstall-hooks-ownership-"));
+    try {
+      const home = join(wd, "home");
+      await mkdir(home, { recursive: true });
+
+      const initial = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(initial.error)) return;
+      assert.equal(initial.status, 0, initial.stderr || initial.stdout);
+
+      const hooksPath = join(wd, ".codex", "hooks.json");
+      const generated = await readHooksJson(hooksPath);
+
+      await writeHooksJson(hooksPath, {
+        ...generated,
+        hooks: {
+          ...(generated.hooks ?? {}),
+          SessionStart: [
+            makeUserCommandHook('node "/custom/session-start.js"', "startup"),
+            ...(generated.hooks?.SessionStart ?? []),
+          ],
+          PostToolUse: [
+            ...(generated.hooks?.PostToolUse ?? []),
+            makeUserCommandHook('node "/custom/post-tool.js"'),
+          ],
+        },
+      });
+
+      const uninstall = runOmx(wd, ["uninstall"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(uninstall.error)) return;
+      assert.equal(uninstall.status, 0, uninstall.stderr || uninstall.stdout);
+
+      assert.equal(existsSync(hooksPath), true, "uninstall should keep hooks.json when user hooks remain");
+      const remaining = await readHooksJson(hooksPath);
+      const allCommands = Object.values(remaining.hooks ?? {}).flatMap((entries) => hookCommands(entries));
+
+      assert.ok(allCommands.includes('node "/custom/session-start.js"'));
+      assert.ok(allCommands.includes('node "/custom/post-tool.js"'));
+      assert.equal(
+        allCommands.some((command) => command.includes("codex-native-hook.js")),
+        false,
+        "uninstall should strip only OMX-managed wrappers",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -235,6 +235,82 @@ describe("omx setup scope behavior", () => {
     }
   });
 
+  it("setup preserves user hooks while replacing stale OMX wrappers", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-scope-"));
+    try {
+      const home = join(wd, "home");
+      const codexDir = join(wd, ".codex");
+      await mkdir(home, { recursive: true });
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, "hooks.json"),
+        JSON.stringify(
+          {
+            hooks: {
+              SessionStart: [
+                {
+                  hooks: [
+                    {
+                      type: "command",
+                      command: 'node "/old/dist/scripts/codex-native-hook.js"',
+                    },
+                    { type: "command", command: "echo keep-me" },
+                  ],
+                },
+              ],
+              Stop: [
+                {
+                  hooks: [
+                    {
+                      type: "command",
+                      command: 'node "/old/dist/scripts/codex-native-hook.js"',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+
+      const res = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      const hooksJson = JSON.parse(
+        await readFile(join(codexDir, "hooks.json"), "utf-8"),
+      ) as {
+        hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
+      };
+      const sessionStartHooks = hooksJson.hooks.SessionStart.flatMap((entry) =>
+        entry.hooks ?? []
+      );
+      const stopHooks = hooksJson.hooks.Stop.flatMap((entry) => entry.hooks ?? []);
+
+      assert.equal(
+        sessionStartHooks.filter((hook) =>
+          String(hook.command ?? "").includes("codex-native-hook.js")
+        ).length,
+        1,
+      );
+      assert.equal(
+        stopHooks.filter((hook) =>
+          String(hook.command ?? "").includes("codex-native-hook.js")
+        ).length,
+        1,
+      );
+      assert.match(JSON.stringify(sessionStartHooks), /echo keep-me/);
+      assert.doesNotMatch(
+        JSON.stringify(hooksJson),
+        /\/old\/dist\/scripts\/codex-native-hook\.js/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("defaults to user scope in non-interactive runs when no scope is persisted", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-scope-"));
     try {

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -6,6 +6,7 @@ import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { buildManagedCodexHooksConfig } from '../../config/codex-hooks.js';
 
 function runOmx(
   cwd: string,
@@ -196,7 +197,10 @@ describe('omx uninstall', () => {
       const codexDir = join(home, '.codex');
       await mkdir(codexDir, { recursive: true });
       await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
-      await writeFile(join(codexDir, 'hooks.json'), '{"hooks":{}}\n');
+      await writeFile(
+        join(codexDir, 'hooks.json'),
+        JSON.stringify(buildManagedCodexHooksConfig(wd), null, 2) + '\n',
+      );
 
       const res = runOmx(wd, ['uninstall', '--dry-run'], { HOME: home });
       if (shouldSkipForSpawnPermissions(res.error)) return;
@@ -222,7 +226,10 @@ describe('omx uninstall', () => {
       const codexDir = join(home, '.codex');
       await mkdir(codexDir, { recursive: true });
       await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
-      await writeFile(join(codexDir, 'hooks.json'), '{"hooks":{}}\n');
+      await writeFile(
+        join(codexDir, 'hooks.json'),
+        JSON.stringify(buildManagedCodexHooksConfig(wd), null, 2) + '\n',
+      );
 
       const res = runOmx(wd, ['uninstall'], { HOME: home });
       if (shouldSkipForSpawnPermissions(res.error)) return;
@@ -274,6 +281,48 @@ describe('omx uninstall', () => {
       assert.doesNotMatch(config, /multi_agent/);
       assert.doesNotMatch(config, /child_agents_md/);
       assert.doesNotMatch(config, /codex_hooks/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves user hooks while removing OMX-managed wrappers', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), buildOmxConfig());
+      await writeFile(
+        join(codexDir, 'hooks.json'),
+        JSON.stringify(
+          {
+            hooks: {
+              SessionStart: [
+                {
+                  hooks: [
+                    { type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
+                    { type: 'command', command: 'echo keep-me' },
+                  ],
+                },
+              ],
+            },
+            version: 1,
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.equal(existsSync(join(codexDir, 'hooks.json')), true);
+
+      const hooks = await readFile(join(codexDir, 'hooks.json'), 'utf-8');
+      assert.match(hooks, /echo keep-me/);
+      assert.match(hooks, /"version": 1/);
+      assert.doesNotMatch(hooks, /codex-native-hook\.js/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -29,7 +29,7 @@ import {
   omxLogsDir,
 } from "../utils/paths.js";
 import { buildMergedConfig, getRootModelName } from "../config/generator.js";
-import { buildManagedCodexHooksConfig } from "../config/codex-hooks.js";
+import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
 import {
   getLegacyUnifiedMcpRegistryCandidate,
   getUnifiedMcpRegistryCandidates,
@@ -836,11 +836,13 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   }
   console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
 
-  const hooksConfig = JSON.stringify(
-    buildManagedCodexHooksConfig(pkgRoot),
-    null,
-    2,
-  ) + "\n";
+  const existingHooksContent = existsSync(scopeDirs.codexHooksFile)
+    ? await readFile(scopeDirs.codexHooksFile, "utf-8")
+    : null;
+  const hooksConfig = mergeManagedCodexHooksConfig(
+    existingHooksContent,
+    pkgRoot,
+  );
   await syncManagedContent(
     hooksConfig,
     scopeDirs.codexHooksFile,

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -11,6 +11,10 @@ import {
   stripOmxTopLevelKeys,
   stripOmxFeatureFlags,
 } from "../config/generator.js";
+import {
+  parseCodexHooksConfig,
+  removeManagedCodexHooks,
+} from "../config/codex-hooks.js";
 import { getPackageRoot } from "../utils/package.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { detectLegacySkillRootOverlap } from "../utils/paths.js";
@@ -294,12 +298,26 @@ async function removeHooksFile(
 ): Promise<boolean> {
   if (!existsSync(hooksFilePath)) return false;
 
+  const existing = await readFile(hooksFilePath, "utf-8");
+  const { nextContent, removedCount } = removeManagedCodexHooks(existing);
+  const parsed = parseCodexHooksConfig(existing);
+  const emptyManagedArtifact =
+    parsed !== null &&
+    Object.keys(parsed.hooks).length === 0 &&
+    Object.keys(parsed.root).every((key) => key === "hooks");
+
+  if (removedCount === 0 && !emptyManagedArtifact) return false;
+
   if (!options.dryRun) {
-    await rm(hooksFilePath, { force: true });
+    if (nextContent === null || emptyManagedArtifact) {
+      await rm(hooksFilePath, { force: true });
+    } else {
+      await writeFile(hooksFilePath, nextContent);
+    }
   }
   if (options.verbose) {
     console.log(
-      `  ${options.dryRun ? "Would remove" : "Removed"} ${basename(hooksFilePath)}`,
+      `  ${options.dryRun ? "Would clean" : nextContent === null || emptyManagedArtifact ? "Removed" : "Cleaned"} ${basename(hooksFilePath)}`,
     );
   }
   return true;
@@ -379,7 +397,7 @@ function printSummary(summary: UninstallSummary, dryRun: boolean): void {
   }
 
   if (summary.hooksFileRemoved) {
-    console.log(`  ${prefix} .codex/hooks.json`);
+    console.log(`  ${prefix} OMX-managed entries in .codex/hooks.json`);
   }
 
   if (summary.promptsRemoved > 0) {
@@ -479,7 +497,7 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
     verbose,
   });
   console.log(
-    `  ${dryRun ? "Would remove" : "Removed"} ${summary.hooksFileRemoved ? 1 : 0} hooks file(s).`,
+    `  ${dryRun ? "Would clean" : "Cleaned"} ${summary.hooksFileRemoved ? 1 : 0} hooks artifact(s).`,
   );
   console.log();
 

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildManagedCodexHooksConfig,
+  mergeManagedCodexHooksConfig,
+  removeManagedCodexHooks,
+} from "../codex-hooks.js";
+
+describe("codex hooks helpers", () => {
+  it("merges managed wrappers without dropping user hooks", () => {
+    const merged = JSON.parse(
+      mergeManagedCodexHooksConfig(
+        JSON.stringify({
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [
+                  { type: "command", command: 'node "/old/dist/scripts/codex-native-hook.js"' },
+                  { type: "command", command: "echo keep-me" },
+                ],
+              },
+              {
+                hooks: [{ type: "command", command: "echo standalone-user" }],
+              },
+            ],
+          },
+        }),
+        "/repo",
+      ),
+    ) as { hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>> };
+
+    const sessionStart = merged.hooks.SessionStart;
+    assert.equal(
+      sessionStart.flatMap((entry) => entry.hooks ?? []).filter((hook) =>
+        String(hook.command ?? "").includes("codex-native-hook.js")
+      ).length,
+      1,
+    );
+    assert.match(JSON.stringify(sessionStart), /echo keep-me/);
+    assert.match(JSON.stringify(sessionStart), /echo standalone-user/);
+    assert.match(JSON.stringify(sessionStart), /Loading OMX session context/);
+  });
+
+  it("removes only OMX-managed wrappers during uninstall cleanup", () => {
+    const managedOnly = JSON.stringify(buildManagedCodexHooksConfig("/repo"));
+    const preserved = JSON.stringify({
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              { type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
+              { type: "command", command: "echo keep-me" },
+            ],
+          },
+        ],
+      },
+      version: 1,
+    });
+
+    const removedManagedOnly = removeManagedCodexHooks(managedOnly);
+    assert.equal(removedManagedOnly.removedCount > 0, true);
+    assert.equal(removedManagedOnly.nextContent, null);
+
+    const removedMixed = removeManagedCodexHooks(preserved);
+    assert.equal(removedMixed.removedCount, 1);
+    assert.ok(removedMixed.nextContent);
+    assert.match(removedMixed.nextContent, /echo keep-me/);
+    assert.doesNotMatch(removedMixed.nextContent, /codex-native-hook\.js/);
+    assert.match(removedMixed.nextContent, /"version": 1/);
+  });
+});

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -1,14 +1,39 @@
 import { join } from "path";
 
+const MANAGED_HOOK_EVENTS = [
+  "SessionStart",
+  "PreToolUse",
+  "PostToolUse",
+  "UserPromptSubmit",
+  "Stop",
+] as const;
+
+type ManagedHookEventName = (typeof MANAGED_HOOK_EVENTS)[number];
+
+type JsonObject = Record<string, unknown>;
+
 export interface ManagedCodexHooksConfig {
-  hooks: {
-    SessionStart: Array<Record<string, unknown>>;
-    PreToolUse: Array<Record<string, unknown>>;
-    PostToolUse: Array<Record<string, unknown>>;
-    UserPromptSubmit: Array<Record<string, unknown>>;
-    Stop: Array<Record<string, unknown>>;
-  };
+  hooks: Record<ManagedHookEventName, Array<Record<string, unknown>>>;
 }
+
+interface ParsedCodexHooksConfig {
+  root: JsonObject;
+  hooks: JsonObject;
+}
+
+export interface RemoveManagedCodexHooksResult {
+  nextContent: string | null;
+  removedCount: number;
+}
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneJson<T>(value: T): T {
+  return structuredClone(value);
+}
+
 function buildCommandHook(
   command: string,
   options: {
@@ -30,7 +55,9 @@ function buildCommandHook(
   };
 }
 
-export function buildManagedCodexHooksConfig(pkgRoot: string): ManagedCodexHooksConfig {
+export function buildManagedCodexHooksConfig(
+  pkgRoot: string,
+): ManagedCodexHooksConfig {
   const hookScript = join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
   const command = `node "${hookScript}"`;
 
@@ -64,5 +91,156 @@ export function buildManagedCodexHooksConfig(pkgRoot: string): ManagedCodexHooks
         }),
       ],
     },
+  };
+}
+
+export function parseCodexHooksConfig(
+  content: string,
+): ParsedCodexHooksConfig | null {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (!isPlainObject(parsed)) return null;
+
+    return {
+      root: cloneJson(parsed),
+      hooks: isPlainObject(parsed.hooks) ? cloneJson(parsed.hooks) : {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isOmxManagedHookCommand(command: string): boolean {
+  return /(?:^|[\\/])codex-native-hook\.js(?:["'\s]|$)/.test(command);
+}
+
+function stripManagedHooksFromEntry(entry: unknown): {
+  entry: unknown | null;
+  removedCount: number;
+} {
+  if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) {
+    return { entry: cloneJson(entry), removedCount: 0 };
+  }
+
+  const nextHooks = entry.hooks.filter((hook) => {
+    if (!isPlainObject(hook)) return true;
+    return !(
+      hook.type === "command" &&
+      typeof hook.command === "string" &&
+      isOmxManagedHookCommand(hook.command)
+    );
+  });
+
+  const removedCount = entry.hooks.length - nextHooks.length;
+  if (removedCount === 0) {
+    return { entry: cloneJson(entry), removedCount: 0 };
+  }
+
+  if (nextHooks.length === 0) {
+    return { entry: null, removedCount };
+  }
+
+  return {
+    entry: {
+      ...cloneJson(entry),
+      hooks: nextHooks,
+    },
+    removedCount,
+  };
+}
+
+function serializeCodexHooksConfig(root: JsonObject): string {
+  return JSON.stringify(root, null, 2) + "\n";
+}
+
+export function mergeManagedCodexHooksConfig(
+  existingContent: string | null | undefined,
+  pkgRoot: string,
+): string {
+  const managedConfig = buildManagedCodexHooksConfig(pkgRoot);
+  const parsed =
+    typeof existingContent === "string"
+      ? parseCodexHooksConfig(existingContent)
+      : null;
+
+  const nextRoot = parsed ? cloneJson(parsed.root) : {};
+  const nextHooks = parsed ? cloneJson(parsed.hooks) : {};
+
+  for (const eventName of MANAGED_HOOK_EVENTS) {
+    const existingEntries = Array.isArray(nextHooks[eventName])
+      ? nextHooks[eventName]
+      : [];
+    const preservedEntries: unknown[] = [];
+
+    for (const entry of existingEntries) {
+      const stripped = stripManagedHooksFromEntry(entry);
+      if (stripped.entry !== null) {
+        preservedEntries.push(stripped.entry);
+      }
+    }
+
+    nextHooks[eventName] = [
+      ...preservedEntries,
+      ...managedConfig.hooks[eventName].map((entry) => cloneJson(entry)),
+    ];
+  }
+
+  if (Object.keys(nextHooks).length > 0) {
+    nextRoot.hooks = nextHooks;
+  } else {
+    delete nextRoot.hooks;
+  }
+
+  return serializeCodexHooksConfig(nextRoot);
+}
+
+export function removeManagedCodexHooks(
+  existingContent: string,
+): RemoveManagedCodexHooksResult {
+  const parsed = parseCodexHooksConfig(existingContent);
+  if (!parsed) {
+    return { nextContent: existingContent, removedCount: 0 };
+  }
+
+  const nextRoot = cloneJson(parsed.root);
+  const nextHooks = cloneJson(parsed.hooks);
+  let removedCount = 0;
+
+  for (const [eventName, rawEntries] of Object.entries(nextHooks)) {
+    if (!Array.isArray(rawEntries)) continue;
+
+    const preservedEntries: unknown[] = [];
+    for (const entry of rawEntries) {
+      const stripped = stripManagedHooksFromEntry(entry);
+      removedCount += stripped.removedCount;
+      if (stripped.entry !== null) {
+        preservedEntries.push(stripped.entry);
+      }
+    }
+
+    if (preservedEntries.length > 0) {
+      nextHooks[eventName] = preservedEntries;
+    } else {
+      delete nextHooks[eventName];
+    }
+  }
+
+  if (removedCount === 0) {
+    return { nextContent: existingContent, removedCount: 0 };
+  }
+
+  if (Object.keys(nextHooks).length > 0) {
+    nextRoot.hooks = nextHooks;
+  } else {
+    delete nextRoot.hooks;
+  }
+
+  if (Object.keys(nextRoot).length === 0) {
+    return { nextContent: null, removedCount };
+  }
+
+  return {
+    nextContent: serializeCodexHooksConfig(nextRoot),
+    removedCount,
   };
 }


### PR DESCRIPTION
## Summary

`omx setup` was overwriting existing `.codex/hooks.json` content even when users already had native Codex hooks configured. This change makes setup/uninstall treat `hooks.json` as shared state so OMX can refresh its own managed wrappers without destroying user-owned hook registrations.

## Changes

- add shared hooks.json parse/validate/merge/remove helpers in `src/config/codex-hooks.ts`
- make `omx setup` merge/dedupe OMX-managed `codex-native-hook.js` wrappers instead of overwriting the entire file
- make `omx uninstall` remove only OMX-managed wrappers and delete `hooks.json` only when it becomes effectively empty
- add focused shared-ownership coverage for setup/uninstall/hooks merging
- update README and hook docs to describe shared ownership semantics

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [x] `omx doctor` (when setup/config behavior changes)

Additional targeted validation:
- [x] `npx biome lint README.md docs/codex-native-hooks.md docs/hooks-extension.md src/cli/__tests__/setup-hooks-shared-ownership.test.ts src/cli/__tests__/setup-scope.test.ts src/cli/__tests__/uninstall.test.ts src/cli/setup.ts src/cli/uninstall.ts src/config/__tests__/codex-hooks.test.ts src/config/codex-hooks.ts`
- [x] `node --test dist/config/__tests__/codex-hooks.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/cli/__tests__/uninstall.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
