### PR TITLE
fix: add per-launch native-hook opt-out for plain Codex sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ For non-team sessions, native Codex hooks are now the canonical lifecycle surfac
 - `.omx/hooks/*.mjs` = OMX plugin hooks
 - `omx tmux-hook` / notify-hook / derived watcher = tmux + runtime fallback paths
 
+Need one plain Codex session without the OMX harness? Launch Codex with `OMX_NATIVE_HOOKS=0` to disable OMX-managed native hook behavior just for that process tree, without uninstalling OMX or changing other sessions.
+
 See [Codex native hook mapping](./docs/codex-native-hooks.md) for the current native / fallback matrix.
 
 ### Explore and sparkshell

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -22,6 +22,16 @@ For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of sourc
 
 OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js`. User-managed hook entries in the same `.codex/hooks.json` file are preserved across `omx setup` refreshes and `omx uninstall`.
 
+## Per-launch opt-out
+
+To keep OMX installed but bypass its native-hook harness for one Codex launch, start Codex with:
+
+```bash
+OMX_NATIVE_HOOKS=0 codex
+```
+
+This is a per-process-tree opt-out: the OMX-managed entries in `.codex/hooks.json` still exist, but `codex-native-hook.js` returns immediately for that launch so SessionStart, UserPromptSubmit, Stop, and Bash pre/post hook behavior stay out of the session.
+
 ## Mapping matrix
 
 | OMC / OMX surface | Native Codex source | OMX runtime target | Status | Notes |

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -19,6 +19,8 @@ import {
 } from "../codex-native-hook.js";
 import { writeSessionStart } from "../../hooks/session.js";
 
+const OMX_NATIVE_HOOKS_ENV = "OMX_NATIVE_HOOKS";
+
 async function writeJson(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true }).catch(() => {});
   await writeFile(path, JSON.stringify(value, null, 2));
@@ -76,8 +78,11 @@ const TEAM_ENV_KEYS = [
 ] as const;
 
 const priorTeamEnv = new Map<(typeof TEAM_ENV_KEYS)[number], string | undefined>();
+let priorNativeHooksEnv: string | undefined;
 
 beforeEach(() => {
+  priorNativeHooksEnv = process.env[OMX_NATIVE_HOOKS_ENV];
+  delete process.env[OMX_NATIVE_HOOKS_ENV];
   priorTeamEnv.clear();
   for (const key of TEAM_ENV_KEYS) {
     priorTeamEnv.set(key, process.env[key]);
@@ -86,6 +91,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  if (typeof priorNativeHooksEnv === "string") process.env[OMX_NATIVE_HOOKS_ENV] = priorNativeHooksEnv;
+  else delete process.env[OMX_NATIVE_HOOKS_ENV];
   for (const key of TEAM_ENV_KEYS) {
     const value = priorTeamEnv.get(key);
     if (typeof value === "string") process.env[key] = value;
@@ -162,6 +169,32 @@ describe("codex native hook dispatch", () => {
       String(output.hookSpecificOutput?.additionalContext ?? ""),
       /stdin JSON parsing failed inside codex-native-hook:/,
     );
+  });
+
+  it("returns no output and skips OMX side effects when native hooks are disabled for the launch", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-disabled-"));
+    try {
+      process.env[OMX_NATIVE_HOOKS_ENV] = "0";
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "sess-disabled-1",
+        },
+        {
+          cwd,
+          sessionOwnerPid: 43210,
+        },
+      );
+
+      assert.equal(result.hookEventName, "SessionStart");
+      assert.equal(result.omxEventName, "session-start");
+      assert.equal(result.outputJson, null);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "session.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it("maps Codex events onto OMX logical surfaces", () => {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -71,6 +71,8 @@ const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
 const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);
 const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
+const OMX_NATIVE_HOOKS_ENV = "OMX_NATIVE_HOOKS";
+const DISABLED_ENV_VALUES = new Set(["0", "false", "no", "off"]);
 const STABLE_FINAL_RECOMMENDATION_PATTERNS = [
   /^\s*(?:launch|release|ship)-?ready\s*:\s*(?:yes|no)\b[^\n\r]*/im,
   /^\s*ready to release\s*:\s*(?:yes|no)\b[^\n\r]*/im,
@@ -95,6 +97,12 @@ function safePositiveInteger(value: unknown): number | null {
     if (Number.isInteger(parsed) && parsed > 0) return parsed;
   }
   return null;
+}
+
+function areOmxNativeHooksEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[OMX_NATIVE_HOOKS_ENV];
+  if (typeof raw !== "string") return true;
+  return !DISABLED_ENV_VALUES.has(raw.trim().toLowerCase());
 }
 
 function readHookEventName(payload: CodexHookPayload): CodexHookEventName | null {
@@ -1313,11 +1321,18 @@ export async function dispatchCodexNativeHook(
   options: NativeHookDispatchOptions = {},
 ): Promise<NativeHookDispatchResult> {
   const hookEventName = readHookEventName(payload);
+  const omxEventName = mapCodexHookEventToOmxEvent(hookEventName);
+  if (!areOmxNativeHooksEnabled()) {
+    return {
+      hookEventName,
+      omxEventName,
+      skillState: null,
+      outputJson: null,
+    };
+  }
   const cwd = options.cwd ?? (safeString(payload.cwd).trim() || process.cwd());
   const stateDir = join(cwd, ".omx", "state");
   await mkdir(stateDir, { recursive: true });
-
-  const omxEventName = mapCodexHookEventToOmxEvent(hookEventName);
   let skillState: SkillActiveState | null = null;
 
   const nativeSessionId = safeString(payload.session_id ?? payload.sessionId).trim();
@@ -1435,6 +1450,9 @@ async function readStdinJson(): Promise<NativeHookCliReadResult> {
 
 export async function runCodexNativeHookCli(): Promise<void> {
   const { payload, parseError } = await readStdinJson();
+  if (!areOmxNativeHooksEnabled()) {
+    return;
+  }
   if (parseError) {
     process.stdout.write(`${JSON.stringify({
       decision: "block",


### PR DESCRIPTION
## Summary
- add a per-launch  escape hatch at the native hook entrypoint
- skip OMX SessionStart/prompt-routing/Stop/pre-post behavior entirely for that Codex process tree
- document the new narrow opt-out contract and add a regression test

## Testing
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js
- npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts README.md docs/codex-native-hooks.md

Closes #1552
Related to #1551