### PR TITLE
fix: auto-finalize release-readiness session stops

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -10,6 +10,7 @@ import {
   initTeamState,
   readTeamLeaderAttention,
   readTeamPhase,
+  writeTeamLeaderAttention,
 } from "../../team/state.js";
 import {
   dispatchCodexNativeHook,
@@ -21,6 +22,46 @@ import { writeSessionStart } from "../../hooks/session.js";
 async function writeJson(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true }).catch(() => {});
   await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+async function writeReleaseReadinessLeaderAttention(
+  teamName: string,
+  sessionId: string,
+  cwd: string,
+  options: { workRemaining: boolean },
+): Promise<void> {
+  await writeTeamLeaderAttention(teamName, {
+    team_name: teamName,
+    updated_at: "2026-04-12T17:20:00.000Z",
+    source: "notify_hook",
+    leader_decision_state: "done_waiting_on_leader",
+    leader_attention_pending: true,
+    leader_attention_reason: "leader_session_stopped",
+    attention_reasons: ["leader_session_stopped"],
+    leader_stale: true,
+    leader_session_active: false,
+    leader_session_id: sessionId,
+    leader_session_stopped_at: "2026-04-12T17:20:00.000Z",
+    unread_leader_message_count: 0,
+    work_remaining: options.workRemaining,
+    stalled_for_ms: null,
+  }, cwd);
+}
+
+async function writeReleaseReadinessStateMarker(
+  sessionId: string,
+  teamName: string,
+  cwd: string,
+): Promise<void> {
+  await writeJson(
+    join(cwd, ".omx", "state", "sessions", sessionId, "release-readiness-state.json"),
+    {
+      active: true,
+      session_id: sessionId,
+      team_name: teamName,
+      stable_final_recommendation_emitted: true,
+    },
+  );
 }
 
 const TEAM_STOP_COMMIT_GUIDANCE =
@@ -1356,6 +1397,101 @@ esac
         decision: "block",
         reason:
           `OMX team pipeline is still active (canonical-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("emits one concise final decision summary and auto-finalize guidance when release-readiness already has a stable final recommendation and no active worker tasks", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-release-readiness-finalize-"));
+    try {
+      await initTeamState(
+        "release-ready-team",
+        "release readiness finalize",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-release-ready" },
+      );
+      await writeReleaseReadinessLeaderAttention(
+        "release-ready-team",
+        "sess-stop-release-ready",
+        cwd,
+        { workRemaining: false },
+      );
+      await writeReleaseReadinessStateMarker(
+        "sess-stop-release-ready",
+        "release-ready-team",
+        cwd,
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-release-ready",
+          thread_id: "thread-stop-release-ready",
+          turn_id: "turn-stop-release-ready-1",
+          mode: "release-readiness",
+          last_assistant_message: "Launch-ready: yes",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          'Stable final recommendation already reached with no active worker tasks. Emit exactly one concise final decision summary aligned to "Launch-ready: yes." with no filler or residual acknowledgements (for example "yes"), then stop.',
+        stopReason: "release_readiness_auto_finalize",
+        systemMessage:
+          "OMX release-readiness detected a stable final recommendation with no active worker tasks; emit one concise final decision summary and finalize.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not auto-finalize non-release team stops that happen to contain a stable recommendation summary", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-non-release-readiness-control-"));
+    try {
+      await initTeamState(
+        "general-review-team",
+        "general team stop control",
+        "executor",
+        1,
+        cwd,
+        undefined,
+        { ...process.env, OMX_SESSION_ID: "sess-stop-general-review" },
+      );
+      await writeReleaseReadinessLeaderAttention(
+        "general-review-team",
+        "sess-stop-general-review",
+        cwd,
+        { workRemaining: false },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-general-review",
+          thread_id: "thread-stop-general-review",
+          turn_id: "turn-stop-general-review-1",
+          last_assistant_message: "Launch-ready: yes",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          `OMX team pipeline is still active (general-review-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
         stopReason: "team_team-exec",
         systemMessage: "OMX team pipeline is still active at phase team-exec.",
       });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -71,6 +71,14 @@ const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
 const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);
 const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
+const STABLE_FINAL_RECOMMENDATION_PATTERNS = [
+  /^\s*(?:launch|release|ship)-?ready\s*:\s*(?:yes|no)\b[^\n\r]*/im,
+  /^\s*ready to release\s*:\s*(?:yes|no)\b[^\n\r]*/im,
+  /^\s*(?:final\s+)?recommendation\s*:\s*(?:yes|no|ship|hold|release|do not release|proceed|do not proceed)\b[^\n\r]*/im,
+  /^\s*decision\s*:\s*(?:yes|no|ship|hold|release|do not release|proceed|do not proceed)\b[^\n\r]*/im,
+] as const;
+const RELEASE_READINESS_FINALIZE_SYSTEM_MESSAGE =
+  "OMX release-readiness detected a stable final recommendation with no active worker tasks; emit one concise final decision summary and finalize.";
 
 function safeString(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -720,6 +728,54 @@ function buildTeamStopOutputForPhase(teamName: string, phase: string): Record<st
   };
 }
 
+function extractStableFinalRecommendationSummary(message: string): string {
+  for (const pattern of STABLE_FINAL_RECOMMENDATION_PATTERNS) {
+    const match = pattern.exec(message);
+    if (!match) continue;
+    const summary = match[0]?.trim().replace(/\s+/g, " ");
+    if (!summary) continue;
+    return /[.!?]$/.test(summary) ? summary : `${summary}.`;
+  }
+  return "";
+}
+
+function buildStableFinalRecommendationStopSignature(
+  payload: CodexHookPayload,
+  teamName: string,
+  summary: string,
+): string {
+  const sessionId = readPayloadSessionId(payload) || "no-session";
+  const threadId = readPayloadThreadId(payload) || "no-thread";
+  const normalizedSummary = normalizeAutoNudgeSignatureText(summary) || summary.toLowerCase();
+  return ["release-readiness-finalize", sessionId, threadId, teamName, normalizedSummary].join("|");
+}
+
+function hasReleaseReadinessMode(payload: CodexHookPayload): boolean {
+  const mode = safeString(payload.mode).trim().toLowerCase();
+  return mode === "release-readiness";
+}
+
+async function hasReleaseReadinessStopMarker(
+  cwd: string,
+  sessionId: string,
+  teamName: string,
+): Promise<boolean> {
+  if (!sessionId) return false;
+
+  const markerState = await readStopSessionPinnedState("release-readiness-state.json", cwd, sessionId);
+  if (markerState?.active !== true || markerState.stable_final_recommendation_emitted !== true) {
+    return false;
+  }
+
+  const markerTeamName = safeString(markerState.team_name).trim();
+  if (markerTeamName && markerTeamName !== teamName) return false;
+
+  const markerSessionId = safeString(markerState.session_id).trim();
+  if (markerSessionId && markerSessionId !== sessionId) return false;
+
+  return true;
+}
+
 function readPayloadSessionId(payload: CodexHookPayload): string {
   return safeString(payload.session_id ?? payload.sessionId).trim();
 }
@@ -959,6 +1015,66 @@ async function findCanonicalActiveTeamForSession(
   return null;
 }
 
+async function resolveActiveTeamNameForStop(
+  cwd: string,
+  sessionId: string,
+): Promise<string> {
+  const directState = await readTeamModeStateForStop(cwd, sessionId);
+  const directTeamName = safeString(directState?.team_name).trim();
+  if (directState?.active === true && directTeamName) return directTeamName;
+
+  const canonicalTeam = await findCanonicalActiveTeamForSession(cwd, sessionId);
+  return canonicalTeam?.teamName ?? "";
+}
+
+async function maybeBuildReleaseReadinessFinalizeStopOutput(
+  payload: CodexHookPayload,
+  cwd: string,
+  stateDir: string,
+  sessionId: string,
+): Promise<{ matched: boolean; output: Record<string, unknown> | null }> {
+  if (!sessionId) return { matched: false, output: null };
+
+  const teamName = await resolveActiveTeamNameForStop(cwd, sessionId);
+  if (!teamName) return { matched: false, output: null };
+
+  const explicitReleaseReadinessContext =
+    hasReleaseReadinessMode(payload)
+    || await hasReleaseReadinessStopMarker(cwd, sessionId, teamName);
+  if (!explicitReleaseReadinessContext) {
+    return { matched: false, output: null };
+  }
+
+  const summary = extractStableFinalRecommendationSummary(
+    safeString(payload.last_assistant_message ?? payload.lastAssistantMessage),
+  );
+  if (!summary) return { matched: false, output: null };
+
+  const leaderAttention = await readTeamLeaderAttention(teamName, cwd);
+  if (
+    !leaderAttention
+    || leaderAttention.leader_decision_state !== "done_waiting_on_leader"
+    || leaderAttention.work_remaining !== false
+  ) {
+    return { matched: false, output: null };
+  }
+
+  const signature = buildStableFinalRecommendationStopSignature(payload, teamName, summary);
+  const output = await maybeReturnRepeatableStopOutput(
+    payload,
+    stateDir,
+    signature,
+    {
+      decision: "block",
+      reason:
+        `Stable final recommendation already reached with no active worker tasks. Emit exactly one concise final decision summary aligned to "${summary}" with no filler or residual acknowledgements (for example "yes"), then stop.`,
+      stopReason: "release_readiness_auto_finalize",
+      systemMessage: RELEASE_READINESS_FINALIZE_SYSTEM_MESSAGE,
+    },
+  );
+  return { matched: true, output };
+}
+
 async function buildSkillStopOutput(
   cwd: string,
   sessionId: string,
@@ -1111,6 +1227,14 @@ async function buildStopHookOutput(
 
     const ultraqaOutput = await buildModeBasedStopOutput("ultraqa", cwd, canonicalSessionId);
     if (!stopHookActive && ultraqaOutput) return ultraqaOutput;
+
+    const releaseReadinessFinalizeResult = await maybeBuildReleaseReadinessFinalizeStopOutput(
+      payload,
+      cwd,
+      stateDir,
+      canonicalSessionId,
+    );
+    if (releaseReadinessFinalizeResult.matched) return releaseReadinessFinalizeResult.output;
 
     const teamOutput = await buildTeamStopOutput(cwd, canonicalSessionId);
     if (teamOutput) {


### PR DESCRIPTION
## Summary
- auto-finalize release-readiness session-stop output only when explicit release-readiness identity is present
- replace lingering low-value stop summaries with one concise final decision summary
- preserve non-release team-stop behavior with a negative regression case

## Testing
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/extensibility/__tests__/runtime.test.js
- npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts

Closes #1513