### PR TITLE
Fix Stop-hook Ralph session scoping for issue #1461

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 OMX is a workflow layer for [OpenAI Codex CLI](https://github.com/openai/codex).
 
+<table>
+<tr>
+<td><strong>🚨 CAUTION — RECOMMENDED DEFAULT ONLY: macOS or Linux with Codex CLI.</strong><br><br><strong>OMX is primarily designed and actively tuned for that path.</strong><br><strong>Native Windows and Codex App are not the default experience, may break or behave inconsistently, and currently receive less support.</strong></td>
+</tr>
+</table>
+
 It keeps Codex as the execution engine and makes it easier to:
 - start a stronger Codex session by default
 - run one consistent workflow from clarification to completion
@@ -85,8 +91,8 @@ If you want plain Codex with no extra workflow layer, you probably do not need O
 - Node.js 20+
 - Codex CLI installed: `npm install -g @openai/codex`
 - Codex auth configured
-- `tmux` on macOS/Linux if you later want the durable team runtime
-- `psmux` on native Windows if you later want Windows team mode
+- `tmux` on macOS/Linux if you want the recommended durable team runtime
+- `psmux` on native Windows only if you intentionally want the less-supported Windows team path
 
 ### A good first session
 
@@ -196,7 +202,8 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 
 ### Platform notes for team mode
 
-`omx team` needs a tmux-compatible backend:
+`omx team` works best on macOS/Linux with `tmux`.
+Native Windows remains a secondary path, and WSL2 is generally the better choice if you want a Windows-hosted setup.
 
 | Platform | Install |
 | --- | --- |

--- a/docs/STATE_MODEL.md
+++ b/docs/STATE_MODEL.md
@@ -1,0 +1,238 @@
+# OMX State Model
+
+This document explains how OMX tracks workflow/skill state, how transition rules are evaluated, and which transitions are commonly allowed or blocked.
+
+## Goals
+
+- make mode state predictable across CLI, MCP, hooks, and HUD
+- show which files are authoritative vs compatibility-only
+- explain how allowlisted handoffs and overlap rules work
+- document common workflow transitions in one place
+
+## State authorities
+
+### 1. Per-mode state files — authoritative
+
+Authoritative workflow state lives in per-mode files under `.omx/state/`:
+
+- root scope: `.omx/state/<mode>-state.json`
+- session scope: `.omx/state/sessions/<session_id>/<mode>-state.json`
+
+Examples:
+
+- `.omx/state/ralplan-state.json`
+- `.omx/state/sessions/<session_id>/ralph-state.json`
+- `.omx/state/team-state.json`
+
+These files determine whether a workflow mode is active, completed, cancelled, or failed.
+
+### 2. `skill-active-state.json` — compatibility / visibility layer
+
+`skill-active-state.json` is still used as a compatibility surface for hooks/HUD/native messaging, but transition reconciliation should be driven from the shared transition/reconciliation helpers rather than re-deriving semantics ad hoc.
+
+Locations:
+
+- `.omx/state/skill-active-state.json`
+- `.omx/state/sessions/<session_id>/skill-active-state.json`
+
+### 3. Session precedence
+
+Read precedence is:
+
+1. explicit session scope
+2. current session scope
+3. root scope fallback
+
+If root and session disagree for the same mode, session wins for the active execution context, but stale root survivors should be terminalized during reconciliation when they would otherwise resurrect old state.
+
+## Core files
+
+- `src/state/workflow-transition.ts` — transition policy and decision model
+- `src/state/workflow-transition-reconcile.ts` — shared transition reconciliation helper
+- `src/modes/base.ts` — mode start/update lifecycle
+- `src/mcp/state-server.ts` — MCP state writes/reads/clears
+- `src/hooks/keyword-detector.ts` — prompt keyword activation + state seeding
+- `src/scripts/codex-native-hook.ts` — native hook routing and prompt-submit output
+
+## Transition flow
+
+```mermaid
+flowchart TD
+  A[Prompt / CLI / MCP request] --> B[Detect requested workflow skill(s)]
+  B --> C[Evaluate transition policy]
+  C -->|deny| D[Return denial message]
+  C -->|allow overlap| E[Keep current active modes + add destination]
+  C -->|allow auto-complete| F[Complete source mode(s)]
+  F --> G[Sync compatibility skill-active state]
+  G --> H[Activate destination mode(s)]
+  E --> G
+  H --> I[Emit routing / transition message]
+```
+
+## Reconciliation sequence
+
+The shared reconciliation helper should follow this sequence:
+
+1. decide outcome
+2. complete source mode(s) with audit metadata
+3. sync compatibility `skill-active` state
+4. activate destination mode(s)
+5. return transition message for rendering
+
+This ordering matters because syncing too early can resurrect a mode that was just auto-completed.
+
+## Prompt-submit flow
+
+```mermaid
+flowchart TD
+  A[UserPromptSubmit] --> B[detectKeywords()]
+  B --> C[ordered explicit skill list]
+  C --> D[recordSkillActivation()]
+  D --> E[shared reconciliation helper]
+  E --> F[final active skills]
+  F --> G[buildAdditionalContextMessage()]
+  G --> H[native hook output]
+```
+
+## Transition rule categories
+
+### A. Allow with no change
+
+The requested mode is already active.
+
+### B. Allow as overlap
+
+The requested mode is added without completing the source mode.
+
+Examples:
+
+- `team + ralph`
+- `ultrawork + <any tracked mode>`
+
+### C. Allow with source auto-complete
+
+The source mode is terminalized and the destination becomes active.
+
+Current allowlisted forward handoffs:
+
+- `deep-interview -> ralplan`
+- `ralplan -> team`
+- `ralplan -> ralph`
+- `ralplan -> autopilot`
+
+### D. Deny
+
+The requested transition is not allowed and no state is changed.
+
+## Common transition rules
+
+| From | To | Result |
+|---|---|---|
+| `deep-interview` | `ralplan` | auto-complete `deep-interview`, start `ralplan` |
+| `ralplan` | `team` | auto-complete `ralplan`, start `team` |
+| `ralplan` | `ralph` | auto-complete `ralplan`, start `ralph` |
+| `ralplan` | `autopilot` | auto-complete `ralplan`, start `autopilot` |
+| `team` | `ralph` | allowed overlap |
+| `ralph` | `team` | allowed overlap |
+| `<any tracked mode>` | `ultrawork` | allowed overlap |
+| `ultrawork` | `<any tracked mode>` | allowed overlap |
+| execution-like mode | planning-like mode | denied rollback auto-complete |
+| anything else non-allowlisted | new conflicting mode | denied |
+
+## Planning-like vs execution-like
+
+### Planning-like
+
+- `deep-interview`
+- `ralplan`
+- `autoresearch`
+
+### Execution-like
+
+- `team`
+- `ralph`
+- `autopilot`
+- `ultrawork`
+- `ultraqa`
+
+Execution-like -> planning-like rollback auto-complete is forbidden. The denial should tell the user, in substance:
+
+> first clear current state first and retry if this action is intended
+
+## Multi-skill prompt-submit behavior
+
+A single prompt can explicitly invoke multiple contiguous `$skill` tokens.
+
+Example:
+
+```text
+$ralplan $team $ralph ship this fix
+```
+
+Expected result:
+
+1. `ralplan` is recognized as the planning source
+2. `team` is activated through the allowlisted forward handoff
+3. `ralph` is added as an allowed overlap with `team`
+4. final active skills are `team`, `ralph`
+5. native hook output should describe all explicit skills, not only the primary one
+
+Recommended message shape:
+
+- detected keywords summary
+- transition summary, e.g. `mode transiting: ralplan -> team + ralph`
+- final active skills summary
+- team runtime hint when `team` is among final active skills
+
+## Audit fields for auto-complete
+
+When a source mode is auto-completed during transition, the source state should record:
+
+- `active: false`
+- `current_phase: completed`
+- `completed_at`
+- `auto_completed_reason` or equivalent
+- `completion_note` or equivalent
+- destination metadata when useful (`transition_target_mode`, source path, etc.)
+
+## Invariants
+
+These rules should remain true unless intentionally changed:
+
+- rollback to planning never auto-completes
+- non-allowlisted transitions remain blocked
+- `ultrawork` overlap-any must not weaken `ralplan-first` gating
+- native-hook output is a presentation layer over shared transition results, not a separate decision engine
+- compatibility sync must not resurrect completed source modes
+
+## Practical guidance
+
+### If you are changing transition rules
+
+Update together:
+
+- `src/state/workflow-transition.ts`
+- `src/state/workflow-transition-reconcile.ts`
+- lifecycle / MCP callers
+- prompt-submit/native-hook rendering
+- regression tests
+
+### If you are debugging stale state
+
+Check these in order:
+
+1. session-scoped `<mode>-state.json`
+2. root `<mode>-state.json`
+3. session/root `skill-active-state.json`
+4. whether a previous auto-complete wrote audit metadata but compatibility sync reintroduced the mode
+
+### If you are adding a new allowlisted handoff
+
+Define:
+
+- source mode
+- destination mode(s)
+- whether source auto-completes or destination overlaps
+- rollback behavior
+- expected native-hook / CLI / MCP transition output
+- regression tests for both session and root scope

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -46,6 +46,20 @@ OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js
 | `session-end` | none | `session-end` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
 | `session-idle` | none | `session-idle` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
 
+## Combined workflow note
+
+Stop/continuation readers must interpret approved combined workflow state from
+the shared active-set contract rather than from a single legacy `skill` owner.
+For the first-pass multi-state rollout, the approved overlaps are:
+
+- `team + ralph`
+- `team + ultrawork`
+
+Unsupported overlaps should preserve the current state unchanged and direct the
+operator to clear incompatible state explicitly via `omx state ...` or the
+`omx_state.*` MCP tools before retrying. See
+`docs/contracts/multi-state-transition-contract.md`.
+
 ## Verification guidance
 
 When validating hooks, keep the proof boundary explicit:

--- a/docs/contracts/multi-state-transition-contract.md
+++ b/docs/contracts/multi-state-transition-contract.md
@@ -1,0 +1,115 @@
+# Multi-state transition compatibility contract
+
+This document freezes the first-pass peer workflow state model for the approved
+multi-state compatibility rollout from `.omx/plans/prd-multi-state-compat.md`.
+
+## Canonical sources of truth
+
+The runtime must treat workflow state as a combination of:
+
+- mode state files under `.omx/state/{scope}/<mode>-state.json`
+- canonical workflow enumeration under `.omx/state/{scope}/skill-active-state.json`
+
+`skill-active-state.json` is the canonical active-set inventory. Legacy top-level
+fields such as `skill` or `phase` may remain as compatibility metadata, but they
+must not override the authoritative active set when multiple workflow members
+are live.
+
+## Approved first-pass combinations
+
+Allowed active-set shapes in this rollout are intentionally narrow:
+
+- standalone single-workflow state for tracked workflows
+- `team + ralph`
+- `team + ultrawork`
+
+The resulting active set is peer state. Neither member is semantically primary
+just because it was activated first or happens to occupy the legacy top-level
+`skill` field.
+
+## Standalone-only workflows
+
+These workflows remain standalone in this pass and must reject overlap attempts:
+
+- `autopilot`
+- `autoresearch`
+
+A denied overlap must preserve the current state unchanged.
+
+## Transition rules
+
+A canonical transition helper should answer three questions for every writer or
+consumer that mutates workflow state:
+
+1. Is the requested transition allowed from the current active set?
+2. What is the resulting active set if it is allowed?
+3. What operator guidance should be shown if it is denied?
+
+Until a combination is explicitly approved, the default rule is deny-without-
+mutation.
+
+## Invalid transition UX
+
+Every denied transition must:
+
+1. keep the current active state unchanged
+2. name the denied combination explicitly
+3. explain how to clear incompatible state before retrying
+4. mention both supported clearing surfaces:
+   - `omx state ...`
+   - `omx_state.*` MCP tools
+
+Example operator guidance shape:
+
+> Cannot activate `<requested>` while `<active-set>` is still active. Clear the
+> incompatible state first via `omx state ...` or the `omx_state.*` MCP tools,
+> then retry the transition.
+
+### Operator recovery examples
+
+CLI parity surface:
+
+- `omx state clear --input '{"mode":"team"}' --json`
+- `omx state clear --input '{"mode":"ralph","all_sessions":true}' --json`
+
+MCP parity surface:
+
+- `omx_state.state_clear({ mode: "team" })`
+- `omx_state.state_clear({ mode: "ralph", all_sessions: true })`
+
+## Brownfield consumer expectations
+
+The following surfaces must consume the same transition semantics instead of
+re-inventing their own precedence rules:
+
+- `src/state/skill-active.ts` — canonical active-set persistence/sync
+- `src/hooks/keyword-detector.ts` — keyword-triggered activation should add or
+  deny according to the allowlist instead of overwriting to a single owner
+- `src/modes/base.ts` — mode start validation must defer to the same transition
+  rules and emit the same operator guidance
+- `src/mcp/state-server.ts` — state writes/clears must preserve combined state
+  correctly and remove only the cleared member
+- `src/hud/state.ts` — HUD rendering must show approved combined states even
+  when legacy top-level metadata is non-authoritative
+- `src/hooks/agents-overlay.ts` — AGENTS overlay active-mode reporting must list
+  every active approved member
+- `src/scripts/codex-native-hook.ts` — Stop/continuation logic must respect the
+  combined state and stop blocking when the relevant member is cleared
+
+## Scope behavior
+
+Session-scoped state remains authoritative when present. Root scope remains a
+compatibility fallback only. Clearing one member of an approved combined set
+must not accidentally delete the entire combined state.
+
+## Regression expectations
+
+Implementation should be considered complete only when tests prove:
+
+1. canonical active state can hold a multi-entry active set
+2. `team + ralph` is allowed in both activation orders
+3. `team + ultrawork` is allowed in both activation orders
+4. unsupported overlaps deny without mutation
+5. denial messages mention both `omx state` and `omx_state.*`
+6. HUD / overlay / stop-hook consumers honor the combined set consistently
+7. `autopilot` and `autoresearch` still reject overlap attempts

--- a/docs/contracts/multi-state-transition-review.md
+++ b/docs/contracts/multi-state-transition-review.md
@@ -1,0 +1,134 @@
+# Multi-state transition compatibility review notes
+
+Date: 2026-04-09  
+Reviewer lane: worker-3
+
+## Scope reviewed
+
+Compared the branch state against:
+
+- `.omx/plans/prd-multi-state-compat.md`
+- `.omx/plans/test-spec-multi-state-compat.md`
+
+Reviewed brownfield surfaces:
+
+- `src/state/skill-active.ts`
+- `src/hooks/keyword-detector.ts`
+- `src/modes/base.ts`
+- `src/mcp/state-server.ts`
+- `src/hud/state.ts`
+- `src/hooks/agents-overlay.ts`
+- `src/scripts/codex-native-hook.ts`
+
+## Current branch snapshot
+
+**Status:** the repository already contains partial multi-state foundations, but
+it does not yet expose one documented canonical transition contract.
+
+Observed strengths:
+
+- `src/state/skill-active.ts` already persists `active_skills[]`, normalizes
+  visible entries, and can sync more than one tracked workflow into the
+  canonical state file.
+- `src/hud/state.ts` and `src/hooks/agents-overlay.ts` already read canonical
+  skill-active state and are structurally closer to a peer-state model than a
+  strict single-owner model.
+- `src/modes/base.ts` already preserves key standalone restrictions:
+  `autopilot` and `autoresearch` remain exclusive; `ralph` and `ultrawork`
+  remain mutually exclusive with each other.
+
+Primary gaps relative to the PRD/test-spec:
+
+1. **No explicit transition-rule helper exists yet.**
+   - Transition semantics are still distributed across mode lifecycle,
+     keyword detection, MCP writes, HUD/overlay readers, and native-stop logic.
+2. **Keyword activation is still effectively single-owner.**
+   - `recordSkillActivation()` uses `detectPrimaryKeyword()` and writes a fresh
+     one-entry `active_skills` array for the selected skill, so prompt-side
+     activation still overwrites rather than validating/appending approved peer
+     combinations.
+3. **Invalid-transition guidance is not standardized.**
+   - `src/modes/base.ts` still throws `Run cancel first.` for exclusivity
+     failures, which does not meet the new requirement to mention explicit
+     clearing paths via `omx state` and `omx_state.*`.
+4. **The contract is not documented in one operator-facing place.**
+   - The PRD and test spec define the rollout, but the repo lacked a dedicated
+     contract doc describing the allowed set, the denied set, and the required
+     recovery UX.
+
+## Brownfield review details
+
+### `src/state/skill-active.ts`
+
+- Good base for canonical peer state: it already deduplicates `active_skills[]`
+  and can retain multiple active entries.
+- Still needs a shared allowlist-aware transition layer above persistence so the
+  state file cannot drift into unsupported combinations.
+
+### `src/hooks/keyword-detector.ts`
+
+- Main brownfield risk for this feature.
+- The prompt-side path currently records only the primary detected keyword and
+  seeds one active skill at a time.
+- This is the clearest remaining single-owner assumption in the review sample.
+
+### `src/modes/base.ts`
+
+- Current exclusivity rules are partly aligned with the rollout goals, because
+  `team` is not exclusive while `autopilot`/`autoresearch` are.
+- However, the rules are encoded as a hard-coded exclusive set and generic error
+  text, not as a canonical transition model with machine-testable guidance.
+
+### `src/mcp/state-server.ts`
+
+- Already syncs canonical skill-active state for mode writes/clears.
+- Needs to consume the same allowlist/error builder as every other writer so
+  MCP state writes cannot permit combinations the keyword or mode path denies.
+
+### `src/hud/state.ts` and `src/hooks/agents-overlay.ts`
+
+- These consumers already appear structurally ready for a combined active set.
+- They still depend on upstream writers to keep the canonical state valid and to
+  stop relying on top-level legacy fields as semantic truth.
+
+### `src/scripts/codex-native-hook.ts`
+
+- Stop handling already reads canonical skill-active state plus mode files.
+- It still needs the finalized transition contract so combined-state blocking and
+  clearing behavior stay aligned with the eventual allowlist.
+
+## Documentation action taken in this lane
+
+Added a dedicated contract doc:
+
+- `docs/contracts/multi-state-transition-contract.md`
+
+This freezes the rollout expectations for:
+
+- approved first-pass overlaps
+- standalone-only workflows
+- denial UX requirements
+- brownfield consumer responsibilities
+- regression expectations
+
+Also clarified two adjacent operator-facing docs so the approved overlap is not
+misread as the old linked `team ralph` lifecycle:
+
+- `docs/contracts/ralph-state-contract.md`
+- `docs/codex-native-hooks.md`
+
+Added concrete recovery examples to the compatibility contract so denial
+messages can point operators at exact parity surfaces instead of vague
+placeholders:
+
+- `omx state clear --input '{"mode":"team"}' --json`
+- `omx_state.state_clear({ mode: "team" })`
+
+## Reviewer conclusion
+
+The branch already has meaningful peer-state groundwork, but the PRD is correct
+that behavior is still fragmented. The main implementation risk is not raw state
+storage; it is inconsistent transition ownership across keyword activation, mode
+start validation, MCP writes, and stop/overlay consumers. The new contract doc
+should give the implementation lanes a stable operator-facing target while the
+code is migrated to a single allowlist-driven transition model.

--- a/docs/contracts/ralph-state-contract.md
+++ b/docs/contracts/ralph-state-contract.md
@@ -21,9 +21,12 @@ Ralph runtime state is stored at `.omx/state/{scope}/ralph-state.json` and MUST 
 - Optional stop/audit fields:
   - `stop_reason`
 
-Ralph remains a standalone mode. Other workflows may start Ralph later as an
-explicit follow-up, but there is no built-in `omx team ralph ...` linked launch
-path anymore.
+Ralph still owns its own mode state and there is no built-in
+`omx team ralph ...` linked launch path anymore. Under the multi-state
+transition compatibility contract, `team + ralph` is an approved peer overlap,
+so Ralph may coexist with team when the canonical allowlist permits it. Other
+overlaps remain deny-by-default until they are explicitly approved. See
+`docs/contracts/multi-state-transition-contract.md`.
 
 Legacy phase aliases may be normalized for compatibility, but persisted values MUST end in the frozen enum below.
 

--- a/docs/prompt-guidance-contract.md
+++ b/docs/prompt-guidance-contract.md
@@ -196,7 +196,7 @@ If a change only affects posture overlays or native agent metadata, document it 
 
 ## Canonical role prompts vs specialized behavior prompts
 
-The main role catalog is the installable specialized-agent set used by `/prompts:name` and native agent generation.
+The main role catalog is the installable specialized-agent set used by native agent generation and internal role prompt composition.
 
 - Files like `prompts/executor.md`, `prompts/planner.md`, and `prompts/architect.md` are canonical XML-tagged role prompt surfaces.
 - `prompts/sisyphus-lite.md` should be treated as a specialized worker-behavior prompt, not as a first-class main catalog role.

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -66,6 +66,46 @@ command = "node"
     }
   });
 
+  it('warns about retired omx_team_run config left behind after upgrade', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-copy-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        `
+[mcp_servers.omx_team_run]
+command = "node"
+args = ["/tmp/team-server.js"]
+enabled = true
+`.trimStart(),
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: join(home, '.codex'),
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Config: retired \[mcp_servers\.omx_team_run\] table still present; run "omx setup --force" to repair the config/,
+      );
+      assert.match(
+        res.stdout,
+        /MCP Servers: 1 servers configured, but retired \[mcp_servers\.omx_team_run\] is not supported; run "omx setup --force" to repair the config/,
+      );
+      assert.doesNotMatch(res.stdout, /Config: config\.toml has OMX entries/);
+      assert.doesNotMatch(
+        res.stdout,
+        /MCP Servers: 1 servers but no OMX servers yet \(expected before first setup; run "omx setup --force" once\)/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('warns when explore harness sources are packaged but cargo is unavailable', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-explore-copy-'));
     try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -28,6 +28,7 @@ import {
   resolveSetupScopeArg,
   readPersistedSetupPreferences,
   readPersistedSetupScope,
+  resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
   buildDetachedSessionBootstrapSteps,
   buildDetachedTmuxSessionName,
@@ -1027,6 +1028,23 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("uses project config.toml for launch repair when persisted scope is project", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(
+        resolveCodexConfigPathForLaunch(wd, {}),
+        join(wd, ".codex", "config.toml"),
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps explicit CODEX_HOME override from env", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
     try {
@@ -1040,6 +1058,25 @@ describe("project launch scope helpers", () => {
           CODEX_HOME: "/tmp/explicit-codex-home",
         }),
         "/tmp/explicit-codex-home",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("uses explicit CODEX_HOME config.toml for launch repair overrides", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      assert.equal(
+        resolveCodexConfigPathForLaunch(wd, {
+          CODEX_HOME: "/tmp/explicit-codex-home",
+        }),
+        "/tmp/explicit-codex-home/config.toml",
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1416,6 +1416,9 @@ describe("detached tmux new-session sequencing", () => {
     assert.match(leaderCmd!, /if \[ "\$status" -lt 128 \]; then/);
     assert.match(leaderCmd!, /tmux kill-session -t/);
     assert.match(leaderCmd!, /"omx-demo"/);
+    assert.match(leaderCmd!, /cd /);
+    assert.match(leaderCmd!, /\/tmp\/project/);
+    assert.match(leaderCmd!, /\|\| exit 1;/);
     assert.match(leaderCmd!, /exit \$status/);
   });
 
@@ -1728,7 +1731,7 @@ exit 0
     );
     assert.deepEqual(
       steps.map((step) => step.name),
-      ["set-mouse", "attach-session"],
+      ["set-mouse", "sanitize-copy-mode-style", "attach-session"],
     );
   });
 
@@ -1746,6 +1749,25 @@ exit 0
     assert.equal(
       steps.some((step) => step.args.includes("terminal-overrides")),
       false,
+    );
+  });
+
+  it("buildDetachedSessionFinalizeSteps sanitizes copy-mode styling before attach when mouse mode is enabled", () => {
+    const steps = buildDetachedSessionFinalizeSteps(
+      "omx-demo",
+      "%12",
+      "3",
+      true,
+    );
+    assert.equal(
+      steps.findIndex((step) => step.name === "sanitize-copy-mode-style")
+      > steps.findIndex((step) => step.name === "set-mouse"),
+      true,
+    );
+    assert.equal(
+      steps.findIndex((step) => step.name === "attach-session")
+      > steps.findIndex((step) => step.name === "sanitize-copy-mode-style"),
+      true,
     );
   });
 
@@ -1810,6 +1832,21 @@ describe("buildTmuxPaneCommand", () => {
     assert.ok(
       result.startsWith("'/usr/bin/zsh' -c "),
       "should start with zsh non-login shell to preserve tmux cwd",
+    );
+    assert.ok(!result.includes(" -lc "), "should not use a login shell");
+    assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");
+    assert.ok(result.includes("exec "), "should exec the command");
+  });
+
+  it("allows Homebrew zsh paths while preserving tmux cwd", () => {
+    const result = buildTmuxPaneCommand(
+      "codex",
+      ["--model", "gpt-5"],
+      "/opt/homebrew/bin/zsh",
+    );
+    assert.ok(
+      result.startsWith("'/opt/homebrew/bin/zsh' -c "),
+      "should preserve Homebrew zsh instead of falling back to /bin/sh",
     );
     assert.ok(!result.includes(" -lc "), "should not use a login shell");
     assert.ok(result.includes("source ~/.zshrc"), "should source .zshrc");

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -402,6 +402,34 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
+  it("repairs retired omx_team_run config during setup refresh", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".codex"), { recursive: true });
+      await writeFile(
+        join(wd, ".codex", "config.toml"),
+        [
+          '[mcp_servers.omx_team_run]',
+          'command = "node"',
+          'args = ["./dist/cli/team-mcp.js"]',
+          "",
+        ].join("\n"),
+      );
+
+      const output = await runSetupWithCapturedLogs(wd, { scope: "project" });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(
+        output,
+        /Removed retired \[mcp_servers\.omx_team_run\] config during refresh\./,
+      );
+      assert.doesNotMatch(config, /^\[mcp_servers\.omx_team_run\]$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("syncs shared MCP registry entries into ~/.claude/settings.json for user scope", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     const previousHome = process.env.HOME;

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -376,6 +376,32 @@ describe("omx setup refresh summary and dry-run behavior", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("backfills launcher-backed MCP startup timeouts during setup refresh", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
+    try {
+      await mkdir(join(wd, ".omx", "state"), { recursive: true });
+      await mkdir(join(wd, ".codex"), { recursive: true });
+      await writeFile(
+        join(wd, ".codex", "config.toml"),
+        [
+          '[mcp_servers.filesystem]',
+          'command = "npx"',
+          'args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]',
+          "",
+        ].join("\n"),
+      );
+
+      await runSetupInTempDir(wd, { scope: "project" });
+
+      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      assert.match(config, /^\[mcp_servers\.filesystem\]$/m);
+      assert.match(config, /^startup_timeout_sec = 15$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("syncs shared MCP registry entries into ~/.claude/settings.json for user scope", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     const previousHome = process.env.HOME;

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -268,6 +268,52 @@ describe('teamCommand shutdown --force parsing', () => {
     assert.equal(force, true);
   });
 
+  it('persists cancelled team mode state on shutdown even when no team mode state existed beforehand', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-mode-state-'));
+    const previousCwd = process.cwd();
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    const logs: string[] = [];
+    const warns: string[] = [];
+
+    try {
+      process.chdir(wd);
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({ session_id: 'sess-team-shutdown-state' }),
+      );
+      await initTeamState(
+        'team-shutdown-mode-state',
+        'persist cancelled team mode state after shutdown',
+        'executor',
+        1,
+        wd,
+      );
+
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+      console.warn = (...args: unknown[]) => warns.push(args.map(String).join(' '));
+
+      await teamCommand(['shutdown', 'team-shutdown-mode-state', '--force']);
+
+      const state = await readModeState('team', wd);
+      assert.ok(state);
+      assert.equal(state?.active, false);
+      assert.equal(state?.current_phase, 'cancelled');
+      assert.equal(state?.team_name, 'team-shutdown-mode-state');
+      assert.equal(warns.length, 0);
+      assert.ok(
+        logs.some((line) =>
+          line.includes('Team shutdown complete: team-shutdown-mode-state')),
+      );
+    } finally {
+      console.log = originalLog;
+      console.warn = originalWarn;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('parses --confirm-issues from shutdown args', () => {
     const teamArgs = ['shutdown', 'my-team', '--confirm-issues'];
     const confirmIssues = teamArgs.includes('--confirm-issues');

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -67,6 +67,26 @@ function withoutTeamTestWorkerEnv<T>(fn: () => T): T {
   }
 }
 
+function withMockPromptModeCodexAllowed<T>(fn: () => T): T {
+  const previous = process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = '1';
+  let restoreImmediately = true;
+  const restore = () => {
+    if (typeof previous === 'string') process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = previous;
+    else delete process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      restoreImmediately = false;
+      return result.finally(restore) as T;
+    }
+    return result;
+  } finally {
+    if (restoreImmediately) restore();
+  }
+}
+
 async function runNodeCli(
   args: string[],
   options: {
@@ -1802,7 +1822,8 @@ process.on('SIGTERM', () => process.exit(0));
         return true;
       }) as typeof process.stderr.write;
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+      await withMockPromptModeCodexAllowed(() =>
+        withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask])));
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       logs.length = 0;
@@ -1868,7 +1889,8 @@ process.on('SIGTERM', () => process.exit(0));
       process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
       process.env.OMX_TEAM_WORKER_CLI = 'codex';
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+      await withMockPromptModeCodexAllowed(() =>
+        withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask])));
 
       const startedState = await readModeState('team', wd);
       assert.equal(startedState?.active, true);
@@ -1928,7 +1950,8 @@ process.on('SIGTERM', () => process.exit(0));
       process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
       process.env.OMX_TEAM_WORKER_CLI = 'codex';
 
-      await withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask]));
+      await withMockPromptModeCodexAllowed(() =>
+        withoutTeamTestWorkerEnv(() => teamCommand(['1:executor', teamTask])));
       await writeFile(
         join(wd, '.omx', 'state', 'team', teamName, 'phase.json'),
         JSON.stringify({

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -14,6 +14,7 @@ import { getCatalogExpectations } from './catalog-contract.js';
 import { parse as parseToml } from '@iarna/toml';
 import { resolvePackagedExploreHarnessCommand, EXPLORE_BIN_ENV } from './explore.js';
 import { getPackageRoot } from '../utils/package.js';
+import { hasLegacyOmxTeamRunTable } from '../config/generator.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
 import { isLeaderRuntimeStale } from '../team/leader-activity.js';
@@ -583,6 +584,15 @@ async function checkConfig(configPath: string): Promise<Check> {
       };
     }
 
+    if (hasLegacyOmxTeamRunTable(content)) {
+      return {
+        name: 'Config',
+        status: 'warn',
+        message:
+          'retired [mcp_servers.omx_team_run] table still present; run "omx setup --force" to repair the config',
+      };
+    }
+
     const hasOmx = content.includes('omx_') || content.includes('oh-my-codex');
     if (hasOmx) {
       return { name: 'Config', status: 'pass', message: 'config.toml has OMX entries' };
@@ -756,6 +766,13 @@ async function checkMcpServers(configPath: string): Promise<Check> {
     const content = await readFile(configPath, 'utf-8');
     const mcpCount = (content.match(/\[mcp_servers\./g) || []).length;
     if (mcpCount > 0) {
+      if (hasLegacyOmxTeamRunTable(content)) {
+        return {
+          name: 'MCP Servers',
+          status: 'warn',
+          message: `${mcpCount} servers configured, but retired [mcp_servers.omx_team_run] is not supported; run "omx setup --force" to repair the config`,
+        };
+      }
       const hasOmx = content.includes('omx_state') || content.includes('omx_memory');
       if (hasOmx) {
         return { name: 'MCP Servers', status: 'pass', message: `${mcpCount} servers configured (OMX present)` };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -344,6 +344,16 @@ export function resolveCodexHomeForLaunch(
   return undefined;
 }
 
+export function resolveCodexConfigPathForLaunch(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, env);
+  return codexHomeOverride
+    ? join(codexHomeOverride, "config.toml")
+    : codexConfigPath();
+}
+
 export function resolveSetupScopeArg(args: string[]): SetupScope | undefined {
   let value: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
@@ -932,7 +942,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
   // TOML parser rejects duplicates, so we repair before spawning the CLI.
   try {
     const repaired = await repairConfigIfNeeded(
-      codexConfigPath(),
+      resolveCodexConfigPathForLaunch(launchCwd, process.env),
       getPackageRoot(),
     );
     if (repaired) {
@@ -1013,7 +1023,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
 
   try {
     const repaired = await repairConfigIfNeeded(
-      codexConfigPath(),
+      resolveCodexConfigPathForLaunch(launchCwd, process.env),
       getPackageRoot(),
     );
     if (repaired) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2162,7 +2162,7 @@ ${launchAppendix}`
   await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
 
   // 3. Write session state
-  await resetSessionMetrics(cwd);
+  await resetSessionMetrics(cwd, sessionId);
   await writeSessionStart(cwd, sessionId);
 
   // 4. Start notify fallback watcher (best effort)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -75,6 +75,8 @@ import {
   isMsysOrGitBash,
   isNativeWindows,
   isTmuxAvailable,
+  mitigateCopyModeUnderlineArtifacts,
+  translatePathForMsys,
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
 import { codexConfigPath, rememberOmxLaunchContext, resolveOmxEntryPath } from "../utils/paths.js";
@@ -226,6 +228,9 @@ const ALLOWED_SHELLS = new Set([
   "/bin/zsh",
   "/bin/dash",
   "/bin/fish",
+  "/opt/homebrew/bin/bash",
+  "/opt/homebrew/bin/zsh",
+  "/opt/homebrew/bin/fish",
   "/usr/bin/sh",
   "/usr/bin/bash",
   "/usr/bin/zsh",
@@ -234,6 +239,7 @@ const ALLOWED_SHELLS = new Set([
   "/usr/local/bin/bash",
   "/usr/local/bin/zsh",
   "/usr/local/bin/fish",
+  "/opt/homebrew/bin/zsh",
 ]);
 const WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS = 2500;
 const CODEX_VERSION_FLAGS = new Set(["--version", "-V"]);
@@ -1549,6 +1555,7 @@ function buildDetachedSessionLeaderCommand(
   sessionName: string,
   codexCmd: string,
 ): string {
+  const leaderCwd = translatePathForMsys(cwd);
   const wrapped = [
     buildTmuxExtendedKeysAcquireShellSnippet(cwd),
     "omx_detached_session_cleanup() {",
@@ -1561,6 +1568,7 @@ function buildDetachedSessionLeaderCommand(
     "exit $status;",
     "};",
     "trap omx_detached_session_cleanup 0;",
+    `cd ${quoteShellArg(leaderCwd)} || exit 1;`,
     codexCmd,
   ].join(" ");
   return `/bin/sh -c ${quoteShellArg(wrapped)}`;
@@ -1824,6 +1832,10 @@ export function buildDetachedSessionFinalizeSteps(
     steps.push({
       name: "set-mouse",
       args: ["set-option", "-t", sessionName, "mouse", "on"],
+    });
+    steps.push({
+      name: "sanitize-copy-mode-style",
+      args: [],
     });
   }
   steps.push({
@@ -2424,6 +2436,14 @@ function runCodex(
             );
           }
           for (const finalizeStep of finalizeSteps) {
+            if (finalizeStep.name === "sanitize-copy-mode-style") {
+              try {
+                mitigateCopyModeUnderlineArtifacts(sessionName);
+              } catch (err) {
+                process.stderr.write(`[cli/index] operation failed: ${err}\n`);
+              }
+              continue;
+            }
             const stdio =
               finalizeStep.name === "attach-session" ? "inherit" : "ignore";
             try {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -28,7 +28,11 @@ import {
   omxPlansDir,
   omxLogsDir,
 } from "../utils/paths.js";
-import { buildMergedConfig, getRootModelName } from "../config/generator.js";
+import {
+  buildMergedConfig,
+  getRootModelName,
+  hasLegacyOmxTeamRunTable,
+} from "../config/generator.js";
 import { mergeManagedCodexHooksConfig } from "../config/codex-hooks.js";
 import {
   getLegacyUnifiedMcpRegistryCandidate,
@@ -113,6 +117,7 @@ interface SetupBackupContext {
 interface ManagedConfigResult {
   finalConfig: string;
   omxManagesTui: boolean;
+  repairedLegacyTeamRunTable: boolean;
 }
 
 interface LegacySkillOverlapNotice {
@@ -826,6 +831,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     { codexVersionProbe: options.codexVersionProbe, dryRun, verbose, modelUpgradePrompt },
   );
   const resolvedConfig = managedConfig.finalConfig;
+  if (managedConfig.repairedLegacyTeamRunTable) {
+    console.log(
+      "  Removed retired [mcp_servers.omx_team_run] config during refresh.",
+    );
+  }
   if (resolvedScope.scope === "user") {
     await syncClaudeCodeMcpSettings(
       sharedMcpRegistry,
@@ -1563,6 +1573,7 @@ async function updateManagedConfig(
   const existing = existsSync(configPath)
     ? await readFile(configPath, "utf-8")
     : "";
+  const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
   const currentModel = getRootModelName(existing);
   let modelOverride: string | undefined;
   const codexVersion =
@@ -1594,7 +1605,11 @@ async function updateManagedConfig(
 
   if (!changed) {
     summary.unchanged += 1;
-    return { finalConfig, omxManagesTui };
+    return {
+      finalConfig,
+      omxManagesTui,
+      repairedLegacyTeamRunTable: false,
+    };
   }
 
   if (
@@ -1629,7 +1644,12 @@ async function updateManagedConfig(
       `  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
     );
   }
-  return { finalConfig, omxManagesTui };
+  return {
+    finalConfig,
+    omxManagesTui,
+    repairedLegacyTeamRunTable:
+      hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
+  };
 }
 
 function getClaudeCodeSettingsPath(homeDir = homedir()): string {

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1233,6 +1233,46 @@ async function ensureTeamModeState(
 
 }
 
+async function persistTeamShutdownModeState(
+  teamName: string,
+  cwd: string,
+  configSnapshot?: {
+    task: string;
+    workerCount: number;
+    agentType: string;
+  } | null,
+): Promise<void> {
+  const existing = await readModeState('team', cwd);
+  if (!existing) {
+    if (configSnapshot) {
+      await ensureTeamModeState({
+        task: configSnapshot.task,
+        workerCount: configSnapshot.workerCount,
+        agentType: configSnapshot.agentType,
+        explicitAgentType: false,
+        explicitWorkerCount: false,
+        teamName,
+      });
+    } else {
+      await startMode('team', `shutdown team ${teamName}`, 50, cwd);
+    }
+  }
+
+  await updateModeState('team', {
+    active: false,
+    current_phase: 'cancelled',
+    completed_at: new Date().toISOString(),
+    team_name: teamName,
+    ...(configSnapshot
+      ? {
+        task_description: configSnapshot.task,
+        agent_count: configSnapshot.workerCount,
+        agent_types: configSnapshot.agentType,
+      }
+      : {}),
+  }, cwd);
+}
+
 
 async function renderStartSummary(runtime: TeamRuntime, staffingPlan?: FollowupStaffingPlan): Promise<void> {
   console.log(`Team started: ${runtime.teamName}`);
@@ -1528,12 +1568,19 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     if (!name) throw new Error('Usage: omx team shutdown <team-name> [--force] [--confirm-issues]');
     const force = teamArgs.includes('--force');
     const confirmIssues = teamArgs.includes('--confirm-issues');
+    const configBeforeShutdown = await readTeamConfig(name, cwd);
     const summary = await shutdownTeam(name, cwd, { force, confirmIssues });
-    await updateModeState('team', {
-      active: false,
-      current_phase: 'cancelled',
-      completed_at: new Date().toISOString(),
-    }).catch((error: unknown) => {
+    await persistTeamShutdownModeState(
+      name,
+      cwd,
+      configBeforeShutdown
+        ? {
+          task: configBeforeShutdown.task,
+          workerCount: configBeforeShutdown.worker_count,
+          agentType: configBeforeShutdown.agent_type,
+        }
+        : null,
+    ).catch((error: unknown) => {
       console.warn('[omx] warning: failed to persist team mode shutdown state', {
         team: name,
         error: error instanceof Error ? error.message : String(error),

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -783,4 +783,80 @@ describe("config generator idempotency (#384)", () => {
     assert.equal(count(merged, /^\[mcp_servers\.eslint\]$/gm), 1);
   });
 
+  it("adds a default startup timeout to launcher-backed non-OMX MCP servers and stays idempotent", () => {
+    const existing = [
+      '[mcp_servers.filesystem]',
+      'command = "npx"',
+      'args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]',
+      "",
+    ].join("\n");
+
+    const first = buildMergedConfig(existing, "/tmp/omx");
+    const second = buildMergedConfig(first, "/tmp/omx");
+
+    assert.match(first, /^\[mcp_servers\.filesystem\]$/m);
+    assert.match(first, /^startup_timeout_sec = 15$/m);
+    assert.equal(count(second, /^startup_timeout_sec = 15$/gm), 1);
+  });
+
+  it("preserves explicit launcher timeouts and leaves non-launcher MCP servers untouched", () => {
+    const existing = [
+      '[mcp_servers.fetch]',
+      'command = "uvx"',
+      'args = ["mcp-server-fetch"]',
+      "startup_timeout_sec = 22",
+      "",
+      '[mcp_servers.custom]',
+      'command = "custom-mcp"',
+      'args = ["serve"]',
+      "",
+    ].join("\n");
+
+    const merged = buildMergedConfig(existing, "/tmp/omx");
+
+    assert.equal(count(merged, /^startup_timeout_sec = 22$/gm), 1);
+    assert.doesNotMatch(
+      merged,
+      /\[mcp_servers\.custom\][\s\S]*?startup_timeout_sec = 15/,
+    );
+  });
+
+  it("treats npm exec launchers as timeout-backed MCP commands", () => {
+    const existing = [
+      '[mcp_servers.seq]',
+      'command = "npm"',
+      'args = ["exec", "@modelcontextprotocol/server-sequential-thinking"]',
+      "",
+    ].join("\n");
+
+    const merged = buildMergedConfig(existing, "/tmp/omx");
+
+    assert.match(merged, /^\[mcp_servers\.seq\]$/m);
+    assert.match(merged, /^startup_timeout_sec = 15$/m);
+  });
+
+  it("repairConfigIfNeeded backfills launcher-backed MCP startup timeouts", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      await writeFile(
+        configPath,
+        [
+          '[mcp_servers.filesystem]',
+          'command = "npx"',
+          'args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]',
+          "",
+        ].join("\n"),
+      );
+
+      const repaired = await repairConfigIfNeeded(configPath, wd);
+      const config = await readFile(configPath, "utf-8");
+
+      assert.equal(repaired, true);
+      assert.match(config, /^startup_timeout_sec = 15$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -57,6 +57,10 @@ const OMX_TUI_STATUS_LINE =
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
 
+export function hasLegacyOmxTeamRunTable(config: string): boolean {
+  return LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(config);
+}
+
 function unwrapTomlString(value: string | undefined): string | undefined {
   return value?.match(/^"(.*)"$/)?.[1];
 }
@@ -981,7 +985,7 @@ export async function repairConfigIfNeeded(
 
   const content = await readFile(configPath, "utf-8");
   const tuiCount = (content.match(/^\s*\[tui\]\s*$/gm) || []).length;
-  const hasLegacyTeamRunTable = LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(content);
+  const hasLegacyTeamRunTable = hasLegacyOmxTeamRunTable(content);
   const hasLauncherTimeoutGap = findLauncherTimeoutRepairTargets(content).length > 0;
   if (tuiCount <= 1 && !hasLegacyTeamRunTable && !hasLauncherTimeoutGap) return false;
 

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -13,6 +13,7 @@
 import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
+import TOML from "@iarna/toml";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
@@ -50,6 +51,7 @@ const OMX_AGENTS_MAX_THREADS = 6;
 const OMX_AGENTS_MAX_DEPTH = 2;
 const OMX_EXPLORE_ROUTING_DEFAULT = '1';
 const OMX_EXPLORE_CMD_ENV = 'USE_OMX_EXPLORE_CMD';
+const DEFAULT_LAUNCHER_MCP_STARTUP_TIMEOUT_SEC = 15;
 const OMX_TUI_STATUS_LINE =
   'status_line = ["model-with-reasoning", "git-branch", "context-remaining", "total-input-tokens", "total-output-tokens", "five-hour-limit", "weekly-limit"]';
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
@@ -672,6 +674,110 @@ function configHasMcpServer(config: string, name: string): boolean {
   return new RegExp(`^\\s*\\[${tableName}\\]\\s*$`, "m").test(config);
 }
 
+function launcherCommandBasename(command: string): string {
+  return command.replace(/\\/g, "/").trim().split("/").pop()?.toLowerCase() ?? "";
+}
+
+function isLauncherBackedMcpCommand(
+  command: string,
+  args: readonly string[],
+): boolean {
+  const base = launcherCommandBasename(command);
+  if (base === "npx" || base === "uvx") {
+    return true;
+  }
+
+  return base === "npm" && args[0]?.toLowerCase() === "exec";
+}
+
+interface LauncherTimeoutRepairTarget {
+  insertAt: number;
+}
+
+function findLauncherTimeoutRepairTargets(
+  config: string,
+): LauncherTimeoutRepairTarget[] {
+  const lines = config.split(/\r?\n/);
+  const targets: LauncherTimeoutRepairTarget[] = [];
+
+  for (let start = 0; start < lines.length; start += 1) {
+    const isMcpSection = /^\s*\[mcp_servers\./.test(lines[start] ?? "");
+    if (!isMcpSection) continue;
+
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i += 1) {
+      if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i] ?? "")) {
+        end = i;
+        break;
+      }
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = TOML.parse(lines.slice(start, end).join("\n"));
+    } catch {
+      start = end - 1;
+      continue;
+    }
+
+    const mcpServers = (parsed as { mcp_servers?: Record<string, unknown> })
+      .mcp_servers;
+    const [name, value] = Object.entries(mcpServers ?? {})[0] ?? [];
+    if (!name || name.startsWith("omx_") || typeof value !== "object" || !value) {
+      start = end - 1;
+      continue;
+    }
+
+    const section = value as Record<string, unknown>;
+    const command =
+      typeof section.command === "string" ? section.command : undefined;
+    const args =
+      Array.isArray(section.args) &&
+      section.args.every((item) => typeof item === "string")
+        ? (section.args as string[])
+        : [];
+    const hasStartupTimeout =
+      (
+        typeof section.startup_timeout_sec === "number" &&
+        Number.isFinite(section.startup_timeout_sec)
+      ) || (
+        typeof section.startupTimeoutSec === "number" &&
+        Number.isFinite(section.startupTimeoutSec)
+      );
+
+    if (!command || hasStartupTimeout || !isLauncherBackedMcpCommand(command, args)) {
+      start = end - 1;
+      continue;
+    }
+
+    let insertAt = end;
+    while (insertAt > start + 1 && (lines[insertAt - 1] ?? "").trim() === "") {
+      insertAt -= 1;
+    }
+
+    targets.push({ insertAt });
+    start = end - 1;
+  }
+
+  return targets;
+}
+
+function addDefaultLauncherMcpStartupTimeouts(config: string): string {
+  const targets = findLauncherTimeoutRepairTargets(config);
+  if (targets.length === 0) return config;
+
+  const lines = config.split(/\r?\n/);
+  for (const target of [...targets].reverse()) {
+    lines.splice(
+      target.insertAt,
+      0,
+      `startup_timeout_sec = ${DEFAULT_LAUNCHER_MCP_STARTUP_TIMEOUT_SEC}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
 function getSharedMcpRegistryBlock(
   servers: UnifiedMcpRegistryServer[],
   sourcePath: string | undefined,
@@ -850,7 +956,9 @@ export function buildMergedConfig(
     body = body ? `${body}\n\n${sharedRegistryBlock}` : sharedRegistryBlock;
   }
 
-  return topLines.join("\n") + "\n\n" + body + "\n" + tablesBlock;
+  return addDefaultLauncherMcpStartupTimeouts(
+    topLines.join("\n") + "\n\n" + body + "\n" + tablesBlock,
+  );
 }
 
 /**
@@ -874,7 +982,8 @@ export async function repairConfigIfNeeded(
   const content = await readFile(configPath, "utf-8");
   const tuiCount = (content.match(/^\s*\[tui\]\s*$/gm) || []).length;
   const hasLegacyTeamRunTable = LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(content);
-  if (tuiCount <= 1 && !hasLegacyTeamRunTable) return false;
+  const hasLauncherTimeoutGap = findLauncherTimeoutRepairTargets(content).length > 0;
+  if (tuiCount <= 1 && !hasLegacyTeamRunTable && !hasLauncherTimeoutGap) return false;
 
   // Managed config compatibility issue detected — run full merge to repair
   const repaired = buildMergedConfig(content, pkgRoot, options);

--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -136,6 +136,41 @@ describe("generateOverlay", () => {
     assert.ok(overlay.includes("iteration 1/5"));
   });
 
+  it("lists both approved combined workflow members from canonical skill state", async () => {
+    const sessionId = "combined-session";
+    const sessionDir = join(tempDir, ".omx", "state", "sessions", sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(tempDir, ".omx", "state", "session.json"),
+      JSON.stringify({ session_id: sessionId }),
+    );
+    await writeFile(
+      join(sessionDir, "skill-active-state.json"),
+      JSON.stringify({
+        active: true,
+        skill: "team",
+        phase: "running",
+        session_id: sessionId,
+        active_skills: [
+          { skill: "team", phase: "running", active: true, session_id: sessionId },
+          { skill: "ralph", phase: "executing", active: true, session_id: sessionId },
+        ],
+      }),
+    );
+    await writeFile(
+      join(sessionDir, "team-state.json"),
+      JSON.stringify({ active: true, current_phase: "running" }),
+    );
+    await writeFile(
+      join(sessionDir, "ralph-state.json"),
+      JSON.stringify({ active: true, iteration: 2, max_iterations: 5, current_phase: "executing" }),
+    );
+
+    const overlay = await generateOverlay(tempDir, sessionId);
+    assert.match(overlay, /- team: phase: running/);
+    assert.match(overlay, /- ralph: iteration 2\/5, phase: executing/);
+  });
+
   it("generates overlay with notepad priority content", async () => {
     await writeFile(
       join(tempDir, ".omx", "notepad.md"),

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -401,21 +401,20 @@ describe('keyword detector skill-active-state lifecycle', () => {
         }, null, 2),
       );
 
-      const denied = await recordSkillActivation({
+      const allowed = await recordSkillActivation({
         stateDir,
         text: '$ultrawork continue',
         sessionId: 'sess-visible',
         nowIso: '2026-04-10T00:00:00.000Z',
       });
 
-      assert.ok(denied?.transition_error);
-      assert.match(String(denied?.transition_error), /Unsupported workflow overlap: team \+ ralph \+ ultrawork\./);
-      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-visible', 'ultrawork-state.json')), false);
+      assert.equal(allowed?.transition_error, undefined);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-visible', 'ultrawork-state.json')), true);
 
       const persisted = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
       ) as { active_skills?: Array<{ skill: string }> };
-      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
+      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph', 'ultrawork']);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -444,6 +443,72 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.mode, 'ralplan');
       assert.equal(modeState.active, true);
       assert.equal(modeState.current_phase, 'planning');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('auto-completes deep-interview during allowlisted forward handoff', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-handoff-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-handoff'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-handoff', SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'deep-interview',
+          phase: 'planning',
+          session_id: 'sess-handoff',
+          active_skills: [{ skill: 'deep-interview', phase: 'planning', active: true, session_id: 'sess-handoff' }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-handoff', 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'intent-first' }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan implement the approved contract',
+        sessionId: 'sess-handoff',
+        nowIso: '2026-04-10T00:00:00.000Z',
+      });
+
+      assert.equal(result?.transition_error, undefined);
+      assert.equal(result?.transition_message, 'mode transiting: deep-interview -> ralplan');
+
+      const completed = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-handoff', 'deep-interview-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, 'completed');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('supports multi-skill forward handoff from ralplan to team + ralph in one prompt', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-multi-handoff-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan $team $ralph ship this fix',
+        sessionId: 'sess-multi',
+        nowIso: '2026-04-10T00:00:00.000Z',
+      });
+
+      assert.equal(result?.transition_error, undefined);
+      assert.equal(result?.transition_message, 'mode transiting: ralplan -> team');
+      assert.equal(result?.skill, 'team');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-multi', 'ralplan-state.json')), false);
+      assert.equal(existsSync(join(stateDir, 'team-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-multi', 'ralph-state.json')), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -286,6 +287,90 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('adds approved workflow overlaps without deleting the existing canonical state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-overlap-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      await recordSkillActivation({
+        stateDir,
+        text: '$team ship this',
+        sessionId: 'sess-overlap',
+        threadId: 'thread-overlap',
+        turnId: 'turn-1',
+        nowIso: '2026-02-26T00:00:00.000Z',
+      });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralph continue verification',
+        sessionId: 'sess-overlap',
+        threadId: 'thread-overlap',
+        turnId: 'turn-2',
+        nowIso: '2026-02-26T00:05:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.deepEqual(
+        result.active_skills?.map((entry) => entry.skill),
+        ['team', 'ralph'],
+      );
+
+      const persisted = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-overlap', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(
+        persisted.active_skills?.map((entry) => entry.skill),
+        ['team', 'ralph'],
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('hard-fails denied workflow overlaps without mutating current state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deny-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      await recordSkillActivation({
+        stateDir,
+        text: '$team ship this',
+        sessionId: 'sess-deny',
+        threadId: 'thread-deny',
+        turnId: 'turn-1',
+        nowIso: '2026-02-26T00:00:00.000Z',
+      });
+
+      const denied = await recordSkillActivation({
+        stateDir,
+        text: '$autopilot do it too',
+        sessionId: 'sess-deny',
+        threadId: 'thread-deny',
+        turnId: 'turn-2',
+        nowIso: '2026-02-26T00:05:00.000Z',
+      });
+
+      assert.ok(denied?.transition_error);
+      assert.match(String(denied?.transition_error), /Unsupported workflow overlap: team \+ autopilot\./);
+      assert.match(String(denied?.transition_error), /`omx state clear --mode <mode>`/);
+      assert.match(String(denied?.transition_error), /`omx_state\.\*` MCP tools/);
+
+      const persisted = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-deny', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team']);
+      assert.equal(
+        existsSync(join(stateDir, 'sessions', 'sess-deny', 'autopilot-state.json')),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds first-class state for ralplan prompt-submit activation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-'));
     const stateDir = join(cwd, '.omx', 'state');
@@ -377,6 +462,59 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.active, true);
       assert.equal(modeState.current_phase, 'team-verify');
       assert.equal(modeState.team_name, 'review-team');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves root team state when $ralph is activated for the current session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-ralph-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await recordSkillActivation({
+        stateDir,
+        text: '$team coordinate the rollout',
+        sessionId: 'sess-team-ralph',
+        nowIso: '2026-04-09T00:00:00.000Z',
+      });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralph complete the approved plan',
+        sessionId: 'sess-team-ralph',
+        nowIso: '2026-04-09T00:05:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ralph');
+
+      const rootCanonical = JSON.parse(
+        await readFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        rootCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [{ skill: 'team', phase: 'planning', session_id: 'sess-team-ralph' }],
+      );
+
+      const sessionCanonical = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-team-ralph', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        sessionCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [
+          { skill: 'team', phase: 'planning', session_id: 'sess-team-ralph' },
+          { skill: 'ralph', phase: 'planning', session_id: 'sess-team-ralph' },
+        ],
+      );
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -646,8 +784,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
-  it('resets activated_at when skill changes', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-skill-switch-'));
+  it('denies switching away from a standalone workflow without explicit clear', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-skill-switch-deny-'));
     const stateDir = join(cwd, '.omx', 'state');
     const statePath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
     try {
@@ -673,8 +811,9 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
 
       assert.ok(result);
-      assert.equal(result.skill, 'ralph');
-      assert.equal(result.activated_at, '2026-02-26T00:00:00.000Z');
+      assert.equal(result.skill, 'autopilot');
+      assert.match(String(result.transition_error), /Unsupported workflow overlap: autopilot \+ ralph\./);
+      assert.equal(result.activated_at, '2026-02-25T00:00:00.000Z');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -371,6 +371,56 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('denies prompt-submit overlaps against the current session-visible canonical state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-session-visible-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-visible'), { recursive: true });
+      await writeFile(
+        join(stateDir, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          active_skills: [
+            { skill: 'team', phase: 'running', active: true },
+          ],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          session_id: 'sess-visible',
+          active_skills: [
+            { skill: 'team', phase: 'running', active: true },
+            { skill: 'ralph', phase: 'executing', active: true, session_id: 'sess-visible' },
+          ],
+        }, null, 2),
+      );
+
+      const denied = await recordSkillActivation({
+        stateDir,
+        text: '$ultrawork continue',
+        sessionId: 'sess-visible',
+        nowIso: '2026-04-10T00:00:00.000Z',
+      });
+
+      assert.ok(denied?.transition_error);
+      assert.match(String(denied?.transition_error), /Unsupported workflow overlap: team \+ ralph \+ ultrawork\./);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-visible', 'ultrawork-state.json')), false);
+
+      const persisted = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds first-class state for ralplan prompt-submit activation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralplan-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -720,7 +720,8 @@ describe('notify-fallback watcher', () => {
         autoNudge: { enabled: true, delaySec: 0, ttlMs: 30_000 },
       }, null, 2));
       await writeSessionStart(wd, 'sess-managed-fallback');
-      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
         last_agent_output: 'Keep going and finish the cleanup from here.',
@@ -1286,7 +1287,8 @@ exit 0
         autoNudge: { enabled: true, delaySec: 0, ttlMs: 30_000 },
       }, null, 2));
       await writeSessionStart(wd, 'sess-managed-fallback');
-      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
         last_agent_output: 'Keep going and finish the cleanup from here.',
@@ -1345,7 +1347,8 @@ exit 0
         target: { type: 'pane', value: '%42' },
       }, null, 2));
       await writeSessionStart(wd, 'sess-managed-fallback');
-      await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'sessions', 'sess-managed-fallback', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
         last_agent_output: 'Keep going and finish the cleanup from here.',
@@ -1938,7 +1941,7 @@ exit 0
         owner_omx_session_id: omxSessionId,
         owner_codex_session_id: codexSessionId,
       }, null, 2));
-      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+      await writeFile(join(stateDir, 'sessions', omxSessionId, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
       }, null, 2));
       await writeFile(statePath, JSON.stringify({
@@ -2704,7 +2707,7 @@ exit 0
         current_phase: 'executing',
         tmux_pane_id: '%42',
       }, null, 2));
-      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+      await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
       }, null, 2));
       await writeFile(join(stateDir, 'notify-fallback-state.json'), JSON.stringify({

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -10,6 +10,8 @@ import { initTeamState, enqueueDispatchRequest, readDispatchRequest } from '../.
 import { buildWindowsMsysBackgroundHelperBootstrapScript } from '../../cli/index.js';
 import { writeSessionStart } from '../session.js';
 
+const DEFAULT_AUTO_NUDGE_RESPONSE = 'continue with the current task only if it is already authorized';
+
 async function appendLine(path: string, line: object): Promise<void> {
   const prev = await readFile(path, 'utf-8');
   const content = prev + `${JSON.stringify(line)}\n`;
@@ -164,6 +166,10 @@ async function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number = 
       throw new Error(`process ${child.pid ?? 'unknown'} did not exit within ${timeoutMs}ms`);
     }),
   ]);
+}
+
+function defaultAutoNudgePattern(targetPane: string): RegExp {
+  return new RegExp(`send-keys -t ${targetPane} -l ${DEFAULT_AUTO_NUDGE_RESPONSE.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')} \\[OMX_TMUX_INJECT\\]`);
 }
 
 function buildFakeTmux(
@@ -717,7 +723,7 @@ describe('notify-fallback watcher', () => {
       await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
-        last_agent_output: 'If you want, I can keep going from here.',
+        last_agent_output: 'Keep going and finish the cleanup from here.',
       }, null, 2));
       await writeFile(join(wd, '.omx', 'state', 'notify-fallback.pid'), JSON.stringify({
         pid: process.pid,
@@ -752,7 +758,7 @@ describe('notify-fallback watcher', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%42'));
 
       const watcherState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), 'utf-8'));
       assert.equal(watcherState.pid, process.pid, 'authority backoff should preserve the primary watcher state owner');
@@ -823,7 +829,7 @@ describe('notify-fallback watcher', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
       assert.doesNotMatch(tmuxLog, /Ralph loop active continue/);
       assert.doesNotMatch(tmuxLog, /Team dispatch-team:/);
-      assert.doesNotMatch(tmuxLog, /yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, new RegExp(`${DEFAULT_AUTO_NUDGE_RESPONSE.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')} \\[OMX_TMUX_INJECT\\]`));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -894,7 +900,7 @@ describe('notify-fallback watcher', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
       assert.doesNotMatch(tmuxLog, /Ralph loop active continue/);
       assert.doesNotMatch(tmuxLog, /Team dispatch-team:/);
-      assert.doesNotMatch(tmuxLog, /yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, new RegExp(`${DEFAULT_AUTO_NUDGE_RESPONSE.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')} \\[OMX_TMUX_INJECT\\]`));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1283,7 +1289,7 @@ exit 0
       await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
-        last_agent_output: 'If you want, I can keep going from here.',
+        last_agent_output: 'Keep going and finish the cleanup from here.',
       }, null, 2));
 
       const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
@@ -1307,7 +1313,7 @@ exit 0
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8');
-      assert.match(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.match(tmuxLog, defaultAutoNudgePattern('%42'));
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
@@ -1342,7 +1348,7 @@ exit 0
       await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 7,
-        last_agent_output: 'If you want, I can keep going from here.',
+        last_agent_output: 'Keep going and finish the cleanup from here.',
       }, null, 2));
 
       const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
@@ -1365,7 +1371,7 @@ exit 0
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%42'));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1389,7 +1395,7 @@ exit 0
       await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 6_000).toISOString(),
         turn_count: 9,
-        last_agent_output: 'If you want, I can keep going from here.',
+        last_agent_output: 'Keep going and finish the cleanup from here.',
       }, null, 2));
 
       const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
@@ -1411,7 +1417,7 @@ exit 0
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%42'));
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
@@ -1443,7 +1449,7 @@ exit 0
       await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
         last_turn_at: new Date(Date.now() - 1_000).toISOString(),
         turn_count: 8,
-        last_agent_output: 'If you want, I can keep going from here.',
+        last_agent_output: 'Keep going and finish the cleanup from here.',
       }, null, 2));
 
       const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
@@ -1465,7 +1471,7 @@ exit 0
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%42'));
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
@@ -1482,7 +1488,7 @@ exit 0
     const tmuxLogPath = join(wd, 'tmux.log');
     const codexHome = join(wd, 'codex-home');
     const lastTurnAt = new Date(Date.now() - 6_000).toISOString();
-    const lastMessage = 'If you want, I can keep going from here.';
+    const lastMessage = 'Keep going and finish the cleanup from here.';
     try {
       await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
@@ -1524,7 +1530,7 @@ exit 0
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%42'));
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
@@ -1541,7 +1547,7 @@ exit 0
     const tmuxLogPath = join(wd, 'tmux.log');
     const codexHome = join(wd, 'codex-home');
     const lastTurnAt = '2026-03-01T00:00:00.000Z';
-    const lastMessage = 'If you want, I can keep going from here.';
+    const lastMessage = 'Keep going and finish the cleanup from here.';
     try {
       await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
@@ -1583,7 +1589,7 @@ exit 0
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%42'));
 
       const watcherStatePath = join(wd, '.omx', 'state', 'notify-fallback-state.json');
       const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -42,6 +42,97 @@ async function readJsonLines(path: string): Promise<Array<Record<string, unknown
     .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
+async function writeCanonicalWatcherTeamFixture(
+  wd: string,
+  {
+    teamName = 'dispatch-team',
+    sessionId = 'sess-current',
+    ownerSessionId = sessionId,
+    coarseState = 'missing',
+    terminal = false,
+  }: {
+    teamName?: string;
+    sessionId?: string;
+    ownerSessionId?: string;
+    coarseState?: 'missing' | 'inactive' | 'active';
+    terminal?: boolean;
+  } = {},
+): Promise<void> {
+  const stateDir = join(wd, '.omx', 'state');
+  const teamDir = join(stateDir, 'team', teamName);
+  const nowIso = new Date().toISOString();
+
+  await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+  await mkdir(join(teamDir, 'workers'), { recursive: true });
+  await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+  if (coarseState !== 'missing') {
+    await writeFile(join(stateDir, 'team-state.json'), JSON.stringify({
+      active: coarseState === 'active',
+      team_name: teamName,
+      current_phase: terminal ? 'complete' : 'team-exec',
+      ...(terminal ? { completed_at: nowIso } : {}),
+    }, null, 2));
+  }
+  await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+    last_turn_at: new Date(Date.now() - 300_000).toISOString(),
+    turn_count: 3,
+  }, null, 2));
+  const manifest = {
+    schema_version: 2,
+    name: teamName,
+    task: 'canonical watcher fallback repro',
+    leader: {
+      session_id: ownerSessionId,
+      worker_id: 'leader-fixed',
+      role: 'coordinator',
+    },
+    policy: {
+      worker_launch_mode: 'interactive',
+      display_mode: 'split_pane',
+      dispatch_mode: 'hook_preferred_with_fallback',
+      dispatch_ack_timeout_ms: 2000,
+    },
+    governance: {
+      delegation_only: false,
+      plan_approval_required: false,
+      nested_teams_allowed: false,
+      one_team_per_leader_session: true,
+      cleanup_requires_all_workers_inactive: true,
+    },
+    lifecycle_profile: 'default',
+    permissions_snapshot: {
+      approval_mode: 'never',
+      sandbox_mode: 'danger-full-access',
+      network_access: true,
+    },
+    tmux_session: `${teamName}:0`,
+    leader_pane_id: '%42',
+    hud_pane_id: null,
+    resize_hook_name: null,
+    resize_hook_target: null,
+    worker_count: 1,
+    next_task_id: 1,
+    workers: [
+      { name: 'worker-1', index: 1, pane_id: '%42', role: 'executor' },
+    ],
+    created_at: nowIso,
+  };
+  await writeFile(join(teamDir, 'manifest.v2.json'), JSON.stringify(manifest, null, 2));
+  await writeFile(join(teamDir, 'config.json'), JSON.stringify({
+    name: teamName,
+    tmux_session: `${teamName}:0`,
+    leader_pane_id: '%42',
+    workers: [
+      { name: 'worker-1', pane_id: '%42' },
+    ],
+  }, null, 2));
+  await writeFile(join(teamDir, 'phase.json'), JSON.stringify({
+    current_phase: terminal ? 'complete' : 'team-exec',
+    updated_at: nowIso,
+    transitions: terminal ? [{ from: 'team-exec', to: 'complete', at: nowIso }] : [],
+  }, null, 2));
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -844,6 +935,7 @@ describe('notify-fallback watcher', () => {
           encoding: 'utf-8',
           env: buildCleanNotifyEnv({
             PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_SESSION_ID: 'sess-canonical-inactive',
           }),
         },
       );
@@ -874,6 +966,43 @@ describe('notify-fallback watcher', () => {
         && entry.source === 'notify_fallback_watcher'
         && entry.transport === 'send-keys'
         && entry.result === 'sent'));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('runs leader nudge checks from canonical fallback when coarse team-state is inactive', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-leader-nudge-canonical-inactive-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalWatcherTeamFixture(wd, {
+        teamName: 'dispatch-team',
+        sessionId: 'sess-canonical-inactive',
+        ownerSessionId: 'sess-canonical-inactive',
+        coarseState: 'inactive',
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_SESSION_ID: 'sess-canonical-inactive',
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8');
+      assert.match(tmuxLog, /send-keys -t %42 -l Team dispatch-team: leader stale, \d+ worker pane\(s\) still active\./);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -927,6 +1056,7 @@ describe('notify-fallback watcher', () => {
           encoding: 'utf-8',
           env: buildCleanNotifyEnv({
             PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_SESSION_ID: 'sess-canonical-inactive',
           }),
         },
       );
@@ -2734,6 +2864,149 @@ exit 0
       assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
         entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
       )));
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('stays alive after parent exit when coarse team-state is missing but canonical team is active for the current session', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-canonical-team-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-canonical-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalWatcherTeamFixture(wd, {
+        teamName: 'dispatch-team',
+        sessionId: 'sess-parent-canonical',
+        ownerSessionId: 'sess-parent-canonical',
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        }
+      );
+
+      await waitFor(async () => isPidAlive(child?.pid), 4000, 50);
+      await waitFor(async () => {
+        const logEntries = (await readFile(logPath, 'utf-8').catch(() => ''))
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map((line) => JSON.parse(line));
+        return logEntries.some((entry: { type?: string; reason?: string }) => (
+          entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+        ));
+      }, 4000, 50);
+
+      assert.ok(isPidAlive(child.pid), 'expected watcher to stay alive while canonical team panes remain active');
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('does not defer parent-loss shutdown when canonical owner session is blank and coarse team-state is missing', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-ownerless-team-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-parent-gone-ownerless-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalWatcherTeamFixture(wd, {
+        teamName: 'dispatch-team',
+        sessionId: 'sess-parent-ownerless',
+        ownerSessionId: '',
+      });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        }
+      );
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
+      )));
+      assert.ok(!logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+      )), 'ownerless canonical team must not defer parent-loss shutdown');
     } finally {
       if (child && isPidAlive(child.pid)) {
         child.kill('SIGTERM');

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -211,6 +211,8 @@ describe('notify-hook auto-nudge', () => {
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
         'last-assistant-message': 'I analyzed the code. Keep going and finish the focused cleanup.',
@@ -220,7 +222,7 @@ describe('notify-hook auto-nudge', () => {
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
       assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
 
-      const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
+      const nudgeState = JSON.parse(await readFile(join(sessionStateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 0);
       assert.ok(nudgeState.pendingSignature);
       assert.ok(nudgeState.pendingSince);
@@ -701,6 +703,9 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1012,6 +1017,9 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 0 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1032,7 +1040,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
-      const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
+      const nudgeState = JSON.parse(await readFile(join(sessionStateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1);
       assert.match(nudgeState.lastSignature, /^hud:1\|.*\|stall:proceed_intent$/);
     });
@@ -1055,6 +1063,9 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 5000 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1074,7 +1085,7 @@ exit 0
       let tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
-      const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+      const nudgeStatePath = join(sessionStateDir, 'auto-nudge-state.json');
       const nudgeStateBeforeThird = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       await writeJson(nudgeStatePath, {
         ...nudgeStateBeforeThird,
@@ -1115,7 +1126,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 5000 },
       });
-      await writeJson(join(stateDir, 'hud-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'hud-state.json'), {
         last_turn_at: lastTurnAt,
         turn_count: 1,
         last_agent_output: lastMessage,
@@ -1130,7 +1144,7 @@ exit 0
       });
       assert.equal(first.status, 0, `first hook failed: ${first.stderr || first.stdout}`);
 
-      const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+      const nudgeStatePath = join(sessionStateDir, 'auto-nudge-state.json');
       const firstState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       await writeJson(nudgeStatePath, {
         ...firstState,
@@ -1171,6 +1185,7 @@ exit 0
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0, ttlMs: 0 },
       });
       await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1192,10 +1207,10 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
-      const hudState = JSON.parse(await readFile(join(stateDir, 'hud-state.json'), 'utf-8'));
+      const hudState = JSON.parse(await readFile(join(sessionStateDir, 'hud-state.json'), 'utf-8'));
       assert.equal(hudState.turn_count, 1);
 
-      const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
+      const nudgeState = JSON.parse(await readFile(join(sessionStateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1);
       assert.match(nudgeState.lastSignature, /^hud:1\|.*\|stall:proceed_intent$/);
     });
@@ -1249,6 +1264,9 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -1258,7 +1276,7 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
+      const nudgeStatePath = join(sessionStateDir, 'auto-nudge-state.json');
       assert.ok(existsSync(nudgeStatePath), 'auto-nudge-state.json should be created');
       const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1, 'nudge count should be 1');
@@ -1360,7 +1378,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
         version: 1,
         active: true,
         skill: 'deep-interview',
@@ -1603,7 +1624,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
         version: 1,
         active: true,
         skill: 'deep-interview',
@@ -1628,7 +1652,7 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
         active: boolean;
         phase: string;
         input_lock?: { active: boolean; released_at?: string; exit_reason?: string };
@@ -1657,7 +1681,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
         version: 1,
         active: true,
         skill: 'deep-interview',
@@ -1682,7 +1709,7 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
         active: boolean;
         phase: string;
         input_lock?: { active: boolean; released_at?: string; exit_reason?: string };
@@ -1711,7 +1738,10 @@ exit 0
       await writeJson(join(codexHome, '.omx-config.json'), {
         autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
       });
-      await writeJson(join(stateDir, 'skill-active-state.json'), {
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
         version: 1,
         active: true,
         skill: 'deep-interview',
@@ -1737,7 +1767,7 @@ exit 0
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
-      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
         skill: string;
         active: boolean;
         phase: string;

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -10,6 +10,7 @@ import { buildTmuxSessionName } from '../../cli/index.js';
 const NOTIFY_HOOK_SCRIPT = new URL('../../../dist/scripts/notify-hook.js', import.meta.url);
 const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'];
 const NEXT_I_SHOULD_RESPONSE = 'Next I should update the focused tests.';
+const DEFAULT_AUTO_NUDGE_RESPONSE = 'continue with the current task only if it is already authorized';
 
 async function withTempWorkingDir(run: (cwd: string) => Promise<void>): Promise<void> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-auto-nudge-'));
@@ -63,6 +64,10 @@ async function writeManagedSessionState(stateDir: string, cwd: string): Promise<
 
 function escapeRegex(value: string): string {
   return value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+function defaultAutoNudgePattern(targetPane: string): RegExp {
+  return new RegExp(`send-keys -t ${escapeRegex(targetPane)} -l ${escapeRegex(DEFAULT_AUTO_NUDGE_RESPONSE)} \\[OMX_TMUX_INJECT\\]`);
 }
 
 /**
@@ -208,12 +213,12 @@ describe('notify-hook auto-nudge', () => {
       await writeManagedSessionState(stateDir, cwd);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'I analyzed the code. If you want me to make these changes, let me know.',
+        'last-assistant-message': 'I analyzed the code. Keep going and finish the focused cleanup.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
 
       const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 0);
@@ -246,16 +251,58 @@ describe('notify-hook auto-nudge', () => {
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'I analyzed the code. If you want me to make these changes, let me know.',
+        'last-assistant-message': 'I analyzed the code. Keep going and finish the focused cleanup.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should send nudge response with injection marker');
+      assert.match(tmuxLog, defaultAutoNudgePattern('%99'), 'should send nudge response with injection marker');
       // Codex CLI needs C-m sent twice with a delay for reliable submission
       const cmMatches = tmuxLog.match(/send-keys -t %99 C-m/g);
       assert.ok(cmMatches && cmMatches.length >= 2, `should send C-m twice, got ${cmMatches?.length ?? 0}`);
+    });
+  });
+
+  it('does not auto-nudge planning-phase skill state into execution', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      await writeJson(join(stateDir, 'skill-active-state.json'), {
+        active: true,
+        skill: 'analyze',
+        keyword: 'investigate',
+        phase: 'planning',
+        source: 'keyword-detector',
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'I can continue with the plan from here.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l/, 'planning-phase prompts should not be auto-nudged');
+
+      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(skillState.phase, 'planning');
     });
   });
 
@@ -291,7 +338,7 @@ describe('notify-hook auto-nudge', () => {
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
     });
   });
 
@@ -341,7 +388,7 @@ describe('notify-hook auto-nudge', () => {
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
     });
   });
 
@@ -374,7 +421,7 @@ describe('notify-hook auto-nudge', () => {
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
     });
   });
 
@@ -412,7 +459,7 @@ describe('notify-hook auto-nudge', () => {
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
     });
   });
 
@@ -456,7 +503,7 @@ describe('notify-hook auto-nudge', () => {
         new RegExp(`list-panes -s -t ${escapeRegex(expectedManagedSessionName)}`),
         'should resolve panes against the current OMX session identity, not the drifted tmux session name',
       );
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
     });
   });
 
@@ -481,7 +528,7 @@ describe('notify-hook auto-nudge', () => {
       await writeManagedSessionState(stateDir, cwd);
 
       // capture-pane will return content with a stall pattern
-      await writeFile(captureFile, 'Here are the results.\nWould you like me to continue with the implementation?\n› ');
+      await writeFile(captureFile, 'Here are the results.\nKeep going and finish the implementation.\n› ');
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
@@ -495,7 +542,7 @@ describe('notify-hook auto-nudge', () => {
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /capture-pane/, 'should have tried capture-pane');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should send nudge via capture-pane fallback with marker');
+      assert.match(tmuxLog, defaultAutoNudgePattern('%99'), 'should send nudge via capture-pane fallback with marker');
     });
   });
 
@@ -589,14 +636,14 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'If you want, I can keep going from here.',
+        'last-assistant-message': 'Keep going and finish the cleanup from here.',
       }, {
         TMUX_PANE: '',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %100 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should upgrade anchored shell pane to sibling codex pane');
+      assert.match(tmuxLog, defaultAutoNudgePattern('%100'), 'should upgrade anchored shell pane to sibling codex pane');
     });
   });
 
@@ -630,7 +677,7 @@ exit 0
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'team-worker context should still send auto-nudge');
+      assert.match(tmuxLog, defaultAutoNudgePattern('%99'), 'team-worker context should still send auto-nudge');
 
       const nudgeStatePath = join(workerStateRoot, 'auto-nudge-state.json');
       assert.ok(existsSync(nudgeStatePath), 'worker state root should receive auto-nudge state');
@@ -665,7 +712,7 @@ exit 0
 
       if (existsSync(tmuxLogPath)) {
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-        assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed/, 'should NOT send nudge');
+        assert.doesNotMatch(tmuxLog, new RegExp(`send-keys -t %99 -l ${escapeRegex(DEFAULT_AUTO_NUDGE_RESPONSE)}`), 'should NOT send nudge');
       }
     });
   });
@@ -733,7 +780,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.ok(tmuxLog.includes('display-message -p -t %99 #S'), 'should inspect the managed anchor pane before deciding');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'shell pane should not receive auto-nudge injection');
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'), 'shell pane should not receive auto-nudge injection');
     });
   });
 
@@ -798,7 +845,7 @@ shift || true
   exit 0
 fi
 if [[ "$cmd" == "capture-pane" ]]; then
-  printf "› say \\"if you want\\"\\n\\n• if you want\\n\\n› Implement {feature}\\n\\n  gpt-5.4 high · dev · 98%% left\\n"
+  printf "› keep going\\n\\n• keep going\\n\\n› Implement {feature}\\n\\n  gpt-5.4 high · dev · 98%% left\\n"
   exit 0
 fi
 if [[ "$cmd" == "send-keys" ]]; then
@@ -825,14 +872,14 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'if you want',
+        'last-assistant-message': 'keep going',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p #S/);
       assert.ok(tmuxLog.includes('display-message -p -t %99 #S'), 'should inspect the anchored shell pane before upgrading');
-      assert.match(tmuxLog, /send-keys -t %100 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.match(tmuxLog, defaultAutoNudgePattern('%100'));
     });
   });
 
@@ -859,13 +906,13 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'If you want, I can keep going from here.',
+        'last-assistant-message': 'Keep going and finish the cleanup from here.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p #S/);
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'copy-mode pane should not receive auto-nudge injection');
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'), 'copy-mode pane should not receive auto-nudge injection');
     });
   });
 
@@ -910,7 +957,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p #S/);
       assert.match(tmuxLog, /capture-pane -t %99/, 'busy pane detection should inspect capture output');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'busy pane should not receive auto-nudge injection');
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'), 'busy pane should not receive auto-nudge injection');
     });
   });
 
@@ -972,18 +1019,18 @@ exit 0
       const sharedTurnId = 'semantic-dedup-turn';
       const first = runNotifyHook(cwd, fakeBinDir, codexHome, {
         'turn-id': sharedTurnId,
-        'last-assistant-message': 'If you want, I can keep going from here.',
+        'last-assistant-message': 'Keep going and finish the cleanup from here.',
       });
       assert.equal(first.status, 0, `first hook failed: ${first.stderr || first.stdout}`);
 
       const second = runNotifyHook(cwd, fakeBinDir, codexHome, {
         'turn-id': sharedTurnId,
-        'last-assistant-message': 'Shall I proceed from here?',
+        'last-assistant-message': 'Continue with the cleanup from here.',
       });
       assert.equal(second.status, 0, `second hook failed: ${second.stderr || second.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 1);
+      assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
       const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1);
@@ -1014,7 +1061,7 @@ exit 0
 
       const first = runNotifyHook(cwd, fakeBinDir, codexHome, {
         'turn-id': 'cooldown-turn-1',
-        'last-assistant-message': 'Would you like me to continue with the implementation?',
+        'last-assistant-message': 'Continue with the implementation from here.',
       });
       assert.equal(first.status, 0, `first hook failed: ${first.stderr || first.stdout}`);
 
@@ -1025,7 +1072,7 @@ exit 0
       assert.equal(second.status, 0, `second hook failed: ${second.stderr || second.stdout}`);
 
       let tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 1);
+      assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
       const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
       const nudgeStateBeforeThird = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
@@ -1036,12 +1083,12 @@ exit 0
 
       const third = runNotifyHook(cwd, fakeBinDir, codexHome, {
         'turn-id': 'cooldown-turn-3',
-        'last-assistant-message': 'Do you want me to proceed with the focused tests?',
+        'last-assistant-message': 'Keep going and finish the focused tests.',
       });
       assert.equal(third.status, 0, `third hook failed: ${third.stderr || third.stdout}`);
 
       tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 2);
+      assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 2);
 
       const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 2);
@@ -1058,7 +1105,7 @@ exit 0
       const fakeBinDir = join(cwd, 'fake-bin');
       const tmuxLogPath = join(cwd, 'tmux.log');
       const lastTurnAt = '2026-03-01T00:00:00.000Z';
-      const lastMessage = 'If you want, I can keep going from here.';
+      const lastMessage = 'Keep going and finish the cleanup from here.';
 
       await mkdir(logsDir, { recursive: true });
       await mkdir(stateDir, { recursive: true });
@@ -1097,7 +1144,7 @@ exit 0
       assert.equal(result.status, 0, `second hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 1);
+      assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
       const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
       assert.equal(nudgeState.nudgeCount, 1);
@@ -1113,7 +1160,7 @@ exit 0
       const codexHome = join(cwd, 'codex-home');
       const fakeBinDir = join(cwd, 'fake-bin');
       const tmuxLogPath = join(cwd, 'tmux.log');
-      const lastMessage = 'If you want, I can keep going from here.';
+      const lastMessage = 'Keep going and finish the cleanup from here.';
 
       await mkdir(logsDir, { recursive: true });
       await mkdir(stateDir, { recursive: true });
@@ -1143,7 +1190,7 @@ exit 0
       assert.equal(second.status, 0, `second hook failed: ${second.stderr || second.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/g) || []).length, 1);
+      assert.equal((tmuxLog.match(new RegExp(defaultAutoNudgePattern('%99').source, 'g')) || []).length, 1);
 
       const hudState = JSON.parse(await readFile(join(stateDir, 'hud-state.json'), 'utf-8'));
       assert.equal(hudState.turn_count, 1);
@@ -1176,7 +1223,7 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'Do you want me to implement this feature?',
+        'last-assistant-message': 'Keep going and implement this feature.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
@@ -1207,7 +1254,7 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'Ready to proceed when you are.',
+        'last-assistant-message': 'Keep going and finish the focused cleanup.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
@@ -1291,7 +1338,7 @@ exit 0
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
     });
   });
 
@@ -1318,7 +1365,7 @@ exit 0
         active: true,
         skill: 'deep-interview',
         keyword: 'deep interview',
-        phase: 'planning',
+        phase: 'executing',
         activated_at: '2026-02-25T00:00:00.000Z',
         updated_at: '2026-02-25T00:00:00.000Z',
         source: 'keyword-detector',
@@ -1340,7 +1387,7 @@ exit 0
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/);
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'));
     });
   });
 
@@ -1432,7 +1479,7 @@ exit 0
         await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
         const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-          'last-assistant-message': 'Would you like me to continue?',
+          'last-assistant-message': 'Keep going and finish the cleanup.',
         });
         assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
@@ -1443,7 +1490,7 @@ exit 0
     });
   }
 
-  it('logs deep-interview auto-approval suppression without injecting tmux input', async () => {
+  it('suppresses deep-interview auto-approval without injecting tmux input', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
       const stateDir = join(omxDir, 'state');
@@ -1482,18 +1529,12 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'Would you like me to continue?',
+        'last-assistant-message': 'Keep going and finish the cleanup.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.doesNotMatch(tmuxLog, /send-keys -t %99 -l Deep interview is active; auto-approval shortcuts are blocked until the interview finishes\. \[OMX_TMUX_INJECT\]/);
-
-      const hookLogPath = join(logsDir, `tmux-hook-${new Date().toISOString().split('T')[0]}.jsonl`);
-      const hookLog = await readFile(hookLogPath, 'utf-8');
-      assert.match(hookLog, /"type":"auto_nudge_blocked"/);
-      assert.match(hookLog, /"blocked_by":"deep-interview-lock"/);
-      assert.match(hookLog, /"suppressed":true/);
     });
   });
 
@@ -1740,7 +1781,7 @@ exit 0
 
       // Default pattern should NOT trigger with custom config
       const result1 = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'Would you like me to proceed?',
+        'last-assistant-message': 'Keep going and finish the focused cleanup.',
       });
       assert.equal(result1.status, 0);
 
@@ -1761,7 +1802,7 @@ exit 0
       assert.equal(result2.status, 0);
 
       const log2 = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(log2, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'custom pattern should trigger nudge with marker');
+      assert.match(log2, defaultAutoNudgePattern('%99'), 'custom pattern should trigger nudge with marker');
     });
   });
 
@@ -1788,13 +1829,13 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'If you want, I can fix the remaining issues.',
+        'last-assistant-message': 'Keep going and fix the remaining issues.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
 
       assert.ok(existsSync(tmuxLogPath), 'tmux should be called with defaults');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should nudge with default config and marker');
+      assert.match(tmuxLog, defaultAutoNudgePattern('%99'), 'should nudge with default config and marker');
     });
   });
 
@@ -1820,7 +1861,7 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'last-assistant-message': 'Would you like me to continue?',
+        'last-assistant-message': 'Keep going and finish the focused cleanup.',
       }, {
         TMUX_PANE: '',  // No pane available
         TMUX: '',
@@ -1829,7 +1870,7 @@ exit 0
 
       if (existsSync(tmuxLogPath)) {
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-        assert.match(tmuxLog, /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/, 'should fall back to the managed session pane when TMUX_PANE is absent');
+        assert.match(tmuxLog, defaultAutoNudgePattern('%99'), 'should fall back to the managed session pane when TMUX_PANE is absent');
       }
     });
   });

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -199,24 +199,25 @@ describe('notify-hook/operational-events – deriveAssistantSignalEvents', () =>
 // auto-nudge.js – detectStallPattern
 // ---------------------------------------------------------------------------
 describe('notify-hook/auto-nudge – detectStallPattern', () => {
-  it('detects default stall patterns case-insensitively', async () => {
+  it('detects default continuation patterns case-insensitively', async () => {
     const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
-    assert.equal(detectStallPattern('Would you like me to continue?', DEFAULT_STALL_PATTERNS), true);
-    assert.equal(detectStallPattern('WOULD YOU LIKE me to continue?', DEFAULT_STALL_PATTERNS), true);
-    assert.equal(detectStallPattern('Shall I proceed?', DEFAULT_STALL_PATTERNS), true);
-    assert.equal(detectStallPattern('If you want, I can refactor.', DEFAULT_STALL_PATTERNS), true);
-    assert.equal(detectStallPattern('Let me know if you need more help.', DEFAULT_STALL_PATTERNS), true);
-    assert.equal(detectStallPattern('Ready to proceed whenever you are.', DEFAULT_STALL_PATTERNS), true);
-    assert.equal(detectStallPattern('I’M READY TO take the next step.', DEFAULT_STALL_PATTERNS), true);
     assert.equal(detectStallPattern('KEEP GOING and I will finish the patch.', DEFAULT_STALL_PATTERNS), true);
+    assert.equal(detectStallPattern('Continue with the existing cleanup from here.', DEFAULT_STALL_PATTERNS), true);
   });
 
-  it('detects team-worker follow-up phrases like continue with and next step', async () => {
+  it('detects team-worker continuation phrases like continue with and keep going', async () => {
     const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
     assert.equal(detectStallPattern('I can continue with the worker follow-up from here.', DEFAULT_STALL_PATTERNS), true);
-    assert.equal(detectStallPattern('The next step is to finish the worker handoff.', DEFAULT_STALL_PATTERNS), true);
-    assert.equal(detectStallPattern('The NEXT STEPS would be running tests and posting the summary.', DEFAULT_STALL_PATTERNS), true);
     assert.equal(detectStallPattern('We can pick up with the cleanup after this.', DEFAULT_STALL_PATTERNS), true);
+  });
+
+  it('does not treat permission-seeking or planning prompts as auto-nudge stalls', async () => {
+    const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
+    assert.equal(detectStallPattern('Would you like me to continue?', DEFAULT_STALL_PATTERNS), false);
+    assert.equal(detectStallPattern('Shall I proceed?', DEFAULT_STALL_PATTERNS), false);
+    assert.equal(detectStallPattern('If you want, I can refactor.', DEFAULT_STALL_PATTERNS), false);
+    assert.equal(detectStallPattern('Ready to proceed whenever you are.', DEFAULT_STALL_PATTERNS), false);
+    assert.equal(detectStallPattern('I can continue with the plan from here.', DEFAULT_STALL_PATTERNS), false);
   });
 
   it('returns false when no stall pattern present', async () => {
@@ -250,7 +251,7 @@ describe('notify-hook/auto-nudge – detectStallPattern', () => {
   it('focuses detection on the last few lines (hotZone)', async () => {
     const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
     // Stall phrase only in the last line — should detect
-    const text = 'Line 1\nLine 2\nLine 3\nLine 4\nWould you like me to continue?';
+    const text = 'Line 1\nLine 2\nLine 3\nLine 4\nKeep going and finish the patch.';
     assert.equal(detectStallPattern(text, DEFAULT_STALL_PATTERNS), true);
   });
 
@@ -317,6 +318,15 @@ describe('notify-hook/auto-nudge – normalizeAutoNudgeConfig', () => {
     // Empty array → fall back to defaults
     const cfg = normalizeAutoNudgeConfig({ patterns: [] });
     assert.deepEqual(cfg.patterns, DEFAULT_STALL_PATTERNS);
+  });
+});
+
+describe('notify-hook/auto-nudge – resolveEffectiveAutoNudgeResponse', () => {
+  it('maps legacy approval-style responses to a non-authorizing continuation message', async () => {
+    const { DEFAULT_AUTO_NUDGE_RESPONSE, resolveEffectiveAutoNudgeResponse } = await loadModule('notify-hook/auto-nudge.js');
+    assert.equal(resolveEffectiveAutoNudgeResponse('yes, proceed'), DEFAULT_AUTO_NUDGE_RESPONSE);
+    assert.equal(resolveEffectiveAutoNudgeResponse('continue'), DEFAULT_AUTO_NUDGE_RESPONSE);
+    assert.equal(resolveEffectiveAutoNudgeResponse('custom follow-up'), 'custom follow-up');
   });
 });
 

--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -172,6 +172,41 @@ describe('notify-hook/operational-events – buildOperationalContext', () => {
       else process.env.TMUX = originalTmux;
     }
   });
+
+  it('writes PR lifecycle details into the repo baseline registry as best effort state', async () => {
+    const { buildOperationalContext } = await loadModule('notify-hook/operational-events.js');
+    const { mkdtemp, rm, writeFile, readFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { execFileSync } = await import('node:child_process');
+
+    const repo = await mkdtemp(join(tmpdir(), 'omx-opctx-baseline-'));
+    try {
+      execFileSync('git', ['init'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo, stdio: 'ignore' });
+      await writeFile(join(repo, 'README.md'), 'hello\n', 'utf-8');
+      execFileSync('git', ['add', 'README.md'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['checkout', '-b', 'feature/opctx-pr'], { cwd: repo, stdio: 'ignore' });
+
+      const context = buildOperationalContext({
+        cwd: repo,
+        normalizedEvent: 'pr-merged',
+        text: 'Merged issue #1407 via PR #1416',
+        prUrl: 'https://github.com/Yeachan-Heo/oh-my-codex/pull/1416',
+      });
+
+      assert.equal(context.branch, 'feature/opctx-pr');
+      const baseline = JSON.parse(await readFile(join(repo, '.omx', 'state', 'current-task-baseline.json'), 'utf-8'));
+      const entry = baseline.tasks.find((item: { branch_name: string }) => item.branch_name === 'feature/opctx-pr');
+      assert.equal(entry.issue_number, 1407);
+      assert.equal(entry.pr_number, 1416);
+      assert.equal(entry.status, 'merged');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('notify-hook/operational-events – deriveAssistantSignalEvents', () => {

--- a/src/hooks/__tests__/notify-hook-regression-205.test.ts
+++ b/src/hooks/__tests__/notify-hook-regression-205.test.ts
@@ -2,9 +2,8 @@
  * Regression tests for issue #205:
  * - notify-hook.js must be the thin orchestrator (imports from sub-modules)
  * - resolveTeamStateDirForWorker must be exported from team-worker.js
- * - DEFAULT_STALL_PATTERNS must contain 'if you want'
- * - detectStallPattern must match 'if you want'
- * - notify-hook end-to-end keeps 'if you want' stall detection, but default injection now waits for a real stall window
+ * - legacy 'if you want' permission-seeking prompts must stay excluded from default stall detection after #1416
+ * - notify-hook end-to-end must not treat 'if you want' as a default auto-nudge stall candidate
  */
 
 import { describe, it, before, after } from 'node:test';
@@ -132,41 +131,38 @@ function runNotifyHook(
 }
 
 // ---------------------------------------------------------------------------
-// auto-nudge.js – DEFAULT_STALL_PATTERNS contains 'if you want'
+// auto-nudge.js – permission-seeking prompts stay excluded after #1416
 // ---------------------------------------------------------------------------
-describe('regression-205: DEFAULT_STALL_PATTERNS contains "if you want"', () => {
-  it('DEFAULT_STALL_PATTERNS array includes "if you want"', async () => {
+describe('regression-205: DEFAULT_STALL_PATTERNS excludes permission-seeking prompts after #1416', () => {
+  it('DEFAULT_STALL_PATTERNS array does not include "if you want"', async () => {
     const { DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
     assert.ok(
       Array.isArray(DEFAULT_STALL_PATTERNS),
       'DEFAULT_STALL_PATTERNS should be an array',
     );
-    assert.ok(
-      DEFAULT_STALL_PATTERNS.includes('if you want'),
-      `Expected DEFAULT_STALL_PATTERNS to contain "if you want", got: ${JSON.stringify(DEFAULT_STALL_PATTERNS)}`,
-    );
-    assert.ok(DEFAULT_STALL_PATTERNS.includes('i\'m ready to'));
     assert.ok(DEFAULT_STALL_PATTERNS.includes('keep going'));
+    assert.equal(DEFAULT_STALL_PATTERNS.includes('if you want'), false);
+    assert.equal(DEFAULT_STALL_PATTERNS.includes('i\'m ready to'), false);
   });
 });
 
 // ---------------------------------------------------------------------------
-// auto-nudge.js – detectStallPattern matches 'if you want'
+// auto-nudge.js – detectStallPattern no longer matches permission-seeking 'if you want'
 // ---------------------------------------------------------------------------
-describe('regression-205: detectStallPattern matches "if you want"', () => {
-  it('detects "if you want" pattern', async () => {
+describe('regression-205: detectStallPattern excludes "if you want" after #1416', () => {
+  it('does not detect "if you want" pattern', async () => {
     const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
     assert.equal(
       detectStallPattern('If you want, I can refactor the module.', DEFAULT_STALL_PATTERNS),
-      true,
+      false,
     );
   });
 
-  it('detects "if you want" case-insensitively', async () => {
+  it('does not detect "if you want" case-insensitively', async () => {
     const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
     assert.equal(
       detectStallPattern('IF YOU WANT I can do more.', DEFAULT_STALL_PATTERNS),
-      true,
+      false,
     );
   });
 
@@ -188,10 +184,9 @@ describe('regression-205: detectStallPattern matches "if you want"', () => {
 });
 
 // ---------------------------------------------------------------------------
-// notify-hook.js – "if you want" still marks a stall candidate, but default
-// injection now waits for the stall window instead of firing immediately.
+// notify-hook.js – "if you want" no longer marks a default stall candidate.
 // ---------------------------------------------------------------------------
-describe('regression-205: notify-hook records pending stall state on "if you want" by default', () => {
+describe('regression-205: notify-hook ignores "if you want" for default auto-nudge', () => {
   let originalTeamWorker: string | undefined;
   let originalTeamStateRoot: string | undefined;
 
@@ -209,7 +204,7 @@ describe('regression-205: notify-hook records pending stall state on "if you wan
     else process.env.OMX_TEAM_STATE_ROOT = originalTeamStateRoot;
   });
 
-  it('records pending stall state instead of injecting immediately', async () => {
+  it('does not record pending stall state for permission-seeking "if you want" text', async () => {
     await withTempWorkingDir(async (cwd) => {
       const stateDir = join(cwd, '.omx', 'state');
       const logsDir = join(cwd, '.omx', 'logs');
@@ -240,13 +235,9 @@ describe('regression-205: notify-hook records pending stall state on "if you wan
       assert.doesNotMatch(
         tmuxLog,
         /send-keys -t %99 -l yes, proceed \[OMX_TMUX_INJECT\]/,
-        'default notify-hook path should not inject before the real stall window elapses',
+        'default notify-hook path should not inject for permission-seeking prompts',
       );
-
-      const nudgeState = JSON.parse(await readFile(join(stateDir, 'auto-nudge-state.json'), 'utf-8'));
-      assert.equal(nudgeState.nudgeCount, 0);
-      assert.ok(nudgeState.pendingSignature, 'expected pending stall signature to be recorded');
-      assert.ok(nudgeState.pendingSince, 'expected pending stall timestamp to be recorded');
+      assert.equal(existsSync(join(stateDir, 'auto-nudge-state.json')), false);
     });
   });
 });

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -22,6 +22,95 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+async function writeCanonicalTeamFixture(
+  cwd: string,
+  {
+    teamName,
+    sessionId,
+    ownerSessionId,
+    coarseState = 'missing',
+  }: {
+    teamName: string;
+    sessionId: string;
+    ownerSessionId: string;
+    coarseState?: 'missing' | 'inactive' | 'active';
+  },
+): Promise<void> {
+  const stateDir = join(cwd, '.omx', 'state');
+  const teamDir = join(stateDir, 'team', teamName);
+  const workersDir = join(teamDir, 'workers');
+  const nowIso = new Date().toISOString();
+
+  await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
+  await mkdir(workersDir, { recursive: true });
+
+  await writeJson(join(stateDir, 'session.json'), { session_id: sessionId });
+  if (coarseState !== 'missing') {
+    await writeJson(join(stateDir, 'team-state.json'), {
+      active: coarseState === 'active',
+      team_name: teamName,
+      current_phase: 'team-exec',
+    });
+  }
+  await writeJson(join(stateDir, 'hud-state.json'), {
+    last_turn_at: nowIso,
+    turn_count: 1,
+  });
+  await writeJson(join(teamDir, 'manifest.v2.json'), {
+    schema_version: 2,
+    name: teamName,
+    task: 'canonical notify fallback repro',
+    leader: {
+      session_id: ownerSessionId,
+      worker_id: 'leader-fixed',
+      role: 'coordinator',
+    },
+    policy: {
+      worker_launch_mode: 'interactive',
+      display_mode: 'split_pane',
+      dispatch_mode: 'hook_preferred_with_fallback',
+      dispatch_ack_timeout_ms: 2000,
+    },
+    governance: {
+      delegation_only: false,
+      plan_approval_required: false,
+      nested_teams_allowed: false,
+      one_team_per_leader_session: true,
+      cleanup_requires_all_workers_inactive: true,
+    },
+    lifecycle_profile: 'default',
+    permissions_snapshot: {
+      approval_mode: 'never',
+      sandbox_mode: 'danger-full-access',
+      network_access: true,
+    },
+    tmux_session: `${teamName}:0`,
+    leader_pane_id: '%97',
+    hud_pane_id: null,
+    resize_hook_name: null,
+    resize_hook_target: null,
+    worker_count: 2,
+    next_task_id: 1,
+    workers: [
+      { name: 'worker-1', index: 1, pane_id: '%1', role: 'executor' },
+      { name: 'worker-2', index: 2, pane_id: '%2', role: 'executor' },
+    ],
+    created_at: nowIso,
+  });
+  await writeJson(join(teamDir, 'phase.json'), {
+    current_phase: 'team-exec',
+    updated_at: nowIso,
+    transitions: [],
+  });
+  for (const worker of ['worker-1', 'worker-2']) {
+    await mkdir(join(workersDir, worker), { recursive: true });
+    await writeJson(join(workersDir, worker, 'status.json'), {
+      state: 'idle',
+      updated_at: nowIso,
+    });
+  }
+}
+
 async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
   const path = join(cwd, '.omx', 'logs', `team-delivery-${new Date().toISOString().slice(0, 10)}.jsonl`);
   const raw = await readFile(path, 'utf-8').catch(() => '');
@@ -155,7 +244,9 @@ describe('notify-hook leader-side authority handoff', () => {
       await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-missing',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
@@ -181,7 +272,9 @@ describe('notify-hook leader-side authority handoff', () => {
         trigger_message: 'dispatch ping',
       }, cwd);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-inactive',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const request = await readDispatchRequest('handoff-dispatch', queued.request.request_id, cwd);
@@ -237,7 +330,9 @@ describe('notify-hook leader-side authority handoff', () => {
       await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345']));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-current',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       if (existsSync(tmuxLogPath)) {
@@ -293,7 +388,9 @@ describe('notify-hook team leader nudge', () => {
       await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-missing',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
       assert.doesNotMatch(tmuxLog, /send-keys -t %97 -l Team deep-interview-suppressed:/);
@@ -348,7 +445,9 @@ describe('notify-hook team leader nudge', () => {
       await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-inactive',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -428,7 +527,9 @@ describe('notify-hook team leader nudge', () => {
       await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345', '%11 12346']));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-missing',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -494,7 +595,9 @@ describe('notify-hook team leader nudge', () => {
       await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345', '%11 12346']));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir);
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-inactive',
+      });
       assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -627,6 +730,61 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /send-keys/);
       assert.match(tmuxLog, /-t %97/, 'should still target the leader pane');
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'global team-state fallback should still fire idle nudge');
+    });
+  });
+
+  it('falls back to canonical team state when coarse team-state is missing', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalTeamFixture(cwd, {
+        teamName: 'canonical-missing',
+        sessionId: 'sess-canonical-missing',
+        ownerSessionId: 'sess-canonical-missing',
+      });
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-missing',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys/);
+      assert.match(tmuxLog, /-t %97/, 'should target canonical leader pane');
+      assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'canonical fallback should still fire idle nudge');
+    });
+  });
+
+  it('falls back to canonical team state when coarse team-state is inactive', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalTeamFixture(cwd, {
+        teamName: 'canonical-inactive',
+        sessionId: 'sess-canonical-inactive',
+        ownerSessionId: 'sess-canonical-inactive',
+        coarseState: 'inactive',
+      });
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-inactive',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /send-keys/);
+      assert.match(tmuxLog, /-t %97/, 'should still target canonical leader pane');
+      assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'inactive coarse state should still fall back canonically');
     });
   });
 
@@ -1544,6 +1702,31 @@ exit 0
       if (existsSync(tmuxLogPath)) {
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
         assert.doesNotMatch(tmuxLog, /send-keys/, 'must not nudge teams owned by another session');
+      }
+    });
+  });
+
+  it('does not nudge a canonical-only team when owner session is blank', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalTeamFixture(cwd, {
+        teamName: 'ownerless-team',
+        sessionId: 'sess-current',
+        ownerSessionId: '',
+      });
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys/, 'ownerless canonical teams must not nudge');
       }
     });
   });

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -62,6 +62,25 @@ describe('session lifecycle manager', () => {
     }
   });
 
+  it('writes hud session metrics into the active session scope when session id is provided', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-metrics-scoped-'));
+    try {
+      await resetSessionMetrics(cwd, 'sess-scoped');
+
+      const metricsPath = join(cwd, '.omx', 'metrics.json');
+      const hudPath = join(cwd, '.omx', 'state', 'sessions', 'sess-scoped', 'hud-state.json');
+      assert.equal(existsSync(metricsPath), true);
+      assert.equal(existsSync(hudPath), true);
+
+      const hud = JSON.parse(await readFile(hudPath, 'utf-8')) as {
+        turn_count: number;
+      };
+      assert.equal(hud.turn_count, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('writes session start/end lifecycle artifacts and archives session history', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lifecycle-'));
     const sessionId = 'sess-lifecycle-1';

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -9,6 +9,7 @@ import {
   writeSessionStart,
   writeSessionEnd,
   readSessionState,
+  readUsableSessionState,
   isSessionStale,
   type SessionState,
 } from '../session.js';
@@ -133,6 +134,47 @@ describe('session lifecycle manager', () => {
       await resetSessionMetrics(cwd);
       await writeFile(statePath, '{ not-json', 'utf-8');
       const state = await readSessionState(cwd);
+      assert.equal(state, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores session.json when its recorded cwd points at another worktree', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-mismatched-cwd-'));
+    try {
+      const statePath = join(cwd, '.omx', 'state', 'session.json');
+      await resetSessionMetrics(cwd);
+      await writeFile(statePath, JSON.stringify({
+        session_id: 'sess-other-worktree',
+        cwd: join(cwd, '..', 'different-worktree'),
+      }), 'utf-8');
+
+      const state = await readUsableSessionState(cwd);
+      assert.equal(state, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores session.json when its PID identity is stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-stale-pointer-'));
+    try {
+      const statePath = join(cwd, '.omx', 'state', 'session.json');
+      await resetSessionMetrics(cwd);
+      await writeFile(statePath, JSON.stringify({
+        session_id: 'sess-stale-pointer',
+        cwd,
+        pid: 4242,
+        pid_start_ticks: 11,
+        pid_cmdline: 'node omx',
+      }), 'utf-8');
+
+      const state = await readUsableSessionState(cwd, {
+        platform: 'linux',
+        isPidAlive: () => true,
+        readLinuxIdentity: () => ({ startTicks: 22, cmdline: 'node omx' }),
+      });
       assert.equal(state, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -28,6 +28,7 @@ import {
   evaluateWorkflowTransition,
   isTrackedWorkflowMode,
 } from '../state/workflow-transition.js';
+import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -68,6 +69,9 @@ export interface SkillActiveState {
   initialized_mode?: string;
   initialized_state_path?: string;
   transition_error?: string;
+  transition_message?: string;
+  transition_messages?: string[];
+  requested_skills?: string[];
   [key: string]: unknown;
 }
 
@@ -521,6 +525,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     const requestedWorkflowSkills = workflowMatches.length > 0 ? workflowMatches : [match.skill];
 
     let nextWorkflowEntries = previousWorkflowEntries.map((entry) => ({ ...entry }));
+    const transitionMessages: string[] = [];
     for (const requestedMode of requestedWorkflowSkills) {
       const decision = evaluateWorkflowTransition(
         nextWorkflowEntries.map((entry) => entry.skill),
@@ -549,6 +554,27 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           ),
         };
       }
+
+      if (decision.autoCompleteModes.length > 0) {
+        const transition = await reconcileWorkflowTransition(
+          dirname(dirname(input.stateDir)),
+          requestedMode,
+          {
+            action: 'activate',
+            sessionId: input.sessionId,
+            source: 'keyword-detector',
+            currentModes: nextWorkflowEntries.map((entry) => entry.skill),
+          },
+        );
+        if (transition.transitionMessage) {
+          transitionMessages.push(transition.transitionMessage);
+        }
+      }
+
+      const survivingSkills = new Set(decision.resultingModes);
+      nextWorkflowEntries = nextWorkflowEntries.filter((entry) => (
+        isTrackedWorkflowMode(entry.skill) && survivingSkills.has(entry.skill)
+      ));
 
       const existingEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
       if (existingEntry) {
@@ -581,40 +607,44 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       ];
     }
 
-    const matchedEntry = nextWorkflowEntries.find((entry) => entry.skill === match.skill) ?? nextWorkflowEntries[0];
+    const primaryEntry = nextWorkflowEntries.find((entry) => entry.skill === match.skill) ?? nextWorkflowEntries[0];
+    const primarySkill = primaryEntry?.skill || match.skill;
     const workflowState: SkillActiveState = {
       version: 1,
       active: true,
-      skill: match.skill,
-      keyword: match.keyword,
-      phase: matchedEntry?.phase || 'planning',
-      activated_at: matchedEntry?.activated_at || nowIso,
+      skill: primarySkill,
+      keyword: primarySkill === match.skill ? match.keyword : `$${primarySkill}`,
+      phase: primaryEntry?.phase || 'planning',
+      activated_at: primaryEntry?.activated_at || nowIso,
       updated_at: nowIso,
       source: 'keyword-detector',
       session_id: input.sessionId,
       thread_id: input.threadId,
       turn_id: input.turnId,
       active_skills: nextWorkflowEntries,
+      ...(transitionMessages[0] ? { transition_message: transitionMessages[0] } : {}),
+      ...(transitionMessages.length > 0 ? { transition_messages: [...new Set(transitionMessages)] } : {}),
+      ...(requestedWorkflowSkills.length > 1 ? { requested_skills: requestedWorkflowSkills } : {}),
       ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
     };
 
     try {
       let nextState: SkillActiveState = { ...workflowState };
-      for (const requestedMode of requestedWorkflowSkills) {
-        const requestedEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
+      for (const requestedEntry of nextWorkflowEntries) {
         const seeded = await persistStatefulSkillSeedState(
           input.stateDir,
           {
             ...workflowState,
-            skill: requestedMode,
-            phase: requestedEntry?.phase || workflowState.phase,
-            activated_at: requestedEntry?.activated_at || workflowState.activated_at,
-            updated_at: requestedEntry?.updated_at || workflowState.updated_at,
+            skill: requestedEntry.skill,
+            keyword: requestedEntry.skill === workflowState.skill ? workflowState.keyword : `$${requestedEntry.skill}`,
+            phase: requestedEntry.phase || workflowState.phase,
+            activated_at: requestedEntry.activated_at || workflowState.activated_at,
+            updated_at: requestedEntry.updated_at || workflowState.updated_at,
           },
           nowIso,
           previous,
         );
-        if (requestedMode === match.skill) {
+        if (requestedEntry.skill === workflowState.skill) {
           nextState = {
             ...workflowState,
             initialized_mode: seeded.initialized_mode,

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -19,9 +19,16 @@ import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts
 import { KEYWORD_TRIGGER_DEFINITIONS, compareKeywordMatches } from './keyword-registry.js';
 import {
   SKILL_ACTIVE_STATE_FILE,
+  listActiveSkills,
   writeSkillActiveStateCopies,
   type SkillActiveEntry,
 } from '../state/skill-active.js';
+import {
+  buildWorkflowTransitionError,
+  evaluateWorkflowTransition,
+  isTrackedWorkflowMode,
+  pickPrimaryWorkflowMode,
+} from '../state/workflow-transition.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -50,7 +57,7 @@ export interface SkillActiveState {
   active: boolean;
   skill: string;
   keyword: string;
-  phase: SkillActivePhase;
+  phase: string;
   activated_at: string;
   updated_at: string;
   source: 'keyword-detector';
@@ -61,6 +68,7 @@ export interface SkillActiveState {
   active_skills?: SkillActiveEntry[];
   initialized_mode?: string;
   initialized_state_path?: string;
+  transition_error?: string;
   [key: string]: unknown;
 }
 
@@ -144,6 +152,9 @@ async function readExistingSkillState(statePath: string): Promise<SkillActiveSta
 
 function buildActiveSkills(state: SkillActiveState): SkillActiveEntry[] | undefined {
   if (!state.active) return undefined;
+  if (Array.isArray(state.active_skills) && state.active_skills.length > 0) {
+    return state.active_skills.filter((entry) => entry.active !== false);
+  }
   return [{
     skill: state.skill,
     phase: state.phase,
@@ -469,7 +480,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     };
 
     try {
-      await writeSkillActiveStateCopies(dirname(dirname(input.stateDir)), state, input.sessionId);
+      await writeSkillActiveStateCopies(
+        dirname(dirname(input.stateDir)),
+        state,
+        input.sessionId,
+        previous ?? state,
+      );
       await persistDeepInterviewModeState(input.stateDir, state, nowIso, previous, input);
     } catch (error) {
       console.warn('[omx] warning: failed to persist keyword activation state', error);
@@ -480,10 +496,143 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
   const sameSkill = previous?.active === true && previous.skill === match.skill;
   const sameKeyword = previous?.keyword?.toLowerCase() === match.keyword.toLowerCase();
+  const previousEntries = listActiveSkills(previous ?? {});
+  const previousWorkflowEntries = previousEntries.filter((entry) => (
+    isTrackedWorkflowMode(entry.skill)
+    && (
+      !input.sessionId
+      || !safeString(entry.session_id).trim()
+      || safeString(entry.session_id).trim() === safeString(input.sessionId).trim()
+    )
+  ));
 
   const deepInterviewInputLock = match.skill === 'deep-interview'
     ? createDeepInterviewInputLock(nowIso, previous?.input_lock)
     : releaseDeepInterviewInputLock(previous?.input_lock, nowIso);
+
+  if (isTrackedWorkflowMode(match.skill)) {
+    const workflowMatches = extractExplicitSkillInvocations(input.text)
+      .map((entry) => entry.skill)
+      .filter(isTrackedWorkflowMode);
+    const requestedWorkflowSkills = workflowMatches.length > 0 ? workflowMatches : [match.skill];
+
+    let nextWorkflowEntries = previousWorkflowEntries.map((entry) => ({ ...entry }));
+    for (const requestedMode of requestedWorkflowSkills) {
+      const decision = evaluateWorkflowTransition(
+        nextWorkflowEntries.map((entry) => entry.skill),
+        requestedMode,
+      );
+      if (!decision.allowed) {
+        return {
+          ...(previous ?? {}),
+          version: 1,
+          active: previous?.active ?? nextWorkflowEntries.length > 0,
+          skill: previous?.skill || match.skill,
+          keyword: previous?.keyword || match.keyword,
+          phase: previous?.phase || 'planning',
+          activated_at: previous?.activated_at || nowIso,
+          updated_at: nowIso,
+          source: 'keyword-detector',
+          session_id: input.sessionId ?? previous?.session_id,
+          thread_id: input.threadId ?? previous?.thread_id,
+          turn_id: input.turnId ?? previous?.turn_id,
+          active_skills: previousEntries,
+          ...(previous?.input_lock ? { input_lock: previous.input_lock } : {}),
+          transition_error: buildWorkflowTransitionError(
+            nextWorkflowEntries.map((entry) => entry.skill),
+            requestedMode,
+            'activate',
+          ),
+        };
+      }
+
+      const existingEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
+      if (existingEntry) {
+        existingEntry.phase = requestedMode === match.skill ? 'planning' : existingEntry.phase;
+        existingEntry.active = true;
+        existingEntry.activated_at = requestedMode === match.skill
+          ? (sameSkill && sameKeyword ? existingEntry.activated_at || previous?.activated_at || nowIso : nowIso)
+          : existingEntry.activated_at;
+        existingEntry.updated_at = nowIso;
+        existingEntry.session_id = input.sessionId ?? existingEntry.session_id;
+        existingEntry.thread_id = input.threadId ?? existingEntry.thread_id;
+        existingEntry.turn_id = input.turnId ?? existingEntry.turn_id;
+        continue;
+      }
+
+      nextWorkflowEntries = [
+        ...nextWorkflowEntries,
+        {
+          skill: requestedMode,
+          phase: requestedMode === match.skill ? 'planning' : undefined,
+          active: true,
+          activated_at: requestedMode === match.skill && sameSkill && sameKeyword
+            ? previous?.activated_at
+            : nowIso,
+          updated_at: nowIso,
+          session_id: input.sessionId,
+          thread_id: input.threadId,
+          turn_id: input.turnId,
+        },
+      ];
+    }
+
+    const matchedEntry = nextWorkflowEntries.find((entry) => entry.skill === match.skill) ?? nextWorkflowEntries[0];
+    const workflowState: SkillActiveState = {
+      version: 1,
+      active: true,
+      skill: match.skill,
+      keyword: match.keyword,
+      phase: matchedEntry?.phase || 'planning',
+      activated_at: matchedEntry?.activated_at || nowIso,
+      updated_at: nowIso,
+      source: 'keyword-detector',
+      session_id: input.sessionId,
+      thread_id: input.threadId,
+      turn_id: input.turnId,
+      active_skills: nextWorkflowEntries,
+      ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
+    };
+
+    try {
+      let nextState: SkillActiveState = { ...workflowState };
+      for (const requestedMode of requestedWorkflowSkills) {
+        const requestedEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
+        const seeded = await persistStatefulSkillSeedState(
+          input.stateDir,
+          {
+            ...workflowState,
+            skill: requestedMode,
+            phase: requestedEntry?.phase || workflowState.phase,
+            activated_at: requestedEntry?.activated_at || workflowState.activated_at,
+            updated_at: requestedEntry?.updated_at || workflowState.updated_at,
+          },
+          nowIso,
+          previous,
+        );
+        if (requestedMode === match.skill) {
+          nextState = {
+            ...workflowState,
+            initialized_mode: seeded.initialized_mode,
+            initialized_state_path: seeded.initialized_state_path,
+          };
+        }
+      }
+      nextState.active_skills = buildActiveSkills(nextState);
+      await writeSkillActiveStateCopies(
+        dirname(dirname(input.stateDir)),
+        nextState,
+        input.sessionId,
+        input.sessionId && previous ? previous : nextState,
+      );
+      await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
+      return nextState;
+    } catch (error) {
+      console.warn('[omx] warning: failed to persist keyword activation state', error);
+    }
+
+    return workflowState;
+  }
 
   const state: SkillActiveState = {
     version: 1,
@@ -513,7 +662,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   try {
     const nextState = await persistStatefulSkillSeedState(input.stateDir, state, nowIso, previous);
     nextState.active_skills = buildActiveSkills(nextState);
-    await writeSkillActiveStateCopies(dirname(dirname(input.stateDir)), nextState, input.sessionId);
+    await writeSkillActiveStateCopies(
+      dirname(dirname(input.stateDir)),
+      nextState,
+      input.sessionId,
+      input.sessionId && previous ? previous : nextState,
+    );
     await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
     return nextState;
   } catch (error) {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -27,7 +27,6 @@ import {
   buildWorkflowTransitionError,
   evaluateWorkflowTransition,
   isTrackedWorkflowMode,
-  pickPrimaryWorkflowMode,
 } from '../state/workflow-transition.js';
 
 export interface KeywordMatch {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -455,8 +455,13 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   if (!match) return null;
 
   const nowIso = input.nowIso ?? new Date().toISOString();
-  const statePath = join(input.stateDir, SKILL_ACTIVE_STATE_FILE);
-  const previous = await readExistingSkillState(statePath);
+  const rootStatePath = join(input.stateDir, SKILL_ACTIVE_STATE_FILE);
+  const sessionStatePath = input.sessionId
+    ? join(input.stateDir, 'sessions', input.sessionId, SKILL_ACTIVE_STATE_FILE)
+    : null;
+  const previousRoot = await readExistingSkillState(rootStatePath);
+  const previousSession = sessionStatePath ? await readExistingSkillState(sessionStatePath) : null;
+  const previous = previousSession ?? previousRoot;
   const hadDeepInterviewLock = previous?.skill === 'deep-interview' && previous?.input_lock?.active === true;
   const matches = detectKeywords(input.text);
   const hasCancelIntent = matches.some((entry) => entry.skill === 'cancel');
@@ -483,7 +488,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         dirname(dirname(input.stateDir)),
         state,
         input.sessionId,
-        previous ?? state,
+        input.sessionId ? (previousRoot ?? state) : state,
       );
       await persistDeepInterviewModeState(input.stateDir, state, nowIso, previous, input);
     } catch (error) {
@@ -622,7 +627,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         dirname(dirname(input.stateDir)),
         nextState,
         input.sessionId,
-        input.sessionId && previous ? previous : nextState,
+        input.sessionId ? (previousRoot ?? nextState) : nextState,
       );
       await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
       return nextState;
@@ -665,7 +670,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       dirname(dirname(input.stateDir)),
       nextState,
       input.sessionId,
-      input.sessionId && previous ? previous : nextState,
+      input.sessionId ? (previousRoot ?? nextState) : nextState,
     );
     await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
     return nextState;

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -6,7 +6,7 @@
  */
 
 import { readFile, writeFile, mkdir, unlink, appendFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { dirname, join, resolve as resolvePath } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { omxStateDir, omxLogsDir } from '../utils/paths.js';
 import { getStateFilePath } from '../mcp/state-paths.js';
@@ -23,6 +23,7 @@ export interface SessionState {
 
 const SESSION_FILE = 'session.json';
 const HISTORY_FILE = 'session-history.jsonl';
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 // No age-based threshold: staleness is determined by PID liveness/identity.
 // Long-running sessions (>2h) are legitimate and should not be reaped.
 
@@ -79,6 +80,42 @@ export async function readSessionState(cwd: string): Promise<SessionState | null
   } catch {
     return null;
   }
+}
+
+export function isSessionStateAuthoritativeForCwd(state: SessionState, cwd: string): boolean {
+  if (!SESSION_ID_PATTERN.test(state.session_id)) return false;
+
+  if (typeof state.cwd === 'string' && state.cwd.trim() !== '') {
+    return resolvePath(state.cwd) === resolvePath(cwd);
+  }
+
+  return true;
+}
+
+export function isSessionStateUsable(
+  state: SessionState,
+  cwd: string,
+  options: SessionStaleCheckOptions = {},
+): boolean {
+  if (!isSessionStateAuthoritativeForCwd(state, cwd)) return false;
+
+  const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
+  const hasLinuxIdentityMetadata = typeof state.pid_start_ticks === 'number'
+    || typeof state.pid_cmdline === 'string';
+  if (hasPidMetadata || hasLinuxIdentityMetadata) {
+    return !isSessionStale(state, options);
+  }
+
+  return true;
+}
+
+export async function readUsableSessionState(
+  cwd: string,
+  options: SessionStaleCheckOptions = {},
+): Promise<SessionState | null> {
+  const state = await readSessionState(cwd);
+  if (!state) return null;
+  return isSessionStateUsable(state, cwd, options) ? state : null;
 }
 
 interface LinuxProcessIdentity {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -6,9 +6,10 @@
  */
 
 import { readFile, writeFile, mkdir, unlink, appendFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { omxStateDir, omxLogsDir } from '../utils/paths.js';
+import { getStateFilePath } from '../mcp/state-paths.js';
 
 export interface SessionState {
   session_id: string;
@@ -37,7 +38,7 @@ function historyPath(cwd: string): string {
  * Reset session-scoped HUD/metrics files at launch so stale values do not leak
  * into a new Codex session.
  */
-export async function resetSessionMetrics(cwd: string): Promise<void> {
+export async function resetSessionMetrics(cwd: string, sessionId?: string): Promise<void> {
   const omxDir = join(cwd, '.omx');
   const stateDir = omxStateDir(cwd);
   await mkdir(omxDir, { recursive: true });
@@ -55,7 +56,9 @@ export async function resetSessionMetrics(cwd: string): Promise<void> {
     weekly_limit_pct: 0,
   }, null, 2));
 
-  await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+  const hudStatePath = getStateFilePath('hud-state.json', cwd, sessionId);
+  await mkdir(dirname(hudStatePath), { recursive: true });
+  await writeFile(hudStatePath, JSON.stringify({
     last_turn_at: now,
     last_progress_at: now,
     turn_count: 0,

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -378,4 +378,42 @@ describe('readAllState canonical skill precedence', () => {
       assert.deepEqual(state.team, { active: true, team_name: 'alpha', current_phase: 'running' });
     });
   });
+
+  it('surfaces approved combined workflow state from canonical multi-skill data', async () => {
+    await withTempRepo('omx-hud-canonical-combined-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-combined';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        session_id: sessionId,
+        active_skills: [
+          { skill: 'team', phase: 'running', active: true, session_id: sessionId },
+          { skill: 'ralph', phase: 'executing', active: true, session_id: sessionId },
+        ],
+      }));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'alpha',
+      }));
+      await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        iteration: 2,
+        max_iterations: 5,
+      }));
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.team, { active: true, team_name: 'alpha', current_phase: 'running' });
+      assert.deepEqual(state.ralph, {
+        active: true,
+        iteration: 2,
+        max_iterations: 5,
+        current_phase: 'executing',
+      });
+    });
+  });
 });

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -220,12 +220,28 @@ describe('readRalphState scope precedence', () => {
     });
   });
 
-  it('falls back to root Ralph state when current session has no Ralph state file', async () => {
+  it('does not fall back to root Ralph state when current session has no Ralph state file', async () => {
     await withTempRepo('omx-hud-ralph-fallback-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');
       const sessionId = 'sess-fallback';
       await mkdir(join(rootStateDir, 'sessions', sessionId), { recursive: true });
       await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(rootStateDir, 'ralph-state.json'), JSON.stringify({ active: true, iteration: 4, max_iterations: 10 }));
+
+      const state = await readRalphState(cwd);
+      assert.equal(state, null);
+    });
+  });
+
+  it('ignores session.json authority when it points at another worktree cwd', async () => {
+    await withTempRepo('omx-hud-ralph-cwd-mismatch-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-mismatch';
+      await mkdir(join(rootStateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: join(cwd, '..', 'other-worktree'),
+      }));
       await writeFile(join(rootStateDir, 'ralph-state.json'), JSON.stringify({ active: true, iteration: 4, max_iterations: 10 }));
 
       const state = await readRalphState(cwd);

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -7,6 +7,7 @@ import {
   buildGitBranchLabel,
   readGitBranch,
   readAllState,
+  readHudNotifyState,
   readRalphState,
   readRalplanState,
   readDeepInterviewState,
@@ -318,6 +319,21 @@ describe('additional HUD mode state readers', () => {
     await withTempRepo('omx-hud-ultraqa-', async (cwd) => {
       await writeModeState(cwd, 'ultraqa', { active: true, current_phase: 'diagnose' });
       assert.deepEqual(await readUltraqaState(cwd), { active: true, current_phase: 'diagnose' });
+    });
+  });
+
+  it('reads hud notify state from the current session scope', async () => {
+    await withTempRepo('omx-hud-notify-session-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-hud-notify';
+      const sessionStateDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(rootStateDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'root', turn_count: 99 }));
+      await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'session', turn_count: 2 }));
+
+      const state = await readHudNotifyState(cwd);
+      assert.deepEqual(state, { last_turn_at: 'session', turn_count: 2 });
     });
   });
 });

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -13,7 +13,7 @@ import { omxStateDir } from '../utils/paths.js';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
-import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { getReadScopedStateFilePaths, getReadScopedStatePaths } from '../mcp/state-paths.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import type {
   RalphStateForHud,
@@ -168,7 +168,10 @@ export async function readMetrics(cwd: string): Promise<HudMetrics | null> {
 }
 
 export async function readHudNotifyState(cwd: string): Promise<HudNotifyState | null> {
-  return readJsonFile<HudNotifyState>(join(omxStateDir(cwd), 'hud-state.json'));
+  const [hudStatePath] = await getReadScopedStateFilePaths('hud-state.json', cwd, undefined, {
+    rootFallback: false,
+  });
+  return readJsonFile<HudNotifyState>(hudStatePath);
 }
 
 export async function readSessionState(cwd: string): Promise<SessionStateForHud | null> {

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -14,6 +14,7 @@ import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
 import { getReadScopedStateFilePaths, getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { readUsableSessionState } from '../hooks/session.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import type {
   RalphStateForHud,
@@ -41,15 +42,6 @@ async function readJsonFile<T>(path: string): Promise<T | null> {
   } catch {
     return null;
   }
-}
-
-async function readScopedModeState<T>(cwd: string, mode: string): Promise<T | null> {
-  const candidates = await getReadScopedStatePaths(mode, cwd);
-  for (const candidate of candidates) {
-    const state = await readJsonFile<T>(candidate);
-    if (state) return state;
-  }
-  return null;
 }
 
 async function readSessionAwareModeState<T>(cwd: string, mode: string): Promise<T | null> {
@@ -113,22 +105,22 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
 }
 
 export async function readRalphState(cwd: string): Promise<RalphStateForHud | null> {
-  const state = await readScopedModeState<RalphStateForHud>(cwd, 'ralph');
+  const state = await readSessionAwareModeState<RalphStateForHud>(cwd, 'ralph');
   return state?.active ? state : null;
 }
 
 export async function readUltraworkState(cwd: string): Promise<UltraworkStateForHud | null> {
-  const state = await readScopedModeState<UltraworkStateForHud>(cwd, 'ultrawork');
+  const state = await readSessionAwareModeState<UltraworkStateForHud>(cwd, 'ultrawork');
   return state?.active ? state : null;
 }
 
 export async function readAutopilotState(cwd: string): Promise<AutopilotStateForHud | null> {
-  const state = await readScopedModeState<AutopilotStateForHud>(cwd, 'autopilot');
+  const state = await readSessionAwareModeState<AutopilotStateForHud>(cwd, 'autopilot');
   return state?.active ? state : null;
 }
 
 export async function readRalplanState(cwd: string): Promise<RalplanStateForHud | null> {
-  const state = await readScopedModeState<RalplanStateForHud>(cwd, 'ralplan');
+  const state = await readSessionAwareModeState<RalplanStateForHud>(cwd, 'ralplan');
   return state?.active ? state : null;
 }
 
@@ -139,7 +131,7 @@ interface DeepInterviewRawState extends DeepInterviewStateForHud {
 }
 
 export async function readDeepInterviewState(cwd: string): Promise<DeepInterviewStateForHud | null> {
-  const state = await readScopedModeState<DeepInterviewRawState>(cwd, 'deep-interview');
+  const state = await readSessionAwareModeState<DeepInterviewRawState>(cwd, 'deep-interview');
   if (!state?.active) return null;
 
   return {
@@ -149,17 +141,17 @@ export async function readDeepInterviewState(cwd: string): Promise<DeepInterview
 }
 
 export async function readAutoresearchState(cwd: string): Promise<AutoresearchStateForHud | null> {
-  const state = await readScopedModeState<AutoresearchStateForHud>(cwd, 'autoresearch');
+  const state = await readSessionAwareModeState<AutoresearchStateForHud>(cwd, 'autoresearch');
   return state?.active ? state : null;
 }
 
 export async function readUltraqaState(cwd: string): Promise<UltraqaStateForHud | null> {
-  const state = await readScopedModeState<UltraqaStateForHud>(cwd, 'ultraqa');
+  const state = await readSessionAwareModeState<UltraqaStateForHud>(cwd, 'ultraqa');
   return state?.active ? state : null;
 }
 
 export async function readTeamState(cwd: string): Promise<TeamStateForHud | null> {
-  const state = await readScopedModeState<TeamStateForHud>(cwd, 'team');
+  const state = await readSessionAwareModeState<TeamStateForHud>(cwd, 'team');
   return state?.active ? state : null;
 }
 
@@ -175,7 +167,7 @@ export async function readHudNotifyState(cwd: string): Promise<HudNotifyState | 
 }
 
 export async function readSessionState(cwd: string): Promise<SessionStateForHud | null> {
-  const state = await readJsonFile<SessionStateForHud>(join(omxStateDir(cwd), 'session.json'));
+  const state = await readUsableSessionState(cwd);
   return state?.session_id ? state : null;
 }
 

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { shouldAutoStartMcpServer, type McpServerName } from '../bootstrap.js';
+import { isParentProcessAlive, shouldAutoStartMcpServer, type McpServerName } from '../bootstrap.js';
 
 const ALL_SERVERS: readonly McpServerName[] = [
   'state',
@@ -51,6 +51,30 @@ describe('mcp bootstrap auto-start guard', () => {
   });
 });
 
+describe('mcp parent watchdog liveness checks', () => {
+  it('treats missing or root-like parent pids as gone', () => {
+    assert.equal(isParentProcessAlive(0, () => true), false);
+    assert.equal(isParentProcessAlive(1, () => true), false);
+    assert.equal(isParentProcessAlive(Number.NaN, () => true), false);
+  });
+
+  it('treats kill(0) success as parent alive', () => {
+    assert.equal(isParentProcessAlive(42, () => true), true);
+  });
+
+  it('treats ESRCH as parent gone and EPERM as still alive', () => {
+    const missing = Object.assign(new Error('missing'), { code: 'ESRCH' });
+    const denied = Object.assign(new Error('denied'), { code: 'EPERM' });
+
+    assert.equal(isParentProcessAlive(42, () => {
+      throw missing;
+    }), false);
+    assert.equal(isParentProcessAlive(42, () => {
+      throw denied;
+    }), true);
+  });
+});
+
 describe('mcp shared stdio lifecycle contract', () => {
   it('keeps shared stdio lifecycle wiring in bootstrap', async () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
@@ -58,6 +82,9 @@ describe('mcp shared stdio lifecycle contract', () => {
     assert.match(src, /StdioServerTransport/, 'bootstrap should own stdio transport creation');
     assert.match(src, /server\.connect\(/, 'bootstrap should own MCP server connection');
     assert.match(src, /stdin/i, 'bootstrap should react to stdin/client disconnect');
+    assert.match(src, /parent_gone/, 'bootstrap should watch for the parent process disappearing');
+    assert.match(src, /isParentProcessAlive\(trackedParentPid\)/, 'bootstrap should probe parent liveness directly');
+    assert.match(src, /process\.exit\(0\)/, 'bootstrap should force child exit after shutdown completes');
     assert.match(src, /SIGTERM/, 'bootstrap should handle SIGTERM');
     assert.match(src, /SIGINT/, 'bootstrap should handle SIGINT');
   });

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -84,6 +84,10 @@ async function waitForExit(
   stderr: string[],
   stdout: string[],
 ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+
   try {
     const [code, signal] = (await Promise.race([
       once(child, 'exit') as Promise<[number | null, NodeJS.Signals | null]>,

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm } from 'fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve as resolvePath } from 'path';
@@ -10,9 +10,12 @@ import {
   getBaseStateDir,
   getAllSessionScopedStateDirs,
   getAllSessionScopedStatePaths,
+  getReadScopedStateFilePaths,
   resolveWorkingDirectoryForState,
   getStateDir,
+  getStateFilePath,
   getStatePath,
+  validateStateFileName,
   validateStateModeSegment,
   validateSessionId,
 } from '../state-paths.js';
@@ -40,6 +43,19 @@ describe('validateStateModeSegment', () => {
     assert.throws(() => validateStateModeSegment('../evil'), /must not contain "\.\."/);
     assert.throws(() => validateStateModeSegment('foo/bar'), /path separators/);
     assert.throws(() => validateStateModeSegment('foo\\bar'), /path separators/);
+  });
+});
+
+describe('validateStateFileName', () => {
+  it('accepts safe file names', () => {
+    assert.equal(validateStateFileName('hud-state.json'), 'hud-state.json');
+    assert.equal(validateStateFileName('session.json'), 'session.json');
+  });
+
+  it('rejects traversal and path separators', () => {
+    assert.throws(() => validateStateFileName('../evil.json'), /must not contain "\.\."/);
+    assert.throws(() => validateStateFileName('foo/bar.json'), /path separators/);
+    assert.throws(() => validateStateFileName('foo\\bar.json'), /path separators/);
   });
 });
 
@@ -105,6 +121,10 @@ describe('state paths', () => {
     assert.equal(
       getStatePath('ralph', '/repo', 'sess1'),
       '/repo/.omx/state/sessions/sess1/ralph-state.json'
+    );
+    assert.equal(
+      getStateFilePath('hud-state.json', '/repo', 'sess1'),
+      '/repo/.omx/state/sessions/sess1/hud-state.json'
     );
   });
 
@@ -184,6 +204,23 @@ describe('state paths', () => {
 
       const paths = await getAllSessionScopedStatePaths('team', wd);
       assert.deepEqual(paths, [getStatePath('team', wd, 'valid-session')]);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reads session-sensitive runtime files from the current session without root fallback when requested', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-paths-'));
+    try {
+      const stateDir = getBaseStateDir(wd);
+      await mkdir(join(stateDir, 'sessions', 'sess-current'), { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-current' }));
+
+      const paths = await getReadScopedStateFilePaths('hud-state.json', wd, undefined, {
+        rootFallback: false,
+      });
+      assert.deepEqual(paths, [join(stateDir, 'sessions', 'sess-current', 'hud-state.json')]);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -417,7 +417,7 @@ describe('state-server directory initialization', () => {
     }
   });
 
-  it('denies invalid writes before touching the requested mode file when canonical session state is stricter than mode files', async () => {
+  it('allows ultrawork when canonical session state is stricter than mode files', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
 
@@ -451,7 +451,7 @@ describe('state-server directory initialization', () => {
         }, null, 2),
       );
 
-      const denied = await handleStateToolCall({
+      const allowed = await handleStateToolCall({
         params: {
           name: 'state_write',
           arguments: {
@@ -464,11 +464,10 @@ describe('state-server directory initialization', () => {
         },
       });
 
-      assert.equal(denied.isError, true);
-      assert.match(denied.content[0]?.text || '', /Unsupported workflow overlap: team \+ ralph \+ ultrawork\./);
+      assert.equal(allowed.isError, undefined);
       assert.equal(
         existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-canonical-deny', 'ultrawork-state.json')),
-        false,
+        true,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -692,6 +691,126 @@ describe('state-server directory initialization', () => {
         [{ skill: 'autopilot', phase: 'planning', session_id: 'sess-standalone' }],
       );
       assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-standalone', 'team-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('auto-completes deep-interview when starting ralplan and returns transition messaging', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-handoff-interview-'));
+    try {
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-handoff'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'sessions', 'sess-handoff', 'deep-interview-state.json'),
+        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'intent-first' }, null, 2),
+      );
+
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-handoff',
+            mode: 'ralplan',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const body = JSON.parse(response.content[0]?.text || '{}') as { transition?: string };
+      assert.equal(body.transition, 'mode transiting: deep-interview -> ralplan');
+
+      const completed = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-handoff', 'deep-interview-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string; completed_at?: string; auto_completed_reason?: string };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, 'completed');
+      assert.equal(typeof completed.completed_at, 'string');
+      assert.match(completed.auto_completed_reason || '', /mode transiting: deep-interview -> ralplan/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects execution-to-planning rollback with clear-first guidance', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-rollback-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-rollback',
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      const denied = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-rollback',
+            mode: 'ralplan',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(denied.isError, true);
+      const body = JSON.parse(denied.content[0]?.text || '{}') as { error?: string };
+      assert.match(body.error || '', /Execution-to-planning rollback auto-complete is not allowed/i);
+      assert.match(body.error || '', /First clear current state first and retry if this action is intended/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows ultrawork overlap with any tracked mode', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-ultrawork-any-'));
+    try {
+      const first = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-ulw',
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+      assert.equal(first.isError, undefined);
+
+      const second = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-ulw',
+            mode: 'ultrawork',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+      assert.equal(second.isError, undefined);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -309,6 +309,114 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('allows approved overlaps and preserves the remaining canonical state on clear', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-overlap-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-overlap',
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-overlap',
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            max_iterations: 3,
+            current_phase: 'executing',
+          },
+        },
+      });
+
+      const canonicalPath = join(wd, '.omx', 'state', 'sessions', 'sess-overlap', 'skill-active-state.json');
+      const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active_skills?: Array<{ skill: string }>;
+      };
+      assert.deepEqual(canonical.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-overlap',
+            mode: 'team',
+          },
+        },
+      });
+
+      const clearedCanonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active: boolean;
+        skill: string;
+        active_skills?: Array<{ skill: string }>;
+      };
+      assert.equal(clearedCanonical.active, true);
+      assert.equal(clearedCanonical.skill, 'ralph');
+      assert.deepEqual(clearedCanonical.active_skills?.map((entry) => entry.skill), ['ralph']);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies unsupported overlaps without writing the requested mode state', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-deny-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-deny',
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+
+      const denied = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-deny',
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(denied.isError, true);
+      assert.match(denied.content[0]?.text || '', /Unsupported workflow overlap: team \+ autopilot\./);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-deny', 'autopilot-state.json')), false);
+
+      const canonical = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-deny', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(canonical.active_skills?.map((entry) => entry.skill), ['team']);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('removes tracked workflows from canonical skill-active state on all_sessions clear', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
@@ -345,6 +453,133 @@ describe('state-server directory initialization', () => {
       };
       assert.equal(canonical.active, false);
       assert.deepEqual(canonical.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves root-scoped team state when session-scoped ralph is added via state_write', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-team-ralph-'));
+    try {
+      const teamWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+      assert.equal(teamWrite.isError, undefined);
+
+      const ralphWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-team-ralph',
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            max_iterations: 5,
+            current_phase: 'executing',
+          },
+        },
+      });
+      assert.equal(ralphWrite.isError, undefined);
+
+      const rootCanonical = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        rootCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [{ skill: 'team', phase: 'running', session_id: undefined }],
+      );
+
+      const sessionCanonical = JSON.parse(
+        await readFile(
+          join(wd, '.omx', 'state', 'sessions', 'sess-team-ralph', 'skill-active-state.json'),
+          'utf-8',
+        ),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        sessionCanonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [
+          { skill: 'team', phase: 'running', session_id: undefined },
+          { skill: 'ralph', phase: 'executing', session_id: 'sess-team-ralph' },
+        ],
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects standalone overlaps without mutating canonical state', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-standalone-overlap-'));
+    try {
+      const autopilotWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-standalone',
+            mode: 'autopilot',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+      assert.equal(autopilotWrite.isError, undefined);
+
+      const invalidTeamWrite = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-standalone',
+            mode: 'team',
+            active: true,
+            current_phase: 'starting',
+          },
+        },
+      });
+
+      assert.equal(invalidTeamWrite.isError, true);
+      const body = JSON.parse(invalidTeamWrite.content[0]?.text || '{}') as { error?: string };
+      assert.match(body.error || '', /omx state/i);
+      assert.match(body.error || '', /omx_state\.\*/i);
+
+      const canonical = JSON.parse(
+        await readFile(
+          join(wd, '.omx', 'state', 'sessions', 'sess-standalone', 'skill-active-state.json'),
+          'utf-8',
+        ),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        canonical.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [{ skill: 'autopilot', phase: 'planning', session_id: 'sess-standalone' }],
+      );
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-standalone', 'team-state.json')), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -417,6 +417,64 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('denies invalid writes before touching the requested mode file when canonical session state is stricter than mode files', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-canonical-prevalidate-'));
+    try {
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-canonical-deny'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'team-state.json'),
+        JSON.stringify({ active: true, mode: 'team', current_phase: 'running' }, null, 2),
+      );
+      await writeFile(
+        join(wd, '.omx', 'state', 'skill-active-state.json'),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          active_skills: [{ skill: 'team', phase: 'running', active: true }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(wd, '.omx', 'state', 'sessions', 'sess-canonical-deny', 'skill-active-state.json'),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          session_id: 'sess-canonical-deny',
+          active_skills: [
+            { skill: 'team', phase: 'running', active: true },
+            { skill: 'ralph', phase: 'executing', active: true, session_id: 'sess-canonical-deny' },
+          ],
+        }, null, 2),
+      );
+
+      const denied = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-canonical-deny',
+            mode: 'ultrawork',
+            active: true,
+            current_phase: 'planning',
+          },
+        },
+      });
+
+      assert.equal(denied.isError, true);
+      assert.match(denied.content[0]?.text || '', /Unsupported workflow overlap: team \+ ralph \+ ultrawork\./);
+      assert.equal(
+        existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-canonical-deny', 'ultrawork-state.json')),
+        false,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('removes tracked workflows from canonical skill-active state on all_sessions clear', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');
@@ -453,6 +511,60 @@ describe('state-server directory initialization', () => {
       };
       assert.equal(canonical.active, false);
       assert.deepEqual(canonical.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('propagates root clears into inherited session canonical copies', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-root-clear-propagate-'));
+    try {
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+            active: true,
+            current_phase: 'running',
+          },
+        },
+      });
+      await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-root-clear',
+            mode: 'ralph',
+            active: true,
+            iteration: 1,
+            max_iterations: 3,
+            current_phase: 'executing',
+          },
+        },
+      });
+
+      await handleStateToolCall({
+        params: {
+          name: 'state_clear',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'team',
+          },
+        },
+      });
+
+      const sessionCanonical = JSON.parse(
+        await readFile(
+          join(wd, '.omx', 'state', 'sessions', 'sess-root-clear', 'skill-active-state.json'),
+          'utf-8',
+        ),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(sessionCanonical.active_skills?.map((entry) => entry.skill), ['ralph']);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -11,10 +11,27 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
 
 const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
 const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
+const PARENT_WATCHDOG_INTERVAL_MS = 25;
 
 interface StdioLifecycleServer {
   connect(transport: StdioServerTransport): Promise<unknown>;
   close(): Promise<unknown>;
+}
+
+export function isParentProcessAlive(
+  parentPid: number,
+  signalProcess: typeof process.kill = process.kill,
+): boolean {
+  if (!Number.isInteger(parentPid) || parentPid <= 1) {
+    return false;
+  }
+
+  try {
+    signalProcess(parentPid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException | undefined)?.code === 'EPERM';
+  }
 }
 
 export function shouldAutoStartMcpServer(
@@ -38,6 +55,7 @@ export function autoStartStdioMcpServer(
   const transport = new StdioServerTransport();
   let shuttingDown = false;
   const lifecycleDebugEnabled = env[LIFECYCLE_DEBUG_ENV] === '1';
+  const trackedParentPid = Number.isInteger(process.ppid) ? process.ppid : 0;
 
   const logLifecycle = (message: string, error?: unknown) => {
     if (!lifecycleDebugEnabled) return;
@@ -45,12 +63,24 @@ export function autoStartStdioMcpServer(
     process.stderr.write(`[omx-${serverName}-server] ${message}${detail}\n`);
   };
 
+  const parentWatchdog = trackedParentPid > 1
+    ? setInterval(() => {
+      if (!isParentProcessAlive(trackedParentPid)) {
+        void shutdown('parent_gone');
+      }
+    }, PARENT_WATCHDOG_INTERVAL_MS)
+    : null;
+  parentWatchdog?.unref();
+
   const shutdown = async (reason: string) => {
     if (shuttingDown) {
       return;
     }
     shuttingDown = true;
     logLifecycle(`transport shutdown: ${reason}`);
+    if (parentWatchdog) {
+      clearInterval(parentWatchdog);
+    }
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
     process.off('SIGTERM', handleSigterm);
@@ -61,6 +91,9 @@ export function autoStartStdioMcpServer(
     } catch (error) {
       console.error(`[omx-${serverName}-server] shutdown failed`, error);
     }
+
+    logLifecycle('transport shutdown: exit');
+    process.exit(0);
   };
 
   const handleStdinEnd = () => {

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -5,6 +5,7 @@ import { readdir, readFile } from 'fs/promises';
 export const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 export const STATE_MODE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const STATE_FILE_SUFFIX = '-state.json';
+const STATE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const WORKDIR_ALLOWLIST_ENV = 'OMX_MCP_WORKDIR_ROOTS';
 
 export type StateFileScope = 'root' | 'session';
@@ -48,6 +49,26 @@ export function validateStateModeSegment(mode: unknown): string {
 
 function getStateFilename(mode: string): string {
   return `${validateStateModeSegment(mode)}${STATE_FILE_SUFFIX}`;
+}
+
+export function validateStateFileName(fileName: unknown): string {
+  if (typeof fileName !== 'string') {
+    throw new Error('fileName must be a string');
+  }
+  const normalized = fileName.trim();
+  if (!normalized) {
+    throw new Error('fileName must be a non-empty string');
+  }
+  if (normalized.includes('..')) {
+    throw new Error('fileName must not contain ".."');
+  }
+  if (normalized.includes('/') || normalized.includes('\\')) {
+    throw new Error('fileName must not contain path separators');
+  }
+  if (!STATE_FILE_NAME_PATTERN.test(normalized)) {
+    throw new Error('fileName must match ^[A-Za-z0-9._-]{1,128}$');
+  }
+  return normalized;
 }
 
 function convertWindowsToWslPath(raw: string): string {
@@ -155,6 +176,10 @@ export function getStatePath(mode: string, workingDirectory?: string, sessionId?
   return join(getStateDir(workingDirectory, sessionId), getStateFilename(mode));
 }
 
+export function getStateFilePath(fileName: string, workingDirectory?: string, sessionId?: string): string {
+  return join(getStateDir(workingDirectory, sessionId), validateStateFileName(fileName));
+}
+
 export type StateScopeSource = 'explicit' | 'session' | 'root';
 
 export interface ResolvedStateScope {
@@ -229,6 +254,26 @@ export async function getReadScopedStatePaths(
   const dirs = await getReadScopedStateDirs(workingDirectory, explicitSessionId);
   const fileName = getStateFilename(mode);
   return dirs.map((dir) => join(dir, fileName));
+}
+
+export async function getReadScopedStateFilePaths(
+  fileName: string,
+  workingDirectory?: string,
+  explicitSessionId?: string,
+  options: { rootFallback?: boolean } = {},
+): Promise<string[]> {
+  const normalizedFileName = validateStateFileName(fileName);
+  const scope = await resolveStateScope(workingDirectory, explicitSessionId);
+  if (scope.source === 'root') {
+    return [join(scope.stateDir, normalizedFileName)];
+  }
+  if (options.rootFallback === false) {
+    return [join(scope.stateDir, normalizedFileName)];
+  }
+  return [
+    join(scope.stateDir, normalizedFileName),
+    join(getBaseStateDir(workingDirectory), normalizedFileName),
+  ];
 }
 
 export async function getAllSessionScopedStatePaths(

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,6 +1,7 @@
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
 import { existsSync } from 'fs';
-import { readdir, readFile } from 'fs/promises';
+import { readdir } from 'fs/promises';
+import { readUsableSessionState } from '../hooks/session.js';
 
 export const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 export const STATE_MODE_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -189,14 +190,8 @@ export interface ResolvedStateScope {
 }
 
 export async function readCurrentSessionId(workingDirectory?: string): Promise<string | undefined> {
-  const sessionPath = join(getBaseStateDir(workingDirectory), 'session.json');
-  if (!existsSync(sessionPath)) return undefined;
-  try {
-    const parsed = JSON.parse(await readFile(sessionPath, 'utf-8')) as { session_id?: unknown };
-    return validateSessionId(parsed.session_id);
-  } catch {
-    return undefined;
-  }
+  const cwd = resolveWorkingDirectoryForState(workingDirectory);
+  return (await readUsableSessionState(cwd))?.session_id;
 }
 
 export async function resolveStateScope(

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -37,6 +37,11 @@ import {
 	writeSkillActiveStateCopies,
 } from "../state/skill-active.js";
 import {
+	assertWorkflowTransitionAllowed,
+	isTrackedWorkflowMode,
+	readActiveWorkflowModes,
+} from "../state/workflow-transition.js";
+import {
 	RALPH_PHASES,
 	validateAndNormalizeRalphState,
 } from "../ralph/contract.js";
@@ -353,6 +358,15 @@ export async function handleStateToolCall(request: {
 						...fields,
 						...((customState as Record<string, unknown>) || {}),
 					} as Record<string, unknown>;
+					if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
+						try {
+							const activeModes = await readActiveWorkflowModes(cwd, effectiveSessionId);
+							assertWorkflowTransitionAllowed(activeModes, mode, "write");
+						} catch (error) {
+							validationError = (error as Error).message;
+							return;
+						}
+					}
 					if (
 						mode === "ralph" &&
 						effectiveSessionId &&

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -32,17 +32,14 @@ import {
 import { withModeRuntimeContext } from "../state/mode-state-context.js";
 import {
 	SKILL_ACTIVE_STATE_MODE,
-	listActiveSkills,
 	readSkillActiveState,
-	readVisibleSkillActiveState,
 	syncCanonicalSkillStateForMode,
 	writeSkillActiveStateCopies,
 } from "../state/skill-active.js";
 import {
-	assertWorkflowTransitionAllowed,
 	isTrackedWorkflowMode,
-	readActiveWorkflowModes,
 } from "../state/workflow-transition.js";
+import { reconcileWorkflowTransition } from "../state/workflow-transition-reconcile.js";
 import {
 	RALPH_PHASES,
 	validateAndNormalizeRalphState,
@@ -84,18 +81,6 @@ async function listStateSessionIds(cwd: string): Promise<string[]> {
 		.filter((entry) => entry.isDirectory())
 		.map((entry) => entry.name)
 		.filter((entry) => entry.trim().length > 0);
-}
-
-async function readWorkflowModesForValidation(
-	cwd: string,
-	sessionId?: string,
-): Promise<string[]> {
-	const canonical = await readVisibleSkillActiveState(cwd, sessionId);
-	const canonicalModes = listActiveSkills(canonical ?? {})
-		.map((entry) => entry.skill)
-		.filter(isTrackedWorkflowMode);
-	if (canonicalModes.length > 0) return canonicalModes;
-	return readActiveWorkflowModes(cwd, sessionId);
 }
 
 async function withStateWriteLock<T>(
@@ -365,6 +350,7 @@ export async function handleStateToolCall(request: {
 					...fields
 				} = args as Record<string, unknown>;
 				let validationError: string | null = null;
+				let transitionMessage: string | undefined;
 				await withStateWriteLock(path, async () => {
 					let existing: Record<string, unknown> = {};
 					if (existsSync(path)) {
@@ -384,14 +370,22 @@ export async function handleStateToolCall(request: {
 					} as Record<string, unknown>;
 					if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
 						try {
-							const activeModes = await readWorkflowModesForValidation(cwd, effectiveSessionId);
-							assertWorkflowTransitionAllowed(activeModes, mode, "write");
 							if (!effectiveSessionId) {
 								for (const sessionId of await listStateSessionIds(cwd)) {
-									const sessionModes = await readWorkflowModesForValidation(cwd, sessionId);
-									assertWorkflowTransitionAllowed(sessionModes, mode, "write");
+									const sessionTransition = await reconcileWorkflowTransition(cwd, mode, {
+										action: "write",
+										sessionId,
+										source: "state-server",
+									});
+									transitionMessage ??= sessionTransition.transitionMessage;
 								}
 							}
+							const transition = await reconcileWorkflowTransition(cwd, mode, {
+								action: "write",
+								sessionId: effectiveSessionId,
+								source: "state-server",
+							});
+							transitionMessage ??= transition.transitionMessage;
 						} catch (error) {
 							validationError = (error as Error).message;
 							return;
@@ -458,7 +452,12 @@ export async function handleStateToolCall(request: {
 					content: [
 						{
 							type: "text",
-							text: JSON.stringify({ success: true, mode, path }),
+							text: JSON.stringify({
+								success: true,
+								mode,
+								path,
+								...(transitionMessage ? { transition: transitionMessage } : {}),
+							}),
 						},
 					],
 				};

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -32,7 +32,9 @@ import {
 import { withModeRuntimeContext } from "../state/mode-state-context.js";
 import {
 	SKILL_ACTIVE_STATE_MODE,
+	listActiveSkills,
 	readSkillActiveState,
+	readVisibleSkillActiveState,
 	syncCanonicalSkillStateForMode,
 	writeSkillActiveStateCopies,
 } from "../state/skill-active.js";
@@ -73,6 +75,28 @@ const STATE_TOOL_NAMES = new Set([
 const TEAM_COMM_TOOL_NAMES: Set<string> = new Set([...LEGACY_TEAM_MCP_TOOLS]);
 
 const stateWriteQueues = new Map<string, Promise<void>>();
+
+async function listStateSessionIds(cwd: string): Promise<string[]> {
+	const sessionsDir = join(getStateDir(cwd), "sessions");
+	if (!existsSync(sessionsDir)) return [];
+	const entries = await readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+	return entries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.filter((entry) => entry.trim().length > 0);
+}
+
+async function readWorkflowModesForValidation(
+	cwd: string,
+	sessionId?: string,
+): Promise<string[]> {
+	const canonical = await readVisibleSkillActiveState(cwd, sessionId);
+	const canonicalModes = listActiveSkills(canonical ?? {})
+		.map((entry) => entry.skill)
+		.filter(isTrackedWorkflowMode);
+	if (canonicalModes.length > 0) return canonicalModes;
+	return readActiveWorkflowModes(cwd, sessionId);
+}
 
 async function withStateWriteLock<T>(
 	path: string,
@@ -360,8 +384,14 @@ export async function handleStateToolCall(request: {
 					} as Record<string, unknown>;
 					if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
 						try {
-							const activeModes = await readActiveWorkflowModes(cwd, effectiveSessionId);
+							const activeModes = await readWorkflowModesForValidation(cwd, effectiveSessionId);
 							assertWorkflowTransitionAllowed(activeModes, mode, "write");
+							if (!effectiveSessionId) {
+								for (const sessionId of await listStateSessionIds(cwd)) {
+									const sessionModes = await readWorkflowModesForValidation(cwd, sessionId);
+									assertWorkflowTransitionAllowed(sessionModes, mode, "write");
+								}
+							}
 						} catch (error) {
 							validationError = (error as Error).message;
 							return;

--- a/src/modes/__tests__/base-autoresearch-contract.test.ts
+++ b/src/modes/__tests__/base-autoresearch-contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { readModeState, startMode } from '../base.js';
@@ -23,6 +23,26 @@ describe('modes/base deep-interview contract integration', () => {
 });
 
 describe('modes/base autoresearch contract integration', () => {
+  it('startMode auto-completes deep-interview when starting ralplan', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-interview-ralplan-handoff-'));
+    try {
+      await startMode('deep-interview', 'clarify contract', 3, wd);
+      const started = await startMode('ralplan', 'plan contract', 5, wd);
+      assert.equal(started.mode, 'ralplan');
+      assert.equal(started.active, true);
+      assert.equal(started.transition_message, 'mode transiting: deep-interview -> ralplan');
+
+      const completed = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'deep-interview-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string; completed_at?: string };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, 'completed');
+      assert.equal(typeof completed.completed_at, 'string');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('startMode allows the approved team + ralph overlap', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-team-ralph-overlap-'));
     try {
@@ -48,13 +68,25 @@ describe('modes/base autoresearch contract integration', () => {
     }
   });
 
-  it('startMode blocks unsupported ralph + ultrawork overlap', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-ralph-ultrawork-deny-'));
+  it('startMode allows ultrawork overlap with any tracked mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-ralph-ultrawork-allow-'));
     try {
       await startMode('ralph', 'demo', 5, wd);
+      const started = await startMode('ultrawork', 'demo mission', 1, wd);
+      assert.equal(started.mode, 'ultrawork');
+      assert.equal(started.active, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('startMode blocks execution-to-planning rollback auto-complete', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-rollback-deny-'));
+    try {
+      await startMode('autopilot', 'demo', 5, wd);
       await assert.rejects(
-        () => startMode('ultrawork', 'demo mission', 1, wd),
-        /Unsupported workflow overlap: ralph \+ ultrawork\./i,
+        () => startMode('ralplan', 'plan again', 5, wd),
+        /Execution-to-planning rollback auto-complete is not allowed/i,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/modes/__tests__/base-autoresearch-contract.test.ts
+++ b/src/modes/__tests__/base-autoresearch-contract.test.ts
@@ -23,6 +23,18 @@ describe('modes/base deep-interview contract integration', () => {
 });
 
 describe('modes/base autoresearch contract integration', () => {
+  it('startMode allows the approved team + ralph overlap', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-team-ralph-overlap-'));
+    try {
+      await startMode('team', 'demo team', 5, wd);
+      const started = await startMode('ralph', 'demo ralph', 5, wd);
+      assert.equal(started.mode, 'ralph');
+      assert.equal(started.active, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('startMode blocks autoresearch when ralph is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autoresearch-contract-'));
     try {
@@ -30,6 +42,19 @@ describe('modes/base autoresearch contract integration', () => {
       await assert.rejects(
         () => startMode('autoresearch', 'demo mission', 1, wd),
         /Cannot start autoresearch: ralph is already active/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('startMode blocks unsupported ralph + ultrawork overlap', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-ralph-ultrawork-deny-'));
+    try {
+      await startMode('ralph', 'demo', 5, wd);
+      await assert.rejects(
+        () => startMode('ultrawork', 'demo mission', 1, wd),
+        /Unsupported workflow overlap: ralph \+ ultrawork\./i,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/modes/__tests__/base-multi-state-compat.test.ts
+++ b/src/modes/__tests__/base-multi-state-compat.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readModeState, startMode } from '../base.js';
+
+describe('modes/base multi-state compatibility', () => {
+  it('allows the approved team + ralph overlap across root and session scopes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-team-ralph-'));
+    try {
+      await startMode('team', 'coordinate execution', 5, wd);
+      await writeFile(
+        join(wd, '.omx', 'state', 'session.json'),
+        JSON.stringify({ session_id: 'sess-team-ralph' }),
+      );
+
+      await startMode('ralph', 'complete the approved plan', 5, wd);
+
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'team-state.json')), true);
+      assert.equal(
+        existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-team-ralph', 'ralph-state.json')),
+        true,
+      );
+      assert.equal((await readModeState('team', wd))?.active, true);
+      assert.equal((await readModeState('ralph', wd))?.active, true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects standalone autopilot + team overlaps with actionable clearing guidance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-team-'));
+    try {
+      await startMode('autopilot', 'run solo automation', 5, wd);
+
+      await assert.rejects(
+        () => startMode('team', 'attempt invalid overlap', 5, wd),
+        /omx state.*omx_state\.\*/i,
+      );
+
+      const autopilotState = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8'),
+      ) as { active?: boolean };
+      assert.equal(autopilotState.active, true);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'team-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/modes/__tests__/base-tmux-pane.test.ts
+++ b/src/modes/__tests__/base-tmux-pane.test.ts
@@ -31,7 +31,7 @@ describe('modes/base tmux pane capture', () => {
 
       await assert.rejects(
         () => startMode('autopilot', 'test', 1, wd),
-        /state file is malformed or unreadable/i,
+        /clear or repair state via `omx state clear --mode ralph` or the `omx_state\.\*` MCP tools/i,
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -11,6 +11,8 @@ import {
   isTrackedWorkflowMode,
   readActiveWorkflowModes,
 } from '../state/workflow-transition.js';
+import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
+import { syncCanonicalSkillStateForMode } from '../state/skill-active.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
 import {
   getBaseStateDir,
@@ -98,8 +100,16 @@ export async function startMode(
   const dir = stateDir(projectRoot);
   await mkdir(dir, { recursive: true });
 
-  await assertModeStartAllowed(mode, projectRoot);
   const scope = await resolveStateScope(projectRoot);
+  let transitionMessage: string | undefined;
+  if (isTrackedWorkflowMode(mode)) {
+    const transition = await reconcileWorkflowTransition(projectRoot ?? process.cwd(), mode, {
+      action: 'start',
+      sessionId: scope.sessionId,
+      source: 'startMode',
+    });
+    transitionMessage = transition.transitionMessage;
+  }
   await mkdir(scope.stateDir, { recursive: true });
 
   const stateBase: ModeState = {
@@ -110,6 +120,7 @@ export async function startMode(
     current_phase: 'starting',
     task_description: taskDescription,
     started_at: new Date().toISOString(),
+    ...(transitionMessage ? { transition_message: transitionMessage } : {}),
     ...(mode === 'ralph' && scope.sessionId ? { owner_omx_session_id: scope.sessionId } : {}),
   };
 
@@ -118,6 +129,16 @@ export async function startMode(
     ? normalizeRalphModeStateOrThrow(withContext)
     : withContext;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(state, null, 2));
+  if (isTrackedWorkflowMode(mode)) {
+    await syncCanonicalSkillStateForMode({
+      cwd: projectRoot ?? process.cwd(),
+      mode,
+      active: true,
+      currentPhase: typeof state.current_phase === 'string' ? state.current_phase : undefined,
+      sessionId: scope.sessionId,
+      source: 'startMode',
+    });
+  }
   return state;
 }
 

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -6,6 +6,11 @@
 import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { withModeRuntimeContext } from '../state/mode-state-context.js';
+import {
+  assertWorkflowTransitionAllowed,
+  isTrackedWorkflowMode,
+  readActiveWorkflowModes,
+} from '../state/workflow-transition.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
 import {
   getBaseStateDir,
@@ -50,8 +55,6 @@ export function getDeprecationWarning(mode: string): string | null {
   return `[DEPRECATED] Mode "${mode}" is deprecated. ${warning}`;
 }
 
-const EXCLUSIVE_MODES: ModeName[] = ['autopilot', 'autoresearch', 'ralph', 'ultrawork'];
-
 function normalizeRalphModeStateOrThrow(state: ModeState): ModeState {
   const originalPhase = state.current_phase;
   const validation = validateAndNormalizeRalphState(state as Record<string, unknown>);
@@ -77,30 +80,10 @@ export async function assertModeStartAllowed(
   mode: ModeName,
   projectRoot?: string,
 ): Promise<void> {
-  if (!EXCLUSIVE_MODES.includes(mode)) return;
-
-  for (const other of EXCLUSIVE_MODES) {
-    if (other === mode) continue;
-    const otherPaths = await getReadScopedStatePaths(other, projectRoot);
-    for (const otherPath of otherPaths) {
-      if (!existsSync(otherPath)) continue;
-      try {
-        const raw = await readFile(otherPath, 'utf-8');
-        const otherState = JSON.parse(raw) as { active?: unknown };
-        if (otherState.active) {
-          throw new Error(`Cannot start ${mode}: ${other} is already active. Run cancel first.`);
-        }
-        break;
-      } catch (e) {
-        const err = e as NodeJS.ErrnoException;
-        if (err?.message.includes('Cannot start')) throw err;
-        if (err?.code === 'ENOENT') continue;
-        throw new Error(
-          `Cannot start ${mode}: ${other} state file is malformed or unreadable (${otherPath}). Run cancel or repair the state file.`
-        );
-      }
-    }
-  }
+  if (!isTrackedWorkflowMode(mode)) return;
+  const scope = await resolveStateScope(projectRoot);
+  const activeModes = await readActiveWorkflowModes(projectRoot ?? process.cwd(), scope.sessionId);
+  assertWorkflowTransitionAllowed(activeModes, mode, 'start');
 }
 
 /**

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -147,6 +147,10 @@ export async function startMode(
  */
 export async function readModeState(mode: string, projectRoot?: string): Promise<ModeState | null> {
   const paths = await getReadScopedStatePaths(mode, projectRoot);
+  return readModeStateFromPaths(paths);
+}
+
+async function readModeStateFromPaths(paths: string[]): Promise<ModeState | null> {
   for (const path of paths) {
     if (!existsSync(path)) continue;
     try {
@@ -158,17 +162,34 @@ export async function readModeState(mode: string, projectRoot?: string): Promise
   return null;
 }
 
+export async function readModeStateForSession(
+  mode: string,
+  sessionId: string | undefined,
+  projectRoot?: string,
+): Promise<ModeState | null> {
+  let paths: string[];
+  try {
+    paths = await getReadScopedStatePaths(mode, projectRoot, sessionId);
+  } catch {
+    return null;
+  }
+  return readModeStateFromPaths(paths);
+}
+
 /**
  * Update mode state (merge fields)
  */
 export async function updateModeState(
   mode: string,
   updates: Partial<ModeState>,
-  projectRoot?: string
+  projectRoot?: string,
+  explicitSessionId?: string,
 ): Promise<ModeState> {
-  const current = await readModeState(mode, projectRoot);
+  const current = explicitSessionId
+    ? await readModeStateForSession(mode, explicitSessionId, projectRoot)
+    : await readModeState(mode, projectRoot);
   if (!current) throw new Error(`Mode ${mode} not found`);
-  const scope = await resolveStateScope(projectRoot);
+  const scope = await resolveStateScope(projectRoot, explicitSessionId);
   await mkdir(scope.stateDir, { recursive: true });
 
   const updatedBase = { ...current, ...updates };

--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { spawn, type spawnSync } from 'node:child_process';
 import type { ClientRequestArgs, IncomingMessage } from 'node:http';
 import { PassThrough } from 'node:stream';
 import {
@@ -262,6 +262,27 @@ describe('isReplyListenerProcess', () => {
 
   it('returns false for a non-existent PID', () => {
     assert.equal(isReplyListenerProcess(0), false);
+  });
+
+  it('returns false on Windows when ps is unavailable', () => {
+    const result = isReplyListenerProcess(123, {
+      platform: 'win32',
+      env: {
+        PATH: '',
+        PATHEXT: '.EXE;.CMD;.PS1',
+      },
+      spawnImpl: ((() => ({
+        pid: 0,
+        output: [null, '', ''],
+        stdout: '',
+        stderr: '',
+        status: null,
+        signal: null,
+        error: Object.assign(new Error('spawnSync ps ENOENT'), { code: 'ENOENT' }),
+      })) as unknown) as typeof spawnSync,
+    });
+
+    assert.equal(result, false);
   });
 });
 

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -32,6 +32,7 @@ import {
 } from './session-registry.js';
 import { parseMentionAllowedMentions } from './config.js';
 import { parseTmuxTail } from './formatter.js';
+import { spawnPlatformCommandSync } from '../utils/platform-command.js';
 import type { ReplyConfig } from './types.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -270,19 +271,36 @@ const DAEMON_IDENTITY_MARKER = 'pollLoop';
  * inspecting its command line for the daemon identity marker. Returns false if
  * the process cannot be positively identified (safe default).
  */
-export function isReplyListenerProcess(pid: number): boolean {
+export function isReplyListenerProcess(
+  pid: number,
+  options: {
+    platform?: NodeJS.Platform;
+    env?: NodeJS.ProcessEnv;
+    existsImpl?: typeof existsSync;
+    spawnImpl?: typeof spawnSync;
+  } = {},
+): boolean {
   try {
-    if (process.platform === 'linux') {
+    const platform = options.platform ?? process.platform;
+    if (platform === 'linux') {
       // NUL-separated argv available without spawning a subprocess
       const cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
       return cmdline.includes(DAEMON_IDENTITY_MARKER);
     }
     if (process.platform === 'win32') return false;
     // macOS and other POSIX systems
-    const result = spawnSync('ps', ['-p', String(pid), '-o', 'args='], {
-      encoding: 'utf-8',
-      timeout: 3000,
-    });
+    const { result } = spawnPlatformCommandSync(
+      'ps',
+      ['-p', String(pid), '-o', 'args='],
+      {
+        encoding: 'utf-8',
+        timeout: 3000,
+      },
+      platform,
+      options.env,
+      options.existsImpl,
+      options.spawnImpl,
+    );
     if (result.status !== 0 || result.error) return false;
     return (result.stdout ?? '').includes(DAEMON_IDENTITY_MARKER);
   } catch {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -311,6 +311,47 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("returns actionable denial guidance for unsupported workflow overlaps on prompt submit", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-transition-deny-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-deny-1",
+          thread_id: "thread-deny-1",
+          turn_id: "turn-deny-1",
+          prompt: "$team ship this fix",
+        },
+        { cwd },
+      );
+
+      const denied = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-deny-1",
+          thread_id: "thread-deny-1",
+          turn_id: "turn-deny-2",
+          prompt: "$autopilot also run this",
+        },
+        { cwd },
+      );
+
+      assert.match(JSON.stringify(denied.outputJson), /denied workflow keyword/i);
+      assert.match(JSON.stringify(denied.outputJson), /Unsupported workflow overlap: team \+ autopilot\./);
+      assert.match(JSON.stringify(denied.outputJson), /`omx state clear --mode <mode>`/);
+      assert.match(JSON.stringify(denied.outputJson), /`omx_state\.\*` MCP tools/);
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", "sess-deny-1", "autopilot-state.json")),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("runs prompt-submit HUD reconciliation as a best-effort tmux-only side effect", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reconcile-"));
     const originalTmux = process.env.TMUX;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1735,6 +1735,70 @@ esac
     }
   });
 
+  it("does not block Stop from root Ralph fallback when the current session has no scoped Ralph state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-ralph-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current", cwd });
+      await writeJson(join(stateDir, "ralph-state.json"), {
+        active: true,
+        current_phase: "executing",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores mismatched session.json cwd and still blocks from active root Ralph fallback", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-cwd-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: "sess-elsewhere",
+        cwd: join(cwd, "..", "different-worktree"),
+      });
+      await writeJson(join(stateDir, "ralph-state.json"), {
+        active: true,
+        current_phase: "executing",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_executing",
+        systemMessage:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not re-block Ralph when Stop already continued once", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-once-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1575,7 +1575,7 @@ esac
     }
   });
 
-  it("returns Stop continuation output for active deep-interview skill with matching active mode state and without active subagents", async () => {
+  it("does not block Stop solely because deep-interview is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1600,13 +1600,7 @@ esac
         { cwd },
       );
 
-      assert.deepEqual(result.outputJson, {
-        decision: "block",
-        reason:
-          "OMX skill deep-interview is still active (phase: planning); continue until the current deep-interview workflow reaches a terminal state.",
-        stopReason: "skill_deep-interview_planning",
-        systemMessage: "OMX skill deep-interview is still active (phase: planning).",
-      });
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1904,7 +1898,7 @@ esac
     }
   });
 
-  it("suppresses native auto-nudge when only the deep-interview input lock is active", async () => {
+  it("still allows native auto-nudge when deep-interview state is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-deep-interview-lock-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1934,7 +1928,7 @@ esac
           session_id: "sess-stop-auto-lock",
           thread_id: "thread-stop-auto-lock",
           turn_id: "turn-stop-auto-lock-1",
-          last_assistant_message: "Would you like me to continue with the next step?",
+          last_assistant_message: "Keep going and finish the cleanup from here.",
         },
         { cwd },
       );
@@ -1942,10 +1936,10 @@ esac
       assert.equal(result.omxEventName, "stop");
       assert.deepEqual(result.outputJson, {
         decision: "block",
-        reason:
-          "OMX skill deep-interview is still active (phase: planning); continue until the current deep-interview workflow reaches a terminal state.",
-        stopReason: "skill_deep-interview_planning",
-        systemMessage: "OMX skill deep-interview is still active (phase: planning).",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -24,6 +24,8 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 
 const TEAM_STOP_COMMIT_GUIDANCE =
   " If system-generated worker auto-checkpoint commits exist, rewrite them into Lore-format final commits before merge/finalization.";
+const DEFAULT_AUTO_NUDGE_RESPONSE =
+  "continue with the current task only if it is already authorized";
 
 const TEAM_ENV_KEYS = [
   "OMX_TEAM_WORKER",
@@ -1596,7 +1598,7 @@ esac
           hook_event_name: "Stop",
           cwd,
           session_id: "sess-stop-auto",
-          last_assistant_message: "Would you like me to keep going and finish the cleanup?",
+          last_assistant_message: "Keep going and finish the cleanup.",
         },
         { cwd },
       );
@@ -1604,7 +1606,7 @@ esac
       assert.equal(result.omxEventName, "stop");
       assert.deepEqual(result.outputJson, {
         decision: "block",
-        reason: "yes, proceed",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
         stopReason: "auto_nudge",
         systemMessage:
           "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
@@ -1627,7 +1629,7 @@ esac
           session_id: "sess-stop-auto-once",
           thread_id: "thread-stop-auto",
           turn_id: "turn-stop-auto-1",
-          last_assistant_message: "Would you like me to continue?",
+          last_assistant_message: "Keep going and finish the cleanup.",
         },
         { cwd },
       );
@@ -1640,7 +1642,7 @@ esac
           thread_id: "thread-stop-auto",
           turn_id: "turn-stop-auto-1",
           stop_hook_active: true,
-          last_assistant_message: "Would you like me to continue?",
+          last_assistant_message: "Keep going and finish the cleanup.",
         },
         { cwd },
       );
@@ -1665,7 +1667,7 @@ esac
           session_id: "sess-stop-auto-refire",
           thread_id: "thread-stop-auto-refire",
           turn_id: "turn-stop-auto-refire-1",
-          last_assistant_message: "Would you like me to continue?",
+          last_assistant_message: "Keep going and finish the cleanup.",
         },
         { cwd },
       );
@@ -1678,7 +1680,7 @@ esac
           thread_id: "thread-stop-auto-refire",
           turn_id: "turn-stop-auto-refire-2",
           stop_hook_active: true,
-          last_assistant_message: "If you want, I can keep going and finish the cleanup.",
+          last_assistant_message: "Continue with the cleanup from here.",
         },
         { cwd },
       );
@@ -1686,11 +1688,33 @@ esac
       assert.equal(result.omxEventName, "stop");
       assert.deepEqual(result.outputJson, {
         decision: "block",
-        reason: "yes, proceed",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
         stopReason: "auto_nudge",
         systemMessage:
           "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
       });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not auto-continue native Stop on permission-seeking prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-permission-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-permission",
+          last_assistant_message: "Would you like me to continue with the cleanup?",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1822,7 +1846,7 @@ esac
           session_id: "sess-stop-auto-stale-root-mode",
           thread_id: "thread-stop-auto-stale-root-mode",
           turn_id: "turn-stop-auto-stale-root-mode-1",
-          last_assistant_message: "Would you like me to continue with the next step?",
+          last_assistant_message: "Keep going and finish the cleanup.",
         },
         { cwd },
       );
@@ -1830,7 +1854,7 @@ esac
       assert.equal(result.omxEventName, "stop");
       assert.deepEqual(result.outputJson, {
         decision: "block",
-        reason: "yes, proceed",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
         stopReason: "auto_nudge",
         systemMessage:
           "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
@@ -1858,7 +1882,7 @@ esac
           session_id: "sess-stop-auto-stale-root-skill",
           thread_id: "thread-stop-auto-stale-root-skill",
           turn_id: "turn-stop-auto-stale-root-skill-1",
-          last_assistant_message: "Would you like me to continue with the next step?",
+          last_assistant_message: "Keep going and finish the cleanup.",
         },
         { cwd },
       );
@@ -1866,7 +1890,7 @@ esac
       assert.equal(result.omxEventName, "stop");
       assert.deepEqual(result.outputJson, {
         decision: "block",
-        reason: "yes, proceed",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
         stopReason: "auto_nudge",
         systemMessage:
           "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
@@ -1900,7 +1924,7 @@ esac
           session_id: "sess-stop-auto-stale-root-lock",
           thread_id: "thread-stop-auto-stale-root-lock",
           turn_id: "turn-stop-auto-stale-root-lock-1",
-          last_assistant_message: "Would you like me to continue with the next step?",
+          last_assistant_message: "Keep going and finish the cleanup.",
         },
         { cwd },
       );
@@ -1908,7 +1932,7 @@ esac
       assert.equal(result.omxEventName, "stop");
       assert.deepEqual(result.outputJson, {
         decision: "block",
-        reason: "yes, proceed",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
         stopReason: "auto_nudge",
         systemMessage:
           "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -354,6 +354,79 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("surfaces transition success output for allowlisted prompt-submit handoffs", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-transition-success-"));
+    try {
+      const sessionDir = join(cwd, ".omx", "state", "sessions", "sess-handoff-1");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(sessionDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+      });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-handoff-1",
+        active_skills: [{ skill: "deep-interview", phase: "planning", active: true, session_id: "sess-handoff-1" }],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-handoff-1",
+          thread_id: "thread-handoff-1",
+          turn_id: "turn-handoff-1",
+          prompt: "$ralplan implement the approved contract",
+        },
+        { cwd },
+      );
+
+      assert.match(JSON.stringify(result.outputJson), /mode transiting: deep-interview -> ralplan/);
+      const completed = JSON.parse(await readFile(join(sessionDir, "deep-interview-state.json"), "utf-8")) as {
+        active?: boolean;
+        current_phase?: string;
+      };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, "completed");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces multi-skill prompt-submit output for ralplan -> team + ralph", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-transition-multi-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-multi-1",
+          thread_id: "thread-multi-1",
+          turn_id: "turn-multi-1",
+          prompt: "$ralplan $team $ralph ship this fix",
+        },
+        { cwd },
+      );
+
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || '',
+      );
+      assert.match(message, /\$ralplan" -> ralplan/);
+      assert.match(message, /\$team" -> team/);
+      assert.match(message, /\$ralph" -> ralph/);
+      assert.match(message, /mode transiting: ralplan -> team \+ ralph/);
+      assert.match(message, /active skills: team, ralph\./);
+      assert.match(message, /Use the durable OMX team runtime via `omx team \.\.\.`/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("runs prompt-submit HUD reconciliation as a best-effort tmux-only side effect", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reconcile-"));
     const originalTmux = process.env.TMUX;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1381,6 +1381,41 @@ esac
     }
   });
 
+  it("blocks Stop from session-scoped team mode when session.json points to another session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-session-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-live-team"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-other-team" });
+      await writeJson(join(stateDir, "sessions", "sess-live-team", "team-state.json"), {
+        active: true,
+        mode: "team",
+        current_phase: "team-exec",
+        team_name: "session-live-team",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-live-team",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          `OMX team pipeline is still active (session-live-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns Stop continuation output for active ralplan skill with matching active mode state and without active subagents", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-skill-"));
     try {
@@ -1624,6 +1659,41 @@ esac
           hook_event_name: "Stop",
           cwd,
           session_id: "sess-stop",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_executing",
+        systemMessage:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Stop from session-scoped Ralph state when session.json points to another session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-session-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-live-ralph"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-other-ralph" });
+      await writeJson(join(stateDir, "sessions", "sess-live-ralph", "ralph-state.json"), {
+        active: true,
+        current_phase: "executing",
+        session_id: "sess-live-ralph",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-live-ralph",
         },
         { cwd },
       );

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2273,4 +2273,46 @@ esac
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("does not fall back to active root team state when the current scoped team state is inactive", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-inactive-scoped-team-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current" });
+      await writeJson(join(stateDir, "sessions", "sess-current", "team-state.json"), {
+        active: false,
+        current_phase: "complete",
+        team_name: "scoped-finished-team",
+        session_id: "sess-current",
+      });
+      await writeJson(join(stateDir, "team-state.json"), {
+        active: true,
+        current_phase: "starting",
+        team_name: "root-fallback-team",
+        session_id: "sess-current",
+      });
+      await writeJson(join(stateDir, "team", "root-fallback-team", "phase.json"), {
+        current_phase: "team-exec",
+        max_fix_attempts: 3,
+        current_fix_attempt: 0,
+        transitions: [],
+        updated_at: new Date().toISOString(),
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2237,4 +2237,40 @@ esac
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("does not block Stop from another session's stale root team state when no scoped team state exists", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-root-team-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current" });
+      await writeJson(join(stateDir, "team-state.json"), {
+        active: true,
+        current_phase: "starting",
+        team_name: "stale-root-team",
+        session_id: "sess-other",
+      });
+      await writeJson(join(stateDir, "team", "stale-root-team", "phase.json"), {
+        current_phase: "team-exec",
+        max_fix_attempts: 3,
+        current_fix_attempt: 0,
+        transitions: [],
+        updated_at: new Date().toISOString(),
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1635,7 +1635,7 @@ esac
     }
   });
 
-  it("returns Stop continuation output while Ralph is active", async () => {
+  it("returns Stop continuation output while Ralph is active without an explicit session pin", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1652,7 +1652,6 @@ esac
         {
           hook_event_name: "Stop",
           cwd,
-          session_id: "sess-stop",
         },
         { cwd },
       );
@@ -1735,6 +1734,33 @@ esac
     }
   });
 
+  it("does not block Stop from another session-scoped Ralph state when an explicit session_id has no active Ralph state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-explicit-session-ralph-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-other"), { recursive: true });
+      await writeJson(join(stateDir, "sessions", "sess-other", "ralph-state.json"), {
+        active: true,
+        current_phase: "starting",
+        session_id: "sess-other",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop from root Ralph fallback when the current session has no scoped Ralph state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-ralph-"));
     try {
@@ -1762,7 +1788,7 @@ esac
     }
   });
 
-  it("ignores mismatched session.json cwd and still blocks from active root Ralph fallback", async () => {
+  it("does not block Stop from root Ralph fallback when an explicit session_id is present and session.json points to another worktree", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-cwd-mismatch-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1786,14 +1812,7 @@ esac
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.deepEqual(result.outputJson, {
-        decision: "block",
-        reason:
-          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
-        stopReason: "ralph_executing",
-        systemMessage:
-          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
-      });
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9,6 +9,7 @@ import {
 } from "../state/skill-active.js";
 import { readSubagentSessionSummary } from "../subagents/tracker.js";
 import { resolveCanonicalTeamStateRoot } from "../team/state-root.js";
+import { readUsableSessionState } from "../hooks/session.js";
 import {
   appendTeamEvent,
   readTeamLeaderAttention,
@@ -181,7 +182,7 @@ async function readActiveRalphState(
   stateDir: string,
   preferredSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
-  const sessionInfo = await readJsonIfExists(join(stateDir, "session.json"));
+  const sessionInfo = await readUsableSessionState(resolve(stateDir, "..", ".."));
   const currentOmxSessionId = safeString(sessionInfo?.session_id).trim();
   const sessionCandidates = [...new Set([
     safeString(preferredSessionId).trim(),
@@ -202,12 +203,12 @@ async function readActiveRalphState(
     }
   }
 
+  if (currentOmxSessionId) return null;
+
   const direct = await readJsonIfExists(join(stateDir, "ralph-state.json"));
   if (direct?.active === true && !TERMINAL_RALPH_PHASES.has(safeString(direct.current_phase).trim().toLowerCase())) {
     return direct;
   }
-
-  if (sessionCandidates.length > 0) return null;
 
   const sessionsRoot = join(stateDir, "sessions");
   if (!existsSync(sessionsRoot)) return null;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -27,6 +27,7 @@ import {
   detectStallPattern,
   loadAutoNudgeConfig,
   normalizeAutoNudgeSignatureText,
+  resolveEffectiveAutoNudgeResponse,
 } from "./notify-hook/auto-nudge.js";
 import {
   buildNativePostToolUseOutput,
@@ -1027,13 +1028,14 @@ async function buildStopHookOutput(
       && autoNudgeConfig.enabled
       && detectStallPattern(lastAssistantMessage, autoNudgeConfig.patterns)
     ) {
+      const effectiveResponse = resolveEffectiveAutoNudgeResponse(autoNudgeConfig.response);
       return await maybeReturnRepeatableStopOutput(
         payload,
         stateDir,
         buildRepeatableStopSignature(payload, "auto-nudge", lastAssistantMessage),
         {
           decision: "block",
-          reason: autoNudgeConfig.response,
+          reason: effectiveResponse,
           stopReason: "auto_nudge",
           systemMessage:
             "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19,6 +19,7 @@ import {
 } from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath, omxStateDir } from "../utils/paths.js";
 import {
+  detectKeywords,
   detectPrimaryKeyword,
   recordSkillActivation,
   type SkillActiveState,
@@ -426,39 +427,73 @@ async function buildSessionStartContext(
 
 function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveState | null): string | null {
   if (!prompt) return null;
+  const matches = detectKeywords(prompt);
   const match = detectPrimaryKeyword(prompt);
   if (!match) return null;
+  const requestedSkills = matches.map((entry) => entry.skill);
+  const detectedKeywordMessage = matches.length > 1
+    ? `OMX native UserPromptSubmit detected workflow keywords ${matches.map((entry) => `"${entry.keyword}" -> ${entry.skill}`).join(", ")}.`
+    : `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`;
+  const activeSkills = Array.isArray(skillState?.active_skills)
+    ? skillState.active_skills.map((entry) => entry.skill)
+    : [];
+  const teamDetected = activeSkills.includes("team") || requestedSkills.includes("team");
+  const combinedTransitionMessage = (() => {
+    if (!skillState?.transition_message) return null;
+    if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
+    const source = skillState.transition_message.match(/^mode transiting: (.+?) -> /)?.[1];
+    if (!source) return skillState.transition_message;
+    return `mode transiting: ${source} -> ${activeSkills.join(" + ")}`;
+  })();
 
   if (skillState?.transition_error) {
     return [
       `OMX native UserPromptSubmit denied workflow keyword "${match.keyword}" -> ${match.skill}.`,
       skillState.transition_error,
-      'Follow AGENTS.md routing and preserve ralplan/ralph execution gates.',
+      'Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.',
     ].join(' ');
   }
 
-  if (match.skill === "team") {
+  if (skillState?.transition_message) {
+    return [
+      detectedKeywordMessage,
+      combinedTransitionMessage,
+      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
+      skillState.initialized_mode && skillState.initialized_state_path
+        ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
+        : null,
+      teamDetected
+        ? "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout."
+        : null,
+      teamDetected ? "If you need help, run `omx team --help`." : null,
+      'Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.',
+    ].filter(Boolean).join(' ');
+  }
+
+  if (teamDetected) {
     const initializedStateMessage = skillState?.initialized_mode && skillState.initialized_state_path
       ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
       : null;
     return [
-      `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`,
+      detectedKeywordMessage,
+      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
       initializedStateMessage,
       "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
       "If you need help, run `omx team --help`.",
-      "Follow AGENTS.md routing and preserve ralplan/ralph execution gates.",
+      "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].filter(Boolean).join(" ");
   }
 
   if (skillState?.initialized_mode && skillState.initialized_state_path) {
     return [
-      `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`,
+      detectedKeywordMessage,
+      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
-      "Follow AGENTS.md routing and preserve ralplan/ralph execution gates.",
+      "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].join(" ");
   }
 
-  return `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}. Follow AGENTS.md routing and preserve ralplan/ralph execution gates.`;
+  return `${detectedKeywordMessage} Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.`;
 }
 
 function parseTeamWorkerEnv(rawValue: string): { teamName: string; workerName: string } | null {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -428,6 +428,14 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
   const match = detectPrimaryKeyword(prompt);
   if (!match) return null;
 
+  if (skillState?.transition_error) {
+    return [
+      `OMX native UserPromptSubmit denied workflow keyword "${match.keyword}" -> ${match.skill}.`,
+      skillState.transition_error,
+      'Follow AGENTS.md routing and preserve ralplan/ralph execution gates.',
+    ].join(' ');
+  }
+
   if (match.skill === "team") {
     const initializedStateMessage = skillState?.initialized_mode && skillState.initialized_state_path
       ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join, resolve } from "path";
-import { readModeState, updateModeState } from "../modes/base.js";
+import { readModeState, readModeStateForSession, updateModeState } from "../modes/base.js";
 import {
   listActiveSkills,
   readVisibleSkillActiveState,
@@ -176,12 +176,20 @@ function formatPhase(value: unknown, fallback = "active"): string {
   return phase || fallback;
 }
 
-async function readActiveRalphState(stateDir: string): Promise<Record<string, unknown> | null> {
+async function readActiveRalphState(
+  stateDir: string,
+  preferredSessionId?: string,
+): Promise<Record<string, unknown> | null> {
   const sessionInfo = await readJsonIfExists(join(stateDir, "session.json"));
   const currentOmxSessionId = safeString(sessionInfo?.session_id).trim();
-  if (currentOmxSessionId) {
+  const sessionCandidates = [...new Set([
+    safeString(preferredSessionId).trim(),
+    currentOmxSessionId,
+  ].filter(Boolean))];
+
+  for (const sessionId of sessionCandidates) {
     const sessionScoped = await readJsonIfExists(
-      join(stateDir, "sessions", currentOmxSessionId, "ralph-state.json"),
+      join(stateDir, "sessions", sessionId, "ralph-state.json"),
     );
     if (
       sessionScoped?.active === true
@@ -198,7 +206,7 @@ async function readActiveRalphState(stateDir: string): Promise<Record<string, un
     return direct;
   }
 
-  if (currentOmxSessionId) return null;
+  if (sessionCandidates.length > 0) return null;
 
   const sessionsRoot = join(stateDir, "sessions");
   if (!existsSync(sessionsRoot)) return null;
@@ -614,8 +622,11 @@ function isStopExempt(payload: CodexHookPayload): boolean {
 async function buildModeBasedStopOutput(
   mode: "autopilot" | "ultrawork" | "ultraqa",
   cwd: string,
+  sessionId?: string,
 ): Promise<Record<string, unknown> | null> {
-  const state = await readModeState(mode, cwd);
+  const state = sessionId
+    ? await readModeStateForSession(mode, sessionId, cwd)
+    : await readModeState(mode, cwd);
   if (state?.active !== true || !isNonTerminalPhase(state.current_phase)) return null;
   const phase = formatPhase(state.current_phase);
   return {
@@ -626,8 +637,10 @@ async function buildModeBasedStopOutput(
   };
 }
 
-async function buildTeamStopOutput(cwd: string): Promise<Record<string, unknown> | null> {
-  const teamState = await readModeState("team", cwd);
+async function buildTeamStopOutput(cwd: string, sessionId?: string): Promise<Record<string, unknown> | null> {
+  const teamState = sessionId
+    ? await readModeStateForSession("team", sessionId, cwd)
+    : await readModeState("team", cwd);
   if (teamState?.active !== true) return null;
   const teamName = safeString(teamState.team_name).trim();
   const coarsePhase = teamState.current_phase;
@@ -907,7 +920,7 @@ async function findActiveTeamForTransportFailure(
   cwd: string,
   sessionId: string,
 ): Promise<{ teamName: string; phase: string } | null> {
-  const teamState = await readModeState("team", cwd);
+  const teamState = await readModeStateForSession("team", sessionId, cwd);
   if (teamState?.active === true) {
     const teamName = safeString(teamState.team_name).trim();
     const coarsePhase = formatPhase(teamState.current_phase);
@@ -1001,6 +1014,7 @@ async function markTeamTransportFailure(
         last_turn_at: nowIso,
       },
       cwd,
+      sessionId || undefined,
     );
   } catch {
     // Canonical team state already carries the preserved failure for coarse-state-missing sessions.
@@ -1018,22 +1032,22 @@ async function buildStopHookOutput(
 
   const sessionId = readPayloadSessionId(payload);
   const threadId = readPayloadThreadId(payload);
-  const ralphState = await readActiveRalphState(stateDir);
+  const ralphState = await readActiveRalphState(stateDir, sessionId);
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
   if (!ralphState) {
     const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);
     if (!stopHookActive && hasTeamWorkerContext()) return teamWorkerOutput;
 
-    const autopilotOutput = await buildModeBasedStopOutput("autopilot", cwd);
+    const autopilotOutput = await buildModeBasedStopOutput("autopilot", cwd, sessionId);
     if (!stopHookActive && autopilotOutput) return autopilotOutput;
 
-    const ultraworkOutput = await buildModeBasedStopOutput("ultrawork", cwd);
+    const ultraworkOutput = await buildModeBasedStopOutput("ultrawork", cwd, sessionId);
     if (!stopHookActive && ultraworkOutput) return ultraworkOutput;
 
-    const ultraqaOutput = await buildModeBasedStopOutput("ultraqa", cwd);
+    const ultraqaOutput = await buildModeBasedStopOutput("ultraqa", cwd, sessionId);
     if (!stopHookActive && ultraqaOutput) return ultraqaOutput;
 
-    const teamOutput = await buildTeamStopOutput(cwd);
+    const teamOutput = await buildTeamStopOutput(cwd, sessionId);
     if (teamOutput) {
       const teamSignature = buildRepeatableStopSignature(payload, "team-stop", safeString(teamOutput.stopReason));
       return await maybeReturnRepeatableStopOutput(payload, stateDir, teamSignature, teamOutput);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -649,7 +649,7 @@ async function readTeamModeStateForStop(
   }
 
   const scopedState = await readStopSessionPinnedState("team-state.json", cwd, normalizedSessionId);
-  if (scopedState?.active === true) return scopedState;
+  if (scopedState) return scopedState;
 
   const rootState = await readJsonIfExists(join(cwd, ".omx", "state", "team-state.json"));
   if (rootState?.active !== true) return null;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -17,7 +17,7 @@ import {
   writeTeamLeaderAttention,
   writeTeamPhase,
 } from "../team/state.js";
-import { omxNotepadPath, omxProjectMemoryPath, omxStateDir } from "../utils/paths.js";
+import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
 import { getStateFilePath } from "../mcp/state-paths.js";
 import {
   detectKeywords,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -18,6 +18,7 @@ import {
   writeTeamPhase,
 } from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath, omxStateDir } from "../utils/paths.js";
+import { getStateFilePath } from "../mcp/state-paths.js";
 import {
   detectKeywords,
   detectPrimaryKeyword,
@@ -66,7 +67,7 @@ export interface NativeHookDispatchResult {
 
 const TERMINAL_RALPH_PHASES = new Set(["complete", "failed", "cancelled"]);
 const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
-const SKILL_STOP_BLOCKERS = new Set(["ralplan", "deep-interview"]);
+const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);
 const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
 
@@ -675,40 +676,12 @@ function readPayloadTurnId(payload: CodexHookPayload): string {
   return safeString(payload.turn_id ?? payload.turnId).trim();
 }
 
-async function isDeepInterviewSuppressedForStop(
-  cwd: string,
-  sessionId: string,
-  threadId: string,
-): Promise<boolean> {
-  const scopedModeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId);
-  if (scopedModeState?.active === true) return true;
-
-  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
-  const deepInterviewEntry = canonicalState
-    ? listActiveSkills(canonicalState).find((entry) => (
-      entry.skill === "deep-interview"
-      && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
-    ))
-    : null;
-  if (
-    deepInterviewEntry
-    && safeObject(canonicalState?.input_lock).active === true
-  ) {
-    return true;
-  }
-
-  return (await readBlockingSkillForStop(cwd, sessionId, threadId, "deep-interview")) !== null;
-}
-
 async function readStopSessionPinnedState(
   fileName: string,
   cwd: string,
   sessionId: string,
 ): Promise<Record<string, unknown> | null> {
-  const stateDir = omxStateDir(cwd);
-  const statePath = sessionId
-    ? join(stateDir, "sessions", sessionId, fileName)
-    : join(stateDir, fileName);
+  const statePath = getStateFilePath(fileName, cwd, sessionId || undefined);
   return readJsonIfExists(statePath);
 }
 
@@ -807,10 +780,6 @@ function buildRepeatableStopSignature(
   ].join("|");
 }
 
-async function readNativeStopState(stateDir: string): Promise<Record<string, unknown>> {
-  return await readJsonIfExists(join(stateDir, NATIVE_STOP_STATE_FILE)) ?? {};
-}
-
 function readNativeStopSessionKey(payload: CodexHookPayload): string {
   return readPayloadSessionId(payload) || readPayloadThreadId(payload) || "global";
 }
@@ -830,7 +799,8 @@ async function persistNativeStopSignature(
   signature: string,
 ): Promise<void> {
   if (!signature) return;
-  const state = await readNativeStopState(stateDir);
+  const statePath = join(stateDir, NATIVE_STOP_STATE_FILE);
+  const state = await readJsonIfExists(statePath) ?? {};
   const sessions = safeObject(state.sessions);
   const sessionKey = readNativeStopSessionKey(payload);
   sessions[sessionKey] = {
@@ -838,7 +808,8 @@ async function persistNativeStopSignature(
     last_signature: signature,
     updated_at: new Date().toISOString(),
   };
-  await writeFile(join(stateDir, NATIVE_STOP_STATE_FILE), JSON.stringify({
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(statePath, JSON.stringify({
     ...state,
     sessions,
   }, null, 2));
@@ -853,7 +824,7 @@ async function maybeReturnRepeatableStopOutput(
   if (!output) return null;
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
   if (stopHookActive) {
-    const state = await readNativeStopState(stateDir);
+    const state = await readJsonIfExists(join(stateDir, NATIVE_STOP_STATE_FILE)) ?? {};
     const previousSignature = readPreviousNativeStopSignature(state, readNativeStopSessionKey(payload));
     if (!signature || previousSignature === signature) {
       return null;
@@ -1074,15 +1045,13 @@ async function buildStopHookOutput(
       if (!stopHookActive && skillOutput) return skillOutput;
     }
 
-    const deepInterviewActive = await isDeepInterviewSuppressedForStop(cwd, sessionId, threadId);
     const lastAssistantMessage = safeString(
       payload.last_assistant_message ?? payload.lastAssistantMessage,
     );
     const autoNudgeConfig = await loadAutoNudgeConfig();
 
     if (
-      !deepInterviewActive
-      && autoNudgeConfig.enabled
+      autoNudgeConfig.enabled
       && detectStallPattern(lastAssistantMessage, autoNudgeConfig.patterns)
     ) {
       const effectiveResponse = resolveEffectiveAutoNudgeResponse(autoNudgeConfig.response);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -639,10 +639,31 @@ async function buildModeBasedStopOutput(
   };
 }
 
+async function readTeamModeStateForStop(
+  cwd: string,
+  sessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  const normalizedSessionId = safeString(sessionId).trim();
+  if (!normalizedSessionId) {
+    return await readModeState("team", cwd);
+  }
+
+  const scopedState = await readStopSessionPinnedState("team-state.json", cwd, normalizedSessionId);
+  if (scopedState?.active === true) return scopedState;
+
+  const rootState = await readJsonIfExists(join(cwd, ".omx", "state", "team-state.json"));
+  if (rootState?.active !== true) return null;
+
+  const ownerSessionId = safeString(rootState.session_id).trim();
+  if (ownerSessionId && ownerSessionId !== normalizedSessionId) {
+    return null;
+  }
+
+  return rootState;
+}
+
 async function buildTeamStopOutput(cwd: string, sessionId?: string): Promise<Record<string, unknown> | null> {
-  const teamState = sessionId
-    ? await readModeStateForSession("team", sessionId, cwd)
-    : await readModeState("team", cwd);
+  const teamState = await readTeamModeStateForStop(cwd, sessionId);
   if (teamState?.active !== true) return null;
   const teamName = safeString(teamState.team_name).trim();
   const coarsePhase = teamState.current_phase;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -203,7 +203,7 @@ async function readActiveRalphState(
     }
   }
 
-  if (currentOmxSessionId) return null;
+  if (sessionCandidates.length > 0) return null;
 
   const direct = await readJsonIfExists(join(stateDir, "ralph-state.json"));
   if (direct?.active === true && !TERMINAL_RALPH_PHASES.has(safeString(direct.current_phase).trim().toLowerCase())) {

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -27,7 +27,7 @@ import {
 } from './notify-hook/team-leader-nudge.js';
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 import { isTerminalPhase } from './notify-hook/utils.js';
-import { isSessionStale, readSessionState } from '../hooks/session.js';
+import { isSessionStale, isSessionStateAuthoritativeForCwd, readSessionState } from '../hooks/session.js';
 import {
   DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS,
   readSubagentSessionSummary,
@@ -511,8 +511,10 @@ async function resolveActiveModeState(mode: string): Promise<ActiveModeResult> {
   let currentSessionIsLive = false;
   const session = await readSessionState(cwd);
   if (session?.session_id) {
-    currentSessionId = safeString(session.session_id).trim();
-    currentSessionIsLive = !isSessionStale(session);
+    if (isSessionStateAuthoritativeForCwd(session, cwd)) {
+      currentSessionId = safeString(session.session_id).trim();
+      currentSessionIsLive = !isSessionStale(session);
+    }
     if (currentSessionId && currentSessionIsLive) {
       candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
     }
@@ -566,19 +568,22 @@ async function resolveActiveRalphState(): Promise<ActiveModeResult> {
 async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
   const candidateDirs: string[] = [];
   let currentSessionId = '';
-  const sessionPath = join(stateDir, 'session.json');
-  try {
-    const session = JSON.parse(await readFile(sessionPath, 'utf-8')) as Record<string, unknown>;
-    currentSessionId = safeString(session?.session_id).trim();
-    if (currentSessionId) {
+  let currentSessionIsLive = false;
+  const session = await readSessionState(cwd);
+  if (session?.session_id) {
+    currentSessionId = safeString(session.session_id).trim();
+    currentSessionIsLive = !isSessionStale(session);
+    if (currentSessionId && currentSessionIsLive) {
       candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
     }
-  } catch {
-    // No active session file; fall back to root state only.
   }
   if (!candidateDirs.includes(stateDir)) candidateDirs.push(stateDir);
 
   for (const dir of candidateDirs) {
+    if (dir === stateDir && currentSessionId) {
+      continue;
+    }
+
     const path = join(dir, 'team-state.json');
     if (!existsSync(path)) continue;
     const parsed = await readFile(path, 'utf-8')
@@ -659,6 +664,17 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
       },
       team_name: team.teamName,
       pane_count: paneStatus.paneCount,
+    };
+  }
+
+  if (currentSessionId) {
+    return {
+      active: false,
+      reason: currentSessionIsLive ? 'blocked_by_current_session' : 'stale_current_session',
+      path: '',
+      state: null,
+      team_name: '',
+      pane_count: 0,
     };
   }
 

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -16,7 +16,6 @@ import {
   resolveAutoNudgeSignature,
 } from './notify-hook/auto-nudge.js';
 import {
-  getScopedStatePath,
   readScopedJsonIfExists,
 } from './notify-hook/state-io.js';
 import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
@@ -1212,7 +1211,6 @@ async function readAutoNudgeState(): Promise<Record<string, unknown> | null> {
 async function runFallbackAutoNudgeTick(): Promise<void> {
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
-  const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', undefined);
   const hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', undefined, null);
 
   lastFallbackAutoNudge = {

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -15,6 +15,10 @@ import {
   normalizeAutoNudgeSignatureText,
   resolveAutoNudgeSignature,
 } from './notify-hook/auto-nudge.js';
+import {
+  getScopedStatePath,
+  readScopedJsonIfExists,
+} from './notify-hook/state-io.js';
 import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
 import {
   checkWorkerPanesAlive,
@@ -787,7 +791,7 @@ async function readRalphProgressGate(
     }
   }
 
-  const hudState = await readJsonObject(join(stateDir, 'hud-state.json'));
+  const hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', undefined, null);
   if (!hudState || typeof hudState !== 'object') {
     return { allow: false, reason: 'progress_missing', progress_at: '', subagent_session_id: subagentSessionId };
   }
@@ -1197,19 +1201,19 @@ async function readJsonObject(path: string): Promise<Record<string, unknown> | n
 }
 
 async function readAutoNudgeCount(): Promise<number> {
-  const parsed = await readJsonObject(join(stateDir, 'auto-nudge-state.json'));
+  const parsed = await readScopedJsonIfExists(stateDir, 'auto-nudge-state.json', undefined, null);
   return Math.max(0, Math.trunc(asNumber(parsed?.nudgeCount as string | number | undefined, 0)));
 }
 
 async function readAutoNudgeState(): Promise<Record<string, unknown> | null> {
-  return readJsonObject(join(stateDir, 'auto-nudge-state.json'));
+  return readScopedJsonIfExists(stateDir, 'auto-nudge-state.json', undefined, null);
 }
 
 async function runFallbackAutoNudgeTick(): Promise<void> {
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
-  const hudStatePath = join(stateDir, 'hud-state.json');
-  const hudState = await readJsonObject(hudStatePath);
+  const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', undefined);
+  const hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', undefined, null);
 
   lastFallbackAutoNudge = {
     ...lastFallbackAutoNudge,
@@ -1678,8 +1682,8 @@ async function runDispatchDrainTick(): Promise<boolean> {
 
 async function shouldSuppressInteractiveFallbackTicks(): Promise<boolean> {
   const [deepInterviewStateActive, deepInterviewInputLockActive] = await Promise.all([
-    isDeepInterviewStateActive(stateDir),
-    isDeepInterviewInputLockActive(stateDir),
+    isDeepInterviewStateActive(stateDir, undefined),
+    isDeepInterviewInputLockActive(stateDir, undefined),
   ]);
   return deepInterviewStateActive || deepInterviewInputLockActive;
 }

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS,
   readSubagentSessionSummary,
 } from '../subagents/tracker.js';
+import { listNotifyCanonicalActiveTeams } from './notify-hook/active-team.js';
 
 function argValue(name: string, fallback = ''): string {
   const idx = process.argv.indexOf(name);
@@ -561,12 +562,13 @@ async function resolveActiveRalphState(): Promise<ActiveModeResult> {
 
 async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
   const candidateDirs: string[] = [];
+  let currentSessionId = '';
   const sessionPath = join(stateDir, 'session.json');
   try {
     const session = JSON.parse(await readFile(sessionPath, 'utf-8')) as Record<string, unknown>;
-    const sessionId = safeString(session?.session_id).trim();
-    if (sessionId) {
-      candidateDirs.push(join(stateDir, 'sessions', sessionId));
+    currentSessionId = safeString(session?.session_id).trim();
+    if (currentSessionId) {
+      candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
     }
   } catch {
     // No active session file; fall back to root state only.
@@ -618,6 +620,41 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
       path,
       state: parsed,
       team_name: teamName,
+      pane_count: paneStatus.paneCount,
+    };
+  }
+
+  const canonicalFallbackTeams = await listNotifyCanonicalActiveTeams(cwd, currentSessionId).catch(() => []);
+  for (const team of canonicalFallbackTeams) {
+    const teamConfigDir = join(stateDir, 'team', team.teamName);
+    const manifestPath = join(teamConfigDir, 'manifest.v2.json');
+    const configPath = join(teamConfigDir, 'config.json');
+    const teamConfigPath = existsSync(manifestPath) ? manifestPath : configPath;
+    const teamConfig = existsSync(teamConfigPath)
+      ? await readFile(teamConfigPath, 'utf-8')
+        .then((content) => JSON.parse(content) as Record<string, unknown>)
+        .catch(() => null)
+      : null;
+    const tmuxSession = safeString(teamConfig?.tmux_session).trim();
+    if (!tmuxSession) continue;
+
+    const workers = Array.isArray(teamConfig?.workers) ? teamConfig.workers as Array<Record<string, unknown>> : [];
+    const workerPaneIds: string[] = workers
+      .map((worker) => safeString(worker?.pane_id).trim())
+      .filter(Boolean);
+    const paneStatus = await checkWorkerPanesAlive(tmuxSession, workerPaneIds as any);
+    if (!paneStatus.alive) continue;
+
+    return {
+      active: true,
+      reason: team.source,
+      path: team.path,
+      state: {
+        active: true,
+        team_name: team.teamName,
+        current_phase: team.phase,
+      },
+      team_name: team.teamName,
       pane_count: paneStatus.paneCount,
     };
   }

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -30,7 +30,6 @@ import {
 } from './notify-hook/payload-parser.js';
 import {
   getScopedStatePath,
-  readJsonIfExists,
   readScopedJsonIfExists,
   getScopedStateDirsForCurrentSession,
   normalizeNotifyState,

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -20,7 +20,7 @@
 
 import { writeFile, appendFile, mkdir, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 
 import { safeString, asNumber } from './notify-hook/utils.js';
 import {
@@ -29,7 +29,9 @@ import {
   normalizeInputMessages,
 } from './notify-hook/payload-parser.js';
 import {
+  getScopedStatePath,
   readJsonIfExists,
+  readScopedJsonIfExists,
   getScopedStateDirsForCurrentSession,
   normalizeNotifyState,
   pruneRecentTurns,
@@ -195,14 +197,17 @@ async function main() {
       const threadId = safeString(payload['thread-id'] || payload.thread_id || '');
       const eventType = safeString(payload.type || 'agent-turn-complete');
       const key = `${threadId || 'no-thread'}|${turnId}|${eventType}`;
-      const dedupeStatePath = join(stateDir, 'notify-hook-state.json');
-      const dedupeState = normalizeNotifyState(await readJsonIfExists(dedupeStatePath, null));
+      const dedupeStatePath = await getScopedStatePath(stateDir, 'notify-hook-state.json', payloadSessionId);
+      const dedupeState = normalizeNotifyState(
+        await readScopedJsonIfExists(stateDir, 'notify-hook-state.json', payloadSessionId, null),
+      );
       dedupeState.recent_turns = pruneRecentTurns(dedupeState.recent_turns, now);
       if (dedupeState.recent_turns[key]) {
         process.exit(0);
       }
       dedupeState.recent_turns[key] = now;
       dedupeState.last_event_at = new Date().toISOString();
+      await mkdir(dirname(dedupeStatePath), { recursive: true }).catch(() => {});
       await writeFile(dedupeStatePath, JSON.stringify(dedupeState, null, 2)).catch(() => {});
     }
   } catch {
@@ -417,18 +422,19 @@ async function main() {
 
   // 4. Write HUD state summary for `omx hud` (lead session only)
   if (!isTeamWorker) {
-    const hudStatePath = join(stateDir, 'hud-state.json');
     try {
-      let hudState = { last_turn_at: '', turn_count: 0 };
-      if (existsSync(hudStatePath)) {
-        hudState = JSON.parse(await readFile(hudStatePath, 'utf-8'));
-      }
+      const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', payloadSessionId);
+      let hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', payloadSessionId, {
+        last_turn_at: '',
+        turn_count: 0,
+      });
       const nowIso = new Date().toISOString();
       hudState.last_turn_at = nowIso;
       (hudState as any).last_progress_at = nowIso;
       hudState.turn_count = (hudState.turn_count || 0) + 1;
       (hudState as any).last_agent_output = (payload['last-assistant-message'] || payload.last_assistant_message || '')
         .slice(0, 100);
+      await mkdir(dirname(hudStatePath), { recursive: true }).catch(() => {});
       await writeFile(hudStatePath, JSON.stringify(hudState, null, 2));
     } catch {
       // Non-critical
@@ -463,7 +469,7 @@ async function main() {
     // Non-fatal: keyword detector module may not be built yet
   }
 
-  const deepInterviewStateActive = await isDeepInterviewStateActive(stateDir);
+  const deepInterviewStateActive = await isDeepInterviewStateActive(stateDir, payloadSessionId);
 
   // 4.55. Notify leader when individual worker transitions to idle (worker session only)
   if (isTeamWorker && parsedTeamWorker && !deepInterviewStateActive) {

--- a/src/scripts/notify-hook/active-team.ts
+++ b/src/scripts/notify-hook/active-team.ts
@@ -1,0 +1,54 @@
+import { existsSync } from 'fs';
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+import { readTeamManifestV2, readTeamPhase } from '../../team/state.js';
+import { resolveCanonicalTeamStateRoot } from '../../team/state-root.js';
+import { isTerminalPhase, safeString } from './utils.js';
+
+export interface NotifyCanonicalActiveTeam {
+  teamName: string;
+  phase: string;
+  ownerSessionId: string;
+  path: string;
+  source: 'canonical_fallback';
+}
+
+export async function listNotifyCanonicalActiveTeams(
+  cwd: string,
+  currentSessionId: string,
+): Promise<NotifyCanonicalActiveTeam[]> {
+  const sessionId = safeString(currentSessionId).trim();
+  if (!sessionId) return [];
+
+  const teamsRoot = join(resolveCanonicalTeamStateRoot(cwd), 'team');
+  if (!existsSync(teamsRoot)) return [];
+
+  const entries = await readdir(teamsRoot, { withFileTypes: true }).catch(() => []);
+  const teams: NotifyCanonicalActiveTeam[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const teamName = entry.name.trim();
+    if (!teamName) continue;
+
+    const [manifest, phaseState] = await Promise.all([
+      readTeamManifestV2(teamName, cwd),
+      readTeamPhase(teamName, cwd),
+    ]);
+    if (!manifest || !phaseState) continue;
+
+    const ownerSessionId = safeString(manifest.leader?.session_id).trim();
+    if (!ownerSessionId || ownerSessionId !== sessionId) continue;
+
+    const phase = safeString(phaseState.current_phase).trim();
+    if (!phase || isTerminalPhase(phase)) continue;
+
+    teams.push({
+      teamName,
+      phase,
+      ownerSessionId,
+      path: join(teamsRoot, teamName, 'phase.json'),
+      source: 'canonical_fallback',
+    });
+  }
+  return teams;
+}

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -26,6 +26,7 @@ import {
 export const SKILL_ACTIVE_STATE_FILE = 'skill-active-state.json';
 export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'];
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
+export const DEFAULT_AUTO_NUDGE_RESPONSE = 'continue with the current task only if it is already authorized';
 const DEEP_INTERVIEW_ERROR_PATTERNS = [' error', ' failed', ' failure', ' exception', 'unable to continue', 'cannot continue', 'could not continue'];
 const DEEP_INTERVIEW_ABORT_PATTERNS = ['aborted', 'cancelled', 'canceled'];
 const DEEP_INTERVIEW_ABORT_INPUTS = new Set(['abort', 'cancel', 'stop']);
@@ -218,68 +219,63 @@ function latestUserInputFromPayload(payload) {
 }
 
 export const DEFAULT_STALL_PATTERNS = [
-  'if you want',
-  'would you like',
-  'shall i',
-  'next i can',
   'continue with',
   'continue on',
-  'do you want me to',
-  'let me know if',
-  'do you want',
-  'want me to',
-  'let me know',
-  'just let me know',
-  'i can also',
-  'i could also',
   'pick up with',
-  'next step',
-  'next steps',
-  'ready to proceed',
-  'i\'m ready to',
   'keep going',
-  'should i',
-  'whenever you',
-  'say go',
-  'say yes',
-  'type continue',
   'and i\'ll continue',
-  'and i\'ll proceed',
   'keep driving',
   'keep pushing',
   'move forward',
   'drive forward',
-  'proceed from here',
   'i\'ll continue from',
 ];
 
 const SEMANTIC_STALL_PROMPT_PATTERNS = [
-  /\bif you want\b/g,
-  /\bwould you like\b/g,
-  /\bshall i\b/g,
-  /\bshould i\b/g,
-  /\bdo you want(?: me)? to\b/g,
-  /\bwant me to\b/g,
-  /\blet me know(?: if)?\b/g,
-  /\bjust let me know\b/g,
-  /\bi can also\b/g,
-  /\bi could also\b/g,
-  /\bnext i can\b/g,
   /\bcontinue (?:with|on)\b/g,
   /\bpick up with\b/g,
-  /\bnext steps?\b/g,
-  /\bready to proceed\b/g,
-  /\bi'?m ready to\b/g,
   /\bkeep going\b/g,
-  /\bwhenever you\b/g,
-  /\bsay (?:go|yes)\b/g,
-  /\btype continue\b/g,
-  /\band i'?ll (?:continue|proceed)\b/g,
+  /\band i'?ll continue\b/g,
   /\bkeep (?:driving|pushing)\b/g,
   /\bmove forward\b/g,
   /\bdrive forward\b/g,
-  /\bproceed from here\b/g,
   /\bi'?ll continue from\b/g,
+];
+
+const PLANNING_ONLY_STALL_PATTERNS = [
+  'plan',
+  'planning',
+  'approach',
+  'proposal',
+  'options',
+  'review',
+  'feedback',
+  'spec',
+  'design',
+  'next step',
+  'next steps',
+  'ready to proceed',
+];
+
+const PERMISSION_SEEKING_STALL_PATTERNS = [
+  'if you want',
+  'would you like',
+  'shall i',
+  'should i',
+  'do you want me to',
+  'do you want',
+  'want me to',
+  'let me know if',
+  'let me know',
+  'just let me know',
+  'i can also',
+  'i could also',
+  'next i can',
+  'whenever you',
+  'say go',
+  'say yes',
+  'type continue',
+  'proceed from here',
 ];
 
 function normalizeStallDetectionText(text) {
@@ -313,6 +309,34 @@ export function normalizeAutoNudgeSignatureText(text) {
   }
 
   return normalized;
+}
+
+function normalizePatternList(patterns) {
+  return patterns.map((pattern) => normalizeStallDetectionText(pattern)).filter(Boolean);
+}
+
+function usesDefaultStallPatterns(patterns) {
+  const normalizedPatterns = normalizePatternList(patterns);
+  const normalizedDefaults = normalizePatternList(DEFAULT_STALL_PATTERNS);
+  return normalizedPatterns.length === normalizedDefaults.length
+    && normalizedPatterns.every((pattern, index) => pattern === normalizedDefaults[index]);
+}
+
+function matchesNormalizedPatterns(normalizedText, normalizedPatterns) {
+  if (!normalizedText || normalizedPatterns.length === 0) return false;
+  const tail = normalizedText.slice(-800);
+  const lines = tail.split('\n').filter((line) => line.trim());
+  const hotZone = lines.slice(-3).join('\n');
+  if (normalizedPatterns.some((pattern) => hotZone.includes(pattern))) return true;
+  return normalizedPatterns.some((pattern) => tail.includes(pattern));
+}
+
+function looksLikePlanningOnlyContinuation(normalizedText) {
+  return matchesNormalizedPatterns(normalizedText, normalizePatternList(PLANNING_ONLY_STALL_PATTERNS));
+}
+
+function looksLikePermissionSeekingContinuation(normalizedText) {
+  return matchesNormalizedPatterns(normalizedText, normalizePatternList(PERMISSION_SEEKING_STALL_PATTERNS));
 }
 
 function summarizePaneCaptureForLog(captured, maxLines = 6) {
@@ -358,6 +382,12 @@ export function normalizeAutoNudgeConfig(raw) {
   };
 }
 
+export function resolveEffectiveAutoNudgeResponse(response) {
+  const normalized = safeString(response).trim();
+  if (!normalized) return DEFAULT_AUTO_NUDGE_RESPONSE;
+  return isBlockedAutoApprovalInput(normalized) ? DEFAULT_AUTO_NUDGE_RESPONSE : normalized;
+}
+
 export async function loadAutoNudgeConfig() {
   const codexHomePath = process.env.CODEX_HOME || join(homedir(), '.codex');
   const configPath = join(codexHomePath, '.omx-config.json');
@@ -373,16 +403,16 @@ async function localTmuxInjectionDisabled(cwd) {
   return tmuxHookExplicitlyDisablesInjection(raw);
 }
 
-export function detectStallPattern(text, patterns) {
+export function detectStallPattern(text, patterns, currentPhase = '') {
   if (!text || typeof text !== 'string') return false;
   const normalized = normalizeStallDetectionText(text);
   if (!normalized) return false;
-  const tail = normalized.slice(-800);
-  const normalizedPatterns = patterns.map((pattern) => normalizeStallDetectionText(pattern)).filter(Boolean);
-  const lines = tail.split('\n').filter((line) => line.trim());
-  const hotZone = lines.slice(-3).join('\n');
-  if (normalizedPatterns.some((pattern) => hotZone.includes(pattern))) return true;
-  return normalizedPatterns.some((pattern) => tail.includes(pattern));
+  const normalizedPatterns = normalizePatternList(patterns);
+  if (!matchesNormalizedPatterns(normalized, normalizedPatterns)) return false;
+  if (!usesDefaultStallPatterns(patterns)) return true;
+  if (looksLikePermissionSeekingContinuation(normalized)) return false;
+  if (safeString(currentPhase).trim().toLowerCase() === 'planning') return false;
+  return !looksLikePlanningOnlyContinuation(normalized);
 }
 
 export async function capturePane(paneId, lines = 10) {
@@ -426,6 +456,7 @@ export async function resolveNudgePaneTarget(stateDir: any, cwd = '', payload: a
 
 export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
   const config = await loadAutoNudgeConfig();
+  const effectiveResponse = resolveEffectiveAutoNudgeResponse(config.response);
   if (!config.enabled) return;
   if (await localTmuxInjectionDisabled(cwd)) {
     await logTmuxHookEvent(logsDir, {
@@ -470,13 +501,13 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     }
     const paneId = await resolveNudgePaneTarget(stateDir, cwd, payload);
 
-    let detected = detectStallPattern(lastMessage, config.patterns);
+    let detected = detectStallPattern(lastMessage, config.patterns, skillState?.phase);
     let source = 'payload';
     let captured = '';
 
     if (!detected && paneId) {
       captured = await capturePane(paneId);
-      detected = detectStallPattern(captured, config.patterns);
+      detected = detectStallPattern(captured, config.patterns, skillState?.phase);
       source = 'capture-pane';
     }
 
@@ -556,10 +587,10 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
         timestamp: new Date().toISOString(),
         type: 'auto_nudge_blocked',
         pane_id: paneId,
-        response: config.response,
+        response: effectiveResponse,
         source,
         blocked_by: 'deep-interview-lock',
-        block_kind: isBlockedAutoApprovalInput(config.response, skillState.input_lock?.blocked_inputs)
+        block_kind: isBlockedAutoApprovalInput(effectiveResponse, skillState.input_lock?.blocked_inputs)
           ? 'blocked-auto-approval'
           : 'input-lock-active',
         message: blockedMessage,
@@ -576,7 +607,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     try {
       const sendResult = await sendPaneInput({
         paneTarget: paneId,
-        prompt: `${config.response} ${DEFAULT_MARKER}`,
+        prompt: `${effectiveResponse} ${DEFAULT_MARKER}`,
         submitKeyPresses: 2,
         submitDelayMs: 100,
       });
@@ -592,18 +623,11 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
       nudgeState.pendingSince = '';
       await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
 
-      if (skillState && skillState.phase === 'planning') {
-        skillState.phase = 'executing';
-        skillState.active = true;
-        skillState.updated_at = nowIso;
-        await persistSkillActiveState(stateDir, skillState);
-      }
-
       await logTmuxHookEvent(logsDir, {
         timestamp: nowIso,
         type: 'auto_nudge',
         pane_id: paneId,
-        response: config.response,
+        response: effectiveResponse,
         source,
         nudge_count: nudgeState.nudgeCount,
       });

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -4,11 +4,18 @@
  * automatically send a continuation prompt so the agent keeps working.
  */
 
-import { readFile, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
 import { asNumber, safeString } from './utils.js';
-import { readJsonIfExists, getScopedStateDirsForCurrentSession, readdir } from './state-io.js';
+import {
+  getScopedStateDirsForCurrentSession,
+  getScopedStatePath,
+  readJsonIfExists,
+  readScopedJsonIfExists,
+  readdir,
+  writeScopedJson,
+} from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
@@ -172,29 +179,30 @@ export function inferSkillPhaseFromText(text, currentPhase = 'planning') {
   return normalizeSkillPhase(currentPhase);
 }
 
-async function loadSkillActiveState(stateDir) {
-  const raw = await readJsonIfExists(join(stateDir, SKILL_ACTIVE_STATE_FILE), null);
+async function loadSkillActiveState(stateDir, sessionId) {
+  const raw = await readScopedJsonIfExists(stateDir, SKILL_ACTIVE_STATE_FILE, sessionId, null);
   return normalizeSkillActiveState(raw);
 }
 
-async function persistSkillActiveState(stateDir, state) {
-  await writeFile(join(stateDir, SKILL_ACTIVE_STATE_FILE), JSON.stringify(state, null, 2)).catch(() => {});
+async function persistSkillActiveState(stateDir, sessionId, state) {
+  await writeScopedJson(stateDir, SKILL_ACTIVE_STATE_FILE, sessionId, state).catch(() => {});
 }
 
 
-export async function isDeepInterviewStateActive(stateDir) {
-  const modeState = await readJsonIfExists(join(stateDir, 'deep-interview-state.json'), null);
+export async function isDeepInterviewStateActive(stateDir, sessionId) {
+  const modeState = await readScopedJsonIfExists(stateDir, 'deep-interview-state.json', sessionId, null);
   return Boolean(modeState && modeState.active === true);
 }
 
-export async function isDeepInterviewInputLockActive(stateDir) {
-  const skillState = await loadSkillActiveState(stateDir);
+export async function isDeepInterviewInputLockActive(stateDir, sessionId) {
+  const skillState = await loadSkillActiveState(stateDir, sessionId);
   return isDeepInterviewAutoApprovalLocked(skillState);
 }
 
 export async function resolveAutoNudgeSignature(stateDir, payload, lastMessage = '') {
   const normalizedMessage = normalizeAutoNudgeSignatureText(lastMessage);
-  const hudState = await readJsonIfExists(join(stateDir, 'hud-state.json'), null);
+  const invocationSessionId = resolveInvocationSessionId(payload);
+  const hudState = await readScopedJsonIfExists(stateDir, 'hud-state.json', invocationSessionId, null);
   const hudTurnAt = safeString(hudState?.last_turn_at).trim();
   const hudTurnCount = Number.isFinite(hudState?.turn_count) ? hudState.turn_count : null;
   const hudMessage = normalizeAutoNudgeSignatureText(hudState?.last_agent_output || hudState?.last_agent_message || '');
@@ -481,7 +489,8 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
 
   const lastMessage = safeString(payload['last-assistant-message'] || payload.last_assistant_message || '');
   const latestUserInput = latestUserInputFromPayload(payload);
-  let skillState = await loadSkillActiveState(stateDir);
+  const invocationSessionId = resolveInvocationSessionId(payload);
+  let skillState = await loadSkillActiveState(stateDir, invocationSessionId);
   let releaseReason = null;
 
   try {
@@ -491,11 +500,11 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
       skillState.active = inferredPhase !== 'completing';
       skillState.updated_at = new Date().toISOString();
       releaseReason = inferDeepInterviewReleaseReason({ skillState, latestUserInput, lastMessage });
-      await persistSkillActiveState(stateDir, skillState);
+      await persistSkillActiveState(stateDir, invocationSessionId, skillState);
     }
 
-    const nudgeStatePath = join(stateDir, 'auto-nudge-state.json');
-    let nudgeState = await readJsonIfExists(nudgeStatePath, null);
+    const nudgeStatePath = await getScopedStatePath(stateDir, 'auto-nudge-state.json', invocationSessionId);
+    let nudgeState = await readScopedJsonIfExists(stateDir, 'auto-nudge-state.json', invocationSessionId, null);
     if (!nudgeState || typeof nudgeState !== 'object') {
       nudgeState = { nudgeCount: 0, lastNudgeAt: '', lastSignature: '', lastSemanticSignature: '' };
     }
@@ -554,6 +563,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
     if (!isFallbackWatcherSource && config.stallMs > 0) {
       nudgeState.pendingSignature = signature;
       nudgeState.pendingSince = new Date().toISOString();
+      await mkdir(dirname(nudgeStatePath), { recursive: true }).catch(() => {});
       await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
       await logTmuxHookEvent(logsDir, {
         timestamp: new Date().toISOString(),
@@ -621,6 +631,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
       nudgeState.lastSemanticSignature = semanticSignature;
       nudgeState.pendingSignature = '';
       nudgeState.pendingSince = '';
+      await mkdir(dirname(nudgeStatePath), { recursive: true }).catch(() => {});
       await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
 
       await logTmuxHookEvent(logsDir, {
@@ -642,7 +653,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
   } finally {
     if (releaseReason && skillState && isDeepInterviewAutoApprovalLocked(skillState)) {
       releaseDeepInterviewInputLock(skillState, releaseReason, new Date().toISOString());
-      await persistSkillActiveState(stateDir, skillState).catch(() => {});
+      await persistSkillActiveState(stateDir, invocationSessionId, skillState).catch(() => {});
     }
   }
 }

--- a/src/scripts/notify-hook/operational-events.ts
+++ b/src/scripts/notify-hook/operational-events.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'child_process';
 import { basename, dirname } from 'path';
 import { safeString } from './utils.js';
+import { upsertCurrentTaskBaseline } from '../../team/current-task-baseline.js';
 
 const TEST_SEGMENT_PATTERNS = [
   /^npm\s+(?:run\s+)?test\b/i,
@@ -215,6 +216,26 @@ export function buildOperationalContext({
     ...(prUrl !== undefined ? { pr_url: prUrl } : {}),
   };
   const resolvedSessionName = resolveOperationalSessionName(cwd, sessionId, sessionName);
+
+  if (repoMeta.repo_path && repoMeta.branch) {
+    try {
+      const lifecycleStatus = normalizedEvent === 'pr-merged'
+        ? 'merged'
+        : normalizedEvent === 'pr-closed'
+          ? 'closed'
+          : undefined;
+      upsertCurrentTaskBaseline(repoMeta.repo_path, {
+        branch_name: repoMeta.branch,
+        worktree_path: repoMeta.worktree_path,
+        issue_number: detectedIssue,
+        pr_number: detectedPrInfo.pr_number,
+        pr_url: detectedPrInfo.pr_url,
+        ...(lifecycleStatus ? { status: lifecycleStatus } : {}),
+      });
+    } catch {
+      // best effort only; operational context building must stay non-fatal
+    }
+  }
 
   return {
     normalized_event: normalizedEvent,

--- a/src/scripts/notify-hook/ralph-session-resume.ts
+++ b/src/scripts/notify-hook/ralph-session-resume.ts
@@ -1,7 +1,8 @@
 import { existsSync } from 'fs';
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { captureTmuxPaneFromEnv } from '../../state/mode-state-context.js';
+import { readUsableSessionState } from '../../hooks/session.js';
 import { resolveCodexPane } from '../tmux-hook-engine.js';
 import { safeString } from './utils.js';
 
@@ -128,7 +129,7 @@ function isActiveRalphCandidate(state: Record<string, unknown> | null): state is
 }
 
 async function readCurrentOmxSessionId(stateDir: string): Promise<string> {
-  const session = await readJson(join(stateDir, 'session.json'));
+  const session = await readUsableSessionState(resolve(stateDir, '..', '..'));
   const sessionId = safeString(session?.session_id).trim();
   return SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
 }

--- a/src/scripts/notify-hook/state-io.ts
+++ b/src/scripts/notify-hook/state-io.ts
@@ -3,8 +3,9 @@
  */
 
 import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { existsSync } from 'fs';
+import { readUsableSessionState } from '../../hooks/session.js';
 import { asNumber, safeString } from './utils.js';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -25,14 +26,10 @@ function isSafeStateFileName(fileName: string): boolean {
 }
 
 export async function readCurrentSessionId(baseStateDir: string): Promise<string | undefined> {
-  const sessionPath = join(baseStateDir, 'session.json');
-  try {
-    const session = JSON.parse(await readFile(sessionPath, 'utf-8'));
-    const sessionId = safeString(session && session.session_id ? session.session_id : '');
-    return SESSION_ID_PATTERN.test(sessionId) ? sessionId : undefined;
-  } catch {
-    return undefined;
-  }
+  const cwd = resolve(baseStateDir, '..', '..');
+  const session = await readUsableSessionState(cwd);
+  const sessionId = safeString(session?.session_id);
+  return SESSION_ID_PATTERN.test(sessionId) ? sessionId : undefined;
 }
 
 export async function resolveScopedStateDir(

--- a/src/scripts/notify-hook/state-io.ts
+++ b/src/scripts/notify-hook/state-io.ts
@@ -2,8 +2,9 @@
  * State file I/O helpers for notify-hook modules.
  */
 
-import { readFile, readdir } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { existsSync } from 'fs';
 import { asNumber, safeString } from './utils.js';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
@@ -16,18 +17,97 @@ export function readJsonIfExists(path: string, fallback: any): Promise<any> {
     .catch(() => fallback);
 }
 
-export async function getScopedStateDirsForCurrentSession(baseStateDir: string): Promise<string[]> {
+function isSafeStateFileName(fileName: string): boolean {
+  return fileName.length > 0
+    && !fileName.includes('..')
+    && !fileName.includes('/')
+    && !fileName.includes('\\');
+}
+
+export async function readCurrentSessionId(baseStateDir: string): Promise<string | undefined> {
   const sessionPath = join(baseStateDir, 'session.json');
   try {
     const session = JSON.parse(await readFile(sessionPath, 'utf-8'));
     const sessionId = safeString(session && session.session_id ? session.session_id : '');
-    if (SESSION_ID_PATTERN.test(sessionId)) {
-      return [join(baseStateDir, 'sessions', sessionId)];
-    }
+    return SESSION_ID_PATTERN.test(sessionId) ? sessionId : undefined;
   } catch {
-    // No session file or malformed - fall back to global only
+    return undefined;
   }
-  return [baseStateDir];
+}
+
+export async function resolveScopedStateDir(
+  baseStateDir: string,
+  explicitSessionId?: string,
+): Promise<string> {
+  const normalizedExplicit = safeString(explicitSessionId).trim();
+  if (SESSION_ID_PATTERN.test(normalizedExplicit)) {
+    const explicitDir = join(baseStateDir, 'sessions', normalizedExplicit);
+    const currentSessionId = await readCurrentSessionId(baseStateDir);
+    if (currentSessionId === normalizedExplicit || existsSync(explicitDir)) {
+      return explicitDir;
+    }
+  }
+  const currentSessionId = await readCurrentSessionId(baseStateDir);
+  if (currentSessionId) {
+    return join(baseStateDir, 'sessions', currentSessionId);
+  }
+  return baseStateDir;
+}
+
+export async function getScopedStateDirsForCurrentSession(
+  baseStateDir: string,
+  explicitSessionId?: string,
+  options: { includeRootFallback?: boolean } = {},
+): Promise<string[]> {
+  const scopedDir = await resolveScopedStateDir(baseStateDir, explicitSessionId);
+  if (scopedDir === baseStateDir || options.includeRootFallback !== true) {
+    return [scopedDir];
+  }
+  return [scopedDir, baseStateDir];
+}
+
+export async function getScopedStatePath(
+  baseStateDir: string,
+  fileName: string,
+  explicitSessionId?: string,
+): Promise<string> {
+  if (!isSafeStateFileName(fileName)) {
+    throw new Error(`unsafe state file name: ${fileName}`);
+  }
+  return join(await resolveScopedStateDir(baseStateDir, explicitSessionId), fileName);
+}
+
+export async function readScopedJsonIfExists(
+  baseStateDir: string,
+  fileName: string,
+  explicitSessionId: string | undefined,
+  fallback: any,
+  options: { includeRootFallback?: boolean } = {},
+): Promise<any> {
+  if (!isSafeStateFileName(fileName)) {
+    throw new Error(`unsafe state file name: ${fileName}`);
+  }
+  const candidateDirs = await getScopedStateDirsForCurrentSession(
+    baseStateDir,
+    explicitSessionId,
+    options,
+  );
+  for (const dir of candidateDirs) {
+    const value = await readJsonIfExists(join(dir, fileName), fallback);
+    if (value !== fallback) return value;
+  }
+  return fallback;
+}
+
+export async function writeScopedJson(
+  baseStateDir: string,
+  fileName: string,
+  explicitSessionId: string | undefined,
+  value: unknown,
+): Promise<void> {
+  const targetPath = await getScopedStatePath(baseStateDir, fileName, explicitSessionId);
+  await mkdir(dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, JSON.stringify(value, null, 2));
 }
 
 export function normalizeTmuxState(raw: any): any {

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -5,7 +5,8 @@
 
 import { readFile, writeFile, mkdir, appendFile, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
+import { readUsableSessionState } from '../../hooks/session.js';
 import { asNumber, safeString, isTerminalPhase } from './utils.js';
 import { readJsonIfExists, getScopedStateDirsForCurrentSession } from './state-io.js';
 import { runProcess } from './process-runner.js';
@@ -249,16 +250,7 @@ async function resolveCurrentSessionId(stateDir) {
     || '',
   ).trim();
   if (fromEnv) return fromEnv;
-
-  const sessionPath = join(stateDir, 'session.json');
-  try {
-    if (!existsSync(sessionPath)) return '';
-    const parsed = JSON.parse(await readFile(sessionPath, 'utf-8'));
-    const sessionId = safeString(parsed && parsed.session_id ? parsed.session_id : '').trim();
-    return sessionId;
-  } catch {
-    return '';
-  }
+  return safeString((await readUsableSessionState(resolve(stateDir, '..', '..')))?.session_id).trim();
 }
 
 async function readWorkerStatusSnapshot(stateDir, teamName, workerName) {

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -12,6 +12,7 @@ import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, sendPaneInput } from './team-tmux-guard.js';
 import { resolvePaneTarget } from './tmux-injection.js';
+import { listNotifyCanonicalActiveTeams } from './active-team.js';
 import {
   classifyLeaderActionState,
   resolveLeaderNudgeIntent,
@@ -599,6 +600,11 @@ export async function maybeNudgeTeamLeader({
     }
   } catch {
     // Non-critical
+  }
+
+  const canonicalFallbackTeams = await listNotifyCanonicalActiveTeams(cwd, currentSessionId).catch(() => []);
+  for (const team of canonicalFallbackTeams) {
+    candidateTeamNames.add(team.teamName);
   }
 
   // Use pre-computed staleness (captured before HUD state was updated this turn)

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -93,4 +93,51 @@ describe('skill-active state helpers', () => {
       }]);
     });
   });
+
+  it('preserves root-scoped team state when a session-scoped ralph overlap is activated', async () => {
+    await withTempRepo('omx-skill-active-team-ralph-', async (cwd) => {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeSkillActiveStateCopies(cwd, {
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        active_skills: [{ skill: 'team', phase: 'running', active: true }],
+      });
+
+      await syncCanonicalSkillStateForMode({
+        cwd,
+        mode: 'ralph',
+        active: true,
+        currentPhase: 'executing',
+        sessionId: 'sess-overlap',
+        nowIso: '2026-04-09T00:00:00.000Z',
+      });
+
+      const rootState = JSON.parse(
+        await readFile(join(cwd, '.omx', 'state', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; phase?: string; session_id?: string }> };
+      assert.deepEqual(
+        rootState.active_skills?.map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [{ skill: 'team', phase: 'running', session_id: undefined }],
+      );
+
+      const sessionState = await readVisibleSkillActiveState(cwd, 'sess-overlap');
+      assert.ok(sessionState);
+      assert.deepEqual(
+        listActiveSkills(sessionState).map(({ skill, phase, session_id }) => ({
+          skill,
+          phase,
+          session_id,
+        })),
+        [
+          { skill: 'team', phase: 'running', session_id: undefined },
+          { skill: 'ralph', phase: 'executing', session_id: 'sess-overlap' },
+        ],
+      );
+    });
+  });
 });

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildWorkflowTransitionError,
+  evaluateWorkflowTransition,
+} from '../workflow-transition.js';
+
+describe('workflow transition rules', () => {
+  it('allows the approved overlap matrix and denies unsupported combinations', () => {
+    const cases: Array<{
+      current: string[];
+      requested: 'team' | 'ralph' | 'ultrawork' | 'autopilot' | 'autoresearch';
+      allowed: boolean;
+      resulting: string[];
+    }> = [
+      { current: [], requested: 'team', allowed: true, resulting: ['team'] },
+      { current: ['team'], requested: 'ralph', allowed: true, resulting: ['team', 'ralph'] },
+      { current: ['ralph'], requested: 'team', allowed: true, resulting: ['ralph', 'team'] },
+      { current: ['team'], requested: 'ultrawork', allowed: true, resulting: ['team', 'ultrawork'] },
+      { current: ['ultrawork'], requested: 'team', allowed: true, resulting: ['ultrawork', 'team'] },
+      { current: ['ralph'], requested: 'ultrawork', allowed: false, resulting: ['ralph'] },
+      { current: ['ultrawork'], requested: 'ralph', allowed: false, resulting: ['ultrawork'] },
+      { current: ['autopilot'], requested: 'team', allowed: false, resulting: ['autopilot'] },
+      { current: ['team'], requested: 'autopilot', allowed: false, resulting: ['team'] },
+      { current: ['autoresearch'], requested: 'ralph', allowed: false, resulting: ['autoresearch'] },
+      { current: ['team', 'ralph'], requested: 'ultrawork', allowed: false, resulting: ['team', 'ralph'] },
+      { current: ['team', 'ultrawork'], requested: 'ralph', allowed: false, resulting: ['team', 'ultrawork'] },
+    ];
+
+    for (const testCase of cases) {
+      const decision = evaluateWorkflowTransition(testCase.current, testCase.requested);
+      assert.equal(decision.allowed, testCase.allowed, `${testCase.current.join(',')} -> ${testCase.requested}`);
+      assert.deepEqual(decision.resultingModes, testCase.resulting, `${testCase.current.join(',')} -> ${testCase.requested}`);
+    }
+  });
+
+  it('builds actionable denial guidance that names both clearing paths', () => {
+    const error = buildWorkflowTransitionError(['team'], 'autopilot', 'start');
+    assert.match(error, /Cannot start autopilot: team is already active\./);
+    assert.match(error, /Unsupported workflow overlap: team \+ autopilot\./);
+    assert.match(error, /Current state is unchanged\./);
+    assert.match(error, /`omx state clear --mode <mode>`/);
+    assert.match(error, /`omx_state\.\*` MCP tools/);
+  });
+});

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  buildWorkflowTransitionMessage,
   buildWorkflowTransitionError,
   evaluateWorkflowTransition,
 } from '../workflow-transition.js';
@@ -18,13 +19,13 @@ describe('workflow transition rules', () => {
       { current: ['ralph'], requested: 'team', allowed: true, resulting: ['ralph', 'team'] },
       { current: ['team'], requested: 'ultrawork', allowed: true, resulting: ['team', 'ultrawork'] },
       { current: ['ultrawork'], requested: 'team', allowed: true, resulting: ['ultrawork', 'team'] },
-      { current: ['ralph'], requested: 'ultrawork', allowed: false, resulting: ['ralph'] },
-      { current: ['ultrawork'], requested: 'ralph', allowed: false, resulting: ['ultrawork'] },
+      { current: ['ralph'], requested: 'ultrawork', allowed: true, resulting: ['ralph', 'ultrawork'] },
+      { current: ['ultrawork'], requested: 'ralph', allowed: true, resulting: ['ultrawork', 'ralph'] },
       { current: ['autopilot'], requested: 'team', allowed: false, resulting: ['autopilot'] },
       { current: ['team'], requested: 'autopilot', allowed: false, resulting: ['team'] },
       { current: ['autoresearch'], requested: 'ralph', allowed: false, resulting: ['autoresearch'] },
-      { current: ['team', 'ralph'], requested: 'ultrawork', allowed: false, resulting: ['team', 'ralph'] },
-      { current: ['team', 'ultrawork'], requested: 'ralph', allowed: false, resulting: ['team', 'ultrawork'] },
+      { current: ['team', 'ralph'], requested: 'ultrawork', allowed: true, resulting: ['team', 'ralph', 'ultrawork'] },
+      { current: ['team', 'ultrawork'], requested: 'ralph', allowed: true, resulting: ['team', 'ultrawork', 'ralph'] },
     ];
 
     for (const testCase of cases) {
@@ -41,5 +42,33 @@ describe('workflow transition rules', () => {
     assert.match(error, /Current state is unchanged\./);
     assert.match(error, /`omx state clear --mode <mode>`/);
     assert.match(error, /`omx_state\.\*` MCP tools/);
+  });
+
+  it('returns auto-complete decisions for allowlisted forward transitions', () => {
+    const interviewToRalplan = evaluateWorkflowTransition(['deep-interview'], 'ralplan');
+    assert.equal(interviewToRalplan.allowed, true);
+    assert.equal(interviewToRalplan.kind, 'auto-complete');
+    assert.deepEqual(interviewToRalplan.autoCompleteModes, ['deep-interview']);
+    assert.deepEqual(interviewToRalplan.resultingModes, ['ralplan']);
+    assert.equal(interviewToRalplan.transitionMessage, 'mode transiting: deep-interview -> ralplan');
+
+    const ralplanToRalph = evaluateWorkflowTransition(['ralplan', 'ultrawork'], 'ralph');
+    assert.equal(ralplanToRalph.allowed, true);
+    assert.equal(ralplanToRalph.kind, 'auto-complete');
+    assert.deepEqual(ralplanToRalph.autoCompleteModes, ['ralplan']);
+    assert.deepEqual(ralplanToRalph.resultingModes, ['ultrawork', 'ralph']);
+  });
+
+  it('builds rollback denial guidance for execution-to-planning transitions', () => {
+    const error = buildWorkflowTransitionError(['autopilot'], 'ralplan', 'start');
+    assert.match(error, /Execution-to-planning rollback auto-complete is not allowed\./);
+    assert.match(error, /First clear current state first and retry if this action is intended\./);
+  });
+
+  it('formats transition audit messages', () => {
+    assert.equal(
+      buildWorkflowTransitionMessage('ralplan', 'ralph'),
+      'mode transiting: ralplan -> ralph',
+    );
   });
 });

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -2,6 +2,11 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { omxStateDir } from '../utils/paths.js';
+import {
+  assertWorkflowTransitionAllowed,
+  isTrackedWorkflowMode,
+  pickPrimaryWorkflowMode,
+} from './workflow-transition.js';
 
 export const SKILL_ACTIVE_STATE_MODE = 'skill-active';
 export const SKILL_ACTIVE_STATE_FILE = `${SKILL_ACTIVE_STATE_MODE}-state.json`;
@@ -171,16 +176,20 @@ export async function writeSkillActiveStateCopies(
   cwd: string,
   state: SkillActiveStateLike,
   sessionId?: string,
+  rootState?: SkillActiveStateLike,
 ): Promise<void> {
   const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
-  const payload = JSON.stringify(state, null, 2);
+  const normalized = { version: 1, ...state };
+  const normalizedRoot = { version: 1, ...(rootState ?? normalized) };
+  const rootPayload = JSON.stringify(normalizedRoot, null, 2);
 
   await mkdir(dirname(rootPath), { recursive: true });
-  await writeFile(rootPath, payload);
+  await writeFile(rootPath, rootPayload);
 
   if (sessionPath) {
+    const sessionPayload = JSON.stringify(normalized, null, 2);
     await mkdir(dirname(sessionPath), { recursive: true });
-    await writeFile(sessionPath, payload);
+    await writeFile(sessionPath, sessionPayload);
   }
 }
 
@@ -213,42 +222,113 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
 
   if (!tracksCanonicalWorkflowSkill(mode)) return;
 
-  const { rootPath } = getSkillActiveStatePaths(cwd, sessionId);
-  const existing = await readSkillActiveState(rootPath);
-  if (!existing && !active) return;
+  const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+  const existingRoot = await readSkillActiveState(rootPath);
+  const existingSession = sessionPath ? await readSkillActiveState(sessionPath) : null;
+  if (!existingRoot && !existingSession && !active) return;
 
-  const entries = filterEntriesForSession(listActiveSkills(existing ?? {}), sessionId);
-  const filtered = entries.filter((entry) => entry.skill !== mode);
+  const normalizedSessionId = safeString(sessionId).trim();
+  const rootEntries = normalizedSessionId
+    ? listActiveSkills(existingRoot ?? {}).filter((entry) => {
+      const entrySessionId = safeString(entry.session_id).trim();
+      return entrySessionId.length === 0 || entrySessionId === normalizedSessionId;
+    })
+    : listActiveSkills(existingRoot ?? {});
+  const sessionOnlyEntries = normalizedSessionId
+    ? listActiveSkills(existingSession ?? {}).filter((entry) => (
+      safeString(entry.session_id).trim() === normalizedSessionId
+      && !rootEntries.some((rootEntry) => (
+        rootEntry.skill === entry.skill
+        && safeString(rootEntry.session_id).trim() === safeString(entry.session_id).trim()
+      ))
+    ))
+    : [];
+  const visibleEntries = normalizedSessionId
+    ? [...rootEntries, ...sessionOnlyEntries]
+    : [...rootEntries];
+
+  if (active && isTrackedWorkflowMode(mode)) {
+    const currentWorkflowModes = visibleEntries
+      .map((entry) => entry.skill)
+      .filter(isTrackedWorkflowMode);
+    assertWorkflowTransitionAllowed(currentWorkflowModes, mode, 'write');
+  }
+
+  const applyEntriesToState = (
+    base: SkillActiveStateLike | null,
+    entries: SkillActiveEntry[],
+    fallbackMode: string,
+  ): SkillActiveStateLike => {
+    const currentPrimary = safeString(base?.skill).trim();
+    const primarySkill = pickPrimaryWorkflowMode(currentPrimary, entries.map((entry) => entry.skill), fallbackMode);
+    const primaryEntry = entries.find((entry) => entry.skill === primarySkill) ?? entries[0];
+    return {
+      ...(base ?? {}),
+      version: 1,
+      active: entries.length > 0,
+      skill: primaryEntry?.skill || primarySkill || fallbackMode,
+      keyword: safeString(base?.keyword).trim(),
+      phase: primaryEntry?.phase || safeString(base?.phase).trim(),
+      activated_at: primaryEntry?.activated_at || safeString(base?.activated_at).trim() || nowIso,
+      updated_at: nowIso,
+      source: safeString(base?.source).trim() || source,
+      session_id: primaryEntry?.session_id || safeString(base?.session_id).trim() || undefined,
+      thread_id: primaryEntry?.thread_id || safeString(base?.thread_id).trim() || undefined,
+      turn_id: primaryEntry?.turn_id || safeString(base?.turn_id).trim() || undefined,
+      active_skills: entries,
+    };
+  };
+
+  if (normalizedSessionId) {
+    const nextSessionEntries = sessionOnlyEntries.filter((entry) => entry.skill !== mode);
+    if (active) {
+      nextSessionEntries.push({
+        skill: mode,
+        phase: safeString(currentPhase).trim() || undefined,
+        active: true,
+        activated_at: sessionOnlyEntries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
+        updated_at: nowIso,
+        session_id: normalizedSessionId,
+        thread_id: safeString(threadId).trim() || undefined,
+        turn_id: safeString(turnId).trim() || undefined,
+      });
+    }
+
+    const nextRootEntries = rootEntries.filter((entry) => !(
+      entry.skill === mode
+      && safeString(entry.session_id).trim() === normalizedSessionId
+    ));
+
+    const nextSessionState = applyEntriesToState(
+      existingSession ?? existingRoot,
+      [...nextRootEntries, ...nextSessionEntries],
+      mode,
+    );
+    const nextRootState = nextRootEntries.length > 0
+      ? applyEntriesToState(existingRoot, nextRootEntries, mode)
+      : applyEntriesToState(
+        existingSession ?? existingRoot,
+        active ? nextSessionEntries : [],
+        mode,
+      );
+    await writeSkillActiveStateCopies(cwd, nextSessionState, sessionId, nextRootState);
+    return;
+  }
+
+  const nextRootEntries = rootEntries.filter((entry) => entry.skill !== mode);
   if (active) {
-    filtered.push({
+    nextRootEntries.push({
       skill: mode,
       phase: safeString(currentPhase).trim() || undefined,
       active: true,
-      activated_at: entries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
+      activated_at: rootEntries.find((entry) => entry.skill === mode)?.activated_at || nowIso,
       updated_at: nowIso,
-      session_id: safeString(sessionId).trim() || undefined,
+      session_id: undefined,
       thread_id: safeString(threadId).trim() || undefined,
       turn_id: safeString(turnId).trim() || undefined,
     });
   }
 
-  const currentPrimary = safeString(existing?.skill).trim();
-  const primaryEntry = filtered.find((entry) => entry.skill === currentPrimary) ?? filtered[0];
-  const nextState: SkillActiveStateLike = {
-    ...(existing ?? {}),
-    version: 1,
-    active: filtered.length > 0,
-    skill: primaryEntry?.skill || currentPrimary || mode,
-    keyword: safeString(existing?.keyword).trim(),
-    phase: primaryEntry?.phase || safeString(currentPhase).trim() || safeString(existing?.phase).trim(),
-    activated_at: primaryEntry?.activated_at || safeString(existing?.activated_at).trim() || nowIso,
-    updated_at: nowIso,
-    source: safeString(existing?.source).trim() || source,
-    session_id: safeString(sessionId).trim() || safeString(existing?.session_id).trim() || undefined,
-    thread_id: safeString(threadId).trim() || safeString(existing?.thread_id).trim() || undefined,
-    turn_id: safeString(turnId).trim() || safeString(existing?.turn_id).trim() || undefined,
-    active_skills: filtered.length > 0 ? filtered : [],
-  };
-
-  await writeSkillActiveStateCopies(cwd, nextState, sessionId);
+  const nextRootState = applyEntriesToState(existingRoot, nextRootEntries, mode);
+  await writeSkillActiveStateCopies(cwd, nextRootState, undefined, nextRootState);
 }

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -69,15 +69,6 @@ function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-function filterEntriesForSession(
-  entries: SkillActiveEntry[],
-  sessionId?: string,
-): SkillActiveEntry[] {
-  const normalizedSessionId = safeString(sessionId).trim();
-  if (!normalizedSessionId) return entries;
-  return entries.filter((entry) => safeString(entry.session_id).trim() === normalizedSessionId);
-}
-
 function normalizeSkillActiveEntry(raw: unknown): SkillActiveEntry | null {
   if (!raw || typeof raw !== 'object') return null;
   const skill = safeString((raw as Record<string, unknown>).skill).trim();

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile, readdir, unlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { omxStateDir } from '../utils/paths.js';
 import {
@@ -67,6 +67,31 @@ export interface SyncCanonicalSkillStateOptions {
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+function entryKey(entry: Pick<SkillActiveEntry, 'skill' | 'session_id'>): string {
+  return `${entry.skill}::${safeString(entry.session_id).trim()}`;
+}
+
+function filterRootEntriesForSession(entries: SkillActiveEntry[], sessionId?: string): SkillActiveEntry[] {
+  const normalizedSessionId = safeString(sessionId).trim();
+  if (!normalizedSessionId) return entries;
+  return entries.filter((entry) => {
+    const entrySessionId = safeString(entry.session_id).trim();
+    return entrySessionId.length === 0 || entrySessionId === normalizedSessionId;
+  });
+}
+
+function filterSessionOnlyEntries(
+  sessionState: SkillActiveStateLike | null,
+  rootEntries: SkillActiveEntry[],
+  sessionId: string,
+): SkillActiveEntry[] {
+  const inheritedKeys = new Set(filterRootEntriesForSession(rootEntries, sessionId).map(entryKey));
+  return listActiveSkills(sessionState ?? {}).filter((entry) => (
+    safeString(entry.session_id).trim() === sessionId
+    && !inheritedKeys.has(entryKey(entry))
+  ));
 }
 
 function normalizeSkillActiveEntry(raw: unknown): SkillActiveEntry | null {
@@ -322,4 +347,33 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
 
   const nextRootState = applyEntriesToState(existingRoot, nextRootEntries, mode);
   await writeSkillActiveStateCopies(cwd, nextRootState, undefined, nextRootState);
+
+  const sessionsDir = join(omxStateDir(cwd), 'sessions');
+  if (!existsSync(sessionsDir)) return;
+
+  const sessionIds = await readdir(sessionsDir).catch(() => []);
+  for (const candidate of sessionIds) {
+    const sessionId = safeString(candidate).trim();
+    if (!sessionId) continue;
+
+    const sessionPath = join(sessionsDir, sessionId, SKILL_ACTIVE_STATE_FILE);
+    if (!existsSync(sessionPath)) continue;
+
+    const existingSessionState = await readSkillActiveState(sessionPath);
+    const sessionOnlyEntries = filterSessionOnlyEntries(existingSessionState, rootEntries, sessionId);
+    const nextVisibleRootEntries = filterRootEntriesForSession(nextRootEntries, sessionId);
+    const nextSessionEntries = [...nextVisibleRootEntries, ...sessionOnlyEntries];
+
+    if (nextSessionEntries.length === 0) {
+      await unlink(sessionPath).catch(() => {});
+      continue;
+    }
+
+    const nextSessionState = applyEntriesToState(
+      existingSessionState ?? existingRoot,
+      nextSessionEntries,
+      nextSessionEntries[0]?.skill || mode,
+    );
+    await writeSkillActiveStateCopies(cwd, nextSessionState, sessionId, nextRootState);
+  }
 }

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -1,0 +1,160 @@
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname } from 'path';
+import { getStatePath } from '../mcp/state-paths.js';
+import {
+  buildWorkflowTransitionError,
+  evaluateWorkflowTransition,
+  isTrackedWorkflowMode,
+  TRACKED_WORKFLOW_MODES,
+  type TrackedWorkflowMode,
+  type WorkflowTransitionAction,
+  type WorkflowTransitionDecision,
+} from './workflow-transition.js';
+import {
+  listActiveSkills,
+  readVisibleSkillActiveState,
+  syncCanonicalSkillStateForMode,
+} from './skill-active.js';
+
+interface TransitionStateLike {
+  active?: unknown;
+  current_phase?: unknown;
+  completed_at?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ReconciledWorkflowTransition {
+  decision: WorkflowTransitionDecision;
+  transitionMessage?: string;
+  autoCompletedModes: TrackedWorkflowMode[];
+  completedPaths: string[];
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+async function readJsonIfExists(path: string): Promise<TransitionStateLike | null> {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as TransitionStateLike;
+  } catch {
+    return null;
+  }
+}
+
+async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<TrackedWorkflowMode[]> {
+  const canonical = await readVisibleSkillActiveState(cwd, sessionId);
+  const canonicalModes = listActiveSkills(canonical ?? {})
+    .map((entry) => entry.skill)
+    .filter(isTrackedWorkflowMode);
+
+  const visibleModes = new Set<TrackedWorkflowMode>(canonicalModes);
+  for (const mode of TRACKED_WORKFLOW_MODES) {
+    const candidatePaths = sessionId
+      ? [getStatePath(mode, cwd, sessionId), getStatePath(mode, cwd)]
+      : [getStatePath(mode, cwd)];
+    for (const candidatePath of candidatePaths) {
+      const state = await readJsonIfExists(candidatePath);
+      if (state?.active === true) {
+        visibleModes.add(mode);
+      }
+    }
+  }
+
+  return [...visibleModes];
+}
+
+async function completeSourceModeState(
+  cwd: string,
+  sourceMode: TrackedWorkflowMode,
+  destinationMode: TrackedWorkflowMode,
+  sessionId: string | undefined,
+  nowIso: string,
+  source: string,
+): Promise<string[]> {
+  const transitionMessage = `mode transiting: ${sourceMode} -> ${destinationMode}`;
+  const candidatePaths = sessionId
+    ? [getStatePath(sourceMode, cwd, sessionId), getStatePath(sourceMode, cwd)]
+    : [getStatePath(sourceMode, cwd)];
+  const completedPaths: string[] = [];
+
+  for (const candidatePath of candidatePaths) {
+    const existing = await readJsonIfExists(candidatePath);
+    if (!existing || existing.active !== true) continue;
+
+    const nextState: TransitionStateLike = {
+      ...existing,
+      active: false,
+      current_phase: 'completed',
+      completed_at: safeString(existing.completed_at).trim() || nowIso,
+      auto_completed_reason: transitionMessage,
+      completion_note: `Auto-completed ${sourceMode} during allowlisted transition to ${destinationMode}.`,
+      transition_source: source,
+      transition_target_mode: destinationMode,
+    };
+
+    await mkdir(dirname(candidatePath), { recursive: true });
+    await writeFile(candidatePath, JSON.stringify(nextState, null, 2));
+    completedPaths.push(candidatePath);
+  }
+
+  await syncCanonicalSkillStateForMode({
+    cwd,
+    mode: sourceMode,
+    active: false,
+    currentPhase: 'completed',
+    sessionId,
+    nowIso,
+    source,
+  });
+
+  return completedPaths;
+}
+
+export async function reconcileWorkflowTransition(
+  cwd: string,
+  requestedMode: TrackedWorkflowMode,
+  options: {
+    action?: WorkflowTransitionAction;
+    sessionId?: string;
+    nowIso?: string;
+    source?: string;
+    currentModes?: Iterable<string>;
+  } = {},
+): Promise<ReconciledWorkflowTransition> {
+  const {
+    action = 'activate',
+    sessionId,
+    nowIso = new Date().toISOString(),
+    source = 'workflow-transition',
+  } = options;
+  const currentModes = options.currentModes
+    ? [...options.currentModes].filter(isTrackedWorkflowMode)
+    : await visibleTrackedModes(cwd, sessionId);
+  const decision = evaluateWorkflowTransition(currentModes, requestedMode);
+
+  if (!decision.allowed) {
+    throw new Error(buildWorkflowTransitionError(currentModes, requestedMode, action));
+  }
+
+  const completedPaths: string[] = [];
+  for (const sourceMode of decision.autoCompleteModes) {
+    completedPaths.push(...await completeSourceModeState(
+      cwd,
+      sourceMode,
+      requestedMode,
+      sessionId,
+      nowIso,
+      source,
+    ));
+  }
+
+  return {
+    decision,
+    transitionMessage: decision.transitionMessage,
+    autoCompletedModes: decision.autoCompleteModes,
+    completedPaths,
+  };
+}

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -35,11 +35,19 @@ function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-async function readJsonIfExists(path: string): Promise<TransitionStateLike | null> {
+async function readJsonIfExists(
+  path: string,
+  options?: { mode?: TrackedWorkflowMode; throwOnParseError?: boolean },
+): Promise<TransitionStateLike | null> {
   if (!existsSync(path)) return null;
   try {
     return JSON.parse(await readFile(path, 'utf-8')) as TransitionStateLike;
   } catch {
+    if (options?.throwOnParseError && options.mode) {
+      throw new Error(
+        `Cannot read ${options.mode} workflow state at ${path}. Clear or repair state via \`omx state clear --mode ${options.mode}\` or the \`omx_state.*\` MCP tools.`,
+      );
+    }
     return null;
   }
 }
@@ -56,7 +64,10 @@ async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<Tra
       ? [getStatePath(mode, cwd, sessionId), getStatePath(mode, cwd)]
       : [getStatePath(mode, cwd)];
     for (const candidatePath of candidatePaths) {
-      const state = await readJsonIfExists(candidatePath);
+      const state = await readJsonIfExists(candidatePath, {
+        mode,
+        throwOnParseError: true,
+      });
       if (state?.active === true) {
         visibleModes.add(mode);
       }

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -1,0 +1,168 @@
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+
+export const TRACKED_WORKFLOW_MODES = [
+  'autopilot',
+  'autoresearch',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
+  'ralplan',
+  'deep-interview',
+] as const;
+
+export type TrackedWorkflowMode = (typeof TRACKED_WORKFLOW_MODES)[number];
+export type WorkflowTransitionAction = 'activate' | 'start' | 'write';
+
+const ALLOWED_OVERLAP_PAIRS = new Set([
+  'ralph|team',
+  'team|ultrawork',
+]);
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function normalizeTrackedModes(modes: Iterable<string>): TrackedWorkflowMode[] {
+  const deduped = new Set<TrackedWorkflowMode>();
+  for (const mode of modes) {
+    if (isTrackedWorkflowMode(mode)) {
+      deduped.add(mode);
+    }
+  }
+  return [...deduped];
+}
+
+function buildPairKey(a: string, b: string): string {
+  return [a, b].sort((left, right) => left.localeCompare(right)).join('|');
+}
+
+function isAllowedOverlap(a: TrackedWorkflowMode, b: TrackedWorkflowMode): boolean {
+  return ALLOWED_OVERLAP_PAIRS.has(buildPairKey(a, b));
+}
+
+function formatActiveModes(modes: readonly string[]): string {
+  if (modes.length === 0) return 'no tracked workflows';
+  if (modes.length === 1) return `${modes[0]} is already active`;
+  if (modes.length === 2) return `${modes[0]} and ${modes[1]} are already active`;
+  return `${modes.slice(0, -1).join(', ')}, and ${modes[modes.length - 1]} are already active`;
+}
+
+export interface WorkflowTransitionDecision {
+  allowed: boolean;
+  currentModes: TrackedWorkflowMode[];
+  requestedMode: TrackedWorkflowMode;
+  resultingModes: TrackedWorkflowMode[];
+}
+
+export function isTrackedWorkflowMode(mode: string): mode is TrackedWorkflowMode {
+  return (TRACKED_WORKFLOW_MODES as readonly string[]).includes(mode);
+}
+
+export function evaluateWorkflowTransition(
+  currentActiveModes: Iterable<string>,
+  requestedMode: TrackedWorkflowMode,
+): WorkflowTransitionDecision {
+  const currentModes = normalizeTrackedModes(currentActiveModes);
+
+  if (currentModes.includes(requestedMode)) {
+    return {
+      allowed: true,
+      currentModes,
+      requestedMode,
+      resultingModes: currentModes,
+    };
+  }
+
+  if (currentModes.length === 0) {
+    return {
+      allowed: true,
+      currentModes,
+      requestedMode,
+      resultingModes: [requestedMode],
+    };
+  }
+
+  if (currentModes.length === 1 && isAllowedOverlap(currentModes[0], requestedMode)) {
+    return {
+      allowed: true,
+      currentModes,
+      requestedMode,
+      resultingModes: [currentModes[0], requestedMode],
+    };
+  }
+
+  return {
+    allowed: false,
+    currentModes,
+    requestedMode,
+    resultingModes: currentModes,
+  };
+}
+
+export function buildWorkflowTransitionError(
+  currentActiveModes: Iterable<string>,
+  requestedMode: TrackedWorkflowMode,
+  action: WorkflowTransitionAction = 'activate',
+): string {
+  const currentModes = normalizeTrackedModes(currentActiveModes);
+  const activeModesMessage = formatActiveModes(currentModes);
+  const overlap = [...currentModes, requestedMode].join(' + ');
+  return [
+    `Cannot ${action} ${requestedMode}: ${activeModesMessage}.`,
+    `Unsupported workflow overlap: ${overlap}.`,
+    'Current state is unchanged.',
+    `Clear incompatible workflow state via \`omx state clear --mode <mode>\` or the \`omx_state.*\` MCP tools, then retry.`,
+  ].join(' ');
+}
+
+export function assertWorkflowTransitionAllowed(
+  currentActiveModes: Iterable<string>,
+  requestedMode: TrackedWorkflowMode,
+  action: WorkflowTransitionAction = 'activate',
+): void {
+  const decision = evaluateWorkflowTransition(currentActiveModes, requestedMode);
+  if (decision.allowed) return;
+  throw new Error(buildWorkflowTransitionError(currentActiveModes, requestedMode, action));
+}
+
+export async function readActiveWorkflowModes(
+  cwd: string,
+  sessionId?: string,
+): Promise<TrackedWorkflowMode[]> {
+  const activeModes: TrackedWorkflowMode[] = [];
+
+  for (const mode of TRACKED_WORKFLOW_MODES) {
+    const candidatePaths = await getReadScopedStatePaths(mode, cwd, sessionId);
+    for (const candidatePath of candidatePaths) {
+      if (!existsSync(candidatePath)) continue;
+      try {
+        const parsed = JSON.parse(await readFile(candidatePath, 'utf-8')) as { active?: unknown };
+        if (parsed.active === true) {
+          activeModes.push(mode);
+        }
+        break;
+      } catch {
+        throw new Error(
+          `Cannot read ${mode} workflow state at ${candidatePath}. Clear or repair state via \`omx state clear --mode ${mode}\` or the \`omx_state.*\` MCP tools.`,
+        );
+      }
+    }
+  }
+
+  return activeModes;
+}
+
+export function pickPrimaryWorkflowMode(
+  currentPrimary: unknown,
+  resultingModes: readonly string[],
+  fallbackMode: string,
+): string {
+  const normalizedCurrent = safeString(currentPrimary).trim();
+  if (normalizedCurrent && resultingModes.includes(normalizedCurrent)) {
+    return normalizedCurrent;
+  }
+  return resultingModes[0] || fallbackMode;
+}

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -15,10 +15,31 @@ export const TRACKED_WORKFLOW_MODES = [
 
 export type TrackedWorkflowMode = (typeof TRACKED_WORKFLOW_MODES)[number];
 export type WorkflowTransitionAction = 'activate' | 'start' | 'write';
+export type WorkflowTransitionKind = 'allow' | 'overlap' | 'auto-complete' | 'deny';
 
 const ALLOWED_OVERLAP_PAIRS = new Set([
   'ralph|team',
-  'team|ultrawork',
+]);
+
+const AUTO_COMPLETE_TRANSITIONS = new Set([
+  'deep-interview->ralplan',
+  'ralplan->team',
+  'ralplan->ralph',
+  'ralplan->autopilot',
+]);
+
+const PLANNING_LIKE_MODES = new Set<TrackedWorkflowMode>([
+  'deep-interview',
+  'ralplan',
+  'autoresearch',
+]);
+
+const EXECUTION_LIKE_MODES = new Set<TrackedWorkflowMode>([
+  'autopilot',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
 ]);
 
 function safeString(value: unknown): string {
@@ -40,7 +61,31 @@ function buildPairKey(a: string, b: string): string {
 }
 
 function isAllowedOverlap(a: TrackedWorkflowMode, b: TrackedWorkflowMode): boolean {
+  if (a === 'ultrawork' || b === 'ultrawork') return true;
   return ALLOWED_OVERLAP_PAIRS.has(buildPairKey(a, b));
+}
+
+function buildAutoCompleteKey(a: TrackedWorkflowMode, b: TrackedWorkflowMode): string {
+  return `${a}->${b}`;
+}
+
+function isAutoCompleteTransition(a: TrackedWorkflowMode, b: TrackedWorkflowMode): boolean {
+  return AUTO_COMPLETE_TRANSITIONS.has(buildAutoCompleteKey(a, b));
+}
+
+function isRollbackTransition(
+  currentModes: readonly TrackedWorkflowMode[],
+  requestedMode: TrackedWorkflowMode,
+): boolean {
+  return PLANNING_LIKE_MODES.has(requestedMode)
+    && currentModes.some((mode) => EXECUTION_LIKE_MODES.has(mode));
+}
+
+export function buildWorkflowTransitionMessage(
+  sourceMode: TrackedWorkflowMode,
+  requestedMode: TrackedWorkflowMode,
+): string {
+  return `mode transiting: ${sourceMode} -> ${requestedMode}`;
 }
 
 function formatActiveModes(modes: readonly string[]): string {
@@ -52,9 +97,13 @@ function formatActiveModes(modes: readonly string[]): string {
 
 export interface WorkflowTransitionDecision {
   allowed: boolean;
+  kind: WorkflowTransitionKind;
   currentModes: TrackedWorkflowMode[];
   requestedMode: TrackedWorkflowMode;
   resultingModes: TrackedWorkflowMode[];
+  autoCompleteModes: TrackedWorkflowMode[];
+  transitionMessage?: string;
+  denialReason?: 'rollback';
 }
 
 export function isTrackedWorkflowMode(mode: string): mode is TrackedWorkflowMode {
@@ -70,35 +119,59 @@ export function evaluateWorkflowTransition(
   if (currentModes.includes(requestedMode)) {
     return {
       allowed: true,
+      kind: 'allow',
       currentModes,
       requestedMode,
       resultingModes: currentModes,
+      autoCompleteModes: [],
     };
   }
 
   if (currentModes.length === 0) {
     return {
       allowed: true,
+      kind: 'allow',
       currentModes,
       requestedMode,
       resultingModes: [requestedMode],
+      autoCompleteModes: [],
     };
   }
 
-  if (currentModes.length === 1 && isAllowedOverlap(currentModes[0], requestedMode)) {
+  const autoCompleteModes = currentModes.filter((mode) => isAutoCompleteTransition(mode, requestedMode));
+  const survivableModes = currentModes.filter((mode) => !autoCompleteModes.includes(mode));
+
+  if (autoCompleteModes.length > 0 && survivableModes.every((mode) => isAllowedOverlap(mode, requestedMode))) {
     return {
       allowed: true,
+      kind: 'auto-complete',
       currentModes,
       requestedMode,
-      resultingModes: [currentModes[0], requestedMode],
+      resultingModes: normalizeTrackedModes([...survivableModes, requestedMode]),
+      autoCompleteModes,
+      transitionMessage: buildWorkflowTransitionMessage(autoCompleteModes[0], requestedMode),
+    };
+  }
+
+  if (currentModes.every((mode) => isAllowedOverlap(mode, requestedMode))) {
+    return {
+      allowed: true,
+      kind: 'overlap',
+      currentModes,
+      requestedMode,
+      resultingModes: normalizeTrackedModes([...currentModes, requestedMode]),
+      autoCompleteModes: [],
     };
   }
 
   return {
     allowed: false,
+    kind: 'deny',
     currentModes,
     requestedMode,
     resultingModes: currentModes,
+    autoCompleteModes: [],
+    ...(isRollbackTransition(currentModes, requestedMode) ? { denialReason: 'rollback' as const } : {}),
   };
 }
 
@@ -107,9 +180,17 @@ export function buildWorkflowTransitionError(
   requestedMode: TrackedWorkflowMode,
   action: WorkflowTransitionAction = 'activate',
 ): string {
-  const currentModes = normalizeTrackedModes(currentActiveModes);
-  const activeModesMessage = formatActiveModes(currentModes);
-  const overlap = [...currentModes, requestedMode].join(' + ');
+  const decision = evaluateWorkflowTransition(currentActiveModes, requestedMode);
+  const activeModesMessage = formatActiveModes(decision.currentModes);
+  const overlap = [...decision.currentModes, requestedMode].join(' + ');
+  if (decision.denialReason === 'rollback') {
+    return [
+      `Cannot ${action} ${requestedMode}: ${activeModesMessage}.`,
+      'Execution-to-planning rollback auto-complete is not allowed.',
+      'First clear current state first and retry if this action is intended.',
+      `Clear incompatible workflow state via \`omx state clear --mode <mode>\` or the \`omx_state.*\` MCP tools, then retry.`,
+    ].join(' ');
+  }
   return [
     `Cannot ${action} ${requestedMode}: ${activeModesMessage}.`,
     `Unsupported workflow overlap: ${overlap}.`,

--- a/src/team/__tests__/current-task-baseline.test.ts
+++ b/src/team/__tests__/current-task-baseline.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  assertCurrentTaskBranchAvailable,
+  findActiveCurrentTaskByBranch,
+  upsertCurrentTaskBaseline,
+} from '../current-task-baseline.js';
+import { ensureWorktree, planWorktreeTarget } from '../worktree.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-current-task-baseline-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+describe('current-task-baseline', () => {
+  it('records a launch worktree branch baseline on successful ensureWorktree', async () => {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: false, name: 'feature/task-baseline' },
+      });
+      assert.equal(plan.enabled, true);
+      if (!plan.enabled) return;
+
+      const ensured = ensureWorktree(plan);
+      assert.equal(ensured.enabled, true);
+      if (!ensured.enabled) return;
+
+      const entry = findActiveCurrentTaskByBranch(repo, 'feature/task-baseline');
+      assert.ok(entry, 'baseline entry should exist');
+      assert.equal(entry?.worktree_path, ensured.worktreePath);
+      assert.equal(entry?.status, 'active');
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'current-task-baseline.json')), true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks duplicate branch creation when baseline points at another worktree path', async () => {
+    const repo = await initRepo();
+    try {
+      upsertCurrentTaskBaseline(repo, {
+        branch_name: 'feature/already-active',
+        worktree_path: join(repo, '..', 'some-other-worktree'),
+        status: 'active',
+      });
+
+      assert.throws(
+        () => assertCurrentTaskBranchAvailable(repo, 'feature/already-active', join(repo, '..', 'new-worktree')),
+        /current_task_branch_guard:feature\/already-active:/,
+      );
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('updates branch lifecycle metadata when PR info is observed', async () => {
+    const repo = await initRepo();
+    try {
+      upsertCurrentTaskBaseline(repo, {
+        branch_name: 'feature/pr-lifecycle',
+        worktree_path: repo,
+        status: 'active',
+      });
+
+      upsertCurrentTaskBaseline(repo, {
+        branch_name: 'feature/pr-lifecycle',
+        worktree_path: repo,
+        issue_number: 1407,
+        pr_number: 1416,
+        pr_url: 'https://github.com/Yeachan-Heo/oh-my-codex/pull/1416',
+        status: 'merged',
+      });
+
+      const raw = JSON.parse(readFileSync(join(repo, '.omx', 'state', 'current-task-baseline.json'), 'utf-8'));
+      const entry = raw.tasks.find((item: { branch_name: string }) => item.branch_name === 'feature/pr-lifecycle');
+      assert.equal(entry.issue_number, 1407);
+      assert.equal(entry.pr_number, 1416);
+      assert.equal(entry.status, 'merged');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1193,8 +1193,6 @@ sleep 5
       assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
 
       const expectedArgv = [
-        '--approval-mode',
-        'yolo',
         '-i',
         'Read .omx/state/team/team-gemini-prompt/workers/worker-1/inbox.md, start work now, report concrete progress, then continue assigned work or next feasible task.',
       ];
@@ -1290,8 +1288,8 @@ process.on('SIGTERM', () => process.exit(0));
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
       assert.ok(argv, 'codex argv capture file should be written');
-      assert.equal(argv.includes('--dangerously-bypass-approvals-and-sandbox'), true);
-      assert.equal(argv.filter((arg) => arg === '--dangerously-bypass-approvals-and-sandbox').length, 1);
+      assert.equal(argv.includes('--dangerously-bypass-approvals-and-sandbox'), false);
+      assert.equal(argv.filter((arg) => arg === '--dangerously-bypass-approvals-and-sandbox').length, 0);
       assert.equal(argv.includes('--model'), true);
       assert.equal(argv[argv.indexOf('--model') + 1], 'gpt-5.3-codex-spark');
       assert.equal(argv.includes('-c'), true);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1187,6 +1187,14 @@ case "\${1:-}" in
   split-window)
     case "$*" in
       *" -h "*)
+        mkdir -p "${cwd}/.omx/state/team/team-pane-pid/workers/worker-1"
+        cat > "${cwd}/.omx/state/team/team-pane-pid/workers/worker-1/status.json" <<'EOF'
+{
+  "state": "working",
+  "current_task_id": "1",
+  "updated_at": "2026-04-10T00:00:00.000Z"
+}
+EOF
         echo "%2"
         ;;
       *)

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -138,6 +138,26 @@ function withoutTeamWorkerEnv<T>(fn: () => T): T {
   }
 }
 
+function withMockPromptModeCodexAllowed<T>(fn: () => T): T {
+  const previous = process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = '1';
+  let restoreImmediately = true;
+  const restore = () => {
+    if (typeof previous === 'string') process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = previous;
+    else delete process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      restoreImmediately = false;
+      return result.finally(restore) as T;
+    }
+    return result;
+  } finally {
+    if (restoreImmediately) restore();
+  }
+}
+
 async function waitForFileText(
   filePath: string,
   matcher: (content: string) => boolean,
@@ -198,6 +218,7 @@ async function withPromptModeCodexEnv<T>(
     TMUX: undefined,
     OMX_TEAM_WORKER_LAUNCH_MODE: 'prompt',
     OMX_TEAM_WORKER_CLI: 'codex',
+    OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT: '1',
     ...extraEnv,
   };
 
@@ -1912,18 +1933,19 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-role-routing',
-          'heuristic routing handoff',
-          'executor',
-          2,
-          [
-            { subject: 'test routing report only', description: 'test routing report only', owner: 'worker-1', role: 'test-engineer' },
-            { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
-          ],
-          cwd,
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-role-routing',
+            'heuristic routing handoff',
+            'executor',
+            2,
+            [
+              { subject: 'test routing report only', description: 'test routing report only', owner: 'worker-1', role: 'test-engineer' },
+              { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' },
+            ],
+            cwd,
+          )));
 
       assert.equal(runtime.config.worker_launch_mode, 'prompt');
       assert.equal(runtime.config.workers[0]?.role, 'test-engineer');
@@ -2033,17 +2055,18 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-mini-tuned-routing',
-          'mini tuned routing handoff',
-          'executor',
-          1,
-          [
-            { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-1', role: 'writer' },
-          ],
-          cwd,
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-mini-tuned-routing',
+            'mini tuned routing handoff',
+            'executor',
+            1,
+            [
+              { subject: 'document routing report only', description: 'document routing report only', owner: 'worker-1', role: 'writer' },
+            ],
+            cwd,
+          )));
 
       const workerInstructions = await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'AGENTS.md'), 'utf-8');
       assert.match(workerInstructions, /You are operating as the \*\*writer\*\* role/);
@@ -2321,16 +2344,17 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-paths',
-          'detached worktree path resolution',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-detached-worktree-paths',
+            'detached worktree path resolution',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )));
 
       const workerPath = runtime.config.workers[0]?.worktree_path;
       assert.ok(workerPath, 'detached worker should have a worktree path');
@@ -2423,16 +2447,17 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-shutdown',
-          'detached worktree shutdown cleanup',
-          'executor',
-          1,
-          [],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-detached-worktree-shutdown',
+            'detached worktree shutdown cleanup',
+            'executor',
+            1,
+            [],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )));
 
       const worktreePath = runtime.config.workers[0]?.worktree_path;
       assert.ok(worktreePath, 'worker worktree path should be persisted');
@@ -2501,16 +2526,17 @@ process.on('SIGTERM', () => process.exit(0));
 
     let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-detached-worktree-resume-metadata',
-          'detached worktree resume metadata',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-detached-worktree-resume-metadata',
+            'detached worktree resume metadata',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )));
 
       const originalWorker = runtime.config.workers[0];
       const originalWorktreePath = originalWorker?.worktree_path;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -21,6 +21,7 @@ import {
   readMonitorSnapshot,
   claimTask,
   transitionTaskStatus,
+  readWorkerStatus,
   writeWorkerStatus,
 } from '../state.js';
 import {
@@ -40,6 +41,7 @@ import {
 } from '../runtime.js';
 import { resolveTeamLowComplexityDefaultModel } from '../model-contract.js';
 import { readTeamEvents } from '../state/events.js';
+import { sanitizeTeamName } from '../tmux-session.js';
 
 async function initRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-repo-'));
@@ -1277,7 +1279,7 @@ esac
     assert.equal(saveIndex < readyIndex, true);
   });
 
-  it('startTeam rejects interactive startup when fallback delivery never produces startup evidence', async () => {
+  it('startTeam records recoverable startup issues per worker instead of failing launch early when panes stay alive', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-no-startup-evidence-'));
     const previousTmux = process.env.TMUX;
     const previousTmuxPane = process.env.TMUX_PANE;
@@ -1285,6 +1287,8 @@ esac
     const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
     const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+    let runtime: TeamRuntime | null = null;
+    const teamName = 'team-no-startup-evidence';
 
     try {
       await withMockTmuxFixture(
@@ -1311,6 +1315,9 @@ case "$1" in
     ;;
   list-panes)
     case "$*" in
+      *"#{pane_dead}"*)
+        echo "0"
+        ;;
       *"#{pane_dead} #{pane_pid}"*)
         echo "0 4242"
         ;;
@@ -1367,25 +1374,308 @@ process.on('SIGTERM', () => process.exit(0));
           process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
           process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
 
+          runtime = await withoutTeamWorkerEnv(() =>
+            startTeam(
+              teamName,
+              'interactive startup should keep evaluating per-worker startup issues while panes stay alive',
+              'executor',
+              2,
+              [
+                { subject: 'worker-1 task', description: 'd', owner: 'worker-1' },
+                { subject: 'worker-2 task', description: 'd', owner: 'worker-2' },
+              ],
+              cwd,
+            ));
+
+          const worker1Status = await readWorkerStatus(teamName, 'worker-1', cwd);
+          const worker2Status = await readWorkerStatus(teamName, 'worker-2', cwd);
+          assert.equal(worker1Status.state, 'unknown');
+          assert.equal(worker2Status.state, 'unknown');
+          assert.match(worker1Status.reason ?? '', /startup_no_evidence|fallback_attempted_but_unconfirmed/);
+          assert.match(worker2Status.reason ?? '', /startup_no_evidence|fallback_attempted_but_unconfirmed/);
+
+          const task1 = await readTask(teamName, '1', cwd);
+          const task2 = await readTask(teamName, '2', cwd);
+          assert.equal(task1?.status, 'pending');
+          assert.equal(task2?.status, 'pending');
+        },
+      );
+    } finally {
+      if (runtime) {
+        await shutdownTeam(teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = previousSkipReadyWait;
+      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+      if (typeof previousStartupEvidenceTimeout === 'string') {
+        process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam still fails startup when the worker pane is dead/unrecoverable', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-dead-startup-pane-'));
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-dead-startup-pane-bin-',
+          tmuxScript: () => `#!/bin/sh
+set -eu
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*) echo "120" ;;
+      *) echo "leader:0 %1" ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "1 4242"
+        ;;
+      *"#{pane_pid}"*)
+        echo "4242"
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*) echo "%2" ;;
+      *) echo "%3" ;;
+    esac
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session|resize-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [{ name: 'codex', content: '#!/usr/bin/env node\nprocess.stdin.resume();\n' }],
+        },
+        async () => {
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+
           await assert.rejects(
             () => withoutTeamWorkerEnv(() =>
               startTeam(
-                'team-no-startup-evidence',
-                'interactive startup should fail without claim evidence',
+                'team-dead-startup-pane',
+                'dead pane should still fail startup',
                 'executor',
                 1,
                 [{ subject: 's', description: 'd', owner: 'worker-1' }],
                 cwd,
               )),
-            /worker_notify_failed:worker-1/,
+            /Worker worker-1 did not become ready/,
+          );
+        },
+      );
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousStartupEvidenceTimeout === 'string') {
+        process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam materializes all worker identity/inbox files before worker-1 startup evidence can block later workers', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-materialize-before-evidence-'));
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+    const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-materialize-before-evidence-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "0 4242"
+        ;;
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *"-t %2"*"#{pane_pid}"*)
+        echo "4242"
+        ;;
+      *"-t %3"*"#{pane_pid}"*)
+        echo "4343"
+        ;;
+      *"-t %4"*"#{pane_pid}"*)
+        echo "4444"
+        ;;
+      *"#{pane_pid}"*)
+        echo "4141"
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    exit 0
+    ;;
+  split-window)
+    count_file="${cwd}/split-window-count"
+    count=0
+    if [ -f "$count_file" ]; then
+      count=$(cat "$count_file")
+    fi
+    count=$((count + 1))
+    printf '%s' "$count" > "$count_file"
+    case "$count" in
+      1) echo "%2" ;;
+      2) echo "%3" ;;
+      3) echo "%4" ;;
+      *) echo "%5" ;;
+    esac
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session|resize-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [
+            {
+              name: 'codex',
+              content: `#!/usr/bin/env node
+process.stdin.resume();
+setTimeout(() => process.exit(0), 30000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+            },
+          ],
+        },
+        async () => {
+          const sanitizedTeamName = sanitizeTeamName('team-materialize-before-evidence');
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+
+          const teamPromise = withoutTeamWorkerEnv(() =>
+            startTeam(
+              'team-materialize-before-evidence',
+              'later workers should materialize before startup evidence failure',
+              'executor',
+              2,
+              [
+                { subject: 'w1', description: 'worker one', owner: 'worker-1' },
+                { subject: 'w2', description: 'worker two', owner: 'worker-2' },
+              ],
+              cwd,
+            ));
+          const observedTeamPromise = teamPromise.then(
+            (runtime) => ({ ok: true as const, runtime }),
+            (error: unknown) => ({ ok: false as const, error }),
           );
 
+          const workerOneIdentity = join(cwd, '.omx', 'state', 'team', sanitizedTeamName, 'workers', 'worker-1', 'identity.json');
+          const workerTwoIdentity = join(cwd, '.omx', 'state', 'team', sanitizedTeamName, 'workers', 'worker-2', 'identity.json');
+          const workerTwoInbox = join(cwd, '.omx', 'state', 'team', sanitizedTeamName, 'workers', 'worker-2', 'inbox.md');
+
+          let materializedAllWorkers = false;
+          for (let attempt = 0; attempt < 450; attempt += 1) {
+            if (
+              existsSync(workerOneIdentity)
+              && existsSync(workerTwoIdentity)
+              && existsSync(workerTwoInbox)
+            ) {
+              materializedAllWorkers = true;
+              break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+
           assert.equal(
-            existsSync(join(cwd, '.omx', 'state', 'team', 'team-no-startup-evidence')),
-            false,
+            materializedAllWorkers,
+            true,
+            'worker-2 durable state should exist before worker-1 startup evidence failure rejects launch',
           );
+
+          const outcome = await observedTeamPromise;
+          assert.equal(outcome.ok, false);
+          assert.match(String((outcome as { ok: false; error: Error }).error), /worker_notify_failed:worker-1/);
+
           assert.equal(
-            existsSync(join(cwd, '.omx', 'team', 'team-no-startup-evidence')),
+            existsSync(join(cwd, '.omx', 'state', 'team', sanitizedTeamName)),
             false,
           );
         },
@@ -1528,20 +1818,15 @@ sleep 5
     }
   });
 
-  it('startTeam preserves explicit codex launch args while forcing bypass in prompt mode', async () => {
+  it('startTeam rejects codex prompt mode even when explicit launch args are provided', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-explicit-launch-'));
     const binDir = join(cwd, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
-    const capturePath = join(cwd, 'codex-argv.json');
     await mkdir(binDir, { recursive: true });
     await writeFile(
       fakeCodexPath,
       `#!/usr/bin/env node
-const fs = require('fs');
-fs.writeFileSync(process.env.OMX_CODEX_ARGV_CAPTURE_PATH, JSON.stringify(process.argv.slice(2), null, 2));
-process.stdin.resume();
-setTimeout(() => process.exit(0), 5000);
-process.on('SIGTERM', () => process.exit(0));
+process.exit(0);
 `,
       { mode: 0o755 },
     );
@@ -1551,53 +1836,27 @@ process.on('SIGTERM', () => process.exit(0));
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const prevLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-    const prevCapture = process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
 
     process.env.PATH = `${binDir}:${prevPath ?? ''}`;
     delete process.env.TMUX;
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
     process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--model gpt-5.3-codex-spark -c model_reasoning_effort="low"';
-    process.env.OMX_CODEX_ARGV_CAPTURE_PATH = capturePath;
-
-    let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-codex-explicit-launch',
-          'codex prompt-mode team bootstrap',
-          'explore',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
-
-      assert.equal(runtime.config.worker_launch_mode, 'prompt');
-      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
-
-      let argv: string[] | null = null;
-      for (let attempt = 0; attempt < 50; attempt += 1) {
-        if (existsSync(capturePath)) {
-          argv = JSON.parse(await readFile(capturePath, 'utf-8')) as string[];
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      assert.ok(argv, 'codex argv capture file should be written');
-      assert.equal(argv.includes('--dangerously-bypass-approvals-and-sandbox'), false);
-      assert.equal(argv.filter((arg) => arg === '--dangerously-bypass-approvals-and-sandbox').length, 0);
-      assert.equal(argv.includes('--model'), true);
-      assert.equal(argv[argv.indexOf('--model') + 1], 'gpt-5.3-codex-spark');
-      assert.equal(argv.includes('-c'), true);
-      assert.equal(argv.includes('model_reasoning_effort="low"'), true);
-      assert.equal(argv.some((arg) => arg.includes('model_instructions_file=')), true);
-
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
+      await assert.rejects(
+        () => withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-codex-explicit-launch',
+            'codex prompt-mode team bootstrap',
+            'explore',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+          )),
+        /prompt_mode_codex_requires_tty/,
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'team-codex-explicit-launch')), false);
     } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
       else delete process.env.PATH;
       if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
@@ -1608,8 +1867,6 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = prevLaunchArgs;
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
-      if (typeof prevCapture === 'string') process.env.OMX_CODEX_ARGV_CAPTURE_PATH = prevCapture;
-      else delete process.env.OMX_CODEX_ARGV_CAPTURE_PATH;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -1831,7 +2088,7 @@ process.on('SIGTERM', () => process.exit(0));
     }
   });
 
-  it('startTeam supports prompt launch mode without tmux and pipes trigger text via stdin', async () => {
+  it('startTeam rejects codex prompt mode without tmux with an explicit non-tty error', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-'));
     const binDir = join(cwd, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
@@ -1856,28 +2113,21 @@ process.on('SIGTERM', () => process.exit(0));
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
 
-    let runtime: TeamRuntime | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-prompt',
-          'prompt-mode team bootstrap',
-          'executor',
-          1,
-          [{ subject: 's', description: 'd', owner: 'worker-1' }],
-          cwd,
-        ));
-
-      assert.equal(runtime.config.worker_launch_mode, 'prompt');
-      assert.equal(runtime.config.leader_pane_id, null);
-      assert.equal((runtime.config.workers[0]?.pid ?? 0) > 0, true);
-
-      await shutdownTeam(runtime.teamName, cwd, { force: true });
-      runtime = null;
+      await assert.rejects(
+        () => withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-prompt',
+            'prompt-mode team bootstrap',
+            'executor',
+            1,
+            [{ subject: 's', description: 'd', owner: 'worker-1' }],
+            cwd,
+          )),
+        /prompt_mode_codex_requires_tty/,
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'team-prompt')), false);
     } finally {
-      if (runtime) {
-        await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
-      }
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
       else delete process.env.PATH;
       if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -637,6 +637,155 @@ describe('runtime', () => {
     }
   });
 
+  it('startTeam rejects interactive startup when tmux fallback never produces worker startup evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-startup-no-evidence-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+    let receiptFailer: NodeJS.Timeout | null = null;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-startup-no-evidence-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%1\\tzsh\\tzsh\\n"
+        exit 0
+        ;;
+      *"#{pane_pid}"*)
+        echo "4321"
+        exit 0
+        ;;
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "0 4321"
+        exit 0
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    printf 'OpenAI Codex\\n> '
+    exit 0
+    ;;
+  send-keys|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|kill-pane|kill-session)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [
+            {
+              name: 'codex',
+              content: '#!/bin/sh\nsleep 30\n',
+            },
+          ],
+        },
+        async ({ tmuxLogPath }) => {
+          process.env.TMUX = 'leader-session';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+
+          receiptFailer = setInterval(() => {
+            void (async () => {
+              const requests = await listDispatchRequests(
+                'team-startup-no-evidence',
+                cwd,
+                { kind: 'inbox' },
+              ).catch(() => []);
+              for (const request of requests) {
+                if (request.status !== 'pending') continue;
+                await transitionDispatchRequest(
+                  'team-startup-no-evidence',
+                  request.request_id,
+                  'pending',
+                  'failed',
+                  { last_reason: 'test_failed_receipt' },
+                  cwd,
+                ).catch(() => {});
+              }
+            })();
+          }, 20);
+
+          await assert.rejects(
+            () => withoutTeamWorkerEnv(() =>
+              startTeam(
+                'team-startup-no-evidence',
+                'interactive startup must observe worker evidence',
+                'executor',
+                1,
+                [{ subject: 's', description: 'd', owner: 'worker-1' }],
+                cwd,
+              )),
+            /worker_notify_failed/,
+          );
+
+          if (receiptFailer) {
+            clearInterval(receiptFailer);
+            receiptFailer = null;
+          }
+
+          assert.equal(await readTeamConfig('team-startup-no-evidence', cwd), null);
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /send-keys -t %2 -l --/);
+        },
+      );
+    } finally {
+      if (receiptFailer) clearInterval(receiptFailer);
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
+      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('resolveWorkerLaunchArgsFromEnv logs source=none/default-none when thinking is not explicit', () => {
     const logs: string[] = [];
     const originalLog = console.log;
@@ -1103,15 +1252,154 @@ esac
 
   it('startTeam saves interactive pane ids before readiness waits in source order', async () => {
     const source = await readFile(join(process.cwd(), 'src', 'team', 'runtime.ts'), 'utf-8');
-    const applyIndex = source.indexOf('applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);');
-    const saveIndex = source.indexOf('await saveTeamConfig(config, leaderCwd);', applyIndex);
-    const readyIndex = source.indexOf('const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);', saveIndex);
+    const applyMatch = source.match(
+      /applyCreatedInteractiveSessionToConfig\(\s*config,\s*createdSession,\s*workerPaneIds\s*\);/m,
+    );
+    const saveMatch = source.match(/await saveTeamConfig\(config, leaderCwd\);/m);
+    const readyMatch = source.match(/const ready = waitForWorkerReady\(/m);
 
-    assert.notEqual(applyIndex, -1);
-    assert.notEqual(saveIndex, -1);
-    assert.notEqual(readyIndex, -1);
+    const applyIndex = applyMatch?.index ?? -1;
+    const saveIndex = saveMatch?.index ?? -1;
+    const readyIndex = readyMatch?.index ?? -1;
+
+    assert.notEqual(applyMatch, null);
+    assert.notEqual(saveMatch, null);
+    assert.notEqual(readyMatch, null);
     assert.equal(applyIndex < saveIndex, true);
     assert.equal(saveIndex < readyIndex, true);
+  });
+
+  it('startTeam rejects interactive startup when fallback delivery never produces startup evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-no-startup-evidence-'));
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+    const previousStartupEvidenceTimeout = process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-no-startup-evidence-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"#{pane_dead} #{pane_pid}"*)
+        echo "0 4242"
+        ;;
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *"#{pane_pid}"*)
+        echo "4242"
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  capture-pane)
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session|resize-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [
+            {
+              name: 'codex',
+              content: `#!/usr/bin/env node
+process.stdin.resume();
+setTimeout(() => process.exit(0), 30000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+            },
+          ],
+        },
+        async () => {
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'codex';
+          process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+          process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = '500';
+
+          await assert.rejects(
+            () => withoutTeamWorkerEnv(() =>
+              startTeam(
+                'team-no-startup-evidence',
+                'interactive startup should fail without claim evidence',
+                'executor',
+                1,
+                [{ subject: 's', description: 'd', owner: 'worker-1' }],
+                cwd,
+              )),
+            /worker_notify_failed:worker-1/,
+          );
+
+          assert.equal(
+            existsSync(join(cwd, '.omx', 'state', 'team', 'team-no-startup-evidence')),
+            false,
+          );
+          assert.equal(
+            existsSync(join(cwd, '.omx', 'team', 'team-no-startup-evidence')),
+            false,
+          );
+        },
+      );
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = previousSkipReadyWait;
+      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+      if (typeof previousStartupEvidenceTimeout === 'string') {
+        process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS = previousStartupEvidenceTimeout;
+      } else {
+        delete process.env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('startTeam rejects dirty leader workspace before provisioning worker worktrees', async () => {

--- a/src/team/__tests__/shutdown-fallback.test.ts
+++ b/src/team/__tests__/shutdown-fallback.test.ts
@@ -28,6 +28,15 @@ function withoutTeamWorkerEnv<T>(fn: () => Promise<T>): Promise<T> {
   });
 }
 
+function withMockPromptModeCodexAllowed<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = '1';
+  return fn().finally(() => {
+    if (typeof previous === 'string') process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = previous;
+    else delete process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+  });
+}
+
 describe('shutdown fallback worktree reports', () => {
   it('shutdownTeam checkpoints dirty detached worker worktrees, merges them, and writes a report', async () => {
     const repo = await initRepo();
@@ -56,16 +65,17 @@ process.on('SIGTERM', () => process.exit(0));
     let runtime: TeamRuntime | null = null;
     let preservedWorktreePath: string | null = null;
     try {
-      runtime = await withoutTeamWorkerEnv(() =>
-        startTeam(
-          'team-shutdown-fallback-report',
-          'shutdown fallback merge report',
-          'executor',
-          1,
-          [],
-          repo,
-          { worktreeMode: { enabled: true, detached: true, name: null } },
-        ));
+      runtime = await withMockPromptModeCodexAllowed(() =>
+        withoutTeamWorkerEnv(() =>
+          startTeam(
+            'team-shutdown-fallback-report',
+            'shutdown fallback merge report',
+            'executor',
+            1,
+            [],
+            repo,
+            { worktreeMode: { enabled: true, detached: true, name: null } },
+          )));
 
       const worktreePath = runtime.config.workers[0]?.worktree_path;
       assert.ok(worktreePath, 'worker worktree path should be present');

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1231,6 +1231,13 @@ describe('team worker CLI helpers', () => {
     );
   });
 
+  it('translateWorkerLaunchArgsForCli keeps read-only claude roles out of skip-permissions mode', () => {
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('claude', ['--model', 'claude-3-7-sonnet'], undefined, 'architect'),
+      [],
+    );
+  });
+
   it('translateWorkerLaunchArgsForCli emits gemini approval-mode by default and adds -i when initial prompt is provided', () => {
     assert.deepEqual(
       translateWorkerLaunchArgsForCli('gemini', ['--model', 'gemini-2.0-pro', '--json']),
@@ -1254,6 +1261,13 @@ describe('team worker CLI helpers', () => {
     assert.deepEqual(
       translateWorkerLaunchArgsForCli('gemini', ['--model', 'gpt-5.3-codex-spark'], 'Read worker inbox'),
       ['--approval-mode', 'yolo', '-i', 'Read worker inbox'],
+    );
+  });
+
+  it('translateWorkerLaunchArgsForCli keeps planning/read-only gemini roles out of yolo mode', () => {
+    assert.deepEqual(
+      translateWorkerLaunchArgsForCli('gemini', ['--model', 'gemini-2.0-pro'], 'Read worker inbox', 'planner'),
+      ['-i', 'Read worker inbox', '--model', 'gemini-2.0-pro'],
     );
   });
 
@@ -1386,6 +1400,27 @@ describe('team worker launch mode helpers', () => {
       assert.deepEqual(spec.args, ['--model', 'gpt-5.3-codex', '--dangerously-bypass-approvals-and-sandbox']);
       assert.equal(spec.env.OMX_TEAM_WORKER, 'alpha-team/worker-2');
       assert.equal(spec.env.OMX_TEAM_STATE_ROOT, '/tmp/workspace/.omx/state');
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('buildWorkerProcessLaunchSpec does not force codex bypass for read-only roles', () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const spec = buildWorkerProcessLaunchSpec(
+        'alpha-team',
+        2,
+        ['--model', 'gpt-5.3-codex-spark'],
+        '/tmp/workspace',
+        { OMX_TEAM_STATE_ROOT: '/tmp/workspace/.omx/state' },
+        'codex',
+        undefined,
+        'explore',
+      );
+      assert.deepEqual(spec.args, ['--model', 'gpt-5.3-codex-spark']);
     } finally {
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -48,6 +48,8 @@ import {
   waitForWorkerReady,
   paneIsBootstrapping,
   dismissTrustPromptIfPresent,
+  getWorkerPanePid,
+  mitigateCopyModeUnderlineArtifacts,
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import * as tmuxSessionModule from '../tmux-session.js';
@@ -169,6 +171,45 @@ describe('chooseTeamLeaderPaneId', () => {
       { paneId: '%3', currentCommand: 'node', startCommand: "node omx hud --watch" },
     ];
     assert.equal(chooseTeamLeaderPaneId(panes, '%2'), '%2');
+  });
+});
+
+describe('getWorkerPanePid', () => {
+  it('queries the targeted pane directly instead of taking the first row from list-panes output', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-pane-pid-',
+      (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  display-message)
+    case "$*" in
+      *"-p -t %2 #{pane_pid}"*)
+        echo "4242"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  list-panes)
+    printf "1111\\n4242\\n"
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        assert.equal(getWorkerPanePid('leader:0', 1, '%2'), 4242);
+
+        const tmuxLog = await readFile(logPath, 'utf-8');
+        assert.match(tmuxLog, /display-message -p -t %2 #\{pane_pid\}/);
+        assert.doesNotMatch(tmuxLog, /list-panes -t %2 -F #\{pane_pid\}/);
+      },
+    );
   });
 });
 
@@ -726,6 +767,9 @@ describe('buildWorkerStartupCommand', () => {
       assert.match(cmd, /OMX_TEAM_WORKER=alpha\/worker-2/);
       assert.match(cmd, /'\/bin\/zsh' -lc/);
       assert.match(cmd, /source ~\/\.zshrc/);
+      assert.match(cmd, /cd /);
+      assert.match(cmd, /Workspace\/oh-my-codex/);
+      assert.match(cmd, /\|\| exit 1;/);
       assert.match(cmd, /exec .*codex/);
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;
@@ -772,6 +816,31 @@ describe('buildWorkerStartupCommand', () => {
       );
       assert.match(cmd, /OMX_TEAM_STATE_ROOT=\/tmp\/leader\/\.omx\/state/);
       assert.match(cmd, /OMX_TEAM_LEADER_CWD=\/tmp\/leader/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('re-enters the requested worker cwd after shell startup files run', () => {
+    const prevShell = process.env.SHELL;
+    process.env.SHELL = '/bin/bash';
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const cmd = buildWorkerStartupCommand(
+        'alpha',
+        1,
+        [],
+        '/tmp/project with spaces',
+      );
+      assert.match(cmd, /source ~\/\.bashrc/);
+      assert.match(cmd, /cd /);
+      assert.match(cmd, /\/tmp\/project with spaces/);
+      assert.match(cmd, /\|\| exit 1;/);
+      assert.match(cmd, /exec .*codex/);
     } finally {
       if (typeof prevShell === 'string') process.env.SHELL = prevShell;
       else delete process.env.SHELL;
@@ -2704,6 +2773,13 @@ describe('enableMouseScrolling session scoping (issue #817)', () => {
       (tmuxLogPath) => `#!/bin/sh
 printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
+  show-options)
+    if [ "$2" = "-gv" ] && [ "$3" = "-t" ] && [ "$4" = "omx-team-x" ] && [ "$5" = "mode-style" ]; then
+      printf '%s\n' 'bg=yellow,fg=black,underscore'
+      exit 0
+    fi
+    exit 1
+    ;;
   set-option)
     if [ "$2" = "-t" ]; then
       exit 0
@@ -2720,8 +2796,58 @@ esac
         const tmuxLog = await readFile(logPath, 'utf-8');
         assert.match(tmuxLog, /set-option -t omx-team-x mouse on/);
         assert.match(tmuxLog, /set-option -t omx-team-x set-clipboard on/);
+        assert.match(
+          tmuxLog,
+          /set-option -t omx-team-x mode-style bg=yellow,fg=black,underscore,nounderscore,nodouble-underscore,nocurly-underscore,nodotted-underscore,nodashed-underscore/,
+        );
         assert.doesNotMatch(tmuxLog, /bind-key/);
         assert.doesNotMatch(tmuxLog, /terminal-overrides/);
+      },
+    );
+  });
+});
+
+describe('mitigateCopyModeUnderlineArtifacts', () => {
+  it('best-effort sanitizes copy-mode style options without requiring global tmux changes', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-sanitize-copy-style-',
+      (tmuxLogPath) => `#!/bin/sh
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  show-options)
+    if [ "$2" = "-gv" ] && [ "$3" = "-t" ] && [ "$4" = "omx-team-x" ] && [ "$5" = "mode-style" ]; then
+      printf '%s\n' 'bg=yellow,fg=black,underscore'
+      exit 0
+    fi
+    if [ "$2" = "-gv" ] && [ "$3" = "-t" ] && [ "$4" = "omx-team-x" ] && [ "$5" = "copy-mode-selection-style" ]; then
+      printf '%s\n' 'fg=white,bg=blue,curly-underscore'
+      exit 0
+    fi
+    exit 1
+    ;;
+  set-option)
+    if [ "$2" = "-t" ]; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        assert.equal(mitigateCopyModeUnderlineArtifacts('omx-team-x'), true);
+        const tmuxLog = await readFile(logPath, 'utf-8');
+        assert.match(
+          tmuxLog,
+          /set-option -t omx-team-x mode-style bg=yellow,fg=black,underscore,nounderscore,nodouble-underscore,nocurly-underscore,nodotted-underscore,nodashed-underscore/,
+        );
+        assert.match(
+          tmuxLog,
+          /set-option -t omx-team-x copy-mode-selection-style fg=white,bg=blue,curly-underscore,nounderscore,nodouble-underscore,nocurly-underscore,nodotted-underscore,nodashed-underscore/,
+        );
+        assert.doesNotMatch(tmuxLog, /set-option -g/);
       },
     );
   });

--- a/src/team/current-task-baseline.ts
+++ b/src/team/current-task-baseline.ts
@@ -1,0 +1,129 @@
+import { existsSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { omxStateDir } from '../utils/paths.js';
+
+export type CurrentTaskStatus = 'active' | 'merged' | 'closed' | 'superseded';
+
+export interface CurrentTaskBaselineEntry {
+  branch_name: string;
+  worktree_path: string | null;
+  base_ref?: string;
+  issue_number?: number;
+  pr_number?: number;
+  pr_url?: string;
+  status: CurrentTaskStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+interface CurrentTaskBaselineFile {
+  version: 1;
+  tasks: CurrentTaskBaselineEntry[];
+}
+
+export interface UpsertCurrentTaskBaselineInput {
+  branch_name: string;
+  worktree_path?: string | null;
+  base_ref?: string;
+  issue_number?: number;
+  pr_number?: number;
+  pr_url?: string;
+  status?: CurrentTaskStatus;
+}
+
+function baselinePath(repoRoot: string): string {
+  return join(omxStateDir(repoRoot), 'current-task-baseline.json');
+}
+
+function emptyBaseline(): CurrentTaskBaselineFile {
+  return { version: 1, tasks: [] };
+}
+
+export function readCurrentTaskBaseline(repoRoot: string): CurrentTaskBaselineFile {
+  const path = baselinePath(repoRoot);
+  if (!existsSync(path)) return emptyBaseline();
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as CurrentTaskBaselineFile;
+    if (parsed.version !== 1 || !Array.isArray(parsed.tasks)) return emptyBaseline();
+    return {
+      version: 1,
+      tasks: parsed.tasks
+        .filter((entry) => entry && typeof entry.branch_name === 'string' && typeof entry.status === 'string')
+        .map((entry) => ({
+          ...entry,
+          worktree_path: typeof entry.worktree_path === 'string' ? resolve(entry.worktree_path) : null,
+        })),
+    };
+  } catch {
+    return emptyBaseline();
+  }
+}
+
+function writeCurrentTaskBaseline(repoRoot: string, data: CurrentTaskBaselineFile): void {
+  const stateDir = omxStateDir(repoRoot);
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(baselinePath(repoRoot), JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+export function listActiveCurrentTasks(repoRoot: string): CurrentTaskBaselineEntry[] {
+  return readCurrentTaskBaseline(repoRoot).tasks.filter((entry) => entry.status === 'active');
+}
+
+export function findActiveCurrentTaskByBranch(repoRoot: string, branchName: string): CurrentTaskBaselineEntry | null {
+  const normalized = branchName.trim();
+  if (!normalized) return null;
+  return listActiveCurrentTasks(repoRoot).find((entry) => entry.branch_name === normalized) ?? null;
+}
+
+export function upsertCurrentTaskBaseline(
+  repoRoot: string,
+  input: UpsertCurrentTaskBaselineInput,
+): CurrentTaskBaselineEntry {
+  const branchName = input.branch_name.trim();
+  if (!branchName) {
+    throw new Error('current_task_baseline_branch_required');
+  }
+
+  const now = new Date().toISOString();
+  const current = readCurrentTaskBaseline(repoRoot);
+  const existing = current.tasks.find((entry) => entry.branch_name === branchName) ?? null;
+  const next: CurrentTaskBaselineEntry = {
+    branch_name: branchName,
+    worktree_path: typeof input.worktree_path === 'string'
+      ? resolve(input.worktree_path)
+      : input.worktree_path === null
+        ? null
+        : existing?.worktree_path ?? null,
+    base_ref: input.base_ref ?? existing?.base_ref,
+    issue_number: input.issue_number ?? existing?.issue_number,
+    pr_number: input.pr_number ?? existing?.pr_number,
+    pr_url: input.pr_url ?? existing?.pr_url,
+    status: input.status ?? existing?.status ?? 'active',
+    created_at: existing?.created_at ?? now,
+    updated_at: now,
+  };
+
+  const tasks = current.tasks.filter((entry) => entry.branch_name !== branchName);
+  tasks.push(next);
+  tasks.sort((a, b) => a.branch_name.localeCompare(b.branch_name));
+  writeCurrentTaskBaseline(repoRoot, { version: 1, tasks });
+  return next;
+}
+
+export function assertCurrentTaskBranchAvailable(
+  repoRoot: string,
+  branchName: string,
+  requestedWorktreePath: string,
+): void {
+  const current = findActiveCurrentTaskByBranch(repoRoot, branchName);
+  if (!current) return;
+
+  const requested = resolve(requestedWorktreePath);
+  if (!current.worktree_path || current.worktree_path !== requested) {
+    throw new Error(
+      `current_task_branch_guard:${branchName}:${current.worktree_path ?? 'unknown_worktree'}`,
+    );
+  }
+}

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1210,6 +1210,7 @@ const TEAM_LEADER_CWD_ENV = 'OMX_TEAM_LEADER_CWD';
 const WORKTREE_TRIGGER_STATE_ROOT = '$OMX_TEAM_STATE_ROOT';
 const STARTUP_EVIDENCE_TIMEOUT_MS = 2_000;
 const STARTUP_EVIDENCE_POLL_MS = 100;
+const STARTUP_EVIDENCE_LAUNCH_TIMEOUT_MS = 5_000;
 
 interface PromptWorkerHandle {
   child: ChildProcessByStdio<Writable, null, null>;
@@ -1232,6 +1233,18 @@ function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
   const parsed = Number.parseInt(String(raw ?? ''), 10);
   if (Number.isFinite(parsed) && parsed >= 5_000) return parsed;
   return 45_000;
+}
+
+function resolveWorkerStartupEvidenceTimeoutMs(
+  env: NodeJS.ProcessEnv,
+  workerReadyTimeoutMs: number,
+): number {
+  const raw = Number.parseInt(String(env.OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS ?? ''), 10);
+  if (Number.isFinite(raw) && raw >= 500) return raw;
+  return Math.max(
+    STARTUP_EVIDENCE_TIMEOUT_MS,
+    Math.min(workerReadyTimeoutMs, STARTUP_EVIDENCE_LAUNCH_TIMEOUT_MS),
+  );
 }
 
 function parseTeamWorkerContext(raw: string | undefined): { teamName: string; workerName: string } | null {
@@ -1883,6 +1896,10 @@ export async function startTeam(
   });
   const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, sharedWorkerLaunchArgs, process.env);
   const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(process.env);
+  const workerStartupEvidenceTimeoutMs = resolveWorkerStartupEvidenceTimeoutMs(
+    process.env,
+    workerReadyTimeoutMs,
+  );
   const skipWorkerReadyWait = shouldSkipWorkerReadyWait(process.env);
 
   try {
@@ -2181,6 +2198,7 @@ export async function startTeam(
             dispatchPolicy,
             inboxCorrelationKey: `startup:${workerName}`,
             requireWorkerStartupEvidence: true,
+            startupEvidenceTimeoutMs: workerStartupEvidenceTimeoutMs,
           });
           if (dispatchOutcome.ok) break;
           if (attempt < maxStartupDispatchRetries) {
@@ -3367,6 +3385,7 @@ async function dispatchCriticalInboxInstruction(params: {
   dispatchPolicy: TeamPolicy;
   inboxCorrelationKey: string;
   requireWorkerStartupEvidence?: boolean;
+  startupEvidenceTimeoutMs?: number;
 }): Promise<DispatchOutcome> {
   const {
     teamName,
@@ -3382,6 +3401,7 @@ async function dispatchCriticalInboxInstruction(params: {
     dispatchPolicy,
     inboxCorrelationKey,
     requireWorkerStartupEvidence,
+    startupEvidenceTimeoutMs,
   } = params;
 
   if (config.worker_launch_mode === 'prompt') {
@@ -3454,6 +3474,7 @@ async function dispatchCriticalInboxInstruction(params: {
       workerName,
       workerCli,
       cwd,
+      timeoutMs: startupEvidenceTimeoutMs,
     });
     if (startupEvidence !== 'none') {
       return {
@@ -3467,6 +3488,30 @@ async function dispatchCriticalInboxInstruction(params: {
   if (receipt?.status === 'failed') {
     const fallback = await notifyWorkerOutcome(config, workerIndex, triggerMessage, paneId);
     if (fallback.ok) {
+      const fallbackStartupEvidence = await waitForRequiredStartupEvidenceAfterDirectFallback({
+        requireWorkerStartupEvidence,
+        workerCli,
+        teamName,
+        workerName,
+        cwd,
+        timeoutMs: startupEvidenceTimeoutMs,
+      });
+      if (requiresObservedStartupEvidence && fallbackStartupEvidence === 'none') {
+        await transitionDispatchRequest(
+          teamName,
+          queued.request_id,
+          'failed',
+          'failed',
+          { last_reason: `${workerCli}_startup_no_evidence_after_fallback:${fallback.reason}` },
+          cwd,
+        ).catch(() => {});
+        return {
+          ok: false,
+          transport: fallback.transport,
+          reason: `${workerCli}_startup_no_evidence_after_fallback:${fallback.reason}`,
+          request_id: queued.request_id,
+        };
+      }
       await transitionDispatchRequest(
         teamName,
         queued.request_id,
@@ -3506,6 +3551,33 @@ async function dispatchCriticalInboxInstruction(params: {
     ? `${startupFallbackLabel}_fallback_failed:${fallback.reason}`
     : `fallback_attempted_but_unconfirmed:${fallback.reason}`;
   if (fallback.ok) {
+    const fallbackStartupEvidence = await waitForRequiredStartupEvidenceAfterDirectFallback({
+      requireWorkerStartupEvidence,
+      workerCli,
+      teamName,
+      workerName,
+      cwd,
+      timeoutMs: startupEvidenceTimeoutMs,
+    });
+    if (requiresObservedStartupEvidence && fallbackStartupEvidence === 'none') {
+      const current = await readDispatchRequest(teamName, queued.request_id, cwd);
+      if (current && current.status !== 'failed') {
+        await transitionDispatchRequest(
+          teamName,
+          queued.request_id,
+          current.status,
+          'failed',
+          { last_reason: `${workerCli}_startup_no_evidence_after_fallback:${fallback.reason}` },
+          cwd,
+        ).catch(() => {});
+      }
+      return {
+        ok: false,
+        transport: fallback.transport,
+        reason: `${workerCli}_startup_no_evidence_after_fallback:${fallback.reason}`,
+        request_id: queued.request_id,
+      };
+    }
     const marked = await markDispatchRequestNotified(
       teamName,
       queued.request_id,
@@ -3549,6 +3621,36 @@ async function dispatchCriticalInboxInstruction(params: {
     reason: fallbackFailureReason,
     request_id: queued.request_id,
   };
+}
+
+async function waitForRequiredStartupEvidenceAfterDirectFallback(params: {
+  requireWorkerStartupEvidence?: boolean;
+  workerCli?: TeamWorkerCli;
+  teamName: string;
+  workerName: string;
+  cwd: string;
+  timeoutMs?: number;
+}): Promise<WorkerStartupEvidence> {
+  const {
+    requireWorkerStartupEvidence,
+    workerCli,
+    teamName,
+    workerName,
+    cwd,
+    timeoutMs,
+  } = params;
+  const requiresObservedStartupEvidence = requireWorkerStartupEvidence === true
+    && (workerCli === 'claude' || workerCli === 'codex');
+  if (!requiresObservedStartupEvidence || !workerCli) {
+    return 'none';
+  }
+  return await waitForWorkerStartupEvidence({
+    teamName,
+    workerName,
+    workerCli,
+    cwd,
+    timeoutMs,
+  });
 }
 
 async function finalizeHookPreferredMailboxDispatch(params: {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1692,6 +1692,7 @@ function spawnPromptWorker(
   workerEnv: Record<string, string>,
   workerCli: 'codex' | 'claude' | 'gemini',
   initialPrompt?: string,
+  workerRole?: string,
 ): ChildProcessByStdio<Writable, null, null> {
   const processSpec = buildWorkerProcessLaunchSpec(
     teamName,
@@ -1701,6 +1702,7 @@ function spawnPromptWorker(
     workerEnv,
     workerCli,
     initialPrompt,
+    workerRole,
   );
   const child = spawn(
     processSpec.command,
@@ -2042,6 +2044,7 @@ export async function startTeam(
         initialPrompt: plan.initialPrompt,
         launchArgs: plan.workerLaunchArgs,
         workerCli: plan.workerCli,
+        workerRole: plan.workerRole,
       };
     });
 
@@ -2073,6 +2076,7 @@ export async function startTeam(
           startup.env || {},
           startup.workerCli || workerCliPlan[i - 1],
           startup.initialPrompt,
+          startup.workerRole,
         );
         if (config.workers[i - 1]) {
           config.workers[i - 1].pid = child.pid;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -21,6 +21,7 @@ import {
   sendToWorker,
   sendToWorkerStdin,
   isWorkerAlive,
+  isWorkerPaneOpen,
   getWorkerPanePid,
   killWorkerByPaneIdAsync,
   restoreStandaloneHudPane,
@@ -64,6 +65,7 @@ import {
   teamWriteMonitorSnapshot as writeMonitorSnapshot,
   teamReadPhase as readTeamPhaseState,
   teamWritePhase as writeTeamPhaseState,
+  teamWriteWorkerStatus as writeWorkerStatus,
   type TeamConfig,
   type WorkerInfo,
   type WorkerHeartbeat,
@@ -1223,9 +1225,18 @@ const previousModelInstructionsFileByTeam = new Map<string, string | undefined>(
 const PROMPT_WORKER_SIGTERM_WAIT_MS = 3_000;
 const PROMPT_WORKER_SIGKILL_WAIT_MS = 2_000;
 const PROMPT_WORKER_EXIT_POLL_MS = 100;
+const PROMPT_MODE_CODEX_UNSUPPORTED_REASON = 'prompt_mode_codex_requires_tty';
 
 function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
   return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
+}
+
+function assertPromptModeWorkerCliSupported(workerCliPlan: readonly TeamWorkerCli[]): void {
+  if (workerCliPlan.some((workerCli) => workerCli === 'codex')) {
+    throw new Error(
+      `${PROMPT_MODE_CODEX_UNSUPPORTED_REASON}: Codex prompt workers require a terminal; use interactive team mode or set OMX_TEAM_WORKER_CLI=claude/gemini for prompt-mode teammates.`,
+    );
+  }
 }
 
 function resolveWorkerReadyTimeoutMs(env: NodeJS.ProcessEnv): number {
@@ -1352,6 +1363,47 @@ export async function waitForClaudeStartupEvidence(params: {
 
 function shouldSkipWorkerReadyWait(env: NodeJS.ProcessEnv): boolean {
   return env.OMX_TEAM_SKIP_READY_WAIT === '1';
+}
+
+function isRecoverableInteractiveStartupReason(reason: string): boolean {
+  const normalized = reason.trim().toLowerCase();
+  return normalized.includes('startup_no_evidence')
+    || normalized.includes('fallback_attempted_but_unconfirmed')
+    || normalized.includes('ready_prompt_timeout');
+}
+
+async function recordRecoverableStartupIssue(params: {
+  teamName: string;
+  workerName: string;
+  taskIds: string[];
+  reason: string;
+  cwd: string;
+}): Promise<void> {
+  const { teamName, workerName, taskIds, reason, cwd } = params;
+  const updatedAt = new Date().toISOString();
+  await writeWorkerStatus(
+    teamName,
+    workerName,
+    {
+      state: 'unknown',
+      current_task_id: taskIds[0],
+      reason,
+      updated_at: updatedAt,
+    },
+    cwd,
+  ).catch(() => {});
+  await appendTeamEvent(
+    teamName,
+    {
+      type: 'worker_state_changed',
+      worker: workerName,
+      state: 'unknown',
+      prev_state: 'unknown',
+      task_id: taskIds[0],
+      reason,
+    },
+    cwd,
+  ).catch(() => {});
 }
 
 function setTeamModelInstructionsFile(teamName: string, filePath: string): void {
@@ -1895,6 +1947,9 @@ export async function startTeam(
     fallbackModel: resolveAgentDefaultModel(agentType, process.env.CODEX_HOME),
   });
   const workerCliPlan = resolveTeamWorkerCliPlan(workerCount, sharedWorkerLaunchArgs, process.env);
+  if (workerLaunchMode === 'prompt') {
+    assertPromptModeWorkerCliSupported(workerCliPlan);
+  }
   const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(process.env);
   const workerStartupEvidenceTimeoutMs = resolveWorkerStartupEvidenceTimeoutMs(
     process.env,
@@ -2067,6 +2122,55 @@ export async function startTeam(
 
     const workerPaneIds = Array.from({ length: workerCount }, () => undefined as string | undefined);
 
+    const materializeWorkerStartupState = async (
+      bootstrapPlan: typeof workerBootstrapPlans[number],
+      workerIndex: number,
+      paneId: string | undefined,
+    ): Promise<void> => {
+      const workerWorkspace = bootstrapPlan.workerWorkspace;
+      const identity: WorkerInfo = {
+        name: bootstrapPlan.workerName,
+        index: workerIndex,
+        role: bootstrapPlan.workerRole,
+        worker_cli: bootstrapPlan.workerCli,
+        assigned_tasks: bootstrapPlan.workerTasks.map((task) => task.id),
+        working_dir: workerWorkspace.cwd,
+        worktree_repo_root: workerWorkspace.worktreeRepoRoot,
+        worktree_path: workerWorkspace.worktreePath,
+        worktree_branch: workerWorkspace.worktreeBranch,
+        worktree_detached: workerWorkspace.worktreeDetached,
+        worktree_created: workerWorkspace.worktreeCreated,
+        team_state_root: teamStateRoot,
+      };
+
+      if (workerLaunchMode === 'interactive') {
+        const panePid = getWorkerPanePid(sessionName, workerIndex, paneId);
+        if (panePid) identity.pid = panePid;
+      } else if (config?.workers[workerIndex - 1]?.pid) {
+        identity.pid = config.workers[workerIndex - 1].pid;
+      }
+
+      if (paneId) identity.pane_id = paneId;
+
+      if (config?.workers[workerIndex - 1]) {
+        config.workers[workerIndex - 1].pid = identity.pid;
+        config.workers[workerIndex - 1].pane_id = paneId;
+        config.workers[workerIndex - 1].role = bootstrapPlan.workerRole;
+        config.workers[workerIndex - 1].worker_cli = bootstrapPlan.workerCli;
+        config.workers[workerIndex - 1].assigned_tasks = bootstrapPlan.workerTasks.map((task) => task.id);
+        config.workers[workerIndex - 1].working_dir = workerWorkspace.cwd;
+        config.workers[workerIndex - 1].worktree_repo_root = workerWorkspace.worktreeRepoRoot;
+        config.workers[workerIndex - 1].worktree_path = workerWorkspace.worktreePath;
+        config.workers[workerIndex - 1].worktree_branch = workerWorkspace.worktreeBranch;
+        config.workers[workerIndex - 1].worktree_detached = workerWorkspace.worktreeDetached;
+        config.workers[workerIndex - 1].worktree_created = workerWorkspace.worktreeCreated;
+        config.workers[workerIndex - 1].team_state_root = teamStateRoot;
+      }
+
+      await writeWorkerIdentity(sanitized, bootstrapPlan.workerName, identity, leaderCwd);
+      await writeWorkerInbox(sanitized, bootstrapPlan.workerName, bootstrapPlan.inbox, leaderCwd);
+    };
+
     // 6. Create worker runtime (interactive tmux panes or prompt-mode child processes)
     if (workerLaunchMode === 'interactive') {
       const createdSession = createTeamSession(sanitized, workerCount, leaderCwd, sharedWorkerLaunchArgs, workerStartups);
@@ -2100,6 +2204,16 @@ export async function startTeam(
         }
       }
     }
+
+    // Materialize durable startup state for every worker before any per-worker
+    // readiness wait or startup-evidence gate can block later workers.
+    for (let i = 1; i <= workerCount; i++) {
+      const bootstrapPlan = workerBootstrapPlans[i - 1];
+      if (!bootstrapPlan) {
+        throw new Error(`missing bootstrap plan for worker-${i}`);
+      }
+      await materializeWorkerStartupState(bootstrapPlan, i, workerPaneIds[i - 1]);
+    }
     await saveTeamConfig(config, leaderCwd);
 
     // 7. Wait for all workers to be ready (interactive mode), then bootstrap them
@@ -2110,66 +2224,35 @@ export async function startTeam(
       if (!bootstrapPlan) {
         throw new Error(`missing bootstrap plan for worker-${i}`);
       }
-      const { workerName, paneId, workerTasks, workerRole, inbox, trigger, triggerIntent, initialPrompt } = {
+      const { workerName, paneId, workerTasks, inbox, trigger, triggerIntent, initialPrompt } = {
         workerName: bootstrapPlan.workerName,
         paneId: workerPaneIds[i - 1],
         workerTasks: bootstrapPlan.workerTasks,
-        workerRole: bootstrapPlan.workerRole,
         inbox: bootstrapPlan.inbox,
         trigger: bootstrapPlan.trigger,
         triggerIntent: bootstrapPlan.triggerIntent,
         initialPrompt: bootstrapPlan.initialPrompt,
       };
-      const workerWorkspace = bootstrapPlan.workerWorkspace;
 
       if (workerTasks.map(t => t.role).filter(Boolean).length > 0 && new Set(workerTasks.map(t => t.role).filter(Boolean)).size > 1) {
         console.log(`[omx:team] ${workerName}: mixed task roles [${[...new Set(workerTasks.map(t => t.role).filter(Boolean))].join(', ')}], falling back to ${agentType}`);
       }
 
-      // Write worker identity
-      const identity: WorkerInfo = {
-        name: workerName,
-        index: i,
-        role: workerRole,
-        worker_cli: workerCliPlan[i - 1],
-        assigned_tasks: workerTasks.map(t => t.id),
-        working_dir: workerWorkspace.cwd,
-        worktree_repo_root: workerWorkspace.worktreeRepoRoot,
-        worktree_path: workerWorkspace.worktreePath,
-        worktree_branch: workerWorkspace.worktreeBranch,
-        worktree_detached: workerWorkspace.worktreeDetached,
-        worktree_created: workerWorkspace.worktreeCreated,
-        team_state_root: teamStateRoot,
-      };
-
-      // Get pane PID and store it (interactive mode) or process PID (prompt mode)
-      if (workerLaunchMode === 'interactive') {
-        const panePid = getWorkerPanePid(sessionName, i, paneId);
-        if (panePid) identity.pid = panePid;
-      } else if (config.workers[i - 1]?.pid) {
-        identity.pid = config.workers[i - 1].pid;
-      }
-      if (paneId) identity.pane_id = paneId;
-      if (config.workers[i - 1]) {
-        config.workers[i - 1].pid = identity.pid;
-        config.workers[i - 1].pane_id = paneId;
-        config.workers[i - 1].role = workerRole;
-        config.workers[i - 1].worker_cli = workerCliPlan[i - 1];
-        config.workers[i - 1].working_dir = workerWorkspace.cwd;
-        config.workers[i - 1].worktree_repo_root = workerWorkspace.worktreeRepoRoot;
-        config.workers[i - 1].worktree_path = workerWorkspace.worktreePath;
-        config.workers[i - 1].worktree_branch = workerWorkspace.worktreeBranch;
-        config.workers[i - 1].worktree_detached = workerWorkspace.worktreeDetached;
-        config.workers[i - 1].worktree_created = workerWorkspace.worktreeCreated;
-        config.workers[i - 1].team_state_root = teamStateRoot;
-      }
-
-      await writeWorkerIdentity(sanitized, workerName, identity, leaderCwd);
-
       // Wait for worker readiness
       if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt) {
         const ready = waitForWorkerReady(sessionName, i, workerReadyTimeoutMs, paneId);
         if (!ready) {
+          const workerAlive = isWorkerPaneOpen(sessionName, i, paneId);
+          if (workerAlive) {
+            await recordRecoverableStartupIssue({
+              teamName: sanitized,
+              workerName,
+              taskIds: workerTasks.map((task) => task.id),
+              reason: 'ready_prompt_timeout',
+              cwd: leaderCwd,
+            });
+            continue;
+          }
           throw new Error(`Worker ${workerName} did not become ready in tmux session ${sessionName}`);
         }
       }
@@ -2213,10 +2296,27 @@ export async function startTeam(
               sleepFractionalSeconds(startupRetryDelayS);
             }
           }
-        }
+      }
       }
       if (!dispatchOutcome.ok) {
-        throw new Error(`worker_notify_failed:${workerName}`);
+        const workerAlive = workerLaunchMode === 'prompt'
+          ? isPromptWorkerAlive(config, config.workers[i - 1]!)
+          : isWorkerPaneOpen(sessionName, i, paneId);
+        if (
+          workerLaunchMode === 'interactive'
+          && workerAlive
+          && isRecoverableInteractiveStartupReason(dispatchOutcome.reason)
+        ) {
+          await recordRecoverableStartupIssue({
+            teamName: sanitized,
+            workerName,
+            taskIds: workerTasks.map((task) => task.id),
+            reason: dispatchOutcome.reason,
+            cwd: leaderCwd,
+          });
+          continue;
+        }
+        throw new Error(`worker_notify_failed:${workerName}:${dispatchOutcome.reason}`);
       }
     }
     await saveTeamConfig(config, leaderCwd);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1226,13 +1226,18 @@ const PROMPT_WORKER_SIGTERM_WAIT_MS = 3_000;
 const PROMPT_WORKER_SIGKILL_WAIT_MS = 2_000;
 const PROMPT_WORKER_EXIT_POLL_MS = 100;
 const PROMPT_MODE_CODEX_UNSUPPORTED_REASON = 'prompt_mode_codex_requires_tty';
+// Test-only escape hatch for fake prompt workers that intentionally do not require a real TTY.
+const PROMPT_MODE_CODEX_TEST_ALLOW_ENV = 'OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT';
 
 function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
   return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
 }
 
 function assertPromptModeWorkerCliSupported(workerCliPlan: readonly TeamWorkerCli[]): void {
-  if (workerCliPlan.some((workerCli) => workerCli === 'codex')) {
+  if (
+    workerCliPlan.some((workerCli) => workerCli === 'codex')
+    && process.env[PROMPT_MODE_CODEX_TEST_ALLOW_ENV] !== '1'
+  ) {
     throw new Error(
       `${PROMPT_MODE_CODEX_UNSUPPORTED_REASON}: Codex prompt workers require a terminal; use interactive team mode or set OMX_TEAM_WORKER_CLI=claude/gemini for prompt-mode teammates.`,
     );

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3617,14 +3617,17 @@ async function dispatchCriticalInboxInstruction(params: {
           request_id: queued.request_id,
         };
       }
-      await transitionDispatchRequest(
-        teamName,
-        queued.request_id,
-        'pending',
-        'failed',
-        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
-        cwd,
-      ).catch(() => {});
+      const current = await readDispatchRequest(teamName, queued.request_id, cwd);
+      if (current) {
+        await transitionDispatchRequest(
+          teamName,
+          queued.request_id,
+          current.status,
+          'failed',
+          { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
+          cwd,
+        ).catch(() => {});
+      }
       return {
         ok: true,
         transport: fallback.transport,
@@ -3690,14 +3693,17 @@ async function dispatchCriticalInboxInstruction(params: {
       cwd,
     );
     if (!marked) {
-      await transitionDispatchRequest(
-        teamName,
-        queued.request_id,
-        'pending',
-        'failed',
-        { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
-        cwd,
-      ).catch(() => {});
+      const current = await readDispatchRequest(teamName, queued.request_id, cwd);
+      if (current) {
+        await transitionDispatchRequest(
+          teamName,
+          queued.request_id,
+          current.status,
+          'failed',
+          { last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
+          cwd,
+        ).catch(() => {});
+      }
     }
     return {
       ok: true,
@@ -3805,14 +3811,17 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   if (receipt?.status === 'failed') {
     if (fallback.ok) {
       await markMessageNotified(teamName, workerName, messageId, cwd).catch(() => false);
-      await transitionDispatchRequest(
-        teamName,
-        requestId,
-        'failed',
-        'failed',
-        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
-        cwd,
-      ).catch(() => null);
+      const current = await readDispatchRequest(teamName, requestId, cwd);
+      if (current) {
+        await transitionDispatchRequest(
+          teamName,
+          requestId,
+          current.status,
+          'failed',
+          { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
+          cwd,
+        ).catch(() => null);
+      }
       const outcome = {
         ok: true,
         transport: fallback.transport,
@@ -3869,14 +3878,17 @@ async function finalizeHookPreferredMailboxDispatch(params: {
       cwd,
     );
     if (!marked) {
-      await transitionDispatchRequest(
-        teamName,
-        requestId,
-        'failed',
-        'failed',
-        { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
-        cwd,
-      ).catch(() => {});
+      const current = await readDispatchRequest(teamName, requestId, cwd);
+      if (current) {
+        await transitionDispatchRequest(
+          teamName,
+          requestId,
+          current.status,
+          'failed',
+          { message_id: messageId, last_reason: `fallback_confirmed_after_failed_receipt:${fallback.reason}` },
+          cwd,
+        ).catch(() => {});
+      }
     }
     const outcome = {
       ok: true,

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -392,6 +392,8 @@ export async function scaleUp(
         workerCwd,
         extraEnv,
         workerCliPlan[i],
+        undefined,
+        workerRole,
       );
 
       // Find the right-most worker pane to split from, or fall back to leader pane.

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -2,6 +2,7 @@ import { appendFile, readFile, writeFile, mkdir, rm, rename, readdir } from 'fs/
 import { join, dirname, resolve, sep } from 'path';
 import { existsSync } from 'fs';
 import { randomUUID } from 'crypto';
+import { readUsableSessionState } from '../hooks/session.js';
 import { omxStateDir } from '../utils/paths.js';
 import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
@@ -531,17 +532,7 @@ function resolvePermissionsSnapshot(env: NodeJS.ProcessEnv): PermissionsSnapshot
 async function resolveLeaderSessionId(cwd: string, env: NodeJS.ProcessEnv): Promise<string> {
   const fromEnv = readEnvValue(env, ['OMX_SESSION_ID', 'CODEX_SESSION_ID', 'SESSION_ID']);
   if (fromEnv) return fromEnv;
-
-  const sessionPath = join(omxStateDir(cwd), 'session.json');
-  try {
-    if (!existsSync(sessionPath)) return '';
-    const raw = await readFile(sessionPath, 'utf8');
-    const parsed = JSON.parse(raw) as { session_id?: unknown };
-    if (typeof parsed.session_id === 'string' && parsed.session_id.trim() !== '') return parsed.session_id.trim();
-  } catch {
-    // best effort
-  }
-  return '';
+  return (await readUsableSessionState(cwd))?.session_id ?? '';
 }
 
 function normalizeTask(task: TeamTask): TeamTaskV2 {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -9,6 +9,7 @@ import {
   LONG_CONFIG_FLAG,
   MODEL_FLAG,
 } from '../cli/constants.js';
+import { getAgent } from '../agents/definitions.js';
 import {
   buildCapturePaneArgv as sharedBuildCapturePaneArgv,
   buildVisibleCapturePaneArgv as sharedBuildVisibleCapturePaneArgv,
@@ -603,12 +604,27 @@ export function resolveTeamWorkerCliPlan(
   });
 }
 
-export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: string[], initialPrompt?: string): string[] {
+function shouldGrantExecutionBypassForRole(workerRole?: string): boolean {
+  const normalizedRole = workerRole?.trim().toLowerCase();
+  if (!normalizedRole) return true;
+  const agent = getAgent(normalizedRole);
+  if (!agent) return true;
+  return agent.tools === 'execution';
+}
+
+export function translateWorkerLaunchArgsForCli(
+  workerCli: TeamWorkerCli,
+  args: string[],
+  initialPrompt?: string,
+  workerRole?: string,
+): string[] {
   if (workerCli === 'codex') return [...args];
   if (workerCli === 'gemini') {
     const model = extractModelOverride(args);
     const geminiModel = model && /gemini/i.test(model) ? model : null;
-    const translatedArgs = [GEMINI_APPROVAL_MODE_FLAG, GEMINI_APPROVAL_MODE_YOLO];
+    const translatedArgs = shouldGrantExecutionBypassForRole(workerRole)
+      ? [GEMINI_APPROVAL_MODE_FLAG, GEMINI_APPROVAL_MODE_YOLO]
+      : [];
     const trimmedPrompt = initialPrompt?.trim();
     if (trimmedPrompt) translatedArgs.push(GEMINI_PROMPT_INTERACTIVE_FLAG, trimmedPrompt);
     if (geminiModel) translatedArgs.push(MODEL_FLAG, geminiModel);
@@ -618,7 +634,7 @@ export function translateWorkerLaunchArgsForCli(workerCli: TeamWorkerCli, args: 
   // Claude workers must launch with exactly one permissions bypass flag.
   // All other launch args are dropped to avoid Codex-only flags and model/config overrides.
   void args;
-  return [CLAUDE_SKIP_PERMISSIONS_FLAG];
+  return shouldGrantExecutionBypassForRole(workerRole) ? [CLAUDE_SKIP_PERMISSIONS_FLAG] : [];
 }
 
 function commandExists(binary: string): boolean {
@@ -693,6 +709,7 @@ export function buildWorkerStartupCommand(
   extraEnv: Record<string, string> = {},
   workerCliOverride?: TeamWorkerCli,
   initialPrompt?: string,
+  workerRole?: string,
 ): string {
   const processSpec = buildWorkerProcessLaunchSpec(
     teamName,
@@ -702,6 +719,7 @@ export function buildWorkerStartupCommand(
     extraEnv,
     workerCliOverride,
     initialPrompt,
+    workerRole,
   );
   const resolvedLeaderNodePath = resolveLeaderNodePath();
   const leaderNodeDir = /[\\/]/.test(resolvedLeaderNodePath)
@@ -745,12 +763,15 @@ export function buildWorkerProcessLaunchSpec(
   extraEnv: Record<string, string> = {},
   workerCliOverride?: TeamWorkerCli,
   initialPrompt?: string,
+  workerRole?: string,
 ): WorkerProcessLaunchSpec {
   const effectiveEnv: NodeJS.ProcessEnv = { ...process.env, ...extraEnv };
   const fullLaunchArgs = resolveWorkerLaunchArgs(launchArgs, cwd, effectiveEnv);
   const workerCli = workerCliOverride ?? resolveTeamWorkerCli(fullLaunchArgs, effectiveEnv);
-  const cliLaunchArgs = translateWorkerLaunchArgsForCli(workerCli, fullLaunchArgs, initialPrompt);
-  const effectiveCliLaunchArgs = workerCli === 'codex' && !cliLaunchArgs.includes(CODEX_BYPASS_FLAG)
+  const cliLaunchArgs = translateWorkerLaunchArgsForCli(workerCli, fullLaunchArgs, initialPrompt, workerRole);
+  const effectiveCliLaunchArgs = workerCli === 'codex'
+    && shouldGrantExecutionBypassForRole(workerRole)
+    && !cliLaunchArgs.includes(CODEX_BYPASS_FLAG)
     ? [...cliLaunchArgs, CODEX_BYPASS_FLAG]
     : cliLaunchArgs;
   const workerCodexHomeOverride = typeof effectiveEnv.CODEX_HOME === 'string'
@@ -850,6 +871,7 @@ export function createTeamSession(
     initialPrompt?: string;
     launchArgs?: string[];
     workerCli?: TeamWorkerCli;
+    workerRole?: string;
   }> = [],
 ): TeamSession {
   if (!isTmuxAvailable()) {
@@ -915,6 +937,7 @@ export function createTeamSession(
         workerEnv,
         workerCliPlan[i - 1],
         startup.initialPrompt,
+        startup.workerRole,
       );
       // First split creates the right side from leader. Remaining splits stack on the right.
       const splitDirection = i === 1 ? '-h' : '-v';

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1588,6 +1588,19 @@ export function isWorkerAlive(sessionName: string, workerIndex: number, workerPa
   }
 }
 
+export function isWorkerPaneOpen(sessionName: string, workerIndex: number, workerPaneId?: string): boolean {
+  const result = runTmux([
+    'list-panes',
+    '-t', paneTarget(sessionName, workerIndex, workerPaneId),
+    '-F',
+    '#{pane_dead}',
+  ]);
+  if (!result.ok) return false;
+  const line = result.stdout.split('\n')[0]?.trim();
+  if (!line) return false;
+  return line !== '1';
+}
+
 // Kill a specific worker: send C-c, then C-d, then kill-pane if still alive.
 // leaderPaneId: when provided, the kill is skipped entirely if workerPaneId matches it.
 export async function killWorker(sessionName: string, workerIndex: number, workerPaneId?: string, leaderPaneId?: string): Promise<void> {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -61,6 +61,17 @@ const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
 const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
 const OMX_LEADER_NODE_PATH_ENV = 'OMX_LEADER_NODE_PATH';
 const OMX_LEADER_CLI_PATH_ENV = 'OMX_LEADER_CLI_PATH';
+const TMUX_NO_UNDERLINE_STYLE_FLAGS = [
+  'nounderscore',
+  'nodouble-underscore',
+  'nocurly-underscore',
+  'nodotted-underscore',
+  'nodashed-underscore',
+] as const;
+const TMUX_COPY_MODE_STYLE_OPTIONS = [
+  'mode-style',
+  'copy-mode-selection-style',
+] as const;
 
 export type TeamWorkerCli = 'codex' | 'claude' | 'gemini';
 type TeamWorkerCliMode = 'auto' | TeamWorkerCli;
@@ -276,6 +287,54 @@ async function isWorkerAliveAsync(sessionName: string, workerIndex: number, work
 
 function shellQuoteSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function appendNoUnderlineStyleFlags(style: string): string {
+  const normalized = style
+    .split(/[,\s]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+  const combined = [...normalized];
+  for (const flag of TMUX_NO_UNDERLINE_STYLE_FLAGS) {
+    if (!combined.includes(flag)) combined.push(flag);
+  }
+  return combined.join(',');
+}
+
+function sanitizeTmuxStyleOption(sessionTarget: string, optionName: string): boolean {
+  const shown = runTmux(['show-options', '-gv', '-t', sessionTarget, optionName]);
+  if (!shown.ok) return false;
+
+  const current = shown.stdout.trim();
+  if (current === '') return false;
+
+  const sanitized = appendNoUnderlineStyleFlags(current);
+  if (sanitized === current) return true;
+
+  const result = runTmux(['set-option', '-t', sessionTarget, optionName, sanitized]);
+  return result.ok;
+}
+
+/**
+ * Remove underline attributes from tmux copy-mode/session mode styling for an
+ * OMX-managed session. Some terminal/tmux combinations render underlined
+ * spaces as visible underscore glyphs during mouse selection/copy-mode.
+ *
+ * This keeps the user's existing colours/other attrs intact by appending only
+ * the explicit no-underline flags, and stays session-scoped so it does not
+ * mutate global tmux config or other sessions.
+ */
+export function mitigateCopyModeUnderlineArtifacts(sessionTarget: string): boolean {
+  const normalizedTarget = sessionTarget.trim();
+  if (normalizedTarget === '') return false;
+
+  let applied = false;
+  for (const optionName of TMUX_COPY_MODE_STYLE_OPTIONS) {
+    if (sanitizeTmuxStyleOption(normalizedTarget, optionName)) {
+      applied = true;
+    }
+  }
+  return applied;
 }
 
 function quotePowerShellArg(value: string): string {
@@ -745,11 +804,12 @@ export function buildWorkerStartupCommand(
   }
 
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
+  const targetCwd = shellQuoteSingle(translatePathForMsys(cwd));
   const pathPrefix = leaderNodeDir ? `export PATH='${leaderNodeDir}':$PATH; ` : '';
   const quotedArgs = processSpec.args.map(shellQuoteSingle).join(' ');
   const cliInvocation = quotedArgs.length > 0 ? `exec ${processSpec.command} ${quotedArgs}` : `exec ${processSpec.command}`;
   const rcPrefix = launchSpec.rcFile ? `if [ -f ${launchSpec.rcFile} ]; then source ${launchSpec.rcFile}; fi; ` : '';
-  const inner = `${rcPrefix}${pathPrefix}${cliInvocation}`;
+  const inner = `${rcPrefix}cd ${targetCwd} || exit 1; ${pathPrefix}${cliInvocation}`;
   const envParts = Object.entries(processSpec.env).map(([key, value]) => `${key}=${value}`);
 
   return `env ${envParts.map(shellQuoteSingle).join(' ')} ${shellQuoteSingle(launchSpec.shell)} -lc ${shellQuoteSingle(inner)}`;
@@ -1144,6 +1204,11 @@ export function enableMouseScrolling(sessionTarget: string): boolean {
   // Enable OSC 52 so copy-selection-and-cancel propagates selected text to
   // the terminal's clipboard without requiring xclip or pbcopy. (closes #206)
   runTmux(['set-option', '-t', sessionTarget, 'set-clipboard', 'on']);
+
+  // Mouse selection enters tmux copy-mode. Strip underline attrs from the
+  // session-scoped copy/mode styling so terminals that render underlined
+  // spaces as "_" do not leave stray underline artifacts behind. (issue #1448)
+  mitigateCopyModeUnderlineArtifacts(sessionTarget);
 
   return true;
 }
@@ -1547,7 +1612,7 @@ export function notifyLeaderStatus(sessionName: string, message: string): boolea
 
 // Get PID of the shell process in a worker's tmux pane
 export function getWorkerPanePid(sessionName: string, workerIndex: number, workerPaneId?: string): number | null {
-  const result = runTmux(['list-panes', '-t', paneTarget(sessionName, workerIndex, workerPaneId), '-F', '#{pane_pid}']);
+  const result = runTmux(['display-message', '-p', '-t', paneTarget(sessionName, workerIndex, workerPaneId), '#{pane_pid}']);
   if (!result.ok) return null;
 
   const firstLine = result.stdout.split('\n')[0]?.trim();

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -2,6 +2,10 @@ import { execFile as execFileCb, execFileSync, spawnSync } from 'child_process';
 import { existsSync, mkdirSync } from 'fs';
 import { basename, dirname, join, resolve } from 'path';
 import { promisify } from 'util';
+import {
+  assertCurrentTaskBranchAvailable,
+  upsertCurrentTaskBaseline,
+} from './current-task-baseline.js';
 
 const execFilePromise = promisify(execFileCb);
 
@@ -375,7 +379,7 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
       throw new Error(`worktree_dirty:${plan.worktreePath}`);
     }
 
-    return {
+    const reused = {
       enabled: true,
       repoRoot: plan.repoRoot,
       worktreePath: resolve(plan.worktreePath),
@@ -384,7 +388,18 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
       created: false,
       reused: true,
       createdBranch: false,
-    };
+    } satisfies EnsureWorktreeResult;
+
+    if (plan.branchName) {
+      upsertCurrentTaskBaseline(plan.repoRoot, {
+        branch_name: plan.branchName,
+        worktree_path: reused.worktreePath,
+        base_ref: plan.baseRef,
+        status: 'active',
+      });
+    }
+
+    return reused;
   }
 
   if (existsSync(plan.worktreePath)) {
@@ -393,6 +408,10 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
 
   if (plan.branchName && hasBranchInUse(allWorktrees, plan.branchName, plan.worktreePath)) {
     throw new Error(`branch_in_use:${plan.branchName}`);
+  }
+
+  if (plan.branchName) {
+    assertCurrentTaskBranchAvailable(plan.repoRoot, plan.branchName, plan.worktreePath);
   }
 
   mkdirSync(dirname(plan.worktreePath), { recursive: true });
@@ -421,7 +440,7 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
     throw new Error(stderr || `worktree_add_failed:${addArgs.join(' ')}`);
   }
 
-  return {
+  const ensured = {
     enabled: true,
     repoRoot: plan.repoRoot,
     worktreePath: resolve(plan.worktreePath),
@@ -430,7 +449,18 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
     created: true,
     reused: false,
     createdBranch: Boolean(plan.branchName && !branchAlreadyExisted),
-  };
+  } satisfies EnsureWorktreeResult;
+
+  if (plan.branchName) {
+    upsertCurrentTaskBaseline(plan.repoRoot, {
+      branch_name: plan.branchName,
+      worktree_path: ensured.worktreePath,
+      base_ref: plan.baseRef,
+      status: 'active',
+    });
+  }
+
+  return ensured;
 }
 
 export interface RollbackWorktreeOptions {

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -168,7 +168,7 @@ Rules:
 <invocation_conventions>
 - `$name` — invoke a workflow skill
 - `/skills` — browse available skills
-- `/prompts:name` — advanced specialist role surface when the task already needs a specific agent
+- Prefer skill invocation and keyword routing as the primary user-facing workflow surface
 </invocation_conventions>
 
 <model_routing>
@@ -191,7 +191,7 @@ Key roles:
 - `executor` — implementation and refactoring
 - `verifier` — completion evidence and validation
 
-Specialists remain available through advanced role surfaces such as `/prompts:*` when the task clearly benefits from them.
+Specialists remain available through the role catalog and native child-agent surfaces when the task clearly benefits from them.
 </agent_catalog>
 
 ---
@@ -208,7 +208,7 @@ The `deep-interview` skill is the Socratic deep interview workflow and includes 
 Runtime availability gate:
 - Treat `autopilot`, `ralph`, `ultrawork`, `ultraqa`, `team`/`swarm`, and `ecomode` as **OMX runtime workflows**, not generic prompt aliases.
 - Auto-activate those runtime workflows only when the current session is actually running under OMX CLI/runtime (for example, launched via `omx`, with OMX session overlay/runtime state available, or when the user explicitly asks to run `omx ...` in the shell).
-- In Codex App or plain Codex sessions without OMX runtime, do **not** treat those keywords alone as activation. Explain that they require OMX CLI runtime support, and continue with the nearest App-safe surface (`deep-interview`, `ralplan`, `plan`, `/prompts:*`, or native subagents) unless the user explicitly wants you to launch OMX from the shell.
+- In Codex App or plain Codex sessions without OMX runtime, do **not** treat those keywords alone as activation. Explain that they require OMX CLI runtime support, and continue with the nearest App-safe surface (`deep-interview`, `ralplan`, `plan`, or native subagents) unless the user explicitly wants you to launch OMX from the shell.
 
 | Keyword(s) | Skill | Action |
 |-------------|-------|--------|
@@ -234,7 +234,6 @@ Detection rules:
 - Explicit `$name` invocations run left-to-right and override non-explicit keyword resolution.
 - If multiple non-explicit keywords match, use the most specific match.
 - Runtime-only keywords must pass the runtime availability gate before activation.
-- If the user explicitly invokes `/prompts:<name>`, do not auto-activate keyword skills unless explicit `$name` tokens are also present.
 - The rest of the user message becomes the task description.
 
 Ralph / Ralplan execution gate:


### PR DESCRIPTION
## Summary
- pin Ralph Stop-hook blocking to the requested/current session
- avoid root and cross-session fallback when Stop already names a session
- add regression coverage for cross-session and stale session.json cases

## Testing
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js
- node --test --test-name-pattern='Ralph|root Ralph fallback|session-scoped Ralph state' dist/scripts/__tests__/codex-native-hook.test.js\n- npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts