### PR TITLE
Keep native hook metadata from hijacking Codex routing

### DIFF
--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -39,7 +39,7 @@ describe("codex hooks helpers", () => {
     );
     assert.match(JSON.stringify(sessionStart), /echo keep-me/);
     assert.match(JSON.stringify(sessionStart), /echo standalone-user/);
-    assert.match(JSON.stringify(sessionStart), /Loading OMX session context/);
+    assert.doesNotMatch(JSON.stringify(sessionStart), /Loading OMX session context/);
   });
 
   it("removes only OMX-managed wrappers during uninstall cleanup", () => {

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -66,7 +66,6 @@ export function buildManagedCodexHooksConfig(
       SessionStart: [
         buildCommandHook(command, {
           matcher: "startup|resume",
-          statusMessage: "Loading OMX session context",
         }),
       ],
       PreToolUse: [

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -106,6 +106,13 @@ describe("codex native hook config", () => {
       "Stop",
     ]);
 
+    const sessionStart = config.hooks.SessionStart[0] as {
+      matcher?: string;
+      hooks?: Array<Record<string, unknown>>;
+    };
+    assert.equal(sessionStart.matcher, "startup|resume");
+    assert.equal(sessionStart.hooks?.[0]?.statusMessage, undefined);
+
     const preToolUse = config.hooks.PreToolUse[0] as {
       matcher?: string;
       hooks?: Array<Record<string, unknown>>;
@@ -173,7 +180,7 @@ describe("codex native hook dispatch", () => {
     assert.equal(mapCodexHookEventToOmxEvent("Stop"), "stop");
   });
 
-  it("writes SessionStart state against the long-lived session owner pid", async () => {
+  it("writes SessionStart state against the long-lived session owner pid and stays quiet for clean sessions", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-start-"));
     try {
       const result = await dispatchCodexNativeHook(
@@ -189,13 +196,7 @@ describe("codex native hook dispatch", () => {
       );
 
       assert.equal(result.omxEventName, "session-start");
-      assert.deepEqual(result.outputJson, {
-        hookSpecificOutput: {
-          hookEventName: "SessionStart",
-          additionalContext:
-            "OMX native SessionStart detected. Load workspace conventions from AGENTS.md, restore relevant .omx runtime/project memory context, and continue from existing mode state before making changes.",
-        },
-      });
+      assert.equal(result.outputJson, null);
       const sessionState = JSON.parse(
         await readFile(join(cwd, ".omx", "state", "session.json"), "utf-8"),
       ) as { session_id?: string; native_session_id?: string; pid?: number };
@@ -405,6 +406,49 @@ describe("codex native hook dispatch", () => {
       assert.match(message, /skill: ralph activated and initial state initialized at \.omx\/state\/sessions\/sess-ralph-msg\/ralph-state\.json; write subsequent updates via omx_state MCP\./);
       assert.match(message, /Prompt-side `\$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`\./);
       assert.match(message, /Use `omx ralph --prd \.\.\.` only when you explicitly want the PRD-gated CLI startup path\./);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores generic wrapper fields so metadata cannot trigger workflow routing or Stop blocking", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-wrapper-metadata-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const promptResult = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-wrapper-meta-1",
+          thread_id: "thread-wrapper-meta-1",
+          turn_id: "turn-wrapper-meta-1",
+          input: "$ralplan hidden wrapper text should stay non-routing",
+          text: JSON.stringify({
+            hook_run_id: "native-stop-wrapper-1",
+            note: "cancel stop wrapper metadata must not be treated like user intent",
+          }),
+        },
+        { cwd },
+      );
+
+      assert.equal(promptResult.omxEventName, "keyword-detector");
+      assert.equal(promptResult.skillState, null);
+      assert.equal(promptResult.outputJson, null);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "skill-active-state.json")), false);
+
+      const stopResult = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-wrapper-meta-1",
+          thread_id: "thread-wrapper-meta-1",
+          turn_id: "turn-wrapper-meta-2",
+        },
+        { cwd },
+      );
+
+      assert.equal(stopResult.omxEventName, "stop");
+      assert.equal(stopResult.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -139,10 +139,8 @@ export function mapCodexHookEventToOmxEvent(
 function readPromptText(payload: CodexHookPayload): string {
   const candidates = [
     payload.prompt,
-    payload.input,
     payload.user_prompt,
     payload.userPrompt,
-    payload.text,
   ];
   for (const candidate of candidates) {
     const value = safeString(candidate).trim();
@@ -379,10 +377,8 @@ async function ensureOmxGitignoreEntry(cwd: string): Promise<{ changed: boolean;
 async function buildSessionStartContext(
   cwd: string,
   sessionId: string,
-): Promise<string> {
-  const sections = [
-    "OMX native SessionStart detected. Load workspace conventions from AGENTS.md, restore relevant .omx runtime/project memory context, and continue from existing mode state before making changes.",
-  ];
+): Promise<string | null> {
+  const sections: string[] = [];
 
   const gitignoreResult = await ensureOmxGitignoreEntry(cwd);
   if (gitignoreResult.changed) {
@@ -458,7 +454,7 @@ async function buildSessionStartContext(
     sections.push(`[Subagents]\n- active subagent threads: ${subagentSummary.activeSubagentThreadIds.length}`);
   }
 
-  return sections.join("\n\n");
+  return sections.length > 0 ? sections.join("\n\n") : null;
 }
 
 function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveState | null): string | null {


### PR DESCRIPTION
## Summary
- treat only explicit prompt-bearing fields as user intent when extracting native hook routing text
- stop wrapper metadata/generic JSON fields from hijacking Codex prompt routing and additional-context behavior
- add regression coverage for hook metadata payloads so SessionStart/Stop wrapper data stays non-intentful

## Testing
- npx biome lint src/config/codex-hooks.ts src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts
- npm run check:no-unused

Closes #1386