### PR TITLE
Keep notify hooks tracking live teams when coarse state drifts

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -42,6 +42,97 @@ async function readJsonLines(path: string): Promise<Array<Record<string, unknown
     .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
+async function writeCanonicalWatcherTeamFixture(
+  wd: string,
+  {
+    teamName = 'dispatch-team',
+    sessionId = 'sess-current',
+    ownerSessionId = sessionId,
+    coarseState = 'missing',
+    terminal = false,
+  }: {
+    teamName?: string;
+    sessionId?: string;
+    ownerSessionId?: string;
+    coarseState?: 'missing' | 'inactive' | 'active';
+    terminal?: boolean;
+  } = {},
+): Promise<void> {
+  const stateDir = join(wd, '.omx', 'state');
+  const teamDir = join(stateDir, 'team', teamName);
+  const nowIso = new Date().toISOString();
+
+  await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+  await mkdir(join(teamDir, 'workers'), { recursive: true });
+  await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+  if (coarseState !== 'missing') {
+    await writeFile(join(stateDir, 'team-state.json'), JSON.stringify({
+      active: coarseState === 'active',
+      team_name: teamName,
+      current_phase: terminal ? 'complete' : 'team-exec',
+      ...(terminal ? { completed_at: nowIso } : {}),
+    }, null, 2));
+  }
+  await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+    last_turn_at: new Date(Date.now() - 300_000).toISOString(),
+    turn_count: 3,
+  }, null, 2));
+  const manifest = {
+    schema_version: 2,
+    name: teamName,
+    task: 'canonical watcher fallback repro',
+    leader: {
+      session_id: ownerSessionId,
+      worker_id: 'leader-fixed',
+      role: 'coordinator',
+    },
+    policy: {
+      worker_launch_mode: 'interactive',
+      display_mode: 'split_pane',
+      dispatch_mode: 'hook_preferred_with_fallback',
+      dispatch_ack_timeout_ms: 2000,
+    },
+    governance: {
+      delegation_only: false,
+      plan_approval_required: false,
+      nested_teams_allowed: false,
+      one_team_per_leader_session: true,
+      cleanup_requires_all_workers_inactive: true,
+    },
+    lifecycle_profile: 'default',
+    permissions_snapshot: {
+      approval_mode: 'never',
+      sandbox_mode: 'danger-full-access',
+      network_access: true,
+    },
+    tmux_session: `${teamName}:0`,
+    leader_pane_id: '%42',
+    hud_pane_id: null,
+    resize_hook_name: null,
+    resize_hook_target: null,
+    worker_count: 1,
+    next_task_id: 1,
+    workers: [
+      { name: 'worker-1', index: 1, pane_id: '%42', role: 'executor' },
+    ],
+    created_at: nowIso,
+  };
+  await writeFile(join(teamDir, 'manifest.v2.json'), JSON.stringify(manifest, null, 2));
+  await writeFile(join(teamDir, 'config.json'), JSON.stringify({
+    name: teamName,
+    tmux_session: `${teamName}:0`,
+    leader_pane_id: '%42',
+    workers: [
+      { name: 'worker-1', pane_id: '%42' },
+    ],
+  }, null, 2));
+  await writeFile(join(teamDir, 'phase.json'), JSON.stringify({
+    current_phase: terminal ? 'complete' : 'team-exec',
+    updated_at: nowIso,
+    transitions: terminal ? [{ from: 'team-exec', to: 'complete', at: nowIso }] : [],
+  }, null, 2));
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -844,6 +935,7 @@ describe('notify-fallback watcher', () => {
           encoding: 'utf-8',
           env: buildCleanNotifyEnv({
             PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_SESSION_ID: 'sess-canonical-inactive',
           }),
         },
       );
@@ -874,6 +966,43 @@ describe('notify-fallback watcher', () => {
         && entry.source === 'notify_fallback_watcher'
         && entry.transport === 'send-keys'
         && entry.result === 'sent'));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('runs leader nudge checks from canonical fallback when coarse team-state is inactive', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-leader-nudge-canonical-inactive-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalWatcherTeamFixture(wd, {
+        teamName: 'dispatch-team',
+        sessionId: 'sess-canonical-inactive',
+        ownerSessionId: 'sess-canonical-inactive',
+        coarseState: 'inactive',
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_SESSION_ID: 'sess-canonical-inactive',
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(tmuxLog, /send-keys -t %42 -l Team dispatch-team: leader stale, \d+ worker pane\(s\) still active\./);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -927,6 +1056,7 @@ describe('notify-fallback watcher', () => {
           encoding: 'utf-8',
           env: buildCleanNotifyEnv({
             PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_SESSION_ID: 'sess-canonical-inactive',
           }),
         },
       );
@@ -2734,6 +2864,149 @@ exit 0
       assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
         entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
       )));
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('stays alive after parent exit when coarse team-state is missing but canonical team is active for the current session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-canonical-team-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-canonical-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalWatcherTeamFixture(wd, {
+        teamName: 'dispatch-team',
+        sessionId: 'sess-parent-canonical',
+        ownerSessionId: 'sess-parent-canonical',
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        }
+      );
+
+      await waitFor(async () => isPidAlive(child?.pid), 4000, 50);
+      await waitFor(async () => {
+        const logEntries = (await readFile(logPath, 'utf-8').catch(() => ''))
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map((line) => JSON.parse(line));
+        return logEntries.some((entry: { type?: string; reason?: string }) => (
+          entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+        ));
+      }, 4000, 50);
+
+      assert.ok(isPidAlive(child.pid), 'expected watcher to stay alive while canonical team panes remain active');
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('does not defer parent-loss shutdown when canonical owner session is blank and coarse team-state is missing', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-ownerless-team-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-ownerless-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalWatcherTeamFixture(wd, {
+        teamName: 'dispatch-team',
+        sessionId: 'sess-parent-ownerless',
+        ownerSessionId: '',
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        }
+      );
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
+      )));
+      assert.ok(!logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+      )), 'ownerless canonical team must not defer parent-loss shutdown');
     } finally {
       if (child && isPidAlive(child.pid)) {
         child.kill('SIGTERM');

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -22,6 +22,95 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+async function writeCanonicalTeamFixture(
+  cwd: string,
+  {
+    teamName,
+    sessionId,
+    ownerSessionId,
+    coarseState = 'missing',
+  }: {
+    teamName: string;
+    sessionId: string;
+    ownerSessionId: string;
+    coarseState?: 'missing' | 'inactive' | 'active';
+  },
+): Promise<void> {
+  const stateDir = join(cwd, '.omx', 'state');
+  const teamDir = join(stateDir, 'team', teamName);
+  const workersDir = join(teamDir, 'workers');
+  const nowIso = new Date().toISOString();
+
+  await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
+  await mkdir(workersDir, { recursive: true });
+
+  await writeJson(join(stateDir, 'session.json'), { session_id: sessionId });
+  if (coarseState !== 'missing') {
+    await writeJson(join(stateDir, 'team-state.json'), {
+      active: coarseState === 'active',
+      team_name: teamName,
+      current_phase: 'team-exec',
+    });
+  }
+  await writeJson(join(stateDir, 'hud-state.json'), {
+    last_turn_at: nowIso,
+    turn_count: 1,
+  });
+  await writeJson(join(teamDir, 'manifest.v2.json'), {
+    schema_version: 2,
+    name: teamName,
+    task: 'canonical notify fallback repro',
+    leader: {
+      session_id: ownerSessionId,
+      worker_id: 'leader-fixed',
+      role: 'coordinator',
+    },
+    policy: {
+      worker_launch_mode: 'interactive',
+      display_mode: 'split_pane',
+      dispatch_mode: 'hook_preferred_with_fallback',
+      dispatch_ack_timeout_ms: 2000,
+    },
+    governance: {
+      delegation_only: false,
+      plan_approval_required: false,
+      nested_teams_allowed: false,
+      one_team_per_leader_session: true,
+      cleanup_requires_all_workers_inactive: true,
+    },
+    lifecycle_profile: 'default',
+    permissions_snapshot: {
+      approval_mode: 'never',
+      sandbox_mode: 'danger-full-access',
+      network_access: true,
+    },
+    tmux_session: `${teamName}:0`,
+    leader_pane_id: '%97',
+    hud_pane_id: null,
+    resize_hook_name: null,
+    resize_hook_target: null,
+    worker_count: 2,
+    next_task_id: 1,
+    workers: [
+      { name: 'worker-1', index: 1, pane_id: '%1', role: 'executor' },
+      { name: 'worker-2', index: 2, pane_id: '%2', role: 'executor' },
+    ],
+    created_at: nowIso,
+  });
+  await writeJson(join(teamDir, 'phase.json'), {
+    current_phase: 'team-exec',
+    updated_at: nowIso,
+    transitions: [],
+  });
+  for (const worker of ['worker-1', 'worker-2']) {
+    await mkdir(join(workersDir, worker), { recursive: true });
+    await writeJson(join(workersDir, worker, 'status.json'), {
+      state: 'idle',
+      updated_at: nowIso,
+    });
+  }
+}
+
 async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
   const path = join(cwd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
   const raw = await readFile(path, 'utf-8').catch(() => '');
@@ -155,7 +244,9 @@ describe('notify-hook leader-side authority handoff', () => {
       await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-missing',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
@@ -181,7 +272,9 @@ describe('notify-hook leader-side authority handoff', () => {
         trigger_message: 'dispatch ping',
       }, cwd);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-inactive',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const request = await readDispatchRequest('handoff-dispatch', queued.request.request_id, cwd);
@@ -237,7 +330,9 @@ describe('notify-hook leader-side authority handoff', () => {
       await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345']));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-current',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       if (existsSync(tmuxLogPath)) {
@@ -293,7 +388,9 @@ describe('notify-hook team leader nudge', () => {
       await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-missing',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
       assert.doesNotMatch(tmuxLog, /send-keys -t %97 -l Team deep-interview-suppressed:/);
@@ -348,7 +445,9 @@ describe('notify-hook team leader nudge', () => {
       await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-inactive',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -428,7 +527,9 @@ describe('notify-hook team leader nudge', () => {
       await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345', '%11 12346']));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-missing',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -494,7 +595,9 @@ describe('notify-hook team leader nudge', () => {
       await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345', '%11 12346']));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-inactive',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -627,6 +730,61 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /send-keys/);
       assert.match(tmuxLog, /-t %97/, 'should still target the leader pane');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'global team-state fallback should still fire idle nudge');
+    });
+  });
+
+  it('falls back to canonical team state when coarse team-state is missing', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalTeamFixture(cwd, {
+        teamName: 'canonical-missing',
+        sessionId: 'sess-canonical-missing',
+        ownerSessionId: 'sess-canonical-missing',
+      });
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-missing',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys/);
+      assert.match(tmuxLog, /-t %97/, 'should target canonical leader pane');
+      assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'canonical fallback should still fire idle nudge');
+    });
+  });
+
+  it('falls back to canonical team state when coarse team-state is inactive', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalTeamFixture(cwd, {
+        teamName: 'canonical-inactive',
+        sessionId: 'sess-canonical-inactive',
+        ownerSessionId: 'sess-canonical-inactive',
+        coarseState: 'inactive',
+      });
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-inactive',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys/);
+      assert.match(tmuxLog, /-t %97/, 'should still target canonical leader pane');
+      assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'inactive coarse state should still fall back canonically');
     });
   });
 
@@ -1544,6 +1702,31 @@ exit 0
       if (existsSync(tmuxLogPath)) {
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
         assert.doesNotMatch(tmuxLog, /send-keys/, 'must not nudge teams owned by another session');
+      }
+    });
+  });
+
+  it('does not nudge a canonical-only team when owner session is blank', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalTeamFixture(cwd, {
+        teamName: 'ownerless-team',
+        sessionId: 'sess-current',
+        ownerSessionId: '',
+      });
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys/, 'ownerless canonical teams must not nudge');
       }
     });
   });

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS,
   readSubagentSessionSummary,
 } from '../subagents/tracker.js';
+import { listNotifyCanonicalActiveTeams } from './notify-hook/active-team.js';
 
 function argValue(name: string, fallback = ''): string {
   const idx = process.argv.indexOf(name);
@@ -561,12 +562,13 @@ async function resolveActiveRalphState(): Promise<ActiveModeResult> {
 
 async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
   const candidateDirs: string[] = [];
+  let currentSessionId = '';
   const sessionPath = join(stateDir, 'session.json');
   try {
     const session = JSON.parse(await readFile(sessionPath, 'utf-8')) as Record<string, unknown>;
-    const sessionId = safeString(session?.session_id).trim();
-    if (sessionId) {
-      candidateDirs.push(join(stateDir, 'sessions', sessionId));
+    currentSessionId = safeString(session?.session_id).trim();
+    if (currentSessionId) {
+      candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
     }
   } catch {
     // No active session file; fall back to root state only.
@@ -618,6 +620,41 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
       path,
       state: parsed,
       team_name: teamName,
+      pane_count: paneStatus.paneCount,
+    };
+  }
+
+  const canonicalFallbackTeams = await listNotifyCanonicalActiveTeams(cwd, currentSessionId).catch(() => []);
+  for (const team of canonicalFallbackTeams) {
+    const teamConfigDir = join(stateDir, 'team', team.teamName);
+    const manifestPath = join(teamConfigDir, 'manifest.v2.json');
+    const configPath = join(teamConfigDir, 'config.json');
+    const teamConfigPath = existsSync(manifestPath) ? manifestPath : configPath;
+    const teamConfig = existsSync(teamConfigPath)
+      ? await readFile(teamConfigPath, 'utf-8')
+        .then((content) => JSON.parse(content) as Record<string, unknown>)
+        .catch(() => null)
+      : null;
+    const tmuxSession = safeString(teamConfig?.tmux_session).trim();
+    if (!tmuxSession) continue;
+
+    const workers = Array.isArray(teamConfig?.workers) ? teamConfig.workers as Array<Record<string, unknown>> : [];
+    const workerPaneIds: string[] = workers
+      .map((worker) => safeString(worker?.pane_id).trim())
+      .filter(Boolean);
+    const paneStatus = await checkWorkerPanesAlive(tmuxSession, workerPaneIds as any);
+    if (!paneStatus.alive) continue;
+
+    return {
+      active: true,
+      reason: team.source,
+      path: team.path,
+      state: {
+        active: true,
+        team_name: team.teamName,
+        current_phase: team.phase,
+      },
+      team_name: team.teamName,
       pane_count: paneStatus.paneCount,
     };
   }

--- a/src/scripts/notify-hook/active-team.ts
+++ b/src/scripts/notify-hook/active-team.ts
@@ -1,0 +1,54 @@
+import { existsSync } from 'fs';
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+import { readTeamManifestV2, readTeamPhase } from '../../team/state.js';
+import { resolveCanonicalTeamStateRoot } from '../../team/state-root.js';
+import { isTerminalPhase, safeString } from './utils.js';
+
+export interface NotifyCanonicalActiveTeam {
+  teamName: string;
+  phase: string;
+  ownerSessionId: string;
+  path: string;
+  source: 'canonical_fallback';
+}
+
+export async function listNotifyCanonicalActiveTeams(
+  cwd: string,
+  currentSessionId: string,
+): Promise<NotifyCanonicalActiveTeam[]> {
+  const sessionId = safeString(currentSessionId).trim();
+  if (!sessionId) return [];
+
+  const teamsRoot = join(resolveCanonicalTeamStateRoot(cwd), 'team');
+  if (!existsSync(teamsRoot)) return [];
+
+  const entries = await readdir(teamsRoot, { withFileTypes: true }).catch(() => []);
+  const teams: NotifyCanonicalActiveTeam[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const teamName = entry.name.trim();
+    if (!teamName) continue;
+
+    const [manifest, phaseState] = await Promise.all([
+      readTeamManifestV2(teamName, cwd),
+      readTeamPhase(teamName, cwd),
+    ]);
+    if (!manifest || !phaseState) continue;
+
+    const ownerSessionId = safeString(manifest.leader?.session_id).trim();
+    if (!ownerSessionId || ownerSessionId !== sessionId) continue;
+
+    const phase = safeString(phaseState.current_phase).trim();
+    if (!phase || isTerminalPhase(phase)) continue;
+
+    teams.push({
+      teamName,
+      phase,
+      ownerSessionId,
+      path: join(teamsRoot, teamName, 'phase.json'),
+      source: 'canonical_fallback',
+    });
+  }
+  return teams;
+}

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -12,6 +12,7 @@ import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
+import { listNotifyCanonicalActiveTeams } from './active-team.js';
 import {
   classifyLeaderActionState,
   resolveLeaderNudgeIntent,
@@ -599,6 +600,11 @@ export async function maybeNudgeTeamLeader({
     }
   } catch {
     // Non-critical
+  }
+
+  const canonicalFallbackTeams = await listNotifyCanonicalActiveTeams(cwd, currentSessionId).catch(() => []);
+  for (const team of canonicalFallbackTeams) {
+    candidateTeamNames.add(team.teamName);
   }
 
   // Use pre-computed staleness (captured before HUD state was updated this turn)


### PR DESCRIPTION
## Summary

Notify hook surfaces could lose track of a live team when coarse `team-state.json` drifted, disappeared, or flipped inactive even though canonical team state was still present. This change adds a canonical active-team fallback for notify-path readers so leader nudges and fallback watcher behavior continue working until explicit shutdown.

## Changes

- add `src/scripts/notify-hook/active-team.ts` for strict notify-path canonical active-team discovery
- wire canonical fallback into `team-leader-nudge` when coarse team state is missing or inactive
- wire canonical fallback into `notify-fallback-watcher` for active-team resolution and parent-loss guarding
- add regression coverage for missing/inactive coarse state, owner mismatch, blank owner rejection, and terminal canonical phase guards
- preserve the stricter notify-path ownership rule without changing stop-hook or shutdown cleanup semantics

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx biome lint src/scripts/notify-hook/active-team.ts src/scripts/notify-hook/team-leader-nudge.ts src/scripts/notify-fallback-watcher.ts src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts src/hooks/__tests__/notify-fallback-watcher.test.ts`
- [x] `node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js`
- [x] `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/team/__tests__/runtime-cli.test.js dist/team/__tests__/runtime.test.js dist/cli/__tests__/team.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
