### PR TITLE
Fix detached reconnect noise from escalating stale/lifecycle signals

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -2538,6 +2538,108 @@ exit 0
     });
   });
 
+  it('suppresses stale leader follow-up when detached worktree progress is still fresh', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'fresh-detached-progress';
+      const teamDir = join(stateDir, 'team', teamName);
+      const workersDir = join(teamDir, 'workers');
+      const tasksDir = join(teamDir, 'tasks');
+      const workerWorktree = join(cwd, 'worktrees', 'worker-1');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(tasksDir, { recursive: true });
+      await mkdir(join(workersDir, 'worker-1'), { recursive: true });
+      await mkdir(join(workerWorktree, '.omx', 'state'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'omx-team-fresh-detached-progress',
+        leader_pane_id: '%99',
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10', worktree_path: workerWorktree },
+        ],
+      });
+      await writeJson(join(stateDir, 'hud-state.json'), {
+        last_turn_at: new Date(Date.now() - 300_000).toISOString(),
+        turn_count: 5,
+      });
+      await writeJson(join(tasksDir, 'task-1.json'), {
+        id: '1',
+        subject: 'Apply detached fix',
+        description: 'keep going',
+        status: 'in_progress',
+        owner: 'worker-1',
+        created_at: new Date(Date.now() - 300_000).toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'working',
+        current_task_id: '1',
+        updated_at: new Date(Date.now() - 300_000).toISOString(),
+      });
+      await writeJson(join(workersDir, 'worker-1', 'heartbeat.json'), {
+        last_turn_at: new Date(Date.now() - 300_000).toISOString(),
+        turn_count: 2,
+        alive: true,
+      });
+      await writeJson(join(stateDir, 'team-leader-nudge.json'), {
+        last_nudged_by_team: {
+          [teamName]: {
+            at: new Date(Date.now() - 60_000).toISOString(),
+            last_message_id: '',
+            reason: 'stale_leader_panes_alive',
+          },
+        },
+        progress_by_team: {
+          [teamName]: {
+            signature: JSON.stringify({
+              tasks: [{ id: '1', owner: 'worker-1', status: 'in_progress' }],
+              workers: [{
+                worker: 'worker-1',
+                state: 'working',
+                current_task_id: '1',
+                status_missing: false,
+                turn_count: 2,
+                heartbeat_missing: false,
+              }],
+            }),
+            last_progress_at: new Date(Date.now() - 300_000).toISOString(),
+          },
+        },
+      });
+      await writeJson(join(workerWorktree, '.omx', 'state', 'current-task-baseline.json'), {
+        version: 1,
+        tasks: [],
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%10 12345']));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_TEAM_PROGRESS_STALL_MS: '60000',
+        OMX_TEAM_LEADER_NUDGE_MS: '30000',
+        OMX_TEAM_LEADER_STALE_MS: '60000',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /Team fresh-detached-progress: leader stale,/);
+      }
+    });
+  });
+
   it('emits team_leader_nudge event to events.ndjson when nudge fires', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/notifications/__tests__/lifecycle-dedupe.test.ts
+++ b/src/notifications/__tests__/lifecycle-dedupe.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  shouldSendLifecycleNotification,
+  recordLifecycleNotificationSent,
+} from '../lifecycle-dedupe.js';
+import type { FullNotificationPayload } from '../types.js';
+
+function buildPayload(overrides: Partial<FullNotificationPayload> = {}): FullNotificationPayload {
+  return {
+    event: 'session-end',
+    sessionId: 'session-1475',
+    message: 'done',
+    timestamp: '2026-04-11T00:00:00.000Z',
+    projectPath: '/tmp/project',
+    projectName: 'project',
+    reason: 'session_exit',
+    ...overrides,
+  };
+}
+
+describe('lifecycle notification dedupe', () => {
+  it('suppresses duplicate session lifecycle notifications for the same session transition', async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), 'omx-lifecycle-dedupe-'));
+    try {
+      const payload = buildPayload();
+      assert.equal(shouldSendLifecycleNotification(stateDir, payload), true);
+      recordLifecycleNotificationSent(stateDir, payload);
+      assert.equal(shouldSendLifecycleNotification(stateDir, payload), false);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('re-emits when the lifecycle fingerprint changes', async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), 'omx-lifecycle-dedupe-change-'));
+    try {
+      const payload = buildPayload();
+      recordLifecycleNotificationSent(stateDir, payload);
+      assert.equal(shouldSendLifecycleNotification(stateDir, buildPayload({ reason: 'completed' })), true);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('stores dedupe state per session id', async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), 'omx-lifecycle-dedupe-session-'));
+    try {
+      const payload = buildPayload({ sessionId: 'session-a', event: 'session-start' });
+      recordLifecycleNotificationSent(stateDir, payload);
+
+      const sessionFile = join(stateDir, 'sessions', 'session-a', 'lifecycle-notif-state.json');
+      const state = JSON.parse(await readFile(sessionFile, 'utf-8')) as {
+        events?: Record<string, { fingerprint?: string }>;
+      };
+
+      assert.equal(typeof state.events?.['session-start']?.fingerprint, 'string');
+      assert.equal(shouldSendLifecycleNotification(stateDir, buildPayload({ sessionId: 'session-b', event: 'session-start' })), true);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -138,6 +138,11 @@ import { formatNotification } from "./formatter.js";
 import { dispatchNotifications } from "./dispatcher.js";
 import { getCurrentTmuxSession, captureTmuxPane } from "./tmux.js";
 import { basename } from "path";
+import { omxStateDir } from "../utils/paths.js";
+import {
+  shouldSendLifecycleNotification,
+  recordLifecycleNotificationSent,
+} from "./lifecycle-dedupe.js";
 import type { OpenClawHookEvent } from "../openclaw/types.js";
 
 // Suppress unused import — used by callers via re-export
@@ -239,7 +244,19 @@ export async function notifyLifecycle(
 
     payload.message = data.message || formatNotification(payload);
 
+    const lifecycleStateDir = payload.projectPath ? omxStateDir(payload.projectPath) : "";
+    if (!shouldSendLifecycleNotification(lifecycleStateDir, payload)) {
+      return {
+        event,
+        anySuccess: true,
+        results: [],
+      };
+    }
+
     const result = await dispatchNotifications(config, event, payload);
+    if (result.anySuccess) {
+      recordLifecycleNotificationSent(lifecycleStateDir, payload);
+    }
 
     // Fire-and-forget OpenClaw gateway call
     const openClawEvent = toOpenClawEvent(event);

--- a/src/notifications/lifecycle-dedupe.ts
+++ b/src/notifications/lifecycle-dedupe.ts
@@ -1,0 +1,79 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { NotificationEvent, FullNotificationPayload } from './types.js';
+
+const SESSION_ID_SAFE_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+const LIFECYCLE_DEDUPE_FILE = 'lifecycle-notif-state.json';
+const DEDUPED_EVENTS = new Set<NotificationEvent>(['session-start', 'session-stop', 'session-end']);
+
+interface LifecycleDedupeState {
+  events?: Record<string, { fingerprint?: string; sentAt?: string }>;
+}
+
+function normalizeFingerprint(payload: FullNotificationPayload): string {
+  return JSON.stringify({
+    event: payload.event,
+    reason: payload.reason || '',
+    activeMode: payload.activeMode || '',
+    question: payload.question || '',
+    incompleteTasks: payload.incompleteTasks || 0,
+  });
+}
+
+function getStatePath(stateDir: string, sessionId: string): string {
+  if (SESSION_ID_SAFE_PATTERN.test(sessionId)) {
+    return join(stateDir, 'sessions', sessionId, LIFECYCLE_DEDUPE_FILE);
+  }
+  return join(stateDir, LIFECYCLE_DEDUPE_FILE);
+}
+
+function readState(path: string): LifecycleDedupeState {
+  try {
+    if (!existsSync(path)) return {};
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as LifecycleDedupeState;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeState(path: string, state: LifecycleDedupeState): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(state, null, 2));
+  } catch {
+    // best effort
+  }
+}
+
+export function shouldDedupeLifecycleNotification(event: NotificationEvent): boolean {
+  return DEDUPED_EVENTS.has(event);
+}
+
+export function shouldSendLifecycleNotification(
+  stateDir: string,
+  payload: FullNotificationPayload,
+): boolean {
+  if (!shouldDedupeLifecycleNotification(payload.event)) return true;
+  if (!payload.sessionId || !stateDir) return true;
+  const path = getStatePath(stateDir, payload.sessionId);
+  const state = readState(path);
+  const previous = state.events?.[payload.event];
+  return previous?.fingerprint !== normalizeFingerprint(payload);
+}
+
+export function recordLifecycleNotificationSent(
+  stateDir: string,
+  payload: FullNotificationPayload,
+): void {
+  if (!shouldDedupeLifecycleNotification(payload.event)) return;
+  if (!payload.sessionId || !stateDir) return;
+  const path = getStatePath(stateDir, payload.sessionId);
+  const state = readState(path);
+  state.events = state.events && typeof state.events === 'object' ? state.events : {};
+  state.events[payload.event] = {
+    fingerprint: normalizeFingerprint(payload),
+    sentAt: new Date().toISOString(),
+  };
+  writeState(path, state);
+}

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -22,6 +22,7 @@ import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
 import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 import { writeTeamLeaderAttention } from '../../team/state.js';
+import { readLatestTeamProgressEvidenceMs } from '../../team/progress-evidence.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
@@ -674,11 +675,15 @@ export async function maybeNudgeTeamLeader({
     const workerTurnProgress = hasWorkerTurnProgress(progressSnapshot.workerSnapshot, previousTurnCounts);
     const hasTrackableTurnSignals = hasTrackableActiveWorkerTurns(progressSnapshot.workerSnapshot, previousTurnCounts);
     const progressChanged = !previousSignature || previousSignature !== progressSnapshot.signature || workerTurnProgress;
+    const extraProgressEvidenceMs = await readLatestTeamProgressEvidenceMs(cwd, teamName).catch(() => Number.NaN);
     const effectiveProgressAtMs = progressChanged || !Number.isFinite(previousProgressAtMs)
       ? nowMs
       : previousProgressAtMs;
-    const effectiveProgressAtIso = new Date(effectiveProgressAtMs).toISOString();
-    const stalledForMs = Math.max(0, nowMs - effectiveProgressAtMs);
+    const latestProgressEvidenceMs = Number.isFinite(extraProgressEvidenceMs)
+      ? Math.max(effectiveProgressAtMs, extraProgressEvidenceMs)
+      : effectiveProgressAtMs;
+    const effectiveProgressAtIso = new Date(latestProgressEvidenceMs).toISOString();
+    const stalledForMs = Math.max(0, nowMs - latestProgressEvidenceMs);
     const stallThresholdMs = hasTrackableTurnSignals ? workerTurnStallThresholdMs : fallbackProgressStallThresholdMs;
     const teamProgressStalled =
       progressSnapshot.workRemaining
@@ -686,6 +691,9 @@ export async function maybeNudgeTeamLeader({
       && !allWorkersIdle
       && !progressChanged
       && stalledForMs >= stallThresholdMs;
+    const hasFreshProgressEvidence =
+      progressSnapshot.workRemaining
+      && stalledForMs < stallThresholdMs;
     const leaderActionState = classifyLeaderActionState({
       allWorkersIdle,
       workerPanesAlive: paneStatus.alive,
@@ -722,7 +730,7 @@ export async function maybeNudgeTeamLeader({
 
     // Stale-leader follow-up is the only periodic visible nudge path.
     // This keeps the leader pane quieter when the leader is not actually stale.
-    const stalePanesNudge = paneStatus.alive && leaderStale;
+    const stalePanesNudge = paneStatus.alive && leaderStale && !hasFreshProgressEvidence;
     const previousStalledTeamNudge = prevReason === 'stuck_waiting_on_leader';
     const stalledTeamNudge = teamProgressStalled && (dueByTime || !previousStalledTeamNudge);
     const staleFollowupDue = stalePanesNudge && dueByTime;

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -1667,6 +1667,59 @@ describe('executeTeamApiOperation: read-stall-state', () => {
     }
   });
 
+  it('suppresses stale native-stop attention after newer detached worktree progress', async () => {
+    const { cwd, cleanup } = await setupTeam('stall-state-detached-progress');
+    try {
+      const workerWorktree = join(cwd, 'worktrees', 'worker-1');
+      await mkdir(join(workerWorktree, '.omx', 'state'), { recursive: true });
+
+      const manifest = await readTeamManifestV2('stall-state-detached-progress', cwd);
+      assert.ok(manifest);
+      await writeTeamManifestV2({
+        ...manifest!,
+        workers: (manifest!.workers ?? []).map((worker) => (
+          worker.name === 'worker-1'
+            ? { ...worker, worktree_path: workerWorktree }
+            : worker
+        )),
+      }, cwd);
+
+      await writeTeamLeaderAttention('stall-state-detached-progress', {
+        team_name: 'stall-state-detached-progress',
+        updated_at: '2026-03-10T10:05:00.000Z',
+        source: 'native_stop',
+        leader_decision_state: 'still_actionable',
+        leader_attention_pending: true,
+        leader_attention_reason: 'leader_session_stopped',
+        attention_reasons: ['leader_session_stopped'],
+        leader_stale: false,
+        leader_session_active: false,
+        leader_session_id: 'leader-session-1',
+        leader_session_stopped_at: '2026-03-10T10:05:00.000Z',
+        unread_leader_message_count: 0,
+        work_remaining: false,
+        stalled_for_ms: null,
+      }, cwd);
+      await writeFile(join(workerWorktree, '.omx', 'state', 'current-task-baseline.json'), JSON.stringify({
+        version: 1,
+        tasks: [],
+      }, null, 2));
+
+      const result = await executeTeamApiOperation('read-stall-state', {
+        team_name: 'stall-state-detached-progress',
+      }, cwd);
+
+      assert.equal(result.ok, true);
+      if (result.ok) {
+        assert.equal(result.data.leader_attention_pending, false);
+        assert.equal(result.data.leader_stale, false);
+        assert.doesNotMatch((result.data.reasons as string[]).join(' '), /leader_attention_pending:leader_session_stopped/);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('marks only active leader-owned teams as stopped on session end', async () => {
     const { cwd, cleanup } = await setupTeam('owned-team');
     try {

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -16,6 +16,7 @@ import { readTeamEvents, waitForTeamEvent } from './state/events.js';
 import { queueDirectMailboxMessage } from './mcp-comm.js';
 import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
 import { isTerminalPhase } from './orchestrator.js';
+import { readLatestTeamProgressEvidenceMs } from './progress-evidence.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { buildLeaderMailboxTriggerDirective, buildMailboxTriggerDirective } from './worker-bootstrap.js';
 import {
@@ -309,6 +310,15 @@ function readLatestLeaderRuntimeActivityMs(cwd: string): number {
   } catch {
     return Number.NaN;
   }
+}
+
+async function readLatestLeaderProgressEvidenceMs(cwd: string, teamName: string): Promise<number> {
+  const [leaderRuntimeMs, teamProgressMs] = await Promise.all([
+    Promise.resolve(readLatestLeaderRuntimeActivityMs(cwd)),
+    readLatestTeamProgressEvidenceMs(cwd, teamName).catch(() => Number.NaN),
+  ]);
+  const candidates = [leaderRuntimeMs, teamProgressMs].filter((value) => Number.isFinite(value));
+  return candidates.length > 0 ? Math.max(...candidates) : Number.NaN;
 }
 
 function buildStallState(
@@ -1040,7 +1050,7 @@ export async function executeTeamApiOperation(
           teamReadLeaderAttention(teamName, cwd),
           listMailboxMessages(teamName, 'leader-fixed', cwd).catch(() => []),
           teamListDispatchRequests(teamName, cwd, { to_worker: 'leader-fixed', limit: 200 }).catch(() => []),
-          readLatestLeaderRuntimeActivityMs(cwd),
+          readLatestLeaderProgressEvidenceMs(cwd, teamName),
         ]);
         if (!summary) {
           return { ok: false, operation, error: { code: 'team_not_found', message: 'team_not_found' } };

--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -120,8 +120,7 @@ function stateDirToProjectRoot(stateDir: string): string {
   return dirname(dirname(stateDir));
 }
 
-async function readLeaderBranchGitActivityMs(stateDir: string): Promise<number> {
-  const cwd = stateDirToProjectRoot(stateDir);
+export async function readBranchGitActivityMsForPath(cwd: string): Promise<number> {
   const gitDir = tryReadGitValue(cwd, ['rev-parse', '--git-dir']);
   if (!gitDir) return Number.NaN;
 
@@ -140,6 +139,10 @@ async function readLeaderBranchGitActivityMs(stateDir: string): Promise<number> 
 
   const candidates = [headLogMs, branchLogMs, headCommitMs].filter((ms) => Number.isFinite(ms));
   return candidates.length > 0 ? Math.max(...candidates) : Number.NaN;
+}
+
+async function readLeaderBranchGitActivityMs(stateDir: string): Promise<number> {
+  return await readBranchGitActivityMsForPath(stateDirToProjectRoot(stateDir));
 }
 
 export function leaderRuntimeActivityPath(cwd: string): string {

--- a/src/team/progress-evidence.ts
+++ b/src/team/progress-evidence.ts
@@ -1,0 +1,80 @@
+import { existsSync } from 'node:fs';
+import { readFile, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { readBranchGitActivityMsForPath } from './leader-activity.js';
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function parseIsoMs(value: unknown): number {
+  if (typeof value !== 'string' || value.trim() === '') return Number.NaN;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+async function readJsonIfExists(path: string): Promise<Record<string, unknown> | null> {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+async function statMsIfExists(path: string): Promise<number> {
+  if (!existsSync(path)) return Number.NaN;
+  try {
+    return (await stat(path)).mtimeMs;
+  } catch {
+    return Number.NaN;
+  }
+}
+
+async function readTeamWorktreePaths(cwd: string, teamName: string): Promise<string[]> {
+  const teamRoot = join(cwd, '.omx', 'state', 'team', teamName);
+  const manifestPath = join(teamRoot, 'manifest.v2.json');
+  const configPath = join(teamRoot, 'config.json');
+  const sourcePath = existsSync(manifestPath) ? manifestPath : configPath;
+  const parsed = await readJsonIfExists(sourcePath);
+  const workers = Array.isArray(parsed?.workers) ? parsed.workers : [];
+  const candidates = new Set<string>([resolve(cwd)]);
+
+  for (const worker of workers) {
+    if (!worker || typeof worker !== 'object') continue;
+    const worktreePath = safeString((worker as Record<string, unknown>).worktree_path).trim();
+    const workingDir = safeString((worker as Record<string, unknown>).working_dir).trim();
+    if (worktreePath) candidates.add(resolve(worktreePath));
+    else if (workingDir) candidates.add(resolve(workingDir));
+  }
+
+  return [...candidates];
+}
+
+async function readTeamNudgeProgressMs(cwd: string, teamName: string): Promise<number> {
+  const nudgeState = await readJsonIfExists(join(cwd, '.omx', 'state', 'team-leader-nudge.json'));
+  const progressByTeam = nudgeState?.progress_by_team;
+  if (!progressByTeam || typeof progressByTeam !== 'object') return Number.NaN;
+  const teamProgress = (progressByTeam as Record<string, unknown>)[teamName];
+  if (!teamProgress || typeof teamProgress !== 'object') return Number.NaN;
+  return parseIsoMs((teamProgress as Record<string, unknown>).last_progress_at);
+}
+
+async function readCurrentTaskBaselineMs(worktreePath: string): Promise<number> {
+  return await statMsIfExists(join(worktreePath, '.omx', 'state', 'current-task-baseline.json'));
+}
+
+export async function readLatestTeamProgressEvidenceMs(
+  cwd: string,
+  teamName: string,
+): Promise<number> {
+  const worktreePaths = await readTeamWorktreePaths(cwd, teamName);
+  const [nudgeProgressMs, gitActivityMs, baselineMs] = await Promise.all([
+    readTeamNudgeProgressMs(cwd, teamName),
+    Promise.all(worktreePaths.map((worktreePath) => readBranchGitActivityMsForPath(worktreePath))),
+    Promise.all(worktreePaths.map((worktreePath) => readCurrentTaskBaselineMs(worktreePath))),
+  ]);
+
+  const candidates = [nudgeProgressMs, ...gitActivityMs, ...baselineMs].filter((value) => Number.isFinite(value));
+  return candidates.length > 0 ? Math.max(...candidates) : Number.NaN;
+}


### PR DESCRIPTION
## Summary
- suppress stale leader follow-ups when detached worktree git/PR progress is still fresh
- treat detached worktree progress as valid evidence when reading stall state after transient native-stop noise
- deduplicate session lifecycle notifications for the same session transition

## Testing
- npm install
- npm run build
- node --test dist/notifications/__tests__/lifecycle-dedupe.test.js dist/team/__tests__/api-interop.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js

Closes #1475.