### PR TITLE
Preserve user-authored AGENTS guidance during setup

### DIFF
--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -106,7 +106,7 @@ describe('omx setup AGENTS refresh behavior', () => {
     const restoreTty = setMockTty(true);
     const home = join(wd, 'home');
     const restoreHome = setMockHome(home);
-    const existing = '# old agents file\n';
+    const existing = '# oh-my-codex - Intelligent Multi-Agent Orchestration\n\nUser-owned guidance.\n';
     try {
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(join(wd, 'AGENTS.md'), existing);
@@ -121,7 +121,7 @@ describe('omx setup AGENTS refresh behavior', () => {
       assert.match(output, /agents_md: updated=1, unchanged=0, backed_up=1, skipped=0, removed=0/);
       assert.match(agentsContent, /^<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->/);
       assert.match(agentsContent, /# oh-my-codex - Intelligent Multi-Agent Orchestration/);
-      assert.doesNotMatch(agentsContent, /# old agents file/);
+      assert.doesNotMatch(agentsContent, /User-owned guidance\./);
 
       const backupsRoot = join(wd, '.omx', 'backups', 'setup');
       assert.equal(existsSync(backupsRoot), true);
@@ -180,6 +180,81 @@ describe('omx setup AGENTS refresh behavior', () => {
       );
       assert.doesNotMatch(agentsContent, /legacy-frontier/);
       assert.doesNotMatch(agentsContent, /legacy-spark/);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes only the explicit OMX-owned model block inside a user-authored AGENTS.md', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      const existing = [
+        '# Team Instructions',
+        '',
+        'Keep this custom guidance.',
+        '',
+        '<!-- OMX:MODELS:START -->',
+        '## Model Capability Table',
+        '',
+        '| Role | Model | Reasoning Effort | Use Case |',
+        '| --- | --- | --- | --- |',
+        '| Frontier (leader) | `legacy-frontier` | high | stale |',
+        '<!-- OMX:MODELS:END -->',
+        '',
+        'Footer guidance stays user-owned.',
+      ].join('\n');
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+      });
+
+      const agentsContent = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      const expectedContext = resolveAgentsModelTableContext(
+        await readFile(join(wd, '.codex', 'config.toml'), 'utf-8'),
+        { codexHomeOverride: join(wd, '.codex') },
+      );
+
+      assert.match(output, /Refreshed AGENTS\.md model capability table in project root\./);
+      assert.match(agentsContent, /Keep this custom guidance\./);
+      assert.match(agentsContent, /Footer guidance stays user-owned\./);
+      assert.match(
+        agentsContent,
+        new RegExp(`\\| Frontier \\(leader\\) \\| \`${expectedContext.frontierModel}\` \\| high \\|`),
+      );
+      assert.doesNotMatch(agentsContent, /legacy-frontier/);
+      assert.doesNotMatch(agentsContent, /<!-- omx:generated:agents-md -->/);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a title-only user-authored AGENTS.md by default when no OMX markers exist', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const existing = '# oh-my-codex - Intelligent Multi-Agent Orchestration\n\nUser-owned guidance.\n';
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+      });
+
+      assert.match(output, /Skipped AGENTS\.md overwrite/);
+      assert.doesNotMatch(output, /Refreshed AGENTS\.md model capability table/);
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), existing);
+      assert.equal(existsSync(join(wd, '.omx', 'backups', 'setup')), false);
     } finally {
       restoreHome();
       restoreTty();

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -50,6 +50,7 @@ import { tryReadCatalogManifest } from "../catalog/reader.js";
 import { DEFAULT_FRONTIER_MODEL } from "../config/models.js";
 import {
   addGeneratedAgentsMarker,
+  hasOmxManagedAgentsSections,
   isOmxGeneratedAgentsMd,
 } from "../utils/agents-md.js";
 import {
@@ -909,7 +910,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     if (agentsMdExists) {
       const existing = await readFile(agentsMdDst, "utf-8");
       changed = existing !== rewritten;
-      if (isOmxGeneratedAgentsMd(existing)) {
+      if (hasOmxManagedAgentsSections(existing)) {
         managedRefreshContent = upsertAgentsModelTable(
           existing,
           modelTableContext,

--- a/src/utils/__tests__/agents-md.test.ts
+++ b/src/utils/__tests__/agents-md.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { addGeneratedAgentsMarker, isOmxGeneratedAgentsMd, OMX_GENERATED_AGENTS_MARKER } from '../agents-md.js';
+import {
+  addGeneratedAgentsMarker,
+  hasOmxManagedAgentsSections,
+  isOmxGeneratedAgentsMd,
+  OMX_GENERATED_AGENTS_MARKER,
+} from '../agents-md.js';
 
 describe('agents-md helpers', () => {
   it('inserts the generated marker after the autonomy directive block', () => {
@@ -36,5 +41,29 @@ describe('agents-md helpers', () => {
     ].join('\n');
 
     assert.equal(isOmxGeneratedAgentsMd(content), true);
+  });
+
+  it('does not treat title-only user AGENTS.md content as OMX-generated', () => {
+    const content = [
+      '# oh-my-codex - Intelligent Multi-Agent Orchestration',
+      '',
+      'User-authored guidance without any OMX ownership markers.',
+    ].join('\n');
+
+    assert.equal(isOmxGeneratedAgentsMd(content), false);
+    assert.equal(hasOmxManagedAgentsSections(content), false);
+  });
+
+  it('recognizes explicit OMX-owned model table blocks as managed sections', () => {
+    const content = [
+      '# Shared ownership AGENTS',
+      '',
+      '<!-- OMX:MODELS:START -->',
+      'managed table',
+      '<!-- OMX:MODELS:END -->',
+    ].join('\n');
+
+    assert.equal(isOmxGeneratedAgentsMd(content), false);
+    assert.equal(hasOmxManagedAgentsSections(content), true);
   });
 });

--- a/src/utils/agents-md.ts
+++ b/src/utils/agents-md.ts
@@ -1,12 +1,20 @@
+import {
+  OMX_MODELS_END_MARKER,
+  OMX_MODELS_START_MARKER,
+} from './agents-model-table.js'
+
 export const OMX_GENERATED_AGENTS_MARKER = '<!-- omx:generated:agents-md -->'
-const OMX_GENERATED_AGENTS_TITLE =
-  '# oh-my-codex - Intelligent Multi-Agent Orchestration'
 const AUTONOMY_DIRECTIVE_END_MARKER = '<!-- END AUTONOMY DIRECTIVE -->'
 
 export function isOmxGeneratedAgentsMd(content: string): boolean {
+  return content.includes(OMX_GENERATED_AGENTS_MARKER)
+}
+
+export function hasOmxManagedAgentsSections(content: string): boolean {
   return (
-    content.includes(OMX_GENERATED_AGENTS_MARKER) ||
-    content.includes(OMX_GENERATED_AGENTS_TITLE)
+    isOmxGeneratedAgentsMd(content) ||
+    (content.includes(OMX_MODELS_START_MARKER) &&
+      content.includes(OMX_MODELS_END_MARKER))
   )
 }
 


### PR DESCRIPTION
## Summary
- stop treating the OMX heading alone as proof that AGENTS.md is OMX-owned
- refresh AGENTS.md only when explicit OMX-managed markers/blocks exist
- add regression coverage for preserved user files and shared-ownership model-table refreshes

## Verification
- npm run build
- node --test dist/utils/__tests__/agents-md.test.js dist/cli/__tests__/setup-agents-overwrite.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/uninstall.test.js
- npm run check:no-unused
- npm run lint -- src/cli/setup.ts src/utils/agents-md.ts src/utils/__tests__/agents-md.test.ts src/cli/__tests__/setup-agents-overwrite.test.ts

Closes #1521