### PR TITLE
feat: add Hermes adapt follow-on

### DIFF
--- a/docs/adapt.md
+++ b/docs/adapt.md
@@ -21,6 +21,13 @@ Current targets:
 - `openclaw`
 - `hermes`
 
+Hermes follow-on behavior in this worktree:
+
+- `probe` inspects external Hermes ACP, gateway, and session-store evidence
+- `status` synthesizes `unavailable` / `installed` / `degraded` / `running` from observable Hermes files only
+- `envelope` includes Hermes bootstrap metadata for ACP commands, lifecycle bridge guidance, and status commands
+- `init --write` still writes only under `.omx/adapters/hermes/...`; Hermes runtime files remain read-only inputs
+
 Examples:
 
 ```bash
@@ -39,4 +46,4 @@ Foundation constraints:
 - OpenClaw status is local evidence only; it does not claim downstream runtime acknowledgement or execution
 - command-gateway readiness still requires `OMX_OPENCLAW_COMMAND=1`
 
-Hermes-specific probe/integration logic remains deferred.
+Hermes-specific evidence discovery uses `HERMES_HOME` plus an overrideable Hermes source root (`OMX_ADAPT_HERMES_ROOT`) so OMX can inspect an external runtime without vendoring or mutating it.

--- a/src/adapt/__tests__/foundation.test.ts
+++ b/src/adapt/__tests__/foundation.test.ts
@@ -163,16 +163,16 @@ describe("adapt foundation", () => {
 		assert.equal(existsSync(paths.envelopePath), true);
 		assert.equal(existsSync(join(tempDir, ".omx", "state")), false);
 
-	const envelope = JSON.parse(readFileSync(paths.envelopePath, "utf-8")) as {
-		target: string;
-		openclaw?: {
-			observedState: string;
-			hooks: Array<{ event: string; status: string }>;
+		const envelope = JSON.parse(readFileSync(paths.envelopePath, "utf-8")) as {
+			target: string;
+			openclaw?: {
+				observedState: string;
+				hooks: Array<{ event: string; status: string }>;
 			};
 		};
-	assert.equal(envelope.target, "openclaw");
-	assert.equal(envelope.openclaw?.observedState, "configured");
-	assert.equal(envelope.openclaw?.hooks[0]?.event, "session-start");
+		assert.equal(envelope.target, "openclaw");
+		assert.equal(envelope.openclaw?.observedState, "configured");
+		assert.equal(envelope.openclaw?.hooks[0]?.event, "session-start");
 	});
 
 	it("OpenClaw probe degrades gracefully when env/config evidence is absent", () => {
@@ -265,7 +265,10 @@ describe("adapt foundation", () => {
 		);
 		assert.equal(doctor.issues[0]?.code, "adapter_not_initialized");
 		assert.match(doctor.nextSteps.join("\n"), /init --write/i);
-		assert.match(doctor.nextSteps.join("\n"), /follow-on PR/i);
+		assert.match(
+			doctor.nextSteps.join("\n"),
+			/Hermes adapter reads external ACP, gateway, and session-store evidence/i,
+		);
 	});
 
 	it("rejects inherited prototype-like targets during validation", () => {

--- a/src/adapt/__tests__/hermes.test.ts
+++ b/src/adapt/__tests__/hermes.test.ts
@@ -15,6 +15,10 @@ import {
 let tempDir: string;
 let hermesRoot: string;
 let hermesHome: string;
+let processCwdFixtureBase: string;
+let processCwdFixtureRoot: string;
+let suppliedCwd: string;
+let originalCwd: string;
 const originalEnv = {
   root: process.env.OMX_ADAPT_HERMES_ROOT,
   home: process.env.HERMES_HOME,
@@ -73,8 +77,17 @@ function writeHermesFixture(options: {
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "omx-adapt-hermes-"));
+  suppliedCwd = join(tempDir, "sandbox", "worktree");
   hermesRoot = join(tempDir, "hermes-runtime");
   hermesHome = join(tempDir, "hermes-home");
+  originalCwd = process.cwd();
+  processCwdFixtureBase = await mkdtemp(join(tmpdir(), "omx-adapt-hermes-process-cwd-"));
+  processCwdFixtureRoot = join(
+    processCwdFixtureBase,
+    "hermes-codex-skill-omx-aware-prd",
+    "external",
+    "hermes-agent",
+  );
   process.env.OMX_ADAPT_HERMES_ROOT = hermesRoot;
   process.env.HERMES_HOME = hermesHome;
 });
@@ -92,6 +105,12 @@ afterEach(async () => {
     process.env.HERMES_HOME = originalEnv.home;
   }
 
+  process.chdir(originalCwd);
+
+  if (processCwdFixtureBase && existsSync(processCwdFixtureBase)) {
+    await rm(processCwdFixtureBase, { recursive: true, force: true });
+  }
+
   if (tempDir && existsSync(tempDir)) {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -106,6 +125,31 @@ describe("hermes adapter integration", () => {
     assert.equal(probe.targetRuntime.state, "unavailable");
     assert.equal(status.targetRuntime.state, "unavailable");
     assert.match(doctor.issues.map((issue) => issue.code).join(","), /hermes_runtime_missing/);
+  });
+
+  it("anchors sibling-default Hermes discovery to the supplied cwd for programmatic probes", async () => {
+    delete process.env.OMX_ADAPT_HERMES_ROOT;
+    delete process.env.HERMES_HOME;
+
+    mkdirSync(join(processCwdFixtureRoot, "acp_adapter"), { recursive: true });
+    writeFileSync(join(processCwdFixtureRoot, "acp_adapter", "server.py"), "# unrelated sibling runtime\n");
+    const unrelatedProcessCwd = join(processCwdFixtureBase, "workspace");
+    mkdirSync(unrelatedProcessCwd, { recursive: true });
+    process.chdir(unrelatedProcessCwd);
+
+    const tempSiblingRoot = join(
+      suppliedCwd,
+      "..",
+      "hermes-codex-skill-omx-aware-prd",
+      "external",
+      "hermes-agent",
+    );
+    const probe = await buildAdaptProbeReportForTarget(suppliedCwd, "hermes", new Date("2026-04-14T00:00:00.000Z"));
+
+    assert.equal(probe.targetRuntime.state, "unavailable");
+    assert.equal(probe.targetRuntime.evidence?.hermesRoot, tempSiblingRoot);
+    assert.notEqual(probe.targetRuntime.evidence?.hermesRoot, processCwdFixtureRoot);
+    assert.match(probe.targetRuntime.detail, new RegExp(tempSiblingRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   });
 
   it("reports Hermes capability evidence asymmetrically in the envelope", async () => {

--- a/src/adapt/__tests__/hermes.test.ts
+++ b/src/adapt/__tests__/hermes.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildAdaptDoctorReportForTarget,
+  buildAdaptEnvelopeForTarget,
+  buildAdaptProbeReportForTarget,
+  buildAdaptStatusReportForTarget,
+  initAdaptFoundationForTarget,
+} from "../index.js";
+
+let tempDir: string;
+let hermesRoot: string;
+let hermesHome: string;
+const originalEnv = {
+  root: process.env.OMX_ADAPT_HERMES_ROOT,
+  home: process.env.HERMES_HOME,
+};
+
+function writeHermesFixture(options: {
+  withRoot?: boolean;
+  withGatewayRuntime?: boolean;
+  withStateDb?: boolean;
+} = {}): void {
+  const {
+    withRoot = true,
+    withGatewayRuntime = false,
+    withStateDb = false,
+  } = options;
+
+  if (withRoot) {
+    mkdirSync(join(hermesRoot, "acp_adapter"), { recursive: true });
+    mkdirSync(join(hermesRoot, "gateway"), { recursive: true });
+    mkdirSync(join(hermesRoot, "docs"), { recursive: true });
+    mkdirSync(join(hermesRoot, "acp_registry"), { recursive: true });
+    writeFileSync(join(hermesRoot, "acp_adapter", "server.py"), "# acp server\n");
+    writeFileSync(join(hermesRoot, "acp_adapter", "session.py"), "# acp session\n");
+    writeFileSync(join(hermesRoot, "acp_adapter", "events.py"), "# acp events\n");
+    writeFileSync(join(hermesRoot, "acp_adapter", "entry.py"), "# acp entry\n");
+    writeFileSync(join(hermesRoot, "gateway", "status.py"), "# gateway status\n");
+    writeFileSync(join(hermesRoot, "gateway", "hooks.py"), "# gateway hooks\n");
+    writeFileSync(join(hermesRoot, "docs", "acp-setup.md"), "# acp setup\n");
+    writeFileSync(join(hermesRoot, "hermes_state.py"), "# hermes state store\n");
+  }
+
+  if (withGatewayRuntime) {
+    mkdirSync(hermesHome, { recursive: true });
+    writeFileSync(
+      join(hermesHome, "gateway.pid"),
+      JSON.stringify({ pid: 1234, kind: "hermes-gateway", argv: ["hermes", "gateway"] }),
+    );
+    writeFileSync(
+      join(hermesHome, "gateway_state.json"),
+      JSON.stringify({
+        gateway_state: "running",
+        active_agents: 2,
+        updated_at: "2026-04-14T14:00:00.000Z",
+        platforms: {
+          telegram: { state: "connected", updated_at: "2026-04-14T14:00:00.000Z" },
+        },
+      }),
+    );
+  }
+
+  if (withStateDb) {
+    mkdirSync(hermesHome, { recursive: true });
+    writeFileSync(join(hermesHome, "state.db"), "SQLite format 3\u0000 sessions messages");
+  }
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "omx-adapt-hermes-"));
+  hermesRoot = join(tempDir, "hermes-runtime");
+  hermesHome = join(tempDir, "hermes-home");
+  process.env.OMX_ADAPT_HERMES_ROOT = hermesRoot;
+  process.env.HERMES_HOME = hermesHome;
+});
+
+afterEach(async () => {
+  if (originalEnv.root === undefined) {
+    delete process.env.OMX_ADAPT_HERMES_ROOT;
+  } else {
+    process.env.OMX_ADAPT_HERMES_ROOT = originalEnv.root;
+  }
+
+  if (originalEnv.home === undefined) {
+    delete process.env.HERMES_HOME;
+  } else {
+    process.env.HERMES_HOME = originalEnv.home;
+  }
+
+  if (tempDir && existsSync(tempDir)) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("hermes adapter integration", () => {
+  it("degrades gracefully when Hermes runtime evidence is absent", async () => {
+    const probe = await buildAdaptProbeReportForTarget(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
+    const status = await buildAdaptStatusReportForTarget(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
+    const doctor = await buildAdaptDoctorReportForTarget(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
+
+    assert.equal(probe.targetRuntime.state, "unavailable");
+    assert.equal(status.targetRuntime.state, "unavailable");
+    assert.match(doctor.issues.map((issue) => issue.code).join(","), /hermes_runtime_missing/);
+  });
+
+  it("reports Hermes capability evidence asymmetrically in the envelope", async () => {
+    writeHermesFixture({ withRoot: true, withStateDb: true });
+    const envelope = await buildAdaptEnvelopeForTarget(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
+
+    assert.equal(envelope.targetRuntime?.state, "degraded");
+    assert.ok(envelope.bootstrap);
+    assert.match(envelope.bootstrap?.summary ?? "", /bootstrap metadata/i);
+    assert.deepEqual(
+      [...new Set(envelope.capabilities.map((capability) => capability.ownership))].sort(),
+      ["omx-owned", "shared-contract", "target-observed"],
+    );
+    assert.equal(
+      envelope.capabilities.find((capability) => capability.id === "persistent-session-observation")?.status,
+      "ready",
+    );
+    assert.equal(
+      envelope.capabilities.find((capability) => capability.id === "acp-envelope-bridge")?.status,
+      "ready",
+    );
+  });
+
+  it("synthesizes running status from Hermes gateway and session-store evidence", async () => {
+    writeHermesFixture({ withRoot: true, withGatewayRuntime: true, withStateDb: true });
+    const status = await buildAdaptStatusReportForTarget(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
+
+    assert.equal(status.targetRuntime.state, "running");
+    assert.match(status.targetRuntime.detail, /connected platforms: telegram/i);
+  });
+
+  it("keeps Hermes init writes inside OMX-owned adapter paths", async () => {
+    writeHermesFixture({ withRoot: true, withGatewayRuntime: true, withStateDb: true });
+    const result = await initAdaptFoundationForTarget(tempDir, "hermes", true, new Date("2026-04-14T00:00:00.000Z"));
+
+    assert.equal(result.write, true);
+    assert.equal(result.wrotePaths.length, 2);
+    assert.equal(existsSync(join(tempDir, ".omx", "state")), false);
+    assert.equal(existsSync(join(hermesHome, "gateway_state.json")), true);
+    assert.equal(existsSync(join(hermesHome, "state.db")), true);
+
+    const persistedEnvelope = JSON.parse(readFileSync(result.envelope.adapterPaths.envelopePath, "utf-8")) as {
+      targetRuntime?: { state?: string };
+      bootstrap?: { commands?: string[] };
+    };
+    assert.equal(persistedEnvelope.targetRuntime?.state, "running");
+    assert.ok((persistedEnvelope.bootstrap?.commands ?? []).includes("hermes acp"));
+  });
+});

--- a/src/adapt/contracts.ts
+++ b/src/adapt/contracts.ts
@@ -113,7 +113,22 @@ export interface AdaptEnvelope {
 	planning: AdaptPlanningLink;
 	capabilities: AdaptCapabilityReport[];
 	constraints: string[];
+	targetRuntime?: AdaptRuntimeObservation;
+	bootstrap?: AdaptBootstrapMetadata;
 	openclaw?: AdaptOpenClawMetadata;
+}
+
+export interface AdaptRuntimeObservation {
+	state: string;
+	detail: string;
+	evidence?: Record<string, unknown>;
+}
+
+export interface AdaptBootstrapMetadata {
+	summary: string;
+	eventBridge: string[];
+	commands: string[];
+	nextSteps: string[];
 }
 
 export interface AdaptProbeReport {
@@ -125,10 +140,7 @@ export interface AdaptProbeReport {
 	adapterPaths: AdaptPathSet;
 	planning: AdaptPlanningLink;
 	capabilities: AdaptCapabilityReport[];
-	targetRuntime: {
-		state: "not-implemented";
-		detail: string;
-	};
+	targetRuntime: AdaptRuntimeObservation;
 	openclaw?: AdaptOpenClawMetadata;
 	nextSteps: string[];
 }
@@ -145,10 +157,7 @@ export interface AdaptStatusReport {
 		configPath: string;
 		envelopePath: string;
 	};
-	targetRuntime: {
-		state: "unknown";
-		detail: string;
-	};
+	targetRuntime: AdaptRuntimeObservation;
 	planning: AdaptPlanningLink;
 	capabilities: AdaptCapabilityReport[];
 	openclaw?: AdaptOpenClawMetadata;

--- a/src/adapt/hermes.ts
+++ b/src/adapt/hermes.ts
@@ -11,14 +11,6 @@ import {
   type AdaptStatusReport,
 } from "./contracts.js";
 
-const DEFAULT_HERMES_SIBLING_ROOT = resolve(
-  process.cwd(),
-  "..",
-  "hermes-codex-skill-omx-aware-prd",
-  "external",
-  "hermes-agent",
-);
-
 const HERMES_HOME_ENV = "HERMES_HOME";
 const HERMES_ROOT_ENV = "OMX_ADAPT_HERMES_ROOT";
 const HERMES_BOOTSTRAP_ENV = "OMX_ADAPT_HERMES_BOOTSTRAP";
@@ -126,26 +118,40 @@ function safeJsonParse<T>(raw: string): T | null {
   }
 }
 
-function resolveHermesRoot(): { path: string; source: "override" | "sibling-default" } {
+function resolveRelativeToCwd(cwd: string, pathValue: string): string {
+  return isAbsolute(pathValue) ? pathValue : resolve(cwd, pathValue);
+}
+
+function resolveDefaultHermesSiblingRoot(cwd: string): string {
+  return resolve(
+    cwd,
+    "..",
+    "hermes-codex-skill-omx-aware-prd",
+    "external",
+    "hermes-agent",
+  );
+}
+
+function resolveHermesRoot(cwd: string): { path: string; source: "override" | "sibling-default" } {
   const override = process.env[HERMES_ROOT_ENV]?.trim();
   if (override) {
     return {
-      path: isAbsolute(override) ? override : resolve(process.cwd(), override),
+      path: resolveRelativeToCwd(cwd, override),
       source: "override",
     };
   }
 
   return {
-    path: DEFAULT_HERMES_SIBLING_ROOT,
+    path: resolveDefaultHermesSiblingRoot(cwd),
     source: "sibling-default",
   };
 }
 
-function resolveHermesHome(): { path: string; source: "env" | "default" } {
+function resolveHermesHome(cwd: string): { path: string; source: "env" | "default" } {
   const envValue = process.env[HERMES_HOME_ENV]?.trim();
   if (envValue) {
     return {
-      path: isAbsolute(envValue) ? envValue : resolve(process.cwd(), envValue),
+      path: resolveRelativeToCwd(cwd, envValue),
       source: "env",
     };
   }
@@ -235,9 +241,9 @@ function inferGatewayLive(
   return { live, stale };
 }
 
-export async function collectHermesEvidence(): Promise<HermesEvidence> {
-  const hermesRoot = resolveHermesRoot();
-  const hermesHome = resolveHermesHome();
+export async function collectHermesEvidence(cwd = process.cwd()): Promise<HermesEvidence> {
+  const hermesRoot = resolveHermesRoot(cwd);
+  const hermesHome = resolveHermesHome(cwd);
   const sourceAcp = collectPathEvidence(hermesRoot.path, ACP_ENTRYPOINTS);
   const sourceGateway = collectPathEvidence(hermesRoot.path, GATEWAY_ENTRYPOINTS);
   const sourceDocs = collectPathEvidence(hermesRoot.path, DOC_ENTRYPOINTS);

--- a/src/adapt/hermes.ts
+++ b/src/adapt/hermes.ts
@@ -1,0 +1,507 @@
+import { existsSync, readFileSync } from "node:fs";
+import { access, constants, open } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, resolve } from "node:path";
+import {
+  type AdaptBootstrapMetadata,
+  type AdaptCapabilityReport,
+  type AdaptEnvelope,
+  type AdaptProbeReport,
+  type AdaptRuntimeObservation,
+  type AdaptStatusReport,
+} from "./contracts.js";
+
+const DEFAULT_HERMES_SIBLING_ROOT = resolve(
+  process.cwd(),
+  "..",
+  "hermes-codex-skill-omx-aware-prd",
+  "external",
+  "hermes-agent",
+);
+
+const HERMES_HOME_ENV = "HERMES_HOME";
+const HERMES_ROOT_ENV = "OMX_ADAPT_HERMES_ROOT";
+const HERMES_BOOTSTRAP_ENV = "OMX_ADAPT_HERMES_BOOTSTRAP";
+const HERMES_DEFAULT_HOME = join(homedir(), ".hermes");
+const ACP_COMMANDS = ["hermes acp", "hermes-acp", "python -m acp_adapter"];
+const STATUS_COMMANDS = [
+  "hermes gateway status",
+  "hermes sessions list --source acp",
+];
+const ACP_ENTRYPOINTS = [
+  "acp_adapter/server.py",
+  "acp_adapter/session.py",
+  "acp_adapter/events.py",
+  "acp_adapter/entry.py",
+];
+const GATEWAY_ENTRYPOINTS = [
+  "gateway/status.py",
+  "gateway/hooks.py",
+];
+const DOC_ENTRYPOINTS = [
+  "docs/acp-setup.md",
+];
+
+interface HermesGatewayRuntimeFile {
+  gateway_state?: string;
+  exit_reason?: string | null;
+  restart_requested?: boolean;
+  active_agents?: number;
+  updated_at?: string;
+  platforms?: Record<string, {
+    state?: string;
+    error_code?: string | null;
+    error_message?: string | null;
+    updated_at?: string;
+  }>;
+  [key: string]: unknown;
+}
+
+interface HermesPidRecord {
+  pid?: number;
+  kind?: string;
+  argv?: string[];
+  start_time?: number;
+  [key: string]: unknown;
+}
+
+interface HermesEvidence {
+  hermesRoot: string;
+  hermesHome: string;
+  sources: {
+    root: "override" | "sibling-default";
+    home: "env" | "default";
+  };
+  sourceRuntime: {
+    present: boolean;
+    acp: {
+      present: boolean;
+      files: string[];
+      missing: string[];
+    };
+    gateway: {
+      present: boolean;
+      files: string[];
+      missing: string[];
+    };
+    docs: {
+      present: boolean;
+      files: string[];
+      missing: string[];
+    };
+    stateStore: {
+      present: boolean;
+      path: string;
+    };
+    acpRegistry: {
+      present: boolean;
+      path: string;
+    };
+  };
+  installed: boolean;
+  runtimeFiles: {
+    gatewayPidPath: string;
+    gatewayStatePath: string;
+    stateDbPath: string;
+    gatewayPidReadable: boolean;
+    gatewayStateReadable: boolean;
+    stateDbReadable: boolean;
+    stateDbExists: boolean;
+  };
+  gateway: {
+    pidRecord: HermesPidRecord | null;
+    runtimeRecord: HermesGatewayRuntimeFile | null;
+    live: boolean;
+    connectedPlatforms: string[];
+    stale: boolean;
+  };
+  resumable: boolean;
+}
+
+function safeJsonParse<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function resolveHermesRoot(): { path: string; source: "override" | "sibling-default" } {
+  const override = process.env[HERMES_ROOT_ENV]?.trim();
+  if (override) {
+    return {
+      path: isAbsolute(override) ? override : resolve(process.cwd(), override),
+      source: "override",
+    };
+  }
+
+  return {
+    path: DEFAULT_HERMES_SIBLING_ROOT,
+    source: "sibling-default",
+  };
+}
+
+function resolveHermesHome(): { path: string; source: "env" | "default" } {
+  const envValue = process.env[HERMES_HOME_ENV]?.trim();
+  if (envValue) {
+    return {
+      path: isAbsolute(envValue) ? envValue : resolve(process.cwd(), envValue),
+      source: "env",
+    };
+  }
+
+  return {
+    path: HERMES_DEFAULT_HOME,
+    source: "default",
+  };
+}
+
+function collectPathEvidence(root: string, relativePaths: readonly string[]) {
+  const present: string[] = [];
+  const missing: string[] = [];
+
+  for (const relativePath of relativePaths) {
+    const candidate = join(root, relativePath);
+    if (existsSync(candidate)) {
+      present.push(candidate);
+    } else {
+      missing.push(candidate);
+    }
+  }
+
+  return {
+    present: present.length > 0,
+    files: present,
+    missing,
+  };
+}
+
+async function isReadable(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile<T>(path: string): Promise<T | null> {
+  try {
+    const raw = await access(path, constants.R_OK).then(() => readFileSync(path, "utf-8"));
+    return safeJsonParse<T>(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function sqliteHasTable(path: string, table: string): Promise<boolean> {
+  if (!existsSync(path)) return false;
+  let handle;
+  try {
+    handle = await open(path, "r");
+    const buffer = Buffer.alloc(256);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const text = buffer.subarray(0, bytesRead).toString("utf-8");
+    return text.includes(table);
+  } catch {
+    return false;
+  } finally {
+    await handle?.close();
+  }
+}
+
+function extractConnectedPlatforms(runtime: HermesGatewayRuntimeFile | null): string[] {
+  if (!runtime?.platforms || typeof runtime.platforms !== "object") {
+    return [];
+  }
+
+  return Object.entries(runtime.platforms)
+    .filter(([, platform]) => platform?.state === "connected")
+    .map(([name]) => name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function inferGatewayLive(
+  pidRecord: HermesPidRecord | null,
+  runtimeRecord: HermesGatewayRuntimeFile | null,
+): { live: boolean; stale: boolean } {
+  const gatewayState = typeof runtimeRecord?.gateway_state === "string"
+    ? runtimeRecord.gateway_state
+    : null;
+  const runningState = gatewayState === "starting" || gatewayState === "running" || gatewayState === "draining";
+  const pidPresent = Number.isFinite(pidRecord?.pid);
+  const live = Boolean(pidPresent && runningState);
+  const stale = Boolean(pidPresent && gatewayState && !runningState);
+  return { live, stale };
+}
+
+export async function collectHermesEvidence(): Promise<HermesEvidence> {
+  const hermesRoot = resolveHermesRoot();
+  const hermesHome = resolveHermesHome();
+  const sourceAcp = collectPathEvidence(hermesRoot.path, ACP_ENTRYPOINTS);
+  const sourceGateway = collectPathEvidence(hermesRoot.path, GATEWAY_ENTRYPOINTS);
+  const sourceDocs = collectPathEvidence(hermesRoot.path, DOC_ENTRYPOINTS);
+  const stateStorePath = join(hermesRoot.path, "hermes_state.py");
+  const acpRegistryPath = join(hermesRoot.path, "acp_registry");
+  const gatewayPidPath = join(hermesHome.path, "gateway.pid");
+  const gatewayStatePath = join(hermesHome.path, "gateway_state.json");
+  const stateDbPath = join(hermesHome.path, "state.db");
+
+  const [
+    gatewayPidReadable,
+    gatewayStateReadable,
+    stateDbReadable,
+    pidRecord,
+    runtimeRecord,
+    sessionsTablePresent,
+  ] = await Promise.all([
+    isReadable(gatewayPidPath),
+    isReadable(gatewayStatePath),
+    isReadable(stateDbPath),
+    readJsonFile<HermesPidRecord>(gatewayPidPath),
+    readJsonFile<HermesGatewayRuntimeFile>(gatewayStatePath),
+    sqliteHasTable(stateDbPath, "sessions"),
+  ]);
+
+  const connectedPlatforms = extractConnectedPlatforms(runtimeRecord);
+  const gatewayLiveness = inferGatewayLive(pidRecord, runtimeRecord);
+  const installed = sourceAcp.present || sourceGateway.present || existsSync(stateStorePath);
+  const resumable = stateDbReadable && sessionsTablePresent;
+
+  return {
+    hermesRoot: hermesRoot.path,
+    hermesHome: hermesHome.path,
+    sources: {
+      root: hermesRoot.source,
+      home: hermesHome.source,
+    },
+    sourceRuntime: {
+      present: installed,
+      acp: sourceAcp,
+      gateway: sourceGateway,
+      docs: sourceDocs,
+      stateStore: {
+        present: existsSync(stateStorePath),
+        path: stateStorePath,
+      },
+      acpRegistry: {
+        present: existsSync(acpRegistryPath),
+        path: acpRegistryPath,
+      },
+    },
+    installed,
+    runtimeFiles: {
+      gatewayPidPath,
+      gatewayStatePath,
+      stateDbPath,
+      gatewayPidReadable,
+      gatewayStateReadable,
+      stateDbReadable,
+      stateDbExists: existsSync(stateDbPath),
+    },
+    gateway: {
+      pidRecord,
+      runtimeRecord,
+      live: gatewayLiveness.live,
+      connectedPlatforms,
+      stale: gatewayLiveness.stale,
+    },
+    resumable,
+  };
+}
+
+export function buildHermesCapabilityOverrides(
+  capabilities: AdaptCapabilityReport[],
+  evidence: HermesEvidence,
+): AdaptCapabilityReport[] {
+  return capabilities.map((capability) => {
+    if (capability.id === "persistent-session-observation") {
+      return {
+        ...capability,
+        status: evidence.runtimeFiles.stateDbReadable ? "ready" : evidence.installed ? "stub" : "unsupported",
+        summary: evidence.runtimeFiles.stateDbReadable
+          ? `Hermes session-store evidence is readable at ${evidence.runtimeFiles.stateDbPath}.`
+          : evidence.installed
+            ? "Hermes source/runtime surfaces are present, but no readable session store was detected yet."
+            : "Hermes external runtime was not detected from the configured root/home paths.",
+      };
+    }
+
+    if (capability.id === "acp-envelope-bridge") {
+      return {
+        ...capability,
+        status: evidence.sourceRuntime.acp.present ? "ready" : evidence.installed ? "stub" : "unsupported",
+        summary: evidence.sourceRuntime.acp.present
+          ? "Envelope/bootstrap metadata now includes Hermes ACP entrypoints, commands, and bridge guidance."
+          : evidence.installed
+            ? "Hermes root is partially present, but ACP entrypoints were not fully detected."
+            : "No Hermes ACP entrypoints were detected from the configured root.",
+      };
+    }
+
+    return capability;
+  });
+}
+
+export function buildHermesBootstrapMetadata(evidence: HermesEvidence): AdaptBootstrapMetadata {
+  const commands = [
+    ...ACP_COMMANDS,
+    ...STATUS_COMMANDS,
+  ];
+
+  const nextSteps = [
+    `Set ${HERMES_HOME_ENV} to the Hermes profile home you want OMX to observe.`,
+    `Run ${ACP_COMMANDS[0]} from ${evidence.hermesRoot} when validating ACP availability.`,
+    `Use ${STATUS_COMMANDS[0]} to confirm gateway status outside OMX if the runtime evidence looks stale.`,
+  ];
+
+  if (process.env[HERMES_BOOTSTRAP_ENV]?.trim()) {
+    nextSteps.unshift(`Bootstrap override detected via ${HERMES_BOOTSTRAP_ENV}; keep Hermes-side reads pointed at OMX-owned adapter artifacts only.`);
+  }
+
+  return {
+    summary: "Hermes bootstrap metadata maps OMX lifecycle intent into ACP and gateway guidance without claiming direct control over Hermes internals.",
+    eventBridge: [
+      "session-start -> session:start",
+      "session-end -> session:end",
+      "session-idle -> agent:end",
+      "ask-user-question -> agent:step",
+      "stop -> session:end",
+      "gateway-startup -> gateway:startup",
+    ],
+    commands,
+    nextSteps,
+  };
+}
+
+export function buildHermesRuntimeObservation(evidence: HermesEvidence): AdaptRuntimeObservation {
+  if (!evidence.installed) {
+    return {
+      state: "unavailable",
+      detail: `Hermes external runtime was not detected under ${evidence.hermesRoot}.`,
+      evidence: {
+        hermesRoot: evidence.hermesRoot,
+        expectedAcpEntry: join(evidence.hermesRoot, ACP_ENTRYPOINTS[0]),
+        expectedGatewayEntry: join(evidence.hermesRoot, GATEWAY_ENTRYPOINTS[0]),
+        hermesHome: evidence.hermesHome,
+      },
+    };
+  }
+
+  if (evidence.gateway.live) {
+    return {
+      state: "running",
+      detail: evidence.gateway.connectedPlatforms.length > 0
+        ? `Hermes gateway appears live with connected platforms: ${evidence.gateway.connectedPlatforms.join(", ")}.`
+        : "Hermes gateway appears live from PID/status evidence, but no connected platforms were reported.",
+      evidence: {
+        hermesRoot: evidence.hermesRoot,
+        hermesHome: evidence.hermesHome,
+        gatewayState: evidence.gateway.runtimeRecord?.gateway_state ?? null,
+        connectedPlatforms: evidence.gateway.connectedPlatforms,
+        gatewayStatePath: evidence.runtimeFiles.gatewayStatePath,
+        gatewayPidPath: evidence.runtimeFiles.gatewayPidPath,
+        stateDbPath: evidence.runtimeFiles.stateDbPath,
+        resumable: evidence.resumable,
+      },
+    };
+  }
+
+  if (evidence.runtimeFiles.gatewayStateReadable || evidence.runtimeFiles.gatewayPidReadable || evidence.runtimeFiles.stateDbReadable) {
+    const reasons: string[] = [];
+    if (evidence.runtimeFiles.gatewayStateReadable) {
+      reasons.push(`gateway status readable (${basename(evidence.runtimeFiles.gatewayStatePath)})`);
+    }
+    if (evidence.runtimeFiles.gatewayPidReadable) {
+      reasons.push(`gateway pid readable (${basename(evidence.runtimeFiles.gatewayPidPath)})`);
+    }
+    if (evidence.runtimeFiles.stateDbReadable) {
+      reasons.push(`session store readable (${basename(evidence.runtimeFiles.stateDbPath)})`);
+    }
+    if (evidence.gateway.stale) {
+      reasons.push("gateway state appears stale/non-running");
+    }
+
+    return {
+      state: "degraded",
+      detail: `Hermes runtime evidence is present but not currently live: ${reasons.join("; ")}.`,
+      evidence: {
+        hermesRoot: evidence.hermesRoot,
+        hermesHome: evidence.hermesHome,
+        gatewayState: evidence.gateway.runtimeRecord?.gateway_state ?? null,
+        exitReason: evidence.gateway.runtimeRecord?.exit_reason ?? null,
+        connectedPlatforms: evidence.gateway.connectedPlatforms,
+        stateDbPath: evidence.runtimeFiles.stateDbPath,
+        resumable: evidence.resumable,
+      },
+    };
+  }
+
+  return {
+    state: "installed",
+    detail: "Hermes source surfaces were detected, but no readable runtime state files were found yet.",
+    evidence: {
+      hermesRoot: evidence.hermesRoot,
+      hermesHome: evidence.hermesHome,
+      acpFiles: evidence.sourceRuntime.acp.files,
+      gatewayFiles: evidence.sourceRuntime.gateway.files,
+      docs: evidence.sourceRuntime.docs.files,
+      stateStoreSource: evidence.sourceRuntime.stateStore.present,
+      acpRegistry: evidence.sourceRuntime.acpRegistry.present,
+    },
+  };
+}
+
+export function applyHermesEnvelope(
+  envelope: AdaptEnvelope,
+  evidence: HermesEvidence,
+): AdaptEnvelope {
+  return {
+    ...envelope,
+    capabilities: buildHermesCapabilityOverrides(envelope.capabilities, evidence),
+    targetRuntime: buildHermesRuntimeObservation(evidence),
+    bootstrap: buildHermesBootstrapMetadata(evidence),
+  };
+}
+
+export function applyHermesProbe(
+  report: AdaptProbeReport,
+  evidence: HermesEvidence,
+): AdaptProbeReport {
+  const nextSteps = [
+    ...report.nextSteps.filter((step) => !/follow-on PR/i.test(step)),
+    `Inspect Hermes root at ${evidence.hermesRoot}.`,
+    `Inspect Hermes home at ${evidence.hermesHome}.`,
+  ];
+
+  if (!evidence.installed) {
+    nextSteps.push(`If Hermes lives elsewhere, set ${HERMES_ROOT_ENV} and rerun the probe.`);
+  } else if (!evidence.runtimeFiles.stateDbReadable) {
+    nextSteps.push(`Ensure ${HERMES_HOME_ENV} points at the Hermes profile whose state.db OMX should inspect.`);
+  }
+
+  return {
+    ...report,
+    summary: "Hermes probe inspected ACP, gateway, and session-store evidence from the external runtime.",
+    capabilities: buildHermesCapabilityOverrides(report.capabilities, evidence),
+    targetRuntime: buildHermesRuntimeObservation(evidence),
+    nextSteps,
+  };
+}
+
+export function applyHermesStatus(
+  report: AdaptStatusReport,
+  evidence: HermesEvidence,
+): AdaptStatusReport {
+  const targetRuntime = buildHermesRuntimeObservation(evidence);
+  const summary = report.adapter.state === "initialized"
+    ? `Hermes adapter is initialized and ${targetRuntime.state === "running" ? "runtime evidence looks live." : "runtime evidence is available for inspection."}`
+    : `Hermes adapter is not initialized yet; runtime evidence is still ${targetRuntime.state}.`;
+
+  return {
+    ...report,
+    summary,
+    capabilities: buildHermesCapabilityOverrides(report.capabilities, evidence),
+    targetRuntime,
+  };
+}

--- a/src/adapt/index.ts
+++ b/src/adapt/index.ts
@@ -13,6 +13,14 @@ import {
 	type AdaptTarget,
 } from "./contracts.js";
 import {
+	applyHermesEnvelope,
+	applyHermesProbe,
+	applyHermesStatus,
+	buildHermesBootstrapMetadata,
+	buildHermesRuntimeObservation,
+	collectHermesEvidence,
+} from "./hermes.js";
+import {
 	buildOpenClawDoctorReport,
 	buildOpenClawEnvelope,
 	buildOpenClawProbeReport,
@@ -91,6 +99,19 @@ export function buildAdaptEnvelope(
 	};
 }
 
+export async function buildAdaptEnvelopeForTarget(
+	cwd: string,
+	target: AdaptTarget,
+	now = new Date(),
+): Promise<AdaptEnvelope> {
+	const envelope = buildAdaptEnvelope(cwd, target, now);
+	if (target !== "hermes") {
+		return envelope;
+	}
+
+	return applyHermesEnvelope(envelope, await collectHermesEvidence(cwd));
+}
+
 export function buildAdaptProbeReport(
 	cwd: string,
 	target: AdaptTarget,
@@ -131,6 +152,19 @@ export function buildAdaptProbeReport(
 			descriptor.followupHint,
 		],
 	};
+}
+
+export async function buildAdaptProbeReportForTarget(
+	cwd: string,
+	target: AdaptTarget,
+	now = new Date(),
+): Promise<AdaptProbeReport> {
+	const report = buildAdaptProbeReport(cwd, target, now);
+	if (target !== "hermes") {
+		return report;
+	}
+
+	return applyHermesProbe(report, await collectHermesEvidence(cwd));
 }
 
 export function buildAdaptStatusReport(
@@ -180,6 +214,19 @@ export function buildAdaptStatusReport(
 		planning,
 		capabilities: descriptor.capabilities,
 	};
+}
+
+export async function buildAdaptStatusReportForTarget(
+	cwd: string,
+	target: AdaptTarget,
+	now = new Date(),
+): Promise<AdaptStatusReport> {
+	const report = buildAdaptStatusReport(cwd, target, now);
+	if (target !== "hermes") {
+		return report;
+	}
+
+	return applyHermesStatus(report, await collectHermesEvidence(cwd));
 }
 
 export function buildAdaptDoctorReport(
@@ -235,6 +282,56 @@ export function buildAdaptDoctorReport(
 			`Run omx adapt ${target} init --write.`,
 			"Keep follow-on integration work out of .omx/state/... and target runtime internals unless a reviewed contract exists.",
 			descriptor.followupHint,
+		],
+	};
+}
+
+export async function buildAdaptDoctorReportForTarget(
+	cwd: string,
+	target: AdaptTarget,
+	now = new Date(),
+): Promise<AdaptDoctorReport> {
+	const report = buildAdaptDoctorReport(cwd, target, now);
+	if (target !== "hermes") {
+		return report;
+	}
+
+	const evidence = await collectHermesEvidence(cwd);
+	const runtime = buildHermesRuntimeObservation(evidence);
+	const bootstrap = buildHermesBootstrapMetadata(evidence);
+	const issues = report.issues.filter(
+		(issue) => issue.code !== "target_specific_logic_deferred",
+	);
+
+	if (!evidence.installed) {
+		issues.push({
+			code: "hermes_runtime_missing",
+			message: `Hermes external runtime was not detected under ${evidence.hermesRoot}.`,
+		});
+	} else if (!evidence.runtimeFiles.stateDbReadable) {
+		issues.push({
+			code: "hermes_session_store_unavailable",
+			message: `Hermes session store is not readable at ${evidence.runtimeFiles.stateDbPath}.`,
+		});
+	}
+
+	if (runtime.state === "degraded") {
+		issues.push({
+			code: "hermes_runtime_degraded",
+			message: runtime.detail,
+		});
+	}
+
+	return {
+		...report,
+		summary:
+			"Hermes doctor inspects external ACP, gateway, and session-store evidence plus OMX-owned adapter readiness.",
+		issues,
+		nextSteps: [
+			...bootstrap.nextSteps,
+			...report.nextSteps.filter(
+				(step) => !/follow-on integration gaps/i.test(step),
+			),
 		],
 	};
 }
@@ -310,5 +407,32 @@ export function initAdaptFoundation(
 		previewPaths,
 		wrotePaths,
 		envelope,
+	};
+}
+
+export async function initAdaptFoundationForTarget(
+	cwd: string,
+	target: AdaptTarget,
+	write = false,
+	now = new Date(),
+): Promise<AdaptInitResult> {
+	const result = initAdaptFoundation(cwd, target, write, now);
+	if (target !== "hermes") {
+		return result;
+	}
+
+	const evidence = await collectHermesEvidence(cwd);
+	const envelope = applyHermesEnvelope(result.envelope, evidence);
+	if (write) {
+		const paths = envelope.adapterPaths;
+		writeFileSync(paths.envelopePath, `${JSON.stringify(envelope, null, 2)}\n`, "utf-8");
+	}
+
+	return {
+		...result,
+		envelope,
+		summary: write
+			? "Hermes adapter metadata was written under OMX-owned paths with external runtime evidence."
+			: "Hermes adapter metadata preview includes external ACP/gateway/session-store evidence; rerun with --write to materialize it.",
 	};
 }

--- a/src/adapt/registry.ts
+++ b/src/adapt/registry.ts
@@ -77,7 +77,7 @@ const TARGET_DESCRIPTORS: Record<AdaptTarget, AdaptTargetDescriptor> = {
 		summary:
 			"Foundation seam for an OMX-owned adapter around Hermes ACP, gateway, and persistent-session surfaces.",
 		followupHint:
-			"Hermes-specific ACP probing, status synthesis, and path overrides land in a follow-on PR.",
+			"Hermes adapter reads external ACP, gateway, and session-store evidence while keeping all writes under .omx/adapters/hermes/.",
 		capabilities: [
 			...FOUNDATION_CAPABILITIES,
 			capability(
@@ -85,14 +85,14 @@ const TARGET_DESCRIPTORS: Record<AdaptTarget, AdaptTargetDescriptor> = {
 				"Persistent session observation",
 				"target-observed",
 				"stub",
-				"Foundation reports the seam only; it does not inspect Hermes runtime files or session stores yet.",
+				"Hermes session-store evidence is read from HERMES_HOME-scoped state.db when available.",
 			),
 			capability(
 				"acp-envelope-bridge",
 				"ACP envelope bridge",
 				"shared-contract",
 				"stub",
-				"Foundation reserves shared metadata exchange without claiming control over Hermes runtime internals.",
+				"Hermes envelope/bootstrap metadata maps OMX lifecycle intent into ACP and gateway guidance without claiming deep control.",
 			),
 		],
 	},

--- a/src/cli/adapt.ts
+++ b/src/cli/adapt.ts
@@ -4,11 +4,11 @@ import {
 	type AdaptTarget,
 } from "../adapt/contracts.js";
 import {
-	buildAdaptDoctorReport,
-	buildAdaptEnvelope,
-	buildAdaptProbeReport,
-	buildAdaptStatusReport,
-	initAdaptFoundation,
+	buildAdaptDoctorReportForTarget,
+	buildAdaptEnvelopeForTarget,
+	buildAdaptProbeReportForTarget,
+	buildAdaptStatusReportForTarget,
+	initAdaptFoundationForTarget,
 	supportedAdaptTargets,
 } from "../adapt/index.js";
 import { getAdaptTargetDescriptor } from "../adapt/registry.js";
@@ -49,10 +49,14 @@ function targetHelp(target: AdaptTarget): string {
 		"Notes:",
 		target === "openclaw"
 			? "  OpenClaw exposes local config/env/gateway observation and lifecycle bridge metadata."
-			: "  This PR exposes the shared foundation only.",
+			: target === "hermes"
+				? "  Hermes exposes a narrow probe/status/bootstrap integration over external ACP, gateway, and session-store evidence."
+				: "  This PR exposes the shared foundation only.",
 		target === "openclaw"
 			? "  Status remains local-only and does not claim downstream OpenClaw runtime acknowledgement."
-			: "  Target-specific runtime probing and integration logic are intentionally deferred.",
+			: target === "hermes"
+				? "  OMX remains authoritative for OMX state; Hermes internals are observed, not controlled."
+				: "  Target-specific runtime probing and integration logic are intentionally deferred.",
 		`  ${descriptor.followupHint}`,
 		"",
 		HELP,
@@ -160,19 +164,39 @@ export async function adaptCommand(
 
 	switch (subcommand as AdaptSubcommand) {
 		case "probe":
-			render(buildAdaptProbeReport(cwd, descriptor.target), json, stdout);
+			render(
+				await buildAdaptProbeReportForTarget(cwd, descriptor.target),
+				json,
+				stdout,
+			);
 			return;
 		case "status":
-			render(buildAdaptStatusReport(cwd, descriptor.target), json, stdout);
+			render(
+				await buildAdaptStatusReportForTarget(cwd, descriptor.target),
+				json,
+				stdout,
+			);
 			return;
 		case "init":
-			render(initAdaptFoundation(cwd, descriptor.target, write), json, stdout);
+			render(
+				await initAdaptFoundationForTarget(cwd, descriptor.target, write),
+				json,
+				stdout,
+			);
 			return;
 		case "envelope":
-			render(buildAdaptEnvelope(cwd, descriptor.target), json, stdout);
+			render(
+				await buildAdaptEnvelopeForTarget(cwd, descriptor.target),
+				json,
+				stdout,
+			);
 			return;
 		case "doctor":
-			render(buildAdaptDoctorReport(cwd, descriptor.target), json, stdout);
+			render(
+				await buildAdaptDoctorReportForTarget(cwd, descriptor.target),
+				json,
+				stdout,
+			);
 			return;
 	}
 }


### PR DESCRIPTION
## Summary
- add Hermes-specific adapt probe/status/envelope/bootstrap reporting on top of the shared adapt foundation
- keep the integration read-only and evidence-based around ACP, gateway, and session-store surfaces
- add Hermes-focused tests and docs updates

## Testing
- npm run build
- node --test dist/adapt/__tests__/foundation.test.js dist/adapt/__tests__/hermes.test.js dist/cli/__tests__/adapt.test.js dist/cli/__tests__/adapt-help.test.js
- node dist/cli/omx.js adapt hermes probe --json
- node dist/cli/omx.js adapt hermes status --json