### PR TITLE
Lock #1492 queued Codex startup behavior behind regression coverage

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -523,6 +523,59 @@ esac
       },
     );
   });
+
+  it('fails closed when the visible queued-next-tool-call banner never clears after the final submit round', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-codex-stuck-queued-submit-',
+      (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")"
+text_sent_file="$state_dir/text-sent"
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if printf '%s\n' "$*" | grep -q -- ' -S -80'; then
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    else
+      if [ -f "$text_sent_file" ]; then
+        cat <<'EOF'
+${QUEUED_AFTER_TOOL_CALL_CAPTURE}
+EOF
+      else
+        cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+      fi
+    fi
+    exit 0
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "check inbox" ]; then
+      : > "$text_sent_file"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        await assert.rejects(
+          () => sendToWorker('omx-team-x', 1, 'check inbox'),
+          /submit_queued_after_tool_call/,
+        );
+        const log = await readFile(logPath, 'utf-8');
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        assert.ok(
+          enterCount >= 4,
+          `expected repeated submit nudges before failing closed on stuck queued banner:\n${log}`,
+        );
+      },
+    );
+  });
 });
 
 describe('shouldAttemptAdaptiveRetry', () => {


### PR DESCRIPTION
## Summary
- add focused tmux-session coverage for the Codex queued-next-tool-call startup shape from #1492
- prove OMX fails closed when the visible queued banner never clears after the final submit round
- leave runtime and notify-hook logic untouched because current `dev` already carries the production fixes from #1491 and #1493

## Root cause / current-dev status
While investigating issue #1492 on current `dev` (HEAD `adec5ad1` on April 14, 2026), I confirmed the original production bug is already fixed in two merged slices:
1. PR #1491 hardened interactive Codex startup against queued startup drafts / stale scrollback
2. PR #1493 hardened notify-hook dispatch draining so slow tmux injection no longer wedges later mailbox delivery on the global dispatch lock

That means the smallest contract-safe follow-up on current `dev` is to lock the startup-side queued-banner contract behind direct regression coverage instead of re-editing runtime behavior that is already present.

## Verification
- `npm run build`
- `node --test dist/team/__tests__/tmux-session.test.js`
- `node --test dist/hooks/__tests__/notify-hook-team-dispatch.test.js`
- `npx biome lint src/team/__tests__/tmux-session.test.ts`

## Notes
- I intentionally did **not** touch runtime or dispatch production code in this PR.
- `dist/team/__tests__/runtime.test.js` remains a long-running file under filtered `node --test`; I used the narrower changed-path suites that directly cover the #1492 startup and dispatch contracts.