### PR TITLE
Fix Windows MCP orphan cleanup when parent sessions disappear

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { shouldAutoStartMcpServer, type McpServerName } from '../bootstrap.js';
+import { isParentProcessAlive, shouldAutoStartMcpServer, type McpServerName } from '../bootstrap.js';
 
 const ALL_SERVERS: readonly McpServerName[] = [
   'state',
@@ -51,6 +51,30 @@ describe('mcp bootstrap auto-start guard', () => {
   });
 });
 
+describe('mcp parent watchdog liveness checks', () => {
+  it('treats missing or root-like parent pids as gone', () => {
+    assert.equal(isParentProcessAlive(0, () => true), false);
+    assert.equal(isParentProcessAlive(1, () => true), false);
+    assert.equal(isParentProcessAlive(Number.NaN, () => true), false);
+  });
+
+  it('treats kill(0) success as parent alive', () => {
+    assert.equal(isParentProcessAlive(42, () => true), true);
+  });
+
+  it('treats ESRCH as parent gone and EPERM as still alive', () => {
+    const missing = Object.assign(new Error('missing'), { code: 'ESRCH' });
+    const denied = Object.assign(new Error('denied'), { code: 'EPERM' });
+
+    assert.equal(isParentProcessAlive(42, () => {
+      throw missing;
+    }), false);
+    assert.equal(isParentProcessAlive(42, () => {
+      throw denied;
+    }), true);
+  });
+});
+
 describe('mcp shared stdio lifecycle contract', () => {
   it('keeps shared stdio lifecycle wiring in bootstrap', async () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
@@ -58,6 +82,9 @@ describe('mcp shared stdio lifecycle contract', () => {
     assert.match(src, /StdioServerTransport/, 'bootstrap should own stdio transport creation');
     assert.match(src, /server\.connect\(/, 'bootstrap should own MCP server connection');
     assert.match(src, /stdin/i, 'bootstrap should react to stdin/client disconnect');
+    assert.match(src, /parent_gone/, 'bootstrap should watch for the parent process disappearing');
+    assert.match(src, /isParentProcessAlive\(trackedParentPid\)/, 'bootstrap should probe parent liveness directly');
+    assert.match(src, /process\.exit\(0\)/, 'bootstrap should force child exit after shutdown completes');
     assert.match(src, /SIGTERM/, 'bootstrap should handle SIGTERM');
     assert.match(src, /SIGINT/, 'bootstrap should handle SIGINT');
   });

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -84,6 +84,10 @@ async function waitForExit(
   stderr: string[],
   stdout: string[],
 ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+
   try {
     const [code, signal] = (await Promise.race([
       once(child, 'exit') as Promise<[number | null, NodeJS.Signals | null]>,

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -11,10 +11,27 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
 
 const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
 const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
+const PARENT_WATCHDOG_INTERVAL_MS = 25;
 
 interface StdioLifecycleServer {
   connect(transport: StdioServerTransport): Promise<unknown>;
   close(): Promise<unknown>;
+}
+
+export function isParentProcessAlive(
+  parentPid: number,
+  signalProcess: typeof process.kill = process.kill,
+): boolean {
+  if (!Number.isInteger(parentPid) || parentPid <= 1) {
+    return false;
+  }
+
+  try {
+    signalProcess(parentPid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException | undefined)?.code === 'EPERM';
+  }
 }
 
 export function shouldAutoStartMcpServer(
@@ -38,6 +55,7 @@ export function autoStartStdioMcpServer(
   const transport = new StdioServerTransport();
   let shuttingDown = false;
   const lifecycleDebugEnabled = env[LIFECYCLE_DEBUG_ENV] === '1';
+  const trackedParentPid = Number.isInteger(process.ppid) ? process.ppid : 0;
 
   const logLifecycle = (message: string, error?: unknown) => {
     if (!lifecycleDebugEnabled) return;
@@ -45,12 +63,24 @@ export function autoStartStdioMcpServer(
     process.stderr.write(`[omx-${serverName}-server] ${message}${detail}\n`);
   };
 
+  const parentWatchdog = trackedParentPid > 1
+    ? setInterval(() => {
+      if (!isParentProcessAlive(trackedParentPid)) {
+        void shutdown('parent_gone');
+      }
+    }, PARENT_WATCHDOG_INTERVAL_MS)
+    : null;
+  parentWatchdog?.unref();
+
   const shutdown = async (reason: string) => {
     if (shuttingDown) {
       return;
     }
     shuttingDown = true;
     logLifecycle(`transport shutdown: ${reason}`);
+    if (parentWatchdog) {
+      clearInterval(parentWatchdog);
+    }
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
     process.off('SIGTERM', handleSigterm);
@@ -61,6 +91,9 @@ export function autoStartStdioMcpServer(
     } catch (error) {
       console.error(`[omx-${serverName}-server] shutdown failed`, error);
     }
+
+    logLifecycle('transport shutdown: exit');
+    process.exit(0);
   };
 
   const handleStdinEnd = () => {


### PR DESCRIPTION
## Summary\n- add a shared parent-liveness watchdog to the MCP stdio bootstrap\n- force MCP child process exit after shared shutdown completes so paused stdin cannot keep Windows helpers alive\n- add focused bootstrap regression coverage for parent-liveness checks and built entrypoint shutdown behavior\n\nFixes #1435.\n\n## Verification\n- npm run build\n- node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/server-lifecycle.test.js\n- npx biome lint src/mcp/bootstrap.ts src/mcp/__tests__/bootstrap.test.ts src/mcp/__tests__/server-lifecycle.test.ts\n- manual parent-exit probe for dist/mcp/state-server.js