### PR TITLE
feat(cli): soften dirty worktree launch failures into caution flow

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -920,6 +920,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
     notifyTempResult.passthroughArgs,
   );
   let cwd = launchCwd;
+  let worktreeDirty = false;
   if (parsedWorktree.mode.enabled) {
     const planned = planWorktreeTarget({
       cwd: launchCwd,
@@ -929,6 +930,13 @@ export async function launchWithHud(args: string[]): Promise<void> {
     const ensured = ensureWorktree(planned);
     if (ensured.enabled) {
       cwd = ensured.worktreePath;
+      if (ensured.dirty) {
+        worktreeDirty = true;
+        process.stderr.write(
+          `[omx] Caution: worktree at ${cwd} has uncommitted changes.\n` +
+          `  The session will launch as-is. Resolve the dirty state with OMX after launch, then proceed with your task.\n`,
+        );
+      }
       const depBootstrap = ensureReusableNodeModules(cwd);
       if (depBootstrap.strategy === "symlink") {
         console.log(`[omx] Reusing node_modules from ${depBootstrap.sourceNodeModulesPath}`);
@@ -971,7 +979,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
 
   // ── Phase 1: preLaunch ──────────────────────────────────────────────────
   try {
-    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, enableNotifyFallbackAuthority);
+    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, enableNotifyFallbackAuthority, worktreeDirty);
   } catch (err) {
     // preLaunch errors must NOT prevent Codex from starting
     console.error(
@@ -1011,6 +1019,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
     notifyTempResult.passthroughArgs,
   );
   let cwd = launchCwd;
+  let worktreeDirty = false;
 
   if (parsedWorktree.mode.enabled) {
     const planned = planWorktreeTarget({
@@ -1021,6 +1030,13 @@ export async function execWithOverlay(args: string[]): Promise<void> {
     const ensured = ensureWorktree(planned);
     if (ensured.enabled) {
       cwd = ensured.worktreePath;
+      if (ensured.dirty) {
+        worktreeDirty = true;
+        process.stderr.write(
+          `[omx] Caution: worktree at ${cwd} has uncommitted changes.\n` +
+          `  The session will launch as-is. Resolve the dirty state with OMX after launch, then proceed with your task.\n`,
+        );
+      }
       const depBootstrap = ensureReusableNodeModules(cwd);
       if (depBootstrap.strategy === "symlink") {
         console.log(`[omx] Reusing node_modules from ${depBootstrap.sourceNodeModulesPath}`);
@@ -1057,7 +1073,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
   }
 
   try {
-    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, true);
+    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, true, worktreeDirty);
   } catch (err) {
     console.error(
       `[omx] preLaunch warning: ${err instanceof Error ? err.message : err}`,
@@ -2208,6 +2224,7 @@ async function preLaunch(
   notifyTempContract?: NotifyTempContract,
   codexHomeOverride?: string,
   enableNotifyFallbackAuthority: boolean = false,
+  worktreeDirty: boolean = false,
 ): Promise<void> {
   // 1. Best-effort launch-safe orphan cleanup
   try {
@@ -2234,12 +2251,15 @@ async function preLaunch(
   );
   const overlay = await generateOverlay(cwd, sessionId, { orchestrationMode });
   const launchAppendix = await readLaunchAppendInstructions();
+  const dirtyWorktreeGuidance = worktreeDirty
+    ? `\n\n## Session start: dirty worktree detected\n\nThis worktree has uncommitted changes that were present when the session launched.\nBefore executing the requested task, resolve the dirty state first:\n1. Review uncommitted changes with \`git status\` and \`git diff\`.\n2. Commit, stash, or discard changes as appropriate.\n3. Then proceed with the original task.`
+    : "";
   const sessionInstructions =
     launchAppendix.trim().length > 0
       ? `${overlay}
 
-${launchAppendix}`
-      : overlay;
+${launchAppendix}${dirtyWorktreeGuidance}`
+      : `${overlay}${dirtyWorktreeGuidance}`;
   await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
 
   // 3. Write session state

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -927,7 +927,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
       scope: "launch",
       mode: parsedWorktree.mode,
     });
-    const ensured = ensureWorktree(planned);
+    const ensured = ensureWorktree(planned, { allowDirtyReuse: true });
     if (ensured.enabled) {
       cwd = ensured.worktreePath;
       if (ensured.dirty) {
@@ -1027,7 +1027,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
       scope: "launch",
       mode: parsedWorktree.mode,
     });
-    const ensured = ensureWorktree(planned);
+    const ensured = ensureWorktree(planned, { allowDirtyReuse: true });
     if (ensured.enabled) {
       cwd = ensured.worktreePath;
       if (ensured.dirty) {

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -47,6 +47,8 @@ export interface EnsureWorktreeResult {
   created: boolean;
   reused: boolean;
   createdBranch: boolean;
+  /** True when the worktree had uncommitted changes at launch time. */
+  dirty?: boolean;
 }
 
 interface GitWorktreeEntry {
@@ -375,9 +377,7 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
       throw new Error(`worktree_target_mismatch:${plan.worktreePath}`);
     }
 
-    if (isWorktreeDirty(plan.worktreePath)) {
-      throw new Error(`worktree_dirty:${plan.worktreePath}`);
-    }
+    const dirty = isWorktreeDirty(plan.worktreePath);
 
     const reused = {
       enabled: true,
@@ -388,6 +388,7 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
       created: false,
       reused: true,
       createdBranch: false,
+      ...(dirty ? { dirty: true } : {}),
     } satisfies EnsureWorktreeResult;
 
     if (plan.branchName) {

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -51,6 +51,10 @@ export interface EnsureWorktreeResult {
   dirty?: boolean;
 }
 
+export interface EnsureWorktreeOptions {
+  allowDirtyReuse?: boolean;
+}
+
 interface GitWorktreeEntry {
   path: string;
   head: string;
@@ -360,7 +364,10 @@ export function planWorktreeTarget(input: WorktreePlanInput): PlannedWorktreeTar
   };
 }
 
-export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false }): EnsureWorktreeResult | { enabled: false } {
+export function ensureWorktree(
+  plan: PlannedWorktreeTarget | { enabled: false },
+  options: EnsureWorktreeOptions = {},
+): EnsureWorktreeResult | { enabled: false } {
   if (!plan.enabled) return { enabled: false };
 
   const allWorktrees = listWorktrees(plan.repoRoot);
@@ -378,6 +385,9 @@ export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false })
     }
 
     const dirty = isWorktreeDirty(plan.worktreePath);
+    if (dirty && !options.allowDirtyReuse) {
+      throw new Error(`worktree_dirty:${plan.worktreePath}`);
+    }
 
     const reused = {
       enabled: true,


### PR DESCRIPTION
## Summary
- stop turning reusable dirty worktrees into hard launch failures
- surface a caution warning and keep the session launch moving
- thread dirty-worktree guidance into preLaunch session instructions so cleanup happens inside the coding session

## Testing
- npm run build *(pre-existing dependency noise outside touched files; changed files checked clean)*
- npm run build 2>&1 | grep -E "worktree\.(ts|js)|cli/index\.ts" || echo "no errors in changed files"

Closes #1532