### PR TITLE
Fix #1511 false-positive clawhip keyword hits

### DIFF
--- a/src/notifications/__tests__/tmux.test.ts
+++ b/src/notifications/__tests__/tmux.test.ts
@@ -9,6 +9,7 @@ import {
   formatTmuxInfo,
   getTeamTmuxSessions,
   captureTmuxPane,
+  captureTmuxPaneWithLiveness,
 } from '../tmux.js';
 
 describe('getCurrentTmuxSession', () => {
@@ -226,6 +227,7 @@ describe('captureTmuxPane', () => {
   });
 
   it('captures output for valid pane id and sanitizes/clamps lines', () => {
+    const livePid = process.pid;
     const fakeBinDir = mkdtempSync(join(tmpdir(), 'omx-tmux-test-'));
     tmpDirs.push(fakeBinDir);
     const tmuxPath = join(fakeBinDir, 'tmux');
@@ -233,6 +235,10 @@ describe('captureTmuxPane', () => {
       tmuxPath,
       [
         '#!/bin/sh',
+        'if [ "$1" = "list-panes" ]; then',
+        `  printf "0 ${livePid}\\n"`,
+        '  exit 0',
+        'fi',
         'if [ "$1" != "capture-pane" ]; then exit 2; fi',
         'target=""',
         'lines=""',
@@ -251,5 +257,33 @@ describe('captureTmuxPane', () => {
     assert.equal(captureTmuxPane('%42', Number.NaN), 'capture:%42:-12');
     assert.equal(captureTmuxPane('%42', 0), 'capture:%42:-1');
     assert.equal(captureTmuxPane('%42', 999999), 'capture:%42:-2000');
+  });
+
+  it('suppresses capture when the target pane is already dead', () => {
+    const fakeBinDir = mkdtempSync(join(tmpdir(), 'omx-tmux-dead-pane-test-'));
+    tmpDirs.push(fakeBinDir);
+    const tmuxPath = join(fakeBinDir, 'tmux');
+    writeFileSync(
+      tmuxPath,
+      [
+        '#!/bin/sh',
+        'if [ "$1" = "list-panes" ]; then',
+        '  printf "1 99999\\n"',
+        '  exit 0',
+        'fi',
+        'if [ "$1" = "capture-pane" ]; then',
+        '  printf "stale pane output that should never be used\\n"',
+        '  exit 0',
+        'fi',
+        'exit 2',
+      ].join('\n'),
+    );
+    chmodSync(tmuxPath, 0o755);
+    process.env.PATH = `${fakeBinDir}:${originalPath ?? ''}`;
+
+    const result = captureTmuxPaneWithLiveness('%42', 12);
+    assert.equal(result.live, false);
+    assert.equal(result.content, null);
+    assert.equal(captureTmuxPane('%42', 12), null);
   });
 });

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -237,9 +237,13 @@ export async function notifyLifecycle(
       !data.tmuxTail &&
       (event === "session-idle" || event === "session-stop" || event === "session-end")
     ) {
-      payload.tmuxTail = captureTmuxPane(payload.tmuxPaneId) ?? undefined;
+      const { captureTmuxPaneWithLiveness } = await import("./tmux.js");
+      const tmuxCapture = captureTmuxPaneWithLiveness(payload.tmuxPaneId);
+      payload.tmuxTail = tmuxCapture.content ?? undefined;
+      payload.tmuxTailLive = tmuxCapture.live;
     } else {
       payload.tmuxTail = data.tmuxTail;
+      payload.tmuxTailLive = data.tmuxTailLive;
     }
 
     payload.message = data.message || formatNotification(payload);

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -136,7 +136,7 @@ import {
 } from "./temp-contract.js";
 import { formatNotification } from "./formatter.js";
 import { dispatchNotifications } from "./dispatcher.js";
-import { getCurrentTmuxSession, captureTmuxPane } from "./tmux.js";
+import { getCurrentTmuxSession } from "./tmux.js";
 import { basename } from "path";
 import { omxStateDir } from "../utils/paths.js";
 import {

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -11,6 +11,11 @@ const TMUX_PANE_TARGET_RE = /^%\d+$/;
 const DEFAULT_CAPTURE_LINES = 12;
 const MAX_CAPTURE_LINES = 2000;
 
+export interface TmuxPaneCaptureResult {
+  content: string | null;
+  live: boolean;
+}
+
 function shouldUsePidFallback(): boolean {
   return process.env.OMX_TMUX_PID_FALLBACK === "1";
 }
@@ -141,24 +146,46 @@ export function getTeamTmuxSessions(teamName: string): string[] {
  * Returns null if capture fails or tmux is not available.
  */
 export function captureTmuxPane(paneId?: string | null, lines: number = 12): string | null {
+  return captureTmuxPaneWithLiveness(paneId, lines).content;
+}
+
+export function captureTmuxPaneWithLiveness(paneId?: string | null, lines: number = 12): TmuxPaneCaptureResult {
   const target = paneId || process.env.TMUX_PANE;
-  if (!target) return null;
-  if (!process.env.TMUX && !paneId) return null;
-  if (!TMUX_PANE_TARGET_RE.test(target)) return null;
+  if (!target) return { content: null, live: false };
+  if (!process.env.TMUX && !paneId) return { content: null, live: false };
+  if (!TMUX_PANE_TARGET_RE.test(target)) return { content: null, live: false };
 
   const safeLines = Number.isFinite(lines) ? Math.trunc(lines) : DEFAULT_CAPTURE_LINES;
   const clampedLines = Math.max(1, Math.min(MAX_CAPTURE_LINES, safeLines));
 
   try {
+    const paneStatus = execFileSync("tmux", ["list-panes", "-t", target, "-F", "#{pane_dead} #{pane_pid}"], {
+      encoding: "utf-8",
+      timeout: 3000,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    }).trim();
+    const firstStatusLine = paneStatus.split("\n")[0]?.trim() || "";
+    const [paneDead = "", panePidRaw = ""] = firstStatusLine.split(/\s+/, 2);
+    const panePid = Number.parseInt(panePidRaw, 10);
+    if (paneDead === "1" || !Number.isFinite(panePid)) {
+      return { content: null, live: false };
+    }
+    try {
+      process.kill(panePid, 0);
+    } catch {
+      return { content: null, live: false };
+    }
+
     const output = execFileSync("tmux", buildCapturePaneArgv(target, clampedLines), {
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
     }).trim();
-    return output || null;
+    return { content: output || null, live: true };
   } catch {
-    return null;
+    return { content: null, live: false };
   }
 }
 

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -201,6 +201,8 @@ export interface FullNotificationPayload {
   tmuxPaneId?: string;
   /** Captured tmux pane output (tail lines) for session-level notifications */
   tmuxTail?: string;
+  /** Whether the tmux tail came from a session/pane proven live at capture time */
+  tmuxTailLive?: boolean;
   /** Agent name (populated by extensibility plugins, not set by core Codex CLI hooks) */
   agentName?: string;
   /** Agent type (populated by extensibility plugins, not set by core Codex CLI hooks) */

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -35,7 +35,7 @@ import type { OpenClawHookEvent, OpenClawContext, OpenClawResult } from "./types
 import { getOpenClawConfig, resolveGateway } from "./config.js";
 import { wakeGateway, wakeCommandGateway, interpolateInstruction, isCommandGateway } from "./dispatcher.js";
 import { basename } from "path";
-import { getCurrentTmuxSession, captureTmuxPane } from "../notifications/tmux.js";
+import { getCurrentTmuxSession, captureTmuxPaneWithLiveness } from "../notifications/tmux.js";
 
 /** Whether debug logging is enabled */
 const DEBUG = process.env.OMX_OPENCLAW_DEBUG === "1";
@@ -105,15 +105,22 @@ export async function wakeOpenClaw(
 
     // Auto-capture tmux pane content for stop/session-end events (best-effort)
     let tmuxTail = enrichedContext.tmuxTail;
+    let tmuxTailLive = enrichedContext.tmuxTail !== undefined;
     if (!tmuxTail && (event === "stop" || event === "session-end") && process.env.TMUX) {
       try {
         const paneId = process.env.TMUX_PANE;
         if (paneId) {
-          tmuxTail = captureTmuxPane(paneId, 15) ?? undefined;
+          const capture = captureTmuxPaneWithLiveness(paneId, 15);
+          tmuxTail = capture.content ?? undefined;
+          tmuxTailLive = capture.live;
         }
       } catch {
         // Non-blocking: tmux capture is best-effort
       }
+    }
+
+    if (!tmuxTailLive) {
+      tmuxTail = undefined;
     }
 
     // Build template variables from whitelisted context fields

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -338,6 +338,52 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("does not expose submitted prompt text to keyword-detector hook plugins", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-prompt-sanitized-"));
+    try {
+      await mkdir(join(cwd, ".omx", "hooks"), { recursive: true });
+      await writeFile(
+        join(cwd, ".omx", "hooks", "capture-keyword-context.mjs"),
+        `import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export async function onHookEvent(event) {
+  if (event.event !== "keyword-detector") return;
+  const outPath = join(process.cwd(), ".omx", "captured-keyword-context.json");
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, JSON.stringify(event.context, null, 2));
+}
+`,
+        "utf-8",
+      );
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-sanitized-1",
+          thread_id: "thread-sanitized-1",
+          turn_id: "turn-sanitized-1",
+          prompt: "$ralplan approve this blocker-sensitive request",
+        },
+        { cwd },
+      );
+
+      const captured = JSON.parse(
+        await readFile(join(cwd, ".omx", "captured-keyword-context.json"), "utf-8"),
+      ) as { prompt?: string; payload?: Record<string, unknown> };
+
+      assert.equal(captured.prompt, undefined);
+      assert.equal(captured.payload?.prompt, undefined);
+      assert.equal(captured.payload?.input, undefined);
+      assert.equal(captured.payload?.user_prompt, undefined);
+      assert.equal(captured.payload?.userPrompt, undefined);
+      assert.equal(captured.payload?.text, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not emit UserPromptSubmit routing context for unknown $tokens", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-unknown-token-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -142,6 +142,21 @@ function readPromptText(payload: CodexHookPayload): string {
   return "";
 }
 
+function sanitizePayloadForHookContext(
+  payload: CodexHookPayload,
+  hookEventName: CodexHookEventName,
+): CodexHookPayload {
+  if (hookEventName !== "UserPromptSubmit") return payload;
+
+  const sanitized = { ...payload };
+  delete sanitized.prompt;
+  delete sanitized.input;
+  delete sanitized.user_prompt;
+  delete sanitized.userPrompt;
+  delete sanitized.text;
+  return sanitized;
+}
+
 function buildBaseContext(
   cwd: string,
   payload: CodexHookPayload,
@@ -152,10 +167,7 @@ function buildBaseContext(
     project_path: cwd,
     transcript_path: safeString(payload.transcript_path ?? payload.transcriptPath) || null,
     source: safeString(payload.source),
-    payload,
-    ...(hookEventName === "UserPromptSubmit"
-      ? { prompt: readPromptText(payload) }
-      : {}),
+    payload: sanitizePayloadForHookContext(payload, hookEventName),
   };
 }
 


### PR DESCRIPTION
## Summary\n- strip raw prompt/query text from native UserPromptSubmit hook context so clawhip consumers only see post-submit agent output\n- require tmux pane liveness before reading tail text for session-level notifications / OpenClaw forwarding\n- add focused regressions for prompt-text false positives and dead-session stale-pane suppression\n\n## Testing\n- npm run build && node --test dist/scripts/__tests__/codex-native-hook.test.js dist/notifications/__tests__/tmux.test.js\n- node --test dist/openclaw/__tests__/index.test.js\n\nCloses #1511