### PR TITLE
Fix team dispatch lock wedges during slow tmux hook drains

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -1,6 +1,6 @@
 import { after, before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -102,6 +102,13 @@ async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, un
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function listDispatchProcessingLeases(cwd: string, teamName: string): Promise<string[]> {
+  const dispatchDir = join(cwd, '.omx', 'state', 'team', teamName, 'dispatch');
+  return (await readdir(dispatchDir).catch(() => []))
+    .filter((entry) => entry.startsWith('.processing-'))
+    .sort();
 }
 
 async function writeCompatRuntimeFixture(runtimePath: string): Promise<void> {
@@ -852,6 +859,130 @@ exit 0
       else delete process.env.OMX_DISPATCH_LOCK_TIMEOUT_MS;
       if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
       else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reserves per-issue cooldown before releasing the dispatch lock to a concurrent drain', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const previousIssueCooldown = process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS;
+    let markInjectorStarted = () => {};
+    const injectorStarted = new Promise<void>((resolve) => {
+      markInjectorStarted = () => resolve();
+    });
+    let releaseInjector = () => {};
+    const blockFirstInjector = new Promise<void>((resolve) => {
+      releaseInjector = () => resolve();
+    });
+    let injectCount = 0;
+    try {
+      process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS = '900000';
+      await initTeamState('alpha', 'task', 'executor', 2, cwd);
+      const first = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: 'IND-123 first follow-up',
+      }, cwd);
+      const second = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-2',
+        worker_index: 2,
+        trigger_message: 'IND-123 second follow-up',
+      }, cwd);
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const slowDrain = mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 1,
+        injector: async () => {
+          injectCount += 1;
+          if (injectCount === 1) {
+            markInjectorStarted();
+            await blockFirstInjector;
+          }
+          return { ok: true, reason: 'tmux_send_keys_confirmed' };
+        },
+      });
+
+      await injectorStarted;
+      const concurrentDrain = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 1,
+        injector: async () => {
+          injectCount += 1;
+          return { ok: true, reason: 'tmux_send_keys_confirmed' };
+        },
+      });
+      releaseInjector();
+      const firstResult = await slowDrain;
+
+      assert.equal(injectCount, 1, 'concurrent drain must not inject same-issue follow-up while first claim is in flight');
+      assert.equal(firstResult.processed, 1);
+      assert.equal(concurrentDrain.processed, 0);
+      assert.ok(concurrentDrain.skipped >= 1);
+
+      const firstRequest = await readDispatchRequest('alpha', first.request.request_id, cwd);
+      const secondRequest = await readDispatchRequest('alpha', second.request.request_id, cwd);
+      assert.equal(firstRequest?.status, 'notified');
+      assert.equal(secondRequest?.status, 'pending');
+      assert.equal(secondRequest?.attempt_count, 0);
+    } finally {
+      releaseInjector();
+      if (typeof previousIssueCooldown === 'string') process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS = previousIssueCooldown;
+      else delete process.env.OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('releases every preclaimed dispatch lease when a claimed injector throws', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    try {
+      await initTeamState('alpha', 'task', 'executor', 2, cwd);
+      const first = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: 'first request',
+      }, cwd);
+      const second = await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-2',
+        worker_index: 2,
+        trigger_message: 'second request',
+      }, cwd);
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      let attempt = 0;
+      await assert.rejects(
+        () => mod.drainPendingTeamDispatch({
+          cwd,
+          maxPerTick: 5,
+          injector: async () => {
+            attempt += 1;
+            if (attempt === 1) throw new Error('injector exploded');
+            return { ok: true, reason: 'tmux_send_keys_confirmed' };
+          },
+        }),
+        /injector exploded/,
+      );
+
+      assert.deepEqual(await listDispatchProcessingLeases(cwd, 'alpha'), []);
+
+      const retry = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => ({ ok: true, reason: 'tmux_send_keys_confirmed' }),
+      });
+      assert.equal(retry.processed, 2, 'later drain should not be blocked by stale preclaimed leases');
+
+      const firstRequest = await readDispatchRequest('alpha', first.request.request_id, cwd);
+      const secondRequest = await readDispatchRequest('alpha', second.request.request_id, cwd);
+      assert.equal(firstRequest?.status, 'notified');
+      assert.equal(secondRequest?.status, 'notified');
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -801,6 +801,61 @@ exit 0
     }
   });
 
+  it('releases the global dispatch lock before slow tmux injection so mailbox sends do not wedge mid-run', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
+    const previousLockTimeout = process.env.OMX_DISPATCH_LOCK_TIMEOUT_MS;
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      process.env.OMX_DISPATCH_LOCK_TIMEOUT_MS = '1000';
+      process.env.OMX_RUNTIME_BRIDGE = '0';
+
+      await initTeamState('alpha', 'task', 'executor', 1, cwd);
+      await enqueueDispatchRequest('alpha', {
+        kind: 'inbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        trigger_message: 'startup ping',
+      }, cwd);
+
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const slowDrain = mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 1,
+        injector: async () => {
+          await sleep(1_200);
+          return { ok: true, reason: 'tmux_send_keys_confirmed' };
+        },
+      });
+
+      await sleep(100);
+      await assert.doesNotReject(async () => {
+        await enqueueDispatchRequest('alpha', {
+          kind: 'mailbox',
+          to_worker: 'worker-1',
+          worker_index: 1,
+          trigger_message: 'check mailbox',
+          message_id: 'msg-1',
+        }, cwd);
+      });
+
+      const result = await slowDrain;
+      assert.equal(result.processed, 1);
+      assert.equal(result.failed, 0);
+      const requests = JSON.parse(
+        await readFile(join(cwd, '.omx', 'state', 'team', 'alpha', 'dispatch', 'requests.json'), 'utf-8'),
+      ) as Array<{ request_id?: string; kind?: string; status?: string }>;
+      const mailboxRequest = requests.find((entry) => entry.kind === 'mailbox');
+      assert.equal(mailboxRequest?.status, 'pending');
+    } finally {
+      if (typeof previousLockTimeout === 'string') process.env.OMX_DISPATCH_LOCK_TIMEOUT_MS = previousLockTimeout;
+      else delete process.env.OMX_DISPATCH_LOCK_TIMEOUT_MS;
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('leaves unconfirmed injection as pending for retry (#391)', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
     try {

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -184,6 +184,31 @@ function parseTriggerCooldownEntry(entry) {
   };
 }
 
+function reserveDispatchCooldowns({
+  issueCooldownMs,
+  triggerCooldownMs,
+  issueCooldownByIssue,
+  triggerCooldownByKey,
+  issueKey,
+  triggerKey,
+  requestId,
+  reservedAt = Date.now(),
+}) {
+  let mutated = false;
+  if (issueKey && issueCooldownMs > 0) {
+    issueCooldownByIssue[issueKey] = reservedAt;
+    mutated = true;
+  }
+  if (triggerKey && triggerCooldownMs > 0) {
+    triggerCooldownByKey[triggerKey] = {
+      at: reservedAt,
+      last_request_id: safeString(requestId).trim(),
+    };
+    mutated = true;
+  }
+  return mutated;
+}
+
 async function withLockDirectory(lockDir, timeoutError, fn) {
   const ownerPath = join(lockDir, 'owner');
   const ownerToken = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
@@ -416,17 +441,15 @@ async function finalizeClaimedDispatchRequest({
     const nowIso = new Date().toISOString();
     let mutated = false;
 
-    if (issueKey && issueCooldownMs > 0) {
-      issueCooldownByIssue[issueKey] = Date.now();
-      mutated = true;
-    }
-    if (triggerKey && triggerCooldownMs > 0) {
-      triggerCooldownByKey[triggerKey] = {
-        at: Date.now(),
-        last_request_id: safeString(request.request_id).trim(),
-      };
-      mutated = true;
-    }
+    mutated = reserveDispatchCooldowns({
+      issueCooldownMs,
+      triggerCooldownMs,
+      issueCooldownByIssue,
+      triggerCooldownByKey,
+      issueKey,
+      triggerKey,
+      requestId: request.request_id,
+    }) || mutated;
 
     request.attempt_count = Number.isFinite(request.attempt_count) ? Math.max(0, request.attempt_count + 1) : 1;
     request.updated_at = nowIso;
@@ -866,8 +889,6 @@ export async function drainPendingTeamDispatch({
       const triggerCooldownState = await readTriggerCooldownState(teamDirPath);
       const issueCooldownByIssue = issueCooldownState.by_issue || {};
       const triggerCooldownByKey = triggerCooldownState.by_trigger || {};
-      const plannedIssueKeys = new Set();
-      const plannedTriggerKeys = new Set();
       const nowMs = Date.now();
 
       let mutated = false;
@@ -931,10 +952,6 @@ export async function drainPendingTeamDispatch({
 
         const issueKey = extractIssueKey(request.trigger_message);
         if (issueCooldownMs > 0 && issueKey) {
-          if (plannedIssueKeys.has(issueKey)) {
-            skipped += 1;
-            continue;
-          }
           const lastInjectedMs = Number(issueCooldownByIssue[issueKey]);
           if (Number.isFinite(lastInjectedMs) && lastInjectedMs > 0 && nowMs - lastInjectedMs < issueCooldownMs) {
             skipped += 1;
@@ -944,10 +961,6 @@ export async function drainPendingTeamDispatch({
 
         const triggerKey = normalizeTriggerKey(request.trigger_message);
         if (triggerCooldownMs > 0 && triggerKey) {
-          if (plannedTriggerKeys.has(triggerKey)) {
-            skipped += 1;
-            continue;
-          }
           const parsed = parseTriggerCooldownEntry(triggerCooldownByKey[triggerKey]);
           const withinCooldown = Number.isFinite(parsed.at) && parsed.at > 0 && nowMs - parsed.at < triggerCooldownMs;
           const sameRequestRetry = parsed.lastRequestId !== '' && parsed.lastRequestId === safeString(request.request_id).trim();
@@ -962,12 +975,19 @@ export async function drainPendingTeamDispatch({
           skipped += 1;
           continue;
         }
+        mutated = reserveDispatchCooldowns({
+          issueCooldownMs,
+          triggerCooldownMs,
+          issueCooldownByIssue,
+          triggerCooldownByKey,
+          issueKey,
+          triggerKey,
+          requestId: request.request_id,
+        }) || mutated;
         claims.push({
           request: { ...request },
           lease,
         });
-        if (issueKey) plannedIssueKeys.add(issueKey);
-        if (triggerKey) plannedTriggerKeys.add(triggerKey);
       }
 
       if (mutated) {
@@ -982,25 +1002,33 @@ export async function drainPendingTeamDispatch({
       }
     });
 
-    for (const claim of claims) {
-      try {
-        const result = await injector(claim.request, config, resolve(cwd), stateDir);
-        const delta = await finalizeClaimedDispatchRequest({
-          claim,
-          result,
-          teamName,
-          teamDirPath,
-          config,
-          cwd,
-          stateDir,
-          logsDir,
-          issueCooldownMs,
-          triggerCooldownMs,
-        });
-        processed += delta.processed;
-        skipped += delta.skipped;
-        failed += delta.failed;
-      } finally {
+    try {
+      for (const claim of claims) {
+        try {
+          const result = await injector(claim.request, config, resolve(cwd), stateDir);
+          const delta = await finalizeClaimedDispatchRequest({
+            claim,
+            result,
+            teamName,
+            teamDirPath,
+            config,
+            cwd,
+            stateDir,
+            logsDir,
+            issueCooldownMs,
+            triggerCooldownMs,
+          });
+          processed += delta.processed;
+          skipped += delta.skipped;
+          failed += delta.failed;
+        } finally {
+          claim.released = true;
+          await releaseDispatchRequestLease(claim.lease);
+        }
+      }
+    } finally {
+      for (const claim of claims) {
+        if (claim.released) continue;
         await releaseDispatchRequestLease(claim.lease);
       }
     }

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -97,6 +97,7 @@ async function writeJsonAtomic(path, value) {
 
 // Keep stale-timeout semantics aligned with src/team/state.ts LOCK_STALE_MS.
 const DISPATCH_LOCK_STALE_MS = 5 * 60 * 1000;
+const DISPATCH_REQUEST_LEASE_STALE_MS = 30 * 1000;
 const DEFAULT_ISSUE_DISPATCH_COOLDOWN_MS = 15 * 60 * 1000;
 const ISSUE_DISPATCH_COOLDOWN_ENV = 'OMX_TEAM_DISPATCH_ISSUE_COOLDOWN_MS';
 const DEFAULT_DISPATCH_TRIGGER_COOLDOWN_MS = 30 * 1000;
@@ -245,6 +246,49 @@ async function withMailboxLock(teamDirPath, workerName, fn) {
   );
 }
 
+function dispatchRequestLeaseDir(teamDirPath, requestId) {
+  return join(teamDirPath, 'dispatch', `.processing-${safeString(requestId).trim()}`);
+}
+
+async function tryAcquireDispatchRequestLease(teamDirPath, requestId) {
+  const lockDir = dispatchRequestLeaseDir(teamDirPath, requestId);
+  const ownerPath = join(lockDir, 'owner');
+  const ownerToken = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  await mkdir(dirname(lockDir), { recursive: true });
+
+  while (true) {
+    try {
+      await mkdir(lockDir, { recursive: false });
+      await writeFile(ownerPath, ownerToken, 'utf8');
+      return { lockDir, ownerPath, ownerToken, requestId };
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+      try {
+        const info = await stat(lockDir);
+        if (Date.now() - info.mtimeMs > DISPATCH_REQUEST_LEASE_STALE_MS) {
+          await rm(lockDir, { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        // best effort
+      }
+      return null;
+    }
+  }
+}
+
+async function releaseDispatchRequestLease(lease) {
+  if (!lease?.lockDir || !lease?.ownerPath || !lease?.ownerToken) return;
+  try {
+    const currentOwner = await readFile(lease.ownerPath, 'utf8');
+    if (currentOwner.trim() === lease.ownerToken) {
+      await rm(lease.lockDir, { recursive: true, force: true });
+    }
+  } catch {
+    // best effort
+  }
+}
+
 function resolveLeaderPaneId(config) {
   return safeString(config?.leader_pane_id).trim();
 }
@@ -334,6 +378,215 @@ async function appendLeaderNotificationDeferredEvent({
   };
   await mkdir(eventsDir, { recursive: true }).catch(() => {});
   await appendFile(eventsPath, JSON.stringify(event) + '\n').catch(() => {});
+}
+
+async function finalizeClaimedDispatchRequest({
+  claim,
+  result,
+  teamName,
+  teamDirPath,
+  config,
+  cwd,
+  stateDir,
+  logsDir,
+  issueCooldownMs,
+  triggerCooldownMs,
+}) {
+  const requestsPath = join(teamDirPath, 'dispatch', 'requests.json');
+  const issueKey = extractIssueKey(claim.request.trigger_message);
+  const triggerKey = normalizeTriggerKey(claim.request.trigger_message);
+  let summary = { processed: 0, skipped: 0, failed: 0 };
+
+  await withDispatchLock(teamDirPath, async () => {
+    const bridgeRequests = await readBridgeDispatchRequests(stateDir, teamName);
+    const usingLegacyRequests = bridgeRequests === null;
+    const requests = usingLegacyRequests ? await readJson(requestsPath, []) : bridgeRequests;
+    if (!Array.isArray(requests)) return;
+
+    const index = requests.findIndex((entry) => safeString(entry?.request_id).trim() === claim.request.request_id);
+    if (index < 0) return;
+
+    const request = requests[index];
+    if (!request || typeof request !== 'object' || shouldSkipRequest(request) || request.status !== 'pending') return;
+
+    const issueCooldownState = await readIssueCooldownState(teamDirPath);
+    const triggerCooldownState = await readTriggerCooldownState(teamDirPath);
+    const issueCooldownByIssue = issueCooldownState.by_issue || {};
+    const triggerCooldownByKey = triggerCooldownState.by_trigger || {};
+    const nowIso = new Date().toISOString();
+    let mutated = false;
+
+    if (issueKey && issueCooldownMs > 0) {
+      issueCooldownByIssue[issueKey] = Date.now();
+      mutated = true;
+    }
+    if (triggerKey && triggerCooldownMs > 0) {
+      triggerCooldownByKey[triggerKey] = {
+        at: Date.now(),
+        last_request_id: safeString(request.request_id).trim(),
+      };
+      mutated = true;
+    }
+
+    request.attempt_count = Number.isFinite(request.attempt_count) ? Math.max(0, request.attempt_count + 1) : 1;
+    request.updated_at = nowIso;
+
+    if (result.ok) {
+      const MAX_UNCONFIRMED_ATTEMPTS = 3;
+      if (result.reason === 'tmux_send_keys_unconfirmed' && request.attempt_count < MAX_UNCONFIRMED_ATTEMPTS) {
+        request.last_reason = result.reason;
+        summary.skipped += 1;
+        mutated = true;
+        await appendDispatchLog(logsDir, {
+          type: 'dispatch_unconfirmed_retry',
+          team: teamName,
+          request_id: request.request_id,
+          worker: request.to_worker,
+          attempt: request.attempt_count,
+          reason: result.reason,
+          ...buildDispatchAttemptEvidence(result),
+        });
+        await appendDeliveryTelemetry(logsDir, {
+          event: 'dispatch_result',
+          team: teamName,
+          request_id: request.request_id,
+          message_id: request.message_id || null,
+          to_worker: request.to_worker,
+          transport: 'send-keys',
+          result: 'retry',
+          reason: result.reason,
+        });
+        await emitOperationalHookEvent(cwd, 'retry-needed', {
+          team: teamName,
+          worker: request.to_worker,
+          request_id: request.request_id,
+          attempt: request.attempt_count,
+          command: request.trigger_message,
+          reason: result.reason,
+          status: 'retry-needed',
+        });
+      } else if (result.reason === 'tmux_send_keys_unconfirmed') {
+        request.status = 'failed';
+        request.failed_at = nowIso;
+        request.last_reason = 'unconfirmed_after_max_retries';
+        runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: 'unconfirmed_after_max_retries' }, stateDir);
+        summary.processed += 1;
+        summary.failed += 1;
+        mutated = true;
+        await appendDispatchLog(logsDir, {
+          type: 'dispatch_failed',
+          team: teamName,
+          request_id: request.request_id,
+          worker: request.to_worker,
+          message_id: request.message_id || null,
+          reason: request.last_reason,
+          ...buildDispatchAttemptEvidence(result),
+        });
+        await appendDeliveryTelemetry(logsDir, {
+          event: 'dispatch_result',
+          team: teamName,
+          request_id: request.request_id,
+          message_id: request.message_id || null,
+          to_worker: request.to_worker,
+          transport: 'send-keys',
+          result: 'failed',
+          reason: request.last_reason,
+        });
+        await emitOperationalHookEvent(cwd, 'failed', {
+          team: teamName,
+          worker: request.to_worker,
+          request_id: request.request_id,
+          message_id: request.message_id || null,
+          command: request.trigger_message,
+          reason: request.last_reason,
+          error_summary: request.last_reason,
+          status: 'failed',
+        });
+      } else {
+        request.status = 'notified';
+        request.notified_at = nowIso;
+        request.last_reason = result.reason;
+        runtimeExec({ command: 'MarkNotified', request_id: request.request_id, channel: 'tmux' }, stateDir);
+        if (request.kind === 'mailbox' && request.message_id) {
+          runtimeExec({ command: 'MarkMailboxNotified', message_id: request.message_id }, stateDir);
+          if (usingLegacyRequests) {
+            await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(() => {});
+          }
+        }
+        summary.processed += 1;
+        mutated = true;
+        await appendDispatchLog(logsDir, {
+          type: 'dispatch_notified',
+          team: teamName,
+          request_id: request.request_id,
+          worker: request.to_worker,
+          message_id: request.message_id || null,
+          reason: result.reason,
+          ...buildDispatchAttemptEvidence(result),
+        });
+        await appendDeliveryTelemetry(logsDir, {
+          event: 'dispatch_result',
+          team: teamName,
+          request_id: request.request_id,
+          message_id: request.message_id || null,
+          to_worker: request.to_worker,
+          transport: 'send-keys',
+          result: 'notified',
+          reason: result.reason,
+        });
+      }
+    } else {
+      request.status = 'failed';
+      request.failed_at = nowIso;
+      request.last_reason = result.reason;
+      runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: result.reason }, stateDir);
+      summary.processed += 1;
+      summary.failed += 1;
+      mutated = true;
+      await appendDispatchLog(logsDir, {
+        type: 'dispatch_failed',
+        team: teamName,
+        request_id: request.request_id,
+        worker: request.to_worker,
+        message_id: request.message_id || null,
+        reason: result.reason,
+        ...buildDispatchAttemptEvidence(result),
+      });
+      await appendDeliveryTelemetry(logsDir, {
+        event: 'dispatch_result',
+        team: teamName,
+        request_id: request.request_id,
+        message_id: request.message_id || null,
+        to_worker: request.to_worker,
+        transport: 'send-keys',
+        result: 'failed',
+        reason: result.reason,
+      });
+      await emitOperationalHookEvent(cwd, result.reason === LEADER_PANE_MISSING_DEFERRED_REASON ? 'handoff-needed' : 'failed', {
+        team: teamName,
+        worker: request.to_worker,
+        request_id: request.request_id,
+        message_id: request.message_id || null,
+        command: request.trigger_message,
+        reason: result.reason,
+        ...(result.reason === LEADER_PANE_MISSING_DEFERRED_REASON
+          ? { status: 'handoff-needed' }
+          : { status: 'failed', error_summary: result.reason }),
+      });
+    }
+
+    if (!mutated) return;
+    issueCooldownState.by_issue = issueCooldownByIssue;
+    await writeJsonAtomic(issueCooldownStatePath(teamDirPath), issueCooldownState);
+    triggerCooldownState.by_trigger = triggerCooldownByKey;
+    await writeJsonAtomic(triggerCooldownStatePath(teamDirPath), triggerCooldownState);
+    await writeJsonAtomic(requestsPath, requests);
+    if (!usingLegacyRequests) {
+      await writeBridgeDispatchCompat(stateDir, teamName, requests);
+    }
+  });
+
+  return summary;
 }
 
 function resolveWorkerCliForRequest(request, config) {
@@ -602,8 +855,8 @@ export async function drainPendingTeamDispatch({
     const manifestPath = join(teamDirPath, 'manifest.v2.json');
     const configPath = join(teamDirPath, 'config.json');
     const requestsPath = join(teamDirPath, 'dispatch', 'requests.json');
-
     const config = await readJson(existsSync(manifestPath) ? manifestPath : configPath, {});
+    const claims = [];
     await withDispatchLock(teamDirPath, async () => {
       const bridgeRequests = await readBridgeDispatchRequests(stateDir, teamName);
       const usingLegacyRequests = bridgeRequests === null;
@@ -613,11 +866,13 @@ export async function drainPendingTeamDispatch({
       const triggerCooldownState = await readTriggerCooldownState(teamDirPath);
       const issueCooldownByIssue = issueCooldownState.by_issue || {};
       const triggerCooldownByKey = triggerCooldownState.by_trigger || {};
+      const plannedIssueKeys = new Set();
+      const plannedTriggerKeys = new Set();
       const nowMs = Date.now();
 
       let mutated = false;
       for (const request of requests) {
-        if (processed >= maxPerTick) break;
+        if (processed + claims.length >= maxPerTick) break;
         if (!request || typeof request !== 'object') continue;
         if (shouldSkipRequest(request)) {
           skipped += 1;
@@ -660,9 +915,6 @@ export async function drainPendingTeamDispatch({
               result: 'deferred',
               reason: LEADER_PANE_MISSING_DEFERRED_REASON,
             });
-            // On the legacy fallback lane, requests.json still carries the queue
-            // state for this deferred request; this event stays a progress
-            // artifact for hook/watcher readers.
             await appendLeaderNotificationDeferredEvent({
               stateDir,
               teamName,
@@ -679,6 +931,10 @@ export async function drainPendingTeamDispatch({
 
         const issueKey = extractIssueKey(request.trigger_message);
         if (issueCooldownMs > 0 && issueKey) {
+          if (plannedIssueKeys.has(issueKey)) {
+            skipped += 1;
+            continue;
+          }
           const lastInjectedMs = Number(issueCooldownByIssue[issueKey]);
           if (Number.isFinite(lastInjectedMs) && lastInjectedMs > 0 && nowMs - lastInjectedMs < issueCooldownMs) {
             skipped += 1;
@@ -688,6 +944,10 @@ export async function drainPendingTeamDispatch({
 
         const triggerKey = normalizeTriggerKey(request.trigger_message);
         if (triggerCooldownMs > 0 && triggerKey) {
+          if (plannedTriggerKeys.has(triggerKey)) {
+            skipped += 1;
+            continue;
+          }
           const parsed = parseTriggerCooldownEntry(triggerCooldownByKey[triggerKey]);
           const withinCooldown = Number.isFinite(parsed.at) && parsed.at > 0 && nowMs - parsed.at < triggerCooldownMs;
           const sameRequestRetry = parsed.lastRequestId !== '' && parsed.lastRequestId === safeString(request.request_id).trim();
@@ -697,170 +957,17 @@ export async function drainPendingTeamDispatch({
           }
         }
 
-        const result = await injector(request, config, resolve(cwd), stateDir);
-        if (issueKey && issueCooldownMs > 0) {
-          issueCooldownByIssue[issueKey] = Date.now();
-          mutated = true;
+        const lease = await tryAcquireDispatchRequestLease(teamDirPath, request.request_id);
+        if (!lease) {
+          skipped += 1;
+          continue;
         }
-        if (triggerKey && triggerCooldownMs > 0) {
-          triggerCooldownByKey[triggerKey] = {
-            at: Date.now(),
-            last_request_id: safeString(request.request_id).trim(),
-          };
-          mutated = true;
-        }
-        const nowIso = new Date().toISOString();
-        request.attempt_count = Number.isFinite(request.attempt_count) ? Math.max(0, request.attempt_count + 1) : 1;
-        request.updated_at = nowIso;
-
-        if (result.ok) {
-          // Unconfirmed sends: trigger text was still visible after retry
-          // rounds. Leave as pending for the next tick to retry (up to 3
-          // total attempts) rather than marking notified. Fixes #391.
-          const MAX_UNCONFIRMED_ATTEMPTS = 3;
-          if (result.reason === 'tmux_send_keys_unconfirmed' && request.attempt_count < MAX_UNCONFIRMED_ATTEMPTS) {
-            request.last_reason = result.reason;
-            mutated = true;
-            skipped += 1;
-            await appendDispatchLog(logsDir, {
-              type: 'dispatch_unconfirmed_retry',
-              team: teamName,
-              request_id: request.request_id,
-              worker: request.to_worker,
-              attempt: request.attempt_count,
-              reason: result.reason,
-              ...buildDispatchAttemptEvidence(result),
-            });
-            await appendDeliveryTelemetry(logsDir, {
-              event: 'dispatch_result',
-              team: teamName,
-              request_id: request.request_id,
-              message_id: request.message_id || null,
-              to_worker: request.to_worker,
-              transport: 'send-keys',
-              result: 'retry',
-              reason: result.reason,
-            });
-            await emitOperationalHookEvent(cwd, 'retry-needed', {
-              team: teamName,
-              worker: request.to_worker,
-              request_id: request.request_id,
-              attempt: request.attempt_count,
-              command: request.trigger_message,
-              reason: result.reason,
-              status: 'retry-needed',
-            });
-            continue;
-          }
-          if (result.reason === 'tmux_send_keys_unconfirmed') {
-            request.status = 'failed';
-            request.failed_at = nowIso;
-            request.last_reason = 'unconfirmed_after_max_retries';
-            runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: 'unconfirmed_after_max_retries' }, stateDir);
-            processed += 1;
-            failed += 1;
-            mutated = true;
-            await appendDispatchLog(logsDir, {
-              type: 'dispatch_failed',
-              team: teamName,
-              request_id: request.request_id,
-              worker: request.to_worker,
-              message_id: request.message_id || null,
-              reason: request.last_reason,
-              ...buildDispatchAttemptEvidence(result),
-            });
-            await appendDeliveryTelemetry(logsDir, {
-              event: 'dispatch_result',
-              team: teamName,
-              request_id: request.request_id,
-              message_id: request.message_id || null,
-              to_worker: request.to_worker,
-              transport: 'send-keys',
-              result: 'failed',
-              reason: request.last_reason,
-            });
-            await emitOperationalHookEvent(cwd, 'failed', {
-              team: teamName,
-              worker: request.to_worker,
-              request_id: request.request_id,
-              message_id: request.message_id || null,
-              command: request.trigger_message,
-              reason: request.last_reason,
-              error_summary: request.last_reason,
-              status: 'failed',
-            });
-            continue;
-          }
-          request.status = 'notified';
-          request.notified_at = nowIso;
-          request.last_reason = result.reason;
-          runtimeExec({ command: 'MarkNotified', request_id: request.request_id, channel: 'tmux' }, stateDir);
-          if (request.kind === 'mailbox' && request.message_id) {
-            runtimeExec({ command: 'MarkMailboxNotified', message_id: request.message_id }, stateDir);
-            if (usingLegacyRequests) {
-              await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(() => {});
-            }
-          }
-          processed += 1;
-          mutated = true;
-          await appendDispatchLog(logsDir, {
-            type: 'dispatch_notified',
-            team: teamName,
-            request_id: request.request_id,
-            worker: request.to_worker,
-            message_id: request.message_id || null,
-            reason: result.reason,
-            ...buildDispatchAttemptEvidence(result),
-          });
-          await appendDeliveryTelemetry(logsDir, {
-            event: 'dispatch_result',
-            team: teamName,
-            request_id: request.request_id,
-            message_id: request.message_id || null,
-            to_worker: request.to_worker,
-            transport: 'send-keys',
-            result: 'notified',
-            reason: result.reason,
-          });
-        } else {
-          request.status = 'failed';
-          request.failed_at = nowIso;
-          request.last_reason = result.reason;
-          runtimeExec({ command: 'MarkFailed', request_id: request.request_id, reason: result.reason }, stateDir);
-          processed += 1;
-          failed += 1;
-          mutated = true;
-          await appendDispatchLog(logsDir, {
-            type: 'dispatch_failed',
-            team: teamName,
-            request_id: request.request_id,
-            worker: request.to_worker,
-            message_id: request.message_id || null,
-            reason: result.reason,
-            ...buildDispatchAttemptEvidence(result),
-          });
-          await appendDeliveryTelemetry(logsDir, {
-            event: 'dispatch_result',
-            team: teamName,
-            request_id: request.request_id,
-            message_id: request.message_id || null,
-            to_worker: request.to_worker,
-            transport: 'send-keys',
-            result: 'failed',
-            reason: result.reason,
-          });
-          await emitOperationalHookEvent(cwd, result.reason === LEADER_PANE_MISSING_DEFERRED_REASON ? 'handoff-needed' : 'failed', {
-            team: teamName,
-            worker: request.to_worker,
-            request_id: request.request_id,
-            message_id: request.message_id || null,
-            command: request.trigger_message,
-            reason: result.reason,
-            ...(result.reason === LEADER_PANE_MISSING_DEFERRED_REASON
-              ? { status: 'handoff-needed' }
-              : { status: 'failed', error_summary: result.reason }),
-          });
-        }
+        claims.push({
+          request: { ...request },
+          lease,
+        });
+        if (issueKey) plannedIssueKeys.add(issueKey);
+        if (triggerKey) plannedTriggerKeys.add(triggerKey);
       }
 
       if (mutated) {
@@ -874,6 +981,29 @@ export async function drainPendingTeamDispatch({
         }
       }
     });
+
+    for (const claim of claims) {
+      try {
+        const result = await injector(claim.request, config, resolve(cwd), stateDir);
+        const delta = await finalizeClaimedDispatchRequest({
+          claim,
+          result,
+          teamName,
+          teamDirPath,
+          config,
+          cwd,
+          stateDir,
+          logsDir,
+          issueCooldownMs,
+          triggerCooldownMs,
+        });
+        processed += delta.processed;
+        skipped += delta.skipped;
+        failed += delta.failed;
+      } finally {
+        await releaseDispatchRequestLease(claim.lease);
+      }
+    }
   }
 
   return { processed, skipped, failed };


### PR DESCRIPTION
## Summary
- stop `drainPendingTeamDispatch` from holding the global dispatch lock across slow tmux injection work
- claim per-request leases under the lock, inject outside it, then reacquire the lock only to persist results
- add a hook regression proving concurrent mailbox sends no longer time out while a slow injector is running

## Root cause
Issue #1492 turned out to have **separate but interacting causes**:
1. startup stalls were the queued-Codex-draft bug already fixed in #1491
2. mid-run dispatch-lock wedges came from the notify hook monopolizing the global dispatch lock while it performed slow tmux readiness checks / retries

This PR fixes the second root cause without duplicating the startup-draft patch from #1491.

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js`
- `node --test dist/team/__tests__/state.test.js`
- `npx biome lint src/scripts/notify-hook/team-dispatch.ts src/hooks/__tests__/notify-hook-team-dispatch.test.ts`
- realistic local tmux runtime repro on stacked verification worktree (`#1491` + this commit):
  - `omx team 3:executor "1492 smoke runtime"` from a non-git workspace inside tmux
  - `omx team api send-message ...` succeeded twice mid-run
  - final status reached `in_progress=1` with `startup_failure_count=0` and `lock_timeout_count=0`

Closes #1492
Related: #1491
