### PR TITLE
Fix HUD recovery so prompt-submit restores a working HUD

### DIFF
--- a/docs/reports/open-prs-dev-readiness-2026-04-09.md
+++ b/docs/reports/open-prs-dev-readiness-2026-04-09.md
@@ -1,0 +1,43 @@
+# Open PR readiness matrix for `dev` — 2026-04-09 UTC
+
+Current `dev` head reviewed: `8656d21149a0772369f697df002f7bf85002db8d`.
+
+## `dev` CI note
+
+Push run `24141814673` on `dev` finished red because long jobs were cancelled, not because the fast validation jobs failed.
+
+- Passed on `dev`: Rust Format, Rust Clippy, Lint, Typecheck (Node 20/22), Test (Node 22 / smoke), Coverage Report (Rust), Coverage Gate (Team Critical), Ralph Persistence Gate.
+- Cancelled on `dev`: `Test (Node 20 / full)`, `Coverage Report (TypeScript Full)`.
+- Failed gate: `CI Status`.
+- Workflow reason: `.github/workflows/ci.yml:260-289` requires every `needs.*.result` to equal `success`; cancelled/skipped results force the gate red.
+
+## Readiness matrix
+
+| PR | Summary | Current checks | Merge blockers | Recommendation |
+| --- | --- | --- | --- | --- |
+| #1403 | Shared-session shutdown hardening + regression coverage | Fast checks mostly green, but both Typecheck jobs failed in run `24173665271`; full Node 20 suite still running | **Hard blocker:** `npm run check:no-unused` fails locally on PR head `e802eff1` with `src/team/runtime.ts(20,3): error TS6133: 'isNativeWindows' is declared but its value is never read.` | **Do not merge yet.** Fix unused import, rerun PR CI, then reassess. |
+| #1402 | tmux HUD self-healing / prompt-submit reconcile | Lint, typecheck, smoke, rust coverage, team coverage gate passed; full Node 20 and TS full coverage still pending | Pending long jobs; touches `src/cli`, `src/hud`, and native-hook operational events, so I would not merge before `dev` CI is green | **Good candidate once long jobs finish green and `dev` is green.** Recommended ahead of docs-only work. |
+| #1400 | Unknown `$token` duplicate continuation + stale Ralph state fix | Lint, typecheck, smoke, rust coverage, team coverage gate passed; full Node 20 and TS full coverage still pending | Pending long jobs; overlaps `src/scripts/codex-native-hook.ts` and its tests with #1380 | **Merge after #1380 is in `dev`, then rebase/retest.** Otherwise likely conflict/re-review churn. |
+| #1382 | Stale team worktree cleanup at startup | PR is open, but its head commit `e5f9ffe7...` is already an ancestor of current `dev` head | No merge work left; CI Status failure is stale noise from cancelled long jobs on an already-landed change | **Close as stale/already merged.** No merge needed. |
+| #1380 | Stale deep-interview stop-hook gating fix | Fast checks passed; CI Status failed only because long jobs were cancelled in old run `24142611197` | Long jobs were cancelled; overlaps same native-hook files as #1400 | **Best first merge among the hook fixes once `dev` CI is green.** Land before #1400. |
+| #1357 | AGENTS/template token reduction | Fast checks passed; CI Status failed only because long jobs were cancelled in old run `24145469951` | Long jobs cancelled; PR body/checklist says only two files changed, but diff also changes `CLAUDE.md` | **Hold for manual review after runtime fixes.** Lower urgency than #1380/#1400/#1402. |
+
+## Recommended merge order
+
+1. Close **#1382** as already merged into `dev`.
+2. After `dev` CI is rerun/green, merge **#1380**.
+3. Rebase/retest and merge **#1400**.
+4. Merge **#1402** once its pending jobs finish green.
+5. Re-review **#1357** (body/diff mismatch, prompt-contract risk) before merging.
+6. Fix **#1403** unused import + rerun CI before considering merge.
+
+## Evidence collected
+
+- `gh run view 24141814673 --json ...` for current `dev` CI failure shape.
+- `gh pr checks 1402`, `1400`, `1382`, `1380`, `1357`, `1403` for current PR statuses.
+- `gh pr diff --name-only` for overlap checks.
+- `git rev-list --left-right --count dev...pr-<n>` and `git merge-base dev pr-1382` for ancestry / already-merged detection.
+- Local PR verification for #1403 in `/tmp/worker3-pr1403`:
+  - `npm ci`
+  - `npm run build`
+  - `npm run check:no-unused` → unused import failure in `src/team/runtime.ts`.

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -28,12 +28,13 @@ describe('reconcileHudForPromptSubmit', () => {
         resized.push({ paneId, heightLines });
         return true;
       },
-      resolveOmxEntryPath: () => '/repo/dist/index.js',
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
     assert.equal(result.status, 'recreated');
     assert.equal(result.paneId, '%9');
     assert.equal(created.length, 1);
+    assert.match(created[0]?.cmd || '', /\/repo\/dist\/cli\/omx\.js' hud --watch/);
     assert.equal(created[0]?.options?.heightLines, 3);
     assert.equal(resized.length, 1);
     assert.equal(resized[0]?.heightLines, 3);
@@ -60,7 +61,7 @@ describe('reconcileHudForPromptSubmit', () => {
         return '%9';
       },
       resizeTmuxPane: () => true,
-      resolveOmxEntryPath: () => '/repo/dist/index.js',
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
     assert.equal(result.status, 'replaced_duplicates');
@@ -79,7 +80,7 @@ describe('reconcileHudForPromptSubmit', () => {
         resized.push({ paneId, heightLines });
         return true;
       },
-      resolveOmxEntryPath: () => '/repo/dist/index.js',
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
     assert.equal(result.status, 'resized');

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -10,7 +10,7 @@ import {
   resizeTmuxPane,
   type TmuxPaneSnapshot,
 } from './tmux.js';
-import { resolveOmxEntryPath } from '../utils/paths.js';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
 export interface ReconcileHudForPromptSubmitResult {
   status:
@@ -36,7 +36,7 @@ export interface ReconcileHudForPromptSubmitDeps {
   killTmuxPane?: (paneId: string) => boolean;
   resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;
   readHudConfig?: typeof readHudConfig;
-  resolveOmxEntryPath?: typeof resolveOmxEntryPath;
+  resolveOmxCliEntryPath?: typeof resolveOmxCliEntryPath;
 }
 
 export async function reconcileHudForPromptSubmit(
@@ -53,8 +53,8 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
-  const resolveOmxEntryPathFn = deps.resolveOmxEntryPath ?? resolveOmxEntryPath;
-  const omxBin = resolveOmxEntryPathFn();
+  const resolveOmxCliEntryPathFn = deps.resolveOmxCliEntryPath ?? resolveOmxCliEntryPath;
+  const omxBin = resolveOmxCliEntryPathFn();
   if (!omxBin) {
     return {
       status: 'skipped_no_entry',

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -316,6 +316,7 @@ describe("codex native hook dispatch", () => {
     const originalTmux = process.env.TMUX;
     const originalTmuxPane = process.env.TMUX_PANE;
     const originalPath = process.env.PATH;
+    const originalArgv = process.argv;
     try {
       process.env.TMUX = "1";
       process.env.TMUX_PANE = "%1";
@@ -349,6 +350,7 @@ esac
       );
       await chmod(join(binDir, "tmux"), 0o755);
       process.env.PATH = `${binDir}:${originalPath}`;
+      process.argv = [originalArgv[0] || 'node', '/tmp/codex-host-binary'];
 
       const result = await dispatchCodexNativeHook(
         {
@@ -365,6 +367,8 @@ esac
       assert.match(tmuxCalls, /list-panes/);
       assert.match(tmuxCalls, /split-window/);
       assert.match(tmuxCalls, /resize-pane -t %9 -y 3/);
+      assert.match(tmuxCalls, /dist\/cli\/omx\.js' hud --watch --preset=focused/);
+      assert.doesNotMatch(tmuxCalls, /dist\/scripts\/codex-native-hook\.js hud --watch/);
     } finally {
       if (originalTmux === undefined) {
         delete process.env.TMUX;
@@ -377,6 +381,7 @@ esac
         process.env.TMUX_PANE = originalTmuxPane;
       }
       process.env.PATH = originalPath;
+      process.argv = originalArgv;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -22,6 +22,7 @@ import {
   OMX_ENTRY_PATH_ENV,
   OMX_STARTUP_CWD_ENV,
   rememberOmxLaunchContext,
+  resolveOmxCliEntryPath,
   resolveOmxEntryPath,
 } from "../paths.js";
 
@@ -459,6 +460,59 @@ describe("OMX launcher path resolution", () => {
 
       assert.equal(process.env[OMX_STARTUP_CWD_ENV], startupCwd);
       assert.equal(process.env[OMX_ENTRY_PATH_ENV], launcherPath);
+    } finally {
+      await rm(startupCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the packaged CLI entry when argv1 points at a non-CLI script", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-cli-fallback-start-"));
+    const packageRootDir = await mkdtemp(join(tmpdir(), "omx-launcher-cli-fallback-root-"));
+    try {
+      const hookDir = join(startupCwd, "dist", "scripts");
+      const hookPath = join(hookDir, "codex-native-hook.js");
+      const cliDir = join(packageRootDir, "dist", "cli");
+      const cliPath = join(cliDir, "omx.js");
+      await mkdir(hookDir, { recursive: true });
+      await mkdir(cliDir, { recursive: true });
+      await writeFile(hookPath, "#!/usr/bin/env node\n", "utf-8");
+      await writeFile(cliPath, "#!/usr/bin/env node\n", "utf-8");
+
+      const resolved = resolveOmxCliEntryPath({
+        argv1: "dist/scripts/codex-native-hook.js",
+        cwd: startupCwd,
+        env: {
+          ...process.env,
+          [OMX_STARTUP_CWD_ENV]: startupCwd,
+        },
+        packageRootDir,
+      });
+
+      assert.equal(resolved, cliPath);
+    } finally {
+      await rm(startupCwd, { recursive: true, force: true });
+      await rm(packageRootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the resolved path when argv1 already points at the CLI entry", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-cli-direct-start-"));
+    try {
+      const cliDir = join(startupCwd, "dist", "cli");
+      const cliPath = join(cliDir, "omx.js");
+      await mkdir(cliDir, { recursive: true });
+      await writeFile(cliPath, "#!/usr/bin/env node\n", "utf-8");
+
+      const resolved = resolveOmxCliEntryPath({
+        argv1: "dist/cli/omx.js",
+        cwd: startupCwd,
+        env: {
+          ...process.env,
+          [OMX_STARTUP_CWD_ENV]: startupCwd,
+        },
+      });
+
+      assert.equal(resolved, cliPath);
     } finally {
       await rm(startupCwd, { recursive: true, force: true });
     }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -48,6 +48,28 @@ export function resolveOmxEntryPath(
   return resolveLauncherPath(rawPath, startupCwd);
 }
 
+function isOmxCliEntryPath(value: string | null | undefined): boolean {
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().replace(/\\/g, "/");
+  return normalized.endsWith('/dist/cli/omx.js') || normalized.endsWith('/omx.js')
+}
+
+export function resolveOmxCliEntryPath(
+  options: {
+    argv1?: string | null;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    packageRootDir?: string;
+  } = {},
+): string | null {
+  const entry = resolveOmxEntryPath(options);
+  if (isOmxCliEntryPath(entry)) return entry;
+
+  const packageRootDir = options.packageRootDir || packageRoot();
+  const fallback = resolveLauncherPath(join(packageRootDir, 'dist', 'cli', 'omx.js'), options.cwd || process.cwd());
+  return existsSync(fallback) ? fallback : entry;
+}
+
 export function rememberOmxLaunchContext(
   options: {
     argv1?: string | null;


### PR DESCRIPTION
## Summary
- route prompt-submit HUD reconciliation through the CLI-specific OMX entry resolver
- add regression coverage for CLI entry fallback when native hooks run from a script path
- assert native hook HUD recovery launches dist/cli/omx.js instead of the hook script

## Verification
- npm install
- npm run build
- node --test dist/utils/__tests__/paths.test.js dist/hud/__tests__/reconcile.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npx biome lint src/utils/paths.ts src/hud/reconcile.ts src/hud/__tests__/reconcile.test.ts src/scripts/__tests__/codex-native-hook.test.ts src/utils/__tests__/paths.test.ts