### PR TITLE
fix: warn on retired team MCP configs during doctor

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -66,6 +66,38 @@ command = "node"
     }
   });
 
+  it('warns when the retired omx_team_run table is still present', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-legacy-team-run-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        `
+[mcp_servers.omx_state]
+command = "node"
+
+[mcp_servers.omx_team_run]
+command = "node"
+`.trimStart(),
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Config: retired \[mcp_servers\.omx_team_run\] table still present; run "omx setup --force" to repair the config/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('warns when explore harness sources are packaged but cargo is unavailable', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-copy-'));
     try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -14,6 +14,7 @@ import { getCatalogExpectations } from './catalog-contract.js';
 import { parse as parseToml } from '@iarna/toml';
 import { resolvePackagedExploreHarnessCommand, EXPLORE_BIN_ENV } from './explore.js';
 import { getPackageRoot } from '../utils/package.js';
+import { hasLegacyOmxTeamRunTable } from '../config/generator.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
 import { isLeaderRuntimeStale } from '../team/leader-activity.js';
@@ -580,6 +581,15 @@ async function checkConfig(configPath: string): Promise<Check> {
         name: 'Config',
         status: 'fail',
         message: `invalid config.toml (${hint})`,
+      };
+    }
+
+    if (hasLegacyOmxTeamRunTable(content)) {
+      return {
+        name: 'Config',
+        status: 'warn',
+        message:
+          'retired [mcp_servers.omx_team_run] table still present; run "omx setup --force" to repair the config',
       };
     }
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -55,6 +55,10 @@ const OMX_TUI_STATUS_LINE =
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
 
+export function hasLegacyOmxTeamRunTable(config: string): boolean {
+  return LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(config);
+}
+
 function unwrapTomlString(value: string | undefined): string | undefined {
   return value?.match(/^"(.*)"$/)?.[1];
 }
@@ -873,7 +877,7 @@ export async function repairConfigIfNeeded(
 
   const content = await readFile(configPath, "utf-8");
   const tuiCount = (content.match(/^\s*\[tui\]\s*$/gm) || []).length;
-  const hasLegacyTeamRunTable = LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(content);
+  const hasLegacyTeamRunTable = hasLegacyOmxTeamRunTable(content);
   if (tuiCount <= 1 && !hasLegacyTeamRunTable) return false;
 
   // Managed config compatibility issue detected — run full merge to repair


### PR DESCRIPTION
## Summary

`omx doctor` now explicitly warns when a retired `[mcp_servers.omx_team_run]` table is still present in `config.toml`, with a direct remediation hint to run `omx setup --force`.

The underlying repair behavior already existed in the config merge / launch path, so this change does not alter repair logic — it only makes the stale legacy config condition visible to users.

## Changes

- Added a shared legacy-table detector in `src/config/generator.ts`
- Taught `src/cli/doctor.ts` to warn on retired `omx_team_run` config
- Added a regression test in `src/cli/__tests__/doctor-warning-copy.test.ts`

## Validation

- [x] `npm run build`
- [x] `node --test dist/cli/__tests__/doctor-warning-copy.test.js`
- [x] `node --test dist/config/__tests__/generator-idempotent.test.js`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1424
