### PR TITLE
docs: clarify canonical skill root for mixed OMX + Codex environments

### DIFF
--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -7,6 +7,17 @@ description: Diagnose and fix oh-my-codex installation issues
 
 Note: All `~/.codex/...` paths in this guide respect `CODEX_HOME` when that environment variable is set.
 
+## Canonical skill root
+
+OMX installs skills to `${CODEX_HOME:-~/.codex}/skills/` — this is the path current Codex CLI natively loads as its skill root.
+
+`~/.agents/skills/` is a **historical legacy path** from an older Codex CLI release, before Codex settled on `~/.codex` as its home directory. Current Codex CLI and OMX no longer write there.
+
+**In a mixed OMX + plain Codex environment:**
+- **Use**: `${CODEX_HOME:-~/.codex}/skills/` (user scope) or `.codex/skills/` (project scope)
+- **Clean up if present**: `~/.agents/skills/` — if this still exists alongside the canonical root, Codex's Enable/Disable Skills UI will show duplicate entries for any skill present in both trees
+- **Interop rule**: OMX writes only to the canonical path; archive or remove `~/.agents/skills/` once you have confirmed `${CODEX_HOME:-~/.codex}/skills/` is your active root
+
 ## Task: Run Installation Diagnostics
 
 You are the OMX Doctor - diagnose and fix installation issues.

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -44,7 +44,7 @@ Supported setup flags (current implementation):
 - Scope targets:
   - `user`: user directories (`~/.codex`, `~/.codex/skills`, `~/.omx/agents`)
   - `project`: local directories (`./.codex`, `./.codex/skills`, `./.omx/agents`)
-- Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint because Codex may show duplicate skill entries until the legacy tree is removed or archived.
+- Migration hint: in `user` scope, if historical `~/.agents/skills` still exists alongside `${CODEX_HOME:-~/.codex}/skills`, current setup prints a cleanup hint. **Why the paths differ**: `${CODEX_HOME:-~/.codex}/skills/` is the path current Codex CLI natively loads as its skill root; `~/.agents/skills/` was the skill root in an older Codex CLI release before `~/.codex` became the standard home directory. OMX writes only to the canonical `${CODEX_HOME:-~/.codex}/skills/` path. When both directories exist simultaneously, Codex discovers skills from both trees and may show duplicate entries in Enable/Disable Skills. Archive or remove `~/.agents/skills/` to resolve this.
 - If persisted scope is `project`, `omx` launch automatically uses `CODEX_HOME=./.codex` unless user explicitly overrides `CODEX_HOME`.
 - With `--force`, AGENTS overwrite may still be skipped if an active OMX session is detected (safety guard).
 - Legacy persisted scope values (`project-local`) are automatically migrated to `project` with a one-time warning.


### PR DESCRIPTION
## Summary
- document `${CODEX_HOME:-~/.codex}/skills/` as the canonical skill root
- explain why historical `~/.agents/skills/` can still cause duplicate discovery in mixed environments
- expand setup guidance so the cleanup hint explains the canonical-vs-legacy relationship

## Testing
- docs-only surface verification of touched markdown/skill guidance

Closes #1531