### PR TITLE
Align Ralph PRD startup contract with smoke coverage

### DIFF
--- a/docs/contracts/ralph-state-contract.md
+++ b/docs/contracts/ralph-state-contract.md
@@ -85,8 +85,10 @@ starting
 ## Canonical PRD/progress sources
 
 - Canonical PRD: `.omx/plans/prd-{slug}.md`
+- Startup validation source during the legacy-compatibility window: `.omx/prd.json`
 - Canonical progress ledger: `.omx/state/{scope}/ralph-progress.json`
 - Legacy compatibility migration:
   - `.omx/prd.json` migrates one-way to canonical PRD markdown when no canonical PRD exists.
   - `.omx/progress.txt` migrates one-way to canonical `ralph-progress.json` when no canonical ledger exists.
   - Legacy files remain read-only compatibility artifacts for one release cycle.
+- Canonical PRD markdown is storage/documentation-canonical today; Ralph `--prd` startup still validates machine-readable story approval state from `.omx/prd.json` until a structured replacement exists.

--- a/skills/ralph-init/SKILL.md
+++ b/skills/ralph-init/SKILL.md
@@ -29,7 +29,8 @@ Initialize a PRD (Product Requirements Document) for structured ralph-loop execu
 
 - Canonical PRD source of truth is `.omx/plans/prd-{slug}.md`.
 - Ralph progress source of truth is `.omx/state/{scope}/ralph-progress.json` (session scope when available).
-- Legacy `.omx/prd.json` / `.omx/progress.txt` inputs are compatibility-only and migrate one-way into canonical artifacts.
+- During the current compatibility window, Ralph `--prd` startup still validates machine-readable story state from `.omx/prd.json`.
+- Legacy `.omx/prd.json` / `.omx/progress.txt` inputs migrate one-way into canonical artifacts, but canonical PRD markdown is not yet the startup validation source for `omx ralph --prd ...`.
 
 ## Output
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -242,6 +242,8 @@ User input: `--prd build a todo app with React and TypeScript`
 Workflow: Detect flag, extract task, create `.omx/plans/prd-{slug}.md`, create `.omx/state/{scope}/ralph-progress.json`, begin ralph loop.
 
 ### Legacy compatibility
+- During the compatibility window, Ralph `--prd` startup still validates machine-readable story state from `.omx/prd.json`.
+- `.omx/plans/prd-{slug}.md` remains the canonical storage/documentation artifact, but it is not yet the startup validation source.
 - If `.omx/prd.json` exists and canonical PRD is absent, migrate one-way into `.omx/plans/prd-{slug}.md`.
 - If `.omx/progress.txt` exists and canonical progress ledger is absent, import one-way into `.omx/state/{scope}/ralph-progress.json`.
 - Keep legacy files unchanged for one release cycle.

--- a/src/cli/__tests__/ralph-prd-deep-interview.test.ts
+++ b/src/cli/__tests__/ralph-prd-deep-interview.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ralphSkill = readFileSync(join(__dirname, '../../../skills/ralph/SKILL.md'), 'utf-8');
+const ralphInitSkill = readFileSync(join(__dirname, '../../../skills/ralph-init/SKILL.md'), 'utf-8');
 
 describe('ralph PRD mode deep interview gate', () => {
   it('requires deep-interview --quick before PRD artifact creation', () => {
@@ -17,5 +18,10 @@ describe('ralph PRD mode deep interview gate', () => {
   it('documents --no-deslop as a PRD-mode opt-out for the final deslop pass', () => {
     assert.match(ralphSkill, /--no-deslop/);
     assert.match(ralphSkill, /skip the deslop pass/i);
+  });
+
+  it('keeps ralph-init aligned with the PRD startup compatibility contract', () => {
+    assert.match(ralphInitSkill, /startup still validates machine-readable story state from `\.omx\/prd\.json`/i);
+    assert.match(ralphInitSkill, /canonical PRD markdown is not yet the startup validation source/i);
   });
 });

--- a/src/cli/__tests__/ralph-prd-smoke.test.ts
+++ b/src/cli/__tests__/ralph-prd-smoke.test.ts
@@ -1,0 +1,188 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CLI_SPAWN_TIMEOUT_MS = 15_000;
+
+function runOmx(
+  cwd: string,
+  argv: string[],
+  envOverrides: Record<string, string> = {},
+): { status: number | null; stdout: string; stderr: string; error: string } {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
+  const result = spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: CLI_SPAWN_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
+    env: {
+      ...process.env,
+      ...envOverrides,
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message || '',
+  };
+}
+
+function shouldSkipForSpawnPermissions(err: string): boolean {
+  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+}
+
+async function initRepo(prefix: string): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), prefix));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  return cwd;
+}
+
+async function installFakeCodex(fakeBin: string, launchLog: string): Promise<void> {
+  await mkdir(fakeBin, { recursive: true });
+  const fakeCodexPath = join(fakeBin, 'codex');
+  const fakePsPath = join(fakeBin, 'ps');
+  await writeFile(
+    fakeCodexPath,
+    `#!/bin/sh
+printf '%s\n' "$*" >>"${launchLog}"
+exit 0
+`,
+    'utf-8',
+  );
+  await chmod(fakeCodexPath, 0o755);
+  await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n', 'utf-8');
+  await chmod(fakePsPath, 0o755);
+}
+
+function buildEnv(home: string, fakeBin: string): Record<string, string> {
+  return {
+    HOME: home,
+    PATH: `${fakeBin}:/usr/bin:/bin`,
+    OMX_AUTO_UPDATE: '0',
+    OMX_NOTIFY_FALLBACK: '0',
+    OMX_HOOK_DERIVED_SIGNALS: '0',
+  };
+}
+
+async function writePrdJson(
+  cwd: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  await mkdir(join(cwd, '.omx'), { recursive: true });
+  await writeFile(join(cwd, '.omx', 'prd.json'), JSON.stringify(payload, null, 2));
+}
+
+describe('omx ralph --prd smoke gate', () => {
+  it('aborts before Codex launch when .omx/prd.json is missing', async () => {
+    const cwd = await initRepo('omx-ralph-prd-smoke-');
+    const home = join(cwd, 'home');
+    const fakeBin = join(cwd, 'bin');
+    const launchLog = join(cwd, 'codex-launch.log');
+    try {
+      await mkdir(home, { recursive: true });
+      await installFakeCodex(fakeBin, launchLog);
+
+      const result = runOmx(cwd, ['ralph', '--prd', 'ship release checklist'], buildEnv(home, fakeBin));
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.notEqual(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /Missing required PRD\.json at \.omx\/prd\.json/);
+      assert.equal(existsSync(launchLog), false, 'expected no Codex launch log when PRD gate fails');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('aborts before Codex launch when only canonical PRD markdown exists', async () => {
+    const cwd = await initRepo('omx-ralph-prd-smoke-');
+    const home = join(cwd, 'home');
+    const fakeBin = join(cwd, 'bin');
+    const launchLog = join(cwd, 'codex-launch.log');
+    try {
+      await mkdir(home, { recursive: true });
+      await installFakeCodex(fakeBin, launchLog);
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'plans', 'prd-existing.md'), '# Existing canonical PRD\n', 'utf-8');
+
+      const result = runOmx(cwd, ['ralph', '--prd', 'ship release checklist'], buildEnv(home, fakeBin));
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.notEqual(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /Missing required PRD\.json at \.omx\/prd\.json/);
+      assert.equal(existsSync(launchLog), false, 'expected no Codex launch log when only canonical markdown exists');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('aborts before Codex launch when a completed story lacks architect approval', async () => {
+    const cwd = await initRepo('omx-ralph-prd-smoke-');
+    const home = join(cwd, 'home');
+    const fakeBin = join(cwd, 'bin');
+    const launchLog = join(cwd, 'codex-launch.log');
+    try {
+      await mkdir(home, { recursive: true });
+      await installFakeCodex(fakeBin, launchLog);
+      await writePrdJson(cwd, {
+        project: 'Issue 1555',
+        userStories: [{
+          id: 'US-001',
+          title: 'Guard story completion',
+          status: 'completed',
+        }],
+      });
+
+      const result = runOmx(cwd, ['ralph', '--prd', 'ship release checklist'], buildEnv(home, fakeBin));
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.notEqual(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /marked passed\/completed without architect approval/);
+      assert.equal(existsSync(launchLog), false, 'expected no Codex launch log when architect approval is missing');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('launches Codex exactly once when .omx/prd.json is valid', async () => {
+    const cwd = await initRepo('omx-ralph-prd-smoke-');
+    const home = join(cwd, 'home');
+    const fakeBin = join(cwd, 'bin');
+    const launchLog = join(cwd, 'codex-launch.log');
+    try {
+      await mkdir(home, { recursive: true });
+      await installFakeCodex(fakeBin, launchLog);
+      await writePrdJson(cwd, {
+        project: 'Issue 1555',
+        userStories: [{
+          id: 'US-001',
+          title: 'Guard story completion',
+          status: 'completed',
+          architect_review: { verdict: 'approve' },
+        }],
+      });
+
+      const result = runOmx(cwd, ['ralph', '--prd', 'ship release checklist'], buildEnv(home, fakeBin));
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.equal(existsSync(launchLog), true, 'expected a Codex launch log for the valid path');
+      const launches = (await readFile(launchLog, 'utf-8'))
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      assert.equal(launches.length, 1, `expected exactly one Codex launch, got ${launches.length}`);
+      assert.match(launches[0], /ship release checklist/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -93,6 +93,21 @@ describe('assertRequiredRalphPrdJson', () => {
     }
   });
 
+  it('still requires legacy .omx/prd.json even when canonical PRD markdown exists', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-prd-gate-'));
+    try {
+      await mkdir(join(cwd, '.omx', 'plans'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'plans', 'prd-existing.md'), '# Existing canonical PRD\n');
+
+      assert.throws(
+        () => assertRequiredRalphPrdJson(cwd, ['--prd', 'ship release checklist']),
+        /Missing required PRD\.json at \.omx\/prd\.json/,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('rejects completed stories without architect approval', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralph-prd-gate-'));
     try {


### PR DESCRIPTION
## Summary
- add CLI smoke coverage for Ralph `--prd` launch gating, including no-launch failure assertions
- characterize and document that `.omx/prd.json` remains the startup validation source during the compatibility window
- align adjacent Ralph docs/tests so the startup artifact contract stays consistent

## Testing
- npm run build
- node --test dist/cli/__tests__/ralph.test.js dist/cli/__tests__/ralph-prd-smoke.test.js dist/cli/__tests__/ralph-prd-deep-interview.test.js
- npm test
