### PR TITLE
Ignore metadata-only tmux keyword alert lines

### DIFF
--- a/src/notifications/__tests__/tmux.test.ts
+++ b/src/notifications/__tests__/tmux.test.ts
@@ -10,6 +10,7 @@ import {
   getTeamTmuxSessions,
   captureTmuxPane,
   captureTmuxPaneWithLiveness,
+  sanitizeTmuxAlertText,
 } from '../tmux.js';
 
 describe('getCurrentTmuxSession', () => {
@@ -285,5 +286,41 @@ describe('captureTmuxPane', () => {
     assert.equal(result.live, false);
     assert.equal(result.content, null);
     assert.equal(captureTmuxPane('%42', 12), null);
+  });
+});
+
+describe('sanitizeTmuxAlertText', () => {
+  it('drops metadata-only branch and HUD summary lines', () => {
+    const raw = [
+      'fix/issue-1525-post-stop-keyword-replay',
+      'fix/issue-1525-post-stop-keyword-replay | ralph:2/50 | turns:4 | session:1m | last:5s ago',
+      '[OMX#3] ultrawork active',
+    ].join('\n');
+
+    assert.equal(sanitizeTmuxAlertText(raw), undefined);
+  });
+
+  it('preserves real failure lines even when they resemble alert keywords', () => {
+    const raw = [
+      'fix/issue-1525-post-stop-keyword-replay | ralph:2/50 | turns:4 | session:1m | last:5s ago',
+      'stderr: Error: test suite failed',
+    ].join('\n');
+
+    assert.equal(sanitizeTmuxAlertText(raw), 'stderr: Error: test suite failed');
+  });
+
+  it('preserves ordinary runtime lines with separators', () => {
+    const raw = 'vitest summary | 12 passed | 1 failed';
+    assert.equal(sanitizeTmuxAlertText(raw), raw);
+  });
+
+  it('drops metadata-only branch lines even when the branch name contains failure-like words', () => {
+    const raw = 'feature/error-repro | ralph:2/50 | turns:4 | session:1m | last:5s ago';
+    assert.equal(sanitizeTmuxAlertText(raw), undefined);
+  });
+
+  it('preserves a branch line when it carries a real failure marker', () => {
+    const raw = 'feature/error-repro | stderr: TypeError: cannot read properties of undefined';
+    assert.equal(sanitizeTmuxAlertText(raw), raw);
   });
 });

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -51,6 +51,7 @@ export {
   getTeamTmuxSessions,
   formatTmuxInfo,
   captureTmuxPane,
+  sanitizeTmuxAlertText,
 } from "./tmux.js";
 export {
   getNotificationConfig,
@@ -136,7 +137,7 @@ import {
 } from "./temp-contract.js";
 import { formatNotification } from "./formatter.js";
 import { dispatchNotifications } from "./dispatcher.js";
-import { getCurrentTmuxSession } from "./tmux.js";
+import { getCurrentTmuxSession, sanitizeTmuxAlertText } from "./tmux.js";
 import { basename } from "path";
 import { omxStateDir } from "../utils/paths.js";
 import {
@@ -247,10 +248,10 @@ export async function notifyLifecycle(
     ) {
       const { captureTmuxPaneWithLiveness } = await import("./tmux.js");
       const tmuxCapture = captureTmuxPaneWithLiveness(payload.tmuxPaneId);
-      payload.tmuxTail = tmuxCapture.content ?? undefined;
+      payload.tmuxTail = sanitizeTmuxAlertText(tmuxCapture.content);
       payload.tmuxTailLive = tmuxCapture.live;
     } else {
-      payload.tmuxTail = data.tmuxTail;
+      payload.tmuxTail = sanitizeTmuxAlertText(data.tmuxTail);
       payload.tmuxTailLive = data.tmuxTailLive;
     }
 

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -10,6 +10,42 @@ import { buildCapturePaneArgv } from "./tmux-detector.js";
 const TMUX_PANE_TARGET_RE = /^%\d+$/;
 const DEFAULT_CAPTURE_LINES = 12;
 const MAX_CAPTURE_LINES = 2000;
+const ANSI_RE = /\x1b(?:[@-Z\\-_]|\[[0-9;]*[A-Za-z])/g;
+const OMX_METADATA_SEGMENT_RE = /^\[OMX(?:[#\]].*)?$/;
+const HUD_STATUS_SEGMENT_RE = /^(?:ralph:\d+\/(?:\d+|\?)|autopilot:[\w-]+|ralplan:(?:\d+\/(?:\d+|\?)|[\w-]+)|interview:[\w:-]+|research:[\w-]+|qa:[\w-]+|team:(?:\d+\s+workers|[\w.-]+)|ultrawork|turns:\d+|tokens:[\dkm.]+|quota:[\w%,.]+|session:[\dhms]+|last:\d+[smh](?:\s+ago)?|total-turns:\d+|tmux:[\w:.-]+)$/i;
+const BRANCH_METADATA_SEGMENT_RE = /^(?:(?:fix|feat|feature|chore|refactor|hotfix|release|docs|doc|test|tests|ci|build|perf|revert|bugfix|spike|wip)\/[A-Za-z0-9._/-]+|HEAD(?: -> [A-Za-z0-9._/-]+)?|detached)$/;
+
+function isMetadataOnlyTmuxSegment(segment: string): boolean {
+  return OMX_METADATA_SEGMENT_RE.test(segment)
+    || HUD_STATUS_SEGMENT_RE.test(segment)
+    || BRANCH_METADATA_SEGMENT_RE.test(segment);
+}
+
+function isMetadataOnlyTmuxLine(line: string): boolean {
+  const normalized = line.replace(ANSI_RE, "").trim();
+  if (!normalized) return false;
+
+  const segments = normalized.split("|").map((segment) => segment.trim()).filter(Boolean);
+  if (segments.length === 0 || segments.some((segment) => !isMetadataOnlyTmuxSegment(segment))) {
+    return false;
+  }
+
+  const hasExplicitStatusSegment = segments.some((segment) => OMX_METADATA_SEGMENT_RE.test(segment) || HUD_STATUS_SEGMENT_RE.test(segment));
+  return hasExplicitStatusSegment || (segments.length === 1 && BRANCH_METADATA_SEGMENT_RE.test(segments[0]));
+}
+
+/**
+ * Remove metadata-only tmux lines from alert-facing payload text while
+ * preserving real runtime failures. Raw capture helpers remain unchanged.
+ */
+export function sanitizeTmuxAlertText(raw: string | null | undefined): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const filtered = raw
+    .split("\n")
+    .filter((line) => !isMetadataOnlyTmuxLine(line));
+  const joined = filtered.join("\n").trim();
+  return joined || undefined;
+}
 
 export interface TmuxPaneCaptureResult {
   content: string | null;

--- a/src/openclaw/__tests__/index.test.ts
+++ b/src/openclaw/__tests__/index.test.ts
@@ -367,4 +367,54 @@ describe("wakeOpenClaw", () => {
     assert.ok(result !== null);
     assert.equal(result!.success, true);
   });
+
+  it("sanitizes metadata-only tmuxTail provided by callers while preserving failure text", async () => {
+    process.env.OMX_OPENCLAW = "1";
+    delete process.env.OPENCLAW_REPLY_CHANNEL;
+    delete process.env.OPENCLAW_REPLY_TARGET;
+    delete process.env.OPENCLAW_REPLY_THREAD;
+
+    const { createServer } = await import("http");
+    let capturedBody = "";
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+      req.on("end", () => {
+        capturedBody = body;
+        res.writeHead(200);
+        res.end();
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+
+    const configPath = join(tmpDir, "openclaw.json");
+    writeFileSync(configPath, JSON.stringify({
+      enabled: true,
+      gateways: { gw: { type: "http", url: `http://127.0.0.1:${port}/hook` } },
+      hooks: {
+        "session-end": { gateway: "gw", instruction: "Ended", enabled: true },
+      },
+    }));
+    process.env.OMX_OPENCLAW_CONFIG = configPath;
+    const { wakeOpenClaw } = await import("../index.js");
+    const { resetOpenClawConfigCache } = await import("../config.js");
+    resetOpenClawConfigCache();
+
+    const result = await wakeOpenClaw("session-end", {
+      sessionId: "s1",
+      tmuxTail: [
+        "fix/issue-1525-post-stop-keyword-replay | ralph:2/50 | turns:4 | session:1m | last:5s ago",
+        "stderr: Error: test suite failed",
+      ].join("\n"),
+    });
+    server.close();
+
+    assert.ok(result !== null);
+    assert.equal(result!.success, true);
+    const parsed = JSON.parse(capturedBody);
+    assert.equal(parsed.tmuxTail, "stderr: Error: test suite failed");
+    assert.equal(parsed.context.tmuxTail, "stderr: Error: test suite failed");
+  });
 });

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -35,7 +35,7 @@ import type { OpenClawHookEvent, OpenClawContext, OpenClawResult } from "./types
 import { getOpenClawConfig, resolveGateway } from "./config.js";
 import { wakeGateway, wakeCommandGateway, interpolateInstruction, isCommandGateway } from "./dispatcher.js";
 import { basename } from "path";
-import { getCurrentTmuxSession } from "../notifications/tmux.js";
+import { getCurrentTmuxSession, sanitizeTmuxAlertText } from "../notifications/tmux.js";
 
 /** Whether debug logging is enabled */
 const DEBUG = process.env.OMX_OPENCLAW_DEBUG === "1";
@@ -92,9 +92,12 @@ export async function wakeOpenClaw(
     const replyTarget = context.replyTarget ?? process.env.OPENCLAW_REPLY_TARGET ?? undefined;
     const replyThread = context.replyThread ?? process.env.OPENCLAW_REPLY_THREAD ?? undefined;
 
+    const sanitizedContextTmuxTail = sanitizeTmuxAlertText(context.tmuxTail);
+
     // Merge reply context into the context object for whitelisting
     const enrichedContext: OpenClawContext = {
       ...context,
+      tmuxTail: sanitizedContextTmuxTail,
       ...(replyChannel !== undefined && { replyChannel }),
       ...(replyTarget !== undefined && { replyTarget }),
       ...(replyThread !== undefined && { replyThread }),


### PR DESCRIPTION
## Summary\n- suppress metadata-only tmux alert lines at the notification/OpenClaw payload boundary\n- keep raw tmux capture behavior unchanged while preserving real stderr/test/tool failure lines\n- add tmux/OpenClaw regressions for branch-summary noise and failure preservation\n\nFixes #1527\n\n## Verification\n- npm run build\n- node --test dist/notifications/__tests__/tmux.test.js dist/openclaw/__tests__/index.test.js\n- npx biome lint src/notifications/tmux.ts src/notifications/index.ts src/notifications/__tests__/tmux.test.ts src/openclaw/index.ts src/openclaw/__tests__/index.test.ts\n- npx tsc --noEmit --pretty false --project tsconfig.json