### PR TITLE
feat: add current-task baseline branch guardrails

### DIFF
--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -172,6 +172,41 @@ describe('notify-hook/operational-events – buildOperationalContext', () => {
       else process.env.TMUX = originalTmux;
     }
   });
+
+  it('writes PR lifecycle details into the repo baseline registry as best effort state', async () => {
+    const { buildOperationalContext } = await loadModule('notify-hook/operational-events.js');
+    const { mkdtemp, rm, writeFile, readFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { execFileSync } = await import('node:child_process');
+
+    const repo = await mkdtemp(join(tmpdir(), 'omx-opctx-baseline-'));
+    try {
+      execFileSync('git', ['init'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo, stdio: 'ignore' });
+      await writeFile(join(repo, 'README.md'), 'hello\n', 'utf-8');
+      execFileSync('git', ['add', 'README.md'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['checkout', '-b', 'feature/opctx-pr'], { cwd: repo, stdio: 'ignore' });
+
+      const context = buildOperationalContext({
+        cwd: repo,
+        normalizedEvent: 'pr-merged',
+        text: 'Merged issue #1407 via PR #1416',
+        prUrl: 'https://github.com/Yeachan-Heo/oh-my-codex/pull/1416',
+      });
+
+      assert.equal(context.branch, 'feature/opctx-pr');
+      const baseline = JSON.parse(await readFile(join(repo, '.omx', 'state', 'current-task-baseline.json'), 'utf-8'));
+      const entry = baseline.tasks.find((item: { branch_name: string }) => item.branch_name === 'feature/opctx-pr');
+      assert.equal(entry.issue_number, 1407);
+      assert.equal(entry.pr_number, 1416);
+      assert.equal(entry.status, 'merged');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('notify-hook/operational-events – deriveAssistantSignalEvents', () => {

--- a/src/scripts/notify-hook/operational-events.ts
+++ b/src/scripts/notify-hook/operational-events.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'child_process';
 import { basename, dirname } from 'path';
 import { safeString } from './utils.js';
+import { upsertCurrentTaskBaseline } from '../../team/current-task-baseline.js';
 
 const TEST_SEGMENT_PATTERNS = [
   /^npm\s+(?:run\s+)?test\b/i,
@@ -215,6 +216,26 @@ export function buildOperationalContext({
     ...(prUrl !== undefined ? { pr_url: prUrl } : {}),
   };
   const resolvedSessionName = resolveOperationalSessionName(cwd, sessionId, sessionName);
+
+  if (repoMeta.repo_path && repoMeta.branch) {
+    try {
+      const lifecycleStatus = normalizedEvent === 'pr-merged'
+        ? 'merged'
+        : normalizedEvent === 'pr-closed'
+          ? 'closed'
+          : undefined;
+      upsertCurrentTaskBaseline(repoMeta.repo_path, {
+        branch_name: repoMeta.branch,
+        worktree_path: repoMeta.worktree_path,
+        issue_number: detectedIssue,
+        pr_number: detectedPrInfo.pr_number,
+        pr_url: detectedPrInfo.pr_url,
+        ...(lifecycleStatus ? { status: lifecycleStatus } : {}),
+      });
+    } catch {
+      // best effort only; operational context building must stay non-fatal
+    }
+  }
 
   return {
     normalized_event: normalizedEvent,

--- a/src/team/__tests__/current-task-baseline.test.ts
+++ b/src/team/__tests__/current-task-baseline.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  assertCurrentTaskBranchAvailable,
+  findActiveCurrentTaskByBranch,
+  upsertCurrentTaskBaseline,
+} from '../current-task-baseline.js';
+import { ensureWorktree, planWorktreeTarget } from '../worktree.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-current-task-baseline-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+describe('current-task-baseline', () => {
+  it('records a launch worktree branch baseline on successful ensureWorktree', async () => {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: false, name: 'feature/task-baseline' },
+      });
+      assert.equal(plan.enabled, true);
+      if (!plan.enabled) return;
+
+      const ensured = ensureWorktree(plan);
+      assert.equal(ensured.enabled, true);
+      if (!ensured.enabled) return;
+
+      const entry = findActiveCurrentTaskByBranch(repo, 'feature/task-baseline');
+      assert.ok(entry, 'baseline entry should exist');
+      assert.equal(entry?.worktree_path, ensured.worktreePath);
+      assert.equal(entry?.status, 'active');
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'current-task-baseline.json')), true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks duplicate branch creation when baseline points at another worktree path', async () => {
+    const repo = await initRepo();
+    try {
+      upsertCurrentTaskBaseline(repo, {
+        branch_name: 'feature/already-active',
+        worktree_path: join(repo, '..', 'some-other-worktree'),
+        status: 'active',
+      });
+
+      assert.throws(
+        () => assertCurrentTaskBranchAvailable(repo, 'feature/already-active', join(repo, '..', 'new-worktree')),
+        /current_task_branch_guard:feature\/already-active:/,
+      );
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('updates branch lifecycle metadata when PR info is observed', async () => {
+    const repo = await initRepo();
+    try {
+      upsertCurrentTaskBaseline(repo, {
+        branch_name: 'feature/pr-lifecycle',
+        worktree_path: repo,
+        status: 'active',
+      });
+
+      upsertCurrentTaskBaseline(repo, {
+        branch_name: 'feature/pr-lifecycle',
+        worktree_path: repo,
+        issue_number: 1407,
+        pr_number: 1416,
+        pr_url: 'https://github.com/Yeachan-Heo/oh-my-codex/pull/1416',
+        status: 'merged',
+      });
+
+      const raw = JSON.parse(readFileSync(join(repo, '.omx', 'state', 'current-task-baseline.json'), 'utf-8'));
+      const entry = raw.tasks.find((item: { branch_name: string }) => item.branch_name === 'feature/pr-lifecycle');
+      assert.equal(entry.issue_number, 1407);
+      assert.equal(entry.pr_number, 1416);
+      assert.equal(entry.status, 'merged');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/current-task-baseline.ts
+++ b/src/team/current-task-baseline.ts
@@ -1,0 +1,129 @@
+import { existsSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { omxStateDir } from '../utils/paths.js';
+
+export type CurrentTaskStatus = 'active' | 'merged' | 'closed' | 'superseded';
+
+export interface CurrentTaskBaselineEntry {
+  branch_name: string;
+  worktree_path: string | null;
+  base_ref?: string;
+  issue_number?: number;
+  pr_number?: number;
+  pr_url?: string;
+  status: CurrentTaskStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+interface CurrentTaskBaselineFile {
+  version: 1;
+  tasks: CurrentTaskBaselineEntry[];
+}
+
+export interface UpsertCurrentTaskBaselineInput {
+  branch_name: string;
+  worktree_path?: string | null;
+  base_ref?: string;
+  issue_number?: number;
+  pr_number?: number;
+  pr_url?: string;
+  status?: CurrentTaskStatus;
+}
+
+function baselinePath(repoRoot: string): string {
+  return join(omxStateDir(repoRoot), 'current-task-baseline.json');
+}
+
+function emptyBaseline(): CurrentTaskBaselineFile {
+  return { version: 1, tasks: [] };
+}
+
+export function readCurrentTaskBaseline(repoRoot: string): CurrentTaskBaselineFile {
+  const path = baselinePath(repoRoot);
+  if (!existsSync(path)) return emptyBaseline();
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as CurrentTaskBaselineFile;
+    if (parsed.version !== 1 || !Array.isArray(parsed.tasks)) return emptyBaseline();
+    return {
+      version: 1,
+      tasks: parsed.tasks
+        .filter((entry) => entry && typeof entry.branch_name === 'string' && typeof entry.status === 'string')
+        .map((entry) => ({
+          ...entry,
+          worktree_path: typeof entry.worktree_path === 'string' ? resolve(entry.worktree_path) : null,
+        })),
+    };
+  } catch {
+    return emptyBaseline();
+  }
+}
+
+function writeCurrentTaskBaseline(repoRoot: string, data: CurrentTaskBaselineFile): void {
+  const stateDir = omxStateDir(repoRoot);
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(baselinePath(repoRoot), JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+export function listActiveCurrentTasks(repoRoot: string): CurrentTaskBaselineEntry[] {
+  return readCurrentTaskBaseline(repoRoot).tasks.filter((entry) => entry.status === 'active');
+}
+
+export function findActiveCurrentTaskByBranch(repoRoot: string, branchName: string): CurrentTaskBaselineEntry | null {
+  const normalized = branchName.trim();
+  if (!normalized) return null;
+  return listActiveCurrentTasks(repoRoot).find((entry) => entry.branch_name === normalized) ?? null;
+}
+
+export function upsertCurrentTaskBaseline(
+  repoRoot: string,
+  input: UpsertCurrentTaskBaselineInput,
+): CurrentTaskBaselineEntry {
+  const branchName = input.branch_name.trim();
+  if (!branchName) {
+    throw new Error('current_task_baseline_branch_required');
+  }
+
+  const now = new Date().toISOString();
+  const current = readCurrentTaskBaseline(repoRoot);
+  const existing = current.tasks.find((entry) => entry.branch_name === branchName) ?? null;
+  const next: CurrentTaskBaselineEntry = {
+    branch_name: branchName,
+    worktree_path: typeof input.worktree_path === 'string'
+      ? resolve(input.worktree_path)
+      : input.worktree_path === null
+        ? null
+        : existing?.worktree_path ?? null,
+    base_ref: input.base_ref ?? existing?.base_ref,
+    issue_number: input.issue_number ?? existing?.issue_number,
+    pr_number: input.pr_number ?? existing?.pr_number,
+    pr_url: input.pr_url ?? existing?.pr_url,
+    status: input.status ?? existing?.status ?? 'active',
+    created_at: existing?.created_at ?? now,
+    updated_at: now,
+  };
+
+  const tasks = current.tasks.filter((entry) => entry.branch_name !== branchName);
+  tasks.push(next);
+  tasks.sort((a, b) => a.branch_name.localeCompare(b.branch_name));
+  writeCurrentTaskBaseline(repoRoot, { version: 1, tasks });
+  return next;
+}
+
+export function assertCurrentTaskBranchAvailable(
+  repoRoot: string,
+  branchName: string,
+  requestedWorktreePath: string,
+): void {
+  const current = findActiveCurrentTaskByBranch(repoRoot, branchName);
+  if (!current) return;
+
+  const requested = resolve(requestedWorktreePath);
+  if (!current.worktree_path || current.worktree_path !== requested) {
+    throw new Error(
+      `current_task_branch_guard:${branchName}:${current.worktree_path ?? 'unknown_worktree'}`,
+    );
+  }
+}

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -2,6 +2,10 @@ import { execFile as execFileCb, execFileSync, spawnSync } from 'child_process';
 import { existsSync, mkdirSync } from 'fs';
 import { basename, dirname, join, resolve } from 'path';
 import { promisify } from 'util';
+import {
+  assertCurrentTaskBranchAvailable,
+  upsertCurrentTaskBaseline,
+} from './current-task-baseline.js';
 
 const execFilePromise = promisify(execFileCb);
 
@@ -375,7 +379,7 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
       throw new Error(`worktree_dirty:${plan.worktreePath}`);
     }
 
-    return {
+    const reused = {
       enabled: true,
       repoRoot: plan.repoRoot,
       worktreePath: resolve(plan.worktreePath),
@@ -384,7 +388,18 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
       created: false,
       reused: true,
       createdBranch: false,
-    };
+    } satisfies EnsureWorktreeResult;
+
+    if (plan.branchName) {
+      upsertCurrentTaskBaseline(plan.repoRoot, {
+        branch_name: plan.branchName,
+        worktree_path: reused.worktreePath,
+        base_ref: plan.baseRef,
+        status: 'active',
+      });
+    }
+
+    return reused;
   }
 
   if (existsSync(plan.worktreePath)) {
@@ -393,6 +408,10 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
 
   if (plan.branchName && hasBranchInUse(allWorktrees, plan.branchName, plan.worktreePath)) {
     throw new Error(`branch_in_use:${plan.branchName}`);
+  }
+
+  if (plan.branchName) {
+    assertCurrentTaskBranchAvailable(plan.repoRoot, plan.branchName, plan.worktreePath);
   }
 
   mkdirSync(dirname(plan.worktreePath), { recursive: true });
@@ -421,7 +440,7 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
     throw new Error(stderr || `worktree_add_failed:${addArgs.join(' ')}`);
   }
 
-  return {
+  const ensured = {
     enabled: true,
     repoRoot: plan.repoRoot,
     worktreePath: resolve(plan.worktreePath),
@@ -430,7 +449,18 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
     created: true,
     reused: false,
     createdBranch: Boolean(plan.branchName && !branchAlreadyExisted),
-  };
+  } satisfies EnsureWorktreeResult;
+
+  if (plan.branchName) {
+    upsertCurrentTaskBaseline(plan.repoRoot, {
+      branch_name: plan.branchName,
+      worktree_path: ensured.worktreePath,
+      base_ref: plan.baseRef,
+      status: 'active',
+    });
+  }
+
+  return ensured;
 }
 
 export interface RollbackWorktreeOptions {


### PR DESCRIPTION
## Summary
- add a repo-local current-task baseline registry under `.omx/state/current-task-baseline.json`
- register named launch worktrees into that shared baseline and block duplicate branch creation when the active branch is already reserved by another worktree
- update baseline lifecycle metadata from notify-hook operational context when PR/issue info is observed

## Why this slice
This is a practical first-stage guardrail for issue #1407: it establishes a shared current-task baseline for named branch launches and uses it to prevent obvious duplicate branch/worktree drift without attempting the full multi-session orchestration system in one PR.

## Verification
- `npm run build`
- `node --test dist/team/__tests__/current-task-baseline.test.js dist/team/__tests__/worktree.test.js dist/hooks/__tests__/notify-hook-modules.test.js`
