### PR TITLE
Handle stale Ralph cleanup when scoped state already terminated

### DIFF
--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -219,6 +219,53 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('clears a stale root Ralph skill entry when scoped stale cleanup targets a different visible session skill', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-stale-root-global-skill-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-current';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        session_id: sessionId,
+      }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'deep-interview',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{ skill: 'deep-interview', phase: 'planning', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralph',
+        phase: 'starting',
+        active_skills: [{ skill: 'ralph', phase: 'starting', active: true }],
+      }));
+
+      const cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled stale Ralph session\./);
+
+      const rootSkillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(rootSkillState.active, false);
+      assert.deepEqual(rootSkillState.active_skills, []);
+
+      const sessionSkillState = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(sessionSkillState.active, true);
+      assert.equal(sessionSkillState.skill, 'deep-interview');
+      assert.equal(sessionSkillState.active_skills.length, 1);
+      assert.equal(sessionSkillState.active_skills[0].skill, 'deep-interview');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('keeps normal Ralph cancel behavior when --stale is not provided', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-normal-cancel-'));
     try {

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile, readFile } from 'fs/promises';
 import { dirname, join } from 'path';
+import { resolveRepoPath } from '../index.js';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -18,6 +19,13 @@ function runOmx(cwd: string, ...args: string[]) {
 }
 
 describe('CLI session-scoped state parity', () => {
+  it('treats Windows drive-letter evidence paths as absolute when resolving stale evidence', () => {
+    assert.equal(
+      resolveRepoPath('/repo/worktree', 'C:\\Users\\alice\\project\\.omx\\plans\\prd.md'),
+      'C:\\Users\\alice\\project\\.omx\\plans\\prd.md',
+    );
+  });
+
   it('status and cancel include session-scoped states', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-session-scope-'));
     try {
@@ -157,6 +165,55 @@ describe('CLI session-scoped state parity', () => {
       const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8'));
       assert.equal(skillState.active, false);
       assert.deepEqual(skillState.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves unrelated root skill entries when cancelling scoped stale Ralph state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-stale-root-skill-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-current';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        session_id: sessionId,
+      }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralph',
+        phase: 'starting',
+        session_id: sessionId,
+        active_skills: [{ skill: 'ralph', phase: 'starting', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'deep-interview',
+        phase: 'planning',
+        active_skills: [{ skill: 'deep-interview', phase: 'planning', active: true, session_id: '' }],
+      }));
+
+      const cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled stale Ralph session\./);
+
+      const rootSkillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(rootSkillState.active, true);
+      assert.equal(rootSkillState.skill, 'deep-interview');
+      assert.equal(rootSkillState.active_skills.length, 1);
+      assert.equal(rootSkillState.active_skills[0].skill, 'deep-interview');
+      assert.equal(rootSkillState.active_skills[0].phase, 'planning');
+      assert.equal(rootSkillState.active_skills[0].active, true);
+
+      const sessionSkillState = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(sessionSkillState.active, false);
+      assert.deepEqual(sessionSkillState.active_skills, []);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -285,4 +285,97 @@ describe('CLI session-scoped state parity', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('cancels stale root Ralph state when the current session has no scoped Ralph entry', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-stale-root-fallback-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(join(stateDir, 'sessions', 'sess-current'), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-current' }));
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        thread_id: 'sess-current',
+      }));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralph',
+        phase: 'starting',
+        session_id: '',
+        active_skills: [{ skill: 'ralph', phase: 'starting', active: true, session_id: '' }],
+      }));
+
+      const cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled stale Ralph session\./);
+
+      const ralph = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(ralph.active, false);
+      assert.equal(ralph.current_phase, 'cancelled');
+
+      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(skillState.active, false);
+      assert.deepEqual(skillState.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('cancels stale root Ralph state when the current session already has terminal scoped Ralph state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-stale-root-terminal-scoped-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', 'sess-current');
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-current' }));
+      await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({
+        active: false,
+        current_phase: 'cancelled',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        session_id: 'sess-current',
+      }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: false,
+        skill: 'ralph',
+        phase: '',
+        session_id: 'sess-current',
+        active_skills: [],
+      }));
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        thread_id: 'sess-current',
+      }));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralph',
+        phase: 'starting',
+        session_id: '',
+        active_skills: [{ skill: 'ralph', phase: 'starting', active: true, session_id: '' }],
+      }));
+
+      const cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled stale Ralph session\./);
+
+      const rootRalph = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(rootRalph.active, false);
+      assert.equal(rootRalph.current_phase, 'cancelled');
+
+      const rootSkillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(rootSkillState.active, false);
+      assert.deepEqual(rootSkillState.active_skills, []);
+
+      const scopedRalph = JSON.parse(await readFile(join(sessionDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(scopedRalph.active, false);
+      assert.equal(scopedRalph.current_phase, 'cancelled');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -123,4 +123,166 @@ describe('CLI session-scoped state parity', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('cancels stale Ralph startup state and clears matching skill-active state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-stale-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-stale' }));
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        thread_id: 'sess-stale',
+      }));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralph',
+        phase: 'starting',
+        session_id: 'sess-stale',
+        active_skills: [{ skill: 'ralph', phase: 'starting', active: true, session_id: 'sess-stale' }],
+      }));
+
+      const cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled stale Ralph session\./);
+
+      const ralph = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(ralph.active, false);
+      assert.equal(ralph.current_phase, 'cancelled');
+      assert.ok(typeof ralph.completed_at === 'string' && ralph.completed_at.length > 0);
+
+      const skillState = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8'));
+      assert.equal(skillState.active, false);
+      assert.deepEqual(skillState.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps normal Ralph cancel behavior when --stale is not provided', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-normal-cancel-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-normal' }));
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        thread_id: 'sess-normal',
+      }));
+
+      const cancelResult = runOmx(wd, 'cancel', 'ralph');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled: ralph/);
+
+      const ralph = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(ralph.active, false);
+      assert.equal(ralph.current_phase, 'cancelled');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses stale Ralph cancellation when startup evidence exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-stale-refuse-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const contextDir = join(wd, '.omx', 'context');
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(contextDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-refuse' }));
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        thread_id: 'sess-refuse',
+        context_snapshot_path: '.omx/context/seed.md',
+      }));
+      await writeFile(join(contextDir, 'seed.md'), '# snapshot\n');
+
+      const cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 1, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Refused stale Ralph cancellation\./);
+
+      const ralph = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(ralph.active, true);
+      assert.equal(ralph.current_phase, 'starting');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses stale Ralph cancellation for fresh or actively executing runs', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-stale-age-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-fresh' }));
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        thread_id: 'sess-fresh',
+      }));
+
+      let cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 1, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /too fresh/);
+
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        thread_id: 'sess-fresh',
+      }));
+
+      cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 1, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /phase executing/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not mutate unrelated sessions during stale Ralph cancellation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-stale-cross-session-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const otherSessionDir = join(stateDir, 'sessions', 'sess-other');
+      await mkdir(otherSessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-current' }));
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'starting',
+        started_at: '2026-02-22T00:00:00.000Z',
+        updated_at: '2026-02-22T00:00:00.000Z',
+        thread_id: 'sess-current',
+      }));
+      await writeFile(join(otherSessionDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        started_at: '2026-02-22T00:00:00.000Z',
+        session_id: 'sess-other',
+      }));
+
+      const cancelResult = runOmx(wd, 'cancel', 'ralph', '--stale');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+
+      const currentState = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8'));
+      const otherState = JSON.parse(await readFile(join(otherSessionDir, 'ralph-state.json'), 'utf-8'));
+      assert.equal(currentState.current_phase, 'cancelled');
+      assert.equal(otherState.active, true);
+      assert.equal(otherState.current_phase, 'executing');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { basename, dirname, join } from "path";
+import { basename, dirname, isAbsolute, join, win32 } from "path";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { constants as osConstants } from "os";
 import { setup, SETUP_SCOPES, type SetupScope } from "./setup.js";
@@ -3292,10 +3292,10 @@ function asTrimmedString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function resolveRepoPath(cwd: string, value: unknown): string {
+export function resolveRepoPath(cwd: string, value: unknown): string {
   const candidate = asTrimmedString(value);
   if (!candidate) return "";
-  return candidate.startsWith("/") ? candidate : join(cwd, candidate);
+  return isAbsolute(candidate) || win32.isAbsolute(candidate) ? candidate : join(cwd, candidate);
 }
 
 function existingEvidencePath(cwd: string, value: unknown): string {
@@ -3464,6 +3464,36 @@ function isTerminalizedModeEntry(
   return phase === "cancelled" || phase === "failed" || phase === "complete";
 }
 
+function rebuildSkillActiveState(
+  base: Record<string, unknown> | undefined,
+  entries: Array<{
+    skill?: string;
+    phase?: string;
+    activated_at?: string;
+    session_id?: string;
+    thread_id?: string;
+    turn_id?: string;
+  }>,
+  fallbackSkill: string,
+  nowIso: string,
+): Record<string, unknown> {
+  const currentPrimary = asTrimmedString(base?.skill);
+  const primary = entries.find((entry) => asTrimmedString(entry.skill) === currentPrimary) ?? entries[0];
+  return {
+    ...(base ?? {}),
+    version: typeof base?.version === "number" ? base.version : 1,
+    active: entries.length > 0,
+    skill: asTrimmedString(primary?.skill) || currentPrimary || fallbackSkill,
+    phase: asTrimmedString(primary?.phase) || "",
+    activated_at: asTrimmedString(primary?.activated_at) || asTrimmedString(base?.activated_at) || nowIso,
+    updated_at: nowIso,
+    session_id: asTrimmedString(primary?.session_id) || undefined,
+    thread_id: asTrimmedString(primary?.thread_id) || asTrimmedString(base?.thread_id) || undefined,
+    turn_id: asTrimmedString(primary?.turn_id) || asTrimmedString(base?.turn_id) || undefined,
+    active_skills: entries,
+  };
+}
+
 async function deactivateCanonicalSkillEntry(
   cwd: string,
   skill: string,
@@ -3490,17 +3520,40 @@ async function deactivateCanonicalSkillEntry(
 
     if (filtered.length === entries.length && visibleState.active !== true) return false;
 
-    const primary = filtered[0];
-    await writeSkillActiveStateCopies(cwd, {
-      ...visibleState,
-      active: filtered.length > 0,
-      skill: primary?.skill || asTrimmedString(visibleState.skill) || skill,
-      phase: primary?.phase || "",
-      activated_at: primary?.activated_at || asTrimmedString(visibleState.activated_at) || nowIso,
-      updated_at: nowIso,
-      session_id: targetSessionId || asTrimmedString(visibleState.session_id) || undefined,
-      active_skills: filtered,
-    }, targetSessionId || undefined);
+    const nextVisibleState = rebuildSkillActiveState(
+      visibleState,
+      filtered,
+      skill,
+      nowIso,
+    );
+
+    if (targetSessionId) {
+      const rootState = await readSkillActiveState(rootPath);
+      if (!rootState) {
+        writeFileSync(path, JSON.stringify({ version: 1, ...nextVisibleState }, null, 2));
+        return true;
+      }
+
+      const rootEntries = listActiveSkills(rootState);
+      const filteredRootEntries = rootEntries.filter((entry) => {
+        if (entry.skill !== skill) return true;
+        const entrySession = asTrimmedString(entry.session_id);
+        if (entrySession) return entrySession !== targetSessionId;
+        const rootVisibleSession = asTrimmedString(rootState.session_id);
+        if (rootVisibleSession) return rootVisibleSession !== targetSessionId;
+        return true;
+      });
+      const nextRootState = rebuildSkillActiveState(
+        rootState,
+        filteredRootEntries,
+        skill,
+        nowIso,
+      );
+      await writeSkillActiveStateCopies(cwd, nextVisibleState, targetSessionId, nextRootState);
+      return true;
+    }
+
+    await writeSkillActiveStateCopies(cwd, nextVisibleState, undefined, nextVisibleState);
     return true;
   };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@
 
 import { execFileSync, spawn } from "child_process";
 import { basename, dirname, join } from "path";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { constants as osConstants } from "os";
 import { setup, SETUP_SCOPES, type SetupScope } from "./setup.js";
 import { uninstall } from "./uninstall.js";
@@ -45,8 +45,16 @@ import {
   getBaseStateDir,
   getStateDir,
   listModeStateFilesWithScopePreference,
+  readCurrentSessionId,
 } from "../mcp/state-paths.js";
-import { SKILL_ACTIVE_STATE_MODE, syncCanonicalSkillStateForMode } from "../state/skill-active.js";
+import {
+  SKILL_ACTIVE_STATE_MODE,
+  getSkillActiveStatePaths,
+  listActiveSkills,
+  readSkillActiveState,
+  syncCanonicalSkillStateForMode,
+  writeSkillActiveStateCopies,
+} from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
 import { maybeCheckAndPromptUpdate } from "./update.js";
 import { maybePromptGithubStar } from "./star-prompt.js";
@@ -175,6 +183,7 @@ Usage:
   omx help      Show this help message
   omx status    Show active modes and state
   omx cancel    Cancel active execution modes
+                Use \`omx cancel ralph --stale\` for a Ralph session stuck in \`starting\`
   omx reasoning Show or set model reasoning effort (low|medium|high|xhigh)
 
 Options:
@@ -759,7 +768,7 @@ export async function main(args: string[]): Promise<void> {
         await showStatus();
         break;
       case "cancel":
-        await cancelModes();
+        await cancelModes(args.slice(1));
         break;
       case "reasoning":
         await reasoningCommand(args.slice(1));
@@ -3277,11 +3286,215 @@ async function flushHookDerivedWatcherOnce(cwd: string): Promise<void> {
   });
 }
 
-async function cancelModes(): Promise<void> {
+const RALPH_STALE_MIN_AGE_MS = 2 * 60 * 1000;
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function resolveRepoPath(cwd: string, value: unknown): string {
+  const candidate = asTrimmedString(value);
+  if (!candidate) return "";
+  return candidate.startsWith("/") ? candidate : join(cwd, candidate);
+}
+
+function existingEvidencePath(cwd: string, value: unknown): string {
+  const resolved = resolveRepoPath(cwd, value);
+  return resolved && existsSync(resolved) ? resolved : "";
+}
+
+function latestTimestampMs(state: Record<string, unknown> | undefined): number | null {
+  const timestamps = [
+    state?.updated_at,
+    state?.last_turn_at,
+    state?.started_at,
+  ]
+    .map((value) => Date.parse(asTrimmedString(value)))
+    .filter((value) => Number.isFinite(value));
+  if (timestamps.length === 0) return null;
+  return Math.max(...timestamps);
+}
+
+function ralphStateEvidenceReason(cwd: string, state: Record<string, unknown> | undefined): string {
+  const directContextPath = existingEvidencePath(cwd, state?.context_snapshot_path);
+  if (directContextPath) {
+    return `context snapshot exists at ${directContextPath}`;
+  }
+
+  const contextDir = join(cwd, ".omx", "context");
+  if (existsSync(contextDir) && readdirSync(contextDir).some((entry) => entry !== "." && entry !== "..")) {
+    return "context snapshot directory is not empty";
+  }
+
+  const directPlanPath = existingEvidencePath(cwd, state?.approved_plan_path);
+  if (directPlanPath) return `approved plan exists at ${directPlanPath}`;
+
+  const canonicalPrdPath = existingEvidencePath(cwd, state?.canonical_prd_path);
+  if (canonicalPrdPath) return `canonical PRD exists at ${canonicalPrdPath}`;
+
+  const canonicalProgressPath = existingEvidencePath(cwd, state?.canonical_progress_path);
+  if (canonicalProgressPath) return `canonical progress exists at ${canonicalProgressPath}`;
+
+  const approvedTestSpec = Array.isArray(state?.approved_test_spec_paths)
+    ? state.approved_test_spec_paths
+      .map((value) => existingEvidencePath(cwd, value))
+      .find(Boolean)
+    : "";
+  if (approvedTestSpec) return `approved test spec exists at ${approvedTestSpec}`;
+
+  const approvedDeepInterviewSpec = Array.isArray(state?.approved_deep_interview_spec_paths)
+    ? state.approved_deep_interview_spec_paths
+      .map((value) => existingEvidencePath(cwd, value))
+      .find(Boolean)
+    : "";
+  if (approvedDeepInterviewSpec) {
+    return `approved deep-interview spec exists at ${approvedDeepInterviewSpec}`;
+  }
+
+  return "";
+}
+
+function parseCancelModeArgs(args: string[]): {
+  targetMode: string;
+  stale: boolean;
+} {
+  let targetMode = "";
+  let stale = false;
+  for (const arg of args) {
+    const token = asTrimmedString(arg);
+    if (!token) continue;
+    if (token === "--stale") {
+      stale = true;
+      continue;
+    }
+    if (!token.startsWith("-") && !targetMode) {
+      targetMode = token;
+    }
+  }
+  return { targetMode, stale };
+}
+
+function readJsonFile(path: string): Record<string, unknown> | null {
+  if (!path || !existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function shouldRefuseRalphStaleCancel(
+  cwd: string,
+  sessionId: string | undefined,
+  state: Record<string, unknown> | undefined,
+  states: Map<string, {
+    path: string;
+    scope: "root" | "session";
+    state: Record<string, unknown>;
+  }>,
+): string {
+  if (!state || state.active !== true) {
+    return "Ralph is not active in the current session scope";
+  }
+
+  const ownerSession = asTrimmedString(state.owner_omx_session_id)
+    || asTrimmedString(state.session_id)
+    || asTrimmedString(state.thread_id);
+  if (sessionId && ownerSession && ownerSession !== sessionId) {
+    return "a different session owns the active Ralph state";
+  }
+
+  const phase = asTrimmedString(state.current_phase);
+  if (phase !== "starting") {
+    return phase ? `Ralph is in phase ${phase}` : "Ralph phase is not starting";
+  }
+
+  if (states.get("ultrawork")?.state?.active === true || states.get("ecomode")?.state?.active === true) {
+    return "linked execution mode is still active";
+  }
+
+  const evidenceReason = ralphStateEvidenceReason(cwd, state);
+  if (evidenceReason) return evidenceReason;
+
+  const latestTimestamp = latestTimestampMs(state);
+  if (latestTimestamp == null || !Number.isFinite(latestTimestamp)) {
+    return "Ralph state has no timestamp evidence";
+  }
+  if (Date.now() - latestTimestamp < RALPH_STALE_MIN_AGE_MS) {
+    return "Ralph state is too fresh to classify as stale";
+  }
+
+  return "";
+}
+
+function terminalizeModeState(
+  entry: {
+    path: string;
+    scope: "root" | "session";
+    state: Record<string, unknown>;
+  } | undefined,
+  nowIso: string,
+  phase: string = "cancelled",
+): boolean {
+  if (!entry) return false;
+  const needsChange =
+    entry.state.active !== false
+    || entry.state.current_phase !== phase
+    || typeof entry.state.completed_at !== "string"
+    || String(entry.state.completed_at).trim() === "";
+  if (!needsChange) return false;
+  entry.state.active = false;
+  entry.state.current_phase = phase;
+  entry.state.completed_at = nowIso;
+  entry.state.last_turn_at = nowIso;
+  writeFileSync(entry.path, JSON.stringify(entry.state, null, 2));
+  return true;
+}
+
+async function deactivateCanonicalSkillEntry(
+  cwd: string,
+  skill: string,
+  sessionId: string | undefined,
+  nowIso: string,
+): Promise<boolean> {
+  const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
+  const visibleState = sessionPath && existsSync(sessionPath)
+    ? await readSkillActiveState(sessionPath)
+    : await readSkillActiveState(rootPath);
+  if (!visibleState) return false;
+
+  const entries = listActiveSkills(visibleState);
+  const filtered = entries.filter((entry) => {
+    if (entry.skill !== skill) return true;
+    const entrySession = asTrimmedString(entry.session_id);
+    const visibleSession = asTrimmedString(visibleState.session_id);
+    if (sessionId && entrySession && entrySession !== sessionId) return true;
+    if (sessionId && !entrySession && visibleSession && visibleSession !== sessionId) return true;
+    return false;
+  });
+
+  if (filtered.length === entries.length && visibleState.active !== true) return false;
+
+  const primary = filtered[0];
+  await writeSkillActiveStateCopies(cwd, {
+    ...visibleState,
+    active: filtered.length > 0,
+    skill: primary?.skill || asTrimmedString(visibleState.skill) || skill,
+    phase: primary?.phase || "",
+    activated_at: primary?.activated_at || asTrimmedString(visibleState.activated_at) || nowIso,
+    updated_at: nowIso,
+    session_id: sessionId || asTrimmedString(visibleState.session_id) || undefined,
+    active_skills: filtered,
+  }, sessionId || undefined);
+  return true;
+}
+
+async function cancelModes(args: string[] = []): Promise<void> {
   const { writeFile, readFile } = await import("fs/promises");
   const cwd = process.cwd();
   const nowIso = new Date().toISOString();
   try {
+    const { targetMode, stale } = parseCancelModeArgs(args);
     const refs = await listModeStateFilesWithScopePreference(cwd);
     const states = new Map<
       string,
@@ -3306,6 +3519,63 @@ async function cancelModes(): Promise<void> {
         scope: ref.scope,
         state: parsedState,
       });
+    }
+
+    if (stale) {
+      if (targetMode !== "ralph") {
+        console.log("Refused stale Ralph cancellation.");
+        console.log("reason: use `omx cancel ralph --stale`");
+        console.log("next: use `omx cancel ralph`");
+        process.exitCode = 1;
+        return;
+      }
+
+      const sessionId = await readCurrentSessionId(cwd);
+      const ralphEntry = states.get("ralph");
+      const refusalReason = shouldRefuseRalphStaleCancel(cwd, sessionId, ralphEntry?.state, states);
+      if (refusalReason) {
+        console.log("Refused stale Ralph cancellation.");
+        console.log(`reason: ${refusalReason}`);
+        console.log("next: use `omx cancel ralph`");
+        process.exitCode = 1;
+        return;
+      }
+
+      const cleared: string[] = [];
+      if (terminalizeModeState(ralphEntry, nowIso)) {
+        cleared.push(ralphEntry?.scope === "session" ? "session ralph-state" : "legacy global ralph-state");
+      }
+
+      const rootRalphPath = join(getBaseStateDir(cwd), "ralph-state.json");
+      if (ralphEntry?.path !== rootRalphPath) {
+        const rootRalphState = readJsonFile(rootRalphPath);
+        const rootReason = shouldRefuseRalphStaleCancel(cwd, sessionId, rootRalphState ?? undefined, states);
+        if (!rootReason && rootRalphState) {
+          const rootEntry = {
+            path: rootRalphPath,
+            scope: "root" as const,
+            state: rootRalphState,
+          };
+          if (terminalizeModeState(rootEntry, nowIso)) {
+            cleared.push("legacy global ralph-state");
+          }
+        }
+      }
+
+      if (await deactivateCanonicalSkillEntry(cwd, "ralph", sessionId, nowIso)) {
+        cleared.push("matching skill-active-state");
+      }
+
+      console.log("Cancelled stale Ralph session.");
+      console.log(`session_id: ${sessionId || "root"}`);
+      console.log("reason: stuck_in_starting_without_execution_artifacts");
+      if (cleared.length > 0) {
+        console.log("cleared:");
+        for (const item of cleared) {
+          console.log(`  - ${item}`);
+        }
+      }
+      return;
     }
 
     const changed = new Set<string>();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3451,6 +3451,19 @@ function terminalizeModeState(
   return true;
 }
 
+function isTerminalizedModeEntry(
+  entry: {
+    path: string;
+    scope: "root" | "session";
+    state: Record<string, unknown>;
+  } | undefined,
+): boolean {
+  if (!entry) return true;
+  if (entry.state.active !== true) return true;
+  const phase = asTrimmedString(entry.state.current_phase).toLowerCase();
+  return phase === "cancelled" || phase === "failed" || phase === "complete";
+}
+
 async function deactivateCanonicalSkillEntry(
   cwd: string,
   skill: string,
@@ -3458,35 +3471,43 @@ async function deactivateCanonicalSkillEntry(
   nowIso: string,
 ): Promise<boolean> {
   const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
-  const visibleState = sessionPath && existsSync(sessionPath)
-    ? await readSkillActiveState(sessionPath)
-    : await readSkillActiveState(rootPath);
-  if (!visibleState) return false;
+  const updateStateAtPath = async (
+    path: string,
+    targetSessionId: string | undefined,
+  ): Promise<boolean> => {
+    const visibleState = await readSkillActiveState(path);
+    if (!visibleState) return false;
 
-  const entries = listActiveSkills(visibleState);
-  const filtered = entries.filter((entry) => {
-    if (entry.skill !== skill) return true;
-    const entrySession = asTrimmedString(entry.session_id);
-    const visibleSession = asTrimmedString(visibleState.session_id);
-    if (sessionId && entrySession && entrySession !== sessionId) return true;
-    if (sessionId && !entrySession && visibleSession && visibleSession !== sessionId) return true;
-    return false;
-  });
+    const entries = listActiveSkills(visibleState);
+    const filtered = entries.filter((entry) => {
+      if (entry.skill !== skill) return true;
+      const entrySession = asTrimmedString(entry.session_id);
+      const visibleSession = asTrimmedString(visibleState.session_id);
+      if (targetSessionId && entrySession && entrySession !== targetSessionId) return true;
+      if (targetSessionId && !entrySession && visibleSession && visibleSession !== targetSessionId) return true;
+      return false;
+    });
 
-  if (filtered.length === entries.length && visibleState.active !== true) return false;
+    if (filtered.length === entries.length && visibleState.active !== true) return false;
 
-  const primary = filtered[0];
-  await writeSkillActiveStateCopies(cwd, {
-    ...visibleState,
-    active: filtered.length > 0,
-    skill: primary?.skill || asTrimmedString(visibleState.skill) || skill,
-    phase: primary?.phase || "",
-    activated_at: primary?.activated_at || asTrimmedString(visibleState.activated_at) || nowIso,
-    updated_at: nowIso,
-    session_id: sessionId || asTrimmedString(visibleState.session_id) || undefined,
-    active_skills: filtered,
-  }, sessionId || undefined);
-  return true;
+    const primary = filtered[0];
+    await writeSkillActiveStateCopies(cwd, {
+      ...visibleState,
+      active: filtered.length > 0,
+      skill: primary?.skill || asTrimmedString(visibleState.skill) || skill,
+      phase: primary?.phase || "",
+      activated_at: primary?.activated_at || asTrimmedString(visibleState.activated_at) || nowIso,
+      updated_at: nowIso,
+      session_id: targetSessionId || asTrimmedString(visibleState.session_id) || undefined,
+      active_skills: filtered,
+    }, targetSessionId || undefined);
+    return true;
+  };
+
+  if (sessionPath && existsSync(sessionPath) && await updateStateAtPath(sessionPath, sessionId)) {
+    return true;
+  }
+  return await updateStateAtPath(rootPath, undefined);
 }
 
 async function cancelModes(args: string[] = []): Promise<void> {
@@ -3532,8 +3553,31 @@ async function cancelModes(args: string[] = []): Promise<void> {
 
       const sessionId = await readCurrentSessionId(cwd);
       const ralphEntry = states.get("ralph");
+      const rootRalphPath = join(getBaseStateDir(cwd), "ralph-state.json");
+      const rootRalphState = ralphEntry?.path === rootRalphPath
+        ? undefined
+        : readJsonFile(rootRalphPath);
+      const rootEntry = rootRalphState
+        ? {
+          path: rootRalphPath,
+          scope: "root" as const,
+          state: rootRalphState,
+        }
+        : undefined;
+
       const refusalReason = shouldRefuseRalphStaleCancel(cwd, sessionId, ralphEntry?.state, states);
-      if (refusalReason) {
+      const rootReason = rootEntry
+        ? shouldRefuseRalphStaleCancel(cwd, sessionId, rootEntry.state, states)
+        : "Ralph is not active in the current session scope";
+      const chosenEntry = !refusalReason
+        ? ralphEntry
+        : (
+          isTerminalizedModeEntry(ralphEntry) && !rootReason
+            ? rootEntry
+            : undefined
+        );
+
+      if (!chosenEntry) {
         console.log("Refused stale Ralph cancellation.");
         console.log(`reason: ${refusalReason}`);
         console.log("next: use `omx cancel ralph`");
@@ -3542,23 +3586,13 @@ async function cancelModes(args: string[] = []): Promise<void> {
       }
 
       const cleared: string[] = [];
-      if (terminalizeModeState(ralphEntry, nowIso)) {
-        cleared.push(ralphEntry?.scope === "session" ? "session ralph-state" : "legacy global ralph-state");
+      if (terminalizeModeState(chosenEntry, nowIso)) {
+        cleared.push(chosenEntry.scope === "session" ? "session ralph-state" : "legacy global ralph-state");
       }
 
-      const rootRalphPath = join(getBaseStateDir(cwd), "ralph-state.json");
-      if (ralphEntry?.path !== rootRalphPath) {
-        const rootRalphState = readJsonFile(rootRalphPath);
-        const rootReason = shouldRefuseRalphStaleCancel(cwd, sessionId, rootRalphState ?? undefined, states);
-        if (!rootReason && rootRalphState) {
-          const rootEntry = {
-            path: rootRalphPath,
-            scope: "root" as const,
-            state: rootRalphState,
-          };
-          if (terminalizeModeState(rootEntry, nowIso)) {
-            cleared.push("legacy global ralph-state");
-          }
+      if (rootEntry?.path !== chosenEntry.path && !rootReason) {
+        if (terminalizeModeState(rootEntry, nowIso)) {
+          cleared.push("legacy global ralph-state");
         }
       }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3541,7 +3541,7 @@ async function deactivateCanonicalSkillEntry(
         if (entrySession) return entrySession !== targetSessionId;
         const rootVisibleSession = asTrimmedString(rootState.session_id);
         if (rootVisibleSession) return rootVisibleSession !== targetSessionId;
-        return true;
+        return false;
       });
       const nextRootState = rebuildSkillActiveState(
         rootState,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5,6 +5,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import { buildManagedCodexHooksConfig } from "../../config/codex-hooks.js";
 import {
   initTeamState,
@@ -23,6 +24,8 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+const testDir = dirname(fileURLToPath(import.meta.url));
+const omxBin = join(testDir, "..", "..", "cli", "omx.js");
 const TEAM_STOP_COMMIT_GUIDANCE =
   " If system-generated worker auto-checkpoint commits exist, rewrite them into Lore-format final commits before merge/finalization.";
 const DEFAULT_AUTO_NUDGE_RESPONSE =
@@ -1823,6 +1826,74 @@ esac
         systemMessage:
           "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
       });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("stops blocking Stop after stale Ralph cancellation terminalizes the session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-cancel-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", "sess-stop-stale-cancel");
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-stale-cancel" });
+      await writeJson(join(sessionDir, "ralph-state.json"), {
+        active: true,
+        current_phase: "starting",
+        started_at: "2026-02-22T00:00:00.000Z",
+        updated_at: "2026-02-22T00:00:00.000Z",
+        thread_id: "sess-stop-stale-cancel",
+      });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        active: true,
+        skill: "ralph",
+        phase: "starting",
+        session_id: "sess-stop-stale-cancel",
+        active_skills: [{
+          skill: "ralph",
+          phase: "starting",
+          active: true,
+          session_id: "sess-stop-stale-cancel",
+        }],
+      });
+
+      let result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-stale-cancel",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: starting); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_starting",
+        systemMessage:
+          "OMX Ralph is still active (phase: starting); continue the task and gather fresh verification evidence before stopping.",
+      });
+
+      execFileSync(process.execPath, [omxBin, "cancel", "ralph", "--stale"], {
+        cwd,
+        stdio: "pipe",
+      });
+
+      result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-stale-cancel",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add `omx cancel ralph --stale` so half-started Ralph sessions can be terminalized safely instead of blocking Stop hooks forever
- keep stale cleanup session-scoped by default, clear the matching canonical `skill-active` entry, and allow root fallback only when the visible scoped Ralph state is absent or already terminal
- address the first review pass by making stale-evidence path resolution portable across Windows drive-letter paths and preserving unrelated root `skill-active` entries during session-scoped cleanup

## Context
- replaces the closed `main`-targeted PR #1505 with the same scope on the required `dev` base

## Test Plan
- npm run build
- node --test dist/cli/__tests__/session-scoped-runtime.test.js dist/scripts/__tests__/codex-native-hook.test.js
- replay `omx cancel ralph --stale` against stale startup state and confirm the Stop hook no longer re-blocks