### PR TITLE
Fix Homebrew zsh tmux pane shell normalization on macOS

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1779,6 +1779,23 @@ describe("buildTmuxPaneCommand", () => {
     assert.ok(result.includes("exec "), "should exec the command");
   });
 
+  it("keeps Homebrew zsh instead of downgrading to /bin/sh", () => {
+    const result = buildTmuxPaneCommand(
+      "codex",
+      ["--model", "gpt-5"],
+      "/opt/homebrew/bin/zsh",
+    );
+    assert.ok(
+      result.startsWith("'/opt/homebrew/bin/zsh' -c "),
+      "should preserve Homebrew zsh when SHELL points to it",
+    );
+    assert.ok(
+      !result.startsWith("'/bin/sh' -c "),
+      "should not fall back to /bin/sh for supported Homebrew zsh",
+    );
+    assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");
+  });
+
   it("wraps command with bash profile sourcing while preserving tmux cwd", () => {
     const result = buildTmuxPaneCommand("codex", [], "/bin/bash");
     assert.ok(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -234,6 +234,7 @@ const ALLOWED_SHELLS = new Set([
   "/usr/local/bin/bash",
   "/usr/local/bin/zsh",
   "/usr/local/bin/fish",
+  "/opt/homebrew/bin/zsh",
 ]);
 const WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS = 2500;
 const CODEX_VERSION_FLAGS = new Set(["--version", "-V"]);


### PR DESCRIPTION
## Summary
- allow `/opt/homebrew/bin/zsh` in the CLI tmux-pane shell allowlist
- add a regression test covering `SHELL=/opt/homebrew/bin/zsh`
- keep the fix scoped to the actual failing leader/tmux normalization path

## Root cause
`buildTmuxPaneCommand()` in `src/cli/index.ts` recognized `/opt/homebrew/bin/zsh` as zsh for rc sourcing, but `ALLOWED_SHELLS` rejected that path and downgraded execution to `/bin/sh`. That yielded `/bin/sh -c 'source ~/.zshrc; ...'`, which breaks tmux pane startup. The worker launcher in `src/team/tmux-session.ts` already handled Homebrew zsh correctly, so the mismatch was in the CLI leader/tmux path.

## Testing
- `npm run build && node --test dist/cli/__tests__/index.test.js dist/team/__tests__/tmux-session.test.js`

Fixes #1439
