### PR TITLE
Deduplicate duplicate lifecycle broadcasts for the same tmux event

### DIFF
--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -236,4 +236,43 @@ export async function onHookEvent() {}
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('dedupes repeated native lifecycle hook dispatches for the same session/turn fingerprint', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-dedupe-'));
+    try {
+      const dir = join(cwd, '.omx', 'hooks');
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        join(dir, 'good.mjs'),
+        'export async function onHookEvent(event, sdk) { const count = Number((await sdk.state.read("count", 0)) || 0); await sdk.state.write("count", count + 1); }',
+      );
+
+      const event = buildHookEvent('keyword-detector', {
+        source: 'native',
+        session_id: 'sess-1',
+        thread_id: 'thread-1',
+        turn_id: 'turn-1',
+        context: { phase: 'prompt-submitted', marker: 'same-turn' },
+      });
+
+      const first = await dispatchHookEvent(event, {
+        cwd,
+        env: { ...process.env, OMX_HOOK_PLUGINS: '1' },
+      });
+      const second = await dispatchHookEvent(event, {
+        cwd,
+        env: { ...process.env, OMX_HOOK_PLUGINS: '1' },
+      });
+
+      assert.equal(first.enabled, true);
+      assert.equal(first.results.length, 1);
+      assert.equal(first.results[0].ok, true);
+
+      assert.equal(second.enabled, true);
+      assert.equal(second.reason, 'deduped');
+      assert.equal(second.results.length, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -4,6 +4,11 @@ import { appendFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { getPackageRoot } from "../../utils/package.js";
 import {
+	createLifecycleBroadcastFingerprint,
+	recordLifecycleHookBroadcastSent,
+	shouldSendLifecycleHookBroadcast,
+} from "../../notifications/lifecycle-dedupe.js";
+import {
 	discoverHookPlugins,
 	isHookPluginsEnabled,
 	resolveHookPluginTimeoutMs,
@@ -264,6 +269,26 @@ function shouldForceEnableRuntimeHookDispatch(
 	return event.source === "native" || event.source === "derived";
 }
 
+function shouldDedupeHookEvent(event: HookEventEnvelope): boolean {
+	if (event.source !== "native") return false;
+	return event.event === "session-start"
+		|| event.event === "stop"
+		|| event.event === "session-end"
+		|| event.event === "keyword-detector";
+}
+
+function buildHookEventFingerprint(event: HookEventEnvelope): string {
+	return createLifecycleBroadcastFingerprint({
+		event: event.event,
+		source: event.source,
+		session_id: event.session_id || "",
+		thread_id: event.thread_id || "",
+		turn_id: event.turn_id || "",
+		mode: event.mode || "",
+		context: event.context,
+	});
+}
+
 export async function dispatchHookEvent(
 	event: HookEventEnvelope,
 	options: HookDispatchOptions = {},
@@ -290,6 +315,32 @@ export async function dispatchHookEvent(
 			source: event.source,
 			enabled: false,
 			reason: "plugins_disabled",
+		});
+		return summary;
+	}
+
+	const dedupeFingerprint = shouldDedupeHookEvent(event)
+		? buildHookEventFingerprint(event)
+		: "";
+	if (
+		dedupeFingerprint
+		&& !shouldSendLifecycleHookBroadcast(
+			join(cwd, ".omx", "state"),
+			event.session_id,
+			event.event,
+			dedupeFingerprint,
+		)
+	) {
+		summary.reason = "deduped";
+		await appendHooksLog(cwd, {
+			type: "hook_dispatch",
+			event: event.event,
+			source: event.source,
+			enabled: true,
+			reason: "deduped",
+			session_id: event.session_id || null,
+			thread_id: event.thread_id || null,
+			turn_id: event.turn_id || null,
 		});
 		return summary;
 	}
@@ -324,6 +375,15 @@ export async function dispatchHookEvent(
 			error: result.error,
 			duration_ms: result.duration_ms,
 		});
+	}
+
+	if (dedupeFingerprint && summary.results.some((result) => result.ok)) {
+		recordLifecycleHookBroadcastSent(
+			join(cwd, ".omx", "state"),
+			event.session_id,
+			event.event,
+			dedupeFingerprint,
+		);
 	}
 
 	return summary;

--- a/src/notifications/__tests__/lifecycle-dedupe.test.ts
+++ b/src/notifications/__tests__/lifecycle-dedupe.test.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path';
 import {
   shouldSendLifecycleNotification,
   recordLifecycleNotificationSent,
+  shouldSendLifecycleHookBroadcast,
+  recordLifecycleHookBroadcastSent,
 } from '../lifecycle-dedupe.js';
 import type { FullNotificationPayload } from '../types.js';
 
@@ -59,6 +61,44 @@ describe('lifecycle notification dedupe', () => {
 
       assert.equal(typeof state.events?.['session-start']?.fingerprint, 'string');
       assert.equal(shouldSendLifecycleNotification(stateDir, buildPayload({ sessionId: 'session-b', event: 'session-start' })), true);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('re-emits the same lifecycle fingerprint after the dedupe window elapses', async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), 'omx-lifecycle-dedupe-window-'));
+    try {
+      const payload = buildPayload({ event: 'session-start' });
+      const startMs = Date.parse('2026-04-12T00:00:00.000Z');
+
+      recordLifecycleNotificationSent(stateDir, payload, startMs);
+
+      assert.equal(shouldSendLifecycleNotification(stateDir, payload, startMs + 4_999), false);
+      assert.equal(shouldSendLifecycleNotification(stateDir, payload, startMs + 5_000), true);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('tracks hook dedupe separately from notification dedupe state', async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), 'omx-lifecycle-dedupe-hook-'));
+    try {
+      const payload = buildPayload({ event: 'session-start', sessionId: 'hook-session' });
+      const hookFingerprint = 'fp:keyword-detector:turn-1';
+
+      recordLifecycleNotificationSent(stateDir, payload);
+      assert.equal(
+        shouldSendLifecycleHookBroadcast(stateDir, payload.sessionId, 'keyword-detector', hookFingerprint),
+        true,
+      );
+
+      recordLifecycleHookBroadcastSent(stateDir, payload.sessionId, 'keyword-detector', hookFingerprint);
+      assert.equal(
+        shouldSendLifecycleHookBroadcast(stateDir, payload.sessionId, 'keyword-detector', hookFingerprint),
+        false,
+      );
+      assert.equal(shouldSendLifecycleNotification(stateDir, payload), false);
     } finally {
       await rm(stateDir, { recursive: true, force: true });
     }

--- a/src/notifications/lifecycle-dedupe.ts
+++ b/src/notifications/lifecycle-dedupe.ts
@@ -4,10 +4,17 @@ import type { NotificationEvent, FullNotificationPayload } from './types.js';
 
 const SESSION_ID_SAFE_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 const LIFECYCLE_DEDUPE_FILE = 'lifecycle-notif-state.json';
+const LIFECYCLE_DEDUPE_WINDOW_MS = 5_000;
 const DEDUPED_EVENTS = new Set<NotificationEvent>(['session-start', 'session-stop', 'session-end']);
 
+interface LifecycleDedupeEntry {
+  fingerprint?: string;
+  sentAt?: string;
+}
+
 interface LifecycleDedupeState {
-  events?: Record<string, { fingerprint?: string; sentAt?: string }>;
+  events?: Record<string, LifecycleDedupeEntry>;
+  hookEvents?: Record<string, LifecycleDedupeEntry>;
 }
 
 function normalizeFingerprint(payload: FullNotificationPayload): string {
@@ -50,30 +57,141 @@ export function shouldDedupeLifecycleNotification(event: NotificationEvent): boo
   return DEDUPED_EVENTS.has(event);
 }
 
+function stableSerialize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerialize(item)).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, nestedValue]) => nestedValue !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, nestedValue]) => `${JSON.stringify(key)}:${stableSerialize(nestedValue)}`);
+  return `{${entries.join(',')}}`;
+}
+
+function shouldSendFingerprint(
+  previous: LifecycleDedupeEntry | undefined,
+  fingerprint: string,
+  nowMs: number,
+): boolean {
+  if (!previous || previous.fingerprint !== fingerprint) return true;
+  if (!previous.sentAt) return false;
+
+  const previousMs = Date.parse(previous.sentAt);
+  if (!Number.isFinite(previousMs)) return false;
+  return nowMs - previousMs >= LIFECYCLE_DEDUPE_WINDOW_MS;
+}
+
+function shouldSendScopedLifecycleBroadcast(
+  stateDir: string,
+  sessionId: string | undefined,
+  bucket: 'events' | 'hookEvents',
+  eventKey: string,
+  fingerprint: string,
+  nowMs: number = Date.now(),
+): boolean {
+  if (!sessionId || !stateDir) return true;
+
+  const path = getStatePath(stateDir, sessionId);
+  const state = readState(path);
+  const bucketState = state[bucket] && typeof state[bucket] === 'object'
+    ? state[bucket]
+    : {};
+  return shouldSendFingerprint(bucketState?.[eventKey], fingerprint, nowMs);
+}
+
+function recordScopedLifecycleBroadcastSent(
+  stateDir: string,
+  sessionId: string | undefined,
+  bucket: 'events' | 'hookEvents',
+  eventKey: string,
+  fingerprint: string,
+  nowMs: number = Date.now(),
+): void {
+  if (!sessionId || !stateDir) return;
+
+  const path = getStatePath(stateDir, sessionId);
+  const state = readState(path);
+  const bucketState = state[bucket] && typeof state[bucket] === 'object'
+    ? state[bucket]
+    : {};
+  bucketState[eventKey] = {
+    fingerprint,
+    sentAt: new Date(nowMs).toISOString(),
+  };
+  state[bucket] = bucketState;
+  writeState(path, state);
+}
+
+export function createLifecycleBroadcastFingerprint(value: unknown): string {
+  return stableSerialize(value);
+}
+
 export function shouldSendLifecycleNotification(
   stateDir: string,
   payload: FullNotificationPayload,
+  nowMs: number = Date.now(),
 ): boolean {
   if (!shouldDedupeLifecycleNotification(payload.event)) return true;
-  if (!payload.sessionId || !stateDir) return true;
-  const path = getStatePath(stateDir, payload.sessionId);
-  const state = readState(path);
-  const previous = state.events?.[payload.event];
-  return previous?.fingerprint !== normalizeFingerprint(payload);
+  return shouldSendScopedLifecycleBroadcast(
+    stateDir,
+    payload.sessionId,
+    'events',
+    payload.event,
+    normalizeFingerprint(payload),
+    nowMs,
+  );
 }
 
 export function recordLifecycleNotificationSent(
   stateDir: string,
   payload: FullNotificationPayload,
+  nowMs: number = Date.now(),
 ): void {
   if (!shouldDedupeLifecycleNotification(payload.event)) return;
-  if (!payload.sessionId || !stateDir) return;
-  const path = getStatePath(stateDir, payload.sessionId);
-  const state = readState(path);
-  state.events = state.events && typeof state.events === 'object' ? state.events : {};
-  state.events[payload.event] = {
-    fingerprint: normalizeFingerprint(payload),
-    sentAt: new Date().toISOString(),
-  };
-  writeState(path, state);
+  recordScopedLifecycleBroadcastSent(
+    stateDir,
+    payload.sessionId,
+    'events',
+    payload.event,
+    normalizeFingerprint(payload),
+    nowMs,
+  );
+}
+
+export function shouldSendLifecycleHookBroadcast(
+  stateDir: string,
+  sessionId: string | undefined,
+  eventKey: string,
+  fingerprint: string,
+  nowMs: number = Date.now(),
+): boolean {
+  return shouldSendScopedLifecycleBroadcast(
+    stateDir,
+    sessionId,
+    'hookEvents',
+    eventKey,
+    fingerprint,
+    nowMs,
+  );
+}
+
+export function recordLifecycleHookBroadcastSent(
+  stateDir: string,
+  sessionId: string | undefined,
+  eventKey: string,
+  fingerprint: string,
+  nowMs: number = Date.now(),
+): void {
+  recordScopedLifecycleBroadcastSent(
+    stateDir,
+    sessionId,
+    'hookEvents',
+    eventKey,
+    fingerprint,
+    nowMs,
+  );
 }


### PR DESCRIPTION
## Summary

Deduplicate repeated native lifecycle hook broadcasts for the same session/turn fingerprint so duplicate `started`, `prompt-submitted`, and `stopped` relays collapse to one authoritative plugin dispatch.

## Changes

- share lifecycle fingerprint + cooldown logic between notification dedupe and native hook dispatch
- record hook dispatch fingerprints in a separate state bucket so notification dedupe and hook dedupe do not suppress each other
- add focused regression coverage for same-turn hook dedupe, cooldown re-fire behavior, and separate hook/notification state tracking

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/notifications/__tests__/lifecycle-dedupe.test.js dist/hooks/extensibility/__tests__/dispatcher.test.js`
- [x] `npx biome lint src/notifications/lifecycle-dedupe.ts src/notifications/__tests__/lifecycle-dedupe.test.ts src/hooks/extensibility/dispatcher.ts src/hooks/extensibility/__tests__/dispatcher.test.ts`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1515
