### PR TITLE
Keep session-scoped team state from surviving a finished shutdown

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -334,6 +334,53 @@ describe('teamCommand shutdown --force parsing', () => {
     }
   });
 
+  it('persists cancelled session-scoped team mode state on shutdown', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-session-mode-state-'));
+    const previousCwd = process.cwd();
+    const teamName = 'team-shutdown-scoped';
+
+    try {
+      process.chdir(wd);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-team-shutdown-scoped';
+      const scopedStateDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(scopedStateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, 'session.json'),
+        JSON.stringify({ session_id: sessionId }),
+      );
+      await writeFile(
+        join(scopedStateDir, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'team',
+          current_phase: 'team-exec',
+          team_name: teamName,
+        }, null, 2),
+      );
+      await initTeamState(
+        teamName,
+        'persist cancelled session-scoped team mode state after shutdown',
+        'executor',
+        1,
+        wd,
+      );
+
+      await teamCommand(['shutdown', teamName, '--force']);
+
+      const scopedState = JSON.parse(
+        await readFile(join(scopedStateDir, 'team-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(scopedState.active, false);
+      assert.equal(scopedState.current_phase, 'cancelled');
+      assert.equal(scopedState.team_name, teamName);
+      assert.ok(typeof scopedState.completed_at === 'string' && scopedState.completed_at.length > 0);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('parses --confirm-issues from shutdown args', () => {
     const teamArgs = ['shutdown', 'my-team', '--confirm-issues'];
     const confirmIssues = teamArgs.includes('--confirm-issues');

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -381,6 +381,105 @@ describe('teamCommand shutdown --force parsing', () => {
     }
   });
 
+  it('does not create session-scoped team mode state on shutdown when only root team mode state exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-root-mode-only-'));
+    const previousCwd = process.cwd();
+    const teamName = 'team-shutdown-root-only';
+    const sessionId = 'sess-team-shutdown-root-only';
+
+    try {
+      process.chdir(wd);
+      const stateDir = join(wd, '.omx', 'state');
+      const scopedStatePath = join(stateDir, 'sessions', sessionId, 'team-state.json');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(
+        join(stateDir, 'session.json'),
+        JSON.stringify({ session_id: sessionId }),
+      );
+      await writeFile(
+        join(stateDir, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'team',
+          current_phase: 'team-exec',
+          team_name: teamName,
+        }, null, 2),
+      );
+      await initTeamState(
+        teamName,
+        'shutdown should not create scoped team mode state from a root-only mode state',
+        'executor',
+        1,
+        wd,
+      );
+
+      await teamCommand(['shutdown', teamName, '--force']);
+
+      assert.equal(existsSync(scopedStatePath), false);
+      const rootState = JSON.parse(
+        await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(rootState.active, false);
+      assert.equal(rootState.current_phase, 'cancelled');
+      assert.equal(rootState.team_name, teamName);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create session-scoped team mode state on shutdown when a stale session.json remains', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-stale-session-json-'));
+    const previousCwd = process.cwd();
+    const teamName = 'team-shutdown-stale-session';
+    const staleSessionId = 'sess-team-shutdown-stale';
+
+    try {
+      process.chdir(wd);
+      const stateDir = join(wd, '.omx', 'state');
+      const staleSessionDir = join(stateDir, 'sessions', staleSessionId);
+      const scopedStatePath = join(staleSessionDir, 'team-state.json');
+      await mkdir(staleSessionDir, { recursive: true });
+      await writeFile(
+        join(stateDir, 'session.json'),
+        JSON.stringify({ session_id: staleSessionId }),
+      );
+      await writeFile(
+        join(staleSessionDir, 'hud-state.json'),
+        JSON.stringify({ turn_count: 12 }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'team-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'team',
+          current_phase: 'team-exec',
+          team_name: teamName,
+        }, null, 2),
+      );
+      await initTeamState(
+        teamName,
+        'shutdown should ignore stale session.json when only root team mode state exists',
+        'executor',
+        1,
+        wd,
+      );
+
+      await teamCommand(['shutdown', teamName, '--force']);
+
+      assert.equal(existsSync(scopedStatePath), false);
+      const rootState = JSON.parse(
+        await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(rootState.active, false);
+      assert.equal(rootState.current_phase, 'cancelled');
+      assert.equal(rootState.team_name, teamName);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('parses --confirm-issues from shutdown args', () => {
     const teamArgs = ['shutdown', 'my-team', '--confirm-issues'];
     const confirmIssues = teamArgs.includes('--confirm-issues');

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { updateModeState, startMode, readModeState } from '../modes/base.js';
+import { updateModeState, startMode, readModeState, readModeStateForSession } from '../modes/base.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
 import { DEFAULT_MAX_WORKERS } from '../team/state.js';
 import { sanitizeTeamName } from '../team/tmux-session.js';
@@ -1242,6 +1242,19 @@ async function persistTeamShutdownModeState(
     agentType: string;
   } | null,
 ): Promise<void> {
+  const sessionStatePath = join(cwd, '.omx', 'state', 'session.json');
+  let scopedSessionId: string | undefined;
+  if (existsSync(sessionStatePath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(sessionStatePath, 'utf-8')) as { session_id?: unknown };
+      if (typeof parsed.session_id === 'string' && parsed.session_id.trim()) {
+        scopedSessionId = parsed.session_id.trim();
+      }
+    } catch {
+      // Best-effort shutdown state sync only.
+    }
+  }
+
   const existing = await readModeState('team', cwd);
   if (!existing) {
     if (configSnapshot) {
@@ -1271,6 +1284,25 @@ async function persistTeamShutdownModeState(
       }
       : {}),
   }, cwd);
+
+  if (scopedSessionId) {
+    const scopedState = await readModeStateForSession('team', scopedSessionId, cwd);
+    if (scopedState) {
+      await updateModeState('team', {
+        active: false,
+        current_phase: 'cancelled',
+        completed_at: new Date().toISOString(),
+        team_name: teamName,
+        ...(configSnapshot
+          ? {
+            task_description: configSnapshot.task,
+            agent_count: configSnapshot.workerCount,
+            agent_types: configSnapshot.agentType,
+          }
+          : {}),
+      }, cwd, scopedSessionId);
+    }
+  }
 }
 
 

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { updateModeState, startMode, readModeState, readModeStateForSession } from '../modes/base.js';
+import { updateModeState, startMode, readModeState } from '../modes/base.js';
+import { getStatePath, validateSessionId } from '../mcp/state-paths.js';
 import { monitorTeam, resumeTeam, shutdownTeam, startTeam, type TeamRuntime, type TeamSnapshot } from '../team/runtime.js';
 import { DEFAULT_MAX_WORKERS } from '../team/state.js';
 import { sanitizeTeamName } from '../team/tmux-session.js';
@@ -46,6 +47,23 @@ interface TeamFollowupContext {
   explicitWorkerCount: boolean;
   agentType?: string;
   explicitAgentType?: boolean;
+}
+
+function persistExactTeamModeState(
+  cwd: string,
+  updates: Record<string, unknown>,
+  sessionId?: string,
+): boolean {
+  const statePath = getStatePath('team', cwd, sessionId);
+  if (!existsSync(statePath)) return false;
+
+  try {
+    const current = JSON.parse(readFileSync(statePath, 'utf-8')) as Record<string, unknown>;
+    writeFileSync(statePath, JSON.stringify({ ...current, ...updates }, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function readPersistedTeamFollowupState(cwd: string): {
@@ -1247,12 +1265,40 @@ async function persistTeamShutdownModeState(
   if (existsSync(sessionStatePath)) {
     try {
       const parsed = JSON.parse(readFileSync(sessionStatePath, 'utf-8')) as { session_id?: unknown };
-      if (typeof parsed.session_id === 'string' && parsed.session_id.trim()) {
-        scopedSessionId = parsed.session_id.trim();
-      }
+      scopedSessionId = validateSessionId(parsed.session_id);
     } catch {
       // Best-effort shutdown state sync only.
     }
+  }
+
+  const shutdownState: Record<string, unknown> = {
+    active: false,
+    current_phase: 'cancelled',
+    completed_at: new Date().toISOString(),
+    team_name: teamName,
+    ...(configSnapshot
+      ? {
+        task_description: configSnapshot.task,
+        agent_count: configSnapshot.workerCount,
+        agent_types: configSnapshot.agentType,
+      }
+      : {}),
+  };
+
+  const rootStatePath = getStatePath('team', cwd);
+  const hasRootState = existsSync(rootStatePath);
+  const hasScopedState = scopedSessionId
+    ? existsSync(getStatePath('team', cwd, scopedSessionId))
+    : false;
+
+  if (hasRootState || hasScopedState) {
+    if (hasRootState) {
+      persistExactTeamModeState(cwd, shutdownState);
+    }
+    if (scopedSessionId && hasScopedState) {
+      persistExactTeamModeState(cwd, shutdownState, scopedSessionId);
+    }
+    return;
   }
 
   const existing = await readModeState('team', cwd);
@@ -1271,38 +1317,7 @@ async function persistTeamShutdownModeState(
     }
   }
 
-  await updateModeState('team', {
-    active: false,
-    current_phase: 'cancelled',
-    completed_at: new Date().toISOString(),
-    team_name: teamName,
-    ...(configSnapshot
-      ? {
-        task_description: configSnapshot.task,
-        agent_count: configSnapshot.workerCount,
-        agent_types: configSnapshot.agentType,
-      }
-      : {}),
-  }, cwd);
-
-  if (scopedSessionId) {
-    const scopedState = await readModeStateForSession('team', scopedSessionId, cwd);
-    if (scopedState) {
-      await updateModeState('team', {
-        active: false,
-        current_phase: 'cancelled',
-        completed_at: new Date().toISOString(),
-        team_name: teamName,
-        ...(configSnapshot
-          ? {
-            task_description: configSnapshot.task,
-            agent_count: configSnapshot.workerCount,
-            agent_types: configSnapshot.agentType,
-          }
-          : {}),
-      }, cwd, scopedSessionId);
-    }
-  }
+  await updateModeState('team', shutdownState, cwd);
 }
 
 


### PR DESCRIPTION
## Summary
- persist completed/cancelled team mode state in the current session scope during `omx team shutdown`
- prevent stale session-scoped `team-state.json` from making stop hooks think a finished team is still active
- add a CLI shutdown regression test covering the session-scoped team-state path

## Testing
- npm run build
- node --test dist/cli/__tests__/team.test.js --test-name-pattern="persists cancelled session-scoped team mode state on shutdown|persists cancelled team mode state on shutdown even when no team mode state existed beforehand"
- node --test dist/cli/__tests__/session-scoped-runtime.test.js
