### PR TITLE
feat: add tracked job registry and read-only jobs commands

### DIFF
--- a/src/cli/__tests__/jobs.test.ts
+++ b/src/cli/__tests__/jobs.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { jobCommand, jobsCommand } from "../jobs.js";
+import type { TrackedJob } from "../../notifications/types.js";
+
+function createTrackedJob(overrides: Partial<TrackedJob> = {}): TrackedJob {
+  return {
+    jobName: "example-job",
+    status: "running",
+    startedAt: "2026-04-13T00:00:00Z",
+    pid: 12345,
+    artifacts: {
+      outputs: ["/tmp/example-output.json"],
+    },
+    ...overrides,
+  };
+}
+
+describe("jobsCommand", () => {
+  it("prints help for --help", async () => {
+    const out: string[] = [];
+    await jobsCommand(["--help"], {
+      stdout: (line) => out.push(line),
+      stderr: () => undefined,
+      list: () => [],
+    });
+    assert.match(out.join("\n"), /Usage:\s*\n\s*omx jobs/i);
+  });
+
+  it("prints an empty-state message when no jobs exist", async () => {
+    const out: string[] = [];
+    await jobsCommand([], {
+      stdout: (line) => out.push(line),
+      stderr: () => undefined,
+      list: () => [],
+    });
+    assert.deepEqual(out, ["No tracked jobs."]);
+  });
+
+  it("emits a compact JSON envelope when --json is set", async () => {
+    const out: string[] = [];
+    await jobsCommand(["--json"], {
+      stdout: (line) => out.push(line),
+      stderr: () => undefined,
+      list: () => [createTrackedJob()],
+    });
+    assert.deepEqual(out, ['{"jobs":[{"jobName":"example-job","status":"running","startedAt":"2026-04-13T00:00:00Z","pid":12345,"artifacts":{"outputs":["/tmp/example-output.json"]}}]}']);
+  });
+});
+
+describe("jobCommand", () => {
+  it("prints help when no job name is provided", async () => {
+    const out: string[] = [];
+    await jobCommand([], {
+      stdout: (line) => out.push(line),
+      stderr: () => undefined,
+      get: () => null,
+    });
+    assert.match(out.join("\n"), /Usage:\s*\n\s*omx jobs/i);
+  });
+
+  it("emits compact JSON for a known job with --json", async () => {
+    const out: string[] = [];
+    await jobCommand(["example-job", "--json"], {
+      stdout: (line) => out.push(line),
+      stderr: () => undefined,
+      get: () => createTrackedJob(),
+    });
+    assert.deepEqual(out, ['{"jobName":"example-job","status":"running","startedAt":"2026-04-13T00:00:00Z","pid":12345,"artifacts":{"outputs":["/tmp/example-output.json"]}}']);
+  });
+
+  it("writes a structured error to stderr and sets exitCode when the job is missing", async () => {
+    const err: string[] = [];
+    const previousExitCode = process.exitCode;
+
+    try {
+      process.exitCode = undefined;
+      await jobCommand(["missing-job", "--json"], {
+        stdout: () => undefined,
+        stderr: (line) => err.push(line),
+        get: () => null,
+      });
+      assert.equal(process.exitCode, 1);
+      assert.deepEqual(err, ['{"error":"Unknown tracked job: missing-job"}']);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
 import { askCommand } from "./ask.js";
 import { stateCommand } from "./state.js";
+import { jobsCommand, jobCommand } from "./jobs.js";
 import {
   cleanupCommand,
   cleanupOmxMcpProcesses,
@@ -159,6 +160,8 @@ Usage:
   omx hooks     Manage hook plugins (init|status|validate|test)
   omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
   omx state     Read/write/list OMX mode state via CLI parity surface
+  omx jobs      List tracked jobs from the notification control registry
+  omx job       Show one tracked job by name
   omx notepad   CLI parity for OMX notepad MCP tools
   omx project-memory
                 CLI parity for OMX project-memory MCP tools
@@ -266,6 +269,8 @@ type CliCommand =
   | "hooks"
   | "hud"
   | "state"
+  | "jobs"
+  | "job"
   | "status"
   | "cancel"
   | "help"
@@ -282,6 +287,8 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "exec",
   "hooks",
   "hud",
+  "jobs",
+  "job",
   "state",
   "ralph",
   "resume",
@@ -632,6 +639,8 @@ export async function main(args: string[]): Promise<void> {
     "tmux-hook",
     "hooks",
     "hud",
+    "jobs",
+    "job",
     "state",
     "status",
     "cancel",
@@ -728,6 +737,12 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "state":
         await stateCommand(args.slice(1));
+        break;
+      case "jobs":
+        await jobsCommand(args.slice(1));
+        break;
+      case "job":
+        await jobCommand(args.slice(1));
         break;
       case "notepad":
         await mcpParityCommand("notepad", args.slice(1));

--- a/src/cli/jobs.ts
+++ b/src/cli/jobs.ts
@@ -1,0 +1,158 @@
+import {
+  listTrackedJobs,
+  lookupTrackedJob,
+} from "../notifications/job-registry.js";
+import type { TrackedJob } from "../notifications/types.js";
+
+const JOBS_HELP = `Usage:
+  omx jobs [--json]
+  omx job <name> [--json]`;
+
+export interface JobsCommandDependencies {
+  stdout?: (line: string) => void;
+  stderr?: (line: string) => void;
+  list?: typeof listTrackedJobs;
+  get?: typeof lookupTrackedJob;
+}
+
+function formatJobSummary(job: TrackedJob): string {
+  const parts = [job.jobName, job.status];
+  if (job.startedAt) {
+    parts.push(`started ${job.startedAt}`);
+  }
+  if (job.discord?.threadId) {
+    parts.push("thread attached");
+  } else if (job.artifacts?.outputs && job.artifacts.outputs.length > 0) {
+    parts.push("outputs present");
+  }
+  return `- ${parts.join(" | ")}`;
+}
+
+function formatJobDetail(job: TrackedJob): string {
+  const lines = [
+    `job: ${job.jobName}`,
+    `status: ${job.status}`,
+    `started: ${job.startedAt}`,
+  ];
+  if (job.finishedAt) {
+    lines.push(`finished: ${job.finishedAt}`);
+  }
+  if (typeof job.pid === "number") {
+    lines.push(`pid: ${job.pid}`);
+  }
+  if (job.artifacts?.promptPath) {
+    lines.push(`prompt: ${job.artifacts.promptPath}`);
+  }
+  if (job.artifacts?.logPath) {
+    lines.push(`log: ${job.artifacts.logPath}`);
+  }
+  if (job.discord?.channelId) {
+    lines.push(`channel: ${job.discord.channelId}`);
+  }
+  if (job.discord?.threadId) {
+    lines.push(`thread: ${job.discord.threadId}`);
+  }
+  if (job.artifacts?.outputs && job.artifacts.outputs.length > 0) {
+    lines.push("outputs:");
+    for (const output of job.artifacts.outputs) {
+      lines.push(`- ${output}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function parseJobsFlags(args: string[]): { json: boolean } {
+  let json = false;
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    throw new Error(`Unknown jobs argument: ${arg}`);
+  }
+  return { json };
+}
+
+function parseJobArgs(args: string[]): { json: boolean; jobName?: string } {
+  let json = false;
+  let jobName: string | undefined;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (!jobName && !arg.startsWith("-")) {
+      jobName = arg;
+      continue;
+    }
+    throw new Error(`Unknown job argument: ${arg}`);
+  }
+
+  return { json, jobName };
+}
+
+export async function jobsCommand(
+  args: string[],
+  deps: JobsCommandDependencies = {},
+): Promise<void> {
+  const stdout = deps.stdout ?? ((line: string) => console.log(line));
+  const list = deps.list ?? listTrackedJobs;
+
+  if (args.includes("--help") || args.includes("-h") || args.includes("help")) {
+    stdout(JOBS_HELP);
+    return;
+  }
+
+  const { json } = parseJobsFlags(args);
+  const jobs = list();
+
+  if (json) {
+    stdout(JSON.stringify({ jobs }, null, 0));
+    return;
+  }
+
+  if (jobs.length === 0) {
+    stdout("No tracked jobs.");
+    return;
+  }
+
+  stdout("tracked jobs");
+  for (const job of jobs) {
+    stdout(formatJobSummary(job));
+  }
+}
+
+export async function jobCommand(
+  args: string[],
+  deps: JobsCommandDependencies = {},
+): Promise<void> {
+  const stdout = deps.stdout ?? ((line: string) => console.log(line));
+  const stderr = deps.stderr ?? ((line: string) => console.error(line));
+  const get = deps.get ?? lookupTrackedJob;
+
+  if (args.length === 0 || args.includes("--help") || args.includes("-h") || args.includes("help")) {
+    stdout(JOBS_HELP);
+    return;
+  }
+
+  const { json, jobName } = parseJobArgs(args);
+  if (!jobName) {
+    throw new Error(`Missing job name.\n${JOBS_HELP}`);
+  }
+
+  const job = get(jobName);
+  if (!job) {
+    const errorBody = JSON.stringify({ error: `Unknown tracked job: ${jobName}` }, null, json ? 0 : 2);
+    stderr(errorBody);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (json) {
+    stdout(JSON.stringify(job, null, 0));
+    return;
+  }
+
+  stdout(formatJobDetail(job));
+}

--- a/src/notifications/__tests__/job-registry.test.ts
+++ b/src/notifications/__tests__/job-registry.test.ts
@@ -1,0 +1,142 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { TrackedJob } from "../types.js";
+
+function createTrackedJob(overrides: Partial<TrackedJob> = {}): TrackedJob {
+  return {
+    jobName: "example-job",
+    status: "running",
+    startedAt: "2026-04-13T00:00:00Z",
+    pid: 12345,
+    artifacts: {
+      outputs: ["/tmp/example-output.json"],
+    },
+    ...overrides,
+  };
+}
+
+async function importJobRegistryFresh() {
+  const moduleUrl = new URL("../job-registry.js", import.meta.url);
+  moduleUrl.searchParams.set("t", `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  return import(moduleUrl.href);
+}
+
+describe("job-registry", () => {
+  it("returns an empty registry when no file exists", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "omx-job-registry-empty-"));
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      process.env.HOME = homeDir;
+      process.env.USERPROFILE = homeDir;
+      const registry = await importJobRegistryFresh();
+      assert.deepEqual(registry.loadTrackedJobRegistry(), { version: 1, jobs: {} });
+      assert.deepEqual(registry.listTrackedJobs(), []);
+    } finally {
+      if (typeof originalHome === "string") process.env.HOME = originalHome;
+      else delete process.env.HOME;
+      if (typeof originalUserProfile === "string") process.env.USERPROFILE = originalUserProfile;
+      else delete process.env.USERPROFILE;
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("upserts, lists, and looks up tracked jobs", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "omx-job-registry-upsert-"));
+    const stateDir = join(homeDir, ".omx", "state");
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      await mkdir(stateDir, { recursive: true });
+      process.env.HOME = homeDir;
+      process.env.USERPROFILE = homeDir;
+      const registry = await importJobRegistryFresh();
+
+      const older = createTrackedJob({
+        jobName: "older-job",
+        startedAt: "2026-04-13T00:00:00Z",
+      });
+      const newer = createTrackedJob({
+        jobName: "newer-job",
+        status: "finished",
+        startedAt: "2026-04-13T01:00:00Z",
+        finishedAt: "2026-04-13T02:00:00Z",
+      });
+
+      assert.equal(registry.upsertTrackedJob(older), true);
+      assert.equal(registry.upsertTrackedJob(newer), true);
+
+      const loaded = registry.loadTrackedJobRegistry();
+      assert.deepEqual(Object.keys(loaded.jobs).sort(), ["newer-job", "older-job"]);
+      assert.equal(registry.lookupTrackedJob("older-job")?.pid, 12345);
+      assert.deepEqual(registry.listTrackedJobs().map((job: TrackedJob) => job.jobName), [
+        "newer-job",
+        "older-job",
+      ]);
+
+      const fileContent = readFileSync(join(stateDir, "tracked-jobs.json"), "utf-8");
+      assert.match(fileContent, /"newer-job"/);
+      assert.match(fileContent, /"older-job"/);
+    } finally {
+      if (typeof originalHome === "string") process.env.HOME = originalHome;
+      else delete process.env.HOME;
+      if (typeof originalUserProfile === "string") process.env.USERPROFILE = originalUserProfile;
+      else delete process.env.USERPROFILE;
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes tracked jobs cleanly", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "omx-job-registry-remove-"));
+    const stateDir = join(homeDir, ".omx", "state");
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      await mkdir(stateDir, { recursive: true });
+      process.env.HOME = homeDir;
+      process.env.USERPROFILE = homeDir;
+      const registry = await importJobRegistryFresh();
+
+      assert.equal(registry.upsertTrackedJob(createTrackedJob()), true);
+      assert.equal(registry.removeTrackedJob("example-job"), true);
+      assert.equal(registry.lookupTrackedJob("example-job"), null);
+      assert.deepEqual(registry.listTrackedJobs(), []);
+    } finally {
+      if (typeof originalHome === "string") process.env.HOME = originalHome;
+      else delete process.env.HOME;
+      if (typeof originalUserProfile === "string") process.env.USERPROFILE = originalUserProfile;
+      else delete process.env.USERPROFILE;
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed to an empty registry when the file is malformed", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "omx-job-registry-malformed-"));
+    const stateDir = join(homeDir, ".omx", "state");
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, "tracked-jobs.json"), "{not-valid-json", "utf-8");
+      process.env.HOME = homeDir;
+      process.env.USERPROFILE = homeDir;
+      const registry = await importJobRegistryFresh();
+      assert.deepEqual(registry.loadTrackedJobRegistry(), { version: 1, jobs: {} });
+      assert.equal(registry.lookupTrackedJob("anything"), null);
+    } finally {
+      if (typeof originalHome === "string") process.env.HOME = originalHome;
+      else delete process.env.HOME;
+      if (typeof originalUserProfile === "string") process.env.USERPROFILE = originalUserProfile;
+      else delete process.env.USERPROFILE;
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -27,6 +27,9 @@ export type {
   NotificationProfilesConfig,
   NotificationsBlock,
   VerbosityLevel,
+  TrackedJob,
+  TrackedJobRegistry,
+  TrackedJobStatus,
 } from "./types.js";
 
 export {
@@ -74,6 +77,12 @@ export {
   pruneStale,
 } from "./session-registry.js";
 export type { SessionMapping } from "./session-registry.js";
+export {
+  getTrackedJobRegistryPath,
+  loadTrackedJobRegistry,
+  listTrackedJobs,
+  lookupTrackedJob,
+} from "./job-registry.js";
 export {
   startReplyListener,
   stopReplyListener,

--- a/src/notifications/job-registry.ts
+++ b/src/notifications/job-registry.ts
@@ -1,0 +1,426 @@
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  closeSync,
+  writeSync,
+  unlinkSync,
+  statSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  constants,
+} from "fs";
+import { dirname, join } from "path";
+import { homedir } from "os";
+import { randomUUID } from "crypto";
+import { sleepSync } from "../utils/sleep.js";
+import type {
+  TrackedJob,
+  TrackedJobRegistry,
+  TrackedJobSource,
+  TrackedJobStatus,
+} from "./types.js";
+
+const REGISTRY_VERSION = 1;
+const REGISTRY_PATH = join(homedir(), ".omx", "state", "tracked-jobs.json");
+const REGISTRY_LOCK_PATH = join(homedir(), ".omx", "state", "tracked-jobs.lock");
+const SECURE_FILE_MODE = 0o600;
+const LOCK_TIMEOUT_MS = 2_000;
+const LOCK_WAIT_TIMEOUT_MS = 4_000;
+const LOCK_RETRY_MS = 20;
+const LOCK_STALE_MS = 10_000;
+const VALID_STATUSES = new Set<TrackedJobStatus>([
+  "running",
+  "finished",
+  "stopped",
+  "failed",
+]);
+
+interface RegistryLockHandle {
+  fd: number;
+  token: string;
+}
+
+interface LockFileSnapshot {
+  raw: string;
+  pid: number | null;
+  token: string | null;
+}
+
+function createEmptyRegistry(): TrackedJobRegistry {
+  return {
+    version: REGISTRY_VERSION,
+    jobs: {},
+  };
+}
+
+function ensureRegistryDir(): void {
+  const registryDir = dirname(REGISTRY_PATH);
+  if (!existsSync(registryDir)) {
+    mkdirSync(registryDir, { recursive: true, mode: 0o700 });
+  }
+}
+
+function sleepMs(ms: number): void {
+  sleepSync(ms);
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    return err.code === "EPERM";
+  }
+}
+
+function readLockSnapshot(): LockFileSnapshot | null {
+  try {
+    const raw = readFileSync(REGISTRY_LOCK_PATH, "utf-8");
+    const trimmed = raw.trim();
+
+    if (!trimmed) {
+      return { raw, pid: null, token: null };
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed) as { pid?: unknown; token?: unknown };
+      const pid = typeof parsed.pid === "number" && Number.isFinite(parsed.pid) ? parsed.pid : null;
+      const token =
+        typeof parsed.token === "string" && parsed.token.length > 0 ? parsed.token : null;
+      return { raw, pid, token };
+    } catch {
+      const [pidStr] = trimmed.split(":");
+      const parsedPid = Number.parseInt(pidStr ?? "", 10);
+      return {
+        raw,
+        pid: Number.isFinite(parsedPid) && parsedPid > 0 ? parsedPid : null,
+        token: null,
+      };
+    }
+  } catch {
+    return null;
+  }
+}
+
+function removeLockIfUnchanged(snapshot: LockFileSnapshot): boolean {
+  try {
+    const currentRaw = readFileSync(REGISTRY_LOCK_PATH, "utf-8");
+    if (currentRaw !== snapshot.raw) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  try {
+    unlinkSync(REGISTRY_LOCK_PATH);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function acquireRegistryLock(): RegistryLockHandle | null {
+  ensureRegistryDir();
+  const started = Date.now();
+
+  while (Date.now() - started < LOCK_TIMEOUT_MS) {
+    try {
+      const token = randomUUID();
+      const fd = openSync(
+        REGISTRY_LOCK_PATH,
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+        SECURE_FILE_MODE,
+      );
+      const lockPayload = JSON.stringify({
+        pid: process.pid,
+        acquiredAt: Date.now(),
+        token,
+      });
+      writeSync(fd, lockPayload, null, "utf-8");
+      return { fd, token };
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== "EEXIST") {
+        throw error;
+      }
+
+      try {
+        const lockAgeMs = Date.now() - statSync(REGISTRY_LOCK_PATH).mtimeMs;
+        if (lockAgeMs > LOCK_STALE_MS) {
+          const snapshot = readLockSnapshot();
+          if (!snapshot) {
+            sleepMs(LOCK_RETRY_MS);
+            continue;
+          }
+
+          if (snapshot.pid !== null && isPidAlive(snapshot.pid)) {
+            sleepMs(LOCK_RETRY_MS);
+            continue;
+          }
+
+          if (removeLockIfUnchanged(snapshot)) {
+            continue;
+          }
+        }
+      } catch {
+        // Lock may disappear between stat/unlink attempts.
+      }
+
+      sleepMs(LOCK_RETRY_MS);
+    }
+  }
+
+  return null;
+}
+
+function acquireRegistryLockOrWait(maxWaitMs: number = LOCK_WAIT_TIMEOUT_MS): RegistryLockHandle | null {
+  const started = Date.now();
+  while (Date.now() - started < maxWaitMs) {
+    const lock = acquireRegistryLock();
+    if (lock !== null) {
+      return lock;
+    }
+    if (Date.now() - started < maxWaitMs) {
+      sleepMs(LOCK_RETRY_MS);
+    }
+  }
+  return null;
+}
+
+function releaseRegistryLock(lock: RegistryLockHandle): void {
+  try {
+    closeSync(lock.fd);
+  } catch {
+    // Ignore close errors.
+  }
+
+  const snapshot = readLockSnapshot();
+  if (!snapshot || snapshot.token !== lock.token) {
+    return;
+  }
+
+  removeLockIfUnchanged(snapshot);
+}
+
+function withRegistryLockOrWait<T>(onLocked: () => T, onLockUnavailable: () => T): T {
+  const lock = acquireRegistryLockOrWait();
+  if (lock === null) {
+    return onLockUnavailable();
+  }
+  try {
+    return onLocked();
+  } finally {
+    releaseRegistryLock(lock);
+  }
+}
+
+function normalizeTrackedJob(jobName: string, raw: unknown): TrackedJob | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+
+  const record = raw as Record<string, unknown>;
+  const normalizedName =
+    typeof record.jobName === "string" && record.jobName.trim() !== ""
+      ? record.jobName.trim()
+      : jobName;
+  const status = record.status;
+  const startedAt = typeof record.startedAt === "string" ? record.startedAt : null;
+
+  if (!normalizedName || !startedAt || !VALID_STATUSES.has(status as TrackedJobStatus)) {
+    return null;
+  }
+
+  const outputs = Array.isArray(record.artifacts && (record.artifacts as Record<string, unknown>).outputs)
+    ? ((record.artifacts as Record<string, unknown>).outputs as unknown[])
+        .filter((value): value is string => typeof value === "string" && value.trim() !== "")
+    : undefined;
+
+  return {
+    jobName: normalizedName,
+    status: status as TrackedJobStatus,
+    startedAt,
+    finishedAt:
+      typeof record.finishedAt === "string" || record.finishedAt === null
+        ? (record.finishedAt as string | null | undefined)
+        : undefined,
+    pid: typeof record.pid === "number" && Number.isFinite(record.pid) ? Math.trunc(record.pid) : undefined,
+    source:
+      record.source && typeof record.source === "object" && !Array.isArray(record.source)
+        ? {
+            platform:
+              typeof (record.source as Record<string, unknown>).platform === "string"
+                ? ((record.source as Record<string, unknown>).platform as TrackedJobSource["platform"])
+                : undefined,
+            messageId:
+              typeof (record.source as Record<string, unknown>).messageId === "string"
+                ? ((record.source as Record<string, unknown>).messageId as string)
+                : undefined,
+            sessionId:
+              typeof (record.source as Record<string, unknown>).sessionId === "string"
+                ? ((record.source as Record<string, unknown>).sessionId as string)
+                : undefined,
+          }
+        : undefined,
+    artifacts:
+      record.artifacts && typeof record.artifacts === "object" && !Array.isArray(record.artifacts)
+        ? {
+            promptPath:
+              typeof (record.artifacts as Record<string, unknown>).promptPath === "string"
+                ? ((record.artifacts as Record<string, unknown>).promptPath as string)
+                : undefined,
+            logPath:
+              typeof (record.artifacts as Record<string, unknown>).logPath === "string"
+                ? ((record.artifacts as Record<string, unknown>).logPath as string)
+                : undefined,
+            outputs,
+          }
+        : undefined,
+    discord:
+      record.discord && typeof record.discord === "object" && !Array.isArray(record.discord)
+        ? {
+            channelId:
+              typeof (record.discord as Record<string, unknown>).channelId === "string"
+                ? ((record.discord as Record<string, unknown>).channelId as string)
+                : undefined,
+            threadId:
+              typeof (record.discord as Record<string, unknown>).threadId === "string"
+                ? ((record.discord as Record<string, unknown>).threadId as string)
+                : undefined,
+          }
+        : undefined,
+    completion:
+      record.completion && typeof record.completion === "object" && !Array.isArray(record.completion)
+        ? {
+            announced:
+              typeof (record.completion as Record<string, unknown>).announced === "boolean"
+                ? ((record.completion as Record<string, unknown>).announced as boolean)
+                : undefined,
+            messageId:
+              typeof (record.completion as Record<string, unknown>).messageId === "string" ||
+              (record.completion as Record<string, unknown>).messageId === null
+                ? ((record.completion as Record<string, unknown>).messageId as string | null)
+                : undefined,
+          }
+        : undefined,
+  };
+}
+
+function normalizeRegistry(raw: unknown): TrackedJobRegistry {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return createEmptyRegistry();
+  }
+
+  const record = raw as Record<string, unknown>;
+  const rawJobs = record.jobs;
+  const jobs: Record<string, TrackedJob> = {};
+
+  if (rawJobs && typeof rawJobs === "object" && !Array.isArray(rawJobs)) {
+    for (const [jobName, value] of Object.entries(rawJobs as Record<string, unknown>)) {
+      const normalized = normalizeTrackedJob(jobName, value);
+      if (normalized) {
+        jobs[normalized.jobName] = normalized;
+      }
+    }
+  }
+
+  return {
+    version:
+      typeof record.version === "number" && Number.isFinite(record.version)
+        ? Math.trunc(record.version)
+        : REGISTRY_VERSION,
+    jobs,
+  };
+}
+
+function readRegistryUnsafe(): TrackedJobRegistry {
+  if (!existsSync(REGISTRY_PATH)) {
+    return createEmptyRegistry();
+  }
+
+  try {
+    const content = readFileSync(REGISTRY_PATH, "utf-8");
+    if (!content.trim()) {
+      return createEmptyRegistry();
+    }
+    return normalizeRegistry(JSON.parse(content));
+  } catch {
+    return createEmptyRegistry();
+  }
+}
+
+function rewriteRegistryUnsafe(registry: TrackedJobRegistry): void {
+  ensureRegistryDir();
+  const tempPath = `${REGISTRY_PATH}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tempPath, JSON.stringify(registry, null, 2) + "\n", {
+    mode: SECURE_FILE_MODE,
+  });
+  renameSync(tempPath, REGISTRY_PATH);
+}
+
+function normalizeForWrite(job: TrackedJob): TrackedJob | null {
+  return normalizeTrackedJob(job.jobName, job);
+}
+
+function compareStartedAtDesc(left: TrackedJob, right: TrackedJob): number {
+  const leftTs = Date.parse(left.startedAt);
+  const rightTs = Date.parse(right.startedAt);
+  const safeLeft = Number.isFinite(leftTs) ? leftTs : 0;
+  const safeRight = Number.isFinite(rightTs) ? rightTs : 0;
+  return safeRight - safeLeft;
+}
+
+export function getTrackedJobRegistryPath(): string {
+  return REGISTRY_PATH;
+}
+
+export function loadTrackedJobRegistry(): TrackedJobRegistry {
+  return readRegistryUnsafe();
+}
+
+export function listTrackedJobs(): TrackedJob[] {
+  return Object.values(loadTrackedJobRegistry().jobs).sort(compareStartedAtDesc);
+}
+
+export function lookupTrackedJob(jobName: string): TrackedJob | null {
+  return loadTrackedJobRegistry().jobs[jobName] ?? null;
+}
+
+export function upsertTrackedJob(job: TrackedJob): boolean {
+  const normalized = normalizeForWrite(job);
+  if (!normalized) {
+    return false;
+  }
+
+  return withRegistryLockOrWait(
+    () => {
+      const registry = readRegistryUnsafe();
+      registry.jobs[normalized.jobName] = normalized;
+      rewriteRegistryUnsafe(registry);
+      return true;
+    },
+    () => false,
+  );
+}
+
+export function removeTrackedJob(jobName: string): boolean {
+  return withRegistryLockOrWait(
+    () => {
+      const registry = readRegistryUnsafe();
+      if (!(jobName in registry.jobs)) {
+        return false;
+      }
+      delete registry.jobs[jobName];
+      rewriteRegistryUnsafe(registry);
+      return true;
+    },
+    () => false,
+  );
+}

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -258,3 +258,44 @@ export interface ReplyConfig {
   /** Authorized Discord user IDs (REQUIRED for Discord, empty = Discord disabled) */
   authorizedDiscordUserIds: string[];
 }
+
+export type TrackedJobStatus = "running" | "finished" | "stopped" | "failed";
+
+export interface TrackedJobSource {
+  platform?: NotificationPlatform | "cli";
+  messageId?: string;
+  sessionId?: string;
+}
+
+export interface TrackedJobArtifacts {
+  promptPath?: string;
+  logPath?: string;
+  outputs?: string[];
+}
+
+export interface TrackedJobDiscordContext {
+  channelId?: string;
+  threadId?: string;
+}
+
+export interface TrackedJobCompletion {
+  announced?: boolean;
+  messageId?: string | null;
+}
+
+export interface TrackedJob {
+  jobName: string;
+  status: TrackedJobStatus;
+  startedAt: string;
+  finishedAt?: string | null;
+  pid?: number | null;
+  source?: TrackedJobSource;
+  artifacts?: TrackedJobArtifacts;
+  discord?: TrackedJobDiscordContext;
+  completion?: TrackedJobCompletion;
+}
+
+export interface TrackedJobRegistry {
+  version: number;
+  jobs: Record<string, TrackedJob>;
+}


### PR DESCRIPTION
## Summary

This PR adds the minimal read-only PR1 slice for Discord/operator job inspection:

- tracked job types in `src/notifications/types.ts`
- new file-backed tracked job registry in `src/notifications/job-registry.ts`
- read-only registry exports via `src/notifications/index.ts`
- new `omx jobs` and `omx job <name>` CLI commands in `src/cli/jobs.ts`
- minimal CLI wiring in `src/cli/index.ts`
- focused tests for the registry and CLI commands

This is intentionally an inspection-only slice.

Out of scope for this PR:
- launch / stop lifecycle control
- thread-per-job behavior
- completion summaries
- any private-stack or tmux-injection behavior

Related discussion:
- Closes none directly; follows the design discussion in #1528

## Validation

Passed:
- `npm run build`
- `node --test dist/cli/__tests__/jobs.test.js dist/notifications/__tests__/job-registry.test.js`

Important baseline note:
- `node --test dist/cli/__tests__/index.test.js dist/notifications/__tests__/reply-listener.test.js`
- the detached-tmux test `detached leader command preserves the detached tmux session on signal-derived exits` fails on this branch
- the same failure reproduces unchanged on untouched `origin/main`
- so that broader failure appears preexisting and not introduced by this PR

## Notes

- The registry is additive and distinct from the existing reply-correlation `session-registry.ts`
- `notifications/index.ts` exports only the read-only registry surface for this PR
- the CLI command names here are the concrete implementation of the previously discussed inspection-only PR1 slice
