### PR TITLE
Fix Stop-hook Ralph session scoping for issue #1461

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1755,7 +1755,7 @@ esac
     }
   });
 
-  it("returns Stop continuation output while Ralph is active", async () => {
+  it("returns Stop continuation output while Ralph is active without an explicit session pin", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1772,7 +1772,6 @@ esac
         {
           hook_event_name: "Stop",
           cwd,
-          session_id: "sess-stop",
         },
         { cwd },
       );
@@ -1855,6 +1854,33 @@ esac
     }
   });
 
+  it("does not block Stop from another session-scoped Ralph state when an explicit session_id has no active Ralph state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-explicit-session-ralph-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-other"), { recursive: true });
+      await writeJson(join(stateDir, "sessions", "sess-other", "ralph-state.json"), {
+        active: true,
+        current_phase: "starting",
+        session_id: "sess-other",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop from root Ralph fallback when the current session has no scoped Ralph state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-ralph-"));
     try {
@@ -1882,7 +1908,7 @@ esac
     }
   });
 
-  it("ignores mismatched session.json cwd and still blocks from active root Ralph fallback", async () => {
+  it("does not block Stop from root Ralph fallback when an explicit session_id is present and session.json points to another worktree", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-cwd-mismatch-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -1906,14 +1932,7 @@ esac
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.deepEqual(result.outputJson, {
-        decision: "block",
-        reason:
-          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
-        stopReason: "ralph_executing",
-        systemMessage:
-          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
-      });
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -202,7 +202,7 @@ async function readActiveRalphState(
     }
   }
 
-  if (currentOmxSessionId) return null;
+  if (sessionCandidates.length > 0) return null;
 
   const direct = await readJsonIfExists(join(stateDir, "ralph-state.json"));
   if (direct?.active === true && !TERMINAL_RALPH_PHASES.has(safeString(direct.current_phase).trim().toLowerCase())) {


### PR DESCRIPTION
## Summary
- stop treating explicit/requested Stop-hook session candidates as eligible for root or cross-session Ralph fallback
- make session-scoped Ralph lookup authoritative once Stop has a concrete session boundary
- add focused regression coverage for explicit-session isolation, including stale session pointer worktree mismatch cases

## Verification
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js
- node --test --test-name-pattern='Ralph|root Ralph fallback|session-scoped Ralph state' dist/scripts/__tests__/codex-native-hook.test.js
- npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts

Closes #1461
