### PR TITLE
Keep HUD state anchored to one OMX session scope

### DIFF
--- a/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
+++ b/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveManagedSessionContext } from '../../scripts/notify-hook/managed-tmux.js';
+import { writeSessionStart } from '../session.js';
 
 describe('notify-hook managed tmux windows fallback', () => {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
@@ -43,6 +44,33 @@ describe('notify-hook managed tmux windows fallback', () => {
       const result = await resolveManagedSessionContext(cwd, { session_id: sessionId }, { allowTeamWorker: false });
       assert.equal(result.managed, false);
       assert.equal(result.reason, 'stale_session');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts native payload session ids when session state stores a separate native_session_id', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-native-session-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeSessionStart(cwd, 'omx-canonical-session');
+      const current = JSON.parse(await readFile(join(stateDir, 'session.json'), 'utf-8'));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        ...current,
+        native_session_id: 'codex-native-session',
+      }, null, 2));
+
+      delete process.env.TMUX;
+      delete process.env.TMUX_PANE;
+      process.env.OMX_TEAM_WORKER = '';
+
+      const result = await resolveManagedSessionContext(cwd, { session_id: 'codex-native-session' }, { allowTeamWorker: false });
+      assert.equal(result.managed, true);
+      assert.equal(result.invocationSessionId, 'codex-native-session');
+      assert.equal(result.canonicalSessionId, 'omx-canonical-session');
+      assert.equal(result.nativeSessionId, 'codex-native-session');
+      assert.match(result.expectedTmuxSessionName, /omx-canonical-session|canonical-session/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/notify-hook-session-scope.test.ts
+++ b/src/hooks/__tests__/notify-hook-session-scope.test.ts
@@ -191,6 +191,41 @@ describe('notify-hook session-scoped iteration updates', () => {
     }
   });
 
+  it('prefers the canonical OMX session scope over a different native payload session id for notify sidefiles', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-canonical-session-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const canonicalSessionId = 'omx-canonical-session';
+      const nativeSessionId = 'codex-native-session';
+      const canonicalDir = join(stateDir, 'sessions', canonicalSessionId);
+      await mkdir(canonicalDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: canonicalSessionId,
+        native_session_id: nativeSessionId,
+        started_at: new Date().toISOString(),
+        cwd: wd,
+      }));
+
+      const result = runNotifyHook({
+        cwd: wd,
+        session_id: nativeSessionId,
+        type: 'agent-turn-complete',
+        thread_id: 'th-canonical',
+        turn_id: 'tu-canonical',
+        input_messages: [],
+        last_assistant_message: 'ok',
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      assert.equal(existsSync(join(canonicalDir, 'hud-state.json')), true);
+      assert.equal(existsSync(join(canonicalDir, 'notify-hook-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'sessions', nativeSessionId, 'hud-state.json')), false);
+      assert.equal(existsSync(join(stateDir, 'sessions', nativeSessionId, 'notify-hook-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('persists visual-verdict feedback from runtime assistant output', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-notify-visual-'));
     try {

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   resetSessionMetrics,
+  reconcileNativeSessionStart,
   writeSessionStart,
   writeSessionEnd,
   readSessionState,
@@ -16,6 +17,7 @@ import {
 
 interface SessionHistoryEntry {
   session_id: string;
+  native_session_id?: string;
   started_at: string;
   ended_at: string;
   cwd: string;
@@ -122,6 +124,58 @@ describe('session lifecycle manager', () => {
       const dailyLog = await readFile(dailyLogPath, 'utf-8');
       assert.match(dailyLog, /"event":"session_start"/);
       assert.match(dailyLog, /"event":"session_end"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves canonical session id while reconciling native SessionStart metadata', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-reconcile-'));
+    try {
+      await writeSessionStart(cwd, 'omx-launch-1');
+
+      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-1', {
+        pid: 54321,
+        platform: 'win32',
+      });
+
+      assert.equal(reconciled.session_id, 'omx-launch-1');
+      assert.equal(reconciled.native_session_id, 'codex-native-1');
+      assert.equal(reconciled.pid, 54321);
+      assert.equal(reconciled.platform, 'win32');
+
+      const persisted = await readSessionState(cwd);
+      assert.equal(persisted?.session_id, 'omx-launch-1');
+      assert.equal(persisted?.native_session_id, 'codex-native-1');
+      assert.equal(persisted?.pid, 54321);
+
+      const dailyLogPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
+      const dailyLog = await readFile(dailyLogPath, 'utf-8');
+      assert.match(dailyLog, /"event":"session_start_reconciled"/);
+      assert.match(dailyLog, /"native_session_id":"codex-native-1"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to a fresh canonical session when reconciling without authoritative launch state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-fallback-'));
+    try {
+      const statePath = join(cwd, '.omx', 'state', 'session.json');
+      await resetSessionMetrics(cwd);
+      await writeFile(statePath, JSON.stringify({
+        session_id: 'sess-other-worktree',
+        cwd: join(cwd, '..', 'different-worktree'),
+      }), 'utf-8');
+
+      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-fallback-1', {
+        pid: 67890,
+        platform: 'win32',
+      });
+
+      assert.equal(reconciled.session_id, 'codex-fallback-1');
+      assert.equal(reconciled.native_session_id, 'codex-fallback-1');
+      assert.equal(reconciled.pid, 67890);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/extensibility/__tests__/runtime.test.ts
+++ b/src/hooks/extensibility/__tests__/runtime.test.ts
@@ -169,4 +169,37 @@ describe('dispatchHookEventRuntime', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('routes native stop leader attention by canonical OMX session id while preserving native metadata in context', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-stop-team-native-meta-'));
+    try {
+      await initTeamState('stop-owned-team-meta', 'stop test', 'executor', 1, cwd);
+      const manifest = await readTeamManifestV2('stop-owned-team-meta', cwd);
+      assert.ok(manifest);
+      await writeTeamManifestV2({
+        ...manifest!,
+        leader: {
+          ...manifest!.leader,
+          session_id: 'omx-canonical-session',
+        },
+      }, cwd);
+
+      const event = buildHookEvent('stop', {
+        source: 'native',
+        session_id: 'omx-canonical-session',
+        context: {
+          native_session_id: 'codex-native-session',
+        },
+      });
+      const result = await dispatchHookEventRuntime({ cwd, event });
+      const attention = await readTeamLeaderAttention('stop-owned-team-meta', cwd);
+
+      assert.equal(result.dispatched, true);
+      assert.equal(attention?.source, 'native_stop');
+      assert.equal(attention?.leader_session_id, 'omx-canonical-session');
+      assert.equal(attention?.leader_session_active, false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/hooks/extensibility/types.ts
+++ b/src/hooks/extensibility/types.ts
@@ -78,6 +78,7 @@ export type HookPluginSendKeysResult = HookPluginTmuxSendKeysResult;
 
 export interface HookPluginOmxSessionState {
   session_id: string;
+  native_session_id?: string;
   started_at?: string;
   cwd?: string;
   pid?: number;

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -13,6 +13,7 @@ import { getStateFilePath } from '../mcp/state-paths.js';
 
 export interface SessionState {
   session_id: string;
+  native_session_id?: string;
   started_at: string;
   cwd: string;
   pid: number;
@@ -132,6 +133,7 @@ interface SessionStaleCheckOptions {
 interface SessionStartOptions {
   pid?: number;
   platform?: NodeJS.Platform;
+  nativeSessionId?: string;
 }
 
 function defaultIsPidAlive(pid: number): boolean {
@@ -185,6 +187,35 @@ function readLinuxProcessIdentity(pid: number): LinuxProcessIdentity | null {
   }
 }
 
+function createSessionState(
+  cwd: string,
+  sessionId: string,
+  pid: number,
+  platform: NodeJS.Platform,
+  linuxIdentity: LinuxProcessIdentity | null,
+  options: {
+    nowIso?: string;
+    nativeSessionId?: string;
+    startedAt?: string;
+  } = {},
+): SessionState {
+  const nowIso = options.nowIso ?? new Date().toISOString();
+  const nativeSessionId = typeof options.nativeSessionId === 'string' && options.nativeSessionId.trim()
+    ? options.nativeSessionId.trim()
+    : undefined;
+
+  return {
+    session_id: sessionId,
+    ...(nativeSessionId ? { native_session_id: nativeSessionId } : {}),
+    started_at: options.startedAt ?? nowIso,
+    cwd,
+    pid,
+    platform,
+    pid_start_ticks: linuxIdentity?.startTicks,
+    pid_cmdline: linuxIdentity?.cmdline ?? undefined,
+  };
+}
+
 /**
  * Check if a session is stale.
  * - If the owning PID is dead, it is stale.
@@ -226,7 +257,7 @@ export async function writeSessionStart(
   cwd: string,
   sessionId: string,
   options: SessionStartOptions = {},
-): Promise<void> {
+): Promise<SessionState> {
   const stateDir = omxStateDir(cwd);
   await mkdir(stateDir, { recursive: true });
   const pid = Number.isInteger(options.pid) && options.pid && options.pid > 0
@@ -236,24 +267,65 @@ export async function writeSessionStart(
   const linuxIdentity = platform === 'linux'
     ? readLinuxProcessIdentity(pid)
     : null;
-
-  const state: SessionState = {
-    session_id: sessionId,
-    started_at: new Date().toISOString(),
-    cwd,
-    pid,
-    platform,
-    pid_start_ticks: linuxIdentity?.startTicks,
-    pid_cmdline: linuxIdentity?.cmdline ?? undefined,
-  };
+  const state = createSessionState(cwd, sessionId, pid, platform, linuxIdentity, {
+    nativeSessionId: options.nativeSessionId,
+  });
 
   await writeFile(sessionPath(cwd), JSON.stringify(state, null, 2));
   await appendToLog(cwd, {
     event: 'session_start',
     session_id: sessionId,
+    ...(state.native_session_id ? { native_session_id: state.native_session_id } : {}),
     pid,
     timestamp: state.started_at,
   });
+  return state;
+}
+
+/**
+ * Reconcile a native/Codex SessionStart with the canonical OMX launch session.
+ * If an authoritative current session already exists for this cwd/run, preserve
+ * its OMX scope id and refresh PID/native metadata. Otherwise establish a fresh
+ * canonical session using the native session id.
+ */
+export async function reconcileNativeSessionStart(
+  cwd: string,
+  nativeSessionId: string,
+  options: SessionStartOptions = {},
+): Promise<SessionState> {
+  const existing = await readUsableSessionState(cwd, {
+    ...(options.platform ? { platform: options.platform } : {}),
+  });
+  if (!existing) {
+    return await writeSessionStart(cwd, nativeSessionId, {
+      ...options,
+      nativeSessionId,
+    });
+  }
+
+  const pid = Number.isInteger(options.pid) && options.pid && options.pid > 0
+    ? options.pid
+    : process.pid;
+  const platform = options.platform ?? process.platform;
+  const linuxIdentity = platform === 'linux'
+    ? readLinuxProcessIdentity(pid)
+    : null;
+  const nowIso = new Date().toISOString();
+  const state = createSessionState(cwd, existing.session_id, pid, platform, linuxIdentity, {
+    nowIso,
+    nativeSessionId,
+    startedAt: existing.started_at,
+  });
+
+  await writeFile(sessionPath(cwd), JSON.stringify(state, null, 2));
+  await appendToLog(cwd, {
+    event: 'session_start_reconciled',
+    session_id: state.session_id,
+    native_session_id: nativeSessionId,
+    pid,
+    timestamp: nowIso,
+  });
+  return state;
 }
 
 /**
@@ -268,7 +340,8 @@ export async function writeSessionEnd(cwd: string, sessionId: string): Promise<v
   await mkdir(logsDir, { recursive: true });
 
   const historyEntry = {
-    session_id: sessionId,
+    session_id: state?.session_id || sessionId,
+    ...(state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
     started_at: state?.started_at || 'unknown',
     ended_at: endTime,
     cwd,
@@ -284,7 +357,8 @@ export async function writeSessionEnd(cwd: string, sessionId: string): Promise<v
 
   await appendToLog(cwd, {
     event: 'session_end',
-    session_id: sessionId,
+    session_id: state?.session_id || sessionId,
+    ...(state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
     timestamp: endTime,
   });
 }

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -352,6 +352,27 @@ describe('additional HUD mode state readers', () => {
       assert.deepEqual(state, { last_turn_at: 'session', turn_count: 2 });
     });
   });
+
+  it('keeps hud notify pinned to the canonical OMX session when session metadata also carries a native session id', async () => {
+    await withTempRepo('omx-hud-notify-native-meta-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const canonicalSessionId = 'omx-canonical-session';
+      const nativeSessionId = 'codex-native-session';
+      const canonicalDir = join(rootStateDir, 'sessions', canonicalSessionId);
+      const nativeDir = join(rootStateDir, 'sessions', nativeSessionId);
+      await mkdir(canonicalDir, { recursive: true });
+      await mkdir(nativeDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({
+        session_id: canonicalSessionId,
+        native_session_id: nativeSessionId,
+      }));
+      await writeFile(join(canonicalDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'canonical', turn_count: 3 }));
+      await writeFile(join(nativeDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'native', turn_count: 99 }));
+
+      const state = await readHudNotifyState(cwd);
+      assert.deepEqual(state, { last_turn_at: 'canonical', turn_count: 3 });
+    });
+  });
 });
 
 describe('readAllState canonical skill precedence', () => {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -16,6 +16,7 @@ import {
   mapCodexHookEventToOmxEvent,
   resolveSessionOwnerPidFromAncestry,
 } from "../codex-native-hook.js";
+import { writeSessionStart } from "../../hooks/session.js";
 
 async function writeJson(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true }).catch(() => {});
@@ -125,9 +126,64 @@ describe("codex native hook dispatch", () => {
       });
       const sessionState = JSON.parse(
         await readFile(join(cwd, ".omx", "state", "session.json"), "utf-8"),
-      ) as { session_id?: string; pid?: number };
+      ) as { session_id?: string; native_session_id?: string; pid?: number };
       assert.equal(sessionState.session_id, "sess-start-1");
+      assert.equal(sessionState.native_session_id, "sess-start-1");
       assert.equal(sessionState.pid, 43210);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves canonical OMX session scope when native SessionStart arrives with a different id", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-reconcile-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-launch-1";
+      const nativeSessionId = "codex-native-1";
+      await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
+      await writeSessionStart(cwd, canonicalSessionId);
+      await writeJson(join(stateDir, "sessions", canonicalSessionId, "hud-state.json"), {
+        last_turn_at: "2026-04-10T00:00:00.000Z",
+        turn_count: 1,
+      });
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: nativeSessionId,
+        },
+        {
+          cwd,
+          sessionOwnerPid: process.pid,
+        },
+      );
+
+      const sessionState = JSON.parse(
+        await readFile(join(stateDir, "session.json"), "utf-8"),
+      ) as { session_id?: string; native_session_id?: string; pid?: number };
+      assert.equal(sessionState.session_id, canonicalSessionId);
+      assert.equal(sessionState.native_session_id, nativeSessionId);
+      assert.equal(sessionState.pid, process.pid);
+
+      const promptResult = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: nativeSessionId,
+          thread_id: "thread-1",
+          turn_id: "turn-1",
+          prompt: "$ralplan fix hud scope drift",
+        },
+        { cwd },
+      );
+
+      assert.equal(promptResult.omxEventName, "keyword-detector");
+      assert.equal(existsSync(join(stateDir, "sessions", canonicalSessionId, "skill-active-state.json")), true);
+      assert.equal(existsSync(join(stateDir, "sessions", canonicalSessionId, "ralplan-state.json")), true);
+      assert.equal(existsSync(join(stateDir, "sessions", nativeSessionId, "skill-active-state.json")), false);
+      assert.equal(existsSync(join(stateDir, "sessions", nativeSessionId, "ralplan-state.json")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9,7 +9,7 @@ import {
 } from "../state/skill-active.js";
 import { readSubagentSessionSummary } from "../subagents/tracker.js";
 import { resolveCanonicalTeamStateRoot } from "../team/state-root.js";
-import { readUsableSessionState } from "../hooks/session.js";
+import { readUsableSessionState, reconcileNativeSessionStart } from "../hooks/session.js";
 import {
   appendTeamEvent,
   readTeamLeaderAttention,
@@ -42,7 +42,6 @@ import {
 } from "../hooks/extensibility/events.js";
 import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
-import { writeSessionStart } from "../hooks/session.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 
 type CodexHookEventName =
@@ -677,6 +676,21 @@ function readPayloadTurnId(payload: CodexHookPayload): string {
   return safeString(payload.turn_id ?? payload.turnId).trim();
 }
 
+async function resolveInternalSessionIdForPayload(
+  cwd: string,
+  payloadSessionId: string,
+): Promise<string> {
+  const currentSession = await readUsableSessionState(cwd);
+  const canonicalSessionId = safeString(currentSession?.session_id).trim();
+  if (!canonicalSessionId) return payloadSessionId;
+
+  const nativeSessionId = safeString(currentSession?.native_session_id).trim();
+  if (!payloadSessionId) return canonicalSessionId;
+  if (payloadSessionId === canonicalSessionId) return canonicalSessionId;
+  if (nativeSessionId && payloadSessionId === nativeSessionId) return canonicalSessionId;
+  return payloadSessionId;
+}
+
 async function readStopSessionPinnedState(
   fileName: string,
   cwd: string,
@@ -1003,30 +1017,31 @@ async function buildStopHookOutput(
   }
 
   const sessionId = readPayloadSessionId(payload);
+  const canonicalSessionId = await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
-  const ralphState = await readActiveRalphState(stateDir, sessionId);
+  const ralphState = await readActiveRalphState(stateDir, canonicalSessionId);
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
   if (!ralphState) {
     const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);
     if (!stopHookActive && hasTeamWorkerContext()) return teamWorkerOutput;
 
-    const autopilotOutput = await buildModeBasedStopOutput("autopilot", cwd, sessionId);
+    const autopilotOutput = await buildModeBasedStopOutput("autopilot", cwd, canonicalSessionId);
     if (!stopHookActive && autopilotOutput) return autopilotOutput;
 
-    const ultraworkOutput = await buildModeBasedStopOutput("ultrawork", cwd, sessionId);
+    const ultraworkOutput = await buildModeBasedStopOutput("ultrawork", cwd, canonicalSessionId);
     if (!stopHookActive && ultraworkOutput) return ultraworkOutput;
 
-    const ultraqaOutput = await buildModeBasedStopOutput("ultraqa", cwd, sessionId);
+    const ultraqaOutput = await buildModeBasedStopOutput("ultraqa", cwd, canonicalSessionId);
     if (!stopHookActive && ultraqaOutput) return ultraqaOutput;
 
-    const teamOutput = await buildTeamStopOutput(cwd, sessionId);
+    const teamOutput = await buildTeamStopOutput(cwd, canonicalSessionId);
     if (teamOutput) {
       const teamSignature = buildRepeatableStopSignature(payload, "team-stop", safeString(teamOutput.stopReason));
       return await maybeReturnRepeatableStopOutput(payload, stateDir, teamSignature, teamOutput);
     }
 
-    if (sessionId) {
-      const canonicalTeam = await findCanonicalActiveTeamForSession(cwd, sessionId);
+    if (canonicalSessionId) {
+      const canonicalTeam = await findCanonicalActiveTeamForSession(cwd, canonicalSessionId);
       if (canonicalTeam) {
         const canonicalTeamOutput = buildTeamStopOutputForPhase(
           canonicalTeam.teamName,
@@ -1042,7 +1057,7 @@ async function buildStopHookOutput(
         if (repeatedCanonicalTeamOutput) return repeatedCanonicalTeamOutput;
       }
 
-      const skillOutput = await buildSkillStopOutput(cwd, sessionId, threadId);
+      const skillOutput = await buildSkillStopOutput(cwd, canonicalSessionId, threadId);
       if (!stopHookActive && skillOutput) return skillOutput;
     }
 
@@ -1102,15 +1117,22 @@ export async function dispatchCodexNativeHook(
   const omxEventName = mapCodexHookEventToOmxEvent(hookEventName);
   let skillState: SkillActiveState | null = null;
 
-  const sessionId = safeString(payload.session_id ?? payload.sessionId).trim();
+  const nativeSessionId = safeString(payload.session_id ?? payload.sessionId).trim();
   const threadId = safeString(payload.thread_id ?? payload.threadId).trim();
   const turnId = safeString(payload.turn_id ?? payload.turnId).trim();
+  let canonicalSessionId = safeString((await readUsableSessionState(cwd))?.session_id).trim();
 
-  if (hookEventName === "SessionStart" && sessionId) {
-    await writeSessionStart(cwd, sessionId, {
+  if (hookEventName === "SessionStart" && nativeSessionId) {
+    const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
       pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
     });
+    canonicalSessionId = safeString(sessionState.session_id).trim();
+  } else if (!canonicalSessionId) {
+    canonicalSessionId = safeString((await readUsableSessionState(cwd))?.session_id).trim();
   }
+
+  const eventSessionId = canonicalSessionId || nativeSessionId || undefined;
+  const sessionIdForState = canonicalSessionId || nativeSessionId;
 
   if (hookEventName === "UserPromptSubmit") {
     const prompt = readPromptText(payload);
@@ -1118,7 +1140,7 @@ export async function dispatchCodexNativeHook(
       skillState = await recordSkillActivation({
         stateDir,
         text: prompt,
-        sessionId,
+        sessionId: sessionIdForState,
         threadId,
         turnId,
       });
@@ -1127,11 +1149,19 @@ export async function dispatchCodexNativeHook(
   }
 
   if (omxEventName) {
+    const baseContext = buildBaseContext(cwd, payload, hookEventName!);
+    if (nativeSessionId) {
+      baseContext.native_session_id = nativeSessionId;
+      baseContext.codex_session_id = nativeSessionId;
+    }
+    if (canonicalSessionId) {
+      baseContext.omx_session_id = canonicalSessionId;
+    }
     const event: HookEventEnvelope = buildNativeHookEvent(
       omxEventName,
-      buildBaseContext(cwd, payload, hookEventName!),
+      baseContext,
       {
-        session_id: sessionId || undefined,
+        session_id: eventSessionId,
         thread_id: threadId || undefined,
         turn_id: turnId || undefined,
         mode: safeString(payload.mode).trim() || undefined,
@@ -1143,7 +1173,7 @@ export async function dispatchCodexNativeHook(
   let outputJson: Record<string, unknown> | null = null;
   if (hookEventName === "SessionStart" || hookEventName === "UserPromptSubmit") {
     const additionalContext = hookEventName === "SessionStart"
-      ? await buildSessionStartContext(cwd, sessionId)
+      ? await buildSessionStartContext(cwd, canonicalSessionId || nativeSessionId)
       : buildAdditionalContextMessage(readPromptText(payload), skillState);
     if (additionalContext) {
       outputJson = {

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -30,6 +30,7 @@ import {
 } from './notify-hook/payload-parser.js';
 import {
   getScopedStatePath,
+  readCurrentSessionId,
   readScopedJsonIfExists,
   getScopedStateDirsForCurrentSession,
   normalizeNotifyState,
@@ -182,10 +183,12 @@ async function main() {
   const logsDir = join(cwd, '.omx', 'logs');
   const omxDir = join(cwd, '.omx');
   let currentOmxSessionId = '';
+  const getEffectiveSessionId = () => currentOmxSessionId || payloadSessionId;
 
   // Ensure directories exist
   await mkdir(logsDir, { recursive: true }).catch(() => {});
   await mkdir(stateDir, { recursive: true }).catch(() => {});
+  currentOmxSessionId = await readCurrentSessionId(stateDir).catch(() => '') || '';
 
   // Turn-level dedupe prevents double-processing when native notify and fallback
   // watcher both emit the same completed turn.
@@ -196,9 +199,10 @@ async function main() {
       const threadId = safeString(payload['thread-id'] || payload.thread_id || '');
       const eventType = safeString(payload.type || 'agent-turn-complete');
       const key = `${threadId || 'no-thread'}|${turnId}|${eventType}`;
-      const dedupeStatePath = await getScopedStatePath(stateDir, 'notify-hook-state.json', payloadSessionId);
+      const dedupeSessionId = getEffectiveSessionId();
+      const dedupeStatePath = await getScopedStatePath(stateDir, 'notify-hook-state.json', dedupeSessionId);
       const dedupeState = normalizeNotifyState(
-        await readScopedJsonIfExists(stateDir, 'notify-hook-state.json', payloadSessionId, null),
+        await readScopedJsonIfExists(stateDir, 'notify-hook-state.json', dedupeSessionId, null),
       );
       dedupeState.recent_turns = pruneRecentTurns(dedupeState.recent_turns, now);
       if (dedupeState.recent_turns[key]) {
@@ -218,10 +222,10 @@ async function main() {
     try {
       const threadId = safeString(payload['thread-id'] || payload.thread_id || '');
       const turnId = safeString(payload['turn-id'] || payload.turn_id || '');
-      if (payloadSessionId && threadId) {
+      if (getEffectiveSessionId() && threadId) {
         const { recordSubagentTurnForSession } = await import('../subagents/tracker.js');
         await recordSubagentTurnForSession(cwd, {
-          sessionId: payloadSessionId,
+          sessionId: getEffectiveSessionId(),
           threadId,
           ...(turnId ? { turnId } : {}),
           timestamp: new Date().toISOString(),
@@ -422,8 +426,9 @@ async function main() {
   // 4. Write HUD state summary for `omx hud` (lead session only)
   if (!isTeamWorker) {
     try {
-      const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', payloadSessionId);
-      let hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', payloadSessionId, {
+      const scopedSessionId = getEffectiveSessionId();
+      const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', scopedSessionId);
+      let hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', scopedSessionId, {
         last_turn_at: '',
         turn_count: 0,
       });
@@ -456,19 +461,19 @@ async function main() {
   try {
     const { recordSkillActivation } = await import('../hooks/keyword-detector.js');
     if (latestUserInput) {
-      await recordSkillActivation({
-        stateDir,
-        text: latestUserInput,
-        sessionId: payloadSessionId,
-        threadId: payloadThreadId,
-        turnId: safeString(payload['turn-id'] || payload.turn_id || ''),
-      });
+        await recordSkillActivation({
+          stateDir,
+          text: latestUserInput,
+          sessionId: getEffectiveSessionId(),
+          threadId: payloadThreadId,
+          turnId: safeString(payload['turn-id'] || payload.turn_id || ''),
+        });
     }
   } catch {
     // Non-fatal: keyword detector module may not be built yet
   }
 
-  const deepInterviewStateActive = await isDeepInterviewStateActive(stateDir, payloadSessionId);
+  const deepInterviewStateActive = await isDeepInterviewStateActive(stateDir, getEffectiveSessionId());
 
   // 4.55. Notify leader when individual worker transitions to idle (worker session only)
   if (isTeamWorker && parsedTeamWorker && !deepInterviewStateActive) {
@@ -520,7 +525,7 @@ async function main() {
   try {
     const { buildNativeHookEvent, buildDerivedHookEvent } = await import('../hooks/extensibility/events.js');
     const { dispatchHookEvent } = await import('../hooks/extensibility/dispatcher.js');
-    const sessionIdForHooks = safeString(payload.session_id || payload['session-id'] || '');
+    const sessionIdForHooks = getEffectiveSessionId();
     const threadIdForHooks = safeString(payload['thread-id'] || payload.thread_id || '');
     const turnIdForHooks = safeString(payload['turn-id'] || payload.turn_id || '');
     const modeForHooks = safeString(payload.mode || '');
@@ -530,6 +535,8 @@ async function main() {
       type: safeString(payload.type || 'agent-turn-complete'),
       input_messages: normalizeInputMessages(payload),
       output_preview: outputPreview,
+      native_session_id: payloadSessionId || null,
+      omx_session_id: sessionIdForHooks || null,
       ...readRepositoryMetadata(cwd),
       session_name: resolveOperationalSessionName(cwd, sessionIdForHooks),
       project_path: cwd,
@@ -551,6 +558,8 @@ async function main() {
         status: signal.normalized_event,
         errorSummary: signal.error_summary,
         extra: {
+          native_session_id: payloadSessionId || null,
+          omx_session_id: sessionIdForHooks || null,
           source_event: safeString(payload.type || 'agent-turn-complete'),
         },
       }), {
@@ -655,7 +664,7 @@ async function main() {
         payload,
         stateDir,
         logsDir,
-        sessionId: currentOmxSessionId || payloadSessionId,
+        sessionId: getEffectiveSessionId(),
         turnId: safeString(payload['turn-id'] || payload.turn_id || ''),
       });
     } catch (err) {
@@ -665,7 +674,7 @@ async function main() {
         level: 'warn',
         type: 'visual_verdict_import_failure',
         error: (err as any)?.message || String(err),
-        session_id: payloadSessionId,
+        session_id: getEffectiveSessionId(),
         turn_id: safeString(payload['turn-id'] || payload.turn_id || ''),
       });
       const warnFile = join(logsDir, `notify-hook-${new Date().toISOString().split('T')[0]}.jsonl`);

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -56,6 +56,10 @@ export function resolveInvocationSessionId(payload: any): string {
   ).trim();
 }
 
+function readNativeSessionId(sessionState: { native_session_id?: unknown; codex_session_id?: unknown }): string {
+  return safeString(sessionState.native_session_id || sessionState.codex_session_id || '').trim();
+}
+
 function readCurrentTmuxSessionName(): string {
   if (!process.env.TMUX) return '';
   try {
@@ -138,20 +142,25 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
     if (resolvePath(safeString(sessionState.cwd || cwd)) !== resolvePath(cwd)) {
       return { managed: false, reason: 'cwd_mismatch', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
     }
-    if (safeString(sessionState.session_id).trim() !== invocationSessionId) {
+    const canonicalSessionId = safeString(sessionState.session_id).trim();
+    const nativeSessionId = readNativeSessionId(sessionState);
+    const allowedInvocationIds = new Set([canonicalSessionId, nativeSessionId].filter(Boolean));
+    if (!allowedInvocationIds.has(invocationSessionId)) {
       return { managed: false, reason: 'session_id_mismatch', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
     }
     if (isSessionStale(sessionState)) {
       return { managed: false, reason: 'stale_session', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
     }
 
-    const expectedTmuxSessionName = buildExpectedManagedTmuxSessionName(cwd, invocationSessionId);
+    const expectedTmuxSessionName = buildExpectedManagedTmuxSessionName(cwd, canonicalSessionId || invocationSessionId);
     const currentTmuxSessionName = readCurrentTmuxSessionName();
     if (currentTmuxSessionName && currentTmuxSessionName === expectedTmuxSessionName) {
       return {
         managed: true,
         reason: 'tmux_session_match',
         invocationSessionId,
+        canonicalSessionId,
+        nativeSessionId,
         sessionState,
         expectedTmuxSessionName,
         currentTmuxSessionName,
@@ -163,6 +172,8 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
         managed: true,
         reason: currentTmuxSessionName ? 'pid_ancestry_match_tmux_mismatch' : 'pid_ancestry_match',
         invocationSessionId,
+        canonicalSessionId,
+        nativeSessionId,
         sessionState,
         expectedTmuxSessionName,
         currentTmuxSessionName: '',
@@ -173,6 +184,8 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       managed: false,
       reason: currentTmuxSessionName ? 'tmux_session_mismatch' : 'pid_ancestry_mismatch',
       invocationSessionId,
+      canonicalSessionId,
+      nativeSessionId,
       sessionState,
       expectedTmuxSessionName,
       currentTmuxSessionName,

--- a/src/scripts/notify-hook/state-io.ts
+++ b/src/scripts/notify-hook/state-io.ts
@@ -36,17 +36,17 @@ export async function resolveScopedStateDir(
   baseStateDir: string,
   explicitSessionId?: string,
 ): Promise<string> {
-  const normalizedExplicit = safeString(explicitSessionId).trim();
-  if (SESSION_ID_PATTERN.test(normalizedExplicit)) {
-    const explicitDir = join(baseStateDir, 'sessions', normalizedExplicit);
-    const currentSessionId = await readCurrentSessionId(baseStateDir);
-    if (currentSessionId === normalizedExplicit || existsSync(explicitDir)) {
-      return explicitDir;
-    }
-  }
   const currentSessionId = await readCurrentSessionId(baseStateDir);
   if (currentSessionId) {
     return join(baseStateDir, 'sessions', currentSessionId);
+  }
+
+  const normalizedExplicit = safeString(explicitSessionId).trim();
+  if (SESSION_ID_PATTERN.test(normalizedExplicit)) {
+    const explicitDir = join(baseStateDir, 'sessions', normalizedExplicit);
+    if (existsSync(explicitDir)) {
+      return explicitDir;
+    }
   }
   return baseStateDir;
 }

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -210,7 +210,15 @@ export async function resolvePaneTarget(target: any, expectedCwd: any, modePane:
     const expectedSessionTarget = safeString(managedContext.expectedTmuxSessionName).trim();
     const sessionIdTarget = safeString(managedContext.invocationSessionId).trim();
     const stateSessionTarget = safeString(managedContext.sessionState?.session_id).trim();
-    const allowedSessionTargets = new Set([expectedSessionTarget, sessionIdTarget, stateSessionTarget].filter(Boolean));
+    const nativeSessionTarget = safeString(managedContext.nativeSessionId).trim();
+    const canonicalSessionTarget = safeString(managedContext.canonicalSessionId).trim();
+    const allowedSessionTargets = new Set([
+      expectedSessionTarget,
+      sessionIdTarget,
+      stateSessionTarget,
+      nativeSessionTarget,
+      canonicalSessionTarget,
+    ].filter(Boolean));
     if (!allowedSessionTargets.has(explicitSessionTarget)) {
       return { paneTarget: null, reason: 'target_session_not_managed' };
     }


### PR DESCRIPTION
## Summary
- preserve the launch OMX session id as the canonical session scope and store the native Codex session id additively
- keep native hook and notify/HUD flows scoped to the canonical OMX session while passing native-id metadata to consumers that need it
- add regressions for session reconciliation, HUD/notify coherence, managed tmux compatibility, and native stop routing

## Testing
- npm run build
- npx biome lint src/hooks/__tests__/notify-hook-managed-tmux.test.ts src/hooks/__tests__/notify-hook-session-scope.test.ts src/hooks/__tests__/session.test.ts src/hooks/extensibility/__tests__/runtime.test.ts src/hooks/extensibility/types.ts src/hooks/session.ts src/hud/__tests__/state.test.ts src/scripts/__tests__/codex-native-hook.test.ts src/scripts/codex-native-hook.ts src/scripts/notify-hook.ts src/scripts/notify-hook/managed-tmux.ts src/scripts/notify-hook/state-io.ts src/scripts/notify-hook/tmux-injection.ts
- node --test dist/hooks/__tests__/session.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/hud/__tests__/state.test.js dist/hooks/__tests__/notify-hook-session-scope.test.js dist/hooks/__tests__/notify-hook-managed-tmux.test.js dist/hooks/extensibility/__tests__/runtime.test.js dist/cli/__tests__/session-scoped-runtime.test.js