### PR TITLE
Fix stale dead-session HUD residue after shutdown

### DIFF
--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -142,6 +142,32 @@ describe('session lifecycle manager', () => {
       const dailyLog = await readFile(dailyLogPath, 'utf-8');
       assert.match(dailyLog, /"event":"session_start"/);
       assert.match(dailyLog, /"event":"session_end"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes canonical and native session-scoped hud state on session end', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-hud-cleanup-'));
+    const canonicalSessionId = 'omx-launch-hud';
+    const nativeSessionId = 'codex-native-hud';
+    try {
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId });
+      const stateDir = join(cwd, '.omx', 'state');
+      const rootHudPath = join(stateDir, 'hud-state.json');
+      const canonicalHudPath = join(stateDir, 'sessions', canonicalSessionId, 'hud-state.json');
+      const nativeHudPath = join(stateDir, 'sessions', nativeSessionId, 'hud-state.json');
+      await mkdir(join(stateDir, 'sessions', canonicalSessionId), { recursive: true });
+      await mkdir(join(stateDir, 'sessions', nativeSessionId), { recursive: true });
+      await writeFile(rootHudPath, JSON.stringify({ last_turn_at: 'root', turn_count: 1 }), 'utf-8');
+      await writeFile(canonicalHudPath, JSON.stringify({ last_turn_at: 'canonical', turn_count: 2 }), 'utf-8');
+      await writeFile(nativeHudPath, JSON.stringify({ last_turn_at: 'native', turn_count: 9 }), 'utf-8');
+
+      await writeSessionEnd(cwd, canonicalSessionId);
+
+      assert.equal(existsSync(rootHudPath), false);
+      assert.equal(existsSync(canonicalHudPath), false);
+      assert.equal(existsSync(nativeHudPath), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { describe, it } from 'node:test';
 import { createHookPluginSdk, clearHookPluginState } from '../sdk.js';
 import type { HookEventEnvelope } from '../types.js';
@@ -19,8 +19,9 @@ function makeEvent(event = 'session-start'): HookEventEnvelope {
 
 async function writeOmxStateFile(cwd: string, fileName: string, value: unknown): Promise<void> {
   const stateDir = join(cwd, '.omx', 'state');
-  await mkdir(stateDir, { recursive: true });
-  await writeFile(join(stateDir, fileName), JSON.stringify(value, null, 2));
+  const targetPath = join(stateDir, fileName);
+  await mkdir(dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, JSON.stringify(value, null, 2));
 }
 
 describe('createHookPluginSdk', () => {
@@ -387,6 +388,36 @@ exit 1
         assert.deepEqual(await sdk.omx.updateCheck.read(), {
           last_checked_at: '2026-01-01T00:00:00.000Z',
           last_seen_latest: '0.11.0',
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('reads hud state from the current session scope instead of stale root fallback', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-sdk-hud-session-'));
+      try {
+        await writeOmxStateFile(cwd, 'session.json', {
+          session_id: 'sess-current',
+          cwd,
+          started_at: '2026-01-01T00:00:00.000Z',
+        });
+        await writeOmxStateFile(cwd, 'hud-state.json', {
+          last_turn_at: 'root-stale',
+          turn_count: 99,
+          last_agent_output: 'Would you like me to continue?',
+        });
+        await writeOmxStateFile(cwd, join('sessions', 'sess-current', 'hud-state.json'), {
+          last_turn_at: '2026-01-01T00:00:00.000Z',
+          turn_count: 3,
+          last_agent_output: 'Current session output',
+        });
+
+        const sdk = createHookPluginSdk({ cwd, pluginName: 'test', event: makeEvent() });
+        assert.deepEqual(await sdk.omx.hud.read(), {
+          last_turn_at: '2026-01-01T00:00:00.000Z',
+          turn_count: 3,
+          last_agent_output: 'Current session output',
         });
       } finally {
         await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/extensibility/sdk/runtime-state.ts
+++ b/src/hooks/extensibility/sdk/runtime-state.ts
@@ -8,6 +8,7 @@ import type {
   HookPluginSdk,
 } from '../types.js';
 import { omxRootStateFilePath } from './paths.js';
+import { getReadScopedStateFilePaths } from '../../../mcp/state-paths.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -42,9 +43,12 @@ export function createHookPluginOmxApi(cwd: string): HookPluginSdk['omx'] {
       ),
     },
     hud: {
-      read: () => readOmxStateFile<HookPluginOmxHudState>(
-        omxRootStateFilePath(cwd, 'hud-state.json'),
-      ),
+      read: async () => {
+        const [hudStatePath] = await getReadScopedStateFilePaths('hud-state.json', cwd, undefined, {
+          rootFallback: false,
+        });
+        return readOmxStateFile<HookPluginOmxHudState>(hudStatePath);
+      },
     },
     notifyFallback: {
       read: () => readOmxStateFile<HookPluginOmxNotifyFallbackState>(

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -5,7 +5,7 @@
  * and provides structured logging for session events.
  */
 
-import { readFile, writeFile, mkdir, unlink, appendFile } from 'fs/promises';
+import { readFile, writeFile, mkdir, unlink, appendFile, rm } from 'fs/promises';
 import { dirname, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { omxStateDir, omxLogsDir, sameFilePath } from '../utils/paths.js';
@@ -34,6 +34,30 @@ function sessionPath(cwd: string): string {
 
 function historyPath(cwd: string): string {
   return join(omxLogsDir(cwd), HISTORY_FILE);
+}
+
+async function removeDeadSessionHudState(
+  cwd: string,
+  sessionIds: Array<string | undefined>,
+): Promise<void> {
+  const uniqueSessionIds = [...new Set(
+    sessionIds
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .map((value) => value.trim()),
+  )];
+
+  const candidatePaths = [
+    getStateFilePath('hud-state.json', cwd),
+    ...uniqueSessionIds.map((sessionId) => getStateFilePath('hud-state.json', cwd, sessionId)),
+  ];
+
+  await Promise.all(candidatePaths.map(async (path) => {
+    try {
+      await rm(path, { force: true });
+    } catch {
+      // best effort only
+    }
+  }));
 }
 
 /**
@@ -349,6 +373,12 @@ export async function writeSessionEnd(cwd: string, sessionId: string): Promise<v
   };
 
   await appendFile(historyPath(cwd), JSON.stringify(historyEntry) + '\n');
+
+  await removeDeadSessionHudState(cwd, [
+    state?.session_id,
+    state?.native_session_id,
+    sessionId,
+  ]);
 
   // Delete session.json
   try {


### PR DESCRIPTION
## Summary

Fixes issue #1538 by removing stale HUD/session residue that could still be scraped after an OMX session had already ended.

## Changes

- remove root and session-scoped `hud-state.json` files during `writeSessionEnd()` cleanup so dead sessions stop advertising stale status/last-output residue
- make hook-plugin OMX HUD reads honor the canonical current-session scope instead of falling back to stale root HUD state
- add focused regressions for shutdown cleanup and scoped HUD reads

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/hooks/__tests__/session.test.js`
- [x] `node --test dist/hooks/extensibility/__tests__/sdk.test.js dist/hud/__tests__/state.test.js`
- [x] `npm run lint -- src/hooks/session.ts src/hooks/__tests__/session.test.ts src/hooks/extensibility/sdk/runtime-state.ts src/hooks/extensibility/__tests__/sdk.test.ts`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1538
