### PR TITLE
fix: terminate codex child when detached leader shell exits on signal

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import { chmod, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, writeFile } 
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { once } from "node:events";
 import {
   normalizeCodexLaunchArgs,
   buildTmuxShellCommand,
@@ -1720,7 +1721,7 @@ exit 0
       assert.equal(typeof leaderCmd, "string");
 
       const { spawn } = await import("node:child_process");
-      const child = spawn("/bin/sh", ["-c", leaderCmd!], {
+      const child = spawn("/bin/sh", ["-c", `exec ${leaderCmd!}`], {
         cwd,
         env: {
           ...process.env,
@@ -1741,21 +1742,23 @@ exit 0
         assert.ok(codexPid > 0, "codex pid must be positive");
         assert.doesNotThrow(() => process.kill(codexPid, 0), "codex must be alive before signal");
 
+        const leaderExit = once(child, "exit");
         process.kill(child.pid!, "SIGHUP");
-
-        let killed = false;
-        for (let i = 0; i < 30; i += 1) {
-          try {
-            process.kill(codexPid, 0);
-          } catch (err) {
-            if ((err as NodeJS.ErrnoException).code === "ESRCH") {
-              killed = true;
-              break;
-            }
-          }
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
-        assert.ok(killed, "codex child must be terminated after leader SIGHUP");
+        await Promise.race([
+          leaderExit,
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error("leader did not exit after SIGHUP")), 3000),
+          ),
+        ]);
+        assert.throws(
+          () => process.kill(codexPid, 0),
+          (err: unknown) =>
+            typeof err === "object" &&
+            err !== null &&
+            "code" in err &&
+            (err as NodeJS.ErrnoException).code === "ESRCH",
+          "codex child must be terminated after leader SIGHUP",
+        );
       } finally {
         try {
           process.kill(child.pid!, "SIGKILL");

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1509,7 +1509,10 @@ describe("detached tmux new-session sequencing", () => {
     assert.doesNotMatch(leaderCmd!, /^\/bin\/sh -lc '/);
     assert.match(leaderCmd!, /acquireTmuxExtendedKeysLease/);
     assert.match(leaderCmd!, /omx_detached_session_cleanup\(\)/);
-    assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0;/);
+    assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0 INT TERM HUP;/);
+    assert.match(leaderCmd!, /omx_codex_pid=\$!;/);
+    assert.match(leaderCmd!, /wait "\$omx_codex_pid";/);
+    assert.match(leaderCmd!, /kill -TERM "\$omx_codex_pid"/);
     assert.match(leaderCmd!, /releaseTmuxExtendedKeysLease/);
     assert.match(leaderCmd!, /if \[ "\$status" -lt 128 \]; then/);
     assert.match(leaderCmd!, /tmux kill-session -t/);
@@ -1667,6 +1670,99 @@ exit 0
       assert.match(log, /tmux:set-option -sq extended-keys always/);
       assert.match(log, /tmux:set-option -sq extended-keys off/);
       assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("detached leader command terminates codex child on external SIGHUP", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-hup-"));
+    const fakeBin = join(cwd, "bin");
+    const pidFile = join(cwd, "codex.pid");
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, "codex"),
+        `#!/bin/sh
+echo $$ > "${pidFile}"
+trap '' HUP
+while true; do sleep 1; done
+`,
+      );
+      await chmod(join(fakeBin, "codex"), 0o755);
+      await writeFile(
+        join(fakeBin, "tmux"),
+        `#!/bin/sh
+case "$1" in
+  display-message)
+    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\\n'
+    else
+      printf '0\\n'
+    fi
+    ;;
+  show-options) printf 'off\\n' ;;
+  set-option|kill-session) ;;
+esac
+exit 0
+`,
+      );
+      await chmod(join(fakeBin, "tmux"), 0o755);
+
+      const steps = buildDetachedSessionBootstrapSteps(
+        "omx-demo",
+        cwd,
+        buildTmuxPaneCommand("codex", [], "/bin/sh"),
+        "'node' '/tmp/omx.js' 'hud' '--watch'",
+        null,
+      );
+      const leaderCmd = steps[0]?.args.at(-1);
+      assert.equal(typeof leaderCmd, "string");
+
+      const { spawn } = await import("node:child_process");
+      const child = spawn("/bin/sh", ["-c", leaderCmd!], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          HOME: cwd,
+        },
+        stdio: "ignore",
+        detached: true,
+      });
+
+      try {
+        for (let i = 0; i < 20; i += 1) {
+          if (existsSync(pidFile)) break;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        assert.ok(existsSync(pidFile), "codex pid file not written");
+        const codexPid = Number.parseInt((await readFile(pidFile, "utf-8")).trim(), 10);
+        assert.ok(codexPid > 0, "codex pid must be positive");
+        assert.doesNotThrow(() => process.kill(codexPid, 0), "codex must be alive before signal");
+
+        process.kill(child.pid!, "SIGHUP");
+
+        let killed = false;
+        for (let i = 0; i < 30; i += 1) {
+          try {
+            process.kill(codexPid, 0);
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === "ESRCH") {
+              killed = true;
+              break;
+            }
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        assert.ok(killed, "codex child must be terminated after leader SIGHUP");
+      } finally {
+        try {
+          process.kill(child.pid!, "SIGKILL");
+        } catch {
+          /* already dead */
+        }
+      }
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1618,17 +1618,24 @@ function buildDetachedSessionLeaderCommand(
 ): string {
   const wrapped = [
     buildTmuxExtendedKeysAcquireShellSnippet(cwd),
+    'omx_codex_pid="";',
     "omx_detached_session_cleanup() {",
     "status=$?;",
     "trap - 0 INT TERM HUP;",
+    'if [ -n "$omx_codex_pid" ] && kill -0 "$omx_codex_pid" 2>/dev/null; then',
+    'kill -TERM "$omx_codex_pid" 2>/dev/null || true;',
+    'wait "$omx_codex_pid" 2>/dev/null || true;',
+    "fi;",
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
     'if [ "$status" -lt 128 ]; then',
     `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
     "fi;",
     "exit $status;",
     "};",
-    "trap omx_detached_session_cleanup 0;",
-    codexCmd,
+    "trap omx_detached_session_cleanup 0 INT TERM HUP;",
+    `${codexCmd} &`,
+    "omx_codex_pid=$!;",
+    'wait "$omx_codex_pid";',
   ].join(" ");
   return `/bin/sh -c ${quoteShellArg(wrapped)}`;
 }


### PR DESCRIPTION
## Summary

Fix a long-running bug where the wrapper `/bin/sh` in `buildDetachedSessionLeaderCommand` leaves the child `codex` process orphaned (PPID=1) when the leader receives an external SIGHUP — e.g. `tmux kill-session` from another client, tmux server crash, or a stray `kill -HUP`. The wrapper currently runs codex as a synchronous foreground child and traps only the EXIT pseudo-signal, so tmux-driven termination of the leader never reaches codex.

## Changes

- `src/cli/index.ts` — in `buildDetachedSessionLeaderCommand`:
  - Run codex as a background job (`&`), capture its PID in `$omx_codex_pid`, and `wait` on it so the leader's `$?` still reflects codex's exit status.
  - Add `INT TERM HUP` to the cleanup trap alongside EXIT (0).
  - In the cleanup function, explicitly `kill -TERM "$omx_codex_pid"` (guarded by `kill -0`) before releasing the tmux extended-keys lease. The existing `[ "$status" -lt 128 ]` guard around `tmux kill-session` is preserved, so normal-exit teardown is unchanged.
- `src/cli/__tests__/index.test.ts`:
  - Update `buildDetachedSessionBootstrapSteps kills detached tmux session on normal shell exit` to match the new wrapper shape (`trap ... 0 INT TERM HUP`, background codex, `omx_codex_pid`, `wait`, inline TERM).
  - Add `detached leader command terminates codex child on external SIGHUP` — spawns the leader, writes codex's PID from a fake binary that ignores HUP (mimicking observed real-world behaviour), sends SIGHUP to the leader, and polls for the codex PID to disappear within ~3 s. Verified to fail on `dev` without this patch and pass with it.

## Validation

- [x] `npm run build`
- [x] `npm test` — new regression test passes; the two unrelated failures in `src/cli/__tests__/index.test.ts` (`preserves cwd and cleanup`, `signal-derived exits`) reproduce on clean `dev` on macOS (Darwin 25.3.0) and are not introduced by this PR.
- [x] `npm run lint` (Biome, 489 files, clean)
- [ ] `omx doctor` — not applicable (no setup/config surface change)

Reproduction observed locally over ~2 weeks of continuous OMX use before cleaning up by hand: the `codex --yolo` process tree accumulated orphans with `PPID=1` every time a tmux session got torn down from outside the wrapper. `pgrep -af 'codex.*--yolo'` returned a dozen+ such orphans before manual SIGKILL.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — no user-facing behaviour change; wrapper is an internal detail
- [x] Backward-compatibility impact considered — the wrapper string is an internal implementation; the existing "kill-session only on status < 128" contract is preserved

## Related

Closes #
