### PR TITLE
Fix flaky hook and HUD state scope handling

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2162,7 +2162,7 @@ ${launchAppendix}`
   await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
 
   // 3. Write session state
-  await resetSessionMetrics(cwd);
+  await resetSessionMetrics(cwd, sessionId);
   await writeSessionStart(cwd, sessionId);
 
   // 4. Start notify fallback watcher (best effort)

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -720,7 +720,8 @@ describe('notify-fallback watcher', () => {
         autoNudge: { enabled: true, delaySec: 0, ttlMs: 30_000 },
       }, null, 2));
       await writeSessionStart(wd, 'sess-managed-fallback');
-      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
         last_agent_output: 'Keep going and finish the cleanup from here.',
@@ -1286,7 +1287,8 @@ exit 0
         autoNudge: { enabled: true, delaySec: 0, ttlMs: 30_000 },
       }, null, 2));
       await writeSessionStart(wd, 'sess-managed-fallback');
-      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
         last_agent_output: 'Keep going and finish the cleanup from here.',
@@ -1345,7 +1347,8 @@ exit 0
         target: { type: 'pane', value: '%42' },
       }, null, 2));
       await writeSessionStart(wd, 'sess-managed-fallback');
-      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
         last_agent_output: 'Keep going and finish the cleanup from here.',
@@ -1938,7 +1941,7 @@ exit 0
         owner_omx_session_id: omxSessionId,
         owner_codex_session_id: codexSessionId,
       }, null, 2));
-      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+      await writeFile(join(stateDir, 'sessions', omxSessionId, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
       }, null, 2));
       await writeFile(statePath, JSON.stringify({
@@ -2704,7 +2707,7 @@ exit 0
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
-      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+      await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
       }, null, 2));
       await writeFile(join(stateDir, 'notify-fallback-state.json'), JSON.stringify({

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -211,6 +211,8 @@ describe('notify-hook auto-nudge', () => {
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
         'last-assistant-message': 'I analyzed the code. Keep going and finish the focused cleanup.',
@@ -220,7 +222,7 @@ describe('notify-hook auto-nudge', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
       assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
 
-      const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
+      const nudgeState = JSON.parse(await readFile(join(sessionStateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 0);
       assert.ok(nudgeState.pendingSignature);
       assert.ok(nudgeState.pendingSince);
@@ -701,6 +703,9 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1012,6 +1017,9 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 0 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1032,7 +1040,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
-      const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
+      const nudgeState = JSON.parse(await readFile(join(sessionStateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1);
       assert.match(nudgeState.lastSignature, /^hud:1\|.*\|stall:proceed_intent$/);
     });
@@ -1055,6 +1063,9 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 5000 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1074,7 +1085,7 @@ exit 0
       let tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
-      const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+      const nudgeStatePath = join(sessionStateDir, 'auto-nudge-state.json');
       const nudgeStateBeforeThird = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       await writeJson(nudgeStatePath, {
         ...nudgeStateBeforeThird,
@@ -1115,7 +1126,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 5000 },
       });
-      await writeJson(join(stateDir, 'hud-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'hud-state.json'), {
         last_turn_at: lastTurnAt,
         turn_count: 1,
         last_agent_output: lastMessage,
@@ -1130,7 +1144,7 @@ exit 0
       });
       assert.equal(first.status, 0, `first hook failed: ${first.stderr || first.stdout}`);
 
-      const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+      const nudgeStatePath = join(sessionStateDir, 'auto-nudge-state.json');
       const firstState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       await writeJson(nudgeStatePath, {
         ...firstState,
@@ -1171,6 +1185,7 @@ exit 0
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 0 },
       });
       await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1192,10 +1207,10 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
-      const hudState = JSON.parse(await readFile(join(stateDir, 'hud-state.json'), 'utf-8'));
+      const hudState = JSON.parse(await readFile(join(sessionStateDir, 'hud-state.json'), 'utf-8'));
       assert.equal(hudState.turn_count, 1);
 
-      const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
+      const nudgeState = JSON.parse(await readFile(join(sessionStateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1);
       assert.match(nudgeState.lastSignature, /^hud:1\|.*\|stall:proceed_intent$/);
     });
@@ -1249,6 +1264,9 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1258,7 +1276,7 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+      const nudgeStatePath = join(sessionStateDir, 'auto-nudge-state.json');
       assert.ok(existsSync(nudgeStatePath), 'auto-nudge-state.json should be created');
       const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1, 'nudge count should be 1');
@@ -1360,7 +1378,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
         version: 1,
         active: true,
         skill: 'deep-interview',
@@ -1603,7 +1624,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
         version: 1,
         active: true,
         skill: 'deep-interview',
@@ -1628,7 +1652,7 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
         active: boolean;
         phase: string;
         input_lock?: { active: boolean; released_at?: string; exit_reason?: string };
@@ -1657,7 +1681,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
         version: 1,
         active: true,
         skill: 'deep-interview',
@@ -1682,7 +1709,7 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
         active: boolean;
         phase: string;
         input_lock?: { active: boolean; released_at?: string; exit_reason?: string };
@@ -1711,7 +1738,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
         version: 1,
         active: true,
         skill: 'deep-interview',
@@ -1737,7 +1767,7 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
         skill: string;
         active: boolean;
         phase: string;

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -62,6 +62,25 @@ describe('session lifecycle manager', () => {
     }
   });
 
+  it('writes hud session metrics into the active session scope when session id is provided', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-metrics-scoped-'));
+    try {
+      await resetSessionMetrics(cwd, 'sess-scoped');
+
+      const metricsPath = join(cwd, '.omx', 'metrics.json');
+      const hudPath = join(cwd, '.omx', 'state', 'sessions', 'sess-scoped', 'hud-state.json');
+      assert.equal(existsSync(metricsPath), true);
+      assert.equal(existsSync(hudPath), true);
+
+      const hud = JSON.parse(await readFile(hudPath, 'utf-8')) as {
+        turn_count: number;
+      };
+      assert.equal(hud.turn_count, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('writes session start/end lifecycle artifacts and archives session history', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lifecycle-'));
     const sessionId = 'sess-lifecycle-1';

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -6,9 +6,10 @@
  */
 
 import { readFile, writeFile, mkdir, unlink, appendFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { omxStateDir, omxLogsDir } from '../utils/paths.js';
+import { getStateFilePath } from '../mcp/state-paths.js';
 
 export interface SessionState {
   session_id: string;
@@ -37,7 +38,7 @@ function historyPath(cwd: string): string {
  * Reset session-scoped HUD/metrics files at launch so stale values do not leak
  * into a new Codex session.
  */
-export async function resetSessionMetrics(cwd: string): Promise<void> {
+export async function resetSessionMetrics(cwd: string, sessionId?: string): Promise<void> {
   const omxDir = join(cwd, '.omx');
   const stateDir = omxStateDir(cwd);
   await mkdir(omxDir, { recursive: true });
@@ -55,7 +56,9 @@ export async function resetSessionMetrics(cwd: string): Promise<void> {
     weekly_limit_pct: 0,
   }, null, 2));
 
-  await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+  const hudStatePath = getStateFilePath('hud-state.json', cwd, sessionId);
+  await mkdir(dirname(hudStatePath), { recursive: true });
+  await writeFile(hudStatePath, JSON.stringify({
     last_turn_at: now,
     last_progress_at: now,
     turn_count: 0,

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -7,6 +7,7 @@ import {
   buildGitBranchLabel,
   readGitBranch,
   readAllState,
+  readHudNotifyState,
   readRalphState,
   readRalplanState,
   readDeepInterviewState,
@@ -318,6 +319,21 @@ describe('additional HUD mode state readers', () => {
     await withTempRepo('omx-hud-ultraqa-', async (cwd) => {
       await writeModeState(cwd, 'ultraqa', { active: true, current_phase: 'diagnose' });
       assert.deepEqual(await readUltraqaState(cwd), { active: true, current_phase: 'diagnose' });
+    });
+  });
+
+  it('reads hud notify state from the current session scope', async () => {
+    await withTempRepo('omx-hud-notify-session-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-hud-notify';
+      const sessionStateDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(rootStateDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'root', turn_count: 99 }));
+      await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'session', turn_count: 2 }));
+
+      const state = await readHudNotifyState(cwd);
+      assert.deepEqual(state, { last_turn_at: 'session', turn_count: 2 });
     });
   });
 });

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -13,7 +13,7 @@ import { omxStateDir } from '../utils/paths.js';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
-import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { getReadScopedStateFilePaths, getReadScopedStatePaths } from '../mcp/state-paths.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import type {
   RalphStateForHud,
@@ -168,7 +168,10 @@ export async function readMetrics(cwd: string): Promise<HudMetrics | null> {
 }
 
 export async function readHudNotifyState(cwd: string): Promise<HudNotifyState | null> {
-  return readJsonFile<HudNotifyState>(join(omxStateDir(cwd), 'hud-state.json'));
+  const [hudStatePath] = await getReadScopedStateFilePaths('hud-state.json', cwd, undefined, {
+    rootFallback: false,
+  });
+  return readJsonFile<HudNotifyState>(hudStatePath);
 }
 
 export async function readSessionState(cwd: string): Promise<SessionStateForHud | null> {

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm } from 'fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve as resolvePath } from 'path';
@@ -10,9 +10,12 @@ import {
   getBaseStateDir,
   getAllSessionScopedStateDirs,
   getAllSessionScopedStatePaths,
+  getReadScopedStateFilePaths,
   resolveWorkingDirectoryForState,
   getStateDir,
+  getStateFilePath,
   getStatePath,
+  validateStateFileName,
   validateStateModeSegment,
   validateSessionId,
 } from '../state-paths.js';
@@ -40,6 +43,19 @@ describe('validateStateModeSegment', () => {
     assert.throws(() => validateStateModeSegment('../evil'), /must not contain "\.\."/);
     assert.throws(() => validateStateModeSegment('foo/bar'), /path separators/);
     assert.throws(() => validateStateModeSegment('foo\\bar'), /path separators/);
+  });
+});
+
+describe('validateStateFileName', () => {
+  it('accepts safe file names', () => {
+    assert.equal(validateStateFileName('hud-state.json'), 'hud-state.json');
+    assert.equal(validateStateFileName('session.json'), 'session.json');
+  });
+
+  it('rejects traversal and path separators', () => {
+    assert.throws(() => validateStateFileName('../evil.json'), /must not contain "\.\."/);
+    assert.throws(() => validateStateFileName('foo/bar.json'), /path separators/);
+    assert.throws(() => validateStateFileName('foo\\bar.json'), /path separators/);
   });
 });
 
@@ -105,6 +121,10 @@ describe('state paths', () => {
     assert.equal(
       getStatePath('ralph', '/repo', 'sess1'),
       '/repo/.omx/state/sessions/sess1/ralph-state.json'
+    );
+    assert.equal(
+      getStateFilePath('hud-state.json', '/repo', 'sess1'),
+      '/repo/.omx/state/sessions/sess1/hud-state.json'
     );
   });
 
@@ -184,6 +204,23 @@ describe('state paths', () => {
 
       const paths = await getAllSessionScopedStatePaths('team', wd);
       assert.deepEqual(paths, [getStatePath('team', wd, 'valid-session')]);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reads session-sensitive runtime files from the current session without root fallback when requested', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-paths-'));
+    try {
+      const stateDir = getBaseStateDir(wd);
+      await mkdir(join(stateDir, 'sessions', 'sess-current'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-current' }));
+
+      const paths = await getReadScopedStateFilePaths('hud-state.json', wd, undefined, {
+        rootFallback: false,
+      });
+      assert.deepEqual(paths, [join(stateDir, 'sessions', 'sess-current', 'hud-state.json')]);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -5,6 +5,7 @@ import { readdir, readFile } from 'fs/promises';
 export const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 export const STATE_MODE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const STATE_FILE_SUFFIX = '-state.json';
+const STATE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const WORKDIR_ALLOWLIST_ENV = 'OMX_MCP_WORKDIR_ROOTS';
 
 export type StateFileScope = 'root' | 'session';
@@ -48,6 +49,26 @@ export function validateStateModeSegment(mode: unknown): string {
 
 function getStateFilename(mode: string): string {
   return `${validateStateModeSegment(mode)}${STATE_FILE_SUFFIX}`;
+}
+
+export function validateStateFileName(fileName: unknown): string {
+  if (typeof fileName !== 'string') {
+    throw new Error('fileName must be a string');
+  }
+  const normalized = fileName.trim();
+  if (!normalized) {
+    throw new Error('fileName must be a non-empty string');
+  }
+  if (normalized.includes('..')) {
+    throw new Error('fileName must not contain ".."');
+  }
+  if (normalized.includes('/') || normalized.includes('\\')) {
+    throw new Error('fileName must not contain path separators');
+  }
+  if (!STATE_FILE_NAME_PATTERN.test(normalized)) {
+    throw new Error('fileName must match ^[A-Za-z0-9._-]{1,128}$');
+  }
+  return normalized;
 }
 
 function convertWindowsToWslPath(raw: string): string {
@@ -155,6 +176,10 @@ export function getStatePath(mode: string, workingDirectory?: string, sessionId?
   return join(getStateDir(workingDirectory, sessionId), getStateFilename(mode));
 }
 
+export function getStateFilePath(fileName: string, workingDirectory?: string, sessionId?: string): string {
+  return join(getStateDir(workingDirectory, sessionId), validateStateFileName(fileName));
+}
+
 export type StateScopeSource = 'explicit' | 'session' | 'root';
 
 export interface ResolvedStateScope {
@@ -229,6 +254,26 @@ export async function getReadScopedStatePaths(
   const dirs = await getReadScopedStateDirs(workingDirectory, explicitSessionId);
   const fileName = getStateFilename(mode);
   return dirs.map((dir) => join(dir, fileName));
+}
+
+export async function getReadScopedStateFilePaths(
+  fileName: string,
+  workingDirectory?: string,
+  explicitSessionId?: string,
+  options: { rootFallback?: boolean } = {},
+): Promise<string[]> {
+  const normalizedFileName = validateStateFileName(fileName);
+  const scope = await resolveStateScope(workingDirectory, explicitSessionId);
+  if (scope.source === 'root') {
+    return [join(scope.stateDir, normalizedFileName)];
+  }
+  if (options.rootFallback === false) {
+    return [join(scope.stateDir, normalizedFileName)];
+  }
+  return [
+    join(scope.stateDir, normalizedFileName),
+    join(getBaseStateDir(workingDirectory), normalizedFileName),
+  ];
 }
 
 export async function getAllSessionScopedStatePaths(

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1575,7 +1575,7 @@ esac
     }
   });
 
-  it("returns Stop continuation output for active deep-interview skill with matching active mode state and without active subagents", async () => {
+  it("does not block Stop solely because deep-interview is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1600,13 +1600,7 @@ esac
         { cwd },
       );
 
-      assert.deepEqual(result.outputJson, {
-        decision: "block",
-        reason:
-          "OMX skill deep-interview is still active (phase: planning); continue until the current deep-interview workflow reaches a terminal state.",
-        stopReason: "skill_deep-interview_planning",
-        systemMessage: "OMX skill deep-interview is still active (phase: planning).",
-      });
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1904,7 +1898,7 @@ esac
     }
   });
 
-  it("suppresses native auto-nudge when only the deep-interview input lock is active", async () => {
+  it("still allows native auto-nudge when deep-interview state is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-deep-interview-lock-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1934,7 +1928,7 @@ esac
           session_id: "sess-stop-auto-lock",
           thread_id: "thread-stop-auto-lock",
           turn_id: "turn-stop-auto-lock-1",
-          last_assistant_message: "Would you like me to continue with the next step?",
+          last_assistant_message: "Keep going and finish the cleanup from here.",
         },
         { cwd },
       );
@@ -1942,10 +1936,10 @@ esac
       assert.equal(result.omxEventName, "stop");
       assert.deepEqual(result.outputJson, {
         decision: "block",
-        reason:
-          "OMX skill deep-interview is still active (phase: planning); continue until the current deep-interview workflow reaches a terminal state.",
-        stopReason: "skill_deep-interview_planning",
-        systemMessage: "OMX skill deep-interview is still active (phase: planning).",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -17,7 +17,7 @@ import {
   writeTeamLeaderAttention,
   writeTeamPhase,
 } from "../team/state.js";
-import { omxNotepadPath, omxProjectMemoryPath, omxStateDir } from "../utils/paths.js";
+import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
 import { getStateFilePath } from "../mcp/state-paths.js";
 import {
   detectKeywords,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -18,6 +18,7 @@ import {
   writeTeamPhase,
 } from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath, omxStateDir } from "../utils/paths.js";
+import { getStateFilePath } from "../mcp/state-paths.js";
 import {
   detectKeywords,
   detectPrimaryKeyword,
@@ -66,7 +67,7 @@ export interface NativeHookDispatchResult {
 
 const TERMINAL_RALPH_PHASES = new Set(["complete", "failed", "cancelled"]);
 const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
-const SKILL_STOP_BLOCKERS = new Set(["ralplan", "deep-interview"]);
+const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);
 const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
 
@@ -675,40 +676,12 @@ function readPayloadTurnId(payload: CodexHookPayload): string {
   return safeString(payload.turn_id ?? payload.turnId).trim();
 }
 
-async function isDeepInterviewSuppressedForStop(
-  cwd: string,
-  sessionId: string,
-  threadId: string,
-): Promise<boolean> {
-  const scopedModeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId);
-  if (scopedModeState?.active === true) return true;
-
-  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
-  const deepInterviewEntry = canonicalState
-    ? listActiveSkills(canonicalState).find((entry) => (
-      entry.skill === "deep-interview"
-      && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
-    ))
-    : null;
-  if (
-    deepInterviewEntry
-    && safeObject(canonicalState?.input_lock).active === true
-  ) {
-    return true;
-  }
-
-  return (await readBlockingSkillForStop(cwd, sessionId, threadId, "deep-interview")) !== null;
-}
-
 async function readStopSessionPinnedState(
   fileName: string,
   cwd: string,
   sessionId: string,
 ): Promise<Record<string, unknown> | null> {
-  const stateDir = omxStateDir(cwd);
-  const statePath = sessionId
-    ? join(stateDir, "sessions", sessionId, fileName)
-    : join(stateDir, fileName);
+  const statePath = getStateFilePath(fileName, cwd, sessionId || undefined);
   return readJsonIfExists(statePath);
 }
 
@@ -807,10 +780,6 @@ function buildRepeatableStopSignature(
   ].join("|");
 }
 
-async function readNativeStopState(stateDir: string): Promise<Record<string, unknown>> {
-  return await readJsonIfExists(join(stateDir, NATIVE_STOP_STATE_FILE)) ?? {};
-}
-
 function readNativeStopSessionKey(payload: CodexHookPayload): string {
   return readPayloadSessionId(payload) || readPayloadThreadId(payload) || "global";
 }
@@ -830,7 +799,8 @@ async function persistNativeStopSignature(
   signature: string,
 ): Promise<void> {
   if (!signature) return;
-  const state = await readNativeStopState(stateDir);
+  const statePath = join(stateDir, NATIVE_STOP_STATE_FILE);
+  const state = await readJsonIfExists(statePath) ?? {};
   const sessions = safeObject(state.sessions);
   const sessionKey = readNativeStopSessionKey(payload);
   sessions[sessionKey] = {
@@ -838,7 +808,8 @@ async function persistNativeStopSignature(
     last_signature: signature,
     updated_at: new Date().toISOString(),
   };
-  await writeFile(join(stateDir, NATIVE_STOP_STATE_FILE), JSON.stringify({
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(statePath, JSON.stringify({
     ...state,
     sessions,
   }, null, 2));
@@ -853,7 +824,7 @@ async function maybeReturnRepeatableStopOutput(
   if (!output) return null;
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
   if (stopHookActive) {
-    const state = await readNativeStopState(stateDir);
+    const state = await readJsonIfExists(join(stateDir, NATIVE_STOP_STATE_FILE)) ?? {};
     const previousSignature = readPreviousNativeStopSignature(state, readNativeStopSessionKey(payload));
     if (!signature || previousSignature === signature) {
       return null;
@@ -1074,15 +1045,13 @@ async function buildStopHookOutput(
       if (!stopHookActive && skillOutput) return skillOutput;
     }
 
-    const deepInterviewActive = await isDeepInterviewSuppressedForStop(cwd, sessionId, threadId);
     const lastAssistantMessage = safeString(
       payload.last_assistant_message ?? payload.lastAssistantMessage,
     );
     const autoNudgeConfig = await loadAutoNudgeConfig();
 
     if (
-      !deepInterviewActive
-      && autoNudgeConfig.enabled
+      autoNudgeConfig.enabled
       && detectStallPattern(lastAssistantMessage, autoNudgeConfig.patterns)
     ) {
       const effectiveResponse = resolveEffectiveAutoNudgeResponse(autoNudgeConfig.response);

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -16,7 +16,6 @@ import {
   resolveAutoNudgeSignature,
 } from './notify-hook/auto-nudge.js';
 import {
-  getScopedStatePath,
   readScopedJsonIfExists,
 } from './notify-hook/state-io.js';
 import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
@@ -1212,7 +1211,6 @@ async function readAutoNudgeState(): Promise<Record<string, unknown> | null> {
 async function runFallbackAutoNudgeTick(): Promise<void> {
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
-  const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', undefined);
   const hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', undefined, null);
 
   lastFallbackAutoNudge = {

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -15,6 +15,10 @@ import {
   normalizeAutoNudgeSignatureText,
   resolveAutoNudgeSignature,
 } from './notify-hook/auto-nudge.js';
+import {
+  getScopedStatePath,
+  readScopedJsonIfExists,
+} from './notify-hook/state-io.js';
 import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
 import {
   checkWorkerPanesAlive,
@@ -787,7 +791,7 @@ async function readRalphProgressGate(
     }
   }
 
-  const hudState = await readJsonObject(join(stateDir, 'hud-state.json'));
+  const hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', undefined, null);
   if (!hudState || typeof hudState !== 'object') {
     return { allow: false, reason: 'progress_missing', progress_at: '', subagent_session_id: subagentSessionId };
   }
@@ -1197,19 +1201,19 @@ async function readJsonObject(path: string): Promise<Record<string, unknown> | n
 }
 
 async function readAutoNudgeCount(): Promise<number> {
-  const parsed = await readJsonObject(join(stateDir, 'auto-nudge-state.json'));
+  const parsed = await readScopedJsonIfExists(stateDir, 'auto-nudge-state.json', undefined, null);
   return Math.max(0, Math.trunc(asNumber(parsed?.nudgeCount as string | number | undefined, 0)));
 }
 
 async function readAutoNudgeState(): Promise<Record<string, unknown> | null> {
-  return readJsonObject(join(stateDir, 'auto-nudge-state.json'));
+  return readScopedJsonIfExists(stateDir, 'auto-nudge-state.json', undefined, null);
 }
 
 async function runFallbackAutoNudgeTick(): Promise<void> {
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
-  const hudStatePath = join(stateDir, 'hud-state.json');
-  const hudState = await readJsonObject(hudStatePath);
+  const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', undefined);
+  const hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', undefined, null);
 
   lastFallbackAutoNudge = {
     ...lastFallbackAutoNudge,
@@ -1678,8 +1682,8 @@ async function runDispatchDrainTick(): Promise<boolean> {
 
 async function shouldSuppressInteractiveFallbackTicks(): Promise<boolean> {
   const [deepInterviewStateActive, deepInterviewInputLockActive] = await Promise.all([
-    isDeepInterviewStateActive(stateDir),
-    isDeepInterviewInputLockActive(stateDir),
+    isDeepInterviewStateActive(stateDir, undefined),
+    isDeepInterviewInputLockActive(stateDir, undefined),
   ]);
   return deepInterviewStateActive || deepInterviewInputLockActive;
 }

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -30,7 +30,6 @@ import {
 } from './notify-hook/payload-parser.js';
 import {
   getScopedStatePath,
-  readJsonIfExists,
   readScopedJsonIfExists,
   getScopedStateDirsForCurrentSession,
   normalizeNotifyState,

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -20,7 +20,7 @@
 
 import { writeFile, appendFile, mkdir, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 
 import { safeString, asNumber } from './notify-hook/utils.js';
 import {
@@ -29,7 +29,9 @@ import {
   normalizeInputMessages,
 } from './notify-hook/payload-parser.js';
 import {
+  getScopedStatePath,
   readJsonIfExists,
+  readScopedJsonIfExists,
   getScopedStateDirsForCurrentSession,
   normalizeNotifyState,
   pruneRecentTurns,
@@ -195,14 +197,17 @@ async function main() {
       const threadId = safeString(payload['thread-id'] || payload.thread_id || '');
       const eventType = safeString(payload.type || 'agent-turn-complete');
       const key = `${threadId || 'no-thread'}|${turnId}|${eventType}`;
-      const dedupeStatePath = join(stateDir, 'notify-hook-state.json');
-      const dedupeState = normalizeNotifyState(await readJsonIfExists(dedupeStatePath, null));
+      const dedupeStatePath = await getScopedStatePath(stateDir, 'notify-hook-state.json', payloadSessionId);
+      const dedupeState = normalizeNotifyState(
+        await readScopedJsonIfExists(stateDir, 'notify-hook-state.json', payloadSessionId, null),
+      );
       dedupeState.recent_turns = pruneRecentTurns(dedupeState.recent_turns, now);
       if (dedupeState.recent_turns[key]) {
         process.exit(0);
       }
       dedupeState.recent_turns[key] = now;
       dedupeState.last_event_at = new Date().toISOString();
+      await mkdir(dirname(dedupeStatePath), { recursive: true }).catch(() => {});
       await writeFile(dedupeStatePath, JSON.stringify(dedupeState, null, 2)).catch(() => {});
     }
   } catch {
@@ -417,18 +422,19 @@ async function main() {
 
   // 4. Write HUD state summary for `omx hud` (lead session only)
   if (!isTeamWorker) {
-    const hudStatePath = join(stateDir, 'hud-state.json');
     try {
-      let hudState = { last_turn_at: '', turn_count: 0 };
-      if (existsSync(hudStatePath)) {
-        hudState = JSON.parse(await readFile(hudStatePath, 'utf-8'));
-      }
+      const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', payloadSessionId);
+      let hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', payloadSessionId, {
+        last_turn_at: '',
+        turn_count: 0,
+      });
       const nowIso = new Date().toISOString();
       hudState.last_turn_at = nowIso;
       (hudState as any).last_progress_at = nowIso;
       hudState.turn_count = (hudState.turn_count || 0) + 1;
       (hudState as any).last_agent_output = (payload['last-assistant-message'] || payload.last_assistant_message || '')
         .slice(0, 100);
+      await mkdir(dirname(hudStatePath), { recursive: true }).catch(() => {});
       await writeFile(hudStatePath, JSON.stringify(hudState, null, 2));
     } catch {
       // Non-critical
@@ -463,7 +469,7 @@ async function main() {
     // Non-fatal: keyword detector module may not be built yet
   }
 
-  const deepInterviewStateActive = await isDeepInterviewStateActive(stateDir);
+  const deepInterviewStateActive = await isDeepInterviewStateActive(stateDir, payloadSessionId);
 
   // 4.55. Notify leader when individual worker transitions to idle (worker session only)
   if (isTeamWorker && parsedTeamWorker && !deepInterviewStateActive) {

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -4,11 +4,18 @@
  * automatically send a continuation prompt so the agent keeps working.
  */
 
-import { readFile, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
 import { asNumber, safeString } from './utils.js';
-import { readJsonIfExists, getScopedStateDirsForCurrentSession, readdir } from './state-io.js';
+import {
+  getScopedStateDirsForCurrentSession,
+  getScopedStatePath,
+  readJsonIfExists,
+  readScopedJsonIfExists,
+  readdir,
+  writeScopedJson,
+} from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
@@ -172,29 +179,30 @@ export function inferSkillPhaseFromText(text, currentPhase = 'planning') {
   return normalizeSkillPhase(currentPhase);
 }
 
-async function loadSkillActiveState(stateDir) {
-  const raw = await readJsonIfExists(join(stateDir, SKILL_ACTIVE_STATE_FILE), null);
+async function loadSkillActiveState(stateDir, sessionId) {
+  const raw = await readScopedJsonIfExists(stateDir, SKILL_ACTIVE_STATE_FILE, sessionId, null);
   return normalizeSkillActiveState(raw);
 }
 
-async function persistSkillActiveState(stateDir, state) {
-  await writeFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), JSON.stringify(state, null, 2)).catch(() => {});
+async function persistSkillActiveState(stateDir, sessionId, state) {
+  await writeScopedJson(stateDir, SKILL_ACTIVE_STATE_FILE, sessionId, state).catch(() => {});
 }
 
 
-export async function isDeepInterviewStateActive(stateDir) {
-  const modeState = await readJsonIfExists(join(stateDir, 'deep-interview-state.json'), null);
+export async function isDeepInterviewStateActive(stateDir, sessionId) {
+  const modeState = await readScopedJsonIfExists(stateDir, 'deep-interview-state.json', sessionId, null);
   return Boolean(modeState && modeState.active === true);
 }
 
-export async function isDeepInterviewInputLockActive(stateDir) {
-  const skillState = await loadSkillActiveState(stateDir);
+export async function isDeepInterviewInputLockActive(stateDir, sessionId) {
+  const skillState = await loadSkillActiveState(stateDir, sessionId);
   return isDeepInterviewAutoApprovalLocked(skillState);
 }
 
 export async function resolveAutoNudgeSignature(stateDir, payload, lastMessage = '') {
   const normalizedMessage = normalizeAutoNudgeSignatureText(lastMessage);
-  const hudState = await readJsonIfExists(join(stateDir, 'hud-state.json'), null);
+  const invocationSessionId = resolveInvocationSessionId(payload);
+  const hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', invocationSessionId, null);
   const hudTurnAt = safeString(hudState?.last_turn_at).trim();
   const hudTurnCount = Number.isFinite(hudState?.turn_count) ? hudState.turn_count : null;
   const hudMessage = normalizeAutoNudgeSignatureText(hudState?.last_agent_output || hudState?.last_agent_message || '');
@@ -481,7 +489,8 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
 
   const lastMessage = safeString(payload['last-assistant-message'] || payload.last_assistant_message || '');
   const latestUserInput = latestUserInputFromPayload(payload);
-  let skillState = await loadSkillActiveState(stateDir);
+  const invocationSessionId = resolveInvocationSessionId(payload);
+  let skillState = await loadSkillActiveState(stateDir, invocationSessionId);
   let releaseReason = null;
 
   try {
@@ -491,11 +500,11 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
       skillState.active = inferredPhase !== 'completing';
       skillState.updated_at = new Date().toISOString();
       releaseReason = inferDeepInterviewReleaseReason({ skillState, latestUserInput, lastMessage });
-      await persistSkillActiveState(stateDir, skillState);
+      await persistSkillActiveState(stateDir, invocationSessionId, skillState);
     }
 
-    const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
-    let nudgeState = await readJsonIfExists(nudgeStatePath, null);
+    const nudgeStatePath = await getScopedStatePath(stateDir, 'auto-nudge-state.json', invocationSessionId);
+    let nudgeState = await readScopedJsonIfExists(stateDir, 'auto-nudge-state.json', invocationSessionId, null);
     if (!nudgeState || typeof nudgeState !== 'object') {
       nudgeState = { nudgeCount: 0, lastNudgeAt: '', lastSignature: '', lastSemanticSignature: '' };
     }
@@ -554,6 +563,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     if (!isFallbackWatcherSource && config.stallMs > 0) {
       nudgeState.pendingSignature = signature;
       nudgeState.pendingSince = new Date().toISOString();
+      await mkdir(dirname(nudgeStatePath), { recursive: true }).catch(() => {});
       await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
       await logTmuxHookEvent(logsDir, {
         timestamp: new Date().toISOString(),
@@ -621,6 +631,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
       nudgeState.lastSemanticSignature = semanticSignature;
       nudgeState.pendingSignature = '';
       nudgeState.pendingSince = '';
+      await mkdir(dirname(nudgeStatePath), { recursive: true }).catch(() => {});
       await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
 
       await logTmuxHookEvent(logsDir, {
@@ -642,7 +653,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
   } finally {
     if (releaseReason && skillState && isDeepInterviewAutoApprovalLocked(skillState)) {
       releaseDeepInterviewInputLock(skillState, releaseReason, new Date().toISOString());
-      await persistSkillActiveState(stateDir, skillState).catch(() => {});
+      await persistSkillActiveState(stateDir, invocationSessionId, skillState).catch(() => {});
     }
   }
 }

--- a/src/scripts/notify-hook/state-io.ts
+++ b/src/scripts/notify-hook/state-io.ts
@@ -2,8 +2,9 @@
  * State file I/O helpers for notify-hook modules.
  */
 
-import { readFile, readdir } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { existsSync } from 'fs';
 import { asNumber, safeString } from './utils.js';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -16,18 +17,97 @@ export function readJsonIfExists(path: string, fallback: any): Promise<any> {
     .catch(() => fallback);
 }
 
-export async function getScopedStateDirsForCurrentSession(baseStateDir: string): Promise<string[]> {
+function isSafeStateFileName(fileName: string): boolean {
+  return fileName.length > 0
+    && !fileName.includes('..')
+    && !fileName.includes('/')
+    && !fileName.includes('\\');
+}
+
+export async function readCurrentSessionId(baseStateDir: string): Promise<string | undefined> {
   const sessionPath = join(baseStateDir, 'session.json');
   try {
     const session = JSON.parse(await readFile(sessionPath, 'utf-8'));
     const sessionId = safeString(session && session.session_id ? session.session_id : '');
-    if (SESSION_ID_PATTERN.test(sessionId)) {
-      return [join(baseStateDir, 'sessions', sessionId)];
-    }
+    return SESSION_ID_PATTERN.test(sessionId) ? sessionId : undefined;
   } catch {
-    // No session file or malformed - fall back to global only
+    return undefined;
   }
-  return [baseStateDir];
+}
+
+export async function resolveScopedStateDir(
+  baseStateDir: string,
+  explicitSessionId?: string,
+): Promise<string> {
+  const normalizedExplicit = safeString(explicitSessionId).trim();
+  if (SESSION_ID_PATTERN.test(normalizedExplicit)) {
+    const explicitDir = join(baseStateDir, 'sessions', normalizedExplicit);
+    const currentSessionId = await readCurrentSessionId(baseStateDir);
+    if (currentSessionId === normalizedExplicit || existsSync(explicitDir)) {
+      return explicitDir;
+    }
+  }
+  const currentSessionId = await readCurrentSessionId(baseStateDir);
+  if (currentSessionId) {
+    return join(baseStateDir, 'sessions', currentSessionId);
+  }
+  return baseStateDir;
+}
+
+export async function getScopedStateDirsForCurrentSession(
+  baseStateDir: string,
+  explicitSessionId?: string,
+  options: { includeRootFallback?: boolean } = {},
+): Promise<string[]> {
+  const scopedDir = await resolveScopedStateDir(baseStateDir, explicitSessionId);
+  if (scopedDir === baseStateDir || options.includeRootFallback !== true) {
+    return [scopedDir];
+  }
+  return [scopedDir, baseStateDir];
+}
+
+export async function getScopedStatePath(
+  baseStateDir: string,
+  fileName: string,
+  explicitSessionId?: string,
+): Promise<string> {
+  if (!isSafeStateFileName(fileName)) {
+    throw new Error(`unsafe state file name: ${fileName}`);
+  }
+  return join(await resolveScopedStateDir(baseStateDir, explicitSessionId), fileName);
+}
+
+export async function readScopedJsonIfExists(
+  baseStateDir: string,
+  fileName: string,
+  explicitSessionId: string | undefined,
+  fallback: any,
+  options: { includeRootFallback?: boolean } = {},
+): Promise<any> {
+  if (!isSafeStateFileName(fileName)) {
+    throw new Error(`unsafe state file name: ${fileName}`);
+  }
+  const candidateDirs = await getScopedStateDirsForCurrentSession(
+    baseStateDir,
+    explicitSessionId,
+    options,
+  );
+  for (const dir of candidateDirs) {
+    const value = await readJsonIfExists(join(dir, fileName), fallback);
+    if (value !== fallback) return value;
+  }
+  return fallback;
+}
+
+export async function writeScopedJson(
+  baseStateDir: string,
+  fileName: string,
+  explicitSessionId: string | undefined,
+  value: unknown,
+): Promise<void> {
+  const targetPath = await getScopedStatePath(baseStateDir, fileName, explicitSessionId);
+  await mkdir(dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, JSON.stringify(value, null, 2));
 }
 
 export function normalizeTmuxState(raw: any): any {


### PR DESCRIPTION
## Summary

Hook firing, native Stop behavior, and HUD rendering were still mixing canonical session-aware state lookup with direct root-state access. This change makes session-scoped runtime state authoritative across those surfaces, removes deep-interview Stop blocking on the native hook surface, and restores native auto-nudge firing when deep-interview is active.

## Changes

- add shared helpers for session-sensitive runtime file paths in `src/mcp/state-paths.ts`
- centralize notify-hook scoped runtime reads/writes in `src/scripts/notify-hook/state-io.ts`
- move notify-hook HUD and auto-nudge state handling onto session-scoped paths
- write HUD reset state into the active session scope during session start
- make HUD read `hud-state.json` from the active session scope
- remove deep-interview Stop-only blocking from `src/scripts/codex-native-hook.ts`
- keep native auto-nudge firing for real stall prompts even while deep-interview is active
- add/update regression coverage for state paths, HUD state visibility, notify-hook session scope, and native Stop behavior

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx biome lint src/cli/index.ts src/hooks/__tests__/notify-hook-auto-nudge.test.ts src/hooks/__tests__/session.test.ts src/hooks/session.ts src/hud/__tests__/state.test.ts src/hud/state.ts src/mcp/__tests__/state-paths.test.ts src/mcp/state-paths.ts src/scripts/__tests__/codex-native-hook.test.ts src/scripts/codex-native-hook.ts src/scripts/notify-fallback-watcher.ts src/scripts/notify-hook.ts src/scripts/notify-hook/auto-nudge.ts src/scripts/notify-hook/state-io.ts`
- [x] `node --test dist/mcp/__tests__/state-paths.test.js dist/hud/__tests__/state.test.js dist/hooks/__tests__/session.test.js dist/hooks/__tests__/notify-hook-session-scope.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/scripts/__tests__/codex-native-hook.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

- Follow-up tightening issue: #1445
