### PR TITLE
fix: harden malformed native hook stdin JSON

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -93,6 +93,36 @@ describe("codex native hook config", () => {
 });
 
 describe("codex native hook dispatch", () => {
+  it("emits deterministic JSON stdout when CLI stdin is malformed", () => {
+    const stdout = execFileSync(
+      process.execPath,
+      [join(process.cwd(), "dist", "scripts", "codex-native-hook.js")],
+      {
+        cwd: process.cwd(),
+        input: "{",
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    const output = JSON.parse(stdout.trim()) as {
+      decision?: string;
+      reason?: string;
+      hookSpecificOutput?: { hookEventName?: string; additionalContext?: string };
+    };
+
+    assert.equal(output.decision, "block");
+    assert.equal(
+      output.reason,
+      "OMX native hook received malformed JSON input. Preserve runtime state and inspect the emitting hook payload before retrying.",
+    );
+    assert.equal(output.hookSpecificOutput?.hookEventName, "Unknown");
+    assert.match(
+      String(output.hookSpecificOutput?.additionalContext ?? ""),
+      /stdin JSON parsing failed inside codex-native-hook:/,
+    );
+  });
+
   it("maps Codex events onto OMX logical surfaces", () => {
     assert.equal(mapCodexHookEventToOmxEvent("SessionStart"), "session-start");
     assert.equal(mapCodexHookEventToOmxEvent("UserPromptSubmit"), "keyword-detector");

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1269,17 +1269,49 @@ export async function dispatchCodexNativeHook(
   };
 }
 
-async function readStdinJson(): Promise<CodexHookPayload> {
+interface NativeHookCliReadResult {
+  payload: CodexHookPayload;
+  parseError: Error | null;
+}
+
+async function readStdinJson(): Promise<NativeHookCliReadResult> {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
   }
   const raw = Buffer.concat(chunks).toString("utf-8").trim();
-  return raw ? safeObject(JSON.parse(raw)) : {};
+  if (!raw) {
+    return { payload: {}, parseError: null };
+  }
+
+  try {
+    return {
+      payload: safeObject(JSON.parse(raw)),
+      parseError: null,
+    };
+  } catch (error) {
+    return {
+      payload: {},
+      parseError: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
 }
 
 export async function runCodexNativeHookCli(): Promise<void> {
-  const payload = await readStdinJson();
+  const { payload, parseError } = await readStdinJson();
+  if (parseError) {
+    process.stdout.write(`${JSON.stringify({
+      decision: "block",
+      reason: "OMX native hook received malformed JSON input. Preserve runtime state and inspect the emitting hook payload before retrying.",
+      hookSpecificOutput: {
+        hookEventName: "Unknown",
+        additionalContext:
+          `stdin JSON parsing failed inside codex-native-hook: ${parseError.message}. Emit valid JSON from the native hook caller before retrying.`,
+      },
+    })}\n`);
+    return;
+  }
+
   const result = await dispatchCodexNativeHook(payload);
   if (result.outputJson) {
     process.stdout.write(`${JSON.stringify(result.outputJson)}\n`);


### PR DESCRIPTION
## Summary
- make codex-native-hook CLI return deterministic JSON stdout when stdin JSON is malformed
- avoid stderr-only crash behavior that surfaces as invalid native hook JSON churn
- add regression coverage for malformed stdin JSON

## Testing
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js

Closes #1503