### PR TITLE
fix: cache leader git activity to reduce macOS syspolicyd CPU

### DIFF
--- a/docs/reports/macos-m1-high-cpu-usage-2026-04-16.md
+++ b/docs/reports/macos-m1-high-cpu-usage-2026-04-16.md
@@ -1,0 +1,76 @@
+## macOS M1 High CPU Usage Investigation
+
+Date: 2026-04-16
+
+### Symptom
+
+Launching `omx --madmax --xhigh` on an Apple Silicon Mac caused `syspolicyd`
+to spike, often alongside visible CPU churn in `sysmond`.
+
+### Root Cause
+
+The dominant trigger was not `syspolicyd` itself. OMX startup entered the
+fallback watcher path in a repository with stale runtime state, which caused
+`leader_nudge` polling to run roughly every 250 to 350 ms.
+
+That polling path called `isLeaderRuntimeStale()`, which read leader git
+activity by shelling out to multiple short-lived `git` processes:
+
+- `git rev-parse --git-dir`
+- `git symbolic-ref --quiet --short HEAD`
+- `git rev-parse --git-path logs/HEAD`
+- `git rev-parse --git-path logs/refs/heads/<branch>`
+- `git show -s --format=%ct HEAD`
+
+On macOS, each of those short-lived `git` execs triggered code-signing and
+policy checks in `syspolicyd`. The repeated exec bursts were sufficient to
+drive `syspolicyd` CPU well above normal idle levels during startup.
+
+### Patch
+
+File changed:
+
+- `src/team/leader-activity.ts`
+
+Implementation:
+
+- Added a process-local cache for leader git activity lookups.
+- Cache key is the repository root derived from `stateDir`.
+- Cache TTL is bounded between `1000 ms` and `5000 ms`.
+- TTL is computed as `thresholdMs / 4`, clamped to that range.
+- `readLeaderRuntimeSignalStatuses()` now uses the cached git activity lookup
+  instead of invoking the git-reading path on every poll cycle.
+
+### Why This Shape
+
+- The fix targets the verified hotspot directly.
+- It preserves stale-detection semantics.
+- It avoids broader changes to watcher cadence or team lifecycle behavior.
+- It keeps the diff small and reversible.
+
+### Validation
+
+Controlled reproduction before the patch:
+
+- `omx --madmax --xhigh` in `GhostVMPriv`
+- `notify-fallback-watcher` active with `poll_ms = 250`
+- `leader_nudge` firing repeatedly
+- `syspolicyd` observed around `66% CPU`
+- `fs_usage -f exec` showed repeated `git` exec bursts
+
+Controlled reproduction after the patch:
+
+- Same repository and startup command
+- Same `leader_nudge` loop still active
+- 4-second post-start sampling window observed `0` `git` execs
+- `syspolicyd` dropped to low single-digit CPU usage
+
+### Remaining Risks
+
+- Stale `.omx/state` can still keep `leader_nudge` polling active; this patch
+  removes the dominant git-exec hotspot but does not stop the poll loop.
+- Other synchronous git metadata reads still exist in separate paths such as
+  operational event enrichment and HUD rendering, but they were no longer the
+  dominant startup hotspot in the reproduced window.
+- Git activity freshness is now cached briefly, so stale detection can lag by
+  at most the configured cache TTL.

--- a/src/team/__tests__/leader-activity.test.ts
+++ b/src/team/__tests__/leader-activity.test.ts
@@ -162,6 +162,36 @@ describe('leader runtime activity', () => {
     }
   });
 
+  it('reuses cached git activity within one process to avoid repeated shell-outs', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-cache-'));
+    const originalPath = process.env.PATH;
+    try {
+      execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+      await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+      execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+
+      const first = await readLatestLeaderActivityMsFromStateDir(stateDir);
+      assert.equal(Number.isFinite(first), true);
+
+      process.env.PATH = '/definitely-missing-for-omx-test';
+      const second = await readLatestLeaderActivityMsFromStateDir(stateDir);
+      assert.equal(second, first);
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('treats worktree .git file pointers as recent branch activity on Windows', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-leader-activity-worktree-'));
     try {

--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -5,6 +5,10 @@ import { dirname, join, posix, resolve, win32 } from 'node:path';
 import { omxStateDir } from '../utils/paths.js';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 
+const MIN_GIT_ACTIVITY_CACHE_TTL_MS = 1000;
+const MAX_GIT_ACTIVITY_CACHE_TTL_MS = 5000;
+const gitActivityCache = new Map<string, { value: number; expiresAt: number }>();
+
 interface LeaderRuntimeActivityDoc {
   last_activity_at?: string;
   last_team_status_at?: string;
@@ -145,6 +149,36 @@ async function readLeaderBranchGitActivityMs(stateDir: string): Promise<number> 
   return await readBranchGitActivityMsForPath(stateDirToProjectRoot(stateDir));
 }
 
+function resolveLeaderGitActivityCacheTtlMs(thresholdMs: number): number {
+  if (!Number.isFinite(thresholdMs) || thresholdMs <= 0) {
+    return MAX_GIT_ACTIVITY_CACHE_TTL_MS;
+  }
+
+  return Math.max(
+    MIN_GIT_ACTIVITY_CACHE_TTL_MS,
+    Math.min(MAX_GIT_ACTIVITY_CACHE_TTL_MS, Math.floor(thresholdMs / 4)),
+  );
+}
+
+async function readLeaderBranchGitActivityMsCached(
+  stateDir: string,
+  thresholdMs: number,
+  nowMs: number,
+): Promise<number> {
+  const cacheKey = stateDirToProjectRoot(stateDir);
+  const cached = gitActivityCache.get(cacheKey);
+  if (cached && cached.expiresAt > nowMs) {
+    return cached.value;
+  }
+
+  const value = await readLeaderBranchGitActivityMs(stateDir);
+  gitActivityCache.set(cacheKey, {
+    value,
+    expiresAt: nowMs + resolveLeaderGitActivityCacheTtlMs(thresholdMs),
+  });
+  return value;
+}
+
 export function leaderRuntimeActivityPath(cwd: string): string {
   return join(omxStateDir(cwd), 'leader-runtime-activity.json');
 }
@@ -183,7 +217,7 @@ export async function readLeaderRuntimeSignalStatuses(
   const [hudState, leaderActivity, leaderGitActivityMs] = await Promise.all([
     existsSync(hudPath) ? readJsonIfExists(hudPath) : Promise.resolve(null),
     existsSync(leaderActivityPath) ? readJsonIfExists(leaderActivityPath) : Promise.resolve(null),
-    readLeaderBranchGitActivityMs(stateDir),
+    readLeaderBranchGitActivityMsCached(stateDir, thresholdMs, nowMs),
   ]);
 
   const signals: Array<{ source: LeaderRuntimeSignalStatus['source']; at: unknown; ms?: number }> = [


### PR DESCRIPTION
## Summary

This patch reduces a verified macOS startup hotspot in the stale leader polling path.

In the reproduced case, stale OMX runtime state kept `notify-fallback-watcher` on the `leader_nudge` path at sub-second cadence. That path repeatedly called `isLeaderRuntimeStale()`, which shelled out to several short-lived `git` commands. On macOS, those repeated `git` execs kept `syspolicyd` busy and drove unnecessary CPU usage.

Environment note from reproduction:
- Reproduces consistently on an `M1 Pro` machine running `macOS 26.3`
- Does not reproduce in the same way on an `M4 mini` running `macOS 26.3.1`

## Changes

- add a short-lived in-process cache for leader git activity lookups in `src/team/leader-activity.ts`
- keep stale-detection semantics unchanged while removing repeated shell-outs in the hot polling path
- add a regression test proving cached leader git activity can be reused within one process
- add an investigation report under `docs/reports/` with sanitized reproduction details and validation notes

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Additional validation performed:
- [x] `npm run lint`
- [x] `node --test dist/team/__tests__/leader-activity.test.js`
- [x] local macOS reproduction before/after the mitigation

Notes:
- local reproduction before the patch showed repeated `git` exec bursts and `syspolicyd` around 66% CPU during the hot window
- local reproduction after the patch showed 0 `git` execs in the sampled post-start window and `syspolicyd` dropping to low single-digit CPU
- local full `npm test` in this checkout still hit unrelated failures outside the touched area, including suites under `omx ask`, `omx autoresearch`, `resolveExploreHarnessCommand`, detached tmux launch sequencing, `omx session search`, and `notify-fallback watcher`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1618
