### PR TITLE
feat: gate Ralph PRD runs on required story validation

### DIFF
--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -1,11 +1,16 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
+  assertRequiredRalphPrdJson,
   buildRalphAppendInstructions,
   buildRalphChangedFilesSeedContents,
   extractRalphTaskDescription,
-  normalizeRalphCliArgs,
   filterRalphCodexArgs,
+  isRalphPrdMode,
+  normalizeRalphCliArgs,
 } from '../ralph.js';
 import type { ApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 
@@ -24,6 +29,20 @@ describe('extractRalphTaskDescription', () => {
   });
   it('supports -- separator', () => {
     assert.equal(extractRalphTaskDescription(['--model', 'gpt-5', '--', 'fix', '--weird-name']), 'fix --weird-name');
+  });
+});
+
+describe('isRalphPrdMode', () => {
+  it('detects --prd flag usage', () => {
+    assert.equal(isRalphPrdMode(['--prd', 'ship release checklist']), true);
+  });
+
+  it('detects --prd=value usage', () => {
+    assert.equal(isRalphPrdMode(['--prd=ship release checklist']), true);
+  });
+
+  it('ignores non-prd Ralph runs', () => {
+    assert.equal(isRalphPrdMode(['fix', 'the', 'bug']), false);
   });
 });
 
@@ -60,6 +79,86 @@ const approvedHint: ApprovedExecutionLaunchHint = {
   testSpecPaths: ['.omx/plans/test-spec-issue-1072.md'],
   deepInterviewSpecPaths: ['.omx/specs/deep-interview-issue-1072.md'],
 };
+
+describe('assertRequiredRalphPrdJson', () => {
+  it('throws when --prd mode starts without .omx/prd.json', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-prd-gate-'));
+    try {
+      assert.throws(
+        () => assertRequiredRalphPrdJson(cwd, ['--prd', 'ship release checklist']),
+        /Missing required PRD\.json at \.omx\/prd\.json/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects completed stories without architect approval', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-prd-gate-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'prd.json'), JSON.stringify({
+        project: 'Issue 1555',
+        userStories: [{
+          id: 'US-001',
+          title: 'Guard story completion',
+          passes: true,
+        }],
+      }, null, 2));
+
+      assert.throws(
+        () => assertRequiredRalphPrdJson(cwd, ['--prd', 'ship release checklist']),
+        /marked passed\/completed without architect approval/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows completed stories with architect approval recorded', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-prd-gate-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'prd.json'), JSON.stringify({
+        project: 'Issue 1555',
+        userStories: [{
+          id: 'US-001',
+          title: 'Guard story completion',
+          status: 'completed',
+          architect_review: { verdict: 'approve' },
+        }],
+      }, null, 2));
+
+      assert.doesNotThrow(() => assertRequiredRalphPrdJson(cwd, ['--prd', 'ship release checklist']));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows --prd mode when .omx/prd.json exists', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-prd-gate-'));
+    try {
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'prd.json'), JSON.stringify({
+        project: 'Issue 1555',
+        userStories: [],
+      }, null, 2));
+
+      assert.doesNotThrow(() => assertRequiredRalphPrdJson(cwd, ['--prd', 'ship release checklist']));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not gate non-prd Ralph runs', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-prd-gate-'));
+    try {
+      assert.doesNotThrow(() => assertRequiredRalphPrdJson(cwd, ['fix', 'the', 'bug']));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('ralph deslop launch wiring', () => {
   it('consumes --no-deslop so it is not forwarded to codex', () => {

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { startMode, updateModeState } from '../modes/base.js';
@@ -36,6 +37,84 @@ Common patterns:
 const VALUE_TAKING_FLAGS = new Set(['--model', '--provider', '--config', '-c', '-i', '--images-dir']);
 const RALPH_OMX_FLAGS = new Set(['--prd', '--no-deslop']);
 const RALPH_APPEND_ENV = 'OMX_RALPH_APPEND_INSTRUCTIONS_FILE';
+const REQUIRED_RALPH_PRD_JSON_PATH = '.omx/prd.json';
+const COMPLETED_RALPH_STORY_STATUSES = new Set(['passed', 'complete', 'completed']);
+const APPROVED_RALPH_ARCHITECT_VERDICTS = new Set(['approve', 'approved']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isStoryMarkedPassedOrCompleted(story: Record<string, unknown>): boolean {
+  if (story.passes === true) return true;
+  if (typeof story.status !== 'string') return false;
+  return COMPLETED_RALPH_STORY_STATUSES.has(story.status.trim().toLowerCase());
+}
+
+function hasApprovedArchitectValidation(story: Record<string, unknown>): boolean {
+  const candidates = [story.architect_validation, story.architectValidation, story.architect_review, story.architectReview];
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) continue;
+    if (candidate.approved === true) return true;
+    if (typeof candidate.verdict === 'string' && APPROVED_RALPH_ARCHITECT_VERDICTS.has(candidate.verdict.trim().toLowerCase())) {
+      return true;
+    }
+    if (typeof candidate.status === 'string' && APPROVED_RALPH_ARCHITECT_VERDICTS.has(candidate.status.trim().toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function describeStory(story: Record<string, unknown>, index: number): string {
+  const id = typeof story.id === 'string' && story.id.trim() !== '' ? story.id.trim() : null;
+  const title = typeof story.title === 'string' && story.title.trim() !== '' ? story.title.trim() : null;
+  if (id && title) return `${id} (${title})`;
+  if (id) return id;
+  if (title) return title;
+  return `story #${index + 1}`;
+}
+
+function readAndValidateRequiredRalphPrdJson(cwd: string): void {
+  const requiredPath = join(cwd, REQUIRED_RALPH_PRD_JSON_PATH);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(requiredPath, 'utf-8'));
+  } catch (error) {
+    throw new Error(`[ralph] Invalid PRD.json at ${REQUIRED_RALPH_PRD_JSON_PATH}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(`[ralph] Invalid PRD.json at ${REQUIRED_RALPH_PRD_JSON_PATH}: expected a JSON object.`);
+  }
+
+  if (parsed.userStories == null) return;
+  if (!Array.isArray(parsed.userStories)) {
+    throw new Error(`[ralph] Invalid PRD.json at ${REQUIRED_RALPH_PRD_JSON_PATH}: userStories must be an array when present.`);
+  }
+
+  for (const [index, story] of parsed.userStories.entries()) {
+    if (!isRecord(story)) continue;
+    if (!isStoryMarkedPassedOrCompleted(story)) continue;
+    if (hasApprovedArchitectValidation(story)) continue;
+    throw new Error(`[ralph] PRD.json ${describeStory(story, index)} is marked passed/completed without architect approval. Record architect_validation.verdict="approved" (or architect_review.verdict="approve") before running Ralph.`);
+  }
+}
+
+export function isRalphPrdMode(args: readonly string[]): boolean {
+  return args.some((arg) => arg === '--prd' || arg.startsWith('--prd='));
+}
+
+export function assertRequiredRalphPrdJson(cwd: string, args: readonly string[]): void {
+  if (!isRalphPrdMode(args)) return;
+
+  const requiredPath = join(cwd, REQUIRED_RALPH_PRD_JSON_PATH);
+  if (!existsSync(requiredPath)) {
+    throw new Error(`[ralph] Missing required PRD.json at ${REQUIRED_RALPH_PRD_JSON_PATH}. Create the file before running \`omx ralph --prd ...\`.`);
+  }
+
+  readAndValidateRequiredRalphPrdJson(cwd);
+}
 
 export function extractRalphTaskDescription(args: readonly string[], fallbackTask?: string): string {
   const words: string[] = [];
@@ -172,6 +251,7 @@ export async function ralphCommand(args: string[]): Promise<void> {
     console.log(RALPH_HELP);
     return;
   }
+  assertRequiredRalphPrdJson(cwd, args);
   const artifacts = await ensureCanonicalRalphArtifacts(cwd);
   const approvedHint = readApprovedExecutionLaunchHint(cwd, 'ralph');
   const explicitTask = extractRalphTaskDescription(normalizedArgs);


### PR DESCRIPTION
## Summary
- require `.omx/prd.json` before `omx ralph --prd ...` starts
- reject PRD stories already marked passed/completed unless architect approval is recorded
- add focused Ralph CLI tests and smoke checks for the new startup gate

Closes #1555