### PR TITLE
docs: remove stale prompts invocation guidance

### DIFF
--- a/docs/prompt-guidance-contract.md
+++ b/docs/prompt-guidance-contract.md
@@ -196,7 +196,7 @@ If a change only affects posture overlays or native agent metadata, document it 
 
 ## Canonical role prompts vs specialized behavior prompts
 
-The main role catalog is the installable specialized-agent set used by `/prompts:name` and native agent generation.
+The main role catalog is the installable specialized-agent set used by native agent generation and internal role prompt composition.
 
 - Files like `prompts/executor.md`, `prompts/planner.md`, and `prompts/architect.md` are canonical XML-tagged role prompt surfaces.
 - `prompts/sisyphus-lite.md` should be treated as a specialized worker-behavior prompt, not as a first-class main catalog role.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -168,7 +168,7 @@ Rules:
 <invocation_conventions>
 - `$name` — invoke a workflow skill
 - `/skills` — browse available skills
-- `/prompts:name` — advanced specialist role surface when the task already needs a specific agent
+- Prefer skill invocation and keyword routing as the primary user-facing workflow surface
 </invocation_conventions>
 
 <model_routing>
@@ -191,7 +191,7 @@ Key roles:
 - `executor` — implementation and refactoring
 - `verifier` — completion evidence and validation
 
-Specialists remain available through advanced role surfaces such as `/prompts:*` when the task clearly benefits from them.
+Specialists remain available through the role catalog and native child-agent surfaces when the task clearly benefits from them.
 </agent_catalog>
 
 ---
@@ -208,7 +208,7 @@ The `deep-interview` skill is the Socratic deep interview workflow and includes 
 Runtime availability gate:
 - Treat `autopilot`, `ralph`, `ultrawork`, `ultraqa`, `team`/`swarm`, and `ecomode` as **OMX runtime workflows**, not generic prompt aliases.
 - Auto-activate those runtime workflows only when the current session is actually running under OMX CLI/runtime (for example, launched via `omx`, with OMX session overlay/runtime state available, or when the user explicitly asks to run `omx ...` in the shell).
-- In Codex App or plain Codex sessions without OMX runtime, do **not** treat those keywords alone as activation. Explain that they require OMX CLI runtime support, and continue with the nearest App-safe surface (`deep-interview`, `ralplan`, `plan`, `/prompts:*`, or native subagents) unless the user explicitly wants you to launch OMX from the shell.
+- In Codex App or plain Codex sessions without OMX runtime, do **not** treat those keywords alone as activation. Explain that they require OMX CLI runtime support, and continue with the nearest App-safe surface (`deep-interview`, `ralplan`, `plan`, or native subagents) unless the user explicitly wants you to launch OMX from the shell.
 
 | Keyword(s) | Skill | Action |
 |-------------|-------|--------|
@@ -234,7 +234,6 @@ Detection rules:
 - Explicit `$name` invocations run left-to-right and override non-explicit keyword resolution.
 - If multiple non-explicit keywords match, use the most specific match.
 - Runtime-only keywords must pass the runtime availability gate before activation.
-- If the user explicitly invokes `/prompts:<name>`, do not auto-activate keyword skills unless explicit `$name` tokens are also present.
 - The rest of the user message becomes the task description.
 
 Ralph / Ralplan execution gate:


### PR DESCRIPTION
## Summary
- remove stale `/prompts:<name>` guidance from the AGENTS template surfaces
- prefer skill invocation / keyword routing wording in user-facing orchestration guidance
- trim the prompt-guidance contract so it no longer frames `/prompts:name` as the public main role surface

## Verification
- targeted grep over AGENTS/prompt-guidance surfaces for stale `/prompts:<name>` guidance

Closes #1415