### PR TITLE
Fix Stop-hook terminal-state mismatch after team cleanup

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1514,6 +1514,13 @@ esac
         current_phase: "team-exec",
         team_name: "session-live-team",
       });
+      await writeJson(join(stateDir, "team", "session-live-team", "phase.json"), {
+        current_phase: "team-exec",
+        max_fix_attempts: 3,
+        current_fix_attempt: 0,
+        transitions: [],
+        updated_at: new Date().toISOString(),
+      });
 
       const result = await dispatchCodexNativeHook(
         {
@@ -2473,6 +2480,35 @@ esac
         current_fix_attempt: 0,
         transitions: [],
         updated_at: new Date().toISOString(),
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block Stop from orphaned team mode state after cleanup removed canonical team artifacts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-orphaned-team-state-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current" });
+      await writeJson(join(stateDir, "team-state.json"), {
+        active: true,
+        current_phase: "starting",
+        team_name: "cleaned-team",
+        session_id: "sess-current",
       });
 
       const result = await dispatchCodexNativeHook(

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -682,6 +682,12 @@ async function buildTeamStopOutput(cwd: string, sessionId?: string): Promise<Rec
   const teamState = await readTeamModeStateForStop(cwd, sessionId);
   if (teamState?.active !== true) return null;
   const teamName = safeString(teamState.team_name).trim();
+  if (teamName) {
+    const canonicalTeamDir = join(resolveCanonicalTeamStateRoot(cwd), "team", teamName);
+    if (!existsSync(canonicalTeamDir)) {
+      return null;
+    }
+  }
   const coarsePhase = teamState.current_phase;
   const canonicalPhase = teamName ? (await readTeamPhase(teamName, cwd))?.current_phase ?? coarsePhase : coarsePhase;
   if (!isNonTerminalPhase(canonicalPhase)) return null;

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -1859,6 +1859,60 @@ describe('executeTeamApiOperation: cleanup', () => {
     }
   });
 
+  it('deactivates lingering team mode state after cleanup removes canonical team state', async () => {
+    const { cwd, cleanup } = await setupTeam('cleanup-mode-sync');
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-cleanup-mode-sync';
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+
+      const manifest = await readTeamManifestV2('cleanup-mode-sync', cwd);
+      assert.ok(manifest);
+      if (!manifest) throw new Error('manifest missing');
+      await writeTeamManifestV2({
+        ...manifest,
+        leader: {
+          ...(manifest.leader ?? {}),
+          session_id: sessionId,
+        },
+      }, cwd);
+
+      const activeState = {
+        active: true,
+        current_phase: 'starting',
+        team_name: 'cleanup-mode-sync',
+        session_id: sessionId,
+      };
+      await writeFile(join(stateDir, 'team-state.json'), JSON.stringify(activeState, null, 2));
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'team-state.json'),
+        JSON.stringify(activeState, null, 2),
+      );
+
+      const result = await executeTeamApiOperation('cleanup', {
+        team_name: 'cleanup-mode-sync',
+      }, cwd);
+      assert.equal(result.ok, true);
+
+      const rootState = JSON.parse(
+        await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(rootState.active, false);
+      assert.equal(rootState.current_phase, 'cancelled');
+      assert.ok(typeof rootState.completed_at === 'string' && rootState.completed_at.length > 0);
+
+      const scopedState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'team-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(scopedState.active, false);
+      assert.equal(scopedState.current_phase, 'cancelled');
+      assert.ok(typeof scopedState.completed_at === 'string' && scopedState.completed_at.length > 0);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('does not bypass shutdown gate for pending work', async () => {
     const { cwd, cleanup } = await setupTeam('cleanup-gated');
     try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -120,6 +120,7 @@ import { inferPhaseTargetFromTaskCounts, reconcilePhaseStateForMonitor } from '.
 import { getTeamTmuxSessions } from '../notifications/tmux.js';
 import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
 import { buildRebalanceDecisions } from './rebalance-policy.js';
+import { getStatePath } from '../mcp/state-paths.js';
 import { readModeState, updateModeState } from '../modes/base.js';
 import {
   appendTeamCommitHygieneEntries,
@@ -206,6 +207,54 @@ async function syncRootTeamModeStateOnTerminalPhase(
     await updateModeState('team', updates, cwd);
   } catch {
     // Best-effort compatibility sync only.
+  }
+}
+
+function matchesTeamModeStateForShutdown(
+  state: Record<string, unknown> | null,
+  teamName: string,
+): boolean {
+  const stateTeamName = typeof state?.team_name === 'string' ? state.team_name.trim() : '';
+  return !stateTeamName || stateTeamName === teamName;
+}
+
+async function syncExactTeamModeStateOnShutdown(
+  teamName: string,
+  cwd: string,
+  sessionId?: string,
+): Promise<void> {
+  const path = getStatePath('team', cwd, sessionId);
+  if (!existsSync(path)) return;
+
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+    if (!matchesTeamModeStateForShutdown(parsed, teamName)) return;
+
+    const next = {
+      ...parsed,
+      active: false,
+      current_phase: 'cancelled',
+      completed_at:
+        typeof parsed.completed_at === 'string' && parsed.completed_at.trim().length > 0
+          ? parsed.completed_at
+          : new Date().toISOString(),
+      team_name: teamName,
+    };
+    await writeFile(path, JSON.stringify(next, null, 2));
+  } catch {
+    // Best-effort compatibility sync only.
+  }
+}
+
+async function syncTeamModeStateOnShutdown(
+  teamName: string,
+  cwd: string,
+  leaderSessionId?: string,
+): Promise<void> {
+  await syncExactTeamModeStateOnShutdown(teamName, cwd);
+  const normalizedLeaderSessionId = typeof leaderSessionId === 'string' ? leaderSessionId.trim() : '';
+  if (normalizedLeaderSessionId) {
+    await syncExactTeamModeStateOnShutdown(teamName, cwd, normalizedLeaderSessionId);
   }
 }
 
@@ -2853,10 +2902,14 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
     }
     await cleanupTeamState(sanitized, cwd);
+    await syncTeamModeStateOnShutdown(sanitized, cwd);
     restoreTeamModelInstructionsFile(sanitized);
     return { commitHygieneArtifacts: null };
   }
   const manifest = await readTeamManifestV2(sanitized, cwd);
+  const leaderSessionId = typeof manifest?.leader?.session_id === 'string'
+    ? manifest.leader.session_id.trim()
+    : '';
   const governance = resolveGovernancePolicy(
     manifest?.governance,
     manifest?.policy as Partial<TeamGovernance> | undefined,
@@ -3168,10 +3221,15 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   }
 
   // 7. Cleanup state
+  let teamStateCleaned = false;
   try {
     await cleanupTeamState(sanitized, cwd);
+    teamStateCleaned = true;
   } catch (err) {
     cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+  }
+  if (teamStateCleaned) {
+    await syncTeamModeStateOnShutdown(sanitized, cwd, leaderSessionId);
   }
 
   if (cleanupErrors.length > 0) {


### PR DESCRIPTION
## Summary
- deactivate lingering root/session `team-state.json` files when runtime/API cleanup removes canonical team state
- make the Stop hook ignore orphaned team mode state once canonical team artifacts are gone
- add regressions for the cleanup sync path and the Stop-vs-Stale mismatch from #1497

## Testing
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/team/__tests__/api-interop.test.js
- npm run test:recent-bug-regressions:compiled

Closes #1497.
