### PR TITLE
fix: suppress duplicate visible leader nudges for issue #1500

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1443,6 +1443,113 @@ exit 0
     });
   });
 
+  it('suppresses duplicate visible leader injection when the pane already shows the same classified state', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'same-classified-state';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'same-classified-state:0',
+        leader_pane_id: '%75',
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'same-classified-msg',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'please review latest output',
+            created_at: '2026-03-12T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%75" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%75" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  cat <<'EOF'
+Team same-classified-state: 1 msg(s) for leader. Next: read messages; keep orchestrating; if done, gracefully shut down: omx team shutdown same-classified-state.
+EOF
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%1 12345"
+  exit 0
+fi
+exit 0
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /capture-pane -t %75 -p -S -80/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %75 -l Team same-classified-state: 1 msg\(s\) for leader\./, 'same visible classified state should not be reinjected');
+
+      const eventsPath = join(teamDir, 'events', 'events.ndjson');
+      const events = (await readFile(eventsPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      const nudgeEvent = events.find((entry: { type?: string; reason?: string; orchestration_intent?: string }) =>
+        entry.type === 'team_leader_nudge' && entry.reason === 'new_mailbox_message');
+      assert.ok(nudgeEvent, 'suppressed visible sends should still emit leader nudge events');
+      assert.equal(nudgeEvent.orchestration_intent, 'pending-mailbox-review');
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'nudge_triggered'
+        && entry.team === teamName
+        && entry.to_worker === 'leader-fixed'
+        && entry.result === 'suppressed'
+        && entry.reason === 'new_mailbox_message'
+        && entry.suppression_reason === 'pane_already_shows_same_classified_state'));
+    });
+  });
+
   it('does not inject leader nudge while leader pane is in copy-mode', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -25,6 +25,7 @@ import { writeTeamLeaderAttention } from '../../team/state.js';
 import { readLatestTeamProgressEvidenceMs } from '../../team/progress-evidence.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
+const LEADER_PANE_SAME_CLASSIFIED_STATE_SUPPRESSED_REASON = 'pane_already_shows_same_classified_state';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
 const ACK_WITHOUT_START_EVIDENCE_REASON = 'ack_without_start_evidence';
 const ACK_LIKE_PATTERNS = [
@@ -437,6 +438,27 @@ function formatMailboxBodyForLeader(body, maxLength = 40) {
   if (!normalized) return 'ack-like update';
   if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function normalizeVisibleLeaderStateText(text) {
+  return safeString(text)
+    .toLowerCase()
+    .replace(/\[omx_tmux_inject\]/g, ' ')
+    .replace(/\[omx_intent:[^\]]+\]/g, ' ')
+    .replace(/said\s+"[^"]*"/g, 'said "<content>"')
+    .replace(/said\s+'[^']*'/g, 'said "<content>"')
+    .replace(/\b\d+[smhd](?:\s+\d+[smhd])*\b/g, '<duration>')
+    .replace(/\b\d+\b/g, '<n>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function paneAlreadyShowsVisibleLeaderState(paneCapture, visibleText) {
+  const normalizedVisibleText = normalizeVisibleLeaderStateText(visibleText);
+  if (!normalizedVisibleText) return false;
+  const normalizedPaneCapture = normalizeVisibleLeaderStateText(paneCapture);
+  if (!normalizedPaneCapture) return false;
+  return normalizedPaneCapture.includes(normalizedVisibleText);
 }
 
 async function workerHasOwnedStartedTask(stateDir, teamName, workerName) {
@@ -927,6 +949,55 @@ export async function maybeNudgeTeamLeader({
         result: 'deferred',
         reason: deferredReason,
         orchestration_intent: orchestrationIntent,
+      }).catch(() => {});
+      continue;
+    }
+
+    if (paneAlreadyShowsVisibleLeaderState(paneGuard.paneCapture, capped)) {
+      nudgeState.last_nudged_by_team[teamName] = {
+        at: nowIso,
+        last_message_id: newestId || prevMsgId || '',
+        reason: nudgeReason,
+        orchestration_intent: orchestrationIntent,
+      };
+      if (shouldSendAllIdleNudge) {
+        nudgeState.last_idle_nudged_by_team[teamName] = {
+          at: nowIso,
+          worker_count: workerNames.length,
+          orchestration_intent: orchestrationIntent,
+        };
+      }
+
+      await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
+
+      try {
+        await logTmuxHookEvent(logsDir, {
+          timestamp: nowIso,
+          type: 'team_leader_nudge',
+          team: teamName,
+          tmux_target: tmuxTarget,
+          reason: nudgeReason,
+          orchestration_intent: orchestrationIntent,
+          pane_count: paneStatus.paneCount,
+          leader_stale: leaderStale,
+          message_count: messages.length,
+          stalled_for_ms: teamProgressStalled ? stalledForMs : undefined,
+          missing_signal_workers: progressSnapshot.missingSignalWorkers,
+          visible_injection_suppressed: true,
+          suppression_reason: LEADER_PANE_SAME_CLASSIFIED_STATE_SUPPRESSED_REASON,
+        });
+      } catch { /* ignore */ }
+      await appendTeamDeliveryLog(logsDir, {
+        event: 'nudge_triggered',
+        source,
+        team: teamName,
+        to_worker: 'leader-fixed',
+        transport: 'send-keys',
+        result: 'suppressed',
+        reason: nudgeReason,
+        orchestration_intent: orchestrationIntent,
+        visible_injection_suppressed: true,
+        suppression_reason: LEADER_PANE_SAME_CLASSIFIED_STATE_SUPPRESSED_REASON,
       }).catch(() => {});
       continue;
     }

--- a/src/team/delivery-log.ts
+++ b/src/team/delivery-log.ts
@@ -19,6 +19,7 @@ export type TeamDeliveryResult =
   | 'missing'
   | 'retry'
   | 'deferred'
+  | 'suppressed'
   | 'sent'
   | 'failed';
 


### PR DESCRIPTION
## Summary
- suppress leader-pane send-keys injection when the live pane already shows the same classified leader nudge state
- keep emitting `team_leader_nudge` events and delivery/tmux-hook evidence, logging the visible send as `suppressed`
- add focused regression coverage for the duplicate-visible suppression path

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js`
- `npx biome lint src/scripts/notify-hook/team-leader-nudge.ts src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts src/team/delivery-log.ts`
