### PR TITLE
Recognize psmux on native Windows tmux call sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ omx wiki refresh --json
 
 `omx team` works best on macOS/Linux with `tmux`.
 Native Windows remains a secondary path, and WSL2 is generally the better choice if you want a Windows-hosted setup.
+On native Windows, OMX accepts `psmux` as the tmux-compatible binary for the existing tmux-backed paths it already uses.
 
 | Platform | Install |
 | --- | --- |

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,6 +1,5 @@
-import { describe, it } from "node:test";
+import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -35,6 +34,7 @@ import {
   buildDetachedTmuxSessionName,
   buildDetachedSessionFinalizeSteps,
   buildDetachedSessionRollbackSteps,
+  detectDetachedSessionWindowIndex,
   resolveNotifyTempContract,
   buildNotifyTempStartupMessages,
   buildNotifyFallbackWatcherEnv,
@@ -50,6 +50,7 @@ import {
   resolveNotifyHookScript,
   buildDetachedWindowsBootstrapScript,
   acquireTmuxExtendedKeysLease,
+  resolveNativeSessionName,
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
 } from "../index.js";
@@ -66,6 +67,10 @@ import type { ProcessEntry } from "../cleanup.js";
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
   return getTeamLowComplexityModel(codexHomeOverride);
 }
+
+afterEach(() => {
+  mock.restoreAll();
+});
 
 describe("normalizeCodexLaunchArgs", () => {
   it("maps --madmax to codex bypass flag", () => {
@@ -1553,7 +1558,7 @@ exit 0
       const leaderCmd = steps[0]?.args.at(-1);
       assert.equal(typeof leaderCmd, "string");
 
-      execFileSync("/bin/sh", ["-c", leaderCmd!], {
+      (await import("node:child_process")).execFileSync("/bin/sh", ["-c", leaderCmd!], {
         cwd,
         env: {
           ...process.env,
@@ -1631,7 +1636,7 @@ exit 0
       const leaderCmd = steps[0]?.args.at(-1);
       assert.equal(typeof leaderCmd, "string");
 
-      const result = spawnSync("/bin/sh", ["-lc", leaderCmd!], {
+      const result = (await import("node:child_process")).spawnSync("/bin/sh", ["-lc", leaderCmd!], {
         cwd,
         env: {
           ...process.env,
@@ -2040,6 +2045,79 @@ describe("buildDetachedTmuxSessionName", () => {
       "omx-1770992424158-abc123",
     );
     assert.equal(sessionName, "omx-my-repo-detached-1770992424158-abc123");
+  });
+});
+
+describe("native Windows psmux-compatible tmux resolution", () => {
+  it("resolveNativeSessionName uses the shared tmux-aware resolver for current session lookup", async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    const originalPath = process.env.PATH;
+    const originalPathext = process.env.PATHEXT;
+    const wd = await mkdtemp(join(tmpdir(), "omx-psmux-native-session-"));
+    const fakeBin = join(wd, "bin");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, "psmux.exe"),
+        `#!/bin/sh
+if [ "$1" = "display-message" ] && [ "$2" = "-p" ] && [ "$3" = "-t" ] && [ "$4" = "%7" ] && [ "$5" = "#S" ]; then
+  printf 'psmux-session\\n'
+  exit 0
+fi
+printf 'unexpected:%s\\n' "$*" >&2
+exit 1
+`,
+      );
+      await chmod(join(fakeBin, "psmux.exe"), 0o755);
+      process.env.PATH = fakeBin;
+      process.env.PATHEXT = ".EXE";
+      const sessionName = resolveNativeSessionName("/tmp/repo", "omx-abc123", {
+        ...process.env,
+        TMUX: "1",
+        TMUX_PANE: "%7",
+      });
+      assert.equal(sessionName, "psmux-session");
+    } finally {
+      process.env.PATH = originalPath;
+      process.env.PATHEXT = originalPathext;
+      if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("detectDetachedSessionWindowIndex uses the shared tmux-aware resolver on native Windows", async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    const originalPath = process.env.PATH;
+    const originalPathext = process.env.PATHEXT;
+    const wd = await mkdtemp(join(tmpdir(), "omx-psmux-window-index-"));
+    const fakeBin = join(wd, "bin");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, "psmux.exe"),
+        `#!/bin/sh
+if [ "$1" = "display-message" ] && [ "$2" = "-p" ] && [ "$3" = "-t" ] && [ "$4" = "omx-demo" ] && [ "$5" = "#{window_index}" ]; then
+  printf '3\\n'
+  exit 0
+fi
+printf 'unexpected:%s\\n' "$*" >&2
+exit 1
+`,
+      );
+      await chmod(join(fakeBin, "psmux.exe"), 0o755);
+      process.env.PATH = fakeBin;
+      process.env.PATHEXT = ".EXE";
+      assert.equal(detectDetachedSessionWindowIndex("omx-demo"), "3");
+    } finally {
+      process.env.PATH = originalPath;
+      process.env.PATHEXT = originalPathext;
+      if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+      await rm(wd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -48,6 +48,7 @@ import {
   resolveNotifyFallbackWatcherScript,
   resolveHookDerivedWatcherScript,
   resolveNotifyHookScript,
+  buildDetachedWindowsBootstrapScript,
   acquireTmuxExtendedKeysLease,
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
@@ -1462,6 +1463,18 @@ describe("detached tmux new-session sequencing", () => {
     assert.equal(steps[0]?.args.at(-1), "powershell.exe");
     assert.equal(steps[1]?.name, "split-and-capture-hud-pane");
     assert.equal(steps[1]?.args.at(-1), hudCmd);
+  });
+
+  it("buildDetachedWindowsBootstrapScript targets the resolved tmux-compatible command", () => {
+    const script = buildDetachedWindowsBootstrapScript(
+      "omx-demo",
+      "powershell.exe -NoLogo -NoExit -EncodedCommand abc",
+      2500,
+      "C:\\Program Files\\psmux\\psmux.exe",
+    );
+    assert.match(script, /const tmuxCommand = "C:\\\\Program Files\\\\psmux\\\\psmux\.exe";/);
+    assert.match(script, /execFileSync\(tmuxCommand, \['send-keys'/);
+    assert.doesNotMatch(script, /execFileSync\('tmux'/);
   });
 
   it("buildDetachedSessionBootstrapSteps kills detached tmux session on normal shell exit", () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1258,12 +1258,19 @@ function extractIssueNumber(text: string): number | undefined {
   return generic ? Number.parseInt(generic[2], 10) : undefined;
 }
 
-function resolveNativeSessionName(cwd: string, sessionId: string): string {
-  if (process.env.TMUX) {
+export function resolveNativeSessionName(
+  cwd: string,
+  sessionId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (env.TMUX) {
     try {
-      const tmuxSession = execFileSync(
-        "tmux",
-        ["display-message", "-p", "#S"],
+      const tmuxPaneTarget = env.TMUX_PANE?.trim();
+      const displayArgs = tmuxPaneTarget
+        ? ["display-message", "-p", "-t", tmuxPaneTarget, "#S"]
+        : ["display-message", "-p", "#S"];
+      const tmuxSession = execTmuxFileSync(
+        displayArgs,
         {
           encoding: "utf-8",
           stdio: ["ignore", "pipe", "ignore"],
@@ -1473,10 +1480,9 @@ function parseWindowIndexFromTmuxOutput(rawOutput: string): string | null {
   return /^[0-9]+$/.test(windowIndex) ? windowIndex : null;
 }
 
-function detectDetachedSessionWindowIndex(sessionName: string): string | null {
+export function detectDetachedSessionWindowIndex(sessionName: string): string | null {
   try {
-    const output = execFileSync(
-      "tmux",
+    const output = execTmuxFileSync(
       ["display-message", "-p", "-t", sessionName, "#{window_index}"],
       { encoding: "utf-8" },
     );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -95,6 +95,7 @@ export { parseTmuxPaneSnapshot, isHudWatchPane, findHudWatchPaneIds } from "../h
 rememberOmxLaunchContext();
 import {
   classifySpawnError,
+  resolveTmuxBinaryForPlatform,
   spawnPlatformCommandSync,
 } from "../utils/platform-command.js";
 import { buildHookEvent } from "../hooks/extensibility/events.js";
@@ -485,6 +486,20 @@ type ExecFileSyncFailure = NodeJS.ErrnoException & {
   status?: number | null;
   signal?: NodeJS.Signals | null;
 };
+
+function resolveTmuxExecutableForLaunch(): string {
+  return resolveTmuxBinaryForPlatform() || "tmux";
+}
+
+function execTmuxFileSync(
+  args: string[],
+  options?: Parameters<typeof execFileSync>[2],
+): string {
+  return execFileSync(resolveTmuxExecutableForLaunch(), args, {
+    ...(options ?? {}),
+    ...(process.platform === "win32" ? { windowsHide: true } : {}),
+  }) as string;
+}
 
 function hasErrnoCode(error: unknown, code: string): boolean {
   return Boolean(
@@ -1612,9 +1627,10 @@ function execTmuxSync(
   execFileSyncImpl: TmuxExecSync = (file, tmuxArgs) =>
     execFileSync(file, tmuxArgs, {
       encoding: "utf-8",
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
     }) as string,
 ): string {
-  return execFileSyncImpl("tmux", [...args]).trim();
+  return execFileSyncImpl(resolveTmuxExecutableForLaunch(), [...args]).trim();
 }
 
 export function acquireTmuxExtendedKeysLease(
@@ -1622,6 +1638,7 @@ export function acquireTmuxExtendedKeysLease(
   execFileSyncImpl: TmuxExecSync = (file, tmuxArgs) =>
     execFileSync(file, tmuxArgs, {
       encoding: "utf-8",
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
     }) as string,
 ): string | null {
   try {
@@ -1661,6 +1678,7 @@ export function releaseTmuxExtendedKeysLease(
   execFileSyncImpl: TmuxExecSync = (file, tmuxArgs) =>
     execFileSync(file, tmuxArgs, {
       encoding: "utf-8",
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
     }) as string,
 ): void {
   if (!leaseHandle.trim()) return;
@@ -1724,6 +1742,7 @@ export function withTmuxExtendedKeys<T>(
   execFileSyncImpl: TmuxExecSync = (file, tmuxArgs) =>
     execFileSync(file, tmuxArgs, {
       encoding: "utf-8",
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
     }) as string,
 ): T {
   const leaseHandle = acquireTmuxExtendedKeysLease(cwd, execFileSyncImpl);
@@ -2415,7 +2434,7 @@ function runCodex(
         const displayArgs = tmuxPaneTarget
           ? ["display-message", "-p", "-t", tmuxPaneTarget, "#S"]
           : ["display-message", "-p", "#S"];
-        const tmuxSession = execFileSync("tmux", displayArgs, {
+        const tmuxSession = execTmuxFileSync(displayArgs, {
           encoding: "utf-8",
         }).trim();
         if (tmuxSession) enableMouseScrolling(tmuxSession);
@@ -2428,7 +2447,7 @@ function runCodex(
     const activePaneId = process.env.TMUX_PANE?.trim();
     if (activePaneId) {
       try {
-        execFileSync("tmux", ["display-message", "-p", "-t", activePaneId, "#S"], {
+        execTmuxFileSync(["display-message", "-p", "-t", activePaneId, "#S"], {
           encoding: "utf-8",
         });
       } catch {}
@@ -2476,7 +2495,7 @@ function runCodex(
         sessionId,
       );
       for (const step of bootstrapSteps) {
-        const output = execFileSync("tmux", step.args, {
+        const output = execTmuxFileSync(step.args, {
           stdio: "pipe",
           encoding: "utf-8",
         });
@@ -2536,7 +2555,7 @@ function runCodex(
             const stdio =
               finalizeStep.name === "attach-session" ? "inherit" : "ignore";
             try {
-              execFileSync("tmux", finalizeStep.args, { stdio });
+              execTmuxFileSync(finalizeStep.args, { stdio });
             } catch (err) {
               process.stderr.write(`[cli/index] operation failed: ${err}\n`);
               if (finalizeStep.name === "attach-session")
@@ -2571,7 +2590,7 @@ function runCodex(
         );
         for (const rollbackStep of rollbackSteps) {
           try {
-            execFileSync("tmux", rollbackStep.args, { stdio: "ignore" });
+            execTmuxFileSync(rollbackStep.args, { stdio: "ignore" });
           } catch (err) {
             process.stderr.write(`[cli/index] operation failed: ${err}\n`);
             // best-effort rollback only
@@ -2668,10 +2687,11 @@ function quotePowerShellArg(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
-function buildDetachedWindowsBootstrapScript(
+export function buildDetachedWindowsBootstrapScript(
   sessionName: string,
   commandText: string,
   delayMs: number = WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS,
+  tmuxCommand: string = resolveTmuxExecutableForLaunch(),
 ): string {
   const delay =
     Number.isFinite(delayMs) && delayMs > 0
@@ -2679,12 +2699,14 @@ function buildDetachedWindowsBootstrapScript(
       : WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS;
   const targetLiteral = JSON.stringify(`${sessionName}:0.0`);
   const commandLiteral = JSON.stringify(commandText);
+  const tmuxCommandLiteral = JSON.stringify(tmuxCommand);
 
   return [
     "const { execFileSync } = require('child_process');",
+    `const tmuxCommand = ${tmuxCommandLiteral};`,
     `setTimeout(() => {`,
-    `try { execFileSync('tmux', ['send-keys', '-t', ${targetLiteral}, '-l', '--', ${commandLiteral}], { stdio: 'ignore' }); } catch {}`,
-    `try { execFileSync('tmux', ['send-keys', '-t', ${targetLiteral}, 'C-m'], { stdio: 'ignore' }); } catch {}`,
+    `try { execFileSync(tmuxCommand, ['send-keys', '-t', ${targetLiteral}, '-l', '--', ${commandLiteral}], { stdio: 'ignore' }); } catch {}`,
+    `try { execFileSync(tmuxCommand, ['send-keys', '-t', ${targetLiteral}, 'C-m'], { stdio: 'ignore' }); } catch {}`,
     `}, ${delay});`,
   ].join("");
 }

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -4,6 +4,7 @@ import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { getPackageRoot } from '../utils/package.js';
 import { resolveCodexPane } from '../scripts/tmux-hook-engine.js';
+import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 
 type TmuxTargetType = 'session' | 'pane';
 
@@ -207,7 +208,7 @@ async function loadConfigForCommand(
 }
 
 function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
-  const result = spawnSync('tmux', args, { encoding: 'utf-8',
+  const result = spawnSync(resolveTmuxBinaryForPlatform() || 'tmux', args, { encoding: 'utf-8',
       windowsHide: true,
     });
   if (result.error) {

--- a/src/hooks/extensibility/sdk/tmux.ts
+++ b/src/hooks/extensibility/sdk/tmux.ts
@@ -5,6 +5,7 @@ import { dirname } from 'path';
 import { spawnSync } from 'child_process';
 import { sleepSync } from '../../../utils/sleep.js';
 import { resolveCodexPane } from '../../../scripts/tmux-hook-engine.js';
+import { resolveTmuxBinaryForPlatform } from '../../../utils/platform-command.js';
 import type {
   HookEventEnvelope,
   HookPluginSdk,
@@ -55,7 +56,7 @@ function sleepFractionalSeconds(seconds: number): void {
 }
 
 function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; stderr: string } {
-  const result = spawnSync('tmux', args, { encoding: 'utf-8',
+  const result = spawnSync(resolveTmuxBinaryForPlatform() || 'tmux', args, { encoding: 'utf-8',
       windowsHide: true,
     });
   if (result.error) return { ok: false, stderr: result.error.message };

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'child_process';
 import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
+import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 
 export interface TmuxPaneSnapshot {
   paneId: string;
@@ -10,7 +11,10 @@ export interface TmuxPaneSnapshot {
 type TmuxExecSync = (args: string[]) => string;
 
 function defaultExecTmuxSync(args: string[]): string {
-  return execFileSync('tmux', args, { encoding: 'utf-8' });
+  return execFileSync(resolveTmuxBinaryForPlatform() || 'tmux', args, {
+    encoding: 'utf-8',
+    ...(process.platform === 'win32' ? { windowsHide: true } : {}),
+  });
 }
 
 export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {

--- a/src/notifications/__tests__/tmux-detector.test.ts
+++ b/src/notifications/__tests__/tmux-detector.test.ts
@@ -173,7 +173,7 @@ describe('buildSendPaneArgvs', () => {
     const calls: string[][] = [];
     const sleeps: number[] = [];
     const fakeSpawnSync = (command: string, argv: readonly string[]) => {
-      assert.equal(command, 'tmux');
+      assert.match(command, /(?:^|[\\/])(?:tmux|psmux)(?:\.exe)?$/i);
       calls.push([...argv]);
       return { status: 0 };
     };

--- a/src/notifications/tmux-detector.ts
+++ b/src/notifications/tmux-detector.ts
@@ -7,7 +7,7 @@
 
 import { execFileSync, spawnSync } from 'child_process';
 import { sleepSync } from '../utils/sleep.js';
-import { resolveCommandPathForPlatform } from '../utils/platform-command.js';
+import { resolveCommandPathForPlatform, resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 import { buildCapturePaneArgv as sharedBuildCapturePaneArgv } from '../scripts/tmux-hook-engine.js';
 
 export function isTmuxAvailable(): boolean {
@@ -25,10 +25,11 @@ export function buildCapturePaneArgv(paneId: string, lines: number): string[] {
 
 export function capturePaneContent(paneId: string, lines: number = 15): string {
   try {
-    return execFileSync('tmux', buildCapturePaneArgv(paneId, lines), {
+    return execFileSync(resolveTmuxBinaryForPlatform() || 'tmux', buildCapturePaneArgv(paneId, lines), {
       encoding: 'utf-8',
       timeout: 3000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: process.platform === 'win32',
     });
   } catch {
     return '';
@@ -134,6 +135,7 @@ type SpawnSyncImpl = (
     timeout?: number;
     stdio?: ['pipe', 'pipe', 'pipe'];
     encoding?: 'utf-8';
+    windowsHide?: boolean;
   },
 ) => { error?: Error; status: number | null };
 
@@ -151,12 +153,14 @@ export function sendToPane(
   const spawnSyncImpl = deps.spawnSyncImpl ?? spawnSync;
   const sleepImpl = deps.sleepImpl ?? sleepSync;
   const argvs = buildSendPaneArgvs(paneId, text, pressEnter);
+  const tmuxCommand = resolveTmuxBinaryForPlatform() || 'tmux';
 
   for (const [index, argv] of argvs.entries()) {
-    const result = spawnSyncImpl('tmux', argv, {
+    const result = spawnSyncImpl(tmuxCommand, argv, {
       timeout: 3000,
       stdio: ['pipe', 'pipe', 'pipe'],
       encoding: 'utf-8',
+      windowsHide: process.platform === 'win32',
     });
     if (result.error || result.status !== 0) return false;
 

--- a/src/notifications/tmux.ts
+++ b/src/notifications/tmux.ts
@@ -4,8 +4,9 @@
  * Detects the current tmux session name and pane ID for inclusion in notification payloads.
  */
 
-import { execFileSync, execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { buildCapturePaneArgv } from "./tmux-detector.js";
+import { resolveTmuxBinaryForPlatform } from "../utils/platform-command.js";
 
 const TMUX_PANE_TARGET_RE = /^%\d+$/;
 const DEFAULT_CAPTURE_LINES = 12;
@@ -56,6 +57,15 @@ function shouldUsePidFallback(): boolean {
   return process.env.OMX_TMUX_PID_FALLBACK === "1";
 }
 
+function execTmux(args: string[]): string {
+  return execFileSync(resolveTmuxBinaryForPlatform() || "tmux", args, {
+    encoding: "utf-8",
+    timeout: 3000,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: process.platform === "win32",
+  }).trim();
+}
+
 /**
  * Get the current tmux session name.
  * First checks $TMUX env, then falls back to finding the tmux session
@@ -68,15 +78,11 @@ export function getCurrentTmuxSession(): string | null {
     try {
       const tmuxPaneTarget = process.env.TMUX_PANE;
       const paneTargetSafe = tmuxPaneTarget && TMUX_PANE_TARGET_RE.test(tmuxPaneTarget) ? tmuxPaneTarget : null;
-      const displayCmd = paneTargetSafe
-        ? `tmux display-message -p -t ${paneTargetSafe} '#S'`
-        : "tmux display-message -p '#S'";
-      const sessionName = execSync(displayCmd, {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
-    }).trim();
+      const sessionName = execTmux(
+        paneTargetSafe
+          ? ["display-message", "-p", "-t", paneTargetSafe, "#S"]
+          : ["display-message", "-p", "#S"],
+      );
       if (sessionName) return sessionName;
     } catch {
       // fall through to PID-based detection
@@ -99,14 +105,7 @@ function detectTmuxSessionByPid(): string | null {
   if (process.platform === 'win32') return null;
   try {
     // Get all tmux pane PIDs with their session names
-    const output = execSync(
-      "tmux list-panes -a -F '#{pane_pid} #{session_name}'",
-      {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"],
-      }
-    ).trim();
+    const output = execTmux(["list-panes", "-a", "-F", "#{pane_pid} #{session_name}"]);
     if (!output) return null;
 
     const panePids = new Map<number, string>();
@@ -162,11 +161,7 @@ export function getTeamTmuxSessions(teamName: string): string[] {
 
   const prefix = `omx-team-${sanitized}`;
   try {
-    const output = execSync("tmux list-sessions -F '#{session_name}'", {
-      encoding: "utf-8",
-      timeout: 3000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    const output = execTmux(["list-sessions", "-F", "#{session_name}"]);
     return output
       .trim()
       .split("\n")
@@ -195,12 +190,7 @@ export function captureTmuxPaneWithLiveness(paneId?: string | null, lines: numbe
   const clampedLines = Math.max(1, Math.min(MAX_CAPTURE_LINES, safeLines));
 
   try {
-    const paneStatus = execFileSync("tmux", ["list-panes", "-t", target, "-F", "#{pane_dead} #{pane_pid}"], {
-      encoding: "utf-8",
-      timeout: 3000,
-      stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
-    }).trim();
+    const paneStatus = execTmux(["list-panes", "-t", target, "-F", "#{pane_dead} #{pane_pid}"]);
     const firstStatusLine = paneStatus.split("\n")[0]?.trim() || "";
     const [paneDead = "", panePidRaw = ""] = firstStatusLine.split(/\s+/, 2);
     const panePid = Number.parseInt(panePidRaw, 10);
@@ -213,11 +203,11 @@ export function captureTmuxPaneWithLiveness(paneId?: string | null, lines: numbe
       return { content: null, live: false };
     }
 
-    const output = execFileSync("tmux", buildCapturePaneArgv(target, clampedLines), {
+    const output = execFileSync(resolveTmuxBinaryForPlatform() || "tmux", buildCapturePaneArgv(target, clampedLines), {
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
+      windowsHide: process.platform === "win32",
     }).trim();
     return { content: output || null, live: true };
   } catch {
@@ -252,11 +242,7 @@ export function getCurrentTmuxPaneId(): string | null {
   // but it is still better than nothing and matches the PID-walk fallback below.
   if (process.env.TMUX) {
     try {
-      const paneId = execSync("tmux display-message -p '#{pane_id}'", {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"],
-      }).trim();
+      const paneId = execTmux(["display-message", "-p", "#{pane_id}"]);
       if (paneId && /^%\d+$/.test(paneId)) return paneId;
     } catch {
       // fall through
@@ -275,14 +261,7 @@ export function getCurrentTmuxPaneId(): string | null {
 function detectTmuxPaneByPid(): string | null {
   if (process.platform === 'win32') return null;
   try {
-    const output = execSync(
-      "tmux list-panes -a -F '#{pane_pid} #{pane_id}'",
-      {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"],
-      }
-    ).trim();
+    const output = execTmux(["list-panes", "-a", "-F", "#{pane_pid} #{pane_id}"]);
     if (!output) return null;
 
     const panePids = new Map<number, string>();

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
+import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
 
 export const DEFAULT_ALLOWED_MODES = ['ralph', 'ultrawork', 'team'];
 export const DEFAULT_MARKER = '[OMX_TMUX_INJECT]';
@@ -203,14 +204,15 @@ function isHudStartCommand(startCommand: string): boolean {
  */
 export function resolveCodexPane(): string {
   const envPane = (process.env.TMUX_PANE || '').trim();
+  const tmuxCommand = resolveTmuxBinaryForPlatform() || 'tmux';
   if (!envPane) return '';
 
   try {
-    const cmd = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{pane_current_command}'], {
-      encoding: 'utf-8', timeout: 2000,
+    const cmd = execFileSync(tmuxCommand, ['display-message', '-t', envPane, '-p', '#{pane_current_command}'], {
+      encoding: 'utf-8', timeout: 2000, windowsHide: process.platform === 'win32',
     }).trim().toLowerCase();
-    const startCmd = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#{pane_start_command}'], {
-      encoding: 'utf-8', timeout: 2000,
+    const startCmd = execFileSync(tmuxCommand, ['display-message', '-t', envPane, '-p', '#{pane_start_command}'], {
+      encoding: 'utf-8', timeout: 2000, windowsHide: process.platform === 'win32',
     }).trim().toLowerCase();
     const base = cmd.split('/').pop()?.replace(/^-/, '') || '';
     if (AGENT_COMMANDS.has(base) && !isHudStartCommand(startCmd)) {
@@ -225,16 +227,16 @@ export function resolveCodexPane(): string {
   }
 
   try {
-    const sessionName = execFileSync('tmux', ['display-message', '-t', envPane, '-p', '#S'], {
+    const sessionName = execFileSync(tmuxCommand, ['display-message', '-t', envPane, '-p', '#S'], {
       encoding: 'utf-8', timeout: 2000,
       windowsHide: true,
     }).trim();
     if (!sessionName) return '';
 
-    const panes = execFileSync('tmux', [
+    const panes = execFileSync(tmuxCommand, [
       'list-panes', '-s', '-t', sessionName,
       '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}',
-    ], { encoding: 'utf-8', timeout: 2000 }).trim().split('\n');
+    ], { encoding: 'utf-8', timeout: 2000, windowsHide: process.platform === 'win32' }).trim().split('\n');
 
     for (const line of panes) {
       const parts = line.split('\t');

--- a/src/utils/__tests__/platform-command.test.ts
+++ b/src/utils/__tests__/platform-command.test.ts
@@ -7,6 +7,7 @@ import {
   buildPlatformCommandSpec,
   classifySpawnError,
   resolveCommandPathForPlatform,
+  resolveTmuxBinaryForPlatform,
   spawnPlatformCommandSync,
 } from '../platform-command.js';
 
@@ -220,6 +221,37 @@ describe('resolveCommandPathForPlatform', () => {
           },
         ),
         exePath,
+      );
+    } finally {
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to psmux on Windows when tmux is absent', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-platform-psmux-path-'));
+    try {
+      const psmuxPath = join(fakeBin, 'psmux.exe');
+      await writeFile(psmuxPath, '');
+      assert.equal(
+        resolveCommandPathForPlatform(
+          'tmux',
+          'win32',
+          {
+            PATH: fakeBin,
+            PATHEXT: '.EXE;.CMD',
+          },
+        ),
+        psmuxPath,
+      );
+      assert.equal(
+        resolveTmuxBinaryForPlatform(
+          'win32',
+          {
+            PATH: fakeBin,
+            PATHEXT: '.EXE;.CMD',
+          },
+        ),
+        psmuxPath,
       );
     } finally {
       await rm(fakeBin, { recursive: true, force: true });

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -23,6 +23,9 @@ const WINDOWS_DIRECT_EXTENSIONS = new Set(['.com', '.exe']);
 const WINDOWS_CMD_EXTENSIONS = new Set(['.bat', '.cmd']);
 const WINDOWS_EXTENSION_PRIORITY = ['.exe', '.com', '.cmd', '.bat', '.ps1'];
 const NODE_HOSTED_SCRIPT_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
+const WINDOWS_COMPATIBLE_COMMAND_ALIASES: Record<string, string[]> = {
+  tmux: ['tmux', 'psmux'],
+};
 const WINDOWS_NODE_HOSTED_COMMANDS: Record<string, string[]> = {
   codex: ['node_modules', '@openai', 'codex', 'bin', 'codex.js'],
 };
@@ -62,6 +65,14 @@ function normalizeWindowsCommandName(command: string): string {
   return basename(command, extname(command)).toLowerCase();
 }
 
+function resolveWindowsCommandVariants(command: string): string[] {
+  if (isWindowsPathLike(command)) return [command];
+  const extension = extname(command);
+  const aliases = WINDOWS_COMPATIBLE_COMMAND_ALIASES[normalizeWindowsCommandName(command)];
+  if (!aliases || aliases.length === 0) return [command];
+  return [...new Set(aliases.map((alias) => `${alias}${extension}`))];
+}
+
 function resolveWindowsNodeHostedCommandPath(
   command: string,
   resolvedPath: string,
@@ -87,35 +98,38 @@ function resolveWindowsCommandPath(
   env: NodeJS.ProcessEnv,
   existsImpl: ExistsSyncLike,
 ): string | null {
-  const candidates: string[] = [];
-  const extension = extname(command).toLowerCase();
   const pathext = normalizeWindowsPathext(env);
+  const pathEntries = String(env.Path ?? env.PATH ?? '')
+    .split(delimiter)
+    .map((value) => value.trim())
+    .filter(Boolean);
 
-  const addCandidatesForBase = (base: string): void => {
-    if (extension) {
+  for (const commandVariant of resolveWindowsCommandVariants(command)) {
+    const candidates: string[] = [];
+    const extension = extname(commandVariant).toLowerCase();
+
+    const addCandidatesForBase = (base: string): void => {
+      if (extension) {
+        candidates.push(base);
+        return;
+      }
+      for (const ext of pathext) {
+        candidates.push(`${base}${ext}`);
+      }
       candidates.push(base);
-      return;
-    }
-    for (const ext of pathext) {
-      candidates.push(`${base}${ext}`);
-    }
-    candidates.push(base);
-  };
+    };
 
-  if (isWindowsPathLike(command)) {
-    addCandidatesForBase(command);
-  } else {
-    const pathEntries = String(env.Path ?? env.PATH ?? '')
-      .split(delimiter)
-      .map((value) => value.trim())
-      .filter(Boolean);
-    for (const entry of pathEntries) {
-      addCandidatesForBase(join(entry, command));
+    if (isWindowsPathLike(commandVariant)) {
+      addCandidatesForBase(commandVariant);
+    } else {
+      for (const entry of pathEntries) {
+        addCandidatesForBase(join(entry, commandVariant));
+      }
     }
-  }
 
-  for (const candidate of candidates) {
-    if (existsImpl(candidate)) return candidate;
+    for (const candidate of candidates) {
+      if (existsImpl(candidate)) return candidate;
+    }
   }
 
   return null;
@@ -189,6 +203,14 @@ export function resolveCommandPathForPlatform(
     return resolveWindowsCommandPath(command, env, existsImpl);
   }
   return resolvePosixCommandPath(command, env, existsImpl);
+}
+
+export function resolveTmuxBinaryForPlatform(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  existsImpl: ExistsSyncLike = existsFileSync,
+): string | null {
+  return resolveCommandPathForPlatform('tmux', platform, env, existsImpl);
 }
 
 export function buildPlatformCommandSpec(


### PR DESCRIPTION
## Summary
- resolve native-Windows tmux invocation points through the shared platform command layer so `psmux` is accepted when `tmux` is absent
- update detached Windows bootstrap and helper tmux callers to use the resolved tmux-compatible binary without changing launch policy
- add focused tests for command resolution/bootstrap behavior and document the narrow native-Windows compatibility path

## Testing
- npm run build
- node --test dist/utils/__tests__/platform-command.test.js dist/notifications/__tests__/tmux-detector.test.js dist/hooks/__tests__/tmux-hook-engine.test.js dist/cli/__tests__/index.test.js