### PR TITLE
Fix local Codex team workers getting stuck behind queued startup drafts

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -110,6 +110,11 @@ const VIEWPORT_SCROLLBACK_READY_CAPTURE = `${VIEWPORT_WITHOUT_VISIBLE_PROMPT_CAP
 
 › support lane on multi-image attach`;
 
+const QUEUED_AFTER_TOOL_CALL_CAPTURE = `• Messages to be submitted after next tool call (press esc to interrupt and send immediately)
+  ↳ Read $OMX_TEAM_STATE_ROOT/team/demo/workers/worker-1/inbox.md, work now, report progress
+
+› Write tests for @filename`;
+
 async function withMockTmuxFixture<T>(
   dirPrefix: string,
   tmuxScript: (tmuxLogPath: string) => string,
@@ -393,6 +398,69 @@ esac
         assert.notEqual(acceptIndex, -1, `expected bypass acceptance in log:\n${log}`);
         assert.notEqual(submitIndex, -1, `expected worker text submission in log:\n${log}`);
         assert.ok(acceptIndex < submitIndex, `expected bypass acceptance before worker text:\n${log}`);
+      },
+    );
+  });
+
+  it('keeps nudging Codex when the trigger is queued for the next tool call instead of executing immediately', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-codex-queued-submit-',
+      (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")"
+text_sent_file="$state_dir/text-sent"
+enter_count_file="$state_dir/enter-count"
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    enter_count=0
+    if [ -f "$enter_count_file" ]; then
+      enter_count=$(cat "$enter_count_file")
+    fi
+    if [ "$enter_count" -ge 4 ]; then
+      cat <<'EOF'
+initialized in .
+
+◦ Waiting for background terminal (59s…)
+EOF
+    elif [ -f "$text_sent_file" ]; then
+      cat <<'EOF'
+${QUEUED_AFTER_TOOL_CALL_CAPTURE}
+EOF
+    else
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    fi
+    exit 0
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "check inbox" ]; then
+      : > "$text_sent_file"
+    fi
+    if [ "\${4:-}" = "C-m" ]; then
+      enter_count=0
+      if [ -f "$enter_count_file" ]; then
+        enter_count=$(cat "$enter_count_file")
+      fi
+      enter_count=$((enter_count + 1))
+      printf '%s' "$enter_count" > "$enter_count_file"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        await sendToWorker('omx-team-x', 1, 'check inbox');
+        const log = await readFile(logPath, 'utf-8');
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        assert.ok(
+          enterCount >= 4,
+          `expected extra submit nudges when Codex queues the trigger:\n${log}`,
+        );
       },
     );
   });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -402,9 +402,62 @@ esac
     );
   });
 
-  it('keeps nudging Codex when the trigger is queued for the next tool call instead of executing immediately', async () => {
+  it('ignores stale queued-next-tool-call banner text that only survives in scrollback history', async () => {
     await withMockTmuxFixture(
-      'omx-tmux-codex-queued-submit-',
+      'omx-tmux-codex-stale-queued-scrollback-',
+      (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")"
+text_sent_file="$state_dir/text-sent"
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if printf '%s\n' "$*" | grep -q -- ' -S -80'; then
+      if [ -f "$text_sent_file" ]; then
+        cat <<'EOF'
+${QUEUED_AFTER_TOOL_CALL_CAPTURE}
+EOF
+      else
+        cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+      fi
+    else
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    fi
+    exit 0
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "check inbox" ]; then
+      : > "$text_sent_file"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        await sendToWorker('omx-team-x', 1, 'check inbox');
+        const log = await readFile(logPath, 'utf-8');
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        assert.equal(
+          enterCount,
+          2,
+          `expected only the baseline submit presses when the queued banner is stale scrollback:\n${log}`,
+        );
+        assert.match(log, /capture-pane -t omx-team-x:1 -p/);
+        assert.match(log, /capture-pane -t omx-team-x:1 -p -S -80/);
+      },
+    );
+  });
+
+  it('keeps nudging Codex when the visible pane still shows a live queued-next-tool-call banner', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-codex-visible-queued-submit-',
       (logPath) => `#!/bin/sh
 set -eu
 state_dir="$(dirname "${logPath}")"
@@ -417,20 +470,26 @@ case "$1" in
     if [ -f "$enter_count_file" ]; then
       enter_count=$(cat "$enter_count_file")
     fi
-    if [ "$enter_count" -ge 4 ]; then
+    if printf '%s\n' "$*" | grep -q -- ' -S -80'; then
       cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    else
+      if [ "$enter_count" -ge 4 ]; then
+        cat <<'EOF'
 initialized in .
 
 ◦ Waiting for background terminal (59s…)
 EOF
-    elif [ -f "$text_sent_file" ]; then
-      cat <<'EOF'
+      elif [ -f "$text_sent_file" ]; then
+        cat <<'EOF'
 ${QUEUED_AFTER_TOOL_CALL_CAPTURE}
 EOF
-    else
-      cat <<'EOF'
+      else
+        cat <<'EOF'
 ${READY_HELPER_CAPTURE}
 EOF
+      fi
     fi
     exit 0
     ;;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1345,6 +1345,13 @@ function sendLiteralTextOrThrow(target: string, text: string): void {
   }
 }
 
+function paneHasQueuedCodexSubmission(captured: string | null | undefined): boolean {
+  const normalized = normalizeTmuxCapture(captured ?? '');
+  if (normalized === '') return false;
+  return /messages to be submitted after next tool call/i.test(normalized)
+    || /press esc to interrupt and send immediately/i.test(normalized);
+}
+
 async function attemptSubmitRounds(
   target: string,
   text: string,
@@ -1369,7 +1376,13 @@ async function attemptSubmitRounds(
     }
     await sleep(140);
     const captured = await capturePaneAsync(target);
-    if (!normalizeTmuxCapture(captured).includes(normalizeTmuxCapture(text))) return true;
+    const normalizedCapture = normalizeTmuxCapture(captured);
+    if (
+      !normalizedCapture.includes(normalizeTmuxCapture(text))
+      && !paneHasQueuedCodexSubmission(captured)
+    ) {
+      return true;
+    }
     await sleep(140);
   }
   return false;
@@ -1583,11 +1596,20 @@ export async function sendToWorker(
   const verifyCapture = await capturePaneAsync(target);
   if (verifyCapture) {
     if (paneHasActiveTask(verifyCapture)) return;
-    if (!normalizeTmuxCapture(verifyCapture).includes(normalizeTmuxCapture(text))) return;
+    if (
+      !normalizeTmuxCapture(verifyCapture).includes(normalizeTmuxCapture(text))
+      && !paneHasQueuedCodexSubmission(verifyCapture)
+    ) {
+      return;
+    }
     // Draft still visible and no active task — one more C-m attempt.
     await sendKeyAsync(target, 'C-m');
     await sleep(150);
     await sendKeyAsync(target, 'C-m');
+    const finalCapture = await capturePaneAsync(target);
+    if (paneHasQueuedCodexSubmission(finalCapture)) {
+      throw new Error('sendToWorker: submit_queued_after_tool_call');
+    }
   }
 }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -295,6 +295,12 @@ async function capturePaneAsync(target: string): Promise<string> {
   return result.stdout;
 }
 
+async function captureVisiblePaneAsync(target: string): Promise<string> {
+  const result = await runTmuxAsync(sharedBuildVisibleCapturePaneArgv(target));
+  if (!result.ok) return '';
+  return result.stdout;
+}
+
 async function isWorkerAliveAsync(sessionName: string, workerIndex: number, workerPaneId?: string): Promise<boolean> {
   const result = await runTmuxAsync([
     'list-panes',
@@ -1375,11 +1381,14 @@ async function attemptSubmitRounds(
       }
     }
     await sleep(140);
-    const captured = await capturePaneAsync(target);
+    const [captured, visibleCapture] = await Promise.all([
+      capturePaneAsync(target),
+      captureVisiblePaneAsync(target),
+    ]);
     const normalizedCapture = normalizeTmuxCapture(captured);
     if (
       !normalizedCapture.includes(normalizeTmuxCapture(text))
-      && !paneHasQueuedCodexSubmission(captured)
+      && !paneHasQueuedCodexSubmission(visibleCapture)
     ) {
       return true;
     }
@@ -1593,12 +1602,15 @@ export async function sendToWorker(
   // Post-submit verification: wait briefly and confirm the worker consumed the
   // trigger (draft disappeared or active-task indicator appeared). Fixes #391.
   await sleep(300);
-  const verifyCapture = await capturePaneAsync(target);
+  const [verifyCapture, verifyVisibleCapture] = await Promise.all([
+    capturePaneAsync(target),
+    captureVisiblePaneAsync(target),
+  ]);
   if (verifyCapture) {
     if (paneHasActiveTask(verifyCapture)) return;
     if (
       !normalizeTmuxCapture(verifyCapture).includes(normalizeTmuxCapture(text))
-      && !paneHasQueuedCodexSubmission(verifyCapture)
+      && !paneHasQueuedCodexSubmission(verifyVisibleCapture)
     ) {
       return;
     }
@@ -1606,8 +1618,8 @@ export async function sendToWorker(
     await sendKeyAsync(target, 'C-m');
     await sleep(150);
     await sendKeyAsync(target, 'C-m');
-    const finalCapture = await capturePaneAsync(target);
-    if (paneHasQueuedCodexSubmission(finalCapture)) {
+    const finalVisibleCapture = await captureVisiblePaneAsync(target);
+    if (paneHasQueuedCodexSubmission(finalVisibleCapture)) {
       throw new Error('sendToWorker: submit_queued_after_tool_call');
     }
   }


### PR DESCRIPTION
## Summary
- detect Codex's queued-next-tool-call banner as an unsubmitted worker trigger
- keep nudging interactive Codex panes until the queued draft clears or the transport fails explicitly
- add tmux-session regression coverage for the queued-draft capture shape

## Root cause
Interactive Codex workers could accept the tmux-injected startup trigger into the "Messages to be submitted after next tool call" queue without actually starting execution. Team startup treated that hidden draft as a successful submit, so workers stayed pending until someone pressed Enter manually.

## Verification
- `npm run build`
- `node --test dist/team/__tests__/tmux-session.test.js`
- `node --test dist/team/__tests__/runtime.test.js`
- Manual local OMX runtime repro from a clean detached verification worktree: `./dist/cli/omx.js team 1:executor "issue 1490 repro verify"` reached `in_progress=1` on `omx team status issue-1490-repro-verify --json` without a manual pane nudge

Closes #1490.
