### PR TITLE
Fix HUD scope drift toward stale/root fallback

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2,8 +2,9 @@ import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import {
   normalizeCodexLaunchArgs,
   buildTmuxShellCommand,
@@ -63,6 +64,9 @@ import {
   getTeamLowComplexityModel,
 } from "../../config/models.js";
 import type { ProcessEntry } from "../cleanup.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(testDir, "..", "..", "..");
 
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
   return getTeamLowComplexityModel(codexHomeOverride);
@@ -1431,7 +1435,7 @@ describe("detached tmux new-session sequencing", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",
       "/tmp/project",
-      "'codex' '--model' 'gpt-5'",
+      "'env' 'OMX_SESSION_ID=sess-detached-managed' 'codex' '--model' 'gpt-5'",
       "'node' '/tmp/omx.js' 'hud' '--watch'",
       null,
       undefined,
@@ -1445,6 +1449,14 @@ describe("detached tmux new-session sequencing", () => {
       newSession!.args.includes("-e") &&
         newSession!.args.some((arg) => arg === "OMX_SESSION_ID=sess-detached-managed"),
       true,
+    );
+  });
+
+  it("runCodex builds inside-tmux HUD command with OMX_SESSION_ID", async () => {
+    const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
+    assert.match(
+      source,
+      /buildTmuxPaneCommand\("env", \[`OMX_SESSION_ID=\$\{sessionId\}`, "node", omxBin, "hud", "--watch"\]\)/,
     );
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -84,7 +84,6 @@ import { codexConfigPath, rememberOmxLaunchContext, resolveOmxEntryPath } from "
 import { repairConfigIfNeeded } from "../config/generator.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
 import {
-  buildHudWatchCommand,
   createHudWatchPane as createSharedHudWatchPane,
   killTmuxPane as killSharedTmuxPane,
   listCurrentWindowHudPaneIds,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -84,6 +84,7 @@ import { codexConfigPath, rememberOmxLaunchContext, resolveOmxEntryPath } from "
 import { repairConfigIfNeeded } from "../config/generator.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../hud/constants.js";
 import {
+  buildHudWatchCommand,
   createHudWatchPane as createSharedHudWatchPane,
   killTmuxPane as killSharedTmuxPane,
   listCurrentWindowHudPaneIds,
@@ -2381,7 +2382,7 @@ function runCodex(
   }
   const hudCmd = nativeWindows
     ? buildWindowsPromptCommand("node", [omxBin, "hud", "--watch"])
-    : buildTmuxPaneCommand("node", [omxBin, "hud", "--watch"]);
+    : buildTmuxPaneCommand("env", [`OMX_SESSION_ID=${sessionId}`, "node", omxBin, "hud", "--watch"]);
   const inheritLeaderFlags = process.env[TEAM_INHERIT_LEADER_FLAGS_ENV] !== "0";
   const workerLaunchArgs = resolveTeamWorkerLaunchArgsEnv(
     process.env[TEAM_WORKER_LAUNCH_ARGS_ENV],

--- a/src/hud/__tests__/hud-tmux-injection.test.ts
+++ b/src/hud/__tests__/hud-tmux-injection.test.ts
@@ -193,4 +193,10 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
     assert.equal(cmd, "node '/usr/bin/omx.js' hud --watch");
     assert.ok(!cmd.includes('--preset='));
   });
+
+  it('prepends OMX_SESSION_ID when provided', () => {
+    const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', 'focused', 'sess-managed');
+    const cmd = args[6];
+    assert.equal(cmd, "OMX_SESSION_ID='sess-managed' node '/usr/bin/omx.js' hud --watch --preset=focused");
+  });
 });

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -373,6 +373,35 @@ describe('additional HUD mode state readers', () => {
       assert.deepEqual(state, { last_turn_at: 'canonical', turn_count: 3 });
     });
   });
+
+  it('prefers OMX_SESSION_ID over stale session.json for hud notify state', async () => {
+    await withTempRepo('omx-hud-notify-env-session-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const activeSessionId = 'sess-active';
+      const staleSessionId = 'sess-stale';
+      const activeDir = join(rootStateDir, 'sessions', activeSessionId);
+      const staleDir = join(rootStateDir, 'sessions', staleSessionId);
+      await mkdir(activeDir, { recursive: true });
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({
+        session_id: staleSessionId,
+        cwd: join(cwd, '..', 'other-worktree'),
+      }));
+      await writeFile(join(rootStateDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'root', turn_count: 99 }));
+      await writeFile(join(activeDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'active', turn_count: 5 }));
+      await writeFile(join(staleDir, 'hud-state.json'), JSON.stringify({ last_turn_at: 'stale', turn_count: 1 }));
+
+      const previousSessionId = process.env.OMX_SESSION_ID;
+      process.env.OMX_SESSION_ID = activeSessionId;
+      try {
+        const state = await readHudNotifyState(cwd);
+        assert.deepEqual(state, { last_turn_at: 'active', turn_count: 5 });
+      } finally {
+        if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
 });
 
 describe('readAllState canonical skill precedence', () => {
@@ -496,6 +525,91 @@ describe('readAllState canonical skill precedence', () => {
       const state = await readAllState(cwd);
       assert.equal(state.autoresearch, null);
       assert.deepEqual(state.team, { active: true, team_name: 'gamma', current_phase: 'running' });
+    });
+  });
+
+  it('binds canonical HUD state to OMX_SESSION_ID instead of stale session.json/root fallback', async () => {
+    await withTempRepo('omx-hud-canonical-env-session-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const activeSessionId = 'sess-active';
+      const staleSessionId = 'sess-stale';
+      const activeDir = join(rootStateDir, 'sessions', activeSessionId);
+      await mkdir(activeDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({
+        session_id: staleSessionId,
+        cwd: join(cwd, '..', 'other-worktree'),
+      }));
+      await writeFile(join(rootStateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        iteration: 9,
+        max_iterations: 10,
+        current_phase: 'stale-root',
+      }));
+      await writeFile(join(activeDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'team',
+        phase: 'running',
+        session_id: activeSessionId,
+        active_skills: [{ skill: 'team', phase: 'running', active: true, session_id: activeSessionId }],
+      }));
+      await writeFile(join(activeDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'env-authority',
+      }));
+
+      const previousSessionId = process.env.OMX_SESSION_ID;
+      process.env.OMX_SESSION_ID = activeSessionId;
+      try {
+        const state = await readAllState(cwd);
+        assert.equal(state.session, null);
+        assert.equal(state.ralph, null);
+        assert.deepEqual(state.team, {
+          active: true,
+          team_name: 'env-authority',
+          current_phase: 'running',
+        });
+        assert.equal(state.hudNotify, null);
+      } finally {
+        if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
+  it('preserves root fallback when no usable session or OMX_SESSION_ID exists', async () => {
+    await withTempRepo('omx-hud-canonical-root-fallback-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      await mkdir(rootStateDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({
+        session_id: 'sess-stale',
+        cwd: join(cwd, '..', 'other-worktree'),
+      }));
+      await writeFile(join(rootStateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        iteration: 4,
+        max_iterations: 10,
+        current_phase: 'executing',
+      }));
+      await writeFile(join(rootStateDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralph',
+        phase: 'executing',
+        active_skills: [{ skill: 'ralph', phase: 'executing', active: true }],
+      }));
+
+      const previousSessionId = process.env.OMX_SESSION_ID;
+      delete process.env.OMX_SESSION_ID;
+      try {
+        const state = await readAllState(cwd);
+        assert.deepEqual(state.ralph, {
+          active: true,
+          iteration: 4,
+          max_iterations: 10,
+          current_phase: 'executing',
+        });
+      } finally {
+        if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      }
     });
   });
 });

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -255,11 +255,14 @@ export function buildTmuxSplitArgs(
   cwd: string,
   omxBin: string,
   preset?: string,
+  sessionId?: string,
 ): string[] {
   // Defense-in-depth: keep preset constrained even if this helper is reused.
   const safePreset = parseHudPreset(preset);
   const presetArg = safePreset ? ` --preset=${safePreset}` : '';
-  const cmd = `node ${shellEscape(omxBin)} hud --watch${presetArg}`;
+  const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+  const sessionPrefix = safeSessionId ? `OMX_SESSION_ID=${shellEscape(safeSessionId)} ` : '';
+  const cmd = `${sessionPrefix}node ${shellEscape(omxBin)} hud --watch${presetArg}`;
   return ['split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES), '-c', cwd, cmd];
 }
 
@@ -275,7 +278,7 @@ async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
     console.error('Failed to resolve OMX launcher path for tmux HUD startup.');
     process.exit(1);
   }
-  const args = buildTmuxSplitArgs(cwd, omxBin, flags.preset);
+  const args = buildTmuxSplitArgs(cwd, omxBin, flags.preset, process.env.OMX_SESSION_ID);
 
   try {
     // Split bottom pane, 4 lines tall, running omx hud --watch.

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -79,7 +79,7 @@ export async function reconcileHudForPromptSubmit(
   const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
   const hudConfig = await readHudConfigFn(cwd).catch(() => null);
   const preset = hudConfig?.preset;
-  const hudCmd = buildHudWatchCommand(omxBin, preset);
+  const hudCmd = buildHudWatchCommand(omxBin, preset, env.OMX_SESSION_ID?.trim() || undefined);
 
   if (hudPaneIds.length === 1) {
     const resized = resizePane(hudPaneIds[0], desiredHeight);

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -13,7 +13,7 @@ import { omxStateDir } from '../utils/paths.js';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
-import { getReadScopedStateFilePaths, getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { getReadScopedStateFilePaths, getReadScopedStatePaths, readCurrentSessionId } from '../mcp/state-paths.js';
 import { readUsableSessionState } from '../hooks/session.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import type {
@@ -46,9 +46,9 @@ async function readJsonFile<T>(path: string): Promise<T | null> {
 
 async function readSessionAwareModeState<T>(cwd: string, mode: string): Promise<T | null> {
   const candidates = await getReadScopedStatePaths(mode, cwd);
-  const session = await readSessionState(cwd);
+  const sessionId = await readCurrentSessionId(cwd);
 
-  if (session?.session_id) {
+  if (sessionId) {
     if (candidates.length === 0) return null;
     return readJsonFile<T>(candidates[0]);
   }
@@ -353,12 +353,13 @@ function mergePhase<T extends { active?: boolean; current_phase?: string }>(
 export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFAULT_HUD_CONFIG): Promise<HudRenderContext> {
   const version = readVersion();
   const gitBranch = buildGitBranchLabel(cwd, config);
-  const [metrics, hudNotify, session] = await Promise.all([
+  const [metrics, hudNotify, session, currentSessionId] = await Promise.all([
     readMetrics(cwd),
     readHudNotifyState(cwd),
     readSessionState(cwd),
+    readCurrentSessionId(cwd),
   ]);
-  const canonicalSkillState = await readVisibleSkillActiveState(cwd, session?.session_id);
+  const canonicalSkillState = await readVisibleSkillActiveState(cwd, currentSessionId);
   const canonicalSkills = new Map(
     listActiveSkills(canonicalSkillState).map((entry) => [entry.skill, entry] as const),
   );

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -61,11 +61,13 @@ export function shellEscapeSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-export function buildHudWatchCommand(omxBin: string, preset?: string): string {
+export function buildHudWatchCommand(omxBin: string, preset?: string, sessionId?: string): string {
   const safePreset = preset === 'minimal' || preset === 'focused' || preset === 'full'
     ? ` --preset=${preset}`
     : '';
-  return `node ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
+  const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+  const sessionPrefix = safeSessionId ? `OMX_SESSION_ID=${shellEscapeSingle(safeSessionId)} ` : '';
+  return `${sessionPrefix}node ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
 }
 
 export function listCurrentWindowPanes(

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -11,6 +11,7 @@ import {
   getAllSessionScopedStateDirs,
   getAllSessionScopedStatePaths,
   getReadScopedStateFilePaths,
+  readCurrentSessionId,
   resolveWorkingDirectoryForState,
   getStateDir,
   getStateFilePath,
@@ -222,6 +223,27 @@ describe('state paths', () => {
       });
       assert.deepEqual(paths, [join(stateDir, 'sessions', 'sess-current', 'hud-state.json')]);
     } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers OMX_SESSION_ID over stale session.json when resolving current session id', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-paths-'));
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    try {
+      const stateDir = getBaseStateDir(wd);
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(join(stateDir, 'sessions', 'sess-env'), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: 'sess-stale',
+        cwd: join(wd, '..', 'other-worktree'),
+      }));
+      process.env.OMX_SESSION_ID = 'sess-env';
+
+      assert.equal(await readCurrentSessionId(wd), 'sess-env');
+    } finally {
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
       await rm(wd, { recursive: true, force: true });
     }
   });

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -189,8 +189,25 @@ export interface ResolvedStateScope {
   stateDir: string;
 }
 
+function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const candidates = [env.OMX_SESSION_ID, env.CODEX_SESSION_ID, env.SESSION_ID];
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue;
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    return validateSessionId(trimmed);
+  }
+  return undefined;
+}
+
 export async function readCurrentSessionId(workingDirectory?: string): Promise<string | undefined> {
   const cwd = resolveWorkingDirectoryForState(workingDirectory);
+  const envSessionId = readSessionIdFromEnvironment();
+  if (envSessionId) {
+    const envScopedDir = getStateDir(cwd, envSessionId);
+    if (existsSync(envScopedDir)) return envSessionId;
+  }
+
   return (await readUsableSessionState(cwd))?.session_id;
 }
 


### PR DESCRIPTION
## Summary\n- prefer the live managed OMX session id when resolving HUD state paths\n- pass OMX_SESSION_ID into HUD watch launch commands so spawned HUD panes bind to the active session scope\n- add focused regression coverage for env-backed active-session precedence and preserved root fallback\n\n## Verification\n- npm run build\n- node --test dist/hud/__tests__/state.test.js dist/mcp/__tests__/state-paths.test.js dist/hud/__tests__/hud-tmux-injection.test.js dist/cli/__tests__/index.test.js\n- npx biome lint src/mcp/state-paths.ts src/mcp/__tests__/state-paths.test.ts src/hud/state.ts src/hud/tmux.ts src/hud/index.ts src/hud/reconcile.ts src/hud/__tests__/state.test.ts src/hud/__tests__/hud-tmux-injection.test.ts src/cli/__tests__/index.test.ts\n\n## Notes\n- follow-up structural debt: HUD/session authority still spans multiple readers; this keeps them aligned via readCurrentSessionId semantics without broader refactoring\n