### PR TITLE
Fix wiki skill registration during OMX setup

### DIFF
--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -7,6 +7,24 @@ import { tmpdir } from 'node:os';
 import { setup } from '../setup.js';
 
 describe('omx setup skills overwrite behavior', () => {
+  it('installs wiki during setup even though it is omitted from the current manifest', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const wikiSkill = join(wd, '.codex', 'skills', 'wiki', 'SKILL.md');
+      assert.equal(existsSync(wikiSkill), true);
+      assert.match(await readFile(wikiSkill, 'utf-8'), /^---\nname: wiki/m);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('installs only active/internal catalog skills (skips alias/merged)', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
     const previousCwd = process.cwd();
@@ -28,6 +46,7 @@ describe('omx setup skills overwrite behavior', () => {
       assert.equal(installed.has('frontend-ui-ux'), false);
       assert.equal(installed.has('pipeline'), false);
       assert.equal(installed.has('configure-notifications'), true);
+      assert.equal(installed.has('wiki'), true);
       assert.equal(installed.has('configure-discord'), false);
       assert.equal(installed.has('configure-telegram'), false);
       assert.equal(installed.has('configure-slack'), false);
@@ -92,6 +111,33 @@ describe('omx setup skills overwrite behavior', () => {
     }
   });
 
+  it('retains wiki on --force while still removing unrelated stale unlisted skills', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const wikiDir = join(wd, '.codex', 'skills', 'wiki');
+      const stalePipelineDir = join(wd, '.codex', 'skills', 'pipeline');
+      assert.equal(existsSync(wikiDir), true);
+
+      await mkdir(stalePipelineDir, { recursive: true });
+      await writeFile(join(stalePipelineDir, 'SKILL.md'), '# stale pipeline\n');
+
+      await setup({ scope: 'project', force: true });
+
+      assert.equal(existsSync(wikiDir), true);
+      assert.equal(existsSync(join(wikiDir, 'SKILL.md')), true);
+      assert.equal(existsSync(stalePipelineDir), false);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('refreshes existing skill files by default and restores packaged content', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
     const previousCwd = process.cwd();
@@ -116,6 +162,31 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project', force: true });
       assert.equal(await readFile(skillPath, 'utf-8'), installed);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves unrelated user-authored skill directories during setup and --force refresh', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const customSkillDir = join(wd, '.codex', 'skills', 'my-custom-skill');
+      const customSkillPath = join(customSkillDir, 'SKILL.md');
+      await mkdir(customSkillDir, { recursive: true });
+      await writeFile(customSkillPath, '---\nname: my-custom-skill\ndescription: local custom skill\n---\n');
+
+      await setup({ scope: 'project' });
+      assert.equal(await readFile(customSkillPath, 'utf-8'), '---\nname: my-custom-skill\ndescription: local custom skill\n---\n');
+
+      await setup({ scope: 'project', force: true });
+      assert.equal(await readFile(customSkillPath, 'utf-8'), '---\nname: my-custom-skill\ndescription: local custom skill\n---\n');
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -143,6 +143,7 @@ const PROJECT_GITIGNORE_ENTRIES = [
   "!.codex/prompts/**",
 ] as const;
 const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
+const SETUP_ONLY_INSTALLABLE_SKILLS = new Set(["wiki"]);
 
 function applyScopePathRewritesToAgentsTemplate(
   content: string,
@@ -1476,6 +1477,11 @@ export async function installSkills(
     : null;
   const isInstallableStatus = (status: string | undefined): boolean =>
     status === "active" || status === "internal";
+  const isSetupInstallableSkill = (
+    skillName: string,
+    status: string | undefined,
+  ): boolean =>
+    isInstallableStatus(status) || SETUP_ONLY_INSTALLABLE_SKILLS.has(skillName);
   const entries = await readdir(srcDir, { withFileTypes: true });
   const staleCandidateSkillNames = new Set(
     manifest?.skills.map((skill) => skill.name) ?? [],
@@ -1484,7 +1490,7 @@ export async function installSkills(
     if (!entry.isDirectory()) continue;
     staleCandidateSkillNames.add(entry.name);
     const status = skillStatusByName?.get(entry.name);
-    if (skillStatusByName && !isInstallableStatus(status)) {
+    if (skillStatusByName && !isSetupInstallableSkill(entry.name, status)) {
       summary.skipped += 1;
       if (options.verbose) {
         const label = status ?? "unlisted";
@@ -1538,7 +1544,7 @@ export async function installSkills(
   if (options.force && manifest && existsSync(dstDir)) {
     for (const staleSkill of staleCandidateSkillNames) {
       const status = skillStatusByName?.get(staleSkill);
-      if (isInstallableStatus(status)) continue;
+      if (isSetupInstallableSkill(staleSkill, status)) continue;
 
       const staleSkillDir = join(dstDir, staleSkill);
       if (!existsSync(staleSkillDir)) continue;


### PR DESCRIPTION
## Summary
- reproduce the setup/wiki split where shipped `skills/wiki` assets existed but manifest-gated setup skipped registration/install
- add a wiki-only setup exception so normal setup installs wiki and `setup --force` does not remove it as stale
- add focused setup regression coverage for wiki install, wiki force retention, and unchanged behavior for unrelated stale/custom skills

## Root cause
`installSkills()` relied on the catalog manifest as the only installability source, but `wiki` is a shipped setup asset omitted from the current manifest templates. That left setup generating wiki-adjacent surfaces without actually installing the wiki skill.

## Testing
- npm run build
- node --test dist/cli/__tests__/setup-skills-overwrite.test.js dist/cli/__tests__/setup-skill-validation.test.js
- direct `omx setup --scope project` repro in a temp directory (wiki installed, pipeline still excluded)
- direct `omx setup --scope project --force` repro after adding stale pipeline dir (wiki retained, stale pipeline removed)
- npx biome lint src/cli/setup.ts src/cli/__tests__/setup-skills-overwrite.test.ts

## Follow-up
- catalog/wiki source-of-truth drift still exists and should be reconciled separately from this setup-only hotfix
