### PR TITLE
fix: surface native hook drift before OMX looks broken

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -250,6 +250,102 @@ USE_OMX_EXPLORE_CMD = "off"
     }
   });
 
+  it('warns when hooks.json is missing OMX-managed native hook coverage', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-coverage-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'hooks.json'),
+        JSON.stringify(
+          {
+            hooks: {
+              SessionStart: [
+                {
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: 'node "/repo/dist/scripts/codex-native-hook.js"',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: codexDir,
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Native hooks: hooks\.json is missing OMX-managed coverage for PreToolUse, PostToolUse, UserPromptSubmit, Stop; run "omx setup --force" to restore native hooks/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('warns when hooks.json is missing after OMX config was already installed', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-missing-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        `
+omx_enabled = true
+[mcp_servers.omx_state]
+command = "node"
+`.trimStart(),
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: codexDir,
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /Native hooks: hooks\.json not found even though config\.toml has OMX entries; run "omx setup --force" to restore native hook coverage/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails when hooks.json is invalid and native hook coverage cannot be read', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-invalid-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'hooks.json'), '{invalid json\n');
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: codexDir,
+      });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /\[XX\] Native hooks: invalid hooks\.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('passes when legacy skill root is a link to the canonical skills directory', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-skill-link-'));
     try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -15,6 +15,7 @@ import { parse as parseToml } from '@iarna/toml';
 import { resolvePackagedExploreHarnessCommand, EXPLORE_BIN_ENV } from './explore.js';
 import { getPackageRoot } from '../utils/package.js';
 import { hasLegacyOmxTeamRunTable } from '../config/generator.js';
+import { getMissingManagedCodexHookEvents } from '../config/codex-hooks.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
 import { isLeaderRuntimeStale } from '../team/leader-activity.js';
@@ -42,6 +43,7 @@ interface DoctorScopeResolution {
 interface DoctorPaths {
   codexHomeDir: string;
   configPath: string;
+  hooksPath: string;
   promptsDir: string;
   skillsDir: string;
   stateDir: string;
@@ -82,6 +84,7 @@ function resolveDoctorPaths(cwd: string, scope: DoctorSetupScope): DoctorPaths {
     return {
       codexHomeDir,
       configPath: join(codexHomeDir, 'config.toml'),
+      hooksPath: join(codexHomeDir, 'hooks.json'),
       promptsDir: join(codexHomeDir, 'prompts'),
       skillsDir: projectSkillsDir(cwd),
       stateDir: omxStateDir(cwd),
@@ -91,6 +94,7 @@ function resolveDoctorPaths(cwd: string, scope: DoctorSetupScope): DoctorPaths {
   return {
     codexHomeDir: codexHome(),
     configPath: codexConfigPath(),
+    hooksPath: join(codexHome(), 'hooks.json'),
     promptsDir: codexPromptsDir(),
     skillsDir: userSkillsDir(),
     stateDir: omxStateDir(cwd),
@@ -130,6 +134,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
   // Check 4: Config file
   checks.push(await checkConfig(paths.configPath));
+
+  // Check 4.25: Native hooks coverage
+  checks.push(await checkNativeHooks(paths.hooksPath, paths.configPath));
 
   // Check 4.5: Explore routing default
   checks.push(await checkExploreRouting(paths.configPath));
@@ -657,6 +664,66 @@ async function checkExploreRouting(configPath: string): Promise<Check> {
       name: 'Explore routing',
       status: 'fail',
       message: 'cannot read config.toml for explore routing check',
+    };
+  }
+}
+
+async function checkNativeHooks(hooksPath: string, configPath: string): Promise<Check> {
+  if (!existsSync(hooksPath)) {
+    if (existsSync(configPath)) {
+      try {
+        const configContent = await readFile(configPath, 'utf-8');
+        const hasOmx = configContent.includes('omx_') || configContent.includes('oh-my-codex');
+        if (hasOmx) {
+          return {
+            name: 'Native hooks',
+            status: 'warn',
+            message: 'hooks.json not found even though config.toml has OMX entries; run "omx setup --force" to restore native hook coverage',
+          };
+        }
+      } catch {
+        // fall through to the neutral first-setup path when config cannot be read here;
+        // the dedicated config check will report read failures separately.
+      }
+    }
+
+    return {
+      name: 'Native hooks',
+      status: 'pass',
+      message: 'hooks.json not found yet (expected before first setup)',
+    };
+  }
+
+  try {
+    const content = await readFile(hooksPath, 'utf-8');
+    const missingEvents = getMissingManagedCodexHookEvents(content);
+    if (missingEvents === null) {
+      return {
+        name: 'Native hooks',
+        status: 'fail',
+        message: 'invalid hooks.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it',
+      };
+    }
+
+    if (missingEvents.length > 0) {
+      return {
+        name: 'Native hooks',
+        status: 'warn',
+        message:
+          `hooks.json is missing OMX-managed coverage for ${missingEvents.join(', ')}; run "omx setup --force" to restore native hooks`,
+      };
+    }
+
+    return {
+      name: 'Native hooks',
+      status: 'pass',
+      message: 'hooks.json includes OMX-managed coverage for all native hook events',
+    };
+  } catch {
+    return {
+      name: 'Native hooks',
+      status: 'fail',
+      message: 'cannot read hooks.json',
     };
   }
 }

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -8,6 +8,7 @@ Resolved setup scope: user
   [EXPLORE_HARNESS_STATUS]
   [OK] Codex home: <CODEX_HOME>
   [!!] Config: config.toml exists but no OMX entries yet (expected before first setup; run "omx setup --force" once)
+  [OK] Native hooks: hooks.json not found yet (expected before first setup)
   [OK] Explore routing: enabled by default
   [!!] Prompts: prompts directory not found
   [!!] Skills: skills directory not found

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   buildManagedCodexHooksConfig,
+  getMissingManagedCodexHookEvents,
   mergeManagedCodexHooksConfig,
   removeManagedCodexHooks,
 } from "../codex-hooks.js";
@@ -67,5 +68,34 @@ describe("codex hooks helpers", () => {
     assert.match(removedMixed.nextContent, /echo keep-me/);
     assert.doesNotMatch(removedMixed.nextContent, /codex-native-hook\.js/);
     assert.match(removedMixed.nextContent, /"version": 1/);
+  });
+
+  it("reports missing managed hook coverage by event", () => {
+    const missing = getMissingManagedCodexHookEvents(
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                { type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
+              ],
+            },
+          ],
+          UserPromptSubmit: [
+            {
+              hooks: [
+                { type: "command", command: "echo custom-only" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    assert.deepEqual(missing, ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"]);
+  });
+
+  it("returns null for invalid hooks.json content", () => {
+    assert.equal(getMissingManagedCodexHookEvents("{ invalid json"), null);
   });
 });

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 
-const MANAGED_HOOK_EVENTS = [
+export const MANAGED_HOOK_EVENTS = [
   "SessionStart",
   "PreToolUse",
   "PostToolUse",
@@ -112,6 +112,33 @@ export function parseCodexHooksConfig(
 
 function isOmxManagedHookCommand(command: string): boolean {
   return /(?:^|[\\/])codex-native-hook\.js(?:["'\s]|$)/.test(command);
+}
+
+function countManagedHooksInEntry(entry: unknown): number {
+  if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) {
+    return 0;
+  }
+
+  return entry.hooks.filter((hook) => {
+    return isPlainObject(hook)
+      && hook.type === "command"
+      && typeof hook.command === "string"
+      && isOmxManagedHookCommand(hook.command);
+  }).length;
+}
+
+export function getMissingManagedCodexHookEvents(
+  content: string,
+): ManagedHookEventName[] | null {
+  const parsed = parseCodexHooksConfig(content);
+  if (!parsed) return null;
+
+  return MANAGED_HOOK_EVENTS.filter((eventName) => {
+    const entries = Array.isArray(parsed.hooks[eventName])
+      ? parsed.hooks[eventName]
+      : [];
+    return !entries.some((entry) => countManagedHooksInEntry(entry) > 0);
+  });
 }
 
 function stripManagedHooksFromEntry(entry: unknown): {


### PR DESCRIPTION
## Summary
- teach `omx doctor` to check whether `.codex/hooks.json` still has OMX-managed native hook coverage
- distinguish first-setup absence from post-setup drift so missing hooks do not read like runtime failures
- add regression coverage for partial, missing, and invalid `hooks.json` states and update the doctor compat fixture

## Testing
- npm run build
- node --test dist/config/__tests__/codex-hooks.test.js dist/cli/__tests__/doctor-warning-copy.test.js dist/compat/__tests__/doctor-contract.test.js

Closes #1544