### PR TITLE
fix: keep OMX Stop auto-nudges out of plain Codex sessions

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -73,6 +73,7 @@ const TEAM_ENV_KEYS = [
   "OMX_TEAM_WORKER",
   "OMX_TEAM_STATE_ROOT",
   "OMX_TEAM_LEADER_CWD",
+  "OMX_SESSION_ID",
 ] as const;
 
 const priorTeamEnv = new Map<(typeof TEAM_ENV_KEYS)[number], string | undefined>();
@@ -2226,6 +2227,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto";
 
       const result = await dispatchCodexNativeHook(
         {
@@ -2255,6 +2257,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-once";
 
       await dispatchCodexNativeHook(
         {
@@ -2293,6 +2296,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-refire";
 
       await dispatchCodexNativeHook(
         {
@@ -2336,6 +2340,7 @@ esac
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-permission-"));
     try {
       await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-permission";
 
       const result = await dispatchCodexNativeHook(
         {
@@ -2359,6 +2364,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(join(stateDir, "sessions", "sess-stop-auto-question"), { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-question";
       await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-auto-question" });
       await writeJson(join(stateDir, "sessions", "sess-stop-auto-question", "skill-active-state.json"), {
         version: 1,
@@ -2409,6 +2415,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(join(stateDir, "sessions", "sess-stop-auto-interview"), { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-interview";
       await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-auto-interview" });
       await writeJson(join(stateDir, "sessions", "sess-stop-auto-interview", "deep-interview-state.json"), {
         active: true,
@@ -2441,6 +2448,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-mode";
       await writeJson(join(stateDir, "deep-interview-state.json"), {
         active: true,
         mode: "deep-interview",
@@ -2469,6 +2477,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-stale-root-mode";
       await writeJson(join(stateDir, "deep-interview-state.json"), {
         active: true,
         mode: "deep-interview",
@@ -2505,6 +2514,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-stale-root-skill";
       await writeJson(join(stateDir, "skill-active-state.json"), {
         active: true,
         skill: "deep-interview",
@@ -2541,6 +2551,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-stale-root-lock";
       await writeJson(join(stateDir, "skill-active-state.json"), {
         active: true,
         skill: "deep-interview",
@@ -2583,6 +2594,7 @@ esac
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(join(stateDir, "sessions", "sess-stop-auto-inactive-mode"), { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-inactive-mode";
       await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-auto-inactive-mode" });
       await writeJson(join(stateDir, "sessions", "sess-stop-auto-inactive-mode", "deep-interview-state.json"), {
         active: false,
@@ -2615,6 +2627,40 @@ esac
         systemMessage:
           "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
       });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not auto-continue native Stop for a plain Codex session started outside OMX runtime", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-plain-session-"));
+    try {
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "plain-stop-session",
+        },
+        {
+          cwd,
+          sessionOwnerPid: process.pid,
+        },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "plain-stop-session",
+          thread_id: "plain-thread",
+          turn_id: "plain-turn-1",
+          last_assistant_message: "Keep going and finish the cleanup.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -44,6 +44,7 @@ import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
+import { sessionModelInstructionsPath } from "../hooks/agents-overlay.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -933,6 +934,29 @@ function readNativeStopSessionKey(payload: CodexHookPayload): string {
   return readPayloadSessionId(payload) || readPayloadThreadId(payload) || "global";
 }
 
+function hasManagedStopSessionEnv(sessionIds: string[]): boolean {
+  const envSessionId = safeString(process.env.OMX_SESSION_ID).trim();
+  if (!envSessionId) return false;
+  return sessionIds.length === 0 || sessionIds.includes(envSessionId);
+}
+
+async function hasManagedStopContext(
+  cwd: string,
+  payload: CodexHookPayload,
+  canonicalSessionId: string,
+): Promise<boolean> {
+  if (hasTeamWorkerContext()) return true;
+
+  const sessionIds = [...new Set([
+    canonicalSessionId,
+    readPayloadSessionId(payload),
+  ].map((value) => safeString(value).trim()).filter(Boolean))];
+
+  if (hasManagedStopSessionEnv(sessionIds)) return true;
+
+  return sessionIds.some((sessionId) => existsSync(sessionModelInstructionsPath(cwd, sessionId)));
+}
+
 function readPreviousNativeStopSignature(
   state: Record<string, unknown>,
   sessionKey: string,
@@ -1215,6 +1239,7 @@ async function buildStopHookOutput(
   const threadId = readPayloadThreadId(payload);
   const ralphState = await readActiveRalphState(stateDir, canonicalSessionId);
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
+  const managedStopContext = await hasManagedStopContext(cwd, payload, canonicalSessionId);
   if (!ralphState) {
     const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);
     if (!stopHookActive && hasTeamWorkerContext()) return teamWorkerOutput;
@@ -1261,6 +1286,10 @@ async function buildStopHookOutput(
 
       const skillOutput = await buildSkillStopOutput(cwd, canonicalSessionId, threadId);
       if (!stopHookActive && skillOutput) return skillOutput;
+    }
+
+    if (!managedStopContext) {
+      return null;
     }
 
     const lastAssistantMessage = safeString(


### PR DESCRIPTION
## Summary
- gate native Stop auto-nudge behavior on active OMX ownership signals instead of stale .omx state alone
- preserve managed OMX/team-worker Stop behavior while leaving plain Codex sessions untouched
- add regression coverage for the reported plain-session Stop interjection path

## Reproduction
1. Start an OMX-backed session so native SessionStart writes .omx session bookkeeping
2. End OMX workflow activity, then continue in a regular/plain Codex session in the same workspace
3. Hit a Stop event on an assistant message like "Keep going and finish the cleanup."
4. Before this fix, native Stop could emit an automatic continuation block/output; after this fix, plain-session Stop stays null

## Testing
- npm run build
- npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts
- node --test dist/scripts/__tests__/codex-native-hook.test.js
- manual compiled reproduction of plain SessionStart + Stop returning null

Closes #1551