### PR TITLE
Add OMX daemon lifecycle and approval flow

### DIFF
--- a/docs/qa/cli-polish-pass-review-2026-04-09.md
+++ b/docs/qa/cli-polish-pass-review-2026-04-09.md
@@ -1,0 +1,174 @@
+# CLI Polish Pass Review - 2026-04-09
+
+Date: **2026-04-09**  
+Baseline commit: **`84f2467a`**
+
+## Scope
+
+This note documents the review/documentation lane for the approved
+CLI polish pass in `.omx/plans/prd-cli-polish-passes.md` and
+`.omx/plans/test-spec-cli-polish-passes.md`.
+
+The review stayed intentionally bounded to daemon/help/setup/catalog/test seams.
+
+## Summary
+
+The current branch already presents a coherent daemon onboarding
+story across the main user-facing surfaces:
+
+1. `omx --help` advertises `omx daemon` as a lifecycle
+   surface, not a second setup workflow.
+2. `omx daemon --help` points users to `$setup-omx-daemon`
+   for onboarding and keeps `omx daemon scaffold` as the
+   explicit recovery path.
+3. `skills/setup-omx-daemon/SKILL.md` matches that split:
+   tracked governance files and `.gitignore` shaping happen
+   during setup, while runtime control stays under
+   `omx daemon`.
+4. Project-scoped setup keeps `.omx/daemon/*` trackable
+   while `.omx/state/daemon/*` remains ignored, and
+   catalog-driven setup still installs `setup-omx-daemon`.
+
+## Reviewed surfaces
+
+### Help and onboarding consistency
+
+Reviewed together:
+
+- `src/cli/index.ts`
+- `src/cli/daemon.ts`
+- `skills/setup-omx-daemon/SKILL.md`
+
+Result:
+
+- Top-level help is intentionally terse and lifecycle-oriented.
+- Command-local daemon help adds the onboarding bridge and
+  explicitly names `omx daemon scaffold` as the fallback path.
+- The setup skill keeps CLI ownership clear: scaffold/configure
+  first, then `run-once` or `start`.
+
+No contradictory setup-vs-runtime wording was found in these surfaces.
+
+### Setup and `.gitignore` contract clarity
+
+Reviewed together:
+
+- `src/cli/setup.ts`
+- `src/cli/__tests__/setup-refresh.test.ts`
+
+Result:
+
+- The `.gitignore` contract is explicit and git-valid.
+- The review confirmed the intended carve-out chain:
+  - `.omx/*`
+  - `!.omx/daemon/`
+  - `.omx/daemon/*`
+  - `!.omx/daemon/*.md`
+  - `!.omx/daemon/daemon.config.json`
+- Setup messaging correctly describes tracked daemon governance
+  inputs versus ignored runtime state.
+
+### Catalog discoverability
+
+Reviewed together:
+
+- `src/catalog/manifest.json`
+- `templates/catalog-manifest.json`
+- `src/catalog/generated/public-catalog.json`
+- `src/catalog/__tests__/generator.test.ts`
+- `src/cli/__tests__/setup-skills-overwrite.test.ts`
+- `src/cli/__tests__/setup-scope.test.ts`
+
+Result:
+
+- `setup-omx-daemon` remains present in
+  source/template/generated catalog surfaces.
+- Project-scoped setup still installs the skill, keeping
+  catalog-driven discoverability intact.
+
+### Status and targeted verification lane
+
+Reviewed together:
+
+- `src/daemon/index.ts`
+- `src/daemon/__tests__/index.test.ts`
+- `src/cli/__tests__/daemon.test.ts`
+- `src/cli/__tests__/nested-help-routing.test.ts`
+
+Result:
+
+- The shipped status copy is actionable for pre-setup,
+  stopped/running, and missing-credential branches.
+- The current baseline already proves pre-setup guidance,
+  help routing, catalog sync, and setup/gitignore behavior.
+- **Follow-up still worth keeping explicit before merge:**
+  add/retain direct automated coverage for the
+  stopped/running/missing-credentials daemon status branches
+  so AC4 is proven as directly as the rest of the polish lane.
+
+That follow-up is a targeted test-lane requirement, not a
+reason to widen the polish scope.
+
+## Verification evidence
+
+### Manual / CLI checks
+
+Commands run:
+
+```bash
+node dist/cli/omx.js --help
+node dist/cli/omx.js daemon --help
+(cd "$TMPDIR" && node /path/to/dist/cli/omx.js daemon status)
+(cd "$TMPDIR" && node /path/to/dist/cli/omx.js setup --scope project)
+```
+
+Observed results:
+
+- `omx --help` includes `omx daemon    Manage daemon lifecycle
+  for GitHub issue triage (start|stop|status|run-once|approve|reject)`.
+- `omx daemon --help` points users to `$setup-omx-daemon`
+  and keeps `omx daemon scaffold` visible as the
+  recovery/onboarding command.
+- In a fresh temp repo, `omx daemon status` reports:
+  `Daemon is not initialized for this worktree. Use
+  $setup-omx-daemon or scaffold .omx/daemon first.`
+- In that same temp repo, project-scoped setup:
+  - installs `.codex/skills/setup-omx-daemon/SKILL.md`
+  - writes the expected daemon `.gitignore` carve-out sequence
+  - leaves `.omx/state/daemon/queue.json` ignored via `.gitignore:1:.omx/*`
+
+### Targeted automated verification
+
+Commands run:
+
+```bash
+npm run build
+node --test dist/cli/__tests__/daemon.test.js \
+  dist/cli/__tests__/nested-help-routing.test.js \
+  dist/cli/__tests__/setup-refresh.test.js \
+  dist/cli/__tests__/setup-skills-overwrite.test.js \
+  dist/cli/__tests__/setup-scope.test.js \
+  dist/catalog/__tests__/generator.test.js \
+  dist/daemon/__tests__/index.test.js
+node dist/scripts/generate-catalog-docs.js --check
+```
+
+Observed results:
+
+- `npm run build` ✅
+- targeted node test batch ✅
+  (`41` + `11` passing checks across the selected suites;
+  `0` failures)
+- catalog contract check ✅ (`catalog check ok`)
+
+## Residual risk / handoff note
+
+The documentation and manual review lane found the main
+polish story coherent. The remaining high-value merge gate
+is to keep the verification lane explicit around daemon
+status branches beyond pre-setup, especially
+missing-credentials and stopped/running messaging.
+
+If those direct assertions are present in the final
+integrated branch, this review lane has no blocking
+documentation concerns.

--- a/skills/setup-omx-daemon/SKILL.md
+++ b/skills/setup-omx-daemon/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: setup-omx-daemon
+description: Scaffold and launch the OMX GitHub issue-triage daemon for the current repo
+---
+
+# Setup OMX Daemon
+
+Use this skill when the user wants a repo-local OMX daemon that continuously watches GitHub issues, drafts triage proposals, and maintains an approval-gated project wiki sink.
+
+## What this skill should do
+
+1. Scaffold tracked governance inputs if missing:
+   - `.omx/daemon/ISSUE_GATE.md`
+   - `.omx/daemon/PROJECT_CONTEXT.md`
+   - `.omx/daemon/RULES.md`
+   - `.omx/daemon/daemon.config.json`
+2. Ensure project `.gitignore` keeps `.omx/daemon/*.md` and `.omx/daemon/daemon.config.json` trackable while `.omx/state/daemon/` stays ignored.
+3. Check daemon status:
+
+```bash
+omx daemon status
+```
+
+4. If the repo is not initialized yet, scaffold the default daemon files:
+
+```bash
+omx daemon scaffold
+```
+
+5. After reviewing the governance/config files, run one foreground cycle or start the background daemon:
+
+```bash
+omx daemon run-once
+# or
+omx daemon start
+```
+
+## Expected v1 behavior
+
+- The daemon is **approval-first**.
+- `.omx/daemon/*` is tracked governance input; the daemon must not rewrite those files automatically.
+- Runtime state lives under `.omx/state/daemon/`.
+- Draft triage/wiki proposals land in `.omx/state/daemon/outbox/`.
+- Approved publications land in `docs/project-wiki/`.
+- Queue items are actioned with:
+
+```bash
+omx daemon approve <item-id>
+omx daemon reject <item-id>
+```
+
+## Credential expectations
+
+Default config expects a token reference rather than a raw token. The daemon resolves credentials in this order:
+1. `.omx/daemon/daemon.config.json` token reference
+2. `GH_TOKEN`
+3. `GITHUB_TOKEN`
+4. `gh auth token`
+
+## Notes for the agent
+
+- Prefer preserving any existing repo-specific policy text instead of overwriting it.
+- If the repository remote is not GitHub, explain that the current daemon implementation is GitHub-specific.
+- If credentials are missing, stop after status guidance instead of pretending the daemon is active.

--- a/skills/setup-omx-daemon/SKILL.md
+++ b/skills/setup-omx-daemon/SKILL.md
@@ -5,7 +5,7 @@ description: Scaffold and launch the OMX GitHub issue-triage daemon for the curr
 
 # Setup OMX Daemon
 
-Use this skill when the user wants a repo-local OMX daemon that continuously watches GitHub issues, drafts triage proposals, and maintains an approval-gated project wiki sink.
+Use this skill when the user wants a repo-local OMX daemon that continuously watches GitHub issues, drafts triage proposals, and maintains an approval-gated project wiki sink. This skill is the guided onboarding wrapper around the CLI-owned `omx daemon` scaffold/status/start workflow.
 
 ## What this skill should do
 

--- a/src/catalog/__tests__/generator.test.ts
+++ b/src/catalog/__tests__/generator.test.ts
@@ -50,4 +50,16 @@ describe('catalog reader/contract', () => {
     const targetRaw = await readFile(join(process.cwd(), 'templates', 'catalog-manifest.json'), 'utf8');
     assert.equal(JSON.parse(targetRaw).catalogVersion, JSON.parse(sourceRaw).catalogVersion);
   });
+
+  it('keeps setup-omx-daemon discoverable across source, template, and generated public catalog artifacts', async () => {
+    const sourceManifest = JSON.parse(await readFile(join(process.cwd(), 'src', 'catalog', 'manifest.json'), 'utf8'));
+    const templateManifest = JSON.parse(await readFile(join(process.cwd(), 'templates', 'catalog-manifest.json'), 'utf8'));
+    const publicCatalog = JSON.parse(await readFile(join(process.cwd(), 'src', 'catalog', 'generated', 'public-catalog.json'), 'utf8'));
+
+    for (const catalog of [sourceManifest, templateManifest, publicCatalog]) {
+      assert.ok(
+        catalog.skills.some((entry: { name: string; status: string }) => entry.name === 'setup-omx-daemon' && entry.status === 'active'),
+      );
+    }
+  });
 });

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -2,9 +2,9 @@
   "generatedAt": "2026-03-10T10:43:36.374Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 39,
+    "skillCount": 40,
     "promptCount": 30,
-    "activeSkillCount": 23,
+    "activeSkillCount": 24,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -249,6 +249,13 @@
     },
     {
       "name": "omx-setup",
+      "category": "utility",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "setup-omx-daemon",
       "category": "utility",
       "status": "active",
       "core": false,

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -183,6 +183,13 @@
       "status": "active"
     },
     {
+      "name": "setup-omx-daemon",
+      "category": "utility",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "configure-notifications",
       "category": "utility",
       "status": "active",

--- a/src/cli/__tests__/daemon.test.ts
+++ b/src/cli/__tests__/daemon.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { daemonCommand } from "../daemon.js";
+
+describe("omx daemon CLI", () => {
+  it("prints command-local help", async () => {
+    const lines: string[] = [];
+    await daemonCommand(["--help"], {
+      stdout: (line) => lines.push(line),
+      stderr: (line) => lines.push(line),
+    });
+    assert.match(lines.join("\n"), /omx daemon start/);
+    assert.match(lines.join("\n"), /omx daemon approve <item-id>/);
+  });
+
+  it("scaffolds daemon governance files from the CLI", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
+    const previous = process.cwd();
+    const lines: string[] = [];
+    process.chdir(cwd);
+    try {
+      await daemonCommand(["scaffold"], {
+        stdout: (line) => lines.push(line),
+        stderr: (line) => lines.push(line),
+      });
+      assert.match(lines.join("\n"), /Scaffolded daemon governance files/);
+    } finally {
+      process.chdir(previous);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/daemon.test.ts
+++ b/src/cli/__tests__/daemon.test.ts
@@ -6,6 +6,25 @@ import { tmpdir } from "node:os";
 import { daemonCommand } from "../daemon.js";
 import { runOmxDaemonOnce } from "../../daemon/index.js";
 
+async function withTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
+  const previous = process.cwd();
+  process.chdir(cwd);
+  try {
+    await fn(cwd);
+  } finally {
+    process.chdir(previous);
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function writeDaemonConfig(cwd: string, config: Record<string, unknown>): Promise<void> {
+  await writeFile(
+    join(cwd, ".omx", "daemon", "daemon.config.json"),
+    JSON.stringify(config, null, 2),
+  );
+}
+
 describe("omx daemon CLI", () => {
   it("prints command-local help", async () => {
     const lines: string[] = [];
@@ -20,59 +39,46 @@ describe("omx daemon CLI", () => {
   });
 
   it("scaffolds daemon governance files from the CLI", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
-    const previous = process.cwd();
     const lines: string[] = [];
-    process.chdir(cwd);
-    try {
+    await withTempCwd(async () => {
       await daemonCommand(["scaffold"], {
         stdout: (line) => lines.push(line),
         stderr: (line) => lines.push(line),
       });
       assert.match(lines.join("\n"), /Scaffolded daemon governance files/);
-    } finally {
-      process.chdir(previous);
-      await rm(cwd, { recursive: true, force: true });
-    }
+    });
   });
 
   it("defaults to status and explains setup before daemon initialization", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
-    const previous = process.cwd();
     const lines: string[] = [];
-    process.chdir(cwd);
-    try {
+    await withTempCwd(async () => {
       await daemonCommand([], {
         stdout: (line) => lines.push(line),
         stderr: (line) => lines.push(line),
       });
       assert.match(lines.join("\n"), /not initialized/i);
       assert.match(lines.join("\n"), /\$setup-omx-daemon|scaffold \.omx\/daemon/i);
-    } finally {
-      process.chdir(previous);
-      await rm(cwd, { recursive: true, force: true });
-    }
+    });
   });
 
   it("surfaces missing-credential guidance after daemon scaffolding", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
-    const previous = process.cwd();
     const previousGhToken = process.env.GH_TOKEN;
     const previousGithubToken = process.env.GITHUB_TOKEN;
     const previousPath = process.env.PATH;
     const lines: string[] = [];
-    process.chdir(cwd);
     delete process.env.GH_TOKEN;
     delete process.env.GITHUB_TOKEN;
     process.env.PATH = "";
     try {
-      await daemonCommand(["scaffold"], {
-        stdout: () => undefined,
-        stderr: () => undefined,
-      });
-      await daemonCommand(["status"], {
-        stdout: (line) => lines.push(line),
-        stderr: (line) => lines.push(line),
+      await withTempCwd(async () => {
+        await daemonCommand(["scaffold"], {
+          stdout: () => undefined,
+          stderr: () => undefined,
+        });
+        await daemonCommand(["status"], {
+          stdout: (line) => lines.push(line),
+          stderr: (line) => lines.push(line),
+        });
       });
       assert.match(lines.join("\n"), /credentials are missing/i);
       assert.match(lines.join("\n"), /GH_TOKEN|GITHUB_TOKEN|gh auth token/i);
@@ -83,73 +89,61 @@ describe("omx daemon CLI", () => {
       else delete process.env.GITHUB_TOKEN;
       if (typeof previousPath === "string") process.env.PATH = previousPath;
       else delete process.env.PATH;
-      process.chdir(previous);
-      await rm(cwd, { recursive: true, force: true });
     }
   });
 
   it("reports the stopped state when credentials are configured but the daemon is not running", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
-    const previous = process.cwd();
     const previousGhToken = process.env.GH_TOKEN;
     const lines: string[] = [];
-    process.chdir(cwd);
     process.env.GH_TOKEN = "test-token";
     try {
-      await daemonCommand(["scaffold"], {
-        stdout: () => undefined,
-        stderr: () => undefined,
-      });
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
+      await withTempCwd(async (cwd) => {
+        await daemonCommand(["scaffold"], {
+          stdout: () => undefined,
+          stderr: () => undefined,
+        });
+        await writeDaemonConfig(cwd, {
           repository: "octo/example",
           githubCredentialSource: "env",
           githubTokenEnvVar: "GH_TOKEN",
-        }, null, 2),
-      );
-      await daemonCommand(["status"], {
-        stdout: (line) => lines.push(line),
-        stderr: (line) => lines.push(line),
+        });
+        await daemonCommand(["status"], {
+          stdout: (line) => lines.push(line),
+          stderr: (line) => lines.push(line),
+        });
       });
       assert.match(lines.join("\n"), /Daemon is stopped/i);
       assert.match(lines.join("\n"), /queued=0, approved=0, rejected=0, published=0, total=0/);
     } finally {
       if (typeof previousGhToken === "string") process.env.GH_TOKEN = previousGhToken;
       else delete process.env.GH_TOKEN;
-      process.chdir(previous);
-      await rm(cwd, { recursive: true, force: true });
     }
   });
 
   it("surfaces insufficient-permission guidance after a failed poll", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
-    const previous = process.cwd();
     const previousGhToken = process.env.GH_TOKEN;
     const lines: string[] = [];
     const originalFetch = globalThis.fetch;
-    process.chdir(cwd);
     process.env.GH_TOKEN = "test-token";
     globalThis.fetch = (async () => new Response("Resource not accessible by integration", { status: 403 })) as typeof fetch;
     try {
-      await daemonCommand(["scaffold"], {
-        stdout: () => undefined,
-        stderr: () => undefined,
-      });
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
+      await withTempCwd(async (cwd) => {
+        await daemonCommand(["scaffold"], {
+          stdout: () => undefined,
+          stderr: () => undefined,
+        });
+        await writeDaemonConfig(cwd, {
           repository: "octo/example",
           githubCredentialSource: "env",
           githubTokenEnvVar: "GH_TOKEN",
-        }, null, 2),
-      );
-      const runOnce = await runOmxDaemonOnce(cwd);
-      if (runOnce.message) lines.push(runOnce.message);
-      if (runOnce.error) lines.push(runOnce.error);
-      await daemonCommand(["status"], {
-        stdout: (line) => lines.push(line),
-        stderr: (line) => lines.push(line),
+        });
+        const runOnce = await runOmxDaemonOnce(cwd);
+        if (runOnce.message) lines.push(runOnce.message);
+        if (runOnce.error) lines.push(runOnce.error);
+        await daemonCommand(["status"], {
+          stdout: (line) => lines.push(line),
+          stderr: (line) => lines.push(line),
+        });
       });
       assert.match(lines.join("\n"), /permissions are insufficient/i);
       assert.match(lines.join("\n"), /issue-read permission/i);
@@ -157,8 +151,6 @@ describe("omx daemon CLI", () => {
       globalThis.fetch = originalFetch;
       if (typeof previousGhToken === "string") process.env.GH_TOKEN = previousGhToken;
       else delete process.env.GH_TOKEN;
-      process.chdir(previous);
-      await rm(cwd, { recursive: true, force: true });
     }
   });
 });

--- a/src/cli/__tests__/daemon.test.ts
+++ b/src/cli/__tests__/daemon.test.ts
@@ -12,8 +12,10 @@ describe("omx daemon CLI", () => {
       stdout: (line) => lines.push(line),
       stderr: (line) => lines.push(line),
     });
+    assert.match(lines.join("\n"), /omx daemon scaffold/);
     assert.match(lines.join("\n"), /omx daemon start/);
     assert.match(lines.join("\n"), /omx daemon approve <item-id>/);
+    assert.match(lines.join("\n"), /\$setup-omx-daemon is the guided onboarding wrapper/i);
   });
 
   it("scaffolds daemon governance files from the CLI", async () => {
@@ -28,6 +30,84 @@ describe("omx daemon CLI", () => {
       });
       assert.match(lines.join("\n"), /Scaffolded daemon governance files/);
     } finally {
+      process.chdir(previous);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults to status and explains setup before daemon initialization", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
+    const previous = process.cwd();
+    const lines: string[] = [];
+    process.chdir(cwd);
+    try {
+      await daemonCommand([], {
+        stdout: (line) => lines.push(line),
+        stderr: (line) => lines.push(line),
+      });
+      assert.match(lines.join("\n"), /not initialized/i);
+      assert.match(lines.join("\n"), /\$setup-omx-daemon|scaffold \.omx\/daemon/i);
+    } finally {
+      process.chdir(previous);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces missing-credential guidance after daemon scaffolding", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
+    const previous = process.cwd();
+    const previousGhToken = process.env.GH_TOKEN;
+    const previousGithubToken = process.env.GITHUB_TOKEN;
+    const previousPath = process.env.PATH;
+    const lines: string[] = [];
+    process.chdir(cwd);
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    process.env.PATH = "";
+    try {
+      await daemonCommand(["scaffold"], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      });
+      await daemonCommand(["status"], {
+        stdout: (line) => lines.push(line),
+        stderr: (line) => lines.push(line),
+      });
+      assert.match(lines.join("\n"), /credentials are missing/i);
+      assert.match(lines.join("\n"), /GH_TOKEN|GITHUB_TOKEN|gh auth token/i);
+    } finally {
+      if (typeof previousGhToken === "string") process.env.GH_TOKEN = previousGhToken;
+      else delete process.env.GH_TOKEN;
+      if (typeof previousGithubToken === "string") process.env.GITHUB_TOKEN = previousGithubToken;
+      else delete process.env.GITHUB_TOKEN;
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      process.chdir(previous);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reports the stopped state when credentials are configured but the daemon is not running", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
+    const previous = process.cwd();
+    const previousGhToken = process.env.GH_TOKEN;
+    const lines: string[] = [];
+    process.chdir(cwd);
+    process.env.GH_TOKEN = "test-token";
+    try {
+      await daemonCommand(["scaffold"], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      });
+      await daemonCommand(["status"], {
+        stdout: (line) => lines.push(line),
+        stderr: (line) => lines.push(line),
+      });
+      assert.match(lines.join("\n"), /Daemon is stopped/i);
+      assert.match(lines.join("\n"), /queued=0, published=0, total=0/);
+    } finally {
+      if (typeof previousGhToken === "string") process.env.GH_TOKEN = previousGhToken;
+      else delete process.env.GH_TOKEN;
       process.chdir(previous);
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/daemon.test.ts
+++ b/src/cli/__tests__/daemon.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { daemonCommand } from "../daemon.js";
+import { runOmxDaemonOnce } from "../../daemon/index.js";
 
 describe("omx daemon CLI", () => {
   it("prints command-local help", async () => {
@@ -106,6 +107,46 @@ describe("omx daemon CLI", () => {
       assert.match(lines.join("\n"), /Daemon is stopped/i);
       assert.match(lines.join("\n"), /queued=0, published=0, total=0/);
     } finally {
+      if (typeof previousGhToken === "string") process.env.GH_TOKEN = previousGhToken;
+      else delete process.env.GH_TOKEN;
+      process.chdir(previous);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces insufficient-permission guidance after a failed poll", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-cli-"));
+    const previous = process.cwd();
+    const previousGhToken = process.env.GH_TOKEN;
+    const lines: string[] = [];
+    const originalFetch = globalThis.fetch;
+    process.chdir(cwd);
+    process.env.GH_TOKEN = "test-token";
+    globalThis.fetch = (async () => new Response("Resource not accessible by integration", { status: 403 })) as typeof fetch;
+    try {
+      await daemonCommand(["scaffold"], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+      });
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          repository: "octo/example",
+          githubCredentialSource: "env",
+          githubTokenEnvVar: "GH_TOKEN",
+        }, null, 2),
+      );
+      const runOnce = await runOmxDaemonOnce(cwd);
+      if (runOnce.message) lines.push(runOnce.message);
+      if (runOnce.error) lines.push(runOnce.error);
+      await daemonCommand(["status"], {
+        stdout: (line) => lines.push(line),
+        stderr: (line) => lines.push(line),
+      });
+      assert.match(lines.join("\n"), /permissions are insufficient/i);
+      assert.match(lines.join("\n"), /issue-read permission/i);
+    } finally {
+      globalThis.fetch = originalFetch;
       if (typeof previousGhToken === "string") process.env.GH_TOKEN = previousGhToken;
       else delete process.env.GH_TOKEN;
       process.chdir(previous);

--- a/src/cli/__tests__/daemon.test.ts
+++ b/src/cli/__tests__/daemon.test.ts
@@ -100,12 +100,20 @@ describe("omx daemon CLI", () => {
         stdout: () => undefined,
         stderr: () => undefined,
       });
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          repository: "octo/example",
+          githubCredentialSource: "env",
+          githubTokenEnvVar: "GH_TOKEN",
+        }, null, 2),
+      );
       await daemonCommand(["status"], {
         stdout: (line) => lines.push(line),
         stderr: (line) => lines.push(line),
       });
       assert.match(lines.join("\n"), /Daemon is stopped/i);
-      assert.match(lines.join("\n"), /queued=0, published=0, total=0/);
+      assert.match(lines.join("\n"), /queued=0, approved=0, rejected=0, published=0, total=0/);
     } finally {
       if (typeof previousGhToken === "string") process.env.GH_TOKEN = previousGhToken;
       else delete process.env.GH_TOKEN;

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -26,6 +26,7 @@ describe('nested help routing', () => {
   for (const [argv, expectedUsage] of [
     [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
     [['autoresearch', '--help'], /Usage:[\s\S]*omx autoresearch <mission-dir>/i],
+    [['daemon', '--help'], /omx daemon start/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
     [['state', '--help'], /Usage:\s*omx state <read\|write\|clear\|list-active\|get-status>/i],

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -23,10 +23,21 @@ function runOmx(cwd: string, argv: string[]) {
 }
 
 describe('nested help routing', () => {
+  it('keeps top-level daemon help aligned with guided onboarding', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-top-help-'));
+    try {
+      const result = runOmx(cwd, ['--help']);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /omx daemon\s+Use \$setup-omx-daemon for guided onboarding/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   for (const [argv, expectedUsage] of [
     [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
     [['autoresearch', '--help'], /Usage:[\s\S]*omx autoresearch <mission-dir>/i],
-    [['daemon', '--help'], /omx daemon start/i],
+    [['daemon', '--help'], /omx daemon scaffold/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
     [['state', '--help'], /Usage:\s*omx state <read\|write\|clear\|list-active\|get-status>/i],

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -15,7 +15,11 @@ import { tmpdir } from "node:os";
 import { setup } from "../setup.js";
 
 const EXPECTED_PROJECT_GITIGNORE = [
-  ".omx/",
+  ".omx/*",
+  "!.omx/daemon/",
+  ".omx/daemon/*",
+  "!.omx/daemon/*.md",
+  "!.omx/daemon/daemon.config.json",
   ".codex/*",
   "!.codex/agents/",
   "!.codex/agents/**",
@@ -133,7 +137,8 @@ describe("omx setup refresh summary and dry-run behavior", () => {
 
       const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
       assert.equal(gitignore, `node_modules/\n${EXPECTED_PROJECT_GITIGNORE}`);
-      assert.equal(gitignore.match(/^\.omx\/$/gm)?.length ?? 0, 1);
+      assert.equal(gitignore.match(/^\.omx\/\*$/gm)?.length ?? 0, 1);
+      assert.equal(gitignore.match(/^!\.omx\/daemon\/$/gm)?.length ?? 0, 1);
       assert.equal(gitignore.match(/^\.codex\/\*$/gm)?.length ?? 0, 1);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -190,6 +195,47 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       const gitignore = await readFile(join(wd, ".gitignore"), "utf-8");
       assert.equal(gitignore, EXPECTED_PROJECT_GITIGNORE);
       assert.equal(gitignore.match(/^\.codex\/$/gm)?.length ?? 0, 0);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+
+  it("keeps tracked .omx/daemon governance files visible while ignoring runtime daemon state", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      const initResult = spawnSync("git", ["init", "-q"], { cwd: wd });
+      assert.equal(initResult.status, 0);
+
+      await runSetupInTempDir(wd, { scope: "project" });
+      await mkdir(join(wd, ".omx", "daemon"), { recursive: true });
+      await mkdir(join(wd, ".omx", "state", "daemon"), { recursive: true });
+      await writeFile(join(wd, ".omx", "daemon", "ISSUE_GATE.md"), "# gate\n");
+      await writeFile(join(wd, ".omx", "daemon", "daemon.config.json"), "{}\n");
+      await writeFile(join(wd, ".omx", "state", "daemon", "queue.json"), "[]\n");
+
+      const status = spawnSync(
+        "git",
+        [
+          "status",
+          "--short",
+          "--ignored",
+          ".omx/daemon/ISSUE_GATE.md",
+          ".omx/daemon/daemon.config.json",
+        ],
+        { cwd: wd, encoding: "utf-8" },
+      );
+      assert.equal(status.status, 0);
+      assert.match(status.stdout, /^\?\? \.omx\/daemon\/ISSUE_GATE\.md$/m);
+      assert.match(status.stdout, /^\?\? \.omx\/daemon\/daemon\.config\.json$/m);
+      const ignored = spawnSync(
+        "git",
+        ["check-ignore", "-v", ".omx/state/daemon/queue.json"],
+        { cwd: wd, encoding: "utf-8" },
+      );
+      assert.equal(ignored.status, 0, ignored.stderr || ignored.stdout);
+      assert.match(ignored.stdout, /\.gitignore:1:\.omx\/\*/);
+      assert.match(ignored.stdout, /\.omx\/state\/daemon\/queue\.json\s*$/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -203,6 +203,10 @@ describe("omx setup scope behavior", () => {
         existsSync(join(localSkills, "ask-gemini", "SKILL.md")),
         true,
       );
+      assert.equal(
+        existsSync(join(localSkills, "setup-omx-daemon", "SKILL.md")),
+        true,
+      );
       assert.ok(
         (await readdir(localPrompts)).length > 0,
         "local prompts should be installed",

--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -28,6 +28,7 @@ describe('omx setup skills overwrite behavior', () => {
       assert.equal(installed.has('frontend-ui-ux'), false);
       assert.equal(installed.has('pipeline'), false);
       assert.equal(installed.has('configure-notifications'), true);
+      assert.equal(installed.has('setup-omx-daemon'), true);
       assert.equal(installed.has('configure-discord'), false);
       assert.equal(installed.has('configure-telegram'), false);
       assert.equal(installed.has('configure-slack'), false);

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -1,0 +1,98 @@
+import {
+  approveOmxDaemonItem,
+  getOmxDaemonStatus,
+  rejectOmxDaemonItem,
+  runOmxDaemonOnce,
+  scaffoldOmxDaemonFiles,
+  startOmxDaemon,
+  stopOmxDaemon,
+} from "../daemon/index.js";
+
+const DAEMON_HELP = `Usage:
+  omx daemon start
+  omx daemon stop
+  omx daemon status
+  omx daemon run-once
+  omx daemon approve <item-id>
+  omx daemon reject <item-id>
+
+Notes:
+  - $setup-omx-daemon is the guided onboarding surface.
+  - The CLI owns runtime lifecycle; start/stop/status/run-once manage the current worktree.
+  - If the daemon is not initialized yet, use the setup skill or:
+      omx daemon scaffold
+    to create tracked .omx/daemon inputs.`;
+
+export interface DaemonCommandDependencies {
+  stdout?: (line: string) => void;
+  stderr?: (line: string) => void;
+}
+
+function emitResult(
+  result: { success: boolean; message: string; error?: string; state?: unknown; queue?: unknown },
+  stdout: (line: string) => void,
+  stderr: (line: string) => void,
+): void {
+  if (result.success) {
+    stdout(result.message);
+  } else {
+    stderr(result.error ? `${result.message}\n${result.error}` : result.message);
+    process.exitCode = 1;
+  }
+}
+
+export async function daemonCommand(
+  args: string[],
+  deps: DaemonCommandDependencies = {},
+): Promise<void> {
+  const stdout = deps.stdout ?? ((line: string) => console.log(line));
+  const stderr = deps.stderr ?? ((line: string) => console.error(line));
+  const subcommand = args[0] ?? "status";
+
+  switch (subcommand) {
+    case "help":
+    case "--help":
+    case "-h":
+      stdout(DAEMON_HELP);
+      return;
+    case "scaffold": {
+      const changed = await scaffoldOmxDaemonFiles(process.cwd());
+      stdout(
+        changed.length > 0
+          ? `Scaffolded daemon governance files:\n${changed.map((file) => `- ${file}`).join("\n")}`
+          : "Daemon governance files already exist.",
+      );
+      return;
+    }
+    case "start":
+      emitResult(startOmxDaemon(process.cwd()), stdout, stderr);
+      return;
+    case "stop":
+      emitResult(stopOmxDaemon(process.cwd()), stdout, stderr);
+      return;
+    case "status":
+      emitResult(getOmxDaemonStatus(process.cwd()), stdout, stderr);
+      return;
+    case "run-once":
+      emitResult(await runOmxDaemonOnce(process.cwd()), stdout, stderr);
+      return;
+    case "approve": {
+      const itemId = args[1];
+      if (!itemId) {
+        throw new Error(`Missing queue item id for approve.\n${DAEMON_HELP}`);
+      }
+      emitResult(await approveOmxDaemonItem(process.cwd(), itemId), stdout, stderr);
+      return;
+    }
+    case "reject": {
+      const itemId = args[1];
+      if (!itemId) {
+        throw new Error(`Missing queue item id for reject.\n${DAEMON_HELP}`);
+      }
+      emitResult(rejectOmxDaemonItem(process.cwd(), itemId), stdout, stderr);
+      return;
+    }
+    default:
+      throw new Error(`Unknown daemon subcommand: ${subcommand}\n${DAEMON_HELP}`);
+  }
+}

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -9,6 +9,7 @@ import {
 } from "../daemon/index.js";
 
 const DAEMON_HELP = `Usage:
+  omx daemon scaffold
   omx daemon start
   omx daemon stop
   omx daemon status
@@ -17,11 +18,9 @@ const DAEMON_HELP = `Usage:
   omx daemon reject <item-id>
 
 Notes:
-  - $setup-omx-daemon is the guided onboarding surface.
-  - The CLI owns runtime lifecycle; start/stop/status/run-once manage the current worktree.
-  - If the daemon is not initialized yet, use the setup skill or:
-      omx daemon scaffold
-    to create tracked .omx/daemon inputs.`;
+  - $setup-omx-daemon is the guided onboarding wrapper for this command surface.
+  - The CLI owns current-worktree lifecycle: scaffold/start/stop/status/run-once/approve/reject.
+  - If tracked .omx/daemon inputs are missing, run the setup skill or \`omx daemon scaffold\`.`;
 
 export interface DaemonCommandDependencies {
   stdout?: (line: string) => void;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
 import { askCommand } from "./ask.js";
 import { stateCommand } from "./state.js";
+import { daemonCommand } from "./daemon.js";
 import {
   cleanupCommand,
   cleanupOmxMcpProcesses,
@@ -144,6 +145,7 @@ Usage:
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx resume    Resume a previous interactive Codex session
   omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
+  omx daemon    Manage daemon lifecycle for GitHub issue triage (start|stop|status|run-once|approve|reject)
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree
@@ -255,6 +257,7 @@ type CliCommand =
   | "cleanup"
   | "ask"
   | "explore"
+  | "daemon"
   | "sparkshell"
   | "team"
   | "session"
@@ -285,6 +288,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "resume",
   "session",
   "sparkshell",
+  "daemon",
   "team",
   "tmux-hook",
 ]);
@@ -621,6 +625,7 @@ export async function main(args: string[]): Promise<void> {
     "ask",
     "autoresearch",
     "explore",
+    "daemon",
     "sparkshell",
     "team",
     "ralph",
@@ -702,6 +707,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "explore":
         await exploreCommand(args.slice(1));
+        break;
+      case "daemon":
+        await daemonCommand(args.slice(1));
         break;
       case "exec":
         await execWithOverlay(launchArgs);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -145,7 +145,7 @@ Usage:
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx resume    Resume a previous interactive Codex session
   omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
-  omx daemon    Manage daemon lifecycle for GitHub issue triage (start|stop|status|run-once|approve|reject)
+  omx daemon    Use $setup-omx-daemon for guided onboarding, then manage current-worktree daemon lifecycle
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -131,7 +131,11 @@ export interface SkillFrontmatterMetadata {
 }
 
 const PROJECT_GITIGNORE_ENTRIES = [
-  ".omx/",
+  ".omx/*",
+  "!.omx/daemon/",
+  ".omx/daemon/*",
+  "!.omx/daemon/*.md",
+  "!.omx/daemon/daemon.config.json",
   ".codex/*",
   "!.codex/agents/",
   "!.codex/agents/**",
@@ -141,7 +145,7 @@ const PROJECT_GITIGNORE_ENTRIES = [
   "!.codex/prompts/",
   "!.codex/prompts/**",
 ] as const;
-const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
+const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".omx/", ".codex/"] as const;
 
 function applyScopePathRewritesToAgentsTemplate(
   content: string,
@@ -707,11 +711,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     );
     if (gitignoreResult === "created") {
       console.log(
-        "  Created .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
+        "  Created .gitignore with OMX project ignore rules so local runtime state stays out of source control while `.omx/daemon/*` policy inputs and `.codex` assets remain trackable.\n",
       );
     } else if (gitignoreResult === "updated") {
       console.log(
-        "  Updated .gitignore with OMX project ignore rules so local runtime state stays out of source control while .codex agents, skills, and prompts remain trackable.\n",
+        "  Updated .gitignore with OMX project ignore rules so local runtime state stays out of source control while `.omx/daemon/*` policy inputs and `.codex` assets remain trackable.\n",
       );
     }
   }

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  approveOmxDaemonItem,
+  getOmxDaemonStatus,
+  resolveGitHubToken,
+  runOmxDaemonOnce,
+  scaffoldOmxDaemonFiles,
+} from "../index.js";
+
+const originalFetch = globalThis.fetch;
+const originalGhToken = process.env.GH_TOKEN;
+const originalGithubToken = process.env.GITHUB_TOKEN;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (typeof originalGhToken === "string") process.env.GH_TOKEN = originalGhToken; else delete process.env.GH_TOKEN;
+  if (typeof originalGithubToken === "string") process.env.GITHUB_TOKEN = originalGithubToken; else delete process.env.GITHUB_TOKEN;
+});
+
+describe("omx daemon runtime", () => {
+  it("scaffolds tracked governance inputs", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-scaffold-"));
+    try {
+      const changed = await scaffoldOmxDaemonFiles(cwd);
+      assert.ok(changed.includes(".omx/daemon/ISSUE_GATE.md"));
+      assert.ok(changed.includes(".omx/daemon/daemon.config.json"));
+      assert.equal(existsSync(join(cwd, ".omx", "daemon", "RULES.md")), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves GitHub credentials in the documented order", () => {
+    const result = resolveGitHubToken(
+      { githubCredentialSource: "config-token-ref", githubTokenEnvVar: "CUSTOM_DAEMON_TOKEN" },
+      { CUSTOM_DAEMON_TOKEN: "config-token", GH_TOKEN: "gh-token", GITHUB_TOKEN: "github-token" },
+      (() => ({ status: 1, stdout: "", stderr: "" })) as never,
+    );
+    assert.equal(result.token, "config-token");
+    assert.equal(result.source, "config-token-ref");
+  });
+
+  it("queues proposals from GitHub issues and publishes approved wiki docs", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-runonce-"));
+    try {
+      await scaffoldOmxDaemonFiles(cwd);
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          repository: "octo/example",
+          githubCredentialSource: "env",
+          githubTokenEnvVar: "GH_TOKEN",
+          pollIntervalMs: 10000,
+          maxIssuesPerRun: 5,
+          knowledgeSink: "docs/project-wiki",
+        }, null, 2),
+      );
+      process.env.GH_TOKEN = "token-from-env";
+      globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/issues?")) {
+          return new Response(JSON.stringify([
+            {
+              number: 42,
+              title: "Security regression in daemon flow",
+              html_url: "https://github.com/octo/example/issues/42",
+              body: "Regression needs urgent follow-up.",
+              updated_at: "2026-04-09T12:00:00Z",
+              labels: [{ name: "bug" }],
+              comments: 6,
+            },
+          ]), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+        if (url.includes("/issues/42") && init?.method === "PATCH") {
+          return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }) as typeof fetch;
+
+      const runResult = await runOmxDaemonOnce(cwd);
+      assert.equal(runResult.success, true);
+      assert.equal(runResult.queue?.length, 1);
+      const item = runResult.queue?.[0];
+      assert.ok(item);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "daemon", "outbox", `issue-${item?.id}.md`)), true);
+
+      const approveResult = await approveOmxDaemonItem(cwd, item!.id);
+      assert.equal(approveResult.success, true);
+      assert.equal(existsSync(join(cwd, "docs", "project-wiki", "issue-42.md")), true);
+      const published = await readFile(join(cwd, "docs", "project-wiki", "issue-42.md"), "utf-8");
+      assert.match(published, /Approved at:/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reports actionable status before setup", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-status-"));
+    try {
+      const status = getOmxDaemonStatus(cwd);
+      assert.equal(status.success, true);
+      assert.match(status.message, /not initialized/i);
+      assert.equal(status.state?.statusReason, "not-initialized");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import {
   approveOmxDaemonItem,
   getOmxDaemonStatus,
+  rejectOmxDaemonItem,
   resolveGitHubToken,
   runOmxDaemonOnce,
   scaffoldOmxDaemonFiles,
@@ -32,7 +33,27 @@ describe("omx daemon runtime", () => {
       const changed = await scaffoldOmxDaemonFiles(cwd);
       assert.ok(changed.includes(".omx/daemon/ISSUE_GATE.md"));
       assert.ok(changed.includes(".omx/daemon/daemon.config.json"));
+      assert.ok(changed.includes(".gitignore"));
       assert.equal(existsSync(join(cwd, ".omx", "daemon", "RULES.md")), true);
+      const gitignore = await readFile(join(cwd, ".gitignore"), "utf-8");
+      assert.match(gitignore, /^\.omx\/\*$/m);
+      assert.match(gitignore, /^!\.omx\/daemon\/$/m);
+      assert.match(gitignore, /^!\.omx\/daemon\/daemon\.config\.json$/m);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs legacy .gitignore entries during daemon scaffold", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-scaffold-"));
+    try {
+      await writeFile(join(cwd, ".gitignore"), ".omx/\nnode_modules/\n");
+      const changed = await scaffoldOmxDaemonFiles(cwd);
+      assert.ok(changed.includes(".gitignore"));
+      const gitignore = await readFile(join(cwd, ".gitignore"), "utf-8");
+      assert.doesNotMatch(gitignore, /^\.omx\/$/m);
+      assert.match(gitignore, /^node_modules\/$/m);
+      assert.match(gitignore, /^!\.omx\/daemon\/$/m);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -162,6 +183,7 @@ describe("omx daemon runtime", () => {
       await writeFile(
         join(cwd, ".omx", "daemon", "daemon.config.json"),
         JSON.stringify({
+          repository: "octo/example",
           githubCredentialSource: "config-token-ref",
           githubTokenEnvVar: "OMX_DAEMON_TEST_TOKEN",
         }, null, 2),
@@ -193,10 +215,182 @@ describe("omx daemon runtime", () => {
     }
   });
 
+  it("reports missing-repository before start and status when repository cannot be resolved", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-status-"));
+    try {
+      await scaffoldOmxDaemonFiles(cwd);
+      process.env.GH_TOKEN = "token-from-env";
+      const start = startOmxDaemon(cwd);
+      assert.equal(start.success, false);
+      assert.equal(start.state?.statusReason, "missing-repository");
+      assert.match(start.message, /cannot start daemon without a resolvable github repository/i);
+
+      const status = getOmxDaemonStatus(cwd);
+      assert.equal(status.success, true);
+      assert.equal(status.state?.statusReason, "missing-repository");
+      assert.match(status.message, /repository is not resolvable/i);
+      assert.match(status.message, /set git remote origin/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("includes last triage activity and rejected counts in status output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-status-"));
+    try {
+      await scaffoldOmxDaemonFiles(cwd);
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          repository: "octo/example",
+          githubCredentialSource: "env",
+          githubTokenEnvVar: "GH_TOKEN",
+          maxIssuesPerRun: 5,
+        }, null, 2),
+      );
+      process.env.GH_TOKEN = "token-from-env";
+      globalThis.fetch = (async (input: string | URL) => {
+        const url = String(input);
+        if (url.includes("/issues?")) {
+          return new Response(JSON.stringify([
+            {
+              number: 7,
+              title: "Bug in setup flow",
+              html_url: "https://github.com/octo/example/issues/7",
+              body: "needs review",
+              updated_at: "2026-04-09T12:00:00Z",
+              labels: [],
+              comments: 0,
+            },
+          ]), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }) as typeof fetch;
+
+      const runOnce = await runOmxDaemonOnce(cwd);
+      assert.equal(runOnce.success, true);
+      const item = runOnce.queue?.[0];
+      assert.ok(item);
+      const rejected = rejectOmxDaemonItem(cwd, item!.id);
+      assert.equal(rejected.success, true);
+
+      const status = getOmxDaemonStatus(cwd);
+      assert.match(status.message, /rejected=1/);
+      assert.match(status.message, /last triage=/i);
+      assert.match(status.message, /last poll=/i);
+      assert.match(status.message, /last issue scan=/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps approvals resumable when local publish or configured GitHub mutation cannot finish", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-approve-"));
+    try {
+      await scaffoldOmxDaemonFiles(cwd);
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          repository: "octo/example",
+          githubCredentialSource: "env",
+          githubTokenEnvVar: "GH_TOKEN",
+          maxIssuesPerRun: 5,
+          applyGitHubLabelsOnApprove: true,
+        }, null, 2),
+      );
+      process.env.GH_TOKEN = "token-from-env";
+      globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/issues?")) {
+          return new Response(JSON.stringify([
+            {
+              number: 8,
+              title: "Approval retry case",
+              html_url: "https://github.com/octo/example/issues/8",
+              body: "needs review",
+              updated_at: "2026-04-09T12:00:00Z",
+              labels: [],
+              comments: 0,
+            },
+          ]), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+        if (url.includes("/issues/8") && init?.method === "PATCH") {
+          return new Response("forbidden", { status: 403 });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }) as typeof fetch;
+
+      const runOnce = await runOmxDaemonOnce(cwd);
+      const item = runOnce.queue?.[0];
+      assert.ok(item);
+      const approval = await approveOmxDaemonItem(cwd, item!.id);
+      assert.equal(approval.success, false);
+      const retained = approval.queue?.find((entry) => entry.id === item!.id);
+      assert.equal(retained?.status, "approved");
+      assert.equal(retained?.githubLabelMutationApplied, undefined);
+      assert.match(approval.message, /permissions are insufficient/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats duplicate reject attempts as idempotent success", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-reject-"));
+    try {
+      await scaffoldOmxDaemonFiles(cwd);
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          repository: "octo/example",
+          githubCredentialSource: "env",
+          githubTokenEnvVar: "GH_TOKEN",
+          maxIssuesPerRun: 5,
+        }, null, 2),
+      );
+      process.env.GH_TOKEN = "token-from-env";
+      globalThis.fetch = (async (input: string | URL) => {
+        const url = String(input);
+        if (url.includes("/issues?")) {
+          return new Response(JSON.stringify([
+            {
+              number: 9,
+              title: "Duplicate reject",
+              html_url: "https://github.com/octo/example/issues/9",
+              body: "needs review",
+              updated_at: "2026-04-09T12:00:00Z",
+              labels: [],
+              comments: 0,
+            },
+          ]), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }) as typeof fetch;
+
+      const runOnce = await runOmxDaemonOnce(cwd);
+      const item = runOnce.queue?.[0];
+      assert.ok(item);
+      const first = rejectOmxDaemonItem(cwd, item!.id);
+      const second = rejectOmxDaemonItem(cwd, item!.id);
+      assert.equal(first.success, true);
+      assert.equal(second.success, true);
+      assert.match(second.message, /already rejected/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("reports running status when the daemon loop is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-status-"));
     try {
       await scaffoldOmxDaemonFiles(cwd);
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          repository: "octo/example",
+          githubCredentialSource: "env",
+          githubTokenEnvVar: "GH_TOKEN",
+        }, null, 2),
+      );
       process.env.GH_TOKEN = "token-from-env";
 
       const start = startOmxDaemon(cwd);

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -20,6 +20,14 @@ const originalFetch = globalThis.fetch;
 const originalGhToken = process.env.GH_TOKEN;
 const originalGithubToken = process.env.GITHUB_TOKEN;
 
+function daemonConfigPath(cwd: string): string {
+  return join(cwd, ".omx", "daemon", "daemon.config.json");
+}
+
+async function writeDaemonConfig(cwd: string, config: Record<string, unknown>): Promise<void> {
+  await writeFile(daemonConfigPath(cwd), JSON.stringify(config, null, 2));
+}
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
   if (typeof originalGhToken === "string") process.env.GH_TOKEN = originalGhToken; else delete process.env.GH_TOKEN;
@@ -73,18 +81,15 @@ describe("omx daemon runtime", () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-runonce-"));
     try {
       await scaffoldOmxDaemonFiles(cwd);
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
-          repository: "octo/example",
-          githubCredentialSource: "env",
-          githubTokenEnvVar: "GH_TOKEN",
-          pollIntervalMs: 10000,
-          maxIssuesPerRun: 5,
-          knowledgeSink: "docs/project-wiki",
-          applyGitHubLabelsOnApprove: true,
-        }, null, 2),
-      );
+      await writeDaemonConfig(cwd, {
+        repository: "octo/example",
+        githubCredentialSource: "env",
+        githubTokenEnvVar: "GH_TOKEN",
+        pollIntervalMs: 10000,
+        maxIssuesPerRun: 5,
+        knowledgeSink: "docs/project-wiki",
+        applyGitHubLabelsOnApprove: true,
+      });
       process.env.GH_TOKEN = "token-from-env";
       globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
         const url = String(input);
@@ -135,14 +140,11 @@ describe("omx daemon runtime", () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-perms-"));
     try {
       await scaffoldOmxDaemonFiles(cwd);
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
-          repository: "octo/example",
-          githubCredentialSource: "env",
-          githubTokenEnvVar: "GH_TOKEN",
-        }, null, 2),
-      );
+      await writeDaemonConfig(cwd, {
+        repository: "octo/example",
+        githubCredentialSource: "env",
+        githubTokenEnvVar: "GH_TOKEN",
+      });
       process.env.GH_TOKEN = "token-from-env";
       globalThis.fetch = (async () => new Response("Resource not accessible by integration", { status: 403 })) as typeof fetch;
 
@@ -180,14 +182,11 @@ describe("omx daemon runtime", () => {
     const originalPath = process.env.PATH;
     try {
       await scaffoldOmxDaemonFiles(cwd);
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
-          repository: "octo/example",
-          githubCredentialSource: "config-token-ref",
-          githubTokenEnvVar: "OMX_DAEMON_TEST_TOKEN",
-        }, null, 2),
-      );
+      await writeDaemonConfig(cwd, {
+        repository: "octo/example",
+        githubCredentialSource: "config-token-ref",
+        githubTokenEnvVar: "OMX_DAEMON_TEST_TOKEN",
+      });
 
       delete process.env.GH_TOKEN;
       delete process.env.GITHUB_TOKEN;
@@ -239,15 +238,12 @@ describe("omx daemon runtime", () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-status-"));
     try {
       await scaffoldOmxDaemonFiles(cwd);
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
-          repository: "octo/example",
-          githubCredentialSource: "env",
-          githubTokenEnvVar: "GH_TOKEN",
-          maxIssuesPerRun: 5,
-        }, null, 2),
-      );
+      await writeDaemonConfig(cwd, {
+        repository: "octo/example",
+        githubCredentialSource: "env",
+        githubTokenEnvVar: "GH_TOKEN",
+        maxIssuesPerRun: 5,
+      });
       process.env.GH_TOKEN = "token-from-env";
       globalThis.fetch = (async (input: string | URL) => {
         const url = String(input);
@@ -288,16 +284,13 @@ describe("omx daemon runtime", () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-approve-"));
     try {
       await scaffoldOmxDaemonFiles(cwd);
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
-          repository: "octo/example",
-          githubCredentialSource: "env",
-          githubTokenEnvVar: "GH_TOKEN",
-          maxIssuesPerRun: 5,
-          applyGitHubLabelsOnApprove: true,
-        }, null, 2),
-      );
+      await writeDaemonConfig(cwd, {
+        repository: "octo/example",
+        githubCredentialSource: "env",
+        githubTokenEnvVar: "GH_TOKEN",
+        maxIssuesPerRun: 5,
+        applyGitHubLabelsOnApprove: true,
+      });
       process.env.GH_TOKEN = "token-from-env";
       globalThis.fetch = (async (input: string | URL, init?: RequestInit) => {
         const url = String(input);
@@ -338,15 +331,12 @@ describe("omx daemon runtime", () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-reject-"));
     try {
       await scaffoldOmxDaemonFiles(cwd);
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
-          repository: "octo/example",
-          githubCredentialSource: "env",
-          githubTokenEnvVar: "GH_TOKEN",
-          maxIssuesPerRun: 5,
-        }, null, 2),
-      );
+      await writeDaemonConfig(cwd, {
+        repository: "octo/example",
+        githubCredentialSource: "env",
+        githubTokenEnvVar: "GH_TOKEN",
+        maxIssuesPerRun: 5,
+      });
       process.env.GH_TOKEN = "token-from-env";
       globalThis.fetch = (async (input: string | URL) => {
         const url = String(input);
@@ -383,14 +373,11 @@ describe("omx daemon runtime", () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-status-"));
     try {
       await scaffoldOmxDaemonFiles(cwd);
-      await writeFile(
-        join(cwd, ".omx", "daemon", "daemon.config.json"),
-        JSON.stringify({
-          repository: "octo/example",
-          githubCredentialSource: "env",
-          githubTokenEnvVar: "GH_TOKEN",
-        }, null, 2),
-      );
+      await writeDaemonConfig(cwd, {
+        repository: "octo/example",
+        githubCredentialSource: "env",
+        githubTokenEnvVar: "GH_TOKEN",
+      });
       process.env.GH_TOKEN = "token-from-env";
 
       const start = startOmxDaemon(cwd);

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -61,6 +61,7 @@ describe("omx daemon runtime", () => {
           pollIntervalMs: 10000,
           maxIssuesPerRun: 5,
           knowledgeSink: "docs/project-wiki",
+          applyGitHubLabelsOnApprove: true,
         }, null, 2),
       );
       process.env.GH_TOKEN = "token-from-env";
@@ -90,6 +91,7 @@ describe("omx daemon runtime", () => {
       assert.equal(runResult.queue?.length, 1);
       const item = runResult.queue?.[0];
       assert.ok(item);
+      assert.deepEqual(item.transitions.map((entry) => entry.state), ["proposed", "queued"]);
       assert.equal(existsSync(join(cwd, ".omx", "state", "daemon", "outbox", `issue-${item?.id}.md`)), true);
 
       const approveResult = await approveOmxDaemonItem(cwd, item!.id);
@@ -97,6 +99,43 @@ describe("omx daemon runtime", () => {
       assert.equal(existsSync(join(cwd, "docs", "project-wiki", "issue-42.md")), true);
       const published = await readFile(join(cwd, "docs", "project-wiki", "issue-42.md"), "utf-8");
       assert.match(published, /Approved at:/);
+      const approvedItem = approveResult.queue?.find((entry) => entry.id === item?.id);
+      assert.ok(approvedItem);
+      assert.deepEqual(approvedItem.transitions.map((entry) => entry.state), ["proposed", "queued", "approved", "published"]);
+      const log = await readFile(join(cwd, ".omx", "state", "daemon", "daemon.log"), "utf-8");
+      assert.match(log, /Applied approved GitHub labels to issue #42/i);
+      assert.match(log, /Published approved queue item/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces actionable insufficient-permission status after a 403 poll failure", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-perms-"));
+    try {
+      await scaffoldOmxDaemonFiles(cwd);
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          repository: "octo/example",
+          githubCredentialSource: "env",
+          githubTokenEnvVar: "GH_TOKEN",
+        }, null, 2),
+      );
+      process.env.GH_TOKEN = "token-from-env";
+      globalThis.fetch = (async () => new Response("Resource not accessible by integration", { status: 403 })) as typeof fetch;
+
+      const runResult = await runOmxDaemonOnce(cwd);
+      assert.equal(runResult.success, false);
+      assert.equal(runResult.state?.statusReason, "insufficient-permissions");
+      assert.match(runResult.message, /permissions are insufficient/i);
+      assert.match(runResult.error ?? "", /issue-read permission/i);
+
+      const status = getOmxDaemonStatus(cwd);
+      assert.equal(status.success, true);
+      assert.equal(status.state?.statusReason, "insufficient-permissions");
+      assert.match(status.message, /permissions are insufficient/i);
+      assert.match(status.message, /issue-read permission/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/daemon/__tests__/index.test.ts
+++ b/src/daemon/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -10,6 +11,8 @@ import {
   resolveGitHubToken,
   runOmxDaemonOnce,
   scaffoldOmxDaemonFiles,
+  startOmxDaemon,
+  stopOmxDaemon,
 } from "../index.js";
 
 const originalFetch = globalThis.fetch;
@@ -105,8 +108,67 @@ describe("omx daemon runtime", () => {
       const status = getOmxDaemonStatus(cwd);
       assert.equal(status.success, true);
       assert.match(status.message, /not initialized/i);
+      assert.match(status.message, /\$setup-omx-daemon/i);
       assert.equal(status.state?.statusReason, "not-initialized");
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reports actionable stopped and missing-credential statuses after scaffold", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-status-"));
+    const originalPath = process.env.PATH;
+    try {
+      await scaffoldOmxDaemonFiles(cwd);
+      await writeFile(
+        join(cwd, ".omx", "daemon", "daemon.config.json"),
+        JSON.stringify({
+          githubCredentialSource: "config-token-ref",
+          githubTokenEnvVar: "OMX_DAEMON_TEST_TOKEN",
+        }, null, 2),
+      );
+
+      delete process.env.GH_TOKEN;
+      delete process.env.GITHUB_TOKEN;
+      delete process.env.OMX_DAEMON_TEST_TOKEN;
+      process.env.PATH = "";
+
+      const missingCredentials = getOmxDaemonStatus(cwd);
+      assert.equal(missingCredentials.success, true);
+      assert.equal(missingCredentials.state?.statusReason, "missing-credentials");
+      assert.match(missingCredentials.message, /GitHub credentials are missing/i);
+      assert.match(missingCredentials.message, /GITHUB_TOKEN/i);
+      assert.match(missingCredentials.message, /gh auth token/i);
+
+      process.env.PATH = originalPath;
+      process.env.OMX_DAEMON_TEST_TOKEN = "token-from-env";
+      const stopped = getOmxDaemonStatus(cwd);
+      assert.equal(stopped.success, true);
+      assert.equal(stopped.state?.statusReason, "stopped");
+      assert.match(stopped.message, /Daemon is stopped/i);
+      assert.match(stopped.message, /omx daemon start/i);
+      assert.match(stopped.message, /omx daemon run-once/i);
+    } finally {
+      if (typeof originalPath === "string") process.env.PATH = originalPath; else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reports running status when the daemon loop is active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-daemon-status-"));
+    try {
+      await scaffoldOmxDaemonFiles(cwd);
+      process.env.GH_TOKEN = "token-from-env";
+
+      const start = startOmxDaemon(cwd);
+      assert.equal(start.success, true, start.error ?? start.message);
+
+      const running = getOmxDaemonStatus(cwd);
+      assert.equal(running.success, true);
+      assert.equal(running.state?.statusReason, "running");
+      assert.match(running.message, /Daemon is running/i);
+    } finally {
+      stopOmxDaemon(cwd);
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,0 +1,1046 @@
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { omxStateDir } from "../utils/paths.js";
+
+const SECURE_FILE_MODE = 0o600;
+const LOG_FILE_MODE = 0o600;
+const MAX_LOG_SIZE_BYTES = 1 * 1024 * 1024;
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60_000;
+const MIN_POLL_INTERVAL_MS = 10_000;
+const MAX_POLL_INTERVAL_MS = 60 * 60_000;
+const DEFAULT_MAX_ISSUES_PER_RUN = 25;
+const MIN_MAX_ISSUES_PER_RUN = 1;
+const MAX_MAX_ISSUES_PER_RUN = 100;
+const DAEMON_IDENTITY_MARKER = "runOmxDaemonLoop";
+const DEFAULT_KNOWLEDGE_SINK = "docs/project-wiki";
+
+export type GitHubCredentialSource = "config-token-ref" | "env" | "gh-auth";
+export type QueueItemStatus = "queued" | "approved" | "rejected" | "published";
+export type DaemonPriority = "high" | "medium" | "low";
+
+export interface OmxDaemonConfig {
+  repository?: string;
+  pollIntervalMs?: number;
+  maxIssuesPerRun?: number;
+  knowledgeSink?: string;
+  githubCredentialSource?: GitHubCredentialSource;
+  githubTokenEnvVar?: string;
+  applyGitHubLabelsOnApprove?: boolean;
+}
+
+export interface OmxDaemonQueueItem {
+  id: string;
+  issueNumber: number;
+  issueTitle: string;
+  issueUrl: string;
+  issueUpdatedAt: string;
+  priority: DaemonPriority;
+  recommendedLabels: string[];
+  matchedRules: string[];
+  status: QueueItemStatus;
+  proposedAt: string;
+  approvedAt?: string;
+  publishedAt?: string;
+  rejectedAt?: string;
+  summary: string;
+  draftPath: string;
+  publicationPath: string;
+  publicationReason: string;
+  githubLabelMutationApplied?: boolean;
+}
+
+export interface OmxDaemonState {
+  isRunning: boolean;
+  pid: number | null;
+  startedAt: string | null;
+  lastPollAt: string | null;
+  lastTriageAt: string | null;
+  lastIssueScanAt: string | null;
+  queueSize: number;
+  proposalsCreated: number;
+  publishedCount: number;
+  rejectedCount: number;
+  lastError?: string;
+  credentialSource?: string | null;
+  repository?: string | null;
+  statusReason?: string;
+  processedIssueKeys?: Record<string, string>;
+}
+
+export interface DaemonResponse {
+  success: boolean;
+  message: string;
+  state?: OmxDaemonState;
+  queue?: OmxDaemonQueueItem[];
+  error?: string;
+}
+
+export interface ResolveGitHubTokenResult {
+  token: string | null;
+  source: "config-token-ref" | "GH_TOKEN" | "GITHUB_TOKEN" | "gh-auth" | "none";
+  error?: string;
+}
+
+interface GitHubIssue {
+  number: number;
+  title: string;
+  html_url: string;
+  body?: string | null;
+  updated_at: string;
+  labels: Array<{ name?: string } | string>;
+  comments?: number;
+  pull_request?: unknown;
+}
+
+interface ParsedIssueGate {
+  highPriorityKeywords: string[];
+  mediumPriorityKeywords: string[];
+  ignoreLabels: string[];
+  escalateLabels: string[];
+}
+
+interface EvaluateIssueResult {
+  priority: DaemonPriority;
+  matchedRules: string[];
+  recommendedLabels: string[];
+  summary: string;
+  skippedReason?: string;
+}
+
+interface DaemonPaths {
+  projectRoot: string;
+  governanceDir: string;
+  issueGatePath: string;
+  projectContextPath: string;
+  rulesPath: string;
+  configPath: string;
+  runtimeDir: string;
+  statePath: string;
+  pidPath: string;
+  logPath: string;
+  queuePath: string;
+  outboxDir: string;
+  knowledgeSinkDir: string;
+}
+
+function daemonPaths(projectRoot = process.cwd()): DaemonPaths {
+  const governanceDir = join(projectRoot, ".omx", "daemon");
+  const runtimeDir = join(omxStateDir(projectRoot), "daemon");
+  return {
+    projectRoot,
+    governanceDir,
+    issueGatePath: join(governanceDir, "ISSUE_GATE.md"),
+    projectContextPath: join(governanceDir, "PROJECT_CONTEXT.md"),
+    rulesPath: join(governanceDir, "RULES.md"),
+    configPath: join(governanceDir, "daemon.config.json"),
+    runtimeDir,
+    statePath: join(runtimeDir, "daemon-state.json"),
+    pidPath: join(runtimeDir, "daemon.pid"),
+    logPath: join(runtimeDir, "daemon.log"),
+    queuePath: join(runtimeDir, "queue.json"),
+    outboxDir: join(runtimeDir, "outbox"),
+    knowledgeSinkDir: join(projectRoot, DEFAULT_KNOWLEDGE_SINK),
+  };
+}
+
+function resolveKnowledgeSinkDir(projectRoot: string, config: OmxDaemonConfig | null): string {
+  return join(projectRoot, normalizeConfig(config ?? {}).knowledgeSink);
+}
+
+function ensureDir(dirPath: string): void {
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+  }
+}
+
+function ensureParentDir(filePath: string): void {
+  mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
+}
+
+function writeSecureText(filePath: string, content: string): void {
+  ensureParentDir(filePath);
+  writeFileSync(filePath, content, { mode: SECURE_FILE_MODE });
+  try {
+    chmodSync(filePath, SECURE_FILE_MODE);
+  } catch {
+    // ignore chmod failures
+  }
+}
+
+function writeTrackedText(filePath: string, content: string): void {
+  ensureParentDir(filePath);
+  writeFileSync(filePath, content);
+}
+
+function rotateLogIfNeeded(logPath: string): void {
+  try {
+    if (!existsSync(logPath)) return;
+    const stats = statSync(logPath);
+    if (stats.size <= MAX_LOG_SIZE_BYTES) return;
+    const backupPath = `${logPath}.old`;
+    if (existsSync(backupPath)) unlinkSync(backupPath);
+    renameSync(logPath, backupPath);
+  } catch {
+    // ignore rotation failures
+  }
+}
+
+function logToFile(logPath: string, message: string): void {
+  try {
+    ensureParentDir(logPath);
+    rotateLogIfNeeded(logPath);
+    appendFileSync(logPath, `[${new Date().toISOString()}] ${message}\n`, { mode: LOG_FILE_MODE });
+    try {
+      chmodSync(logPath, LOG_FILE_MODE);
+    } catch {
+      // ignore chmod failures
+    }
+  } catch {
+    // ignore logging failures
+  }
+}
+
+function readJsonFile<T>(filePath: string, fallback: T): T {
+  try {
+    if (!existsSync(filePath)) return fallback;
+    return JSON.parse(readFileSync(filePath, "utf-8")) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJsonFile(filePath: string, value: unknown, secure = true): void {
+  const content = `${JSON.stringify(value, null, 2)}\n`;
+  if (secure) {
+    writeSecureText(filePath, content);
+  } else {
+    writeTrackedText(filePath, content);
+  }
+}
+
+function normalizeInteger(value: unknown, fallback: number, min: number, max: number): number {
+  const numeric = typeof value === "number"
+    ? Math.trunc(value)
+    : (typeof value === "string" && value.trim() ? Number.parseInt(value, 10) : Number.NaN);
+  if (!Number.isFinite(numeric)) return fallback;
+  if (numeric < min) return min;
+  if (numeric > max) return max;
+  return numeric;
+}
+
+function defaultState(): OmxDaemonState {
+  return {
+    isRunning: false,
+    pid: null,
+    startedAt: null,
+    lastPollAt: null,
+    lastTriageAt: null,
+    lastIssueScanAt: null,
+    queueSize: 0,
+    proposalsCreated: 0,
+    publishedCount: 0,
+    rejectedCount: 0,
+    processedIssueKeys: {},
+  };
+}
+
+function readDaemonState(projectRoot = process.cwd()): OmxDaemonState {
+  const paths = daemonPaths(projectRoot);
+  return {
+    ...defaultState(),
+    ...readJsonFile(paths.statePath, defaultState()),
+  };
+}
+
+function writeDaemonState(projectRoot: string, state: OmxDaemonState): void {
+  const paths = daemonPaths(projectRoot);
+  ensureDir(paths.runtimeDir);
+  writeJsonFile(paths.statePath, state);
+}
+
+function readQueue(projectRoot = process.cwd()): OmxDaemonQueueItem[] {
+  const paths = daemonPaths(projectRoot);
+  return readJsonFile(paths.queuePath, [] as OmxDaemonQueueItem[]);
+}
+
+function writeQueue(projectRoot: string, queue: OmxDaemonQueueItem[]): void {
+  const paths = daemonPaths(projectRoot);
+  ensureDir(paths.runtimeDir);
+  writeJsonFile(paths.queuePath, queue);
+}
+
+function readPid(projectRoot = process.cwd()): number | null {
+  const paths = daemonPaths(projectRoot);
+  try {
+    if (!existsSync(paths.pidPath)) return null;
+    const parsed = Number.parseInt(readFileSync(paths.pidPath, "utf-8").trim(), 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writePid(projectRoot: string, pid: number): void {
+  const paths = daemonPaths(projectRoot);
+  writeSecureText(paths.pidPath, `${pid}`);
+}
+
+function removePid(projectRoot: string): void {
+  const paths = daemonPaths(projectRoot);
+  try {
+    if (existsSync(paths.pidPath)) unlinkSync(paths.pidPath);
+  } catch {
+    // ignore cleanup failures
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isDaemonProcess(pid: number): boolean {
+  try {
+    if (process.platform === "linux") {
+      const cmdline = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+      return cmdline.includes(DAEMON_IDENTITY_MARKER);
+    }
+    if (process.platform === "win32") return false;
+    const result = spawnSync("ps", ["-p", String(pid), "-o", "args="], {
+      encoding: "utf-8",
+      timeout: 3000,
+    });
+    if (result.status !== 0 || result.error) return false;
+    return (result.stdout ?? "").includes(DAEMON_IDENTITY_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+export function isOmxDaemonRunning(projectRoot = process.cwd()): boolean {
+  const pid = readPid(projectRoot);
+  if (pid === null) return false;
+  if (!isProcessRunning(pid)) {
+    removePid(projectRoot);
+    return false;
+  }
+  if (!isDaemonProcess(pid)) {
+    removePid(projectRoot);
+    return false;
+  }
+  return true;
+}
+
+function normalizeConfig(config: OmxDaemonConfig): Required<Pick<OmxDaemonConfig, "pollIntervalMs" | "maxIssuesPerRun" | "knowledgeSink" | "githubCredentialSource">> & OmxDaemonConfig {
+  return {
+    ...config,
+    pollIntervalMs: normalizeInteger(config.pollIntervalMs, DEFAULT_POLL_INTERVAL_MS, MIN_POLL_INTERVAL_MS, MAX_POLL_INTERVAL_MS),
+    maxIssuesPerRun: normalizeInteger(config.maxIssuesPerRun, DEFAULT_MAX_ISSUES_PER_RUN, MIN_MAX_ISSUES_PER_RUN, MAX_MAX_ISSUES_PER_RUN),
+    knowledgeSink: config.knowledgeSink?.trim() || DEFAULT_KNOWLEDGE_SINK,
+    githubCredentialSource: config.githubCredentialSource ?? "env",
+  };
+}
+
+export function readOmxDaemonConfig(projectRoot = process.cwd()): OmxDaemonConfig | null {
+  const paths = daemonPaths(projectRoot);
+  if (!existsSync(paths.configPath)) return null;
+  return normalizeConfig(readJsonFile(paths.configPath, {} as OmxDaemonConfig));
+}
+
+export async function scaffoldOmxDaemonFiles(projectRoot = process.cwd()): Promise<string[]> {
+  const paths = daemonPaths(projectRoot);
+  ensureDir(paths.governanceDir);
+  const changed: string[] = [];
+  const templates: Array<[string, string]> = [
+    [paths.issueGatePath, `# ISSUE_GATE\n\n## High Priority Keywords\n- security\n- outage\n- regression\n- urgent\n\n## Medium Priority Keywords\n- bug\n- flaky\n- docs\n- onboarding\n\n## Ignore Labels\n- duplicate\n- wontfix\n- invalid\n\n## Escalate Labels\n- bug\n- security\n- incident\n`],
+    [paths.projectContextPath, `# PROJECT_CONTEXT\n\nDescribe the project goals, release posture, active milestones, and triage context the daemon should use when summarizing issues. This file is tracked governance input and is not auto-written by the daemon in v1.\n`],
+    [paths.rulesPath, `# RULES\n\n- Do not mutate GitHub issues or publish docs without approval.\n- Treat .omx/daemon/*.md as tracked governance input.\n- Publish approved knowledge updates into docs/project-wiki/.\n`],
+    [paths.configPath, `${JSON.stringify({
+      githubCredentialSource: "env",
+      githubTokenEnvVar: "GH_TOKEN",
+      pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+      maxIssuesPerRun: DEFAULT_MAX_ISSUES_PER_RUN,
+      knowledgeSink: DEFAULT_KNOWLEDGE_SINK,
+    }, null, 2)}\n`],
+  ];
+
+  for (const [filePath, content] of templates) {
+    if (!existsSync(filePath)) {
+      if (filePath.endsWith(".json")) {
+        writeTrackedText(filePath, content);
+      } else {
+        writeTrackedText(filePath, content);
+      }
+      changed.push(relative(projectRoot, filePath));
+    }
+  }
+  return changed;
+}
+
+function hasRequiredGovernanceFiles(projectRoot = process.cwd()): boolean {
+  const paths = daemonPaths(projectRoot);
+  return [paths.issueGatePath, paths.projectContextPath, paths.rulesPath, paths.configPath].every((filePath) => existsSync(filePath));
+}
+
+function parseMarkdownBulletSection(content: string): Map<string, string[]> {
+  const sections = new Map<string, string[]>();
+  let current = "";
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith("#")) {
+      current = line.replace(/^#+\s*/, "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "-");
+      if (!sections.has(current)) sections.set(current, []);
+      continue;
+    }
+    if (line.startsWith("- ") && current) {
+      const values = sections.get(current) ?? [];
+      values.push(line.slice(2).trim().toLowerCase());
+      sections.set(current, values);
+    }
+  }
+  return sections;
+}
+
+function readIssueGate(projectRoot = process.cwd()): ParsedIssueGate {
+  const paths = daemonPaths(projectRoot);
+  const sections = parseMarkdownBulletSection(readFileSync(paths.issueGatePath, "utf-8"));
+  return {
+    highPriorityKeywords: sections.get("high-priority-keywords") ?? [],
+    mediumPriorityKeywords: sections.get("medium-priority-keywords") ?? [],
+    ignoreLabels: sections.get("ignore-labels") ?? [],
+    escalateLabels: sections.get("escalate-labels") ?? [],
+  };
+}
+
+function readContextSnippet(projectRoot = process.cwd()): { projectContext: string; rules: string } {
+  const paths = daemonPaths(projectRoot);
+  const projectContext = existsSync(paths.projectContextPath)
+    ? readFileSync(paths.projectContextPath, "utf-8").trim().slice(0, 700)
+    : "";
+  const rules = existsSync(paths.rulesPath)
+    ? readFileSync(paths.rulesPath, "utf-8").trim().slice(0, 500)
+    : "";
+  return { projectContext, rules };
+}
+
+function normalizeIssueLabels(issue: GitHubIssue): string[] {
+  return issue.labels
+    .map((label) => typeof label === "string" ? label : label?.name)
+    .filter((value): value is string => typeof value === "string" && value.trim() !== "")
+    .map((value) => value.toLowerCase());
+}
+
+function evaluateIssue(issue: GitHubIssue, gate: ParsedIssueGate, context: { projectContext: string; rules: string }): EvaluateIssueResult {
+  const labels = normalizeIssueLabels(issue);
+  const searchable = `${issue.title}\n${issue.body ?? ""}`.toLowerCase();
+  const ignoredLabel = labels.find((label) => gate.ignoreLabels.includes(label));
+  if (ignoredLabel) {
+    return {
+      priority: "low",
+      matchedRules: [`ignored-label:${ignoredLabel}`],
+      recommendedLabels: [],
+      summary: `Skipped because label \"${ignoredLabel}\" is listed in Ignore Labels.`,
+      skippedReason: "ignored-label",
+    };
+  }
+
+  let score = 0;
+  const matchedRules: string[] = [];
+  for (const keyword of gate.highPriorityKeywords) {
+    if (keyword && searchable.includes(keyword)) {
+      score += 2;
+      matchedRules.push(`high-keyword:${keyword}`);
+    }
+  }
+  for (const keyword of gate.mediumPriorityKeywords) {
+    if (keyword && searchable.includes(keyword)) {
+      score += 1;
+      matchedRules.push(`medium-keyword:${keyword}`);
+    }
+  }
+  for (const label of gate.escalateLabels) {
+    if (labels.includes(label)) {
+      score += 2;
+      matchedRules.push(`escalate-label:${label}`);
+    }
+  }
+  if (labels.length === 0) {
+    score += 1;
+    matchedRules.push("unlabeled");
+  }
+  if ((issue.comments ?? 0) >= 5) {
+    score += 1;
+    matchedRules.push("high-comment-volume");
+  }
+
+  const priority: DaemonPriority = score >= 3 ? "high" : score >= 1 ? "medium" : "low";
+  const recommendedLabels = ["needs-triage", priority === "high" ? "high-priority" : priority === "medium" ? "triage/soon" : "triage/backlog"];
+  const contextLine = context.projectContext ? `\n\nProject context excerpt:\n${context.projectContext}` : "";
+  const rulesLine = context.rules ? `\n\nRule excerpt:\n${context.rules}` : "";
+  const summary = [
+    `Priority: ${priority.toUpperCase()}`,
+    matchedRules.length > 0 ? `Matched rules: ${matchedRules.join(", ")}` : "Matched rules: default-triage",
+    `Recommended labels: ${recommendedLabels.join(", ")}`,
+    contextLine,
+    rulesLine,
+  ].join("\n");
+
+  return {
+    priority,
+    matchedRules: matchedRules.length > 0 ? matchedRules : ["default-triage"],
+    recommendedLabels,
+    summary,
+  };
+}
+
+function queueSummary(queue: OmxDaemonQueueItem[]): string {
+  const queued = queue.filter((item) => item.status === "queued").length;
+  const published = queue.filter((item) => item.status === "published").length;
+  return `queued=${queued}, published=${published}, total=${queue.length}`;
+}
+
+function createQueueItem(
+  projectRoot: string,
+  config: OmxDaemonConfig | null,
+  issue: GitHubIssue,
+  evaluation: EvaluateIssueResult,
+): OmxDaemonQueueItem {
+  const paths = daemonPaths(projectRoot);
+  ensureDir(paths.outboxDir);
+  const timestamp = new Date().toISOString();
+  const issueKey = `${issue.number}-${issue.updated_at.replace(/[^0-9]/g, "")}`;
+  const draftPath = join(paths.outboxDir, `issue-${issueKey}.md`);
+  const publicationPath = join(resolveKnowledgeSinkDir(projectRoot, config), `issue-${issue.number}.md`);
+  const draft = `# Issue ${issue.number}: ${issue.title}\n\n- URL: ${issue.html_url}\n- Updated: ${issue.updated_at}\n- Recommended labels: ${evaluation.recommendedLabels.join(", ")}\n- Priority: ${evaluation.priority}\n\n## Proposed triage summary\n${evaluation.summary}\n\n## Issue body\n${issue.body ?? "(no issue body provided)"}\n`;
+  writeTrackedText(draftPath, draft);
+  return {
+    id: issueKey,
+    issueNumber: issue.number,
+    issueTitle: issue.title,
+    issueUrl: issue.html_url,
+    issueUpdatedAt: issue.updated_at,
+    priority: evaluation.priority,
+    recommendedLabels: evaluation.recommendedLabels,
+    matchedRules: evaluation.matchedRules,
+    status: "queued",
+    proposedAt: timestamp,
+    summary: evaluation.summary,
+    draftPath,
+    publicationPath,
+    publicationReason: `Awaiting approval before publishing knowledge update or applying GitHub mutations for issue #${issue.number}.`,
+  };
+}
+
+function createMinimalDaemonEnv(config: OmxDaemonConfig | null): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  const allowlist = new Set([
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "USER",
+    "USERNAME",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "SHELL",
+    "NODE_ENV",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+  ]);
+  if (config?.githubTokenEnvVar) {
+    allowlist.add(config.githubTokenEnvVar);
+  }
+  for (const key of allowlist) {
+    if (process.env[key] !== undefined) {
+      env[key] = process.env[key];
+    }
+  }
+  return env;
+}
+
+function parseGitHubRepository(raw: string): string | null {
+  const normalized = raw.trim();
+  if (!normalized) return null;
+  const matchers = [
+    /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+)(?:\.git)?$/i,
+    /^(?<owner>[^/]+)\/(?<repo>[^/.]+)$/,
+  ];
+  for (const matcher of matchers) {
+    const match = normalized.match(matcher);
+    if (match?.groups?.owner && match?.groups?.repo) {
+      return `${match.groups.owner}/${match.groups.repo}`;
+    }
+  }
+  return null;
+}
+
+function resolveRepository(projectRoot: string, config: OmxDaemonConfig | null): string | null {
+  const fromConfig = parseGitHubRepository(config?.repository ?? "");
+  if (fromConfig) return fromConfig;
+  const remote = spawnSync("git", ["remote", "get-url", "origin"], {
+    cwd: projectRoot,
+    encoding: "utf-8",
+    timeout: 3000,
+    windowsHide: true,
+  });
+  if (remote.status === 0 && remote.stdout) {
+    return parseGitHubRepository(remote.stdout.trim());
+  }
+  return null;
+}
+
+export function resolveGitHubToken(
+  config: OmxDaemonConfig | null,
+  env: NodeJS.ProcessEnv = process.env,
+  spawnSyncImpl: typeof spawnSync = spawnSync,
+): ResolveGitHubTokenResult {
+  if (config?.githubCredentialSource === "config-token-ref" && config.githubTokenEnvVar) {
+    const token = env[config.githubTokenEnvVar]?.trim();
+    if (token) return { token, source: "config-token-ref" };
+  }
+  const ghToken = env.GH_TOKEN?.trim();
+  if (ghToken) return { token: ghToken, source: "GH_TOKEN" };
+  const githubToken = env.GITHUB_TOKEN?.trim();
+  if (githubToken) return { token: githubToken, source: "GITHUB_TOKEN" };
+  const gh = spawnSyncImpl("gh", ["auth", "token"], {
+    encoding: "utf-8",
+    timeout: 3000,
+    windowsHide: true,
+  });
+  if (gh.status === 0) {
+    const token = gh.stdout?.trim();
+    if (token) return { token, source: "gh-auth" };
+  }
+  return {
+    token: null,
+    source: "none",
+    error: "No GitHub credential available (expected daemon config token ref, GH_TOKEN, GITHUB_TOKEN, or `gh auth token`).",
+  };
+}
+
+async function fetchOpenIssues(repository: string, token: string, maxIssues: number): Promise<GitHubIssue[]> {
+  const response = await fetch(`https://api.github.com/repos/${repository}/issues?state=open&per_page=${maxIssues}&sort=updated&direction=desc`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "oh-my-codex-omx-daemon",
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub issue fetch failed (${response.status}): ${body.slice(0, 300)}`);
+  }
+  const issues = await response.json() as GitHubIssue[];
+  return issues.filter((issue) => !issue.pull_request);
+}
+
+async function applyApprovedGitHubLabels(repository: string, item: OmxDaemonQueueItem, token: string): Promise<void> {
+  if (item.recommendedLabels.length === 0) return;
+  const response = await fetch(`https://api.github.com/repos/${repository}/issues/${item.issueNumber}`, {
+    method: "PATCH",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "oh-my-codex-omx-daemon",
+    },
+    body: JSON.stringify({ labels: item.recommendedLabels }),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub label update failed (${response.status}): ${body.slice(0, 300)}`);
+  }
+}
+
+export async function runOmxDaemonOnce(projectRoot = process.cwd()): Promise<DaemonResponse> {
+  const paths = daemonPaths(projectRoot);
+  if (!hasRequiredGovernanceFiles(projectRoot)) {
+    return {
+      success: false,
+      message: "Daemon is not initialized for this worktree. Use $setup-omx-daemon (or scaffold the .omx/daemon files) first.",
+      state: {
+        ...readDaemonState(projectRoot),
+        statusReason: "not-initialized",
+      },
+    };
+  }
+
+  ensureDir(paths.runtimeDir);
+  ensureDir(paths.outboxDir);
+
+  const config = readOmxDaemonConfig(projectRoot);
+  const repository = resolveRepository(projectRoot, config);
+  if (!repository) {
+    const state = {
+      ...readDaemonState(projectRoot),
+      statusReason: "missing-repository",
+      lastError: "Unable to resolve GitHub repository from daemon config or git remote origin.",
+    };
+    writeDaemonState(projectRoot, state);
+    return {
+      success: false,
+      message: "Unable to resolve GitHub repository. Add `repository` to .omx/daemon/daemon.config.json or set git remote origin.",
+      state,
+      error: state.lastError,
+    };
+  }
+
+  const tokenResult = resolveGitHubToken(config);
+  if (!tokenResult.token) {
+    const state = {
+      ...readDaemonState(projectRoot),
+      repository,
+      credentialSource: tokenResult.source,
+      statusReason: "missing-credentials",
+      lastError: tokenResult.error,
+    };
+    writeDaemonState(projectRoot, state);
+    return {
+      success: false,
+      message: "GitHub credentials are missing or insufficient. Check daemon.config.json and status guidance.",
+      state,
+      error: tokenResult.error,
+    };
+  }
+
+  const gate = readIssueGate(projectRoot);
+  const context = readContextSnippet(projectRoot);
+  const queue = readQueue(projectRoot);
+  const state = readDaemonState(projectRoot);
+  const processedIssueKeys = { ...(state.processedIssueKeys ?? {}) };
+
+  try {
+    const issues = await fetchOpenIssues(repository, tokenResult.token, normalizeConfig(config ?? {}).maxIssuesPerRun);
+    const queuedIssueIds = new Set(queue.filter((item) => item.status === "queued").map((item) => `${item.issueNumber}:${item.issueUpdatedAt}`));
+    let created = 0;
+
+    for (const issue of issues) {
+      const issueVersionKey = `${issue.number}:${issue.updated_at}`;
+      if (queuedIssueIds.has(issueVersionKey)) continue;
+      if (processedIssueKeys[String(issue.number)] === issue.updated_at) continue;
+
+      const evaluation = evaluateIssue(issue, gate, context);
+      processedIssueKeys[String(issue.number)] = issue.updated_at;
+      if (evaluation.skippedReason) continue;
+
+      const queueItem = createQueueItem(projectRoot, config, issue, evaluation);
+      queue.push(queueItem);
+      queuedIssueIds.add(issueVersionKey);
+      created += 1;
+      logToFile(paths.logPath, `Queued issue #${issue.number} (${evaluation.priority}) with rules ${evaluation.matchedRules.join(", ")}`);
+    }
+
+    const nextState: OmxDaemonState = {
+      ...state,
+      repository,
+      credentialSource: tokenResult.source,
+      lastPollAt: new Date().toISOString(),
+      lastIssueScanAt: new Date().toISOString(),
+      lastTriageAt: created > 0 ? new Date().toISOString() : state.lastTriageAt,
+      queueSize: queue.filter((item) => item.status === "queued").length,
+      proposalsCreated: (state.proposalsCreated ?? 0) + created,
+      statusReason: created > 0 ? "triage-updated" : "triage-noop",
+      lastError: undefined,
+      processedIssueKeys,
+      isRunning: state.isRunning,
+      pid: state.pid,
+      startedAt: state.startedAt,
+    };
+
+    writeQueue(projectRoot, queue);
+    writeDaemonState(projectRoot, nextState);
+    return {
+      success: true,
+      message: created > 0
+        ? `Queued ${created} issue proposal(s); ${queueSummary(queue)}`
+        : `No new issue proposals created; ${queueSummary(queue)}`,
+      state: nextState,
+      queue,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const nextState: OmxDaemonState = {
+      ...state,
+      repository,
+      credentialSource: tokenResult.source,
+      lastPollAt: new Date().toISOString(),
+      statusReason: "poll-failed",
+      lastError: message,
+      processedIssueKeys,
+    };
+    writeDaemonState(projectRoot, nextState);
+    logToFile(paths.logPath, `ERROR ${message}`);
+    return {
+      success: false,
+      message: "Daemon poll failed.",
+      state: nextState,
+      queue,
+      error: message,
+    };
+  }
+}
+
+export async function approveOmxDaemonItem(projectRoot: string, itemId: string): Promise<DaemonResponse> {
+  const paths = daemonPaths(projectRoot);
+  const queue = readQueue(projectRoot);
+  const item = queue.find((entry) => entry.id === itemId);
+  const state = readDaemonState(projectRoot);
+  if (!item) {
+    return { success: false, message: `Queue item ${itemId} was not found.`, state, error: "queue_item_not_found" };
+  }
+  if (item.status !== "queued") {
+    return { success: false, message: `Queue item ${itemId} is already ${item.status}.`, state, error: "queue_item_not_queued" };
+  }
+
+  const config = readOmxDaemonConfig(projectRoot);
+  const repository = resolveRepository(projectRoot, config);
+  const tokenResult = resolveGitHubToken(config);
+  const approvedAt = new Date().toISOString();
+
+  await mkdir(resolveKnowledgeSinkDir(projectRoot, config), { recursive: true });
+  const draft = await readFile(item.draftPath, "utf-8");
+  await writeFile(item.publicationPath, `${draft}\n\n---\nApproved at: ${approvedAt}\n`, "utf-8");
+
+  let githubLabelMutationApplied = false;
+  if (config?.applyGitHubLabelsOnApprove && repository && tokenResult.token) {
+    await applyApprovedGitHubLabels(repository, item, tokenResult.token);
+    githubLabelMutationApplied = true;
+  }
+
+  item.status = "published";
+  item.approvedAt = approvedAt;
+  item.publishedAt = approvedAt;
+  item.githubLabelMutationApplied = githubLabelMutationApplied;
+
+  const nextState: OmxDaemonState = {
+    ...state,
+    queueSize: queue.filter((entry) => entry.status === "queued").length,
+    publishedCount: (state.publishedCount ?? 0) + 1,
+    lastTriageAt: approvedAt,
+    statusReason: "approved-published",
+    lastError: undefined,
+  };
+  writeQueue(projectRoot, queue);
+  writeDaemonState(projectRoot, nextState);
+  logToFile(paths.logPath, `Published approved queue item ${itemId} -> ${item.publicationPath}`);
+  return {
+    success: true,
+    message: `Approved ${itemId} and published to ${relative(projectRoot, item.publicationPath)}.`,
+    state: nextState,
+    queue,
+  };
+}
+
+export function rejectOmxDaemonItem(projectRoot: string, itemId: string): DaemonResponse {
+  const queue = readQueue(projectRoot);
+  const item = queue.find((entry) => entry.id === itemId);
+  const state = readDaemonState(projectRoot);
+  if (!item) {
+    return { success: false, message: `Queue item ${itemId} was not found.`, state, error: "queue_item_not_found" };
+  }
+  if (item.status !== "queued") {
+    return { success: false, message: `Queue item ${itemId} is already ${item.status}.`, state, error: "queue_item_not_queued" };
+  }
+  item.status = "rejected";
+  item.rejectedAt = new Date().toISOString();
+  const nextState: OmxDaemonState = {
+    ...state,
+    queueSize: queue.filter((entry) => entry.status === "queued").length,
+    rejectedCount: (state.rejectedCount ?? 0) + 1,
+    statusReason: "rejected",
+    lastError: undefined,
+  };
+  writeQueue(projectRoot, queue);
+  writeDaemonState(projectRoot, nextState);
+  logToFile(daemonPaths(projectRoot).logPath, `Rejected queue item ${itemId}`);
+  return {
+    success: true,
+    message: `Rejected ${itemId}.`,
+    state: nextState,
+    queue,
+  };
+}
+
+export function getOmxDaemonStatus(projectRoot = process.cwd()): DaemonResponse {
+  const configured = hasRequiredGovernanceFiles(projectRoot);
+  const state = readDaemonState(projectRoot);
+  const queue = readQueue(projectRoot);
+  if (!configured) {
+    return {
+      success: true,
+      message: "Daemon is not initialized for this worktree. Use $setup-omx-daemon or scaffold .omx/daemon first.",
+      state: {
+        ...state,
+        statusReason: "not-initialized",
+      },
+      queue,
+    };
+  }
+
+  const config = readOmxDaemonConfig(projectRoot);
+  const tokenResult = resolveGitHubToken(config);
+  const repository = resolveRepository(projectRoot, config);
+  const running = isOmxDaemonRunning(projectRoot);
+  const statusReason = !tokenResult.token
+    ? "missing-credentials"
+    : running ? "running" : "stopped";
+  return {
+    success: true,
+    message: !tokenResult.token
+      ? `Daemon is configured but credentials are missing (${tokenResult.error}).`
+      : running
+        ? `Daemon is running for ${repository ?? "unknown-repo"}; ${queueSummary(queue)}.`
+        : `Daemon is stopped for ${repository ?? "unknown-repo"}; ${queueSummary(queue)}.`,
+    state: {
+      ...state,
+      isRunning: running,
+      pid: running ? readPid(projectRoot) : null,
+      credentialSource: tokenResult.source,
+      repository,
+      queueSize: queue.filter((item) => item.status === "queued").length,
+      statusReason,
+      lastError: !tokenResult.token ? tokenResult.error : state.lastError,
+    },
+    queue,
+  };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function runOmxDaemonLoop(projectRoot = process.cwd()): Promise<void> {
+  const paths = daemonPaths(projectRoot);
+  const config = readOmxDaemonConfig(projectRoot);
+  if (!config) {
+    logToFile(paths.logPath, "No daemon config found; exiting poll loop.");
+    return;
+  }
+  let stopping = false;
+  const stop = () => {
+    stopping = true;
+    const current = readDaemonState(projectRoot);
+    writeDaemonState(projectRoot, {
+      ...current,
+      isRunning: false,
+      pid: null,
+      statusReason: "stopped",
+    });
+    removePid(projectRoot);
+  };
+  process.on("SIGTERM", stop);
+  process.on("SIGINT", stop);
+  logToFile(paths.logPath, `Starting daemon poll loop (${DAEMON_IDENTITY_MARKER})`);
+  while (!stopping) {
+    const result = await runOmxDaemonOnce(projectRoot);
+    logToFile(paths.logPath, result.success ? result.message : `WARN ${result.error ?? result.message}`);
+    if (stopping) break;
+    await sleep(normalizeConfig(config).pollIntervalMs);
+  }
+  logToFile(paths.logPath, "Poll loop ended.");
+}
+
+export function startOmxDaemon(projectRoot = process.cwd()): DaemonResponse {
+  if (!hasRequiredGovernanceFiles(projectRoot)) {
+    return {
+      success: false,
+      message: "Daemon is not initialized for this worktree. Use $setup-omx-daemon or scaffold .omx/daemon first.",
+      state: { ...readDaemonState(projectRoot), statusReason: "not-initialized" },
+    };
+  }
+  if (isOmxDaemonRunning(projectRoot)) {
+    const state = readDaemonState(projectRoot);
+    return { success: true, message: "omx daemon is already running.", state };
+  }
+
+  const config = readOmxDaemonConfig(projectRoot);
+  const tokenResult = resolveGitHubToken(config);
+  if (!tokenResult.token) {
+    const state = { ...readDaemonState(projectRoot), statusReason: "missing-credentials", lastError: tokenResult.error };
+    writeDaemonState(projectRoot, state);
+    return { success: false, message: "Cannot start daemon without GitHub credentials.", state, error: tokenResult.error };
+  }
+
+  const modulePath = import.meta.url;
+  const child = spawn(process.execPath, ["-e", `import('${modulePath}').then((m) => m.runOmxDaemonLoop(${JSON.stringify(projectRoot)})).catch((err) => { console.error('${DAEMON_IDENTITY_MARKER}', err); process.exit(1); });`], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+    cwd: projectRoot,
+    env: createMinimalDaemonEnv(config),
+  });
+  child.unref();
+  const pid = child.pid;
+  if (!pid) {
+    return { success: false, message: "Failed to start daemon process.", error: "missing_child_pid" };
+  }
+  writePid(projectRoot, pid);
+  const state: OmxDaemonState = {
+    ...readDaemonState(projectRoot),
+    isRunning: true,
+    pid,
+    startedAt: new Date().toISOString(),
+    credentialSource: tokenResult.source,
+    statusReason: "running",
+  };
+  writeDaemonState(projectRoot, state);
+  logToFile(daemonPaths(projectRoot).logPath, `Started omx daemon with PID ${pid}`);
+  return { success: true, message: `omx daemon started with PID ${pid}.`, state };
+}
+
+export function stopOmxDaemon(projectRoot = process.cwd()): DaemonResponse {
+  const pid = readPid(projectRoot);
+  if (pid === null) {
+    return { success: true, message: "omx daemon is not running.", state: { ...readDaemonState(projectRoot), isRunning: false, pid: null, statusReason: "stopped" } };
+  }
+  if (!isProcessRunning(pid)) {
+    removePid(projectRoot);
+    return { success: true, message: "omx daemon was not running (removed stale PID file).", state: { ...readDaemonState(projectRoot), isRunning: false, pid: null, statusReason: "stopped" } };
+  }
+  if (!isDaemonProcess(pid)) {
+    removePid(projectRoot);
+    return { success: false, message: `Refusing to kill PID ${pid}: process identity does not match omx daemon.`, error: "pid_identity_mismatch" };
+  }
+  try {
+    process.kill(pid, "SIGTERM");
+    removePid(projectRoot);
+    const state = { ...readDaemonState(projectRoot), isRunning: false, pid: null, statusReason: "stopped" };
+    writeDaemonState(projectRoot, state);
+    logToFile(daemonPaths(projectRoot).logPath, `Stopped omx daemon PID ${pid}`);
+    return { success: true, message: `omx daemon stopped (PID ${pid}).`, state };
+  } catch (error) {
+    return {
+      success: false,
+      message: "Failed to stop omx daemon.",
+      error: error instanceof Error ? error.message : String(error),
+      state: readDaemonState(projectRoot),
+    };
+  }
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -25,6 +25,14 @@ const MIN_MAX_ISSUES_PER_RUN = 1;
 const MAX_MAX_ISSUES_PER_RUN = 100;
 const DAEMON_IDENTITY_MARKER = "runOmxDaemonLoop";
 const DEFAULT_KNOWLEDGE_SINK = "docs/project-wiki";
+const DAEMON_GITIGNORE_ENTRIES = [
+  ".omx/*",
+  "!.omx/daemon/",
+  ".omx/daemon/*",
+  "!.omx/daemon/*.md",
+  "!.omx/daemon/daemon.config.json",
+] as const;
+const LEGACY_DAEMON_GITIGNORE_ENTRIES = [".omx/"] as const;
 
 export type GitHubCredentialSource = "config-token-ref" | "env" | "gh-auth";
 export type QueueItemStatus = "queued" | "approved" | "rejected" | "published";
@@ -260,6 +268,37 @@ function normalizeInteger(value: unknown, fallback: number, min: number, max: nu
   return numeric;
 }
 
+function hasGitignoreEntry(content: string, entry: string): boolean {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .some((line) => line === entry);
+}
+
+function stripLegacyGitignoreEntries(content: string, legacyEntries: readonly string[]): { content: string; removed: boolean } {
+  const legacyEntrySet = new Set(legacyEntries);
+  const lines = content.split(/\r?\n/);
+  const filteredLines = lines.filter((line) => !legacyEntrySet.has(line.trim()));
+  const removed = filteredLines.length !== lines.length;
+  return {
+    content: filteredLines.join("\n").replace(/\n+$/, "\n"),
+    removed,
+  };
+}
+
+function ensureDaemonGitignore(projectRoot: string): boolean {
+  const gitignorePath = join(projectRoot, ".gitignore");
+  const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf-8") : "";
+  const normalized = stripLegacyGitignoreEntries(existing, LEGACY_DAEMON_GITIGNORE_ENTRIES);
+  const missingEntries = DAEMON_GITIGNORE_ENTRIES.filter((entry) => !hasGitignoreEntry(normalized.content, entry));
+  if (missingEntries.length === 0 && !normalized.removed) return false;
+  const nextContent = existsSync(gitignorePath)
+    ? `${normalized.content}${normalized.content.endsWith("\n") || normalized.content.length === 0 ? "" : "\n"}${missingEntries.join("\n")}${missingEntries.length > 0 ? "\n" : ""}`
+    : `${DAEMON_GITIGNORE_ENTRIES.join("\n")}\n`;
+  writeTrackedText(gitignorePath, nextContent);
+  return true;
+}
+
 function defaultState(): OmxDaemonState {
   return {
     isRunning: false,
@@ -409,13 +448,12 @@ export async function scaffoldOmxDaemonFiles(projectRoot = process.cwd()): Promi
 
   for (const [filePath, content] of templates) {
     if (!existsSync(filePath)) {
-      if (filePath.endsWith(".json")) {
-        writeTrackedText(filePath, content);
-      } else {
-        writeTrackedText(filePath, content);
-      }
+      writeTrackedText(filePath, content);
       changed.push(relative(projectRoot, filePath));
     }
+  }
+  if (ensureDaemonGitignore(projectRoot)) {
+    changed.push(".gitignore");
   }
   return changed;
 }
@@ -538,8 +576,10 @@ function evaluateIssue(issue: GitHubIssue, gate: ParsedIssueGate, context: { pro
 
 function queueSummary(queue: OmxDaemonQueueItem[]): string {
   const queued = queue.filter((item) => item.status === "queued").length;
+  const approved = queue.filter((item) => item.status === "approved").length;
+  const rejected = queue.filter((item) => item.status === "rejected").length;
   const published = queue.filter((item) => item.status === "published").length;
-  return `queued=${queued}, published=${published}, total=${queue.length}`;
+  return `queued=${queued}, approved=${approved}, rejected=${rejected}, published=${published}, total=${queue.length}`;
 }
 
 function formatDaemonTarget(repository: string | null): string {
@@ -548,6 +588,10 @@ function formatDaemonTarget(repository: string | null): string {
 
 function formatCredentialGuidance(): string {
   return "Check .omx/daemon/daemon.config.json, GH_TOKEN, GITHUB_TOKEN, or gh auth token.";
+}
+
+function formatRepositoryGuidance(): string {
+  return "Add `repository` to .omx/daemon/daemon.config.json or set git remote origin to a GitHub repository.";
 }
 
 function formatPermissionGuidance(permissionClass: "issue-read" | "issue-write"): string {
@@ -563,6 +607,13 @@ function appendTransition(
   at = new Date().toISOString(),
 ): void {
   item.transitions.push({ state, at, ...(note ? { note } : {}) });
+}
+
+function formatLastActivity(state: OmxDaemonState): string {
+  const lastTriage = state.lastTriageAt ?? "never";
+  const lastPoll = state.lastPollAt ?? "never";
+  const lastScan = state.lastIssueScanAt ?? "never";
+  return `last triage=${lastTriage}; last poll=${lastPoll}; last issue scan=${lastScan}`;
 }
 
 function createQueueItem(
@@ -888,29 +939,73 @@ export async function approveOmxDaemonItem(projectRoot: string, itemId: string):
   if (!item) {
     return { success: false, message: `Queue item ${itemId} was not found.`, state, error: "queue_item_not_found" };
   }
-  if (item.status !== "queued") {
+  if (item.status === "published") {
+    return { success: true, message: `Queue item ${itemId} is already published.`, state, queue };
+  }
+  if (item.status === "rejected") {
     return { success: false, message: `Queue item ${itemId} is already ${item.status}.`, state, error: "queue_item_not_queued" };
   }
 
   const config = readOmxDaemonConfig(projectRoot);
   const repository = resolveRepository(projectRoot, config);
   const tokenResult = resolveGitHubToken(config);
-  const approvedAt = new Date().toISOString();
+  const requiresGitHubMutation = Boolean(config?.applyGitHubLabelsOnApprove);
+  if (requiresGitHubMutation && !repository) {
+    const nextState = {
+      ...state,
+      credentialSource: tokenResult.source,
+      statusReason: "missing-repository",
+      lastError: formatRepositoryGuidance(),
+    };
+    writeDaemonState(projectRoot, nextState);
+    return {
+      success: false,
+      message: "Approval cannot apply the configured GitHub mutation because the repository is not configured.",
+      state: nextState,
+      queue,
+      error: formatRepositoryGuidance(),
+    };
+  }
+  if (requiresGitHubMutation && !tokenResult.token) {
+    const nextState = {
+      ...state,
+      repository,
+      credentialSource: tokenResult.source,
+      statusReason: "missing-credentials",
+      lastError: tokenResult.error,
+    };
+    writeDaemonState(projectRoot, nextState);
+    return {
+      success: false,
+      message: "Approval cannot apply the configured GitHub mutation without GitHub credentials.",
+      state: nextState,
+      queue,
+      error: tokenResult.error,
+    };
+  }
+  const approvedAt = item.approvedAt ?? new Date().toISOString();
+  if (item.status === "queued") {
+    item.status = "approved";
+    item.approvedAt = approvedAt;
+    appendTransition(item, "approved", "Approval accepted; publishing immediately.", approvedAt);
+    writeQueue(projectRoot, queue);
+  }
 
   let githubLabelMutationApplied = false;
   try {
-    appendTransition(item, "approved", "Approval accepted; publishing immediately.", approvedAt);
-    if (config?.applyGitHubLabelsOnApprove && repository && tokenResult.token) {
-      await applyApprovedGitHubLabels(repository, item, tokenResult.token);
+    if (!existsSync(item.publicationPath)) {
+      await mkdir(resolveKnowledgeSinkDir(projectRoot, config), { recursive: true });
+      const draft = await readFile(item.draftPath, "utf-8");
+      await writeFile(item.publicationPath, `${draft}\n\n---\nApproved at: ${approvedAt}\n`, "utf-8");
+    }
+    if (requiresGitHubMutation && !item.githubLabelMutationApplied) {
+      await applyApprovedGitHubLabels(repository as string, item, tokenResult.token as string);
       githubLabelMutationApplied = true;
       logToFile(paths.logPath, `Applied approved GitHub labels to issue #${item.issueNumber}: ${item.recommendedLabels.join(", ")}`);
+    } else {
+      githubLabelMutationApplied = Boolean(item.githubLabelMutationApplied);
     }
-
-    await mkdir(resolveKnowledgeSinkDir(projectRoot, config), { recursive: true });
-    const draft = await readFile(item.draftPath, "utf-8");
-    await writeFile(item.publicationPath, `${draft}\n\n---\nApproved at: ${approvedAt}\n`, "utf-8");
   } catch (error) {
-    item.transitions = item.transitions.filter((entry) => !(entry.state === "approved" && entry.at === approvedAt));
     const message = error instanceof Error ? error.message : String(error);
     const statusReason = error instanceof GitHubPermissionError
       ? "insufficient-permissions"
@@ -929,7 +1024,7 @@ export async function approveOmxDaemonItem(projectRoot: string, itemId: string):
       success: false,
       message: statusReason === "insufficient-permissions"
         ? "Approval could not apply GitHub mutations because permissions are insufficient."
-        : `Approval failed for ${itemId}.`,
+        : `Approval failed for ${itemId}; the item remains approved for retry.`,
       state: nextState,
       queue,
       error: message,
@@ -939,7 +1034,7 @@ export async function approveOmxDaemonItem(projectRoot: string, itemId: string):
   item.status = "published";
   item.approvedAt = approvedAt;
   item.publishedAt = approvedAt;
-  item.githubLabelMutationApplied = githubLabelMutationApplied;
+  item.githubLabelMutationApplied = requiresGitHubMutation ? githubLabelMutationApplied : false;
   appendTransition(item, "published", "Approved publication written to the knowledge sink.", approvedAt);
 
   const nextState: OmxDaemonState = {
@@ -967,6 +1062,9 @@ export function rejectOmxDaemonItem(projectRoot: string, itemId: string): Daemon
   const state = readDaemonState(projectRoot);
   if (!item) {
     return { success: false, message: `Queue item ${itemId} was not found.`, state, error: "queue_item_not_found" };
+  }
+  if (item.status === "rejected") {
+    return { success: true, message: `Queue item ${itemId} is already rejected.`, state, queue };
   }
   if (item.status !== "queued") {
     return { success: false, message: `Queue item ${itemId} is already ${item.status}.`, state, error: "queue_item_not_queued" };
@@ -1014,6 +1112,8 @@ export function getOmxDaemonStatus(projectRoot = process.cwd()): DaemonResponse 
   const running = isOmxDaemonRunning(projectRoot);
   const statusReason = !tokenResult.token
     ? "missing-credentials"
+    : !repository
+      ? "missing-repository"
     : state.statusReason === "insufficient-permissions"
       ? "insufficient-permissions"
     : running ? "running" : "stopped";
@@ -1022,11 +1122,13 @@ export function getOmxDaemonStatus(projectRoot = process.cwd()): DaemonResponse 
     success: true,
     message: !tokenResult.token
       ? `Daemon is configured for ${target}, but GitHub credentials are missing. ${formatCredentialGuidance()}`
+      : !repository
+        ? `Daemon is configured for ${target}, but the GitHub repository is not resolvable. ${formatRepositoryGuidance()}`
       : statusReason === "insufficient-permissions"
         ? `Daemon is configured for ${target}, but GitHub permissions are insufficient. ${state.lastError ?? formatPermissionGuidance("issue-read")}`
       : running
-        ? `Daemon is running for ${target}; ${queueSummary(queue)}.`
-        : `Daemon is stopped for ${target}; ${queueSummary(queue)}. Use \`omx daemon start\` for background polling or \`omx daemon run-once\` for a foreground pass.`,
+        ? `Daemon is running for ${target}; ${queueSummary(queue)}; ${formatLastActivity(state)}.`
+        : `Daemon is stopped for ${target}; ${queueSummary(queue)}; ${formatLastActivity(state)}. Use \`omx daemon start\` for background polling or \`omx daemon run-once\` for a foreground pass.`,
     state: {
       ...state,
       isRunning: running,
@@ -1096,6 +1198,17 @@ export function startOmxDaemon(projectRoot = process.cwd()): DaemonResponse {
     writeDaemonState(projectRoot, state);
     return { success: false, message: "Cannot start daemon without GitHub credentials.", state, error: tokenResult.error };
   }
+  const repository = resolveRepository(projectRoot, config);
+  if (!repository) {
+    const state = {
+      ...readDaemonState(projectRoot),
+      credentialSource: tokenResult.source,
+      statusReason: "missing-repository",
+      lastError: formatRepositoryGuidance(),
+    };
+    writeDaemonState(projectRoot, state);
+    return { success: false, message: "Cannot start daemon without a resolvable GitHub repository.", state, error: formatRepositoryGuidance() };
+  }
 
   const modulePath = import.meta.url;
   const child = spawn(process.execPath, ["-e", `import('${modulePath}').then((m) => m.runOmxDaemonLoop(${JSON.stringify(projectRoot)})).catch((err) => { console.error('${DAEMON_IDENTITY_MARKER}', err); process.exit(1); });`], {
@@ -1117,6 +1230,7 @@ export function startOmxDaemon(projectRoot = process.cwd()): DaemonResponse {
     pid,
     startedAt: new Date().toISOString(),
     credentialSource: tokenResult.source,
+    repository,
     statusReason: "running",
   };
   writeDaemonState(projectRoot, state);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -38,6 +38,19 @@ export type GitHubCredentialSource = "config-token-ref" | "env" | "gh-auth";
 export type QueueItemStatus = "queued" | "approved" | "rejected" | "published";
 export type DaemonPriority = "high" | "medium" | "low";
 export type QueueTransitionState = "proposed" | "queued" | "approved" | "rejected" | "published";
+export type DaemonStatusReason =
+  | "not-initialized"
+  | "missing-repository"
+  | "missing-credentials"
+  | "insufficient-permissions"
+  | "poll-failed"
+  | "approval-failed"
+  | "triage-updated"
+  | "triage-noop"
+  | "approved-published"
+  | "rejected"
+  | "running"
+  | "stopped";
 
 export interface OmxDaemonQueueTransition {
   state: QueueTransitionState;
@@ -575,11 +588,8 @@ function evaluateIssue(issue: GitHubIssue, gate: ParsedIssueGate, context: { pro
 }
 
 function queueSummary(queue: OmxDaemonQueueItem[]): string {
-  const queued = queue.filter((item) => item.status === "queued").length;
-  const approved = queue.filter((item) => item.status === "approved").length;
-  const rejected = queue.filter((item) => item.status === "rejected").length;
-  const published = queue.filter((item) => item.status === "published").length;
-  return `queued=${queued}, approved=${approved}, rejected=${rejected}, published=${published}, total=${queue.length}`;
+  const counts = countQueueStatuses(queue);
+  return `queued=${counts.queued}, approved=${counts.approved}, rejected=${counts.rejected}, published=${counts.published}, total=${counts.total}`;
 }
 
 function formatDaemonTarget(repository: string | null): string {
@@ -607,6 +617,17 @@ function appendTransition(
   at = new Date().toISOString(),
 ): void {
   item.transitions.push({ state, at, ...(note ? { note } : {}) });
+}
+
+function countQueueStatuses(queue: OmxDaemonQueueItem[]): Record<QueueItemStatus | "total", number> {
+  return queue.reduce<Record<QueueItemStatus | "total", number>>(
+    (counts, item) => {
+      counts[item.status] += 1;
+      counts.total += 1;
+      return counts;
+    },
+    { queued: 0, approved: 0, rejected: 0, published: 0, total: 0 },
+  );
 }
 
 function formatLastActivity(state: OmxDaemonState): string {
@@ -856,6 +877,7 @@ export async function runOmxDaemonOnce(projectRoot = process.cwd()): Promise<Dae
   const processedIssueKeys = { ...(state.processedIssueKeys ?? {}) };
 
   try {
+    const now = new Date().toISOString();
     const issues = await fetchOpenIssues(repository, tokenResult.token, normalizeConfig(config ?? {}).maxIssuesPerRun);
     const queuedIssueIds = new Set(queue.filter((item) => item.status === "queued").map((item) => `${item.issueNumber}:${item.issueUpdatedAt}`));
     let created = 0;
@@ -880,9 +902,9 @@ export async function runOmxDaemonOnce(projectRoot = process.cwd()): Promise<Dae
       ...state,
       repository,
       credentialSource: tokenResult.source,
-      lastPollAt: new Date().toISOString(),
-      lastIssueScanAt: new Date().toISOString(),
-      lastTriageAt: created > 0 ? new Date().toISOString() : state.lastTriageAt,
+      lastPollAt: now,
+      lastIssueScanAt: now,
+      lastTriageAt: created > 0 ? now : state.lastTriageAt,
       queueSize: queue.filter((item) => item.status === "queued").length,
       proposalsCreated: (state.proposalsCreated ?? 0) + created,
       statusReason: created > 0 ? "triage-updated" : "triage-noop",
@@ -1110,25 +1132,34 @@ export function getOmxDaemonStatus(projectRoot = process.cwd()): DaemonResponse 
   const tokenResult = resolveGitHubToken(config);
   const repository = resolveRepository(projectRoot, config);
   const running = isOmxDaemonRunning(projectRoot);
-  const statusReason = !tokenResult.token
-    ? "missing-credentials"
-    : !repository
-      ? "missing-repository"
-    : state.statusReason === "insufficient-permissions"
-      ? "insufficient-permissions"
-    : running ? "running" : "stopped";
+  let statusReason: DaemonStatusReason;
+  if (!tokenResult.token) {
+    statusReason = "missing-credentials";
+  } else if (!repository) {
+    statusReason = "missing-repository";
+  } else if (state.statusReason === "insufficient-permissions") {
+    statusReason = "insufficient-permissions";
+  } else if (running) {
+    statusReason = "running";
+  } else {
+    statusReason = "stopped";
+  }
   const target = formatDaemonTarget(repository);
+  let message: string;
+  if (statusReason === "missing-credentials") {
+    message = `Daemon is configured for ${target}, but GitHub credentials are missing. ${formatCredentialGuidance()}`;
+  } else if (statusReason === "missing-repository") {
+    message = `Daemon is configured for ${target}, but the GitHub repository is not resolvable. ${formatRepositoryGuidance()}`;
+  } else if (statusReason === "insufficient-permissions") {
+    message = `Daemon is configured for ${target}, but GitHub permissions are insufficient. ${state.lastError ?? formatPermissionGuidance("issue-read")}`;
+  } else if (running) {
+    message = `Daemon is running for ${target}; ${queueSummary(queue)}; ${formatLastActivity(state)}.`;
+  } else {
+    message = `Daemon is stopped for ${target}; ${queueSummary(queue)}; ${formatLastActivity(state)}. Use \`omx daemon start\` for background polling or \`omx daemon run-once\` for a foreground pass.`;
+  }
   return {
     success: true,
-    message: !tokenResult.token
-      ? `Daemon is configured for ${target}, but GitHub credentials are missing. ${formatCredentialGuidance()}`
-      : !repository
-        ? `Daemon is configured for ${target}, but the GitHub repository is not resolvable. ${formatRepositoryGuidance()}`
-      : statusReason === "insufficient-permissions"
-        ? `Daemon is configured for ${target}, but GitHub permissions are insufficient. ${state.lastError ?? formatPermissionGuidance("issue-read")}`
-      : running
-        ? `Daemon is running for ${target}; ${queueSummary(queue)}; ${formatLastActivity(state)}.`
-        : `Daemon is stopped for ${target}; ${queueSummary(queue)}; ${formatLastActivity(state)}. Use \`omx daemon start\` for background polling or \`omx daemon run-once\` for a foreground pass.`,
+    message,
     state: {
       ...state,
       isRunning: running,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -29,6 +29,13 @@ const DEFAULT_KNOWLEDGE_SINK = "docs/project-wiki";
 export type GitHubCredentialSource = "config-token-ref" | "env" | "gh-auth";
 export type QueueItemStatus = "queued" | "approved" | "rejected" | "published";
 export type DaemonPriority = "high" | "medium" | "low";
+export type QueueTransitionState = "proposed" | "queued" | "approved" | "rejected" | "published";
+
+export interface OmxDaemonQueueTransition {
+  state: QueueTransitionState;
+  at: string;
+  note?: string;
+}
 
 export interface OmxDaemonConfig {
   repository?: string;
@@ -59,6 +66,7 @@ export interface OmxDaemonQueueItem {
   publicationPath: string;
   publicationReason: string;
   githubLabelMutationApplied?: boolean;
+  transitions: OmxDaemonQueueTransition[];
 }
 
 export interface OmxDaemonState {
@@ -91,6 +99,18 @@ export interface ResolveGitHubTokenResult {
   token: string | null;
   source: "config-token-ref" | "GH_TOKEN" | "GITHUB_TOKEN" | "gh-auth" | "none";
   error?: string;
+}
+
+class GitHubPermissionError extends Error {
+  readonly status: number;
+  readonly permissionClass: "issue-read" | "issue-write";
+
+  constructor(status: number, permissionClass: "issue-read" | "issue-write", message: string) {
+    super(message);
+    this.name = "GitHubPermissionError";
+    this.status = status;
+    this.permissionClass = permissionClass;
+  }
 }
 
 interface GitHubIssue {
@@ -270,9 +290,16 @@ function writeDaemonState(projectRoot: string, state: OmxDaemonState): void {
   writeJsonFile(paths.statePath, state);
 }
 
+function normalizeQueueItem(item: OmxDaemonQueueItem): OmxDaemonQueueItem {
+  return {
+    ...item,
+    transitions: Array.isArray(item.transitions) ? item.transitions : [],
+  };
+}
+
 function readQueue(projectRoot = process.cwd()): OmxDaemonQueueItem[] {
   const paths = daemonPaths(projectRoot);
-  return readJsonFile(paths.queuePath, [] as OmxDaemonQueueItem[]);
+  return readJsonFile(paths.queuePath, [] as OmxDaemonQueueItem[]).map(normalizeQueueItem);
 }
 
 function writeQueue(projectRoot: string, queue: OmxDaemonQueueItem[]): void {
@@ -523,6 +550,21 @@ function formatCredentialGuidance(): string {
   return "Check .omx/daemon/daemon.config.json, GH_TOKEN, GITHUB_TOKEN, or gh auth token.";
 }
 
+function formatPermissionGuidance(permissionClass: "issue-read" | "issue-write"): string {
+  return permissionClass === "issue-write"
+    ? "Daemon approval needs issue-write permission to apply approved GitHub mutations."
+    : "Daemon polling needs issue-read permission to list and evaluate GitHub issues.";
+}
+
+function appendTransition(
+  item: OmxDaemonQueueItem,
+  state: QueueTransitionState,
+  note?: string,
+  at = new Date().toISOString(),
+): void {
+  item.transitions.push({ state, at, ...(note ? { note } : {}) });
+}
+
 function createQueueItem(
   projectRoot: string,
   config: OmxDaemonConfig | null,
@@ -552,6 +594,10 @@ function createQueueItem(
     draftPath,
     publicationPath,
     publicationReason: `Awaiting approval before publishing knowledge update or applying GitHub mutations for issue #${issue.number}.`,
+    transitions: [
+      { state: "proposed", at: timestamp, note: "Drafted triage summary and outbox artifact." },
+      { state: "queued", at: timestamp, note: "Queued for approval before publication or GitHub mutation." },
+    ],
   };
 }
 
@@ -663,6 +709,13 @@ async function fetchOpenIssues(repository: string, token: string, maxIssues: num
   });
   if (!response.ok) {
     const body = await response.text();
+    if (response.status === 401 || response.status === 403) {
+      throw new GitHubPermissionError(
+        response.status,
+        "issue-read",
+        `GitHub issue fetch failed (${response.status}): ${formatPermissionGuidance("issue-read")} ${body.slice(0, 300)}`.trim(),
+      );
+    }
     throw new Error(`GitHub issue fetch failed (${response.status}): ${body.slice(0, 300)}`);
   }
   const issues = await response.json() as GitHubIssue[];
@@ -683,6 +736,13 @@ async function applyApprovedGitHubLabels(repository: string, item: OmxDaemonQueu
   });
   if (!response.ok) {
     const body = await response.text();
+    if (response.status === 401 || response.status === 403) {
+      throw new GitHubPermissionError(
+        response.status,
+        "issue-write",
+        `GitHub label update failed (${response.status}): ${formatPermissionGuidance("issue-write")} ${body.slice(0, 300)}`.trim(),
+      );
+    }
     throw new Error(`GitHub label update failed (${response.status}): ${body.slice(0, 300)}`);
   }
 }
@@ -794,12 +854,15 @@ export async function runOmxDaemonOnce(projectRoot = process.cwd()): Promise<Dae
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const statusReason = error instanceof GitHubPermissionError
+      ? "insufficient-permissions"
+      : "poll-failed";
     const nextState: OmxDaemonState = {
       ...state,
       repository,
       credentialSource: tokenResult.source,
       lastPollAt: new Date().toISOString(),
-      statusReason: "poll-failed",
+      statusReason,
       lastError: message,
       processedIssueKeys,
     };
@@ -807,7 +870,9 @@ export async function runOmxDaemonOnce(projectRoot = process.cwd()): Promise<Dae
     logToFile(paths.logPath, `ERROR ${message}`);
     return {
       success: false,
-      message: "Daemon poll failed.",
+      message: statusReason === "insufficient-permissions"
+        ? "Daemon poll failed because GitHub permissions are insufficient."
+        : "Daemon poll failed.",
       state: nextState,
       queue,
       error: message,
@@ -832,20 +897,50 @@ export async function approveOmxDaemonItem(projectRoot: string, itemId: string):
   const tokenResult = resolveGitHubToken(config);
   const approvedAt = new Date().toISOString();
 
-  await mkdir(resolveKnowledgeSinkDir(projectRoot, config), { recursive: true });
-  const draft = await readFile(item.draftPath, "utf-8");
-  await writeFile(item.publicationPath, `${draft}\n\n---\nApproved at: ${approvedAt}\n`, "utf-8");
-
   let githubLabelMutationApplied = false;
-  if (config?.applyGitHubLabelsOnApprove && repository && tokenResult.token) {
-    await applyApprovedGitHubLabels(repository, item, tokenResult.token);
-    githubLabelMutationApplied = true;
+  try {
+    appendTransition(item, "approved", "Approval accepted; publishing immediately.", approvedAt);
+    if (config?.applyGitHubLabelsOnApprove && repository && tokenResult.token) {
+      await applyApprovedGitHubLabels(repository, item, tokenResult.token);
+      githubLabelMutationApplied = true;
+      logToFile(paths.logPath, `Applied approved GitHub labels to issue #${item.issueNumber}: ${item.recommendedLabels.join(", ")}`);
+    }
+
+    await mkdir(resolveKnowledgeSinkDir(projectRoot, config), { recursive: true });
+    const draft = await readFile(item.draftPath, "utf-8");
+    await writeFile(item.publicationPath, `${draft}\n\n---\nApproved at: ${approvedAt}\n`, "utf-8");
+  } catch (error) {
+    item.transitions = item.transitions.filter((entry) => !(entry.state === "approved" && entry.at === approvedAt));
+    const message = error instanceof Error ? error.message : String(error);
+    const statusReason = error instanceof GitHubPermissionError
+      ? "insufficient-permissions"
+      : "approval-failed";
+    const nextState: OmxDaemonState = {
+      ...state,
+      repository,
+      credentialSource: tokenResult.source,
+      statusReason,
+      lastError: message,
+    };
+    writeQueue(projectRoot, queue);
+    writeDaemonState(projectRoot, nextState);
+    logToFile(paths.logPath, `ERROR approval ${itemId}: ${message}`);
+    return {
+      success: false,
+      message: statusReason === "insufficient-permissions"
+        ? "Approval could not apply GitHub mutations because permissions are insufficient."
+        : `Approval failed for ${itemId}.`,
+      state: nextState,
+      queue,
+      error: message,
+    };
   }
 
   item.status = "published";
   item.approvedAt = approvedAt;
   item.publishedAt = approvedAt;
   item.githubLabelMutationApplied = githubLabelMutationApplied;
+  appendTransition(item, "published", "Approved publication written to the knowledge sink.", approvedAt);
 
   const nextState: OmxDaemonState = {
     ...state,
@@ -878,6 +973,7 @@ export function rejectOmxDaemonItem(projectRoot: string, itemId: string): Daemon
   }
   item.status = "rejected";
   item.rejectedAt = new Date().toISOString();
+  appendTransition(item, "rejected", "Rejected without applying external mutations.", item.rejectedAt);
   const nextState: OmxDaemonState = {
     ...state,
     queueSize: queue.filter((entry) => entry.status === "queued").length,
@@ -918,12 +1014,16 @@ export function getOmxDaemonStatus(projectRoot = process.cwd()): DaemonResponse 
   const running = isOmxDaemonRunning(projectRoot);
   const statusReason = !tokenResult.token
     ? "missing-credentials"
+    : state.statusReason === "insufficient-permissions"
+      ? "insufficient-permissions"
     : running ? "running" : "stopped";
   const target = formatDaemonTarget(repository);
   return {
     success: true,
     message: !tokenResult.token
       ? `Daemon is configured for ${target}, but GitHub credentials are missing. ${formatCredentialGuidance()}`
+      : statusReason === "insufficient-permissions"
+        ? `Daemon is configured for ${target}, but GitHub permissions are insufficient. ${state.lastError ?? formatPermissionGuidance("issue-read")}`
       : running
         ? `Daemon is running for ${target}; ${queueSummary(queue)}.`
         : `Daemon is stopped for ${target}; ${queueSummary(queue)}. Use \`omx daemon start\` for background polling or \`omx daemon run-once\` for a foreground pass.`,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -515,6 +515,14 @@ function queueSummary(queue: OmxDaemonQueueItem[]): string {
   return `queued=${queued}, published=${published}, total=${queue.length}`;
 }
 
+function formatDaemonTarget(repository: string | null): string {
+  return repository ?? "this worktree";
+}
+
+function formatCredentialGuidance(): string {
+  return "Check .omx/daemon/daemon.config.json, GH_TOKEN, GITHUB_TOKEN, or gh auth token.";
+}
+
 function createQueueItem(
   projectRoot: string,
   config: OmxDaemonConfig | null,
@@ -895,7 +903,7 @@ export function getOmxDaemonStatus(projectRoot = process.cwd()): DaemonResponse 
   if (!configured) {
     return {
       success: true,
-      message: "Daemon is not initialized for this worktree. Use $setup-omx-daemon or scaffold .omx/daemon first.",
+      message: "Daemon is not initialized for this worktree. Use $setup-omx-daemon for guided onboarding or `omx daemon scaffold` to create tracked .omx/daemon inputs.",
       state: {
         ...state,
         statusReason: "not-initialized",
@@ -911,13 +919,14 @@ export function getOmxDaemonStatus(projectRoot = process.cwd()): DaemonResponse 
   const statusReason = !tokenResult.token
     ? "missing-credentials"
     : running ? "running" : "stopped";
+  const target = formatDaemonTarget(repository);
   return {
     success: true,
     message: !tokenResult.token
-      ? `Daemon is configured but credentials are missing (${tokenResult.error}).`
+      ? `Daemon is configured for ${target}, but GitHub credentials are missing. ${formatCredentialGuidance()}`
       : running
-        ? `Daemon is running for ${repository ?? "unknown-repo"}; ${queueSummary(queue)}.`
-        : `Daemon is stopped for ${repository ?? "unknown-repo"}; ${queueSummary(queue)}.`,
+        ? `Daemon is running for ${target}; ${queueSummary(queue)}.`
+        : `Daemon is stopped for ${target}; ${queueSummary(queue)}. Use \`omx daemon start\` for background polling or \`omx daemon run-once\` for a foreground pass.`,
     state: {
       ...state,
       isRunning: running,

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -242,6 +242,13 @@
       "internalRequired": false
     },
     {
+      "name": "setup-omx-daemon",
+      "category": "utility",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "configure-notifications",
       "category": "utility",
       "status": "active",


### PR DESCRIPTION
## Summary
- add the OMX daemon lifecycle and approval-first review flow for repo/worktree issue triage
- tighten daemon truthfulness around setup, repository resolution, approval retries, and status reporting
- clean up the scoped daemon runtime/tests after a targeted deslop pass without changing verified behavior

## What changed
- added daemon runtime queue/approval handling, CLI surface, and setup/onboarding polish
- repaired daemon-specific `.gitignore` carve-outs during scaffold/setup
- gated `omx daemon start`/`status` on repository + credential reality and surfaced richer queue/activity status
- made approval retries durable/truthful under partial-failure paths and improved idempotent reject behavior
- simplified scoped daemon/test code by reducing repeated test scaffolding and clarifying status branching

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/cli/__tests__/daemon.test.js dist/cli/__tests__/nested-help-routing.test.js dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-skills-overwrite.test.js dist/cli/__tests__/setup-scope.test.js dist/daemon/__tests__/index.test.js dist/catalog/__tests__/generator.test.js`
- `node dist/scripts/generate-catalog-docs.js --check`

## Notes
- draft PR because this branch bundles the daemon feature, follow-up review fixes, and a bounded cleanup pass
- full repo-wide test suite was not rerun; verification stayed on the targeted daemon/CLI/setup/catalog lane
