### PR TITLE
Reduce stale tmux follow-up keyword alert churn

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -297,6 +297,18 @@ describe('parseTmuxTail', () => {
     assert.ok(!result.includes('ctrl+o'));
   });
 
+  it('parseTmuxTail preserves operator-visible lines until idle dedupe decides whether to resend them', () => {
+    const raw = [
+      'risk summary',
+      '{"severity":"error","message":"old metadata"}',
+      'resolved setup failure',
+      'Fresh actionable failure',
+    ].join('\n');
+    const result = formatSessionIdle({ ...basePayload, tmuxTail: raw });
+    assert.ok(result.includes('Fresh actionable failure'));
+    assert.ok(result.includes('risk summary'));
+  });
+
   it('buildTmuxTailBlock omits block when all lines filtered', () => {
     const raw = '● spinner only\n⎿ more spinner';
     const result = formatSessionIdle({ ...basePayload, tmuxTail: raw });

--- a/src/notifications/__tests__/idle-cooldown.test.ts
+++ b/src/notifications/__tests__/idle-cooldown.test.ts
@@ -14,6 +14,8 @@ import {
   recordIdleNotificationSent,
   shouldSendSessionIdleHookEvent,
   recordSessionIdleHookEventSent,
+  shouldIncludeSessionIdleTmuxTail,
+  recordSessionIdleTmuxTailSent,
 } from '../idle-cooldown.js';
 
 function makeTmpStateDir(): string {
@@ -236,5 +238,51 @@ describe('session-idle hook event dedupe', () => {
       shouldSendSessionIdleHookEvent(stateDir, sessionId, '{"phase":"idle","summary":"Waiting on user input"}'),
       true,
     );
+  });
+});
+
+describe('session-idle tmux tail dedupe', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = makeTmpStateDir();
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('suppresses unchanged parsed tmux tails for repeated idle notifications', () => {
+    const sessionId = 'test-session-idle-tmux-tail';
+    const fingerprint = 'Waiting on review';
+
+    recordSessionIdleTmuxTailSent(stateDir, sessionId, fingerprint);
+
+    assert.equal(shouldIncludeSessionIdleTmuxTail(stateDir, sessionId, fingerprint), false);
+  });
+
+  it('allows newly changed tmux tails to be included immediately', () => {
+    const sessionId = 'test-session-idle-tmux-tail-change';
+    recordSessionIdleTmuxTailSent(stateDir, sessionId, 'Waiting on review');
+
+    assert.equal(shouldIncludeSessionIdleTmuxTail(stateDir, sessionId, 'Fresh setup error'), true);
+  });
+
+  it('treats empty tmux tails as nothing to resend', () => {
+    const sessionId = 'test-session-idle-tmux-tail-empty';
+
+    assert.equal(shouldIncludeSessionIdleTmuxTail(stateDir, sessionId, ''), false);
+  });
+
+  it('keeps lifecycle fingerprint and tmux-tail fingerprint independently', () => {
+    const sessionId = 'test-session-idle-tmux-tail-independent';
+    recordIdleNotificationSent(stateDir, sessionId, '{"phase":"idle","summary":"Waiting on review"}');
+    recordSessionIdleTmuxTailSent(stateDir, sessionId, 'Waiting on review');
+
+    assert.equal(
+      shouldSendIdleNotification(stateDir, sessionId, '{"phase":"idle","summary":"Waiting on user input"}'),
+      true,
+    );
+    assert.equal(shouldIncludeSessionIdleTmuxTail(stateDir, sessionId, 'Waiting on review'), false);
   });
 });

--- a/src/notifications/__tests__/session-idle-tail-dedupe.test.ts
+++ b/src/notifications/__tests__/session-idle-tail-dedupe.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const ENV_KEYS = [
+  'CODEX_HOME',
+  'OMX_NOTIFY_TEMP',
+  'OMX_NOTIFY_TEMP_CONTRACT',
+  'OMX_NOTIFY_PROFILE',
+  'OMX_DISCORD_WEBHOOK_URL',
+  'OMX_OPENCLAW',
+] as const;
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) delete process.env[key];
+}
+
+describe('session-idle tmux tail dedupe integration', () => {
+  let notifyLifecycle: typeof import('../index.js').notifyLifecycle;
+  let tempCodexHome = '';
+  let projectPath = '';
+  let originalFetch: typeof globalThis.fetch | undefined;
+  const capturedBodies: Array<Record<string, unknown>> = [];
+
+  beforeEach(async () => {
+    clearEnv();
+    const root = await mkdtemp(join(tmpdir(), 'omx-session-idle-tail-'));
+    tempCodexHome = join(root, '.codex');
+    projectPath = join(root, 'project');
+    await mkdir(tempCodexHome, { recursive: true });
+    await mkdir(projectPath, { recursive: true });
+    await writeFile(join(tempCodexHome, '.omx-config.json'), JSON.stringify({
+      notifications: {
+        enabled: true,
+        events: {
+          'session-idle': {
+            enabled: true,
+            webhook: { enabled: true, url: 'https://example.com/webhook' },
+          },
+        },
+        webhook: { enabled: true, url: 'https://example.com/webhook' },
+      },
+    }, null, 2));
+    process.env.CODEX_HOME = tempCodexHome;
+    ({ notifyLifecycle } = await import(`../index.js?session-idle-tail-dedupe=${Date.now()}`));
+    originalFetch = globalThis.fetch;
+    capturedBodies.length = 0;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedBodies.push(JSON.parse(String(init?.body || '{}')));
+      return {
+        ok: true,
+        status: 200,
+      } as Response;
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, 'fetch');
+    } else {
+      globalThis.fetch = originalFetch;
+    }
+    const root = tempCodexHome ? join(tempCodexHome, '..') : '';
+    clearEnv();
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  it('drops unchanged stale tmux tails from repeated idle notifications but keeps fresh tails', async () => {
+    const base = {
+      sessionId: 'sess-idle-tail',
+      projectPath,
+      projectName: 'project',
+    };
+
+    const staleTail = [
+      'risk summary',
+      '{"severity":"error","message":"old metadata"}',
+      'resolved setup failure',
+    ].join('\n');
+
+    const first = await notifyLifecycle('session-idle', { ...base, tmuxTail: staleTail });
+    assert.equal(first?.anySuccess, true);
+    assert.equal(capturedBodies.length, 1);
+    assert.match(String(capturedBodies[0]?.message || ''), /risk summary/);
+
+    const second = await notifyLifecycle('session-idle', { ...base, tmuxTail: staleTail });
+    assert.equal(second?.anySuccess, true);
+    assert.equal(capturedBodies.length, 2);
+    assert.doesNotMatch(String(capturedBodies[1]?.message || ''), /risk summary/);
+    assert.doesNotMatch(String(capturedBodies[1]?.message || ''), /severity/);
+
+    const third = await notifyLifecycle('session-idle', { ...base, tmuxTail: 'fresh setup error' });
+    assert.equal(third?.anySuccess, true);
+    assert.equal(capturedBodies.length, 3);
+    assert.match(String(capturedBodies[2]?.message || ''), /fresh setup error/);
+  });
+});

--- a/src/notifications/idle-cooldown.ts
+++ b/src/notifications/idle-cooldown.ts
@@ -25,6 +25,7 @@ const SESSION_IDLE_HOOK_STATE_FILE = 'session-idle-hook-state.json';
 interface IdleNotificationState {
   lastSentAt?: string;
   fingerprint?: string;
+  tmuxTailFingerprint?: string;
 }
 
 /**
@@ -98,21 +99,22 @@ function readIdleNotificationState(cooldownPath: string): IdleNotificationState 
     return {
       lastSentAt: typeof data?.lastSentAt === 'string' ? data.lastSentAt : undefined,
       fingerprint: normalizeIdleFingerprint(typeof data?.fingerprint === 'string' ? data.fingerprint : ''),
+      tmuxTailFingerprint: normalizeIdleFingerprint(typeof data?.tmuxTailFingerprint === 'string' ? data.tmuxTailFingerprint : ''),
     };
   } catch {
     return null;
   }
 }
 
-function writeIdleNotificationState(cooldownPath: string, fingerprint?: string): void {
+function writeIdleNotificationState(cooldownPath: string, patch: IdleNotificationState): void {
   try {
     const dir = dirname(cooldownPath);
     mkdirSync(dir, { recursive: true });
-    const normalizedFingerprint = normalizeIdleFingerprint(fingerprint);
-    const state: IdleNotificationState = { lastSentAt: new Date().toISOString() };
-    if (normalizedFingerprint) {
-      state.fingerprint = normalizedFingerprint;
-    }
+    const previous = readIdleNotificationState(cooldownPath) ?? {};
+    const state: IdleNotificationState = {
+      ...previous,
+      ...patch,
+    };
     writeFileSync(cooldownPath, JSON.stringify(state, null, 2));
   } catch {
     // ignore write errors — best effort
@@ -159,7 +161,11 @@ export function shouldSendIdleNotification(stateDir: string, sessionId?: string,
  */
 export function recordIdleNotificationSent(stateDir: string, sessionId?: string, fingerprint?: string): void {
   const cooldownPath = getCooldownStatePath(stateDir, sessionId);
-  writeIdleNotificationState(cooldownPath, fingerprint);
+  const normalizedFingerprint = normalizeIdleFingerprint(fingerprint);
+  writeIdleNotificationState(cooldownPath, {
+    lastSentAt: new Date().toISOString(),
+    fingerprint: normalizedFingerprint || undefined,
+  });
 }
 
 /**
@@ -184,5 +190,44 @@ export function shouldSendSessionIdleHookEvent(stateDir: string, sessionId?: str
  * Record that the coarse session-idle hook event was dispatched.
  */
 export function recordSessionIdleHookEventSent(stateDir: string, sessionId?: string, fingerprint?: string): void {
-  writeIdleNotificationState(getSessionIdleHookStatePath(stateDir, sessionId), fingerprint);
+  const normalizedFingerprint = normalizeIdleFingerprint(fingerprint);
+  writeIdleNotificationState(getSessionIdleHookStatePath(stateDir, sessionId), {
+    lastSentAt: new Date().toISOString(),
+    fingerprint: normalizedFingerprint || undefined,
+  });
+}
+
+/**
+ * Check whether a session-idle notification should include the captured tmux tail.
+ *
+ * Repeated idle notifications often reuse the same pane history. When the parsed
+ * tail text is unchanged, downstream keyword scanners should not see it again.
+ */
+export function shouldIncludeSessionIdleTmuxTail(
+  stateDir: string,
+  sessionId?: string,
+  tmuxTailFingerprint?: string,
+): boolean {
+  const normalizedFingerprint = normalizeIdleFingerprint(tmuxTailFingerprint);
+  if (!normalizedFingerprint) return false;
+
+  const state = readIdleNotificationState(getCooldownStatePath(stateDir, sessionId));
+  if (!state) return true;
+
+  return state.tmuxTailFingerprint !== normalizedFingerprint;
+}
+
+/**
+ * Record the parsed tmux-tail fingerprint last included in a session-idle notification.
+ */
+export function recordSessionIdleTmuxTailSent(
+  stateDir: string,
+  sessionId?: string,
+  tmuxTailFingerprint?: string,
+): void {
+  const normalizedFingerprint = normalizeIdleFingerprint(tmuxTailFingerprint);
+  const cooldownPath = getCooldownStatePath(stateDir, sessionId);
+  writeIdleNotificationState(cooldownPath, {
+    tmuxTailFingerprint: normalizedFingerprint || undefined,
+  });
 }

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -144,6 +144,11 @@ import {
   recordLifecycleNotificationSent,
 } from "./lifecycle-dedupe.js";
 import type { OpenClawHookEvent } from "../openclaw/types.js";
+import { parseTmuxTail } from "./formatter.js";
+import {
+  shouldIncludeSessionIdleTmuxTail,
+  recordSessionIdleTmuxTailSent,
+} from "./idle-cooldown.js";
 
 // Suppress unused import — used by callers via re-export
 void getActiveProfileName;
@@ -232,11 +237,12 @@ export async function notifyLifecycle(
 
     // Capture tmux tail for session+ verbosity on idle/stop/end events
     const verbosity = getVerbosity(config);
-    if (
-      shouldIncludeTmuxTail(verbosity) &&
-      !data.tmuxTail &&
-      (event === "session-idle" || event === "session-stop" || event === "session-end")
-    ) {
+    const shouldAttemptTmuxTail =
+      shouldIncludeTmuxTail(verbosity)
+      && !data.tmuxTail
+      && (event === "session-idle" || event === "session-stop" || event === "session-end");
+
+    if (shouldAttemptTmuxTail) {
       const { captureTmuxPaneWithLiveness } = await import("./tmux.js");
       const tmuxCapture = captureTmuxPaneWithLiveness(payload.tmuxPaneId);
       payload.tmuxTail = tmuxCapture.content ?? undefined;
@@ -246,9 +252,21 @@ export async function notifyLifecycle(
       payload.tmuxTailLive = data.tmuxTailLive;
     }
 
+    const lifecycleStateDir = payload.projectPath ? omxStateDir(payload.projectPath) : "";
+    const normalizedIdleTmuxTail = event === "session-idle" ? parseTmuxTail(payload.tmuxTail || "") : "";
+    const sessionIdleTmuxTailAllowed = event !== "session-idle"
+      || shouldIncludeSessionIdleTmuxTail(lifecycleStateDir, payload.sessionId, normalizedIdleTmuxTail);
+
+    if (
+      event === "session-idle"
+      && !sessionIdleTmuxTailAllowed
+    ) {
+      payload.tmuxTail = undefined;
+      payload.tmuxTailLive = undefined;
+    }
+
     payload.message = data.message || formatNotification(payload);
 
-    const lifecycleStateDir = payload.projectPath ? omxStateDir(payload.projectPath) : "";
     if (!shouldSendLifecycleNotification(lifecycleStateDir, payload)) {
       return {
         event,
@@ -260,6 +278,9 @@ export async function notifyLifecycle(
     const result = await dispatchNotifications(config, event, payload);
     if (result.anySuccess) {
       recordLifecycleNotificationSent(lifecycleStateDir, payload);
+      if (event === "session-idle" && sessionIdleTmuxTailAllowed) {
+        recordSessionIdleTmuxTailSent(lifecycleStateDir, payload.sessionId, normalizedIdleTmuxTail);
+      }
     }
 
     // Fire-and-forget OpenClaw gateway call


### PR DESCRIPTION
## Summary
- stop repeated `session-idle` notifications from re-sending the same parsed tmux tail
- keep idle-state dedupe separate from tail dedupe so fresh failures still surface immediately
- add focused regression coverage around repeated stale tails vs fresh idle tails

## Testing
- `npm run build`
- `node --test dist/notifications/__tests__/idle-cooldown.test.js dist/hooks/__tests__/notify-hook-session-idle-dedupe.test.js dist/notifications/__tests__/formatter.test.js dist/cli/__tests__/lifecycle-notifications.test.js dist/notifications/__tests__/session-idle-tail-dedupe.test.js`
- `npx biome lint src/notifications/index.ts src/notifications/idle-cooldown.ts src/notifications/__tests__/idle-cooldown.test.ts src/notifications/__tests__/formatter.test.ts src/notifications/__tests__/session-idle-tail-dedupe.test.ts`
- `npm run check:no-unused`

## Notes
This is intentionally narrow: it does not change keyword scanning rules directly. Instead it removes the repeated stale tmux pane residue that kept making old review/diagnostic/setup text look new to downstream operator alerts.
