### PR TITLE
Fix stale detached worktree startup failure

### DIFF
--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -161,6 +161,35 @@ describe('worktree ensure + rollback', () => {
     }
   });
 
+  it('recreates a detached worktree when git worktree list still contains a missing stale path', async () => {
+    const repo = await initRepo();
+    try {
+      const planned = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: true, name: null },
+      });
+      assert.equal(planned.enabled, true);
+      if (!planned.enabled) return;
+
+      const created = ensureWorktree(planned);
+      assert.equal(created.enabled, true);
+      if (!created.enabled) return;
+
+      await rm(created.worktreePath, { recursive: true, force: true });
+      assert.equal(existsSync(created.worktreePath), false);
+
+      const recreated = ensureWorktree(planned);
+      assert.equal(recreated.enabled, true);
+      if (!recreated.enabled) return;
+      assert.equal(recreated.created, true);
+      assert.equal(recreated.reused, false);
+      assert.equal(existsSync(recreated.worktreePath), true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('creates per-worker named branch and blocks branch-in-use collisions', async () => {
     const repo = await initRepo();
     try {

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -189,6 +189,17 @@ function listWorktrees(repoRoot: string): GitWorktreeEntry[] {
   return entries;
 }
 
+function pruneStaleWorktreePath(repoRoot: string, worktreePath: string): void {
+  const result = spawnSync('git', ['worktree', 'prune'], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    windowsHide: true,
+  });
+  if (result.status === 0) return;
+  const stderr = (result.stderr || '').trim();
+  throw new Error(stderr || `worktree_prune_failed:${worktreePath}`);
+}
+
 function resolveBranchName(input: WorktreePlanInput): string | null {
   if (!input.mode.enabled || input.mode.detached) return null;
 
@@ -370,7 +381,12 @@ export function ensureWorktree(
 ): EnsureWorktreeResult | { enabled: false } {
   if (!plan.enabled) return { enabled: false };
 
-  const allWorktrees = listWorktrees(plan.repoRoot);
+  let allWorktrees = listWorktrees(plan.repoRoot);
+  const staleAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath);
+  if (staleAtPath && !existsSync(staleAtPath.path)) {
+    pruneStaleWorktreePath(plan.repoRoot, staleAtPath.path);
+    allWorktrees = listWorktrees(plan.repoRoot);
+  }
   const existingAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath)
     ?? readWorktreeEntryFromPath(plan.repoRoot, plan.worktreePath);
   const expectedBranchRef = plan.branchName ? `refs/heads/${plan.branchName}` : null;


### PR DESCRIPTION
## Summary
- prune a stale registered worktree when the target detached worktree path is missing on disk
- keep ensureWorktree behavior otherwise unchanged
- add a focused regression test covering missing-path entries from git worktree list

## Reproduction
- create a detached worktree via the existing ensureWorktree path
- delete that worktree directory without pruning it from git
- retry startup on the same detached worktree path
- before this fix, Git rejected worktree add because the missing path was still registered

## Verification
- npm run build
- node --test dist/team/__tests__/worktree.test.js
- npx biome lint src/team/worktree.ts src/team/__tests__/worktree.test.ts
- npx tsc --noEmit --pretty false --project tsconfig.json
