### PR TITLE
Tighten session.json ownership and fallback semantics

### DIFF
--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -9,6 +9,7 @@ import {
   writeSessionStart,
   writeSessionEnd,
   readSessionState,
+  readUsableSessionState,
   isSessionStale,
   type SessionState,
 } from '../session.js';
@@ -133,6 +134,47 @@ describe('session lifecycle manager', () => {
       await resetSessionMetrics(cwd);
       await writeFile(statePath, '{ not-json', 'utf-8');
       const state = await readSessionState(cwd);
+      assert.equal(state, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores session.json when its recorded cwd points at another worktree', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-mismatched-cwd-'));
+    try {
+      const statePath = join(cwd, '.omx', 'state', 'session.json');
+      await resetSessionMetrics(cwd);
+      await writeFile(statePath, JSON.stringify({
+        session_id: 'sess-other-worktree',
+        cwd: join(cwd, '..', 'different-worktree'),
+      }), 'utf-8');
+
+      const state = await readUsableSessionState(cwd);
+      assert.equal(state, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores session.json when its PID identity is stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-stale-pointer-'));
+    try {
+      const statePath = join(cwd, '.omx', 'state', 'session.json');
+      await resetSessionMetrics(cwd);
+      await writeFile(statePath, JSON.stringify({
+        session_id: 'sess-stale-pointer',
+        cwd,
+        pid: 4242,
+        pid_start_ticks: 11,
+        pid_cmdline: 'node omx',
+      }), 'utf-8');
+
+      const state = await readUsableSessionState(cwd, {
+        platform: 'linux',
+        isPidAlive: () => true,
+        readLinuxIdentity: () => ({ startTicks: 22, cmdline: 'node omx' }),
+      });
       assert.equal(state, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -6,7 +6,7 @@
  */
 
 import { readFile, writeFile, mkdir, unlink, appendFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { dirname, join, resolve as resolvePath } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { omxStateDir, omxLogsDir } from '../utils/paths.js';
 import { getStateFilePath } from '../mcp/state-paths.js';
@@ -23,6 +23,7 @@ export interface SessionState {
 
 const SESSION_FILE = 'session.json';
 const HISTORY_FILE = 'session-history.jsonl';
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 // No age-based threshold: staleness is determined by PID liveness/identity.
 // Long-running sessions (>2h) are legitimate and should not be reaped.
 
@@ -79,6 +80,42 @@ export async function readSessionState(cwd: string): Promise<SessionState | null
   } catch {
     return null;
   }
+}
+
+export function isSessionStateAuthoritativeForCwd(state: SessionState, cwd: string): boolean {
+  if (!SESSION_ID_PATTERN.test(state.session_id)) return false;
+
+  if (typeof state.cwd === 'string' && state.cwd.trim() !== '') {
+    return resolvePath(state.cwd) === resolvePath(cwd);
+  }
+
+  return true;
+}
+
+export function isSessionStateUsable(
+  state: SessionState,
+  cwd: string,
+  options: SessionStaleCheckOptions = {},
+): boolean {
+  if (!isSessionStateAuthoritativeForCwd(state, cwd)) return false;
+
+  const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
+  const hasLinuxIdentityMetadata = typeof state.pid_start_ticks === 'number'
+    || typeof state.pid_cmdline === 'string';
+  if (hasPidMetadata || hasLinuxIdentityMetadata) {
+    return !isSessionStale(state, options);
+  }
+
+  return true;
+}
+
+export async function readUsableSessionState(
+  cwd: string,
+  options: SessionStaleCheckOptions = {},
+): Promise<SessionState | null> {
+  const state = await readSessionState(cwd);
+  if (!state) return null;
+  return isSessionStateUsable(state, cwd, options) ? state : null;
 }
 
 interface LinuxProcessIdentity {

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -220,12 +220,28 @@ describe('readRalphState scope precedence', () => {
     });
   });
 
-  it('falls back to root Ralph state when current session has no Ralph state file', async () => {
+  it('does not fall back to root Ralph state when current session has no Ralph state file', async () => {
     await withTempRepo('omx-hud-ralph-fallback-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');
       const sessionId = 'sess-fallback';
       await mkdir(join(rootStateDir, 'sessions', sessionId), { recursive: true });
       await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(rootStateDir, 'ralph-state.json'), JSON.stringify({ active: true, iteration: 4, max_iterations: 10 }));
+
+      const state = await readRalphState(cwd);
+      assert.equal(state, null);
+    });
+  });
+
+  it('ignores session.json authority when it points at another worktree cwd', async () => {
+    await withTempRepo('omx-hud-ralph-cwd-mismatch-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-mismatch';
+      await mkdir(join(rootStateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: join(cwd, '..', 'other-worktree'),
+      }));
       await writeFile(join(rootStateDir, 'ralph-state.json'), JSON.stringify({ active: true, iteration: 4, max_iterations: 10 }));
 
       const state = await readRalphState(cwd);

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -14,6 +14,7 @@ import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
 import { getReadScopedStateFilePaths, getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { readUsableSessionState } from '../hooks/session.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import type {
   RalphStateForHud,
@@ -41,15 +42,6 @@ async function readJsonFile<T>(path: string): Promise<T | null> {
   } catch {
     return null;
   }
-}
-
-async function readScopedModeState<T>(cwd: string, mode: string): Promise<T | null> {
-  const candidates = await getReadScopedStatePaths(mode, cwd);
-  for (const candidate of candidates) {
-    const state = await readJsonFile<T>(candidate);
-    if (state) return state;
-  }
-  return null;
 }
 
 async function readSessionAwareModeState<T>(cwd: string, mode: string): Promise<T | null> {
@@ -113,22 +105,22 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
 }
 
 export async function readRalphState(cwd: string): Promise<RalphStateForHud | null> {
-  const state = await readScopedModeState<RalphStateForHud>(cwd, 'ralph');
+  const state = await readSessionAwareModeState<RalphStateForHud>(cwd, 'ralph');
   return state?.active ? state : null;
 }
 
 export async function readUltraworkState(cwd: string): Promise<UltraworkStateForHud | null> {
-  const state = await readScopedModeState<UltraworkStateForHud>(cwd, 'ultrawork');
+  const state = await readSessionAwareModeState<UltraworkStateForHud>(cwd, 'ultrawork');
   return state?.active ? state : null;
 }
 
 export async function readAutopilotState(cwd: string): Promise<AutopilotStateForHud | null> {
-  const state = await readScopedModeState<AutopilotStateForHud>(cwd, 'autopilot');
+  const state = await readSessionAwareModeState<AutopilotStateForHud>(cwd, 'autopilot');
   return state?.active ? state : null;
 }
 
 export async function readRalplanState(cwd: string): Promise<RalplanStateForHud | null> {
-  const state = await readScopedModeState<RalplanStateForHud>(cwd, 'ralplan');
+  const state = await readSessionAwareModeState<RalplanStateForHud>(cwd, 'ralplan');
   return state?.active ? state : null;
 }
 
@@ -139,7 +131,7 @@ interface DeepInterviewRawState extends DeepInterviewStateForHud {
 }
 
 export async function readDeepInterviewState(cwd: string): Promise<DeepInterviewStateForHud | null> {
-  const state = await readScopedModeState<DeepInterviewRawState>(cwd, 'deep-interview');
+  const state = await readSessionAwareModeState<DeepInterviewRawState>(cwd, 'deep-interview');
   if (!state?.active) return null;
 
   return {
@@ -149,17 +141,17 @@ export async function readDeepInterviewState(cwd: string): Promise<DeepInterview
 }
 
 export async function readAutoresearchState(cwd: string): Promise<AutoresearchStateForHud | null> {
-  const state = await readScopedModeState<AutoresearchStateForHud>(cwd, 'autoresearch');
+  const state = await readSessionAwareModeState<AutoresearchStateForHud>(cwd, 'autoresearch');
   return state?.active ? state : null;
 }
 
 export async function readUltraqaState(cwd: string): Promise<UltraqaStateForHud | null> {
-  const state = await readScopedModeState<UltraqaStateForHud>(cwd, 'ultraqa');
+  const state = await readSessionAwareModeState<UltraqaStateForHud>(cwd, 'ultraqa');
   return state?.active ? state : null;
 }
 
 export async function readTeamState(cwd: string): Promise<TeamStateForHud | null> {
-  const state = await readScopedModeState<TeamStateForHud>(cwd, 'team');
+  const state = await readSessionAwareModeState<TeamStateForHud>(cwd, 'team');
   return state?.active ? state : null;
 }
 
@@ -175,7 +167,7 @@ export async function readHudNotifyState(cwd: string): Promise<HudNotifyState | 
 }
 
 export async function readSessionState(cwd: string): Promise<SessionStateForHud | null> {
-  const state = await readJsonFile<SessionStateForHud>(join(omxStateDir(cwd), 'session.json'));
+  const state = await readUsableSessionState(cwd);
   return state?.session_id ? state : null;
 }
 

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,6 +1,7 @@
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
 import { existsSync } from 'fs';
-import { readdir, readFile } from 'fs/promises';
+import { readdir } from 'fs/promises';
+import { readUsableSessionState } from '../hooks/session.js';
 
 export const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 export const STATE_MODE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -189,14 +190,8 @@ export interface ResolvedStateScope {
 }
 
 export async function readCurrentSessionId(workingDirectory?: string): Promise<string | undefined> {
-  const sessionPath = join(getBaseStateDir(workingDirectory), 'session.json');
-  if (!existsSync(sessionPath)) return undefined;
-  try {
-    const parsed = JSON.parse(await readFile(sessionPath, 'utf-8')) as { session_id?: unknown };
-    return validateSessionId(parsed.session_id);
-  } catch {
-    return undefined;
-  }
+  const cwd = resolveWorkingDirectoryForState(workingDirectory);
+  return (await readUsableSessionState(cwd))?.session_id;
 }
 
 export async function resolveStateScope(

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1735,6 +1735,70 @@ esac
     }
   });
 
+  it("does not block Stop from root Ralph fallback when the current session has no scoped Ralph state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-ralph-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current", cwd });
+      await writeJson(join(stateDir, "ralph-state.json"), {
+        active: true,
+        current_phase: "executing",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores mismatched session.json cwd and still blocks from active root Ralph fallback", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-cwd-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: "sess-elsewhere",
+        cwd: join(cwd, "..", "different-worktree"),
+      });
+      await writeJson(join(stateDir, "ralph-state.json"), {
+        active: true,
+        current_phase: "executing",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_executing",
+        systemMessage:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not re-block Ralph when Stop already continued once", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-once-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9,6 +9,7 @@ import {
 } from "../state/skill-active.js";
 import { readSubagentSessionSummary } from "../subagents/tracker.js";
 import { resolveCanonicalTeamStateRoot } from "../team/state-root.js";
+import { readUsableSessionState } from "../hooks/session.js";
 import {
   appendTeamEvent,
   readTeamLeaderAttention,
@@ -181,7 +182,7 @@ async function readActiveRalphState(
   stateDir: string,
   preferredSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
-  const sessionInfo = await readJsonIfExists(join(stateDir, "session.json"));
+  const sessionInfo = await readUsableSessionState(resolve(stateDir, "..", ".."));
   const currentOmxSessionId = safeString(sessionInfo?.session_id).trim();
   const sessionCandidates = [...new Set([
     safeString(preferredSessionId).trim(),
@@ -202,12 +203,12 @@ async function readActiveRalphState(
     }
   }
 
+  if (currentOmxSessionId) return null;
+
   const direct = await readJsonIfExists(join(stateDir, "ralph-state.json"));
   if (direct?.active === true && !TERMINAL_RALPH_PHASES.has(safeString(direct.current_phase).trim().toLowerCase())) {
     return direct;
   }
-
-  if (sessionCandidates.length > 0) return null;
 
   const sessionsRoot = join(stateDir, "sessions");
   if (!existsSync(sessionsRoot)) return null;

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -27,7 +27,7 @@ import {
 } from './notify-hook/team-leader-nudge.js';
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 import { isTerminalPhase } from './notify-hook/utils.js';
-import { isSessionStale, readSessionState } from '../hooks/session.js';
+import { isSessionStale, isSessionStateAuthoritativeForCwd, readSessionState } from '../hooks/session.js';
 import {
   DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS,
   readSubagentSessionSummary,
@@ -511,8 +511,10 @@ async function resolveActiveModeState(mode: string): Promise<ActiveModeResult> {
   let currentSessionIsLive = false;
   const session = await readSessionState(cwd);
   if (session?.session_id) {
-    currentSessionId = safeString(session.session_id).trim();
-    currentSessionIsLive = !isSessionStale(session);
+    if (isSessionStateAuthoritativeForCwd(session, cwd)) {
+      currentSessionId = safeString(session.session_id).trim();
+      currentSessionIsLive = !isSessionStale(session);
+    }
     if (currentSessionId && currentSessionIsLive) {
       candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
     }
@@ -566,19 +568,22 @@ async function resolveActiveRalphState(): Promise<ActiveModeResult> {
 async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
   const candidateDirs: string[] = [];
   let currentSessionId = '';
-  const sessionPath = join(stateDir, 'session.json');
-  try {
-    const session = JSON.parse(await readFile(sessionPath, 'utf-8')) as Record<string, unknown>;
-    currentSessionId = safeString(session?.session_id).trim();
-    if (currentSessionId) {
+  let currentSessionIsLive = false;
+  const session = await readSessionState(cwd);
+  if (session?.session_id) {
+    currentSessionId = safeString(session.session_id).trim();
+    currentSessionIsLive = !isSessionStale(session);
+    if (currentSessionId && currentSessionIsLive) {
       candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
     }
-  } catch {
-    // No active session file; fall back to root state only.
   }
   if (!candidateDirs.includes(stateDir)) candidateDirs.push(stateDir);
 
   for (const dir of candidateDirs) {
+    if (dir === stateDir && currentSessionId) {
+      continue;
+    }
+
     const path = join(dir, 'team-state.json');
     if (!existsSync(path)) continue;
     const parsed = await readFile(path, 'utf-8')
@@ -659,6 +664,17 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
       },
       team_name: team.teamName,
       pane_count: paneStatus.paneCount,
+    };
+  }
+
+  if (currentSessionId) {
+    return {
+      active: false,
+      reason: currentSessionIsLive ? 'blocked_by_current_session' : 'stale_current_session',
+      path: '',
+      state: null,
+      team_name: '',
+      pane_count: 0,
     };
   }
 

--- a/src/scripts/notify-hook/ralph-session-resume.ts
+++ b/src/scripts/notify-hook/ralph-session-resume.ts
@@ -1,7 +1,8 @@
 import { existsSync } from 'fs';
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { captureTmuxPaneFromEnv } from '../../state/mode-state-context.js';
+import { readUsableSessionState } from '../../hooks/session.js';
 import { resolveCodexPane } from '../tmux-hook-engine.js';
 import { safeString } from './utils.js';
 
@@ -128,7 +129,7 @@ function isActiveRalphCandidate(state: Record<string, unknown> | null): state is
 }
 
 async function readCurrentOmxSessionId(stateDir: string): Promise<string> {
-  const session = await readJson(join(stateDir, 'session.json'));
+  const session = await readUsableSessionState(resolve(stateDir, '..', '..'));
   const sessionId = safeString(session?.session_id).trim();
   return SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
 }

--- a/src/scripts/notify-hook/state-io.ts
+++ b/src/scripts/notify-hook/state-io.ts
@@ -3,8 +3,9 @@
  */
 
 import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { existsSync } from 'fs';
+import { readUsableSessionState } from '../../hooks/session.js';
 import { asNumber, safeString } from './utils.js';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -25,14 +26,10 @@ function isSafeStateFileName(fileName: string): boolean {
 }
 
 export async function readCurrentSessionId(baseStateDir: string): Promise<string | undefined> {
-  const sessionPath = join(baseStateDir, 'session.json');
-  try {
-    const session = JSON.parse(await readFile(sessionPath, 'utf-8'));
-    const sessionId = safeString(session && session.session_id ? session.session_id : '');
-    return SESSION_ID_PATTERN.test(sessionId) ? sessionId : undefined;
-  } catch {
-    return undefined;
-  }
+  const cwd = resolve(baseStateDir, '..', '..');
+  const session = await readUsableSessionState(cwd);
+  const sessionId = safeString(session?.session_id);
+  return SESSION_ID_PATTERN.test(sessionId) ? sessionId : undefined;
 }
 
 export async function resolveScopedStateDir(

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -5,7 +5,8 @@
 
 import { readFile, writeFile, mkdir, appendFile, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
+import { readUsableSessionState } from '../../hooks/session.js';
 import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-io.js';
 import { runProcess } from './process-runner.js';
@@ -249,16 +250,7 @@ async function resolveCurrentSessionId(stateDir) {
     || '',
   ).trim();
   if (fromEnv) return fromEnv;
-
-  const sessionPath = join(stateDir, 'session.json');
-  try {
-    if (!existsSync(sessionPath)) return '';
-    const parsed = JSON.parse(await readFile(sessionPath, 'utf-8'));
-    const sessionId = safeString(parsed && parsed.session_id ? parsed.session_id : '').trim();
-    return sessionId;
-  } catch {
-    return '';
-  }
+  return safeString((await readUsableSessionState(resolve(stateDir, '..', '..')))?.session_id).trim();
 }
 
 async function readWorkerStatusSnapshot(stateDir, teamName, workerName) {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -2,6 +2,7 @@ import { appendFile, readFile, writeFile, mkdir, rm, rename, readdir } from 'fs/
 import { join, dirname, resolve, sep } from 'path';
 import { existsSync } from 'fs';
 import { randomUUID } from 'crypto';
+import { readUsableSessionState } from '../hooks/session.js';
 import { omxStateDir } from '../utils/paths.js';
 import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
@@ -531,17 +532,7 @@ function resolvePermissionsSnapshot(env: NodeJS.ProcessEnv): PermissionsSnapshot
 async function resolveLeaderSessionId(cwd: string, env: NodeJS.ProcessEnv): Promise<string> {
   const fromEnv = readEnvValue(env, ['OMX_SESSION_ID', 'CODEX_SESSION_ID', 'SESSION_ID']);
   if (fromEnv) return fromEnv;
-
-  const sessionPath = join(omxStateDir(cwd), 'session.json');
-  try {
-    if (!existsSync(sessionPath)) return '';
-    const raw = await readFile(sessionPath, 'utf8');
-    const parsed = JSON.parse(raw) as { session_id?: unknown };
-    if (typeof parsed.session_id === 'string' && parsed.session_id.trim() !== '') return parsed.session_id.trim();
-  } catch {
-    // best effort
-  }
-  return '';
+  return (await readUsableSessionState(cwd))?.session_id ?? '';
 }
 
 function normalizeTask(task: TeamTask): TeamTaskV2 {


### PR DESCRIPTION
## Summary\n- validate root `.omx/state/session.json` against current worktree ownership and live session identity before treating it as authoritative\n- suppress root active-state fallback for session-aware readers once a trustworthy current session exists\n- add regressions for stale pointer, cwd mismatch, and root fallback suppression\n\nCloses #1445\n\n## Verification\n- npm run build\n- node --test dist/hooks/__tests__/session.test.js dist/hud/__tests__/state.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js\n- npm test\n- npm run lint\n- npx tsc --noEmit --pretty false --project tsconfig.json\n