### PR TITLE
Fix HUD recovery when non-OMX hosts recreate panes

### DIFF
--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -16,7 +16,7 @@ import type { HudFlags, HudPreset, HudRenderContext, ResolvedHudConfig } from '.
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MAX_HEIGHT_LINES } from './constants.js';
 import { sleep } from '../utils/sleep.js';
 import { runHudAuthorityTick } from './authority.js';
-import { resolveOmxEntryPath } from '../utils/paths.js';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
 export const HUD_USAGE = [
   'Usage:',
@@ -270,7 +270,7 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
     process.exit(1);
   }
 
-  const omxBin = resolveOmxEntryPath();
+  const omxBin = resolveOmxCliEntryPath();
   if (!omxBin) {
     console.error('Failed to resolve OMX launcher path for tmux HUD startup.');
     process.exit(1);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -368,7 +368,7 @@ esac
       assert.match(tmuxCalls, /split-window/);
       assert.match(tmuxCalls, /resize-pane -t %9 -y 3/);
       assert.match(tmuxCalls, /dist\/cli\/omx\.js' hud --watch --preset=focused/);
-      assert.doesNotMatch(tmuxCalls, /dist\/scripts\/codex-native-hook\.js hud --watch/);
+      assert.doesNotMatch(tmuxCalls, /\/tmp\/codex-host-binary' hud --watch/);
     } finally {
       if (originalTmux === undefined) {
         delete process.env.TMUX;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -2272,6 +2272,46 @@ esac
       await rm(startupCwd, { recursive: true, force: true });
     }
   });
+
+  it('restores standalone HUD panes with the packaged CLI entry when argv1 is not the OMX CLI', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-noncli-hud-'));
+    const previousArgv = process.argv;
+
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-noncli-standalone-hud-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  split-window)
+    echo "%44"
+    exit 0
+    ;;
+  run-shell|select-pane|resize-pane|set-hook)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          process.argv = [previousArgv[0] || 'node', '/tmp/codex-host-binary'];
+
+          const paneId = restoreStandaloneHudPane('%11', cwd);
+          assert.equal(paneId, '%44');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /dist\/cli\/omx\.js' hud --watch/);
+          assert.doesNotMatch(tmuxLog, /\/tmp\/codex-host-binary' hud --watch/);
+        },
+      );
+    } finally {
+      process.argv = previousArgv;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('dismissTrustPromptIfPresent capture shape', () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -26,7 +26,7 @@ import {
   resolveCommandPathForPlatform,
   spawnPlatformCommandSync,
 } from '../utils/platform-command.js';
-import { resolveOmxEntryPath } from '../utils/paths.js';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
@@ -965,7 +965,7 @@ export function createTeamSession(
     let hudPaneId: string | null = null;
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
-    const omxEntry = resolveOmxEntryPath();
+    const omxEntry = resolveOmxCliEntryPath();
     if (omxEntry && omxEntry.trim() !== '') {
       const hudCmd = `node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
@@ -1070,7 +1070,7 @@ export function restoreStandaloneHudPane(
   const normalizedLeaderPaneId = normalizePaneTarget(leaderPaneId);
   if (!normalizedLeaderPaneId) return null;
 
-  const omxEntry = resolveOmxEntryPath();
+  const omxEntry = resolveOmxCliEntryPath();
   if (!omxEntry || omxEntry.trim() === '') return null;
 
   const hudCmd = `${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -517,4 +517,33 @@ describe("OMX launcher path resolution", () => {
       await rm(startupCwd, { recursive: true, force: true });
     }
   });
+
+  it("falls back from a non-OMX host binary to the packaged CLI entry", async () => {
+    const startupCwd = await mkdtemp(join(tmpdir(), "omx-launcher-cli-host-start-"));
+    const packageRootDir = await mkdtemp(join(tmpdir(), "omx-launcher-cli-host-root-"));
+    try {
+      const hostPath = join(startupCwd, "codex-host");
+      const cliDir = join(packageRootDir, "dist", "cli");
+      const cliPath = join(cliDir, "omx.js");
+      await writeFile(hostPath, "#!/usr/bin/env node\n", "utf-8");
+      await mkdir(cliDir, { recursive: true });
+      await writeFile(cliPath, "#!/usr/bin/env node\n", "utf-8");
+
+      const resolved = resolveOmxCliEntryPath({
+        argv1: hostPath,
+        cwd: startupCwd,
+        env: {
+          ...process.env,
+          [OMX_STARTUP_CWD_ENV]: startupCwd,
+        },
+        packageRootDir,
+      });
+
+      assert.equal(resolved, cliPath);
+    } finally {
+      await rm(startupCwd, { recursive: true, force: true });
+      await rm(packageRootDir, { recursive: true, force: true });
+    }
+  });
+
 });


### PR DESCRIPTION
## Summary
- route HUD/tmux re-entry paths through the CLI-specific resolver instead of the generic host-path resolver
- cover native prompt-submit recovery and standalone HUD restoration when the current host binary is not OMX
- keep existing host-binary fallback coverage around 

## Verification
- npm run build
- node --test dist/utils/__tests__/paths.test.js dist/hud/__tests__/reconcile.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/team/__tests__/tmux-session.test.js
- npm run lint
- npm test
- tsc diagnostics on changed files