### PR TITLE
fix(notifications): tolerate missing ps on Windows

### DIFF
--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { spawn, type spawnSync } from 'node:child_process';
 import type { ClientRequestArgs, IncomingMessage } from 'node:http';
 import { PassThrough } from 'node:stream';
 import {
@@ -237,6 +237,27 @@ describe('isReplyListenerProcess', () => {
 
   it('returns false for a non-existent PID', () => {
     assert.equal(isReplyListenerProcess(0), false);
+  });
+
+  it('returns false on Windows when ps is unavailable', () => {
+    const result = isReplyListenerProcess(123, {
+      platform: 'win32',
+      env: {
+        PATH: '',
+        PATHEXT: '.EXE;.CMD;.PS1',
+      },
+      spawnImpl: ((() => ({
+        pid: 0,
+        output: [null, '', ''],
+        stdout: '',
+        stderr: '',
+        status: null,
+        signal: null,
+        error: Object.assign(new Error('spawnSync ps ENOENT'), { code: 'ENOENT' }),
+      })) as unknown) as typeof spawnSync,
+    });
+
+    assert.equal(result, false);
   });
 });
 

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -32,6 +32,7 @@ import {
 } from './session-registry.js';
 import { parseMentionAllowedMentions } from './config.js';
 import { parseTmuxTail } from './formatter.js';
+import { spawnPlatformCommandSync } from '../utils/platform-command.js';
 import type { ReplyConfig } from './types.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -270,18 +271,35 @@ const DAEMON_IDENTITY_MARKER = 'pollLoop';
  * inspecting its command line for the daemon identity marker. Returns false if
  * the process cannot be positively identified (safe default).
  */
-export function isReplyListenerProcess(pid: number): boolean {
+export function isReplyListenerProcess(
+  pid: number,
+  options: {
+    platform?: NodeJS.Platform;
+    env?: NodeJS.ProcessEnv;
+    existsImpl?: typeof existsSync;
+    spawnImpl?: typeof spawnSync;
+  } = {},
+): boolean {
   try {
-    if (process.platform === 'linux') {
+    const platform = options.platform ?? process.platform;
+    if (platform === 'linux') {
       // NUL-separated argv available without spawning a subprocess
       const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
       return cmdline.includes(DAEMON_IDENTITY_MARKER);
     }
     // macOS and other POSIX systems
-    const result = spawnSync('ps', ['-p', String(pid), '-o', 'args='], {
-      encoding: 'utf-8',
-      timeout: 3000,
-    });
+    const { result } = spawnPlatformCommandSync(
+      'ps',
+      ['-p', String(pid), '-o', 'args='],
+      {
+        encoding: 'utf-8',
+        timeout: 3000,
+      },
+      platform,
+      options.env,
+      options.existsImpl,
+      options.spawnImpl,
+    );
     if (result.status !== 0 || result.error) return false;
     return (result.stdout ?? '').includes(DAEMON_IDENTITY_MARKER);
   } catch {


### PR DESCRIPTION
## Summary
- route reply-listener process inspection through the shared platform command helper
- return `false` instead of blowing up when Windows environments do not have `ps` available
- add regression coverage for the missing-`ps` Windows path

## Validation
- `npm run build && node --test dist/notifications/__tests__/reply-listener.test.js`
