### PR TITLE
feat: add MiniMax provider support to omx ask command

### DIFF
--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -92,6 +92,20 @@ describe('parseAskArgs', () => {
     assert.throws(() => parseAskArgs(['openai', 'hello']), /Invalid provider/);
   });
 
+  it('parses minimax provider', () => {
+    assert.deepEqual(parseAskArgs(['minimax', 'hello', 'world']), {
+      provider: 'minimax',
+      prompt: 'hello world',
+    });
+  });
+
+  it('parses minimax with -p flag', () => {
+    assert.deepEqual(parseAskArgs(['minimax', '-p', 'what is MiniMax?']), {
+      provider: 'minimax',
+      prompt: 'what is MiniMax?',
+    });
+  });
+
   it('throws when prompt is missing', () => {
     assert.throws(() => parseAskArgs(['claude']), /Missing prompt text/);
   });
@@ -283,6 +297,21 @@ describe('omx ask', () => {
       assert.equal(res.status, 1, res.stderr || res.stdout);
       assert.match(res.stderr, /--agent-prompt role "planner" not found/i);
       assert.doesNotMatch(res.stdout, /should-not-run/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('minimax provider writes artifact and returns 1 without MINIMAX_API_KEY', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-ask-minimax-no-key-'));
+    try {
+      const res = runOmx(wd, ['ask', 'minimax', 'hello minimax'], {
+        MINIMAX_API_KEY: '',
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stderr, /MINIMAX_API_KEY/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,16 @@ import { getPackageRoot } from '../utils/package.js';
 import { codexPromptsDir } from '../utils/paths.js';
 
 export const ASK_USAGE = [
-  'Usage: omx ask <claude|gemini> <question or task>',
-  '   or: omx ask <claude|gemini> -p "<prompt>"',
+  'Usage: omx ask <claude|gemini|minimax> <question or task>',
+  '   or: omx ask <claude|gemini|minimax> -p "<prompt>"',
   '   or: omx ask claude --print "<prompt>"',
   '   or: omx ask gemini --prompt "<prompt>"',
-  '   or: omx ask <claude|gemini> --agent-prompt <role> "<prompt>"',
-  '   or: omx ask <claude|gemini> --agent-prompt=<role> --prompt "<prompt>"',
+  '   or: omx ask minimax "<prompt>"  (requires MINIMAX_API_KEY)',
+  '   or: omx ask <claude|gemini|minimax> --agent-prompt <role> "<prompt>"',
+  '   or: omx ask <claude|gemini|minimax> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'gemini'] as const;
+const ASK_PROVIDERS = ['claude', 'gemini', 'minimax'] as const;
 type AskProvider = typeof ASK_PROVIDERS[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 const ASK_ADVISOR_SCRIPT_ENV = 'OMX_ASK_ADVISOR_SCRIPT';

--- a/src/scripts/run-provider-advisor.ts
+++ b/src/scripts/run-provider-advisor.ts
@@ -4,17 +4,21 @@ import { join } from 'path';
 import process from 'process';
 import { spawnSync } from 'child_process';
 
-const PROVIDER_BINARIES: Record<string, string> = {
+const PROVIDER_BINARIES: Record<string, string | null> = {
   claude: 'claude',
   gemini: 'gemini',
+  minimax: null,
 };
 const ASK_ORIGINAL_TASK_ENV = 'OMX_ASK_ORIGINAL_TASK';
+const MINIMAX_BASE_URL_DEFAULT = 'https://api.minimax.io/v1';
+const MINIMAX_MODEL_DEFAULT = 'MiniMax-M2.7';
 
 function usage(): void {
-  console.error('Usage: omx ask <claude|gemini> "<prompt>"');
-  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini> <prompt...>');
+  console.error('Usage: omx ask <claude|gemini|minimax> "<prompt>"');
+  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|gemini|minimax> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
+  console.error('Env: MINIMAX_API_KEY required for minimax provider');
 }
 
 function slugify(value: string): string {
@@ -68,6 +72,48 @@ function ensureBinary(binary: string): void {
     console.error(`[ask-${binary}] Install/configure ${binary} CLI, then verify with: ${verify}`);
     process.exit(1);
   }
+}
+
+async function callMiniMaxAPI(prompt: string): Promise<{ output: string; exitCode: number }> {
+  const apiKey = process.env.MINIMAX_API_KEY;
+  if (!apiKey) {
+    console.error('[ask-minimax] Missing MINIMAX_API_KEY environment variable');
+    console.error('[ask-minimax] Set MINIMAX_API_KEY to your MiniMax API key and retry');
+    return { output: '', exitCode: 1 };
+  }
+
+  const baseUrl = (process.env.MINIMAX_BASE_URL || MINIMAX_BASE_URL_DEFAULT).replace(/\/$/, '');
+  const model = process.env.MINIMAX_MODEL || MINIMAX_MODEL_DEFAULT;
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 1.0,
+      }),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[ask-minimax] Network error: ${msg}`);
+    return { output: msg, exitCode: 1 };
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    console.error(`[ask-minimax] API error (${response.status}): ${errorText}`);
+    return { output: errorText, exitCode: 1 };
+  }
+
+  const data = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+  const content = data.choices?.[0]?.message?.content ?? '';
+  return { output: content, exitCode: 0 };
 }
 
 function buildSummary(exitCode: number, output: string): string {
@@ -147,20 +193,33 @@ async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, e
 
 async function main(): Promise<void> {
   const { provider, prompt } = parseArgs(process.argv.slice(2));
-  const binary = PROVIDER_BINARIES[provider];
 
-  ensureBinary(binary);
+  let rawOutput: string;
+  let exitCode: number;
+  let spawnError: string | undefined;
 
-  const run = spawnSync(binary, ['-p', prompt], {
-    encoding: 'utf8',
-    maxBuffer: 10 * 1024 * 1024,
-      windowsHide: true,
-    });
+  if (provider === 'minimax') {
+    const result = await callMiniMaxAPI(prompt);
+    rawOutput = result.output;
+    exitCode = result.exitCode;
+  } else {
+    const binary = PROVIDER_BINARIES[provider] as string;
+    ensureBinary(binary);
 
-  const stdout = run.stdout || '';
-  const stderr = run.stderr || '';
-  const rawOutput = [stdout, stderr].filter(Boolean).join(stdout && stderr ? '\n\n' : '');
-  const exitCode = typeof run.status === 'number' ? run.status : 1;
+    const run = spawnSync(binary, ['-p', prompt], {
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+        windowsHide: true,
+      });
+
+    const stdout = run.stdout || '';
+    const stderr = run.stderr || '';
+    rawOutput = [stdout, stderr].filter(Boolean).join(stdout && stderr ? '\n\n' : '');
+    exitCode = typeof run.status === 'number' ? run.status : 1;
+    if (run.error) {
+      spawnError = run.error.message;
+    }
+  }
 
   const artifactPath = await writeArtifact({
     provider,
@@ -172,8 +231,8 @@ async function main(): Promise<void> {
 
   console.log(artifactPath);
 
-  if (run.error) {
-    console.error(`[ask-${provider}] ${run.error.message}`);
+  if (spawnError) {
+    console.error(`[ask-${provider}] ${spawnError}`);
   }
 
   if (exitCode !== 0) {


### PR DESCRIPTION
## Summary

- Add `minimax` as a native provider in the `omx ask` command
- Calls MiniMax's OpenAI-compatible API directly via Node.js `fetch` (no separate CLI binary required)
- Requires `MINIMAX_API_KEY` environment variable
- Default model: `MiniMax-M2.7` (override via `MINIMAX_MODEL`)
- Default base URL: `https://api.minimax.io/v1` (override via `MINIMAX_BASE_URL`)

## Usage

```bash
# Set your API key
export MINIMAX_API_KEY=your_key_here

# Ask MiniMax a question
omx ask minimax "what is the best way to structure a multi-agent workflow?"

# Use with agent prompt roles
omx ask minimax --agent-prompt executor "implement the approved plan"
```

## Changes

- `src/cli/ask.ts`: Added `minimax` to `ASK_PROVIDERS` and updated usage docs
- `src/scripts/run-provider-advisor.ts`: Added native `callMiniMaxAPI()` handler using fetch, with error handling for missing API key and network failures
- `src/cli/__tests__/ask.test.ts`: Added unit tests for minimax provider parsing and missing API key behavior

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan

- [x] Unit tests: `parseAskArgs(['minimax', ...])` parses correctly
- [x] Unit test: missing `MINIMAX_API_KEY` returns exit code 1 with clear error message
- [x] Integration test: `omx ask minimax "Say only: test passed"` returns successful response
- [x] All 19 existing tests pass after changes