### PR TITLE
Preserve recent-bug regression coverage without shell-drift flakes

### DIFF
--- a/docs/qa/recent-bug-regression-hardening-2026-04-11.md
+++ b/docs/qa/recent-bug-regression-hardening-2026-04-11.md
@@ -1,0 +1,21 @@
+# Recent bug regression hardening — 2026-04-11
+
+Focused regression additions for the compiled recent-bug suite on this branch:
+
+1. **Planning-precedence follow-ups** — keeps approved short `ralph` follow-ups from being re-gated back into `ralplan` after planning artifacts already exist.
+2. **Stop-hook stale-root vs current-session** — treats an explicitly inactive session-scoped deep-interview mode state as authoritative over an active root fallback, so auto-nudge is not suppressed by stale root state.
+3. **Detached tmux launch shell drift fallback** — confirms detached tmux launch preserves the requested cwd when an unsupported `SHELL` value forces OMX to fall back away from rc-driven cwd drift.
+4. **Team startup worker-state evidence** — accepts malformed external worker status inputs without breaking the hardening-e2e coverage, and accepts `blocked` worker status as real startup progress before a worker has persisted `current_task_id`.
+
+Covered files:
+
+- `src/hooks/__tests__/keyword-detector.test.ts`
+- `src/scripts/__tests__/codex-native-hook.test.ts`
+- `src/cli/__tests__/launch-fallback.test.ts`
+- `src/team/__tests__/runtime.test.ts`
+
+Verification target:
+
+- `npm run build`
+- `node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/launch-fallback.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/hardening-e2e.test.js`
+- `npm run test:recent-bug-regressions:compiled`

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test:explore": "cargo test -p omx-explore-harness && node --test dist/cli/__tests__/explore.test.js dist/hooks/__tests__/explore-routing.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js",
     "test:team:cross-rebase-smoke": "npm run build && node --test dist/team/__tests__/cross-rebase-smoke.test.js",
     "test:team:cross-rebase-smoke:compiled": "node --test dist/team/__tests__/cross-rebase-smoke.test.js",
+    "test:recent-bug-regressions": "npm run build && npm run test:recent-bug-regressions:compiled",
+    "test:recent-bug-regressions:compiled": "node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/launch-fallback.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/hardening-e2e.test.js",
     "test:node": "node dist/scripts/run-test-files.js dist",
     "test:node:cross-platform": "npm run test:node",
     "test": "npm run build && npm run test:node && node dist/scripts/generate-catalog-docs.js --check",

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -164,4 +164,200 @@ exit 0
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('preserves the requested cwd through detached tmux launch when an unsupported SHELL value falls back away from rc-driven cwd drift', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-cwd-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const fakeTmuxPath = join(fakeBin, 'tmux');
+      const tmuxLogPath = join(wd, 'tmux.log');
+      const codexLogPath = join(wd, 'codex.log');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(home, '.profile'), 'cd ..\n');
+      await writeFile(join(home, '.zshrc'), 'cd ..\n');
+      await writeFile(join(home, '.bashrc'), 'cd ..\n');
+      await writeFile(
+        fakeCodexPath,
+        `#!/bin/sh
+printf 'codex:%s\\n' "$*" >> "${codexLogPath}"
+printf 'codex-pwd:%s\\n' "$(pwd)" >> "${codexLogPath}"
+exit 0
+`,
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+      await writeFile(
+        fakeTmuxPath,
+        `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+case "$cmd" in
+  -V)
+    printf 'tmux 3.4\\n'
+    exit 0
+    ;;
+  new-session)
+    for last; do :; done
+    if [ -n "\${last:-}" ]; then
+      /bin/sh -c "$last"
+    fi
+    printf 'leader-pane\\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$1" = '-p' ] && [ "$2" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\\n'
+    else
+      printf '0\\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    printf 'off\\n'
+    exit 0
+    ;;
+  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane|select-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        ['--madmax', '--tmux'],
+        {
+          HOME: home,
+          SHELL: '/definitely/missing-shell',
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const codexLog = await readFile(codexLogPath, 'utf-8');
+      assert.match(codexLog, /codex:.*--dangerously-bypass-approvals-and-sandbox/);
+      assert.match(codexLog, new RegExp(`codex-pwd:${wd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to /bin/sh for detached tmux launch when SHELL drifts to an unsupported path', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-shell-fallback-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const fakeTmuxPath = join(fakeBin, 'tmux');
+      const tmuxLogPath = join(wd, 'tmux.log');
+      const codexLogPath = join(wd, 'codex.log');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(home, '.profile'), 'cd ..\n');
+      await writeFile(
+        fakeCodexPath,
+        `#!/bin/sh
+printf 'codex:%s\\n' "$*" >> "${codexLogPath}"
+printf 'codex-pwd:%s\\n' "$(pwd)" >> "${codexLogPath}"
+exit 0
+`,
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+      await writeFile(
+        fakeTmuxPath,
+        `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+case "$cmd" in
+  -V)
+    printf 'tmux 3.4\\n'
+    exit 0
+    ;;
+  new-session)
+    for last; do :; done
+    if [ -n "\${last:-}" ]; then
+      /bin/sh -c "$last"
+    fi
+    printf 'leader-pane\\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$1" = '-p' ] && [ "$2" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\\n'
+    else
+      printf '0\\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    printf 'off\\n'
+    exit 0
+    ;;
+  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane|select-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        ['--madmax', '--tmux'],
+        {
+          HOME: home,
+          SHELL: '/bin/not-a-real-shell',
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      const codexLog = await readFile(codexLogPath, 'utf-8');
+      assert.match(tmuxLog, /\/bin\/sh/);
+      assert.doesNotMatch(tmuxLog, /not-a-real-shell/);
+      assert.match(codexLog, /codex:.*--dangerously-bypass-approvals-and-sandbox/);
+      assert.match(codexLog, new RegExp(`codex-pwd:${wd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -607,6 +607,51 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('preserves active team root state when planning follow-up defers a simultaneous $team re-entry', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-planning-followup-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'team',
+          current_phase: 'team-verify',
+          started_at: '2026-04-08T00:00:00.000Z',
+          updated_at: '2026-04-08T00:05:00.000Z',
+          team_name: 'review-team',
+          session_id: 'sess-team-root',
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan $team tighten the approved execution handoff',
+        sessionId: 'sess-team-followup',
+        nowIso: '2026-04-10T00:15:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result?.skill, 'ralplan');
+      assert.equal(result?.initialized_mode, 'ralplan');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['ralplan']);
+      assert.deepEqual(result?.deferred_skills, ['team']);
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
+      ) as { mode: string; active: boolean; current_phase: string; team_name?: string; session_id?: string };
+      assert.equal(modeState.mode, 'team');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'team-verify');
+      assert.equal(modeState.team_name, 'review-team');
+      assert.equal(modeState.session_id, 'sess-team-root');
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-team-followup', 'team-state.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves root team state when $ralph is activated for the current session', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-team-ralph-'));
     const stateDir = join(cwd, '.omx', 'state');
@@ -1115,6 +1160,25 @@ describe('applyRalplanGate', () => {
       const result = applyRalplanGate(['team'], 'team으로 해줘', { cwd });
       assert.equal(result.gateApplied, false);
       assert.deepEqual(result.keywords, ['team']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not re-enter ralplan for a short approved ralph follow-up', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-gate-followup-ralph-'));
+    try {
+      const plansDir = join(cwd, '.omx', 'plans');
+      await mkdir(plansDir, { recursive: true });
+      await writeFile(
+        join(plansDir, 'prd-issue-832.md'),
+        '# Approved plan\n\nLaunch hint: omx ralph "Execute approved issue 832 plan"\n',
+      );
+      await writeFile(join(plansDir, 'test-spec-issue-832.md'), '# Test spec\n');
+
+      const result = applyRalplanGate(['ralph'], 'ralph please', { cwd, priorSkill: 'ralplan' });
+      assert.equal(result.gateApplied, false);
+      assert.deepEqual(result.keywords, ['ralph']);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1909,6 +1909,39 @@ esac
     }
   });
 
+  it("does not block Stop when the current session Ralph state is cancelled even if stale root fallback remains", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-cancelled-session-ralph-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current", cwd });
+      await writeJson(join(stateDir, "sessions", "sess-current", "ralph-state.json"), {
+        active: false,
+        current_phase: "cancelled",
+        completed_at: "2026-04-10T23:30:38.000Z",
+        session_id: "sess-current",
+      });
+      await writeJson(join(stateDir, "ralph-state.json"), {
+        active: true,
+        current_phase: "starting",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop from root Ralph fallback when an explicit session_id is present and session.json points to another worktree", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-cwd-mismatch-"));
     try {
@@ -2324,6 +2357,48 @@ esac
     }
   });
 
+  it("does not suppress native auto-nudge from active root deep-interview state when the current scoped mode state is explicitly inactive", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-inactive-scoped-mode-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-auto-inactive-mode"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-auto-inactive-mode" });
+      await writeJson(join(stateDir, "sessions", "sess-stop-auto-inactive-mode", "deep-interview-state.json"), {
+        active: false,
+        mode: "deep-interview",
+        current_phase: "completed",
+      });
+      await writeJson(join(stateDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-inactive-mode",
+          thread_id: "thread-stop-auto-inactive-mode",
+          turn_id: "turn-stop-auto-inactive-mode-1",
+          last_assistant_message: "Keep going and finish the cleanup.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("re-fires team Stop output for a later fresh Stop reply while the team is still active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-refire-"));
     try {
@@ -2409,6 +2484,61 @@ esac
 
       assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers the current session team state over a stale root team fallback during Stop", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-current-session-team-preferred-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current" });
+      await writeJson(join(stateDir, "sessions", "sess-current", "team-state.json"), {
+        active: true,
+        current_phase: "starting",
+        team_name: "current-team",
+        session_id: "sess-current",
+      });
+      await writeJson(join(stateDir, "team", "current-team", "phase.json"), {
+        current_phase: "team-verify",
+        max_fix_attempts: 3,
+        current_fix_attempt: 1,
+        transitions: [],
+        updated_at: new Date().toISOString(),
+      });
+      await writeJson(join(stateDir, "team-state.json"), {
+        active: true,
+        current_phase: "starting",
+        team_name: "stale-root-team",
+        session_id: "sess-other",
+      });
+      await writeJson(join(stateDir, "team", "stale-root-team", "phase.json"), {
+        current_phase: "team-exec",
+        max_fix_attempts: 3,
+        current_fix_attempt: 0,
+        transitions: [],
+        updated_at: new Date().toISOString(),
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          `OMX team pipeline is still active (current-team) at phase team-verify; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
+        stopReason: "team_team-verify",
+        systemMessage: "OMX team pipeline is still active at phase team-verify.",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/hardening-e2e.test.ts
+++ b/src/team/__tests__/hardening-e2e.test.ts
@@ -83,4 +83,30 @@ describe('team hardening e2e', () => {
       await rm(repo, { recursive: true, force: true });
     }
   });
+
+  it('tolerates malformed worker status from an external team state root', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-hardening-worker-state-'));
+    const sharedRoot = join(cwd, 'shared-state');
+    try {
+      process.env.OMX_TEAM_STATE_ROOT = sharedRoot;
+      await initTeamState('team-hardening-worker-state', 'worker status corruption smoke', 'executor', 1, cwd);
+
+      const statusPath = join(
+        sharedRoot,
+        'team',
+        'team-hardening-worker-state',
+        'workers',
+        'worker-1',
+        'status.json',
+      );
+      await writeFile(statusPath, '{not valid json', 'utf-8');
+
+      const snapshot = await monitorTeam('team-hardening-worker-state', cwd);
+      assert.ok(snapshot);
+      assert.equal(snapshot?.workers[0]?.name, 'worker-1');
+      assert.equal(snapshot?.workers[0]?.status.state, 'unknown');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -660,6 +660,33 @@ describe('runtime', () => {
     }
   });
 
+  it('waitForWorkerStartupEvidence treats blocked worker status as settled progress even without a claimed task id', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-blocked-startup-'));
+    try {
+      await initTeamState('codex-blocked-startup', 'blocked startup evidence test', 'executor', 1, cwd);
+
+      await writeAtomic(
+        join(cwd, '.omx', 'state', 'team', 'codex-blocked-startup', 'workers', 'worker-1', 'status.json'),
+        JSON.stringify({
+          state: 'blocked',
+          reason: 'waiting on shared file',
+          updated_at: new Date().toISOString(),
+        }, null, 2),
+      );
+      const progress = await waitForWorkerStartupEvidence({
+        teamName: 'codex-blocked-startup',
+        workerName: 'worker-1',
+        workerCli: 'codex',
+        cwd,
+        timeoutMs: 25,
+        pollMs: 5,
+      });
+      assert.equal(progress, 'worker_progress');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam rejects interactive startup when tmux fallback never produces worker startup evidence', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-startup-no-evidence-'));
     const prevTmux = process.env.TMUX;


### PR DESCRIPTION
## Summary
- add a focused `test:recent-bug-regressions(:compiled)` entrypoint
- harden regression coverage around recent bug clusters in prompt routing, stop-hook/session scope, detached tmux launch, and team runtime worker-state evidence
- document the new recent-bug regression slice in `docs/qa/recent-bug-regression-hardening-2026-04-11.md`
- remove the flaky zsh rc-drift assertion and keep the deterministic unsupported-SHELL fallback contract

## Testing
- npm run build
- node --test dist/cli/__tests__/launch-fallback.test.js dist/team/__tests__/hardening-e2e.test.js
- npm run test:recent-bug-regressions:compiled
