### PR TITLE
fix: repair retired team MCP config on upgrade

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -1,245 +1,335 @@
-import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { tmpdir } from 'node:os';
-import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import { withPackagedExploreHarnessHidden, withPackagedExploreHarnessLock } from './packaged-explore-harness-lock.js';
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+	withPackagedExploreHarnessHidden,
+	withPackagedExploreHarnessLock,
+} from "./packaged-explore-harness-lock.js";
 
 function runOmx(
-  cwd: string,
-  argv: string[],
-  envOverrides: Record<string, string> = {},
+	cwd: string,
+	argv: string[],
+	envOverrides: Record<string, string> = {},
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
-  const testDir = dirname(fileURLToPath(import.meta.url));
-  const repoRoot = join(testDir, '..', '..', '..');
-  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
-  const mergedEnv = { ...process.env, ...envOverrides };
-  if (typeof envOverrides.HOME === 'string' && typeof envOverrides.USERPROFILE !== 'string') {
-    mergedEnv.USERPROFILE = envOverrides.HOME;
-  }
-  const r = spawnSync(process.execPath, [omxBin, ...argv], {
-    cwd,
-    encoding: 'utf-8',
-    env: mergedEnv,
-  });
-  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
+	const testDir = dirname(fileURLToPath(import.meta.url));
+	const repoRoot = join(testDir, "..", "..", "..");
+	const omxBin = join(repoRoot, "dist", "cli", "omx.js");
+	const mergedEnv = { ...process.env, ...envOverrides };
+	if (
+		typeof envOverrides.HOME === "string" &&
+		typeof envOverrides.USERPROFILE !== "string"
+	) {
+		mergedEnv.USERPROFILE = envOverrides.HOME;
+	}
+	const r = spawnSync(process.execPath, [omxBin, ...argv], {
+		cwd,
+		encoding: "utf-8",
+		env: mergedEnv,
+	});
+	return {
+		status: r.status,
+		stdout: r.stdout || "",
+		stderr: r.stderr || "",
+		error: r.error?.message,
+	};
 }
 
 function shouldSkipForSpawnPermissions(err?: string): boolean {
-  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+	return typeof err === "string" && /(EPERM|EACCES)/i.test(err);
 }
 
-describe('omx doctor onboarding warning copy', () => {
-  it('explains first-setup expectation for config and MCP onboarding warnings', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-copy-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      await mkdir(codexDir, { recursive: true });
-      await writeFile(
-        join(codexDir, 'config.toml'),
-        `
+describe("omx doctor onboarding warning copy", () => {
+	it("explains first-setup expectation for config and MCP onboarding warnings", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-copy-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
 [mcp_servers.non_omx]
 command = "node"
 `.trimStart(),
-      );
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: join(home, '.codex'),
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Config: config\.toml exists but no OMX entries yet \(expected before first setup; run "omx setup --force" once\)/,
-      );
-      assert.match(
-        res.stdout,
-        /MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: join(home, ".codex"),
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Config: config\.toml exists but no OMX entries yet \(expected before first setup; run "omx setup --force" once\)/,
+			);
+			assert.match(
+				res.stdout,
+				/MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('warns when explore harness sources are packaged but cargo is unavailable', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-copy-'));
-    try {
-      await withPackagedExploreHarnessHidden(async () => {
-        const home = join(wd, 'home');
-        const codexDir = join(home, '.codex');
-        const fakeBin = join(wd, 'bin');
-        await mkdir(codexDir, { recursive: true });
-        await mkdir(fakeBin, { recursive: true });
-        await writeFile(join(fakeBin, 'codex'), '#!/bin/sh\necho "codex test"\n');
-        spawnSync('chmod', ['+x', join(fakeBin, 'codex')], { encoding: 'utf-8' });
+	it("warns about retired omx_team_run config left behind after upgrade", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-copy-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
+[mcp_servers.omx_team_run]
+command = "node"
+args = ["/tmp/team-server.js"]
+enabled = true
+`.trimStart(),
+			);
 
-        const res = runOmx(wd, ['doctor'], {
-          HOME: home,
-          CODEX_HOME: join(home, '.codex'),
-          PATH: fakeBin,
-        });
-        if (shouldSkipForSpawnPermissions(res.error)) return;
-        assert.equal(res.status, 0, res.stderr || res.stdout);
-        assert.match(
-          res.stdout,
-          /Explore Harness: (Rust harness sources are packaged, but no compatible packaged prebuilt or cargo was found \(install Rust or set OMX_EXPLORE_BIN for omx explore\)|not ready \(no packaged binary, OMX_EXPLORE_BIN, or cargo toolchain\))/,
-        );
-      });
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: join(home, ".codex"),
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Config: retired \[mcp_servers\.omx_team_run\] table still present; run "omx setup --force" to repair the config/,
+			);
+			assert.match(
+				res.stdout,
+				/MCP Servers: 1 servers configured, but retired \[mcp_servers\.omx_team_run\] is not supported; run "omx setup --force" to repair the config/,
+			);
+			assert.doesNotMatch(res.stdout, /Config: config\.toml has OMX entries/);
+			assert.doesNotMatch(
+				res.stdout,
+				/MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('passes explore harness check when a packaged native binary is present even without cargo', async () => {
-    await withPackagedExploreHarnessLock(async () => {
-      const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-binary-'));
-      try {
-        const home = join(wd, 'home');
-        const codexDir = join(home, '.codex');
-        const fakeBin = join(wd, 'bin');
-        const packageBinDir = join(process.cwd(), 'bin');
-        const packagedBinary = join(packageBinDir, process.platform === 'win32' ? 'omx-explore-harness.exe' : 'omx-explore-harness');
-        const packagedMeta = join(packageBinDir, 'omx-explore-harness.meta.json');
-        const hadExistingBinary = existsSync(packagedBinary);
-        const hadExistingMeta = existsSync(packagedMeta);
+	it("warns when explore harness sources are packaged but cargo is unavailable", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-explore-copy-"));
+		try {
+			await withPackagedExploreHarnessHidden(async () => {
+				const home = join(wd, "home");
+				const codexDir = join(home, ".codex");
+				const fakeBin = join(wd, "bin");
+				await mkdir(codexDir, { recursive: true });
+				await mkdir(fakeBin, { recursive: true });
+				await writeFile(
+					join(fakeBin, "codex"),
+					'#!/bin/sh\necho "codex test"\n',
+				);
+				spawnSync("chmod", ["+x", join(fakeBin, "codex")], {
+					encoding: "utf-8",
+				});
 
-        await mkdir(codexDir, { recursive: true });
-        await mkdir(fakeBin, { recursive: true });
-        await writeFile(join(fakeBin, 'codex'), '#!/bin/sh\necho "codex test"\n');
-        spawnSync('chmod', ['+x', join(fakeBin, 'codex')], { encoding: 'utf-8' });
-        const fsPromises = await import('node:fs/promises');
-        const originalBinary = hadExistingBinary ? await fsPromises.readFile(packagedBinary) : null;
-        const originalMeta = hadExistingMeta ? await fsPromises.readFile(packagedMeta, 'utf-8') : null;
-        await mkdir(packageBinDir, { recursive: true });
-        await writeFile(packagedBinary, '#!/bin/sh\necho "stub harness"\n');
-        await writeFile(packagedMeta, JSON.stringify({ binaryName: process.platform === 'win32' ? 'omx-explore-harness.exe' : 'omx-explore-harness', platform: process.platform, arch: process.arch }));
-        spawnSync('chmod', ['+x', packagedBinary], { encoding: 'utf-8' });
+				const res = runOmx(wd, ["doctor"], {
+					HOME: home,
+					CODEX_HOME: join(home, ".codex"),
+					PATH: fakeBin,
+				});
+				if (shouldSkipForSpawnPermissions(res.error)) return;
+				assert.equal(res.status, 0, res.stderr || res.stdout);
+				assert.match(
+					res.stdout,
+					/Explore Harness: (Rust harness sources are packaged, but no compatible packaged prebuilt or cargo was found \(install Rust or set OMX_EXPLORE_BIN for omx explore\)|not ready \(no packaged binary, OMX_EXPLORE_BIN, or cargo toolchain\))/,
+				);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-        try {
-          const res = runOmx(wd, ['doctor'], {
-            HOME: home,
-            CODEX_HOME: join(home, '.codex'),
-            PATH: fakeBin,
-          });
-          if (shouldSkipForSpawnPermissions(res.error)) return;
-          assert.equal(res.status, 0, res.stderr || res.stdout);
-          assert.match(
-            res.stdout,
-            /Explore Harness: ready \(packaged native binary:/,
-          );
-        } finally {
-          if (originalBinary) {
-            await writeFile(packagedBinary, originalBinary);
-            spawnSync('chmod', ['+x', packagedBinary], { encoding: 'utf-8' });
-          } else {
-            await rm(packagedBinary, { force: true });
-          }
-          if (originalMeta !== null) {
-            await writeFile(packagedMeta, originalMeta);
-          } else {
-            await rm(packagedMeta, { force: true });
-          }
-        }
-      } finally {
-        await rm(wd, { recursive: true, force: true });
-      }
-    });
-  });
+	it("passes explore harness check when a packaged native binary is present even without cargo", async () => {
+		await withPackagedExploreHarnessLock(async () => {
+			const wd = await mkdtemp(join(tmpdir(), "omx-doctor-explore-binary-"));
+			try {
+				const home = join(wd, "home");
+				const codexDir = join(home, ".codex");
+				const fakeBin = join(wd, "bin");
+				const packageBinDir = join(process.cwd(), "bin");
+				const packagedBinary = join(
+					packageBinDir,
+					process.platform === "win32"
+						? "omx-explore-harness.exe"
+						: "omx-explore-harness",
+				);
+				const packagedMeta = join(
+					packageBinDir,
+					"omx-explore-harness.meta.json",
+				);
+				const hadExistingBinary = existsSync(packagedBinary);
+				const hadExistingMeta = existsSync(packagedMeta);
 
-  it('warns when explore routing is explicitly disabled in config.toml', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-routing-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      await mkdir(codexDir, { recursive: true });
-      await writeFile(
-        join(codexDir, 'config.toml'),
-        `
+				await mkdir(codexDir, { recursive: true });
+				await mkdir(fakeBin, { recursive: true });
+				await writeFile(
+					join(fakeBin, "codex"),
+					'#!/bin/sh\necho "codex test"\n',
+				);
+				spawnSync("chmod", ["+x", join(fakeBin, "codex")], {
+					encoding: "utf-8",
+				});
+				const fsPromises = await import("node:fs/promises");
+				const originalBinary = hadExistingBinary
+					? await fsPromises.readFile(packagedBinary)
+					: null;
+				const originalMeta = hadExistingMeta
+					? await fsPromises.readFile(packagedMeta, "utf-8")
+					: null;
+				await mkdir(packageBinDir, { recursive: true });
+				await writeFile(packagedBinary, '#!/bin/sh\necho "stub harness"\n');
+				await writeFile(
+					packagedMeta,
+					JSON.stringify({
+						binaryName:
+							process.platform === "win32"
+								? "omx-explore-harness.exe"
+								: "omx-explore-harness",
+						platform: process.platform,
+						arch: process.arch,
+					}),
+				);
+				spawnSync("chmod", ["+x", packagedBinary], { encoding: "utf-8" });
+
+				try {
+					const res = runOmx(wd, ["doctor"], {
+						HOME: home,
+						CODEX_HOME: join(home, ".codex"),
+						PATH: fakeBin,
+					});
+					if (shouldSkipForSpawnPermissions(res.error)) return;
+					assert.equal(res.status, 0, res.stderr || res.stdout);
+					assert.match(
+						res.stdout,
+						/Explore Harness: ready \(packaged native binary:/,
+					);
+				} finally {
+					if (originalBinary) {
+						await writeFile(packagedBinary, originalBinary);
+						spawnSync("chmod", ["+x", packagedBinary], { encoding: "utf-8" });
+					} else {
+						await rm(packagedBinary, { force: true });
+					}
+					if (originalMeta !== null) {
+						await writeFile(packagedMeta, originalMeta);
+					} else {
+						await rm(packagedMeta, { force: true });
+					}
+				}
+			} finally {
+				await rm(wd, { recursive: true, force: true });
+			}
+		});
+	});
+
+	it("warns when explore routing is explicitly disabled in config.toml", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-explore-routing-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				`
 [env]
 USE_OMX_EXPLORE_CMD = "off"
 `.trimStart(),
-      );
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: join(home, '.codex'),
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Explore routing: disabled in config\.toml \[env\]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: join(home, ".codex"),
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Explore routing: disabled in config\.toml \[env\]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('warns when canonical and legacy skill roots overlap', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-skill-overlap-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      const canonicalHelp = join(codexDir, 'skills', 'help');
-      const canonicalPlan = join(codexDir, 'skills', 'plan');
-      const legacyHelp = join(home, '.agents', 'skills', 'help');
-      await mkdir(canonicalHelp, { recursive: true });
-      await mkdir(canonicalPlan, { recursive: true });
-      await mkdir(legacyHelp, { recursive: true });
-      await writeFile(join(canonicalHelp, 'SKILL.md'), '# canonical help\n');
-      await writeFile(join(canonicalPlan, 'SKILL.md'), '# canonical plan\n');
-      await writeFile(join(legacyHelp, 'SKILL.md'), '# legacy help\n');
+	it("warns when canonical and legacy skill roots overlap", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-skill-overlap-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			const canonicalHelp = join(codexDir, "skills", "help");
+			const canonicalPlan = join(codexDir, "skills", "plan");
+			const legacyHelp = join(home, ".agents", "skills", "help");
+			await mkdir(canonicalHelp, { recursive: true });
+			await mkdir(canonicalPlan, { recursive: true });
+			await mkdir(legacyHelp, { recursive: true });
+			await writeFile(join(canonicalHelp, "SKILL.md"), "# canonical help\n");
+			await writeFile(join(canonicalPlan, "SKILL.md"), "# canonical plan\n");
+			await writeFile(join(legacyHelp, "SKILL.md"), "# legacy help\n");
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: codexDir,
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Legacy skill roots: 1 overlapping skill names between .*\.codex[\\/]+skills and .*\.agents[\\/]+skills; 1 differ in SKILL\.md content; Codex Enable\/Disable Skills may show duplicates until ~\/\.agents\/skills is cleaned up/,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Legacy skill roots: 1 overlapping skill names between .*\.codex[\\/]+skills and .*\.agents[\\/]+skills; 1 differ in SKILL\.md content; Codex Enable\/Disable Skills may show duplicates until ~\/\.agents\/skills is cleaned up/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it('passes when legacy skill root is a link to the canonical skills directory', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-skill-link-'));
-    try {
-      const home = join(wd, 'home');
-      const codexDir = join(home, '.codex');
-      const canonicalSkillsRoot = join(codexDir, 'skills');
-      const canonicalHelp = join(canonicalSkillsRoot, 'help');
-      const legacyRoot = join(home, '.agents', 'skills');
-      await mkdir(canonicalHelp, { recursive: true });
-      await mkdir(join(home, '.agents'), { recursive: true });
-      await writeFile(join(canonicalHelp, 'SKILL.md'), '# canonical help\n');
-      await symlink(
-        canonicalSkillsRoot,
-        legacyRoot,
-        process.platform === 'win32' ? 'junction' : 'dir',
-      );
+	it("passes when legacy skill root is a link to the canonical skills directory", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-skill-link-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			const canonicalSkillsRoot = join(codexDir, "skills");
+			const canonicalHelp = join(canonicalSkillsRoot, "help");
+			const legacyRoot = join(home, ".agents", "skills");
+			await mkdir(canonicalHelp, { recursive: true });
+			await mkdir(join(home, ".agents"), { recursive: true });
+			await writeFile(join(canonicalHelp, "SKILL.md"), "# canonical help\n");
+			await symlink(
+				canonicalSkillsRoot,
+				legacyRoot,
+				process.platform === "win32" ? "junction" : "dir",
+			);
 
-      const res = runOmx(wd, ['doctor'], {
-        HOME: home,
-        CODEX_HOME: codexDir,
-      });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.match(
-        res.stdout,
-        /Legacy skill roots: ~\/\.agents\/skills links to canonical .*\.codex[\\/]+skills; treating both paths as one shared skill root/,
-      );
-      assert.doesNotMatch(res.stdout, /\[!!\] Legacy skill roots:/);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Legacy skill roots: ~\/\.agents\/skills links to canonical .*\.codex[\\/]+skills; treating both paths as one shared skill root/,
+			);
+			assert.doesNotMatch(res.stdout, /\[!!\] Legacy skill roots:/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -28,6 +28,7 @@ import {
   resolveSetupScopeArg,
   readPersistedSetupPreferences,
   readPersistedSetupScope,
+  resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
   buildDetachedSessionBootstrapSteps,
   buildDetachedTmuxSessionName,
@@ -1027,6 +1028,23 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("uses project config.toml for launch repair when persisted scope is project", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(
+        resolveCodexConfigPathForLaunch(wd, {}),
+        join(wd, ".codex", "config.toml"),
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps explicit CODEX_HOME override from env", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
     try {
@@ -1040,6 +1058,25 @@ describe("project launch scope helpers", () => {
           CODEX_HOME: "/tmp/explicit-codex-home",
         }),
         "/tmp/explicit-codex-home",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("uses explicit CODEX_HOME config.toml for launch repair overrides", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(
+        resolveCodexConfigPathForLaunch(wd, {
+          CODEX_HOME: "/tmp/explicit-codex-home",
+        }),
+        "/tmp/explicit-codex-home/config.toml",
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -2,511 +2,580 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
-  mkdtemp,
-  mkdir,
-  readFile,
-  readdir,
-  rm,
-  writeFile,
+	mkdtemp,
+	mkdir,
+	readFile,
+	readdir,
+	rm,
+	writeFile,
 } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { setup } from "../setup.js";
 
-const EXPECTED_PROJECT_GITIGNORE = [
-  ".omx/",
-  ".codex/*",
-  "!.codex/agents/",
-  "!.codex/agents/**",
-  "!.codex/skills/",
-  "!.codex/skills/**",
-  ".codex/skills/.system/**",
-  "!.codex/prompts/",
-  "!.codex/prompts/**",
-].join("\n") + "\n";
+const EXPECTED_PROJECT_GITIGNORE =
+	[
+		".omx/",
+		".codex/*",
+		"!.codex/agents/",
+		"!.codex/agents/**",
+		"!.codex/skills/",
+		"!.codex/skills/**",
+		".codex/skills/.system/**",
+		"!.codex/prompts/",
+		"!.codex/prompts/**",
+	].join("\n") + "\n";
 
 async function runSetupWithCapturedLogs(
-  cwd: string,
-  options: Parameters<typeof setup>[0],
+	cwd: string,
+	options: Parameters<typeof setup>[0],
 ): Promise<string> {
-  const previousCwd = process.cwd();
-  const logs: string[] = [];
-  const originalLog = console.log;
-  process.chdir(cwd);
-  console.log = (...args: unknown[]) => {
-    logs.push(args.map((arg) => String(arg)).join(" "));
-  };
-  try {
-    await setup(options);
-    return logs.join("\n");
-  } finally {
-    console.log = originalLog;
-    process.chdir(previousCwd);
-  }
+	const previousCwd = process.cwd();
+	const logs: string[] = [];
+	const originalLog = console.log;
+	process.chdir(cwd);
+	console.log = (...args: unknown[]) => {
+		logs.push(args.map((arg) => String(arg)).join(" "));
+	};
+	try {
+		await setup(options);
+		return logs.join("\n");
+	} finally {
+		console.log = originalLog;
+		process.chdir(previousCwd);
+	}
 }
 
 describe("omx setup refresh summary and dry-run behavior", () => {
-  async function runSetupInTempDir(
-    wd: string,
-    options: Parameters<typeof setup>[0],
-  ): Promise<void> {
-    const previousCwd = process.cwd();
-    process.chdir(wd);
-    try {
-      await setup(options);
-    } finally {
-      process.chdir(previousCwd);
-    }
-  }
+	async function runSetupInTempDir(
+		wd: string,
+		options: Parameters<typeof setup>[0],
+	): Promise<void> {
+		const previousCwd = process.cwd();
+		process.chdir(wd);
+		try {
+			await setup(options);
+		} finally {
+			process.chdir(previousCwd);
+		}
+	}
 
-  it("prints per-category summary and verbose changed-file detail", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await runSetupInTempDir(wd, { scope: "project" });
+	it("prints per-category summary and verbose changed-file detail", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await runSetupInTempDir(wd, { scope: "project" });
 
-      const skillPath = join(wd, ".codex", "skills", "help", "SKILL.md");
-      await writeFile(skillPath, "# locally modified help\n");
+			const skillPath = join(wd, ".codex", "skills", "help", "SKILL.md");
+			await writeFile(skillPath, "# locally modified help\n");
 
-      const output = await runSetupWithCapturedLogs(wd, {
-        scope: "project",
-        verbose: true,
-      });
-      assert.match(output, /Setup refresh summary:/);
-      assert.match(output, /prompts: updated=/);
-      assert.match(output, /skills: updated=/);
-      assert.match(output, /native_agents: updated=/);
-      assert.match(output, /agents_md: updated=/);
-      assert.match(output, /config: updated=/);
-      assert.match(output, /updated skill help\/SKILL\.md/);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const output = await runSetupWithCapturedLogs(wd, {
+				scope: "project",
+				verbose: true,
+			});
+			assert.match(output, /Setup refresh summary:/);
+			assert.match(output, /prompts: updated=/);
+			assert.match(output, /skills: updated=/);
+			assert.match(output, /native_agents: updated=/);
+			assert.match(output, /agents_md: updated=/);
+			assert.match(output, /config: updated=/);
+			assert.match(output, /updated skill help\/SKILL\.md/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("does not overwrite or create backups during dry-run", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await runSetupInTempDir(wd, { scope: "project" });
+	it("does not overwrite or create backups during dry-run", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await runSetupInTempDir(wd, { scope: "project" });
 
-      const skillPath = join(wd, ".codex", "skills", "help", "SKILL.md");
-      const customized = "# locally modified help\n";
-      await writeFile(skillPath, customized);
+			const skillPath = join(wd, ".codex", "skills", "help", "SKILL.md");
+			const customized = "# locally modified help\n";
+			await writeFile(skillPath, customized);
 
-      const output = await runSetupWithCapturedLogs(wd, {
-        scope: "project",
-        dryRun: true,
-      });
-      assert.equal(await readFile(skillPath, "utf-8"), customized);
-      assert.equal(existsSync(join(wd, ".omx", "backups", "setup")), false);
-      assert.match(output, /skills: updated=/);
-      assert.match(output, /skills: .*backed_up=1/);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const output = await runSetupWithCapturedLogs(wd, {
+				scope: "project",
+				dryRun: true,
+			});
+			assert.equal(await readFile(skillPath, "utf-8"), customized);
+			assert.equal(existsSync(join(wd, ".omx", "backups", "setup")), false);
+			assert.match(output, /skills: updated=/);
+			assert.match(output, /skills: .*backed_up=1/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("creates .gitignore with OMX project ignore rules during project-scoped setup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await runSetupInTempDir(wd, { scope: "project" });
+	it("creates .gitignore with OMX project ignore rules during project-scoped setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await runSetupInTempDir(wd, { scope: "project" });
 
-      assert.equal(existsSync(join(wd, ".omx", "state")), true);
-      assert.equal(
-        await readFile(join(wd, ".gitignore"), "utf-8"),
-        EXPECTED_PROJECT_GITIGNORE,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			assert.equal(existsSync(join(wd, ".omx", "state")), true);
+			assert.equal(
+				await readFile(join(wd, ".gitignore"), "utf-8"),
+				EXPECTED_PROJECT_GITIGNORE,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("appends missing OMX project ignore rules to an existing project .gitignore without duplicating them", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await writeFile(join(wd, ".gitignore"), "node_modules/\n");
+	it("appends missing OMX project ignore rules to an existing project .gitignore without duplicating them", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await writeFile(join(wd, ".gitignore"), "node_modules/\n");
 
-      await runSetupInTempDir(wd, { scope: "project" });
-      await runSetupInTempDir(wd, { scope: "project" });
+			await runSetupInTempDir(wd, { scope: "project" });
+			await runSetupInTempDir(wd, { scope: "project" });
 
-      const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
-      assert.equal(gitignore, `node_modules/\n${EXPECTED_PROJECT_GITIGNORE}`);
-      assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 1);
-      assert.equal(gitignore.match(/^\.codex\/\*$/gm)?.length ?? 0, 1);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
+			assert.equal(gitignore, `node_modules/\n${EXPECTED_PROJECT_GITIGNORE}`);
+			assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 1);
+			assert.equal(gitignore.match(/^\.codex\/\*$/gm)?.length ?? 0, 1);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("ignores project-local config while keeping .codex agents, skills, and prompts trackable", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      const initResult = spawnSync("git", ["init", "-q"], { cwd: wd });
-      assert.equal(initResult.status, 0);
+	it("ignores project-local config while keeping .codex agents, skills, and prompts trackable", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			const initResult = spawnSync("git", ["init", "-q"], { cwd: wd });
+			assert.equal(initResult.status, 0);
 
-      await runSetupInTempDir(wd, { scope: "project" });
-      await mkdir(join(wd, ".codex", "skills", ".system"), { recursive: true });
-      await writeFile(join(wd, ".codex", "agents", "local.toml"), "# local\n");
-      await writeFile(join(wd, ".codex", "prompts", "local.md"), "# local\n");
-      await writeFile(
-        join(wd, ".codex", "skills", ".system", "cache.json"),
-        "{}\n",
-      );
+			await runSetupInTempDir(wd, { scope: "project" });
+			await mkdir(join(wd, ".codex", "skills", ".system"), { recursive: true });
+			await writeFile(join(wd, ".codex", "agents", "local.toml"), "# local\n");
+			await writeFile(join(wd, ".codex", "prompts", "local.md"), "# local\n");
+			await writeFile(
+				join(wd, ".codex", "skills", ".system", "cache.json"),
+				"{}\n",
+			);
 
-      const status = spawnSync(
-        "git",
-        [
-          "status",
-          "--short",
-          "--ignored",
-          ".codex/config.toml",
-          ".codex/agents/local.toml",
-          ".codex/prompts/local.md",
-          ".codex/skills/help/SKILL.md",
-          ".codex/skills/.system/cache.json",
-        ],
-        { cwd: wd, encoding: "utf-8" },
-      );
-      assert.equal(status.status, 0);
-      assert.match(status.stdout, /^!! \.codex\/config\.toml$/m);
-      assert.match(status.stdout, /^\?\? \.codex\/agents\/local\.toml$/m);
-      assert.match(status.stdout, /^\?\? \.codex\/prompts\/local\.md$/m);
-      assert.match(status.stdout, /^\?\? \.codex\/skills\/help\/SKILL\.md$/m);
-      assert.match(status.stdout, /^!! \.codex\/skills\/\.system\/cache\.json$/m);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const status = spawnSync(
+				"git",
+				[
+					"status",
+					"--short",
+					"--ignored",
+					".codex/config.toml",
+					".codex/agents/local.toml",
+					".codex/prompts/local.md",
+					".codex/skills/help/SKILL.md",
+					".codex/skills/.system/cache.json",
+				],
+				{ cwd: wd, encoding: "utf-8" },
+			);
+			assert.equal(status.status, 0);
+			assert.match(status.stdout, /^!! \.codex\/config\.toml$/m);
+			assert.match(status.stdout, /^\?\? \.codex\/agents\/local\.toml$/m);
+			assert.match(status.stdout, /^\?\? \.codex\/prompts\/local\.md$/m);
+			assert.match(status.stdout, /^\?\? \.codex\/skills\/help\/SKILL\.md$/m);
+			assert.match(
+				status.stdout,
+				/^!! \.codex\/skills\/\.system\/cache\.json$/m,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("replaces legacy .codex/ ignores so the project allowlist can take effect", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await writeFile(join(wd, ".gitignore"), ".omx/\n.codex/\n");
+	it("replaces legacy .codex/ ignores so the project allowlist can take effect", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await writeFile(join(wd, ".gitignore"), ".omx/\n.codex/\n");
 
-      await runSetupInTempDir(wd, { scope: "project" });
+			await runSetupInTempDir(wd, { scope: "project" });
 
-      const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
-      assert.equal(gitignore, EXPECTED_PROJECT_GITIGNORE);
-      assert.equal(gitignore.match(/^\.codex\/$/gm)?.length ?? 0, 0);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
+			assert.equal(gitignore, EXPECTED_PROJECT_GITIGNORE);
+			assert.equal(gitignore.match(/^\.codex\/$/gm)?.length ?? 0, 0);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("creates backup files under the scope-specific setup backup root when refreshing modified managed files", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await runSetupInTempDir(wd, { scope: "project" });
+	it("creates backup files under the scope-specific setup backup root when refreshing modified managed files", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await runSetupInTempDir(wd, { scope: "project" });
 
-      const promptPath = join(wd, ".codex", "prompts", "executor.md");
-      const oldPrompt = "# local prompt\n";
-      await writeFile(promptPath, oldPrompt);
+			const promptPath = join(wd, ".codex", "prompts", "executor.md");
+			const oldPrompt = "# local prompt\n";
+			await writeFile(promptPath, oldPrompt);
 
-      await runSetupInTempDir(wd, { scope: "project" });
+			await runSetupInTempDir(wd, { scope: "project" });
 
-      const backupsRoot = join(wd, ".omx", "backups", "setup");
-      assert.equal(existsSync(backupsRoot), true);
-      const timestamps = await readdir(backupsRoot);
-      assert.ok(timestamps.length >= 1);
-      const latestBackup = join(
-        backupsRoot,
-        timestamps.sort().at(-1)!,
-        ".codex",
-        "prompts",
-        "executor.md",
-      );
-      assert.equal(existsSync(latestBackup), true);
-      assert.equal(await readFile(latestBackup, "utf-8"), oldPrompt);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const backupsRoot = join(wd, ".omx", "backups", "setup");
+			assert.equal(existsSync(backupsRoot), true);
+			const timestamps = await readdir(backupsRoot);
+			assert.ok(timestamps.length >= 1);
+			const latestBackup = join(
+				backupsRoot,
+				timestamps.sort().at(-1)!,
+				".codex",
+				"prompts",
+				"executor.md",
+			);
+			assert.equal(existsSync(latestBackup), true);
+			assert.equal(await readFile(latestBackup, "utf-8"), oldPrompt);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("offers an upgrade from gpt-5.3-codex to gpt-5.4 when accepted", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await mkdir(join(wd, ".codex"), { recursive: true });
-      await writeFile(
-        join(wd, ".codex", "config.toml"),
-        'model = \"gpt-5.3-codex\"\n',
-      );
+	it("offers an upgrade from gpt-5.3-codex to gpt-5.4 when accepted", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await mkdir(join(wd, ".codex"), { recursive: true });
+			await writeFile(
+				join(wd, ".codex", "config.toml"),
+				'model = \"gpt-5.3-codex\"\n',
+			);
 
-      let promptCalls = 0;
-      await runSetupInTempDir(wd, {
-        scope: "project",
-        modelUpgradePrompt: async (currentModel, targetModel) => {
-          promptCalls += 1;
-          assert.equal(currentModel, "gpt-5.3-codex");
-          assert.equal(targetModel, "gpt-5.4");
-          return true;
-        },
-      });
+			let promptCalls = 0;
+			await runSetupInTempDir(wd, {
+				scope: "project",
+				modelUpgradePrompt: async (currentModel, targetModel) => {
+					promptCalls += 1;
+					assert.equal(currentModel, "gpt-5.3-codex");
+					assert.equal(targetModel, "gpt-5.4");
+					return true;
+				},
+			});
 
-      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.equal(promptCalls, 1);
-      assert.match(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model = "gpt-5\.3-codex"$/m);
-      assert.match(config, /^model_context_window = 1000000$/m);
-      assert.match(config, /^model_auto_compact_token_limit = 900000$/m);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+			assert.equal(promptCalls, 1);
+			assert.match(config, /^model = "gpt-5\.4"$/m);
+			assert.doesNotMatch(config, /^model = "gpt-5\.3-codex"$/m);
+			assert.match(config, /^model_context_window = 1000000$/m);
+			assert.match(config, /^model_auto_compact_token_limit = 900000$/m);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("preserves gpt-5.3-codex when the upgrade prompt is declined", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await mkdir(join(wd, ".codex"), { recursive: true });
-      await writeFile(
-        join(wd, ".codex", "config.toml"),
-        'model = \"gpt-5.3-codex\"\n',
-      );
+	it("preserves gpt-5.3-codex when the upgrade prompt is declined", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await mkdir(join(wd, ".codex"), { recursive: true });
+			await writeFile(
+				join(wd, ".codex", "config.toml"),
+				'model = \"gpt-5.3-codex\"\n',
+			);
 
-      await runSetupInTempDir(wd, {
-        scope: "project",
-        modelUpgradePrompt: async () => false,
-      });
+			await runSetupInTempDir(wd, {
+				scope: "project",
+				modelUpgradePrompt: async () => false,
+			});
 
-      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.match(config, /^model = "gpt-5\.3-codex"$/m);
-      assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+			assert.match(config, /^model = "gpt-5\.3-codex"$/m);
+			assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
+			assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
+			assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("preserves gpt-5.3-codex in non-interactive runs without prompting", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await mkdir(join(wd, ".codex"), { recursive: true });
-      await writeFile(
-        join(wd, ".codex", "config.toml"),
-        'model = \"gpt-5.3-codex\"\n',
-      );
+	it("preserves gpt-5.3-codex in non-interactive runs without prompting", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await mkdir(join(wd, ".codex"), { recursive: true });
+			await writeFile(
+				join(wd, ".codex", "config.toml"),
+				'model = \"gpt-5.3-codex\"\n',
+			);
 
-      await runSetupInTempDir(wd, { scope: "project" });
+			await runSetupInTempDir(wd, { scope: "project" });
 
-      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.match(config, /^model = "gpt-5\.3-codex"$/m);
-      assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
-      assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
-      assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+			assert.match(config, /^model = "gpt-5\.3-codex"$/m);
+			assert.doesNotMatch(config, /^model = "gpt-5\.4"$/m);
+			assert.doesNotMatch(config, /^model_context_window = 1000000$/m);
+			assert.doesNotMatch(config, /^model_auto_compact_token_limit = 900000$/m);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("skips OMX-managed [tui] writes for Codex CLI >= 0.107.0 and preserves an existing [tui] table", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await mkdir(join(wd, ".codex"), { recursive: true });
-      await writeFile(
-        join(wd, ".codex", "config.toml"),
-        ['model = "gpt-5.4"', "", "[tui]", 'theme = "night"', 'status_line = ["git-branch"]', ""].join("\n"),
-      );
+	it("skips OMX-managed [tui] writes for Codex CLI >= 0.107.0 and preserves an existing [tui] table", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await mkdir(join(wd, ".codex"), { recursive: true });
+			await writeFile(
+				join(wd, ".codex", "config.toml"),
+				[
+					'model = "gpt-5.4"',
+					"",
+					"[tui]",
+					'theme = "night"',
+					'status_line = ["git-branch"]',
+					"",
+				].join("\n"),
+			);
 
-      const output = await runSetupWithCapturedLogs(wd, {
-        scope: "project",
-        codexVersionProbe: () => "codex-cli 0.107.0",
-      });
+			const output = await runSetupWithCapturedLogs(wd, {
+				scope: "project",
+				codexVersionProbe: () => "codex-cli 0.107.0",
+			});
 
-      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.equal(config.match(/^\[tui\]$/gm)?.length ?? 0, 1);
-      assert.match(config, /^theme = "night"$/m);
-      assert.match(config, /^status_line = \["git-branch"\]$/m);
-      assert.match(
-        output,
-        /Codex CLI >= 0\.107\.0 manages \[tui\]; OMX left that section untouched\./,
-      );
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+			assert.equal(config.match(/^\[tui\]$/gm)?.length ?? 0, 1);
+			assert.match(config, /^theme = "night"$/m);
+			assert.match(config, /^status_line = \["git-branch"\]$/m);
+			assert.match(
+				output,
+				/Codex CLI >= 0\.107\.0 manages \[tui\]; OMX left that section untouched\./,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("keeps OMX-managed [tui] writes for older Codex CLI versions", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+	it("keeps OMX-managed [tui] writes for older Codex CLI versions", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
 
-      const output = await runSetupWithCapturedLogs(wd, {
-        scope: "project",
-        codexVersionProbe: () => "codex-cli 0.106.0",
-      });
+			const output = await runSetupWithCapturedLogs(wd, {
+				scope: "project",
+				codexVersionProbe: () => "codex-cli 0.106.0",
+			});
 
-      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.match(config, /^\[tui\]$/m);
-      assert.match(output, /StatusLine configured in config\.toml via \[tui\] section\./);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+			assert.match(config, /^\[tui\]$/m);
+			assert.match(
+				output,
+				/StatusLine configured in config\.toml via \[tui\] section\./,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("syncs shared MCP registry entries into config.toml during setup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    try {
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      const registryPath = join(wd, "mcp-registry.json");
-      await writeFile(
-        registryPath,
-        JSON.stringify({
-          eslint: { command: "npx", args: ["@eslint/mcp@latest"], timeout: 9 },
-        }),
-      );
+	it("repairs retired omx_team_run config during setup refresh", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await mkdir(join(wd, ".codex"), { recursive: true });
+			await writeFile(
+				join(wd, ".codex", "config.toml"),
+				[
+					"[user.before]",
+					'name = "kept-before"',
+					"",
+					"[mcp_servers.omx_team_run]",
+					'command = "node"',
+					'args = ["/tmp/team-server.js"]',
+					"enabled = true",
+					"",
+					"[user.after]",
+					'name = "kept-after"',
+					"",
+				].join("\n"),
+			);
 
-      await runSetupInTempDir(wd, {
-        scope: "project",
-        mcpRegistryCandidates: [registryPath],
-      });
+			const output = await runSetupWithCapturedLogs(wd, { scope: "project" });
 
-      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.match(config, /oh-my-codex \(OMX\) Shared MCP Registry Sync/);
-      assert.match(config, /^\[mcp_servers\.eslint\]$/m);
-      assert.match(config, /^command = "npx"$/m);
-      assert.match(config, /^startup_timeout_sec = 9$/m);
-    } finally {
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
-  it("syncs shared MCP registry entries into ~/.claude/settings.json for user scope", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    const previousHome = process.env.HOME;
-    const previousCodexHome = process.env.CODEX_HOME;
-    try {
-      process.env.HOME = wd;
-      delete process.env.CODEX_HOME;
+			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+			assert.match(
+				output,
+				/Removed retired \[mcp_servers\.omx_team_run\] config during refresh\./,
+			);
+			assert.doesNotMatch(config, /^\[mcp_servers\.omx_team_run\]$/m);
+			assert.doesNotMatch(config, /team-server\.js/);
+			assert.match(config, /^\[user\.before\]$/m);
+			assert.match(config, /^name = "kept-before"$/m);
+			assert.match(config, /^\[user\.after\]$/m);
+			assert.match(config, /^name = "kept-after"$/m);
+			assert.match(config, /^\[mcp_servers\.omx_state\]$/m);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await mkdir(join(wd, ".claude"), { recursive: true });
-      await writeFile(
-        join(wd, ".claude", "settings.json"),
-        JSON.stringify(
-          {
-            uiTheme: "dark",
-            mcpServers: {
-              existing_server: {
-                command: "custom-existing-server",
-                args: ["serve"],
-                enabled: true,
-              },
-            },
-          },
-          null,
-          2,
-        ),
-      );
-      const registryPath = join(wd, "mcp-registry.json");
-      await writeFile(
-        registryPath,
-        JSON.stringify({
-          existing_server: { command: "existing-server", args: ["mcp"] },
-          eslint: { command: "npx", args: ["@eslint/mcp@latest"], enabled: false },
-        }),
-      );
+	it("syncs shared MCP registry entries into config.toml during setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		try {
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			const registryPath = join(wd, "mcp-registry.json");
+			await writeFile(
+				registryPath,
+				JSON.stringify({
+					eslint: { command: "npx", args: ["@eslint/mcp@latest"], timeout: 9 },
+				}),
+			);
 
-      await runSetupInTempDir(wd, {
-        scope: "user",
-        mcpRegistryCandidates: [registryPath],
-      });
+			await runSetupInTempDir(wd, {
+				scope: "project",
+				mcpRegistryCandidates: [registryPath],
+			});
 
-      const settings = JSON.parse(
-        await readFile(join(wd, ".claude", "settings.json"), "utf-8"),
-      ) as {
-        uiTheme?: string;
-        mcpServers?: Record<string, { command: string; args: string[]; enabled: boolean }>;
-      };
-      assert.equal(settings.uiTheme, "dark");
-      assert.deepEqual(settings.mcpServers?.existing_server, {
-        command: "custom-existing-server",
-        args: ["serve"],
-        enabled: true,
-      });
-      assert.deepEqual(settings.mcpServers?.eslint, {
-        command: "npx",
-        args: ["@eslint/mcp@latest"],
-        enabled: false,
-      });
-    } finally {
-      if (typeof previousHome === "string") process.env.HOME = previousHome;
-      else delete process.env.HOME;
-      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
-      else delete process.env.CODEX_HOME;
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+			assert.match(config, /oh-my-codex \(OMX\) Shared MCP Registry Sync/);
+			assert.match(config, /^\[mcp_servers\.eslint\]$/m);
+			assert.match(config, /^command = "npx"$/m);
+			assert.match(config, /^startup_timeout_sec = 9$/m);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("does not write ~/.claude/settings.json during project-scoped setup", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    const previousHome = process.env.HOME;
-    const previousCodexHome = process.env.CODEX_HOME;
-    try {
-      process.env.HOME = wd;
-      delete process.env.CODEX_HOME;
+	it("syncs shared MCP registry entries into ~/.claude/settings.json for user scope", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		const previousHome = process.env.HOME;
+		const previousCodexHome = process.env.CODEX_HOME;
+		try {
+			process.env.HOME = wd;
+			delete process.env.CODEX_HOME;
 
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      const registryPath = join(wd, "mcp-registry.json");
-      await writeFile(
-        registryPath,
-        JSON.stringify({
-          eslint: { command: "npx", args: ["@eslint/mcp@latest"] },
-        }),
-      );
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await mkdir(join(wd, ".claude"), { recursive: true });
+			await writeFile(
+				join(wd, ".claude", "settings.json"),
+				JSON.stringify(
+					{
+						uiTheme: "dark",
+						mcpServers: {
+							existing_server: {
+								command: "custom-existing-server",
+								args: ["serve"],
+								enabled: true,
+							},
+						},
+					},
+					null,
+					2,
+				),
+			);
+			const registryPath = join(wd, "mcp-registry.json");
+			await writeFile(
+				registryPath,
+				JSON.stringify({
+					existing_server: { command: "existing-server", args: ["mcp"] },
+					eslint: {
+						command: "npx",
+						args: ["@eslint/mcp@latest"],
+						enabled: false,
+					},
+				}),
+			);
 
-      await runSetupInTempDir(wd, {
-        scope: "project",
-        mcpRegistryCandidates: [registryPath],
-      });
+			await runSetupInTempDir(wd, {
+				scope: "user",
+				mcpRegistryCandidates: [registryPath],
+			});
 
-      assert.equal(existsSync(join(wd, ".claude", "settings.json")), false);
-    } finally {
-      if (typeof previousHome === "string") process.env.HOME = previousHome;
-      else delete process.env.HOME;
-      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
-      else delete process.env.CODEX_HOME;
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+			const settings = JSON.parse(
+				await readFile(join(wd, ".claude", "settings.json"), "utf-8"),
+			) as {
+				uiTheme?: string;
+				mcpServers?: Record<
+					string,
+					{ command: string; args: string[]; enabled: boolean }
+				>;
+			};
+			assert.equal(settings.uiTheme, "dark");
+			assert.deepEqual(settings.mcpServers?.existing_server, {
+				command: "custom-existing-server",
+				args: ["serve"],
+				enabled: true,
+			});
+			assert.deepEqual(settings.mcpServers?.eslint, {
+				command: "npx",
+				args: ["@eslint/mcp@latest"],
+				enabled: false,
+			});
+		} finally {
+			if (typeof previousHome === "string") process.env.HOME = previousHome;
+			else delete process.env.HOME;
+			if (typeof previousCodexHome === "string")
+				process.env.CODEX_HOME = previousCodexHome;
+			else delete process.env.CODEX_HOME;
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-  it("ignores legacy ~/.omc/mcp-registry.json during setup unless candidates are passed explicitly", async () => {
-    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
-    const previousHome = process.env.HOME;
-    const previousCodexHome = process.env.CODEX_HOME;
-    try {
-      process.env.HOME = wd;
-      delete process.env.CODEX_HOME;
+	it("does not write ~/.claude/settings.json during project-scoped setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		const previousHome = process.env.HOME;
+		const previousCodexHome = process.env.CODEX_HOME;
+		try {
+			process.env.HOME = wd;
+			delete process.env.CODEX_HOME;
 
-      await mkdir(join(wd, ".omx", "state"), { recursive: true });
-      await mkdir(join(wd, ".omc"), { recursive: true });
-      await writeFile(
-        join(wd, ".omc", "mcp-registry.json"),
-        JSON.stringify({
-          legacy_helper: { command: "legacy-helper", args: ["mcp"] },
-        }),
-      );
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			const registryPath = join(wd, "mcp-registry.json");
+			await writeFile(
+				registryPath,
+				JSON.stringify({
+					eslint: { command: "npx", args: ["@eslint/mcp@latest"] },
+				}),
+			);
 
-      await runSetupInTempDir(wd, { scope: "project" });
+			await runSetupInTempDir(wd, {
+				scope: "project",
+				mcpRegistryCandidates: [registryPath],
+			});
 
-      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.doesNotMatch(config, /^\[mcp_servers\.legacy_helper\]$/m);
-      assert.doesNotMatch(config, /Shared MCP Server: legacy_helper/);
+			assert.equal(existsSync(join(wd, ".claude", "settings.json")), false);
+		} finally {
+			if (typeof previousHome === "string") process.env.HOME = previousHome;
+			else delete process.env.HOME;
+			if (typeof previousCodexHome === "string")
+				process.env.CODEX_HOME = previousCodexHome;
+			else delete process.env.CODEX_HOME;
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-      const output = await runSetupWithCapturedLogs(wd, { scope: "project" });
-      assert.match(output, /legacy shared MCP registry detected at .*\.omc\/mcp-registry\.json but ignored by default/i);
-      assert.match(output, /move it to .*\.omx\/mcp-registry\.json/i);
-    } finally {
-      if (typeof previousHome === "string") process.env.HOME = previousHome;
-      else delete process.env.HOME;
-      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
-      else delete process.env.CODEX_HOME;
-      await rm(wd, { recursive: true, force: true });
-    }
-  });
+	it("ignores legacy ~/.omc/mcp-registry.json during setup unless candidates are passed explicitly", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+		const previousHome = process.env.HOME;
+		const previousCodexHome = process.env.CODEX_HOME;
+		try {
+			process.env.HOME = wd;
+			delete process.env.CODEX_HOME;
+
+			await mkdir(join(wd, ".omx", "state"), { recursive: true });
+			await mkdir(join(wd, ".omc"), { recursive: true });
+			await writeFile(
+				join(wd, ".omc", "mcp-registry.json"),
+				JSON.stringify({
+					legacy_helper: { command: "legacy-helper", args: ["mcp"] },
+				}),
+			);
+
+			await runSetupInTempDir(wd, { scope: "project" });
+
+			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+			assert.doesNotMatch(config, /^\[mcp_servers\.legacy_helper\]$/m);
+			assert.doesNotMatch(config, /Shared MCP Server: legacy_helper/);
+
+			const output = await runSetupWithCapturedLogs(wd, { scope: "project" });
+			assert.match(
+				output,
+				/legacy shared MCP registry detected at .*\.omc\/mcp-registry\.json but ignored by default/i,
+			);
+			assert.match(output, /move it to .*\.omx\/mcp-registry\.json/i);
+		} finally {
+			if (typeof previousHome === "string") process.env.HOME = previousHome;
+			else delete process.env.HOME;
+			if (typeof previousCodexHome === "string")
+				process.env.CODEX_HOME = previousCodexHome;
+			else delete process.env.CODEX_HOME;
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,772 +2,953 @@
  * omx doctor - Validate oh-my-codex installation
  */
 
-import { existsSync } from 'fs';
-import { readdir, readFile } from 'fs/promises';
-import { join } from 'path';
+import { existsSync } from "fs";
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
 import {
-  codexHome, codexConfigPath, codexPromptsDir,
-  userSkillsDir, projectSkillsDir, omxStateDir, detectLegacySkillRootOverlap,
-} from '../utils/paths.js';
-import { classifySpawnError, spawnPlatformCommandSync } from '../utils/platform-command.js';
-import { getCatalogExpectations } from './catalog-contract.js';
-import { parse as parseToml } from '@iarna/toml';
-import { resolvePackagedExploreHarnessCommand, EXPLORE_BIN_ENV } from './explore.js';
-import { getPackageRoot } from '../utils/package.js';
-import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
-import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
-import { isLeaderRuntimeStale } from '../team/leader-activity.js';
+	codexHome,
+	codexConfigPath,
+	codexPromptsDir,
+	userSkillsDir,
+	projectSkillsDir,
+	omxStateDir,
+	detectLegacySkillRootOverlap,
+} from "../utils/paths.js";
+import {
+	classifySpawnError,
+	spawnPlatformCommandSync,
+} from "../utils/platform-command.js";
+import { getCatalogExpectations } from "./catalog-contract.js";
+import { parse as parseToml } from "@iarna/toml";
+import {
+	resolvePackagedExploreHarnessCommand,
+	EXPLORE_BIN_ENV,
+} from "./explore.js";
+import { getPackageRoot } from "../utils/package.js";
+import { hasLegacyOmxTeamRunTable } from "../config/generator.js";
+import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
+import {
+	OMX_EXPLORE_CMD_ENV,
+	isExploreCommandRoutingEnabled,
+} from "../hooks/explore-routing.js";
+import { isLeaderRuntimeStale } from "../team/leader-activity.js";
 
 interface DoctorOptions {
-  verbose?: boolean;
-  force?: boolean;
-  dryRun?: boolean;
-  team?: boolean;
+	verbose?: boolean;
+	force?: boolean;
+	dryRun?: boolean;
+	team?: boolean;
 }
 
 interface Check {
-  name: string;
-  status: 'pass' | 'warn' | 'fail';
-  message: string;
+	name: string;
+	status: "pass" | "warn" | "fail";
+	message: string;
 }
 
-type DoctorSetupScope = 'user' | 'project';
+type DoctorSetupScope = "user" | "project";
 
 interface DoctorScopeResolution {
-  scope: DoctorSetupScope;
-  source: 'persisted' | 'default';
+	scope: DoctorSetupScope;
+	source: "persisted" | "default";
 }
 
 interface DoctorPaths {
-  codexHomeDir: string;
-  configPath: string;
-  promptsDir: string;
-  skillsDir: string;
-  stateDir: string;
+	codexHomeDir: string;
+	configPath: string;
+	promptsDir: string;
+	skillsDir: string;
+	stateDir: string;
 }
 
 const LEGACY_SCOPE_MIGRATION: Record<string, DoctorSetupScope> = {
-  'project-local': 'project',
+	"project-local": "project",
 };
 
+const SUPPORTED_OMX_MCP_SERVERS = [
+	"omx_state",
+	"omx_memory",
+	"omx_code_intel",
+	"omx_trace",
+] as const;
+
+function hasSupportedOmxMcpServer(content: string): boolean {
+	return SUPPORTED_OMX_MCP_SERVERS.some((name) =>
+		new RegExp(`^\\s*\\[mcp_servers\\.(?:"${name}"|${name})\\]\\s*$`, "m").test(
+			content,
+		),
+	);
+}
+
 async function resolveDoctorScope(cwd: string): Promise<DoctorScopeResolution> {
-  const scopePath = join(cwd, '.omx', 'setup-scope.json');
-  if (!existsSync(scopePath)) {
-    return { scope: 'user', source: 'default' };
-  }
+	const scopePath = join(cwd, ".omx", "setup-scope.json");
+	if (!existsSync(scopePath)) {
+		return { scope: "user", source: "default" };
+	}
 
-  try {
-    const raw = await readFile(scopePath, 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<{ scope: string }>;
-    if (typeof parsed.scope === 'string') {
-      if (parsed.scope === 'user' || parsed.scope === 'project') {
-        return { scope: parsed.scope, source: 'persisted' };
-      }
-      const migrated = LEGACY_SCOPE_MIGRATION[parsed.scope];
-      if (migrated) {
-        return { scope: migrated, source: 'persisted' };
-      }
-    }
-  } catch {
-    // ignore invalid persisted scope and fall back to default
-  }
+	try {
+		const raw = await readFile(scopePath, "utf-8");
+		const parsed = JSON.parse(raw) as Partial<{ scope: string }>;
+		if (typeof parsed.scope === "string") {
+			if (parsed.scope === "user" || parsed.scope === "project") {
+				return { scope: parsed.scope, source: "persisted" };
+			}
+			const migrated = LEGACY_SCOPE_MIGRATION[parsed.scope];
+			if (migrated) {
+				return { scope: migrated, source: "persisted" };
+			}
+		}
+	} catch {
+		// ignore invalid persisted scope and fall back to default
+	}
 
-  return { scope: 'user', source: 'default' };
+	return { scope: "user", source: "default" };
 }
 
 function resolveDoctorPaths(cwd: string, scope: DoctorSetupScope): DoctorPaths {
-  if (scope === 'project') {
-    const codexHomeDir = join(cwd, '.codex');
-    return {
-      codexHomeDir,
-      configPath: join(codexHomeDir, 'config.toml'),
-      promptsDir: join(codexHomeDir, 'prompts'),
-      skillsDir: projectSkillsDir(cwd),
-      stateDir: omxStateDir(cwd),
-    };
-  }
+	if (scope === "project") {
+		const codexHomeDir = join(cwd, ".codex");
+		return {
+			codexHomeDir,
+			configPath: join(codexHomeDir, "config.toml"),
+			promptsDir: join(codexHomeDir, "prompts"),
+			skillsDir: projectSkillsDir(cwd),
+			stateDir: omxStateDir(cwd),
+		};
+	}
 
-  return {
-    codexHomeDir: codexHome(),
-    configPath: codexConfigPath(),
-    promptsDir: codexPromptsDir(),
-    skillsDir: userSkillsDir(),
-    stateDir: omxStateDir(cwd),
-  };
+	return {
+		codexHomeDir: codexHome(),
+		configPath: codexConfigPath(),
+		promptsDir: codexPromptsDir(),
+		skillsDir: userSkillsDir(),
+		stateDir: omxStateDir(cwd),
+	};
 }
 
 export async function doctor(options: DoctorOptions = {}): Promise<void> {
-  if (options.team) {
-    await doctorTeam();
-    return;
-  }
+	if (options.team) {
+		await doctorTeam();
+		return;
+	}
 
-  const cwd = process.cwd();
-  const scopeResolution = await resolveDoctorScope(cwd);
-  const paths = resolveDoctorPaths(cwd, scopeResolution.scope);
-  const scopeSourceMessage = scopeResolution.source === 'persisted'
-    ? ' (from .omx/setup-scope.json)'
-    : '';
+	const cwd = process.cwd();
+	const scopeResolution = await resolveDoctorScope(cwd);
+	const paths = resolveDoctorPaths(cwd, scopeResolution.scope);
+	const scopeSourceMessage =
+		scopeResolution.source === "persisted"
+			? " (from .omx/setup-scope.json)"
+			: "";
 
-  console.log('oh-my-codex doctor');
-  console.log('==================\n');
-  console.log(`Resolved setup scope: ${scopeResolution.scope}${scopeSourceMessage}\n`);
+	console.log("oh-my-codex doctor");
+	console.log("==================\n");
+	console.log(
+		`Resolved setup scope: ${scopeResolution.scope}${scopeSourceMessage}\n`,
+	);
 
-  const checks: Check[] = [];
+	const checks: Check[] = [];
 
-  // Check 1: Codex CLI installed
-  checks.push(checkCodexCli());
+	// Check 1: Codex CLI installed
+	checks.push(checkCodexCli());
 
-  // Check 2: Node.js version
-  checks.push(checkNodeVersion());
+	// Check 2: Node.js version
+	checks.push(checkNodeVersion());
 
-  // Check 2.5: Explore harness readiness
-  checks.push(checkExploreHarness());
+	// Check 2.5: Explore harness readiness
+	checks.push(checkExploreHarness());
 
-  // Check 3: Codex home directory
-  checks.push(checkDirectory('Codex home', paths.codexHomeDir));
+	// Check 3: Codex home directory
+	checks.push(checkDirectory("Codex home", paths.codexHomeDir));
 
-  // Check 4: Config file
-  checks.push(await checkConfig(paths.configPath));
+	// Check 4: Config file
+	checks.push(await checkConfig(paths.configPath));
 
-  // Check 4.5: Explore routing default
-  checks.push(await checkExploreRouting(paths.configPath));
+	// Check 4.5: Explore routing default
+	checks.push(await checkExploreRouting(paths.configPath));
 
-  // Check 5: Prompts installed
-  checks.push(await checkPrompts(paths.promptsDir));
+	// Check 5: Prompts installed
+	checks.push(await checkPrompts(paths.promptsDir));
 
-  // Check 6: Skills installed
-  checks.push(await checkSkills(paths.skillsDir));
+	// Check 6: Skills installed
+	checks.push(await checkSkills(paths.skillsDir));
 
-  // Check 6.5: Legacy/current skill-root overlap
-  if (scopeResolution.scope === 'user') {
-    checks.push(await checkLegacySkillRootOverlap());
-  }
+	// Check 6.5: Legacy/current skill-root overlap
+	if (scopeResolution.scope === "user") {
+		checks.push(await checkLegacySkillRootOverlap());
+	}
 
-  // Check 7: AGENTS.md in project
-  checks.push(checkAgentsMd(scopeResolution.scope, paths.codexHomeDir));
+	// Check 7: AGENTS.md in project
+	checks.push(checkAgentsMd(scopeResolution.scope, paths.codexHomeDir));
 
-  // Check 8: State directory
-  checks.push(checkDirectory('State dir', paths.stateDir));
+	// Check 8: State directory
+	checks.push(checkDirectory("State dir", paths.stateDir));
 
-  // Check 9: MCP servers configured
-  checks.push(await checkMcpServers(paths.configPath));
+	// Check 9: MCP servers configured
+	checks.push(await checkMcpServers(paths.configPath));
 
-  // Print results
-  let passCount = 0;
-  let warnCount = 0;
-  let failCount = 0;
+	// Print results
+	let passCount = 0;
+	let warnCount = 0;
+	let failCount = 0;
 
-  for (const check of checks) {
-    const icon = check.status === 'pass' ? '[OK]' : check.status === 'warn' ? '[!!]' : '[XX]';
-    console.log(`  ${icon} ${check.name}: ${check.message}`);
-    if (check.status === 'pass') passCount++;
-    else if (check.status === 'warn') warnCount++;
-    else failCount++;
-  }
+	for (const check of checks) {
+		const icon =
+			check.status === "pass"
+				? "[OK]"
+				: check.status === "warn"
+					? "[!!]"
+					: "[XX]";
+		console.log(`  ${icon} ${check.name}: ${check.message}`);
+		if (check.status === "pass") passCount++;
+		else if (check.status === "warn") warnCount++;
+		else failCount++;
+	}
 
-  console.log(`\nResults: ${passCount} passed, ${warnCount} warnings, ${failCount} failed`);
+	console.log(
+		`\nResults: ${passCount} passed, ${warnCount} warnings, ${failCount} failed`,
+	);
 
-  if (failCount > 0) {
-    console.log('\nRun "omx setup" to fix installation issues.');
-  } else if (warnCount > 0) {
-    console.log('\nRun "omx setup --force" to refresh all components.');
-  } else {
-    console.log('\nAll checks passed! oh-my-codex is ready.');
-  }
+	if (failCount > 0) {
+		console.log('\nRun "omx setup" to fix installation issues.');
+	} else if (warnCount > 0) {
+		console.log('\nRun "omx setup --force" to refresh all components.');
+	} else {
+		console.log("\nAll checks passed! oh-my-codex is ready.");
+	}
 }
 
 interface TeamDoctorIssue {
-  code: 'delayed_status_lag' | 'slow_shutdown' | 'orphan_tmux_session' | 'resume_blocker' | 'stale_leader';
-  message: string;
-  severity: 'warn' | 'fail';
+	code:
+		| "delayed_status_lag"
+		| "slow_shutdown"
+		| "orphan_tmux_session"
+		| "resume_blocker"
+		| "stale_leader";
+	message: string;
+	severity: "warn" | "fail";
 }
 
 async function doctorTeam(): Promise<void> {
-  console.log('oh-my-codex doctor --team');
-  console.log('=========================\n');
+	console.log("oh-my-codex doctor --team");
+	console.log("=========================\n");
 
-  const issues = await collectTeamDoctorIssues(process.cwd());
-  if (issues.length === 0) {
-    console.log('  [OK] team diagnostics: no issues');
-    console.log('\nAll team checks passed.');
-    return;
-  }
+	const issues = await collectTeamDoctorIssues(process.cwd());
+	if (issues.length === 0) {
+		console.log("  [OK] team diagnostics: no issues");
+		console.log("\nAll team checks passed.");
+		return;
+	}
 
-  const failureCount = issues.filter(issue => issue.severity === 'fail').length;
-  const warningCount = issues.length - failureCount;
+	const failureCount = issues.filter(
+		(issue) => issue.severity === "fail",
+	).length;
+	const warningCount = issues.length - failureCount;
 
-  for (const issue of issues) {
-    const icon = issue.severity === 'warn' ? '[!!]' : '[XX]';
-    console.log(`  ${icon} ${issue.code}: ${issue.message}`);
-  }
+	for (const issue of issues) {
+		const icon = issue.severity === "warn" ? "[!!]" : "[XX]";
+		console.log(`  ${icon} ${issue.code}: ${issue.message}`);
+	}
 
-  console.log(`\nResults: ${warningCount} warnings, ${failureCount} failed`);
-  // Ensure non-zero exit for `omx doctor --team` failures.
-  if (failureCount > 0) process.exitCode = 1;
+	console.log(`\nResults: ${warningCount} warnings, ${failureCount} failed`);
+	// Ensure non-zero exit for `omx doctor --team` failures.
+	if (failureCount > 0) process.exitCode = 1;
 }
 
-async function collectTeamDoctorIssues(cwd: string): Promise<TeamDoctorIssue[]> {
-  const issues: TeamDoctorIssue[] = [];
-  const stateDir = omxStateDir(cwd);
-  const teamsRoot = join(stateDir, 'team');
-  const nowMs = Date.now();
-  const lagThresholdMs = 60_000;
-  const shutdownThresholdMs = 30_000;
-  const leaderStaleThresholdMs = 180_000;
+async function collectTeamDoctorIssues(
+	cwd: string,
+): Promise<TeamDoctorIssue[]> {
+	const issues: TeamDoctorIssue[] = [];
+	const stateDir = omxStateDir(cwd);
+	const teamsRoot = join(stateDir, "team");
+	const nowMs = Date.now();
+	const lagThresholdMs = 60_000;
+	const shutdownThresholdMs = 30_000;
+	const leaderStaleThresholdMs = 180_000;
 
-  // Rust-first: if the runtime bridge is enabled, use Rust-authored readiness
-  // and authority as the semantic truth source for runtime health.
-  if (isBridgeEnabled()) {
-    const bridge = getDefaultBridge(stateDir);
-    const readiness = bridge.readReadiness();
-    const authority = bridge.readAuthority();
-    if (readiness && !readiness.ready) {
-      for (const reason of readiness.reasons) {
-        issues.push({
-          code: 'resume_blocker',
-          message: `runtime not ready: ${reason}`,
-          severity: 'fail',
-        });
-      }
-    }
-    if (authority?.stale) {
-      issues.push({
-        code: 'stale_leader',
-        message: `authority stale (owner: ${authority.owner ?? 'unknown'}): ${authority.stale_reason ?? 'unknown reason'}`,
-        severity: 'fail',
-      });
-    }
-  }
+	// Rust-first: if the runtime bridge is enabled, use Rust-authored readiness
+	// and authority as the semantic truth source for runtime health.
+	if (isBridgeEnabled()) {
+		const bridge = getDefaultBridge(stateDir);
+		const readiness = bridge.readReadiness();
+		const authority = bridge.readAuthority();
+		if (readiness && !readiness.ready) {
+			for (const reason of readiness.reasons) {
+				issues.push({
+					code: "resume_blocker",
+					message: `runtime not ready: ${reason}`,
+					severity: "fail",
+				});
+			}
+		}
+		if (authority?.stale) {
+			issues.push({
+				code: "stale_leader",
+				message: `authority stale (owner: ${authority.owner ?? "unknown"}): ${authority.stale_reason ?? "unknown reason"}`,
+				severity: "fail",
+			});
+		}
+	}
 
-  const teamDirs: string[] = [];
-  if (existsSync(teamsRoot)) {
-    const entries = await readdir(teamsRoot, { withFileTypes: true });
-    for (const e of entries) {
-      if (e.isDirectory()) teamDirs.push(e.name);
-    }
-  }
+	const teamDirs: string[] = [];
+	if (existsSync(teamsRoot)) {
+		const entries = await readdir(teamsRoot, { withFileTypes: true });
+		for (const e of entries) {
+			if (e.isDirectory()) teamDirs.push(e.name);
+		}
+	}
 
-  const tmuxSessions = listTeamTmuxSessions();
-  const tmuxUnavailable = tmuxSessions === null;
-  const knownTeamSessions = new Set<string>();
+	const tmuxSessions = listTeamTmuxSessions();
+	const tmuxUnavailable = tmuxSessions === null;
+	const knownTeamSessions = new Set<string>();
 
-  for (const teamName of teamDirs) {
-    const teamDir = join(teamsRoot, teamName);
-    const manifestPath = join(teamDir, 'manifest.v2.json');
-    const configPath = join(teamDir, 'config.json');
+	for (const teamName of teamDirs) {
+		const teamDir = join(teamsRoot, teamName);
+		const manifestPath = join(teamDir, "manifest.v2.json");
+		const configPath = join(teamDir, "config.json");
 
-    let tmuxSession = `omx-team-${teamName}`;
-    if (existsSync(manifestPath)) {
-      try {
-        const raw = await readFile(manifestPath, 'utf-8');
-        const parsed = JSON.parse(raw) as { tmux_session?: string };
-        if (typeof parsed.tmux_session === 'string' && parsed.tmux_session.trim() !== '') {
-          tmuxSession = parsed.tmux_session;
-        }
-      } catch {
-        // ignore malformed manifest
-      }
-    } else if (existsSync(configPath)) {
-      try {
-        const raw = await readFile(configPath, 'utf-8');
-        const parsed = JSON.parse(raw) as { tmux_session?: string };
-        if (typeof parsed.tmux_session === 'string' && parsed.tmux_session.trim() !== '') {
-          tmuxSession = parsed.tmux_session;
-        }
-      } catch {
-        // ignore malformed config
-      }
-    }
+		let tmuxSession = `omx-team-${teamName}`;
+		if (existsSync(manifestPath)) {
+			try {
+				const raw = await readFile(manifestPath, "utf-8");
+				const parsed = JSON.parse(raw) as { tmux_session?: string };
+				if (
+					typeof parsed.tmux_session === "string" &&
+					parsed.tmux_session.trim() !== ""
+				) {
+					tmuxSession = parsed.tmux_session;
+				}
+			} catch {
+				// ignore malformed manifest
+			}
+		} else if (existsSync(configPath)) {
+			try {
+				const raw = await readFile(configPath, "utf-8");
+				const parsed = JSON.parse(raw) as { tmux_session?: string };
+				if (
+					typeof parsed.tmux_session === "string" &&
+					parsed.tmux_session.trim() !== ""
+				) {
+					tmuxSession = parsed.tmux_session;
+				}
+			} catch {
+				// ignore malformed config
+			}
+		}
 
-    knownTeamSessions.add(tmuxSession);
+		knownTeamSessions.add(tmuxSession);
 
-    // resume_blocker: only meaningful if tmux is available to query
-    if (!tmuxUnavailable && !tmuxSessions.has(tmuxSession)) {
-      issues.push({
-        code: 'resume_blocker',
-        message: `${teamName} references missing tmux session ${tmuxSession}`,
-        severity: 'fail',
-      });
-    }
+		// resume_blocker: only meaningful if tmux is available to query
+		if (!tmuxUnavailable && !tmuxSessions.has(tmuxSession)) {
+			issues.push({
+				code: "resume_blocker",
+				message: `${teamName} references missing tmux session ${tmuxSession}`,
+				severity: "fail",
+			});
+		}
 
-    // delayed_status_lag + slow_shutdown checks
-    const workersRoot = join(teamDir, 'workers');
-    if (!existsSync(workersRoot)) continue;
-    const workers = await readdir(workersRoot, { withFileTypes: true });
-    for (const worker of workers) {
-      if (!worker.isDirectory()) continue;
-      const workerDir = join(workersRoot, worker.name);
-      const statusPath = join(workerDir, 'status.json');
-      const heartbeatPath = join(workerDir, 'heartbeat.json');
-      const shutdownReqPath = join(workerDir, 'shutdown-request.json');
-      const shutdownAckPath = join(workerDir, 'shutdown-ack.json');
+		// delayed_status_lag + slow_shutdown checks
+		const workersRoot = join(teamDir, "workers");
+		if (!existsSync(workersRoot)) continue;
+		const workers = await readdir(workersRoot, { withFileTypes: true });
+		for (const worker of workers) {
+			if (!worker.isDirectory()) continue;
+			const workerDir = join(workersRoot, worker.name);
+			const statusPath = join(workerDir, "status.json");
+			const heartbeatPath = join(workerDir, "heartbeat.json");
+			const shutdownReqPath = join(workerDir, "shutdown-request.json");
+			const shutdownAckPath = join(workerDir, "shutdown-ack.json");
 
-      if (existsSync(statusPath) && existsSync(heartbeatPath)) {
-        try {
-          const [statusRaw, hbRaw] = await Promise.all([
-            readFile(statusPath, 'utf-8'),
-            readFile(heartbeatPath, 'utf-8'),
-          ]);
-          const status = JSON.parse(statusRaw) as { state?: string };
-          const hb = JSON.parse(hbRaw) as { last_turn_at?: string };
-          const lastTurnMs = hb.last_turn_at ? Date.parse(hb.last_turn_at) : NaN;
-          if (status.state === 'working' && Number.isFinite(lastTurnMs) && nowMs - lastTurnMs > lagThresholdMs) {
-            issues.push({
-              code: 'delayed_status_lag',
-              message: `${teamName}/${worker.name} working with stale heartbeat`,
-              severity: 'fail',
-            });
-          }
-        } catch {
-          // ignore malformed files
-        }
-      }
+			if (existsSync(statusPath) && existsSync(heartbeatPath)) {
+				try {
+					const [statusRaw, hbRaw] = await Promise.all([
+						readFile(statusPath, "utf-8"),
+						readFile(heartbeatPath, "utf-8"),
+					]);
+					const status = JSON.parse(statusRaw) as { state?: string };
+					const hb = JSON.parse(hbRaw) as { last_turn_at?: string };
+					const lastTurnMs = hb.last_turn_at
+						? Date.parse(hb.last_turn_at)
+						: NaN;
+					if (
+						status.state === "working" &&
+						Number.isFinite(lastTurnMs) &&
+						nowMs - lastTurnMs > lagThresholdMs
+					) {
+						issues.push({
+							code: "delayed_status_lag",
+							message: `${teamName}/${worker.name} working with stale heartbeat`,
+							severity: "fail",
+						});
+					}
+				} catch {
+					// ignore malformed files
+				}
+			}
 
-      if (existsSync(shutdownReqPath) && !existsSync(shutdownAckPath)) {
-        try {
-          const reqRaw = await readFile(shutdownReqPath, 'utf-8');
-          const req = JSON.parse(reqRaw) as { requested_at?: string };
-          const reqMs = req.requested_at ? Date.parse(req.requested_at) : NaN;
-          if (Number.isFinite(reqMs) && nowMs - reqMs > shutdownThresholdMs) {
-            issues.push({
-              code: 'slow_shutdown',
-              message: `${teamName}/${worker.name} has stale shutdown request without ack`,
-              severity: 'fail',
-            });
-          }
-        } catch {
-          // ignore malformed files
-        }
-      }
-    }
-  }
+			if (existsSync(shutdownReqPath) && !existsSync(shutdownAckPath)) {
+				try {
+					const reqRaw = await readFile(shutdownReqPath, "utf-8");
+					const req = JSON.parse(reqRaw) as { requested_at?: string };
+					const reqMs = req.requested_at ? Date.parse(req.requested_at) : NaN;
+					if (Number.isFinite(reqMs) && nowMs - reqMs > shutdownThresholdMs) {
+						issues.push({
+							code: "slow_shutdown",
+							message: `${teamName}/${worker.name} has stale shutdown request without ack`,
+							severity: "fail",
+						});
+					}
+				} catch {
+					// ignore malformed files
+				}
+			}
+		}
+	}
 
-  // stale_leader: team has active workers but leader has no recent activity
-  const hudStatePath = join(stateDir, 'hud-state.json');
-  const leaderActivityPath = join(stateDir, 'leader-runtime-activity.json');
-  if ((existsSync(hudStatePath) || existsSync(leaderActivityPath)) && teamDirs.length > 0) {
-    try {
-      const leaderIsStale = await isLeaderRuntimeStale(stateDir, leaderStaleThresholdMs, nowMs);
+	// stale_leader: team has active workers but leader has no recent activity
+	const hudStatePath = join(stateDir, "hud-state.json");
+	const leaderActivityPath = join(stateDir, "leader-runtime-activity.json");
+	if (
+		(existsSync(hudStatePath) || existsSync(leaderActivityPath)) &&
+		teamDirs.length > 0
+	) {
+		try {
+			const leaderIsStale = await isLeaderRuntimeStale(
+				stateDir,
+				leaderStaleThresholdMs,
+				nowMs,
+			);
 
-      if (leaderIsStale && !tmuxUnavailable) {
-        // Check if any team tmux session has live worker panes
-        for (const teamName of teamDirs) {
-          const session = knownTeamSessions.has(`omx-team-${teamName}`)
-            ? `omx-team-${teamName}`
-            : [...knownTeamSessions].find(s => s.includes(teamName));
-          if (!session || !tmuxSessions.has(session)) continue;
-          issues.push({
-            code: 'stale_leader',
-            message: `${teamName} has active tmux session but leader has no recent activity`,
-            severity: 'fail',
-          });
-        }
-      }
-    } catch {
-      // ignore malformed HUD state
-    }
-  }
+			if (leaderIsStale && !tmuxUnavailable) {
+				// Check if any team tmux session has live worker panes
+				for (const teamName of teamDirs) {
+					const session = knownTeamSessions.has(`omx-team-${teamName}`)
+						? `omx-team-${teamName}`
+						: [...knownTeamSessions].find((s) => s.includes(teamName));
+					if (!session || !tmuxSessions.has(session)) continue;
+					issues.push({
+						code: "stale_leader",
+						message: `${teamName} has active tmux session but leader has no recent activity`,
+						severity: "fail",
+					});
+				}
+			}
+		} catch {
+			// ignore malformed HUD state
+		}
+	}
 
-  // orphan_tmux_session: session exists but no matching team state
-  if (!tmuxUnavailable) {
-    for (const session of tmuxSessions) {
-      if (!knownTeamSessions.has(session)) {
-        issues.push({
-          code: 'orphan_tmux_session',
-          message: `${session} exists without matching team state (possibly external project)`,
-          severity: 'warn',
-        });
-      }
-    }
-  }
+	// orphan_tmux_session: session exists but no matching team state
+	if (!tmuxUnavailable) {
+		for (const session of tmuxSessions) {
+			if (!knownTeamSessions.has(session)) {
+				issues.push({
+					code: "orphan_tmux_session",
+					message: `${session} exists without matching team state (possibly external project)`,
+					severity: "warn",
+				});
+			}
+		}
+	}
 
-  return dedupeIssues(issues);
+	return dedupeIssues(issues);
 }
 
 function dedupeIssues(issues: TeamDoctorIssue[]): TeamDoctorIssue[] {
-  const seen = new Set<string>();
-  const out: TeamDoctorIssue[] = [];
-  for (const issue of issues) {
-    const key = `${issue.code}:${issue.message}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push(issue);
-  }
-  return out;
+	const seen = new Set<string>();
+	const out: TeamDoctorIssue[] = [];
+	for (const issue of issues) {
+		const key = `${issue.code}:${issue.message}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(issue);
+	}
+	return out;
 }
 
 function listTeamTmuxSessions(): Set<string> | null {
-  const { result: res } = spawnPlatformCommandSync('tmux', ['list-sessions', '-F', '#{session_name}'], { encoding: 'utf-8' });
-  if (res.error) {
-    // tmux binary unavailable or not executable.
-    return null;
-  }
+	const { result: res } = spawnPlatformCommandSync(
+		"tmux",
+		["list-sessions", "-F", "#{session_name}"],
+		{ encoding: "utf-8" },
+	);
+	if (res.error) {
+		// tmux binary unavailable or not executable.
+		return null;
+	}
 
-  if (res.status !== 0) {
-    const stderr = (res.stderr || '').toLowerCase();
-    // tmux installed but no server/session is running.
-    if (stderr.includes('no server running') || stderr.includes('failed to connect to server')) {
-      return new Set();
-    }
-    return null;
-  }
+	if (res.status !== 0) {
+		const stderr = (res.stderr || "").toLowerCase();
+		// tmux installed but no server/session is running.
+		if (
+			stderr.includes("no server running") ||
+			stderr.includes("failed to connect to server")
+		) {
+			return new Set();
+		}
+		return null;
+	}
 
-  const sessions = (res.stdout || '')
-    .split('\n')
-    .map((s) => s.trim())
-    .filter((s) => s.startsWith('omx-team-'));
-  return new Set(sessions);
+	const sessions = (res.stdout || "")
+		.split("\n")
+		.map((s) => s.trim())
+		.filter((s) => s.startsWith("omx-team-"));
+	return new Set(sessions);
 }
 
 function checkCodexCli(): Check {
-  const { result } = spawnPlatformCommandSync('codex', ['--version'], {
-    encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  if (result.error) {
-    const code = (result.error as NodeJS.ErrnoException).code;
-    const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
-    if (kind === 'missing') {
-      return { name: 'Codex CLI', status: 'fail', message: 'not found - install from https://github.com/openai/codex' };
-    }
-    if (kind === 'blocked') {
-      return {
-        name: 'Codex CLI',
-        status: 'fail',
-        message: `found but could not be executed in this environment (${code || 'blocked'})`,
-      };
-    }
-    return {
-      name: 'Codex CLI',
-      status: 'fail',
-      message: `probe failed - ${result.error.message}`,
-    };
-  }
-  if (result.status === 0) {
-    const version = (result.stdout || '').trim();
-    return { name: 'Codex CLI', status: 'pass', message: `installed (${version})` };
-  }
-  const stderr = (result.stderr || '').trim();
-  return {
-    name: 'Codex CLI',
-    status: 'fail',
-    message: stderr !== '' ? `probe failed - ${stderr}` : `probe failed with exit ${result.status}`,
-  };
+	const { result } = spawnPlatformCommandSync("codex", ["--version"], {
+		encoding: "utf-8",
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	if (result.error) {
+		const code = (result.error as NodeJS.ErrnoException).code;
+		const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
+		if (kind === "missing") {
+			return {
+				name: "Codex CLI",
+				status: "fail",
+				message: "not found - install from https://github.com/openai/codex",
+			};
+		}
+		if (kind === "blocked") {
+			return {
+				name: "Codex CLI",
+				status: "fail",
+				message: `found but could not be executed in this environment (${code || "blocked"})`,
+			};
+		}
+		return {
+			name: "Codex CLI",
+			status: "fail",
+			message: `probe failed - ${result.error.message}`,
+		};
+	}
+	if (result.status === 0) {
+		const version = (result.stdout || "").trim();
+		return {
+			name: "Codex CLI",
+			status: "pass",
+			message: `installed (${version})`,
+		};
+	}
+	const stderr = (result.stderr || "").trim();
+	return {
+		name: "Codex CLI",
+		status: "fail",
+		message:
+			stderr !== ""
+				? `probe failed - ${stderr}`
+				: `probe failed with exit ${result.status}`,
+	};
 }
 
 function checkNodeVersion(): Check {
-  const major = parseInt(process.versions.node.split('.')[0] ?? '0', 10);
-  if (isNaN(major)) {
-    return { name: 'Node.js', status: 'fail', message: `v${process.versions.node} (unable to parse major version)` };
-  }
-  if (major >= 20) {
-    return { name: 'Node.js', status: 'pass', message: `v${process.versions.node}` };
-  }
-  return { name: 'Node.js', status: 'fail', message: `v${process.versions.node} (need >= 20)` };
+	const major = parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+	if (isNaN(major)) {
+		return {
+			name: "Node.js",
+			status: "fail",
+			message: `v${process.versions.node} (unable to parse major version)`,
+		};
+	}
+	if (major >= 20) {
+		return {
+			name: "Node.js",
+			status: "pass",
+			message: `v${process.versions.node}`,
+		};
+	}
+	return {
+		name: "Node.js",
+		status: "fail",
+		message: `v${process.versions.node} (need >= 20)`,
+	};
 }
 
 function checkExploreHarness(): Check {
-  const packageRoot = getPackageRoot();
-  const manifestPath = join(packageRoot, 'crates', 'omx-explore', 'Cargo.toml');
-  if (!existsSync(manifestPath)) {
-    return {
-      name: 'Explore Harness',
-      status: 'warn',
-      message: 'Rust harness sources not found in this install (omx explore unavailable until packaged or OMX_EXPLORE_BIN is set)',
-    };
-  }
+	const packageRoot = getPackageRoot();
+	const manifestPath = join(packageRoot, "crates", "omx-explore", "Cargo.toml");
+	if (!existsSync(manifestPath)) {
+		return {
+			name: "Explore Harness",
+			status: "warn",
+			message:
+				"Rust harness sources not found in this install (omx explore unavailable until packaged or OMX_EXPLORE_BIN is set)",
+		};
+	}
 
-  const override = process.env[EXPLORE_BIN_ENV]?.trim();
-  if (override) {
-    const resolved = join(packageRoot, override);
-    if (existsSync(override) || existsSync(resolved)) {
-      return {
-        name: 'Explore Harness',
-        status: 'pass',
-        message: `${EXPLORE_BIN_ENV} configured (${override})`,
-      };
-    }
-    return {
-      name: 'Explore Harness',
-      status: 'warn',
-      message: `OMX_EXPLORE_BIN is set but path was not found (${override})`,
-    };
-  }
+	const override = process.env[EXPLORE_BIN_ENV]?.trim();
+	if (override) {
+		const resolved = join(packageRoot, override);
+		if (existsSync(override) || existsSync(resolved)) {
+			return {
+				name: "Explore Harness",
+				status: "pass",
+				message: `${EXPLORE_BIN_ENV} configured (${override})`,
+			};
+		}
+		return {
+			name: "Explore Harness",
+			status: "warn",
+			message: `OMX_EXPLORE_BIN is set but path was not found (${override})`,
+		};
+	}
 
-  const packaged = resolvePackagedExploreHarnessCommand(packageRoot);
-  if (packaged) {
-    return {
-      name: 'Explore Harness',
-      status: 'pass',
-      message: `ready (packaged native binary: ${packaged.command})`,
-    };
-  }
+	const packaged = resolvePackagedExploreHarnessCommand(packageRoot);
+	if (packaged) {
+		return {
+			name: "Explore Harness",
+			status: "pass",
+			message: `ready (packaged native binary: ${packaged.command})`,
+		};
+	}
 
-  const { result } = spawnPlatformCommandSync('cargo', ['--version'], {
-    encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  if (result.error) {
-    const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
-    if (kind === 'missing') {
-      return {
-        name: 'Explore Harness',
-        status: 'warn',
-        message: `Rust harness sources are packaged, but no compatible packaged prebuilt or cargo was found (install Rust or set ${EXPLORE_BIN_ENV} for omx explore)`,
-      };
-    }
-    return {
-      name: 'Explore Harness',
-      status: 'warn',
-      message: `Rust harness sources are packaged, but cargo probe failed (${result.error.message})`,
-    };
-  }
+	const { result } = spawnPlatformCommandSync("cargo", ["--version"], {
+		encoding: "utf-8",
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	if (result.error) {
+		const kind = classifySpawnError(result.error as NodeJS.ErrnoException);
+		if (kind === "missing") {
+			return {
+				name: "Explore Harness",
+				status: "warn",
+				message: `Rust harness sources are packaged, but no compatible packaged prebuilt or cargo was found (install Rust or set ${EXPLORE_BIN_ENV} for omx explore)`,
+			};
+		}
+		return {
+			name: "Explore Harness",
+			status: "warn",
+			message: `Rust harness sources are packaged, but cargo probe failed (${result.error.message})`,
+		};
+	}
 
-  if (result.status === 0) {
-    const version = (result.stdout || '').trim();
-    return {
-      name: 'Explore Harness',
-      status: 'pass',
-      message: `ready (${version || 'cargo available'})`,
-    };
-  }
+	if (result.status === 0) {
+		const version = (result.stdout || "").trim();
+		return {
+			name: "Explore Harness",
+			status: "pass",
+			message: `ready (${version || "cargo available"})`,
+		};
+	}
 
-  return {
-    name: 'Explore Harness',
-    status: 'warn',
-    message: `Rust harness sources are packaged, but cargo probe failed with exit ${result.status} (install Rust or set ${EXPLORE_BIN_ENV})`,
-  };
+	return {
+		name: "Explore Harness",
+		status: "warn",
+		message: `Rust harness sources are packaged, but cargo probe failed with exit ${result.status} (install Rust or set ${EXPLORE_BIN_ENV})`,
+	};
 }
 
 function checkDirectory(name: string, path: string): Check {
-  if (existsSync(path)) {
-    return { name, status: 'pass', message: path };
-  }
-  return { name, status: 'warn', message: `${path} (not created yet)` };
+	if (existsSync(path)) {
+		return { name, status: "pass", message: path };
+	}
+	return { name, status: "warn", message: `${path} (not created yet)` };
 }
 
 function validateToml(content: string): string | null {
-  try {
-    parseToml(content);
-    return null;
-  } catch (error) {
-    if (error instanceof Error) {
-      return error.message;
-    }
-    return 'unknown TOML parse error';
-  }
+	try {
+		parseToml(content);
+		return null;
+	} catch (error) {
+		if (error instanceof Error) {
+			return error.message;
+		}
+		return "unknown TOML parse error";
+	}
 }
 
 async function checkConfig(configPath: string): Promise<Check> {
-  if (!existsSync(configPath)) {
-    return { name: 'Config', status: 'warn', message: 'config.toml not found' };
-  }
+	if (!existsSync(configPath)) {
+		return { name: "Config", status: "warn", message: "config.toml not found" };
+	}
 
-  try {
-    const content = await readFile(configPath, 'utf-8');
-    const tomlError = validateToml(content);
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const tomlError = validateToml(content);
 
-    if (tomlError) {
-      const hint =
-        tomlError.includes("Can't redefine existing key") ||
-        tomlError.includes('duplicate') ||
-        tomlError.includes('[tui]')
-          ? 'possible duplicate TOML table such as [tui]'
-          : 'invalid TOML syntax';
+		if (tomlError) {
+			const hint =
+				tomlError.includes("Can't redefine existing key") ||
+				tomlError.includes("duplicate") ||
+				tomlError.includes("[tui]")
+					? "possible duplicate TOML table such as [tui]"
+					: "invalid TOML syntax";
 
-      return {
-        name: 'Config',
-        status: 'fail',
-        message: `invalid config.toml (${hint})`,
-      };
-    }
+			return {
+				name: "Config",
+				status: "fail",
+				message: `invalid config.toml (${hint})`,
+			};
+		}
 
-    const hasOmx = content.includes('omx_') || content.includes('oh-my-codex');
-    if (hasOmx) {
-      return { name: 'Config', status: 'pass', message: 'config.toml has OMX entries' };
-    }
+		if (hasLegacyOmxTeamRunTable(content)) {
+			return {
+				name: "Config",
+				status: "warn",
+				message:
+					'retired [mcp_servers.omx_team_run] table still present; run "omx setup --force" to repair the config',
+			};
+		}
 
-    return {
-      name: 'Config',
-      status: 'warn',
-      message: 'config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)',
-    };
-  } catch {
-    return { name: 'Config', status: 'fail', message: 'cannot read config.toml' };
-  }
+		const hasOmx = content.includes("omx_") || content.includes("oh-my-codex");
+		if (hasOmx) {
+			return {
+				name: "Config",
+				status: "pass",
+				message: "config.toml has OMX entries",
+			};
+		}
+
+		return {
+			name: "Config",
+			status: "warn",
+			message:
+				'config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)',
+		};
+	} catch {
+		return {
+			name: "Config",
+			status: "fail",
+			message: "cannot read config.toml",
+		};
+	}
 }
 
-
 async function checkExploreRouting(configPath: string): Promise<Check> {
-  const envValue = process.env[OMX_EXPLORE_CMD_ENV];
-  if (typeof envValue === 'string' && !isExploreCommandRoutingEnabled(process.env)) {
-    return {
-      name: 'Explore routing',
-      status: 'warn',
-      message:
-        'disabled by environment override; enable with USE_OMX_EXPLORE_CMD=1 (or remove the explicit opt-out)',
-    };
-  }
+	const envValue = process.env[OMX_EXPLORE_CMD_ENV];
+	if (
+		typeof envValue === "string" &&
+		!isExploreCommandRoutingEnabled(process.env)
+	) {
+		return {
+			name: "Explore routing",
+			status: "warn",
+			message:
+				"disabled by environment override; enable with USE_OMX_EXPLORE_CMD=1 (or remove the explicit opt-out)",
+		};
+	}
 
-  if (!existsSync(configPath)) {
-    return {
-      name: 'Explore routing',
-      status: 'pass',
-      message: 'enabled by default (config.toml not found yet)',
-    };
-  }
+	if (!existsSync(configPath)) {
+		return {
+			name: "Explore routing",
+			status: "pass",
+			message: "enabled by default (config.toml not found yet)",
+		};
+	}
 
-  try {
-    const content = await readFile(configPath, 'utf-8');
-    const parsed = parseToml(content) as { env?: Record<string, unknown> };
-    const configuredValue = parsed?.env?.USE_OMX_EXPLORE_CMD;
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const parsed = parseToml(content) as { env?: Record<string, unknown> };
+		const configuredValue = parsed?.env?.USE_OMX_EXPLORE_CMD;
 
-    if (
-      typeof configuredValue === 'string' &&
-      !isExploreCommandRoutingEnabled({
-        USE_OMX_EXPLORE_CMD: configuredValue,
-      })
-    ) {
-      return {
-        name: 'Explore routing',
-        status: 'warn',
-        message:
-          'disabled in config.toml [env]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing',
-      };
-    }
+		if (
+			typeof configuredValue === "string" &&
+			!isExploreCommandRoutingEnabled({
+				USE_OMX_EXPLORE_CMD: configuredValue,
+			})
+		) {
+			return {
+				name: "Explore routing",
+				status: "warn",
+				message:
+					'disabled in config.toml [env]; set USE_OMX_EXPLORE_CMD = "1" to restore default explore-first routing',
+			};
+		}
 
-    return {
-      name: 'Explore routing',
-      status: 'pass',
-      message: 'enabled by default',
-    };
-  } catch {
-    return {
-      name: 'Explore routing',
-      status: 'fail',
-      message: 'cannot read config.toml for explore routing check',
-    };
-  }
+		return {
+			name: "Explore routing",
+			status: "pass",
+			message: "enabled by default",
+		};
+	} catch {
+		return {
+			name: "Explore routing",
+			status: "fail",
+			message: "cannot read config.toml for explore routing check",
+		};
+	}
 }
 
 async function checkPrompts(dir: string): Promise<Check> {
-  const expectations = getCatalogExpectations();
-  if (!existsSync(dir)) {
-    return { name: 'Prompts', status: 'warn', message: 'prompts directory not found' };
-  }
-  try {
-    const files = await readdir(dir);
-    const mdFiles = files.filter(f => f.endsWith('.md'));
-    if (mdFiles.length >= expectations.promptMin) {
-      return { name: 'Prompts', status: 'pass', message: `${mdFiles.length} agent prompts installed` };
-    }
-    return { name: 'Prompts', status: 'warn', message: `${mdFiles.length} prompts (expected >= ${expectations.promptMin})` };
-  } catch {
-    return { name: 'Prompts', status: 'fail', message: 'cannot read prompts directory' };
-  }
+	const expectations = getCatalogExpectations();
+	if (!existsSync(dir)) {
+		return {
+			name: "Prompts",
+			status: "warn",
+			message: "prompts directory not found",
+		};
+	}
+	try {
+		const files = await readdir(dir);
+		const mdFiles = files.filter((f) => f.endsWith(".md"));
+		if (mdFiles.length >= expectations.promptMin) {
+			return {
+				name: "Prompts",
+				status: "pass",
+				message: `${mdFiles.length} agent prompts installed`,
+			};
+		}
+		return {
+			name: "Prompts",
+			status: "warn",
+			message: `${mdFiles.length} prompts (expected >= ${expectations.promptMin})`,
+		};
+	} catch {
+		return {
+			name: "Prompts",
+			status: "fail",
+			message: "cannot read prompts directory",
+		};
+	}
 }
 
 async function checkLegacySkillRootOverlap(): Promise<Check> {
-  const overlap = await detectLegacySkillRootOverlap();
-  if (!overlap.legacyExists) {
-    return {
-      name: 'Legacy skill roots',
-      status: 'pass',
-      message: 'no ~/.agents/skills overlap detected',
-    };
-  }
+	const overlap = await detectLegacySkillRootOverlap();
+	if (!overlap.legacyExists) {
+		return {
+			name: "Legacy skill roots",
+			status: "pass",
+			message: "no ~/.agents/skills overlap detected",
+		};
+	}
 
-  if (overlap.sameResolvedTarget) {
-    return {
-      name: 'Legacy skill roots',
-      status: 'pass',
-      message:
-        `~/.agents/skills links to canonical ${overlap.canonicalDir}; treating both paths as one shared skill root`,
-    };
-  }
+	if (overlap.sameResolvedTarget) {
+		return {
+			name: "Legacy skill roots",
+			status: "pass",
+			message: `~/.agents/skills links to canonical ${overlap.canonicalDir}; treating both paths as one shared skill root`,
+		};
+	}
 
-  if (overlap.overlappingSkillNames.length === 0) {
-    return {
-      name: 'Legacy skill roots',
-      status: 'warn',
-      message:
-        `legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}; remove or archive it if Codex shows duplicate entries`,
-    };
-  }
+	if (overlap.overlappingSkillNames.length === 0) {
+		return {
+			name: "Legacy skill roots",
+			status: "warn",
+			message: `legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}; remove or archive it if Codex shows duplicate entries`,
+		};
+	}
 
-  const mismatchMessage = overlap.mismatchedSkillNames.length > 0
-    ? `; ${overlap.mismatchedSkillNames.length} differ in SKILL.md content`
-    : '';
-  return {
-    name: 'Legacy skill roots',
-    status: 'warn',
-    message:
-      `${overlap.overlappingSkillNames.length} overlapping skill names between ${overlap.canonicalDir} and ${overlap.legacyDir}${mismatchMessage}; Codex Enable/Disable Skills may show duplicates until ~/.agents/skills is cleaned up`,
-  };
+	const mismatchMessage =
+		overlap.mismatchedSkillNames.length > 0
+			? `; ${overlap.mismatchedSkillNames.length} differ in SKILL.md content`
+			: "";
+	return {
+		name: "Legacy skill roots",
+		status: "warn",
+		message: `${overlap.overlappingSkillNames.length} overlapping skill names between ${overlap.canonicalDir} and ${overlap.legacyDir}${mismatchMessage}; Codex Enable/Disable Skills may show duplicates until ~/.agents/skills is cleaned up`,
+	};
 }
 
 async function checkSkills(dir: string): Promise<Check> {
-  const expectations = getCatalogExpectations();
-  if (!existsSync(dir)) {
-    return { name: 'Skills', status: 'warn', message: 'skills directory not found' };
-  }
-  try {
-    const entries = await readdir(dir, { withFileTypes: true });
-    const skillDirs = entries.filter(e => e.isDirectory());
-    if (skillDirs.length >= expectations.skillMin) {
-      return { name: 'Skills', status: 'pass', message: `${skillDirs.length} skills installed` };
-    }
-    return { name: 'Skills', status: 'warn', message: `${skillDirs.length} skills (expected >= ${expectations.skillMin})` };
-  } catch {
-    return { name: 'Skills', status: 'fail', message: 'cannot read skills directory' };
-  }
+	const expectations = getCatalogExpectations();
+	if (!existsSync(dir)) {
+		return {
+			name: "Skills",
+			status: "warn",
+			message: "skills directory not found",
+		};
+	}
+	try {
+		const entries = await readdir(dir, { withFileTypes: true });
+		const skillDirs = entries.filter((e) => e.isDirectory());
+		if (skillDirs.length >= expectations.skillMin) {
+			return {
+				name: "Skills",
+				status: "pass",
+				message: `${skillDirs.length} skills installed`,
+			};
+		}
+		return {
+			name: "Skills",
+			status: "warn",
+			message: `${skillDirs.length} skills (expected >= ${expectations.skillMin})`,
+		};
+	} catch {
+		return {
+			name: "Skills",
+			status: "fail",
+			message: "cannot read skills directory",
+		};
+	}
 }
 
 function checkAgentsMd(scope: DoctorSetupScope, codexHomeDir: string): Check {
-  if (scope === 'user') {
-    const userAgentsMd = join(codexHomeDir, 'AGENTS.md');
-    if (existsSync(userAgentsMd)) {
-      return { name: 'AGENTS.md', status: 'pass', message: `found in ${userAgentsMd}` };
-    }
-    return {
-      name: 'AGENTS.md',
-      status: 'warn',
-      message: `not found in ${userAgentsMd} (run omx setup --scope user)`,
-    };
-  }
+	if (scope === "user") {
+		const userAgentsMd = join(codexHomeDir, "AGENTS.md");
+		if (existsSync(userAgentsMd)) {
+			return {
+				name: "AGENTS.md",
+				status: "pass",
+				message: `found in ${userAgentsMd}`,
+			};
+		}
+		return {
+			name: "AGENTS.md",
+			status: "warn",
+			message: `not found in ${userAgentsMd} (run omx setup --scope user)`,
+		};
+	}
 
-  const projectAgentsMd = join(process.cwd(), 'AGENTS.md');
-  if (existsSync(projectAgentsMd)) {
-    return { name: 'AGENTS.md', status: 'pass', message: 'found in project root' };
-  }
-  return {
-    name: 'AGENTS.md',
-    status: 'warn',
-    message: 'not found in project root (run omx agents-init . or omx setup --scope project)',
-  };
+	const projectAgentsMd = join(process.cwd(), "AGENTS.md");
+	if (existsSync(projectAgentsMd)) {
+		return {
+			name: "AGENTS.md",
+			status: "pass",
+			message: "found in project root",
+		};
+	}
+	return {
+		name: "AGENTS.md",
+		status: "warn",
+		message:
+			"not found in project root (run omx agents-init . or omx setup --scope project)",
+	};
 }
 
 async function checkMcpServers(configPath: string): Promise<Check> {
-  if (!existsSync(configPath)) {
-    return { name: 'MCP Servers', status: 'warn', message: 'config.toml not found' };
-  }
-  try {
-    const content = await readFile(configPath, 'utf-8');
-    const mcpCount = (content.match(/\[mcp_servers\./g) || []).length;
-    if (mcpCount > 0) {
-      const hasOmx = content.includes('omx_state') || content.includes('omx_memory');
-      if (hasOmx) {
-        return { name: 'MCP Servers', status: 'pass', message: `${mcpCount} servers configured (OMX present)` };
-      }
-      return {
-        name: 'MCP Servers',
-        status: 'warn',
-        message: `${mcpCount} servers but no OMX servers yet (expected before first setup; run "omx setup --force" once)`,
-      };
-    }
-    return { name: 'MCP Servers', status: 'warn', message: 'no MCP servers configured' };
-  } catch {
-    return { name: 'MCP Servers', status: 'fail', message: 'cannot read config.toml' };
-  }
+	if (!existsSync(configPath)) {
+		return {
+			name: "MCP Servers",
+			status: "warn",
+			message: "config.toml not found",
+		};
+	}
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const mcpCount = (content.match(/\[mcp_servers\./g) || []).length;
+		if (mcpCount > 0) {
+			const hasOmx = hasSupportedOmxMcpServer(content);
+			if (hasOmx) {
+				return {
+					name: "MCP Servers",
+					status: "pass",
+					message: `${mcpCount} servers configured (OMX present)`,
+				};
+			}
+			if (hasLegacyOmxTeamRunTable(content)) {
+				return {
+					name: "MCP Servers",
+					status: "warn",
+					message: `${mcpCount} servers configured, but retired [mcp_servers.omx_team_run] is not supported; run "omx setup --force" to repair the config`,
+				};
+			}
+			return {
+				name: "MCP Servers",
+				status: "warn",
+				message: `${mcpCount} servers but no OMX servers yet (expected before first setup; run "omx setup --force" once)`,
+			};
+		}
+		return {
+			name: "MCP Servers",
+			status: "warn",
+			message: "no MCP servers configured",
+		};
+	} catch {
+		return {
+			name: "MCP Servers",
+			status: "fail",
+			message: "cannot read config.toml",
+		};
+	}
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -344,6 +344,16 @@ export function resolveCodexHomeForLaunch(
   return undefined;
 }
 
+export function resolveCodexConfigPathForLaunch(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
+  return codexHomeOverride
+    ? join(codexHomeOverride, "config.toml")
+    : codexConfigPath();
+}
+
 export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {
   let value: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
@@ -932,7 +942,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
   // TOML parser rejects duplicates, so we repair before spawning the CLI.
   try {
     const repaired = await repairConfigIfNeeded(
-      codexConfigPath(),
+      resolveCodexConfigPathForLaunch(launchCwd, process.env),
       getPackageRoot(),
     );
     if (repaired) {
@@ -1013,7 +1023,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
 
   try {
     const repaired = await repairConfigIfNeeded(
-      codexConfigPath(),
+      resolveCodexConfigPathForLaunch(launchCwd, process.env),
       getPackageRoot(),
     );
     if (repaired) {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -4,13 +4,13 @@
  */
 
 import {
-  mkdir,
-  copyFile,
-  readdir,
-  readFile,
-  writeFile,
-  stat,
-  rm,
+	mkdir,
+	copyFile,
+	readdir,
+	readFile,
+	writeFile,
+	stat,
+	rm,
 } from "fs/promises";
 import { join, dirname, relative } from "path";
 import { existsSync } from "fs";
@@ -18,24 +18,28 @@ import { spawnSync } from "child_process";
 import { createInterface } from "readline/promises";
 import { homedir } from "os";
 import {
-  codexHome,
-  codexConfigPath,
-  codexPromptsDir,
-  codexAgentsDir,
-  userSkillsDir,
-  omxStateDir,
-  detectLegacySkillRootOverlap,
-  omxPlansDir,
-  omxLogsDir,
+	codexHome,
+	codexConfigPath,
+	codexPromptsDir,
+	codexAgentsDir,
+	userSkillsDir,
+	omxStateDir,
+	detectLegacySkillRootOverlap,
+	omxPlansDir,
+	omxLogsDir,
 } from "../utils/paths.js";
-import { buildMergedConfig, getRootModelName } from "../config/generator.js";
+import {
+	buildMergedConfig,
+	getRootModelName,
+	hasLegacyOmxTeamRunTable,
+} from "../config/generator.js";
 import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
 import {
-  getLegacyUnifiedMcpRegistryCandidate,
-  getUnifiedMcpRegistryCandidates,
-  loadUnifiedMcpRegistry,
-  planClaudeCodeMcpSettingsSync,
-  type UnifiedMcpRegistryLoadResult,
+	getLegacyUnifiedMcpRegistryCandidate,
+	getUnifiedMcpRegistryCandidates,
+	loadUnifiedMcpRegistry,
+	planClaudeCodeMcpSettingsSync,
+	type UnifiedMcpRegistryLoadResult,
 } from "../config/mcp-registry.js";
 import { generateAgentToml } from "../agents/native-config.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
@@ -45,27 +49,27 @@ import { getCatalogHeadlineCounts } from "./catalog-contract.js";
 import { tryReadCatalogManifest } from "../catalog/reader.js";
 import { DEFAULT_FRONTIER_MODEL } from "../config/models.js";
 import {
-  addGeneratedAgentsMarker,
-  isOmxGeneratedAgentsMd,
+	addGeneratedAgentsMarker,
+	isOmxGeneratedAgentsMd,
 } from "../utils/agents-md.js";
 import {
-  resolveAgentsModelTableContext,
-  upsertAgentsModelTable,
+	resolveAgentsModelTableContext,
+	upsertAgentsModelTable,
 } from "../utils/agents-model-table.js";
 import { spawnPlatformCommandSync } from "../utils/platform-command.js";
 
 interface SetupOptions {
-  codexVersionProbe?: () => string | null;
-  force?: boolean;
-  dryRun?: boolean;
-  scope?: SetupScope;
-  verbose?: boolean;
-  agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
-  modelUpgradePrompt?: (
-    currentModel: string,
-    targetModel: string,
-  ) => Promise<boolean>;
-  mcpRegistryCandidates?: string[];
+	codexVersionProbe?: () => string | null;
+	force?: boolean;
+	dryRun?: boolean;
+	scope?: SetupScope;
+	verbose?: boolean;
+	agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
+	modelUpgradePrompt?: (
+		currentModel: string,
+		targetModel: string,
+	) => Promise<boolean>;
+	mcpRegistryCandidates?: string[];
 }
 
 /**
@@ -74,91 +78,92 @@ interface SetupOptions {
  * migrated to the current 'project' scope on read.
  */
 const LEGACY_SCOPE_MIGRATION: Record<string, "project"> = {
-  "project-local": "project",
+	"project-local": "project",
 };
 
 export const SETUP_SCOPES = ["user", "project"] as const;
 export type SetupScope = (typeof SETUP_SCOPES)[number];
 
 export interface ScopeDirectories {
-  codexConfigFile: string;
-  codexHomeDir: string;
-  codexHooksFile: string;
-  nativeAgentsDir: string;
-  promptsDir: string;
-  skillsDir: string;
+	codexConfigFile: string;
+	codexHomeDir: string;
+	codexHooksFile: string;
+	nativeAgentsDir: string;
+	promptsDir: string;
+	skillsDir: string;
 }
 
 interface SetupCategorySummary {
-  updated: number;
-  unchanged: number;
-  backedUp: number;
-  skipped: number;
-  removed: number;
+	updated: number;
+	unchanged: number;
+	backedUp: number;
+	skipped: number;
+	removed: number;
 }
 
 interface SetupRunSummary {
-  prompts: SetupCategorySummary;
-  skills: SetupCategorySummary;
-  nativeAgents: SetupCategorySummary;
-  agentsMd: SetupCategorySummary;
-  config: SetupCategorySummary;
+	prompts: SetupCategorySummary;
+	skills: SetupCategorySummary;
+	nativeAgents: SetupCategorySummary;
+	agentsMd: SetupCategorySummary;
+	config: SetupCategorySummary;
 }
 
 interface SetupBackupContext {
-  backupRoot: string;
-  baseRoot: string;
+	backupRoot: string;
+	baseRoot: string;
 }
 
 interface ManagedConfigResult {
-  finalConfig: string;
-  omxManagesTui: boolean;
+	finalConfig: string;
+	omxManagesTui: boolean;
+	repairedLegacyTeamRunTable: boolean;
 }
 
 interface LegacySkillOverlapNotice {
-  shouldWarn: boolean;
-  message: string;
+	shouldWarn: boolean;
+	message: string;
 }
 
 export interface SkillFrontmatterMetadata {
-  name: string;
-  description: string;
+	name: string;
+	description: string;
 }
 
 const PROJECT_GITIGNORE_ENTRIES = [
-  ".omx/",
-  ".codex/*",
-  "!.codex/agents/",
-  "!.codex/agents/**",
-  "!.codex/skills/",
-  "!.codex/skills/**",
-  ".codex/skills/.system/**",
-  "!.codex/prompts/",
-  "!.codex/prompts/**",
+	".omx/",
+	".codex/*",
+	"!.codex/agents/",
+	"!.codex/agents/**",
+	"!.codex/skills/",
+	"!.codex/skills/**",
+	".codex/skills/.system/**",
+	"!.codex/prompts/",
+	"!.codex/prompts/**",
 ] as const;
 const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
 
 function applyScopePathRewritesToAgentsTemplate(
-  content: string,
-  scope: SetupScope,
+	content: string,
+	scope: SetupScope,
 ): string {
-  if (scope !== "project") return content;
-  return content.replaceAll("~/.codex", "./.codex");
+	if (scope !== "project") return content;
+	return content.replaceAll("~/.codex", "./.codex");
 }
 
 interface PersistedSetupScope {
-  scope: SetupScope;
+	scope: SetupScope;
 }
 
 interface ResolvedSetupScope {
-  scope: SetupScope;
-  source: "cli" | "persisted" | "prompt" | "default";
+	scope: SetupScope;
+	source: "cli" | "persisted" | "prompt" | "default";
 }
 
 const REQUIRED_TEAM_CLI_API_MARKERS = [
-  "if (subcommand === 'api')",
-  "executeTeamApiOperation",
-  "TEAM_API_OPERATIONS",
+	"if (subcommand === 'api')",
+	"executeTeamApiOperation",
+	"TEAM_API_OPERATIONS",
 ] as const;
 
 const DEFAULT_SETUP_SCOPE: SetupScope = "user";
@@ -168,1553 +173,1583 @@ const OBSOLETE_NATIVE_AGENT_FIELD = ["skill", "ref"].join("_");
 const TUI_OWNED_BY_CODEX_VERSION = [0, 107, 0] as const;
 
 function createEmptyCategorySummary(): SetupCategorySummary {
-  return {
-    updated: 0,
-    unchanged: 0,
-    backedUp: 0,
-    skipped: 0,
-    removed: 0,
-  };
+	return {
+		updated: 0,
+		unchanged: 0,
+		backedUp: 0,
+		skipped: 0,
+		removed: 0,
+	};
 }
 
 function createEmptyRunSummary(): SetupRunSummary {
-  return {
-    prompts: createEmptyCategorySummary(),
-    skills: createEmptyCategorySummary(),
-    nativeAgents: createEmptyCategorySummary(),
-    agentsMd: createEmptyCategorySummary(),
-    config: createEmptyCategorySummary(),
-  };
+	return {
+		prompts: createEmptyCategorySummary(),
+		skills: createEmptyCategorySummary(),
+		nativeAgents: createEmptyCategorySummary(),
+		agentsMd: createEmptyCategorySummary(),
+		config: createEmptyCategorySummary(),
+	};
 }
 
 function getBackupContext(
-  scope: SetupScope,
-  projectRoot: string,
+	scope: SetupScope,
+	projectRoot: string,
 ): SetupBackupContext {
-  const timestamp = new Date().toISOString().replace(/[:]/g, "-");
-  if (scope === "project") {
-    return {
-      backupRoot: join(projectRoot, ".omx", "backups", "setup", timestamp),
-      baseRoot: projectRoot,
-    };
-  }
-  return {
-    backupRoot: join(homedir(), ".omx", "backups", "setup", timestamp),
-    baseRoot: homedir(),
-  };
+	const timestamp = new Date().toISOString().replace(/[:]/g, "-");
+	if (scope === "project") {
+		return {
+			backupRoot: join(projectRoot, ".omx", "backups", "setup", timestamp),
+			baseRoot: projectRoot,
+		};
+	}
+	return {
+		backupRoot: join(homedir(), ".omx", "backups", "setup", timestamp),
+		baseRoot: homedir(),
+	};
 }
 
 async function ensureBackup(
-  destinationPath: string,
-  contentChanged: boolean,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	destinationPath: string,
+	contentChanged: boolean,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<boolean> {
-  if (!contentChanged || !existsSync(destinationPath)) return false;
+	if (!contentChanged || !existsSync(destinationPath)) return false;
 
-  const relativePath = relative(backupContext.baseRoot, destinationPath);
-  const safeRelativePath =
-    relativePath.startsWith("..") || relativePath === ""
-      ? destinationPath.replace(/^[/]+/, "")
-      : relativePath;
-  const backupPath = join(backupContext.backupRoot, safeRelativePath);
+	const relativePath = relative(backupContext.baseRoot, destinationPath);
+	const safeRelativePath =
+		relativePath.startsWith("..") || relativePath === ""
+			? destinationPath.replace(/^[/]+/, "")
+			: relativePath;
+	const backupPath = join(backupContext.backupRoot, safeRelativePath);
 
-  if (!options.dryRun) {
-    await mkdir(dirname(backupPath), { recursive: true });
-    await copyFile(destinationPath, backupPath);
-  }
-  if (options.verbose) {
-    console.log(`  backup ${destinationPath} -> ${backupPath}`);
-  }
-  return true;
+	if (!options.dryRun) {
+		await mkdir(dirname(backupPath), { recursive: true });
+		await copyFile(destinationPath, backupPath);
+	}
+	if (options.verbose) {
+		console.log(`  backup ${destinationPath} -> ${backupPath}`);
+	}
+	return true;
 }
 
 async function filesDiffer(src: string, dst: string): Promise<boolean> {
-  if (!existsSync(dst)) return true;
-  const [srcContent, dstContent] = await Promise.all([
-    readFile(src, "utf-8"),
-    readFile(dst, "utf-8"),
-  ]);
-  return srcContent !== dstContent;
+	if (!existsSync(dst)) return true;
+	const [srcContent, dstContent] = await Promise.all([
+		readFile(src, "utf-8"),
+		readFile(dst, "utf-8"),
+	]);
+	return srcContent !== dstContent;
 }
 
 function containsTomlKey(content: string, key: string): boolean {
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^\\s*${escapedKey}\\s*=`, "m").test(content);
+	const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(`^\\s*${escapedKey}\\s*=`, "m").test(content);
 }
 
 function parseSkillFrontmatterScalar(
-  value: string,
-  key: string,
-  filePath: string,
+	value: string,
+	key: string,
+	filePath: string,
 ): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
-  }
-  if (trimmed === "|" || trimmed === ">") {
-    throw new Error(
-      `${filePath} frontmatter "${key}" must be a single-line string`,
-    );
-  }
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+	}
+	if (trimmed === "|" || trimmed === ">") {
+		throw new Error(
+			`${filePath} frontmatter "${key}" must be a single-line string`,
+		);
+	}
 
-  const quote = trimmed[0];
-  if (quote === '"' || quote === "'") {
-    if (trimmed.length < 2 || trimmed.at(-1) !== quote) {
-      throw new Error(
-        `${filePath} frontmatter "${key}" has an unterminated quoted string`,
-      );
-    }
-    const unquoted = trimmed.slice(1, -1).trim();
-    if (!unquoted) {
-      throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
-    }
-    return unquoted;
-  }
+	const quote = trimmed[0];
+	if (quote === '"' || quote === "'") {
+		if (trimmed.length < 2 || trimmed.at(-1) !== quote) {
+			throw new Error(
+				`${filePath} frontmatter "${key}" has an unterminated quoted string`,
+			);
+		}
+		const unquoted = trimmed.slice(1, -1).trim();
+		if (!unquoted) {
+			throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+		}
+		return unquoted;
+	}
 
-  const unquoted = trimmed.replace(/\s+#.*$/, "").trim();
-  if (!unquoted) {
-    throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
-  }
-  return unquoted;
+	const unquoted = trimmed.replace(/\s+#.*$/, "").trim();
+	if (!unquoted) {
+		throw new Error(`${filePath} frontmatter "${key}" must not be empty`);
+	}
+	return unquoted;
 }
 
 export function parseSkillFrontmatter(
-  content: string,
-  filePath = "SKILL.md",
+	content: string,
+	filePath = "SKILL.md",
 ): SkillFrontmatterMetadata {
-  const frontmatterMatch = content.match(
-    /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/,
-  );
-  if (!frontmatterMatch) {
-    throw new Error(
-      `${filePath} must start with YAML frontmatter containing non-empty name and description fields`,
-    );
-  }
+	const frontmatterMatch = content.match(
+		/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/,
+	);
+	if (!frontmatterMatch) {
+		throw new Error(
+			`${filePath} must start with YAML frontmatter containing non-empty name and description fields`,
+		);
+	}
 
-  let name: string | undefined;
-  let description: string | undefined;
-  const lines = frontmatterMatch[1].split(/\r?\n/);
+	let name: string | undefined;
+	let description: string | undefined;
+	const lines = frontmatterMatch[1].split(/\r?\n/);
 
-  for (const [index, rawLine] of lines.entries()) {
-    const line = rawLine.trimEnd();
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    if (/^\s/.test(rawLine)) continue;
+	for (const [index, rawLine] of lines.entries()) {
+		const line = rawLine.trimEnd();
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		if (/^\s/.test(rawLine)) continue;
 
-    const match = line.match(/^([A-Za-z0-9_-]+):(.*)$/);
-    if (!match) {
-      throw new Error(
-        `${filePath} has invalid YAML frontmatter on line ${index + 2}: ${trimmed}`,
-      );
-    }
+		const match = line.match(/^([A-Za-z0-9_-]+):(.*)$/);
+		if (!match) {
+			throw new Error(
+				`${filePath} has invalid YAML frontmatter on line ${index + 2}: ${trimmed}`,
+			);
+		}
 
-    const [, key, rawValue] = match;
-    if (!rawValue.trim()) continue;
+		const [, key, rawValue] = match;
+		if (!rawValue.trim()) continue;
 
-    const parsedValue = parseSkillFrontmatterScalar(rawValue, key, filePath);
-    if (key === "name") name = parsedValue;
-    if (key === "description") description = parsedValue;
-  }
+		const parsedValue = parseSkillFrontmatterScalar(rawValue, key, filePath);
+		if (key === "name") name = parsedValue;
+		if (key === "description") description = parsedValue;
+	}
 
-  if (!name) {
-    throw new Error(`${filePath} is missing a non-empty frontmatter "name"`);
-  }
-  if (!description) {
-    throw new Error(
-      `${filePath} is missing a non-empty frontmatter "description"`,
-    );
-  }
+	if (!name) {
+		throw new Error(`${filePath} is missing a non-empty frontmatter "name"`);
+	}
+	if (!description) {
+		throw new Error(
+			`${filePath} is missing a non-empty frontmatter "description"`,
+		);
+	}
 
-  return { name, description };
+	return { name, description };
 }
 
 export async function validateSkillFile(skillMdPath: string): Promise<void> {
-  const content = await readFile(skillMdPath, "utf-8");
-  parseSkillFrontmatter(content, skillMdPath);
+	const content = await readFile(skillMdPath, "utf-8");
+	parseSkillFrontmatter(content, skillMdPath);
 }
 
 async function buildLegacySkillOverlapNotice(
-  scope: SetupScope,
+	scope: SetupScope,
 ): Promise<LegacySkillOverlapNotice> {
-  if (scope !== "user") {
-    return { shouldWarn: false, message: "" };
-  }
+	if (scope !== "user") {
+		return { shouldWarn: false, message: "" };
+	}
 
-  const overlap = await detectLegacySkillRootOverlap();
-  if (!overlap.legacyExists) {
-    return { shouldWarn: false, message: "" };
-  }
+	const overlap = await detectLegacySkillRootOverlap();
+	if (!overlap.legacyExists) {
+		return { shouldWarn: false, message: "" };
+	}
 
-  if (overlap.overlappingSkillNames.length === 0) {
-    return {
-      shouldWarn: true,
-      message:
-        `Legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}. Codex may still discover both roots; archive or remove ~/.agents/skills if Enable/Disable Skills shows duplicates.`,
-    };
-  }
+	if (overlap.overlappingSkillNames.length === 0) {
+		return {
+			shouldWarn: true,
+			message: `Legacy ~/.agents/skills still exists (${overlap.legacySkillCount} skills) alongside canonical ${overlap.canonicalDir}. Codex may still discover both roots; archive or remove ~/.agents/skills if Enable/Disable Skills shows duplicates.`,
+		};
+	}
 
-  const mismatchSuffix = overlap.mismatchedSkillNames.length > 0
-    ? ` ${overlap.mismatchedSkillNames.length} overlapping skills have different SKILL.md content.`
-    : "";
-  return {
-    shouldWarn: true,
-    message:
-      `Detected ${overlap.overlappingSkillNames.length} overlapping skill names between canonical ${overlap.canonicalDir} and legacy ${overlap.legacyDir}.${mismatchSuffix} Remove or archive ~/.agents/skills after confirming ${overlap.canonicalDir} is the version you want Codex to load.`,
-  };
+	const mismatchSuffix =
+		overlap.mismatchedSkillNames.length > 0
+			? ` ${overlap.mismatchedSkillNames.length} overlapping skills have different SKILL.md content.`
+			: "";
+	return {
+		shouldWarn: true,
+		message: `Detected ${overlap.overlappingSkillNames.length} overlapping skill names between canonical ${overlap.canonicalDir} and legacy ${overlap.legacyDir}.${mismatchSuffix} Remove or archive ~/.agents/skills after confirming ${overlap.canonicalDir} is the version you want Codex to load.`,
+	};
 }
 
 function logCategorySummary(name: string, summary: SetupCategorySummary): void {
-  console.log(
-    `  ${name}: updated=${summary.updated}, unchanged=${summary.unchanged}, ` +
-      `backed_up=${summary.backedUp}, skipped=${summary.skipped}, removed=${summary.removed}`,
-  );
+	console.log(
+		`  ${name}: updated=${summary.updated}, unchanged=${summary.unchanged}, ` +
+			`backed_up=${summary.backedUp}, skipped=${summary.skipped}, removed=${summary.removed}`,
+	);
 }
 
 function isSetupScope(value: string): value is SetupScope {
-  return SETUP_SCOPES.includes(value as SetupScope);
+	return SETUP_SCOPES.includes(value as SetupScope);
 }
 function getScopeFilePath(projectRoot: string): string {
-  return join(projectRoot, ".omx", "setup-scope.json");
+	return join(projectRoot, ".omx", "setup-scope.json");
 }
 
 export function resolveScopeDirectories(
-  scope: SetupScope,
-  projectRoot: string,
+	scope: SetupScope,
+	projectRoot: string,
 ): ScopeDirectories {
-  if (scope === "project") {
-    const codexHomeDir = join(projectRoot, ".codex");
-    return {
-      codexConfigFile: join(codexHomeDir, "config.toml"),
-      codexHomeDir,
-      codexHooksFile: join(codexHomeDir, "hooks.json"),
-      nativeAgentsDir: join(codexHomeDir, "agents"),
-      promptsDir: join(codexHomeDir, "prompts"),
-      skillsDir: join(codexHomeDir, "skills"),
-    };
-  }
-  return {
-    codexConfigFile: codexConfigPath(),
-    codexHomeDir: codexHome(),
-    codexHooksFile: join(codexHome(), "hooks.json"),
-    nativeAgentsDir: codexAgentsDir(),
-    promptsDir: codexPromptsDir(),
-    skillsDir: userSkillsDir(),
-  };
+	if (scope === "project") {
+		const codexHomeDir = join(projectRoot, ".codex");
+		return {
+			codexConfigFile: join(codexHomeDir, "config.toml"),
+			codexHomeDir,
+			codexHooksFile: join(codexHomeDir, "hooks.json"),
+			nativeAgentsDir: join(codexHomeDir, "agents"),
+			promptsDir: join(codexHomeDir, "prompts"),
+			skillsDir: join(codexHomeDir, "skills"),
+		};
+	}
+	return {
+		codexConfigFile: codexConfigPath(),
+		codexHomeDir: codexHome(),
+		codexHooksFile: join(codexHome(), "hooks.json"),
+		nativeAgentsDir: codexAgentsDir(),
+		promptsDir: codexPromptsDir(),
+		skillsDir: userSkillsDir(),
+	};
 }
 
 async function readPersistedSetupPreferences(
-  projectRoot: string,
+	projectRoot: string,
 ): Promise<Partial<PersistedSetupScope> | undefined> {
-  const scopePath = getScopeFilePath(projectRoot);
-  if (!existsSync(scopePath)) return undefined;
-  try {
-    const raw = await readFile(scopePath, "utf-8");
-    const parsed = JSON.parse(raw) as Partial<PersistedSetupScope>;
-    const persisted: Partial<PersistedSetupScope> = {};
-    if (parsed && typeof parsed.scope === "string") {
-      // Direct match to current scopes
-      if (isSetupScope(parsed.scope)) {
-        persisted.scope = parsed.scope;
-      }
-      // Migrate legacy scope values (project-local → project)
-      const migrated = LEGACY_SCOPE_MIGRATION[parsed.scope];
-      if (migrated) {
-        console.warn(
-          `[omx] Migrating persisted setup scope "${parsed.scope}" → "${migrated}" ` +
-            `(see issue #243: simplified to user/project).`,
-        );
-        persisted.scope = migrated;
-      }
-    }
-    return Object.keys(persisted).length > 0 ? persisted : undefined;
-  } catch {
-    // ignore invalid persisted scope and fall back to prompt/default
-  }
-  return undefined;
+	const scopePath = getScopeFilePath(projectRoot);
+	if (!existsSync(scopePath)) return undefined;
+	try {
+		const raw = await readFile(scopePath, "utf-8");
+		const parsed = JSON.parse(raw) as Partial<PersistedSetupScope>;
+		const persisted: Partial<PersistedSetupScope> = {};
+		if (parsed && typeof parsed.scope === "string") {
+			// Direct match to current scopes
+			if (isSetupScope(parsed.scope)) {
+				persisted.scope = parsed.scope;
+			}
+			// Migrate legacy scope values (project-local → project)
+			const migrated = LEGACY_SCOPE_MIGRATION[parsed.scope];
+			if (migrated) {
+				console.warn(
+					`[omx] Migrating persisted setup scope "${parsed.scope}" → "${migrated}" ` +
+						`(see issue #243: simplified to user/project).`,
+				);
+				persisted.scope = migrated;
+			}
+		}
+		return Object.keys(persisted).length > 0 ? persisted : undefined;
+	} catch {
+		// ignore invalid persisted scope and fall back to prompt/default
+	}
+	return undefined;
 }
 
 async function promptForSetupScope(
-  defaultScope: SetupScope,
+	defaultScope: SetupScope,
 ): Promise<SetupScope> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return defaultScope;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    console.log("Select setup scope:");
-    console.log(
-      `  1) user (default) — installs to ~/.codex (skills default to ~/.codex/skills)`,
-    );
-    console.log("  2) project — installs to ./.codex (local to project)");
-    const answer = (await rl.question("Scope [1-2] (default: 1): "))
-      .trim()
-      .toLowerCase();
-    if (answer === "2" || answer === "project") return "project";
-    return defaultScope;
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return defaultScope;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		console.log("Select setup scope:");
+		console.log(
+			`  1) user (default) — installs to ~/.codex (skills default to ~/.codex/skills)`,
+		);
+		console.log("  2) project — installs to ./.codex (local to project)");
+		const answer = (await rl.question("Scope [1-2] (default: 1): "))
+			.trim()
+			.toLowerCase();
+		if (answer === "2" || answer === "project") return "project";
+		return defaultScope;
+	} finally {
+		rl.close();
+	}
 }
 
 async function promptForModelUpgrade(
-  currentModel: string,
-  targetModel: string,
+	currentModel: string,
+	targetModel: string,
 ): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return false;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const answer = (
-      await rl.question(
-        `Detected model "${currentModel}". Update to "${targetModel}"? [Y/n]: `,
-      )
-    )
-      .trim()
-      .toLowerCase();
-    return answer === "" || answer === "y" || answer === "yes";
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return false;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const answer = (
+			await rl.question(
+				`Detected model "${currentModel}". Update to "${targetModel}"? [Y/n]: `,
+			)
+		)
+			.trim()
+			.toLowerCase();
+		return answer === "" || answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
 }
 
 function parseSemverTriplet(version: string): [number, number, number] | null {
-  const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
-  if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
+	const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
+	if (!match) return null;
+	return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 function semverGte(
-  version: [number, number, number],
-  minimum: readonly [number, number, number],
+	version: [number, number, number],
+	minimum: readonly [number, number, number],
 ): boolean {
-  if (version[0] !== minimum[0]) return version[0] > minimum[0];
-  if (version[1] !== minimum[1]) return version[1] > minimum[1];
-  return version[2] >= minimum[2];
+	if (version[0] !== minimum[0]) return version[0] > minimum[0];
+	if (version[1] !== minimum[1]) return version[1] > minimum[1];
+	return version[2] >= minimum[2];
 }
 
 function probeInstalledCodexVersion(): string | null {
-  const { result } = spawnPlatformCommandSync("codex", ["--version"], {
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  if (result.error || result.status !== 0) return null;
-  const stdout = (result.stdout || "").trim();
-  return stdout === "" ? null : stdout;
+	const { result } = spawnPlatformCommandSync("codex", ["--version"], {
+		encoding: "utf-8",
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	if (result.error || result.status !== 0) return null;
+	const stdout = (result.stdout || "").trim();
+	return stdout === "" ? null : stdout;
 }
 
-function shouldOmxManageTuiFromCodexVersion(versionOutput: string | null): boolean {
-  if (!versionOutput) return true;
-  const parsed = parseSemverTriplet(versionOutput);
-  if (!parsed) return true;
-  return !semverGte(parsed, TUI_OWNED_BY_CODEX_VERSION);
+function shouldOmxManageTuiFromCodexVersion(
+	versionOutput: string | null,
+): boolean {
+	if (!versionOutput) return true;
+	const parsed = parseSemverTriplet(versionOutput);
+	if (!parsed) return true;
+	return !semverGte(parsed, TUI_OWNED_BY_CODEX_VERSION);
 }
 
 async function promptForAgentsOverwrite(
-  destinationPath: string,
+	destinationPath: string,
 ): Promise<boolean> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return false;
-  }
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const answer = (
-      await rl.question(
-        `Overwrite existing AGENTS.md at "${destinationPath}"? [y/N]: `,
-      )
-    )
-      .trim()
-      .toLowerCase();
-    return answer === "y" || answer === "yes";
-  } finally {
-    rl.close();
-  }
+	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return false;
+	}
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const answer = (
+			await rl.question(
+				`Overwrite existing AGENTS.md at "${destinationPath}"? [y/N]: `,
+			)
+		)
+			.trim()
+			.toLowerCase();
+		return answer === "y" || answer === "yes";
+	} finally {
+		rl.close();
+	}
 }
 
 async function resolveSetupScope(
-  projectRoot: string,
-  requestedScope?: SetupScope,
+	projectRoot: string,
+	requestedScope?: SetupScope,
 ): Promise<ResolvedSetupScope> {
-  if (requestedScope) {
-    return { scope: requestedScope, source: "cli" };
-  }
-  const persisted = await readPersistedSetupPreferences(projectRoot);
-  if (persisted?.scope) {
-    return { scope: persisted.scope, source: "persisted" };
-  }
-  if (process.stdin.isTTY && process.stdout.isTTY) {
-    const scope = await promptForSetupScope(DEFAULT_SETUP_SCOPE);
-    return { scope, source: "prompt" };
-  }
-  return { scope: DEFAULT_SETUP_SCOPE, source: "default" };
+	if (requestedScope) {
+		return { scope: requestedScope, source: "cli" };
+	}
+	const persisted = await readPersistedSetupPreferences(projectRoot);
+	if (persisted?.scope) {
+		return { scope: persisted.scope, source: "persisted" };
+	}
+	if (process.stdin.isTTY && process.stdout.isTTY) {
+		const scope = await promptForSetupScope(DEFAULT_SETUP_SCOPE);
+		return { scope, source: "prompt" };
+	}
+	return { scope: DEFAULT_SETUP_SCOPE, source: "default" };
 }
 
 function hasGitignoreEntry(content: string, entry: string): boolean {
-  return content
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .some((line) => line === entry);
+	return content
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.some((line) => line === entry);
 }
 
 function stripLegacyGitignoreEntries(
-  content: string,
-  legacyEntries: readonly string[],
+	content: string,
+	legacyEntries: readonly string[],
 ): { content: string; removed: boolean } {
-  const legacyEntrySet = new Set(legacyEntries);
-  const lines = content.split(/\r?\n/);
-  const filteredLines = lines.filter((line) => !legacyEntrySet.has(line.trim()));
-  const removed = filteredLines.length !== lines.length;
+	const legacyEntrySet = new Set(legacyEntries);
+	const lines = content.split(/\r?\n/);
+	const filteredLines = lines.filter(
+		(line) => !legacyEntrySet.has(line.trim()),
+	);
+	const removed = filteredLines.length !== lines.length;
 
-  return {
-    content: filteredLines.join("\n").replace(/\n+$/, "\n"),
-    removed,
-  };
+	return {
+		content: filteredLines.join("\n").replace(/\n+$/, "\n"),
+		removed,
+	};
 }
 
 async function ensureProjectGitignore(
-  projectRoot: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	projectRoot: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<"created" | "updated" | "unchanged"> {
-  const gitignorePath = join(projectRoot, ".gitignore");
-  const destinationExists = existsSync(gitignorePath);
-  const existing = destinationExists
-    ? await readFile(gitignorePath, "utf-8")
-    : "";
-  const normalized = stripLegacyGitignoreEntries(
-    existing,
-    LEGACY_PROJECT_GITIGNORE_ENTRIES,
-  );
+	const gitignorePath = join(projectRoot, ".gitignore");
+	const destinationExists = existsSync(gitignorePath);
+	const existing = destinationExists
+		? await readFile(gitignorePath, "utf-8")
+		: "";
+	const normalized = stripLegacyGitignoreEntries(
+		existing,
+		LEGACY_PROJECT_GITIGNORE_ENTRIES,
+	);
 
-  const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter(
-    (entry) => !hasGitignoreEntry(normalized.content, entry),
-  );
+	const missingEntries = PROJECT_GITIGNORE_ENTRIES.filter(
+		(entry) => !hasGitignoreEntry(normalized.content, entry),
+	);
 
-  if (missingEntries.length === 0 && !normalized.removed) {
-    return "unchanged";
-  }
+	if (missingEntries.length === 0 && !normalized.removed) {
+		return "unchanged";
+	}
 
-  const nextContent = destinationExists
-    ? `${normalized.content}${normalized.content.endsWith("\n") || normalized.content.length === 0 ? "" : "\n"}${missingEntries.join("\n")}${missingEntries.length > 0 ? "\n" : ""}`
-    : `${PROJECT_GITIGNORE_ENTRIES.join("\n")}\n`;
+	const nextContent = destinationExists
+		? `${normalized.content}${normalized.content.endsWith("\n") || normalized.content.length === 0 ? "" : "\n"}${missingEntries.join("\n")}${missingEntries.length > 0 ? "\n" : ""}`
+		: `${PROJECT_GITIGNORE_ENTRIES.join("\n")}\n`;
 
-  if (
-    await ensureBackup(gitignorePath, destinationExists, backupContext, options)
-  ) {
-    // backup created when refreshing a pre-existing .gitignore
-  }
+	if (
+		await ensureBackup(gitignorePath, destinationExists, backupContext, options)
+	) {
+		// backup created when refreshing a pre-existing .gitignore
+	}
 
-  if (!options.dryRun) {
-    await writeFile(gitignorePath, nextContent);
-  }
+	if (!options.dryRun) {
+		await writeFile(gitignorePath, nextContent);
+	}
 
-  if (options.verbose) {
-    const changedDetails = [
-      normalized.removed ? "removed legacy .codex/" : "",
-      missingEntries.length > 0 ? missingEntries.join(", ") : "",
-    ]
-      .filter(Boolean)
-      .join("; ");
-    console.log(
-      `  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore${changedDetails ? ` (${changedDetails})` : ""}`,
-    );
-  }
+	if (options.verbose) {
+		const changedDetails = [
+			normalized.removed ? "removed legacy .codex/" : "",
+			missingEntries.length > 0 ? missingEntries.join(", ") : "",
+		]
+			.filter(Boolean)
+			.join("; ");
+		console.log(
+			`  ${options.dryRun ? "would update" : destinationExists ? "updated" : "created"} .gitignore${changedDetails ? ` (${changedDetails})` : ""}`,
+		);
+	}
 
-  return destinationExists ? "updated" : "created";
+	return destinationExists ? "updated" : "created";
 }
 
 async function persistSetupScope(
-  projectRoot: string,
-  scope: SetupScope,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	projectRoot: string,
+	scope: SetupScope,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-  const scopePath = getScopeFilePath(projectRoot);
-  if (options.dryRun) {
-    if (options.verbose) console.log(`  dry-run: skip persisting ${scopePath}`);
-    return;
-  }
-  await mkdir(dirname(scopePath), { recursive: true });
-  const payload: PersistedSetupScope = { scope };
-  await writeFile(scopePath, JSON.stringify(payload, null, 2) + "\n");
-  if (options.verbose) console.log(`  Wrote ${scopePath}`);
+	const scopePath = getScopeFilePath(projectRoot);
+	if (options.dryRun) {
+		if (options.verbose) console.log(`  dry-run: skip persisting ${scopePath}`);
+		return;
+	}
+	await mkdir(dirname(scopePath), { recursive: true });
+	const payload: PersistedSetupScope = { scope };
+	await writeFile(scopePath, JSON.stringify(payload, null, 2) + "\n");
+	if (options.verbose) console.log(`  Wrote ${scopePath}`);
 }
 
 export async function setup(options: SetupOptions = {}): Promise<void> {
-  const {
-    force = false,
-    dryRun = false,
-    scope: requestedScope,
-    verbose = false,
-    modelUpgradePrompt,
-  } = options;
-  const pkgRoot = getPackageRoot();
-  const projectRoot = process.cwd();
-  const resolvedScope = await resolveSetupScope(projectRoot, requestedScope);
-  const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
-  const scopeSourceMessage =
-    resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
-  const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
+	const {
+		force = false,
+		dryRun = false,
+		scope: requestedScope,
+		verbose = false,
+		modelUpgradePrompt,
+	} = options;
+	const pkgRoot = getPackageRoot();
+	const projectRoot = process.cwd();
+	const resolvedScope = await resolveSetupScope(projectRoot, requestedScope);
+	const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
+	const scopeSourceMessage =
+		resolvedScope.source === "persisted" ? " (from .omx/setup-scope.json)" : "";
+	const backupContext = getBackupContext(resolvedScope.scope, projectRoot);
 
-  console.log("oh-my-codex setup");
-  console.log("=================\n");
-  console.log(
-    `Using setup scope: ${resolvedScope.scope}${scopeSourceMessage}\n`,
-  );
+	console.log("oh-my-codex setup");
+	console.log("=================\n");
+	console.log(
+		`Using setup scope: ${resolvedScope.scope}${scopeSourceMessage}\n`,
+	);
 
-  // Step 1: Ensure directories exist
-  console.log("[1/8] Creating directories...");
-  const dirs = [
-    scopeDirs.codexHomeDir,
-    scopeDirs.promptsDir,
-    scopeDirs.skillsDir,
-    scopeDirs.nativeAgentsDir,
-    omxStateDir(projectRoot),
-    omxPlansDir(projectRoot),
-    omxLogsDir(projectRoot),
-  ];
-  for (const dir of dirs) {
-    if (!dryRun) {
-      await mkdir(dir, { recursive: true });
-    }
-    if (verbose) console.log(`  mkdir ${dir}`);
-  }
-  await persistSetupScope(projectRoot, resolvedScope.scope, {
-    dryRun,
-    verbose,
-  });
-  console.log("  Done.\n");
+	// Step 1: Ensure directories exist
+	console.log("[1/8] Creating directories...");
+	const dirs = [
+		scopeDirs.codexHomeDir,
+		scopeDirs.promptsDir,
+		scopeDirs.skillsDir,
+		scopeDirs.nativeAgentsDir,
+		omxStateDir(projectRoot),
+		omxPlansDir(projectRoot),
+		omxLogsDir(projectRoot),
+	];
+	for (const dir of dirs) {
+		if (!dryRun) {
+			await mkdir(dir, { recursive: true });
+		}
+		if (verbose) console.log(`  mkdir ${dir}`);
+	}
+	await persistSetupScope(projectRoot, resolvedScope.scope, {
+		dryRun,
+		verbose,
+	});
+	console.log("  Done.\n");
 
-  if (resolvedScope.scope === "project") {
-    const gitignoreResult = await ensureProjectGitignore(
-      projectRoot,
-      backupContext,
-      { dryRun, verbose },
-    );
-    if (gitignoreResult === "created") {
-      console.log(
-        "  Created .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
-      );
-    } else if (gitignoreResult === "updated") {
-      console.log(
-        "  Updated .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
-      );
-    }
-  }
+	if (resolvedScope.scope === "project") {
+		const gitignoreResult = await ensureProjectGitignore(
+			projectRoot,
+			backupContext,
+			{ dryRun, verbose },
+		);
+		if (gitignoreResult === "created") {
+			console.log(
+				"  Created .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
+			);
+		} else if (gitignoreResult === "updated") {
+			console.log(
+				"  Updated .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
+			);
+		}
+	}
 
-  const catalogCounts = getCatalogHeadlineCounts();
-  const summary = createEmptyRunSummary();
+	const catalogCounts = getCatalogHeadlineCounts();
+	const summary = createEmptyRunSummary();
 
-  // Step 2: Install agent prompts
-  console.log("[2/8] Installing agent prompts...");
-  {
-    const promptsSrc = join(pkgRoot, "prompts");
-    const promptsDst = scopeDirs.promptsDir;
-    summary.prompts = await installPrompts(
-      promptsSrc,
-      promptsDst,
-      backupContext,
-      { force, dryRun, verbose },
-    );
-    const cleanedLegacyPromptShims = await cleanupLegacySkillPromptShims(
-      promptsSrc,
-      promptsDst,
-      {
-        dryRun,
-        verbose,
-      },
-    );
-    summary.prompts.removed += cleanedLegacyPromptShims;
-    if (cleanedLegacyPromptShims > 0) {
-      if (dryRun) {
-        console.log(
-          `  Would remove ${cleanedLegacyPromptShims} legacy skill prompt shim file(s).`,
-        );
-      } else {
-        console.log(
-          `  Removed ${cleanedLegacyPromptShims} legacy skill prompt shim file(s).`,
-        );
-      }
-    }
-    if (catalogCounts) {
-      console.log(
-        `  Prompt refresh complete (catalog baseline: ${catalogCounts.prompts}).\n`,
-      );
-    } else {
-      console.log("  Prompt refresh complete.\n");
-    }
-  }
+	// Step 2: Install agent prompts
+	console.log("[2/8] Installing agent prompts...");
+	{
+		const promptsSrc = join(pkgRoot, "prompts");
+		const promptsDst = scopeDirs.promptsDir;
+		summary.prompts = await installPrompts(
+			promptsSrc,
+			promptsDst,
+			backupContext,
+			{ force, dryRun, verbose },
+		);
+		const cleanedLegacyPromptShims = await cleanupLegacySkillPromptShims(
+			promptsSrc,
+			promptsDst,
+			{
+				dryRun,
+				verbose,
+			},
+		);
+		summary.prompts.removed += cleanedLegacyPromptShims;
+		if (cleanedLegacyPromptShims > 0) {
+			if (dryRun) {
+				console.log(
+					`  Would remove ${cleanedLegacyPromptShims} legacy skill prompt shim file(s).`,
+				);
+			} else {
+				console.log(
+					`  Removed ${cleanedLegacyPromptShims} legacy skill prompt shim file(s).`,
+				);
+			}
+		}
+		if (catalogCounts) {
+			console.log(
+				`  Prompt refresh complete (catalog baseline: ${catalogCounts.prompts}).\n`,
+			);
+		} else {
+			console.log("  Prompt refresh complete.\n");
+		}
+	}
 
-  // Step 3: Install skills
-  console.log("[3/8] Installing skills...");
-  {
-    const skillsSrc = join(pkgRoot, "skills");
-    const skillsDst = scopeDirs.skillsDir;
-    summary.skills = await installSkills(skillsSrc, skillsDst, backupContext, {
-      force,
-      dryRun,
-      verbose,
-    });
-    if (catalogCounts) {
-      console.log(
-        `  Skill refresh complete (catalog baseline: ${catalogCounts.skills}).\n`,
-      );
-    } else {
-      console.log("  Skill refresh complete.\n");
-    }
-  }
+	// Step 3: Install skills
+	console.log("[3/8] Installing skills...");
+	{
+		const skillsSrc = join(pkgRoot, "skills");
+		const skillsDst = scopeDirs.skillsDir;
+		summary.skills = await installSkills(skillsSrc, skillsDst, backupContext, {
+			force,
+			dryRun,
+			verbose,
+		});
+		if (catalogCounts) {
+			console.log(
+				`  Skill refresh complete (catalog baseline: ${catalogCounts.skills}).\n`,
+			);
+		} else {
+			console.log("  Skill refresh complete.\n");
+		}
+	}
 
-  // Step 4: Install native agent configs
-  console.log("[4/8] Installing native agent configs...");
-  {
-    summary.nativeAgents = await refreshNativeAgentConfigs(
-      pkgRoot,
-      scopeDirs.nativeAgentsDir,
-      backupContext,
-      {
-        force,
-        dryRun,
-        verbose,
-      },
-    );
-    console.log(
-      `  Native agent refresh complete (${scopeDirs.nativeAgentsDir}).\n`,
-    );
-  }
+	// Step 4: Install native agent configs
+	console.log("[4/8] Installing native agent configs...");
+	{
+		summary.nativeAgents = await refreshNativeAgentConfigs(
+			pkgRoot,
+			scopeDirs.nativeAgentsDir,
+			backupContext,
+			{
+				force,
+				dryRun,
+				verbose,
+			},
+		);
+		console.log(
+			`  Native agent refresh complete (${scopeDirs.nativeAgentsDir}).\n`,
+		);
+	}
 
-  // Step 5: Update config.toml
-  console.log("[5/8] Updating config.toml...");
-  const registryCandidates = getUnifiedMcpRegistryCandidates();
-  const defaultRegistryCandidates = registryCandidates.slice(0, 1);
-  const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
-  const sharedMcpRegistry = await loadUnifiedMcpRegistry({
-    candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
-  });
-  if (
-    !options.mcpRegistryCandidates &&
-    !sharedMcpRegistry.sourcePath &&
-    existsSync(legacyRegistryCandidate) &&
-    !existsSync(defaultRegistryCandidates[0])
-  ) {
-    console.log(
-      `  warning: legacy shared MCP registry detected at ${legacyRegistryCandidate} but ignored by default; move it to ${defaultRegistryCandidates[0]} if you still want setup to sync those servers`,
-    );
-  }
-  if (verbose && sharedMcpRegistry.sourcePath) {
-    console.log(
-      `  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
-    );
-  }
-  for (const warning of sharedMcpRegistry.warnings) {
-    console.log(`  warning: ${warning}`);
-  }
-  const managedConfig = await updateManagedConfig(
-    scopeDirs.codexConfigFile,
-    pkgRoot,
-    sharedMcpRegistry,
-    summary.config,
-    backupContext,
-    { codexVersionProbe: options.codexVersionProbe, dryRun, verbose, modelUpgradePrompt },
-  );
-  const resolvedConfig = managedConfig.finalConfig;
-  if (resolvedScope.scope === "user") {
-    await syncClaudeCodeMcpSettings(
-      sharedMcpRegistry,
-      summary.config,
-      backupContext,
-      { dryRun, verbose },
-    );
-  }
-  console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
+	// Step 5: Update config.toml
+	console.log("[5/8] Updating config.toml...");
+	const registryCandidates = getUnifiedMcpRegistryCandidates();
+	const defaultRegistryCandidates = registryCandidates.slice(0, 1);
+	const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
+	const sharedMcpRegistry = await loadUnifiedMcpRegistry({
+		candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
+	});
+	if (
+		!options.mcpRegistryCandidates &&
+		!sharedMcpRegistry.sourcePath &&
+		existsSync(legacyRegistryCandidate) &&
+		!existsSync(defaultRegistryCandidates[0])
+	) {
+		console.log(
+			`  warning: legacy shared MCP registry detected at ${legacyRegistryCandidate} but ignored by default; move it to ${defaultRegistryCandidates[0]} if you still want setup to sync those servers`,
+		);
+	}
+	if (verbose && sharedMcpRegistry.sourcePath) {
+		console.log(
+			`  shared MCP registry: ${sharedMcpRegistry.sourcePath} (${sharedMcpRegistry.servers.length} servers)`,
+		);
+	}
+	for (const warning of sharedMcpRegistry.warnings) {
+		console.log(`  warning: ${warning}`);
+	}
+	const managedConfig = await updateManagedConfig(
+		scopeDirs.codexConfigFile,
+		pkgRoot,
+		sharedMcpRegistry,
+		summary.config,
+		backupContext,
+		{
+			codexVersionProbe: options.codexVersionProbe,
+			dryRun,
+			verbose,
+			modelUpgradePrompt,
+		},
+	);
+	const resolvedConfig = managedConfig.finalConfig;
+	if (managedConfig.repairedLegacyTeamRunTable) {
+		console.log(
+			"  Removed retired [mcp_servers.omx_team_run] config during refresh.",
+		);
+	}
+	if (resolvedScope.scope === "user") {
+		await syncClaudeCodeMcpSettings(
+			sharedMcpRegistry,
+			summary.config,
+			backupContext,
+			{ dryRun, verbose },
+		);
+	}
+	console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
 
-  const existingHooksContent = existsSync(scopeDirs.codexHooksFile)
-    ? await readFile(scopeDirs.codexHooksFile, "utf-8")
-    : null;
-  const hooksConfig = mergeManagedCodexHooksConfig(
-    existingHooksContent,
-    pkgRoot,
-  );
-  await syncManagedContent(
-    hooksConfig,
-    scopeDirs.codexHooksFile,
-    summary.config,
-    backupContext,
-    { dryRun, verbose },
-    `native hooks ${scopeDirs.codexHooksFile}`,
-  );
-  console.log(
-    `  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
-  );
+	const existingHooksContent = existsSync(scopeDirs.codexHooksFile)
+		? await readFile(scopeDirs.codexHooksFile, "utf-8")
+		: null;
+	const hooksConfig = mergeManagedCodexHooksConfig(
+		existingHooksContent,
+		pkgRoot,
+	);
+	await syncManagedContent(
+		hooksConfig,
+		scopeDirs.codexHooksFile,
+		summary.config,
+		backupContext,
+		{ dryRun, verbose },
+		`native hooks ${scopeDirs.codexHooksFile}`,
+	);
+	console.log(
+		`  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
+	);
 
-  // Step 5.5: Verify team CLI interop surface is available.
-  console.log("[5.5/8] Verifying Team CLI API interop...");
-  const teamToolsCheck = await verifyTeamCliApiInterop(pkgRoot);
-  if (teamToolsCheck.ok) {
-    console.log("  omx team api command detected (CLI-first interop ready)");
-  } else {
-    console.log(`  WARNING: ${teamToolsCheck.message}`);
-    console.log("  Run `npm run build` and then re-run `omx setup`.");
-  }
-  console.log();
+	// Step 5.5: Verify team CLI interop surface is available.
+	console.log("[5.5/8] Verifying Team CLI API interop...");
+	const teamToolsCheck = await verifyTeamCliApiInterop(pkgRoot);
+	if (teamToolsCheck.ok) {
+		console.log("  omx team api command detected (CLI-first interop ready)");
+	} else {
+		console.log(`  WARNING: ${teamToolsCheck.message}`);
+		console.log("  Run `npm run build` and then re-run `omx setup`.");
+	}
+	console.log();
 
-  // Step 6: Generate AGENTS.md
-  console.log("[6/8] Generating AGENTS.md...");
-  const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
-  const agentsMdDst =
-    resolvedScope.scope === "project"
-      ? join(projectRoot, "AGENTS.md")
-      : join(scopeDirs.codexHomeDir, "AGENTS.md");
-  const agentsMdExists = existsSync(agentsMdDst);
+	// Step 6: Generate AGENTS.md
+	console.log("[6/8] Generating AGENTS.md...");
+	const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
+	const agentsMdDst =
+		resolvedScope.scope === "project"
+			? join(projectRoot, "AGENTS.md")
+			: join(scopeDirs.codexHomeDir, "AGENTS.md");
+	const agentsMdExists = existsSync(agentsMdDst);
 
-  // Guard: refuse to overwrite project-root AGENTS.md during active session
-  const activeSession =
-    resolvedScope.scope === "project"
-      ? await readSessionState(projectRoot)
-      : null;
-  const sessionIsActive = activeSession && !isSessionStale(activeSession);
+	// Guard: refuse to overwrite project-root AGENTS.md during active session
+	const activeSession =
+		resolvedScope.scope === "project"
+			? await readSessionState(projectRoot)
+			: null;
+	const sessionIsActive = activeSession && !isSessionStale(activeSession);
 
-  if (existsSync(agentsMdSrc)) {
-    const content = await readFile(agentsMdSrc, "utf-8");
-    const modelTableContext = resolveAgentsModelTableContext(resolvedConfig, {
-      codexHomeOverride: scopeDirs.codexHomeDir,
-    });
-    const rewritten = upsertAgentsModelTable(
-      addGeneratedAgentsMarker(
-        applyScopePathRewritesToAgentsTemplate(content, resolvedScope.scope),
-      ),
-      modelTableContext,
-    );
-    let changed = true;
-    let canApplyManagedModelRefresh = false;
-    let managedRefreshContent = "";
-    if (agentsMdExists) {
-      const existing = await readFile(agentsMdDst, "utf-8");
-      changed = existing !== rewritten;
-      if (isOmxGeneratedAgentsMd(existing)) {
-        managedRefreshContent = upsertAgentsModelTable(
-          existing,
-          modelTableContext,
-        );
-        canApplyManagedModelRefresh = managedRefreshContent !== existing;
-      }
-    }
+	if (existsSync(agentsMdSrc)) {
+		const content = await readFile(agentsMdSrc, "utf-8");
+		const modelTableContext = resolveAgentsModelTableContext(resolvedConfig, {
+			codexHomeOverride: scopeDirs.codexHomeDir,
+		});
+		const rewritten = upsertAgentsModelTable(
+			addGeneratedAgentsMarker(
+				applyScopePathRewritesToAgentsTemplate(content, resolvedScope.scope),
+			),
+			modelTableContext,
+		);
+		let changed = true;
+		let canApplyManagedModelRefresh = false;
+		let managedRefreshContent = "";
+		if (agentsMdExists) {
+			const existing = await readFile(agentsMdDst, "utf-8");
+			changed = existing !== rewritten;
+			if (isOmxGeneratedAgentsMd(existing)) {
+				managedRefreshContent = upsertAgentsModelTable(
+					existing,
+					modelTableContext,
+				);
+				canApplyManagedModelRefresh = managedRefreshContent !== existing;
+			}
+		}
 
-    if (
-      resolvedScope.scope === "project" &&
-      sessionIsActive &&
-      agentsMdExists &&
-      changed
-    ) {
-      summary.agentsMd.skipped += 1;
-      console.log(
-        "  WARNING: Active omx session detected (pid " +
-          activeSession?.pid +
-          ").",
-      );
-      console.log(
-        "  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
-      );
-      console.log("  Stop the active session first, then re-run setup.");
-    } else if (canApplyManagedModelRefresh) {
-      await syncManagedContent(
-        managedRefreshContent,
-        agentsMdDst,
-        summary.agentsMd,
-        backupContext,
-        { dryRun, verbose },
-        `AGENTS model table ${agentsMdDst}`,
-      );
-      console.log(
-        resolvedScope.scope === "project"
-          ? "  Refreshed AGENTS.md model capability table in project root."
-          : `  Refreshed AGENTS.md model capability table in ${scopeDirs.codexHomeDir}.`,
-      );
-    } else {
-      const result = await syncManagedAgentsContent(
-        rewritten,
-        agentsMdDst,
-        summary.agentsMd,
-        backupContext,
-        {
-          agentsOverwritePrompt: options.agentsOverwritePrompt,
-          dryRun,
-          force,
-          verbose,
-        },
-      );
+		if (
+			resolvedScope.scope === "project" &&
+			sessionIsActive &&
+			agentsMdExists &&
+			changed
+		) {
+			summary.agentsMd.skipped += 1;
+			console.log(
+				"  WARNING: Active omx session detected (pid " +
+					activeSession?.pid +
+					").",
+			);
+			console.log(
+				"  Skipping AGENTS.md overwrite to avoid corrupting runtime overlay.",
+			);
+			console.log("  Stop the active session first, then re-run setup.");
+		} else if (canApplyManagedModelRefresh) {
+			await syncManagedContent(
+				managedRefreshContent,
+				agentsMdDst,
+				summary.agentsMd,
+				backupContext,
+				{ dryRun, verbose },
+				`AGENTS model table ${agentsMdDst}`,
+			);
+			console.log(
+				resolvedScope.scope === "project"
+					? "  Refreshed AGENTS.md model capability table in project root."
+					: `  Refreshed AGENTS.md model capability table in ${scopeDirs.codexHomeDir}.`,
+			);
+		} else {
+			const result = await syncManagedAgentsContent(
+				rewritten,
+				agentsMdDst,
+				summary.agentsMd,
+				backupContext,
+				{
+					agentsOverwritePrompt: options.agentsOverwritePrompt,
+					dryRun,
+					force,
+					verbose,
+				},
+			);
 
-      if (result === "updated") {
-        console.log(
-          resolvedScope.scope === "project"
-            ? "  Generated AGENTS.md in project root."
-            : `  Generated AGENTS.md in ${scopeDirs.codexHomeDir}.`,
-        );
-      } else if (result === "unchanged") {
-        console.log(
-          resolvedScope.scope === "project"
-            ? "  AGENTS.md already up to date in project root."
-            : `  AGENTS.md already up to date in ${scopeDirs.codexHomeDir}.`,
-        );
-      } else if (agentsMdExists) {
-        console.log(
-          `  Skipped AGENTS.md overwrite for ${agentsMdDst}. Re-run interactively to confirm or use --force.`,
-        );
-      }
-    }
-    if (resolvedScope.scope === "user") {
-      console.log("  User scope leaves project AGENTS.md unchanged.");
-    }
-  } else {
-    summary.agentsMd.skipped += 1;
-    console.log("  AGENTS.md template not found, skipping.");
-  }
-  console.log();
+			if (result === "updated") {
+				console.log(
+					resolvedScope.scope === "project"
+						? "  Generated AGENTS.md in project root."
+						: `  Generated AGENTS.md in ${scopeDirs.codexHomeDir}.`,
+				);
+			} else if (result === "unchanged") {
+				console.log(
+					resolvedScope.scope === "project"
+						? "  AGENTS.md already up to date in project root."
+						: `  AGENTS.md already up to date in ${scopeDirs.codexHomeDir}.`,
+				);
+			} else if (agentsMdExists) {
+				console.log(
+					`  Skipped AGENTS.md overwrite for ${agentsMdDst}. Re-run interactively to confirm or use --force.`,
+				);
+			}
+		}
+		if (resolvedScope.scope === "user") {
+			console.log("  User scope leaves project AGENTS.md unchanged.");
+		}
+	} else {
+		summary.agentsMd.skipped += 1;
+		console.log("  AGENTS.md template not found, skipping.");
+	}
+	console.log();
 
-  // Step 7: Set up notify hook
-  console.log("[7/8] Configuring notification hook...");
-  await setupNotifyHook(pkgRoot, { dryRun, verbose });
-  console.log("  Done.\n");
+	// Step 7: Set up notify hook
+	console.log("[7/8] Configuring notification hook...");
+	await setupNotifyHook(pkgRoot, { dryRun, verbose });
+	console.log("  Done.\n");
 
-  // Step 8: Configure HUD
-  console.log("[8/8] Configuring HUD...");
-  const hudConfigPath = join(projectRoot, ".omx", "hud-config.json");
-  if (force || !existsSync(hudConfigPath)) {
-    if (!dryRun) {
-      const defaultHudConfig = { preset: "focused" };
-      await writeFile(hudConfigPath, JSON.stringify(defaultHudConfig, null, 2));
-    }
-    if (verbose) console.log("  Wrote .omx/hud-config.json");
-    console.log("  HUD config created (preset: focused).");
-  } else {
-    console.log("  HUD config already exists (use --force to overwrite).");
-  }
-  if (managedConfig.omxManagesTui) {
-    console.log("  StatusLine configured in config.toml via [tui] section.");
-  } else {
-    console.log("  Codex CLI >= 0.107.0 manages [tui]; OMX left that section untouched.");
-  }
-  console.log();
+	// Step 8: Configure HUD
+	console.log("[8/8] Configuring HUD...");
+	const hudConfigPath = join(projectRoot, ".omx", "hud-config.json");
+	if (force || !existsSync(hudConfigPath)) {
+		if (!dryRun) {
+			const defaultHudConfig = { preset: "focused" };
+			await writeFile(hudConfigPath, JSON.stringify(defaultHudConfig, null, 2));
+		}
+		if (verbose) console.log("  Wrote .omx/hud-config.json");
+		console.log("  HUD config created (preset: focused).");
+	} else {
+		console.log("  HUD config already exists (use --force to overwrite).");
+	}
+	if (managedConfig.omxManagesTui) {
+		console.log("  StatusLine configured in config.toml via [tui] section.");
+	} else {
+		console.log(
+			"  Codex CLI >= 0.107.0 manages [tui]; OMX left that section untouched.",
+		);
+	}
+	console.log();
 
-  console.log("Setup refresh summary:");
-  logCategorySummary("prompts", summary.prompts);
-  logCategorySummary("skills", summary.skills);
-  logCategorySummary("native_agents", summary.nativeAgents);
-  logCategorySummary("agents_md", summary.agentsMd);
-  logCategorySummary("config", summary.config);
-  console.log();
+	console.log("Setup refresh summary:");
+	logCategorySummary("prompts", summary.prompts);
+	logCategorySummary("skills", summary.skills);
+	logCategorySummary("native_agents", summary.nativeAgents);
+	logCategorySummary("agents_md", summary.agentsMd);
+	logCategorySummary("config", summary.config);
+	console.log();
 
-  const legacySkillOverlapNotice = await buildLegacySkillOverlapNotice(resolvedScope.scope);
-  if (legacySkillOverlapNotice.shouldWarn) {
-    console.log(`Migration hint: ${legacySkillOverlapNotice.message}`);
-    console.log();
-  }
+	const legacySkillOverlapNotice = await buildLegacySkillOverlapNotice(
+		resolvedScope.scope,
+	);
+	if (legacySkillOverlapNotice.shouldWarn) {
+		console.log(`Migration hint: ${legacySkillOverlapNotice.message}`);
+		console.log();
+	}
 
-  if (force) {
-    console.log(
-      "Force mode: enabled additional destructive maintenance (for example stale deprecated skill cleanup).",
-    );
-    console.log();
-  }
+	if (force) {
+		console.log(
+			"Force mode: enabled additional destructive maintenance (for example stale deprecated skill cleanup).",
+		);
+		console.log();
+	}
 
-  console.log('Setup complete! Run "omx doctor" to verify installation.');
-  console.log("\nNext steps:");
-  console.log("  1. Start Codex CLI in your project directory");
-  console.log(
-    "  2. Use role/workflow keywords like $architect, $executor, and $plan in Codex",
-  );
-  console.log("  3. Browse skills with /skills; AGENTS keyword routing can also activate them implicitly");
-  console.log("  4. The AGENTS.md orchestration brain is loaded automatically");
-  console.log(
-    "  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/",
-  );
-  console.log(
-    '  6. "omx explore" and "omx sparkshell" can hydrate native release binaries on first use; source installs still allow repo-local fallbacks and OMX_EXPLORE_BIN / OMX_SPARKSHELL_BIN overrides',
-  );
-  if (isGitHubCliConfigured()) {
-    console.log("\nSupport the project: gh repo star Yeachan-Heo/oh-my-codex");
-  }
+	console.log('Setup complete! Run "omx doctor" to verify installation.');
+	console.log("\nNext steps:");
+	console.log("  1. Start Codex CLI in your project directory");
+	console.log(
+		"  2. Use role/workflow keywords like $architect, $executor, and $plan in Codex",
+	);
+	console.log(
+		"  3. Browse skills with /skills; AGENTS keyword routing can also activate them implicitly",
+	);
+	console.log("  4. The AGENTS.md orchestration brain is loaded automatically");
+	console.log(
+		"  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/",
+	);
+	console.log(
+		'  6. "omx explore" and "omx sparkshell" can hydrate native release binaries on first use; source installs still allow repo-local fallbacks and OMX_EXPLORE_BIN / OMX_SPARKSHELL_BIN overrides',
+	);
+	if (isGitHubCliConfigured()) {
+		console.log("\nSupport the project: gh repo star Yeachan-Heo/oh-my-codex");
+	}
 }
 
 function isLegacySkillPromptShim(content: string): boolean {
-  const marker =
-    /Read and follow the full skill instructions at\s+.*\/skills\/[^/\s]+\/SKILL\.md/i;
-  return marker.test(content);
+	const marker =
+		/Read and follow the full skill instructions at\s+.*\/skills\/[^/\s]+\/SKILL\.md/i;
+	return marker.test(content);
 }
 
 async function cleanupLegacySkillPromptShims(
-  promptsSrcDir: string,
-  promptsDstDir: string,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	promptsSrcDir: string,
+	promptsDstDir: string,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<number> {
-  if (!existsSync(promptsSrcDir) || !existsSync(promptsDstDir)) return 0;
+	if (!existsSync(promptsSrcDir) || !existsSync(promptsDstDir)) return 0;
 
-  const sourceFiles = new Set(
-    (await readdir(promptsSrcDir)).filter((name) => name.endsWith(".md")),
-  );
+	const sourceFiles = new Set(
+		(await readdir(promptsSrcDir)).filter((name) => name.endsWith(".md")),
+	);
 
-  const installedFiles = await readdir(promptsDstDir);
-  let removed = 0;
+	const installedFiles = await readdir(promptsDstDir);
+	let removed = 0;
 
-  for (const file of installedFiles) {
-    if (!file.endsWith(".md")) continue;
-    if (sourceFiles.has(file)) continue;
+	for (const file of installedFiles) {
+		if (!file.endsWith(".md")) continue;
+		if (sourceFiles.has(file)) continue;
 
-    const fullPath = join(promptsDstDir, file);
-    let content = "";
-    try {
-      content = await readFile(fullPath, "utf-8");
-    } catch {
-      continue;
-    }
+		const fullPath = join(promptsDstDir, file);
+		let content = "";
+		try {
+			content = await readFile(fullPath, "utf-8");
+		} catch {
+			continue;
+		}
 
-    if (!isLegacySkillPromptShim(content)) continue;
+		if (!isLegacySkillPromptShim(content)) continue;
 
-    if (!options.dryRun) {
-      await rm(fullPath, { force: true });
-    }
-    if (options.verbose) console.log(`  removed legacy prompt shim ${file}`);
-    removed++;
-  }
+		if (!options.dryRun) {
+			await rm(fullPath, { force: true });
+		}
+		if (options.verbose) console.log(`  removed legacy prompt shim ${file}`);
+		removed++;
+	}
 
-  return removed;
+	return removed;
 }
 
 function isGitHubCliConfigured(): boolean {
-  const result = spawnSync("gh", ["auth", "status"], { stdio: "ignore",
-      windowsHide: true,
-    });
-  return result.status === 0;
+	const result = spawnSync("gh", ["auth", "status"], {
+		stdio: "ignore",
+		windowsHide: true,
+	});
+	return result.status === 0;
 }
 
 async function syncManagedFileFromDisk(
-  srcPath: string,
-  dstPath: string,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
-  verboseLabel: string,
+	srcPath: string,
+	dstPath: string,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	verboseLabel: string,
 ): Promise<void> {
-  const destinationExists = existsSync(dstPath);
-  const changed = !destinationExists || (await filesDiffer(srcPath, dstPath));
+	const destinationExists = existsSync(dstPath);
+	const changed = !destinationExists || (await filesDiffer(srcPath, dstPath));
 
-  if (!changed) {
-    summary.unchanged += 1;
-    return;
-  }
+	if (!changed) {
+		summary.unchanged += 1;
+		return;
+	}
 
-  if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
-    summary.backedUp += 1;
-  }
+	if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
+		summary.backedUp += 1;
+	}
 
-  if (!options.dryRun) {
-    await mkdir(dirname(dstPath), { recursive: true });
-    await copyFile(srcPath, dstPath);
-  }
+	if (!options.dryRun) {
+		await mkdir(dirname(dstPath), { recursive: true });
+		await copyFile(srcPath, dstPath);
+	}
 
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
-    );
-  }
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
+		);
+	}
 }
 
 async function syncManagedContent(
-  content: string,
-  dstPath: string,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
-  verboseLabel: string,
+	content: string,
+	dstPath: string,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	verboseLabel: string,
 ): Promise<void> {
-  const destinationExists = existsSync(dstPath);
-  let changed = true;
-  if (destinationExists) {
-    const existing = await readFile(dstPath, "utf-8");
-    changed = existing !== content;
-  }
+	const destinationExists = existsSync(dstPath);
+	let changed = true;
+	if (destinationExists) {
+		const existing = await readFile(dstPath, "utf-8");
+		changed = existing !== content;
+	}
 
-  if (!changed) {
-    summary.unchanged += 1;
-    return;
-  }
+	if (!changed) {
+		summary.unchanged += 1;
+		return;
+	}
 
-  if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
-    summary.backedUp += 1;
-  }
+	if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
+		summary.backedUp += 1;
+	}
 
-  if (!options.dryRun) {
-    await mkdir(dirname(dstPath), { recursive: true });
-    await writeFile(dstPath, content);
-  }
+	if (!options.dryRun) {
+		await mkdir(dirname(dstPath), { recursive: true });
+		await writeFile(dstPath, content);
+	}
 
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
-    );
-  }
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
+		);
+	}
 }
 
 async function syncManagedAgentsContent(
-  content: string,
-  dstPath: string,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<
-    SetupOptions,
-    "agentsOverwritePrompt" | "dryRun" | "force" | "verbose"
-  >,
+	content: string,
+	dstPath: string,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<
+		SetupOptions,
+		"agentsOverwritePrompt" | "dryRun" | "force" | "verbose"
+	>,
 ): Promise<"updated" | "unchanged" | "skipped"> {
-  const destinationExists = existsSync(dstPath);
-  let existing = "";
-  let changed = true;
+	const destinationExists = existsSync(dstPath);
+	let existing = "";
+	let changed = true;
 
-  if (destinationExists) {
-    existing = await readFile(dstPath, "utf-8");
-    changed = existing !== content;
-  }
+	if (destinationExists) {
+		existing = await readFile(dstPath, "utf-8");
+		changed = existing !== content;
+	}
 
-  if (!changed) {
-    summary.unchanged += 1;
-    return "unchanged";
-  }
+	if (!changed) {
+		summary.unchanged += 1;
+		return "unchanged";
+	}
 
-  if (destinationExists && !options.force) {
-    if (options.dryRun) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        console.log(`  would prompt before overwriting ${dstPath}`);
-      }
-      return "skipped";
-    }
+	if (destinationExists && !options.force) {
+		if (options.dryRun) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				console.log(`  would prompt before overwriting ${dstPath}`);
+			}
+			return "skipped";
+		}
 
-    const shouldOverwrite = options.agentsOverwritePrompt
-      ? await options.agentsOverwritePrompt(dstPath)
-      : await promptForAgentsOverwrite(dstPath);
+		const shouldOverwrite = options.agentsOverwritePrompt
+			? await options.agentsOverwritePrompt(dstPath)
+			: await promptForAgentsOverwrite(dstPath);
 
-    if (!shouldOverwrite) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        const managedLabel = isOmxGeneratedAgentsMd(existing)
-          ? "managed"
-          : "unmanaged";
-        console.log(`  skipped ${managedLabel} AGENTS.md at ${dstPath}`);
-      }
-      return "skipped";
-    }
-  }
+		if (!shouldOverwrite) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				const managedLabel = isOmxGeneratedAgentsMd(existing)
+					? "managed"
+					: "unmanaged";
+				console.log(`  skipped ${managedLabel} AGENTS.md at ${dstPath}`);
+			}
+			return "skipped";
+		}
+	}
 
-  if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
-    summary.backedUp += 1;
-  }
+	if (await ensureBackup(dstPath, destinationExists, backupContext, options)) {
+		summary.backedUp += 1;
+	}
 
-  if (!options.dryRun) {
-    await mkdir(dirname(dstPath), { recursive: true });
-    await writeFile(dstPath, content);
-  }
+	if (!options.dryRun) {
+		await mkdir(dirname(dstPath), { recursive: true });
+		await writeFile(dstPath, content);
+	}
 
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} AGENTS ${dstPath}`,
-    );
-  }
-  return "updated";
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} AGENTS ${dstPath}`,
+		);
+	}
+	return "updated";
 }
 
 async function installPrompts(
-  srcDir: string,
-  dstDir: string,
-  backupContext: SetupBackupContext,
-  options: SetupOptions,
+	srcDir: string,
+	dstDir: string,
+	backupContext: SetupBackupContext,
+	options: SetupOptions,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
-  if (!existsSync(srcDir)) return summary;
+	const summary = createEmptyCategorySummary();
+	if (!existsSync(srcDir)) return summary;
 
-  const manifest = tryReadCatalogManifest();
-  const agentStatusByName = manifest
-    ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
-    : null;
-  const isInstallableStatus = (status: string | undefined): boolean =>
-    status === "active" || status === "internal";
+	const manifest = tryReadCatalogManifest();
+	const agentStatusByName = manifest
+		? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
+		: null;
+	const isInstallableStatus = (status: string | undefined): boolean =>
+		status === "active" || status === "internal";
 
-  const files = await readdir(srcDir);
-  const staleCandidatePromptNames = new Set(
-    manifest?.agents.map((agent) => agent.name) ?? [],
-  );
+	const files = await readdir(srcDir);
+	const staleCandidatePromptNames = new Set(
+		manifest?.agents.map((agent) => agent.name) ?? [],
+	);
 
-  for (const file of files) {
-    if (!file.endsWith(".md")) continue;
-    const promptName = file.slice(0, -3);
-    staleCandidatePromptNames.add(promptName);
+	for (const file of files) {
+		if (!file.endsWith(".md")) continue;
+		const promptName = file.slice(0, -3);
+		staleCandidatePromptNames.add(promptName);
 
-    const status = agentStatusByName?.get(promptName);
-    if (agentStatusByName && !isInstallableStatus(status)) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        const label = status ?? "unlisted";
-        console.log(`  skipped ${file} (status: ${label})`);
-      }
-      continue;
-    }
+		const status = agentStatusByName?.get(promptName);
+		if (agentStatusByName && !isInstallableStatus(status)) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				const label = status ?? "unlisted";
+				console.log(`  skipped ${file} (status: ${label})`);
+			}
+			continue;
+		}
 
-    const src = join(srcDir, file);
-    const dst = join(dstDir, file);
-    const srcStat = await stat(src);
-    if (!srcStat.isFile()) continue;
-    await syncManagedFileFromDisk(
-      src,
-      dst,
-      summary,
-      backupContext,
-      options,
-      `prompt ${file}`,
-    );
-  }
+		const src = join(srcDir, file);
+		const dst = join(dstDir, file);
+		const srcStat = await stat(src);
+		if (!srcStat.isFile()) continue;
+		await syncManagedFileFromDisk(
+			src,
+			dst,
+			summary,
+			backupContext,
+			options,
+			`prompt ${file}`,
+		);
+	}
 
-  if (options.force && manifest && existsSync(dstDir)) {
-    const installedFiles = await readdir(dstDir);
-    for (const file of installedFiles) {
-      if (!file.endsWith(".md")) continue;
-      const promptName = file.slice(0, -3);
-      const status = agentStatusByName?.get(promptName);
-      if (isInstallableStatus(status)) continue;
-      if (!staleCandidatePromptNames.has(promptName) && status === undefined)
-        continue;
+	if (options.force && manifest && existsSync(dstDir)) {
+		const installedFiles = await readdir(dstDir);
+		for (const file of installedFiles) {
+			if (!file.endsWith(".md")) continue;
+			const promptName = file.slice(0, -3);
+			const status = agentStatusByName?.get(promptName);
+			if (isInstallableStatus(status)) continue;
+			if (!staleCandidatePromptNames.has(promptName) && status === undefined)
+				continue;
 
-      const stalePromptPath = join(dstDir, file);
-      if (!existsSync(stalePromptPath)) continue;
+			const stalePromptPath = join(dstDir, file);
+			if (!existsSync(stalePromptPath)) continue;
 
-      if (!options.dryRun) {
-        await rm(stalePromptPath, { force: true });
-      }
-      summary.removed += 1;
-      if (options.verbose) {
-        const prefix = options.dryRun
-          ? "would remove stale prompt"
-          : "removed stale prompt";
-        const label = status ?? "unlisted";
-        console.log(`  ${prefix} ${file} (status: ${label})`);
-      }
-    }
-  }
+			if (!options.dryRun) {
+				await rm(stalePromptPath, { force: true });
+			}
+			summary.removed += 1;
+			if (options.verbose) {
+				const prefix = options.dryRun
+					? "would remove stale prompt"
+					: "removed stale prompt";
+				const label = status ?? "unlisted";
+				console.log(`  ${prefix} ${file} (status: ${label})`);
+			}
+		}
+	}
 
-  return summary;
+	return summary;
 }
 
 async function refreshNativeAgentConfigs(
-  pkgRoot: string,
-  agentsDir: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose" | "force">,
+	pkgRoot: string,
+	agentsDir: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose" | "force">,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
+	const summary = createEmptyCategorySummary();
 
-  if (!options.dryRun) {
-    await mkdir(agentsDir, { recursive: true });
-  }
+	if (!options.dryRun) {
+		await mkdir(agentsDir, { recursive: true });
+	}
 
-  const manifest = tryReadCatalogManifest();
-  const agentStatusByName = manifest
-    ? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
-    : null;
-  const isInstallableStatus = (status: string | undefined): boolean =>
-    status === "active" || status === "internal";
-  const staleCandidateNativeAgentNames = new Set(
-    manifest?.agents.map((agent) => agent.name) ?? [],
-  );
+	const manifest = tryReadCatalogManifest();
+	const agentStatusByName = manifest
+		? new Map(manifest.agents.map((agent) => [agent.name, agent.status]))
+		: null;
+	const isInstallableStatus = (status: string | undefined): boolean =>
+		status === "active" || status === "internal";
+	const staleCandidateNativeAgentNames = new Set(
+		manifest?.agents.map((agent) => agent.name) ?? [],
+	);
 
-  for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
-    staleCandidateNativeAgentNames.add(name);
-    const status = agentStatusByName?.get(name);
-    if (agentStatusByName && !isInstallableStatus(status)) {
-      if (options.verbose) {
-        const label = status ?? "unlisted";
-        console.log(`  skipped native agent ${name}.toml (status: ${label})`);
-      }
-      summary.skipped += 1;
-      continue;
-    }
+	for (const [name, agent] of Object.entries(AGENT_DEFINITIONS)) {
+		staleCandidateNativeAgentNames.add(name);
+		const status = agentStatusByName?.get(name);
+		if (agentStatusByName && !isInstallableStatus(status)) {
+			if (options.verbose) {
+				const label = status ?? "unlisted";
+				console.log(`  skipped native agent ${name}.toml (status: ${label})`);
+			}
+			summary.skipped += 1;
+			continue;
+		}
 
-    const promptPath = join(pkgRoot, "prompts", `${name}.md`);
-    if (!existsSync(promptPath)) {
-      continue;
-    }
+		const promptPath = join(pkgRoot, "prompts", `${name}.md`);
+		if (!existsSync(promptPath)) {
+			continue;
+		}
 
-    const promptContent = await readFile(promptPath, "utf-8");
-    const toml = generateAgentToml(agent, promptContent, {
-      codexHomeOverride: join(agentsDir, ".."),
-    });
-    const dst = join(agentsDir, `${name}.toml`);
-    await syncManagedContent(
-      toml,
-      dst,
-      summary,
-      backupContext,
-      options,
-      `native agent ${name}.toml`,
-    );
-  }
+		const promptContent = await readFile(promptPath, "utf-8");
+		const toml = generateAgentToml(agent, promptContent, {
+			codexHomeOverride: join(agentsDir, ".."),
+		});
+		const dst = join(agentsDir, `${name}.toml`);
+		await syncManagedContent(
+			toml,
+			dst,
+			summary,
+			backupContext,
+			options,
+			`native agent ${name}.toml`,
+		);
+	}
 
-  summary.removed += await cleanupObsoleteNativeAgents(
-    agentsDir,
-    backupContext,
-    options,
-  );
+	summary.removed += await cleanupObsoleteNativeAgents(
+		agentsDir,
+		backupContext,
+		options,
+	);
 
-  if (options.force && manifest && existsSync(agentsDir)) {
-    const installedFiles = await readdir(agentsDir);
-    for (const file of installedFiles) {
-      if (!file.endsWith(".toml")) continue;
-      const agentName = file.slice(0, -5);
-      const agentStatus = agentStatusByName?.get(agentName);
-      if (isInstallableStatus(agentStatus)) continue;
-      if (
-        !staleCandidateNativeAgentNames.has(agentName) &&
-        agentStatus === undefined
-      )
-        continue;
+	if (options.force && manifest && existsSync(agentsDir)) {
+		const installedFiles = await readdir(agentsDir);
+		for (const file of installedFiles) {
+			if (!file.endsWith(".toml")) continue;
+			const agentName = file.slice(0, -5);
+			const agentStatus = agentStatusByName?.get(agentName);
+			if (isInstallableStatus(agentStatus)) continue;
+			if (
+				!staleCandidateNativeAgentNames.has(agentName) &&
+				agentStatus === undefined
+			)
+				continue;
 
-      const staleAgentPath = join(agentsDir, file);
-      if (!existsSync(staleAgentPath)) continue;
+			const staleAgentPath = join(agentsDir, file);
+			if (!existsSync(staleAgentPath)) continue;
 
-      if (!options.dryRun) {
-        await rm(staleAgentPath, { force: true });
-      }
-      summary.removed += 1;
-      if (options.verbose) {
-        const prefix = options.dryRun
-          ? "would remove stale native agent"
-          : "removed stale native agent";
-        const label = agentStatus ?? "unlisted";
-        console.log(`  ${prefix} ${file} (status: ${label})`);
-      }
-    }
-  }
+			if (!options.dryRun) {
+				await rm(staleAgentPath, { force: true });
+			}
+			summary.removed += 1;
+			if (options.verbose) {
+				const prefix = options.dryRun
+					? "would remove stale native agent"
+					: "removed stale native agent";
+				const label = agentStatus ?? "unlisted";
+				console.log(`  ${prefix} ${file} (status: ${label})`);
+			}
+		}
+	}
 
-  return summary;
+	return summary;
 }
 
 async function cleanupObsoleteNativeAgents(
-  agentsDir: string,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	agentsDir: string,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<number> {
-  if (!existsSync(agentsDir)) return 0;
+	if (!existsSync(agentsDir)) return 0;
 
-  const installedFiles = await readdir(agentsDir);
-  let removed = 0;
+	const installedFiles = await readdir(agentsDir);
+	let removed = 0;
 
-  for (const file of installedFiles) {
-    if (!file.endsWith(".toml")) continue;
+	for (const file of installedFiles) {
+		if (!file.endsWith(".toml")) continue;
 
-    const fullPath = join(agentsDir, file);
-    let content = "";
-    try {
-      content = await readFile(fullPath, "utf-8");
-    } catch {
-      continue;
-    }
+		const fullPath = join(agentsDir, file);
+		let content = "";
+		try {
+			content = await readFile(fullPath, "utf-8");
+		} catch {
+			continue;
+		}
 
-    if (!containsTomlKey(content, OBSOLETE_NATIVE_AGENT_FIELD)) continue;
+		if (!containsTomlKey(content, OBSOLETE_NATIVE_AGENT_FIELD)) continue;
 
-    if (await ensureBackup(fullPath, true, backupContext, options)) {
-      // backup created for pre-existing obsolete native agent config
-    }
-    if (!options.dryRun) {
-      await rm(fullPath, { force: true });
-    }
-    if (options.verbose) {
-      const prefix = options.dryRun
-        ? "would remove stale obsolete native agent"
-        : "removed stale obsolete native agent";
-      console.log(`  ${prefix} ${file}`);
-    }
-    removed += 1;
-  }
+		if (await ensureBackup(fullPath, true, backupContext, options)) {
+			// backup created for pre-existing obsolete native agent config
+		}
+		if (!options.dryRun) {
+			await rm(fullPath, { force: true });
+		}
+		if (options.verbose) {
+			const prefix = options.dryRun
+				? "would remove stale obsolete native agent"
+				: "removed stale obsolete native agent";
+			console.log(`  ${prefix} ${file}`);
+		}
+		removed += 1;
+	}
 
-  return removed;
+	return removed;
 }
 
 export async function installSkills(
-  srcDir: string,
-  dstDir: string,
-  backupContext: SetupBackupContext,
-  options: SetupOptions,
+	srcDir: string,
+	dstDir: string,
+	backupContext: SetupBackupContext,
+	options: SetupOptions,
 ): Promise<SetupCategorySummary> {
-  const summary = createEmptyCategorySummary();
-  if (!existsSync(srcDir)) return summary;
-  const installableSkills: Array<{
-    name: string;
-    sourceDir: string;
-    destinationDir: string;
-  }> = [];
-  const manifest = tryReadCatalogManifest();
-  const skillStatusByName = manifest
-    ? new Map(manifest.skills.map((skill) => [skill.name, skill.status]))
-    : null;
-  const isInstallableStatus = (status: string | undefined): boolean =>
-    status === "active" || status === "internal";
-  const entries = await readdir(srcDir, { withFileTypes: true });
-  const staleCandidateSkillNames = new Set(
-    manifest?.skills.map((skill) => skill.name) ?? [],
-  );
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    staleCandidateSkillNames.add(entry.name);
-    const status = skillStatusByName?.get(entry.name);
-    if (skillStatusByName && !isInstallableStatus(status)) {
-      summary.skipped += 1;
-      if (options.verbose) {
-        const label = status ?? "unlisted";
-        console.log(`  skipped ${entry.name}/ (status: ${label})`);
-      }
-      continue;
-    }
+	const summary = createEmptyCategorySummary();
+	if (!existsSync(srcDir)) return summary;
+	const installableSkills: Array<{
+		name: string;
+		sourceDir: string;
+		destinationDir: string;
+	}> = [];
+	const manifest = tryReadCatalogManifest();
+	const skillStatusByName = manifest
+		? new Map(manifest.skills.map((skill) => [skill.name, skill.status]))
+		: null;
+	const isInstallableStatus = (status: string | undefined): boolean =>
+		status === "active" || status === "internal";
+	const entries = await readdir(srcDir, { withFileTypes: true });
+	const staleCandidateSkillNames = new Set(
+		manifest?.skills.map((skill) => skill.name) ?? [],
+	);
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		staleCandidateSkillNames.add(entry.name);
+		const status = skillStatusByName?.get(entry.name);
+		if (skillStatusByName && !isInstallableStatus(status)) {
+			summary.skipped += 1;
+			if (options.verbose) {
+				const label = status ?? "unlisted";
+				console.log(`  skipped ${entry.name}/ (status: ${label})`);
+			}
+			continue;
+		}
 
-    const skillSrc = join(srcDir, entry.name);
-    const skillDst = join(dstDir, entry.name);
-    const skillMd = join(skillSrc, "SKILL.md");
-    if (!existsSync(skillMd)) continue;
+		const skillSrc = join(srcDir, entry.name);
+		const skillDst = join(dstDir, entry.name);
+		const skillMd = join(skillSrc, "SKILL.md");
+		if (!existsSync(skillMd)) continue;
 
-    installableSkills.push({
-      name: entry.name,
-      sourceDir: skillSrc,
-      destinationDir: skillDst,
-    });
-  }
+		installableSkills.push({
+			name: entry.name,
+			sourceDir: skillSrc,
+			destinationDir: skillDst,
+		});
+	}
 
-  for (const skill of installableSkills) {
-    await validateSkillFile(join(skill.sourceDir, "SKILL.md"));
-  }
+	for (const skill of installableSkills) {
+		await validateSkillFile(join(skill.sourceDir, "SKILL.md"));
+	}
 
-  for (const skill of installableSkills) {
-    const skillName = skill.name;
-    const skillSrc = skill.sourceDir;
-    const skillDst = skill.destinationDir;
+	for (const skill of installableSkills) {
+		const skillName = skill.name;
+		const skillSrc = skill.sourceDir;
+		const skillDst = skill.destinationDir;
 
-    if (!options.dryRun) {
-      await mkdir(skillDst, { recursive: true });
-    }
+		if (!options.dryRun) {
+			await mkdir(skillDst, { recursive: true });
+		}
 
-    const skillFiles = await readdir(skillSrc);
-    for (const sf of skillFiles) {
-      const sfPath = join(skillSrc, sf);
-      const sfStat = await stat(sfPath);
-      if (!sfStat.isFile()) continue;
-      const dstPath = join(skillDst, sf);
-      await syncManagedFileFromDisk(
-        sfPath,
-        dstPath,
-        summary,
-        backupContext,
-        options,
-        `skill ${skillName}/${sf}`,
-      );
-    }
-  }
+		const skillFiles = await readdir(skillSrc);
+		for (const sf of skillFiles) {
+			const sfPath = join(skillSrc, sf);
+			const sfStat = await stat(sfPath);
+			if (!sfStat.isFile()) continue;
+			const dstPath = join(skillDst, sf);
+			await syncManagedFileFromDisk(
+				sfPath,
+				dstPath,
+				summary,
+				backupContext,
+				options,
+				`skill ${skillName}/${sf}`,
+			);
+		}
+	}
 
-  if (options.force && manifest && existsSync(dstDir)) {
-    for (const staleSkill of staleCandidateSkillNames) {
-      const status = skillStatusByName?.get(staleSkill);
-      if (isInstallableStatus(status)) continue;
+	if (options.force && manifest && existsSync(dstDir)) {
+		for (const staleSkill of staleCandidateSkillNames) {
+			const status = skillStatusByName?.get(staleSkill);
+			if (isInstallableStatus(status)) continue;
 
-      const staleSkillDir = join(dstDir, staleSkill);
-      if (!existsSync(staleSkillDir)) continue;
+			const staleSkillDir = join(dstDir, staleSkill);
+			if (!existsSync(staleSkillDir)) continue;
 
-      if (!options.dryRun) {
-        await rm(staleSkillDir, { recursive: true, force: true });
-      }
-      summary.removed += 1;
-      if (options.verbose) {
-        const prefix = options.dryRun
-          ? "would remove stale skill"
-          : "removed stale skill";
-        const label = status ?? "unlisted";
-        console.log(`  ${prefix} ${staleSkill}/ (status: ${label})`);
-      }
-    }
-  }
+			if (!options.dryRun) {
+				await rm(staleSkillDir, { recursive: true, force: true });
+			}
+			summary.removed += 1;
+			if (options.verbose) {
+				const prefix = options.dryRun
+					? "would remove stale skill"
+					: "removed stale skill";
+				const label = status ?? "unlisted";
+				console.log(`  ${prefix} ${staleSkill}/ (status: ${label})`);
+			}
+		}
+	}
 
-  return summary;
+	return summary;
 }
 
 async function updateManagedConfig(
-  configPath: string,
-  pkgRoot: string,
-  sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<
-    SetupOptions,
-    "codexVersionProbe" | "dryRun" | "verbose" | "modelUpgradePrompt"
-  >,
+	configPath: string,
+	pkgRoot: string,
+	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<
+		SetupOptions,
+		"codexVersionProbe" | "dryRun" | "verbose" | "modelUpgradePrompt"
+	>,
 ): Promise<ManagedConfigResult> {
-  const existing = existsSync(configPath)
-    ? await readFile(configPath, "utf-8")
-    : "";
-  const currentModel = getRootModelName(existing);
-  let modelOverride: string | undefined;
-  const codexVersion =
-    options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
-  const omxManagesTui = shouldOmxManageTuiFromCodexVersion(codexVersion);
+	const existing = existsSync(configPath)
+		? await readFile(configPath, "utf-8")
+		: "";
+	const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
+	const currentModel = getRootModelName(existing);
+	let modelOverride: string | undefined;
+	const codexVersion =
+		options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
+	const omxManagesTui = shouldOmxManageTuiFromCodexVersion(codexVersion);
 
-  if (currentModel === LEGACY_SETUP_MODEL) {
-    const shouldPrompt =
-      typeof options.modelUpgradePrompt === "function" ||
-      (process.stdin.isTTY && process.stdout.isTTY);
-    if (shouldPrompt) {
-      const shouldUpgrade = options.modelUpgradePrompt
-        ? await options.modelUpgradePrompt(currentModel, DEFAULT_SETUP_MODEL)
-        : await promptForModelUpgrade(currentModel, DEFAULT_SETUP_MODEL);
-      if (shouldUpgrade) {
-        modelOverride = DEFAULT_SETUP_MODEL;
-      }
-    }
-  }
+	if (currentModel === LEGACY_SETUP_MODEL) {
+		const shouldPrompt =
+			typeof options.modelUpgradePrompt === "function" ||
+			(process.stdin.isTTY && process.stdout.isTTY);
+		if (shouldPrompt) {
+			const shouldUpgrade = options.modelUpgradePrompt
+				? await options.modelUpgradePrompt(currentModel, DEFAULT_SETUP_MODEL)
+				: await promptForModelUpgrade(currentModel, DEFAULT_SETUP_MODEL);
+			if (shouldUpgrade) {
+				modelOverride = DEFAULT_SETUP_MODEL;
+			}
+		}
+	}
 
-  const finalConfig = buildMergedConfig(existing, pkgRoot, {
-    includeTui: omxManagesTui,
-    modelOverride,
-    sharedMcpServers: sharedMcpRegistry.servers,
-    sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
-    verbose: options.verbose,
-  });
-  const changed = existing !== finalConfig;
+	const finalConfig = buildMergedConfig(existing, pkgRoot, {
+		includeTui: omxManagesTui,
+		modelOverride,
+		sharedMcpServers: sharedMcpRegistry.servers,
+		sharedMcpRegistrySource: sharedMcpRegistry.sourcePath,
+		verbose: options.verbose,
+	});
+	const changed = existing !== finalConfig;
 
-  if (!changed) {
-    summary.unchanged += 1;
-    return { finalConfig, omxManagesTui };
-  }
+	if (!changed) {
+		summary.unchanged += 1;
+		return {
+			finalConfig,
+			omxManagesTui,
+			repairedLegacyTeamRunTable: false,
+		};
+	}
 
-  if (
-    await ensureBackup(
-      configPath,
-      existsSync(configPath),
-      backupContext,
-      options,
-    )
-  ) {
-    summary.backedUp += 1;
-  }
+	if (
+		await ensureBackup(
+			configPath,
+			existsSync(configPath),
+			backupContext,
+			options,
+		)
+	) {
+		summary.backedUp += 1;
+	}
 
-  if (!options.dryRun) {
-    await writeFile(configPath, finalConfig);
-  }
+	if (!options.dryRun) {
+		await writeFile(configPath, finalConfig);
+	}
 
-  if (
-    options.verbose &&
-    modelOverride &&
-    currentModel &&
-    currentModel !== modelOverride
-  ) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} root model from ${currentModel} to ${modelOverride}`,
-    );
-  }
+	if (
+		options.verbose &&
+		modelOverride &&
+		currentModel &&
+		currentModel !== modelOverride
+	) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} root model from ${currentModel} to ${modelOverride}`,
+		);
+	}
 
-  summary.updated += 1;
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
-    );
-  }
-  return { finalConfig, omxManagesTui };
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
+		);
+	}
+	return {
+		finalConfig,
+		omxManagesTui,
+		repairedLegacyTeamRunTable:
+			hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
+	};
 }
 
 function getClaudeCodeSettingsPath(homeDir = homedir()): string {
-  return join(homeDir, ".claude", "settings.json");
+	return join(homeDir, ".claude", "settings.json");
 }
 
 async function syncClaudeCodeMcpSettings(
-  sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
-  summary: SetupCategorySummary,
-  backupContext: SetupBackupContext,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-  if (sharedMcpRegistry.servers.length === 0) return;
+	if (sharedMcpRegistry.servers.length === 0) return;
 
-  const settingsPath = getClaudeCodeSettingsPath();
-  const existing = existsSync(settingsPath)
-    ? await readFile(settingsPath, "utf-8")
-    : "";
-  const syncPlan = planClaudeCodeMcpSettingsSync(
-    existing,
-    sharedMcpRegistry.servers,
-  );
+	const settingsPath = getClaudeCodeSettingsPath();
+	const existing = existsSync(settingsPath)
+		? await readFile(settingsPath, "utf-8")
+		: "";
+	const syncPlan = planClaudeCodeMcpSettingsSync(
+		existing,
+		sharedMcpRegistry.servers,
+	);
 
-  for (const warning of syncPlan.warnings) {
-    console.log(`  warning: ${warning}`);
-  }
-  if (syncPlan.warnings.length > 0) {
-    summary.skipped += 1;
-    return;
-  }
-  if (!syncPlan.content) {
-    summary.unchanged += 1;
-    if (options.verbose && syncPlan.unchanged.length > 0) {
-      console.log(
-        `  shared MCP servers already present in Claude Code settings (${settingsPath})`,
-      );
-    }
-    return;
-  }
+	for (const warning of syncPlan.warnings) {
+		console.log(`  warning: ${warning}`);
+	}
+	if (syncPlan.warnings.length > 0) {
+		summary.skipped += 1;
+		return;
+	}
+	if (!syncPlan.content) {
+		summary.unchanged += 1;
+		if (options.verbose && syncPlan.unchanged.length > 0) {
+			console.log(
+				`  shared MCP servers already present in Claude Code settings (${settingsPath})`,
+			);
+		}
+		return;
+	}
 
-  await syncManagedContent(
-    syncPlan.content,
-    settingsPath,
-    summary,
-    backupContext,
-    options,
-    `Claude Code MCP settings ${settingsPath} (+${syncPlan.added.join(", ")})`,
-  );
+	await syncManagedContent(
+		syncPlan.content,
+		settingsPath,
+		summary,
+		backupContext,
+		options,
+		`Claude Code MCP settings ${settingsPath} (+${syncPlan.added.join(", ")})`,
+	);
 }
 
 async function setupNotifyHook(
-  pkgRoot: string,
-  options: Pick<SetupOptions, "dryRun" | "verbose">,
+	pkgRoot: string,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-  const hookScript = join(pkgRoot, "dist", "scripts", "notify-hook.js");
-  if (!existsSync(hookScript)) {
-    if (options.verbose)
-      console.log("  Notify hook script not found, skipping.");
-    return;
-  }
-  // The notify hook is configured in config.toml via mergeConfig
-  if (options.verbose) console.log(`  Notify hook: ${hookScript}`);
+	const hookScript = join(pkgRoot, "dist", "scripts", "notify-hook.js");
+	if (!existsSync(hookScript)) {
+		if (options.verbose)
+			console.log("  Notify hook script not found, skipping.");
+		return;
+	}
+	// The notify hook is configured in config.toml via mergeConfig
+	if (options.verbose) console.log(`  Notify hook: ${hookScript}`);
 }
 
 async function verifyTeamCliApiInterop(
-  pkgRoot: string,
+	pkgRoot: string,
 ): Promise<{ ok: true } | { ok: false; message: string }> {
-  const teamCliPath = join(pkgRoot, "dist", "cli", "team.js");
-  if (!existsSync(teamCliPath)) {
-    return { ok: false, message: `missing ${teamCliPath}` };
-  }
+	const teamCliPath = join(pkgRoot, "dist", "cli", "team.js");
+	if (!existsSync(teamCliPath)) {
+		return { ok: false, message: `missing ${teamCliPath}` };
+	}
 
-  try {
-    const content = await readFile(teamCliPath, "utf-8");
-    const missing = REQUIRED_TEAM_CLI_API_MARKERS.filter(
-      (marker) => !content.includes(marker),
-    );
-    if (missing.length > 0) {
-      return {
-        ok: false,
-        message: `team CLI interop markers missing: ${missing.join(", ")}`,
-      };
-    }
-    return { ok: true };
-  } catch {
-    return { ok: false, message: `cannot read ${teamCliPath}` };
-  }
+	try {
+		const content = await readFile(teamCliPath, "utf-8");
+		const missing = REQUIRED_TEAM_CLI_API_MARKERS.filter(
+			(marker) => !content.includes(marker),
+		);
+		if (missing.length > 0) {
+			return {
+				ok: false,
+				message: `team CLI interop markers missing: ${missing.join(", ")}`,
+			};
+		}
+		return { ok: true };
+	} catch {
+		return { ok: false, message: `cannot read ${teamCliPath}` };
+	}
 }

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -55,6 +55,17 @@ const OMX_TUI_STATUS_LINE =
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
 
+function isOmxMcpServerSection(tableName: string): boolean {
+  const m = tableName.match(/^mcp_servers\.(?:"([^"]+)"|([A-Za-z0-9_-]+))$/);
+  if (!m) return false;
+  const name = m[1] || m[2] || "";
+  return name.startsWith("omx_");
+}
+
+export function hasLegacyOmxTeamRunTable(config: string): boolean {
+  return LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(config);
+}
+
 function unwrapTomlString(value: string | undefined): string | undefined {
   return value?.match(/^"(.*)"$/)?.[1];
 }
@@ -466,7 +477,7 @@ function stripOrphanedOmxSections(config: string): string {
       // The marker-based stripExistingOmxBlocks already handles [tui]
       // when it lives inside the OMX marker block.
       const isOmxSection =
-        /^mcp_servers\.omx_/.test(tableName) ||
+        isOmxMcpServerSection(tableName) ||
         isLegacyOmxAgentSection(tableName);
 
       if (isOmxSection) {
@@ -873,7 +884,7 @@ export async function repairConfigIfNeeded(
 
   const content = await readFile(configPath, "utf-8");
   const tuiCount = (content.match(/^\s*\[tui\]\s*$/gm) || []).length;
-  const hasLegacyTeamRunTable = LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(content);
+  const hasLegacyTeamRunTable = hasLegacyOmxTeamRunTable(content);
   if (tuiCount <= 1 && !hasLegacyTeamRunTable) return false;
 
   // Managed config compatibility issue detected — run full merge to repair


### PR DESCRIPTION
## Summary
- detect retired `omx_team_run` config consistently across doctor/setup/launch flows
- repair stale team MCP config in the resolved scoped config path during upgrade flows
- add regression coverage for doctor/setup/launch-scope behavior

## Verification
- npm run build
- npx biome lint src/cli/doctor.ts src/cli/setup.ts src/cli/index.ts src/config/generator.ts src/cli/__tests__/setup-refresh.test.ts src/cli/__tests__/doctor-warning-copy.test.ts src/cli/__tests__/index.test.ts
- npm run check:no-unused
- node --test dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/doctor-warning-copy.test.js dist/config/__tests__/generator-idempotent.test.js
- node --test --test-name-pattern='project launch scope helpers' dist/cli/__tests__/index.test.js

Closes #1424
