### PR TITLE
Fix tmux Ralph nudge authority drift against canonical session state

### DIFF
--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -170,6 +170,132 @@ exit 1
     });
   });
 
+  it('does not revive a legacy root Ralph fallback when canonical skill state excludes Ralph', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const sessionId = 'omx-abc123';
+      const sessionStateDir = join(stateDir, 'sessions', sessionId);
+      const configPath = join(omxDir, 'tmux-hook.json');
+      const hookStatePath = join(stateDir, 'tmux-hook-state.json');
+      const sessionStatePath = join(stateDir, 'session.json');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const managedSessionName = buildTmuxSessionName(cwd, sessionId);
+
+      await mkdir(sessionStateDir, { recursive: true });
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeManagedSessionState(stateDir, cwd, sessionId);
+      const canonicalSessionState = JSON.parse(await readFile(sessionStatePath, 'utf-8')) as Record<string, unknown>;
+      await writeJson(join(stateDir, 'ralph-state.json'), { active: true, iteration: 0, tmux_pane_id: '%42' });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [
+          { skill: 'ralplan', phase: 'planning', active: true, session_id: sessionId },
+        ],
+      });
+      await writeJson(configPath, {
+        enabled: true,
+        target: { type: 'pane', value: '%42' },
+        allowed_modes: ['ralph'],
+        cooldown_ms: 0,
+        max_injections_per_session: 10,
+        prompt_template: 'Continue [OMX_TMUX_INJECT]',
+        marker: '[OMX_TMUX_INJECT]',
+        dry_run: false,
+        log_level: 'debug',
+      });
+
+      const fakeTmux = `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  if [[ "$format" == "#{pane_id}" && "$target" == "%42" ]]; then
+    echo "%42"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_command}" && "$target" == "%42" ]]; then
+    echo "codex"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_start_command}" && "$target" == "%42" ]]; then
+    echo "codex --model gpt-5"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_current_path}" && "$target" == "%42" ]]; then
+    echo "${cwd}"
+    exit 0
+  fi
+  if [[ "$format" == "#{pane_in_mode}" && "$target" == "%42" ]]; then
+    echo "0"
+    exit 0
+  fi
+  if [[ "$format" == "#S" && "$target" == "%42" ]]; then
+    echo "${managedSessionName}"
+    exit 0
+  fi
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+echo "unsupported tmux call: $cmd $*" >&2
+exit 1
+`;
+      await writeFile(fakeTmuxPath, fakeTmux);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        session_id: sessionId,
+        'thread-id': 'thread-test-canonical-excludes-ralph',
+        'turn-id': 'turn-test-canonical-excludes-ralph',
+        'input-messages': ['no marker here'],
+        'last-assistant-message': 'output',
+      };
+
+      const previousPath = process.env.PATH;
+      const previousTeamWorker = process.env.OMX_TEAM_WORKER;
+      try {
+        process.env.PATH = `${fakeBinDir}:${process.env.PATH || ''}`;
+        process.env.OMX_TEAM_WORKER = '';
+        await handleTmuxInjection({ payload, cwd, stateDir, logsDir });
+      } finally {
+        if (typeof previousPath === 'string') process.env.PATH = previousPath;
+        else delete process.env.PATH;
+        if (typeof previousTeamWorker === 'string') process.env.OMX_TEAM_WORKER = previousTeamWorker;
+        else delete process.env.OMX_TEAM_WORKER;
+      }
+
+      const hookState = await readJson<Record<string, unknown>>(hookStatePath);
+      assert.equal(hookState.total_injections, 0);
+      assert.equal(hookState.last_reason, 'mode_not_allowed');
+      const persistedSessionState = JSON.parse(await readFile(sessionStatePath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(persistedSessionState.session_id, canonicalSessionState.session_id);
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8').catch(() => '');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l/, 'legacy root Ralph state should not trigger a Ralph nudge when canonical skill state excludes Ralph');
+    });
+  });
+
   it('falls back to current tmux pane and heals stale session target', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -14,12 +14,14 @@ import {
   normalizeTmuxState,
   pruneRecentKeys,
   getScopedStateDirsForCurrentSession,
+  readCurrentSessionId,
   readdir,
 } from './state-io.js';
 import { runProcess } from './process-runner.js';
 import { logTmuxHookEvent } from './log.js';
-import { resolveManagedCurrentPane, resolveManagedSessionContext, verifyManagedPaneTarget } from './managed-tmux.js';
+import { resolveInvocationSessionId, resolveManagedCurrentPane, resolveManagedSessionContext, verifyManagedPaneTarget } from './managed-tmux.js';
 import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
+import { listActiveSkills, readVisibleSkillActiveState } from '../../state/skill-active.js';
 import {
   normalizeTmuxHookConfig,
   pickActiveMode,
@@ -114,6 +116,58 @@ async function resolvePreferredModePane(stateDir: string, allowedModes: string[]
     }
   }
   return null;
+}
+
+async function readVisibleAllowedModes(
+  cwd: string,
+  stateDir: string,
+  payload: any,
+  allowedModes: string[],
+): Promise<{ canonicalPresent: boolean; allowedSet: Set<string> | null; preferredMode: string | null }> {
+  const candidateSessionIds = [
+    await readCurrentSessionId(stateDir).catch(() => undefined),
+    resolveInvocationSessionId(payload),
+  ]
+    .map((value) => safeString(value).trim())
+    .filter(Boolean);
+
+  for (const sessionId of candidateSessionIds) {
+    const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+    if (!canonicalState) continue;
+
+    const allowedSet = new Set(
+      listActiveSkills(canonicalState)
+        .map((entry) => entry.skill)
+        .filter((skill) => allowedModes.includes(skill)),
+    );
+    return {
+      canonicalPresent: true,
+      allowedSet,
+      preferredMode: pickActiveMode([...allowedSet], allowedModes),
+    };
+  }
+
+  if (candidateSessionIds.length === 0) {
+    const rootCanonicalState = await readVisibleSkillActiveState(cwd).catch(() => null);
+    if (rootCanonicalState) {
+      const allowedSet = new Set(
+        listActiveSkills(rootCanonicalState)
+          .map((entry) => entry.skill)
+          .filter((skill) => allowedModes.includes(skill)),
+      );
+      return {
+        canonicalPresent: true,
+        allowedSet,
+        preferredMode: pickActiveMode([...allowedSet], allowedModes),
+      };
+    }
+  }
+
+  return {
+    canonicalPresent: false,
+    allowedSet: null,
+    preferredMode: null,
+  };
 }
 
 export async function resolveSessionToPane(sessionName: any): Promise<string | null> {
@@ -266,6 +320,34 @@ export async function handleTmuxInjection({
   const sourceText = inputMessages.join('\n');
   const state = normalizeTmuxState(await readJsonIfExists(hookStatePath, null));
   state.recent_keys = pruneRecentKeys(state.recent_keys, now);
+  const canonicalModeState = await readVisibleAllowedModes(cwd, stateDir, payload, config.allowed_modes).catch(() => ({
+    canonicalPresent: false,
+    allowedSet: null,
+    preferredMode: null,
+  }));
+  if (canonicalModeState.canonicalPresent && !canonicalModeState.preferredMode) {
+    const nextState = {
+      ...state,
+      last_reason: 'mode_not_allowed',
+      last_event_at: nowIso,
+    };
+    await writeFile(hookStatePath, JSON.stringify(nextState, null, 2)).catch(() => {});
+    if (config.enabled || config.log_level === 'debug') {
+      await logTmuxHookEvent(logsDir, {
+        timestamp: nowIso,
+        type: 'tmux_hook',
+        mode: null,
+        reason: 'mode_not_allowed',
+        turn_id: turnId,
+        thread_id: threadId,
+        target: config.target,
+        dry_run: config.dry_run,
+        sent: false,
+        event: 'injection_skipped',
+      });
+    }
+    return;
+  }
 
   const activeModes: string[] = [];
   const activeModeStates: Record<string, any> = {};
@@ -283,6 +365,7 @@ export async function handleTmuxInjection({
         const parsed = JSON.parse(await readFile(path, 'utf-8'));
         if (parsed && parsed.active) {
           const modeName = file.replace('-state.json', '');
+          if (canonicalModeState.allowedSet && !canonicalModeState.allowedSet.has(modeName)) continue;
           activeModes.push(modeName);
           if (!preserveExisting || !activeModeStates[modeName]) {
             activeModeStates[modeName] = parsed;
@@ -302,8 +385,15 @@ export async function handleTmuxInjection({
     // Non-fatal
   }
 
-  const preferredModePane = await resolvePreferredModePane(stateDir, config.allowed_modes).catch(() => null);
-  const mode = preferredModePane?.mode || pickActiveMode(activeModes, config.allowed_modes);
+  const preferredModePane = await resolvePreferredModePane(
+    stateDir,
+    canonicalModeState.canonicalPresent
+      ? (canonicalModeState.preferredMode ? [canonicalModeState.preferredMode] : [])
+      : config.allowed_modes,
+  ).catch(() => null);
+  const mode = canonicalModeState.canonicalPresent
+    ? canonicalModeState.preferredMode
+    : (preferredModePane?.mode || pickActiveMode(activeModes, config.allowed_modes));
   const modeState = preferredModePane?.state || (mode ? (activeModeStates[mode] || {}) : {});
   const modePane = preferredModePane?.pane || safeString(modeState.tmux_pane_id || '');
   const preGuard = evaluateInjectionGuards({


### PR DESCRIPTION
## Summary
- gate tmux notify-hook mode selection through canonical visible skill-active state when it exists
- fail closed with `mode_not_allowed` when canonical session state excludes all allowed modes, instead of reviving root Ralph state
- add a focused regression proving root `ralph-state.json` no longer triggers a Ralph nudge when session canonical state exposes only `ralplan`

## Reproduction
- on clean current `dev`, add the new `notify-hook-tmux-heal` regression only
- build and run `node --test dist/hooks/__tests__/notify-hook-tmux-heal.test.js`
- observe the new case fail with `1 !== 0` because tmux injection still sends a Ralph nudge from legacy root state even though canonical session skill state excludes Ralph

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/notify-hook-tmux-heal.test.js dist/hooks/__tests__/notify-hook-session-scope.test.js dist/hooks/__tests__/tmux-hook-engine.test.js`
- `npx biome lint src/scripts/notify-hook/tmux-injection.ts src/hooks/__tests__/notify-hook-tmux-heal.test.ts`
- changed-file `tsc --noEmit` via LSP diagnostics on touched files
