### PR TITLE
Fix Claude issue-session approval stalls on obvious repo reads

### DIFF
--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -218,6 +218,38 @@ describe('omx ask', () => {
     }
   });
 
+  it('adds Claude skip-permissions for issue-work prompts only', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-ask-issue-permissions-'));
+    try {
+      const fakeBin = join(wd, 'bin');
+      await mkdir(fakeBin, { recursive: true });
+
+      await writeFile(
+        join(fakeBin, 'claude'),
+        '#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo \"fake-claude\"; exit 0; fi\necho \"CLAUDE_ARGS:$*\"; exit 0\n',
+      );
+      await chmod(join(fakeBin, 'claude'), 0o755);
+
+      const env = { PATH: `${fakeBin}:${process.env.PATH || ''}` };
+
+      const issueRes = runOmx(wd, ['ask', 'claude', 'Investigate issue #1536 and summarize it'], env);
+      if (shouldSkipForSpawnPermissions(issueRes.error)) return;
+      assert.equal(issueRes.status, 0, issueRes.stderr || issueRes.stdout);
+      const issueArtifactPath = issueRes.stdout.trim();
+      const issueArtifact = await readFile(issueArtifactPath, 'utf-8');
+      assert.match(issueArtifact, /CLAUDE_ARGS:--dangerously-skip-permissions -p Investigate issue #1536 and summarize it/);
+
+      const genericRes = runOmx(wd, ['ask', 'claude', 'Summarize the README'], env);
+      assert.equal(genericRes.status, 0, genericRes.stderr || genericRes.stdout);
+      const genericArtifactPath = genericRes.stdout.trim();
+      const genericArtifact = await readFile(genericArtifactPath, 'utf-8');
+      assert.match(genericArtifact, /CLAUDE_ARGS:-p Summarize the README/);
+      assert.doesNotMatch(genericArtifact, /--dangerously-skip-permissions/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('injects --agent-prompt content into final prompt while keeping Original task raw', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-ask-agent-prompt-'));
     try {

--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -1,5 +1,6 @@
 export const MADMAX_FLAG = '--madmax';
 export const CODEX_BYPASS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
+export const CLAUDE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 export const HIGH_REASONING_FLAG = '--high';
 export const XHIGH_REASONING_FLAG = '--xhigh';
 export const SPARK_FLAG = '--spark';

--- a/src/scripts/run-provider-advisor.ts
+++ b/src/scripts/run-provider-advisor.ts
@@ -3,12 +3,18 @@ import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 import process from 'process';
 import { spawnSync } from 'child_process';
+import { CLAUDE_SKIP_PERMISSIONS_FLAG } from '../cli/constants.js';
 
 const PROVIDER_BINARIES: Record<string, string> = {
   claude: 'claude',
   gemini: 'gemini',
 };
 const ASK_ORIGINAL_TASK_ENV = 'OMX_ASK_ORIGINAL_TASK';
+const ISSUE_WORK_PROMPT_PATTERNS = [
+  /\bgh\s+issue\b/i,
+  /\b(?:fix|work on|work|investigate|implement|triage|debug|review|handle)\s+issue\s*#?\d+\b/i,
+  /\bissue\s*#\d+\b/i,
+];
 
 function usage(): void {
   console.error('Usage: omx ask <claude|gemini> "<prompt>"');
@@ -68,6 +74,13 @@ function ensureBinary(binary: string): void {
     console.error(`[ask-${binary}] Install/configure ${binary} CLI, then verify with: ${verify}`);
     process.exit(1);
   }
+}
+
+function shouldUseClaudeIssuePermissionsBypass(provider: string, prompt: string): boolean {
+  if (provider !== 'claude') return false;
+  const trimmed = prompt.trim();
+  if (trimmed === '') return false;
+  return ISSUE_WORK_PROMPT_PATTERNS.some((pattern) => pattern.test(trimmed));
 }
 
 function buildSummary(exitCode: number, output: string): string {
@@ -148,10 +161,15 @@ async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, e
 async function main(): Promise<void> {
   const { provider, prompt } = parseArgs(process.argv.slice(2));
   const binary = PROVIDER_BINARIES[provider];
+  const originalTask = process.env[ASK_ORIGINAL_TASK_ENV] ?? prompt;
 
   ensureBinary(binary);
 
-  const run = spawnSync(binary, ['-p', prompt], {
+  const launchArgs = shouldUseClaudeIssuePermissionsBypass(provider, originalTask)
+    ? [CLAUDE_SKIP_PERMISSIONS_FLAG, '-p', prompt]
+    : ['-p', prompt];
+
+  const run = spawnSync(binary, launchArgs, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
       windowsHide: true,
@@ -164,7 +182,7 @@ async function main(): Promise<void> {
 
   const artifactPath = await writeArtifact({
     provider,
-    originalTask: process.env[ASK_ORIGINAL_TASK_ENV] ?? prompt,
+    originalTask,
     finalPrompt: prompt,
     rawOutput,
     exitCode,

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from 'fs';
 import { isAbsolute, join, resolve } from 'path';
 import {
   CODEX_BYPASS_FLAG,
+  CLAUDE_SKIP_PERMISSIONS_FLAG,
   MADMAX_FLAG,
   CONFIG_FLAG,
   LONG_CONFIG_FLAG,
@@ -55,7 +56,6 @@ const OMX_TEAM_WORKER_CLI_ENV = 'OMX_TEAM_WORKER_CLI';
 const OMX_TEAM_WORKER_CLI_MAP_ENV = 'OMX_TEAM_WORKER_CLI_MAP';
 const OMX_TEAM_WORKER_LAUNCH_MODE_ENV = 'OMX_TEAM_WORKER_LAUNCH_MODE';
 const OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV = 'OMX_TEAM_AUTO_INTERRUPT_RETRY';
-const CLAUDE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 const GEMINI_PROMPT_INTERACTIVE_FLAG = '-i';
 const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
 const GEMINI_APPROVAL_MODE_YOLO = 'yolo';


### PR DESCRIPTION
## Summary
- harden Claude provider-advisor launches for issue-work prompts by adding `--dangerously-skip-permissions`
- keep generic Claude ask flows unchanged so the bypass stays scoped to issue sessions
- centralize the Claude skip-permissions flag and cover the issue-vs-non-issue split with regression tests

## Testing
- npm run build
- node --test dist/cli/__tests__/ask.test.js
- node --test dist/team/__tests__/tmux-session.test.js dist/team/__tests__/tmux-claude-workers-demo.test.js

Closes #1536
