### PR TITLE
Fix MCP sibling accumulation under live Codex app-server parents

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -2,7 +2,15 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { isParentProcessAlive, shouldAutoStartMcpServer, type McpServerName } from '../bootstrap.js';
+import {
+  analyzeDuplicateSiblingState,
+  extractMcpEntrypointMarker,
+  isParentProcessAlive,
+  parseProcessTable,
+  shouldAutoStartMcpServer,
+  shouldSelfExitForDuplicateSibling,
+  type McpServerName,
+} from '../bootstrap.js';
 
 const ALL_SERVERS: readonly McpServerName[] = [
   'state',
@@ -90,6 +98,8 @@ describe('mcp shared stdio lifecycle contract', () => {
     assert.match(src, /process\.exit\(0\)/, 'bootstrap should force child exit after shutdown completes');
     assert.match(src, /SIGTERM/, 'bootstrap should handle SIGTERM');
     assert.match(src, /SIGINT/, 'bootstrap should handle SIGINT');
+    assert.match(src, /analyzeDuplicateSiblingState/, 'bootstrap should keep duplicate sibling detection in the shared layer');
+    assert.match(src, /shouldSelfExitForDuplicateSibling/, 'bootstrap should gate self-exit conservatively in the shared layer');
   });
 
   it('keeps individual server entrypoints free of duplicated raw stdio connect snippets', async () => {
@@ -112,5 +122,119 @@ describe('mcp shared stdio lifecycle contract', () => {
         `${file} should not duplicate raw server.connect(transport) bootstrap`,
       );
     }
+  });
+});
+
+describe('mcp duplicate sibling detection', () => {
+  it('extracts same-entrypoint markers from command lines', () => {
+    assert.equal(
+      extractMcpEntrypointMarker('node /tmp/oh-my-codex/dist/mcp/state-server.js'),
+      'state-server.js',
+    );
+    assert.equal(
+      extractMcpEntrypointMarker('node C:\\\\tmp\\\\oh-my-codex\\\\dist\\\\mcp\\\\trace-server.ts'),
+      'trace-server.ts',
+    );
+    assert.equal(extractMcpEntrypointMarker('node something-else.js'), null);
+  });
+
+  it('parses ps output into process table entries', () => {
+    assert.deepEqual(
+      parseProcessTable('101 55 node /tmp/dist/mcp/state-server.js\n'),
+      [{ pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' }],
+    );
+  });
+
+  it('treats a single instance as unique and no-op', () => {
+    const observation = analyzeDuplicateSiblingState(
+      [{ pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' }],
+      101,
+      55,
+      'state-server.js',
+    );
+
+    assert.equal(observation.status, 'unique');
+    assert.deepEqual(observation.matchingPids, [101]);
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 10_000, 9_000, null),
+      false,
+    );
+  });
+
+  it('prefers the newest same-parent same-entrypoint process as survivor', () => {
+    const processes = [
+      { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 140, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      { pid: 160, ppid: 55, command: 'node /tmp/dist/mcp/memory-server.js' },
+    ];
+
+    const older = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
+    const newest = analyzeDuplicateSiblingState(processes, 140, 55, 'state-server.js');
+
+    assert.equal(older.status, 'older_duplicate');
+    assert.deepEqual(older.newerSiblingPids, [140]);
+    assert.equal(newest.status, 'newest');
+    assert.deepEqual(newest.newerSiblingPids, []);
+  });
+
+  it('only lets older duplicates self-exit after the conservative grace window before traffic', () => {
+    const observation = {
+      status: 'older_duplicate' as const,
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 140],
+      newerSiblingPids: [140],
+    };
+
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 10_500, 9_000, null),
+      false,
+    );
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 11_100, 9_000, null),
+      true,
+    );
+  });
+
+  it('does not self-exit after traffic until the duplicate has remained safely idle long enough', () => {
+    const observation = {
+      status: 'older_duplicate' as const,
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 140],
+      newerSiblingPids: [140],
+    };
+
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 35_000, 1_000, 10_000),
+      false,
+    );
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 40_500, 1_000, 10_000),
+      true,
+    );
+  });
+
+  it('treats ambiguous duplicate state as no-op', () => {
+    const missingSelf = analyzeDuplicateSiblingState(
+      [{ pid: 140, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' }],
+      101,
+      55,
+      'state-server.js',
+    );
+    const mismatchedSelfMarker = analyzeDuplicateSiblingState(
+      [
+        { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/memory-server.js' },
+        { pid: 140, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
+      ],
+      101,
+      55,
+      'state-server.js',
+    );
+
+    assert.equal(missingSelf.status, 'ambiguous');
+    assert.equal(mismatchedSelfMarker.status, 'ambiguous');
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(missingSelf, 50_000, 10_000, null),
+      false,
+    );
   });
 });

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'wiki';
@@ -13,10 +14,170 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
 const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
 const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
 const PARENT_WATCHDOG_INTERVAL_MS = 25;
+const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
+const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
+const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 30_000;
+const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 
 interface StdioLifecycleServer {
   connect(transport: StdioServerTransport): Promise<unknown>;
   close(): Promise<unknown>;
+}
+
+export interface ProcessTableEntry {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+export interface DuplicateSiblingObservation {
+  status: 'ambiguous' | 'unique' | 'newest' | 'older_duplicate';
+  entrypoint: string | null;
+  matchingPids: number[];
+  newerSiblingPids: number[];
+}
+
+function normalizeCommand(command: string): string {
+  return command.replace(/\\+/g, '/').trim();
+}
+
+export function extractMcpEntrypointMarker(command: string): string | null {
+  const match = normalizeCommand(command).match(MCP_ENTRYPOINT_PATTERN);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+export function parseProcessTable(output: string): ProcessTableEntry[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      if (!match) return null;
+      const pid = Number.parseInt(match[1], 10);
+      const ppid = Number.parseInt(match[2], 10);
+      const command = match[3]?.trim();
+      if (!Number.isInteger(pid) || pid <= 0) return null;
+      if (!Number.isInteger(ppid) || ppid < 0) return null;
+      if (!command) return null;
+      return { pid, ppid, command } satisfies ProcessTableEntry;
+    })
+    .filter((entry): entry is ProcessTableEntry => entry !== null);
+}
+
+export function listProcessTable(
+  readPs: typeof execFileSync = execFileSync,
+): ProcessTableEntry[] | null {
+  if (process.platform === 'win32') {
+    return null;
+  }
+
+  try {
+    const output = readPs('ps', ['axww', '-o', 'pid=,ppid=,command='], {
+      encoding: 'utf-8',
+      windowsHide: true,
+    });
+    return parseProcessTable(output);
+  } catch {
+    return null;
+  }
+}
+
+export function analyzeDuplicateSiblingState(
+  processes: readonly ProcessTableEntry[],
+  currentPid: number,
+  currentParentPid: number,
+  currentEntrypoint: string | null,
+): DuplicateSiblingObservation {
+  if (!currentEntrypoint || !Number.isInteger(currentPid) || currentPid <= 0) {
+    return {
+      status: 'ambiguous',
+      entrypoint: currentEntrypoint,
+      matchingPids: [],
+      newerSiblingPids: [],
+    };
+  }
+
+  const self = processes.find((entry) => entry.pid === currentPid);
+  if (!self || self.ppid !== currentParentPid) {
+    return {
+      status: 'ambiguous',
+      entrypoint: currentEntrypoint,
+      matchingPids: [],
+      newerSiblingPids: [],
+    };
+  }
+
+  const selfMarker = extractMcpEntrypointMarker(self.command);
+  if (selfMarker !== currentEntrypoint) {
+    return {
+      status: 'ambiguous',
+      entrypoint: currentEntrypoint,
+      matchingPids: [],
+      newerSiblingPids: [],
+    };
+  }
+
+  const matching = processes
+    .filter((entry) => entry.ppid === currentParentPid)
+    .filter((entry) => extractMcpEntrypointMarker(entry.command) === currentEntrypoint)
+    .sort((left, right) => left.pid - right.pid);
+
+  if (!matching.some((entry) => entry.pid === currentPid)) {
+    return {
+      status: 'ambiguous',
+      entrypoint: currentEntrypoint,
+      matchingPids: matching.map((entry) => entry.pid),
+      newerSiblingPids: [],
+    };
+  }
+
+  if (matching.length <= 1) {
+    return {
+      status: 'unique',
+      entrypoint: currentEntrypoint,
+      matchingPids: matching.map((entry) => entry.pid),
+      newerSiblingPids: [],
+    };
+  }
+
+  const newerSiblingPids = matching
+    .filter((entry) => entry.pid > currentPid)
+    .map((entry) => entry.pid);
+
+  return {
+    status: newerSiblingPids.length > 0 ? 'older_duplicate' : 'newest',
+    entrypoint: currentEntrypoint,
+    matchingPids: matching.map((entry) => entry.pid),
+    newerSiblingPids,
+  };
+}
+
+export function shouldSelfExitForDuplicateSibling(
+  observation: DuplicateSiblingObservation,
+  nowMs: number,
+  duplicateObservedAtMs: number | null,
+  lastTrafficAtMs: number | null,
+  preTrafficGraceMs = DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
+  postTrafficIdleMs = DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
+): boolean {
+  if (observation.status !== 'older_duplicate') {
+    return false;
+  }
+  if (!Number.isFinite(nowMs) || duplicateObservedAtMs === null || duplicateObservedAtMs > nowMs) {
+    return false;
+  }
+
+  if (lastTrafficAtMs === null) {
+    return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
+  }
+
+  if (!Number.isFinite(lastTrafficAtMs) || lastTrafficAtMs > nowMs) {
+    return false;
+  }
+
+  const safeIdleAnchorMs = Math.max(lastTrafficAtMs, duplicateObservedAtMs);
+  return nowMs - safeIdleAnchorMs >= postTrafficIdleMs;
 }
 
 export function isParentProcessAlive(
@@ -57,6 +218,9 @@ export function autoStartStdioMcpServer(
   let shuttingDown = false;
   const lifecycleDebugEnabled = env[LIFECYCLE_DEBUG_ENV] === '1';
   const trackedParentPid = Number.isInteger(process.ppid) ? process.ppid : 0;
+  const trackedEntrypoint = extractMcpEntrypointMarker(process.argv[1] ?? '');
+  let lastTrafficAtMs: number | null = null;
+  let duplicateObservedAtMs: number | null = null;
 
   const logLifecycle = (message: string, error?: unknown) => {
     if (!lifecycleDebugEnabled) return;
@@ -72,6 +236,43 @@ export function autoStartStdioMcpServer(
     }, PARENT_WATCHDOG_INTERVAL_MS)
     : null;
   parentWatchdog?.unref();
+  const duplicateSiblingWatchdog = trackedParentPid > 1 && trackedEntrypoint
+    ? setInterval(() => {
+      const processes = listProcessTable();
+      if (!processes) {
+        duplicateObservedAtMs = null;
+        return;
+      }
+
+      const observation = analyzeDuplicateSiblingState(
+        processes,
+        process.pid,
+        trackedParentPid,
+        trackedEntrypoint,
+      );
+
+      if (observation.status !== 'older_duplicate') {
+        duplicateObservedAtMs = null;
+        return;
+      }
+
+      duplicateObservedAtMs ??= Date.now();
+      if (!shouldSelfExitForDuplicateSibling(
+        observation,
+        Date.now(),
+        duplicateObservedAtMs,
+        lastTrafficAtMs,
+      )) {
+        return;
+      }
+
+      const reason = lastTrafficAtMs === null
+        ? 'superseded_duplicate_before_traffic'
+        : 'superseded_duplicate_idle';
+      void shutdown(reason);
+    }, DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS)
+    : null;
+  duplicateSiblingWatchdog?.unref();
 
   const shutdown = async (reason: string) => {
     if (shuttingDown) {
@@ -82,6 +283,10 @@ export function autoStartStdioMcpServer(
     if (parentWatchdog) {
       clearInterval(parentWatchdog);
     }
+    if (duplicateSiblingWatchdog) {
+      clearInterval(duplicateSiblingWatchdog);
+    }
+    process.stdin.off('data', handleStdinData);
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
     process.off('SIGTERM', handleSigterm);
@@ -103,6 +308,9 @@ export function autoStartStdioMcpServer(
   const handleStdinClose = () => {
     void shutdown('stdin_close');
   };
+  const handleStdinData = () => {
+    lastTrafficAtMs = Date.now();
+  };
   const handleSigterm = () => {
     void shutdown('sigterm');
   };
@@ -110,6 +318,7 @@ export function autoStartStdioMcpServer(
     void shutdown('sigint');
   };
 
+  process.stdin.on('data', handleStdinData);
   process.stdin.once('end', handleStdinEnd);
   process.stdin.once('close', handleStdinClose);
   process.once('SIGTERM', handleSigterm);
@@ -122,6 +331,7 @@ export function autoStartStdioMcpServer(
 
   server.connect(transport).catch((error) => {
     logLifecycle('server.connect failed', error);
+    process.stdin.off('data', handleStdinData);
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
     process.off('SIGTERM', handleSigterm);


### PR DESCRIPTION
## Summary
- reproduced the current gap from code: shared MCP bootstrap only exited on stdin/transport close, signals, or parent death, so older same-parent same-entrypoint children could persist if Codex app-server kept stdio open
- added a shared bootstrap-layer duplicate sibling guard in `src/mcp/bootstrap.ts` so the newest same-parent same-entrypoint instance survives
- made only older duplicates self-exit conservatively after grace/idle checks; ambiguous detection stays noop/alive

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/server-lifecycle.test.js`
- `npm run lint -- src/mcp/bootstrap.ts src/mcp/__tests__/bootstrap.test.ts`

Closes #1516