### PR TITLE
fix: bootstrap reusable worktree dependencies

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -52,6 +52,7 @@ import {
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
 } from "../index.js";
+import { ensureReusableNodeModules } from "../../utils/repo-deps.js";
 import { readAllState } from "../../hud/state.js";
 import { generateOverlay } from "../../hooks/agents-overlay.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../../hud/constants.js";
@@ -2026,6 +2027,16 @@ describe("buildDetachedTmuxSessionName", () => {
       "omx-1770992424158-abc123",
     );
     assert.equal(sessionName, "omx-my-repo-detached-1770992424158-abc123");
+  });
+});
+
+describe("worktree dependency bootstrap helpers", () => {
+  it("returns an explicit warning when reusable worktree dependencies are unavailable", () => {
+    const result = ensureReusableNodeModules("/tmp/non-worktree", {
+      gitRunner: () => ({ status: 1, stdout: "", stderr: "not a worktree" }) as any,
+    });
+    assert.equal(result.strategy, "missing");
+    assert.match(String(result.warning || ""), /No reusable parent-repo node_modules was found/);
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -109,6 +109,7 @@ import {
   planWorktreeTarget,
   ensureWorktree,
 } from "../team/worktree.js";
+import { ensureReusableNodeModules } from "../utils/repo-deps.js";
 import {
   OMX_NOTIFY_TEMP_CONTRACT_ENV,
   parseNotifyTempContractFromArgs,
@@ -928,6 +929,12 @@ export async function launchWithHud(args: string[]): Promise<void> {
     const ensured = ensureWorktree(planned);
     if (ensured.enabled) {
       cwd = ensured.worktreePath;
+      const depBootstrap = ensureReusableNodeModules(cwd);
+      if (depBootstrap.strategy === "symlink") {
+        console.log(`[omx] Reusing node_modules from ${depBootstrap.sourceNodeModulesPath}`);
+      } else if (depBootstrap.strategy === "missing" && depBootstrap.warning) {
+        console.warn(`[omx] ${depBootstrap.warning}`);
+      }
     }
   }
   const sessionId = `omx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -1014,6 +1021,12 @@ export async function execWithOverlay(args: string[]): Promise<void> {
     const ensured = ensureWorktree(planned);
     if (ensured.enabled) {
       cwd = ensured.worktreePath;
+      const depBootstrap = ensureReusableNodeModules(cwd);
+      if (depBootstrap.strategy === "symlink") {
+        console.log(`[omx] Reusing node_modules from ${depBootstrap.sourceNodeModulesPath}`);
+      } else if (depBootstrap.strategy === "missing" && depBootstrap.warning) {
+        console.warn(`[omx] ${depBootstrap.warning}`);
+      }
     }
   }
 

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -9,9 +9,6 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import {
   ensureReusableNodeModules,
-  hasUsableNodeModules,
-  resolveGitCommonDir,
-  resolveReusableNodeModulesSource,
 } from '../utils/repo-deps.js';
 
 export {

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1,22 +1,24 @@
 import {
-  existsSync,
-  lstatSync,
   mkdtempSync,
   rmSync,
-  symlinkSync,
 } from 'node:fs';
 import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, dirname, join, resolve } from 'node:path';
+import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
+import {
+  ensureReusableNodeModules,
+  hasUsableNodeModules,
+  resolveGitCommonDir,
+  resolveReusableNodeModulesSource,
+} from '../utils/repo-deps.js';
 
-const REQUIRED_NODE_MODULE_MARKERS = [
-  join('typescript', 'package.json'),
-  join('@iarna', 'toml', 'package.json'),
-  join('@modelcontextprotocol', 'sdk', 'package.json'),
-  join('zod', 'package.json'),
-];
+export {
+  hasUsableNodeModules,
+  resolveGitCommonDir,
+  resolveReusableNodeModulesSource,
+} from '../utils/repo-deps.js';
 
 export const PACKED_INSTALL_SMOKE_CORE_COMMANDS = [
   ['--help'],
@@ -32,65 +34,16 @@ function usage(): string {
   ].join('\n');
 }
 
-function hasNodeModulesPath(nodeModulesPath: string): boolean {
-  try {
-    lstatSync(nodeModulesPath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function hasUsableNodeModules(repoRoot: string): boolean {
-  return REQUIRED_NODE_MODULE_MARKERS.every((marker) => existsSync(join(repoRoot, 'node_modules', marker)));
-}
-
-export function resolveGitCommonDir(cwd: string, gitRunner = spawnSync): string | null {
-  const result = gitRunner('git', ['rev-parse', '--git-common-dir'], {
-    cwd,
-    encoding: 'utf-8',
-  });
-  if (result.status !== 0) {
-    return null;
-  }
-  const value = (result.stdout || '').trim();
-  if (!value) {
-    return null;
-  }
-  return resolve(cwd, value);
-}
-
 interface EnsureRepoDepsOptions {
   gitRunner?: typeof spawnSync;
   install?: (cwd: string) => void;
-  remove?: typeof rmSync;
-  symlink?: typeof symlinkSync;
   log?: (message: string) => void;
-  platformName?: string;
 }
 
 interface EnsureRepoDepsResult {
   strategy: string;
   nodeModulesPath: string;
   sourceNodeModulesPath?: string;
-}
-
-export function resolveReusableNodeModulesSource(repoRoot: string, gitRunner = spawnSync): string | null {
-  const commonDir = resolveGitCommonDir(repoRoot, gitRunner);
-  if (!commonDir || basename(commonDir) !== '.git') {
-    return null;
-  }
-
-  const primaryRepoRoot = dirname(commonDir);
-  if (resolve(primaryRepoRoot) === resolve(repoRoot)) {
-    return null;
-  }
-
-  if (!hasUsableNodeModules(primaryRepoRoot)) {
-    return null;
-  }
-
-  return join(primaryRepoRoot, 'node_modules');
 }
 
 function formatCommandFailure(cmd: string, args: string[], result: { stdout?: string; stderr?: string }): string {
@@ -114,40 +67,23 @@ export function ensureRepoDependencies(repoRoot: string, options: EnsureRepoDeps
         throw new Error(formatCommandFailure('npm', ['ci'], result));
       }
     },
-    remove = rmSync,
-    symlink = symlinkSync,
     log = () => {},
-    platformName = process.platform,
   } = options;
 
-  if (hasUsableNodeModules(repoRoot)) {
-    return {
-      strategy: 'existing',
-      nodeModulesPath: join(repoRoot, 'node_modules'),
-    };
+  const reusable = ensureReusableNodeModules(repoRoot, { gitRunner });
+  if (reusable.strategy === 'existing') {
+    return reusable;
   }
-
-  const targetNodeModules = join(repoRoot, 'node_modules');
-  if (hasNodeModulesPath(targetNodeModules)) {
-    remove(targetNodeModules, { recursive: true, force: true });
-  }
-
-  const reusableNodeModules = resolveReusableNodeModulesSource(repoRoot, gitRunner);
-  if (reusableNodeModules) {
-    symlink(reusableNodeModules, targetNodeModules, platformName === 'win32' ? 'junction' : 'dir');
-    log(`[smoke:packed-install] Reusing node_modules from ${reusableNodeModules}`);
-    return {
-      strategy: 'symlink',
-      nodeModulesPath: targetNodeModules,
-      sourceNodeModulesPath: reusableNodeModules,
-    };
+  if (reusable.strategy === 'symlink') {
+    log(`[smoke:packed-install] Reusing node_modules from ${reusable.sourceNodeModulesPath}`);
+    return reusable;
   }
 
   log('[smoke:packed-install] Installing repo dependencies with npm ci');
   install(repoRoot);
   return {
     strategy: 'installed',
-    nodeModulesPath: targetNodeModules,
+    nodeModulesPath: join(repoRoot, 'node_modules'),
   };
 }
 

--- a/src/utils/__tests__/repo-deps.test.ts
+++ b/src/utils/__tests__/repo-deps.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  ensureReusableNodeModules,
+  hasUsableNodeModules,
+  resolveGitCommonDir,
+  resolveReusableNodeModulesSource,
+} from '../repo-deps.js';
+
+test('resolveGitCommonDir resolves relative git common dir output against cwd', () => {
+  const commonDir = resolveGitCommonDir('/tmp/worktree', () => ({
+    status: 0,
+    stdout: '../primary/.git\n',
+    stderr: '',
+  }) as any);
+  assert.equal(commonDir, '/tmp/primary/.git');
+});
+
+test('hasUsableNodeModules requires core dependency markers', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-repo-deps-'));
+  try {
+    const nodeModules = join(root, 'node_modules');
+    await mkdir(join(nodeModules, 'typescript'), { recursive: true });
+    await mkdir(join(nodeModules, '@iarna', 'toml'), { recursive: true });
+    await mkdir(join(nodeModules, '@modelcontextprotocol', 'sdk'), { recursive: true });
+    await mkdir(join(nodeModules, 'zod'), { recursive: true });
+    await writeFile(join(nodeModules, 'typescript', 'package.json'), '{}');
+    await writeFile(join(nodeModules, '@iarna', 'toml', 'package.json'), '{}');
+    await writeFile(join(nodeModules, '@modelcontextprotocol', 'sdk', 'package.json'), '{}');
+    await writeFile(join(nodeModules, 'zod', 'package.json'), '{}');
+    assert.equal(hasUsableNodeModules(root), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveReusableNodeModulesSource returns parent repo node_modules for worktrees', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-reuse-node-modules-'));
+  try {
+    const primaryRepo = join(root, 'primary');
+    const worktreeRepo = join(root, 'worktree');
+    await mkdir(join(primaryRepo, 'node_modules', 'typescript'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', '@iarna', 'toml'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', '@modelcontextprotocol', 'sdk'), { recursive: true });
+    await mkdir(join(primaryRepo, 'node_modules', 'zod'), { recursive: true });
+    await writeFile(join(primaryRepo, 'node_modules', 'typescript', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', '@iarna', 'toml', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', '@modelcontextprotocol', 'sdk', 'package.json'), '{}');
+    await writeFile(join(primaryRepo, 'node_modules', 'zod', 'package.json'), '{}');
+    await mkdir(worktreeRepo, { recursive: true });
+
+    const reusable = resolveReusableNodeModulesSource(worktreeRepo, () => ({
+      status: 0,
+      stdout: `${join(primaryRepo, '.git')}\n`,
+      stderr: '',
+    }) as any);
+
+    assert.equal(reusable, join(primaryRepo, 'node_modules'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('ensureReusableNodeModules returns warning when no reusable parent dependencies exist', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-missing-node-modules-'));
+  try {
+    const result = ensureReusableNodeModules(root, {
+      gitRunner: () => ({ status: 1, stdout: '', stderr: 'not a worktree' }) as any,
+    });
+    assert.equal(result.strategy, 'missing');
+    assert.match(String(result.warning || ''), /No reusable parent-repo node_modules was found/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/utils/repo-deps.ts
+++ b/src/utils/repo-deps.ts
@@ -1,0 +1,112 @@
+import { existsSync, lstatSync, rmSync, symlinkSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { basename, dirname, join, resolve } from 'node:path';
+
+export const REQUIRED_NODE_MODULE_MARKERS = [
+  join('typescript', 'package.json'),
+  join('@iarna', 'toml', 'package.json'),
+  join('@modelcontextprotocol', 'sdk', 'package.json'),
+  join('zod', 'package.json'),
+];
+
+function hasNodeModulesPath(nodeModulesPath: string): boolean {
+  try {
+    lstatSync(nodeModulesPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function hasUsableNodeModules(repoRoot: string): boolean {
+  return REQUIRED_NODE_MODULE_MARKERS.every((marker) => existsSync(join(repoRoot, 'node_modules', marker)));
+}
+
+export function resolveGitCommonDir(cwd: string, gitRunner = spawnSync): string | null {
+  const result = gitRunner('git', ['rev-parse', '--git-common-dir'], {
+    cwd,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  const value = (result.stdout || '').trim();
+  if (!value) {
+    return null;
+  }
+  return resolve(cwd, value);
+}
+
+export function resolveReusableNodeModulesSource(repoRoot: string, gitRunner = spawnSync): string | null {
+  const commonDir = resolveGitCommonDir(repoRoot, gitRunner);
+  if (!commonDir || basename(commonDir) !== '.git') {
+    return null;
+  }
+
+  const primaryRepoRoot = dirname(commonDir);
+  if (resolve(primaryRepoRoot) === resolve(repoRoot)) {
+    return null;
+  }
+
+  if (!hasUsableNodeModules(primaryRepoRoot)) {
+    return null;
+  }
+
+  return join(primaryRepoRoot, 'node_modules');
+}
+
+export interface EnsureReusableNodeModulesOptions {
+  gitRunner?: typeof spawnSync;
+  remove?: typeof rmSync;
+  symlink?: typeof symlinkSync;
+  platformName?: string;
+}
+
+export interface EnsureReusableNodeModulesResult {
+  strategy: 'existing' | 'symlink' | 'missing';
+  nodeModulesPath: string;
+  sourceNodeModulesPath?: string;
+  warning?: string;
+}
+
+export function ensureReusableNodeModules(
+  repoRoot: string,
+  options: EnsureReusableNodeModulesOptions = {},
+): EnsureReusableNodeModulesResult {
+  const {
+    gitRunner = spawnSync,
+    remove = rmSync,
+    symlink = symlinkSync,
+    platformName = process.platform,
+  } = options;
+
+  const targetNodeModules = join(repoRoot, 'node_modules');
+  if (hasUsableNodeModules(repoRoot)) {
+    return {
+      strategy: 'existing',
+      nodeModulesPath: targetNodeModules,
+    };
+  }
+
+  if (hasNodeModulesPath(targetNodeModules)) {
+    remove(targetNodeModules, { recursive: true, force: true });
+  }
+
+  const reusableNodeModules = resolveReusableNodeModulesSource(repoRoot, gitRunner);
+  if (!reusableNodeModules) {
+    return {
+      strategy: 'missing',
+      nodeModulesPath: targetNodeModules,
+      warning:
+        `No reusable parent-repo node_modules was found for worktree ${repoRoot}. `
+        + 'Downstream build/test verification may fail until dependencies are bootstrapped manually.',
+    };
+  }
+
+  symlink(reusableNodeModules, targetNodeModules, platformName === 'win32' ? 'junction' : 'dir');
+  return {
+    strategy: 'symlink',
+    nodeModulesPath: targetNodeModules,
+    sourceNodeModulesPath: reusableNodeModules,
+  };
+}


### PR DESCRIPTION
## Summary
- extract reusable worktree dependency bootstrap helpers into a shared utility
- reuse parent-repo node_modules for launch/exec worktrees when safe
- emit an explicit early warning when reusable dependencies are unavailable
- keep smoke-packed-install aligned with the shared helper and add focused coverage

## Testing
- npm run build
- node --test dist/utils/__tests__/repo-deps.test.js dist/scripts/__tests__/smoke-packed-install.test.js dist/cli/__tests__/index.test.js --test-name-pattern="worktree dependency bootstrap helpers|reusable|node_modules|packed install smoke|detached worktree"

Closes #1507