### PR TITLE
Fix Windows split-pane shutdown leader-pane targeting

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -4326,6 +4326,83 @@ esac
     }
   });
 
+  it('shutdownTeam reconciles stale leader and hud pane ids before native Windows split-pane teardown', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-win32-stale-topology-'));
+    const teamName = 'team-win32-stale-topo';
+    try {
+      await withNativeWindowsPlatform(async () => {
+        await withMockTmuxFixture(
+          {
+            dirPrefix: 'omx-runtime-shutdown-win32-stale-topology-bin-',
+            tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%21\\tpwsh\\tpwsh\\n%%22\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%23\\tcodex\\tcodex\\n%%24\\tcodex\\tcodex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          },
+          async ({ tmuxLogPath }) => {
+            await initTeamState(teamName, 'shutdown win32 stale topology test', 'executor', 2, cwd);
+            const config = await readTeamConfig(teamName, cwd);
+            assert.ok(config);
+            if (!config) return;
+            config.tmux_session = 'leader:0';
+            config.leader_pane_id = '%11';
+            config.hud_pane_id = '%12';
+            config.workers[0]!.pane_id = '%23';
+            config.workers[1]!.pane_id = '%24';
+            await saveTeamConfig(config, cwd);
+
+            await shutdownTeam(teamName, cwd, { force: true });
+
+            const teamRoot = join(cwd, '.omx', 'state', 'team', teamName);
+            assert.equal(existsSync(teamRoot), false);
+            assert.equal(await readMonitorSnapshot(teamName, cwd), null);
+
+            const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+            assert.doesNotMatch(tmuxLog, /list-panes -t %21 -F #\{pane_pid\}/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %21/);
+            assert.match(tmuxLog, /kill-pane -t %22/);
+            assert.match(tmuxLog, /kill-pane -t %23/);
+            assert.match(tmuxLog, /kill-pane -t %24/);
+            assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %21 -d -P -F #\\{pane_id\\}`));
+            assert.match(tmuxLog, /select-pane -t %21/);
+          },
+        );
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('shutdownTeam skips prekill and keeps the leader pane alive on shared-session shutdown', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-shared-session-'));
     try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -30,6 +30,7 @@ import {
   destroyTeamSession,
   listPaneIds,
   listTeamSessions,
+  resolveSharedSessionShutdownTopology,
 } from './tmux-session.js';
 import {
   teamInit as initTeamState,
@@ -278,12 +279,20 @@ function collectShutdownPaneIds(params: {
   config: TeamConfig;
   livePaneIds?: string[];
   restoredStandaloneHudPaneId?: string | null;
+  leaderPaneId?: string | null;
+  hudPaneId?: string | null;
 }): string[] {
-  const { config, livePaneIds = [], restoredStandaloneHudPaneId = null } = params;
+  const {
+    config,
+    livePaneIds = [],
+    restoredStandaloneHudPaneId = null,
+    leaderPaneId = config.leader_pane_id,
+    hudPaneId = config.hud_pane_id,
+  } = params;
   const excludedPaneIds = new Set(
     [
-      config.leader_pane_id,
-      config.hud_pane_id,
+      leaderPaneId,
+      hudPaneId,
       restoredStandaloneHudPaneId,
     ].filter((paneId): paneId is string => typeof paneId === 'string' && paneId.trim().startsWith('%')),
   );
@@ -2987,8 +2996,20 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   const leaderPaneId = config.leader_pane_id;
   const hudPaneId = config.hud_pane_id;
   if (config.worker_launch_mode === 'interactive') {
-    const livePaneIds = listPaneIds(sessionName);
-    let shutdownPaneIds = collectShutdownPaneIds({ config, livePaneIds });
+    const sharedSessionTopology = sessionName.includes(':')
+      ? resolveSharedSessionShutdownTopology(sessionName, leaderPaneId)
+      : null;
+    const effectiveLeaderPaneId = sharedSessionTopology?.leaderPaneId ?? leaderPaneId;
+    const effectiveHudPaneId = sharedSessionTopology?.hudPaneIds.find((paneId) => paneId === hudPaneId)
+      ?? sharedSessionTopology?.hudPaneIds[0]
+      ?? hudPaneId;
+    const livePaneIds = sharedSessionTopology?.livePaneIds ?? listPaneIds(sessionName);
+    let shutdownPaneIds = collectShutdownPaneIds({
+      config,
+      livePaneIds,
+      leaderPaneId: effectiveLeaderPaneId,
+      hudPaneId: effectiveHudPaneId,
+    });
     if (shouldPrekillInteractiveShutdownProcessTrees(sessionName)) {
       const workerPanePids = shutdownPaneIds
         .map((paneId) => getWorkerPanePid(sessionName, 1, paneId))
@@ -3017,10 +3038,10 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       console.warn(`[team shutdown] ${sanitized}: ${resizeHookWarning}; continuing teardown`);
     }
     let restoredHudPaneId: string | null = null;
-    if (hudPaneId) {
-      await killWorkerByPaneIdAsync(hudPaneId, leaderPaneId ?? undefined);
+    if (effectiveHudPaneId) {
+      await killWorkerByPaneIdAsync(effectiveHudPaneId, effectiveLeaderPaneId ?? undefined);
       if (sessionName.includes(':')) {
-        restoredHudPaneId = restoreStandaloneHudPane(leaderPaneId, cwd);
+        restoredHudPaneId = restoreStandaloneHudPane(effectiveLeaderPaneId, cwd);
         if (!restoredHudPaneId) {
           console.warn(`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`);
         }
@@ -3030,10 +3051,12 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       config,
       livePaneIds: listPaneIds(sessionName),
       restoredStandaloneHudPaneId: restoredHudPaneId,
+      leaderPaneId: effectiveLeaderPaneId,
+      hudPaneId: effectiveHudPaneId,
     });
     await teardownWorkerPanes(shutdownPaneIds, {
-      leaderPaneId,
-      hudPaneId: restoredHudPaneId ?? hudPaneId,
+      leaderPaneId: effectiveLeaderPaneId,
+      hudPaneId: restoredHudPaneId ?? effectiveHudPaneId,
     });
 
     // 4. Destroy tmux session

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1710,6 +1710,12 @@ export interface PaneTeardownOptions {
   graceMs?: number;
 }
 
+export interface SharedSessionShutdownTopology {
+  livePaneIds: string[];
+  leaderPaneId: string | null;
+  hudPaneIds: string[];
+}
+
 function normalizePaneTarget(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
@@ -1747,6 +1753,39 @@ function normalizePaneTargets(
   }
 
   return { killablePaneIds, excluded };
+}
+
+export function resolveSharedSessionShutdownTopology(
+  sessionName: string,
+  preferredLeaderPaneId?: string | null,
+): SharedSessionShutdownTopology {
+  const panes = listPanes(sessionName);
+  const livePaneIds = panes
+    .map((pane) => normalizePaneTarget(pane.paneId))
+    .filter((paneId): paneId is string => Boolean(paneId));
+  const fallbackLeaderPaneId = normalizePaneTarget(preferredLeaderPaneId);
+  if (panes.length === 0) {
+    return {
+      livePaneIds,
+      leaderPaneId: fallbackLeaderPaneId,
+      hudPaneIds: [],
+    };
+  }
+
+  const resolvedLeaderPaneId = normalizePaneTarget(
+    chooseTeamLeaderPaneId(panes, fallbackLeaderPaneId ?? ''),
+  ) ?? fallbackLeaderPaneId;
+  const hudPaneIds = panes
+    .filter((pane) => pane.paneId !== resolvedLeaderPaneId)
+    .filter((pane) => isHudWatchPane(pane))
+    .map((pane) => pane.paneId)
+    .filter((paneId) => paneId.startsWith('%'));
+
+  return {
+    livePaneIds,
+    leaderPaneId: resolvedLeaderPaneId,
+    hudPaneIds,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- reconcile live shared-session leader and HUD panes before interactive shutdown teardown
- keep stale persisted pane ids from targeting the current leader pane during HUD restore and pane cleanup
- add native Windows split-pane regression coverage for stale pane metadata during shutdown

## Testing
- npm run build
- npx biome lint src/team/runtime.ts src/team/tmux-session.ts src/team/__tests__/runtime.test.ts
- node --test --test-name-pattern "native Windows split-pane|shared-session shutdown" dist/team/__tests__/runtime.test.js
- tsc --noEmit diagnostics on changed files

Closes #1353