### PR TITLE
Prevent clawhip false positives from incidental test-log keywords

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -196,6 +196,32 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match.skill, 'deep-interview');
     assert.equal(match.keyword.toLowerCase(), 'deep interview');
   });
+
+  it('treats direct abort commands as cancel intent', () => {
+    const match = detectPrimaryKeyword('abort now');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'cancel');
+    assert.equal(match.keyword.toLowerCase(), 'abort');
+  });
+
+  it('treats direct stop commands as cancel intent', () => {
+    const match = detectPrimaryKeyword('stop now');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'cancel');
+    assert.equal(match.keyword.toLowerCase(), 'stop');
+  });
+
+  it('does not trigger cancel from incidental stop/abort test-log prose', () => {
+    assert.equal(detectPrimaryKeyword('FAIL should stop retrying after max attempts'), null);
+    assert.equal(detectPrimaryKeyword('PASS request aborted when upstream returns 499'), null);
+  });
+
+  it('does not trigger ultrawork from incidental parallel test-log prose', () => {
+    assert.equal(detectPrimaryKeyword('PASS runs assertions in parallel when sharding is enabled'), null);
+    assert.equal(detectPrimaryKeyword('running 8 tests in parallel across 4 workers'), null);
+  });
 });
 
 describe('keyword registry coverage', () => {

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -548,6 +548,51 @@ describe('notify-hook auto-nudge', () => {
     });
   });
 
+  it('does not nudge from PASS/FAIL-style test output captured from the pane', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const captureFile = join(cwd, 'capture-output.txt');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+
+      await writeFile(
+        captureFile,
+        [
+          'PASS should continue with the next step when approvals are present',
+          'FAIL aborts the branch cleanly when the worker exits early',
+          'Test Suites: 1 failed, 1 total',
+        ].join('\n'),
+      );
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'clean output with no stall',
+      }, {
+        OMX_TEST_CAPTURE_FILE: captureFile,
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /capture-pane/, 'should still inspect capture-pane output');
+      assert.doesNotMatch(tmuxLog, defaultAutoNudgePattern('%99'), 'PASS/FAIL-style test output must not trigger a nudge');
+    });
+  });
+
   it('auto-nudges from active mode state by upgrading an anchored shell pane to the sibling codex pane', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -353,9 +353,23 @@ const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> =
   priority: entry.priority,
 }));
 
-const KEYWORDS_REQUIRING_INTENT = new Set(['team', 'swarm']);
+const KEYWORDS_REQUIRING_INTENT = new Set(['team', 'swarm', 'stop', 'abort', 'parallel']);
 
-const TEAM_SWARM_INTENT_PATTERNS: Record<'team' | 'swarm', RegExp[]> = {
+type IntentKeyword = 'team' | 'swarm' | 'stop' | 'abort' | 'parallel';
+
+/**
+ * Per-keyword intent patterns used when a keyword is in KEYWORDS_REQUIRING_INTENT.
+ *
+ * "team" / "swarm" require explicit orchestration phrasing so a generic
+ * reference in prose doesn't spin up the skill.
+ *
+ * "stop" / "abort" require a bare imperative or explicit OMX mode reference so
+ * test-log lines like "stop retrying" or "request aborted" do not trigger cancel.
+ *
+ * "parallel" requires an explicit instruction to run in parallel mode so that
+ * CI output like "running 8 tests in parallel" does not trigger ultrawork.
+ */
+const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
   team: [
     /(?:^|[^\w])\$(?:team)\b/i,
     /\/prompts:team\b/i,
@@ -367,6 +381,30 @@ const TEAM_SWARM_INTENT_PATTERNS: Record<'team' | 'swarm', RegExp[]> = {
     /\/prompts:swarm\b/i,
     /\b(?:use|run|start|enable|launch|invoke|activate|orchestrate|coordinate)\s+(?:a\s+|an\s+|the\s+)?swarm\b/i,
     /\bswarm\s+(?:mode|orchestration|workflow|agents?)\b/i,
+  ],
+  stop: [
+    /^(?:please\s+)?stop(?:\s+now)?\s*[.!]?\s*$/i,
+    /\bcancelomx\b/i,
+    /(?:^|[^\w])\$(?:stop|cancel|abort)\b/i,
+    /\/(?:cancel|stop|abort)\b/i,
+    /\bstop\s+(?:the\s+)?(?:agent|ralph|autopilot|team|ultrawork|execution|current\s+(?:mode|task|run))\b/i,
+    /\b(?:cancel|stop)\s+(?:the\s+)?(?:active|running|current)\s+(?:mode|task|run|execution)\b/i,
+  ],
+  abort: [
+    /^(?:please\s+)?abort(?:\s+now)?\s*[.!]?\s*$/i,
+    /\bcancelomx\b/i,
+    /(?:^|[^\w])\$(?:stop|cancel|abort)\b/i,
+    /\/(?:cancel|stop|abort)\b/i,
+    /\babort\s+(?:the\s+)?(?:agent|ralph|autopilot|team|ultrawork|execution|current\s+(?:mode|task|run))\b/i,
+  ],
+  parallel: [
+    /(?:^|[^\w])\$(?:parallel|ultrawork|ulw)\b/i,
+    /\/(?:parallel|ultrawork)\b/i,
+    /\bultrawork\b/i,
+    /\bulw\b/i,
+    /\b(?:use|run|enable|start|activate|launch)\s+(?:in\s+)?parallel\b/i,
+    /\bparallel\s+(?:mode|execution|workers?|agents?|tasks?)\b/i,
+    /\brun\s+(?:tasks?|agents?|workers?)\s+in\s+parallel\b/i,
   ],
 };
 
@@ -415,9 +453,10 @@ function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
 }
 
 function hasIntentContextForKeyword(text: string, keyword: string): boolean {
-  if (!KEYWORDS_REQUIRING_INTENT.has(keyword.toLowerCase())) return true;
-  const k = keyword.toLowerCase() as 'team' | 'swarm';
-  return TEAM_SWARM_INTENT_PATTERNS[k].some((pattern) => pattern.test(text));
+  const k = keyword.toLowerCase();
+  if (!KEYWORDS_REQUIRING_INTENT.has(k)) return true;
+  const patterns = KEYWORD_INTENT_PATTERNS[k as IntentKeyword];
+  return patterns.some((pattern) => pattern.test(text));
 }
 
 /**

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -347,6 +347,24 @@ function looksLikePermissionSeekingContinuation(normalizedText) {
   return matchesNormalizedPatterns(normalizedText, normalizePatternList(PERMISSION_SEEKING_STALL_PATTERNS));
 }
 
+/**
+ * Pattern to identify test-runner output lines (status symbols, PASS/FAIL prefixes).
+ * These lines may incidentally contain stall-pattern words inside test names and
+ * should be excluded before running stall detection on pane captures.
+ */
+const CAPTURE_TEST_LINE_RE = /^\s*(?:[✓✗✕×●✔✘▶◆○]|(?:PASS|FAIL|SKIP|ERROR)\s)/u;
+
+/**
+ * Strip lines that look like test-runner output so stall patterns inside test
+ * names (e.g. "✓ should continue with the next step") do not trigger a nudge.
+ */
+function filterCapturedTestLines(text) {
+  return safeString(text)
+    .split('\n')
+    .filter((line) => !CAPTURE_TEST_LINE_RE.test(line))
+    .join('\n');
+}
+
 function summarizePaneCaptureForLog(captured, maxLines = 6) {
   const lines = safeString(captured)
     .replace(/\r\n?/g, '\n')
@@ -516,7 +534,7 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
 
     if (!detected && paneId) {
       captured = await capturePane(paneId);
-      detected = detectStallPattern(captured, config.patterns, skillState?.phase);
+      detected = detectStallPattern(filterCapturedTestLines(captured), config.patterns, skillState?.phase);
       source = 'capture-pane';
     }
 


### PR DESCRIPTION
## Summary

Fixes issue #1482 by narrowing clawhip false positives in the current-dev notify/keyword path without expanding into broader alert-pipeline changes.

## Changes

- require explicit intent before `stop`, `abort`, and `parallel` keywords activate workflow routing
- add regressions covering direct cancel intent vs incidental PASS/FAIL test-log prose
- filter PASS/FAIL-style captured test-output lines before notify-hook stall detection evaluates pane captures
- add auto-nudge regression coverage for capture-pane PASS/FAIL output

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npx biome lint src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts src/scripts/notify-hook/auto-nudge.ts src/hooks/__tests__/notify-hook-auto-nudge.test.ts`
- [x] `node --test dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js`
- [x] `node --test dist/utils/__tests__/paths.test.js` *(expected unrelated failure; see note below)*

Exact note: repo-level dist/utils/__tests__/paths.test.js remains an unrelated environment-sensitive blocker.

Observed blocker details from this branch:
- `node --test dist/utils/__tests__/paths.test.js` fails 4 assertions because launcher-path resolution points at the installed global `oh-my-codex` CLI path in this environment instead of the temp startup-cwd path expected by the test.
- The touched scope above is green on top of `origin/dev`.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1482
