### PR TITLE
fix: repair retired team MCP config on upgrade

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -66,6 +66,46 @@ command = "node"
     }
   });
 
+  it('warns about retired omx_team_run config left behind after upgrade', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-copy-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        `
+[mcp_servers.omx_team_run]
+command = "node"
+args = ["/tmp/team-server.js"]
+enabled = true
+`.trimStart(),
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Config: retired \[mcp_servers\.omx_team_run\] table still present; run "omx setup --force" to repair the config/,
+      );
+      assert.match(
+        res.stdout,
+        /MCP Servers: 1 servers configured, but retired \[mcp_servers\.omx_team_run\] is not supported; run "omx setup --force" to repair the config/,
+      );
+      assert.doesNotMatch(res.stdout, /Config: config\.toml has OMX entries/);
+      assert.doesNotMatch(
+        res.stdout,
+        /MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('warns when explore harness sources are packaged but cargo is unavailable', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-copy-'));
     try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -28,6 +28,7 @@ import {
   resolveSetupScopeArg,
   readPersistedSetupPreferences,
   readPersistedSetupScope,
+  resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
   buildDetachedSessionBootstrapSteps,
   buildDetachedTmuxSessionName,
@@ -1027,6 +1028,23 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("uses project config.toml for launch repair when persisted scope is project", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(
+        resolveCodexConfigPathForLaunch(wd, {}),
+        join(wd, ".codex", "config.toml"),
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps explicit CODEX_HOME override from env", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
     try {
@@ -1040,6 +1058,25 @@ describe("project launch scope helpers", () => {
           CODEX_HOME: "/tmp/explicit-codex-home",
         }),
         "/tmp/explicit-codex-home",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("uses explicit CODEX_HOME config.toml for launch repair overrides", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(
+        resolveCodexConfigPathForLaunch(wd, {
+          CODEX_HOME: "/tmp/explicit-codex-home",
+        }),
+        "/tmp/explicit-codex-home/config.toml",
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -402,6 +402,34 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("repairs retired omx_team_run config during setup refresh", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".codex"), { recursive: true });
+      await writeFile(
+        join(wd, ".codex", "config.toml"),
+        [
+          '[mcp_servers.omx_team_run]',
+          'command = "node"',
+          'args = ["./dist/cli/team-mcp.js"]',
+          "",
+        ].join("\n"),
+      );
+
+      const output = await runSetupWithCapturedLogs(wd, { scope: "project" });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(
+        output,
+        /Removed retired \[mcp_servers\.omx_team_run\] config during refresh\./,
+      );
+      assert.doesNotMatch(config, /^\[mcp_servers\.omx_team_run\]$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("syncs shared MCP registry entries into ~/.claude/settings.json for user scope", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     const previousHome = process.env.HOME;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -14,6 +14,7 @@ import { getCatalogExpectations } from './catalog-contract.js';
 import { parse as parseToml } from '@iarna/toml';
 import { resolvePackagedExploreHarnessCommand, EXPLORE_BIN_ENV } from './explore.js';
 import { getPackageRoot } from '../utils/package.js';
+import { hasLegacyOmxTeamRunTable } from '../config/generator.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
 import { isLeaderRuntimeStale } from '../team/leader-activity.js';
@@ -583,6 +584,15 @@ async function checkConfig(configPath: string): Promise<Check> {
       };
     }
 
+    if (hasLegacyOmxTeamRunTable(content)) {
+      return {
+        name: 'Config',
+        status: 'warn',
+        message:
+          'retired [mcp_servers.omx_team_run] table still present; run "omx setup --force" to repair the config',
+      };
+    }
+
     const hasOmx = content.includes('omx_') || content.includes('oh-my-codex');
     if (hasOmx) {
       return { name: 'Config', status: 'pass', message: 'config.toml has OMX entries' };
@@ -756,6 +766,13 @@ async function checkMcpServers(configPath: string): Promise<Check> {
     const content = await readFile(configPath, 'utf-8');
     const mcpCount = (content.match(/\[mcp_servers\./g) || []).length;
     if (mcpCount > 0) {
+      if (hasLegacyOmxTeamRunTable(content)) {
+        return {
+          name: 'MCP Servers',
+          status: 'warn',
+          message: `${mcpCount} servers configured, but retired [mcp_servers.omx_team_run] is not supported; run "omx setup --force" to repair the config`,
+        };
+      }
       const hasOmx = content.includes('omx_state') || content.includes('omx_memory');
       if (hasOmx) {
         return { name: 'MCP Servers', status: 'pass', message: `${mcpCount} servers configured (OMX present)` };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -344,6 +344,16 @@ export function resolveCodexHomeForLaunch(
   return undefined;
 }
 
+export function resolveCodexConfigPathForLaunch(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
+  return codexHomeOverride
+    ? join(codexHomeOverride, "config.toml")
+    : codexConfigPath();
+}
+
 export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {
   let value: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
@@ -932,7 +942,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
   // TOML parser rejects duplicates, so we repair before spawning the CLI.
   try {
     const repaired = await repairConfigIfNeeded(
-      codexConfigPath(),
+      resolveCodexConfigPathForLaunch(launchCwd, process.env),
       getPackageRoot(),
     );
     if (repaired) {
@@ -1013,7 +1023,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
 
   try {
     const repaired = await repairConfigIfNeeded(
-      codexConfigPath(),
+      resolveCodexConfigPathForLaunch(launchCwd, process.env),
       getPackageRoot(),
     );
     if (repaired) {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -28,7 +28,11 @@ import {
   omxPlansDir,
   omxLogsDir,
 } from "../utils/paths.js";
-import { buildMergedConfig, getRootModelName } from "../config/generator.js";
+import {
+  buildMergedConfig,
+  getRootModelName,
+  hasLegacyOmxTeamRunTable,
+} from "../config/generator.js";
 import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
 import {
   getLegacyUnifiedMcpRegistryCandidate,
@@ -113,6 +117,7 @@ interface SetupBackupContext {
 interface ManagedConfigResult {
   finalConfig: string;
   omxManagesTui: boolean;
+  repairedLegacyTeamRunTable: boolean;
 }
 
 interface LegacySkillOverlapNotice {
@@ -826,6 +831,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     { codexVersionProbe: options.codexVersionProbe, dryRun, verbose, modelUpgradePrompt },
   );
   const resolvedConfig = managedConfig.finalConfig;
+  if (managedConfig.repairedLegacyTeamRunTable) {
+    console.log(
+      "  Removed retired [mcp_servers.omx_team_run] config during refresh.",
+    );
+  }
   if (resolvedScope.scope === "user") {
     await syncClaudeCodeMcpSettings(
       sharedMcpRegistry,
@@ -1563,6 +1573,7 @@ async function updateManagedConfig(
   const existing = existsSync(configPath)
     ? await readFile(configPath, "utf-8")
     : "";
+  const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
   const currentModel = getRootModelName(existing);
   let modelOverride: string | undefined;
   const codexVersion =
@@ -1594,7 +1605,11 @@ async function updateManagedConfig(
 
   if (!changed) {
     summary.unchanged += 1;
-    return { finalConfig, omxManagesTui };
+    return {
+      finalConfig,
+      omxManagesTui,
+      repairedLegacyTeamRunTable: false,
+    };
   }
 
   if (
@@ -1629,7 +1644,12 @@ async function updateManagedConfig(
       `  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
     );
   }
-  return { finalConfig, omxManagesTui };
+  return {
+    finalConfig,
+    omxManagesTui,
+    repairedLegacyTeamRunTable:
+      hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
+  };
 }
 
 function getClaudeCodeSettingsPath(homeDir = homedir()): string {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -57,6 +57,10 @@ const OMX_TUI_STATUS_LINE =
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
 
+export function hasLegacyOmxTeamRunTable(config: string): boolean {
+  return LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(config);
+}
+
 function unwrapTomlString(value: string | undefined): string | undefined {
   return value?.match(/^"(.*)"$/)?.[1];
 }
@@ -981,7 +985,7 @@ export async function repairConfigIfNeeded(
 
   const content = await readFile(configPath, "utf-8");
   const tuiCount = (content.match(/^\s*\[tui\]\s*$/gm) || []).length;
-  const hasLegacyTeamRunTable = LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(content);
+  const hasLegacyTeamRunTable = hasLegacyOmxTeamRunTable(content);
   const hasLauncherTimeoutGap = findLauncherTimeoutRepairTargets(content).length > 0;
   if (tuiCount <= 1 && !hasLegacyTeamRunTable && !hasLauncherTimeoutGap) return false;
 


### PR DESCRIPTION
## Summary\n- reland the intended PR #1425 behavior on top of current `dev` without the original formatting churn\n- warn in `omx doctor` when a retired `[mcp_servers.omx_team_run]` table is still present and surface that setup repaired it\n- repair the correct `config.toml` during launch for project-scoped setups and explicit `CODEX_HOME` overrides\n\n## Verification\n- npm run build\n- npx biome lint src/config/generator.ts src/cli/doctor.ts src/cli/index.ts src/cli/setup.ts src/cli/__tests__/index.test.ts src/cli/__tests__/doctor-warning-copy.test.ts src/cli/__tests__/setup-refresh.test.ts\n- node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/doctor-warning-copy.test.js\n- node --test dist/config/__tests__/generator-idempotent.test.js\n\nReland of #1425.