### PR TITLE
feat(notifications): add reply-correlated Discord status probe for tracked sessions

### DIFF
--- a/skills/configure-notifications/SKILL.md
+++ b/skills/configure-notifications/SKILL.md
@@ -257,6 +257,7 @@ Deterministic precedence:
 ### Reply listener
 - `notifications.reply.enabled`
 - env gates: `OMX_REPLY_ENABLED=true`, and for Discord `OMX_REPLY_DISCORD_USER_IDS=...`
+- For Discord bot replies, an authorized operator can reply with exact-match `status` to a tracked OMX notification to receive a bounded read-only session summary. This is a reply-thread-scoped status probe, not a general remote control surface.
 
 ## Step 6: Disable All Notifications
 

--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../reply-listener.js';
 import type { ReplyListenerDaemonConfig, ReplyListenerState } from '../reply-listener.js';
 import type { SessionMapping } from '../session-registry.js';
+import { NO_TRACKED_SESSION_MESSAGE } from '../session-status.js';
 
 function createBaseConfig(overrides: Partial<ReplyListenerDaemonConfig> = {}): ReplyListenerDaemonConfig {
   return {
@@ -383,6 +384,62 @@ describe('formatReplyAcknowledgement', () => {
 });
 
 describe('pollDiscordOnce', () => {
+  it('treats exact-match status replies as read-only Discord session lookups', async () => {
+    resetReplyListenerTransientState();
+    const config = createBaseConfig();
+    const state = createBaseState();
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    let injectCalled = false;
+
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input);
+      fetchCalls.push({ url, init });
+      if (url.endsWith('/messages?limit=10')) {
+        return jsonResponse([
+          {
+            id: 'discord-status-1',
+            author: { id: 'discord-user-1' },
+            content: '  STATUS  ',
+            message_reference: { message_id: 'orig-discord-msg' },
+          },
+        ]);
+      }
+      if (url.endsWith('/messages')) {
+        return jsonResponse({ id: 'status-reply-1' });
+      }
+      throw new Error(`Unexpected fetch url: ${url}`);
+    };
+
+    await pollDiscordOnce(
+      config,
+      state,
+      new RateLimiter(10),
+      {
+        fetchImpl,
+        lookupByMessageIdImpl: () => createMapping('discord-bot'),
+        buildSessionStatusReplyImpl: async (mapping) => {
+          assert.equal(mapping.sessionId, 'session-1');
+          return 'Tracked OMX session status';
+        },
+        injectReplyImpl: () => {
+          injectCalled = true;
+          return true;
+        },
+      },
+    );
+
+    assert.equal(injectCalled, false);
+    assert.equal(state.messagesInjected, 0);
+    assert.equal(state.errors, 0);
+    assert.equal(state.discordLastMessageId, 'discord-status-1');
+    assert.equal(fetchCalls.length, 2);
+
+    const replyBody = JSON.parse(String(fetchCalls[1].init?.body));
+    assert.equal(replyBody.content, 'Tracked OMX session status');
+    assert.deepEqual(replyBody.message_reference, { message_id: 'discord-status-1' });
+    assert.deepEqual(replyBody.allowed_mentions, { parse: [] });
+  });
+
   it('injects authorized replies and posts a threaded acknowledgement with recent output', async () => {
     resetReplyListenerTransientState();
     const config = createBaseConfig({ discordMention: '<@123>' });
@@ -483,6 +540,87 @@ describe('pollDiscordOnce', () => {
     assert.equal(state.messagesInjected, 0);
     assert.equal(state.errors, 0);
     assert.equal(state.discordLastMessageId, 'discord-reply-2');
+  });
+
+  it('does not return status data for unauthorized status replies', async () => {
+    resetReplyListenerTransientState();
+    const state = createBaseState();
+    const fetchCalls: string[] = [];
+
+    await pollDiscordOnce(
+      createBaseConfig(),
+      state,
+      new RateLimiter(10),
+      {
+        fetchImpl: async (input) => {
+          fetchCalls.push(String(input));
+          return jsonResponse([
+            {
+              id: 'discord-reply-unauthorized-status',
+              author: { id: 'intruder' },
+              content: 'status',
+              message_reference: { message_id: 'orig-discord-msg' },
+            },
+          ]);
+        },
+        lookupByMessageIdImpl: () => {
+          throw new Error('lookup should not run for unauthorized status replies');
+        },
+        injectReplyImpl: () => {
+          throw new Error('injectReply should not run for unauthorized status replies');
+        },
+      },
+    );
+
+    assert.deepEqual(fetchCalls, ['https://discord.com/api/v10/channels/discord-channel/messages?limit=10']);
+    assert.equal(state.messagesInjected, 0);
+    assert.equal(state.errors, 0);
+    assert.equal(state.discordLastMessageId, 'discord-reply-unauthorized-status');
+  });
+
+  it('replies with a bounded failure when status has no tracked correlation and does not inject', async () => {
+    resetReplyListenerTransientState();
+    const state = createBaseState();
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    let injectCalled = false;
+
+    await pollDiscordOnce(
+      createBaseConfig(),
+      state,
+      new RateLimiter(10),
+      {
+        fetchImpl: async (input, init) => {
+          const url = String(input);
+          fetchCalls.push({ url, init });
+          if (url.endsWith('/messages?limit=10')) {
+            return jsonResponse([
+              {
+                id: 'discord-status-untracked',
+                author: { id: 'discord-user-1' },
+                content: 'status',
+                message_reference: { message_id: 'unknown-msg' },
+              },
+            ]);
+          }
+          if (url.endsWith('/messages')) {
+            return jsonResponse({ id: 'status-failure-reply' });
+          }
+          throw new Error(`Unexpected fetch url: ${url}`);
+        },
+        lookupByMessageIdImpl: () => null,
+        injectReplyImpl: () => {
+          injectCalled = true;
+          return true;
+        },
+      },
+    );
+
+    assert.equal(injectCalled, false);
+    assert.equal(state.messagesInjected, 0);
+    assert.equal(state.errors, 0);
+    assert.equal(fetchCalls.length, 2);
+    const replyBody = JSON.parse(String(fetchCalls[1].init?.body));
+    assert.equal(replyBody.content, NO_TRACKED_SESSION_MESSAGE);
   });
 
   it('drops mapped Discord replies when the rate limiter rejects them', async () => {

--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -440,6 +440,57 @@ describe('pollDiscordOnce', () => {
     assert.deepEqual(replyBody.allowed_mentions, { parse: [] });
   });
 
+  it('uses the latest correlated session when a Discord notification message id is reused', async () => {
+    resetReplyListenerTransientState();
+    const config = createBaseConfig();
+    const state = createBaseState();
+    const statusSessionIds: string[] = [];
+
+    await pollDiscordOnce(
+      config,
+      state,
+      new RateLimiter(10),
+      {
+        fetchImpl: async (input) => {
+          const url = String(input);
+          if (url.endsWith('/messages?limit=10')) {
+            return jsonResponse([
+              {
+                id: 'discord-status-reused-id',
+                author: { id: 'discord-user-1' },
+                content: 'status',
+                message_reference: { message_id: 'orig-discord-msg' },
+              },
+            ]);
+          }
+          if (url.endsWith('/messages')) {
+            return jsonResponse({ id: 'status-reply-reused-id' });
+          }
+          throw new Error(`Unexpected fetch url: ${url}`);
+        },
+        lookupByMessageIdImpl: () => ({
+          ...createMapping('discord-bot'),
+          messageId: 'orig-discord-msg',
+          sessionId: 'session-newer',
+          tmuxPaneId: '%10',
+          tmuxSessionName: 'latest-session',
+        }),
+        buildSessionStatusReplyImpl: async (mapping) => {
+          statusSessionIds.push(mapping.sessionId);
+          return `Tracked OMX session status\nSession: ${mapping.sessionId}`;
+        },
+        injectReplyImpl: () => {
+          throw new Error('injectReply should not run for exact-match status probes');
+        },
+      },
+    );
+
+    assert.deepEqual(statusSessionIds, ['session-newer']);
+    assert.equal(state.messagesInjected, 0);
+    assert.equal(state.errors, 0);
+    assert.equal(state.discordLastMessageId, 'discord-status-reused-id');
+  });
+
   it('injects authorized replies and posts a threaded acknowledgement with recent output', async () => {
     resetReplyListenerTransientState();
     const config = createBaseConfig({ discordMention: '<@123>' });

--- a/src/notifications/__tests__/session-registry.test.ts
+++ b/src/notifications/__tests__/session-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs';
-import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, appendFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
@@ -204,6 +204,54 @@ describe('session-registry lock contention behavior', () => {
 
       assert.equal(ok, false);
       assert.ok(elapsedMs < 7000, `expected bounded wait, got ${elapsedMs}ms`);
+    } finally {
+      if (typeof originalHome === 'string') process.env.HOME = originalHome;
+      else delete process.env.HOME;
+      if (typeof originalUserProfile === 'string') process.env.USERPROFILE = originalUserProfile;
+      else delete process.env.USERPROFILE;
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('lookupByMessageId', () => {
+  it('prefers the most recent mapping when a platform message id is reused', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'omx-session-registry-reuse-'));
+    const stateDir = join(homeDir, '.omx', 'state');
+    const registryPath = join(stateDir, 'reply-session-registry.jsonl');
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      await mkdir(stateDir, { recursive: true });
+      process.env.HOME = homeDir;
+      process.env.USERPROFILE = homeDir;
+
+      const first = createMockMapping({
+        platform: 'discord-bot',
+        messageId: 'reused-message',
+        sessionId: 'session-earlier',
+        tmuxPaneId: '%1',
+        tmuxSessionName: 'earlier-session',
+        createdAt: '2026-03-20T00:00:00.000Z',
+      });
+      const second = createMockMapping({
+        platform: 'discord-bot',
+        messageId: 'reused-message',
+        sessionId: 'session-later',
+        tmuxPaneId: '%2',
+        tmuxSessionName: 'later-session',
+        createdAt: '2026-03-20T00:10:00.000Z',
+      });
+
+      await appendFile(registryPath, `${JSON.stringify(first)}\n${JSON.stringify(second)}\n`, 'utf-8');
+
+      const registry = await importSessionRegistryFresh();
+      const found = registry.lookupByMessageId('discord-bot', 'reused-message');
+
+      assert.ok(found);
+      assert.equal(found.sessionId, 'session-later');
+      assert.equal(found.tmuxPaneId, '%2');
     } finally {
       if (typeof originalHome === 'string') process.env.HOME = originalHome;
       else delete process.env.HOME;

--- a/src/notifications/__tests__/session-status.test.ts
+++ b/src/notifications/__tests__/session-status.test.ts
@@ -8,6 +8,7 @@ import {
   recordSubagentTurn,
   writeSubagentTrackingState,
 } from '../../subagents/tracker.js';
+import { writeSessionStart } from '../../hooks/session.js';
 import type { SessionMapping } from '../session-registry.js';
 import {
   STATUS_DATA_UNAVAILABLE_MESSAGE,
@@ -44,13 +45,7 @@ describe('session-status helper', () => {
   it('renders a bounded running summary with active subagent details', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-'));
     try {
-      await writeJson(join(wd, '.omx', 'state', 'session.json'), {
-        session_id: 'sess-1',
-        native_session_id: 'native-1',
-        started_at: '2026-03-20T00:00:00.000Z',
-        cwd: wd,
-        pid: 1234,
-      });
+      await writeSessionStart(wd, 'sess-1', { nativeSessionId: 'native-1' });
       await writeJson(join(wd, '.omx', 'state', 'sessions', 'sess-1', 'skill-active-state.json'), {
         active: true,
         skill: 'ralph',
@@ -120,6 +115,59 @@ describe('session-status helper', () => {
       assert.match(status, /Updated: 2026-03-20T00:01:00.000Z/);
       assert.match(status, /Freshness: May be stale \(last updated 2026-03-20T00:01:00.000Z\)/);
       assert.match(status, /Subagents: unknown/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not report a stale tracked session as running when only raw session.json remains', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-orphaned-'));
+    try {
+      await writeJson(join(wd, '.omx', 'state', 'session.json'), {
+        session_id: 'sess-orphaned',
+        native_session_id: 'native-orphaned',
+        started_at: '2026-03-20T00:00:00.000Z',
+        cwd: wd,
+        pid: 4242,
+        pid_start_ticks: 11,
+        pid_cmdline: 'node omx',
+      });
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'logs', 'session-history.jsonl'),
+        `${JSON.stringify({
+          session_id: 'sess-orphaned',
+          native_session_id: 'native-orphaned',
+          started_at: '2026-03-20T00:00:00.000Z',
+          ended_at: '2026-03-20T00:01:00.000Z',
+        })}\n`,
+        'utf-8',
+      );
+
+      const status = await buildDiscordSessionStatusReply(createMapping(wd, 'sess-orphaned'), {
+        now: '2026-03-20T00:10:00.000Z',
+        readSessionStateImpl: async (projectPath) => {
+          assert.equal(projectPath, wd);
+          return {
+            session_id: 'sess-orphaned',
+            native_session_id: 'native-orphaned',
+            started_at: '2026-03-20T00:00:00.000Z',
+            cwd: wd,
+            pid: 4242,
+            pid_start_ticks: 11,
+            pid_cmdline: 'node omx',
+          };
+        },
+        readUsableSessionStateImpl: async (projectPath) => {
+          assert.equal(projectPath, wd);
+          return null;
+        },
+      });
+
+      assert.doesNotMatch(status, /State: running/);
+      assert.match(status, /State: ended/);
+      assert.match(status, /Native: native-orphaned/);
+      assert.match(status, /Freshness: May be stale \(last updated 2026-03-20T00:01:00.000Z\)/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/notifications/__tests__/session-status.test.ts
+++ b/src/notifications/__tests__/session-status.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  createSubagentTrackingState,
+  recordSubagentTurn,
+  writeSubagentTrackingState,
+} from '../../subagents/tracker.js';
+import type { SessionMapping } from '../session-registry.js';
+import {
+  STATUS_DATA_UNAVAILABLE_MESSAGE,
+  buildDiscordSessionStatusReply,
+  isDiscordStatusCommand,
+} from '../session-status.js';
+
+function createMapping(projectPath: string, sessionId = 'sess-1'): SessionMapping {
+  return {
+    platform: 'discord-bot',
+    messageId: 'orig-discord-msg',
+    sessionId,
+    tmuxPaneId: '%9',
+    tmuxSessionName: 'omx-session',
+    event: 'session-idle',
+    createdAt: '2026-03-20T00:00:00.000Z',
+    projectPath,
+  };
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+describe('session-status helper', () => {
+  it('accepts exact-match status commands after trim/case normalization', () => {
+    assert.equal(isDiscordStatusCommand('status'), true);
+    assert.equal(isDiscordStatusCommand('  STATUS  '), true);
+    assert.equal(isDiscordStatusCommand('status now'), false);
+    assert.equal(isDiscordStatusCommand('status?'), false);
+  });
+
+  it('renders a bounded running summary with active subagent details', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-'));
+    try {
+      await writeJson(join(wd, '.omx', 'state', 'session.json'), {
+        session_id: 'sess-1',
+        native_session_id: 'native-1',
+        started_at: '2026-03-20T00:00:00.000Z',
+        cwd: wd,
+        pid: 1234,
+      });
+      await writeJson(join(wd, '.omx', 'state', 'sessions', 'sess-1', 'skill-active-state.json'), {
+        active: true,
+        skill: 'ralph',
+        phase: 'executing',
+        updated_at: '2026-03-20T00:04:30.000Z',
+        session_id: 'sess-1',
+      });
+
+      let tracking = createSubagentTrackingState();
+      for (const [threadId, turnId] of [
+        ['leader-thread', 'turn-1'],
+        ['a1b2c3-thread', 'turn-2'],
+        ['d4e5f6-thread', 'turn-3'],
+        ['g7h8i9-thread', 'turn-4'],
+        ['j0k1l2-thread', 'turn-5'],
+      ] as const) {
+        tracking = recordSubagentTurn(tracking, {
+          sessionId: 'sess-1',
+          threadId,
+          turnId,
+          timestamp: '2026-03-20T00:04:00.000Z',
+          mode: 'ralph',
+        });
+      }
+      await writeSubagentTrackingState(wd, tracking);
+
+      const status = await buildDiscordSessionStatusReply(createMapping(wd), {
+        now: '2026-03-20T00:05:00.000Z',
+      });
+
+      assert.match(status, /^Tracked OMX session status/m);
+      assert.match(status, /Session: sess-1/);
+      assert.match(status, /Native: native-1/);
+      assert.match(status, /State: running \(ralph\/executing\)/);
+      assert.match(status, /Tmux: omx-session \/ %9/);
+      assert.match(status, /Updated: 2026-03-20T00:04:30.000Z/);
+      assert.match(status, /Freshness: Fresh/);
+      assert.match(status, /Subagents: 4 active \(a1b2c3, d4e5f6, g7h8i9, \+1 more\)/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('renders stale partial summaries with explicit unknown fields', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-stale-'));
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'logs', 'session-history.jsonl'),
+        `${JSON.stringify({
+          session_id: 'sess-old',
+          started_at: '2026-03-20T00:00:00.000Z',
+          ended_at: '2026-03-20T00:01:00.000Z',
+          cwd: wd,
+          pid: 999,
+        })}\n`,
+        'utf-8',
+      );
+
+      const status = await buildDiscordSessionStatusReply(createMapping(wd, 'sess-old'), {
+        now: '2026-03-20T00:10:00.000Z',
+      });
+
+      assert.match(status, /Session: sess-old/);
+      assert.match(status, /Native: unknown/);
+      assert.match(status, /State: ended/);
+      assert.match(status, /Updated: 2026-03-20T00:01:00.000Z/);
+      assert.match(status, /Freshness: May be stale \(last updated 2026-03-20T00:01:00.000Z\)/);
+      assert.match(status, /Subagents: unknown/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a bounded failure message when correlated state cannot be resolved', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-session-status-empty-'));
+    try {
+      const status = await buildDiscordSessionStatusReply(createMapping(wd));
+      assert.equal(status, STATUS_DATA_UNAVAILABLE_MESSAGE);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -30,6 +30,11 @@ import {
   removeMessagesByPane,
   pruneStale,
 } from './session-registry.js';
+import {
+  NO_TRACKED_SESSION_MESSAGE,
+  buildDiscordSessionStatusReply,
+  isDiscordStatusCommand,
+} from './session-status.js';
 import { parseMentionAllowedMentions } from './config.js';
 import { parseTmuxTail } from './formatter.js';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
@@ -403,6 +408,7 @@ export interface ReplyListenerPollDeps {
   fetchImpl?: typeof fetch;
   httpsRequestImpl?: typeof httpsRequest;
   injectReplyImpl?: typeof injectReply;
+  buildSessionStatusReplyImpl?: typeof buildDiscordSessionStatusReply;
   captureReplyAcknowledgementSummaryImpl?: typeof captureReplyAcknowledgementSummary;
   lookupByMessageIdImpl?: typeof lookupByMessageId;
   writeDaemonStateImpl?: typeof writeDaemonState;
@@ -467,6 +473,41 @@ function injectReply(
   return success;
 }
 
+async function postDiscordReplyMessage(
+  config: ReplyListenerDaemonConfig,
+  replyToMessageId: string,
+  content: string,
+  deps: {
+    fetchImpl: typeof fetch;
+    logImpl: typeof log;
+  },
+): Promise<void> {
+  try {
+    const response = await deps.fetchImpl(
+      `https://discord.com/api/v10/channels/${config.discordChannelId}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bot ${config.discordBotToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content,
+          message_reference: { message_id: replyToMessageId },
+          allowed_mentions: { parse: [] as string[] },
+        }),
+        signal: AbortSignal.timeout(5000),
+      },
+    );
+
+    if (!response.ok) {
+      deps.logImpl(`WARN: Failed to send Discord reply message: HTTP ${response.status}`);
+    }
+  } catch (error) {
+    deps.logImpl(`WARN: Failed to send Discord reply message: ${error}`);
+  }
+}
+
 // ============================================================================
 // Discord Polling
 // ============================================================================
@@ -498,6 +539,7 @@ export async function pollDiscordOnce(
 
   const fetchImpl = deps.fetchImpl ?? fetch;
   const injectReplyImpl = deps.injectReplyImpl ?? injectReply;
+  const buildSessionStatusReplyImpl = deps.buildSessionStatusReplyImpl ?? buildDiscordSessionStatusReply;
   const captureReplyAcknowledgementSummaryImpl = deps.captureReplyAcknowledgementSummaryImpl ?? captureReplyAcknowledgementSummary;
   const lookupByMessageIdImpl = deps.lookupByMessageIdImpl ?? lookupByMessageId;
   const writeDaemonStateImpl = deps.writeDaemonStateImpl ?? writeDaemonState;
@@ -540,6 +582,8 @@ export async function pollDiscordOnce(
     const sorted = [...messages].reverse();
 
     for (const msg of sorted) {
+      const isStatusCommand = isDiscordStatusCommand(msg.content ?? '');
+
       if (!msg.message_reference?.message_id) {
         state.discordLastMessageId = msg.id;
         writeDaemonStateImpl(state);
@@ -553,22 +597,33 @@ export async function pollDiscordOnce(
       }
 
       const mapping = lookupByMessageIdImpl('discord-bot', msg.message_reference.message_id);
+      state.discordLastMessageId = msg.id;
+      writeDaemonStateImpl(state);
+
       if (!mapping) {
-        state.discordLastMessageId = msg.id;
-        writeDaemonStateImpl(state);
+        if (isStatusCommand) {
+          await postDiscordReplyMessage(config, msg.id, NO_TRACKED_SESSION_MESSAGE, {
+            fetchImpl,
+            logImpl,
+          });
+        }
         continue;
       }
 
       if (!rateLimiter.canProceed()) {
         logImpl(`WARN: Rate limit exceeded, dropping Discord message ${msg.id}`);
-        state.discordLastMessageId = msg.id;
-        writeDaemonStateImpl(state);
         state.errors++;
         continue;
       }
 
-      state.discordLastMessageId = msg.id;
-      writeDaemonStateImpl(state);
+      if (isStatusCommand) {
+        const statusMessage = await buildSessionStatusReplyImpl(mapping);
+        await postDiscordReplyMessage(config, msg.id, statusMessage, {
+          fetchImpl,
+          logImpl,
+        });
+        continue;
+      }
 
       const success = injectReplyImpl(mapping.tmuxPaneId, msg.content, 'discord', config);
       if (success) {

--- a/src/notifications/session-registry.ts
+++ b/src/notifications/session-registry.ts
@@ -293,7 +293,13 @@ function readAllMappingsUnsafe(): SessionMapping[] {
 
 export function lookupByMessageId(platform: string, messageId: string): SessionMapping | null {
   const mappings = loadAllMappings();
-  return mappings.find(m => m.platform === platform && m.messageId === messageId) || null;
+  for (let index = mappings.length - 1; index >= 0; index -= 1) {
+    const mapping = mappings[index];
+    if (mapping.platform === platform && mapping.messageId === messageId) {
+      return mapping;
+    }
+  }
+  return null;
 }
 
 export function removeSession(sessionId: string): void {

--- a/src/notifications/session-status.ts
+++ b/src/notifications/session-status.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { readSessionState } from '../hooks/session.js';
+import { isSessionStateUsable, readSessionState, readUsableSessionState } from '../hooks/session.js';
 import { getSkillActiveStatePaths, listActiveSkills, readSkillActiveState } from '../state/skill-active.js';
 import {
   readSubagentSessionSummary,
@@ -33,6 +33,7 @@ export interface SessionStatusDeps {
   existsSyncImpl?: typeof existsSync;
   readFileSyncImpl?: typeof readFileSync;
   readSessionStateImpl?: typeof readSessionState;
+  readUsableSessionStateImpl?: typeof readUsableSessionState;
   readSubagentSessionSummaryImpl?: typeof readSubagentSessionSummary;
   getSkillActiveStatePathsImpl?: typeof getSkillActiveStatePaths;
   readSkillActiveStateImpl?: typeof readSkillActiveState;
@@ -200,9 +201,21 @@ export async function buildDiscordSessionStatusReply(
     return STATUS_DATA_UNAVAILABLE_MESSAGE;
   }
 
-  const readSessionStateImpl = deps.readSessionStateImpl ?? readSessionState;
+  const readCurrentSessionState = async (projectPath: string) => {
+    if (deps.readUsableSessionStateImpl) {
+      return deps.readUsableSessionStateImpl(projectPath);
+    }
+
+    if (!deps.readSessionStateImpl) {
+      return readUsableSessionState(projectPath);
+    }
+
+    const state = await deps.readSessionStateImpl(projectPath);
+    if (!state) return null;
+    return isSessionStateUsable(state, projectPath) ? state : null;
+  };
   const readSubagentSessionSummaryImpl = deps.readSubagentSessionSummaryImpl ?? readSubagentSessionSummary;
-  const currentSession = await readSessionStateImpl(mapping.projectPath);
+  const currentSession = await readCurrentSessionState(mapping.projectPath);
   const currentSessionMatches = currentSession?.session_id === mapping.sessionId ? currentSession : null;
   const historyEntry = readLatestHistoryEntry(mapping.projectPath, mapping.sessionId, deps);
   const skillState = await readRelevantSkillState(mapping.projectPath, mapping.sessionId, deps);

--- a/src/notifications/session-status.ts
+++ b/src/notifications/session-status.ts
@@ -1,0 +1,244 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { readSessionState } from '../hooks/session.js';
+import { getSkillActiveStatePaths, listActiveSkills, readSkillActiveState } from '../state/skill-active.js';
+import {
+  readSubagentSessionSummary,
+  type SubagentSessionSummary,
+} from '../subagents/tracker.js';
+import { omxLogsDir } from '../utils/paths.js';
+import type { SessionMapping } from './session-registry.js';
+
+export const DISCORD_STATUS_COMMAND = 'status';
+export const DISCORD_STATUS_STALE_AFTER_MS = 5 * 60_000;
+export const DISCORD_STATUS_MAX_SUBAGENTS = 3;
+export const NO_TRACKED_SESSION_MESSAGE = 'No tracked OMX session is associated with this message.';
+export const STATUS_DATA_UNAVAILABLE_MESSAGE = 'Tracked OMX session found, but status data is unavailable.';
+
+interface SessionHistoryEntry {
+  session_id?: string;
+  native_session_id?: string;
+  started_at?: string;
+  ended_at?: string;
+}
+
+interface SkillStateSummary {
+  skill?: string;
+  phase?: string;
+  updatedAt?: string;
+}
+
+export interface SessionStatusDeps {
+  now?: string | Date;
+  existsSyncImpl?: typeof existsSync;
+  readFileSyncImpl?: typeof readFileSync;
+  readSessionStateImpl?: typeof readSessionState;
+  readSubagentSessionSummaryImpl?: typeof readSubagentSessionSummary;
+  getSkillActiveStatePathsImpl?: typeof getSkillActiveStatePaths;
+  readSkillActiveStateImpl?: typeof readSkillActiveState;
+}
+
+export function isDiscordStatusCommand(input: string): boolean {
+  return input.trim().toLowerCase() === DISCORD_STATUS_COMMAND;
+}
+
+function shortenIdentifier(identifier: string): string {
+  const trimmed = identifier.trim();
+  if (trimmed.length <= 6) return trimmed;
+  return trimmed.slice(0, 6);
+}
+
+function readLatestHistoryEntry(
+  projectPath: string,
+  sessionId: string,
+  deps: Pick<SessionStatusDeps, 'existsSyncImpl' | 'readFileSyncImpl'>,
+): SessionHistoryEntry | null {
+  const existsSyncImpl = deps.existsSyncImpl ?? existsSync;
+  const readFileSyncImpl = deps.readFileSyncImpl ?? readFileSync;
+  const historyPath = join(omxLogsDir(projectPath), 'session-history.jsonl');
+  if (!existsSyncImpl(historyPath)) return null;
+
+  try {
+    const content = readFileSyncImpl(historyPath, 'utf-8');
+    const lines = content.split('\n').filter((line) => line.trim() !== '');
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      try {
+        const parsed = JSON.parse(lines[index]) as SessionHistoryEntry;
+        if (parsed.session_id === sessionId) {
+          return parsed;
+        }
+      } catch {
+        // Ignore malformed history lines.
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+async function readRelevantSkillState(
+  projectPath: string,
+  sessionId: string,
+  deps: Pick<
+    SessionStatusDeps,
+    'existsSyncImpl' | 'getSkillActiveStatePathsImpl' | 'readSkillActiveStateImpl'
+  >,
+): Promise<SkillStateSummary | null> {
+  const existsSyncImpl = deps.existsSyncImpl ?? existsSync;
+  const getSkillActiveStatePathsImpl = deps.getSkillActiveStatePathsImpl ?? getSkillActiveStatePaths;
+  const readSkillActiveStateImpl = deps.readSkillActiveStateImpl ?? readSkillActiveState;
+  const { rootPath, sessionPath } = getSkillActiveStatePathsImpl(projectPath, sessionId);
+  const candidatePaths = [sessionPath, rootPath].filter((value): value is string => typeof value === 'string');
+
+  for (const candidatePath of candidatePaths) {
+    if (!existsSyncImpl(candidatePath)) continue;
+    const state = await readSkillActiveStateImpl(candidatePath);
+    if (!state) continue;
+
+    const stateSessionId = typeof state.session_id === 'string' ? state.session_id.trim() : '';
+    if (candidatePath === rootPath && stateSessionId && stateSessionId !== sessionId) {
+      continue;
+    }
+
+    const primary = listActiveSkills(state)[0];
+    const skill = primary?.skill || (typeof state.skill === 'string' ? state.skill.trim() : '');
+    const phase = primary?.phase || (typeof state.phase === 'string' ? state.phase.trim() : '');
+    const updatedAt = typeof state.updated_at === 'string' ? state.updated_at.trim() : '';
+
+    return {
+      ...(skill ? { skill } : {}),
+      ...(phase ? { phase } : {}),
+      ...(updatedAt ? { updatedAt } : {}),
+    };
+  }
+
+  return null;
+}
+
+function selectLatestTimestamp(timestamps: Array<string | undefined>): string | undefined {
+  let latest: string | undefined;
+  let latestMs = Number.NEGATIVE_INFINITY;
+
+  for (const timestamp of timestamps) {
+    if (!timestamp) continue;
+    const parsed = Date.parse(timestamp);
+    if (!Number.isFinite(parsed)) continue;
+    if (parsed > latestMs) {
+      latest = timestamp;
+      latestMs = parsed;
+    }
+  }
+
+  return latest;
+}
+
+function formatFreshnessLabel(latestTimestamp: string | undefined, nowValue: string | Date | undefined): string {
+  if (!latestTimestamp) return 'Freshness unknown';
+
+  const nowMs = typeof nowValue === 'string'
+    ? Date.parse(nowValue)
+    : nowValue instanceof Date
+      ? nowValue.getTime()
+      : Date.now();
+  const updatedMs = Date.parse(latestTimestamp);
+  if (!Number.isFinite(nowMs) || !Number.isFinite(updatedMs)) {
+    return 'Freshness unknown';
+  }
+
+  if (nowMs - updatedMs > DISCORD_STATUS_STALE_AFTER_MS) {
+    return `May be stale (last updated ${latestTimestamp})`;
+  }
+
+  return 'Fresh';
+}
+
+function formatSubagentSummary(summary: SubagentSessionSummary | null): string {
+  if (!summary) return 'unknown';
+
+  const activeIds = summary.activeSubagentThreadIds;
+  if (activeIds.length === 0) {
+    return '0 active';
+  }
+
+  const visible = activeIds.slice(0, DISCORD_STATUS_MAX_SUBAGENTS).map(shortenIdentifier);
+  const hiddenCount = activeIds.length - visible.length;
+  if (hiddenCount > 0) {
+    return `${activeIds.length} active (${visible.join(', ')}, +${hiddenCount} more)`;
+  }
+
+  return `${activeIds.length} active (${visible.join(', ')})`;
+}
+
+function formatStateLabel(
+  isRunning: boolean,
+  hasHistory: boolean,
+  skillState: SkillStateSummary | null,
+): string {
+  const lifecycle = isRunning ? 'running' : hasHistory ? 'ended' : 'unknown';
+  const mode = skillState?.skill
+    ? skillState.phase ? `${skillState.skill}/${skillState.phase}` : skillState.skill
+    : '';
+
+  if (lifecycle === 'running' && mode) {
+    return `${lifecycle} (${mode})`;
+  }
+
+  if (lifecycle === 'unknown' && mode) {
+    return mode;
+  }
+
+  return lifecycle;
+}
+
+export async function buildDiscordSessionStatusReply(
+  mapping: SessionMapping,
+  deps: SessionStatusDeps = {},
+): Promise<string> {
+  if (!mapping.projectPath) {
+    return STATUS_DATA_UNAVAILABLE_MESSAGE;
+  }
+
+  const readSessionStateImpl = deps.readSessionStateImpl ?? readSessionState;
+  const readSubagentSessionSummaryImpl = deps.readSubagentSessionSummaryImpl ?? readSubagentSessionSummary;
+  const currentSession = await readSessionStateImpl(mapping.projectPath);
+  const currentSessionMatches = currentSession?.session_id === mapping.sessionId ? currentSession : null;
+  const historyEntry = readLatestHistoryEntry(mapping.projectPath, mapping.sessionId, deps);
+  const skillState = await readRelevantSkillState(mapping.projectPath, mapping.sessionId, deps);
+  const subagentSummary = await readSubagentSessionSummaryImpl(mapping.projectPath, mapping.sessionId, {
+    ...(deps.now ? { now: deps.now } : {}),
+  });
+
+  if (!currentSessionMatches && !historyEntry && !skillState && !subagentSummary) {
+    return STATUS_DATA_UNAVAILABLE_MESSAGE;
+  }
+
+  const latestTimestamp = selectLatestTimestamp([
+    skillState?.updatedAt,
+    subagentSummary?.updatedAt,
+    historyEntry?.ended_at,
+  ]);
+
+  const nativeSessionId = currentSessionMatches?.native_session_id
+    || historyEntry?.native_session_id
+    || 'unknown';
+  const stateLabel = formatStateLabel(Boolean(currentSessionMatches), Boolean(historyEntry), skillState);
+  const tmuxSessionName = mapping.tmuxSessionName?.trim() || 'unknown';
+  const tmuxPaneId = mapping.tmuxPaneId?.trim() || 'unknown';
+  const subagents = formatSubagentSummary(subagentSummary);
+  const freshness = formatFreshnessLabel(latestTimestamp, deps.now);
+
+  const lines = [
+    'Tracked OMX session status',
+    `Session: ${mapping.sessionId}`,
+    `Native: ${nativeSessionId}`,
+    `State: ${stateLabel}`,
+    `Tmux: ${tmuxSessionName} / ${tmuxPaneId}`,
+    ...(latestTimestamp ? [`Updated: ${latestTimestamp}`] : []),
+    `Freshness: ${freshness}`,
+    `Subagents: ${subagents}`,
+  ];
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- add a reply-correlated Discord `status` command for authorized operators using the existing reply-listener trust boundary
- render a bounded tracked-session summary from existing session and subagent state instead of injecting `status` into tmux
- cover the new control path and preserve non-command reply injection behavior with targeted tests

## Testing
- npm run build
- node --test dist/notifications/__tests__/reply-listener.test.js dist/notifications/__tests__/session-status.test.js
- npx tsc --noEmit
- npm run lint -- src/notifications src/hooks/session.ts src/subagents/tracker.ts skills/configure-notifications/SKILL.md
- node dist/scripts/generate-catalog-docs.js --check

## Notes
- This intentionally ships the narrowest operator-facing slice from #1528: an exact-match, read-only `status` probe only.
- Full `npm test` still has a pre-existing unrelated failure in `dist/utils/__tests__/paths.test.js` around packaged CLI fallback expectations.
