### PR TITLE
fix: repair retired team MCP configs in the resolved launch scope

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -66,6 +66,38 @@ command = "node"
     }
   });
 
+  it('warns when the retired omx_team_run table is still present', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-legacy-team-run-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        `
+[mcp_servers.omx_state]
+command = "node"
+
+[mcp_servers.omx_team_run]
+command = "node"
+`.trimStart(),
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Config: retired \[mcp_servers\.omx_team_run\] table still present; run "omx setup --force" to repair the config/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('warns when explore harness sources are packaged but cargo is unavailable', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-copy-'));
     try {

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -13,6 +13,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { repairLaunchConfigIfNeeded } from "../index.js";
 
 function runOmx(
   cwd: string,
@@ -147,6 +148,58 @@ describe("omx setup scope behavior", () => {
         ),
       );
       assert.doesNotMatch(res.stdout, /Codex home: .*\/home\/\.codex/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("launch repair targets the persisted project config path", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-repair-scope-"));
+    try {
+      const home = join(wd, "home");
+      const userCodexHome = join(home, ".codex");
+      const projectCodexHome = join(wd, ".codex");
+      await mkdir(home, { recursive: true });
+      await mkdir(userCodexHome, { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      await writeFile(
+        join(projectCodexHome, "config.toml"),
+        [
+          '[mcp_servers.omx_team_run]',
+          'command = "node"',
+          'args = ["/tmp/team-server.js"]',
+          'enabled = true',
+          "",
+        ].join("\n"),
+      );
+      const userConfigPath = join(userCodexHome, "config.toml");
+      const userConfig = 'user_marker = true\n';
+      await writeFile(userConfigPath, userConfig);
+
+      const didRepair = await repairLaunchConfigIfNeeded(
+        wd,
+        wd,
+        { HOME: home },
+      );
+      assert.equal(didRepair, true, "project config should be repaired");
+
+      const repairedProject = await readFile(
+        join(projectCodexHome, "config.toml"),
+        "utf-8",
+      );
+      assert.doesNotMatch(
+        repairedProject,
+        /^\[mcp_servers\.omx_team_run\]$/m,
+      );
+      assert.match(repairedProject, /^\[mcp_servers\.omx_state\]$/m);
+
+      const repairedUser = await readFile(userConfigPath, "utf-8");
+      assert.equal(repairedUser, userConfig, "user config should be untouched");
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -14,6 +14,7 @@ import { getCatalogExpectations } from './catalog-contract.js';
 import { parse as parseToml } from '@iarna/toml';
 import { resolvePackagedExploreHarnessCommand, EXPLORE_BIN_ENV } from './explore.js';
 import { getPackageRoot } from '../utils/package.js';
+import { hasLegacyOmxTeamRunTable } from '../config/generator.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
 import { isLeaderRuntimeStale } from '../team/leader-activity.js';
@@ -580,6 +581,15 @@ async function checkConfig(configPath: string): Promise<Check> {
         name: 'Config',
         status: 'fail',
         message: `invalid config.toml (${hint})`,
+      };
+    }
+
+    if (hasLegacyOmxTeamRunTable(content)) {
+      return {
+        name: 'Config',
+        status: 'warn',
+        message:
+          'retired [mcp_servers.omx_team_run] table still present; run "omx setup --force" to repair the config',
       };
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -344,6 +344,24 @@ export function resolveCodexHomeForLaunch(
   return undefined;
 }
 
+export function resolveLaunchConfigPath(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
+  return codexHomeOverride
+    ? join(codexHomeOverride, "config.toml")
+    : codexConfigPath();
+}
+
+export async function repairLaunchConfigIfNeeded(
+  cwd: string,
+  pkgRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  return repairConfigIfNeeded(resolveLaunchConfigPath(cwd, env), pkgRoot);
+}
+
 export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {
   let value: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
@@ -931,9 +949,10 @@ export async function launchWithHud(args: string[]): Promise<void> {
   // have written a config.toml with duplicate [tui] sections.  Codex CLI's
   // TOML parser rejects duplicates, so we repair before spawning the CLI.
   try {
-    const repaired = await repairConfigIfNeeded(
-      codexConfigPath(),
+    const repaired = await repairLaunchConfigIfNeeded(
+      cwd,
       getPackageRoot(),
+      process.env,
     );
     if (repaired) {
       console.log("[omx] Repaired managed config.toml compatibility issue.");
@@ -1012,9 +1031,10 @@ export async function execWithOverlay(args: string[]): Promise<void> {
   }
 
   try {
-    const repaired = await repairConfigIfNeeded(
-      codexConfigPath(),
+    const repaired = await repairLaunchConfigIfNeeded(
+      cwd,
       getPackageRoot(),
+      process.env,
     );
     if (repaired) {
       console.log("[omx] Repaired managed config.toml compatibility issue.");

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -55,6 +55,10 @@ const OMX_TUI_STATUS_LINE =
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
 
+export function hasLegacyOmxTeamRunTable(config: string): boolean {
+  return LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(config);
+}
+
 function unwrapTomlString(value: string | undefined): string | undefined {
   return value?.match(/^"(.*)"$/)?.[1];
 }
@@ -873,7 +877,7 @@ export async function repairConfigIfNeeded(
 
   const content = await readFile(configPath, "utf-8");
   const tuiCount = (content.match(/^\s*\[tui\]\s*$/gm) || []).length;
-  const hasLegacyTeamRunTable = LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(content);
+  const hasLegacyTeamRunTable = hasLegacyOmxTeamRunTable(content);
   if (tuiCount <= 1 && !hasLegacyTeamRunTable) return false;
 
   // Managed config compatibility issue detected — run full merge to repair


### PR DESCRIPTION
## Summary

`omx doctor` already warned about retired `[mcp_servers.omx_team_run]` configs in the correct resolved scope, but launch-time repair was still targeting the user-level `CODEX_HOME` config path. This update makes repair follow the same resolved project/user scope as diagnosis, so project-scoped installs are repaired in the project config path.

## Changes

- Added a launch-config repair helper in `src/cli/index.ts` that resolves the config path from persisted scope or `CODEX_HOME`
- Updated both launch entrypoints to use the resolved launch config path
- Added a regression test proving persisted project scope repairs the project config and leaves the user config untouched

## Validation

- [x] `npm run build`
- [x] `node --test dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/doctor-warning-copy.test.js dist/config/__tests__/generator-idempotent.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1424
