### PR TITLE
Prevent hook cwd alias mismatches from breaking managed session logic

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { once } from 'node:events';
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
@@ -777,6 +777,59 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+
+
+  it('treats symlinked cwd aliases as the same primary watcher during authority handoff', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-cwd-alias-'));
+    const aliasWd = `${wd}-alias`;
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    try {
+      await symlink(wd, aliasWd, process.platform === 'win32' ? 'junction' : 'dir');
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeSessionStart(wd, 'sess-cwd-alias');
+      await writeFile(join(wd, '.omx', 'state', 'notify-fallback.pid'), JSON.stringify({
+        pid: process.pid,
+        cwd: wd,
+        started_at: new Date().toISOString(),
+      }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), JSON.stringify({
+        pid: process.pid,
+        cwd: wd,
+        authority_only: false,
+        poll_ms: 250,
+        dispatch_drain: { last_tick_at: new Date().toISOString() },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--authority-only', '--cwd', aliasWd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+            OMX_SESSION_ID: 'sess-cwd-alias',
+            TMUX: '1',
+            TMUX_PANE: '%42',
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const watcherState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), 'utf-8'));
+      assert.equal(watcherState.authority_backoff?.active, true);
+      assert.equal(watcherState.authority_backoff?.reason, 'primary_watcher_healthy');
+      assert.equal(watcherState.authority_backoff?.primary_pid, process.pid);
+    } finally {
+      await rm(aliasWd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 
   it('disables fallback watcher nudges when deep-interview state is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-deep-interview-suppressed-'));

--- a/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
+++ b/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveManagedSessionContext } from '../../scripts/notify-hook/managed-tmux.js';
@@ -72,6 +72,27 @@ describe('notify-hook managed tmux windows fallback', () => {
       assert.equal(result.nativeSessionId, 'codex-native-session');
       assert.match(result.expectedTmuxSessionName, /omx-canonical-session|canonical-session/);
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts symlinked cwd aliases for the same managed session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-cwd-alias-'));
+    const aliasCwd = `${cwd}-alias`;
+    try {
+      await symlink(cwd, aliasCwd, process.platform === 'win32' ? 'junction' : 'dir');
+      await writeSessionStart(cwd, 'omx-alias-session');
+
+      delete process.env.TMUX;
+      delete process.env.TMUX_PANE;
+      process.env.OMX_TEAM_WORKER = '';
+
+      const result = await resolveManagedSessionContext(aliasCwd, { session_id: 'omx-alias-session' }, { allowTeamWorker: false });
+      assert.equal(result.managed, true);
+      assert.match(result.reason, /ancestry_match$/);
+      assert.equal(result.canonicalSessionId, 'omx-alias-session');
+    } finally {
+      await rm(aliasCwd, { recursive: true, force: true });
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
+++ b/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
@@ -1,12 +1,29 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { resolveManagedSessionContext } from '../../scripts/notify-hook/managed-tmux.js';
+import { buildTmuxSessionName } from '../../cli/index.js';
+import { resolveManagedSessionContext, verifyManagedPaneTarget } from '../../scripts/notify-hook/managed-tmux.js';
 import { writeSessionStart } from '../session.js';
 
 describe('notify-hook managed tmux windows fallback', () => {
+  async function withFakeTmux(cwd: string, script: string, run: () => Promise<void>): Promise<void> {
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const fakeTmuxPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+    await mkdir(fakeBinDir, { recursive: true });
+    await writeFile(fakeTmuxPath, script);
+    await chmod(fakeTmuxPath, 0o755);
+    process.env.PATH = `${fakeBinDir}:${previousPath || ''}`;
+    try {
+      await run();
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+    }
+  }
+
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
   const originalTmux = process.env.TMUX;
   const originalTmuxPane = process.env.TMUX_PANE;
@@ -91,6 +108,54 @@ describe('notify-hook managed tmux windows fallback', () => {
       assert.equal(result.managed, true);
       assert.match(result.reason, /ancestry_match$/);
       assert.equal(result.canonicalSessionId, 'omx-alias-session');
+      assert.equal(result.expectedTmuxSessionName, buildTmuxSessionName(cwd, 'omx-alias-session'));
+    } finally {
+      await rm(aliasCwd, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('verifies managed pane targets when invoked from a cwd alias for the same session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-pane-alias-'));
+    const aliasCwd = `${cwd}-alias`;
+    const sessionId = 'omx-alias-session';
+    try {
+      await symlink(cwd, aliasCwd, process.platform === 'win32' ? 'junction' : 'dir');
+      await writeSessionStart(cwd, sessionId);
+
+      delete process.env.TMUX;
+      delete process.env.TMUX_PANE;
+      process.env.OMX_TEAM_WORKER = '';
+
+      const managedSessionName = buildTmuxSessionName(cwd, sessionId);
+      await withFakeTmux(cwd, `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$target" == "%42" && "$format" == "#S" ]]; then
+    echo "${managedSessionName}"
+    exit 0
+  fi
+fi
+echo "unsupported tmux call: $cmd $*" >&2
+exit 1
+`, async () => {
+        const verdict = await verifyManagedPaneTarget('%42', aliasCwd, { session_id: sessionId }, { allowTeamWorker: false });
+        assert.equal(verdict.ok, true);
+        assert.equal(verdict.reason, 'ok');
+        assert.equal(verdict.paneSessionName, managedSessionName);
+        assert.equal(verdict.managedContext.expectedTmuxSessionName, managedSessionName);
+      });
     } finally {
       await rm(aliasCwd, { recursive: true, force: true });
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -1,12 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildTmuxSessionName } from '../../cli/index.js';
-import { handleTmuxInjection } from '../../scripts/notify-hook/tmux-injection.js';
+import { handleTmuxInjection, resolvePaneTarget } from '../../scripts/notify-hook/tmux-injection.js';
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../dist/scripts/notify-hook.js', import.meta.url);
 
@@ -437,6 +437,96 @@ exit 1
       const hookState = await readJson<Record<string, unknown>>(hookStatePath);
       assert.equal(hookState.last_reason, 'pane_cwd_mismatch');
       assert.equal(hookState.total_injections, 0);
+    });
+  });
+
+  it('accepts alias and canonical twin paths when resolving managed pane ownership', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const aliasCwd = `${cwd}-alias`;
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const sessionId = 'omx-abc123';
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const managedSessionName = buildTmuxSessionName(cwd, sessionId);
+
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await symlink(cwd, aliasCwd, process.platform === 'win32' ? 'junction' : 'dir');
+      await writeManagedSessionState(stateDir, cwd, sessionId);
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$target" == "%42" && "$format" == "#{pane_id}" ]]; then
+    echo "%42"
+    exit 0
+  fi
+  if [[ "$target" == "%42" && "$format" == "#{pane_start_command}" ]]; then
+    echo "codex --model gpt-5"
+    exit 0
+  fi
+  if [[ "$target" == "%42" && "$format" == "#{pane_current_command}" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$target" == "%42" && "$format" == "#{pane_current_path}" ]]; then
+    echo "${cwd}"
+    exit 0
+  fi
+  if [[ "$target" == "%42" && "$format" == "#S" ]]; then
+    echo "${managedSessionName}"
+    exit 0
+  fi
+fi
+echo "unsupported tmux call: $cmd $*" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const previousPath = process.env.PATH;
+      const previousTeamWorker = process.env.OMX_TEAM_WORKER;
+      const previousTmux = process.env.TMUX;
+      const previousTmuxPane = process.env.TMUX_PANE;
+      try {
+        process.env.PATH = `${fakeBinDir}:${process.env.PATH || ''}`;
+        process.env.OMX_TEAM_WORKER = '';
+        delete process.env.TMUX;
+        delete process.env.TMUX_PANE;
+
+        const resolution = await resolvePaneTarget(
+          { type: 'pane', value: '%42' },
+          aliasCwd,
+          '',
+          aliasCwd,
+          { session_id: sessionId },
+        );
+        assert.equal(resolution.paneTarget, '%42');
+        assert.equal(resolution.reason, 'explicit_pane_target');
+        assert.equal(resolution.matched_session, managedSessionName);
+      } finally {
+        if (typeof previousPath === 'string') process.env.PATH = previousPath;
+        else delete process.env.PATH;
+        if (typeof previousTeamWorker === 'string') process.env.OMX_TEAM_WORKER = previousTeamWorker;
+        else delete process.env.OMX_TEAM_WORKER;
+        if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+        else delete process.env.TMUX;
+        if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+        else delete process.env.TMUX_PANE;
+        await rm(aliasCwd, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -80,6 +80,24 @@ describe('session lifecycle manager', () => {
       };
       assert.equal(hud.turn_count, 0);
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('treats symlinked cwd aliases as authoritative for the same session state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-cwd-alias-'));
+    const aliasCwd = `${cwd}-alias`;
+    try {
+      await symlink(cwd, aliasCwd, process.platform === 'win32' ? 'junction' : 'dir');
+      await writeSessionStart(cwd, 'sess-alias');
+
+      const usable = await readUsableSessionState(aliasCwd);
+      assert.ok(usable);
+      assert.equal(usable?.session_id, 'sess-alias');
+      assert.equal(usable?.cwd, cwd);
+    } finally {
+      await rm(aliasCwd, { recursive: true, force: true });
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -6,9 +6,9 @@
  */
 
 import { readFile, writeFile, mkdir, unlink, appendFile } from 'fs/promises';
-import { dirname, join, resolve as resolvePath } from 'path';
+import { dirname, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
-import { omxStateDir, omxLogsDir } from '../utils/paths.js';
+import { omxStateDir, omxLogsDir, sameFilePath } from '../utils/paths.js';
 import { getStateFilePath } from '../mcp/state-paths.js';
 
 export interface SessionState {
@@ -87,7 +87,7 @@ export function isSessionStateAuthoritativeForCwd(state: SessionState, cwd: stri
   if (!SESSION_ID_PATTERN.test(state.session_id)) return false;
 
   if (typeof state.cwd === 'string' && state.cwd.trim() !== '') {
-    return resolvePath(state.cwd) === resolvePath(cwd);
+    return sameFilePath(state.cwd, cwd);
   }
 
   return true;

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -33,6 +33,7 @@ import {
   readSubagentSessionSummary,
 } from '../subagents/tracker.js';
 import { listNotifyCanonicalActiveTeams } from './notify-hook/active-team.js';
+import { sameFilePath } from '../utils/paths.js';
 
 function argValue(name: string, fallback = ''): string {
   const idx = process.argv.indexOf(name);
@@ -919,7 +920,7 @@ async function resolveAuthorityPrimaryWatcherHealth(now = Date.now()): Promise<A
 
   const existingRecord = await readPidFileRecord(pidFilePath).catch(() => null);
   if (!existingRecord) return createAuthorityBackoffState('pid_missing');
-  if (existingRecord.cwd && resolve(existingRecord.cwd) !== cwd) return createAuthorityBackoffState('cwd_mismatch');
+  if (existingRecord.cwd && !sameFilePath(existingRecord.cwd, cwd)) return createAuthorityBackoffState('cwd_mismatch');
   if (!isPidAlive(existingRecord.pid)) {
     return createAuthorityBackoffState('pid_stale', {
       primary_pid: existingRecord.pid,

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from 'child_process';
 import { readFileSync } from 'fs';
-import { basename, dirname, resolve as resolvePath } from 'path';
+import { basename, dirname } from 'path';
 import { readSessionState, isSessionStale } from '../../hooks/session.js';
 import { runProcess } from './process-runner.js';
 import { safeString } from './utils.js';
+import { sameFilePath } from '../../utils/paths.js';
 
 function sanitizeTmuxToken(value: string): string {
   const cleaned = safeString(value)
@@ -139,7 +140,7 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
     if (!sessionState) {
       return { managed: false, reason: 'missing_session_state', invocationSessionId, sessionState: null, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
     }
-    if (resolvePath(safeString(sessionState.cwd || cwd)) !== resolvePath(cwd)) {
+    if (!sameFilePath(safeString(sessionState.cwd || cwd), cwd)) {
       return { managed: false, reason: 'cwd_mismatch', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
     }
     const canonicalSessionId = safeString(sessionState.session_id).trim();

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -153,7 +153,11 @@ export async function resolveManagedSessionContext(cwd: string, payload: any, { 
       return { managed: false, reason: 'stale_session', invocationSessionId, sessionState, expectedTmuxSessionName: '', currentTmuxSessionName: '' };
     }
 
-    const expectedTmuxSessionName = buildExpectedManagedTmuxSessionName(cwd, canonicalSessionId || invocationSessionId);
+    const authoritativeSessionCwd = safeString(sessionState.cwd || cwd).trim() || cwd;
+    const expectedTmuxSessionName = buildExpectedManagedTmuxSessionName(
+      authoritativeSessionCwd,
+      canonicalSessionId || invocationSessionId,
+    );
     const currentTmuxSessionName = readCurrentTmuxSessionName();
     if (currentTmuxSessionName && currentTmuxSessionName === expectedTmuxSessionName) {
       return {

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -8,6 +8,7 @@ import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, resolve as resolvePath } from 'path';
 import { safeString, asNumber } from './utils.js';
+import { sameFilePath } from '../../utils/paths.js';
 import {
   readJsonIfExists,
   normalizeTmuxState,
@@ -35,7 +36,7 @@ async function resolvePaneCwdMismatch(paneId: string, expectedCwd: any): Promise
   try {
     const paneCwdResult = await runProcess('tmux', ['display-message', '-p', '-t', paneId, '#{pane_current_path}']);
     const paneCwd = safeString(paneCwdResult.stdout).trim();
-    if (paneCwd && resolvePath(paneCwd) !== resolvePath(expectedCwd)) {
+    if (paneCwd && !sameFilePath(paneCwd, expectedCwd)) {
       return {
         paneTarget: null,
         reason: 'pane_cwd_mismatch',

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -30,6 +30,22 @@ function resolveLauncherPath(rawPath: string, baseCwd: string): string {
   }
 }
 
+export function canonicalizeComparablePath(rawPath: string): string {
+  const absolutePath = resolve(rawPath);
+  if (!existsSync(absolutePath)) return absolutePath;
+  try {
+    return typeof realpathSync.native === "function"
+      ? realpathSync.native(absolutePath)
+      : realpathSync(absolutePath);
+  } catch {
+    return absolutePath;
+  }
+}
+
+export function sameFilePath(leftPath: string, rightPath: string): boolean {
+  return canonicalizeComparablePath(leftPath) === canonicalizeComparablePath(rightPath);
+}
+
 export function resolveOmxEntryPath(
   options: {
     argv1?: string | null;


### PR DESCRIPTION
## Summary

Fix hook/session cwd identity checks so symlinked or aliased worktrees are treated as the same workspace instead of triggering false `cwd_mismatch` behavior.

## Changes

- add canonical path helpers in `src/utils/paths.ts`
- switch hook/session cwd authority comparisons to canonical path equality
- cover symlinked cwd aliases in session, managed tmux, and notify-fallback watcher regressions

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx biome lint src/utils/paths.ts src/hooks/session.ts src/scripts/notify-hook/managed-tmux.ts src/scripts/notify-fallback-watcher.ts src/hooks/__tests__/session.test.ts src/hooks/__tests__/notify-hook-managed-tmux.test.ts src/hooks/__tests__/notify-fallback-watcher.test.ts`
- [x] `node dist/scripts/run-test-files.js dist/hooks/__tests__ dist/scripts/__tests__/codex-native-hook.test.js dist/scripts/__tests__/hook-derived-watcher.test.js dist/cli/__tests__/hooks.test.js dist/cli/__tests__/native-hook-dispatch-contract.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/config/__tests__/codex-hooks.test.js dist/notifications/__tests__/hook-config.test.js dist/wiki/__tests__/session-hooks.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
