### PR TITLE
Keep team launches recoverable when early workers stall startup

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -67,6 +67,26 @@ function withoutTeamTestWorkerEnv<T>(fn: () => T): T {
   }
 }
 
+function withMockPromptModeCodexAllowed<T>(fn: () => T): T {
+  const previous = process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = '1';
+  let restoreImmediately = true;
+  const restore = () => {
+    if (typeof previous === 'string') process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = previous;
+    else delete process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      restoreImmediately = false;
+      return result.finally(restore) as T;
+    }
+    return result;
+  } finally {
+    if (restoreImmediately) restore();
+  }
+}
+
 async function runNodeCli(
   args: string[],
   options: {
@@ -1802,7 +1822,8 @@ process.on('SIGTERM', () => process.exit(0));
         return true;
       }) as typeof process.stderr.write;
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+      await withMockPromptModeCodexAllowed(() =>
+        withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask])));
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       logs.length = 0;
@@ -1868,7 +1889,8 @@ process.on('SIGTERM', () => process.exit(0));
       process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
       process.env.OMX_TEAM_WORKER_CLI = 'codex';
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+      await withMockPromptModeCodexAllowed(() =>
+        withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask])));
 
       const startedState = await readModeState('team', wd);
       assert.equal(startedState?.active, true);
@@ -1928,7 +1950,8 @@ process.on('SIGTERM', () => process.exit(0));
       process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
       process.env.OMX_TEAM_WORKER_CLI = 'codex';
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+      await withMockPromptModeCodexAllowed(() =>
+        withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask])));
       await writeFile(
         join(wd, '.omx', 'state', 'team', teamName, 'phase.json'),
         JSON.stringify({

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -147,6 +147,10 @@ export async function startMode(
  */
 export async function readModeState(mode: string, projectRoot?: string): Promise<ModeState | null> {
   const paths = await getReadScopedStatePaths(mode, projectRoot);
+  return readModeStateFromPaths(paths);
+}
+
+async function readModeStateFromPaths(paths: string[]): Promise<ModeState | null> {
   for (const path of paths) {
     if (!existsSync(path)) continue;
     try {
@@ -158,17 +162,34 @@ export async function readModeState(mode: string, projectRoot?: string): Promise
   return null;
 }
 
+export async function readModeStateForSession(
+  mode: string,
+  sessionId: string | undefined,
+  projectRoot?: string,
+): Promise<ModeState | null> {
+  let paths: string[];
+  try {
+    paths = await getReadScopedStatePaths(mode, projectRoot, sessionId);
+  } catch {
+    return null;
+  }
+  return readModeStateFromPaths(paths);
+}
+
 /**
  * Update mode state (merge fields)
  */
 export async function updateModeState(
   mode: string,
   updates: Partial<ModeState>,
-  projectRoot?: string
+  projectRoot?: string,
+  explicitSessionId?: string,
 ): Promise<ModeState> {
-  const current = await readModeState(mode, projectRoot);
+  const current = explicitSessionId
+    ? await readModeStateForSession(mode, explicitSessionId, projectRoot)
+    : await readModeState(mode, projectRoot);
   if (!current) throw new Error(`Mode ${mode} not found`);
-  const scope = await resolveStateScope(projectRoot);
+  const scope = await resolveStateScope(projectRoot, explicitSessionId);
   await mkdir(scope.stateDir, { recursive: true });
 
   const updatedBase = { ...current, ...updates };

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1381,6 +1381,41 @@ esac
     }
   });
 
+  it("blocks Stop from session-scoped team mode when session.json points to another session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-session-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-live-team"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-other-team" });
+      await writeJson(join(stateDir, "sessions", "sess-live-team", "team-state.json"), {
+        active: true,
+        mode: "team",
+        current_phase: "team-exec",
+        team_name: "session-live-team",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-live-team",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          `OMX team pipeline is still active (session-live-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns Stop continuation output for active ralplan skill with matching active mode state and without active subagents", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-skill-"));
     try {
@@ -1624,6 +1659,41 @@ esac
           hook_event_name: "Stop",
           cwd,
           session_id: "sess-stop",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_executing",
+        systemMessage:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Stop from session-scoped Ralph state when session.json points to another session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-session-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-live-ralph"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-other-ralph" });
+      await writeJson(join(stateDir, "sessions", "sess-live-ralph", "ralph-state.json"), {
+        active: true,
+        current_phase: "executing",
+        session_id: "sess-live-ralph",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-live-ralph",
         },
         { cwd },
       );

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join, resolve } from "path";
-import { readModeState, updateModeState } from "../modes/base.js";
+import { readModeState, readModeStateForSession, updateModeState } from "../modes/base.js";
 import {
   listActiveSkills,
   readVisibleSkillActiveState,
@@ -176,12 +176,20 @@ function formatPhase(value: unknown, fallback = "active"): string {
   return phase || fallback;
 }
 
-async function readActiveRalphState(stateDir: string): Promise<Record<string, unknown> | null> {
+async function readActiveRalphState(
+  stateDir: string,
+  preferredSessionId?: string,
+): Promise<Record<string, unknown> | null> {
   const sessionInfo = await readJsonIfExists(join(stateDir, "session.json"));
   const currentOmxSessionId = safeString(sessionInfo?.session_id).trim();
-  if (currentOmxSessionId) {
+  const sessionCandidates = [...new Set([
+    safeString(preferredSessionId).trim(),
+    currentOmxSessionId,
+  ].filter(Boolean))];
+
+  for (const sessionId of sessionCandidates) {
     const sessionScoped = await readJsonIfExists(
-      join(stateDir, "sessions", currentOmxSessionId, "ralph-state.json"),
+      join(stateDir, "sessions", sessionId, "ralph-state.json"),
     );
     if (
       sessionScoped?.active === true
@@ -198,7 +206,7 @@ async function readActiveRalphState(stateDir: string): Promise<Record<string, un
     return direct;
   }
 
-  if (currentOmxSessionId) return null;
+  if (sessionCandidates.length > 0) return null;
 
   const sessionsRoot = join(stateDir, "sessions");
   if (!existsSync(sessionsRoot)) return null;
@@ -614,8 +622,11 @@ function isStopExempt(payload: CodexHookPayload): boolean {
 async function buildModeBasedStopOutput(
   mode: "autopilot" | "ultrawork" | "ultraqa",
   cwd: string,
+  sessionId?: string,
 ): Promise<Record<string, unknown> | null> {
-  const state = await readModeState(mode, cwd);
+  const state = sessionId
+    ? await readModeStateForSession(mode, sessionId, cwd)
+    : await readModeState(mode, cwd);
   if (state?.active !== true || !isNonTerminalPhase(state.current_phase)) return null;
   const phase = formatPhase(state.current_phase);
   return {
@@ -626,8 +637,10 @@ async function buildModeBasedStopOutput(
   };
 }
 
-async function buildTeamStopOutput(cwd: string): Promise<Record<string, unknown> | null> {
-  const teamState = await readModeState("team", cwd);
+async function buildTeamStopOutput(cwd: string, sessionId?: string): Promise<Record<string, unknown> | null> {
+  const teamState = sessionId
+    ? await readModeStateForSession("team", sessionId, cwd)
+    : await readModeState("team", cwd);
   if (teamState?.active !== true) return null;
   const teamName = safeString(teamState.team_name).trim();
   const coarsePhase = teamState.current_phase;
@@ -907,7 +920,7 @@ async function findActiveTeamForTransportFailure(
   cwd: string,
   sessionId: string,
 ): Promise<{ teamName: string; phase: string } | null> {
-  const teamState = await readModeState("team", cwd);
+  const teamState = await readModeStateForSession("team", sessionId, cwd);
   if (teamState?.active === true) {
     const teamName = safeString(teamState.team_name).trim();
     const coarsePhase = formatPhase(teamState.current_phase);
@@ -1001,6 +1014,7 @@ async function markTeamTransportFailure(
         last_turn_at: nowIso,
       },
       cwd,
+      sessionId || undefined,
     );
   } catch {
     // Canonical team state already carries the preserved failure for coarse-state-missing sessions.
@@ -1018,22 +1032,22 @@ async function buildStopHookOutput(
 
   const sessionId = readPayloadSessionId(payload);
   const threadId = readPayloadThreadId(payload);
-  const ralphState = await readActiveRalphState(stateDir);
+  const ralphState = await readActiveRalphState(stateDir, sessionId);
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
   if (!ralphState) {
     const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);
     if (!stopHookActive && hasTeamWorkerContext()) return teamWorkerOutput;
 
-    const autopilotOutput = await buildModeBasedStopOutput("autopilot", cwd);
+    const autopilotOutput = await buildModeBasedStopOutput("autopilot", cwd, sessionId);
     if (!stopHookActive && autopilotOutput) return autopilotOutput;
 
-    const ultraworkOutput = await buildModeBasedStopOutput("ultrawork", cwd);
+    const ultraworkOutput = await buildModeBasedStopOutput("ultrawork", cwd, sessionId);
     if (!stopHookActive && ultraworkOutput) return ultraworkOutput;
 
-    const ultraqaOutput = await buildModeBasedStopOutput("ultraqa", cwd);
+    const ultraqaOutput = await buildModeBasedStopOutput("ultraqa", cwd, sessionId);
     if (!stopHookActive && ultraqaOutput) return ultraqaOutput;
 
-    const teamOutput = await buildTeamStopOutput(cwd);
+    const teamOutput = await buildTeamStopOutput(cwd, sessionId);
     if (teamOutput) {
       const teamSignature = buildRepeatableStopSignature(payload, "team-stop", safeString(teamOutput.stopReason));
       return await maybeReturnRepeatableStopOutput(payload, stateDir, teamSignature, teamOutput);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -138,6 +138,26 @@ function withoutTeamWorkerEnv<T>(fn: () => T): T {
   }
 }
 
+function withMockPromptModeCodexAllowed<T>(fn: () => T): T {
+  const previous = process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = '1';
+  let restoreImmediately = true;
+  const restore = () => {
+    if (typeof previous === 'string') process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = previous;
+    else delete process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      restoreImmediately = false;
+      return result.finally(restore) as T;
+    }
+    return result;
+  } finally {
+    if (restoreImmediately) restore();
+  }
+}
+
 async function waitForFileText(
   filePath: string,
   matcher: (content: string) => boolean,
@@ -198,6 +218,7 @@ async function withPromptModeCodexEnv<T>(
     TMUX: undefined,
     OMX_TEAM_WORKER_LAUNCH_MODE: 'prompt',
     OMX_TEAM_WORKER_CLI: 'codex',
+    OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT: '1',
     ...extraEnv,
   };
 
@@ -1912,18 +1933,19 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-role-routing',
-          'heuristic routing handoff',
-          'executor',
-          2,
-          [
-            { subject: 'test routing report only', description: 'test routing report only', owner: 'worker-1', role: 'test-engineer' },
-            { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
-          ],
-          cwd,
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-role-routing',
+            'heuristic routing handoff',
+            'executor',
+            2,
+            [
+              { subject: 'test routing report only', description: 'test routing report only', owner: 'worker-1', role: 'test-engineer' },
+              { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
+            ],
+            cwd,
+          )));
 
       assert.equal(runtime.config.worker_launch_mode, 'prompt');
       assert.equal(runtime.config.workers[0]?.role, 'test-engineer');
@@ -2033,17 +2055,18 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-mini-tuned-routing',
-          'mini tuned routing handoff',
-          'executor',
-          1,
-          [
-            { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-1', role: 'writer' },
-          ],
-          cwd,
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-mini-tuned-routing',
+            'mini tuned routing handoff',
+            'executor',
+            1,
+            [
+              { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-1', role: 'writer' },
+            ],
+            cwd,
+          )));
 
       const workerInstructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'AGENTS.md'), 'utf-8');
       assert.match(workerInstructions, /You are operating as the \*\*writer\*\* role/);
@@ -2321,16 +2344,17 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-paths',
-          'detached worktree path resolution',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-detached-worktree-paths',
+            'detached worktree path resolution',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )));
 
       const workerPath = runtime.config.workers[0]?.worktree_path;
       assert.ok(workerPath, 'detached worker should have a worktree path');
@@ -2423,16 +2447,17 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-shutdown',
-          'detached worktree shutdown cleanup',
-          'executor',
-          1,
-          [],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-detached-worktree-shutdown',
+            'detached worktree shutdown cleanup',
+            'executor',
+            1,
+            [],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )));
 
       const worktreePath = runtime.config.workers[0]?.worktree_path;
       assert.ok(worktreePath, 'worker worktree path should be persisted');
@@ -2501,16 +2526,17 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-resume-metadata',
-          'detached worktree resume metadata',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-detached-worktree-resume-metadata',
+            'detached worktree resume metadata',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )));
 
       const originalWorker = runtime.config.workers[0];
       const originalWorktreePath = originalWorker?.worktree_path;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -21,6 +21,7 @@ import {
   readMonitorSnapshot,
   claimTask,
   transitionTaskStatus,
+  readWorkerStatus,
   writeWorkerStatus,
 } from '../state.js';
 import {
@@ -40,6 +41,7 @@ import {
 } from '../runtime.js';
 import { resolveTeamLowComplexityDefaultModel } from '../model-contract.js';
 import { readTeamEvents } from '../state/events.js';
+import { sanitizeTeamName } from '../tmux-session.js';
 
 async function initRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-repo-'));
@@ -1277,7 +1279,7 @@ esac
     assert.equal(saveIndex < readyIndex, true);
   });
 
-  it('startTeam rejects interactive startup when fallback delivery never produces startup evidence', async () => {
+  it('startTeam records recoverable startup issues per worker instead of failing launch early when panes stay alive', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-no-startup-evidence-'));
     const previousTmux = process.env.TMUX;
     const previousTmuxPane = process.env.TMUX_PANE;
@@ -1285,6 +1287,8 @@ esac
     const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+    let runtime: TeamRuntime | null = null;
+    const teamName = 'team-no-startup-evidence';
 
     try {
       await withMockTmuxFixture(
@@ -1311,6 +1315,9 @@ case "$1" in
     ;;
   list-panes)
     case "$*" in
+      *"#{pane_dead}"*)
+        echo "0"
+        ;;
       *"#{pane_dead} #{pane_pid}"*)
         echo "0 4242"
         ;;
@@ -1367,25 +1374,308 @@ process.on('SIGTERM', () => process.exit(0));
           process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
           process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
 
+          runtime = await withoutTeamWorkerEnv(() =>
+            startTeam(
+              teamName,
+              'interactive startup should keep evaluating per-worker startup issues while panes stay alive',
+              'executor',
+              2,
+              [
+                { subject: 'worker-1 task', description: 'd', owner: 'worker-1' },
+                { subject: 'worker-2 task', description: 'd', owner: 'worker-2' },
+              ],
+              cwd,
+            ));
+
+          const worker1Status = await readWorkerStatus(teamName, 'worker-1', cwd);
+          const worker2Status = await readWorkerStatus(teamName, 'worker-2', cwd);
+          assert.equal(worker1Status.state, 'unknown');
+          assert.equal(worker2Status.state, 'unknown');
+          assert.match(worker1Status.reason ?? '', /startup_no_evidence|fallback_attempted_but_unconfirmed/);
+          assert.match(worker2Status.reason ?? '', /startup_no_evidence|fallback_attempted_but_unconfirmed/);
+
+          const task1 = await readTask(teamName, '1', cwd);
+          const task2 = await readTask(teamName, '2', cwd);
+          assert.equal(task1?.status, 'pending');
+          assert.equal(task2?.status, 'pending');
+        },
+      );
+    } finally {
+      if (runtime) {
+        await shutdownTeam(teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = previousSkipReadyWait;
+      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+      if (typeof previousStartupEvidenceTimeout === 'string') {
+        process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam still fails startup when the worker pane is dead/unrecoverable', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-dead-startup-pane-'));
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-dead-startup-pane-bin-',
+          tmuxScript: () => `#!/bin/sh
+set -eu
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*) echo "120" ;;
+      *) echo "leader:0 %1" ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "1 4242"
+        ;;
+      *"#{pane_pid}"*)
+        echo "4242"
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*) echo "%2" ;;
+      *) echo "%3" ;;
+    esac
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session|resize-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [{ name: 'codex', content: '#!/usr/bin/env node\nprocess.stdin.resume();\n' }],
+        },
+        async () => {
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+
           await assert.rejects(
             () => withoutTeamWorkerEnv(() =>
               startTeam(
-                'team-no-startup-evidence',
-                'interactive startup should fail without claim evidence',
+                'team-dead-startup-pane',
+                'dead pane should still fail startup',
                 'executor',
                 1,
                 [{ subject: 's', description: 'd', owner: 'worker-1' }],
                 cwd,
               )),
-            /worker_notify_failed:worker-1/,
+            /Worker worker-1 did not become ready/,
+          );
+        },
+      );
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousStartupEvidenceTimeout === 'string') {
+        process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam materializes all worker identity/inbox files before worker-1 startup evidence can block later workers', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-materialize-before-evidence-'));
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+    const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-materialize-before-evidence-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "0 4242"
+        ;;
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *"-t %2"*"#{pane_pid}"*)
+        echo "4242"
+        ;;
+      *"-t %3"*"#{pane_pid}"*)
+        echo "4343"
+        ;;
+      *"-t %4"*"#{pane_pid}"*)
+        echo "4444"
+        ;;
+      *"#{pane_pid}"*)
+        echo "4141"
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    exit 0
+    ;;
+  split-window)
+    count_file="${cwd}/split-window-count"
+    count=0
+    if [ -f "$count_file" ]; then
+      count=$(cat "$count_file")
+    fi
+    count=$((count + 1))
+    printf '%s' "$count" > "$count_file"
+    case "$count" in
+      1) echo "%2" ;;
+      2) echo "%3" ;;
+      3) echo "%4" ;;
+      *) echo "%5" ;;
+    esac
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session|resize-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [
+            {
+              name: 'codex',
+              content: `#!/usr/bin/env node
+process.stdin.resume();
+setTimeout(() => process.exit(0), 30000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+            },
+          ],
+        },
+        async () => {
+          const sanitizedTeamName = sanitizeTeamName('team-materialize-before-evidence');
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+
+          const teamPromise = withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-materialize-before-evidence',
+              'later workers should materialize before startup evidence failure',
+              'executor',
+              2,
+              [
+                { subject: 'w1', description: 'worker one', owner: 'worker-1' },
+                { subject: 'w2', description: 'worker two', owner: 'worker-2' },
+              ],
+              cwd,
+            ));
+          const observedTeamPromise = teamPromise.then(
+            (runtime) => ({ ok: true as const, runtime }),
+            (error: unknown) => ({ ok: false as const, error }),
           );
 
+          const workerOneIdentity = join(cwd, '.omx', 'state', 'team', sanitizedTeamName, 'workers', 'worker-1', 'identity.json');
+          const workerTwoIdentity = join(cwd, '.omx', 'state', 'team', sanitizedTeamName, 'workers', 'worker-2', 'identity.json');
+          const workerTwoInbox = join(cwd, '.omx', 'state', 'team', sanitizedTeamName, 'workers', 'worker-2', 'inbox.md');
+
+          let materializedAllWorkers = false;
+          for (let attempt = 0; attempt < 450; attempt += 1) {
+            if (
+              existsSync(workerOneIdentity)
+              && existsSync(workerTwoIdentity)
+              && existsSync(workerTwoInbox)
+            ) {
+              materializedAllWorkers = true;
+              break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+
           assert.equal(
-            existsSync(join(cwd, '.omx', 'state', 'team', 'team-no-startup-evidence')),
-            false,
+            materializedAllWorkers,
+            true,
+            'worker-2 durable state should exist before worker-1 startup evidence failure rejects launch',
           );
+
+          const outcome = await observedTeamPromise;
+          assert.equal(outcome.ok, false);
+          assert.match(String((outcome as { ok: false; error: Error }).error), /worker_notify_failed:worker-1/);
+
           assert.equal(
-            existsSync(join(cwd, '.omx', 'team', 'team-no-startup-evidence')),
+            existsSync(join(cwd, '.omx', 'state', 'team', sanitizedTeamName)),
             false,
           );
         },
@@ -1528,20 +1818,15 @@ sleep 5
     }
   });
 
-  it('startTeam preserves explicit codex launch args while forcing bypass in prompt mode', async () => {
+  it('startTeam rejects codex prompt mode even when explicit launch args are provided', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-explicit-launch-'));
     const binDir = join(cwd, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
-    const capturePath = join(cwd, 'codex-argv.json');
     await mkdir(binDir, { recursive: true });
     await writeFile(
       fakeCodexPath,
       `#!/usr/bin/env node
-const fs = require('fs');
-fs.writeFileSync(process.env.OMX_CODEX_ARGV_CAPTURE_PATH, JSON.stringify(process.argv.slice(2), null, 2));
-process.stdin.resume();
-setTimeout(() => process.exit(0), 5000);
-process.on('SIGTERM', () => process.exit(0));
+process.exit(0);
 `,
       { mode: 0o755 },
     );
@@ -1551,53 +1836,27 @@ process.on('SIGTERM', () => process.exit(0));
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-    const prevCapture = process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
 
     process.env.PATH = `${binDir}:${prevPath ?? ''}`;
     delete process.env.TMUX;
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
     process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.3-codex-spark -c model_reasoning_effort="low"';
-    process.env.OMX_CODEX_ARGV_CAPTURE_PATH = capturePath;
-
-    let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-codex-explicit-launch',
-          'codex prompt-mode team bootstrap',
-          'explore',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
-
-      assert.equal(runtime.config.worker_launch_mode, 'prompt');
-      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
-
-      let argv: string[] | null = null;
-      for (let attempt = 0; attempt < 50; attempt += 1) {
-        if (existsSync(capturePath)) {
-          argv = JSON.parse(await readFile(capturePath, 'utf-8')) as string[];
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      assert.ok(argv, 'codex argv capture file should be written');
-      assert.equal(argv.includes('--dangerously-bypass-approvals-and-sandbox'), false);
-      assert.equal(argv.filter((arg) => arg === '--dangerously-bypass-approvals-and-sandbox').length, 0);
-      assert.equal(argv.includes('--model'), true);
-      assert.equal(argv[argv.indexOf('--model') + 1], 'gpt-5.3-codex-spark');
-      assert.equal(argv.includes('-c'), true);
-      assert.equal(argv.includes('model_reasoning_effort="low"'), true);
-      assert.equal(argv.some((arg) => arg.includes('model_instructions_file=')), true);
-
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
+      await assert.rejects(
+        () => withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-codex-explicit-launch',
+            'codex prompt-mode team bootstrap',
+            'explore',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+          )),
+        /prompt_mode_codex_requires_tty/,
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'team-codex-explicit-launch')), false);
     } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
       else delete process.env.PATH;
       if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
@@ -1608,8 +1867,6 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-      if (typeof prevCapture === 'string') process.env.OMX_CODEX_ARGV_CAPTURE_PATH = prevCapture;
-      else delete process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -1831,7 +2088,7 @@ process.on('SIGTERM', () => process.exit(0));
     }
   });
 
-  it('startTeam supports prompt launch mode without tmux and pipes trigger text via stdin', async () => {
+  it('startTeam rejects codex prompt mode without tmux with an explicit non-tty error', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-'));
     const binDir = join(cwd, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
@@ -1856,28 +2113,21 @@ process.on('SIGTERM', () => process.exit(0));
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
 
-    let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-prompt',
-          'prompt-mode team bootstrap',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
-
-      assert.equal(runtime.config.worker_launch_mode, 'prompt');
-      assert.equal(runtime.config.leader_pane_id, null);
-      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
-
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
+      await assert.rejects(
+        () => withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-prompt',
+            'prompt-mode team bootstrap',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+          )),
+        /prompt_mode_codex_requires_tty/,
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'team-prompt')), false);
     } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
       else delete process.env.PATH;
       if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;

--- a/src/team/__tests__/shutdown-fallback.test.ts
+++ b/src/team/__tests__/shutdown-fallback.test.ts
@@ -28,6 +28,15 @@ function withoutTeamWorkerEnv<T>(fn: () => Promise<T>): Promise<T> {
   });
 }
 
+function withMockPromptModeCodexAllowed<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = '1';
+  return fn().finally(() => {
+    if (typeof previous === 'string') process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = previous;
+    else delete process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  });
+}
+
 describe('shutdown fallback worktree reports', () => {
   it('shutdownTeam checkpoints dirty detached worker worktrees, merges them, and writes a report', async () => {
     const repo = await initRepo();
@@ -56,16 +65,17 @@ process.on('SIGTERM', () => process.exit(0));
     let runtime: TeamRuntime | null = null;
     let preservedWorktreePath: string | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-shutdown-fallback-report',
-          'shutdown fallback merge report',
-          'executor',
-          1,
-          [],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-shutdown-fallback-report',
+            'shutdown fallback merge report',
+            'executor',
+            1,
+            [],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )));
 
       const worktreePath = runtime.config.workers[0]?.worktree_path;
       assert.ok(worktreePath, 'worker worktree path should be present');

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -21,6 +21,7 @@ import {
   sendToWorker,
   sendToWorkerStdin,
   isWorkerAlive,
+  isWorkerPaneOpen,
   getWorkerPanePid,
   killWorkerByPaneIdAsync,
   restoreStandaloneHudPane,
@@ -64,6 +65,7 @@ import {
   teamWriteMonitorSnapshot as writeMonitorSnapshot,
   teamReadPhase as readTeamPhaseState,
   teamWritePhase as writeTeamPhaseState,
+  teamWriteWorkerStatus as writeWorkerStatus,
   type TeamConfig,
   type WorkerInfo,
   type WorkerHeartbeat,
@@ -1223,9 +1225,18 @@ const previousModelInstructionsFileByTeam = new Map<string, string | undefined>(
 const PROMPT_WORKER_SIGTERM_WAIT_MS = 3_000;
 const PROMPT_WORKER_SIGKILL_WAIT_MS = 2_000;
 const PROMPT_WORKER_EXIT_POLL_MS = 100;
+const PROMPT_MODE_CODEX_UNSUPPORTED_REASON = 'prompt_mode_codex_requires_tty';
 
 function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
   return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
+}
+
+function assertPromptModeWorkerCliSupported(workerCliPlan: readonly TeamWorkerCli[]): void {
+  if (workerCliPlan.some((workerCli) => workerCli === 'codex')) {
+    throw new Error(
+      `${PROMPT_MODE_CODEX_UNSUPPORTED_REASON}: Codex prompt workers require a terminal; use interactive team mode or set OMX_TEAM_WORKER_CLI=claude/gemini for prompt-mode teammates.`,
+    );
+  }
 }
 
 function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
@@ -1352,6 +1363,47 @@ export async function waitForClaudeStartupEvidence(params: {
 
 function shouldSkipWorkerReadyWait(env: NodeJS.ProcessEnv): boolean {
   return env.OMX_TEAM_SKIP_READY_WAIT === '1';
+}
+
+function isRecoverableInteractiveStartupReason(reason: string): boolean {
+  const normalized = reason.trim().toLowerCase();
+  return normalized.includes('startup_no_evidence')
+    || normalized.includes('fallback_attempted_but_unconfirmed')
+    || normalized.includes('ready_prompt_timeout');
+}
+
+async function recordRecoverableStartupIssue(params: {
+  teamName: string;
+  workerName: string;
+  taskIds: string[];
+  reason: string;
+  cwd: string;
+}): Promise<void> {
+  const { teamName, workerName, taskIds, reason, cwd } = params;
+  const updatedAt = new Date().toISOString();
+  await writeWorkerStatus(
+    teamName,
+    workerName,
+    {
+      state: 'unknown',
+      current_task_id: taskIds[0],
+      reason,
+      updated_at: updatedAt,
+    },
+    cwd,
+  ).catch(() => {});
+  await appendTeamEvent(
+    teamName,
+    {
+      type: 'worker_state_changed',
+      worker: workerName,
+      state: 'unknown',
+      prev_state: 'unknown',
+      task_id: taskIds[0],
+      reason,
+    },
+    cwd,
+  ).catch(() => {});
 }
 
 function setTeamModelInstructionsFile(teamName: string, filePath: string): void {
@@ -1895,6 +1947,9 @@ export async function startTeam(
     fallbackModel: resolveAgentDefaultModel(agentType, process.env.CODEX_HOME),
   });
   const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, sharedWorkerLaunchArgs, process.env);
+  if (workerLaunchMode === 'prompt') {
+    assertPromptModeWorkerCliSupported(workerCliPlan);
+  }
   const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(process.env);
   const workerStartupEvidenceTimeoutMs = resolveWorkerStartupEvidenceTimeoutMs(
     process.env,
@@ -2067,6 +2122,55 @@ export async function startTeam(
 
     const workerPaneIds = Array.from({ length: workerCount }, () => undefined as string | undefined);
 
+    const materializeWorkerStartupState = async (
+      bootstrapPlan: typeof workerBootstrapPlans[number],
+      workerIndex: number,
+      paneId: string | undefined,
+    ): Promise<void> => {
+      const workerWorkspace = bootstrapPlan.workerWorkspace;
+      const identity: WorkerInfo = {
+        name: bootstrapPlan.workerName,
+        index: workerIndex,
+        role: bootstrapPlan.workerRole,
+        worker_cli: bootstrapPlan.workerCli,
+        assigned_tasks: bootstrapPlan.workerTasks.map((task) => task.id),
+        working_dir: workerWorkspace.cwd,
+        worktree_repo_root: workerWorkspace.worktreeRepoRoot,
+        worktree_path: workerWorkspace.worktreePath,
+        worktree_branch: workerWorkspace.worktreeBranch,
+        worktree_detached: workerWorkspace.worktreeDetached,
+        worktree_created: workerWorkspace.worktreeCreated,
+        team_state_root: teamStateRoot,
+      };
+
+      if (workerLaunchMode === 'interactive') {
+        const panePid = getWorkerPanePid(sessionName, workerIndex, paneId);
+        if (panePid) identity.pid = panePid;
+      } else if (config?.workers[workerIndex - 1]?.pid) {
+        identity.pid = config.workers[workerIndex - 1].pid;
+      }
+
+      if (paneId) identity.pane_id = paneId;
+
+      if (config?.workers[workerIndex - 1]) {
+        config.workers[workerIndex - 1].pid = identity.pid;
+        config.workers[workerIndex - 1].pane_id = paneId;
+        config.workers[workerIndex - 1].role = bootstrapPlan.workerRole;
+        config.workers[workerIndex - 1].worker_cli = bootstrapPlan.workerCli;
+        config.workers[workerIndex - 1].assigned_tasks = bootstrapPlan.workerTasks.map((task) => task.id);
+        config.workers[workerIndex - 1].working_dir = workerWorkspace.cwd;
+        config.workers[workerIndex - 1].worktree_repo_root = workerWorkspace.worktreeRepoRoot;
+        config.workers[workerIndex - 1].worktree_path = workerWorkspace.worktreePath;
+        config.workers[workerIndex - 1].worktree_branch = workerWorkspace.worktreeBranch;
+        config.workers[workerIndex - 1].worktree_detached = workerWorkspace.worktreeDetached;
+        config.workers[workerIndex - 1].worktree_created = workerWorkspace.worktreeCreated;
+        config.workers[workerIndex - 1].team_state_root = teamStateRoot;
+      }
+
+      await writeWorkerIdentity(sanitized, bootstrapPlan.workerName, identity, leaderCwd);
+      await writeWorkerInbox(sanitized, bootstrapPlan.workerName, bootstrapPlan.inbox, leaderCwd);
+    };
+
     // 6. Create worker runtime (interactive tmux panes or prompt-mode child processes)
     if (workerLaunchMode === 'interactive') {
       const createdSession = createTeamSession(sanitized, workerCount, leaderCwd, sharedWorkerLaunchArgs, workerStartups);
@@ -2100,6 +2204,16 @@ export async function startTeam(
         }
       }
     }
+
+    // Materialize durable startup state for every worker before any per-worker
+    // readiness wait or startup-evidence gate can block later workers.
+    for (let i = 1; i <= workerCount; i++) {
+      const bootstrapPlan = workerBootstrapPlans[i - 1];
+      if (!bootstrapPlan) {
+        throw new Error(`missing bootstrap plan for worker-${i}`);
+      }
+      await materializeWorkerStartupState(bootstrapPlan, i, workerPaneIds[i - 1]);
+    }
     await saveTeamConfig(config, leaderCwd);
 
     // 7. Wait for all workers to be ready (interactive mode), then bootstrap them
@@ -2110,66 +2224,35 @@ export async function startTeam(
       if (!bootstrapPlan) {
         throw new Error(`missing bootstrap plan for worker-${i}`);
       }
-      const { workerName, paneId, workerTasks, workerRole, inbox, trigger, triggerIntent, initialPrompt } = {
+      const { workerName, paneId, workerTasks, inbox, trigger, triggerIntent, initialPrompt } = {
         workerName: bootstrapPlan.workerName,
         paneId: workerPaneIds[i - 1],
         workerTasks: bootstrapPlan.workerTasks,
-        workerRole: bootstrapPlan.workerRole,
         inbox: bootstrapPlan.inbox,
         trigger: bootstrapPlan.trigger,
         triggerIntent: bootstrapPlan.triggerIntent,
         initialPrompt: bootstrapPlan.initialPrompt,
       };
-      const workerWorkspace = bootstrapPlan.workerWorkspace;
 
       if (workerTasks.map(t => t.role).filter(Boolean).length > 0 && new Set(workerTasks.map(t => t.role).filter(Boolean)).size > 1) {
         console.log(`[omx:team] ${workerName}: mixed task roles [${[...new Set(workerTasks.map(t => t.role).filter(Boolean))].join(', ')}], falling back to ${agentType}`);
       }
 
-      // Write worker identity
-      const identity: WorkerInfo = {
-        name: workerName,
-        index: i,
-        role: workerRole,
-        worker_cli: workerCliPlan[i - 1],
-        assigned_tasks: workerTasks.map(t => t.id),
-        working_dir: workerWorkspace.cwd,
-        worktree_repo_root: workerWorkspace.worktreeRepoRoot,
-        worktree_path: workerWorkspace.worktreePath,
-        worktree_branch: workerWorkspace.worktreeBranch,
-        worktree_detached: workerWorkspace.worktreeDetached,
-        worktree_created: workerWorkspace.worktreeCreated,
-        team_state_root: teamStateRoot,
-      };
-
-      // Get pane PID and store it (interactive mode) or process PID (prompt mode)
-      if (workerLaunchMode === 'interactive') {
-        const panePid = getWorkerPanePid(sessionName, i, paneId);
-        if (panePid) identity.pid = panePid;
-      } else if (config.workers[i - 1]?.pid) {
-        identity.pid = config.workers[i - 1].pid;
-      }
-      if (paneId) identity.pane_id = paneId;
-      if (config.workers[i - 1]) {
-        config.workers[i - 1].pid = identity.pid;
-        config.workers[i - 1].pane_id = paneId;
-        config.workers[i - 1].role = workerRole;
-        config.workers[i - 1].worker_cli = workerCliPlan[i - 1];
-        config.workers[i - 1].working_dir = workerWorkspace.cwd;
-        config.workers[i - 1].worktree_repo_root = workerWorkspace.worktreeRepoRoot;
-        config.workers[i - 1].worktree_path = workerWorkspace.worktreePath;
-        config.workers[i - 1].worktree_branch = workerWorkspace.worktreeBranch;
-        config.workers[i - 1].worktree_detached = workerWorkspace.worktreeDetached;
-        config.workers[i - 1].worktree_created = workerWorkspace.worktreeCreated;
-        config.workers[i - 1].team_state_root = teamStateRoot;
-      }
-
-      await writeWorkerIdentity(sanitized, workerName, identity, leaderCwd);
-
       // Wait for worker readiness
       if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt) {
         const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);
         if (!ready) {
+          const workerAlive = isWorkerPaneOpen(sessionName, i, paneId);
+          if (workerAlive) {
+            await recordRecoverableStartupIssue({
+              teamName: sanitized,
+              workerName,
+              taskIds: workerTasks.map((task) => task.id),
+              reason: 'ready_prompt_timeout',
+              cwd: leaderCwd,
+            });
+            continue;
+          }
           throw new Error(`Worker ${workerName} did not become ready in tmux session ${sessionName}`);
         }
       }
@@ -2213,10 +2296,27 @@ export async function startTeam(
               sleepFractionalSeconds(startupRetryDelayS);
             }
           }
-        }
+      }
       }
       if (!dispatchOutcome.ok) {
-        throw new Error(`worker_notify_failed:${workerName}`);
+        const workerAlive = workerLaunchMode === 'prompt'
+          ? isPromptWorkerAlive(config, config.workers[i - 1]!)
+          : isWorkerPaneOpen(sessionName, i, paneId);
+        if (
+          workerLaunchMode === 'interactive'
+          && workerAlive
+          && isRecoverableInteractiveStartupReason(dispatchOutcome.reason)
+        ) {
+          await recordRecoverableStartupIssue({
+            teamName: sanitized,
+            workerName,
+            taskIds: workerTasks.map((task) => task.id),
+            reason: dispatchOutcome.reason,
+            cwd: leaderCwd,
+          });
+          continue;
+        }
+        throw new Error(`worker_notify_failed:${workerName}:${dispatchOutcome.reason}`);
       }
     }
     await saveTeamConfig(config, leaderCwd);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1226,13 +1226,18 @@ const PROMPT_WORKER_SIGTERM_WAIT_MS = 3_000;
 const PROMPT_WORKER_SIGKILL_WAIT_MS = 2_000;
 const PROMPT_WORKER_EXIT_POLL_MS = 100;
 const PROMPT_MODE_CODEX_UNSUPPORTED_REASON = 'prompt_mode_codex_requires_tty';
+// Test-only escape hatch for fake prompt workers that intentionally do not require a real TTY.
+const PROMPT_MODE_CODEX_TEST_ALLOW_ENV = 'OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT';
 
 function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
   return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
 }
 
 function assertPromptModeWorkerCliSupported(workerCliPlan: readonly TeamWorkerCli[]): void {
-  if (workerCliPlan.some((workerCli) => workerCli === 'codex')) {
+  if (
+    workerCliPlan.some((workerCli) => workerCli === 'codex')
+    && process.env[PROMPT_MODE_CODEX_TEST_ALLOW_ENV] !== '1'
+  ) {
     throw new Error(
       `${PROMPT_MODE_CODEX_UNSUPPORTED_REASON}: Codex prompt workers require a terminal; use interactive team mode or set OMX_TEAM_WORKER_CLI=claude/gemini for prompt-mode teammates.`,
     );

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1588,6 +1588,19 @@ export function isWorkerAlive(sessionName: string, workerIndex: number, workerPa
   }
 }
 
+export function isWorkerPaneOpen(sessionName: string, workerIndex: number, workerPaneId?: string): boolean {
+  const result = runTmux([
+    'list-panes',
+    '-t', paneTarget(sessionName, workerIndex, workerPaneId),
+    '-F',
+    '#{pane_dead}',
+  ]);
+  if (!result.ok) return false;
+  const line = result.stdout.split('\n')[0]?.trim();
+  if (!line) return false;
+  return line !== '1';
+}
+
 // Kill a specific worker: send C-c, then C-d, then kill-pane if still alive.
 // leaderPaneId: when provided, the kill is skipped entirely if workerPaneId matches it.
 export async function killWorker(sessionName: string, workerIndex: number, workerPaneId?: string, leaderPaneId?: string): Promise<void> {


### PR DESCRIPTION
## Summary
- materialize each worker's identity/inbox before startup-evidence waits so worker-1 stalls cannot starve later workers
- keep interactive startup failures recoverable when panes are still alive, while still failing unrecoverable dead-pane launches
- reject unsupported Codex prompt-mode team launches up front and scope native stop-state lookups to the active session

## Verification
- `./node_modules/.bin/biome lint src/modes/base.ts src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts src/team/runtime.ts src/team/tmux-session.ts src/team/__tests__/runtime.test.ts`
- `npm run build`
- `npm run check:no-unused`
- `node --test --test-name-pattern="session-scoped team mode|session-scoped Ralph state" dist/scripts/__tests__/codex-native-hook.test.js`
- `node --test --test-name-pattern="records recoverable startup issues per worker instead of failing launch early when panes stay alive" dist/team/__tests__/runtime.test.js`
- `node --test --test-name-pattern="still fails startup when the worker pane is dead/unrecoverable" dist/team/__tests__/runtime.test.js`
- `node --test --test-name-pattern="materializes all worker identity/inbox files before worker-1 startup evidence can block later workers" dist/team/__tests__/runtime.test.js`
- `node --test --test-name-pattern="rejects codex prompt mode even when explicit launch args are provided" dist/team/__tests__/runtime.test.js`
- `node --test --test-name-pattern="rejects codex prompt mode without tmux with an explicit non-tty error" dist/team/__tests__/runtime.test.js`

## Notes
- Full `npm test` was not run in this pass.