### PR TITLE
Harden team startup against stale worktrees and truncated Codex ready screens

### DIFF
--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -352,6 +352,10 @@ describe('paneLooksReady', () => {
     );
   });
 
+  it('accepts MCP-startup-incomplete tails as ready when bootstrapping markers are gone', () => {
+    assert.equal(paneLooksReady('⚠ MCP startup incomplete (failed:'), true);
+  });
+
   it('accepts Codex welcome-screen suggestion rows with a prompt glyph', () => {
     assert.equal(paneLooksReady('› Explain this codebase'), true);
   });

--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -336,6 +336,22 @@ describe('paneLooksReady', () => {
     assert.equal(paneLooksReady('How can I help you today?'), true);
   });
 
+  it('accepts Codex welcome frames even when helper text is missing', () => {
+    assert.equal(
+      paneLooksReady(
+        '╭────────────────────────────────────────────╮\n'
+        + '│ >_ OpenAI Codex (v0.120.0)                 │\n'
+        + '│                                            │\n'
+        + '│ model:     gpt-5.4 high   /model to change │\n'
+        + '│ directory: ~/Workspace/demo                │\n'
+        + '╰────────────────────────────────────────────╯\n'
+        + '\n'
+        + '⚠ MCP startup incomplete',
+      ),
+      true,
+    );
+  });
+
   it('accepts Codex welcome-screen suggestion rows with a prompt glyph', () => {
     assert.equal(paneLooksReady('› Explain this codebase'), true);
   });

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -299,6 +299,9 @@ export function paneLooksReady(captured: any): boolean {
     && lines.some((line) => /directory:/i.test(line));
   if (hasCodexWelcomeFrame) return true;
 
+  const hasMcpStartupIncompleteTail = lines.some((line) => /MCP startup incomplete/i.test(line));
+  if (hasMcpStartupIncompleteTail) return true;
+
   return lines.some((line) => /^\s*(?:[›>❯]\s*)?[A-Z][A-Z0-9]+-\d+\s+only(?:\s*(?:…|\.{3}))?\s*$/iu.test(line));
 }
 

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -294,6 +294,11 @@ export function paneLooksReady(captured: any): boolean {
   const hasCodexWelcomePrompt = lines.some((line) => /\bhow can i help(?: you)?\b/i.test(line));
   if (hasCodexWelcomePrompt) return true;
 
+  const hasCodexWelcomeFrame = lines.some((line) => /OpenAI Codex/i.test(line))
+    && lines.some((line) => /model:/i.test(line))
+    && lines.some((line) => /directory:/i.test(line));
+  if (hasCodexWelcomeFrame) return true;
+
   return lines.some((line) => /^\s*(?:[›>❯]\s*)?[A-Z][A-Z0-9]+-\d+\s+only(?:\s*(?:…|\.{3}))?\s*$/iu.test(line));
 }
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1386,6 +1386,37 @@ esac
     );
   });
 
+  it('waitForWorkerReady accepts Codex 0.120.0-style welcome frames without helper text', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-worker-ready-frame-',
+      (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    cat <<'EOF'
+╭────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.120.0)                 │
+│                                            │
+│ model:     gpt-5.4 high   /model to change │
+│ directory: ~/Workspace/demo                │
+╰────────────────────────────────────────────╯
+
+⚠ MCP startup incomplete
+EOF
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async () => {
+        assert.equal(waitForWorkerReady('omx-team-x', 1, 1_000), true);
+      },
+    );
+  });
+
   it('waitForWorkerReady auto-accepts the Claude bypass prompt', async () => {
     await withMockTmuxFixture(
       'omx-tmux-claude-bypass-ready-',

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1417,6 +1417,46 @@ esac
     );
   });
 
+  it('waitForWorkerReady falls back to tailed capture when visible capture is not ready', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-worker-ready-tail-fallback-',
+      (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if printf '%s\n' "$*" | grep -q -- ' -S '; then
+      cat <<'EOF'
+╭────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.120.0)                 │
+│                                            │
+│ model:     gpt-5.4 high   /model to change │
+│ directory: ~/Workspace/demo                │
+╰────────────────────────────────────────────╯
+
+⚠ MCP startup incomplete
+EOF
+    else
+      cat <<'EOF'
+codex session metadata only
+EOF
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        assert.equal(waitForWorkerReady('omx-team-x', 1, 1_000), true);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /capture-pane -t omx-team-x:1 -p\b/);
+        assert.match(log, /capture-pane -t omx-team-x:1 -p -S -120/);
+      },
+    );
+  });
+
   it('waitForWorkerReady auto-accepts the Claude bypass prompt', async () => {
     await withMockTmuxFixture(
       'omx-tmux-claude-bypass-ready-',

--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -2,10 +2,11 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  assertCleanLeaderWorkspaceForWorkerWorktrees,
   parseWorktreeMode,
   planWorktreeTarget,
   ensureWorktree,
@@ -224,6 +225,37 @@ describe('worktree ensure + rollback', () => {
     }
   });
 
+  it('prunes stale missing worktree entries before attempting reuse', async () => {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'team',
+        mode: { enabled: true, detached: true, name: null },
+        teamName: 'alpha',
+        workerName: 'worker-1',
+      });
+      assert.equal(plan.enabled, true);
+      if (!plan.enabled) return;
+
+      const created = ensureWorktree(plan);
+      assert.equal(created.enabled, true);
+      if (!created.enabled) return;
+      assert.equal(created.created, true);
+
+      await rm(created.worktreePath, { recursive: true, force: true });
+      mkdirSync(join(repo, '.omx', 'team', 'alpha', 'worktrees'), { recursive: true });
+
+      const reused = ensureWorktree(plan);
+      assert.equal(reused.enabled, true);
+      if (!reused.enabled) return;
+      assert.equal(reused.created, true);
+      assert.equal(existsSync(reused.worktreePath), true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('preserves mismatch safety when existing alias points to a different branch', async () => {
     const repo = await initRepo();
     try {
@@ -298,6 +330,29 @@ describe('worktree ensure + rollback', () => {
       assert.equal(existsSync(ensured.worktreePath), false);
       // Branch is preserved when skipBranchDeletion is true (ralph policy)
       assert.equal(branchExists(repo, 'feature/ralph-keep'), true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores OMX-generated leader runtime artifacts during dirty-workspace preflight', async () => {
+    const repo = await initRepo();
+    try {
+      mkdirSync(join(repo, '.omx', 'state'), { recursive: true });
+      mkdirSync(join(repo, '.omx', 'logs'), { recursive: true });
+      await writeFile(join(repo, '.omx', 'state', 'leader-runtime-activity.json'), '{"ok":true}\n', 'utf-8');
+      await writeFile(join(repo, '.omx', 'state', 'team-state.json'), '{"ok":true}\n', 'utf-8');
+      await writeFile(join(repo, '.omx', 'state', 'notify-fallback-state.json'), '{"ok":true}\n', 'utf-8');
+      mkdirSync(join(repo, '.omx', 'state', 'team', 'demo'), { recursive: true });
+      await writeFile(join(repo, '.omx', 'state', 'team', 'demo', 'config.json'), '{"ok":true}\n', 'utf-8');
+      mkdirSync(join(repo, '.omx', 'team', 'demo', 'worktrees', 'worker-1'), { recursive: true });
+      await writeFile(join(repo, '.omx', 'team', 'demo', 'worktrees', 'worker-1', 'README.tmp'), 'ok\n', 'utf-8');
+      await writeFile(join(repo, '.omx', 'logs', 'team-dispatch-2026-04-13.jsonl'), '{}\n', 'utf-8');
+      await writeFile(join(repo, '.omx', 'logs', 'notify-fallback-2026-04-13.jsonl'), '{}\n', 'utf-8');
+      assert.doesNotThrow(() => assertCleanLeaderWorkspaceForWorkerWorktrees(repo));
+
+      await writeFile(join(repo, 'notes.txt'), 'user change\n', 'utf-8');
+      assert.throws(() => assertCleanLeaderWorkspaceForWorkerWorktrees(repo), /leader_workspace_dirty_for_worktrees/);
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1235,7 +1235,10 @@ export function waitForWorkerReady(
       blockedByTrustPrompt = true;
       return false;
     }
-    return paneLooksReady(result.stdout);
+    if (paneLooksReady(result.stdout)) return true;
+    const fallback = runTmux(sharedBuildCapturePaneArgv(target, 120));
+    if (!fallback.ok) return false;
+    return paneLooksReady(fallback.stdout);
   };
 
   let delayMs = initialBackoffMs;

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -119,6 +119,17 @@ function isWorktreeDirty(worktreePath: string): boolean {
   return (result.stdout || '').trim() !== '';
 }
 
+function shouldIgnoreLeaderWorkspaceStatusLine(line: string): boolean {
+  const normalized = line.trim();
+  if (normalized.length < 4) return false;
+  const pathText = normalized.slice(3).trim();
+  return /^\.omx\/state\/leader-runtime-activity\.json$/.test(pathText)
+    || /^\.omx\/state\/team-state\.json$/.test(pathText)
+    || /^\.omx\/state\/notify-fallback(?:-[^/]+)?(?:\.[^/]+)?$/.test(pathText)
+    || /^\.omx\/logs\/team-dispatch-\d{4}-\d{2}-\d{2}\.jsonl$/.test(pathText)
+    || /^\.omx\/logs\/notify-fallback-\d{4}-\d{2}-\d{2}\.jsonl$/.test(pathText);
+}
+
 export function readWorkspaceStatusLines(cwd: string): string[] {
   const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
     cwd,
@@ -131,7 +142,8 @@ export function readWorkspaceStatusLines(cwd: string): string[] {
   return (result.stdout || '')
     .split(/\r?\n/)
     .map((line) => line.trimEnd())
-    .filter(Boolean);
+    .filter(Boolean)
+    .filter((line) => !shouldIgnoreLeaderWorkspaceStatusLine(line));
 }
 
 export function assertCleanLeaderWorkspaceForWorkerWorktrees(cwd: string): void {
@@ -172,6 +184,16 @@ function listWorktrees(repoRoot: string): GitWorktreeEntry[] {
   }
 
   return entries;
+}
+
+function pruneWorktrees(repoRoot: string): void {
+  const result = spawnSync('git', ['worktree', 'prune'], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+  });
+  if (result.status === 0) return;
+  const stderr = (result.stderr || '').trim();
+  throw new Error(stderr || `worktree_prune_failed:${repoRoot}`);
 }
 
 function resolveBranchName(input: WorktreePlanInput): string | null {
@@ -349,7 +371,12 @@ export function planWorktreeTarget(input: WorktreePlanInput): PlannedWorktreeTar
 export function ensureWorktree(plan: PlannedWorktreeTarget | { enabled: false }): EnsureWorktreeResult | { enabled: false } {
   if (!plan.enabled) return { enabled: false };
 
-  const allWorktrees = listWorktrees(plan.repoRoot);
+  let allWorktrees = listWorktrees(plan.repoRoot);
+  const staleExistingAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath);
+  if (staleExistingAtPath && !existsSync(plan.worktreePath)) {
+    pruneWorktrees(plan.repoRoot);
+    allWorktrees = listWorktrees(plan.repoRoot);
+  }
   const existingAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath)
     ?? readWorktreeEntryFromPath(plan.repoRoot, plan.worktreePath);
   const expectedBranchRef = plan.branchName ? `refs/heads/${plan.branchName}` : null;

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -125,7 +125,9 @@ function shouldIgnoreLeaderWorkspaceStatusLine(line: string): boolean {
   const pathText = normalized.slice(3).trim();
   return /^\.omx\/state\/leader-runtime-activity\.json$/.test(pathText)
     || /^\.omx\/state\/team-state\.json$/.test(pathText)
+    || /^\.omx\/state\/team(?:\/|$)/.test(pathText)
     || /^\.omx\/state\/notify-fallback(?:-[^/]+)?(?:\.[^/]+)?$/.test(pathText)
+    || /^\.omx\/team(?:\/|$)/.test(pathText)
     || /^\.omx\/logs\/team-dispatch-\d{4}-\d{2}-\d{2}\.jsonl$/.test(pathText)
     || /^\.omx\/logs\/notify-fallback-\d{4}-\d{2}-\d{2}\.jsonl$/.test(pathText);
 }


### PR DESCRIPTION
## Summary

This PR hardens `omx team` startup in three places:

1. prune stale detached worktree registrations before trying to reuse worker worktree paths
2. ignore OMX-owned runtime artifacts in leader dirty-workspace preflight so retries do not self-block
3. accept newer Codex startup screens, including truncated welcome/MCP-warning tails, in worker readiness checks

## Why

This fixes the runtime failures described in:
- closes #1579

## Validation

- `npm run build`
- `node --test dist/team/__tests__/worktree.test.js dist/hooks/__tests__/tmux-hook-engine.test.js dist/team/__tests__/tmux-session.test.js`

## Notes

- branch source: `Shaojie66/oh-my-codex:codex/team-startup-hardening`
- write-access request is documented in #1579, but this PR is ready for fork-based review/merge too
