### PR TITLE
feat: add OpenClaw adapt follow-on

### DIFF
--- a/docs/adapt.md
+++ b/docs/adapt.md
@@ -1,13 +1,20 @@
-# `omx adapt` Foundation
+# `omx adapt`
 
-`omx adapt <target>` is the OMX-owned foundation surface for persistent external-agent adaptation.
+`omx adapt <target>` is the OMX-owned surface for persistent external-agent adaptation.
 
-This PR adds only the shared foundation:
+Shared foundation behavior:
 
 - CLI scaffold for `probe`, `status`, `init`, `envelope`, and `doctor`
 - shared capability reporting with explicit ownership (`omx-owned`, `shared-contract`, `target-observed`)
 - adapter-owned paths under `.omx/adapters/<target>/...`
 - shared envelope/status/doctor/init behavior that does not touch `.omx/state/...`
+
+OpenClaw follow-on behavior:
+
+- `omx adapt openclaw probe` observes existing local OpenClaw config/env/gateway evidence
+- `omx adapt openclaw status` synthesizes local adapter status from env gates, config source, hook mappings, and command-gateway opt-in
+- `omx adapt openclaw envelope` includes lifecycle bridge metadata for the existing OMX to OpenClaw event mapping
+- `omx adapt openclaw init --write` still writes only under `.omx/adapters/openclaw/...`
 
 Current targets:
 
@@ -29,5 +36,7 @@ Foundation constraints:
 - no direct writes to `.omx/state/...`
 - no direct writes to external runtime internals
 - target capability reporting stays asymmetric; OMX reports what it owns, what is shared, and what is only target-observed
+- OpenClaw status is local evidence only; it does not claim downstream runtime acknowledgement or execution
+- command-gateway readiness still requires `OMX_OPENCLAW_COMMAND=1`
 
-Target-specific Hermes and OpenClaw probe/integration logic is intentionally deferred to follow-on PRs.
+Hermes-specific probe/integration logic remains deferred.

--- a/src/adapt/__tests__/foundation.test.ts
+++ b/src/adapt/__tests__/foundation.test.ts
@@ -1,105 +1,275 @@
-import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import {
-  buildAdaptEnvelope,
-  buildAdaptStatusReport,
-  buildAdaptDoctorReport,
-  initAdaptFoundation,
+	buildAdaptDoctorReport,
+	buildAdaptEnvelope,
+	buildAdaptProbeReport,
+	buildAdaptStatusReport,
+	initAdaptFoundation,
 } from "../index.js";
 import { resolveAdaptPaths } from "../paths.js";
 import { getAdaptTargetDescriptor } from "../registry.js";
 
 let tempDir: string;
+let originalEnv: NodeJS.ProcessEnv;
 
 beforeEach(async () => {
-  tempDir = await mkdtemp(join(tmpdir(), "omx-adapt-foundation-"));
+	originalEnv = { ...process.env };
+	tempDir = await mkdtemp(join(tmpdir(), "omx-adapt-foundation-"));
+	process.env.HOME = tempDir;
+	process.env.CODEX_HOME = join(tempDir, ".codex");
+	delete process.env.OMX_OPENCLAW;
+	delete process.env.OMX_OPENCLAW_CONFIG;
+	delete process.env.OMX_OPENCLAW_COMMAND;
 });
 
 afterEach(async () => {
-  if (tempDir && existsSync(tempDir)) {
-    await rm(tempDir, { recursive: true, force: true });
-  }
+	for (const key of Object.keys(process.env)) {
+		if (!(key in originalEnv)) delete process.env[key];
+	}
+	for (const [key, val] of Object.entries(originalEnv)) {
+		process.env[key] = val;
+	}
+	if (tempDir && existsSync(tempDir)) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
 });
 
+async function writeOpenClawOmxConfig(config: unknown): Promise<void> {
+	const configDir = join(tempDir, ".codex");
+	await mkdir(configDir, { recursive: true });
+	await writeFile(
+		join(configDir, ".omx-config.json"),
+		`${JSON.stringify(config, null, 2)}\n`,
+	);
+}
+
 describe("adapt foundation", () => {
-  it("resolves OMX-owned adapter paths under .omx/adapters/<target>", () => {
-    const paths = resolveAdaptPaths(tempDir, "openclaw");
-    assert.equal(paths.adapterRoot, join(tempDir, ".omx", "adapters", "openclaw"));
-    assert.equal(paths.configPath, join(tempDir, ".omx", "adapters", "openclaw", "adapter.json"));
-    assert.equal(paths.envelopePath, join(tempDir, ".omx", "adapters", "openclaw", "envelope.json"));
-    assert.equal(paths.probeReportPath, join(tempDir, ".omx", "adapters", "openclaw", "reports", "probe.json"));
-    assert.equal(paths.statusReportPath, join(tempDir, ".omx", "adapters", "openclaw", "reports", "status.json"));
-  });
+	it("resolves OMX-owned adapter paths under .omx/adapters/<target>", () => {
+		const paths = resolveAdaptPaths(tempDir, "openclaw");
+		assert.equal(
+			paths.adapterRoot,
+			join(tempDir, ".omx", "adapters", "openclaw"),
+		);
+		assert.equal(
+			paths.configPath,
+			join(tempDir, ".omx", "adapters", "openclaw", "adapter.json"),
+		);
+		assert.equal(
+			paths.envelopePath,
+			join(tempDir, ".omx", "adapters", "openclaw", "envelope.json"),
+		);
+		assert.equal(
+			paths.probeReportPath,
+			join(tempDir, ".omx", "adapters", "openclaw", "reports", "probe.json"),
+		);
+		assert.equal(
+			paths.statusReportPath,
+			join(tempDir, ".omx", "adapters", "openclaw", "reports", "status.json"),
+		);
+	});
 
-  it("links the latest canonical PRD/test-spec artifacts into the envelope", async () => {
-    const plansDir = join(tempDir, ".omx", "plans");
-    await mkdir(plansDir, { recursive: true });
-    await writeFile(join(plansDir, "prd-alpha.md"), "# Alpha\n");
-    await writeFile(join(plansDir, "test-spec-alpha.md"), "# Alpha Test Spec\n");
-    await writeFile(join(plansDir, "prd-zeta.md"), "# Zeta\n");
-    await writeFile(join(plansDir, "test-spec-zeta.md"), "# Zeta Test Spec\n");
+	it("links the latest canonical PRD/test-spec artifacts into the envelope", async () => {
+		const plansDir = join(tempDir, ".omx", "plans");
+		await mkdir(plansDir, { recursive: true });
+		await writeFile(join(plansDir, "prd-alpha.md"), "# Alpha\n");
+		await writeFile(
+			join(plansDir, "test-spec-alpha.md"),
+			"# Alpha Test Spec\n",
+		);
+		await writeFile(join(plansDir, "prd-zeta.md"), "# Zeta\n");
+		await writeFile(join(plansDir, "test-spec-zeta.md"), "# Zeta Test Spec\n");
 
-    const envelope = buildAdaptEnvelope(tempDir, "openclaw", new Date("2026-04-14T00:00:00.000Z"));
-    assert.equal(envelope.planning.prdPath, join(plansDir, "prd-zeta.md"));
-    assert.deepEqual(envelope.planning.testSpecPaths, [join(plansDir, "test-spec-zeta.md")]);
-    assert.match(envelope.planning.summary, /matching test spec/i);
-  });
+		const envelope = buildAdaptEnvelope(
+			tempDir,
+			"openclaw",
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		assert.equal(envelope.planning.prdPath, join(plansDir, "prd-zeta.md"));
+		assert.deepEqual(envelope.planning.testSpecPaths, [
+			join(plansDir, "test-spec-zeta.md"),
+		]);
+		assert.match(envelope.planning.summary, /matching test spec/i);
+	});
 
-  it("reports asymmetric capability ownership in the shared envelope", () => {
-    const envelope = buildAdaptEnvelope(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
-    const ownerships = new Set(envelope.capabilities.map((capability) => capability.ownership));
-    assert.deepEqual(
-      [...ownerships].sort(),
-      ["omx-owned", "shared-contract", "target-observed"],
-    );
-  });
+	it("reports asymmetric capability ownership in the shared envelope", () => {
+		const envelope = buildAdaptEnvelope(
+			tempDir,
+			"hermes",
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		const ownerships = new Set(
+			envelope.capabilities.map((capability) => capability.ownership),
+		);
+		assert.deepEqual([...ownerships].sort(), [
+			"omx-owned",
+			"shared-contract",
+			"target-observed",
+		]);
+	});
 
-  it("keeps init preview read-only until --write is used", () => {
-    const result = initAdaptFoundation(tempDir, "hermes", false, new Date("2026-04-14T00:00:00.000Z"));
-    const paths = resolveAdaptPaths(tempDir, "hermes");
-    assert.equal(result.write, false);
-    assert.deepEqual(result.wrotePaths, []);
-    assert.equal(existsSync(paths.configPath), false);
-    assert.equal(existsSync(join(tempDir, ".omx", "state")), false);
-  });
+	it("keeps OpenClaw init preview read-only until --write is used", () => {
+		const result = initAdaptFoundation(
+			tempDir,
+			"openclaw",
+			false,
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		const paths = resolveAdaptPaths(tempDir, "openclaw");
+		assert.equal(result.write, false);
+		assert.deepEqual(result.wrotePaths, []);
+		assert.equal(existsSync(paths.configPath), false);
+		assert.equal(existsSync(join(tempDir, ".omx", "state")), false);
+	});
 
-  it("writes only OMX-owned adapter artifacts during init --write", () => {
-    const result = initAdaptFoundation(tempDir, "openclaw", true, new Date("2026-04-14T00:00:00.000Z"));
-    const paths = resolveAdaptPaths(tempDir, "openclaw");
-    assert.equal(result.write, true);
-    assert.deepEqual(result.wrotePaths, [paths.configPath, paths.envelopePath]);
-    assert.equal(existsSync(paths.configPath), true);
-    assert.equal(existsSync(paths.envelopePath), true);
-    assert.equal(existsSync(join(tempDir, ".omx", "state")), false);
+	it("writes OpenClaw adapter artifacts only under adapter-owned paths", async () => {
+		process.env.OMX_OPENCLAW = "1";
+		await writeOpenClawOmxConfig({
+			notifications: {
+				openclaw: {
+					enabled: true,
+					gateways: {
+						local: {
+							type: "http",
+							url: "https://example.com/hook",
+							timeout: 9000,
+						},
+					},
+					hooks: {
+						"session-start": {
+							enabled: true,
+							gateway: "local",
+							instruction: "start",
+						},
+					},
+				},
+			},
+		});
 
-    const envelope = JSON.parse(readFileSync(paths.envelopePath, "utf-8")) as {
-      target: string;
-      adapterPaths: { configPath: string };
-    };
-    assert.equal(envelope.target, "openclaw");
-    assert.equal(envelope.adapterPaths.configPath, paths.configPath);
-  });
+		const result = initAdaptFoundation(
+			tempDir,
+			"openclaw",
+			true,
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		const paths = resolveAdaptPaths(tempDir, "openclaw");
+		assert.equal(result.write, true);
+		assert.deepEqual(result.wrotePaths, [paths.configPath, paths.envelopePath]);
+		assert.equal(existsSync(paths.configPath), true);
+		assert.equal(existsSync(paths.envelopePath), true);
+		assert.equal(existsSync(join(tempDir, ".omx", "state")), false);
 
-  it("reports initialization status without claiming target-runtime health", () => {
-    const status = buildAdaptStatusReport(tempDir, "openclaw", new Date("2026-04-14T00:00:00.000Z"));
-    assert.equal(status.adapter.state, "not-initialized");
-    assert.equal(status.targetRuntime.state, "unknown");
-    assert.match(status.targetRuntime.detail, /follow-on PR/i);
-  });
+	const envelope = JSON.parse(readFileSync(paths.envelopePath, "utf-8")) as {
+		target: string;
+		openclaw?: {
+			observedState: string;
+			hooks: Array<{ event: string; status: string }>;
+			};
+		};
+	assert.equal(envelope.target, "openclaw");
+	assert.equal(envelope.openclaw?.observedState, "configured");
+	assert.equal(envelope.openclaw?.hooks[0]?.event, "session-start");
+	});
 
-  it("doctor surfaces actionable foundation-only remediation", () => {
-    const doctor = buildAdaptDoctorReport(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
-    assert.equal(doctor.issues[0]?.code, "adapter_not_initialized");
-    assert.match(doctor.nextSteps.join("\n"), /init --write/i);
-    assert.match(doctor.nextSteps.join("\n"), /follow-on PR/i);
-  });
+	it("OpenClaw probe degrades gracefully when env/config evidence is absent", () => {
+		const probe = buildAdaptProbeReport(
+			tempDir,
+			"openclaw",
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		assert.equal(probe.openclaw?.observedState, "disabled");
+		assert.match(probe.summary, /disabled locally/i);
+	});
 
-  it("rejects inherited prototype-like targets during validation", () => {
-    assert.equal(getAdaptTargetDescriptor("__proto__"), null);
-    assert.equal(getAdaptTargetDescriptor("constructor"), null);
-  });
+	it("OpenClaw status degrades gracefully when config is absent", () => {
+		process.env.OMX_OPENCLAW = "1";
+		const status = buildAdaptStatusReport(
+			tempDir,
+			"openclaw",
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		assert.equal(status.adapter.state, "not-initialized");
+		assert.equal(status.openclaw?.observedState, "missing-config");
+		assert.match(
+			status.targetRuntime.detail,
+			/local config\/env\/gateway wiring evidence only/i,
+		);
+	});
+
+	it("OpenClaw status reports local command-gateway blocking without over-claiming health", async () => {
+		process.env.OMX_OPENCLAW = "1";
+		await writeOpenClawOmxConfig({
+			notifications: {
+				openclaw: {
+					enabled: true,
+					gateways: {
+						local: { type: "command", command: "echo hi" },
+					},
+					hooks: {
+						stop: {
+							enabled: true,
+							gateway: "local",
+							instruction: "stop",
+						},
+					},
+				},
+			},
+		});
+
+		const status = buildAdaptStatusReport(
+			tempDir,
+			"openclaw",
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		assert.equal(status.openclaw?.observedState, "degraded");
+		assert.equal(
+			status.openclaw?.hooks.find((hook) => hook.event === "stop")?.status,
+			"blocked",
+		);
+		assert.match(
+			status.targetRuntime.detail,
+			/not authoritative remote OpenClaw runtime health/i,
+		);
+	});
+
+	it("doctor surfaces actionable OpenClaw remediation", () => {
+		const doctor = buildAdaptDoctorReport(
+			tempDir,
+			"openclaw",
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		assert.equal(doctor.issues[0]?.code, "adapter_not_initialized");
+		assert.match(doctor.nextSteps.join("\n"), /OMX_OPENCLAW=1/i);
+		assert.match(doctor.nextSteps.join("\n"), /init --write/i);
+	});
+
+	it("keeps Hermes foundation behavior unchanged", () => {
+		const status = buildAdaptStatusReport(
+			tempDir,
+			"hermes",
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		assert.equal(status.adapter.state, "not-initialized");
+		assert.equal(status.targetRuntime.state, "unknown");
+	});
+
+	it("doctor surfaces actionable foundation-only remediation", () => {
+		const doctor = buildAdaptDoctorReport(
+			tempDir,
+			"hermes",
+			new Date("2026-04-14T00:00:00.000Z"),
+		);
+		assert.equal(doctor.issues[0]?.code, "adapter_not_initialized");
+		assert.match(doctor.nextSteps.join("\n"), /init --write/i);
+		assert.match(doctor.nextSteps.join("\n"), /follow-on PR/i);
+	});
+
+	it("rejects inherited prototype-like targets during validation", () => {
+		assert.equal(getAdaptTargetDescriptor("__proto__"), null);
+		assert.equal(getAdaptTargetDescriptor("constructor"), null);
+	});
 });

--- a/src/adapt/contracts.ts
+++ b/src/adapt/contracts.ts
@@ -4,123 +4,178 @@ export const ADAPT_TARGETS = ["openclaw", "hermes"] as const;
 export type AdaptTarget = (typeof ADAPT_TARGETS)[number];
 
 export const ADAPT_SUBCOMMANDS = [
-  "probe",
-  "status",
-  "init",
-  "envelope",
-  "doctor",
+	"probe",
+	"status",
+	"init",
+	"envelope",
+	"doctor",
 ] as const;
 export type AdaptSubcommand = (typeof ADAPT_SUBCOMMANDS)[number];
 
 export type AdaptCapabilityOwnership =
-  | "omx-owned"
-  | "shared-contract"
-  | "target-observed";
+	| "omx-owned"
+	| "shared-contract"
+	| "target-observed";
 
 export type AdaptCapabilityStatus = "ready" | "stub" | "unsupported";
 
 export interface AdaptCapabilityReport {
-  id: string;
-  label: string;
-  ownership: AdaptCapabilityOwnership;
-  status: AdaptCapabilityStatus;
-  summary: string;
+	id: string;
+	label: string;
+	ownership: AdaptCapabilityOwnership;
+	status: AdaptCapabilityStatus;
+	summary: string;
 }
 
 export interface AdaptTargetDescriptor {
-  target: AdaptTarget;
-  displayName: string;
-  summary: string;
-  followupHint: string;
-  capabilities: AdaptCapabilityReport[];
+	target: AdaptTarget;
+	displayName: string;
+	summary: string;
+	followupHint: string;
+	capabilities: AdaptCapabilityReport[];
 }
 
 export interface AdaptPathSet {
-  adapterRoot: string;
-  configPath: string;
-  envelopePath: string;
-  reportsDir: string;
-  probeReportPath: string;
-  statusReportPath: string;
+	adapterRoot: string;
+	configPath: string;
+	envelopePath: string;
+	reportsDir: string;
+	probeReportPath: string;
+	statusReportPath: string;
 }
 
 export interface AdaptPlanningLink {
-  prdPath: string | null;
-  testSpecPaths: string[];
-  deepInterviewSpecPaths: string[];
-  summary: string;
+	prdPath: string | null;
+	testSpecPaths: string[];
+	deepInterviewSpecPaths: string[];
+	summary: string;
+}
+
+export interface AdaptOpenClawGatewayObservation {
+	name: string;
+	type: "http" | "command";
+	configured: boolean;
+	commandGateRequired: boolean;
+	commandGateEnabled: boolean;
+	timeoutMs: number | null;
+}
+
+export interface AdaptOpenClawHookObservation {
+	event: string;
+	gateway: string | null;
+	gatewayType: "http" | "command" | null;
+	status: "wired" | "blocked" | "unmapped";
+	detail: string;
+}
+
+export interface AdaptOpenClawMetadata {
+	observedState:
+		| "configured"
+		| "degraded"
+		| "disabled"
+		| "missing-config"
+		| "invalid-config"
+		| "not-configured";
+	observedDetail: string;
+	config: {
+		activationGateEnabled: boolean;
+		commandGateEnabled: boolean;
+		configPath: string;
+		configExists: boolean;
+		source: string | null;
+		explicitConfigPresent: boolean;
+		aliasConfigPresent: boolean;
+		aliasSources: Array<"custom_cli_command" | "custom_webhook_command">;
+		explicitOverridesAliases: boolean;
+		warnings: string[];
+	};
+	gateways: AdaptOpenClawGatewayObservation[];
+	hooks: AdaptOpenClawHookObservation[];
+	lifecycleBridge: Array<{
+		omxEvent: string;
+		openclawEvent: string;
+	}>;
+	bootstrap?: {
+		adapterConfigPath: string;
+		envelopePath: string;
+		reportPaths: string[];
+		planningArtifactPaths: string[];
+	};
 }
 
 export interface AdaptEnvelope {
-  schemaVersion: string;
-  generatedAt: string;
-  target: AdaptTarget;
-  displayName: string;
-  summary: string;
-  adapterPaths: AdaptPathSet;
-  planning: AdaptPlanningLink;
-  capabilities: AdaptCapabilityReport[];
-  constraints: string[];
+	schemaVersion: string;
+	generatedAt: string;
+	target: AdaptTarget;
+	displayName: string;
+	summary: string;
+	adapterPaths: AdaptPathSet;
+	planning: AdaptPlanningLink;
+	capabilities: AdaptCapabilityReport[];
+	constraints: string[];
+	openclaw?: AdaptOpenClawMetadata;
 }
 
 export interface AdaptProbeReport {
-  schemaVersion: string;
-  timestamp: string;
-  target: AdaptTarget;
-  phase: "foundation";
-  summary: string;
-  adapterPaths: AdaptPathSet;
-  planning: AdaptPlanningLink;
-  capabilities: AdaptCapabilityReport[];
-  targetRuntime: {
-    state: "not-implemented";
-    detail: string;
-  };
-  nextSteps: string[];
+	schemaVersion: string;
+	timestamp: string;
+	target: AdaptTarget;
+	phase: "foundation";
+	summary: string;
+	adapterPaths: AdaptPathSet;
+	planning: AdaptPlanningLink;
+	capabilities: AdaptCapabilityReport[];
+	targetRuntime: {
+		state: "not-implemented";
+		detail: string;
+	};
+	openclaw?: AdaptOpenClawMetadata;
+	nextSteps: string[];
 }
 
 export interface AdaptStatusReport {
-  schemaVersion: string;
-  timestamp: string;
-  target: AdaptTarget;
-  phase: "foundation";
-  summary: string;
-  adapter: {
-    state: "initialized" | "not-initialized";
-    detail: string;
-    configPath: string;
-    envelopePath: string;
-  };
-  targetRuntime: {
-    state: "unknown";
-    detail: string;
-  };
-  planning: AdaptPlanningLink;
-  capabilities: AdaptCapabilityReport[];
+	schemaVersion: string;
+	timestamp: string;
+	target: AdaptTarget;
+	phase: "foundation";
+	summary: string;
+	adapter: {
+		state: "initialized" | "not-initialized";
+		detail: string;
+		configPath: string;
+		envelopePath: string;
+	};
+	targetRuntime: {
+		state: "unknown";
+		detail: string;
+	};
+	planning: AdaptPlanningLink;
+	capabilities: AdaptCapabilityReport[];
+	openclaw?: AdaptOpenClawMetadata;
 }
 
 export interface AdaptDoctorIssue {
-  code: string;
-  message: string;
+	code: string;
+	message: string;
 }
 
 export interface AdaptDoctorReport {
-  schemaVersion: string;
-  timestamp: string;
-  target: AdaptTarget;
-  phase: "foundation";
-  summary: string;
-  issues: AdaptDoctorIssue[];
-  nextSteps: string[];
+	schemaVersion: string;
+	timestamp: string;
+	target: AdaptTarget;
+	phase: "foundation";
+	summary: string;
+	issues: AdaptDoctorIssue[];
+	nextSteps: string[];
 }
 
 export interface AdaptInitResult {
-  schemaVersion: string;
-  timestamp: string;
-  target: AdaptTarget;
-  write: boolean;
-  summary: string;
-  previewPaths: string[];
-  wrotePaths: string[];
-  envelope: AdaptEnvelope;
+	schemaVersion: string;
+	timestamp: string;
+	target: AdaptTarget;
+	write: boolean;
+	summary: string;
+	previewPaths: string[];
+	wrotePaths: string[];
+	envelope: AdaptEnvelope;
 }

--- a/src/adapt/index.ts
+++ b/src/adapt/index.ts
@@ -1,245 +1,314 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-  ADAPT_SCHEMA_VERSION,
-  type AdaptDoctorIssue,
-  type AdaptDoctorReport,
-  type AdaptEnvelope,
-  type AdaptInitResult,
-  type AdaptPlanningLink,
-  type AdaptProbeReport,
-  type AdaptStatusReport,
-  type AdaptTarget,
-} from "./contracts.js";
-import { getAdaptTargetDescriptor, listAdaptTargets } from "./registry.js";
-import { resolveAdaptPaths } from "./paths.js";
 import { readLatestPlanningArtifacts } from "../planning/artifacts.js";
+import {
+	ADAPT_SCHEMA_VERSION,
+	type AdaptDoctorIssue,
+	type AdaptDoctorReport,
+	type AdaptEnvelope,
+	type AdaptInitResult,
+	type AdaptPlanningLink,
+	type AdaptProbeReport,
+	type AdaptStatusReport,
+	type AdaptTarget,
+} from "./contracts.js";
+import {
+	buildOpenClawDoctorReport,
+	buildOpenClawEnvelope,
+	buildOpenClawProbeReport,
+	buildOpenClawStatusReport,
+	initOpenClawFoundation,
+} from "./openclaw.js";
+import { resolveAdaptPaths } from "./paths.js";
+import { getAdaptTargetDescriptor, listAdaptTargets } from "./registry.js";
 
 const FOUNDATION_CONSTRAINTS = [
-  "Thin adapter surface only; no bidirectional control plane is claimed in this foundation PR.",
-  "No direct writes to .omx/state/... or target runtime internals.",
-  "Capability reporting is asymmetric: OMX-owned, shared-contract, and target-observed surfaces are reported separately.",
+	"Thin adapter surface only; no bidirectional control plane is claimed in this foundation PR.",
+	"No direct writes to .omx/state/... or target runtime internals.",
+	"Capability reporting is asymmetric: OMX-owned, shared-contract, and target-observed surfaces are reported separately.",
 ];
 
 function toIsoTimestamp(now = new Date()): string {
-  return now.toISOString();
+	return now.toISOString();
 }
 
 export function supportedAdaptTargets(): string[] {
-  return listAdaptTargets().map((descriptor) => descriptor.target);
+	return listAdaptTargets().map((descriptor) => descriptor.target);
 }
 
 export function buildAdaptPlanningLink(cwd: string): AdaptPlanningLink {
-  const selection = readLatestPlanningArtifacts(cwd);
-  if (!selection.prdPath) {
-    return {
-      prdPath: null,
-      testSpecPaths: [],
-      deepInterviewSpecPaths: [],
-      summary: "No canonical OMX PRD/test-spec artifacts are present in this worktree.",
-    };
-  }
+	const selection = readLatestPlanningArtifacts(cwd);
+	if (!selection.prdPath) {
+		return {
+			prdPath: null,
+			testSpecPaths: [],
+			deepInterviewSpecPaths: [],
+			summary:
+				"No canonical OMX PRD/test-spec artifacts are present in this worktree.",
+		};
+	}
 
-  const testSpecSummary = selection.testSpecPaths.length > 0
-    ? `${selection.testSpecPaths.length} matching test spec artifact(s) linked.`
-    : "PRD detected, but no matching test spec artifact was found for its slug.";
+	const testSpecSummary =
+		selection.testSpecPaths.length > 0
+			? `${selection.testSpecPaths.length} matching test spec artifact(s) linked.`
+			: "PRD detected, but no matching test spec artifact was found for its slug.";
 
-  return {
-    prdPath: selection.prdPath,
-    testSpecPaths: selection.testSpecPaths,
-    deepInterviewSpecPaths: selection.deepInterviewSpecPaths,
-    summary: testSpecSummary,
-  };
+	return {
+		prdPath: selection.prdPath,
+		testSpecPaths: selection.testSpecPaths,
+		deepInterviewSpecPaths: selection.deepInterviewSpecPaths,
+		summary: testSpecSummary,
+	};
 }
 
 export function buildAdaptEnvelope(
-  cwd: string,
-  target: AdaptTarget,
-  now = new Date(),
+	cwd: string,
+	target: AdaptTarget,
+	now = new Date(),
 ): AdaptEnvelope {
-  const descriptor = getAdaptTargetDescriptor(target);
-  if (!descriptor) {
-    throw new Error(`Unknown adapt target: ${target}`);
-  }
+	const descriptor = getAdaptTargetDescriptor(target);
+	if (!descriptor) {
+		throw new Error(`Unknown adapt target: ${target}`);
+	}
 
-  return {
-    schemaVersion: ADAPT_SCHEMA_VERSION,
-    generatedAt: toIsoTimestamp(now),
-    target,
-    displayName: descriptor.displayName,
-    summary: descriptor.summary,
-    adapterPaths: resolveAdaptPaths(cwd, target),
-    planning: buildAdaptPlanningLink(cwd),
-    capabilities: descriptor.capabilities,
-    constraints: FOUNDATION_CONSTRAINTS,
-  };
+	const paths = resolveAdaptPaths(cwd, target);
+	const planning = buildAdaptPlanningLink(cwd);
+
+	if (target === "openclaw") {
+		return buildOpenClawEnvelope(paths, planning, descriptor.capabilities, now);
+	}
+
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		generatedAt: toIsoTimestamp(now),
+		target,
+		displayName: descriptor.displayName,
+		summary: descriptor.summary,
+		adapterPaths: paths,
+		planning,
+		capabilities: descriptor.capabilities,
+		constraints: FOUNDATION_CONSTRAINTS,
+	};
 }
 
 export function buildAdaptProbeReport(
-  cwd: string,
-  target: AdaptTarget,
-  now = new Date(),
+	cwd: string,
+	target: AdaptTarget,
+	now = new Date(),
 ): AdaptProbeReport {
-  const descriptor = getAdaptTargetDescriptor(target);
-  if (!descriptor) {
-    throw new Error(`Unknown adapt target: ${target}`);
-  }
+	const descriptor = getAdaptTargetDescriptor(target);
+	if (!descriptor) {
+		throw new Error(`Unknown adapt target: ${target}`);
+	}
 
-  return {
-    schemaVersion: ADAPT_SCHEMA_VERSION,
-    timestamp: toIsoTimestamp(now),
-    target,
-    phase: "foundation",
-    summary: `${descriptor.displayName} probe foundation is available, but target-specific runtime probing is deferred.`,
-    adapterPaths: resolveAdaptPaths(cwd, target),
-    planning: buildAdaptPlanningLink(cwd),
-    capabilities: descriptor.capabilities,
-    targetRuntime: {
-      state: "not-implemented",
-      detail: descriptor.followupHint,
-    },
-    nextSteps: [
-      `Run omx adapt ${target} init --write to materialize OMX-owned adapter artifacts.`,
-      descriptor.followupHint,
-    ],
-  };
+	const paths = resolveAdaptPaths(cwd, target);
+	const planning = buildAdaptPlanningLink(cwd);
+
+	if (target === "openclaw") {
+		return buildOpenClawProbeReport(
+			paths,
+			planning,
+			descriptor.capabilities,
+			now,
+		);
+	}
+
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		timestamp: toIsoTimestamp(now),
+		target,
+		phase: "foundation",
+		summary: `${descriptor.displayName} probe foundation is available, but target-specific runtime probing is deferred.`,
+		adapterPaths: paths,
+		planning,
+		capabilities: descriptor.capabilities,
+		targetRuntime: {
+			state: "not-implemented",
+			detail: descriptor.followupHint,
+		},
+		nextSteps: [
+			`Run omx adapt ${target} init --write to materialize OMX-owned adapter artifacts.`,
+			descriptor.followupHint,
+		],
+	};
 }
 
 export function buildAdaptStatusReport(
-  cwd: string,
-  target: AdaptTarget,
-  now = new Date(),
+	cwd: string,
+	target: AdaptTarget,
+	now = new Date(),
 ): AdaptStatusReport {
-  const descriptor = getAdaptTargetDescriptor(target);
-  if (!descriptor) {
-    throw new Error(`Unknown adapt target: ${target}`);
-  }
+	const descriptor = getAdaptTargetDescriptor(target);
+	if (!descriptor) {
+		throw new Error(`Unknown adapt target: ${target}`);
+	}
 
-  const paths = resolveAdaptPaths(cwd, target);
-  const initialized = existsSync(paths.configPath) && existsSync(paths.envelopePath);
+	const paths = resolveAdaptPaths(cwd, target);
+	const initialized =
+		existsSync(paths.configPath) && existsSync(paths.envelopePath);
+	const planning = buildAdaptPlanningLink(cwd);
 
-  return {
-    schemaVersion: ADAPT_SCHEMA_VERSION,
-    timestamp: toIsoTimestamp(now),
-    target,
-    phase: "foundation",
-    summary: initialized
-      ? `${descriptor.displayName} adapter foundation is initialized under OMX-owned paths.`
-      : `${descriptor.displayName} adapter foundation has not been initialized yet.`,
-    adapter: {
-      state: initialized ? "initialized" : "not-initialized",
-      detail: initialized
-        ? "Adapter foundation artifacts exist under .omx/adapters/<target>/..."
-        : "Run init --write to create OMX-owned adapter artifacts.",
-      configPath: paths.configPath,
-      envelopePath: paths.envelopePath,
-    },
-    targetRuntime: {
-      state: "unknown",
-      detail: descriptor.followupHint,
-    },
-    planning: buildAdaptPlanningLink(cwd),
-    capabilities: descriptor.capabilities,
-  };
+	if (target === "openclaw") {
+		return buildOpenClawStatusReport(
+			paths,
+			planning,
+			descriptor.capabilities,
+			now,
+		);
+	}
+
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		timestamp: toIsoTimestamp(now),
+		target,
+		phase: "foundation",
+		summary: initialized
+			? `${descriptor.displayName} adapter foundation is initialized under OMX-owned paths.`
+			: `${descriptor.displayName} adapter foundation has not been initialized yet.`,
+		adapter: {
+			state: initialized ? "initialized" : "not-initialized",
+			detail: initialized
+				? "Adapter foundation artifacts exist under .omx/adapters/<target>/..."
+				: "Run init --write to create OMX-owned adapter artifacts.",
+			configPath: paths.configPath,
+			envelopePath: paths.envelopePath,
+		},
+		targetRuntime: {
+			state: "unknown",
+			detail: descriptor.followupHint,
+		},
+		planning,
+		capabilities: descriptor.capabilities,
+	};
 }
 
 export function buildAdaptDoctorReport(
-  cwd: string,
-  target: AdaptTarget,
-  now = new Date(),
+	cwd: string,
+	target: AdaptTarget,
+	now = new Date(),
 ): AdaptDoctorReport {
-  const descriptor = getAdaptTargetDescriptor(target);
-  if (!descriptor) {
-    throw new Error(`Unknown adapt target: ${target}`);
-  }
+	const descriptor = getAdaptTargetDescriptor(target);
+	if (!descriptor) {
+		throw new Error(`Unknown adapt target: ${target}`);
+	}
 
-  const status = buildAdaptStatusReport(cwd, target, now);
-  const planning = buildAdaptPlanningLink(cwd);
-  const issues: AdaptDoctorIssue[] = [];
+	const status = buildAdaptStatusReport(cwd, target, now);
+	const planning = buildAdaptPlanningLink(cwd);
+	const issues: AdaptDoctorIssue[] = [];
 
-  if (status.adapter.state === "not-initialized") {
-    issues.push({
-      code: "adapter_not_initialized",
-      message: `No adapter foundation artifacts exist for ${target} under ${join(".omx", "adapters", target)}.`,
-    });
-  }
+	if (target === "openclaw") {
+		return buildOpenClawDoctorReport(
+			resolveAdaptPaths(cwd, target),
+			planning,
+			now,
+		);
+	}
 
-  if (!planning.prdPath) {
-    issues.push({
-      code: "planning_artifacts_missing",
-      message: "No canonical OMX PRD artifact is available to link into the adapter envelope.",
-    });
-  }
+	if (status.adapter.state === "not-initialized") {
+		issues.push({
+			code: "adapter_not_initialized",
+			message: `No adapter foundation artifacts exist for ${target} under ${join(".omx", "adapters", target)}.`,
+		});
+	}
 
-  issues.push({
-    code: "target_specific_logic_deferred",
-    message: descriptor.followupHint,
-  });
+	if (!planning.prdPath) {
+		issues.push({
+			code: "planning_artifacts_missing",
+			message:
+				"No canonical OMX PRD artifact is available to link into the adapter envelope.",
+		});
+	}
 
-  return {
-    schemaVersion: ADAPT_SCHEMA_VERSION,
-    timestamp: toIsoTimestamp(now),
-    target,
-    phase: "foundation",
-    summary: `Foundation doctor for ${descriptor.displayName} reports only OMX-owned adapter readiness and shared planning linkage.`,
-    issues,
-    nextSteps: [
-      `Run omx adapt ${target} init --write.`,
-      "Keep follow-on integration work out of .omx/state/... and target runtime internals unless a reviewed contract exists.",
-      descriptor.followupHint,
-    ],
-  };
+	issues.push({
+		code: "target_specific_logic_deferred",
+		message: descriptor.followupHint,
+	});
+
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		timestamp: toIsoTimestamp(now),
+		target,
+		phase: "foundation",
+		summary: `Foundation doctor for ${descriptor.displayName} reports only OMX-owned adapter readiness and shared planning linkage.`,
+		issues,
+		nextSteps: [
+			`Run omx adapt ${target} init --write.`,
+			"Keep follow-on integration work out of .omx/state/... and target runtime internals unless a reviewed contract exists.",
+			descriptor.followupHint,
+		],
+	};
 }
 
 export function initAdaptFoundation(
-  cwd: string,
-  target: AdaptTarget,
-  write = false,
-  now = new Date(),
+	cwd: string,
+	target: AdaptTarget,
+	write = false,
+	now = new Date(),
 ): AdaptInitResult {
-  const descriptor = getAdaptTargetDescriptor(target);
-  if (!descriptor) {
-    throw new Error(`Unknown adapt target: ${target}`);
-  }
+	const descriptor = getAdaptTargetDescriptor(target);
+	if (!descriptor) {
+		throw new Error(`Unknown adapt target: ${target}`);
+	}
 
-  const envelope = buildAdaptEnvelope(cwd, target, now);
-  const paths = envelope.adapterPaths;
-  const previewPaths = [
-    paths.adapterRoot,
-    paths.configPath,
-    paths.envelopePath,
-    paths.reportsDir,
-    paths.probeReportPath,
-    paths.statusReportPath,
-  ];
-  const wrotePaths: string[] = [];
+	const paths = resolveAdaptPaths(cwd, target);
+	const planning = buildAdaptPlanningLink(cwd);
 
-  if (write) {
-    mkdirSync(paths.reportsDir, { recursive: true });
-    const config = {
-      schemaVersion: ADAPT_SCHEMA_VERSION,
-      target,
-      createdAt: toIsoTimestamp(now),
-      phase: "foundation",
-      summary: descriptor.summary,
-      followupHint: descriptor.followupHint,
-      constraints: FOUNDATION_CONSTRAINTS,
-    };
-    writeFileSync(paths.configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
-    writeFileSync(paths.envelopePath, `${JSON.stringify(envelope, null, 2)}\n`, "utf-8");
-    wrotePaths.push(paths.configPath, paths.envelopePath);
-  }
+	if (target === "openclaw") {
+		return initOpenClawFoundation(
+			paths,
+			planning,
+			descriptor.capabilities,
+			write,
+			now,
+		);
+	}
 
-  return {
-    schemaVersion: ADAPT_SCHEMA_VERSION,
-    timestamp: toIsoTimestamp(now),
-    target,
-    write,
-    summary: write
-      ? `${descriptor.displayName} adapter foundation was written under OMX-owned paths.`
-      : `${descriptor.displayName} adapter foundation preview is ready; rerun with --write to materialize it.`,
-    previewPaths,
-    wrotePaths,
-    envelope,
-  };
+	const envelope = buildAdaptEnvelope(cwd, target, now);
+	const envelopePaths = envelope.adapterPaths;
+	const previewPaths = [
+		envelopePaths.adapterRoot,
+		envelopePaths.configPath,
+		envelopePaths.envelopePath,
+		envelopePaths.reportsDir,
+		envelopePaths.probeReportPath,
+		envelopePaths.statusReportPath,
+	];
+	const wrotePaths: string[] = [];
+
+	if (write) {
+		mkdirSync(envelopePaths.reportsDir, { recursive: true });
+		const config = {
+			schemaVersion: ADAPT_SCHEMA_VERSION,
+			target,
+			createdAt: toIsoTimestamp(now),
+			phase: "foundation",
+			summary: descriptor.summary,
+			followupHint: descriptor.followupHint,
+			constraints: FOUNDATION_CONSTRAINTS,
+		};
+		writeFileSync(
+			envelopePaths.configPath,
+			`${JSON.stringify(config, null, 2)}\n`,
+			"utf-8",
+		);
+		writeFileSync(
+			envelopePaths.envelopePath,
+			`${JSON.stringify(envelope, null, 2)}\n`,
+			"utf-8",
+		);
+		wrotePaths.push(envelopePaths.configPath, envelopePaths.envelopePath);
+	}
+
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		timestamp: toIsoTimestamp(now),
+		target,
+		write,
+		summary: write
+			? `${descriptor.displayName} adapter foundation was written under OMX-owned paths.`
+			: `${descriptor.displayName} adapter foundation preview is ready; rerun with --write to materialize it.`,
+		previewPaths,
+		wrotePaths,
+		envelope,
+	};
 }

--- a/src/adapt/openclaw.ts
+++ b/src/adapt/openclaw.ts
@@ -1,0 +1,397 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { inspectOpenClawConfig, resolveGateway } from "../openclaw/config.js";
+import type {
+	AdaptCapabilityReport,
+	AdaptDoctorReport,
+	AdaptEnvelope,
+	AdaptInitResult,
+	AdaptOpenClawGatewayObservation,
+	AdaptOpenClawHookObservation,
+	AdaptOpenClawMetadata,
+	AdaptPathSet,
+	AdaptPlanningLink,
+	AdaptProbeReport,
+	AdaptStatusReport,
+} from "./contracts.js";
+import { ADAPT_SCHEMA_VERSION } from "./contracts.js";
+
+const OPENCLAW_HOOK_EVENTS = [
+	"session-start",
+	"session-end",
+	"session-idle",
+	"ask-user-question",
+	"stop",
+] as const;
+
+const OPENCLAW_LIFECYCLE_BRIDGE = [
+	{ omxEvent: "session-start", openclawEvent: "session-start" },
+	{ omxEvent: "session-end", openclawEvent: "session-end" },
+	{ omxEvent: "session-idle", openclawEvent: "session-idle" },
+	{ omxEvent: "ask-user-question", openclawEvent: "ask-user-question" },
+	{ omxEvent: "session-stop", openclawEvent: "stop" },
+] as const;
+
+function summarizeObservedState(
+	metadata: Omit<AdaptOpenClawMetadata, "bootstrap">,
+): string {
+	switch (metadata.observedState) {
+		case "configured":
+			return `OpenClaw local adapter evidence is present with ${metadata.gateways.length} configured gateway(s) and ${metadata.hooks.filter((hook) => hook.status === "wired").length} wired hook mapping(s).`;
+		case "degraded":
+			return "OpenClaw local adapter evidence is partial; config is present but at least one mapped hook is locally blocked.";
+		case "disabled":
+			return "OpenClaw is disabled locally because OMX_OPENCLAW=1 is not set.";
+		case "missing-config":
+			return "OpenClaw is enabled, but no usable local config file was found.";
+		case "invalid-config":
+			return "OpenClaw config evidence exists, but it is invalid or incomplete.";
+		default:
+			return "OpenClaw has no local config or gateway evidence yet.";
+	}
+}
+
+function observeOpenClaw(
+	paths: AdaptPathSet,
+	planning: AdaptPlanningLink,
+): AdaptOpenClawMetadata {
+	const inspection = inspectOpenClawConfig();
+	const gateways: AdaptOpenClawGatewayObservation[] = [];
+	const hooks: AdaptOpenClawHookObservation[] = [];
+
+	if (inspection.config) {
+		for (const [name, gateway] of Object.entries(inspection.config.gateways)) {
+			const type = gateway.type === "command" ? "command" : "http";
+			gateways.push({
+				name,
+				type,
+				configured:
+					type === "command"
+						? Boolean("command" in gateway && gateway.command)
+						: Boolean("url" in gateway && gateway.url),
+				commandGateRequired: type === "command",
+				commandGateEnabled:
+					type === "command" ? inspection.commandGateEnabled : false,
+				timeoutMs: typeof gateway.timeout === "number" ? gateway.timeout : null,
+			});
+		}
+
+		for (const event of OPENCLAW_HOOK_EVENTS) {
+			const mapping = inspection.config.hooks[event];
+			if (!mapping || !mapping.enabled) {
+				hooks.push({
+					event,
+					gateway: null,
+					gatewayType: null,
+					status: "unmapped",
+					detail: "No enabled OpenClaw mapping exists for this event.",
+				});
+				continue;
+			}
+
+			const resolved = resolveGateway(inspection.config, event);
+			if (!resolved) {
+				hooks.push({
+					event,
+					gateway: mapping.gateway,
+					gatewayType: null,
+					status: "blocked",
+					detail:
+						"The hook mapping exists, but the referenced gateway is missing or disabled locally.",
+				});
+				continue;
+			}
+
+			const gatewayType =
+				resolved.gateway.type === "command" ? "command" : "http";
+			if (gatewayType === "command" && !inspection.commandGateEnabled) {
+				hooks.push({
+					event,
+					gateway: resolved.gatewayName,
+					gatewayType,
+					status: "blocked",
+					detail:
+						"Mapped to a command gateway, but OMX_OPENCLAW_COMMAND=1 is not set.",
+				});
+				continue;
+			}
+
+			hooks.push({
+				event,
+				gateway: resolved.gatewayName,
+				gatewayType,
+				status: "wired",
+				detail:
+					gatewayType === "command"
+						? "Mapped to a local command gateway with command opt-in enabled."
+						: "Mapped to a local HTTP gateway; downstream acknowledgement is not observed here.",
+			});
+		}
+	}
+
+	const observedState =
+		inspection.state === "configured" &&
+		hooks.some((hook) => hook.status === "blocked")
+			? "degraded"
+			: inspection.state;
+
+	const metadata: AdaptOpenClawMetadata = {
+		observedState,
+		observedDetail: inspection.detail,
+		config: {
+			activationGateEnabled: inspection.activationGateEnabled,
+			commandGateEnabled: inspection.commandGateEnabled,
+			configPath: inspection.configPath,
+			configExists: inspection.configExists,
+			source: inspection.configSource,
+			explicitConfigPresent: inspection.explicitConfigPresent,
+			aliasConfigPresent: inspection.aliasConfigPresent,
+			aliasSources: inspection.aliasSources,
+			explicitOverridesAliases: inspection.explicitOverridesAliases,
+			warnings: inspection.warnings,
+		},
+		gateways,
+		hooks,
+		lifecycleBridge: OPENCLAW_LIFECYCLE_BRIDGE.map((entry) => ({ ...entry })),
+		bootstrap: {
+			adapterConfigPath: paths.configPath,
+			envelopePath: paths.envelopePath,
+			reportPaths: [paths.probeReportPath, paths.statusReportPath],
+			planningArtifactPaths: [
+				...(planning.prdPath ? [planning.prdPath] : []),
+				...planning.testSpecPaths,
+				...planning.deepInterviewSpecPaths,
+			],
+		},
+	};
+
+	const { bootstrap: _bootstrap, ...summaryMetadata } = metadata;
+	metadata.observedDetail = summarizeObservedState(summaryMetadata);
+	return metadata;
+}
+
+export function buildOpenClawEnvelope(
+	paths: AdaptPathSet,
+	planning: AdaptPlanningLink,
+	capabilities: AdaptCapabilityReport[],
+	now: Date,
+): AdaptEnvelope {
+	const openclaw = observeOpenClaw(paths, planning);
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		generatedAt: now.toISOString(),
+		target: "openclaw",
+		displayName: "OpenClaw",
+		summary:
+			"OMX-owned OpenClaw adapter metadata built from existing local config, gateway, and lifecycle seams.",
+		adapterPaths: paths,
+		planning,
+		capabilities,
+		constraints: [
+			"Status reflects local OMX/OpenClaw adapter evidence only; it does not claim downstream OpenClaw acknowledgement.",
+			"Bootstrap output stays under .omx/adapters/openclaw/... and does not mutate .omx/state or upstream OpenClaw config.",
+			"Command gateways remain gated by OMX_OPENCLAW_COMMAND=1 even when OMX_OPENCLAW=1 is enabled.",
+		],
+		openclaw,
+	};
+}
+
+export function buildOpenClawProbeReport(
+	paths: AdaptPathSet,
+	planning: AdaptPlanningLink,
+	capabilities: AdaptCapabilityReport[],
+	now: Date,
+): AdaptProbeReport {
+	const openclaw = observeOpenClaw(paths, planning);
+	const blockedHooks = openclaw.hooks.filter(
+		(hook) => hook.status === "blocked",
+	);
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		timestamp: now.toISOString(),
+		target: "openclaw",
+		phase: "foundation",
+		summary: openclaw.observedDetail,
+		adapterPaths: paths,
+		planning,
+		capabilities,
+		targetRuntime: {
+			state: "not-implemented",
+			detail:
+				"Probe reports only local OpenClaw adapter evidence; remote runtime acceptance remains unobserved.",
+		},
+		openclaw,
+		nextSteps:
+			blockedHooks.length > 0
+				? blockedHooks.map((hook) => `${hook.event}: ${hook.detail}`)
+				: [
+						"Run omx adapt openclaw init --write to materialize adapter-owned OpenClaw artifacts.",
+						"Confirm downstream OpenClaw behavior separately; this probe reports local wiring evidence only.",
+					],
+	};
+}
+
+export function buildOpenClawStatusReport(
+	paths: AdaptPathSet,
+	planning: AdaptPlanningLink,
+	capabilities: AdaptCapabilityReport[],
+	now: Date,
+): AdaptStatusReport {
+	const initialized =
+		existsSync(paths.configPath) && existsSync(paths.envelopePath);
+	const openclaw = observeOpenClaw(paths, planning);
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		timestamp: now.toISOString(),
+		target: "openclaw",
+		phase: "foundation",
+		summary: initialized
+			? `OpenClaw adapter artifacts exist under .omx/adapters/openclaw/... and local runtime evidence is ${openclaw.observedState}.`
+			: `OpenClaw adapter artifacts have not been written yet; local runtime evidence is ${openclaw.observedState}.`,
+		adapter: {
+			state: initialized ? "initialized" : "not-initialized",
+			detail: initialized
+				? "Adapter-owned OpenClaw artifacts are present under .omx/adapters/openclaw/..."
+				: "Run init --write to create adapter-owned OpenClaw artifacts.",
+			configPath: paths.configPath,
+			envelopePath: paths.envelopePath,
+		},
+		targetRuntime: {
+			state: "unknown",
+			detail:
+				"Status reflects local config/env/gateway wiring evidence only, not authoritative remote OpenClaw runtime health.",
+		},
+		planning,
+		capabilities,
+		openclaw,
+	};
+}
+
+export function buildOpenClawDoctorReport(
+	paths: AdaptPathSet,
+	planning: AdaptPlanningLink,
+	now: Date,
+): AdaptDoctorReport {
+	const openclaw = observeOpenClaw(paths, planning);
+	const issues = [];
+
+	if (!existsSync(paths.configPath) || !existsSync(paths.envelopePath)) {
+		issues.push({
+			code: "adapter_not_initialized",
+			message:
+				"No OpenClaw adapter artifacts exist under .omx/adapters/openclaw.",
+		});
+	}
+
+	if (!openclaw.config.activationGateEnabled) {
+		issues.push({
+			code: "openclaw_disabled",
+			message:
+				"OMX_OPENCLAW=1 is required before OpenClaw local config can be observed.",
+		});
+	} else if (
+		openclaw.observedState === "missing-config" ||
+		openclaw.observedState === "not-configured"
+	) {
+		issues.push({
+			code: "openclaw_config_missing",
+			message: `No usable OpenClaw config was found at ${openclaw.config.configPath}.`,
+		});
+	} else if (openclaw.observedState === "invalid-config") {
+		issues.push({
+			code: "openclaw_config_invalid",
+			message:
+				"OpenClaw config keys are present but do not form a valid runtime config.",
+		});
+	}
+
+	if (openclaw.hooks.some((hook) => hook.status === "blocked")) {
+		issues.push({
+			code: "openclaw_hook_blocked",
+			message:
+				"At least one enabled OpenClaw hook is locally blocked by missing gateway evidence or command-gateway opt-in.",
+		});
+	}
+
+	if (!planning.prdPath) {
+		issues.push({
+			code: "planning_artifacts_missing",
+			message:
+				"No canonical OMX PRD artifact is available to link into the OpenClaw adapter envelope.",
+		});
+	}
+
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		timestamp: now.toISOString(),
+		target: "openclaw",
+		phase: "foundation",
+		summary:
+			"OpenClaw doctor reports local adapter readiness and local gateway wiring evidence only.",
+		issues,
+		nextSteps: [
+			"Run omx adapt openclaw init --write.",
+			"Set OMX_OPENCLAW=1 and configure notifications.openclaw or compatible aliases in ~/.codex/.omx-config.json.",
+			"If command gateways are configured, also set OMX_OPENCLAW_COMMAND=1 before expecting command mappings to be locally ready.",
+		],
+	};
+}
+
+export function initOpenClawFoundation(
+	paths: AdaptPathSet,
+	planning: AdaptPlanningLink,
+	capabilities: AdaptCapabilityReport[],
+	write: boolean,
+	now: Date,
+): AdaptInitResult {
+	const envelope = buildOpenClawEnvelope(paths, planning, capabilities, now);
+	const previewPaths = [
+		paths.adapterRoot,
+		paths.configPath,
+		paths.envelopePath,
+		paths.reportsDir,
+		paths.probeReportPath,
+		paths.statusReportPath,
+	];
+	const wrotePaths: string[] = [];
+
+	if (write) {
+		mkdirSync(paths.reportsDir, { recursive: true });
+		writeFileSync(
+			paths.configPath,
+			`${JSON.stringify(
+				{
+					schemaVersion: ADAPT_SCHEMA_VERSION,
+					target: "openclaw",
+					createdAt: now.toISOString(),
+					phase: "openclaw-local-observation",
+					observedState: envelope.openclaw?.observedState ?? "not-configured",
+					summary: "OMX-owned OpenClaw adapter bootstrap metadata.",
+					lifecycleBridge: envelope.openclaw?.lifecycleBridge ?? [],
+					constraints: envelope.constraints,
+				},
+				null,
+				2,
+			)}\n`,
+			"utf-8",
+		);
+		writeFileSync(
+			paths.envelopePath,
+			`${JSON.stringify(envelope, null, 2)}\n`,
+			"utf-8",
+		);
+		wrotePaths.push(paths.configPath, paths.envelopePath);
+	}
+
+	return {
+		schemaVersion: ADAPT_SCHEMA_VERSION,
+		timestamp: now.toISOString(),
+		target: "openclaw",
+		write,
+		summary: write
+			? "OpenClaw adapter metadata was written under .omx/adapters/openclaw/..."
+			: "OpenClaw adapter bootstrap preview is ready; rerun with --write to materialize it.",
+		previewPaths,
+		wrotePaths,
+		envelope,
+	};
+}

--- a/src/adapt/registry.ts
+++ b/src/adapt/registry.ts
@@ -1,111 +1,111 @@
 import {
-  type AdaptCapabilityReport,
-  ADAPT_TARGETS,
-  type AdaptTarget,
-  type AdaptTargetDescriptor,
+	ADAPT_TARGETS,
+	type AdaptCapabilityReport,
+	type AdaptTarget,
+	type AdaptTargetDescriptor,
 } from "./contracts.js";
 
 function capability(
-  id: string,
-  label: string,
-  ownership: AdaptCapabilityReport["ownership"],
-  status: AdaptCapabilityReport["status"],
-  summary: string,
+	id: string,
+	label: string,
+	ownership: AdaptCapabilityReport["ownership"],
+	status: AdaptCapabilityReport["status"],
+	summary: string,
 ): AdaptCapabilityReport {
-  return {
-    id,
-    label,
-    ownership,
-    status,
-    summary,
-  };
+	return {
+		id,
+		label,
+		ownership,
+		status,
+		summary,
+	};
 }
 
 const FOUNDATION_CAPABILITIES: AdaptCapabilityReport[] = [
-  capability(
-    "omx-adapter-paths",
-    "OMX-owned adapter paths",
-    "omx-owned",
-    "ready",
-    "Adapter artifacts stay under .omx/adapters/<target>/... rather than .omx/state or target internals.",
-  ),
-  capability(
-    "planning-artifact-linkage",
-    "Planning artifact linkage",
-    "shared-contract",
-    "ready",
-    "Envelope output links canonical OMX PRD/test-spec artifacts when they exist.",
-  ),
-  capability(
-    "foundation-reporting",
-    "Foundation reporting surface",
-    "shared-contract",
-    "ready",
-    "Probe, status, envelope, init, and doctor share a target-agnostic output contract.",
-  ),
+	capability(
+		"omx-adapter-paths",
+		"OMX-owned adapter paths",
+		"omx-owned",
+		"ready",
+		"Adapter artifacts stay under .omx/adapters/<target>/... rather than .omx/state or target internals.",
+	),
+	capability(
+		"planning-artifact-linkage",
+		"Planning artifact linkage",
+		"shared-contract",
+		"ready",
+		"Envelope output links canonical OMX PRD/test-spec artifacts when they exist.",
+	),
+	capability(
+		"foundation-reporting",
+		"Foundation reporting surface",
+		"shared-contract",
+		"ready",
+		"Probe, status, envelope, init, and doctor share a target-agnostic output contract.",
+	),
 ];
 
 const TARGET_DESCRIPTORS: Record<AdaptTarget, AdaptTargetDescriptor> = {
-  openclaw: {
-    target: "openclaw",
-    displayName: "OpenClaw",
-    summary:
-      "Foundation seam for an OMX-owned adapter around existing OpenClaw notification and gateway surfaces.",
-    followupHint:
-      "OpenClaw-specific probe, config observation, and event mapping land in a follow-on PR.",
-    capabilities: [
-      ...FOUNDATION_CAPABILITIES,
-      capability(
-        "gateway-observation",
-        "Gateway observation",
-        "target-observed",
-        "stub",
-        "Foundation reports the seam only; it does not inspect OpenClaw config or remote health yet.",
-      ),
-      capability(
-        "lifecycle-bridge",
-        "Lifecycle bridge metadata",
-        "shared-contract",
-        "stub",
-        "Foundation reserves the shared envelope/reporting seam without implementing OpenClaw event wiring.",
-      ),
-    ],
-  },
-  hermes: {
-    target: "hermes",
-    displayName: "Hermes",
-    summary:
-      "Foundation seam for an OMX-owned adapter around Hermes ACP, gateway, and persistent-session surfaces.",
-    followupHint:
-      "Hermes-specific ACP probing, status synthesis, and path overrides land in a follow-on PR.",
-    capabilities: [
-      ...FOUNDATION_CAPABILITIES,
-      capability(
-        "persistent-session-observation",
-        "Persistent session observation",
-        "target-observed",
-        "stub",
-        "Foundation reports the seam only; it does not inspect Hermes runtime files or session stores yet.",
-      ),
-      capability(
-        "acp-envelope-bridge",
-        "ACP envelope bridge",
-        "shared-contract",
-        "stub",
-        "Foundation reserves shared metadata exchange without claiming control over Hermes runtime internals.",
-      ),
-    ],
-  },
+	openclaw: {
+		target: "openclaw",
+		displayName: "OpenClaw",
+		summary:
+			"OMX-owned adapter around existing OpenClaw notification, gateway, and lifecycle observation surfaces.",
+		followupHint:
+			"Status reflects local OpenClaw config/env/gateway evidence only; remote acknowledgement remains out of scope.",
+		capabilities: [
+			...FOUNDATION_CAPABILITIES,
+			capability(
+				"gateway-observation",
+				"Gateway observation",
+				"target-observed",
+				"ready",
+				"Local OpenClaw config/env/gateway evidence is observed through existing config and gateway resolution seams.",
+			),
+			capability(
+				"lifecycle-bridge",
+				"Lifecycle bridge metadata",
+				"shared-contract",
+				"ready",
+				"Probe, status, and envelope surface the existing OMX to OpenClaw lifecycle mapping without claiming remote execution health.",
+			),
+		],
+	},
+	hermes: {
+		target: "hermes",
+		displayName: "Hermes",
+		summary:
+			"Foundation seam for an OMX-owned adapter around Hermes ACP, gateway, and persistent-session surfaces.",
+		followupHint:
+			"Hermes-specific ACP probing, status synthesis, and path overrides land in a follow-on PR.",
+		capabilities: [
+			...FOUNDATION_CAPABILITIES,
+			capability(
+				"persistent-session-observation",
+				"Persistent session observation",
+				"target-observed",
+				"stub",
+				"Foundation reports the seam only; it does not inspect Hermes runtime files or session stores yet.",
+			),
+			capability(
+				"acp-envelope-bridge",
+				"ACP envelope bridge",
+				"shared-contract",
+				"stub",
+				"Foundation reserves shared metadata exchange without claiming control over Hermes runtime internals.",
+			),
+		],
+	},
 };
 
 export function listAdaptTargets(): AdaptTargetDescriptor[] {
-  return ADAPT_TARGETS.map((target) => TARGET_DESCRIPTORS[target]);
+	return ADAPT_TARGETS.map((target) => TARGET_DESCRIPTORS[target]);
 }
 
 export function getAdaptTargetDescriptor(
-  target: string,
+	target: string,
 ): AdaptTargetDescriptor | null {
-  return Object.hasOwn(TARGET_DESCRIPTORS, target)
-    ? TARGET_DESCRIPTORS[target as AdaptTarget]
-    : null;
+	return Object.hasOwn(TARGET_DESCRIPTORS, target)
+		? TARGET_DESCRIPTORS[target as AdaptTarget]
+		: null;
 }

--- a/src/cli/__tests__/adapt.test.ts
+++ b/src/cli/__tests__/adapt.test.ts
@@ -1,50 +1,73 @@
-import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 import { adaptCommand } from "../adapt.js";
 
 describe("adaptCommand", () => {
-  it("prints help when called without args", async () => {
-    const out: string[] = [];
-    await adaptCommand([], {
-      stdout: (line) => out.push(line),
-    });
-    assert.match(out.join("\n"), /Usage: omx adapt <target>/i);
-  });
+	it("prints help when called without args", async () => {
+		const out: string[] = [];
+		await adaptCommand([], {
+			stdout: (line) => out.push(line),
+		});
+		assert.match(out.join("\n"), /Usage: omx adapt <target>/i);
+	});
 
-  it("fails clearly for unknown targets", async () => {
-    await assert.rejects(
-      adaptCommand(["unknown", "probe"], {
-        stdout: () => undefined,
-      }),
-      /Supported targets: openclaw, hermes/i,
-    );
-  });
+	it("fails clearly for unknown targets", async () => {
+		await assert.rejects(
+			adaptCommand(["unknown", "probe"], {
+				stdout: () => undefined,
+			}),
+			/Supported targets: openclaw, hermes/i,
+		);
+	});
 
-  it("emits compact JSON envelopes when --json is set", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-adapt-cli-"));
-    const out: string[] = [];
-    try {
-      await adaptCommand(["openclaw", "probe", "--json"], {
-        cwd,
-        stdout: (line) => out.push(line),
-      });
-      assert.equal(out.length, 1);
-      assert.match(out[0] ?? "", /^\{"schemaVersion":"1\.0","timestamp":/);
-      assert.match(out[0] ?? "", /"target":"openclaw"/);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
+	it("emits compact JSON envelopes when --json is set", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-adapt-cli-"));
+		const out: string[] = [];
+		try {
+			await adaptCommand(["openclaw", "probe", "--json"], {
+				cwd,
+				stdout: (line) => out.push(line),
+			});
+			assert.equal(out.length, 1);
+			assert.match(out[0] ?? "", /^\{"schemaVersion":"1\.0","timestamp":/);
+			assert.match(out[0] ?? "", /"target":"openclaw"/);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
-  it("rejects --write outside init", async () => {
-    await assert.rejects(
-      adaptCommand(["hermes", "status", "--write"], {
-        stdout: () => undefined,
-      }),
-      /only supported with omx adapt <target> init/i,
-    );
-  });
+	it("rejects --write outside init", async () => {
+		await assert.rejects(
+			adaptCommand(["hermes", "status", "--write"], {
+				stdout: () => undefined,
+			}),
+			/only supported with omx adapt <target> init/i,
+		);
+	});
+
+	it("reports OpenClaw local observation details in JSON status output", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-adapt-cli-openclaw-"));
+		const out: string[] = [];
+		try {
+			process.env.CODEX_HOME = join(cwd, ".codex-home");
+			process.env.OMX_OPENCLAW = "1";
+			await adaptCommand(["openclaw", "status", "--json"], {
+				cwd,
+				stdout: (line) => out.push(line),
+			});
+			const parsed = JSON.parse(out[0] ?? "") as {
+				target: string;
+				openclaw?: { observedState: string };
+			};
+			assert.equal(parsed.target, "openclaw");
+			assert.equal(parsed.openclaw?.observedState, "missing-config");
+		} finally {
+			delete process.env.CODEX_HOME;
+			delete process.env.OMX_OPENCLAW;
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/cli/adapt.ts
+++ b/src/cli/adapt.ts
@@ -1,174 +1,178 @@
 import {
-  ADAPT_SUBCOMMANDS,
-  type AdaptSubcommand,
-  type AdaptTarget,
+	ADAPT_SUBCOMMANDS,
+	type AdaptSubcommand,
+	type AdaptTarget,
 } from "../adapt/contracts.js";
 import {
-  buildAdaptDoctorReport,
-  buildAdaptEnvelope,
-  buildAdaptProbeReport,
-  buildAdaptStatusReport,
-  initAdaptFoundation,
-  supportedAdaptTargets,
+	buildAdaptDoctorReport,
+	buildAdaptEnvelope,
+	buildAdaptProbeReport,
+	buildAdaptStatusReport,
+	initAdaptFoundation,
+	supportedAdaptTargets,
 } from "../adapt/index.js";
 import { getAdaptTargetDescriptor } from "../adapt/registry.js";
 
 const HELP = [
-  "Usage: omx adapt <target> <probe|status|init|envelope|doctor> [--json] [--write]",
-  "",
-  "Targets:",
-  "  openclaw  Foundation seam for OMX-owned OpenClaw adapter artifacts and reporting",
-  "  hermes    Foundation seam for OMX-owned Hermes adapter artifacts and reporting",
-  "",
-  "Subcommands:",
-  "  probe     Report shared foundation probe metadata (target-specific runtime probing is deferred)",
-  "  status    Report OMX-owned adapter initialization status plus deferred target-runtime status",
-  "  init      Preview or write OMX-owned adapter artifacts under .omx/adapters/<target>/...",
-  "  envelope  Print the normalized OMX-owned adapter envelope for the target",
-  "  doctor    Explain blocked foundation steps and follow-on integration gaps",
-  "",
-  "Options:",
-  "  --json    Emit compact machine-readable JSON",
-  "  --write   Only valid with init; write adapter artifacts under .omx/adapters/<target>/...",
-  "",
-  "Examples:",
-  "  omx adapt openclaw probe",
-  "  omx adapt hermes status --json",
-  "  omx adapt openclaw init --write",
-  "  omx adapt hermes envelope --json",
+	"Usage: omx adapt <target> <probe|status|init|envelope|doctor> [--json] [--write]",
+	"",
+	"Targets:",
+	"  openclaw  Foundation seam for OMX-owned OpenClaw adapter artifacts and reporting",
+	"  hermes    Foundation seam for OMX-owned Hermes adapter artifacts and reporting",
+	"",
+	"Subcommands:",
+	"  probe     Report shared foundation probe metadata (target-specific runtime probing is deferred)",
+	"  status    Report OMX-owned adapter initialization status plus deferred target-runtime status",
+	"  init      Preview or write OMX-owned adapter artifacts under .omx/adapters/<target>/...",
+	"  envelope  Print the normalized OMX-owned adapter envelope for the target",
+	"  doctor    Explain blocked foundation steps and follow-on integration gaps",
+	"",
+	"Options:",
+	"  --json    Emit compact machine-readable JSON",
+	"  --write   Only valid with init; write adapter artifacts under .omx/adapters/<target>/...",
+	"",
+	"Examples:",
+	"  omx adapt openclaw probe",
+	"  omx adapt hermes status --json",
+	"  omx adapt openclaw init --write",
+	"  omx adapt hermes envelope --json",
 ].join("\n");
 
 function targetHelp(target: AdaptTarget): string {
-  const descriptor = getAdaptTargetDescriptor(target);
-  if (!descriptor) return HELP;
-  return [
-    `Usage: omx adapt ${target} <${ADAPT_SUBCOMMANDS.join("|")}> [--json] [--write]`,
-    "",
-    descriptor.summary,
-    "",
-    "Notes:",
-    "  This PR exposes the shared foundation only.",
-    "  Target-specific runtime probing and integration logic are intentionally deferred.",
-    `  ${descriptor.followupHint}`,
-    "",
-    HELP,
-  ].join("\n");
+	const descriptor = getAdaptTargetDescriptor(target);
+	if (!descriptor) return HELP;
+	return [
+		`Usage: omx adapt ${target} <${ADAPT_SUBCOMMANDS.join("|")}> [--json] [--write]`,
+		"",
+		descriptor.summary,
+		"",
+		"Notes:",
+		target === "openclaw"
+			? "  OpenClaw exposes local config/env/gateway observation and lifecycle bridge metadata."
+			: "  This PR exposes the shared foundation only.",
+		target === "openclaw"
+			? "  Status remains local-only and does not claim downstream OpenClaw runtime acknowledgement."
+			: "  Target-specific runtime probing and integration logic are intentionally deferred.",
+		`  ${descriptor.followupHint}`,
+		"",
+		HELP,
+	].join("\n");
 }
 
 function parseArgs(args: string[]): {
-  target: string | undefined;
-  subcommand: string | undefined;
-  json: boolean;
-  write: boolean;
-  wantsHelp: boolean;
+	target: string | undefined;
+	subcommand: string | undefined;
+	json: boolean;
+	write: boolean;
+	wantsHelp: boolean;
 } {
-  let target: string | undefined;
-  let subcommand: string | undefined;
-  let json = false;
-  let write = false;
-  let wantsHelp = false;
+	let target: string | undefined;
+	let subcommand: string | undefined;
+	let json = false;
+	let write = false;
+	let wantsHelp = false;
 
-  for (const arg of args) {
-    if (arg === "--json") {
-      json = true;
-      continue;
-    }
-    if (arg === "--write") {
-      write = true;
-      continue;
-    }
-    if (arg === "--help" || arg === "-h" || arg === "help") {
-      wantsHelp = true;
-      continue;
-    }
-    if (!target) {
-      target = arg;
-      continue;
-    }
-    if (!subcommand) {
-      subcommand = arg;
-      continue;
-    }
-    throw new Error(`Unknown adapt argument: ${arg}`);
-  }
+	for (const arg of args) {
+		if (arg === "--json") {
+			json = true;
+			continue;
+		}
+		if (arg === "--write") {
+			write = true;
+			continue;
+		}
+		if (arg === "--help" || arg === "-h" || arg === "help") {
+			wantsHelp = true;
+			continue;
+		}
+		if (!target) {
+			target = arg;
+			continue;
+		}
+		if (!subcommand) {
+			subcommand = arg;
+			continue;
+		}
+		throw new Error(`Unknown adapt argument: ${arg}`);
+	}
 
-  return { target, subcommand, json, write, wantsHelp };
+	return { target, subcommand, json, write, wantsHelp };
 }
 
 function render(
-  value: unknown,
-  json: boolean,
-  stdout: (line: string) => void,
+	value: unknown,
+	json: boolean,
+	stdout: (line: string) => void,
 ): void {
-  stdout(JSON.stringify(value, null, json ? 0 : 2));
+	stdout(JSON.stringify(value, null, json ? 0 : 2));
 }
 
 export interface AdaptCommandDependencies {
-  cwd?: string;
-  stdout?: (line: string) => void;
+	cwd?: string;
+	stdout?: (line: string) => void;
 }
 
 export async function adaptCommand(
-  args: string[],
-  deps: AdaptCommandDependencies = {},
+	args: string[],
+	deps: AdaptCommandDependencies = {},
 ): Promise<void> {
-  const cwd = deps.cwd ?? process.cwd();
-  const stdout = deps.stdout ?? ((line: string) => console.log(line));
-  const { target, subcommand, json, write, wantsHelp } = parseArgs(args);
+	const cwd = deps.cwd ?? process.cwd();
+	const stdout = deps.stdout ?? ((line: string) => console.log(line));
+	const { target, subcommand, json, write, wantsHelp } = parseArgs(args);
 
-  if (!target || wantsHelp) {
-    if (!target) {
-      stdout(HELP);
-      return;
-    }
+	if (!target || wantsHelp) {
+		if (!target) {
+			stdout(HELP);
+			return;
+		}
 
-    const descriptor = getAdaptTargetDescriptor(target);
-    if (!descriptor) {
-      throw new Error(
-        `Unknown adapt target: ${target}. Supported targets: ${supportedAdaptTargets().join(", ")}`,
-      );
-    }
-    stdout(targetHelp(descriptor.target));
-    return;
-  }
+		const descriptor = getAdaptTargetDescriptor(target);
+		if (!descriptor) {
+			throw new Error(
+				`Unknown adapt target: ${target}. Supported targets: ${supportedAdaptTargets().join(", ")}`,
+			);
+		}
+		stdout(targetHelp(descriptor.target));
+		return;
+	}
 
-  const descriptor = getAdaptTargetDescriptor(target);
-  if (!descriptor) {
-    throw new Error(
-      `Unknown adapt target: ${target}. Supported targets: ${supportedAdaptTargets().join(", ")}`,
-    );
-  }
+	const descriptor = getAdaptTargetDescriptor(target);
+	if (!descriptor) {
+		throw new Error(
+			`Unknown adapt target: ${target}. Supported targets: ${supportedAdaptTargets().join(", ")}`,
+		);
+	}
 
-  if (!subcommand) {
-    stdout(targetHelp(descriptor.target));
-    return;
-  }
+	if (!subcommand) {
+		stdout(targetHelp(descriptor.target));
+		return;
+	}
 
-  if (!ADAPT_SUBCOMMANDS.includes(subcommand as AdaptSubcommand)) {
-    throw new Error(
-      `Unknown adapt subcommand: ${subcommand}. Supported subcommands: ${ADAPT_SUBCOMMANDS.join(", ")}`,
-    );
-  }
+	if (!ADAPT_SUBCOMMANDS.includes(subcommand as AdaptSubcommand)) {
+		throw new Error(
+			`Unknown adapt subcommand: ${subcommand}. Supported subcommands: ${ADAPT_SUBCOMMANDS.join(", ")}`,
+		);
+	}
 
-  if (write && subcommand !== "init") {
-    throw new Error("--write is only supported with omx adapt <target> init");
-  }
+	if (write && subcommand !== "init") {
+		throw new Error("--write is only supported with omx adapt <target> init");
+	}
 
-  switch (subcommand as AdaptSubcommand) {
-    case "probe":
-      render(buildAdaptProbeReport(cwd, descriptor.target), json, stdout);
-      return;
-    case "status":
-      render(buildAdaptStatusReport(cwd, descriptor.target), json, stdout);
-      return;
-    case "init":
-      render(initAdaptFoundation(cwd, descriptor.target, write), json, stdout);
-      return;
-    case "envelope":
-      render(buildAdaptEnvelope(cwd, descriptor.target), json, stdout);
-      return;
-    case "doctor":
-      render(buildAdaptDoctorReport(cwd, descriptor.target), json, stdout);
-      return;
-  }
+	switch (subcommand as AdaptSubcommand) {
+		case "probe":
+			render(buildAdaptProbeReport(cwd, descriptor.target), json, stdout);
+			return;
+		case "status":
+			render(buildAdaptStatusReport(cwd, descriptor.target), json, stdout);
+			return;
+		case "init":
+			render(initAdaptFoundation(cwd, descriptor.target, write), json, stdout);
+			return;
+		case "envelope":
+			render(buildAdaptEnvelope(cwd, descriptor.target), json, stdout);
+			return;
+		case "doctor":
+			render(buildAdaptDoctorReport(cwd, descriptor.target), json, stdout);
+			return;
+	}
 }

--- a/src/openclaw/__tests__/config.test.ts
+++ b/src/openclaw/__tests__/config.test.ts
@@ -3,271 +3,396 @@
  * Uses node:test and node:assert/strict
  */
 
-import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { writeFileSync, mkdirSync, rmSync } from "fs";
-import { join } from "path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
+import { join } from "path";
 
 // We'll test by controlling env vars and a temp config dir
 
 describe("getOpenClawConfig", () => {
-  let tmpDir: string;
-  let originalEnv: NodeJS.ProcessEnv;
+	let tmpDir: string;
+	let originalEnv: NodeJS.ProcessEnv;
 
-  beforeEach(() => {
-    originalEnv = { ...process.env };
-    tmpDir = join(tmpdir(), `omx-openclaw-test-${Date.now()}`);
-    mkdirSync(tmpDir, { recursive: true });
-    process.env.CODEX_HOME = join(tmpDir, ".codex");
-  });
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		tmpDir = join(tmpdir(), `omx-openclaw-test-${Date.now()}`);
+		mkdirSync(tmpDir, { recursive: true });
+		process.env.CODEX_HOME = join(tmpDir, ".codex");
+	});
 
-  afterEach(() => {
-    // Restore env
-    for (const key of Object.keys(process.env)) {
-      if (!(key in originalEnv)) delete process.env[key];
-    }
-    for (const [key, val] of Object.entries(originalEnv)) {
-      process.env[key] = val;
-    }
-    // Clean up temp dir
-    try { rmSync(tmpDir, { recursive: true }); } catch { /* ignore */ }
-    // Reset cache between tests (dynamic import to allow resetting)
-  });
+	afterEach(() => {
+		// Restore env
+		for (const key of Object.keys(process.env)) {
+			if (!(key in originalEnv)) delete process.env[key];
+		}
+		for (const [key, val] of Object.entries(originalEnv)) {
+			process.env[key] = val;
+		}
+		// Clean up temp dir
+		try {
+			rmSync(tmpDir, { recursive: true });
+		} catch {
+			/* ignore */
+		}
+		// Reset cache between tests (dynamic import to allow resetting)
+	});
 
-  it("returns null when OMX_OPENCLAW is not set", async () => {
-    delete process.env.OMX_OPENCLAW;
-    const { getOpenClawConfig, resetOpenClawConfigCache } = await import("../config.js");
-    resetOpenClawConfigCache();
-    const result = getOpenClawConfig();
-    assert.equal(result, null);
-  });
+	it("returns null when OMX_OPENCLAW is not set", async () => {
+		delete process.env.OMX_OPENCLAW;
+		const { getOpenClawConfig, resetOpenClawConfigCache } = await import(
+			"../config.js"
+		);
+		resetOpenClawConfigCache();
+		const result = getOpenClawConfig();
+		assert.equal(result, null);
+	});
 
-  it("returns null when OMX_OPENCLAW !== '1'", async () => {
-    process.env.OMX_OPENCLAW = "0";
-    const { getOpenClawConfig, resetOpenClawConfigCache } = await import("../config.js");
-    resetOpenClawConfigCache();
-    const result = getOpenClawConfig();
-    assert.equal(result, null);
-  });
+	it("returns null when OMX_OPENCLAW !== '1'", async () => {
+		process.env.OMX_OPENCLAW = "0";
+		const { getOpenClawConfig, resetOpenClawConfigCache } = await import(
+			"../config.js"
+		);
+		resetOpenClawConfigCache();
+		const result = getOpenClawConfig();
+		assert.equal(result, null);
+	});
 
-  it("returns null when OMX_OPENCLAW_CONFIG file does not exist", async () => {
-    process.env.OMX_OPENCLAW = "1";
-    process.env.OMX_OPENCLAW_CONFIG = join(tmpDir, "nonexistent.json");
-    const { getOpenClawConfig, resetOpenClawConfigCache } = await import("../config.js");
-    resetOpenClawConfigCache();
-    const result = getOpenClawConfig();
-    assert.equal(result, null);
-  });
+	it("returns null when OMX_OPENCLAW_CONFIG file does not exist", async () => {
+		process.env.OMX_OPENCLAW = "1";
+		process.env.OMX_OPENCLAW_CONFIG = join(tmpDir, "nonexistent.json");
+		const { getOpenClawConfig, resetOpenClawConfigCache } = await import(
+			"../config.js"
+		);
+		resetOpenClawConfigCache();
+		const result = getOpenClawConfig();
+		assert.equal(result, null);
+	});
 
-  it("reads config from OMX_OPENCLAW_CONFIG override file", async () => {
-    process.env.OMX_OPENCLAW = "1";
-    const configPath = join(tmpDir, "openclaw.json");
-    const config = {
-      enabled: true,
-      gateways: {
-        myGateway: { type: "http" as const, url: "https://example.com/hook" },
-      },
-      hooks: {
-        "session-start": { gateway: "myGateway", instruction: "Session started", enabled: true },
-      },
-    };
-    writeFileSync(configPath, JSON.stringify(config));
-    process.env.OMX_OPENCLAW_CONFIG = configPath;
-    const { getOpenClawConfig, resetOpenClawConfigCache } = await import("../config.js");
-    resetOpenClawConfigCache();
-    const result = getOpenClawConfig();
-    assert.ok(result !== null);
-    assert.equal(result!.enabled, true);
-    assert.ok("myGateway" in result!.gateways);
-  });
+	it("reads config from OMX_OPENCLAW_CONFIG override file", async () => {
+		process.env.OMX_OPENCLAW = "1";
+		const configPath = join(tmpDir, "openclaw.json");
+		const config = {
+			enabled: true,
+			gateways: {
+				myGateway: { type: "http" as const, url: "https://example.com/hook" },
+			},
+			hooks: {
+				"session-start": {
+					gateway: "myGateway",
+					instruction: "Session started",
+					enabled: true,
+				},
+			},
+		};
+		writeFileSync(configPath, JSON.stringify(config));
+		process.env.OMX_OPENCLAW_CONFIG = configPath;
+		const { getOpenClawConfig, resetOpenClawConfigCache } = await import(
+			"../config.js"
+		);
+		resetOpenClawConfigCache();
+		const result = getOpenClawConfig();
+		assert.ok(result !== null);
+		assert.equal(result!.enabled, true);
+		assert.ok("myGateway" in result!.gateways);
+	});
 
-  it("returns null when config has enabled: false", async () => {
-    process.env.OMX_OPENCLAW = "1";
-    const configPath = join(tmpDir, "openclaw.json");
-    writeFileSync(configPath, JSON.stringify({ enabled: false, gateways: {}, hooks: {} }));
-    process.env.OMX_OPENCLAW_CONFIG = configPath;
-    const { getOpenClawConfig, resetOpenClawConfigCache } = await import("../config.js");
-    resetOpenClawConfigCache();
-    const result = getOpenClawConfig();
-    assert.equal(result, null);
-  });
+	it("returns null when config has enabled: false", async () => {
+		process.env.OMX_OPENCLAW = "1";
+		const configPath = join(tmpDir, "openclaw.json");
+		writeFileSync(
+			configPath,
+			JSON.stringify({ enabled: false, gateways: {}, hooks: {} }),
+		);
+		process.env.OMX_OPENCLAW_CONFIG = configPath;
+		const { getOpenClawConfig, resetOpenClawConfigCache } = await import(
+			"../config.js"
+		);
+		resetOpenClawConfigCache();
+		const result = getOpenClawConfig();
+		assert.equal(result, null);
+	});
 
-  it("returns null for invalid JSON", async () => {
-    process.env.OMX_OPENCLAW = "1";
-    const configPath = join(tmpDir, "openclaw.json");
-    writeFileSync(configPath, "not-valid-json{{{");
-    process.env.OMX_OPENCLAW_CONFIG = configPath;
-    const { getOpenClawConfig, resetOpenClawConfigCache } = await import("../config.js");
-    resetOpenClawConfigCache();
-    const result = getOpenClawConfig();
-    assert.equal(result, null);
-  });
+	it("returns null for invalid JSON", async () => {
+		process.env.OMX_OPENCLAW = "1";
+		const configPath = join(tmpDir, "openclaw.json");
+		writeFileSync(configPath, "not-valid-json{{{");
+		process.env.OMX_OPENCLAW_CONFIG = configPath;
+		const { getOpenClawConfig, resetOpenClawConfigCache } = await import(
+			"../config.js"
+		);
+		resetOpenClawConfigCache();
+		const result = getOpenClawConfig();
+		assert.equal(result, null);
+	});
 });
 
 describe("resolveGateway", () => {
-  it("returns null when event not in hooks", async () => {
-    const { resolveGateway } = await import("../config.js");
-    const config = {
-      enabled: true,
-      gateways: { gw: { url: "https://example.com", type: "http" as const } },
-      hooks: {},
-    };
-    const result = resolveGateway(config, "session-start");
-    assert.equal(result, null);
-  });
+	it("returns null when event not in hooks", async () => {
+		const { resolveGateway } = await import("../config.js");
+		const config = {
+			enabled: true,
+			gateways: { gw: { url: "https://example.com", type: "http" as const } },
+			hooks: {},
+		};
+		const result = resolveGateway(config, "session-start");
+		assert.equal(result, null);
+	});
 
-  it("returns null when mapping is disabled", async () => {
-    const { resolveGateway } = await import("../config.js");
-    const config = {
-      enabled: true,
-      gateways: { gw: { url: "https://example.com", type: "http" as const } },
-      hooks: {
-        "session-start": { gateway: "gw", instruction: "hi", enabled: false },
-      },
-    };
-    const result = resolveGateway(config, "session-start");
-    assert.equal(result, null);
-  });
+	it("returns null when mapping is disabled", async () => {
+		const { resolveGateway } = await import("../config.js");
+		const config = {
+			enabled: true,
+			gateways: { gw: { url: "https://example.com", type: "http" as const } },
+			hooks: {
+				"session-start": { gateway: "gw", instruction: "hi", enabled: false },
+			},
+		};
+		const result = resolveGateway(config, "session-start");
+		assert.equal(result, null);
+	});
 
-  it("returns null when gateway name not found", async () => {
-    const { resolveGateway } = await import("../config.js");
-    const config = {
-      enabled: true,
-      gateways: {},
-      hooks: {
-        "session-start": { gateway: "missing", instruction: "hi", enabled: true },
-      },
-    };
-    const result = resolveGateway(config, "session-start");
-    assert.equal(result, null);
-  });
+	it("returns null when gateway name not found", async () => {
+		const { resolveGateway } = await import("../config.js");
+		const config = {
+			enabled: true,
+			gateways: {},
+			hooks: {
+				"session-start": {
+					gateway: "missing",
+					instruction: "hi",
+					enabled: true,
+				},
+			},
+		};
+		const result = resolveGateway(config, "session-start");
+		assert.equal(result, null);
+	});
 
-  it("resolves an HTTP gateway", async () => {
-    const { resolveGateway } = await import("../config.js");
-    const config = {
-      enabled: true,
-      gateways: { gw: { url: "https://example.com/hook", type: "http" as const } },
-      hooks: {
-        "session-start": { gateway: "gw", instruction: "Session started", enabled: true },
-      },
-    };
-    const result = resolveGateway(config, "session-start");
-    assert.ok(result !== null);
-    assert.equal(result!.gatewayName, "gw");
-    assert.equal(result!.instruction, "Session started");
-  });
+	it("resolves an HTTP gateway", async () => {
+		const { resolveGateway } = await import("../config.js");
+		const config = {
+			enabled: true,
+			gateways: {
+				gw: { url: "https://example.com/hook", type: "http" as const },
+			},
+			hooks: {
+				"session-start": {
+					gateway: "gw",
+					instruction: "Session started",
+					enabled: true,
+				},
+			},
+		};
+		const result = resolveGateway(config, "session-start");
+		assert.ok(result !== null);
+		assert.equal(result!.gatewayName, "gw");
+		assert.equal(result!.instruction, "Session started");
+	});
 
-  it("resolves a command gateway", async () => {
-    const { resolveGateway } = await import("../config.js");
-    const config = {
-      enabled: true,
-      gateways: { cmd: { type: "command" as const, command: "echo hello" } },
-      hooks: {
-        "stop": { gateway: "cmd", instruction: "Stopped", enabled: true },
-      },
-    };
-    const result = resolveGateway(config, "stop");
-    assert.ok(result !== null);
-    assert.equal(result!.gatewayName, "cmd");
-  });
+	it("resolves a command gateway", async () => {
+		const { resolveGateway } = await import("../config.js");
+		const config = {
+			enabled: true,
+			gateways: { cmd: { type: "command" as const, command: "echo hello" } },
+			hooks: {
+				stop: { gateway: "cmd", instruction: "Stopped", enabled: true },
+			},
+		};
+		const result = resolveGateway(config, "stop");
+		assert.ok(result !== null);
+		assert.equal(result!.gatewayName, "cmd");
+	});
 
-  it("returns null when HTTP gateway has no url", async () => {
-    const { resolveGateway } = await import("../config.js");
-    const config = {
-      enabled: true,
-      gateways: { gw: { url: "", type: "http" as const } },
-      hooks: {
-        "session-start": { gateway: "gw", instruction: "hi", enabled: true },
-      },
-    };
-    const result = resolveGateway(config, "session-start");
-    assert.equal(result, null);
-  });
+	it("returns null when HTTP gateway has no url", async () => {
+		const { resolveGateway } = await import("../config.js");
+		const config = {
+			enabled: true,
+			gateways: { gw: { url: "", type: "http" as const } },
+			hooks: {
+				"session-start": { gateway: "gw", instruction: "hi", enabled: true },
+			},
+		};
+		const result = resolveGateway(config, "session-start");
+		assert.equal(result, null);
+	});
 });
 
-
 describe("getOpenClawConfig generic alias normalization", () => {
-  let tmpDir: string;
-  let originalEnv: NodeJS.ProcessEnv;
+	let tmpDir: string;
+	let originalEnv: NodeJS.ProcessEnv;
 
-  beforeEach(() => {
-    originalEnv = { ...process.env };
-    tmpDir = join(tmpdir(), `omx-openclaw-alias-test-${Date.now()}`);
-    mkdirSync(tmpDir, { recursive: true });
-    process.env.OMX_OPENCLAW = "1";
-    process.env.HOME = tmpDir;
-    process.env.CODEX_HOME = join(tmpDir, ".codex");
-    delete process.env.OMX_OPENCLAW_CONFIG;
-  });
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		tmpDir = join(tmpdir(), `omx-openclaw-alias-test-${Date.now()}`);
+		mkdirSync(tmpDir, { recursive: true });
+		process.env.OMX_OPENCLAW = "1";
+		process.env.HOME = tmpDir;
+		process.env.CODEX_HOME = join(tmpDir, ".codex");
+		delete process.env.OMX_OPENCLAW_CONFIG;
+	});
 
-  afterEach(() => {
-    for (const key of Object.keys(process.env)) {
-      if (!(key in originalEnv)) delete process.env[key];
-    }
-    for (const [key, val] of Object.entries(originalEnv)) {
-      process.env[key] = val;
-    }
-    try { rmSync(tmpDir, { recursive: true }); } catch { /* ignore */ }
-  });
+	afterEach(() => {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in originalEnv)) delete process.env[key];
+		}
+		for (const [key, val] of Object.entries(originalEnv)) {
+			process.env[key] = val;
+		}
+		try {
+			rmSync(tmpDir, { recursive: true });
+		} catch {
+			/* ignore */
+		}
+	});
 
-  it("normalizes custom_webhook_command alias to openclaw runtime config", async () => {
-    const omxConfigPath = join(tmpDir, ".codex", ".omx-config.json");
-    mkdirSync(join(tmpDir, ".codex"), { recursive: true });
-    writeFileSync(omxConfigPath, JSON.stringify({
-      notifications: {
-        enabled: true,
-        custom_webhook_command: {
-          enabled: true,
-          url: "https://example.com/hook",
-          events: ["session-end", "ask-user-question"],
-          instruction: "Notify {{event}}",
-        },
-      },
-    }));
+	it("normalizes custom_webhook_command alias to openclaw runtime config", async () => {
+		const omxConfigPath = join(tmpDir, ".codex", ".omx-config.json");
+		mkdirSync(join(tmpDir, ".codex"), { recursive: true });
+		writeFileSync(
+			omxConfigPath,
+			JSON.stringify({
+				notifications: {
+					enabled: true,
+					custom_webhook_command: {
+						enabled: true,
+						url: "https://example.com/hook",
+						events: ["session-end", "ask-user-question"],
+						instruction: "Notify {{event}}",
+					},
+				},
+			}),
+		);
 
-    const { getOpenClawConfig, resetOpenClawConfigCache } = await import("../config.js");
-    resetOpenClawConfigCache();
-    const result = getOpenClawConfig();
-    assert.ok(result !== null);
-    assert.equal(result!.enabled, true);
-    assert.ok(result!.gateways["custom-webhook"]);
-    assert.equal(result!.hooks["session-end"]?.gateway, "custom-webhook");
-  });
+		const { getOpenClawConfig, resetOpenClawConfigCache } = await import(
+			"../config.js"
+		);
+		resetOpenClawConfigCache();
+		const result = getOpenClawConfig();
+		assert.ok(result !== null);
+		assert.equal(result!.enabled, true);
+		assert.ok(result!.gateways["custom-webhook"]);
+		assert.equal(result!.hooks["session-end"]?.gateway, "custom-webhook");
+	});
 
-  it("explicit notifications.openclaw wins over generic aliases", async () => {
-    const omxConfigPath = join(tmpDir, ".codex", ".omx-config.json");
-    mkdirSync(join(tmpDir, ".codex"), { recursive: true });
-    writeFileSync(omxConfigPath, JSON.stringify({
-      notifications: {
-        enabled: true,
-        openclaw: {
-          enabled: true,
-          gateways: {
-            explicit: { type: "http", url: "https://explicit.example/hook" },
-          },
-          hooks: {
-            "session-end": {
-              enabled: true,
-              gateway: "explicit",
-              instruction: "explicit instruction",
-            },
-          },
-        },
-        custom_webhook_command: {
-          enabled: true,
-          url: "https://alias.example/hook",
-          events: ["session-end"],
-          instruction: "alias instruction",
-        },
-      },
-    }));
+	it("explicit notifications.openclaw wins over generic aliases", async () => {
+		const omxConfigPath = join(tmpDir, ".codex", ".omx-config.json");
+		mkdirSync(join(tmpDir, ".codex"), { recursive: true });
+		writeFileSync(
+			omxConfigPath,
+			JSON.stringify({
+				notifications: {
+					enabled: true,
+					openclaw: {
+						enabled: true,
+						gateways: {
+							explicit: { type: "http", url: "https://explicit.example/hook" },
+						},
+						hooks: {
+							"session-end": {
+								enabled: true,
+								gateway: "explicit",
+								instruction: "explicit instruction",
+							},
+						},
+					},
+					custom_webhook_command: {
+						enabled: true,
+						url: "https://alias.example/hook",
+						events: ["session-end"],
+						instruction: "alias instruction",
+					},
+				},
+			}),
+		);
 
-    const { getOpenClawConfig, resetOpenClawConfigCache } = await import("../config.js");
-    resetOpenClawConfigCache();
-    const result = getOpenClawConfig();
-    assert.ok(result !== null);
-    assert.ok(result!.gateways["explicit"]);
-    assert.equal(result!.hooks["session-end"]?.instruction, "explicit instruction");
-  });
+		const { getOpenClawConfig, resetOpenClawConfigCache } = await import(
+			"../config.js"
+		);
+		resetOpenClawConfigCache();
+		const result = getOpenClawConfig();
+		assert.ok(result !== null);
+		assert.ok(result!.gateways["explicit"]);
+		assert.equal(
+			result!.hooks["session-end"]?.instruction,
+			"explicit instruction",
+		);
+	});
+});
+
+describe("inspectOpenClawConfig", () => {
+	let tmpDir: string;
+	let originalEnv: NodeJS.ProcessEnv;
+
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		tmpDir = join(tmpdir(), `omx-openclaw-inspect-test-${Date.now()}`);
+		mkdirSync(tmpDir, { recursive: true });
+		process.env.HOME = tmpDir;
+		process.env.CODEX_HOME = join(tmpDir, ".codex");
+		delete process.env.OMX_OPENCLAW_CONFIG;
+		delete process.env.OMX_OPENCLAW_COMMAND;
+	});
+
+	afterEach(() => {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in originalEnv)) delete process.env[key];
+		}
+		for (const [key, val] of Object.entries(originalEnv)) {
+			process.env[key] = val;
+		}
+		try {
+			rmSync(tmpDir, { recursive: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it("reports disabled state when OMX_OPENCLAW is not enabled", async () => {
+		delete process.env.OMX_OPENCLAW;
+		const { inspectOpenClawConfig } = await import("../config.js");
+		const result = inspectOpenClawConfig();
+		assert.equal(result.state, "disabled");
+		assert.equal(result.activationGateEnabled, false);
+	});
+
+	it("reports explicit config overriding aliases", async () => {
+		process.env.OMX_OPENCLAW = "1";
+		const omxConfigPath = join(tmpDir, ".codex", ".omx-config.json");
+		mkdirSync(join(tmpDir, ".codex"), { recursive: true });
+		writeFileSync(
+			omxConfigPath,
+			JSON.stringify({
+				notifications: {
+					openclaw: {
+						enabled: true,
+						gateways: {
+							explicit: { type: "http", url: "https://explicit.example/hook" },
+						},
+						hooks: {
+							"session-end": {
+								enabled: true,
+								gateway: "explicit",
+								instruction: "done",
+							},
+						},
+					},
+					custom_webhook_command: {
+						enabled: true,
+						url: "https://alias.example/hook",
+						events: ["session-end"],
+						instruction: "alias",
+					},
+				},
+			}),
+		);
+
+		const { inspectOpenClawConfig } = await import("../config.js");
+		const result = inspectOpenClawConfig();
+		assert.equal(result.state, "configured");
+		assert.equal(result.configSource, "notifications.openclaw");
+		assert.equal(result.explicitOverridesAliases, true);
+		assert.deepEqual(result.aliasSources, ["custom_webhook_command"]);
+	});
 });

--- a/src/openclaw/config.ts
+++ b/src/openclaw/config.ts
@@ -9,135 +9,399 @@
  * Config file path can be overridden via OMX_OPENCLAW_CONFIG env var (points to a separate file).
  */
 
-import { readFileSync, existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { codexHome } from "../utils/paths.js";
 import type {
-  OpenClawConfig,
-  OpenClawHookEvent,
-  OpenClawGatewayConfig,
-  OpenClawCommandGatewayConfig,
-  OpenClawHookMapping,
+	OpenClawCommandGatewayConfig,
+	OpenClawConfig,
+	OpenClawGatewayConfig,
+	OpenClawHookEvent,
+	OpenClawHookMapping,
 } from "./types.js";
 
 /** Cached config (null = not yet read, undefined = read but file missing/invalid) */
 let _cachedConfig: OpenClawConfig | undefined | null = null;
 
 const VALID_HOOK_EVENTS: OpenClawHookEvent[] = [
-  "session-start",
-  "session-end",
-  "session-idle",
-  "ask-user-question",
-  "stop",
+	"session-start",
+	"session-end",
+	"session-idle",
+	"ask-user-question",
+	"stop",
 ];
 
-const DEFAULT_ALIAS_EVENTS: OpenClawHookEvent[] = ["session-end", "ask-user-question"];
+const DEFAULT_ALIAS_EVENTS: OpenClawHookEvent[] = [
+	"session-end",
+	"ask-user-question",
+];
+
+export type OpenClawConfigInspectionState =
+	| "configured"
+	| "disabled"
+	| "missing-config"
+	| "invalid-config"
+	| "not-configured";
+
+export type OpenClawConfigSource =
+	| "env-override"
+	| "notifications.openclaw"
+	| "custom-aliases";
+
+export interface OpenClawConfigInspection {
+	state: OpenClawConfigInspectionState;
+	activationGateEnabled: boolean;
+	commandGateEnabled: boolean;
+	configPath: string;
+	configExists: boolean;
+	configSource: OpenClawConfigSource | null;
+	explicitConfigPresent: boolean;
+	aliasConfigPresent: boolean;
+	aliasSources: Array<"custom_cli_command" | "custom_webhook_command">;
+	explicitOverridesAliases: boolean;
+	warnings: string[];
+	detail: string;
+	config: OpenClawConfig | null;
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
 }
 
 function parseEvents(value: unknown): OpenClawHookEvent[] {
-  if (!Array.isArray(value)) return [...DEFAULT_ALIAS_EVENTS];
-  const events = value
-    .filter((entry): entry is OpenClawHookEvent =>
-      typeof entry === "string" && VALID_HOOK_EVENTS.includes(entry as OpenClawHookEvent),
-    );
-  return events.length > 0 ? events : [...DEFAULT_ALIAS_EVENTS];
+	if (!Array.isArray(value)) return [...DEFAULT_ALIAS_EVENTS];
+	const events = value.filter(
+		(entry): entry is OpenClawHookEvent =>
+			typeof entry === "string" &&
+			VALID_HOOK_EVENTS.includes(entry as OpenClawHookEvent),
+	);
+	return events.length > 0 ? events : [...DEFAULT_ALIAS_EVENTS];
 }
 
 function parseInstruction(value: unknown, fallback: string): string {
-  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+	return typeof value === "string" && value.trim() ? value.trim() : fallback;
 }
 
-function normalizeFromCustomAliases(notifications: Record<string, unknown>): OpenClawConfig | null {
-  const webhookAlias = asRecord(notifications.custom_webhook_command);
-  const cliAlias = asRecord(notifications.custom_cli_command);
+function normalizeFromCustomAliases(notifications: Record<string, unknown>): {
+	config: OpenClawConfig | null;
+	sources: Array<"custom_cli_command" | "custom_webhook_command">;
+} {
+	const webhookAlias = asRecord(notifications.custom_webhook_command);
+	const cliAlias = asRecord(notifications.custom_cli_command);
+	const sources: Array<"custom_cli_command" | "custom_webhook_command"> = [];
 
-  const webhookEnabled = webhookAlias?.enabled !== false && typeof webhookAlias?.url === "string";
-  const cliEnabled = cliAlias?.enabled !== false && typeof cliAlias?.command === "string";
+	const webhookEnabled =
+		webhookAlias?.enabled !== false && typeof webhookAlias?.url === "string";
+	const cliEnabled =
+		cliAlias?.enabled !== false && typeof cliAlias?.command === "string";
 
-  if (!webhookEnabled && !cliEnabled) return null;
+	if (!webhookEnabled && !cliEnabled) {
+		return { config: null, sources };
+	}
 
-  const gateways: Record<string, OpenClawGatewayConfig> = {};
-  const hooks: Partial<Record<OpenClawHookEvent, OpenClawHookMapping>> = {};
+	const gateways: Record<string, OpenClawGatewayConfig> = {};
+	const hooks: Partial<Record<OpenClawHookEvent, OpenClawHookMapping>> = {};
 
-  const applyHooks = (events: OpenClawHookEvent[], gateway: string, instruction: string, source: string): void => {
-    for (const event of events) {
-      if (hooks[event]) {
-        console.warn(`[openclaw] warning: ${source} overrides existing mapping for event '${event}'`);
-      }
-      hooks[event] = {
-        enabled: true,
-        gateway,
-        instruction,
-      };
-    }
-  };
+	const applyHooks = (
+		events: OpenClawHookEvent[],
+		gateway: string,
+		instruction: string,
+		source: string,
+	): void => {
+		for (const event of events) {
+			if (hooks[event]) {
+				console.warn(
+					`[openclaw] warning: ${source} overrides existing mapping for event '${event}'`,
+				);
+			}
+			hooks[event] = {
+				enabled: true,
+				gateway,
+				instruction,
+			};
+		}
+	};
 
-  if (cliEnabled && cliAlias) {
-    const gatewayName =
-      typeof cliAlias.gateway === "string" && cliAlias.gateway.trim()
-        ? cliAlias.gateway.trim()
-        : "custom-cli";
+	if (cliEnabled && cliAlias) {
+		sources.push("custom_cli_command");
+		const gatewayName =
+			typeof cliAlias.gateway === "string" && cliAlias.gateway.trim()
+				? cliAlias.gateway.trim()
+				: "custom-cli";
 
-    gateways[gatewayName] = {
-      type: "command",
-      command: (cliAlias.command as string).trim(),
-      ...(typeof cliAlias.timeout === "number" ? { timeout: cliAlias.timeout } : {}),
-    } as OpenClawCommandGatewayConfig;
+		gateways[gatewayName] = {
+			type: "command",
+			command: (cliAlias.command as string).trim(),
+			...(typeof cliAlias.timeout === "number"
+				? { timeout: cliAlias.timeout }
+				: {}),
+		} as OpenClawCommandGatewayConfig;
 
-    applyHooks(
-      parseEvents(cliAlias.events),
-      gatewayName,
-      parseInstruction(
-        cliAlias.instruction,
-        "OMX event {{event}} for {{projectPath}}",
-      ),
-      "custom_cli_command",
-    );
-  }
+		applyHooks(
+			parseEvents(cliAlias.events),
+			gatewayName,
+			parseInstruction(
+				cliAlias.instruction,
+				"OMX event {{event}} for {{projectPath}}",
+			),
+			"custom_cli_command",
+		);
+	}
 
-  if (webhookEnabled && webhookAlias) {
-    const gatewayName =
-      typeof webhookAlias.gateway === "string" && webhookAlias.gateway.trim()
-        ? webhookAlias.gateway.trim()
-        : "custom-webhook";
+	if (webhookEnabled && webhookAlias) {
+		sources.push("custom_webhook_command");
+		const gatewayName =
+			typeof webhookAlias.gateway === "string" && webhookAlias.gateway.trim()
+				? webhookAlias.gateway.trim()
+				: "custom-webhook";
 
-    const method = webhookAlias.method === "PUT" ? "PUT" : "POST";
+		const method = webhookAlias.method === "PUT" ? "PUT" : "POST";
 
-    gateways[gatewayName] = {
-      type: "http",
-      url: (webhookAlias.url as string).trim(),
-      method,
-      ...(typeof webhookAlias.timeout === "number" ? { timeout: webhookAlias.timeout } : {}),
-      ...(asRecord(webhookAlias.headers) ? { headers: webhookAlias.headers as Record<string, string> } : {}),
-    };
+		gateways[gatewayName] = {
+			type: "http",
+			url: (webhookAlias.url as string).trim(),
+			method,
+			...(typeof webhookAlias.timeout === "number"
+				? { timeout: webhookAlias.timeout }
+				: {}),
+			...(asRecord(webhookAlias.headers)
+				? { headers: webhookAlias.headers as Record<string, string> }
+				: {}),
+		};
 
-    applyHooks(
-      parseEvents(webhookAlias.events),
-      gatewayName,
-      parseInstruction(
-        webhookAlias.instruction,
-        "OMX event {{event}} for {{projectPath}}",
-      ),
-      "custom_webhook_command",
-    );
-  }
+		applyHooks(
+			parseEvents(webhookAlias.events),
+			gatewayName,
+			parseInstruction(
+				webhookAlias.instruction,
+				"OMX event {{event}} for {{projectPath}}",
+			),
+			"custom_webhook_command",
+		);
+	}
 
-  if (Object.keys(gateways).length === 0 || Object.keys(hooks).length === 0) return null;
+	if (Object.keys(gateways).length === 0 || Object.keys(hooks).length === 0) {
+		return { config: null, sources };
+	}
 
-  return {
-    enabled: true,
-    gateways,
-    hooks,
-  };
+	return {
+		config: {
+			enabled: true,
+			gateways,
+			hooks,
+		},
+		sources,
+	};
 }
 
-function isValidOpenClawConfig(raw: OpenClawConfig | undefined): raw is OpenClawConfig {
-  return Boolean(raw?.enabled && raw.gateways && raw.hooks);
+function isValidOpenClawConfig(
+	raw: OpenClawConfig | undefined,
+): raw is OpenClawConfig {
+	return Boolean(raw?.enabled && raw.gateways && raw.hooks);
+}
+
+function defaultOmxConfigPath(): string {
+	return join(codexHome(), ".omx-config.json");
+}
+
+export function inspectOpenClawConfig(
+	env: NodeJS.ProcessEnv = process.env,
+): OpenClawConfigInspection {
+	const activationGateEnabled = env.OMX_OPENCLAW === "1";
+	const commandGateEnabled = env.OMX_OPENCLAW_COMMAND === "1";
+	const envOverride = env.OMX_OPENCLAW_CONFIG?.trim();
+	const configPath = envOverride || defaultOmxConfigPath();
+	const configExists = existsSync(configPath);
+
+	if (!activationGateEnabled) {
+		return {
+			state: "disabled",
+			activationGateEnabled,
+			commandGateEnabled,
+			configPath,
+			configExists,
+			configSource: null,
+			explicitConfigPresent: false,
+			aliasConfigPresent: false,
+			aliasSources: [],
+			explicitOverridesAliases: false,
+			warnings: [],
+			detail: "OpenClaw is disabled locally because OMX_OPENCLAW=1 is not set.",
+			config: null,
+		};
+	}
+
+	if (!configExists) {
+		return {
+			state: "missing-config",
+			activationGateEnabled,
+			commandGateEnabled,
+			configPath,
+			configExists,
+			configSource: null,
+			explicitConfigPresent: false,
+			aliasConfigPresent: false,
+			aliasSources: [],
+			explicitOverridesAliases: false,
+			warnings: [],
+			detail: envOverride
+				? `OMX_OPENCLAW_CONFIG points to ${configPath}, but the file does not exist.`
+				: `No OpenClaw config file was found at ${configPath}.`,
+			config: null,
+		};
+	}
+
+	try {
+		if (envOverride) {
+			const raw = JSON.parse(
+				readFileSync(configPath, "utf-8"),
+			) as OpenClawConfig;
+			if (!isValidOpenClawConfig(raw)) {
+				return {
+					state: "invalid-config",
+					activationGateEnabled,
+					commandGateEnabled,
+					configPath,
+					configExists,
+					configSource: null,
+					explicitConfigPresent: false,
+					aliasConfigPresent: false,
+					aliasSources: [],
+					explicitOverridesAliases: false,
+					warnings: [],
+					detail:
+						"OMX_OPENCLAW_CONFIG is present but does not contain a valid OpenClaw config.",
+					config: null,
+				};
+			}
+
+			return {
+				state: "configured",
+				activationGateEnabled,
+				commandGateEnabled,
+				configPath,
+				configExists,
+				configSource: "env-override",
+				explicitConfigPresent: false,
+				aliasConfigPresent: false,
+				aliasSources: [],
+				explicitOverridesAliases: false,
+				warnings: [],
+				detail: "OpenClaw config loaded from OMX_OPENCLAW_CONFIG.",
+				config: raw,
+			};
+		}
+
+		const fullConfig = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+			string,
+			unknown
+		>;
+		const notifications = asRecord(fullConfig.notifications);
+		if (!notifications) {
+			return {
+				state: "not-configured",
+				activationGateEnabled,
+				commandGateEnabled,
+				configPath,
+				configExists,
+				configSource: null,
+				explicitConfigPresent: false,
+				aliasConfigPresent: false,
+				aliasSources: [],
+				explicitOverridesAliases: false,
+				warnings: [],
+				detail:
+					"The OMX config file exists, but notifications are not configured.",
+				config: null,
+			};
+		}
+
+		const explicitOpenClaw = notifications.openclaw as
+			| OpenClawConfig
+			| undefined;
+		const explicitConfigPresent = explicitOpenClaw !== undefined;
+		const aliasInspection = normalizeFromCustomAliases(notifications);
+		const aliasConfigPresent = aliasInspection.config !== null;
+
+		if (isValidOpenClawConfig(explicitOpenClaw)) {
+			const explicitOverridesAliases = aliasInspection.config !== null;
+			return {
+				state: "configured",
+				activationGateEnabled,
+				commandGateEnabled,
+				configPath,
+				configExists,
+				configSource: "notifications.openclaw",
+				explicitConfigPresent,
+				aliasConfigPresent,
+				aliasSources: aliasInspection.sources,
+				explicitOverridesAliases,
+				warnings: explicitOverridesAliases
+					? [
+							"notifications.openclaw overrides custom_cli_command/custom_webhook_command aliases.",
+						]
+					: [],
+				detail: "OpenClaw config loaded from notifications.openclaw.",
+				config: explicitOpenClaw,
+			};
+		}
+
+		if (aliasInspection.config) {
+			return {
+				state: "configured",
+				activationGateEnabled,
+				commandGateEnabled,
+				configPath,
+				configExists,
+				configSource: "custom-aliases",
+				explicitConfigPresent,
+				aliasConfigPresent,
+				aliasSources: aliasInspection.sources,
+				explicitOverridesAliases: false,
+				warnings: [],
+				detail:
+					"OpenClaw config was synthesized from custom notification aliases.",
+				config: aliasInspection.config,
+			};
+		}
+
+		return {
+			state: explicitConfigPresent ? "invalid-config" : "not-configured",
+			activationGateEnabled,
+			commandGateEnabled,
+			configPath,
+			configExists,
+			configSource: null,
+			explicitConfigPresent,
+			aliasConfigPresent: aliasInspection.sources.length > 0,
+			aliasSources: aliasInspection.sources,
+			explicitOverridesAliases: false,
+			warnings: [],
+			detail:
+				explicitConfigPresent || aliasInspection.sources.length > 0
+					? "OpenClaw config keys exist, but they do not form a valid runtime config."
+					: "No OpenClaw-specific config or aliases were found in notifications.",
+			config: null,
+		};
+	} catch {
+		return {
+			state: "invalid-config",
+			activationGateEnabled,
+			commandGateEnabled,
+			configPath,
+			configExists,
+			configSource: null,
+			explicitConfigPresent: false,
+			aliasConfigPresent: false,
+			aliasSources: [],
+			explicitOverridesAliases: false,
+			warnings: [],
+			detail: "OpenClaw config exists but could not be parsed as JSON.",
+			config: null,
+		};
+	}
 }
 
 /**
@@ -155,72 +419,78 @@ function isValidOpenClawConfig(raw: OpenClawConfig | undefined): raw is OpenClaw
  * 3. notifications.custom_cli_command / notifications.custom_webhook_command aliases
  */
 export function getOpenClawConfig(): OpenClawConfig | null {
-  // Activation gate: only active when OMX_OPENCLAW=1
-  if (process.env.OMX_OPENCLAW !== "1") {
-    return null;
-  }
+	// Activation gate: only active when OMX_OPENCLAW=1
+	if (process.env.OMX_OPENCLAW !== "1") {
+		return null;
+	}
 
-  // Return cached result
-  if (_cachedConfig !== null) {
-    return _cachedConfig ?? null;
-  }
+	// Return cached result
+	if (_cachedConfig !== null) {
+		return _cachedConfig ?? null;
+	}
 
-  try {
-    const envOverride = process.env.OMX_OPENCLAW_CONFIG;
+	try {
+		const envOverride = process.env.OMX_OPENCLAW_CONFIG;
 
-    if (envOverride) {
-      // OMX_OPENCLAW_CONFIG points to a separate config file
-      if (!existsSync(envOverride)) {
-        _cachedConfig = undefined;
-        return null;
-      }
-      const raw = JSON.parse(readFileSync(envOverride, "utf-8")) as OpenClawConfig;
-      if (!isValidOpenClawConfig(raw)) {
-        _cachedConfig = undefined;
-        return null;
-      }
-      _cachedConfig = raw;
-      return raw;
-    }
+		if (envOverride) {
+			// OMX_OPENCLAW_CONFIG points to a separate config file
+			if (!existsSync(envOverride)) {
+				_cachedConfig = undefined;
+				return null;
+			}
+			const raw = JSON.parse(
+				readFileSync(envOverride, "utf-8"),
+			) as OpenClawConfig;
+			if (!isValidOpenClawConfig(raw)) {
+				_cachedConfig = undefined;
+				return null;
+			}
+			_cachedConfig = raw;
+			return raw;
+		}
 
-    // Primary: read from notifications block in .omx-config.json
-    const omxConfigPath = join(codexHome(), ".omx-config.json");
-    if (!existsSync(omxConfigPath)) {
-      _cachedConfig = undefined;
-      return null;
-    }
+		// Primary: read from notifications block in .omx-config.json
+		const omxConfigPath = defaultOmxConfigPath();
+		if (!existsSync(omxConfigPath)) {
+			_cachedConfig = undefined;
+			return null;
+		}
 
-    const fullConfig = JSON.parse(readFileSync(omxConfigPath, "utf-8")) as Record<string, unknown>;
-    const notifications = asRecord(fullConfig.notifications);
-    if (!notifications) {
-      _cachedConfig = undefined;
-      return null;
-    }
+		const fullConfig = JSON.parse(
+			readFileSync(omxConfigPath, "utf-8"),
+		) as Record<string, unknown>;
+		const notifications = asRecord(fullConfig.notifications);
+		if (!notifications) {
+			_cachedConfig = undefined;
+			return null;
+		}
 
-    const explicitOpenClaw = notifications.openclaw as OpenClawConfig | undefined;
-    const aliasOpenClaw = normalizeFromCustomAliases(notifications);
+		const explicitOpenClaw = notifications.openclaw as
+			| OpenClawConfig
+			| undefined;
+		const aliasOpenClaw = normalizeFromCustomAliases(notifications);
 
-    if (isValidOpenClawConfig(explicitOpenClaw)) {
-      if (aliasOpenClaw) {
-        console.warn(
-          "[openclaw] warning: notifications.openclaw is set; ignoring custom_cli_command/custom_webhook_command aliases",
-        );
-      }
-      _cachedConfig = explicitOpenClaw;
-      return explicitOpenClaw;
-    }
+		if (isValidOpenClawConfig(explicitOpenClaw)) {
+			if (aliasOpenClaw.config) {
+				console.warn(
+					"[openclaw] warning: notifications.openclaw is set; ignoring custom_cli_command/custom_webhook_command aliases",
+				);
+			}
+			_cachedConfig = explicitOpenClaw;
+			return explicitOpenClaw;
+		}
 
-    if (aliasOpenClaw) {
-      _cachedConfig = aliasOpenClaw;
-      return aliasOpenClaw;
-    }
+		if (aliasOpenClaw.config) {
+			_cachedConfig = aliasOpenClaw.config;
+			return aliasOpenClaw.config;
+		}
 
-    _cachedConfig = undefined;
-    return null;
-  } catch {
-    _cachedConfig = undefined;
-    return null;
-  }
+		_cachedConfig = undefined;
+		return null;
+	} catch {
+		_cachedConfig = undefined;
+		return null;
+	}
 }
 
 /**
@@ -229,33 +499,41 @@ export function getOpenClawConfig(): OpenClawConfig | null {
  * Returns the gateway name alongside config to avoid O(n) reverse lookup.
  */
 export function resolveGateway(
-  config: OpenClawConfig,
-  event: OpenClawHookEvent,
-): { gatewayName: string; gateway: OpenClawGatewayConfig; instruction: string } | null {
-  const mapping = config.hooks[event];
-  if (!mapping || !mapping.enabled) {
-    return null;
-  }
+	config: OpenClawConfig,
+	event: OpenClawHookEvent,
+): {
+	gatewayName: string;
+	gateway: OpenClawGatewayConfig;
+	instruction: string;
+} | null {
+	const mapping = config.hooks[event];
+	if (!mapping || !mapping.enabled) {
+		return null;
+	}
 
-  const gateway = config.gateways[mapping.gateway];
-  if (!gateway) {
-    return null;
-  }
+	const gateway = config.gateways[mapping.gateway];
+	if (!gateway) {
+		return null;
+	}
 
-  // Validate based on gateway type
-  if ((gateway as OpenClawCommandGatewayConfig).type === "command") {
-    if (!(gateway as OpenClawCommandGatewayConfig).command) return null;
-  } else {
-    // HTTP gateway (default when type is absent or "http")
-    if (!("url" in gateway) || !gateway.url) return null;
-  }
+	// Validate based on gateway type
+	if ((gateway as OpenClawCommandGatewayConfig).type === "command") {
+		if (!(gateway as OpenClawCommandGatewayConfig).command) return null;
+	} else {
+		// HTTP gateway (default when type is absent or "http")
+		if (!("url" in gateway) || !gateway.url) return null;
+	}
 
-  return { gatewayName: mapping.gateway, gateway, instruction: mapping.instruction };
+	return {
+		gatewayName: mapping.gateway,
+		gateway,
+		instruction: mapping.instruction,
+	};
 }
 
 /**
  * Reset the config cache (for testing only).
  */
 export function resetOpenClawConfigCache(): void {
-  _cachedConfig = null;
+	_cachedConfig = null;
 }


### PR DESCRIPTION
## Summary
- add OpenClaw-specific adapt observation/reporting on top of the shared adapt foundation
- keep the integration local-observation-only around config, gateway wiring, and lifecycle seams
- add OpenClaw-focused tests and docs updates

## Testing
- npm run build
- node --test dist/openclaw/__tests__/config.test.js dist/adapt/__tests__/foundation.test.js dist/cli/__tests__/adapt.test.js