### PR TITLE
feat: add adapt foundation for persistent targets

### DIFF
--- a/docs/adapt.md
+++ b/docs/adapt.md
@@ -1,0 +1,33 @@
+# `omx adapt` Foundation
+
+`omx adapt <target>` is the OMX-owned foundation surface for persistent external-agent adaptation.
+
+This PR adds only the shared foundation:
+
+- CLI scaffold for `probe`, `status`, `init`, `envelope`, and `doctor`
+- shared capability reporting with explicit ownership (`omx-owned`, `shared-contract`, `target-observed`)
+- adapter-owned paths under `.omx/adapters/<target>/...`
+- shared envelope/status/doctor/init behavior that does not touch `.omx/state/...`
+
+Current targets:
+
+- `openclaw`
+- `hermes`
+
+Examples:
+
+```bash
+omx adapt openclaw probe
+omx adapt hermes status --json
+omx adapt openclaw init --write
+omx adapt hermes envelope --json
+```
+
+Foundation constraints:
+
+- thin adapter surface only, not a bidirectional control plane
+- no direct writes to `.omx/state/...`
+- no direct writes to external runtime internals
+- target capability reporting stays asymmetric; OMX reports what it owns, what is shared, and what is only target-observed
+
+Target-specific Hermes and OpenClaw probe/integration logic is intentionally deferred to follow-on PRs.

--- a/src/adapt/__tests__/foundation.test.ts
+++ b/src/adapt/__tests__/foundation.test.ts
@@ -11,6 +11,7 @@ import {
   initAdaptFoundation,
 } from "../index.js";
 import { resolveAdaptPaths } from "../paths.js";
+import { getAdaptTargetDescriptor } from "../registry.js";
 
 let tempDir: string;
 
@@ -95,5 +96,10 @@ describe("adapt foundation", () => {
     assert.equal(doctor.issues[0]?.code, "adapter_not_initialized");
     assert.match(doctor.nextSteps.join("\n"), /init --write/i);
     assert.match(doctor.nextSteps.join("\n"), /follow-on PR/i);
+  });
+
+  it("rejects inherited prototype-like targets during validation", () => {
+    assert.equal(getAdaptTargetDescriptor("__proto__"), null);
+    assert.equal(getAdaptTargetDescriptor("constructor"), null);
   });
 });

--- a/src/adapt/__tests__/foundation.test.ts
+++ b/src/adapt/__tests__/foundation.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildAdaptEnvelope,
+  buildAdaptStatusReport,
+  buildAdaptDoctorReport,
+  initAdaptFoundation,
+} from "../index.js";
+import { resolveAdaptPaths } from "../paths.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "omx-adapt-foundation-"));
+});
+
+afterEach(async () => {
+  if (tempDir && existsSync(tempDir)) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("adapt foundation", () => {
+  it("resolves OMX-owned adapter paths under .omx/adapters/<target>", () => {
+    const paths = resolveAdaptPaths(tempDir, "openclaw");
+    assert.equal(paths.adapterRoot, join(tempDir, ".omx", "adapters", "openclaw"));
+    assert.equal(paths.configPath, join(tempDir, ".omx", "adapters", "openclaw", "adapter.json"));
+    assert.equal(paths.envelopePath, join(tempDir, ".omx", "adapters", "openclaw", "envelope.json"));
+    assert.equal(paths.probeReportPath, join(tempDir, ".omx", "adapters", "openclaw", "reports", "probe.json"));
+    assert.equal(paths.statusReportPath, join(tempDir, ".omx", "adapters", "openclaw", "reports", "status.json"));
+  });
+
+  it("links the latest canonical PRD/test-spec artifacts into the envelope", async () => {
+    const plansDir = join(tempDir, ".omx", "plans");
+    await mkdir(plansDir, { recursive: true });
+    await writeFile(join(plansDir, "prd-alpha.md"), "# Alpha\n");
+    await writeFile(join(plansDir, "test-spec-alpha.md"), "# Alpha Test Spec\n");
+    await writeFile(join(plansDir, "prd-zeta.md"), "# Zeta\n");
+    await writeFile(join(plansDir, "test-spec-zeta.md"), "# Zeta Test Spec\n");
+
+    const envelope = buildAdaptEnvelope(tempDir, "openclaw", new Date("2026-04-14T00:00:00.000Z"));
+    assert.equal(envelope.planning.prdPath, join(plansDir, "prd-zeta.md"));
+    assert.deepEqual(envelope.planning.testSpecPaths, [join(plansDir, "test-spec-zeta.md")]);
+    assert.match(envelope.planning.summary, /matching test spec/i);
+  });
+
+  it("reports asymmetric capability ownership in the shared envelope", () => {
+    const envelope = buildAdaptEnvelope(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
+    const ownerships = new Set(envelope.capabilities.map((capability) => capability.ownership));
+    assert.deepEqual(
+      [...ownerships].sort(),
+      ["omx-owned", "shared-contract", "target-observed"],
+    );
+  });
+
+  it("keeps init preview read-only until --write is used", () => {
+    const result = initAdaptFoundation(tempDir, "hermes", false, new Date("2026-04-14T00:00:00.000Z"));
+    const paths = resolveAdaptPaths(tempDir, "hermes");
+    assert.equal(result.write, false);
+    assert.deepEqual(result.wrotePaths, []);
+    assert.equal(existsSync(paths.configPath), false);
+    assert.equal(existsSync(join(tempDir, ".omx", "state")), false);
+  });
+
+  it("writes only OMX-owned adapter artifacts during init --write", () => {
+    const result = initAdaptFoundation(tempDir, "openclaw", true, new Date("2026-04-14T00:00:00.000Z"));
+    const paths = resolveAdaptPaths(tempDir, "openclaw");
+    assert.equal(result.write, true);
+    assert.deepEqual(result.wrotePaths, [paths.configPath, paths.envelopePath]);
+    assert.equal(existsSync(paths.configPath), true);
+    assert.equal(existsSync(paths.envelopePath), true);
+    assert.equal(existsSync(join(tempDir, ".omx", "state")), false);
+
+    const envelope = JSON.parse(readFileSync(paths.envelopePath, "utf-8")) as {
+      target: string;
+      adapterPaths: { configPath: string };
+    };
+    assert.equal(envelope.target, "openclaw");
+    assert.equal(envelope.adapterPaths.configPath, paths.configPath);
+  });
+
+  it("reports initialization status without claiming target-runtime health", () => {
+    const status = buildAdaptStatusReport(tempDir, "openclaw", new Date("2026-04-14T00:00:00.000Z"));
+    assert.equal(status.adapter.state, "not-initialized");
+    assert.equal(status.targetRuntime.state, "unknown");
+    assert.match(status.targetRuntime.detail, /follow-on PR/i);
+  });
+
+  it("doctor surfaces actionable foundation-only remediation", () => {
+    const doctor = buildAdaptDoctorReport(tempDir, "hermes", new Date("2026-04-14T00:00:00.000Z"));
+    assert.equal(doctor.issues[0]?.code, "adapter_not_initialized");
+    assert.match(doctor.nextSteps.join("\n"), /init --write/i);
+    assert.match(doctor.nextSteps.join("\n"), /follow-on PR/i);
+  });
+});

--- a/src/adapt/contracts.ts
+++ b/src/adapt/contracts.ts
@@ -1,0 +1,126 @@
+export const ADAPT_SCHEMA_VERSION = "1.0";
+
+export const ADAPT_TARGETS = ["openclaw", "hermes"] as const;
+export type AdaptTarget = (typeof ADAPT_TARGETS)[number];
+
+export const ADAPT_SUBCOMMANDS = [
+  "probe",
+  "status",
+  "init",
+  "envelope",
+  "doctor",
+] as const;
+export type AdaptSubcommand = (typeof ADAPT_SUBCOMMANDS)[number];
+
+export type AdaptCapabilityOwnership =
+  | "omx-owned"
+  | "shared-contract"
+  | "target-observed";
+
+export type AdaptCapabilityStatus = "ready" | "stub" | "unsupported";
+
+export interface AdaptCapabilityReport {
+  id: string;
+  label: string;
+  ownership: AdaptCapabilityOwnership;
+  status: AdaptCapabilityStatus;
+  summary: string;
+}
+
+export interface AdaptTargetDescriptor {
+  target: AdaptTarget;
+  displayName: string;
+  summary: string;
+  followupHint: string;
+  capabilities: AdaptCapabilityReport[];
+}
+
+export interface AdaptPathSet {
+  adapterRoot: string;
+  configPath: string;
+  envelopePath: string;
+  reportsDir: string;
+  probeReportPath: string;
+  statusReportPath: string;
+}
+
+export interface AdaptPlanningLink {
+  prdPath: string | null;
+  testSpecPaths: string[];
+  deepInterviewSpecPaths: string[];
+  summary: string;
+}
+
+export interface AdaptEnvelope {
+  schemaVersion: string;
+  generatedAt: string;
+  target: AdaptTarget;
+  displayName: string;
+  summary: string;
+  adapterPaths: AdaptPathSet;
+  planning: AdaptPlanningLink;
+  capabilities: AdaptCapabilityReport[];
+  constraints: string[];
+}
+
+export interface AdaptProbeReport {
+  schemaVersion: string;
+  timestamp: string;
+  target: AdaptTarget;
+  phase: "foundation";
+  summary: string;
+  adapterPaths: AdaptPathSet;
+  planning: AdaptPlanningLink;
+  capabilities: AdaptCapabilityReport[];
+  targetRuntime: {
+    state: "not-implemented";
+    detail: string;
+  };
+  nextSteps: string[];
+}
+
+export interface AdaptStatusReport {
+  schemaVersion: string;
+  timestamp: string;
+  target: AdaptTarget;
+  phase: "foundation";
+  summary: string;
+  adapter: {
+    state: "initialized" | "not-initialized";
+    detail: string;
+    configPath: string;
+    envelopePath: string;
+  };
+  targetRuntime: {
+    state: "unknown";
+    detail: string;
+  };
+  planning: AdaptPlanningLink;
+  capabilities: AdaptCapabilityReport[];
+}
+
+export interface AdaptDoctorIssue {
+  code: string;
+  message: string;
+}
+
+export interface AdaptDoctorReport {
+  schemaVersion: string;
+  timestamp: string;
+  target: AdaptTarget;
+  phase: "foundation";
+  summary: string;
+  issues: AdaptDoctorIssue[];
+  nextSteps: string[];
+}
+
+export interface AdaptInitResult {
+  schemaVersion: string;
+  timestamp: string;
+  target: AdaptTarget;
+  write: boolean;
+  summary: string;
+  previewPaths: string[];
+  wrotePaths: string[];
+  envelope: AdaptEnvelope;
+}

--- a/src/adapt/index.ts
+++ b/src/adapt/index.ts
@@ -1,0 +1,245 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  ADAPT_SCHEMA_VERSION,
+  type AdaptDoctorIssue,
+  type AdaptDoctorReport,
+  type AdaptEnvelope,
+  type AdaptInitResult,
+  type AdaptPlanningLink,
+  type AdaptProbeReport,
+  type AdaptStatusReport,
+  type AdaptTarget,
+} from "./contracts.js";
+import { getAdaptTargetDescriptor, listAdaptTargets } from "./registry.js";
+import { resolveAdaptPaths } from "./paths.js";
+import { readLatestPlanningArtifacts } from "../planning/artifacts.js";
+
+const FOUNDATION_CONSTRAINTS = [
+  "Thin adapter surface only; no bidirectional control plane is claimed in this foundation PR.",
+  "No direct writes to .omx/state/... or target runtime internals.",
+  "Capability reporting is asymmetric: OMX-owned, shared-contract, and target-observed surfaces are reported separately.",
+];
+
+function toIsoTimestamp(now = new Date()): string {
+  return now.toISOString();
+}
+
+export function supportedAdaptTargets(): string[] {
+  return listAdaptTargets().map((descriptor) => descriptor.target);
+}
+
+export function buildAdaptPlanningLink(cwd: string): AdaptPlanningLink {
+  const selection = readLatestPlanningArtifacts(cwd);
+  if (!selection.prdPath) {
+    return {
+      prdPath: null,
+      testSpecPaths: [],
+      deepInterviewSpecPaths: [],
+      summary: "No canonical OMX PRD/test-spec artifacts are present in this worktree.",
+    };
+  }
+
+  const testSpecSummary = selection.testSpecPaths.length > 0
+    ? `${selection.testSpecPaths.length} matching test spec artifact(s) linked.`
+    : "PRD detected, but no matching test spec artifact was found for its slug.";
+
+  return {
+    prdPath: selection.prdPath,
+    testSpecPaths: selection.testSpecPaths,
+    deepInterviewSpecPaths: selection.deepInterviewSpecPaths,
+    summary: testSpecSummary,
+  };
+}
+
+export function buildAdaptEnvelope(
+  cwd: string,
+  target: AdaptTarget,
+  now = new Date(),
+): AdaptEnvelope {
+  const descriptor = getAdaptTargetDescriptor(target);
+  if (!descriptor) {
+    throw new Error(`Unknown adapt target: ${target}`);
+  }
+
+  return {
+    schemaVersion: ADAPT_SCHEMA_VERSION,
+    generatedAt: toIsoTimestamp(now),
+    target,
+    displayName: descriptor.displayName,
+    summary: descriptor.summary,
+    adapterPaths: resolveAdaptPaths(cwd, target),
+    planning: buildAdaptPlanningLink(cwd),
+    capabilities: descriptor.capabilities,
+    constraints: FOUNDATION_CONSTRAINTS,
+  };
+}
+
+export function buildAdaptProbeReport(
+  cwd: string,
+  target: AdaptTarget,
+  now = new Date(),
+): AdaptProbeReport {
+  const descriptor = getAdaptTargetDescriptor(target);
+  if (!descriptor) {
+    throw new Error(`Unknown adapt target: ${target}`);
+  }
+
+  return {
+    schemaVersion: ADAPT_SCHEMA_VERSION,
+    timestamp: toIsoTimestamp(now),
+    target,
+    phase: "foundation",
+    summary: `${descriptor.displayName} probe foundation is available, but target-specific runtime probing is deferred.`,
+    adapterPaths: resolveAdaptPaths(cwd, target),
+    planning: buildAdaptPlanningLink(cwd),
+    capabilities: descriptor.capabilities,
+    targetRuntime: {
+      state: "not-implemented",
+      detail: descriptor.followupHint,
+    },
+    nextSteps: [
+      `Run omx adapt ${target} init --write to materialize OMX-owned adapter artifacts.`,
+      descriptor.followupHint,
+    ],
+  };
+}
+
+export function buildAdaptStatusReport(
+  cwd: string,
+  target: AdaptTarget,
+  now = new Date(),
+): AdaptStatusReport {
+  const descriptor = getAdaptTargetDescriptor(target);
+  if (!descriptor) {
+    throw new Error(`Unknown adapt target: ${target}`);
+  }
+
+  const paths = resolveAdaptPaths(cwd, target);
+  const initialized = existsSync(paths.configPath) && existsSync(paths.envelopePath);
+
+  return {
+    schemaVersion: ADAPT_SCHEMA_VERSION,
+    timestamp: toIsoTimestamp(now),
+    target,
+    phase: "foundation",
+    summary: initialized
+      ? `${descriptor.displayName} adapter foundation is initialized under OMX-owned paths.`
+      : `${descriptor.displayName} adapter foundation has not been initialized yet.`,
+    adapter: {
+      state: initialized ? "initialized" : "not-initialized",
+      detail: initialized
+        ? "Adapter foundation artifacts exist under .omx/adapters/<target>/..."
+        : "Run init --write to create OMX-owned adapter artifacts.",
+      configPath: paths.configPath,
+      envelopePath: paths.envelopePath,
+    },
+    targetRuntime: {
+      state: "unknown",
+      detail: descriptor.followupHint,
+    },
+    planning: buildAdaptPlanningLink(cwd),
+    capabilities: descriptor.capabilities,
+  };
+}
+
+export function buildAdaptDoctorReport(
+  cwd: string,
+  target: AdaptTarget,
+  now = new Date(),
+): AdaptDoctorReport {
+  const descriptor = getAdaptTargetDescriptor(target);
+  if (!descriptor) {
+    throw new Error(`Unknown adapt target: ${target}`);
+  }
+
+  const status = buildAdaptStatusReport(cwd, target, now);
+  const planning = buildAdaptPlanningLink(cwd);
+  const issues: AdaptDoctorIssue[] = [];
+
+  if (status.adapter.state === "not-initialized") {
+    issues.push({
+      code: "adapter_not_initialized",
+      message: `No adapter foundation artifacts exist for ${target} under ${join(".omx", "adapters", target)}.`,
+    });
+  }
+
+  if (!planning.prdPath) {
+    issues.push({
+      code: "planning_artifacts_missing",
+      message: "No canonical OMX PRD artifact is available to link into the adapter envelope.",
+    });
+  }
+
+  issues.push({
+    code: "target_specific_logic_deferred",
+    message: descriptor.followupHint,
+  });
+
+  return {
+    schemaVersion: ADAPT_SCHEMA_VERSION,
+    timestamp: toIsoTimestamp(now),
+    target,
+    phase: "foundation",
+    summary: `Foundation doctor for ${descriptor.displayName} reports only OMX-owned adapter readiness and shared planning linkage.`,
+    issues,
+    nextSteps: [
+      `Run omx adapt ${target} init --write.`,
+      "Keep follow-on integration work out of .omx/state/... and target runtime internals unless a reviewed contract exists.",
+      descriptor.followupHint,
+    ],
+  };
+}
+
+export function initAdaptFoundation(
+  cwd: string,
+  target: AdaptTarget,
+  write = false,
+  now = new Date(),
+): AdaptInitResult {
+  const descriptor = getAdaptTargetDescriptor(target);
+  if (!descriptor) {
+    throw new Error(`Unknown adapt target: ${target}`);
+  }
+
+  const envelope = buildAdaptEnvelope(cwd, target, now);
+  const paths = envelope.adapterPaths;
+  const previewPaths = [
+    paths.adapterRoot,
+    paths.configPath,
+    paths.envelopePath,
+    paths.reportsDir,
+    paths.probeReportPath,
+    paths.statusReportPath,
+  ];
+  const wrotePaths: string[] = [];
+
+  if (write) {
+    mkdirSync(paths.reportsDir, { recursive: true });
+    const config = {
+      schemaVersion: ADAPT_SCHEMA_VERSION,
+      target,
+      createdAt: toIsoTimestamp(now),
+      phase: "foundation",
+      summary: descriptor.summary,
+      followupHint: descriptor.followupHint,
+      constraints: FOUNDATION_CONSTRAINTS,
+    };
+    writeFileSync(paths.configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+    writeFileSync(paths.envelopePath, `${JSON.stringify(envelope, null, 2)}\n`, "utf-8");
+    wrotePaths.push(paths.configPath, paths.envelopePath);
+  }
+
+  return {
+    schemaVersion: ADAPT_SCHEMA_VERSION,
+    timestamp: toIsoTimestamp(now),
+    target,
+    write,
+    summary: write
+      ? `${descriptor.displayName} adapter foundation was written under OMX-owned paths.`
+      : `${descriptor.displayName} adapter foundation preview is ready; rerun with --write to materialize it.`,
+    previewPaths,
+    wrotePaths,
+    envelope,
+  };
+}

--- a/src/adapt/paths.ts
+++ b/src/adapt/paths.ts
@@ -1,0 +1,19 @@
+import { join } from "node:path";
+import { type AdaptPathSet, type AdaptTarget } from "./contracts.js";
+import { omxAdaptersDir } from "../utils/paths.js";
+
+export function resolveAdaptPaths(
+  cwd: string,
+  target: AdaptTarget,
+): AdaptPathSet {
+  const adapterRoot = join(omxAdaptersDir(cwd), target);
+  const reportsDir = join(adapterRoot, "reports");
+  return {
+    adapterRoot,
+    configPath: join(adapterRoot, "adapter.json"),
+    envelopePath: join(adapterRoot, "envelope.json"),
+    reportsDir,
+    probeReportPath: join(reportsDir, "probe.json"),
+    statusReportPath: join(reportsDir, "status.json"),
+  };
+}

--- a/src/adapt/registry.ts
+++ b/src/adapt/registry.ts
@@ -105,7 +105,7 @@ export function listAdaptTargets(): AdaptTargetDescriptor[] {
 export function getAdaptTargetDescriptor(
   target: string,
 ): AdaptTargetDescriptor | null {
-  return target in TARGET_DESCRIPTORS
+  return Object.hasOwn(TARGET_DESCRIPTORS, target)
     ? TARGET_DESCRIPTORS[target as AdaptTarget]
     : null;
 }

--- a/src/adapt/registry.ts
+++ b/src/adapt/registry.ts
@@ -1,0 +1,111 @@
+import {
+  type AdaptCapabilityReport,
+  ADAPT_TARGETS,
+  type AdaptTarget,
+  type AdaptTargetDescriptor,
+} from "./contracts.js";
+
+function capability(
+  id: string,
+  label: string,
+  ownership: AdaptCapabilityReport["ownership"],
+  status: AdaptCapabilityReport["status"],
+  summary: string,
+): AdaptCapabilityReport {
+  return {
+    id,
+    label,
+    ownership,
+    status,
+    summary,
+  };
+}
+
+const FOUNDATION_CAPABILITIES: AdaptCapabilityReport[] = [
+  capability(
+    "omx-adapter-paths",
+    "OMX-owned adapter paths",
+    "omx-owned",
+    "ready",
+    "Adapter artifacts stay under .omx/adapters/<target>/... rather than .omx/state or target internals.",
+  ),
+  capability(
+    "planning-artifact-linkage",
+    "Planning artifact linkage",
+    "shared-contract",
+    "ready",
+    "Envelope output links canonical OMX PRD/test-spec artifacts when they exist.",
+  ),
+  capability(
+    "foundation-reporting",
+    "Foundation reporting surface",
+    "shared-contract",
+    "ready",
+    "Probe, status, envelope, init, and doctor share a target-agnostic output contract.",
+  ),
+];
+
+const TARGET_DESCRIPTORS: Record<AdaptTarget, AdaptTargetDescriptor> = {
+  openclaw: {
+    target: "openclaw",
+    displayName: "OpenClaw",
+    summary:
+      "Foundation seam for an OMX-owned adapter around existing OpenClaw notification and gateway surfaces.",
+    followupHint:
+      "OpenClaw-specific probe, config observation, and event mapping land in a follow-on PR.",
+    capabilities: [
+      ...FOUNDATION_CAPABILITIES,
+      capability(
+        "gateway-observation",
+        "Gateway observation",
+        "target-observed",
+        "stub",
+        "Foundation reports the seam only; it does not inspect OpenClaw config or remote health yet.",
+      ),
+      capability(
+        "lifecycle-bridge",
+        "Lifecycle bridge metadata",
+        "shared-contract",
+        "stub",
+        "Foundation reserves the shared envelope/reporting seam without implementing OpenClaw event wiring.",
+      ),
+    ],
+  },
+  hermes: {
+    target: "hermes",
+    displayName: "Hermes",
+    summary:
+      "Foundation seam for an OMX-owned adapter around Hermes ACP, gateway, and persistent-session surfaces.",
+    followupHint:
+      "Hermes-specific ACP probing, status synthesis, and path overrides land in a follow-on PR.",
+    capabilities: [
+      ...FOUNDATION_CAPABILITIES,
+      capability(
+        "persistent-session-observation",
+        "Persistent session observation",
+        "target-observed",
+        "stub",
+        "Foundation reports the seam only; it does not inspect Hermes runtime files or session stores yet.",
+      ),
+      capability(
+        "acp-envelope-bridge",
+        "ACP envelope bridge",
+        "shared-contract",
+        "stub",
+        "Foundation reserves shared metadata exchange without claiming control over Hermes runtime internals.",
+      ),
+    ],
+  },
+};
+
+export function listAdaptTargets(): AdaptTargetDescriptor[] {
+  return ADAPT_TARGETS.map((target) => TARGET_DESCRIPTORS[target]);
+}
+
+export function getAdaptTargetDescriptor(
+  target: string,
+): AdaptTargetDescriptor | null {
+  return target in TARGET_DESCRIPTORS
+    ? TARGET_DESCRIPTORS[target as AdaptTarget]
+    : null;
+}

--- a/src/cli/__tests__/adapt-help.test.ts
+++ b/src/cli/__tests__/adapt-help.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function runOmx(cwd: string, argv: string[]) {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
+  return spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+    },
+  });
+}
+
+describe('omx adapt help', () => {
+  it('documents adapt in top-level help and routes adapt-local help output', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-adapt-help-'));
+    try {
+      const mainHelp = runOmx(cwd, ['--help']);
+      assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
+      assert.match(mainHelp.stdout, /omx adapt\s+Scaffold OMX-owned adapter foundations for persistent external targets/i);
+
+      const adaptHelp = runOmx(cwd, ['adapt', '--help']);
+      assert.equal(adaptHelp.status, 0, adaptHelp.stderr || adaptHelp.stdout);
+      assert.match(adaptHelp.stdout, /Usage: omx adapt <target> <probe\|status\|init\|envelope\|doctor>/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/adapt.test.ts
+++ b/src/cli/__tests__/adapt.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { adaptCommand } from "../adapt.js";
+
+describe("adaptCommand", () => {
+  it("prints help when called without args", async () => {
+    const out: string[] = [];
+    await adaptCommand([], {
+      stdout: (line) => out.push(line),
+    });
+    assert.match(out.join("\n"), /Usage: omx adapt <target>/i);
+  });
+
+  it("fails clearly for unknown targets", async () => {
+    await assert.rejects(
+      adaptCommand(["unknown", "probe"], {
+        stdout: () => undefined,
+      }),
+      /Supported targets: openclaw, hermes/i,
+    );
+  });
+
+  it("emits compact JSON envelopes when --json is set", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-adapt-cli-"));
+    const out: string[] = [];
+    try {
+      await adaptCommand(["openclaw", "probe", "--json"], {
+        cwd,
+        stdout: (line) => out.push(line),
+      });
+      assert.equal(out.length, 1);
+      assert.match(out[0] ?? "", /^\{"schemaVersion":"1\.0","timestamp":/);
+      assert.match(out[0] ?? "", /"target":"openclaw"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects --write outside init", async () => {
+    await assert.rejects(
+      adaptCommand(["hermes", "status", "--write"], {
+        stdout: () => undefined,
+      }),
+      /only supported with omx adapt <target> init/i,
+    );
+  });
+});

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -875,6 +875,7 @@ describe("resolveTeamWorkerLaunchArgsEnv (spark)", () => {
 describe("commandOwnsLocalHelp", () => {
   it("returns true for nested commands that render their own help output", () => {
     for (const command of [
+      "adapt",
       "agents-init",
       "ask",
       "autoresearch",

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -24,6 +24,7 @@ function runOmx(cwd: string, argv: string[]) {
 
 describe('nested help routing', () => {
   for (const [argv, expectedUsage] of [
+    [['adapt', '--help'], /Usage:\s*omx adapt <target> <probe\|status\|init\|envelope\|doctor>/i],
     [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
     [['autoresearch', '--help'], /Usage:[\s\S]*omx autoresearch <mission-dir>/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],

--- a/src/cli/adapt.ts
+++ b/src/cli/adapt.ts
@@ -1,0 +1,174 @@
+import {
+  ADAPT_SUBCOMMANDS,
+  type AdaptSubcommand,
+  type AdaptTarget,
+} from "../adapt/contracts.js";
+import {
+  buildAdaptDoctorReport,
+  buildAdaptEnvelope,
+  buildAdaptProbeReport,
+  buildAdaptStatusReport,
+  initAdaptFoundation,
+  supportedAdaptTargets,
+} from "../adapt/index.js";
+import { getAdaptTargetDescriptor } from "../adapt/registry.js";
+
+const HELP = [
+  "Usage: omx adapt <target> <probe|status|init|envelope|doctor> [--json] [--write]",
+  "",
+  "Targets:",
+  "  openclaw  Foundation seam for OMX-owned OpenClaw adapter artifacts and reporting",
+  "  hermes    Foundation seam for OMX-owned Hermes adapter artifacts and reporting",
+  "",
+  "Subcommands:",
+  "  probe     Report shared foundation probe metadata (target-specific runtime probing is deferred)",
+  "  status    Report OMX-owned adapter initialization status plus deferred target-runtime status",
+  "  init      Preview or write OMX-owned adapter artifacts under .omx/adapters/<target>/...",
+  "  envelope  Print the normalized OMX-owned adapter envelope for the target",
+  "  doctor    Explain blocked foundation steps and follow-on integration gaps",
+  "",
+  "Options:",
+  "  --json    Emit compact machine-readable JSON",
+  "  --write   Only valid with init; write adapter artifacts under .omx/adapters/<target>/...",
+  "",
+  "Examples:",
+  "  omx adapt openclaw probe",
+  "  omx adapt hermes status --json",
+  "  omx adapt openclaw init --write",
+  "  omx adapt hermes envelope --json",
+].join("\n");
+
+function targetHelp(target: AdaptTarget): string {
+  const descriptor = getAdaptTargetDescriptor(target);
+  if (!descriptor) return HELP;
+  return [
+    `Usage: omx adapt ${target} <${ADAPT_SUBCOMMANDS.join("|")}> [--json] [--write]`,
+    "",
+    descriptor.summary,
+    "",
+    "Notes:",
+    "  This PR exposes the shared foundation only.",
+    "  Target-specific runtime probing and integration logic are intentionally deferred.",
+    `  ${descriptor.followupHint}`,
+    "",
+    HELP,
+  ].join("\n");
+}
+
+function parseArgs(args: string[]): {
+  target: string | undefined;
+  subcommand: string | undefined;
+  json: boolean;
+  write: boolean;
+  wantsHelp: boolean;
+} {
+  let target: string | undefined;
+  let subcommand: string | undefined;
+  let json = false;
+  let write = false;
+  let wantsHelp = false;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--write") {
+      write = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h" || arg === "help") {
+      wantsHelp = true;
+      continue;
+    }
+    if (!target) {
+      target = arg;
+      continue;
+    }
+    if (!subcommand) {
+      subcommand = arg;
+      continue;
+    }
+    throw new Error(`Unknown adapt argument: ${arg}`);
+  }
+
+  return { target, subcommand, json, write, wantsHelp };
+}
+
+function render(
+  value: unknown,
+  json: boolean,
+  stdout: (line: string) => void,
+): void {
+  stdout(JSON.stringify(value, null, json ? 0 : 2));
+}
+
+export interface AdaptCommandDependencies {
+  cwd?: string;
+  stdout?: (line: string) => void;
+}
+
+export async function adaptCommand(
+  args: string[],
+  deps: AdaptCommandDependencies = {},
+): Promise<void> {
+  const cwd = deps.cwd ?? process.cwd();
+  const stdout = deps.stdout ?? ((line: string) => console.log(line));
+  const { target, subcommand, json, write, wantsHelp } = parseArgs(args);
+
+  if (!target || wantsHelp) {
+    if (!target) {
+      stdout(HELP);
+      return;
+    }
+
+    const descriptor = getAdaptTargetDescriptor(target);
+    if (!descriptor) {
+      throw new Error(
+        `Unknown adapt target: ${target}. Supported targets: ${supportedAdaptTargets().join(", ")}`,
+      );
+    }
+    stdout(targetHelp(descriptor.target));
+    return;
+  }
+
+  const descriptor = getAdaptTargetDescriptor(target);
+  if (!descriptor) {
+    throw new Error(
+      `Unknown adapt target: ${target}. Supported targets: ${supportedAdaptTargets().join(", ")}`,
+    );
+  }
+
+  if (!subcommand) {
+    stdout(targetHelp(descriptor.target));
+    return;
+  }
+
+  if (!ADAPT_SUBCOMMANDS.includes(subcommand as AdaptSubcommand)) {
+    throw new Error(
+      `Unknown adapt subcommand: ${subcommand}. Supported subcommands: ${ADAPT_SUBCOMMANDS.join(", ")}`,
+    );
+  }
+
+  if (write && subcommand !== "init") {
+    throw new Error("--write is only supported with omx adapt <target> init");
+  }
+
+  switch (subcommand as AdaptSubcommand) {
+    case "probe":
+      render(buildAdaptProbeReport(cwd, descriptor.target), json, stdout);
+      return;
+    case "status":
+      render(buildAdaptStatusReport(cwd, descriptor.target), json, stdout);
+      return;
+    case "init":
+      render(initAdaptFoundation(cwd, descriptor.target, write), json, stdout);
+      return;
+    case "envelope":
+      render(buildAdaptEnvelope(cwd, descriptor.target), json, stdout);
+      return;
+    case "doctor":
+      render(buildAdaptDoctorReport(cwd, descriptor.target), json, stdout);
+      return;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ import { agentsCommand } from "./agents.js";
 import { sessionCommand } from "./session-search.js";
 import { autoresearchCommand } from "./autoresearch.js";
 import { mcpParityCommand } from "./mcp-parity.js";
+import { adaptCommand } from "./adapt.js";
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -147,6 +148,7 @@ Usage:
   omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
   omx resume    Resume a previous interactive Codex session
   omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
   omx session   Search prior local session transcripts and history artifacts
@@ -261,6 +263,7 @@ type CliCommand =
   | "doctor"
   | "cleanup"
   | "ask"
+  | "adapt"
   | "explore"
   | "sparkshell"
   | "team"
@@ -281,6 +284,7 @@ type CliCommand =
 const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "ask",
   "cleanup",
+  "adapt",
   "autoresearch",
   "agents",
   "agents-init",
@@ -716,6 +720,9 @@ export async function main(args: string[]): Promise<void> {
       }
       case "ask":
         await askCommand(args.slice(1));
+        break;
+      case "adapt":
+        await adaptCommand(args.slice(1));
         break;
       case "cleanup":
         await cleanupCommand(args.slice(1));

--- a/src/planning/artifacts.ts
+++ b/src/planning/artifacts.ts
@@ -29,6 +29,12 @@ export interface ApprovedExecutionLaunchHint extends ApprovedPlanContext {
   linkedRalph?: boolean;
 }
 
+export interface LatestPlanningArtifactSelection {
+  prdPath: string | null;
+  testSpecPaths: string[];
+  deepInterviewSpecPaths: string[];
+}
+
 function readMatchingPaths(dir: string, pattern: RegExp): string[] {
   if (!existsSync(dir)) {
     return [];
@@ -92,23 +98,49 @@ function readApprovedPlanText(cwd: string): { content: string; context: Approved
   const artifacts = readPlanningArtifacts(cwd);
   if (!isPlanningComplete(artifacts)) return null;
 
-  const latestPrdPath = artifacts.prdPaths.at(-1);
+  const selection = selectLatestPlanningArtifacts(artifacts);
+  const latestPrdPath = selection.prdPath;
   if (!latestPrdPath || !existsSync(latestPrdPath)) return null;
-
-  const slug = artifactSlug(latestPrdPath, /^prd-(?<slug>.*)\.md$/i);
 
   try {
     return {
       content: readFileSync(latestPrdPath, 'utf-8'),
       context: {
         sourcePath: latestPrdPath,
-        testSpecPaths: filterArtifactsForSlug(artifacts.testSpecPaths, /^test-?spec-(?<slug>.*)\.md$/i, slug),
-        deepInterviewSpecPaths: filterArtifactsForSlug(artifacts.deepInterviewSpecPaths, /^deep-interview-(?<slug>.*)\.md$/i, slug),
+        testSpecPaths: selection.testSpecPaths,
+        deepInterviewSpecPaths: selection.deepInterviewSpecPaths,
       },
     };
   } catch {
     return null;
   }
+}
+
+export function selectLatestPlanningArtifacts(
+  artifacts: PlanningArtifacts,
+): LatestPlanningArtifactSelection {
+  const latestPrdPath = artifacts.prdPaths.at(-1) ?? null;
+  const slug = latestPrdPath
+    ? artifactSlug(latestPrdPath, /^prd-(?<slug>.*)\.md$/i)
+    : null;
+
+  return {
+    prdPath: latestPrdPath,
+    testSpecPaths: filterArtifactsForSlug(
+      artifacts.testSpecPaths,
+      /^test-?spec-(?<slug>.*)\.md$/i,
+      slug,
+    ),
+    deepInterviewSpecPaths: filterArtifactsForSlug(
+      artifacts.deepInterviewSpecPaths,
+      /^deep-interview-(?<slug>.*)\.md$/i,
+      slug,
+    ),
+  };
+}
+
+export function readLatestPlanningArtifacts(cwd: string): LatestPlanningArtifactSelection {
+  return selectLatestPlanningArtifacts(readPlanningArtifacts(cwd));
 }
 
 export function readApprovedExecutionLaunchHint(

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -17,6 +17,7 @@ import {
   omxProjectMemoryPath,
   omxNotepadPath,
   omxPlansDir,
+  omxAdaptersDir,
   omxLogsDir,
   packageRoot,
   OMX_ENTRY_PATH_ENV,
@@ -184,6 +185,12 @@ describe("legacyUserSkillsDir", () => {
 
   it("returns ~/.agents/skills under HOME", () => {
     assert.equal(legacyUserSkillsDir(), join("/tmp/test-home", ".agents", "skills"));
+  });
+});
+
+describe("omxAdaptersDir", () => {
+  it("returns .omx/adapters under the project root", () => {
+    assert.equal(omxAdaptersDir("/my/project"), join("/my/project", ".omx", "adapters"));
   });
 });
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -296,6 +296,11 @@ export function omxPlansDir(projectRoot?: string): string {
   return join(projectRoot || process.cwd(), ".omx", "plans");
 }
 
+/** oh-my-codex adapters directory (.omx/adapters/) */
+export function omxAdaptersDir(projectRoot?: string): string {
+  return join(projectRoot || process.cwd(), ".omx", "adapters");
+}
+
 /** oh-my-codex logs directory (.omx/logs/) */
 export function omxLogsDir(projectRoot?: string): string {
   return join(projectRoot || process.cwd(), ".omx", "logs");


### PR DESCRIPTION
## Summary
- add the shared `omx adapt <target>` foundation surface
- introduce target-agnostic contracts, registry, adapter-owned paths, and command scaffolding
- add foundation docs and tests without target-specific runtime integrations

## Testing
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/adapt/__tests__/foundation.test.js dist/cli/__tests__/adapt.test.js dist/cli/__tests__/adapt-help.test.js dist/cli/__tests__/nested-help-routing.test.js dist/planning/__tests__/artifacts.test.js dist/utils/__tests__/paths.test.js dist/cli/__tests__/index.test.js
