### PR TITLE
fix: auto-close linked issues after dev merges

### DIFF
--- a/.github/scripts/dev-merge-issue-close.cjs
+++ b/.github/scripts/dev-merge-issue-close.cjs
@@ -1,0 +1,98 @@
+const CLOSE_KEYWORD_PATTERN = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b/gi;
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function collectMatches(pattern, text) {
+  const matches = [];
+  pattern.lastIndex = 0;
+  let match;
+  while ((match = pattern.exec(text)) !== null) {
+    matches.push(match);
+  }
+  return matches;
+}
+
+function collectIssueNumbersFromSegment(segment, owner, repo) {
+  const escapedOwner = escapeRegex(owner);
+  const escapedRepo = escapeRegex(repo);
+  const issueRefPattern = new RegExp(
+    `(?:^|[\\s([{:;,])(?:${escapedOwner}\\/${escapedRepo})?#(\\d+)\\b|https:\\/\\/github\\.com\\/${escapedOwner}\\/${escapedRepo}\\/issues\\/(\\d+)\\b`,
+    'gi',
+  );
+
+  const issueNumbers = [];
+  for (const match of collectMatches(issueRefPattern, segment)) {
+    const issueNumber = Number(match[1] || match[2]);
+    if (Number.isInteger(issueNumber) && issueNumber > 0) {
+      issueNumbers.push(issueNumber);
+    }
+  }
+  return issueNumbers;
+}
+
+function collectLinkedLocalIssueNumbers({ title = '', body = '', owner, repo }) {
+  const issueNumbers = new Set();
+  const text = [title, body].filter(Boolean).join('\n');
+  const escapedOwner = escapeRegex(owner);
+  const escapedRepo = escapeRegex(repo);
+  const refRegex = new RegExp(
+    `(?:${escapedOwner}\\/${escapedRepo})?#\\d+|https:\\/\\/github\\.com\\/${escapedOwner}\\/${escapedRepo}\\/issues\\/\\d+`,
+    'gi',
+  );
+  const separatorsPattern = /^(?:\s|,|and\b|issues?\b|:|;|\(|\)|\[|\]|\{|\})*$/i;
+
+  for (const line of text.split(/\r?\n/)) {
+    const keywordMatches = collectMatches(CLOSE_KEYWORD_PATTERN, line);
+    if (keywordMatches.length === 0) continue;
+
+    for (const [index, match] of keywordMatches.entries()) {
+      const segmentEnd = keywordMatches[index + 1]?.index ?? line.length;
+      const segment = line.slice(match.index + match[0].length, segmentEnd);
+      const trimmedSegment = segment.trimStart();
+      const normalizedSegment = trimmedSegment.replace(/^:\s*/, '');
+      const issueRefs = collectIssueNumbersFromSegment(normalizedSegment, owner, repo);
+      if (issueRefs.length === 0) continue;
+
+      const issueRefCount = issueRefs.length;
+      const consumed = [];
+      refRegex.lastIndex = 0;
+      let refMatch;
+      while ((refMatch = refRegex.exec(normalizedSegment)) !== null && consumed.length < issueRefCount) {
+        consumed.push({ start: refMatch.index, end: refMatch.index + refMatch[0].length });
+      }
+      if (consumed.length !== issueRefCount) continue;
+
+      let cursor = 0;
+      let explicitReferenceList = true;
+      for (const part of consumed) {
+        if (!separatorsPattern.test(normalizedSegment.slice(cursor, part.start))) {
+          explicitReferenceList = false;
+          break;
+        }
+        cursor = part.end;
+      }
+      if (!explicitReferenceList) continue;
+
+      if (!separatorsPattern.test(normalizedSegment.slice(cursor))) {
+        continue;
+      }
+
+      for (const issueNumber of issueRefs) {
+        issueNumbers.add(issueNumber);
+      }
+    }
+  }
+
+  return [...issueNumbers].sort((a, b) => a - b);
+}
+
+function buildMaintainerCloseComment({ prNumber }) {
+  return `Closing automatically because PR #${prNumber} was merged into \`dev\` and explicitly referenced this issue in the PR title or body.`;
+}
+
+module.exports = {
+  buildMaintainerCloseComment,
+  collectLinkedLocalIssueNumbers,
+};

--- a/.github/workflows/dev-merge-issue-close.yml
+++ b/.github/workflows/dev-merge-issue-close.yml
@@ -1,0 +1,88 @@
+name: Dev Merge Issue Close
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    name: Close explicitly linked issues after dev merge
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const {
+              buildMaintainerCloseComment,
+              collectLinkedLocalIssueNumbers,
+            } = require('./.github/scripts/dev-merge-issue-close.cjs');
+
+            const pullRequest = context.payload.pull_request;
+            const issueNumbers = collectLinkedLocalIssueNumbers({
+              title: pullRequest.title,
+              body: pullRequest.body,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            if (issueNumbers.length === 0) {
+              core.notice('No explicitly linked local issues found in merged PR title/body.');
+              return;
+            }
+
+            const closeComment = buildMaintainerCloseComment({ prNumber: pullRequest.number });
+            const closedIssueNumbers = [];
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
+
+                if (issue.pull_request) {
+                  core.info(`Skipping #${issueNumber} because it is a pull request, not an issue.`);
+                  continue;
+                }
+
+                if (issue.state !== 'open') {
+                  core.info(`Skipping #${issueNumber} because it is already ${issue.state}.`);
+                  continue;
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: closeComment,
+                });
+
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: 'closed',
+                });
+
+                closedIssueNumbers.push(issueNumber);
+              } catch (error) {
+                core.warning(`Failed to close issue #${issueNumber}: ${error.message}`);
+              }
+            }
+
+            if (closedIssueNumbers.length === 0) {
+              core.notice('No open issues required closing.');
+              return;
+            }
+
+            core.notice(`Closed linked issues after merge to dev: ${closedIssueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ')}`);

--- a/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
+++ b/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  buildMaintainerCloseComment,
+  collectLinkedLocalIssueNumbers,
+} = require(join(process.cwd(), '.github', 'scripts', 'dev-merge-issue-close.cjs')) as {
+  buildMaintainerCloseComment: ({ prNumber }: { prNumber: number }) => string;
+  collectLinkedLocalIssueNumbers: (input: {
+    title?: string;
+    body?: string;
+    owner: string;
+    repo: string;
+  }) => number[];
+};
+
+describe('dev merge issue close workflow', () => {
+  it('scopes automation to merged pull_request_target closures into dev with issue write permissions', () => {
+    const workflowPath = join(process.cwd(), '.github', 'workflows', 'dev-merge-issue-close.yml');
+    assert.equal(existsSync(workflowPath), true, `missing workflow: ${workflowPath}`);
+
+    const workflow = readFileSync(workflowPath, 'utf-8');
+    assert.match(workflow, /name:\s*Dev Merge Issue Close/);
+    assert.match(workflow, /pull_request_target:\s*\n\s*types:\s*\[closed\]/);
+    assert.match(workflow, /issues:\s*write/);
+    assert.match(workflow, /pull-requests:\s*read/);
+    assert.match(workflow, /github\.event\.pull_request\.merged == true && github\.event\.pull_request\.base\.ref == 'dev'/);
+    assert.match(workflow, /require\('\.\/\.github\/scripts\/dev-merge-issue-close\.cjs'\)/);
+    assert.match(workflow, /title:\s*pullRequest\.title/);
+    assert.match(workflow, /body:\s*pullRequest\.body/);
+    assert.doesNotMatch(workflow, /commit/i);
+    assert.doesNotMatch(workflow, /discussion/i);
+  });
+
+  it('extracts only explicitly linked local issues from PR title/body close keywords', () => {
+    assert.deepEqual(
+      collectLinkedLocalIssueNumbers({
+        title: 'Fixes #1540, #1541',
+        body: 'Resolves Yeachan-Heo/oh-my-codex#1542 and closes https://github.com/Yeachan-Heo/oh-my-codex/issues/1543',
+        owner: 'Yeachan-Heo',
+        repo: 'oh-my-codex',
+      }),
+      [1540, 1541, 1542, 1543],
+    );
+  });
+
+  it('ignores unrelated references without close keywords or from other repositories', () => {
+    assert.deepEqual(
+      collectLinkedLocalIssueNumbers({
+        title: 'Refs #1540',
+        body: [
+          'Mentions #1541 without a close keyword.',
+          'Fixes octo/example#1542',
+          'Discussion says maybe close #1543 later.',
+        ].join('\n'),
+        owner: 'Yeachan-Heo',
+        repo: 'oh-my-codex',
+      }),
+      [],
+    );
+  });
+
+  it('dedupes repeated references and provides a standard maintainer close comment', () => {
+    assert.deepEqual(
+      collectLinkedLocalIssueNumbers({
+        title: 'Fixes #1540',
+        body: 'Closes #1540 and resolves Yeachan-Heo/oh-my-codex#1540',
+        owner: 'Yeachan-Heo',
+        repo: 'oh-my-codex',
+      }),
+      [1540],
+    );
+    assert.equal(
+      buildMaintainerCloseComment({ prNumber: 1550 }),
+      'Closing automatically because PR #1550 was merged into `dev` and explicitly referenced this issue in the PR title or body.',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1540

## Summary
- add a narrow repo-local workflow that runs only when a PR is merged into `dev`
- close only local issues explicitly referenced by close keywords in the merged PR title/body
- post a standard maintainer close comment before closing each issue
- add targeted workflow/keyword parsing verification coverage

## Testing
- npm run build
- node --test dist/verification/__tests__/ci-rust-gates.test.js dist/verification/__tests__/explore-harness-release-workflow.test.js dist/verification/__tests__/dev-merge-issue-close-workflow.test.js