### PR TITLE
Fix false PostToolUse failures on successful Bash output

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1078,6 +1078,50 @@ esac
     }
   });
 
+  it("stays silent when successful PostToolUse stdout contains command-not-found text", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-stdout-cnf-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-ok-stdout-cnf",
+          tool_input: { command: "printf 'command not found'" },
+          tool_response: "{\"exit_code\":0,\"stdout\":\"command not found\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("stays silent when successful PostToolUse stdout contains permission-denied text", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-stdout-perm-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: "Bash",
+          tool_use_id: "tool-ok-stdout-perm",
+          tool_input: { command: "python3 -c \"print('permission denied')\"" },
+          tool_response: "{\"exit_code\":0,\"stdout\":\"permission denied\",\"stderr\":\"\"}",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns CLI fallback guidance and preserves failed team state on clear MCP transport death", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-posttool-mcp-transport-"));
     try {

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -230,9 +230,20 @@ export function buildNativePostToolUseOutput(
 
   const normalized = normalizePostToolUsePayload(payload);
   if (!normalized.isBash) return null;
+  if (normalized.exitCode === 0) return null;
+
+  const failureContext = [
+    normalized.stderrText,
+    safeString(normalized.parsedToolResponse?.error),
+    safeString(normalized.parsedToolResponse?.message),
+    safeString(normalized.parsedToolResponse?.details),
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
 
   const combined = `${normalized.stderrText}\n${normalized.stdoutText}`.trim();
-  if (containsHardFailure(combined)) {
+  if (containsHardFailure(failureContext)) {
     return {
       decision: "block",
       reason: "The Bash output indicates a command/setup failure that should be fixed before retrying.",
@@ -248,7 +259,7 @@ export function buildNativePostToolUseOutput(
     normalized.exitCode !== null
     && normalized.exitCode !== 0
     && combined.length > 0
-    && !containsHardFailure(combined)
+    && !containsHardFailure(failureContext)
   ) {
     return {
       decision: "block",


### PR DESCRIPTION
## Summary

This fixes a false-positive `PostToolUse` failure path for Bash commands.

Before this change, successful commands could still be blocked if their `stdout` happened to contain phrases such as:

- `command not found`
- `permission denied`
- `no such file or directory`

That made the native hook misclassify benign output from search, debug, or print commands as a hard setup failure.

## Repro

Examples that can succeed but still contain those phrases in `stdout`:

```bash
printf 'command not found\n'
python3 -c "print('permission denied')"
rg -n "command not found" some/file.js
```

## Root cause

`buildNativePostToolUseOutput()` was checking `containsHardFailure()` against the combined `stderr + stdout` text.

That means a successful command with `exit_code = 0` could still be blocked if `stdout` merely mentioned one of the hard-failure phrases.

## Fix

- Return early for successful Bash tool results (`exitCode === 0`)
- Limit hard-failure detection to actual failure-oriented channels:
  - `stderr`
  - structured error fields (`error`, `message`, `details`)
- Preserve the existing review/block guidance for informative non-zero outputs

## Tests

Added regression coverage for:

- successful `stdout` containing `command not found`
- successful `stdout` containing `permission denied`

These now stay silent as expected, while real stderr failures still block.

## Verification

Passed:

```bash
node --test --test-name-pattern='PostToolUse' dist/scripts/__tests__/codex-native-hook.test.js
npx biome lint src/scripts/codex-native-pre-post.ts src/scripts/__tests__/codex-native-hook.test.ts
```

Note: running the full `dist/scripts/__tests__/codex-native-hook.test.js` suite in this fresh clone still shows two unrelated baseline failures outside this diff.
