### PR TITLE
Support approved multi-workflow overlaps in canonical state

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -46,6 +46,20 @@ OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js
 | `session-end` | none | `session-end` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
 | `session-idle` | none | `session-idle` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
 
+## Combined workflow note
+
+Stop/continuation readers must interpret approved combined workflow state from
+the shared active-set contract rather than from a single legacy `skill` owner.
+For the first-pass multi-state rollout, the approved overlaps are:
+
+- `team + ralph`
+- `team + ultrawork`
+
+Unsupported overlaps should preserve the current state unchanged and direct the
+operator to clear incompatible state explicitly via `omx state ...` or the
+`omx_state.*` MCP tools before retrying. See
+`docs/contracts/multi-state-transition-contract.md`.
+
 ## Verification guidance
 
 When validating hooks, keep the proof boundary explicit:

--- a/docs/contracts/multi-state-transition-contract.md
+++ b/docs/contracts/multi-state-transition-contract.md
@@ -1,0 +1,115 @@
+# Multi-state transition compatibility contract
+
+This document freezes the first-pass peer workflow state model for the approved
+multi-state compatibility rollout from `.omx/plans/prd-multi-state-compat.md`.
+
+## Canonical sources of truth
+
+The runtime must treat workflow state as a combination of:
+
+- mode state files under `.omx/state/{scope}/<mode>-state.json`
+- canonical workflow enumeration under `.omx/state/{scope}/skill-active-state.json`
+
+`skill-active-state.json` is the canonical active-set inventory. Legacy top-level
+fields such as `skill` or `phase` may remain as compatibility metadata, but they
+must not override the authoritative active set when multiple workflow members
+are live.
+
+## Approved first-pass combinations
+
+Allowed active-set shapes in this rollout are intentionally narrow:
+
+- standalone single-workflow state for tracked workflows
+- `team + ralph`
+- `team + ultrawork`
+
+The resulting active set is peer state. Neither member is semantically primary
+just because it was activated first or happens to occupy the legacy top-level
+`skill` field.
+
+## Standalone-only workflows
+
+These workflows remain standalone in this pass and must reject overlap attempts:
+
+- `autopilot`
+- `autoresearch`
+
+A denied overlap must preserve the current state unchanged.
+
+## Transition rules
+
+A canonical transition helper should answer three questions for every writer or
+consumer that mutates workflow state:
+
+1. Is the requested transition allowed from the current active set?
+2. What is the resulting active set if it is allowed?
+3. What operator guidance should be shown if it is denied?
+
+Until a combination is explicitly approved, the default rule is deny-without-
+mutation.
+
+## Invalid transition UX
+
+Every denied transition must:
+
+1. keep the current active state unchanged
+2. name the denied combination explicitly
+3. explain how to clear incompatible state before retrying
+4. mention both supported clearing surfaces:
+   - `omx state ...`
+   - `omx_state.*` MCP tools
+
+Example operator guidance shape:
+
+> Cannot activate `<requested>` while `<active-set>` is still active. Clear the
+> incompatible state first via `omx state ...` or the `omx_state.*` MCP tools,
+> then retry the transition.
+
+### Operator recovery examples
+
+CLI parity surface:
+
+- `omx state clear --input '{"mode":"team"}' --json`
+- `omx state clear --input '{"mode":"ralph","all_sessions":true}' --json`
+
+MCP parity surface:
+
+- `omx_state.state_clear({ mode: "team" })`
+- `omx_state.state_clear({ mode: "ralph", all_sessions: true })`
+
+## Brownfield consumer expectations
+
+The following surfaces must consume the same transition semantics instead of
+re-inventing their own precedence rules:
+
+- `src/state/skill-active.ts` — canonical active-set persistence/sync
+- `src/hooks/keyword-detector.ts` — keyword-triggered activation should add or
+  deny according to the allowlist instead of overwriting to a single owner
+- `src/modes/base.ts` — mode start validation must defer to the same transition
+  rules and emit the same operator guidance
+- `src/mcp/state-server.ts` — state writes/clears must preserve combined state
+  correctly and remove only the cleared member
+- `src/hud/state.ts` — HUD rendering must show approved combined states even
+  when legacy top-level metadata is non-authoritative
+- `src/hooks/agents-overlay.ts` — AGENTS overlay active-mode reporting must list
+  every active approved member
+- `src/scripts/codex-native-hook.ts` — Stop/continuation logic must respect the
+  combined state and stop blocking when the relevant member is cleared
+
+## Scope behavior
+
+Session-scoped state remains authoritative when present. Root scope remains a
+compatibility fallback only. Clearing one member of an approved combined set
+must not accidentally delete the entire combined state.
+
+## Regression expectations
+
+Implementation should be considered complete only when tests prove:
+
+1. canonical active state can hold a multi-entry active set
+2. `team + ralph` is allowed in both activation orders
+3. `team + ultrawork` is allowed in both activation orders
+4. unsupported overlaps deny without mutation
+5. denial messages mention both `omx state` and `omx_state.*`
+6. HUD / overlay / stop-hook consumers honor the combined set consistently
+7. `autopilot` and `autoresearch` still reject overlap attempts

--- a/docs/contracts/multi-state-transition-review.md
+++ b/docs/contracts/multi-state-transition-review.md
@@ -1,0 +1,134 @@
+# Multi-state transition compatibility review notes
+
+Date: 2026-04-09  
+Reviewer lane: worker-3
+
+## Scope reviewed
+
+Compared the branch state against:
+
+- `.omx/plans/prd-multi-state-compat.md`
+- `.omx/plans/test-spec-multi-state-compat.md`
+
+Reviewed brownfield surfaces:
+
+- `src/state/skill-active.ts`
+- `src/hooks/keyword-detector.ts`
+- `src/modes/base.ts`
+- `src/mcp/state-server.ts`
+- `src/hud/state.ts`
+- `src/hooks/agents-overlay.ts`
+- `src/scripts/codex-native-hook.ts`
+
+## Current branch snapshot
+
+**Status:** the repository already contains partial multi-state foundations, but
+it does not yet expose one documented canonical transition contract.
+
+Observed strengths:
+
+- `src/state/skill-active.ts` already persists `active_skills[]`, normalizes
+  visible entries, and can sync more than one tracked workflow into the
+  canonical state file.
+- `src/hud/state.ts` and `src/hooks/agents-overlay.ts` already read canonical
+  skill-active state and are structurally closer to a peer-state model than a
+  strict single-owner model.
+- `src/modes/base.ts` already preserves key standalone restrictions:
+  `autopilot` and `autoresearch` remain exclusive; `ralph` and `ultrawork`
+  remain mutually exclusive with each other.
+
+Primary gaps relative to the PRD/test-spec:
+
+1. **No explicit transition-rule helper exists yet.**
+   - Transition semantics are still distributed across mode lifecycle,
+     keyword detection, MCP writes, HUD/overlay readers, and native-stop logic.
+2. **Keyword activation is still effectively single-owner.**
+   - `recordSkillActivation()` uses `detectPrimaryKeyword()` and writes a fresh
+     one-entry `active_skills` array for the selected skill, so prompt-side
+     activation still overwrites rather than validating/appending approved peer
+     combinations.
+3. **Invalid-transition guidance is not standardized.**
+   - `src/modes/base.ts` still throws `Run cancel first.` for exclusivity
+     failures, which does not meet the new requirement to mention explicit
+     clearing paths via `omx state` and `omx_state.*`.
+4. **The contract is not documented in one operator-facing place.**
+   - The PRD and test spec define the rollout, but the repo lacked a dedicated
+     contract doc describing the allowed set, the denied set, and the required
+     recovery UX.
+
+## Brownfield review details
+
+### `src/state/skill-active.ts`
+
+- Good base for canonical peer state: it already deduplicates `active_skills[]`
+  and can retain multiple active entries.
+- Still needs a shared allowlist-aware transition layer above persistence so the
+  state file cannot drift into unsupported combinations.
+
+### `src/hooks/keyword-detector.ts`
+
+- Main brownfield risk for this feature.
+- The prompt-side path currently records only the primary detected keyword and
+  seeds one active skill at a time.
+- This is the clearest remaining single-owner assumption in the review sample.
+
+### `src/modes/base.ts`
+
+- Current exclusivity rules are partly aligned with the rollout goals, because
+  `team` is not exclusive while `autopilot`/`autoresearch` are.
+- However, the rules are encoded as a hard-coded exclusive set and generic error
+  text, not as a canonical transition model with machine-testable guidance.
+
+### `src/mcp/state-server.ts`
+
+- Already syncs canonical skill-active state for mode writes/clears.
+- Needs to consume the same allowlist/error builder as every other writer so
+  MCP state writes cannot permit combinations the keyword or mode path denies.
+
+### `src/hud/state.ts` and `src/hooks/agents-overlay.ts`
+
+- These consumers already appear structurally ready for a combined active set.
+- They still depend on upstream writers to keep the canonical state valid and to
+  stop relying on top-level legacy fields as semantic truth.
+
+### `src/scripts/codex-native-hook.ts`
+
+- Stop handling already reads canonical skill-active state plus mode files.
+- It still needs the finalized transition contract so combined-state blocking and
+  clearing behavior stay aligned with the eventual allowlist.
+
+## Documentation action taken in this lane
+
+Added a dedicated contract doc:
+
+- `docs/contracts/multi-state-transition-contract.md`
+
+This freezes the rollout expectations for:
+
+- approved first-pass overlaps
+- standalone-only workflows
+- denial UX requirements
+- brownfield consumer responsibilities
+- regression expectations
+
+Also clarified two adjacent operator-facing docs so the approved overlap is not
+misread as the old linked `team ralph` lifecycle:
+
+- `docs/contracts/ralph-state-contract.md`
+- `docs/codex-native-hooks.md`
+
+Added concrete recovery examples to the compatibility contract so denial
+messages can point operators at exact parity surfaces instead of vague
+placeholders:
+
+- `omx state clear --input '{"mode":"team"}' --json`
+- `omx_state.state_clear({ mode: "team" })`
+
+## Reviewer conclusion
+
+The branch already has meaningful peer-state groundwork, but the PRD is correct
+that behavior is still fragmented. The main implementation risk is not raw state
+storage; it is inconsistent transition ownership across keyword activation, mode
+start validation, MCP writes, and stop/overlay consumers. The new contract doc
+should give the implementation lanes a stable operator-facing target while the
+code is migrated to a single allowlist-driven transition model.

--- a/docs/contracts/ralph-state-contract.md
+++ b/docs/contracts/ralph-state-contract.md
@@ -21,9 +21,12 @@ Ralph runtime state is stored at `.omx/state/{scope}/ralph-state.json` and MUST 
 - Optional stop/audit fields:
   - `stop_reason`
 
-Ralph remains a standalone mode. Other workflows may start Ralph later as an
-explicit follow-up, but there is no built-in `omx team ralph ...` linked launch
-path anymore.
+Ralph still owns its own mode state and there is no built-in
+`omx team ralph ...` linked launch path anymore. Under the multi-state
+transition compatibility contract, `team + ralph` is an approved peer overlap,
+so Ralph may coexist with team when the canonical allowlist permits it. Other
+overlaps remain deny-by-default until they are explicitly approved. See
+`docs/contracts/multi-state-transition-contract.md`.
 
 Legacy phase aliases may be normalized for compatibility, but persisted values MUST end in the frozen enum below.
 

--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -136,6 +136,41 @@ describe("generateOverlay", () => {
     assert.ok(overlay.includes("iteration 1/5"));
   });
 
+  it("lists both approved combined workflow members from canonical skill state", async () => {
+    const sessionId = "combined-session";
+    const sessionDir = join(tempDir, ".omx", "state", "sessions", sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(tempDir, ".omx", "state", "session.json"),
+      JSON.stringify({ session_id: sessionId }),
+    );
+    await writeFile(
+      join(sessionDir, "skill-active-state.json"),
+      JSON.stringify({
+        active: true,
+        skill: "team",
+        phase: "running",
+        session_id: sessionId,
+        active_skills: [
+          { skill: "team", phase: "running", active: true, session_id: sessionId },
+          { skill: "ralph", phase: "executing", active: true, session_id: sessionId },
+        ],
+      }),
+    );
+    await writeFile(
+      join(sessionDir, "team-state.json"),
+      JSON.stringify({ active: true, current_phase: "running" }),
+    );
+    await writeFile(
+      join(sessionDir, "ralph-state.json"),
+      JSON.stringify({ active: true, iteration: 2, max_iterations: 5, current_phase: "executing" }),
+    );
+
+    const overlay = await generateOverlay(tempDir, sessionId);
+    assert.match(overlay, /- team: phase: running/);
+    assert.match(overlay, /- ralph: iteration 2\/5, phase: executing/);
+  });
+
   it("generates overlay with notepad priority content", async () => {
     await writeFile(
       join(tempDir, ".omx", "notepad.md"),

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -286,6 +287,90 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('adds approved workflow overlaps without deleting the existing canonical state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-overlap-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      await recordSkillActivation({
+        stateDir,
+        text: '$team ship this',
+        sessionId: 'sess-overlap',
+        threadId: 'thread-overlap',
+        turnId: 'turn-1',
+        nowIso: '2026-02-26T00:00:00.000Z',
+      });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralph continue verification',
+        sessionId: 'sess-overlap',
+        threadId: 'thread-overlap',
+        turnId: 'turn-2',
+        nowIso: '2026-02-26T00:05:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.deepEqual(
+        result.active_skills?.map((entry) => entry.skill),
+        ['team', 'ralph'],
+      );
+
+      const persisted = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-overlap', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(
+        persisted.active_skills?.map((entry) => entry.skill),
+        ['team', 'ralph'],
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('hard-fails denied workflow overlaps without mutating current state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deny-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      await recordSkillActivation({
+        stateDir,
+        text: '$team ship this',
+        sessionId: 'sess-deny',
+        threadId: 'thread-deny',
+        turnId: 'turn-1',
+        nowIso: '2026-02-26T00:00:00.000Z',
+      });
+
+      const denied = await recordSkillActivation({
+        stateDir,
+        text: '$autopilot do it too',
+        sessionId: 'sess-deny',
+        threadId: 'thread-deny',
+        turnId: 'turn-2',
+        nowIso: '2026-02-26T00:05:00.000Z',
+      });
+
+      assert.ok(denied?.transition_error);
+      assert.match(String(denied?.transition_error), /Unsupported workflow overlap: team \+ autopilot\./);
+      assert.match(String(denied?.transition_error), /`omx state clear --mode <mode>`/);
+      assert.match(String(denied?.transition_error), /`omx_state\.\*` MCP tools/);
+
+      const persisted = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-deny', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team']);
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-deny', 'autopilot-state.json')),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds first-class state for ralplan prompt-submit activation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-'));
     const stateDir = join(cwd, '.omx', 'state');
@@ -377,6 +462,59 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.active, true);
       assert.equal(modeState.current_phase, 'team-verify');
       assert.equal(modeState.team_name, 'review-team');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves root team state when $ralph is activated for the current session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-ralph-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await recordSkillActivation({
+        stateDir,
+        text: '$team coordinate the rollout',
+        sessionId: 'sess-team-ralph',
+        nowIso: '2026-04-09T00:00:00.000Z',
+      });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralph complete the approved plan',
+        sessionId: 'sess-team-ralph',
+        nowIso: '2026-04-09T00:05:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ralph');
+
+      const rootCanonical = JSON.parse(
+        await readFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        rootCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [{ skill: 'team', phase: 'planning', session_id: 'sess-team-ralph' }],
+      );
+
+      const sessionCanonical = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-team-ralph', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        sessionCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [
+          { skill: 'team', phase: 'planning', session_id: 'sess-team-ralph' },
+          { skill: 'ralph', phase: 'planning', session_id: 'sess-team-ralph' },
+        ],
+      );
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -646,8 +784,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
-  it('resets activated_at when skill changes', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-skill-switch-'));
+  it('denies switching away from a standalone workflow without explicit clear', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-skill-switch-deny-'));
     const stateDir = join(cwd, '.omx', 'state');
     const statePath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
     try {
@@ -673,8 +811,9 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
 
       assert.ok(result);
-      assert.equal(result.skill, 'ralph');
-      assert.equal(result.activated_at, '2026-02-26T00:00:00.000Z');
+      assert.equal(result.skill, 'autopilot');
+      assert.match(String(result.transition_error), /Unsupported workflow overlap: autopilot \+ ralph\./);
+      assert.equal(result.activated_at, '2026-02-25T00:00:00.000Z');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -371,6 +371,56 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('denies prompt-submit overlaps against the current session-visible canonical state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-session-visible-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-visible'), { recursive: true });
+      await writeFile(
+        join(stateDir, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          active_skills: [
+            { skill: 'team', phase: 'running', active: true },
+          ],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          session_id: 'sess-visible',
+          active_skills: [
+            { skill: 'team', phase: 'running', active: true },
+            { skill: 'ralph', phase: 'executing', active: true, session_id: 'sess-visible' },
+          ],
+        }, null, 2),
+      );
+
+      const denied = await recordSkillActivation({
+        stateDir,
+        text: '$ultrawork continue',
+        sessionId: 'sess-visible',
+        nowIso: '2026-04-10T00:00:00.000Z',
+      });
+
+      assert.ok(denied?.transition_error);
+      assert.match(String(denied?.transition_error), /Unsupported workflow overlap: team \+ ralph \+ ultrawork\./);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-visible', 'ultrawork-state.json')), false);
+
+      const persisted = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds first-class state for ralplan prompt-submit activation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -19,9 +19,16 @@ import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts
 import { KEYWORD_TRIGGER_DEFINITIONS, compareKeywordMatches } from './keyword-registry.js';
 import {
   SKILL_ACTIVE_STATE_FILE,
+  listActiveSkills,
   writeSkillActiveStateCopies,
   type SkillActiveEntry,
 } from '../state/skill-active.js';
+import {
+  buildWorkflowTransitionError,
+  evaluateWorkflowTransition,
+  isTrackedWorkflowMode,
+  pickPrimaryWorkflowMode,
+} from '../state/workflow-transition.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -50,7 +57,7 @@ export interface SkillActiveState {
   active: boolean;
   skill: string;
   keyword: string;
-  phase: SkillActivePhase;
+  phase: string;
   activated_at: string;
   updated_at: string;
   source: 'keyword-detector';
@@ -61,6 +68,7 @@ export interface SkillActiveState {
   active_skills?: SkillActiveEntry[];
   initialized_mode?: string;
   initialized_state_path?: string;
+  transition_error?: string;
   [key: string]: unknown;
 }
 
@@ -144,6 +152,9 @@ async function readExistingSkillState(statePath: string): Promise<SkillActiveSta
 
 function buildActiveSkills(state: SkillActiveState): SkillActiveEntry[] | undefined {
   if (!state.active) return undefined;
+  if (Array.isArray(state.active_skills) && state.active_skills.length > 0) {
+    return state.active_skills.filter((entry) => entry.active !== false);
+  }
   return [{
     skill: state.skill,
     phase: state.phase,
@@ -469,7 +480,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     };
 
     try {
-      await writeSkillActiveStateCopies(dirname(dirname(input.stateDir)), state, input.sessionId);
+      await writeSkillActiveStateCopies(
+        dirname(dirname(input.stateDir)),
+        state,
+        input.sessionId,
+        previous ?? state,
+      );
       await persistDeepInterviewModeState(input.stateDir, state, nowIso, previous, input);
     } catch (error) {
       console.warn('[omx] warning: failed to persist keyword activation state', error);
@@ -480,10 +496,143 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
   const sameSkill = previous?.active === true && previous.skill === match.skill;
   const sameKeyword = previous?.keyword?.toLowerCase() === match.keyword.toLowerCase();
+  const previousEntries = listActiveSkills(previous ?? {});
+  const previousWorkflowEntries = previousEntries.filter((entry) => (
+    isTrackedWorkflowMode(entry.skill)
+    && (
+      !input.sessionId
+      || !safeString(entry.session_id).trim()
+      || safeString(entry.session_id).trim() === safeString(input.sessionId).trim()
+    )
+  ));
 
   const deepInterviewInputLock = match.skill === 'deep-interview'
     ? createDeepInterviewInputLock(nowIso, previous?.input_lock)
     : releaseDeepInterviewInputLock(previous?.input_lock, nowIso);
+
+  if (isTrackedWorkflowMode(match.skill)) {
+    const workflowMatches = extractExplicitSkillInvocations(input.text)
+      .map((entry) => entry.skill)
+      .filter(isTrackedWorkflowMode);
+    const requestedWorkflowSkills = workflowMatches.length > 0 ? workflowMatches : [match.skill];
+
+    let nextWorkflowEntries = previousWorkflowEntries.map((entry) => ({ ...entry }));
+    for (const requestedMode of requestedWorkflowSkills) {
+      const decision = evaluateWorkflowTransition(
+        nextWorkflowEntries.map((entry) => entry.skill),
+        requestedMode,
+      );
+      if (!decision.allowed) {
+        return {
+          ...(previous ?? {}),
+          version: 1,
+          active: previous?.active ?? nextWorkflowEntries.length > 0,
+          skill: previous?.skill || match.skill,
+          keyword: previous?.keyword || match.keyword,
+          phase: previous?.phase || 'planning',
+          activated_at: previous?.activated_at || nowIso,
+          updated_at: nowIso,
+          source: 'keyword-detector',
+          session_id: input.sessionId ?? previous?.session_id,
+          thread_id: input.threadId ?? previous?.thread_id,
+          turn_id: input.turnId ?? previous?.turn_id,
+          active_skills: previousEntries,
+          ...(previous?.input_lock ? { input_lock: previous.input_lock } : {}),
+          transition_error: buildWorkflowTransitionError(
+            nextWorkflowEntries.map((entry) => entry.skill),
+            requestedMode,
+            'activate',
+          ),
+        };
+      }
+
+      const existingEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
+      if (existingEntry) {
+        existingEntry.phase = requestedMode === match.skill ? 'planning' : existingEntry.phase;
+        existingEntry.active = true;
+        existingEntry.activated_at = requestedMode === match.skill
+          ? (sameSkill && sameKeyword ? existingEntry.activated_at || previous?.activated_at || nowIso : nowIso)
+          : existingEntry.activated_at;
+        existingEntry.updated_at = nowIso;
+        existingEntry.session_id = input.sessionId ?? existingEntry.session_id;
+        existingEntry.thread_id = input.threadId ?? existingEntry.thread_id;
+        existingEntry.turn_id = input.turnId ?? existingEntry.turn_id;
+        continue;
+      }
+
+      nextWorkflowEntries = [
+        ...nextWorkflowEntries,
+        {
+          skill: requestedMode,
+          phase: requestedMode === match.skill ? 'planning' : undefined,
+          active: true,
+          activated_at: requestedMode === match.skill && sameSkill && sameKeyword
+            ? previous?.activated_at
+            : nowIso,
+          updated_at: nowIso,
+          session_id: input.sessionId,
+          thread_id: input.threadId,
+          turn_id: input.turnId,
+        },
+      ];
+    }
+
+    const matchedEntry = nextWorkflowEntries.find((entry) => entry.skill === match.skill) ?? nextWorkflowEntries[0];
+    const workflowState: SkillActiveState = {
+      version: 1,
+      active: true,
+      skill: match.skill,
+      keyword: match.keyword,
+      phase: matchedEntry?.phase || 'planning',
+      activated_at: matchedEntry?.activated_at || nowIso,
+      updated_at: nowIso,
+      source: 'keyword-detector',
+      session_id: input.sessionId,
+      thread_id: input.threadId,
+      turn_id: input.turnId,
+      active_skills: nextWorkflowEntries,
+      ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
+    };
+
+    try {
+      let nextState: SkillActiveState = { ...workflowState };
+      for (const requestedMode of requestedWorkflowSkills) {
+        const requestedEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
+        const seeded = await persistStatefulSkillSeedState(
+          input.stateDir,
+          {
+            ...workflowState,
+            skill: requestedMode,
+            phase: requestedEntry?.phase || workflowState.phase,
+            activated_at: requestedEntry?.activated_at || workflowState.activated_at,
+            updated_at: requestedEntry?.updated_at || workflowState.updated_at,
+          },
+          nowIso,
+          previous,
+        );
+        if (requestedMode === match.skill) {
+          nextState = {
+            ...workflowState,
+            initialized_mode: seeded.initialized_mode,
+            initialized_state_path: seeded.initialized_state_path,
+          };
+        }
+      }
+      nextState.active_skills = buildActiveSkills(nextState);
+      await writeSkillActiveStateCopies(
+        dirname(dirname(input.stateDir)),
+        nextState,
+        input.sessionId,
+        input.sessionId && previous ? previous : nextState,
+      );
+      await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
+      return nextState;
+    } catch (error) {
+      console.warn('[omx] warning: failed to persist keyword activation state', error);
+    }
+
+    return workflowState;
+  }
 
   const state: SkillActiveState = {
     version: 1,
@@ -513,7 +662,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   try {
     const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous);
     nextState.active_skills = buildActiveSkills(nextState);
-    await writeSkillActiveStateCopies(dirname(dirname(input.stateDir)), nextState, input.sessionId);
+    await writeSkillActiveStateCopies(
+      dirname(dirname(input.stateDir)),
+      nextState,
+      input.sessionId,
+      input.sessionId && previous ? previous : nextState,
+    );
     await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
     return nextState;
   } catch (error) {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -27,7 +27,6 @@ import {
   buildWorkflowTransitionError,
   evaluateWorkflowTransition,
   isTrackedWorkflowMode,
-  pickPrimaryWorkflowMode,
 } from '../state/workflow-transition.js';
 
 export interface KeywordMatch {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -455,8 +455,13 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   if (!match) return null;
 
   const nowIso = input.nowIso ?? new Date().toISOString();
-  const statePath = join(input.stateDir, SKILL_ACTIVE_STATE_FILE);
-  const previous = await readExistingSkillState(statePath);
+  const rootStatePath = join(input.stateDir, SKILL_ACTIVE_STATE_FILE);
+  const sessionStatePath = input.sessionId
+    ? join(input.stateDir, 'sessions', input.sessionId, SKILL_ACTIVE_STATE_FILE)
+    : null;
+  const previousRoot = await readExistingSkillState(rootStatePath);
+  const previousSession = sessionStatePath ? await readExistingSkillState(sessionStatePath) : null;
+  const previous = previousSession ?? previousRoot;
   const hadDeepInterviewLock = previous?.skill === 'deep-interview' && previous?.input_lock?.active === true;
   const matches = detectKeywords(input.text);
   const hasCancelIntent = matches.some((entry) => entry.skill === 'cancel');
@@ -483,7 +488,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         dirname(dirname(input.stateDir)),
         state,
         input.sessionId,
-        previous ?? state,
+        input.sessionId ? (previousRoot ?? state) : state,
       );
       await persistDeepInterviewModeState(input.stateDir, state, nowIso, previous, input);
     } catch (error) {
@@ -622,7 +627,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         dirname(dirname(input.stateDir)),
         nextState,
         input.sessionId,
-        input.sessionId && previous ? previous : nextState,
+        input.sessionId ? (previousRoot ?? nextState) : nextState,
       );
       await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
       return nextState;
@@ -665,7 +670,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       dirname(dirname(input.stateDir)),
       nextState,
       input.sessionId,
-      input.sessionId && previous ? previous : nextState,
+      input.sessionId ? (previousRoot ?? nextState) : nextState,
     );
     await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
     return nextState;

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -378,4 +378,42 @@ describe('readAllState canonical skill precedence', () => {
       assert.deepEqual(state.team, { active: true, team_name: 'alpha', current_phase: 'running' });
     });
   });
+
+  it('surfaces approved combined workflow state from canonical multi-skill data', async () => {
+    await withTempRepo('omx-hud-canonical-combined-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-combined';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        session_id: sessionId,
+        active_skills: [
+          { skill: 'team', phase: 'running', active: true, session_id: sessionId },
+          { skill: 'ralph', phase: 'executing', active: true, session_id: sessionId },
+        ],
+      }));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'alpha',
+      }));
+      await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        iteration: 2,
+        max_iterations: 5,
+      }));
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.team, { active: true, team_name: 'alpha', current_phase: 'running' });
+      assert.deepEqual(state.ralph, {
+        active: true,
+        iteration: 2,
+        max_iterations: 5,
+        current_phase: 'executing',
+      });
+    });
+  });
 });

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -309,6 +309,114 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('allows approved overlaps and preserves the remaining canonical state on clear', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-overlap-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-overlap',
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-overlap',
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            max_iterations: 3,
+            current_phase: 'executing',
+          },
+        },
+      });
+
+      const canonicalPath = join(wd, '.omx', 'state', 'sessions', 'sess-overlap', 'skill-active-state.json');
+      const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active_skills?: Array<{ skill: string }>;
+      };
+      assert.deepEqual(canonical.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-overlap',
+            mode: 'team',
+          },
+        },
+      });
+
+      const clearedCanonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active: boolean;
+        skill: string;
+        active_skills?: Array<{ skill: string }>;
+      };
+      assert.equal(clearedCanonical.active, true);
+      assert.equal(clearedCanonical.skill, 'ralph');
+      assert.deepEqual(clearedCanonical.active_skills?.map((entry) => entry.skill), ['ralph']);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies unsupported overlaps without writing the requested mode state', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-deny-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-deny',
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+
+      const denied = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-deny',
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(denied.isError, true);
+      assert.match(denied.content[0]?.text || '', /Unsupported workflow overlap: team \+ autopilot\./);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-deny', 'autopilot-state.json')), false);
+
+      const canonical = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-deny', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(canonical.active_skills?.map((entry) => entry.skill), ['team']);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('removes tracked workflows from canonical skill-active state on all_sessions clear', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
@@ -345,6 +453,133 @@ describe('state-server directory initialization', () => {
       };
       assert.equal(canonical.active, false);
       assert.deepEqual(canonical.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves root-scoped team state when session-scoped ralph is added via state_write', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-team-ralph-'));
+    try {
+      const teamWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+      assert.equal(teamWrite.isError, undefined);
+
+      const ralphWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-team-ralph',
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            max_iterations: 5,
+            current_phase: 'executing',
+          },
+        },
+      });
+      assert.equal(ralphWrite.isError, undefined);
+
+      const rootCanonical = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        rootCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [{ skill: 'team', phase: 'running', session_id: undefined }],
+      );
+
+      const sessionCanonical = JSON.parse(
+        await readFile(
+          join(wd, '.omx', 'state', 'sessions', 'sess-team-ralph', 'skill-active-state.json'),
+          'utf-8',
+        ),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        sessionCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [
+          { skill: 'team', phase: 'running', session_id: undefined },
+          { skill: 'ralph', phase: 'executing', session_id: 'sess-team-ralph' },
+        ],
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects standalone overlaps without mutating canonical state', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-standalone-overlap-'));
+    try {
+      const autopilotWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-standalone',
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+      assert.equal(autopilotWrite.isError, undefined);
+
+      const invalidTeamWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-standalone',
+            mode: 'team',
+            active: true,
+            current_phase: 'starting',
+          },
+        },
+      });
+
+      assert.equal(invalidTeamWrite.isError, true);
+      const body = JSON.parse(invalidTeamWrite.content[0]?.text || '{}') as { error?: string };
+      assert.match(body.error || '', /omx state/i);
+      assert.match(body.error || '', /omx_state\.\*/i);
+
+      const canonical = JSON.parse(
+        await readFile(
+          join(wd, '.omx', 'state', 'sessions', 'sess-standalone', 'skill-active-state.json'),
+          'utf-8',
+        ),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        canonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [{ skill: 'autopilot', phase: 'planning', session_id: 'sess-standalone' }],
+      );
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-standalone', 'team-state.json')), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -417,6 +417,64 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('denies invalid writes before touching the requested mode file when canonical session state is stricter than mode files', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-canonical-prevalidate-'));
+    try {
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-canonical-deny'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'team-state.json'),
+        JSON.stringify({ active: true, mode: 'team', current_phase: 'running' }, null, 2),
+      );
+      await writeFile(
+        join(wd, '.omx', 'state', 'skill-active-state.json'),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          active_skills: [{ skill: 'team', phase: 'running', active: true }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(wd, '.omx', 'state', 'sessions', 'sess-canonical-deny', 'skill-active-state.json'),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          session_id: 'sess-canonical-deny',
+          active_skills: [
+            { skill: 'team', phase: 'running', active: true },
+            { skill: 'ralph', phase: 'executing', active: true, session_id: 'sess-canonical-deny' },
+          ],
+        }, null, 2),
+      );
+
+      const denied = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-canonical-deny',
+            mode: 'ultrawork',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(denied.isError, true);
+      assert.match(denied.content[0]?.text || '', /Unsupported workflow overlap: team \+ ralph \+ ultrawork\./);
+      assert.equal(
+        existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-canonical-deny', 'ultrawork-state.json')),
+        false,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('removes tracked workflows from canonical skill-active state on all_sessions clear', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
@@ -453,6 +511,60 @@ describe('state-server directory initialization', () => {
       };
       assert.equal(canonical.active, false);
       assert.deepEqual(canonical.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('propagates root clears into inherited session canonical copies', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-root-clear-propagate-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-root-clear',
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            max_iterations: 3,
+            current_phase: 'executing',
+          },
+        },
+      });
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+          },
+        },
+      });
+
+      const sessionCanonical = JSON.parse(
+        await readFile(
+          join(wd, '.omx', 'state', 'sessions', 'sess-root-clear', 'skill-active-state.json'),
+          'utf-8',
+        ),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(sessionCanonical.active_skills?.map((entry) => entry.skill), ['ralph']);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -37,6 +37,11 @@ import {
 	writeSkillActiveStateCopies,
 } from "../state/skill-active.js";
 import {
+	assertWorkflowTransitionAllowed,
+	isTrackedWorkflowMode,
+	readActiveWorkflowModes,
+} from "../state/workflow-transition.js";
+import {
 	RALPH_PHASES,
 	validateAndNormalizeRalphState,
 } from "../ralph/contract.js";
@@ -353,6 +358,15 @@ export async function handleStateToolCall(request: {
 						...fields,
 						...((customState as Record<string, unknown>) || {}),
 					} as Record<string, unknown>;
+					if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
+						try {
+							const activeModes = await readActiveWorkflowModes(cwd, effectiveSessionId);
+							assertWorkflowTransitionAllowed(activeModes, mode, "write");
+						} catch (error) {
+							validationError = (error as Error).message;
+							return;
+						}
+					}
 					if (
 						mode === "ralph" &&
 						effectiveSessionId &&

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -32,7 +32,9 @@ import {
 import { withModeRuntimeContext } from "../state/mode-state-context.js";
 import {
 	SKILL_ACTIVE_STATE_MODE,
+	listActiveSkills,
 	readSkillActiveState,
+	readVisibleSkillActiveState,
 	syncCanonicalSkillStateForMode,
 	writeSkillActiveStateCopies,
 } from "../state/skill-active.js";
@@ -73,6 +75,28 @@ const STATE_TOOL_NAMES = new Set([
 const TEAM_COMM_TOOL_NAMES: Set<string> = new Set([...LEGACY_TEAM_MCP_TOOLS]);
 
 const stateWriteQueues = new Map<string, Promise<void>>();
+
+async function listStateSessionIds(cwd: string): Promise<string[]> {
+	const sessionsDir = join(getStateDir(cwd), "sessions");
+	if (!existsSync(sessionsDir)) return [];
+	const entries = await readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+	return entries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.filter((entry) => entry.trim().length > 0);
+}
+
+async function readWorkflowModesForValidation(
+	cwd: string,
+	sessionId?: string,
+): Promise<string[]> {
+	const canonical = await readVisibleSkillActiveState(cwd, sessionId);
+	const canonicalModes = listActiveSkills(canonical ?? {})
+		.map((entry) => entry.skill)
+		.filter(isTrackedWorkflowMode);
+	if (canonicalModes.length > 0) return canonicalModes;
+	return readActiveWorkflowModes(cwd, sessionId);
+}
 
 async function withStateWriteLock<T>(
 	path: string,
@@ -360,8 +384,14 @@ export async function handleStateToolCall(request: {
 					} as Record<string, unknown>;
 					if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
 						try {
-							const activeModes = await readActiveWorkflowModes(cwd, effectiveSessionId);
+							const activeModes = await readWorkflowModesForValidation(cwd, effectiveSessionId);
 							assertWorkflowTransitionAllowed(activeModes, mode, "write");
+							if (!effectiveSessionId) {
+								for (const sessionId of await listStateSessionIds(cwd)) {
+									const sessionModes = await readWorkflowModesForValidation(cwd, sessionId);
+									assertWorkflowTransitionAllowed(sessionModes, mode, "write");
+								}
+							}
 						} catch (error) {
 							validationError = (error as Error).message;
 							return;

--- a/src/modes/__tests__/base-autoresearch-contract.test.ts
+++ b/src/modes/__tests__/base-autoresearch-contract.test.ts
@@ -23,6 +23,18 @@ describe('modes/base deep-interview contract integration', () => {
 });
 
 describe('modes/base autoresearch contract integration', () => {
+  it('startMode allows the approved team + ralph overlap', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-team-ralph-overlap-'));
+    try {
+      await startMode('team', 'demo team', 5, wd);
+      const started = await startMode('ralph', 'demo ralph', 5, wd);
+      assert.equal(started.mode, 'ralph');
+      assert.equal(started.active, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('startMode blocks autoresearch when ralph is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autoresearch-contract-'));
     try {
@@ -30,6 +42,19 @@ describe('modes/base autoresearch contract integration', () => {
       await assert.rejects(
         () => startMode('autoresearch', 'demo mission', 1, wd),
         /Cannot start autoresearch: ralph is already active/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('startMode blocks unsupported ralph + ultrawork overlap', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-ralph-ultrawork-deny-'));
+    try {
+      await startMode('ralph', 'demo', 5, wd);
+      await assert.rejects(
+        () => startMode('ultrawork', 'demo mission', 1, wd),
+        /Unsupported workflow overlap: ralph \+ ultrawork\./i,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/modes/__tests__/base-multi-state-compat.test.ts
+++ b/src/modes/__tests__/base-multi-state-compat.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readModeState, startMode } from '../base.js';
+
+describe('modes/base multi-state compatibility', () => {
+  it('allows the approved team + ralph overlap across root and session scopes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-team-ralph-'));
+    try {
+      await startMode('team', 'coordinate execution', 5, wd);
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({ session_id: 'sess-team-ralph' }),
+      );
+
+      await startMode('ralph', 'complete the approved plan', 5, wd);
+
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'team-state.json')), true);
+      assert.equal(
+        existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-team-ralph', 'ralph-state.json')),
+        true,
+      );
+      assert.equal((await readModeState('team', wd))?.active, true);
+      assert.equal((await readModeState('ralph', wd))?.active, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects standalone autopilot + team overlaps with actionable clearing guidance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-team-'));
+    try {
+      await startMode('autopilot', 'run solo automation', 5, wd);
+
+      await assert.rejects(
+        () => startMode('team', 'attempt invalid overlap', 5, wd),
+        /omx state.*omx_state\.\*/i,
+      );
+
+      const autopilotState = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8'),
+      ) as { active?: boolean };
+      assert.equal(autopilotState.active, true);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'team-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/modes/__tests__/base-tmux-pane.test.ts
+++ b/src/modes/__tests__/base-tmux-pane.test.ts
@@ -31,7 +31,7 @@ describe('modes/base tmux pane capture', () => {
 
       await assert.rejects(
         () => startMode('autopilot', 'test', 1, wd),
-        /state file is malformed or unreadable/i,
+        /clear or repair state via `omx state clear --mode ralph` or the `omx_state\.\*` MCP tools/i,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -6,6 +6,11 @@
 import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { withModeRuntimeContext } from '../state/mode-state-context.js';
+import {
+  assertWorkflowTransitionAllowed,
+  isTrackedWorkflowMode,
+  readActiveWorkflowModes,
+} from '../state/workflow-transition.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
 import {
   getBaseStateDir,
@@ -50,8 +55,6 @@ export function getDeprecationWarning(mode: string): string | null {
   return `[DEPRECATED] Mode "${mode}" is deprecated. ${warning}`;
 }
 
-const EXCLUSIVE_MODES: ModeName[] = ['autopilot', 'autoresearch', 'ralph', 'ultrawork'];
-
 function normalizeRalphModeStateOrThrow(state: ModeState): ModeState {
   const originalPhase = state.current_phase;
   const validation = validateAndNormalizeRalphState(state as Record<string, unknown>);
@@ -77,30 +80,10 @@ export async function assertModeStartAllowed(
   mode: ModeName,
   projectRoot?: string,
 ): Promise<void> {
-  if (!EXCLUSIVE_MODES.includes(mode)) return;
-
-  for (const other of EXCLUSIVE_MODES) {
-    if (other === mode) continue;
-    const otherPaths = await getReadScopedStatePaths(other, projectRoot);
-    for (const otherPath of otherPaths) {
-      if (!existsSync(otherPath)) continue;
-      try {
-        const raw = await readFile(otherPath, 'utf-8');
-        const otherState = JSON.parse(raw) as { active?: unknown };
-        if (otherState.active) {
-          throw new Error(`Cannot start ${mode}: ${other} is already active. Run cancel first.`);
-        }
-        break;
-      } catch (e) {
-        const err = e as NodeJS.ErrnoException;
-        if (err?.message.includes('Cannot start')) throw err;
-        if (err?.code === 'ENOENT') continue;
-        throw new Error(
-          `Cannot start ${mode}: ${other} state file is malformed or unreadable (${otherPath}). Run cancel or repair the state file.`
-        );
-      }
-    }
-  }
+  if (!isTrackedWorkflowMode(mode)) return;
+  const scope = await resolveStateScope(projectRoot);
+  const activeModes = await readActiveWorkflowModes(projectRoot ?? process.cwd(), scope.sessionId);
+  assertWorkflowTransitionAllowed(activeModes, mode, 'start');
 }
 
 /**

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -311,6 +311,47 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("returns actionable denial guidance for unsupported workflow overlaps on prompt submit", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-transition-deny-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-deny-1",
+          thread_id: "thread-deny-1",
+          turn_id: "turn-deny-1",
+          prompt: "$team ship this fix",
+        },
+        { cwd },
+      );
+
+      const denied = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-deny-1",
+          thread_id: "thread-deny-1",
+          turn_id: "turn-deny-2",
+          prompt: "$autopilot also run this",
+        },
+        { cwd },
+      );
+
+      assert.match(JSON.stringify(denied.outputJson), /denied workflow keyword/i);
+      assert.match(JSON.stringify(denied.outputJson), /Unsupported workflow overlap: team \+ autopilot\./);
+      assert.match(JSON.stringify(denied.outputJson), /`omx state clear --mode <mode>`/);
+      assert.match(JSON.stringify(denied.outputJson), /`omx_state\.\*` MCP tools/);
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", "sess-deny-1", "autopilot-state.json")),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("runs prompt-submit HUD reconciliation as a best-effort tmux-only side effect", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reconcile-"));
     const originalTmux = process.env.TMUX;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -428,6 +428,14 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
   const match = detectPrimaryKeyword(prompt);
   if (!match) return null;
 
+  if (skillState?.transition_error) {
+    return [
+      `OMX native UserPromptSubmit denied workflow keyword "${match.keyword}" -> ${match.skill}.`,
+      skillState.transition_error,
+      'Follow AGENTS.md routing and preserve ralplan/ralph execution gates.',
+    ].join(' ');
+  }
+
   if (match.skill === "team") {
     const initializedStateMessage = skillState?.initialized_mode && skillState.initialized_state_path
       ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -93,4 +93,51 @@ describe('skill-active state helpers', () => {
       }]);
     });
   });
+
+  it('preserves root-scoped team state when a session-scoped ralph overlap is activated', async () => {
+    await withTempRepo('omx-skill-active-team-ralph-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeSkillActiveStateCopies(cwd, {
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        active_skills: [{ skill: 'team', phase: 'running', active: true }],
+      });
+
+      await syncCanonicalSkillStateForMode({
+        cwd,
+        mode: 'ralph',
+        active: true,
+        currentPhase: 'executing',
+        sessionId: 'sess-overlap',
+        nowIso: '2026-04-09T00:00:00.000Z',
+      });
+
+      const rootState = JSON.parse(
+        await readFile(join(cwd, '.omx', 'state', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        rootState.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [{ skill: 'team', phase: 'running', session_id: undefined }],
+      );
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'sess-overlap');
+      assert.ok(sessionState);
+      assert.deepEqual(
+        listActiveSkills(sessionState).map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [
+          { skill: 'team', phase: 'running', session_id: undefined },
+          { skill: 'ralph', phase: 'executing', session_id: 'sess-overlap' },
+        ],
+      );
+    });
+  });
 });

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildWorkflowTransitionError,
+  evaluateWorkflowTransition,
+} from '../workflow-transition.js';
+
+describe('workflow transition rules', () => {
+  it('allows the approved overlap matrix and denies unsupported combinations', () => {
+    const cases: Array<{
+      current: string[];
+      requested: 'team' | 'ralph' | 'ultrawork' | 'autopilot' | 'autoresearch';
+      allowed: boolean;
+      resulting: string[];
+    }> = [
+      { current: [], requested: 'team', allowed: true, resulting: ['team'] },
+      { current: ['team'], requested: 'ralph', allowed: true, resulting: ['team', 'ralph'] },
+      { current: ['ralph'], requested: 'team', allowed: true, resulting: ['ralph', 'team'] },
+      { current: ['team'], requested: 'ultrawork', allowed: true, resulting: ['team', 'ultrawork'] },
+      { current: ['ultrawork'], requested: 'team', allowed: true, resulting: ['ultrawork', 'team'] },
+      { current: ['ralph'], requested: 'ultrawork', allowed: false, resulting: ['ralph'] },
+      { current: ['ultrawork'], requested: 'ralph', allowed: false, resulting: ['ultrawork'] },
+      { current: ['autopilot'], requested: 'team', allowed: false, resulting: ['autopilot'] },
+      { current: ['team'], requested: 'autopilot', allowed: false, resulting: ['team'] },
+      { current: ['autoresearch'], requested: 'ralph', allowed: false, resulting: ['autoresearch'] },
+      { current: ['team', 'ralph'], requested: 'ultrawork', allowed: false, resulting: ['team', 'ralph'] },
+      { current: ['team', 'ultrawork'], requested: 'ralph', allowed: false, resulting: ['team', 'ultrawork'] },
+    ];
+
+    for (const testCase of cases) {
+      const decision = evaluateWorkflowTransition(testCase.current, testCase.requested);
+      assert.equal(decision.allowed, testCase.allowed, `${testCase.current.join(',')} -> ${testCase.requested}`);
+      assert.deepEqual(decision.resultingModes, testCase.resulting, `${testCase.current.join(',')} -> ${testCase.requested}`);
+    }
+  });
+
+  it('builds actionable denial guidance that names both clearing paths', () => {
+    const error = buildWorkflowTransitionError(['team'], 'autopilot', 'start');
+    assert.match(error, /Cannot start autopilot: team is already active\./);
+    assert.match(error, /Unsupported workflow overlap: team \+ autopilot\./);
+    assert.match(error, /Current state is unchanged\./);
+    assert.match(error, /`omx state clear --mode <mode>`/);
+    assert.match(error, /`omx_state\.\*` MCP tools/);
+  });
+});

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -2,6 +2,11 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { omxStateDir } from '../utils/paths.js';
+import {
+  assertWorkflowTransitionAllowed,
+  isTrackedWorkflowMode,
+  pickPrimaryWorkflowMode,
+} from './workflow-transition.js';
 
 export const SKILL_ACTIVE_STATE_MODE = 'skill-active';
 export const SKILL_ACTIVE_STATE_FILE = `${SKILL_ACTIVE_STATE_MODE}-state.json`;
@@ -171,16 +176,20 @@ export async function writeSkillActiveStateCopies(
   cwd: string,
   state: SkillActiveStateLike,
   sessionId?: string,
+  rootState?: SkillActiveStateLike,
 ): Promise<void> {
   const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
-  const payload = JSON.stringify(state, null, 2);
+  const normalized = { version: 1, ...state };
+  const normalizedRoot = { version: 1, ...(rootState ?? normalized) };
+  const rootPayload = JSON.stringify(normalizedRoot, null, 2);
 
   await mkdir(dirname(rootPath), { recursive: true });
-  await writeFile(rootPath, payload);
+  await writeFile(rootPath, rootPayload);
 
   if (sessionPath) {
+    const sessionPayload = JSON.stringify(normalized, null, 2);
     await mkdir(dirname(sessionPath), { recursive: true });
-    await writeFile(sessionPath, payload);
+    await writeFile(sessionPath, sessionPayload);
   }
 }
 
@@ -213,42 +222,113 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
 
   if (!tracksCanonicalWorkflowSkill(mode)) return;
 
-  const { rootPath } = getSkillActiveStatePaths(cwd, sessionId);
-  const existing = await readSkillActiveState(rootPath);
-  if (!existing && !active) return;
+  const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+  const existingRoot = await readSkillActiveState(rootPath);
+  const existingSession = sessionPath ? await readSkillActiveState(sessionPath) : null;
+  if (!existingRoot && !existingSession && !active) return;
 
-  const entries = filterEntriesForSession(listActiveSkills(existing ?? {}), sessionId);
-  const filtered = entries.filter((entry) => entry.skill !== mode);
+  const normalizedSessionId = safeString(sessionId).trim();
+  const rootEntries = normalizedSessionId
+    ? listActiveSkills(existingRoot ?? {}).filter((entry) => {
+      const entrySessionId = safeString(entry.session_id).trim();
+      return entrySessionId.length === 0 || entrySessionId === normalizedSessionId;
+    })
+    : listActiveSkills(existingRoot ?? {});
+  const sessionOnlyEntries = normalizedSessionId
+    ? listActiveSkills(existingSession ?? {}).filter((entry) => (
+      safeString(entry.session_id).trim() === normalizedSessionId
+      && !rootEntries.some((rootEntry) => (
+        rootEntry.skill === entry.skill
+        && safeString(rootEntry.session_id).trim() === safeString(entry.session_id).trim()
+      ))
+    ))
+    : [];
+  const visibleEntries = normalizedSessionId
+    ? [...rootEntries, ...sessionOnlyEntries]
+    : [...rootEntries];
+
+  if (active && isTrackedWorkflowMode(mode)) {
+    const currentWorkflowModes = visibleEntries
+      .map((entry) => entry.skill)
+      .filter(isTrackedWorkflowMode);
+    assertWorkflowTransitionAllowed(currentWorkflowModes, mode, 'write');
+  }
+
+  const applyEntriesToState = (
+    base: SkillActiveStateLike | null,
+    entries: SkillActiveEntry[],
+    fallbackMode: string,
+  ): SkillActiveStateLike => {
+    const currentPrimary = safeString(base?.skill).trim();
+    const primarySkill = pickPrimaryWorkflowMode(currentPrimary, entries.map((entry) => entry.skill), fallbackMode);
+    const primaryEntry = entries.find((entry) => entry.skill === primarySkill) ?? entries[0];
+    return {
+      ...(base ?? {}),
+      version: 1,
+      active: entries.length > 0,
+      skill: primaryEntry?.skill || primarySkill || fallbackMode,
+      keyword: safeString(base?.keyword).trim(),
+      phase: primaryEntry?.phase || safeString(base?.phase).trim(),
+      activated_at: primaryEntry?.activated_at || safeString(base?.activated_at).trim() || nowIso,
+      updated_at: nowIso,
+      source: safeString(base?.source).trim() || source,
+      session_id: primaryEntry?.session_id || safeString(base?.session_id).trim() || undefined,
+      thread_id: primaryEntry?.thread_id || safeString(base?.thread_id).trim() || undefined,
+      turn_id: primaryEntry?.turn_id || safeString(base?.turn_id).trim() || undefined,
+      active_skills: entries,
+    };
+  };
+
+  if (normalizedSessionId) {
+    const nextSessionEntries = sessionOnlyEntries.filter((entry) => entry.skill !== mode);
+    if (active) {
+      nextSessionEntries.push({
+        skill: mode,
+        phase: safeString(currentPhase).trim() || undefined,
+        active: true,
+        activated_at: sessionOnlyEntries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
+        updated_at: nowIso,
+        session_id: normalizedSessionId,
+        thread_id: safeString(threadId).trim() || undefined,
+        turn_id: safeString(turnId).trim() || undefined,
+      });
+    }
+
+    const nextRootEntries = rootEntries.filter((entry) => !(
+      entry.skill === mode
+      && safeString(entry.session_id).trim() === normalizedSessionId
+    ));
+
+    const nextSessionState = applyEntriesToState(
+      existingSession ?? existingRoot,
+      [...nextRootEntries, ...nextSessionEntries],
+      mode,
+    );
+    const nextRootState = nextRootEntries.length > 0
+      ? applyEntriesToState(existingRoot, nextRootEntries, mode)
+      : applyEntriesToState(
+        existingSession ?? existingRoot,
+        active ? nextSessionEntries : [],
+        mode,
+      );
+    await writeSkillActiveStateCopies(cwd, nextSessionState, sessionId, nextRootState);
+    return;
+  }
+
+  const nextRootEntries = rootEntries.filter((entry) => entry.skill !== mode);
   if (active) {
-    filtered.push({
+    nextRootEntries.push({
       skill: mode,
       phase: safeString(currentPhase).trim() || undefined,
       active: true,
-      activated_at: entries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
+      activated_at: rootEntries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
       updated_at: nowIso,
-      session_id: safeString(sessionId).trim() || undefined,
+      session_id: undefined,
       thread_id: safeString(threadId).trim() || undefined,
       turn_id: safeString(turnId).trim() || undefined,
     });
   }
 
-  const currentPrimary = safeString(existing?.skill).trim();
-  const primaryEntry = filtered.find((entry) => entry.skill === currentPrimary) ?? filtered[0];
-  const nextState: SkillActiveStateLike = {
-    ...(existing ?? {}),
-    version: 1,
-    active: filtered.length > 0,
-    skill: primaryEntry?.skill || currentPrimary || mode,
-    keyword: safeString(existing?.keyword).trim(),
-    phase: primaryEntry?.phase || safeString(currentPhase).trim() || safeString(existing?.phase).trim(),
-    activated_at: primaryEntry?.activated_at || safeString(existing?.activated_at).trim() || nowIso,
-    updated_at: nowIso,
-    source: safeString(existing?.source).trim() || source,
-    session_id: safeString(sessionId).trim() || safeString(existing?.session_id).trim() || undefined,
-    thread_id: safeString(threadId).trim() || safeString(existing?.thread_id).trim() || undefined,
-    turn_id: safeString(turnId).trim() || safeString(existing?.turn_id).trim() || undefined,
-    active_skills: filtered.length > 0 ? filtered : [],
-  };
-
-  await writeSkillActiveStateCopies(cwd, nextState, sessionId);
+  const nextRootState = applyEntriesToState(existingRoot, nextRootEntries, mode);
+  await writeSkillActiveStateCopies(cwd, nextRootState, undefined, nextRootState);
 }

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -69,15 +69,6 @@ function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-function filterEntriesForSession(
-  entries: SkillActiveEntry[],
-  sessionId?: string,
-): SkillActiveEntry[] {
-  const normalizedSessionId = safeString(sessionId).trim();
-  if (!normalizedSessionId) return entries;
-  return entries.filter((entry) => safeString(entry.session_id).trim() === normalizedSessionId);
-}
-
 function normalizeSkillActiveEntry(raw: unknown): SkillActiveEntry | null {
   if (!raw || typeof raw !== 'object') return null;
   const skill = safeString((raw as Record<string, unknown>).skill).trim();

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile, readdir, unlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { omxStateDir } from '../utils/paths.js';
 import {
@@ -67,6 +67,31 @@ export interface SyncCanonicalSkillStateOptions {
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+function entryKey(entry: Pick<SkillActiveEntry, 'skill' | 'session_id'>): string {
+  return `${entry.skill}::${safeString(entry.session_id).trim()}`;
+}
+
+function filterRootEntriesForSession(entries: SkillActiveEntry[], sessionId?: string): SkillActiveEntry[] {
+  const normalizedSessionId = safeString(sessionId).trim();
+  if (!normalizedSessionId) return entries;
+  return entries.filter((entry) => {
+    const entrySessionId = safeString(entry.session_id).trim();
+    return entrySessionId.length === 0 || entrySessionId === normalizedSessionId;
+  });
+}
+
+function filterSessionOnlyEntries(
+  sessionState: SkillActiveStateLike | null,
+  rootEntries: SkillActiveEntry[],
+  sessionId: string,
+): SkillActiveEntry[] {
+  const inheritedKeys = new Set(filterRootEntriesForSession(rootEntries, sessionId).map(entryKey));
+  return listActiveSkills(sessionState ?? {}).filter((entry) => (
+    safeString(entry.session_id).trim() === sessionId
+    && !inheritedKeys.has(entryKey(entry))
+  ));
 }
 
 function normalizeSkillActiveEntry(raw: unknown): SkillActiveEntry | null {
@@ -322,4 +347,33 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
 
   const nextRootState = applyEntriesToState(existingRoot, nextRootEntries, mode);
   await writeSkillActiveStateCopies(cwd, nextRootState, undefined, nextRootState);
+
+  const sessionsDir = join(omxStateDir(cwd), 'sessions');
+  if (!existsSync(sessionsDir)) return;
+
+  const sessionIds = await readdir(sessionsDir).catch(() => []);
+  for (const candidate of sessionIds) {
+    const sessionId = safeString(candidate).trim();
+    if (!sessionId) continue;
+
+    const sessionPath = join(sessionsDir, sessionId, SKILL_ACTIVE_STATE_FILE);
+    if (!existsSync(sessionPath)) continue;
+
+    const existingSessionState = await readSkillActiveState(sessionPath);
+    const sessionOnlyEntries = filterSessionOnlyEntries(existingSessionState, rootEntries, sessionId);
+    const nextVisibleRootEntries = filterRootEntriesForSession(nextRootEntries, sessionId);
+    const nextSessionEntries = [...nextVisibleRootEntries, ...sessionOnlyEntries];
+
+    if (nextSessionEntries.length === 0) {
+      await unlink(sessionPath).catch(() => {});
+      continue;
+    }
+
+    const nextSessionState = applyEntriesToState(
+      existingSessionState ?? existingRoot,
+      nextSessionEntries,
+      nextSessionEntries[0]?.skill || mode,
+    );
+    await writeSkillActiveStateCopies(cwd, nextSessionState, sessionId, nextRootState);
+  }
 }

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -1,0 +1,168 @@
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+
+export const TRACKED_WORKFLOW_MODES = [
+  'autopilot',
+  'autoresearch',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
+  'ralplan',
+  'deep-interview',
+] as const;
+
+export type TrackedWorkflowMode = (typeof TRACKED_WORKFLOW_MODES)[number];
+export type WorkflowTransitionAction = 'activate' | 'start' | 'write';
+
+const ALLOWED_OVERLAP_PAIRS = new Set([
+  'ralph|team',
+  'team|ultrawork',
+]);
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function normalizeTrackedModes(modes: Iterable<string>): TrackedWorkflowMode[] {
+  const deduped = new Set<TrackedWorkflowMode>();
+  for (const mode of modes) {
+    if (isTrackedWorkflowMode(mode)) {
+      deduped.add(mode);
+    }
+  }
+  return [...deduped];
+}
+
+function buildPairKey(a: string, b: string): string {
+  return [a, b].sort((left, right) => left.localeCompare(right)).join('|');
+}
+
+function isAllowedOverlap(a: TrackedWorkflowMode, b: TrackedWorkflowMode): boolean {
+  return ALLOWED_OVERLAP_PAIRS.has(buildPairKey(a, b));
+}
+
+function formatActiveModes(modes: readonly string[]): string {
+  if (modes.length === 0) return 'no tracked workflows';
+  if (modes.length === 1) return `${modes[0]} is already active`;
+  if (modes.length === 2) return `${modes[0]} and ${modes[1]} are already active`;
+  return `${modes.slice(0, -1).join(', ')}, and ${modes[modes.length - 1]} are already active`;
+}
+
+export interface WorkflowTransitionDecision {
+  allowed: boolean;
+  currentModes: TrackedWorkflowMode[];
+  requestedMode: TrackedWorkflowMode;
+  resultingModes: TrackedWorkflowMode[];
+}
+
+export function isTrackedWorkflowMode(mode: string): mode is TrackedWorkflowMode {
+  return (TRACKED_WORKFLOW_MODES as readonly string[]).includes(mode);
+}
+
+export function evaluateWorkflowTransition(
+  currentActiveModes: Iterable<string>,
+  requestedMode: TrackedWorkflowMode,
+): WorkflowTransitionDecision {
+  const currentModes = normalizeTrackedModes(currentActiveModes);
+
+  if (currentModes.includes(requestedMode)) {
+    return {
+      allowed: true,
+      currentModes,
+      requestedMode,
+      resultingModes: currentModes,
+    };
+  }
+
+  if (currentModes.length === 0) {
+    return {
+      allowed: true,
+      currentModes,
+      requestedMode,
+      resultingModes: [requestedMode],
+    };
+  }
+
+  if (currentModes.length === 1 && isAllowedOverlap(currentModes[0], requestedMode)) {
+    return {
+      allowed: true,
+      currentModes,
+      requestedMode,
+      resultingModes: [currentModes[0], requestedMode],
+    };
+  }
+
+  return {
+    allowed: false,
+    currentModes,
+    requestedMode,
+    resultingModes: currentModes,
+  };
+}
+
+export function buildWorkflowTransitionError(
+  currentActiveModes: Iterable<string>,
+  requestedMode: TrackedWorkflowMode,
+  action: WorkflowTransitionAction = 'activate',
+): string {
+  const currentModes = normalizeTrackedModes(currentActiveModes);
+  const activeModesMessage = formatActiveModes(currentModes);
+  const overlap = [...currentModes, requestedMode].join(' + ');
+  return [
+    `Cannot ${action} ${requestedMode}: ${activeModesMessage}.`,
+    `Unsupported workflow overlap: ${overlap}.`,
+    'Current state is unchanged.',
+    `Clear incompatible workflow state via \`omx state clear --mode <mode>\` or the \`omx_state.*\` MCP tools, then retry.`,
+  ].join(' ');
+}
+
+export function assertWorkflowTransitionAllowed(
+  currentActiveModes: Iterable<string>,
+  requestedMode: TrackedWorkflowMode,
+  action: WorkflowTransitionAction = 'activate',
+): void {
+  const decision = evaluateWorkflowTransition(currentActiveModes, requestedMode);
+  if (decision.allowed) return;
+  throw new Error(buildWorkflowTransitionError(currentActiveModes, requestedMode, action));
+}
+
+export async function readActiveWorkflowModes(
+  cwd: string,
+  sessionId?: string,
+): Promise<TrackedWorkflowMode[]> {
+  const activeModes: TrackedWorkflowMode[] = [];
+
+  for (const mode of TRACKED_WORKFLOW_MODES) {
+    const candidatePaths = await getReadScopedStatePaths(mode, cwd, sessionId);
+    for (const candidatePath of candidatePaths) {
+      if (!existsSync(candidatePath)) continue;
+      try {
+        const parsed = JSON.parse(await readFile(candidatePath, 'utf-8')) as { active?: unknown };
+        if (parsed.active === true) {
+          activeModes.push(mode);
+        }
+        break;
+      } catch {
+        throw new Error(
+          `Cannot read ${mode} workflow state at ${candidatePath}. Clear or repair state via \`omx state clear --mode ${mode}\` or the \`omx_state.*\` MCP tools.`,
+        );
+      }
+    }
+  }
+
+  return activeModes;
+}
+
+export function pickPrimaryWorkflowMode(
+  currentPrimary: unknown,
+  resultingModes: readonly string[],
+  fallbackMode: string,
+): string {
+  const normalizedCurrent = safeString(currentPrimary).trim();
+  if (normalizedCurrent && resultingModes.includes(normalizedCurrent)) {
+    return normalizedCurrent;
+  }
+  return resultingModes[0] || fallbackMode;
+}


### PR DESCRIPTION
## Summary
- add a canonical workflow-transition model for approved overlaps and invalid-transition denial guidance
- preserve root/session canonical state correctly for `team + ralph` and `team + ultrawork`
- update keyword detection, state sync, HUD/overlay readers, stop handling, docs, and regression coverage around the new multi-skill rules

## Details
This treats the feature as a state-transition model change rather than a HUD-only fix.

Included changes:
- new `workflow-transition` rules and tests
- canonical skill-active/state-server updates for additive approved overlaps
- denial guidance that tells operators how to clear incompatible state via `omx state` or `omx_state.*`
- hook/native-stop/HUD/overlay coverage updates
- contract/review doc updates for the multi-state behavior

## Verification
- `npm run build`
- `node --test dist/state/__tests__/workflow-transition.test.js dist/state/__tests__/skill-active.test.js dist/hooks/__tests__/keyword-detector.test.js dist/mcp/__tests__/state-server.test.js dist/modes/__tests__/base-autoresearch-contract.test.js dist/hud/__tests__/state.test.js dist/hooks/__tests__/agents-overlay.test.js dist/scripts/__tests__/codex-native-hook.test.js`
