### PR TITLE
Clarify prompt-side Ralph activation vs PRD CLI startup

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -28,7 +28,7 @@ OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js
 | --- | --- | --- | --- | --- |
 | `session-start` | `SessionStart` | `session-start` | native | Native adapter refreshes session bookkeeping, restores startup developer context, and ensures `.omx/` is gitignored at the repo root |
 | wiki startup context | `SessionStart` | `session-start` | native | Wiki session-start context can append a compact `.omx/wiki/` summary when wiki pages exist; startup writes stay config-gated |
-| `keyword-detector` | `UserPromptSubmit` | `keyword-detector` | native | Persists skill activation state and can add prompt-side developer context |
+| `keyword-detector` | `UserPromptSubmit` | `keyword-detector` | native | Persists skill activation state and can add prompt-side developer context; `$ralph` prompt routing seeds workflow state only and does not launch `omx ralph --prd ...` |
 | `pre-tool-use` | `PreToolUse` (`Bash`) | `pre-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior cautions on `rm -rf dist` and blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present |
 | `post-tool-use` | `PostToolUse` (`Bash`) | `post-tool-use` | native-partial | Current native scope is Bash-only; built-in native behavior covers command-not-found / permission-denied / missing-path guidance and informative non-zero-output review |
 | Ralph/persistence stop handling | `Stop` | `stop` | native-partial | Native adapter uses the documented native Stop continuation contract (`decision: "block"` + `reason`) for active Ralph runs and avoids re-blocking once `stop_hook_active` is set |

--- a/docs/contracts/ralph-state-contract.md
+++ b/docs/contracts/ralph-state-contract.md
@@ -92,3 +92,4 @@ starting
   - `.omx/progress.txt` migrates one-way to canonical `ralph-progress.json` when no canonical ledger exists.
   - Legacy files remain read-only compatibility artifacts for one release cycle.
 - Canonical PRD markdown is storage/documentation-canonical today; Ralph `--prd` startup still validates machine-readable story approval state from `.omx/prd.json` until a structured replacement exists.
+- Prompt-side `$ralph` workflow activation is not equivalent to `omx ralph --prd ...`; it may seed Ralph mode state and routing context, but the PRD startup gate remains an explicit CLI-path contract.

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -192,6 +192,11 @@ When the user provides the `--prd` flag, initialize a Product Requirements Docum
 ### Detecting PRD Mode
 Check if `{{PROMPT}}` contains `--prd` or `--PRD`.
 
+Prompt-side `$ralph` workflow activation is lighter-weight than `omx ralph --prd ...`.
+It seeds Ralph workflow state and guidance, but it does not implicitly launch the
+CLI entrypoint or apply the PRD startup gate. Treat `omx ralph --prd ...` as the
+explicit PRD-gated path.
+
 ### Detecting `--no-deslop`
 Check if `{{PROMPT}}` contains `--no-deslop`.
 If `--no-deslop` is present, skip the deslop pass entirely after Step 7 and continue using the latest successful pre-deslop verification evidence.

--- a/src/cli/__tests__/ralph.test.ts
+++ b/src/cli/__tests__/ralph.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  RALPH_HELP,
   assertRequiredRalphPrdJson,
   buildRalphAppendInstructions,
   buildRalphChangedFilesSeedContents,
@@ -43,6 +44,13 @@ describe('isRalphPrdMode', () => {
 
   it('ignores non-prd Ralph runs', () => {
     assert.equal(isRalphPrdMode(['fix', 'the', 'bug']), false);
+  });
+});
+
+describe('RALPH_HELP', () => {
+  it('clarifies that prompt-side $ralph activation is separate from CLI --prd mode', () => {
+    assert.match(RALPH_HELP, /Prompt-side `\$ralph` activation is separate from this CLI entrypoint/i);
+    assert.match(RALPH_HELP, /does not imply `--prd` or the PRD\.json startup gate/i);
   });
 });
 

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -26,6 +26,8 @@ PRD mode:
   Ralph initializes persistence artifacts in .omx/ so PRD and progress
   state can survive across Codex sessions. Provide task text either as
   positional words or with --prd.
+  Prompt-side \`$ralph\` activation is separate from this CLI entrypoint and
+  does not imply \`--prd\` or the PRD.json startup gate.
 
 Common patterns:
   omx ralph "Fix flaky notify-hook tests"

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -380,6 +380,36 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("clarifies that prompt-side $ralph activation does not invoke the PRD-gated CLI path", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-routing-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-ralph-msg",
+          thread_id: "thread-ralph-msg",
+          turn_id: "turn-ralph-msg",
+          prompt: "$ralph continue verification",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ralph");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /\$ralph" -> ralph/);
+      assert.match(message, /skill: ralph activated and initial state initialized at \.omx\/state\/sessions\/sess-ralph-msg\/ralph-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /Prompt-side `\$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`\./);
+      assert.match(message, /Use `omx ralph --prd \.\.\.` only when you explicitly want the PRD-gated CLI startup path\./);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not expose submitted prompt text to keyword-detector hook plugins", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-prompt-sanitized-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -476,6 +476,9 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
     ? skillState.deferred_skills
     : [];
   const teamDetected = activeSkills.includes("team");
+  const ralphPromptActivationNote = skillState?.initialized_mode === "ralph"
+    ? "Prompt-side `$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`. Use `omx ralph --prd ...` only when you explicitly want the PRD-gated CLI startup path."
+    : null;
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
     if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
@@ -536,6 +539,7 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
         ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
         : null,
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
+      ralphPromptActivationNote,
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].join(" ");
   }


### PR DESCRIPTION
## Summary
- clarify native prompt-submit messaging so `$ralph` is explicitly state/routing activation only
- keep `omx ralph --prd ...` as the separate PRD-gated CLI path in help/docs/contracts
- add regression coverage for the narrowed contract

## Testing
- npm install
- npm run build
- npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts src/cli/ralph.ts src/cli/__tests__/ralph.test.ts
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/ralph.test.js dist/cli/__tests__/ralph-prd-smoke.test.js dist/cli/__tests__/ralph-prd-deep-interview.test.js
