### PR TITLE
Promote the 0.13.0 release commit to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-16
+
+Minor release for the new `omx adapt` surface, stronger Ralph / runtime session authority, safer cross-platform launch behavior, and another broad pass over hook, HUD, notification, and release-process correctness.
+
+### Added
+- **OMX adapt foundations** — `omx adapt` now exposes OMX-owned adapter foundations for persistent external targets, with read-only probe/status/doctor surfaces, init/envelope output under `.omx/adapters/<target>/...`, planning artifact linkage, and target-specific OpenClaw and Hermes evidence. (PRs [#1600](https://github.com/Yeachan-Heo/oh-my-codex/pull/1600), [#1599](https://github.com/Yeachan-Heo/oh-my-codex/pull/1599), [#1598](https://github.com/Yeachan-Heo/oh-my-codex/pull/1598))
+- **Hermes runtime observation** — Hermes adaptation reports ACP, gateway, session-store, and bootstrap evidence without writing into the Hermes runtime. (PR [#1598](https://github.com/Yeachan-Heo/oh-my-codex/pull/1598))
+- **OpenClaw local observation** — OpenClaw adaptation summarizes local config, gateway, hook mapping, and lifecycle bridge evidence while keeping command gateways gated. (PR [#1599](https://github.com/Yeachan-Heo/oh-my-codex/pull/1599))
+
+### Fixed
+
+#### Ralph / runtime authority / workflow semantics
+- **Ralph session authority** — Ralph assignment and tmux Ralph nudges now stay scoped to the activating/current session instead of drifting across concurrent OMX sessions. (PRs [#1604](https://github.com/Yeachan-Heo/oh-my-codex/pull/1604), [#1591](https://github.com/Yeachan-Heo/oh-my-codex/pull/1591))
+- **Prompt-side Ralph vs PRD CLI startup** — prompt activation no longer pretends to be `omx ralph --prd`, and PRD story validation remains required on the explicit CLI path. (PR [#1608](https://github.com/Yeachan-Heo/oh-my-codex/pull/1608))
+- **Native Stop stability** — Stop handling is stable across session-id drift, permission-seeking handoffs resume automatically, and native hook metadata no longer hijacks routing. (PRs [#1590](https://github.com/Yeachan-Heo/oh-my-codex/pull/1590), [#1611](https://github.com/Yeachan-Heo/oh-my-codex/pull/1611); direct commit `4377e1e`)
+- **MCP state transport resilience** — resumed duplicate MCP state writers stay alive after reconcile/self-teardown paths. (PR [#1596](https://github.com/Yeachan-Heo/oh-my-codex/pull/1596))
+
+#### Launch / platform / worktree safety
+- **Explore harness resolution** — `omx explore` skips unusable PATH node entries, resolves POSIX Codex shims under sandboxed pnpm-style PATHs, and fails closed before Windows paths hit the POSIX allowlist wrapper. (PRs [#1562](https://github.com/Yeachan-Heo/oh-my-codex/pull/1562), [#1610](https://github.com/Yeachan-Heo/oh-my-codex/pull/1610); direct commit `72b1e5d`)
+- **Detached leader cleanup** — detached Codex children are terminated when their leader shell exits on signal, with regression coverage for the orphan path. (PR [#1605](https://github.com/Yeachan-Heo/oh-my-codex/pull/1605))
+- **Windows cleanup discovery** — Windows OMX cleanup finds real orphaned servers again. (PR [#1589](https://github.com/Yeachan-Heo/oh-my-codex/pull/1589))
+- **Stale worktree startup** — detached team startup no longer fails just because an old recorded worktree path is missing. (PR [#1582](https://github.com/Yeachan-Heo/oh-my-codex/pull/1582))
+
+#### Hooks / HUD / notifications
+- **HUD active-session binding** — HUD state stays bound to the live OMX session rather than falling back to stale root scope. (PR [#1573](https://github.com/Yeachan-Heo/oh-my-codex/pull/1573))
+- **macOS leader stale polling** — leader stale polling now reduces repeated git probes on macOS, lowering high-CPU polling churn in long-running sessions. (PR [#1619](https://github.com/Yeachan-Heo/oh-my-codex/pull/1619))
+- **Queued startup and dispatch regressions** — Codex startup banners, queued drafts, and dispatch-lock behavior are covered so inbox/worker startup cannot regress silently. (PR [#1595](https://github.com/Yeachan-Heo/oh-my-codex/pull/1595))
+- **Slack mention parsing** — Slack notification mention environment parsing has focused regression coverage. (PR [#1585](https://github.com/Yeachan-Heo/oh-my-codex/pull/1585))
+- **Receiving-agent ownership** — generated guidance now treats safe reversible OMX/runtime operations as the receiving agent's responsibility instead of asking the user to perform ordinary cleanup. (direct commit `76e808e`)
+
+#### Setup / docs / release workflow
+- **Wiki setup registration** — `omx setup` installs the shipped wiki skill/config assets consistently. (PR [#1571](https://github.com/Yeachan-Heo/oh-my-codex/pull/1571))
+- **Native hook doctor coverage** — doctor/config output now surfaces missing native-hook coverage before it looks like a broken OMX install. (PR [#1546](https://github.com/Yeachan-Heo/oh-my-codex/pull/1546))
+- **Contribution branch guardrail** — normal contribution guidance now makes `dev` the obvious PR base. (PR [#1567](https://github.com/Yeachan-Heo/oh-my-codex/pull/1567))
+
+### Changed
+- **Release workflow dependency refresh** — GitHub Actions and tooling dependencies are refreshed for the release pipeline and TypeScript/Biome baselines. (PRs [#1575](https://github.com/Yeachan-Heo/oh-my-codex/pull/1575), [#1576](https://github.com/Yeachan-Heo/oh-my-codex/pull/1576), [#1577](https://github.com/Yeachan-Heo/oh-my-codex/pull/1577), [#1578](https://github.com/Yeachan-Heo/oh-my-codex/pull/1578))
+- **Release metadata sync** — Node/Cargo package metadata, lockfiles, changelog, release body, release notes, and release-readiness docs aligned to `0.13.0`.
+
 ## [0.12.6] - 2026-04-13
 
 Wiki-first knowledge workflows, notification and hook delivery hardening, launch/worktree safety improvements, and automatic closure of explicitly linked issues after `dev` merges across 32 PRs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,11 +32,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.12.6"
+version = "0.13.0"
 
 [[package]]
 name = "omx-mux"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "fs2",
  "serde",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "omx-mux",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.12.6"
+version = "0.13.0"
 
 edition = "2021"
 license = "MIT"

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,42 +1,48 @@
-# oh-my-codex v0.12.6
+# oh-my-codex v0.13.0
 
-**Wiki-first knowledge workflows, hook/notification hardening, launch safety improvements, and dev-merge issue auto-close**
+**Adapt foundations, Ralph/session authority hardening, safer launch paths, and quieter hook/HUD workflows**
 
-`0.12.6` is the `v0.12.5..v0.12.6` patch train across 32 PR merges. It ships OMX wiki as a first-class local knowledge workflow, deepens hook/notification/session-state hardening, improves launch/worktree safety, and adds automation that closes explicitly linked issues after merges into `dev`.
+`0.13.0` is the `v0.12.6..v0.13.0` minor release train. It adds the first `omx adapt` foundation for persistent external targets, tightens Ralph and native Stop session authority, hardens explore/Windows/detached launch paths, and refreshes setup/release workflow guardrails across 56 first-parent PR merges.
 
 ## Highlights
 
-- **OMX wiki is now first-class** — local markdown wiki storage, query/lint/refresh flows, CLI/MCP parity, and explore integration all land together (#1481).
-- **Hook and session-state hardening** — native hook, notify hook, lifecycle dedupe, reply-listener/session-status, and HUD cleanup paths are more stable and less noisy (#1487, #1491, #1493, #1495, #1496, #1514, #1518, #1520, #1526, #1529, #1539).
-- **Launch/operator safety** — reusable worktree dependency bootstrap, AGENTS preservation during setup, proxy inheritance, dirty-worktree caution handling, and Claude issue approval-flow smoothing all improve day-to-day operator reliability (#1507, #1521, #1522, #1532, #1536).
-- **Discord + dev-merge workflow automation** — tracked Discord sessions get safer control primitives, and merged `dev` PRs can auto-close explicitly linked issues (#1528, #1540).
+- **`omx adapt` foundation** — new adapter-owned CLI/reporting surfaces for persistent targets start with OpenClaw and Hermes, linking canonical planning artifacts while keeping writes under `.omx/adapters/<target>/...` (#1600, #1599, #1598).
+- **Ralph and native Stop authority** — prompt-side Ralph activation, PRD CLI startup, tmux Ralph nudges, session assignment, and permission-seeking Stop continuation now respect session ownership more consistently (#1604, #1608, #1591, #1590, #1611).
+- **Safer platform launch paths** — explore/codex resolution skips unusable PATH entries, handles sandboxed POSIX shims, fails closed before Windows paths reach POSIX wrappers, and cleans detached leader children on signal exit (#1562, #1610, #1605).
+- **Quieter hooks, HUD, and notifications** — live-session HUD binding, startup/dispatch regression coverage, Slack mention parsing, macOS stale-polling git-probe reduction, hook metadata routing, and receiving-agent ownership guidance reduce stale/noisy automation (#1573, #1595, #1585, #1619, #1611).
+- **Release/setup workflow hygiene** — wiki setup registration, native-hook doctor coverage, explicit `dev` PR-base guidance, and dependency refreshes keep operator and release paths aligned (#1571, #1546, #1567, #1575, #1576, #1577, #1578).
 
 ## What's Changed
 
 ### Added
-- OMX wiki workflow, storage engine, CLI/MCP parity, and wiki-aware explore behavior (PR [#1481](https://github.com/Yeachan-Heo/oh-my-codex/pull/1481))
-- Discord tracked-session control primitive and safer message-id reuse handling (PR [#1530](https://github.com/Yeachan-Heo/oh-my-codex/pull/1530))
-- Auto-close workflow for explicitly linked issues after `dev` merges (PR [#1541](https://github.com/Yeachan-Heo/oh-my-codex/pull/1541))
+- `omx adapt` foundation for OMX-owned adapter artifacts, probe/status/doctor reports, envelopes, and canonical planning linkage (PR [#1600](https://github.com/Yeachan-Heo/oh-my-codex/pull/1600))
+- OpenClaw adapter observation for local config, gateways, hook mappings, and lifecycle bridge evidence (PR [#1599](https://github.com/Yeachan-Heo/oh-my-codex/pull/1599))
+- Hermes adapter observation for ACP, gateway, session-store, and bootstrap evidence (PR [#1598](https://github.com/Yeachan-Heo/oh-my-codex/pull/1598))
 
-### Fixed — Hooks / notifications / session state
-- Needs-input watcher parity for array-backed assistant prompts (PR [#1487](https://github.com/Yeachan-Heo/oh-my-codex/pull/1487))
-- Local worker runtime startup / dispatch stability (PRs [#1491](https://github.com/Yeachan-Heo/oh-my-codex/pull/1491), [#1493](https://github.com/Yeachan-Heo/oh-my-codex/pull/1493))
-- Managed-session hook cwd alias and ownership stability (PR [#1495](https://github.com/Yeachan-Heo/oh-my-codex/pull/1495))
-- Ralph steer / release-readiness follow-up scoping (PRs [#1496](https://github.com/Yeachan-Heo/oh-my-codex/pull/1496), [#1514](https://github.com/Yeachan-Heo/oh-my-codex/pull/1514))
-- Lifecycle/keyword alert noise reduction and post-stop replay suppression (PRs [#1518](https://github.com/Yeachan-Heo/oh-my-codex/pull/1518), [#1520](https://github.com/Yeachan-Heo/oh-my-codex/pull/1520), [#1526](https://github.com/Yeachan-Heo/oh-my-codex/pull/1526), [#1529](https://github.com/Yeachan-Heo/oh-my-codex/pull/1529))
-- Dead-session HUD residue cleanup before follow-up tooling reads it (PR [#1539](https://github.com/Yeachan-Heo/oh-my-codex/pull/1539))
+### Fixed — Ralph / runtime authority
+- Ralph assignment, tmux Ralph nudges, and PRD startup semantics now stay session-scoped and explicit (PRs [#1604](https://github.com/Yeachan-Heo/oh-my-codex/pull/1604), [#1608](https://github.com/Yeachan-Heo/oh-my-codex/pull/1608), [#1591](https://github.com/Yeachan-Heo/oh-my-codex/pull/1591))
+- Native Stop resumes permission-seeking handoffs and stays stable across session-id drift (PR [#1590](https://github.com/Yeachan-Heo/oh-my-codex/pull/1590), direct commit `4377e1e`)
+- Native hook metadata can no longer hijack real prompt routing (PR [#1611](https://github.com/Yeachan-Heo/oh-my-codex/pull/1611))
+- Resumed MCP state writers survive duplicate reconcile/self-teardown paths (PR [#1596](https://github.com/Yeachan-Heo/oh-my-codex/pull/1596))
 
-### Fixed — Launch / setup / operator safety
-- Reusable worktree dependency bootstrap (PR [#1510](https://github.com/Yeachan-Heo/oh-my-codex/pull/1510))
-- Defensive handling for malformed native-hook stdin JSON (PR [#1504](https://github.com/Yeachan-Heo/oh-my-codex/pull/1504))
-- Preserve user-authored AGENTS guidance during setup (PR [#1524](https://github.com/Yeachan-Heo/oh-my-codex/pull/1524))
-- Preserve tmux worker proxy environment inheritance (PR [#1523](https://github.com/Yeachan-Heo/oh-my-codex/pull/1523))
-- Dirty worktree caution flow with hard-failure preservation outside launch reuse (PR [#1535](https://github.com/Yeachan-Heo/oh-my-codex/pull/1535))
-- Claude issue sessions continue through obvious repo reads without unnecessary approval stalls (PR [#1537](https://github.com/Yeachan-Heo/oh-my-codex/pull/1537))
+### Fixed — Launch / platform / worktree safety
+- Explore resolves usable node/Codex paths across unusable PATH entries and sandboxed pnpm-style shims (PRs [#1562](https://github.com/Yeachan-Heo/oh-my-codex/pull/1562), [#1610](https://github.com/Yeachan-Heo/oh-my-codex/pull/1610))
+- Windows explore fails closed before POSIX allowlist fallback can run on Windows paths (direct commit `72b1e5d`)
+- Detached leader signal exits terminate child Codex processes (PR [#1605](https://github.com/Yeachan-Heo/oh-my-codex/pull/1605))
+- Windows cleanup and stale worktree startup paths are more resilient (PRs [#1589](https://github.com/Yeachan-Heo/oh-my-codex/pull/1589), [#1582](https://github.com/Yeachan-Heo/oh-my-codex/pull/1582))
 
-### Fixed — MCP / docs / workflow surfaces
-- Superseded MCP stdio sibling cleanup under live Codex app-server parents (PR [#1517](https://github.com/Yeachan-Heo/oh-my-codex/pull/1517))
-- Canonical mixed OMX + Codex skill-root documentation plus wiki docs refresh (PR [#1534](https://github.com/Yeachan-Heo/oh-my-codex/pull/1534))
+### Fixed — Hooks / HUD / notifications
+- HUD stays bound to the live OMX session instead of stale root scope (PR [#1573](https://github.com/Yeachan-Heo/oh-my-codex/pull/1573))
+- Leader stale polling reduces repeated git probes on macOS so long-running sessions do less redundant repo work (PR [#1619](https://github.com/Yeachan-Heo/oh-my-codex/pull/1619))
+- Queued startup and dispatch lock behavior is protected by regression coverage (PR [#1595](https://github.com/Yeachan-Heo/oh-my-codex/pull/1595))
+- Slack mention environment parsing has dedicated coverage (PR [#1585](https://github.com/Yeachan-Heo/oh-my-codex/pull/1585))
+- Safe reversible runtime work is now receiving-agent-owned in generated guidance (direct commit `76e808e`)
+
+### Fixed — Setup / release workflows
+- Wiki setup registration stays aligned with shipped assets (PR [#1571](https://github.com/Yeachan-Heo/oh-my-codex/pull/1571))
+- Native-hook doctor coverage surfaces config drift clearly (PR [#1546](https://github.com/Yeachan-Heo/oh-my-codex/pull/1546))
+- Contributor guidance makes `dev` the normal PR base (PR [#1567](https://github.com/Yeachan-Heo/oh-my-codex/pull/1567))
+- Release workflow and TypeScript/Biome dependencies were refreshed (PRs [#1575](https://github.com/Yeachan-Heo/oh-my-codex/pull/1575), [#1576](https://github.com/Yeachan-Heo/oh-my-codex/pull/1576), [#1577](https://github.com/Yeachan-Heo/oh-my-codex/pull/1577), [#1578](https://github.com/Yeachan-Heo/oh-my-codex/pull/1578))
 
 ## Verification
 
@@ -50,6 +56,8 @@
 ## Contributors
 
 - [@Yeachan-Heo](https://github.com/Yeachan-Heo) (Bellman)
-- [@HaD0Yun](https://github.com/HaD0Yun)
+- [@lifrary](https://github.com/lifrary)
+- [@gujishh](https://github.com/gujishh)
+- [@dependabot](https://github.com/dependabot)
 
-**Full Changelog**: [`v0.12.5...v0.12.6`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.12.5...v0.12.6)
+**Full Changelog**: [`v0.12.6...v0.13.0`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.12.6...v0.13.0)

--- a/docs/qa/release-readiness-0.13.0.md
+++ b/docs/qa/release-readiness-0.13.0.md
@@ -1,0 +1,61 @@
+# Release Readiness Verdict - 0.13.0
+
+Date: **2026-04-16**
+Target version: **0.13.0**
+Comparison base: **`v0.12.6..origin/dev`**
+Verdict: **GO** ✅
+
+`0.13.0` packages the broad post-`0.12.6` release train: `omx adapt` foundations for OpenClaw and Hermes, Ralph/native Stop/session-authority hardening, safer explore and platform launch behavior, reduced repeated macOS stale-polling git probes, HUD/notification cleanup, setup and release workflow hygiene, and dependency refreshes.
+
+## Scope reviewed
+
+### Adapt foundations
+- `src/cli/adapt.ts`, `src/cli/index.ts` — `omx adapt` CLI routing and help surface
+- `src/adapt/*` — adapter contracts, pathing, target registry, OpenClaw/Hermes probe/status/init/envelope/doctor behavior
+- `docs/adapt.md` — user-facing adapter contract and examples
+
+### Ralph / runtime authority / workflow semantics
+- `src/cli/ralph.ts`, `src/ralph/*`, `skills/ralph/SKILL.md`, `skills/ralph-init/SKILL.md` — prompt-side Ralph vs PRD CLI startup and story validation semantics
+- `src/scripts/codex-native-hook.ts`, `src/hooks/keyword-detector.ts`, `src/mcp/state-server.ts`, `src/state/*` — Stop handling, metadata routing, MCP state transport, and session authority
+- `src/scripts/notify-hook/team-leader-nudge.ts`, `src/scripts/notify-hook/team-dispatch.ts` — tmux Ralph nudge authority and startup inbox/dispatch regression coverage
+
+### Launch / platform / worktree safety
+- `src/cli/explore.ts`, `crates/omx-explore/*` — explore harness resolution and Windows/POSIX fail-closed behavior
+- `src/cli/index.ts`, `src/cli/tmux-hook.ts`, `src/scripts/tmux-hook-engine.ts` — detached leader child cleanup and native tmux hook behavior
+- `src/team/worktree.ts`, `src/cli/cleanup.ts`, `src/notifications/tmux.ts` — stale worktree and Windows cleanup resilience
+
+### Hooks / HUD / notifications
+- `src/hud/state.ts`, `src/hud/tmux.ts`, `src/notifications/*`, `src/team/leader-activity.ts` — live-session HUD binding, tmux detection, Slack mention parsing, macOS stale-polling git-probe reduction, and notification formatting/noise paths
+- `src/config/codex-hooks.ts`, `src/scripts/codex-native-pre-post.ts` — native hook configuration and metadata routing contracts
+
+### Setup / docs / release workflow
+- `src/cli/setup.ts`, `src/config/mcp-registry.ts`, `skills/wiki/SKILL.md` — wiki setup registration
+- `src/cli/doctor.ts`, `docs/codex-native-hooks.md` — native-hook doctor coverage and operator docs
+- `CONTRIBUTING.md`, `.github/workflows/release.yml` — dev-base contribution guardrail and release workflow dependency refresh
+
+### Release collateral
+- `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`
+- `CHANGELOG.md`, `RELEASE_BODY.md`
+- `docs/release-notes-0.13.0.md`
+
+## Validation evidence
+
+| Check | Command | Result |
+|---|---|---|
+| Build | `npm run build` | PASS |
+| Lint | `npm run lint` | PASS |
+| Full test suite | `npm test` | PASS (3487 tests, 0 fail) |
+| Recent bug regression suite | `npm run test:recent-bug-regressions` | PASS (292 tests, 0 fail) |
+| Version sync contract | `node --test dist/cli/__tests__/version-sync-contract.test.js` | PASS |
+| Packed-install smoke | `npm run smoke:packed-install` | PASS |
+
+## Risk assessment
+
+- **Adapt foundations** are new user-facing surfaces but intentionally thin: they report local evidence and keep writes under `.omx/adapters/<target>/...`; downstream OpenClaw/Hermes runtime acknowledgement remains outside this release's local proof.
+- **Ralph/native Stop/session authority** changed across several seams at once; monitor long-running concurrent sessions and prompt-side vs CLI-side Ralph activation after release.
+- **Explore/platform launch paths** include Windows and POSIX-shim guardrails; local Linux verification should be complemented by the release workflow and cross-platform CI matrix.
+- **HUD/notification changes** reduce stale/noisy signals but depend on real tmux/session environments; post-release observation should focus on mixed tmux/non-tmux operators and the new macOS leader stale-polling behavior.
+
+## Final verdict
+
+Release **0.13.0** is **ready for release commit/tag cut from `origin/dev`** on the basis of the passing validation evidence above.

--- a/docs/release-notes-0.13.0.md
+++ b/docs/release-notes-0.13.0.md
@@ -1,0 +1,74 @@
+# Release notes — 0.13.0
+
+## Summary
+
+`0.13.0` is a minor release after `0.12.6` because the shipped delta adds the new `omx adapt` foundation while also hardening Ralph/session authority, native Stop routing, HUD state binding, macOS stale polling, explore launch paths, and release/operator workflows across 56 first-parent PR merges plus the latest `dev` follow-up commit in the `v0.12.6..origin/dev` train.
+
+## Highlights
+
+- **`omx adapt` becomes the next persistent-target foundation** — OMX now has a first-party adapter surface for external targets, starting with OpenClaw and Hermes. Adapter artifacts stay under `.omx/adapters/<target>/...`, link to canonical planning artifacts, and report local/read-only runtime evidence without claiming a bidirectional control plane (#1600, #1599, #1598).
+- **Ralph/session authority is stricter** — Ralph assignment, tmux Ralph nudges, prompt-side activation, PRD CLI semantics, and native Stop handoffs now all respect session ownership more consistently (#1604, #1608, #1591, #1590, #1611).
+- **Cross-platform launch paths fail safer** — explore/codex resolution skips unusable PATH entries, handles pnpm-style POSIX shims under sandboxed PATHs, avoids Windows-to-POSIX wrapper confusion, and cleans detached leader children on signal exit (#1562, #1610, #1605).
+- **Hooks, HUD, and notification state are quieter and more accurate** — live-session HUD binding, startup/dispatch regression coverage, Slack mention parsing, macOS stale-polling git-probe reduction, metadata routing, and receiving-agent ownership guidance reduce stale or user-facing noise (#1573, #1595, #1585, #1619, #1611).
+- **Setup and release workflows are more explicit** — wiki setup registration, native-hook doctor coverage, dev-base contribution guidance, and dependency refreshes keep release/operator paths aligned (#1571, #1546, #1567, #1575, #1576, #1577, #1578).
+
+## Included fixes and changes
+
+### Added — Adapt foundations
+- `omx adapt <target> <probe|status|init|envelope|doctor>` exposes an OMX-owned adapter surface for persistent external targets. (PR [#1600](https://github.com/Yeachan-Heo/oh-my-codex/pull/1600))
+- OpenClaw adaptation observes local config, gateway, hook mapping, and lifecycle bridge evidence while preserving command-gateway opt-in gates. (PR [#1599](https://github.com/Yeachan-Heo/oh-my-codex/pull/1599))
+- Hermes adaptation reads ACP, gateway, persistent-session, and bootstrap evidence while keeping writes under adapter-owned OMX paths. (PR [#1598](https://github.com/Yeachan-Heo/oh-my-codex/pull/1598))
+
+### Fixed — Ralph / runtime authority / workflow semantics
+- Ralph assignment no longer leaks across concurrent OMX sessions. (PR [#1604](https://github.com/Yeachan-Heo/oh-my-codex/pull/1604))
+- Prompt-side `$ralph` activation is explicitly distinct from the PRD-gated `omx ralph --prd ...` CLI startup path. (PR [#1608](https://github.com/Yeachan-Heo/oh-my-codex/pull/1608))
+- Tmux Ralph nudges now validate canonical session workflow state before acting. (PR [#1591](https://github.com/Yeachan-Heo/oh-my-codex/pull/1591))
+- Native Stop resumes permission-seeking handoffs and remains stable across session-id drift. (PR [#1590](https://github.com/Yeachan-Heo/oh-my-codex/pull/1590), direct commit `4377e1e`)
+- Native hook metadata no longer hijacks routing intended for real user prompts. (PR [#1611](https://github.com/Yeachan-Heo/oh-my-codex/pull/1611))
+- Resumed MCP state writers survive duplicate reconcile/self-teardown paths. (PR [#1596](https://github.com/Yeachan-Heo/oh-my-codex/pull/1596))
+
+### Fixed — Launch / platform / worktree safety
+- `omx explore` now skips unusable node PATH entries and resolves sandboxed POSIX Codex shims correctly. (PRs [#1562](https://github.com/Yeachan-Heo/oh-my-codex/pull/1562), [#1610](https://github.com/Yeachan-Heo/oh-my-codex/pull/1610))
+- Windows explore fails closed before POSIX allowlist fallback can run against Windows paths. (direct commit `72b1e5d`)
+- Detached leader signal exits terminate their Codex child processes and carry regression coverage. (PR [#1605](https://github.com/Yeachan-Heo/oh-my-codex/pull/1605))
+- Windows OMX cleanup discovers real orphaned servers again. (PR [#1589](https://github.com/Yeachan-Heo/oh-my-codex/pull/1589))
+- Detached team startup tolerates stale missing worktree records. (PR [#1582](https://github.com/Yeachan-Heo/oh-my-codex/pull/1582))
+
+### Fixed — Hooks / HUD / notifications
+- HUD state stays anchored to the live OMX session instead of stale/root fallback. (PR [#1573](https://github.com/Yeachan-Heo/oh-my-codex/pull/1573))
+- Leader stale polling now reduces repeated git probes on macOS, lowering high-CPU churn during long-running sessions. (PR [#1619](https://github.com/Yeachan-Heo/oh-my-codex/pull/1619))
+- Queued Codex startup banner and inbox dispatch behavior is locked behind regression coverage. (PR [#1595](https://github.com/Yeachan-Heo/oh-my-codex/pull/1595))
+- Slack mention env parsing has dedicated notification coverage. (PR [#1585](https://github.com/Yeachan-Heo/oh-my-codex/pull/1585))
+- Safe reversible OMX/runtime work is now treated as receiving-agent owned work in generated guidance. (direct commit `76e808e`)
+
+### Fixed — Setup / docs / release workflow
+- Wiki setup registration now stays aligned with shipped assets. (PR [#1571](https://github.com/Yeachan-Heo/oh-my-codex/pull/1571))
+- Native hook doctor/config checks surface missing coverage before users mistake config drift for OMX breakage. (PR [#1546](https://github.com/Yeachan-Heo/oh-my-codex/pull/1546))
+- Normal contributor guidance now makes `dev` the explicit PR base. (PR [#1567](https://github.com/Yeachan-Heo/oh-my-codex/pull/1567))
+
+### Changed
+- Release workflow/tooling dependencies were refreshed: `actions/github-script@9`, `softprops/action-gh-release@3`, `@types/node@25.6.0`, and `@biomejs/biome@2.4.11`. (PRs [#1575](https://github.com/Yeachan-Heo/oh-my-codex/pull/1575), [#1576](https://github.com/Yeachan-Heo/oh-my-codex/pull/1576), [#1577](https://github.com/Yeachan-Heo/oh-my-codex/pull/1577), [#1578](https://github.com/Yeachan-Heo/oh-my-codex/pull/1578))
+- Node/Cargo package metadata, lockfiles, changelog, release body, and release notes are aligned to `0.13.0`.
+
+## Why this is a minor release
+
+- It adds a new user-facing `omx adapt` CLI surface and target-specific adapter foundations rather than only patch-level fixes.
+- The release train is broad: 56 first-parent PR merges in `v0.12.6..origin/dev`, with 99 files changed relative to the main `v0.12.6` tag.
+- Runtime ownership, native hook/Stop behavior, and cross-platform launch safety changed in operator-visible ways.
+
+## Verification evidence
+
+Release verification evidence is recorded in `docs/qa/release-readiness-0.13.0.md`.
+
+- `npm run build` ✅
+- `npm run lint` ✅
+- `npm test` ✅
+- `npm run test:recent-bug-regressions` ✅
+- `node --test dist/cli/__tests__/version-sync-contract.test.js` ✅
+- `npm run smoke:packed-install` ✅
+
+## Remaining risk
+
+- This is a local release-readiness pass, not a full GitHub Actions matrix rerun.
+- `omx adapt` is intentionally a thin, local-evidence foundation; downstream Hermes/OpenClaw runtime acceptance remains post-release observation territory.
+- The release touches native hooks, Ralph/session scoping, Windows/explore launch paths, and notification/HUD state together, so post-release monitoring should focus on long-running OMX sessions and mixed tmux/non-tmux environments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.12.6",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Promote the shipped 0.13.0 release commit onto `main` so both `dev` and `main` contain the 0.13.0 version bump and release collateral.

## Changes

- cherry-pick the 0.13.0 release commit onto `main`
- align `main` with the shipped 0.13.0 Node/Cargo version metadata and release docs
- keep the promotion scoped to the single release commit only

## Validation

- [x] `npm run build`
- [x] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npm run lint`
- [x] `npm run test:recent-bug-regressions`
- [x] `node --test dist/cli/__tests__/version-sync-contract.test.js`
- [x] `npm run smoke:packed-install`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #
