### PR TITLE
Preserve planning state in mixed workflow prompt routing

### DIFF
--- a/docs/STATE_MODEL.md
+++ b/docs/STATE_MODEL.md
@@ -172,17 +172,17 @@ $ralplan $team $ralph ship this fix
 Expected result:
 
 1. `ralplan` is recognized as the planning source
-2. `team` is activated through the allowlisted forward handoff
-3. `ralph` is added as an allowed overlap with `team`
-4. final active skills are `team`, `ralph`
+2. simultaneous execution follow-ups are deferred instead of auto-starting
+3. final active skill remains `ralplan`
+4. deferred execution skills are surfaced in native-hook output for traceability
 5. native hook output should describe all explicit skills, not only the primary one
 
 Recommended message shape:
 
 - detected keywords summary
-- transition summary, e.g. `mode transiting: ralplan -> team + ralph`
-- final active skills summary
-- team runtime hint when `team` is among final active skills
+- deferred-skill summary, e.g. `planning preserved over simultaneous execution follow-up; deferred skills: team, ralph`
+- final active skill / initialized state summary
+- team runtime hint only when `team` is actually among the final active skills
 
 ## Audit fields for auto-complete
 

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -489,8 +489,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
-  it('supports multi-skill forward handoff from ralplan to team + ralph in one prompt', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-multi-handoff-'));
+  it('preserves the planning skill when planning and execution workflows are invoked together', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-planning-precedence-'));
     const stateDir = join(cwd, '.omx', 'state');
     try {
       await mkdir(stateDir, { recursive: true });
@@ -503,12 +503,37 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
 
       assert.equal(result?.transition_error, undefined);
-      assert.equal(result?.transition_message, 'mode transiting: ralplan -> team');
-      assert.equal(result?.skill, 'team');
-      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['team', 'ralph']);
-      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-multi', 'ralplan-state.json')), false);
-      assert.equal(existsSync(join(stateDir, 'team-state.json')), true);
-      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-multi', 'ralph-state.json')), true);
+      assert.equal(result?.transition_message, undefined);
+      assert.equal(result?.skill, 'ralplan');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['ralplan']);
+      assert.deepEqual(result?.deferred_skills, ['team', 'ralph']);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-multi', 'ralplan-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'team-state.json')), false);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-multi', 'ralph-state.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('lets planning win even when execution appears first in the contiguous skill block', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-planning-beats-execution-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralph $ralplan continue',
+        sessionId: 'sess-priority',
+        nowIso: '2026-04-10T00:00:00.000Z',
+      });
+
+      assert.equal(result?.transition_error, undefined);
+      assert.equal(result?.skill, 'ralplan');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['ralplan']);
+      assert.deepEqual(result?.deferred_skills, ['ralph']);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-priority', 'ralplan-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-priority', 'ralph-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -27,6 +27,7 @@ import {
   buildWorkflowTransitionError,
   evaluateWorkflowTransition,
   isTrackedWorkflowMode,
+  type TrackedWorkflowMode,
 } from '../state/workflow-transition.js';
 import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
 
@@ -72,6 +73,7 @@ export interface SkillActiveState {
   transition_message?: string;
   transition_messages?: string[];
   requested_skills?: string[];
+  deferred_skills?: string[];
   [key: string]: unknown;
 }
 
@@ -96,6 +98,19 @@ interface StatefulSkillSeedConfig {
   includeIteration?: boolean;
   scope?: 'session' | 'root';
 }
+
+const PLANNING_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
+  'deep-interview',
+  'ralplan',
+]);
+
+const EXECUTION_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
+  'autopilot',
+  'ralph',
+  'team',
+  'ultrawork',
+  'ultraqa',
+]);
 
 const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedConfig> = {
   'deep-interview': { mode: 'deep-interview', initialPhase: 'intent-first' },
@@ -454,6 +469,26 @@ export function detectPrimaryKeyword(text: string): KeywordMatch | null {
   return matches.length > 0 ? matches[0] : null;
 }
 
+function resolveRequestedWorkflowSkills(requestedWorkflowSkills: TrackedWorkflowMode[]): {
+  requestedSkills: TrackedWorkflowMode[];
+  deferredSkills: TrackedWorkflowMode[];
+} {
+  const firstPlanningSkill = requestedWorkflowSkills.find((skill) => PLANNING_LIKE_WORKFLOW_SKILLS.has(skill));
+  const hasExecutionSkill = requestedWorkflowSkills.some((skill) => EXECUTION_LIKE_WORKFLOW_SKILLS.has(skill));
+
+  if (!firstPlanningSkill || !hasExecutionSkill) {
+    return {
+      requestedSkills: requestedWorkflowSkills,
+      deferredSkills: [],
+    };
+  }
+
+  return {
+    requestedSkills: [firstPlanningSkill],
+    deferredSkills: requestedWorkflowSkills.filter((skill) => skill !== firstPlanningSkill),
+  };
+}
+
 export async function recordSkillActivation(input: RecordSkillActivationInput): Promise<SkillActiveState | null> {
   const match = detectPrimaryKeyword(input.text);
   if (!match) return null;
@@ -522,7 +557,9 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     const workflowMatches = extractExplicitSkillInvocations(input.text)
       .map((entry) => entry.skill)
       .filter(isTrackedWorkflowMode);
-    const requestedWorkflowSkills = workflowMatches.length > 0 ? workflowMatches : [match.skill];
+    const { requestedSkills: requestedWorkflowSkills, deferredSkills } = resolveRequestedWorkflowSkills(
+      workflowMatches.length > 0 ? workflowMatches : [match.skill],
+    );
 
     let nextWorkflowEntries = previousWorkflowEntries.map((entry) => ({ ...entry }));
     const transitionMessages: string[] = [];
@@ -625,6 +662,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       ...(transitionMessages[0] ? { transition_message: transitionMessages[0] } : {}),
       ...(transitionMessages.length > 0 ? { transition_messages: [...new Set(transitionMessages)] } : {}),
       ...(requestedWorkflowSkills.length > 1 ? { requested_skills: requestedWorkflowSkills } : {}),
+      ...(deferredSkills.length > 0 ? { deferred_skills: deferredSkills } : {}),
       ...(deepInterviewInputLock ? { input_lock: deepInterviewInputLock } : {}),
     };
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -452,8 +452,8 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("surfaces multi-skill prompt-submit output for ralplan -> team + ralph", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-transition-multi-"));
+  it("keeps the planning skill active when planning and execution workflows are invoked together", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-planning-precedence-"));
     try {
       await mkdir(join(cwd, ".omx", "state"), { recursive: true });
 
@@ -475,9 +475,10 @@ describe("codex native hook dispatch", () => {
       assert.match(message, /\$ralplan" -> ralplan/);
       assert.match(message, /\$team" -> team/);
       assert.match(message, /\$ralph" -> ralph/);
-      assert.match(message, /mode transiting: ralplan -> team \+ ralph/);
-      assert.match(message, /active skills: team, ralph\./);
-      assert.match(message, /Use the durable OMX team runtime via `omx team \.\.\.`/);
+      assert.doesNotMatch(message, /mode transiting:/);
+      assert.match(message, /planning preserved over simultaneous execution follow-up; deferred skills: team, ralph\./);
+      assert.match(message, /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-multi-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.doesNotMatch(message, /Use the durable OMX team runtime via `omx team \.\.\.`/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -439,14 +439,16 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
   const matches = detectKeywords(prompt);
   const match = detectPrimaryKeyword(prompt);
   if (!match) return null;
-  const requestedSkills = matches.map((entry) => entry.skill);
   const detectedKeywordMessage = matches.length > 1
     ? `OMX native UserPromptSubmit detected workflow keywords ${matches.map((entry) => `"${entry.keyword}" -> ${entry.skill}`).join(", ")}.`
     : `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`;
   const activeSkills = Array.isArray(skillState?.active_skills)
     ? skillState.active_skills.map((entry) => entry.skill)
     : [];
-  const teamDetected = activeSkills.includes("team") || requestedSkills.includes("team");
+  const deferredSkills = Array.isArray(skillState?.deferred_skills)
+    ? skillState.deferred_skills
+    : [];
+  const teamDetected = activeSkills.includes("team");
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
     if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
@@ -468,6 +470,9 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
       detectedKeywordMessage,
       combinedTransitionMessage,
       activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
+      deferredSkills.length > 0
+        ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
+        : null,
       skillState.initialized_mode && skillState.initialized_state_path
         ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
         : null,
@@ -486,6 +491,9 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
     return [
       detectedKeywordMessage,
       activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
+      deferredSkills.length > 0
+        ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
+        : null,
       initializedStateMessage,
       "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
       "If you need help, run `omx team --help`.",
@@ -497,6 +505,9 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
     return [
       detectedKeywordMessage,
       activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
+      deferredSkills.length > 0
+        ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
+        : null,
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].join(" ");


### PR DESCRIPTION
## Summary

Prompt-submit mixed workflow invocations were letting execution skills supersede planning skills in the same contiguous `$skill` block. This caused `ralph`/`team` state to initialize immediately and suppressed the still-required planning state. This PR makes planning authoritative in mixed planning+execution prompts so the planning workflow remains active and execution follow-ups are deferred.

## Changes

- keep the first planning workflow active when a contiguous `$skill` block mixes planning and execution modes
- record deferred execution skills instead of seeding same-turn execution state
- update native UserPromptSubmit messaging to explain deferred follow-up execution
- refresh regression coverage for mixed invocation ordering and native-hook output
- update state-model docs to describe the new planning-precedence contract

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npm run lint -- src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts docs/STATE_MODEL.md`
- [x] `node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- [x] LSP diagnostics on affected files

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
