### PR TITLE
Fix MCP approval_mode reset during Claude settings sync

### DIFF
--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -408,10 +408,19 @@ describe("omx setup refresh summary and dry-run behavior", () => {
         registryPath,
         JSON.stringify({
           existing_server: { command: "existing-server", args: ["mcp"] },
-          eslint: { command: "npx", args: ["@eslint/mcp@latest"], enabled: false },
+          eslint: {
+            command: "npx",
+            args: ["@eslint/mcp@latest"],
+            enabled: false,
+            approval_mode: "never",
+          },
         }),
       );
 
+      await runSetupInTempDir(wd, {
+        scope: "user",
+        mcpRegistryCandidates: [registryPath],
+      });
       await runSetupInTempDir(wd, {
         scope: "user",
         mcpRegistryCandidates: [registryPath],
@@ -421,7 +430,15 @@ describe("omx setup refresh summary and dry-run behavior", () => {
         await readFile(join(wd, ".claude", "settings.json"), "utf-8"),
       ) as {
         uiTheme?: string;
-        mcpServers?: Record<string, { command: string; args: string[]; enabled: boolean }>;
+        mcpServers?: Record<
+          string,
+          {
+            command: string;
+            args: string[];
+            enabled: boolean;
+            approval_mode?: string;
+          }
+        >;
       };
       assert.equal(settings.uiTheme, "dark");
       assert.deepEqual(settings.mcpServers?.existing_server, {
@@ -433,6 +450,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
         command: "npx",
         args: ["@eslint/mcp@latest"],
         enabled: false,
+        approval_mode: "never",
       });
     } finally {
       if (typeof previousHome === "string") process.env.HOME = previousHome;

--- a/src/config/__tests__/mcp-registry.test.ts
+++ b/src/config/__tests__/mcp-registry.test.ts
@@ -87,6 +87,53 @@ describe("unified MCP registry loader", () => {
     }
   });
 
+  it("preserves string approval_mode values and warns on non-string ones", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-mcp-registry-"));
+    try {
+      const registryPath = join(wd, "registry.json");
+      await writeFile(
+        registryPath,
+        JSON.stringify({
+          eslint: {
+            command: "npx",
+            args: ["@eslint/mcp@latest"],
+            approval_mode: "never",
+          },
+          invalid_mode: {
+            command: "npx",
+            args: ["@example/mcp"],
+            approval_mode: 42,
+          },
+        }),
+      );
+
+      const result = await loadUnifiedMcpRegistry({
+        candidates: [registryPath],
+      });
+      assert.equal(result.servers.length, 2);
+      assert.deepEqual(result.servers[0], {
+        name: "eslint",
+        command: "npx",
+        args: ["@eslint/mcp@latest"],
+        enabled: true,
+        approval_mode: "never",
+        startupTimeoutSec: undefined,
+      });
+      assert.deepEqual(result.servers[1], {
+        name: "invalid_mode",
+        command: "npx",
+        args: ["@example/mcp"],
+        enabled: true,
+        startupTimeoutSec: undefined,
+      });
+      assert.deepEqual(result.warnings, [
+        'registry entry "invalid_mode" has non-string approval_mode; ignoring approval_mode',
+      ]);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("returns canonical home-based registry candidates", () => {
     const candidates = getUnifiedMcpRegistryCandidates("/tmp/home");
     assert.deepEqual(candidates, ["/tmp/home/.omx/mcp-registry.json"]);
@@ -130,7 +177,15 @@ describe("unified MCP registry loader", () => {
 
     const parsed = JSON.parse(plan.content ?? "{}") as {
       theme?: string;
-      mcpServers?: Record<string, { command: string; args: string[]; enabled: boolean }>;
+      mcpServers?: Record<
+        string,
+        {
+          command: string;
+          args: string[];
+          enabled: boolean;
+          approval_mode?: string;
+        }
+      >;
     };
     assert.equal(parsed.theme, "dark");
     assert.deepEqual(parsed.mcpServers?.existing_server, {
@@ -142,6 +197,40 @@ describe("unified MCP registry loader", () => {
       command: "npx",
       args: ["@eslint/mcp@latest"],
       enabled: false,
+    });
+  });
+
+  it("includes approval_mode when adding missing Claude MCP servers", () => {
+    const plan = planClaudeCodeMcpSettingsSync(
+      JSON.stringify({ mcpServers: {} }, null, 2),
+      [
+        {
+          name: "eslint",
+          command: "npx",
+          args: ["@eslint/mcp@latest"],
+          enabled: false,
+          approval_mode: "never",
+        },
+      ],
+    );
+
+    const parsed = JSON.parse(plan.content ?? "{}") as {
+      mcpServers?: Record<
+        string,
+        {
+          command: string;
+          args: string[];
+          enabled: boolean;
+          approval_mode?: string;
+        }
+      >;
+    };
+
+    assert.deepEqual(parsed.mcpServers?.eslint, {
+      command: "npx",
+      args: ["@eslint/mcp@latest"],
+      enabled: false,
+      approval_mode: "never",
     });
   });
 

--- a/src/config/mcp-registry.ts
+++ b/src/config/mcp-registry.ts
@@ -9,6 +9,7 @@ export interface UnifiedMcpRegistryServer {
   args: string[];
   enabled: boolean;
   startupTimeoutSec?: number;
+  approval_mode?: string;
 }
 
 export interface UnifiedMcpRegistryLoadResult {
@@ -21,6 +22,7 @@ export interface ClaudeCodeMcpServerConfig {
   command: string;
   args: string[];
   enabled: boolean;
+  approval_mode?: string;
 }
 
 export interface ClaudeCodeSettingsSyncPlan {
@@ -45,6 +47,7 @@ function toClaudeCodeMcpServerConfig(
     command: server.command,
     args: [...server.args],
     enabled: server.enabled,
+    ...(server.approval_mode !== undefined ? { approval_mode: server.approval_mode } : {}),
   };
 }
 function normalizeTimeout(
@@ -58,6 +61,21 @@ function normalizeTimeout(
     return undefined;
   }
   return Math.floor(value);
+}
+
+function normalizeApprovalMode(
+  value: unknown,
+  name: string,
+  warnings: string[],
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    warnings.push(
+      `registry entry "${name}" has non-string approval_mode; ignoring approval_mode`,
+    );
+    return undefined;
+  }
+  return value;
 }
 
 function normalizeEntry(
@@ -93,6 +111,7 @@ function normalizeEntry(
 
   const timeoutCandidate =
     value.timeout ?? value.startup_timeout_sec ?? value.startupTimeoutSec;
+  const approvalMode = normalizeApprovalMode(value.approval_mode, name, warnings);
 
   return {
     name,
@@ -100,6 +119,7 @@ function normalizeEntry(
     args: (argsValue as string[] | undefined) ?? [],
     enabled: enabledValue ?? true,
     startupTimeoutSec: normalizeTimeout(timeoutCandidate, name, warnings),
+    ...(approvalMode !== undefined ? { approval_mode: approvalMode } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Fix issue #1478 by preserving shared MCP `approval_mode` values when `omx setup` syncs new servers into `~/.claude/settings.json`.

## Changes

- normalize `approval_mode` in the shared MCP registry loader while warning on malformed non-string values
- keep `approval_mode` when building Claude MCP server config entries for sync
- add unit coverage for registry parsing and Claude settings sync serialization
- extend the user-scope setup regression to prove `approval_mode` survives repeated reinstall/update sync runs

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [x] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/config/__tests__/mcp-registry.test.js dist/cli/__tests__/setup-refresh.test.js`
- [x] `npx biome lint src/config/mcp-registry.ts src/config/__tests__/mcp-registry.test.ts src/cli/__tests__/setup-refresh.test.ts`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1478
