### PR TITLE
fix(notify): suppress stale starting-phase Ralph steer after handoff

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1920,6 +1920,60 @@ exit 0
     }
   });
 
+  it('suppresses Ralph continue steer when session-scoped Ralph is stuck in stale starting phase', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-starting-stale-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    const sessionId = 'sess-starting-stale';
+    const sessionStateDir = join(stateDir, 'sessions', sessionId);
+    const watcherStatePath = join(stateDir, 'notify-fallback-state.json');
+    try {
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeSessionStart(wd, sessionId);
+      await writeFile(join(sessionStateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: new Date(Date.now() - 180_000).toISOString(),
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({
+        last_progress_at: new Date(Date.now() - 180_000).toISOString(),
+      }, null, 2));
+      await writeFile(watcherStatePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          }),
+        },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'stale starting phase should suppress continue steer');
+
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'starting_stale');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('suppresses Ralph continue steer while tracked native subagents are still active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-subagents-active-'));
     const fakeBinDir = join(wd, 'fake-bin');

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -547,6 +547,14 @@ async function resolveActiveModeState(mode: string): Promise<ActiveModeResult> {
       .then((content) => JSON.parse(content) as Record<string, unknown>)
       .catch(() => null);
     if (!parsed || typeof parsed !== 'object') continue;
+    if (mode === 'ralph' && dir !== stateDir && isStaleRalphStartingPhase(parsed)) {
+      return {
+        active: false,
+        reason: 'starting_stale',
+        path,
+        state: parsed,
+      };
+    }
     if (hasRalphTerminalState(parsed)) {
       return {
         active: false,
@@ -1014,7 +1022,12 @@ async function runRalphContinueSteerTick(): Promise<void> {
     singleton_lock_path: ralphSteerLockPath,
   };
 
-  if (!activeRalph.active) return;
+  if (!activeRalph.active) {
+    if (activeRalph.reason === 'starting_stale') {
+      lastRalphContinueSteer.last_reason = 'starting_stale';
+    }
+    return;
+  }
 
   if (parseIsoMillis(lastRalphContinueSteer.last_sent_at) === null && parseIsoMillis(lastRalphContinueSteer.cooldown_anchor_at) === null) {
     lastRalphContinueSteer.cooldown_anchor_at = startupIso;


### PR DESCRIPTION
## Summary
- rewrite the stale starting-phase Ralph steer fix onto `dev` instead of the wrong-base `main` PR
- preserve `dev`'s root terminal behavior while surfacing `starting_stale` for session-scoped handoff state
- keep the notify-fallback watcher regression coverage aligned with the dev runtime semantics

## Validation
- npm run build
- node dist/scripts/run-test-files.js dist/hooks/__tests__/notify-fallback-watcher.test.js
- node dist/scripts/run-test-files.js dist/team/__tests__ dist/state/__tests__ dist/ralph/__tests__ dist/ralplan/__tests__ dist/runtime/__tests__

## Notes
- Replacement for wrong-base PR #1494, which was opened from a fork branch based on `main` and could not be force-updated from this workspace.