### PR TITLE
fix(notifications): suppress post-stop tmux replay noise

### DIFF
--- a/src/notifications/__tests__/index.test.ts
+++ b/src/notifications/__tests__/index.test.ts
@@ -1,0 +1,127 @@
+import { after, before, beforeEach, afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const ENV_KEYS = ['CODEX_HOME', 'TMUX', 'TMUX_PANE', 'PATH'] as const;
+
+const originalFetch = globalThis.fetch;
+
+function writeNotificationConfig(codexHome: string): void {
+  writeFileSync(join(codexHome, '.omx-config.json'), JSON.stringify({
+    notifications: {
+      enabled: true,
+      webhook: {
+        enabled: true,
+        url: 'https://example.com/hook',
+      },
+    },
+  }, null, 2));
+}
+
+function writeFakeTmux(fakeBinDir: string, output: string): void {
+  const tmuxPath = join(fakeBinDir, 'tmux');
+  writeFileSync(tmuxPath, `#!/usr/bin/env bash
+set -eu
+if [[ "$1" == "list-panes" ]]; then
+  printf '0 %s\\n' "$PPID"
+  exit 0
+fi
+if [[ "$1" == "capture-pane" ]]; then
+  printf '%s\\n' ${JSON.stringify(output)}
+  exit 0
+fi
+exit 2
+`);
+  chmodSync(tmuxPath, 0o755);
+}
+
+describe('notifyLifecycle tmux tail auto-capture', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  const codexHome = mkdtempSync(join(tmpdir(), 'omx-notify-index-codex-home-'));
+  const fakeBinDir = mkdtempSync(join(tmpdir(), 'omx-notify-index-fake-bin-'));
+
+  before(() => {
+    originalEnv = { ...process.env };
+    process.env.CODEX_HOME = codexHome;
+    process.env.PATH = `${fakeBinDir}:${originalEnv.PATH || ''}`;
+    process.env.TMUX = '/tmp/tmux-1000/default,12345,0';
+    process.env.TMUX_PANE = '%42';
+  });
+
+  beforeEach(() => {
+    process.env.CODEX_HOME = codexHome;
+    process.env.PATH = `${fakeBinDir}:${originalEnv.PATH || ''}`;
+    process.env.TMUX = '/tmp/tmux-1000/default,12345,0';
+    process.env.TMUX_PANE = '%42';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  after(() => {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+    rmSync(codexHome, { recursive: true, force: true });
+    rmSync(fakeBinDir, { recursive: true, force: true });
+  });
+
+  it('does not auto-capture historical tmux tail for terminal notifications', async () => {
+    writeFakeTmux(fakeBinDir, 'historical risk line');
+    writeNotificationConfig(codexHome);
+    const { notifyLifecycle } = await import('../index.js');
+
+    for (const eventName of ['session-end', 'session-stop'] as const) {
+      let capturedBody = '';
+      globalThis.fetch = async (_input, init) => {
+        capturedBody = typeof init?.body === 'string' ? init.body : '';
+        return new Response('', { status: 200 });
+      };
+
+      const projectPath = mkdtempSync(join(tmpdir(), `omx-notify-index-project-${eventName}-`));
+      const result = await notifyLifecycle(eventName, {
+        sessionId: `sess-${eventName}-${Date.now()}`,
+        projectPath,
+        projectName: 'project',
+        reason: 'session_exit',
+      });
+      rmSync(projectPath, { recursive: true, force: true });
+
+      assert.ok(result);
+      assert.equal(result.anySuccess, true);
+      const parsed = JSON.parse(capturedBody) as { message: string };
+      assert.doesNotMatch(parsed.message, /Recent output:/);
+      assert.doesNotMatch(parsed.message, /historical risk line/);
+    }
+  });
+
+  it('keeps auto-capturing tmux tail for live session-idle notifications', async () => {
+    writeFakeTmux(fakeBinDir, 'waiting for live input');
+
+    let capturedBody = '';
+    globalThis.fetch = async (_input, init) => {
+      capturedBody = typeof init?.body === 'string' ? init.body : '';
+      return new Response('', { status: 200 });
+    };
+    writeNotificationConfig(codexHome);
+
+    const projectPath = mkdtempSync(join(tmpdir(), 'omx-notify-index-project-idle-'));
+    const { notifyLifecycle } = await import('../index.js');
+    const result = await notifyLifecycle('session-idle', {
+      sessionId: `sess-idle-${Date.now()}`,
+      projectPath,
+      projectName: 'project',
+    });
+    rmSync(projectPath, { recursive: true, force: true });
+
+    assert.ok(result);
+    assert.equal(result.anySuccess, true);
+    const parsed = JSON.parse(capturedBody) as { message: string };
+    assert.match(parsed.message, /Recent output:/);
+    assert.match(parsed.message, /waiting for live input/);
+  });
+});

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -235,14 +235,16 @@ export async function notifyLifecycle(
       incompleteTasks: data.incompleteTasks,
     };
 
-    // Capture tmux tail for session+ verbosity on idle/stop/end events
+    // Auto-capture tmux tail only for live idle events. Stop/end lifecycle dispatches
+    // happen after the relevant session is stopping or has already completed, so
+    // blind capture-pane reads can replay historical pane lines into follow-up
+    // alerts. Explicitly supplied tmuxTail still passes through unchanged.
     const verbosity = getVerbosity(config);
-    const shouldAttemptTmuxTail =
+    if (
       shouldIncludeTmuxTail(verbosity)
       && !data.tmuxTail
-      && (event === "session-idle" || event === "session-stop" || event === "session-end");
-
-    if (shouldAttemptTmuxTail) {
+      && event === "session-idle"
+    ) {
       const { captureTmuxPaneWithLiveness } = await import("./tmux.js");
       const tmuxCapture = captureTmuxPaneWithLiveness(payload.tmuxPaneId);
       payload.tmuxTail = tmuxCapture.content ?? undefined;

--- a/src/openclaw/__tests__/index.test.ts
+++ b/src/openclaw/__tests__/index.test.ts
@@ -113,6 +113,51 @@ describe("wakeOpenClaw", () => {
     assert.ok(result!.error?.includes("OMX_OPENCLAW_COMMAND"));
   });
 
+  it("does not auto-capture tmux history for stop/session-end events without explicit tmuxTail", async () => {
+    process.env.OMX_OPENCLAW = "1";
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    process.env.TMUX_PANE = "%42";
+
+    for (const eventName of ["stop", "session-end"] as const) {
+      const { createServer } = await import("http");
+      let capturedBody = "";
+      const server = createServer((req, res) => {
+        let body = "";
+        req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+        req.on("end", () => {
+          capturedBody = body;
+          res.writeHead(200);
+          res.end();
+        });
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+
+      const configPath = join(tmpDir, `openclaw-${eventName}.json`);
+      writeFileSync(configPath, JSON.stringify({
+        enabled: true,
+        gateways: { gw: { type: "http", url: `http://127.0.0.1:${port}/hook` } },
+        hooks: {
+          [eventName]: { gateway: "gw", instruction: "Event", enabled: true },
+        },
+      }));
+      process.env.OMX_OPENCLAW_CONFIG = configPath;
+      const { wakeOpenClaw } = await import("../index.js");
+      const { resetOpenClawConfigCache } = await import("../config.js");
+      resetOpenClawConfigCache();
+
+      const result = await wakeOpenClaw(eventName, { projectPath: "/some/project" });
+      server.close();
+
+      assert.ok(result !== null);
+      assert.equal(result!.success, true);
+
+      const payload = JSON.parse(capturedBody) as { tmuxTail?: string };
+      assert.equal(payload.tmuxTail, undefined);
+    }
+  });
+
   it("includes channel/to/threadId in HTTP payload when OPENCLAW_REPLY_* env vars set", async () => {
     process.env.OMX_OPENCLAW = "1";
     process.env.OPENCLAW_REPLY_CHANNEL = "#general";

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -35,7 +35,7 @@ import type { OpenClawHookEvent, OpenClawContext, OpenClawResult } from "./types
 import { getOpenClawConfig, resolveGateway } from "./config.js";
 import { wakeGateway, wakeCommandGateway, interpolateInstruction, isCommandGateway } from "./dispatcher.js";
 import { basename } from "path";
-import { getCurrentTmuxSession, captureTmuxPaneWithLiveness } from "../notifications/tmux.js";
+import { getCurrentTmuxSession } from "../notifications/tmux.js";
 
 /** Whether debug logging is enabled */
 const DEBUG = process.env.OMX_OPENCLAW_DEBUG === "1";
@@ -103,25 +103,10 @@ export async function wakeOpenClaw(
     // Auto-detect tmux session if not provided in context
     const tmuxSession = enrichedContext.tmuxSession ?? getCurrentTmuxSession() ?? undefined;
 
-    // Auto-capture tmux pane content for stop/session-end events (best-effort)
-    let tmuxTail = enrichedContext.tmuxTail;
-    let tmuxTailLive = enrichedContext.tmuxTail !== undefined;
-    if (!tmuxTail && (event === "stop" || event === "session-end") && process.env.TMUX) {
-      try {
-        const paneId = process.env.TMUX_PANE;
-        if (paneId) {
-          const capture = captureTmuxPaneWithLiveness(paneId, 15);
-          tmuxTail = capture.content ?? undefined;
-          tmuxTailLive = capture.live;
-        }
-      } catch {
-        // Non-blocking: tmux capture is best-effort
-      }
-    }
-
-    if (!tmuxTailLive) {
-      tmuxTail = undefined;
-    }
+    // Preserve only explicitly supplied tmux tails. Auto-capturing stop/session-end
+    // pane history here can replay historical pane lines after a session has been
+    // stopped or completed, which creates false follow-up alerts downstream.
+    const tmuxTail = enrichedContext.tmuxTail;
 
     // Build template variables from whitelisted context fields
     const variables: Record<string, string | undefined> = {

--- a/src/openclaw/types.ts
+++ b/src/openclaw/types.ts
@@ -87,7 +87,7 @@ export interface OpenClawPayload {
   projectName?: string;
   /** Tmux session name (if running inside tmux) */
   tmuxSession?: string;
-  /** Recent tmux pane output (for stop/session-end events) */
+  /** Recent tmux pane output when explicitly supplied by the caller. */
   tmuxTail?: string;
   /** Originating channel for reply routing (if OPENCLAW_REPLY_CHANNEL is set) */
   channel?: string;
@@ -113,7 +113,7 @@ export interface OpenClawContext {
   contextSummary?: string;
   reason?: string;
   question?: string;
-  /** Recent tmux pane output (captured automatically for stop/session-end events) */
+  /** Recent tmux pane output when explicitly supplied by the caller. */
   tmuxTail?: string;
   /** Originating channel for reply routing (from OPENCLAW_REPLY_CHANNEL env var) */
   replyChannel?: string;


### PR DESCRIPTION
## Summary
- stop auto-capturing tmux tails for terminal lifecycle notifications and OpenClaw stop/session-end dispatches
- keep live session-idle tmux capture intact so active-session signal still flows
- add regressions covering terminal-event suppression and idle-event preservation

## Root cause
`notifyLifecycle()` and `wakeOpenClaw()` were auto-capturing `tmux capture-pane` output for terminal lifecycle paths. After a PR review session stopped or completed, that capture could replay historical pane lines, which downstream tmux keyword matchers treated as fresh follow-up signal.

## Testing
- `npm run build && node --test dist/openclaw/__tests__/index.test.js dist/notifications/__tests__/index.test.js`
- `npx biome lint src/notifications/index.ts src/openclaw/index.ts src/notifications/__tests__/index.test.ts src/openclaw/__tests__/index.test.ts src/openclaw/types.ts`