### PR TITLE
Fix MCP duplicate self-teardown after resume/reconcile

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -209,7 +209,7 @@ describe('mcp duplicate sibling detection', () => {
     );
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 40_500, 1_000, 10_000),
-      true,
+      false,
     );
   });
 

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -16,7 +16,6 @@ const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
 const PARENT_WATCHDOG_INTERVAL_MS = 25;
 const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
 const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
-const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 30_000;
 const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 
 interface StdioLifecycleServer {
@@ -159,7 +158,6 @@ export function shouldSelfExitForDuplicateSibling(
   duplicateObservedAtMs: number | null,
   lastTrafficAtMs: number | null,
   preTrafficGraceMs = DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
-  postTrafficIdleMs = DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
 ): boolean {
   if (observation.status !== 'older_duplicate') {
     return false;
@@ -171,13 +169,7 @@ export function shouldSelfExitForDuplicateSibling(
   if (lastTrafficAtMs === null) {
     return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
   }
-
-  if (!Number.isFinite(lastTrafficAtMs) || lastTrafficAtMs > nowMs) {
-    return false;
-  }
-
-  const safeIdleAnchorMs = Math.max(lastTrafficAtMs, duplicateObservedAtMs);
-  return nowMs - safeIdleAnchorMs >= postTrafficIdleMs;
+  return false;
 }
 
 export function isParentProcessAlive(
@@ -266,10 +258,7 @@ export function autoStartStdioMcpServer(
         return;
       }
 
-      const reason = lastTrafficAtMs === null
-        ? 'superseded_duplicate_before_traffic'
-        : 'superseded_duplicate_idle';
-      void shutdown(reason);
+      void shutdown('superseded_duplicate_before_traffic');
     }, DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS)
     : null;
   duplicateSiblingWatchdog?.unref();

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -352,4 +352,55 @@ describe('state operations directory initialization', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('keeps session-scoped tracked state writable after root-state parse fallback on resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-resume-root-fallback-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-resume-root-fallback';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(
+        join(stateDir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          current_phase: 'executing',
+          owner_omx_session_id: 'stale-root-owner',
+        }, null, 2),
+      );
+      await writeFile(
+        join(sessionDir, 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          current_phase: 'executing',
+          owner_omx_session_id: sessionId,
+        }, null, 2),
+      );
+
+      const writeResult = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        state: {
+          current_phase: 'verify',
+        },
+      });
+
+      assert.equal(writeResult.isError, undefined);
+      const sessionState = JSON.parse(
+        await readFile(join(sessionDir, 'ralph-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(sessionState.active, true);
+      assert.equal(sessionState.current_phase, 'verifying');
+      assert.equal(sessionState.owner_omx_session_id, sessionId);
+
+      const rootState = JSON.parse(
+        await readFile(join(stateDir, 'ralph-state.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      assert.equal(rootState.current_phase, 'executing');
+      assert.equal(rootState.owner_omx_session_id, 'stale-root-owner');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- keep duplicate stdio MCP self-teardown limited to the pre-traffic window in shared bootstrap lifecycle logic
- add bootstrap regression coverage proving an older duplicate no longer self-exits after it has handled traffic
- add state operation regression coverage for resumed session-scoped writes after root-state fallback

## Verification
- npm run build
- node --test dist/mcp/__tests__/bootstrap.test.js dist/state/__tests__/operations.test.js
- npx biome lint src/mcp/bootstrap.ts src/mcp/__tests__/bootstrap.test.ts src/state/__tests__/operations.test.ts
- npx tsc --noEmit --pretty false

Fixes #1594