### PR TITLE
Fix tmux worker proxy env inheritance

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -929,6 +929,73 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('inherits only allowlisted ambient proxy env vars for tmux startup commands', () => {
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevHttpsProxy = process.env.HTTPS_PROXY;
+    const prevHttpProxy = process.env.HTTP_PROXY;
+    const prevNoProxy = process.env.NO_PROXY;
+    const prevLowerHttpsProxy = process.env.https_proxy;
+    const prevCustom = process.env.AWS_SECRET_ACCESS_KEY;
+    process.env.SHELL = '/bin/bash';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.HTTPS_PROXY = 'https://upper-proxy.example:443';
+    process.env.HTTP_PROXY = 'http://upper-proxy.example:80';
+    process.env.NO_PROXY = 'localhost,127.0.0.1';
+    process.env.https_proxy = 'https://lower-proxy.example:443';
+    process.env.AWS_SECRET_ACCESS_KEY = 'should-not-inherit';
+    try {
+      const cmd = buildWorkerStartupCommand('alpha', 1, [], '/tmp/project');
+      assert.match(cmd, /HTTPS_PROXY=https:\/\/upper-proxy\.example:443/);
+      assert.match(cmd, /HTTP_PROXY=http:\/\/upper-proxy\.example:80/);
+      assert.match(cmd, /NO_PROXY=localhost,127\.0\.0\.1/);
+      assert.match(cmd, /https_proxy=https:\/\/lower-proxy\.example:443/);
+      assert.doesNotMatch(cmd, /AWS_SECRET_ACCESS_KEY=should-not-inherit/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevHttpsProxy === 'string') process.env.HTTPS_PROXY = prevHttpsProxy;
+      else delete process.env.HTTPS_PROXY;
+      if (typeof prevHttpProxy === 'string') process.env.HTTP_PROXY = prevHttpProxy;
+      else delete process.env.HTTP_PROXY;
+      if (typeof prevNoProxy === 'string') process.env.NO_PROXY = prevNoProxy;
+      else delete process.env.NO_PROXY;
+      if (typeof prevLowerHttpsProxy === 'string') process.env.https_proxy = prevLowerHttpsProxy;
+      else delete process.env.https_proxy;
+      if (typeof prevCustom === 'string') process.env.AWS_SECRET_ACCESS_KEY = prevCustom;
+      else delete process.env.AWS_SECRET_ACCESS_KEY;
+    }
+  });
+
+  it('preserves explicit worker env precedence over inherited ambient proxy vars', () => {
+    const prevShell = process.env.SHELL;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevHttpsProxy = process.env.HTTPS_PROXY;
+    process.env.SHELL = '/bin/bash';
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.HTTPS_PROXY = 'https://ambient-proxy.example:443';
+    try {
+      const cmd = buildWorkerStartupCommand(
+        'alpha',
+        1,
+        [],
+        '/tmp/project',
+        { HTTPS_PROXY: 'https://explicit-proxy.example:8443' },
+      );
+      assert.match(cmd, /HTTPS_PROXY=https:\/\/explicit-proxy\.example:8443/);
+      assert.doesNotMatch(cmd, /HTTPS_PROXY=https:\/\/ambient-proxy\.example:443/);
+    } finally {
+      if (typeof prevShell === 'string') process.env.SHELL = prevShell;
+      else delete process.env.SHELL;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevHttpsProxy === 'string') process.env.HTTPS_PROXY = prevHttpsProxy;
+      else delete process.env.HTTPS_PROXY;
+    }
+  });
+
   it('resolves POSIX leader paths before building fish worker startup commands', async () => {
     const fakeBin = await mkdtemp(join(tmpdir(), 'omx-worker-startup-posix-'));
     const prevPath = process.env.PATH;
@@ -1937,6 +2004,29 @@ describe('team worker launch mode helpers', () => {
       else delete process.env.WORKER_PROVIDER_API_KEY;
       await rm(leaderCodexHome, { recursive: true, force: true });
       await rm(workerCodexHome, { recursive: true, force: true });
+    }
+  });
+
+  it('buildWorkerProcessLaunchSpec keeps the worker env contract unchanged for ambient proxy vars', () => {
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevHttpsProxy = process.env.HTTPS_PROXY;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.HTTPS_PROXY = 'https://ambient-proxy.example:443';
+    try {
+      const spec = buildWorkerProcessLaunchSpec(
+        'eta-team',
+        1,
+        [],
+        '/tmp/workspace',
+        {},
+        'codex',
+      );
+      assert.equal(spec.env.HTTPS_PROXY, undefined);
+    } finally {
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevHttpsProxy === 'string') process.env.HTTPS_PROXY = prevHttpsProxy;
+      else delete process.env.HTTPS_PROXY;
     }
   });
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -61,6 +61,14 @@ const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
 const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
 const OMX_LEADER_NODE_PATH_ENV = 'OMX_LEADER_NODE_PATH';
 const OMX_LEADER_CLI_PATH_ENV = 'OMX_LEADER_CLI_PATH';
+const TMUX_WORKER_AMBIENT_ENV_ALLOWLIST = [
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'NO_PROXY',
+  'https_proxy',
+  'http_proxy',
+  'no_proxy',
+] as const;
 const TMUX_NO_UNDERLINE_STYLE_FLAGS = [
   'nounderscore',
   'nodouble-underscore',
@@ -745,6 +753,16 @@ function buildModelInstructionsOverride(cwd: string, env: NodeJS.ProcessEnv): st
   return `${MODEL_INSTRUCTIONS_FILE_KEY}="${escapeTomlString(filePath)}"`;
 }
 
+function readTmuxWorkerAmbientEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const inherited: Record<string, string> = {};
+  for (const key of TMUX_WORKER_AMBIENT_ENV_ALLOWLIST) {
+    const value = env[key];
+    if (typeof value !== 'string' || value.trim() === '') continue;
+    inherited[key] = value;
+  }
+  return inherited;
+}
+
 function resolveWorkerLaunchArgs(extraArgs: string[] = [], cwd: string = process.cwd(), env: NodeJS.ProcessEnv = process.env): string[] {
   const merged = [...extraArgs];
   const wantsBypass = process.argv.includes(CODEX_BYPASS_FLAG) || process.argv.includes(MADMAX_FLAG);
@@ -777,6 +795,10 @@ export function buildWorkerStartupCommand(
     initialPrompt,
     workerRole,
   );
+  const startupEnv = {
+    ...readTmuxWorkerAmbientEnv(process.env),
+    ...processSpec.env,
+  };
   const resolvedLeaderNodePath = processSpec.env[OMX_LEADER_NODE_PATH_ENV]?.trim() || resolveLeaderNodePath();
   const leaderNodeDir = /[\\/]/.test(resolvedLeaderNodePath)
     ? resolvedLeaderNodePath.replace(/[\\/][^\\/]+$/, '')
@@ -785,7 +807,7 @@ export function buildWorkerStartupCommand(
     const pathBootstrap = leaderNodeDir
       ? `$env:PATH = ${quotePowerShellArg(`${leaderNodeDir};`)} + $env:PATH`
       : '';
-    const envAssignments = Object.entries(processSpec.env)
+    const envAssignments = Object.entries(startupEnv)
       .map(([key, value]) => `$env:${key} = ${quotePowerShellArg(value)}`)
       .join('; ');
     const invocation = ['&', quotePowerShellArg(processSpec.command), ...processSpec.args.map(quotePowerShellArg)].join(' ');
@@ -806,7 +828,7 @@ export function buildWorkerStartupCommand(
   const cliInvocation = quotedArgs.length > 0 ? `exec ${processSpec.command} ${quotedArgs}` : `exec ${processSpec.command}`;
   const rcPrefix = launchSpec.rcFile ? `if [ -f ${launchSpec.rcFile} ]; then source ${launchSpec.rcFile}; fi; ` : '';
   const inner = `${rcPrefix}${pathPrefix}${cliInvocation}`;
-  const envParts = Object.entries(processSpec.env).map(([key, value]) => `${key}=${value}`);
+  const envParts = Object.entries(startupEnv).map(([key, value]) => `${key}=${value}`);
 
   return `env ${envParts.map(shellQuoteSingle).join(' ')} ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(inner)}`;
 }


### PR DESCRIPTION
## Summary

Tmux team workers were dropping ambient proxy configuration because the tmux startup path only forwarded OMX-managed variables. This keeps the fix narrow by inheriting a targeted proxy/network allowlist at tmux startup while preserving the existing worker env contract and explicit worker/provider precedence.

## Changes

- add a tmux worker ambient env allowlist for `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` and lowercase variants
- merge the allowlisted ambient vars into tmux startup commands only, leaving `buildWorkerProcessLaunchSpec()` unchanged
- add focused regression coverage for allowlisted inheritance, precedence, and unchanged process launch env contract

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/team/__tests__/tmux-session.test.js`
- [x] `npm run lint -- src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts`
- [x] `npm run check:no-unused`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1522
