### PR TITLE
Restore native Stop permission-seeking auto-continue

### DIFF
--- a/src/hooks/__tests__/notify-hook-modules.test.ts
+++ b/src/hooks/__tests__/notify-hook-modules.test.ts
@@ -269,6 +269,13 @@ describe('notify-hook/auto-nudge – detectStallPattern', () => {
     assert.equal(detectStallPattern('Would you like me to proceed?', custom), false);
   });
 
+  it('keeps native Stop permission-seeking detection separate from default notify-hook detection', async () => {
+    const { detectStallPattern, detectNativeStopStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
+    const text = 'If you want, I can continue with the cleanup from here.';
+    assert.equal(detectStallPattern(text, DEFAULT_STALL_PATTERNS), false);
+    assert.equal(detectNativeStopStallPattern(text, DEFAULT_STALL_PATTERNS), true);
+  });
+
   it('ignores prior OMX injection lines so injected text cannot self-trigger detection', async () => {
     const { detectStallPattern, DEFAULT_STALL_PATTERNS } = await loadModule('notify-hook/auto-nudge.js');
     const text = 'Completed the change.\nyes, proceed [OMX_TMUX_INJECT]\nkeep going [OMX_TMUX_INJECT]';

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2929,7 +2929,7 @@ esac
     }
   });
 
-  it("does not auto-continue native Stop on permission-seeking prompts", async () => {
+  it("auto-continues native Stop on permission-seeking prompts", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-permission-"));
     try {
       await mkdir(join(cwd, ".omx", "state"), { recursive: true });
@@ -2946,7 +2946,42 @@ esac
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("auto-continues native Stop on \"if you want\" permission-seeking prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-if-you-want-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      process.env.OMX_SESSION_ID = "sess-stop-auto-if-you-want";
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-if-you-want",
+          last_assistant_message: "If you want, I can continue with the cleanup from here.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -27,7 +27,7 @@ import {
   type SkillActiveState,
 } from "../hooks/keyword-detector.js";
 import {
-  detectStallPattern,
+  detectNativeStopStallPattern,
   loadAutoNudgeConfig,
   normalizeAutoNudgeSignatureText,
   resolveEffectiveAutoNudgeResponse,
@@ -879,17 +879,36 @@ async function readStopAutoNudgePhase(
   sessionId: string,
   threadId: string,
 ): Promise<string> {
-  if (!sessionId.trim()) return "";
+  const normalizedSessionId = sessionId.trim();
+  if (normalizedSessionId) {
+    const scopedModeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, normalizedSessionId);
+    if (
+      scopedModeState?.active === true
+      && safeString(scopedModeState.current_phase).trim().toLowerCase() === "intent-first"
+    ) {
+      return "planning";
+    }
+  } else {
+    const rootModeState = await readJsonIfExists(join(cwd, ".omx", "state", "deep-interview-state.json"));
+    if (
+      rootModeState?.active === true
+      && safeString(rootModeState.current_phase).trim().toLowerCase() === "intent-first"
+    ) {
+      return "planning";
+    }
+  }
 
-  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+  if (!normalizedSessionId) return "";
+
+  const canonicalState = await readVisibleSkillActiveState(cwd, normalizedSessionId);
   const visibleEntries = canonicalState ? listActiveSkills(canonicalState) : [];
   const deepInterview = visibleEntries.find((entry) => (
     entry.skill === "deep-interview"
-    && matchesSkillStopContext(entry, canonicalState ?? {}, sessionId, threadId)
+    && matchesSkillStopContext(entry, canonicalState ?? {}, normalizedSessionId, threadId)
   ));
   if (!deepInterview) return "";
 
-  const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId);
+  const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, normalizedSessionId);
   if (!modeState || modeState.active !== true) return "";
 
   const modePhase = safeString(modeState.current_phase).trim().toLowerCase();
@@ -1300,7 +1319,7 @@ async function buildStopHookOutput(
 
     if (
       autoNudgeConfig.enabled
-      && detectStallPattern(lastAssistantMessage, autoNudgeConfig.patterns, autoNudgePhase)
+      && detectNativeStopStallPattern(lastAssistantMessage, autoNudgeConfig.patterns, autoNudgePhase)
     ) {
       const effectiveResponse = resolveEffectiveAutoNudgeResponse(autoNudgeConfig.response);
       return await maybeReturnRepeatableStopOutput(

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -429,16 +429,26 @@ async function localTmuxInjectionDisabled(cwd) {
   return tmuxHookExplicitlyDisablesInjection(raw);
 }
 
-export function detectStallPattern(text, patterns, currentPhase = '') {
+function detectStallPatternWithOptions(text, patterns, currentPhase = '', options = {}) {
   if (!text || typeof text !== 'string') return false;
   const normalized = normalizeStallDetectionText(text);
   if (!normalized) return false;
   const normalizedPatterns = normalizePatternList(patterns);
   if (!matchesNormalizedPatterns(normalized, normalizedPatterns)) return false;
   if (!usesDefaultStallPatterns(patterns)) return true;
-  if (looksLikePermissionSeekingContinuation(normalized)) return false;
+  if (options.allowPermissionSeeking !== true && looksLikePermissionSeekingContinuation(normalized)) return false;
   if (safeString(currentPhase).trim().toLowerCase() === 'planning') return false;
   return !looksLikePlanningOnlyContinuation(normalized);
+}
+
+export function detectStallPattern(text, patterns, currentPhase = '') {
+  return detectStallPatternWithOptions(text, patterns, currentPhase);
+}
+
+export function detectNativeStopStallPattern(text, patterns, currentPhase = '') {
+  return detectStallPatternWithOptions(text, patterns, currentPhase, {
+    allowPermissionSeeking: true,
+  });
 }
 
 export async function capturePane(paneId, lines = 10) {


### PR DESCRIPTION
## Summary

Issue #1584 regressed native Stop auto-continue for permission-seeking handoffs because the Stop hook now reused the shared notify-hook default stall detector, which intentionally excludes phrases like `if you want`. This change restores that detection only for native Stop while keeping default notify-hook behavior unchanged.

## Changes

- add an explicit native-Stop-only stall detection helper in `src/scripts/notify-hook/auto-nudge.ts`
- switch `src/scripts/codex-native-hook.ts` to use the native-only helper and preserve intent-first deep-interview suppression from scoped/root mode state
- update focused regressions in `src/scripts/__tests__/codex-native-hook.test.ts`
- add module-level coverage proving native Stop can match permission-seeking prompts while default notify-hook detection still excludes them

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/notify-hook-modules.test.js dist/hooks/__tests__/notify-hook-regression-205.test.js`
- [x] `./node_modules/.bin/biome lint src/scripts/notify-hook/auto-nudge.ts src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts src/hooks/__tests__/notify-hook-modules.test.ts src/hooks/__tests__/notify-hook-regression-205.test.ts`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1584
