### PR TITLE
Fix Ralph assignment leaking across concurrent OMX sessions

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -358,6 +358,48 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('keeps a session-scoped Ralph activation out of the root canonical state for other sessions', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralph-isolation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralph continue verification',
+        sessionId: 'sess-ralph-a',
+        threadId: 'thread-ralph-a',
+        turnId: 'turn-ralph-a',
+        nowIso: '2026-04-14T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+
+      const rootSkillStatePath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
+      assert.equal(
+        existsSync(rootSkillStatePath),
+        false,
+        'session-scoped prompt activation should not create a root canonical skill state',
+      );
+
+      const sessionScopedSkillState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-ralph-a', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; session_id?: string }> };
+      assert.deepEqual(sessionScopedSkillState.active_skills, [{
+        skill: 'ralph',
+        phase: 'planning',
+        active: true,
+        activated_at: '2026-04-14T00:00:00.000Z',
+        updated_at: '2026-04-14T00:00:00.000Z',
+        session_id: 'sess-ralph-a',
+        thread_id: 'thread-ralph-a',
+        turn_id: 'turn-ralph-a',
+      }]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('hard-fails denied workflow overlaps without mutating current state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deny-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -528,6 +528,17 @@ function resolveRequestedWorkflowSkills(requestedWorkflowSkills: TrackedWorkflow
   };
 }
 
+function selectRootSkillStateCopy(
+  previousRoot: SkillActiveState | null,
+  nextState: SkillActiveState,
+  sessionId?: string,
+): SkillActiveState | null | undefined {
+  if (!sessionId) return nextState;
+  if (previousRoot) return previousRoot;
+  if (nextState.skill === 'ralph') return null;
+  return nextState;
+}
+
 export async function recordSkillActivation(input: RecordSkillActivationInput): Promise<SkillActiveState | null> {
   const match = detectPrimaryKeyword(input.text);
   if (!match) return null;
@@ -566,7 +577,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         dirname(dirname(input.stateDir)),
         state,
         input.sessionId,
-        input.sessionId ? (previousRoot ?? state) : state,
+        selectRootSkillStateCopy(previousRoot, state, input.sessionId),
       );
       await persistDeepInterviewModeState(input.stateDir, state, nowIso, previous, input);
     } catch (error) {
@@ -734,7 +745,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         dirname(dirname(input.stateDir)),
         nextState,
         input.sessionId,
-        input.sessionId ? (previousRoot ?? nextState) : nextState,
+        selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
       );
       await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
       return nextState;
@@ -777,7 +788,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       dirname(dirname(input.stateDir)),
       nextState,
       input.sessionId,
-      input.sessionId ? (previousRoot ?? nextState) : nextState,
+      selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
     );
     await persistDeepInterviewModeState(input.stateDir, nextState, nowIso, previous, input);
     return nextState;

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -193,15 +193,18 @@ export async function writeSkillActiveStateCopies(
   cwd: string,
   state: SkillActiveStateLike,
   sessionId?: string,
-  rootState?: SkillActiveStateLike,
+  rootState?: SkillActiveStateLike | null,
 ): Promise<void> {
   const { rootPath, sessionPath } = getSkillActiveStatePaths(cwd, sessionId);
   const normalized = { version: 1, ...state };
-  const normalizedRoot = { version: 1, ...(rootState ?? normalized) };
-  const rootPayload = JSON.stringify(normalizedRoot, null, 2);
-
-  await mkdir(dirname(rootPath), { recursive: true });
-  await writeFile(rootPath, rootPayload);
+  const normalizedRoot = rootState === null
+    ? null
+    : { version: 1, ...(rootState ?? normalized) };
+  if (normalizedRoot !== null) {
+    const rootPayload = JSON.stringify(normalizedRoot, null, 2);
+    await mkdir(dirname(rootPath), { recursive: true });
+    await writeFile(rootPath, rootPayload);
+  }
 
   if (sessionPath) {
     const sessionPayload = JSON.stringify(normalized, null, 2);


### PR DESCRIPTION
## Summary
- keep prompt-submit Ralph activation session-scoped instead of materializing a new root canonical skill state
- add a regression test covering concurrent-session isolation for Ralph prompt routing
- preserve existing root canonical behavior when a real shared/root workflow state already exists

## Testing
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npx biome lint src/hooks/keyword-detector.ts src/state/skill-active.ts src/hooks/__tests__/keyword-detector.test.ts

Closes #1603