### PR TITLE
Canonicalize workflow skill-state parity across CLI, lifecycle, cleanup, and HUD

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -452,6 +453,22 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     assert.equal(ralph.current_phase, "cancelled");
     assert.equal(typeof ralph.completed_at, "string");
     assert.equal(typeof ralph.last_turn_at, "string");
+    const rootCanonicalPath = join(stateDir, "skill-active-state.json");
+    const sessionCanonicalPath = join(sessionStateDir, "skill-active-state.json");
+    if (existsSync(rootCanonicalPath)) {
+      const rootCanonical = JSON.parse(
+        await readFile(rootCanonicalPath, "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(rootCanonical.active, false);
+      assert.deepEqual(rootCanonical.active_skills, []);
+    }
+    if (existsSync(sessionCanonicalPath)) {
+      const sessionCanonical = JSON.parse(
+        await readFile(sessionCanonicalPath, "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(sessionCanonical.active, false);
+      assert.deepEqual(sessionCanonical.active_skills, []);
+    }
     assert.deepEqual(warnings, []);
   });
 
@@ -522,6 +539,14 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     ) as Record<string, unknown>;
     assert.equal(ultrawork.active, false);
     assert.equal(typeof ultrawork.completed_at, "string");
+    const canonicalPath = join(stateDir, "skill-active-state.json");
+    if (existsSync(canonicalPath)) {
+      const canonical = JSON.parse(
+        await readFile(canonicalPath, "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(canonical.active, false);
+      assert.deepEqual(canonical.active_skills, []);
+    }
     assert.equal(await readFile(join(stateDir, "ralph-state.json"), "utf-8"), malformedState);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0] ?? "", /skipped malformed mode state .*ralph-state\.json/);

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -52,6 +52,8 @@ import {
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
 } from "../index.js";
+import { readAllState } from "../../hud/state.js";
+import { generateOverlay } from "../../hooks/agents-overlay.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../../hud/constants.js";
 import {
   DEFAULT_FRONTIER_MODEL,
@@ -550,6 +552,45 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     assert.equal(await readFile(join(stateDir, "ralph-state.json"), "utf-8"), malformedState);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0] ?? "", /skipped malformed mode state .*ralph-state\.json/);
+  });
+
+  it("clears canonical skill-active entries during cleanup and hides them from HUD/overlay readers", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-skill-active-cleanup-"));
+    const sessionId = "sess-skill-active-cleanup";
+    const stateDir = join(wd, ".omx", "state");
+    const sessionStateDir = join(stateDir, "sessions", sessionId);
+
+    await mkdir(sessionStateDir, { recursive: true });
+    await writeFile(join(stateDir, "session.json"), JSON.stringify({ session_id: sessionId }), "utf-8");
+    await writeFile(
+      join(sessionStateDir, "skill-active-state.json"),
+      JSON.stringify({
+        version: 1,
+        active: true,
+        skill: "autoresearch",
+        phase: "running",
+        session_id: sessionId,
+        active_skills: [
+          { skill: "autoresearch", phase: "running", active: true, session_id: sessionId },
+        ],
+      }, null, 2),
+      "utf-8",
+    );
+
+    await cleanupPostLaunchModeStateFiles(wd, sessionId);
+
+    const canonical = JSON.parse(
+      await readFile(join(sessionStateDir, "skill-active-state.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    assert.equal(canonical.active, false);
+    assert.equal(canonical.phase, "complete");
+    assert.deepEqual(canonical.active_skills, []);
+
+    const hudState = await readAllState(wd);
+    assert.equal(hudState.autoresearch, null);
+
+    const overlay = await generateOverlay(wd, sessionId);
+    assert.equal(overlay.includes("- autoresearch:"), false);
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,6 +46,8 @@ import {
   getStateDir,
   listModeStateFilesWithScopePreference,
 } from "../mcp/state-paths.js";
+import { syncCanonicalSkillStateForMode } from "../state/skill-active.js";
+import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
 import { maybeCheckAndPromptUpdate } from "./update.js";
 import { maybePromptGithubStar } from "./star-prompt.js";
 import {
@@ -2064,6 +2066,17 @@ export async function cleanupPostLaunchModeStateFiles(
               path,
               JSON.stringify(buildRecoveredPostLaunchModeState(mode, completedAt), null, 2),
             );
+            if (isTrackedWorkflowMode(mode)) {
+              await syncCanonicalSkillStateForMode({
+                cwd,
+                mode,
+                active: false,
+                currentPhase: "cancelled",
+                sessionId: stateDir === getStateDir(cwd, sessionId) ? sessionId : undefined,
+                nowIso: completedAt,
+                source: "postLaunchCleanup",
+              });
+            }
           } catch (err) {
             writeWarn(
               `[omx] postLaunch: failed to recover mode state ${path}: ${err instanceof Error ? err.message : err}`,
@@ -2079,9 +2092,22 @@ export async function cleanupPostLaunchModeStateFiles(
       if (result.state.active !== true) continue;
 
       try {
+        const completedAt = now().toISOString();
         result.state.active = false;
-        result.state.completed_at = now().toISOString();
+        result.state.current_phase = "cancelled";
+        result.state.completed_at = completedAt;
         await writeFile(path, JSON.stringify(result.state, null, 2));
+        if (isTrackedWorkflowMode(mode)) {
+          await syncCanonicalSkillStateForMode({
+            cwd,
+            mode,
+            active: false,
+            currentPhase: "cancelled",
+            sessionId: stateDir === getStateDir(cwd, sessionId) ? sessionId : undefined,
+            nowIso: completedAt,
+            source: "postLaunchCleanup",
+          });
+        }
       } catch (err) {
         writeWarn(
           `[omx] postLaunch: failed to update mode state ${path}: ${err instanceof Error ? err.message : err}`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,7 +46,7 @@ import {
   getStateDir,
   listModeStateFilesWithScopePreference,
 } from "../mcp/state-paths.js";
-import { syncCanonicalSkillStateForMode } from "../state/skill-active.js";
+import { SKILL_ACTIVE_STATE_MODE, syncCanonicalSkillStateForMode } from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
 import { maybeCheckAndPromptUpdate } from "./update.js";
 import { maybePromptGithubStar } from "./star-prompt.js";
@@ -2038,6 +2038,19 @@ function buildRecoveredPostLaunchModeState(
   };
 }
 
+function buildRecoveredPostLaunchSkillActiveState(
+  completedAt: string,
+): Record<string, unknown> {
+  return {
+    version: 1,
+    active: false,
+    skill: "",
+    phase: "complete",
+    updated_at: completedAt,
+    active_skills: [],
+  };
+}
+
 export async function cleanupPostLaunchModeStateFiles(
   cwd: string,
   sessionId: string,
@@ -2064,7 +2077,13 @@ export async function cleanupPostLaunchModeStateFiles(
             const completedAt = now().toISOString();
             await writeFile(
               path,
-              JSON.stringify(buildRecoveredPostLaunchModeState(mode, completedAt), null, 2),
+              JSON.stringify(
+                mode === SKILL_ACTIVE_STATE_MODE
+                  ? buildRecoveredPostLaunchSkillActiveState(completedAt)
+                  : buildRecoveredPostLaunchModeState(mode, completedAt),
+                null,
+                2,
+              ),
             );
             if (isTrackedWorkflowMode(mode)) {
               await syncCanonicalSkillStateForMode({
@@ -2089,10 +2108,21 @@ export async function cleanupPostLaunchModeStateFiles(
         }
         continue;
       }
-      if (result.state.active !== true) continue;
+      const skillStateStillVisible = mode === SKILL_ACTIVE_STATE_MODE
+        && Array.isArray(result.state.active_skills)
+        && result.state.active_skills.length > 0;
+      if (result.state.active !== true && !skillStateStillVisible) continue;
 
       try {
         const completedAt = now().toISOString();
+        if (mode === SKILL_ACTIVE_STATE_MODE) {
+          result.state.active = false;
+          result.state.phase = "complete";
+          result.state.updated_at = completedAt;
+          result.state.active_skills = [];
+          await writeFile(path, JSON.stringify(result.state, null, 2));
+          continue;
+        }
         result.state.active = false;
         result.state.current_phase = "cancelled";
         result.state.completed_at = completedAt;

--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -430,6 +430,35 @@ describe("resolveSessionOrchestrationMode", () => {
     assert.ok(overlay.includes("- team: phase: running"));
     assert.equal(overlay.includes("ralph"), false);
   });
+
+  it("active mode summary suppresses stale autoresearch mode files when canonical session skill state excludes it", async () => {
+    const sessionId = "sess-autoresearch-summary";
+    const rootStateDir = join(tempDir, ".omx", "state");
+    const sessionDir = join(rootStateDir, "sessions", sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(rootStateDir, "autoresearch-state.json"),
+      JSON.stringify({ active: true, current_phase: "running" }),
+    );
+    await writeFile(
+      join(sessionDir, "skill-active-state.json"),
+      JSON.stringify({
+        active: true,
+        skill: "team",
+        phase: "running",
+        session_id: sessionId,
+        active_skills: [{ skill: "team", phase: "running", active: true, session_id: sessionId }],
+      }),
+    );
+    await writeFile(
+      join(sessionDir, "team-state.json"),
+      JSON.stringify({ active: true, team_name: "delta" }),
+    );
+
+    const overlay = await generateOverlay(tempDir, sessionId);
+    assert.ok(overlay.includes("- team: phase: running"));
+    assert.equal(overlay.includes("- autoresearch:"), false);
+  });
 });
 
 describe("applyOverlay + stripOverlay roundtrip", () => {

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -224,7 +224,6 @@ async function readActiveModes(
     try {
       if (
         !useCompatibilityFallback &&
-        ref.mode !== "autoresearch" &&
         !canonicalSkills.has(ref.mode)
       ) {
         continue;

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -469,4 +469,33 @@ describe('readAllState canonical skill precedence', () => {
       });
     });
   });
+
+  it('suppresses stale autoresearch detail when canonical session skill state excludes it', async () => {
+    await withTempRepo('omx-hud-canonical-autoresearch-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-autoresearch-off';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(rootStateDir, 'autoresearch-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'running',
+      }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        session_id: sessionId,
+        active_skills: [{ skill: 'team', phase: 'running', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'gamma',
+      }));
+
+      const state = await readAllState(cwd);
+      assert.equal(state.autoresearch, null);
+      assert.deepEqual(state.team, { active: true, team_name: 'gamma', current_phase: 'running' });
+    });
+  });
 });

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -414,7 +414,12 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
   const team = canonicalSkills.has('team') || useCompatibilityFallback
     ? mergePhase(teamDetail?.active === true ? teamDetail : null, canonicalPhaseForSkill(canonicalSkills, 'team'))
     : null;
-  const autoresearch = autoresearchDetail?.active === true ? autoresearchDetail : null;
+  const autoresearch = canonicalSkills.has('autoresearch') || useCompatibilityFallback
+    ? mergePhase(
+      autoresearchDetail?.active === true ? autoresearchDetail : null,
+      canonicalPhaseForSkill(canonicalSkills, 'autoresearch'),
+    )
+    : null;
 
   // When the Rust runtime bridge is enabled, prefer Rust-authored snapshot
   // for authority/backlog/readiness display over JS-inferred state.

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -778,6 +778,46 @@ describe('state-server directory initialization', () => {
     }
   });
 
+  it('does not auto-complete existing workflow state when tracked write validation fails', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-server-validate-before-transition-'));
+    try {
+      await mkdir(join(wd, '.omx', 'state', 'sessions', 'sess-invalid'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'state', 'sessions', 'sess-invalid', 'ralplan-state.json'),
+        JSON.stringify({ active: true, mode: 'ralplan', current_phase: 'planning' }, null, 2),
+      );
+
+      const denied = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            session_id: 'sess-invalid',
+            mode: 'ralph',
+            active: true,
+            current_phase: 'definitely-invalid',
+          },
+        },
+      });
+
+      assert.equal(denied.isError, true);
+      const body = JSON.parse(denied.content[0]?.text || '{}') as { error?: string };
+      assert.match(body.error || '', /ralph\.current_phase/i);
+
+      const ralplanState = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-invalid', 'ralplan-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(ralplanState.active, true);
+      assert.equal(ralplanState.current_phase, 'planning');
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-invalid', 'ralph-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('allows ultrawork overlap with any tracked mode', async () => {
     process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
     const { handleStateToolCall } = await import('../state-server.js');

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -53,6 +53,7 @@ import {
 
 const SUPPORTED_MODES = [
 	"autopilot",
+	"autoresearch",
 	"team",
 	"ralph",
 	"ultrawork",

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -349,12 +349,13 @@ export async function handleStateToolCall(request: {
 					session_id: _sid,
 					state: customState,
 					...fields
-				} = args as Record<string, unknown>;
-				let validationError: string | null = null;
-				let transitionMessage: string | undefined;
-				await withStateWriteLock(path, async () => {
-					let existing: Record<string, unknown> = {};
-					if (existsSync(path)) {
+					} = args as Record<string, unknown>;
+					let validationError: string | null = null;
+					let transitionMessage: string | undefined;
+					let ensureRalphArtifacts = false;
+					await withStateWriteLock(path, async () => {
+						let existing: Record<string, unknown> = {};
+						if (existsSync(path)) {
 						try {
 							existing = JSON.parse(await readFile(path, "utf-8"));
 						} catch (e) {
@@ -364,37 +365,14 @@ export async function handleStateToolCall(request: {
 						}
 					}
 
-					const mergedRaw = {
-						...existing,
-						...fields,
-						...((customState as Record<string, unknown>) || {}),
-					} as Record<string, unknown>;
-					if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
-						try {
-							if (!effectiveSessionId) {
-								for (const sessionId of await listStateSessionIds(cwd)) {
-									const sessionTransition = await reconcileWorkflowTransition(cwd, mode, {
-										action: "write",
-										sessionId,
-										source: "state-server",
-									});
-									transitionMessage ??= sessionTransition.transitionMessage;
-								}
-							}
-							const transition = await reconcileWorkflowTransition(cwd, mode, {
-								action: "write",
-								sessionId: effectiveSessionId,
-								source: "state-server",
-							});
-							transitionMessage ??= transition.transitionMessage;
-						} catch (error) {
-							validationError = (error as Error).message;
-							return;
-						}
-					}
-					if (
-						mode === "ralph" &&
-						effectiveSessionId &&
+						const mergedRaw = {
+							...existing,
+							...fields,
+							...((customState as Record<string, unknown>) || {}),
+						} as Record<string, unknown>;
+						if (
+							mode === "ralph" &&
+							effectiveSessionId &&
 						typeof mergedRaw.owner_omx_session_id !== "string"
 					) {
 						mergedRaw.owner_omx_session_id = effectiveSessionId;
@@ -413,16 +391,39 @@ export async function handleStateToolCall(request: {
 							typeof originalPhase === "string" &&
 							typeof validation.state.current_phase === "string" &&
 							validation.state.current_phase !== originalPhase
-						) {
-							validation.state.ralph_phase_normalized_from = originalPhase;
+							) {
+								validation.state.ralph_phase_normalized_from = originalPhase;
+							}
+							Object.assign(mergedRaw, validation.state);
+							ensureRalphArtifacts = true;
 						}
-						Object.assign(mergedRaw, validation.state);
-						await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
-					}
+						if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
+							try {
+								if (!effectiveSessionId) {
+									for (const sessionId of await listStateSessionIds(cwd)) {
+										const sessionTransition = await reconcileWorkflowTransition(cwd, mode, {
+											action: "write",
+											sessionId,
+											source: "state-server",
+										});
+										transitionMessage ??= sessionTransition.transitionMessage;
+									}
+								}
+								const transition = await reconcileWorkflowTransition(cwd, mode, {
+									action: "write",
+									sessionId: effectiveSessionId,
+									source: "state-server",
+								});
+								transitionMessage ??= transition.transitionMessage;
+							} catch (error) {
+								validationError = (error as Error).message;
+								return;
+							}
+						}
 
-					const merged = withModeRuntimeContext(existing, mergedRaw);
-					await writeAtomicFile(path, JSON.stringify(merged, null, 2));
-				});
+						const merged = withModeRuntimeContext(existing, mergedRaw);
+						await writeAtomicFile(path, JSON.stringify(merged, null, 2));
+					});
 				if (validationError) {
 					return {
 						content: [
@@ -433,16 +434,19 @@ export async function handleStateToolCall(request: {
 						],
 						isError: true,
 					};
-				}
-				if (mode === SKILL_ACTIVE_STATE_MODE) {
-					const state = await readSkillActiveState(path);
-					if (state) {
-						await writeSkillActiveStateCopies(cwd, state, effectiveSessionId);
 					}
-				} else {
-					const data = JSON.parse(await readFile(path, "utf-8")) as Record<string, unknown>;
-					await syncCanonicalSkillStateForMode({
-						cwd,
+					if (mode === SKILL_ACTIVE_STATE_MODE) {
+						const state = await readSkillActiveState(path);
+						if (state) {
+							await writeSkillActiveStateCopies(cwd, state, effectiveSessionId);
+						}
+					} else {
+						if (mode === "ralph" && ensureRalphArtifacts) {
+							await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
+						}
+						const data = JSON.parse(await readFile(path, "utf-8")) as Record<string, unknown>;
+						await syncCanonicalSkillStateForMode({
+							cwd,
 						mode,
 						active: data.active === true,
 						currentPhase: typeof data.current_phase === "string" ? data.current_phase : undefined,

--- a/src/modes/__tests__/base-autoresearch-contract.test.ts
+++ b/src/modes/__tests__/base-autoresearch-contract.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { readModeState, startMode } from '../base.js';
+import { readModeState, startMode, updateModeState } from '../base.js';
+import { listActiveSkills, readVisibleSkillActiveState } from '../../state/skill-active.js';
 
 describe('modes/base deep-interview contract integration', () => {
   it('startMode persists deep-interview state', async () => {
@@ -103,6 +104,31 @@ describe('modes/base autoresearch contract integration', () => {
       const persisted = await readModeState('autoresearch', wd);
       assert.equal(persisted?.mode, 'autoresearch');
       assert.equal(persisted?.task_description, 'demo mission');
+
+      const canonical = await readVisibleSkillActiveState(wd);
+      assert.deepEqual(
+        listActiveSkills(canonical ?? {}).map(({ skill, phase }) => ({ skill, phase })),
+        [{ skill: 'autoresearch', phase: 'starting' }],
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState syncs canonical autoresearch completion', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autoresearch-canonical-'));
+    try {
+      await startMode('autoresearch', 'demo mission', 1, wd);
+      await updateModeState('autoresearch', {
+        active: false,
+        current_phase: 'complete',
+        completed_at: '2026-04-11T00:00:00.000Z',
+      }, wd);
+
+      const canonical = await readVisibleSkillActiveState(wd);
+      assert.ok(canonical);
+      assert.equal(canonical?.active, false);
+      assert.deepEqual(listActiveSkills(canonical ?? {}), []);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -201,6 +201,16 @@ export async function updateModeState(
     : updatedBase;
   const updated = withModeRuntimeContext(current, normalizedBase) as ModeState;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(updated, null, 2));
+  if (isTrackedWorkflowMode(mode)) {
+    await syncCanonicalSkillStateForMode({
+      cwd: projectRoot ?? process.cwd(),
+      mode,
+      active: updated.active === true,
+      currentPhase: typeof updated.current_phase === 'string' ? updated.current_phase : undefined,
+      sessionId: scope.sessionId,
+      source: 'updateModeState',
+    });
+  }
   return updated;
 }
 

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -166,6 +166,37 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('writes and reads autoresearch state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autoresearch-'));
+    try {
+      const writeResponse = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'autoresearch',
+        active: true,
+        current_phase: 'running',
+      });
+
+      assert.equal(writeResponse.isError, undefined);
+      assert.deepEqual(writeResponse.payload, {
+        success: true,
+        mode: 'autoresearch',
+        path: join(wd, '.omx', 'state', 'autoresearch-state.json'),
+      });
+
+      const readResponse = await executeStateOperation('state_read', {
+        workingDirectory: wd,
+        mode: 'autoresearch',
+      });
+
+      assert.equal(readResponse.isError, undefined);
+      const readBody = readResponse.payload as Record<string, unknown>;
+      assert.equal(readBody.active, true);
+      assert.equal(readBody.current_phase, 'running');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('creates session-scoped state directory when session_id is provided', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-session-'));
     try {
@@ -205,6 +236,86 @@ describe('state operations directory initialization', () => {
       for (let i = 0; i < 16; i++) {
         assert.equal(state[`k${i}`], i);
       }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('syncs canonical skill-active state for tracked mode writes and clears', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-canonical-'));
+    try {
+      await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: 'sess-sync',
+        mode: 'autoresearch',
+        active: true,
+        current_phase: 'running',
+      });
+
+      const canonicalPath = join(wd, '.omx', 'state', 'sessions', 'sess-sync', 'skill-active-state.json');
+      const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active_skills?: Array<{
+          skill: string;
+          phase?: string;
+          session_id?: string;
+          activated_at?: string;
+          updated_at?: string;
+        }>;
+      };
+      assert.deepEqual(canonical.active_skills, [{
+        skill: 'autoresearch',
+        phase: 'running',
+        active: true,
+        activated_at: canonical.active_skills?.[0]?.activated_at,
+        updated_at: canonical.active_skills?.[0]?.updated_at,
+        session_id: 'sess-sync',
+      }]);
+
+      await executeStateOperation('state_clear', {
+        workingDirectory: wd,
+        session_id: 'sess-sync',
+        mode: 'autoresearch',
+      });
+
+      const cleared = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
+        active: boolean;
+        active_skills?: unknown[];
+      };
+      assert.equal(cleared.active, false);
+      assert.deepEqual(cleared.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies unsupported overlaps without writing the requested mode state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-deny-overlap-'));
+    try {
+      const existing = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: 'sess-deny',
+        mode: 'team',
+        active: true,
+        current_phase: 'running',
+      });
+      assert.equal(existing.isError, undefined);
+
+      const denied = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: 'sess-deny',
+        mode: 'autopilot',
+        active: true,
+        current_phase: 'planning',
+      });
+
+      assert.equal(denied.isError, true);
+      assert.match(String((denied.payload as { error?: string }).error || ''), /Unsupported workflow overlap: team \+ autopilot\./);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-deny', 'autopilot-state.json')), false);
+
+      const canonical = JSON.parse(
+        await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-deny', 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string }> };
+      assert.deepEqual(canonical.active_skills?.map((entry) => entry.skill), ['team']);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -320,4 +320,36 @@ describe('state operations directory initialization', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('does not auto-complete existing workflow state when tracked write validation fails', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-validate-before-transition-'));
+    try {
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', 'sess-invalid');
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(
+        join(sessionDir, 'ralplan-state.json'),
+        JSON.stringify({ active: true, mode: 'ralplan', current_phase: 'planning' }, null, 2),
+      );
+
+      const denied = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: 'sess-invalid',
+        mode: 'ralph',
+        active: true,
+        current_phase: 'definitely-invalid',
+      });
+
+      assert.equal(denied.isError, true);
+      assert.match(String((denied.payload as { error?: string }).error || ''), /ralph\.current_phase/i);
+
+      const ralplanState = JSON.parse(
+        await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(ralplanState.active, true);
+      assert.equal(ralplanState.current_phase, 'planning');
+      assert.equal(existsSync(join(sessionDir, 'ralph-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -16,9 +16,18 @@ import {
 } from '../mcp/state-paths.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
+import {
+  SKILL_ACTIVE_STATE_MODE,
+  readSkillActiveState,
+  syncCanonicalSkillStateForMode,
+  writeSkillActiveStateCopies,
+} from './skill-active.js';
+import { isTrackedWorkflowMode } from './workflow-transition.js';
+import { reconcileWorkflowTransition } from './workflow-transition-reconcile.js';
 
 export const SUPPORTED_STATE_READ_MODES = [
   'autopilot',
+  'autoresearch',
   'team',
   'ralph',
   'ultrawork',
@@ -94,6 +103,16 @@ async function initializeStateEnvironment(cwd: string, effectiveSessionId?: stri
   await ensureTmuxHookInitialized(cwd);
 }
 
+async function listStateSessionIds(cwd: string): Promise<string[]> {
+  const sessionsDir = join(getStateDir(cwd), 'sessions');
+  if (!existsSync(sessionsDir)) return [];
+  const entries = await readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((entry) => entry.trim().length > 0);
+}
+
 export async function listStateStatuses(
   cwd: string,
   explicitSessionId?: string,
@@ -109,6 +128,7 @@ export async function listStateStatuses(
     for (const file of files) {
       if (!file.endsWith('-state.json')) continue;
       const currentMode = file.replace('-state.json', '');
+      if (!mode && currentMode === SKILL_ACTIVE_STATE_MODE) continue;
       if (mode && currentMode !== mode) continue;
       if (seenModes.has(currentMode)) continue;
       seenModes.add(currentMode);
@@ -187,6 +207,7 @@ export async function executeStateOperation(
           ...fields
         } = rawArgs;
         let validationError: string | null = null;
+        let transitionMessage: string | undefined;
 
         await withStateWriteLock(path, async () => {
           let existing: Record<string, unknown> = {};
@@ -203,6 +224,31 @@ export async function executeStateOperation(
             ...fields,
             ...((customState as Record<string, unknown>) || {}),
           } as Record<string, unknown>;
+
+          if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
+            try {
+              if (!effectiveSessionId) {
+                for (const sessionId of await listStateSessionIds(cwd)) {
+                  const sessionTransition = await reconcileWorkflowTransition(cwd, mode, {
+                    action: 'write',
+                    sessionId,
+                    source: 'state-operations',
+                  });
+                  transitionMessage ??= sessionTransition.transitionMessage;
+                }
+              }
+
+              const transition = await reconcileWorkflowTransition(cwd, mode, {
+                action: 'write',
+                sessionId: effectiveSessionId,
+                source: 'state-operations',
+              });
+              transitionMessage ??= transition.transitionMessage;
+            } catch (error) {
+              validationError = (error as Error).message;
+              return;
+            }
+          }
 
           if (
             mode === 'ralph' &&
@@ -241,7 +287,31 @@ export async function executeStateOperation(
           };
         }
 
-        return { payload: { success: true, mode, path } };
+        if (mode === SKILL_ACTIVE_STATE_MODE) {
+          const state = await readSkillActiveState(path);
+          if (state) {
+            await writeSkillActiveStateCopies(cwd, state, effectiveSessionId);
+          }
+        } else {
+          const data = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+          await syncCanonicalSkillStateForMode({
+            cwd,
+            mode,
+            active: data.active === true,
+            currentPhase: typeof data.current_phase === 'string' ? data.current_phase : undefined,
+            sessionId: effectiveSessionId,
+            source: 'state-operations',
+          });
+        }
+
+        return {
+          payload: {
+            success: true,
+            mode,
+            path,
+            ...(transitionMessage ? { transition: transitionMessage } : {}),
+          },
+        };
       }
 
       case 'state_clear': {
@@ -253,6 +323,15 @@ export async function executeStateOperation(
           if (existsSync(path)) {
             await unlink(path);
           }
+          if (mode !== SKILL_ACTIVE_STATE_MODE) {
+            await syncCanonicalSkillStateForMode({
+              cwd,
+              mode,
+              active: false,
+              sessionId: effectiveSessionId,
+              source: 'state-operations',
+            });
+          }
           return { payload: { cleared: true, mode, path } };
         }
 
@@ -262,6 +341,14 @@ export async function executeStateOperation(
           if (!existsSync(path)) continue;
           await unlink(path);
           removedPaths.push(path);
+        }
+        if (mode !== SKILL_ACTIVE_STATE_MODE) {
+          await syncCanonicalSkillStateForMode({
+            cwd,
+            mode,
+            active: false,
+            source: 'state-operations',
+          });
         }
 
         return {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -208,6 +208,7 @@ export async function executeStateOperation(
         } = rawArgs;
         let validationError: string | null = null;
         let transitionMessage: string | undefined;
+        let ensureRalphArtifacts = false;
 
         await withStateWriteLock(path, async () => {
           let existing: Record<string, unknown> = {};
@@ -224,6 +225,32 @@ export async function executeStateOperation(
             ...fields,
             ...((customState as Record<string, unknown>) || {}),
           } as Record<string, unknown>;
+
+          if (
+            mode === 'ralph' &&
+            effectiveSessionId &&
+            typeof mergedRaw.owner_omx_session_id !== 'string'
+          ) {
+            mergedRaw.owner_omx_session_id = effectiveSessionId;
+          }
+
+          if (mode === 'ralph') {
+            const originalPhase = mergedRaw.current_phase;
+            const validation = validateAndNormalizeRalphState(mergedRaw);
+            if (!validation.ok || !validation.state) {
+              validationError = validation.error || `ralph.current_phase must be one of: ${RALPH_PHASES.join(', ')}`;
+              return;
+            }
+            if (
+              typeof originalPhase === 'string' &&
+              typeof validation.state.current_phase === 'string' &&
+              validation.state.current_phase !== originalPhase
+            ) {
+              validation.state.ralph_phase_normalized_from = originalPhase;
+            }
+            Object.assign(mergedRaw, validation.state);
+            ensureRalphArtifacts = true;
+          }
 
           if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
             try {
@@ -250,32 +277,6 @@ export async function executeStateOperation(
             }
           }
 
-          if (
-            mode === 'ralph' &&
-            effectiveSessionId &&
-            typeof mergedRaw.owner_omx_session_id !== 'string'
-          ) {
-            mergedRaw.owner_omx_session_id = effectiveSessionId;
-          }
-
-          if (mode === 'ralph') {
-            const originalPhase = mergedRaw.current_phase;
-            const validation = validateAndNormalizeRalphState(mergedRaw);
-            if (!validation.ok || !validation.state) {
-              validationError = validation.error || `ralph.current_phase must be one of: ${RALPH_PHASES.join(', ')}`;
-              return;
-            }
-            if (
-              typeof originalPhase === 'string' &&
-              typeof validation.state.current_phase === 'string' &&
-              validation.state.current_phase !== originalPhase
-            ) {
-              validation.state.ralph_phase_normalized_from = originalPhase;
-            }
-            Object.assign(mergedRaw, validation.state);
-            await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
-          }
-
           const merged = withModeRuntimeContext(existing, mergedRaw);
           await writeAtomicFile(path, JSON.stringify(merged, null, 2));
         });
@@ -293,6 +294,9 @@ export async function executeStateOperation(
             await writeSkillActiveStateCopies(cwd, state, effectiveSessionId);
           }
         } else {
+          if (mode === 'ralph' && ensureRalphArtifacts) {
+            await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
+          }
           const data = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
           await syncCanonicalSkillStateForMode({
             cwd,

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -13,6 +13,7 @@ export const SKILL_ACTIVE_STATE_FILE = `${SKILL_ACTIVE_STATE_MODE}-state.json`;
 
 export const CANONICAL_WORKFLOW_SKILLS = [
   'autopilot',
+  'autoresearch',
   'team',
   'ralph',
   'ultrawork',


### PR DESCRIPTION
## Summary
- promote `autoresearch` into canonical workflow-state parity across skill-state, CLI state ops, MCP state server, HUD, and overlay readers
- make CLI state operations enforce tracked-mode transition reconciliation and canonical skill-state syncing like the MCP surface
- sync canonical skill state from lifecycle updates and post-launch cleanup, and add regression coverage for the new parity

## Testing
- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node --test dist/state/__tests__/workflow-transition.test.js dist/state/__tests__/skill-active.test.js dist/state/__tests__/operations.test.js dist/mcp/__tests__/state-server.test.js dist/modes/__tests__/base-session-scope.test.js dist/modes/__tests__/base-autoresearch-contract.test.js dist/cli/__tests__/state.test.js dist/cli/__tests__/index.test.js dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/agents-overlay.test.js dist/hud/__tests__/state.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/runtime-cli.test.js`
