### PR TITLE
Make dev the obvious PR base for normal contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 ## Summary
 
+> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.
+
 Describe the problem and why this change is needed.
 
 ## Changes

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,7 +2,7 @@ name: PR Check
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   size-label:
@@ -59,3 +59,19 @@ jobs:
             if (context.payload.pull_request.draft) {
               core.notice('This PR is still in draft state.');
             }
+
+  base-branch-guidance:
+    name: PR Base Guidance
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Remind contributors to target dev for normal contributions
+        run: |
+          message='Normal contributions should target `dev`. If this PR was opened against `main` by accident, please retarget it to `dev`. Maintainer-directed `main` PRs are still allowed.'
+          echo "::warning title=Retarget normal PRs to dev::$message"
+          {
+            echo '## PR base guidance'
+            echo
+            echo "$message"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,10 @@ That document defines the GPT-5.4 behavior contract contributors should preserve
 
 ## Workflow
 
-1. Create a branch from `main`.
+1. Create a branch from `dev` for normal contributions.
 2. Make focused changes.
 3. Run lint, build, and tests locally.
-4. Open a pull request using the provided template.
+4. Open a pull request targeting `dev` using the provided template. Use `main` only for maintainer-directed exceptions.
 
 ## Commit style
 

--- a/src/verification/__tests__/pr-check-workflow.test.ts
+++ b/src/verification/__tests__/pr-check-workflow.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('pr-check workflow', () => {
+  it('keeps the lightweight PR checks and adds non-blocking dev-base guidance for main-based PRs', () => {
+    const workflowPath = join(process.cwd(), '.github', 'workflows', 'pr-check.yml');
+    assert.equal(existsSync(workflowPath), true, `missing workflow: ${workflowPath}`);
+
+    const workflow = readFileSync(workflowPath, 'utf-8');
+    assert.match(workflow, /name:\s*PR Check/);
+    assert.match(workflow, /pull_request_target:\s*\n\s*types:\s*\[opened, synchronize, reopened, edited\]/);
+    assert.match(workflow, /size-label:[\s\S]*pull-requests:\s*write/);
+    assert.match(workflow, /draft-check:/);
+
+    const guidanceSection = workflow.match(/base-branch-guidance:[\s\S]*/)?.[0] ?? '';
+    assert.match(guidanceSection, /base-branch-guidance:/);
+    assert.match(guidanceSection, /name:\s*PR Base Guidance/);
+    assert.match(guidanceSection, /if:\s*github\.event\.pull_request\.base\.ref == 'main'/);
+    assert.match(guidanceSection, /permissions:\s*\{\}/);
+    assert.match(guidanceSection, /::warning title=Retarget normal PRs to dev::/);
+    assert.match(guidanceSection, /Normal contributions should target `dev`\./);
+    assert.match(guidanceSection, /Maintainer-directed `main` PRs are still allowed\./);
+    assert.match(guidanceSection, /GITHUB_STEP_SUMMARY/);
+    assert.doesNotMatch(guidanceSection, /github\.rest\.(issues|pulls)\.(createComment|addLabels|removeLabel)/);
+    assert.doesNotMatch(guidanceSection, /core\.setFailed/);
+  });
+});


### PR DESCRIPTION
## Summary

Clarify the normal contribution path so contributors branch from `dev`, target `dev`, and get a lightweight visible warning if they accidentally open a normal PR against `main`.

## Changes

- fix `CONTRIBUTING.md` workflow guidance to branch from `dev` and target `dev` for normal contributions
- add a short `dev` base reminder to the PR template
- extend the existing PR Check workflow with a non-blocking, read-only base-branch guidance job for `main`-based PRs
- add a workflow contract test that locks the new trigger and no-write-side-effects behavior

## Validation

- [x] `npm run build`
- [x] `node --test dist/verification/__tests__/pr-check-workflow.test.js dist/verification/__tests__/dev-merge-issue-close-workflow.test.js`
- [x] `./node_modules/.bin/biome lint .github/workflows/pr-check.yml src/verification/__tests__/pr-check-workflow.test.ts`
- [ ] `omx doctor` (not needed: no setup/config behavior change)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered
- [x] For normal contributions, this PR targets base branch `dev`

## Related

Closes #1560
