### PR TITLE
Fix workflow handoffs and document the state model

### DIFF
--- a/docs/STATE_MODEL.md
+++ b/docs/STATE_MODEL.md
@@ -1,0 +1,238 @@
+# OMX State Model
+
+This document explains how OMX tracks workflow/skill state, how transition rules are evaluated, and which transitions are commonly allowed or blocked.
+
+## Goals
+
+- make mode state predictable across CLI, MCP, hooks, and HUD
+- show which files are authoritative vs compatibility-only
+- explain how allowlisted handoffs and overlap rules work
+- document common workflow transitions in one place
+
+## State authorities
+
+### 1. Per-mode state files — authoritative
+
+Authoritative workflow state lives in per-mode files under `.omx/state/`:
+
+- root scope: `.omx/state/<mode>-state.json`
+- session scope: `.omx/state/sessions/<session_id>/<mode>-state.json`
+
+Examples:
+
+- `.omx/state/ralplan-state.json`
+- `.omx/state/sessions/<session_id>/ralph-state.json`
+- `.omx/state/team-state.json`
+
+These files determine whether a workflow mode is active, completed, cancelled, or failed.
+
+### 2. `skill-active-state.json` — compatibility / visibility layer
+
+`skill-active-state.json` is still used as a compatibility surface for hooks/HUD/native messaging, but transition reconciliation should be driven from the shared transition/reconciliation helpers rather than re-deriving semantics ad hoc.
+
+Locations:
+
+- `.omx/state/skill-active-state.json`
+- `.omx/state/sessions/<session_id>/skill-active-state.json`
+
+### 3. Session precedence
+
+Read precedence is:
+
+1. explicit session scope
+2. current session scope
+3. root scope fallback
+
+If root and session disagree for the same mode, session wins for the active execution context, but stale root survivors should be terminalized during reconciliation when they would otherwise resurrect old state.
+
+## Core files
+
+- `src/state/workflow-transition.ts` — transition policy and decision model
+- `src/state/workflow-transition-reconcile.ts` — shared transition reconciliation helper
+- `src/modes/base.ts` — mode start/update lifecycle
+- `src/mcp/state-server.ts` — MCP state writes/reads/clears
+- `src/hooks/keyword-detector.ts` — prompt keyword activation + state seeding
+- `src/scripts/codex-native-hook.ts` — native hook routing and prompt-submit output
+
+## Transition flow
+
+```mermaid
+flowchart TD
+  A[Prompt / CLI / MCP request] --> B[Detect requested workflow skill(s)]
+  B --> C[Evaluate transition policy]
+  C -->|deny| D[Return denial message]
+  C -->|allow overlap| E[Keep current active modes + add destination]
+  C -->|allow auto-complete| F[Complete source mode(s)]
+  F --> G[Sync compatibility skill-active state]
+  G --> H[Activate destination mode(s)]
+  E --> G
+  H --> I[Emit routing / transition message]
+```
+
+## Reconciliation sequence
+
+The shared reconciliation helper should follow this sequence:
+
+1. decide outcome
+2. complete source mode(s) with audit metadata
+3. sync compatibility `skill-active` state
+4. activate destination mode(s)
+5. return transition message for rendering
+
+This ordering matters because syncing too early can resurrect a mode that was just auto-completed.
+
+## Prompt-submit flow
+
+```mermaid
+flowchart TD
+  A[UserPromptSubmit] --> B[detectKeywords()]
+  B --> C[ordered explicit skill list]
+  C --> D[recordSkillActivation()]
+  D --> E[shared reconciliation helper]
+  E --> F[final active skills]
+  F --> G[buildAdditionalContextMessage()]
+  G --> H[native hook output]
+```
+
+## Transition rule categories
+
+### A. Allow with no change
+
+The requested mode is already active.
+
+### B. Allow as overlap
+
+The requested mode is added without completing the source mode.
+
+Examples:
+
+- `team + ralph`
+- `ultrawork + <any tracked mode>`
+
+### C. Allow with source auto-complete
+
+The source mode is terminalized and the destination becomes active.
+
+Current allowlisted forward handoffs:
+
+- `deep-interview -> ralplan`
+- `ralplan -> team`
+- `ralplan -> ralph`
+- `ralplan -> autopilot`
+
+### D. Deny
+
+The requested transition is not allowed and no state is changed.
+
+## Common transition rules
+
+| From | To | Result |
+|---|---|---|
+| `deep-interview` | `ralplan` | auto-complete `deep-interview`, start `ralplan` |
+| `ralplan` | `team` | auto-complete `ralplan`, start `team` |
+| `ralplan` | `ralph` | auto-complete `ralplan`, start `ralph` |
+| `ralplan` | `autopilot` | auto-complete `ralplan`, start `autopilot` |
+| `team` | `ralph` | allowed overlap |
+| `ralph` | `team` | allowed overlap |
+| `<any tracked mode>` | `ultrawork` | allowed overlap |
+| `ultrawork` | `<any tracked mode>` | allowed overlap |
+| execution-like mode | planning-like mode | denied rollback auto-complete |
+| anything else non-allowlisted | new conflicting mode | denied |
+
+## Planning-like vs execution-like
+
+### Planning-like
+
+- `deep-interview`
+- `ralplan`
+- `autoresearch`
+
+### Execution-like
+
+- `team`
+- `ralph`
+- `autopilot`
+- `ultrawork`
+- `ultraqa`
+
+Execution-like -> planning-like rollback auto-complete is forbidden. The denial should tell the user, in substance:
+
+> first clear current state first and retry if this action is intended
+
+## Multi-skill prompt-submit behavior
+
+A single prompt can explicitly invoke multiple contiguous `$skill` tokens.
+
+Example:
+
+```text
+$ralplan $team $ralph ship this fix
+```
+
+Expected result:
+
+1. `ralplan` is recognized as the planning source
+2. `team` is activated through the allowlisted forward handoff
+3. `ralph` is added as an allowed overlap with `team`
+4. final active skills are `team`, `ralph`
+5. native hook output should describe all explicit skills, not only the primary one
+
+Recommended message shape:
+
+- detected keywords summary
+- transition summary, e.g. `mode transiting: ralplan -> team + ralph`
+- final active skills summary
+- team runtime hint when `team` is among final active skills
+
+## Audit fields for auto-complete
+
+When a source mode is auto-completed during transition, the source state should record:
+
+- `active: false`
+- `current_phase: completed`
+- `completed_at`
+- `auto_completed_reason` or equivalent
+- `completion_note` or equivalent
+- destination metadata when useful (`transition_target_mode`, source path, etc.)
+
+## Invariants
+
+These rules should remain true unless intentionally changed:
+
+- rollback to planning never auto-completes
+- non-allowlisted transitions remain blocked
+- `ultrawork` overlap-any must not weaken `ralplan-first` gating
+- native-hook output is a presentation layer over shared transition results, not a separate decision engine
+- compatibility sync must not resurrect completed source modes
+
+## Practical guidance
+
+### If you are changing transition rules
+
+Update together:
+
+- `src/state/workflow-transition.ts`
+- `src/state/workflow-transition-reconcile.ts`
+- lifecycle / MCP callers
+- prompt-submit/native-hook rendering
+- regression tests
+
+### If you are debugging stale state
+
+Check these in order:
+
+1. session-scoped `<mode>-state.json`
+2. root `<mode>-state.json`
+3. session/root `skill-active-state.json`
+4. whether a previous auto-complete wrote audit metadata but compatibility sync reintroduced the mode
+
+### If you are adding a new allowlisted handoff
+
+Define:
+
+- source mode
+- destination mode(s)
+- whether source auto-completes or destination overlaps
+- rollback behavior
+- expected native-hook / CLI / MCP transition output
+- regression tests for both session and root scope

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -401,21 +401,20 @@ describe('keyword detector skill-active-state lifecycle', () => {
         }, null, 2),
       );
 
-      const denied = await recordSkillActivation({
+      const allowed = await recordSkillActivation({
         stateDir,
         text: '$ultrawork continue',
         sessionId: 'sess-visible',
         nowIso: '2026-04-10T00:00:00.000Z',
       });
 
-      assert.ok(denied?.transition_error);
-      assert.match(String(denied?.transition_error), /Unsupported workflow overlap: team \+ ralph \+ ultrawork\./);
-      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-visible', 'ultrawork-state.json')), false);
+      assert.equal(allowed?.transition_error, undefined);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-visible', 'ultrawork-state.json')), true);
 
       const persisted = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
       ) as { active_skills?: Array<{ skill: string }> };
-      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
+      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph', 'ultrawork']);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -444,6 +443,72 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.mode, 'ralplan');
       assert.equal(modeState.active, true);
       assert.equal(modeState.current_phase, 'planning');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('auto-completes deep-interview during allowlisted forward handoff', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-handoff-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-handoff'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-handoff', SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'deep-interview',
+          phase: 'planning',
+          session_id: 'sess-handoff',
+          active_skills: [{ skill: 'deep-interview', phase: 'planning', active: true, session_id: 'sess-handoff' }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-handoff', 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'intent-first' }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan implement the approved contract',
+        sessionId: 'sess-handoff',
+        nowIso: '2026-04-10T00:00:00.000Z',
+      });
+
+      assert.equal(result?.transition_error, undefined);
+      assert.equal(result?.transition_message, 'mode transiting: deep-interview -> ralplan');
+
+      const completed = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-handoff', 'deep-interview-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, 'completed');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('supports multi-skill forward handoff from ralplan to team + ralph in one prompt', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-multi-handoff-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan $team $ralph ship this fix',
+        sessionId: 'sess-multi',
+        nowIso: '2026-04-10T00:00:00.000Z',
+      });
+
+      assert.equal(result?.transition_error, undefined);
+      assert.equal(result?.transition_message, 'mode transiting: ralplan -> team');
+      assert.equal(result?.skill, 'team');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-multi', 'ralplan-state.json')), false);
+      assert.equal(existsSync(join(stateDir, 'team-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-multi', 'ralph-state.json')), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -28,6 +28,7 @@ import {
   evaluateWorkflowTransition,
   isTrackedWorkflowMode,
 } from '../state/workflow-transition.js';
+import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -68,6 +69,9 @@ export interface SkillActiveState {
   initialized_mode?: string;
   initialized_state_path?: string;
   transition_error?: string;
+  transition_message?: string;
+  transition_messages?: string[];
+  requested_skills?: string[];
   [key: string]: unknown;
 }
 
@@ -521,6 +525,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     const requestedWorkflowSkills = workflowMatches.length > 0 ? workflowMatches : [match.skill];
 
     let nextWorkflowEntries = previousWorkflowEntries.map((entry) => ({ ...entry }));
+    const transitionMessages: string[] = [];
     for (const requestedMode of requestedWorkflowSkills) {
       const decision = evaluateWorkflowTransition(
         nextWorkflowEntries.map((entry) => entry.skill),
@@ -549,6 +554,27 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           ),
         };
       }
+
+      if (decision.autoCompleteModes.length > 0) {
+        const transition = await reconcileWorkflowTransition(
+          dirname(dirname(input.stateDir)),
+          requestedMode,
+          {
+            action: 'activate',
+            sessionId: input.sessionId,
+            source: 'keyword-detector',
+            currentModes: nextWorkflowEntries.map((entry) => entry.skill),
+          },
+        );
+        if (transition.transitionMessage) {
+          transitionMessages.push(transition.transitionMessage);
+        }
+      }
+
+      const survivingSkills = new Set(decision.resultingModes);
+      nextWorkflowEntries = nextWorkflowEntries.filter((entry) => (
+        isTrackedWorkflowMode(entry.skill) && survivingSkills.has(entry.skill)
+      ));
 
       const existingEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
       if (existingEntry) {
@@ -581,40 +607,44 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       ];
     }
 
-    const matchedEntry = nextWorkflowEntries.find((entry) => entry.skill === match.skill) ?? nextWorkflowEntries[0];
+    const primaryEntry = nextWorkflowEntries.find((entry) => entry.skill === match.skill) ?? nextWorkflowEntries[0];
+    const primarySkill = primaryEntry?.skill || match.skill;
     const workflowState: SkillActiveState = {
       version: 1,
       active: true,
-      skill: match.skill,
-      keyword: match.keyword,
-      phase: matchedEntry?.phase || 'planning',
-      activated_at: matchedEntry?.activated_at || nowIso,
+      skill: primarySkill,
+      keyword: primarySkill === match.skill ? match.keyword : `$${primarySkill}`,
+      phase: primaryEntry?.phase || 'planning',
+      activated_at: primaryEntry?.activated_at || nowIso,
       updated_at: nowIso,
       source: 'keyword-detector',
       session_id: input.sessionId,
       thread_id: input.threadId,
       turn_id: input.turnId,
       active_skills: nextWorkflowEntries,
+      ...(transitionMessages[0] ? { transition_message: transitionMessages[0] } : {}),
+      ...(transitionMessages.length > 0 ? { transition_messages: [...new Set(transitionMessages)] } : {}),
+      ...(requestedWorkflowSkills.length > 1 ? { requested_skills: requestedWorkflowSkills } : {}),
       ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
     };
 
     try {
       let nextState: SkillActiveState = { ...workflowState };
-      for (const requestedMode of requestedWorkflowSkills) {
-        const requestedEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
+      for (const requestedEntry of nextWorkflowEntries) {
         const seeded = await persistStatefulSkillSeedState(
           input.stateDir,
           {
             ...workflowState,
-            skill: requestedMode,
-            phase: requestedEntry?.phase || workflowState.phase,
-            activated_at: requestedEntry?.activated_at || workflowState.activated_at,
-            updated_at: requestedEntry?.updated_at || workflowState.updated_at,
+            skill: requestedEntry.skill,
+            keyword: requestedEntry.skill === workflowState.skill ? workflowState.keyword : `$${requestedEntry.skill}`,
+            phase: requestedEntry.phase || workflowState.phase,
+            activated_at: requestedEntry.activated_at || workflowState.activated_at,
+            updated_at: requestedEntry.updated_at || workflowState.updated_at,
           },
           nowIso,
           previous,
         );
-        if (requestedMode === match.skill) {
+        if (requestedEntry.skill === workflowState.skill) {
           nextState = {
             ...workflowState,
             initialized_mode: seeded.initialized_mode,

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -417,7 +417,7 @@ describe('state-server directory initialization', () => {
     }
   });
 
-  it('denies invalid writes before touching the requested mode file when canonical session state is stricter than mode files', async () => {
+  it('allows ultrawork when canonical session state is stricter than mode files', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
 
@@ -451,7 +451,7 @@ describe('state-server directory initialization', () => {
         }, null, 2),
       );
 
-      const denied = await handleStateToolCall({
+      const allowed = await handleStateToolCall({
         params: {
           name: 'state_write',
           arguments: {
@@ -464,11 +464,10 @@ describe('state-server directory initialization', () => {
         },
       });
 
-      assert.equal(denied.isError, true);
-      assert.match(denied.content[0]?.text || '', /Unsupported workflow overlap: team \+ ralph \+ ultrawork\./);
+      assert.equal(allowed.isError, undefined);
       assert.equal(
         existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-canonical-deny', 'ultrawork-state.json')),
-        false,
+        true,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -692,6 +691,126 @@ describe('state-server directory initialization', () => {
         [{ skill: 'autopilot', phase: 'planning', session_id: 'sess-standalone' }],
       );
       assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-standalone', 'team-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('auto-completes deep-interview when starting ralplan and returns transition messaging', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-handoff-interview-'));
+    try {
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-handoff'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'sessions', 'sess-handoff', 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'intent-first' }, null, 2),
+      );
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-handoff',
+            mode: 'ralplan',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const body = JSON.parse(response.content[0]?.text || '{}') as { transition?: string };
+      assert.equal(body.transition, 'mode transiting: deep-interview -> ralplan');
+
+      const completed = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-handoff', 'deep-interview-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string; completed_at?: string; auto_completed_reason?: string };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, 'completed');
+      assert.equal(typeof completed.completed_at, 'string');
+      assert.match(completed.auto_completed_reason || '', /mode transiting: deep-interview -> ralplan/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects execution-to-planning rollback with clear-first guidance', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-rollback-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-rollback',
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      const denied = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-rollback',
+            mode: 'ralplan',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(denied.isError, true);
+      const body = JSON.parse(denied.content[0]?.text || '{}') as { error?: string };
+      assert.match(body.error || '', /Execution-to-planning rollback auto-complete is not allowed/i);
+      assert.match(body.error || '', /First clear current state first and retry if this action is intended/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows ultrawork overlap with any tracked mode', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-ultrawork-any-'));
+    try {
+      const first = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-ulw',
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+      assert.equal(first.isError, undefined);
+
+      const second = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-ulw',
+            mode: 'ultrawork',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+      assert.equal(second.isError, undefined);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -32,17 +32,14 @@ import {
 import { withModeRuntimeContext } from "../state/mode-state-context.js";
 import {
 	SKILL_ACTIVE_STATE_MODE,
-	listActiveSkills,
 	readSkillActiveState,
-	readVisibleSkillActiveState,
 	syncCanonicalSkillStateForMode,
 	writeSkillActiveStateCopies,
 } from "../state/skill-active.js";
 import {
-	assertWorkflowTransitionAllowed,
 	isTrackedWorkflowMode,
-	readActiveWorkflowModes,
 } from "../state/workflow-transition.js";
+import { reconcileWorkflowTransition } from "../state/workflow-transition-reconcile.js";
 import {
 	RALPH_PHASES,
 	validateAndNormalizeRalphState,
@@ -84,18 +81,6 @@ async function listStateSessionIds(cwd: string): Promise<string[]> {
 		.filter((entry) => entry.isDirectory())
 		.map((entry) => entry.name)
 		.filter((entry) => entry.trim().length > 0);
-}
-
-async function readWorkflowModesForValidation(
-	cwd: string,
-	sessionId?: string,
-): Promise<string[]> {
-	const canonical = await readVisibleSkillActiveState(cwd, sessionId);
-	const canonicalModes = listActiveSkills(canonical ?? {})
-		.map((entry) => entry.skill)
-		.filter(isTrackedWorkflowMode);
-	if (canonicalModes.length > 0) return canonicalModes;
-	return readActiveWorkflowModes(cwd, sessionId);
 }
 
 async function withStateWriteLock<T>(
@@ -365,6 +350,7 @@ export async function handleStateToolCall(request: {
 					...fields
 				} = args as Record<string, unknown>;
 				let validationError: string | null = null;
+				let transitionMessage: string | undefined;
 				await withStateWriteLock(path, async () => {
 					let existing: Record<string, unknown> = {};
 					if (existsSync(path)) {
@@ -384,14 +370,22 @@ export async function handleStateToolCall(request: {
 					} as Record<string, unknown>;
 					if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
 						try {
-							const activeModes = await readWorkflowModesForValidation(cwd, effectiveSessionId);
-							assertWorkflowTransitionAllowed(activeModes, mode, "write");
 							if (!effectiveSessionId) {
 								for (const sessionId of await listStateSessionIds(cwd)) {
-									const sessionModes = await readWorkflowModesForValidation(cwd, sessionId);
-									assertWorkflowTransitionAllowed(sessionModes, mode, "write");
+									const sessionTransition = await reconcileWorkflowTransition(cwd, mode, {
+										action: "write",
+										sessionId,
+										source: "state-server",
+									});
+									transitionMessage ??= sessionTransition.transitionMessage;
 								}
 							}
+							const transition = await reconcileWorkflowTransition(cwd, mode, {
+								action: "write",
+								sessionId: effectiveSessionId,
+								source: "state-server",
+							});
+							transitionMessage ??= transition.transitionMessage;
 						} catch (error) {
 							validationError = (error as Error).message;
 							return;
@@ -458,7 +452,12 @@ export async function handleStateToolCall(request: {
 					content: [
 						{
 							type: "text",
-							text: JSON.stringify({ success: true, mode, path }),
+							text: JSON.stringify({
+								success: true,
+								mode,
+								path,
+								...(transitionMessage ? { transition: transitionMessage } : {}),
+							}),
 						},
 					],
 				};

--- a/src/modes/__tests__/base-autoresearch-contract.test.ts
+++ b/src/modes/__tests__/base-autoresearch-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { readModeState, startMode } from '../base.js';
@@ -23,6 +23,26 @@ describe('modes/base deep-interview contract integration', () => {
 });
 
 describe('modes/base autoresearch contract integration', () => {
+  it('startMode auto-completes deep-interview when starting ralplan', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-interview-ralplan-handoff-'));
+    try {
+      await startMode('deep-interview', 'clarify contract', 3, wd);
+      const started = await startMode('ralplan', 'plan contract', 5, wd);
+      assert.equal(started.mode, 'ralplan');
+      assert.equal(started.active, true);
+      assert.equal(started.transition_message, 'mode transiting: deep-interview -> ralplan');
+
+      const completed = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'deep-interview-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string; completed_at?: string };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, 'completed');
+      assert.equal(typeof completed.completed_at, 'string');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('startMode allows the approved team + ralph overlap', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-team-ralph-overlap-'));
     try {
@@ -48,13 +68,25 @@ describe('modes/base autoresearch contract integration', () => {
     }
   });
 
-  it('startMode blocks unsupported ralph + ultrawork overlap', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-ralph-ultrawork-deny-'));
+  it('startMode allows ultrawork overlap with any tracked mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-ralph-ultrawork-allow-'));
     try {
       await startMode('ralph', 'demo', 5, wd);
+      const started = await startMode('ultrawork', 'demo mission', 1, wd);
+      assert.equal(started.mode, 'ultrawork');
+      assert.equal(started.active, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('startMode blocks execution-to-planning rollback auto-complete', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-rollback-deny-'));
+    try {
+      await startMode('autopilot', 'demo', 5, wd);
       await assert.rejects(
-        () => startMode('ultrawork', 'demo mission', 1, wd),
-        /Unsupported workflow overlap: ralph \+ ultrawork\./i,
+        () => startMode('ralplan', 'plan again', 5, wd),
+        /Execution-to-planning rollback auto-complete is not allowed/i,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -11,6 +11,8 @@ import {
   isTrackedWorkflowMode,
   readActiveWorkflowModes,
 } from '../state/workflow-transition.js';
+import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
+import { syncCanonicalSkillStateForMode } from '../state/skill-active.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
 import {
   getBaseStateDir,
@@ -98,8 +100,16 @@ export async function startMode(
   const dir = stateDir(projectRoot);
   await mkdir(dir, { recursive: true });
 
-  await assertModeStartAllowed(mode, projectRoot);
   const scope = await resolveStateScope(projectRoot);
+  let transitionMessage: string | undefined;
+  if (isTrackedWorkflowMode(mode)) {
+    const transition = await reconcileWorkflowTransition(projectRoot ?? process.cwd(), mode, {
+      action: 'start',
+      sessionId: scope.sessionId,
+      source: 'startMode',
+    });
+    transitionMessage = transition.transitionMessage;
+  }
   await mkdir(scope.stateDir, { recursive: true });
 
   const stateBase: ModeState = {
@@ -110,6 +120,7 @@ export async function startMode(
     current_phase: 'starting',
     task_description: taskDescription,
     started_at: new Date().toISOString(),
+    ...(transitionMessage ? { transition_message: transitionMessage } : {}),
     ...(mode === 'ralph' && scope.sessionId ? { owner_omx_session_id: scope.sessionId } : {}),
   };
 
@@ -118,6 +129,16 @@ export async function startMode(
     ? normalizeRalphModeStateOrThrow(withContext)
     : withContext;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(state, null, 2));
+  if (isTrackedWorkflowMode(mode)) {
+    await syncCanonicalSkillStateForMode({
+      cwd: projectRoot ?? process.cwd(),
+      mode,
+      active: true,
+      currentPhase: typeof state.current_phase === 'string' ? state.current_phase : undefined,
+      sessionId: scope.sessionId,
+      source: 'startMode',
+    });
+  }
   return state;
 }
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -354,6 +354,79 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("surfaces transition success output for allowlisted prompt-submit handoffs", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-transition-success-"));
+    try {
+      const sessionDir = join(cwd, ".omx", "state", "sessions", "sess-handoff-1");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(sessionDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+      });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-handoff-1",
+        active_skills: [{ skill: "deep-interview", phase: "planning", active: true, session_id: "sess-handoff-1" }],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-handoff-1",
+          thread_id: "thread-handoff-1",
+          turn_id: "turn-handoff-1",
+          prompt: "$ralplan implement the approved contract",
+        },
+        { cwd },
+      );
+
+      assert.match(JSON.stringify(result.outputJson), /mode transiting: deep-interview -> ralplan/);
+      const completed = JSON.parse(await readFile(join(sessionDir, "deep-interview-state.json"), "utf-8")) as {
+        active?: boolean;
+        current_phase?: string;
+      };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, "completed");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces multi-skill prompt-submit output for ralplan -> team + ralph", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-transition-multi-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-multi-1",
+          thread_id: "thread-multi-1",
+          turn_id: "turn-multi-1",
+          prompt: "$ralplan $team $ralph ship this fix",
+        },
+        { cwd },
+      );
+
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || '',
+      );
+      assert.match(message, /\$ralplan" -> ralplan/);
+      assert.match(message, /\$team" -> team/);
+      assert.match(message, /\$ralph" -> ralph/);
+      assert.match(message, /mode transiting: ralplan -> team \+ ralph/);
+      assert.match(message, /active skills: team, ralph\./);
+      assert.match(message, /Use the durable OMX team runtime via `omx team \.\.\.`/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("runs prompt-submit HUD reconciliation as a best-effort tmux-only side effect", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reconcile-"));
     const originalTmux = process.env.TMUX;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19,6 +19,7 @@ import {
 } from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath, omxStateDir } from "../utils/paths.js";
 import {
+  detectKeywords,
   detectPrimaryKeyword,
   recordSkillActivation,
   type SkillActiveState,
@@ -426,39 +427,73 @@ async function buildSessionStartContext(
 
 function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveState | null): string | null {
   if (!prompt) return null;
+  const matches = detectKeywords(prompt);
   const match = detectPrimaryKeyword(prompt);
   if (!match) return null;
+  const requestedSkills = matches.map((entry) => entry.skill);
+  const detectedKeywordMessage = matches.length > 1
+    ? `OMX native UserPromptSubmit detected workflow keywords ${matches.map((entry) => `"${entry.keyword}" -> ${entry.skill}`).join(", ")}.`
+    : `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`;
+  const activeSkills = Array.isArray(skillState?.active_skills)
+    ? skillState.active_skills.map((entry) => entry.skill)
+    : [];
+  const teamDetected = activeSkills.includes("team") || requestedSkills.includes("team");
+  const combinedTransitionMessage = (() => {
+    if (!skillState?.transition_message) return null;
+    if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
+    const source = skillState.transition_message.match(/^mode transiting: (.+?) -> /)?.[1];
+    if (!source) return skillState.transition_message;
+    return `mode transiting: ${source} -> ${activeSkills.join(" + ")}`;
+  })();
 
   if (skillState?.transition_error) {
     return [
       `OMX native UserPromptSubmit denied workflow keyword "${match.keyword}" -> ${match.skill}.`,
       skillState.transition_error,
-      'Follow AGENTS.md routing and preserve ralplan/ralph execution gates.',
+      'Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.',
     ].join(' ');
   }
 
-  if (match.skill === "team") {
+  if (skillState?.transition_message) {
+    return [
+      detectedKeywordMessage,
+      combinedTransitionMessage,
+      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
+      skillState.initialized_mode && skillState.initialized_state_path
+        ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
+        : null,
+      teamDetected
+        ? "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout."
+        : null,
+      teamDetected ? "If you need help, run `omx team --help`." : null,
+      'Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.',
+    ].filter(Boolean).join(' ');
+  }
+
+  if (teamDetected) {
     const initializedStateMessage = skillState?.initialized_mode && skillState.initialized_state_path
       ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
       : null;
     return [
-      `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`,
+      detectedKeywordMessage,
+      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
       initializedStateMessage,
       "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
       "If you need help, run `omx team --help`.",
-      "Follow AGENTS.md routing and preserve ralplan/ralph execution gates.",
+      "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].filter(Boolean).join(" ");
   }
 
   if (skillState?.initialized_mode && skillState.initialized_state_path) {
     return [
-      `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`,
+      detectedKeywordMessage,
+      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
-      "Follow AGENTS.md routing and preserve ralplan/ralph execution gates.",
+      "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].join(" ");
   }
 
-  return `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}. Follow AGENTS.md routing and preserve ralplan/ralph execution gates.`;
+  return `${detectedKeywordMessage} Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.`;
 }
 
 function parseTeamWorkerEnv(rawValue: string): { teamName: string; workerName: string } | null {

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  buildWorkflowTransitionMessage,
   buildWorkflowTransitionError,
   evaluateWorkflowTransition,
 } from '../workflow-transition.js';
@@ -18,13 +19,13 @@ describe('workflow transition rules', () => {
       { current: ['ralph'], requested: 'team', allowed: true, resulting: ['ralph', 'team'] },
       { current: ['team'], requested: 'ultrawork', allowed: true, resulting: ['team', 'ultrawork'] },
       { current: ['ultrawork'], requested: 'team', allowed: true, resulting: ['ultrawork', 'team'] },
-      { current: ['ralph'], requested: 'ultrawork', allowed: false, resulting: ['ralph'] },
-      { current: ['ultrawork'], requested: 'ralph', allowed: false, resulting: ['ultrawork'] },
+      { current: ['ralph'], requested: 'ultrawork', allowed: true, resulting: ['ralph', 'ultrawork'] },
+      { current: ['ultrawork'], requested: 'ralph', allowed: true, resulting: ['ultrawork', 'ralph'] },
       { current: ['autopilot'], requested: 'team', allowed: false, resulting: ['autopilot'] },
       { current: ['team'], requested: 'autopilot', allowed: false, resulting: ['team'] },
       { current: ['autoresearch'], requested: 'ralph', allowed: false, resulting: ['autoresearch'] },
-      { current: ['team', 'ralph'], requested: 'ultrawork', allowed: false, resulting: ['team', 'ralph'] },
-      { current: ['team', 'ultrawork'], requested: 'ralph', allowed: false, resulting: ['team', 'ultrawork'] },
+      { current: ['team', 'ralph'], requested: 'ultrawork', allowed: true, resulting: ['team', 'ralph', 'ultrawork'] },
+      { current: ['team', 'ultrawork'], requested: 'ralph', allowed: true, resulting: ['team', 'ultrawork', 'ralph'] },
     ];
 
     for (const testCase of cases) {
@@ -41,5 +42,33 @@ describe('workflow transition rules', () => {
     assert.match(error, /Current state is unchanged\./);
     assert.match(error, /`omx state clear --mode <mode>`/);
     assert.match(error, /`omx_state\.\*` MCP tools/);
+  });
+
+  it('returns auto-complete decisions for allowlisted forward transitions', () => {
+    const interviewToRalplan = evaluateWorkflowTransition(['deep-interview'], 'ralplan');
+    assert.equal(interviewToRalplan.allowed, true);
+    assert.equal(interviewToRalplan.kind, 'auto-complete');
+    assert.deepEqual(interviewToRalplan.autoCompleteModes, ['deep-interview']);
+    assert.deepEqual(interviewToRalplan.resultingModes, ['ralplan']);
+    assert.equal(interviewToRalplan.transitionMessage, 'mode transiting: deep-interview -> ralplan');
+
+    const ralplanToRalph = evaluateWorkflowTransition(['ralplan', 'ultrawork'], 'ralph');
+    assert.equal(ralplanToRalph.allowed, true);
+    assert.equal(ralplanToRalph.kind, 'auto-complete');
+    assert.deepEqual(ralplanToRalph.autoCompleteModes, ['ralplan']);
+    assert.deepEqual(ralplanToRalph.resultingModes, ['ultrawork', 'ralph']);
+  });
+
+  it('builds rollback denial guidance for execution-to-planning transitions', () => {
+    const error = buildWorkflowTransitionError(['autopilot'], 'ralplan', 'start');
+    assert.match(error, /Execution-to-planning rollback auto-complete is not allowed\./);
+    assert.match(error, /First clear current state first and retry if this action is intended\./);
+  });
+
+  it('formats transition audit messages', () => {
+    assert.equal(
+      buildWorkflowTransitionMessage('ralplan', 'ralph'),
+      'mode transiting: ralplan -> ralph',
+    );
   });
 });

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -1,0 +1,160 @@
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname } from 'path';
+import { getStatePath } from '../mcp/state-paths.js';
+import {
+  buildWorkflowTransitionError,
+  evaluateWorkflowTransition,
+  isTrackedWorkflowMode,
+  TRACKED_WORKFLOW_MODES,
+  type TrackedWorkflowMode,
+  type WorkflowTransitionAction,
+  type WorkflowTransitionDecision,
+} from './workflow-transition.js';
+import {
+  listActiveSkills,
+  readVisibleSkillActiveState,
+  syncCanonicalSkillStateForMode,
+} from './skill-active.js';
+
+interface TransitionStateLike {
+  active?: unknown;
+  current_phase?: unknown;
+  completed_at?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ReconciledWorkflowTransition {
+  decision: WorkflowTransitionDecision;
+  transitionMessage?: string;
+  autoCompletedModes: TrackedWorkflowMode[];
+  completedPaths: string[];
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+async function readJsonIfExists(path: string): Promise<TransitionStateLike | null> {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as TransitionStateLike;
+  } catch {
+    return null;
+  }
+}
+
+async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<TrackedWorkflowMode[]> {
+  const canonical = await readVisibleSkillActiveState(cwd, sessionId);
+  const canonicalModes = listActiveSkills(canonical ?? {})
+    .map((entry) => entry.skill)
+    .filter(isTrackedWorkflowMode);
+
+  const visibleModes = new Set<TrackedWorkflowMode>(canonicalModes);
+  for (const mode of TRACKED_WORKFLOW_MODES) {
+    const candidatePaths = sessionId
+      ? [getStatePath(mode, cwd, sessionId), getStatePath(mode, cwd)]
+      : [getStatePath(mode, cwd)];
+    for (const candidatePath of candidatePaths) {
+      const state = await readJsonIfExists(candidatePath);
+      if (state?.active === true) {
+        visibleModes.add(mode);
+      }
+    }
+  }
+
+  return [...visibleModes];
+}
+
+async function completeSourceModeState(
+  cwd: string,
+  sourceMode: TrackedWorkflowMode,
+  destinationMode: TrackedWorkflowMode,
+  sessionId: string | undefined,
+  nowIso: string,
+  source: string,
+): Promise<string[]> {
+  const transitionMessage = `mode transiting: ${sourceMode} -> ${destinationMode}`;
+  const candidatePaths = sessionId
+    ? [getStatePath(sourceMode, cwd, sessionId), getStatePath(sourceMode, cwd)]
+    : [getStatePath(sourceMode, cwd)];
+  const completedPaths: string[] = [];
+
+  for (const candidatePath of candidatePaths) {
+    const existing = await readJsonIfExists(candidatePath);
+    if (!existing || existing.active !== true) continue;
+
+    const nextState: TransitionStateLike = {
+      ...existing,
+      active: false,
+      current_phase: 'completed',
+      completed_at: safeString(existing.completed_at).trim() || nowIso,
+      auto_completed_reason: transitionMessage,
+      completion_note: `Auto-completed ${sourceMode} during allowlisted transition to ${destinationMode}.`,
+      transition_source: source,
+      transition_target_mode: destinationMode,
+    };
+
+    await mkdir(dirname(candidatePath), { recursive: true });
+    await writeFile(candidatePath, JSON.stringify(nextState, null, 2));
+    completedPaths.push(candidatePath);
+  }
+
+  await syncCanonicalSkillStateForMode({
+    cwd,
+    mode: sourceMode,
+    active: false,
+    currentPhase: 'completed',
+    sessionId,
+    nowIso,
+    source,
+  });
+
+  return completedPaths;
+}
+
+export async function reconcileWorkflowTransition(
+  cwd: string,
+  requestedMode: TrackedWorkflowMode,
+  options: {
+    action?: WorkflowTransitionAction;
+    sessionId?: string;
+    nowIso?: string;
+    source?: string;
+    currentModes?: Iterable<string>;
+  } = {},
+): Promise<ReconciledWorkflowTransition> {
+  const {
+    action = 'activate',
+    sessionId,
+    nowIso = new Date().toISOString(),
+    source = 'workflow-transition',
+  } = options;
+  const currentModes = options.currentModes
+    ? [...options.currentModes].filter(isTrackedWorkflowMode)
+    : await visibleTrackedModes(cwd, sessionId);
+  const decision = evaluateWorkflowTransition(currentModes, requestedMode);
+
+  if (!decision.allowed) {
+    throw new Error(buildWorkflowTransitionError(currentModes, requestedMode, action));
+  }
+
+  const completedPaths: string[] = [];
+  for (const sourceMode of decision.autoCompleteModes) {
+    completedPaths.push(...await completeSourceModeState(
+      cwd,
+      sourceMode,
+      requestedMode,
+      sessionId,
+      nowIso,
+      source,
+    ));
+  }
+
+  return {
+    decision,
+    transitionMessage: decision.transitionMessage,
+    autoCompletedModes: decision.autoCompleteModes,
+    completedPaths,
+  };
+}

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -35,11 +35,19 @@ function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-async function readJsonIfExists(path: string): Promise<TransitionStateLike | null> {
+async function readJsonIfExists(
+  path: string,
+  options?: { mode?: TrackedWorkflowMode; throwOnParseError?: boolean },
+): Promise<TransitionStateLike | null> {
   if (!existsSync(path)) return null;
   try {
     return JSON.parse(await readFile(path, 'utf-8')) as TransitionStateLike;
   } catch {
+    if (options?.throwOnParseError && options.mode) {
+      throw new Error(
+        `Cannot read ${options.mode} workflow state at ${path}. Clear or repair state via \`omx state clear --mode ${options.mode}\` or the \`omx_state.*\` MCP tools.`,
+      );
+    }
     return null;
   }
 }
@@ -56,7 +64,10 @@ async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<Tra
       ? [getStatePath(mode, cwd, sessionId), getStatePath(mode, cwd)]
       : [getStatePath(mode, cwd)];
     for (const candidatePath of candidatePaths) {
-      const state = await readJsonIfExists(candidatePath);
+      const state = await readJsonIfExists(candidatePath, {
+        mode,
+        throwOnParseError: true,
+      });
       if (state?.active === true) {
         visibleModes.add(mode);
       }

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -15,10 +15,31 @@ export const TRACKED_WORKFLOW_MODES = [
 
 export type TrackedWorkflowMode = (typeof TRACKED_WORKFLOW_MODES)[number];
 export type WorkflowTransitionAction = 'activate' | 'start' | 'write';
+export type WorkflowTransitionKind = 'allow' | 'overlap' | 'auto-complete' | 'deny';
 
 const ALLOWED_OVERLAP_PAIRS = new Set([
   'ralph|team',
-  'team|ultrawork',
+]);
+
+const AUTO_COMPLETE_TRANSITIONS = new Set([
+  'deep-interview->ralplan',
+  'ralplan->team',
+  'ralplan->ralph',
+  'ralplan->autopilot',
+]);
+
+const PLANNING_LIKE_MODES = new Set<TrackedWorkflowMode>([
+  'deep-interview',
+  'ralplan',
+  'autoresearch',
+]);
+
+const EXECUTION_LIKE_MODES = new Set<TrackedWorkflowMode>([
+  'autopilot',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
 ]);
 
 function safeString(value: unknown): string {
@@ -40,7 +61,31 @@ function buildPairKey(a: string, b: string): string {
 }
 
 function isAllowedOverlap(a: TrackedWorkflowMode, b: TrackedWorkflowMode): boolean {
+  if (a === 'ultrawork' || b === 'ultrawork') return true;
   return ALLOWED_OVERLAP_PAIRS.has(buildPairKey(a, b));
+}
+
+function buildAutoCompleteKey(a: TrackedWorkflowMode, b: TrackedWorkflowMode): string {
+  return `${a}->${b}`;
+}
+
+function isAutoCompleteTransition(a: TrackedWorkflowMode, b: TrackedWorkflowMode): boolean {
+  return AUTO_COMPLETE_TRANSITIONS.has(buildAutoCompleteKey(a, b));
+}
+
+function isRollbackTransition(
+  currentModes: readonly TrackedWorkflowMode[],
+  requestedMode: TrackedWorkflowMode,
+): boolean {
+  return PLANNING_LIKE_MODES.has(requestedMode)
+    && currentModes.some((mode) => EXECUTION_LIKE_MODES.has(mode));
+}
+
+export function buildWorkflowTransitionMessage(
+  sourceMode: TrackedWorkflowMode,
+  requestedMode: TrackedWorkflowMode,
+): string {
+  return `mode transiting: ${sourceMode} -> ${requestedMode}`;
 }
 
 function formatActiveModes(modes: readonly string[]): string {
@@ -52,9 +97,13 @@ function formatActiveModes(modes: readonly string[]): string {
 
 export interface WorkflowTransitionDecision {
   allowed: boolean;
+  kind: WorkflowTransitionKind;
   currentModes: TrackedWorkflowMode[];
   requestedMode: TrackedWorkflowMode;
   resultingModes: TrackedWorkflowMode[];
+  autoCompleteModes: TrackedWorkflowMode[];
+  transitionMessage?: string;
+  denialReason?: 'rollback';
 }
 
 export function isTrackedWorkflowMode(mode: string): mode is TrackedWorkflowMode {
@@ -70,35 +119,59 @@ export function evaluateWorkflowTransition(
   if (currentModes.includes(requestedMode)) {
     return {
       allowed: true,
+      kind: 'allow',
       currentModes,
       requestedMode,
       resultingModes: currentModes,
+      autoCompleteModes: [],
     };
   }
 
   if (currentModes.length === 0) {
     return {
       allowed: true,
+      kind: 'allow',
       currentModes,
       requestedMode,
       resultingModes: [requestedMode],
+      autoCompleteModes: [],
     };
   }
 
-  if (currentModes.length === 1 && isAllowedOverlap(currentModes[0], requestedMode)) {
+  const autoCompleteModes = currentModes.filter((mode) => isAutoCompleteTransition(mode, requestedMode));
+  const survivableModes = currentModes.filter((mode) => !autoCompleteModes.includes(mode));
+
+  if (autoCompleteModes.length > 0 && survivableModes.every((mode) => isAllowedOverlap(mode, requestedMode))) {
     return {
       allowed: true,
+      kind: 'auto-complete',
       currentModes,
       requestedMode,
-      resultingModes: [currentModes[0], requestedMode],
+      resultingModes: normalizeTrackedModes([...survivableModes, requestedMode]),
+      autoCompleteModes,
+      transitionMessage: buildWorkflowTransitionMessage(autoCompleteModes[0], requestedMode),
+    };
+  }
+
+  if (currentModes.every((mode) => isAllowedOverlap(mode, requestedMode))) {
+    return {
+      allowed: true,
+      kind: 'overlap',
+      currentModes,
+      requestedMode,
+      resultingModes: normalizeTrackedModes([...currentModes, requestedMode]),
+      autoCompleteModes: [],
     };
   }
 
   return {
     allowed: false,
+    kind: 'deny',
     currentModes,
     requestedMode,
     resultingModes: currentModes,
+    autoCompleteModes: [],
+    ...(isRollbackTransition(currentModes, requestedMode) ? { denialReason: 'rollback' as const } : {}),
   };
 }
 
@@ -107,9 +180,17 @@ export function buildWorkflowTransitionError(
   requestedMode: TrackedWorkflowMode,
   action: WorkflowTransitionAction = 'activate',
 ): string {
-  const currentModes = normalizeTrackedModes(currentActiveModes);
-  const activeModesMessage = formatActiveModes(currentModes);
-  const overlap = [...currentModes, requestedMode].join(' + ');
+  const decision = evaluateWorkflowTransition(currentActiveModes, requestedMode);
+  const activeModesMessage = formatActiveModes(decision.currentModes);
+  const overlap = [...decision.currentModes, requestedMode].join(' + ');
+  if (decision.denialReason === 'rollback') {
+    return [
+      `Cannot ${action} ${requestedMode}: ${activeModesMessage}.`,
+      'Execution-to-planning rollback auto-complete is not allowed.',
+      'First clear current state first and retry if this action is intended.',
+      `Clear incompatible workflow state via \`omx state clear --mode <mode>\` or the \`omx_state.*\` MCP tools, then retry.`,
+    ].join(' ');
+  }
   return [
     `Cannot ${action} ${requestedMode}: ${activeModesMessage}.`,
     `Unsupported workflow overlap: ${overlap}.`,


### PR DESCRIPTION
## Summary
- centralize workflow transition reconciliation for allowlisted handoffs and overlap rules
- support multi-skill `UserPromptSubmit` routing such as `$ralplan $team $ralph`
- add `docs/STATE_MODEL.md` documenting state authorities, transition flowcharts, and common transition rules

## Testing
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/state/__tests__/workflow-transition.test.js dist/modes/__tests__/base-autoresearch-contract.test.js dist/mcp/__tests__/state-server.test.js
- npx biome lint src/hooks/__tests__/keyword-detector.test.ts src/hooks/keyword-detector.ts src/mcp/__tests__/state-server.test.ts src/mcp/state-server.ts src/modes/__tests__/base-autoresearch-contract.test.ts src/modes/base.ts src/scripts/__tests__/codex-native-hook.test.ts src/scripts/codex-native-hook.ts src/state/__tests__/workflow-transition.test.ts src/state/workflow-transition.ts src/state/workflow-transition-reconcile.ts docs/STATE_MODEL.md

## Notes
- preserves rollback denial and planning-safety rules
- keeps `ultrawork` overlap-any behavior
- native-hook footer wording is generalized to avoid implying only ralplan/ralph-specific gates
