### PR TITLE
feat: add omx shell completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+- **`omx completion` shell installer** — OMX can now install direct shell completion for bash, zsh, fish, and powershell, with static CLI command/subcommand/flag/value coverage, idempotent managed profile updates, a Bash 4+ safety gate, and updated README onboarding.
+
 ## [0.12.6] - 2026-04-13
 
 Wiki-first knowledge workflows, notification and hook delivery hardening, launch/worktree safety improvements, and automatic closure of explicitly linked issues after `dev` merges across 32 PRs.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ $team 3:executor "execute the approved plan in parallel"
 
 Use `$team` when the approved plan needs coordinated parallel work, or `$ralph` when one persistent owner should keep pushing to completion.
 
+### Optional: install shell completion
+
+If you want `omx` command, subcommand, and static flag/value completion in your shell, install it once with:
+
+```bash
+omx completion zsh
+# or: omx completion bash
+# or: omx completion fish
+# or: omx completion powershell
+```
+
+Notes:
+- The command writes directly to the shell's load point/profile and is safe to rerun; OMX-managed completion blocks are updated in place instead of duplicated.
+- Bash completion requires **Bash 4+** because the generated script uses associative arrays and `mapfile`.
+- On Bash 3.x environments (for example the default `/bin/bash` on older macOS setups), `omx completion bash` fails clearly **before** modifying your profile. Use a newer Bash, `zsh`, `fish`, or `powershell` instead.
+
 ## A simple mental model
 
 OMX does **not** replace Codex.

--- a/src/cli/__tests__/completion.test.ts
+++ b/src/cli/__tests__/completion.test.ts
@@ -1,0 +1,293 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ASK_PROVIDERS } from '../ask.js';
+import { AGENTS_SUBCOMMANDS } from '../agents.js';
+import { AUTORESEARCH_SUBCOMMANDS } from '../autoresearch.js';
+import { buildCompletionCatalog, type CompletionNode } from '../completion/catalog.js';
+import { resolvePowerShellProfilePath, upsertManagedBlock } from '../completion/install.js';
+import { renderBashCompletion } from '../completion/render.js';
+import { HOOKS_SUBCOMMANDS } from '../hooks.js';
+import { SESSION_SUBCOMMANDS } from '../session-search.js';
+import { STATE_OPERATION_MAP } from '../state.js';
+import { TEAM_CLI_SUBCOMMANDS } from '../team.js';
+import { TMUX_HOOK_SUBCOMMANDS } from '../tmux-hook.js';
+
+function repoRoot(): string {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  return join(testDir, '..', '..', '..');
+}
+
+function runOmx(cwd: string, argv: string[], envOverrides: Record<string, string> = {}) {
+  const omxBin = join(repoRoot(), 'dist', 'cli', 'omx.js');
+  return spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+      ...envOverrides,
+    },
+  });
+}
+
+async function listRelativeFiles(root: string, prefix = ''): Promise<string[]> {
+  if (!existsSync(root)) return [];
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const relativePath = prefix ? join(prefix, entry.name) : entry.name;
+    const fullPath = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listRelativeFiles(fullPath, relativePath));
+    } else {
+      files.push(relativePath);
+    }
+  }
+  return files.sort();
+}
+
+function findNode(root: CompletionNode, path: string[]): CompletionNode | undefined {
+  let current: CompletionNode | undefined = root;
+  for (const segment of path) {
+    current = current?.subcommands?.find((entry) => entry.name === segment);
+    if (!current) return undefined;
+  }
+  return current;
+}
+
+describe('omx completion', () => {
+  it('prints top-level help with completion listed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-completion-help-'));
+    try {
+      const result = runOmx(cwd, ['--help']);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /omx completion\s+Install shell completion/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unsupported shells with local usage', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-completion-invalid-'));
+    try {
+      const result = runOmx(cwd, ['completion', 'elvish']);
+      assert.equal(result.status, 1);
+      assert.match(`${result.stderr}\n${result.stdout}`, /Usage: omx completion <bash\|zsh\|fish\|powershell>/i);
+      assert.match(`${result.stderr}\n${result.stdout}`, /Unsupported shell/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('installs bash completion, preserves user content, and is idempotent on rerun', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-completion-bash-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+      await writeFile(join(home, '.bashrc'), 'export TEST_FLAG=1\n');
+
+      const env = { HOME: home, USERPROFILE: home };
+      const first = runOmx(wd, ['completion', 'bash'], env);
+      assert.equal(first.status, 0, first.stderr || first.stdout);
+      assert.match(first.stdout, /Installed omx bash completion/i);
+
+      const bashScriptPath = join(home, '.omx', 'completions', 'omx.bash');
+      const bashrcPath = join(home, '.bashrc');
+      const script = await readFile(bashScriptPath, 'utf-8');
+      const bashrc = await readFile(bashrcPath, 'utf-8');
+
+      assert.match(script, /complete -F _omx omx/);
+      assert.match(script, /team api/);
+      assert.match(script, /project-memory/);
+      assert.doesNotMatch(script, /\[""\]=/);
+      assert.match(bashrc, /# >>> omx completion >>>/);
+      assert.match(bashrc, /# <<< omx completion <<</);
+      assert.match(bashrc, /export TEST_FLAG=1/);
+      assert.match(bashrc, /\.omx\/completions\/omx\.bash/);
+
+      const sourceResult = spawnSync('bash', ['-c', `source "${bashScriptPath}"`], {
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+        },
+      });
+      assert.equal(sourceResult.status, 0, `${sourceResult.stderr}\n${sourceResult.stdout}`);
+
+      const backupFiles = await listRelativeFiles(join(home, '.omx', 'backups', 'completion'));
+      assert.ok(backupFiles.some((file) => file.endsWith('.bashrc')), `expected .bashrc backup, got: ${backupFiles.join(', ')}`);
+
+      const second = runOmx(wd, ['completion', 'bash'], env);
+      assert.equal(second.status, 0, second.stderr || second.stdout);
+      assert.match(second.stdout, /already up to date/i);
+
+      const rerunBashrc = await readFile(bashrcPath, 'utf-8');
+      const markerCount = (rerunBashrc.match(/# >>> omx completion >>>/g) || []).length;
+      assert.equal(markerCount, 1, rerunBashrc);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails clearly instead of installing on Bash 3.x', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-completion-bash3-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'fake-bash');
+      await mkdir(home, { recursive: true });
+      await writeFile(join(home, '.bashrc'), 'export TEST_FLAG=1\n');
+      await writeFile(
+        fakeBin,
+        `#!/bin/sh
+if [ "$1" = "-c" ]; then
+  printf '3'
+  exit 0
+fi
+exit 1
+`,
+      );
+      await chmod(fakeBin, 0o755);
+
+      const result = runOmx(wd, ['completion', 'bash'], {
+        HOME: home,
+        USERPROFILE: home,
+        OMX_COMPLETION_BASH_BIN: fakeBin,
+      });
+
+      assert.equal(result.status, 1);
+      assert.match(`${result.stderr}\n${result.stdout}`, /requires Bash 4\+/i);
+      assert.equal(existsSync(join(home, '.omx', 'completions', 'omx.bash')), false);
+      const bashrc = await readFile(join(home, '.bashrc'), 'utf-8');
+      assert.doesNotMatch(bashrc, /# >>> omx completion >>>/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('installs fish completion into the fish-native completions directory', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-completion-fish-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(join(home, '.config', 'fish', 'completions'), { recursive: true });
+      const env = { HOME: home, USERPROFILE: home };
+      const result = runOmx(wd, ['completion', 'fish'], env);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const filePath = join(home, '.config', 'fish', 'completions', 'omx.fish');
+      const content = await readFile(filePath, 'utf-8');
+      assert.match(content, /complete -f -c omx/);
+      assert.match(content, /function __omx_complete/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('installs powershell completion using an overridden profile path', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-completion-powershell-'));
+    try {
+      const home = join(wd, 'home');
+      const profilePath = join(home, 'Documents', 'PowerShell', 'Microsoft.PowerShell_profile.ps1');
+      await mkdir(dirname(profilePath), { recursive: true });
+      await writeFile(profilePath, '$Existing = $true\n');
+
+      const env = {
+        HOME: home,
+        USERPROFILE: home,
+        OMX_COMPLETION_POWERSHELL_PROFILE: profilePath,
+      };
+      const result = runOmx(wd, ['completion', 'powershell'], env);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const scriptPath = join(home, '.omx', 'completions', 'omx.ps1');
+      const profile = await readFile(profilePath, 'utf-8');
+      const script = await readFile(scriptPath, 'utf-8');
+      assert.match(profile, /# >>> omx completion >>>/);
+      assert.match(profile, /\.omx[\\/]completions[\\/]omx\.ps1/);
+      assert.match(profile, /\$Existing = \$true/);
+      assert.match(script, /Register-ArgumentCompleter/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to XDG-based powershell profile paths when shell probing is unavailable', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-completion-pwsh-fallback-'));
+    try {
+      const home = join(wd, 'home');
+      const xdg = join(wd, 'xdg-config');
+      const profilePath = resolvePowerShellProfilePath({
+        HOME: home,
+        USERPROFILE: home,
+        XDG_CONFIG_HOME: xdg,
+        PATH: '',
+      });
+      assert.equal(profilePath, join(xdg, 'powershell', 'Microsoft.PowerShell_profile.ps1'));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses WindowsPowerShell fallback layout when powershell is the configured binary', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-completion-powershell-fallback-'));
+    const previousPlatform = process.platform;
+    try {
+      const home = join(wd, 'home');
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      const profilePath = resolvePowerShellProfilePath({
+        HOME: home,
+        USERPROFILE: home,
+        OMX_COMPLETION_POWERSHELL_BIN: 'powershell',
+        PATH: '',
+      });
+      assert.equal(profilePath, join(home, 'Documents', 'WindowsPowerShell', 'Microsoft.PowerShell_profile.ps1'));
+    } finally {
+      Object.defineProperty(process, 'platform', { value: previousPlatform });
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses exported CLI constants to keep completion structure aligned', async () => {
+    const catalog = await buildCompletionCatalog();
+
+    assert.deepEqual(findNode(catalog, ['agents'])?.subcommands?.map((entry) => entry.name), [...AGENTS_SUBCOMMANDS]);
+    assert.deepEqual(findNode(catalog, ['hooks'])?.subcommands?.map((entry) => entry.name), [...HOOKS_SUBCOMMANDS]);
+    assert.deepEqual(findNode(catalog, ['tmux-hook'])?.subcommands?.map((entry) => entry.name), [...TMUX_HOOK_SUBCOMMANDS]);
+    assert.deepEqual(findNode(catalog, ['session'])?.subcommands?.map((entry) => entry.name), [...SESSION_SUBCOMMANDS]);
+    assert.deepEqual(findNode(catalog, ['autoresearch'])?.subcommands?.map((entry) => entry.name), [...AUTORESEARCH_SUBCOMMANDS]);
+    assert.deepEqual(findNode(catalog, ['team'])?.subcommands?.map((entry) => entry.name), [...TEAM_CLI_SUBCOMMANDS]);
+    assert.deepEqual(findNode(catalog, ['state'])?.subcommands?.map((entry) => entry.name), Object.keys(STATE_OPERATION_MAP));
+    assert.deepEqual(findNode(catalog, ['ask'])?.positionalValues, [...ASK_PROVIDERS]);
+  });
+
+  it('keeps representative static completion coverage in the rendered bash script', async () => {
+    const catalog = await buildCompletionCatalog();
+    const script = renderBashCompletion(catalog);
+
+    assert.match(script, /\["completion"\]="bash zsh fish powershell"/);
+    assert.match(script, /team api/);
+    assert.match(script, /mailbox-list/);
+    assert.match(script, /state/);
+    assert.match(script, /list-active/);
+    assert.match(script, /project-memory/);
+    assert.match(script, /add-directive/);
+    assert.match(script, /reasoning/);
+    assert.match(script, /low medium high xhigh/);
+  });
+
+  it('upserts managed profile blocks without duplicating them', () => {
+    const initial = 'export TEST=1\n';
+    const first = upsertManagedBlock(initial, 'source /tmp/omx.bash');
+    const second = upsertManagedBlock(first.content, 'source /tmp/omx.bash');
+
+    assert.equal((second.content.match(/# >>> omx completion >>>/g) || []).length, 1);
+    assert.match(second.content, /export TEST=1/);
+  });
+});

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -28,6 +28,7 @@ describe('nested help routing', () => {
     [['autoresearch', '--help'], /Usage:[\s\S]*omx autoresearch <mission-dir>/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
+    [['completion', '--help'], /Usage:\s*omx completion <bash\|zsh\|fish\|powershell>/i],
     [['state', '--help'], /Usage:\s*omx state <read\|write\|clear\|list-active\|get-status>/i],
     [['tmux-hook', '--help'], /Usage:\s*\n\s*omx tmux-hook init/i],
     [['ralph', '--help'], /omx ralph - Launch Codex with ralph persistence mode active/i],

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -9,6 +9,8 @@ import { codexAgentsDir, projectCodexAgentsDir } from '../utils/paths.js';
 
 export const RESERVED_NATIVE_AGENT_NAMES = new Set(['default', 'worker', 'explorer']);
 const DEFAULT_AGENT_MODEL = 'gpt-5.4';
+export const AGENTS_SUBCOMMANDS = ['list', 'add', 'edit', 'remove'] as const;
+
 const AGENTS_USAGE = [
   'Usage:',
   '  omx agents list [--scope user|project]',

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -15,7 +15,7 @@ export const ASK_USAGE = [
   '   or: omx ask <claude|gemini> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'gemini'] as const;
+export const ASK_PROVIDERS = ['claude', 'gemini'] as const;
 type AskProvider = typeof ASK_PROVIDERS[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 const ASK_ADVISOR_SCRIPT_ENV = 'OMX_ASK_ADVISOR_SCRIPT';

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -57,6 +57,8 @@ Behavior:
   - --resume loads the authoritative per-run manifest and continues from the last kept commit
 `;
 
+export const AUTORESEARCH_SUBCOMMANDS = ['init', 'run'] as const;
+
 const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
 const AUTORESEARCH_MAX_CONSECUTIVE_NOOPS = 3;
 

--- a/src/cli/completion.ts
+++ b/src/cli/completion.ts
@@ -1,0 +1,77 @@
+import { buildCompletionCatalog } from './completion/catalog.js';
+import { installCompletion, type SupportedShell } from './completion/install.js';
+import {
+  renderBashCompletion,
+  renderFishCompletion,
+  renderPowerShellCompletion,
+  renderZshCompletion,
+} from './completion/render.js';
+
+export const SUPPORTED_COMPLETION_SHELLS = ['bash', 'zsh', 'fish', 'powershell'] as const;
+
+export const COMPLETION_USAGE = [
+  'Usage: omx completion <bash|zsh|fish|powershell>',
+  '',
+  'Install OMX shell completion directly into the target shell load point.',
+  'Re-running the command updates prior OMX-managed completion content instead of duplicating it.',
+].join('\n');
+
+function asSupportedShell(value: string): SupportedShell | null {
+  return (SUPPORTED_COMPLETION_SHELLS as readonly string[]).includes(value)
+    ? (value as SupportedShell)
+    : null;
+}
+
+function usageError(reason: string): Error {
+  return new Error(`${reason}\n${COMPLETION_USAGE}`);
+}
+
+function renderCompletionScript(shell: SupportedShell, catalog: Awaited<ReturnType<typeof buildCompletionCatalog>>): string {
+  switch (shell) {
+    case 'bash':
+      return renderBashCompletion(catalog);
+    case 'zsh':
+      return renderZshCompletion(catalog);
+    case 'fish':
+      return renderFishCompletion(catalog);
+    case 'powershell':
+      return renderPowerShellCompletion(catalog);
+  }
+}
+
+export async function completionCommand(args: string[]): Promise<void> {
+  const first = (args[0] || '').toLowerCase();
+  if (!first || first === '--help' || first === '-h' || first === 'help') {
+    console.log(COMPLETION_USAGE);
+    return;
+  }
+
+  const shell = asSupportedShell(first);
+  if (!shell) {
+    throw usageError(`Unsupported shell "${args[0]}".`);
+  }
+  if (args.length > 1) {
+    throw usageError(`Unexpected arguments after shell: ${args.slice(1).join(' ')}`);
+  }
+
+  const catalog = await buildCompletionCatalog();
+  const script = renderCompletionScript(shell, catalog);
+  const result = await installCompletion(shell, script);
+
+  if (result.changedPaths.length === 0) {
+    console.log(`omx ${shell} completion is already up to date.`);
+    return;
+  }
+
+  console.log(`Installed omx ${shell} completion.`);
+  console.log('Updated paths:');
+  for (const path of result.changedPaths) {
+    console.log(`  - ${path}`);
+  }
+  if (result.backupPaths.length > 0) {
+    console.log('Backups:');
+    for (const path of result.backupPaths) {
+      console.log(`  - ${path}`);
+    }
+  }
+}

--- a/src/cli/completion/catalog.ts
+++ b/src/cli/completion/catalog.ts
@@ -1,0 +1,334 @@
+import { ASK_PROVIDERS } from '../ask.js';
+import { AGENTS_SUBCOMMANDS } from '../agents.js';
+import { AUTORESEARCH_SUBCOMMANDS } from '../autoresearch.js';
+import { HOOKS_SUBCOMMANDS } from '../hooks.js';
+import { SESSION_SUBCOMMANDS } from '../session-search.js';
+import { STATE_OPERATION_MAP } from '../state.js';
+import { TEAM_CLI_SUBCOMMANDS } from '../team.js';
+import { TMUX_HOOK_SUBCOMMANDS } from '../tmux-hook.js';
+import { TOP_LEVEL_CLI_COMMANDS } from '../top-level-commands.js';
+import { TEAM_API_OPERATIONS } from '../../team/api-interop.js';
+
+export interface CompletionOptionSpec {
+  flags: string[];
+  values?: string[];
+}
+
+export interface CompletionNode {
+  name: string;
+  subcommands?: CompletionNode[];
+  options?: CompletionOptionSpec[];
+  positionalValues?: string[];
+}
+
+const LOCAL_HELP_OPTION: CompletionOptionSpec = {
+  flags: ['--help', '-h'],
+};
+
+function option(flags: string[], values?: readonly string[]): CompletionOptionSpec {
+  return {
+    flags: [...flags],
+    ...(values && values.length > 0 ? { values: [...values] } : {}),
+  };
+}
+
+function node(name: string, spec: Omit<CompletionNode, 'name'> = {}): CompletionNode {
+  const existing = spec.options ?? [];
+  const seen = new Set<string>();
+  const merged = [...existing, LOCAL_HELP_OPTION].filter((entry) => {
+    const key = entry.flags.join('\u0000');
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return {
+    name,
+    ...(spec.subcommands ? { subcommands: spec.subcommands } : {}),
+    ...(merged.length > 0 ? { options: merged } : {}),
+    ...(spec.positionalValues && spec.positionalValues.length > 0
+      ? { positionalValues: [...spec.positionalValues] }
+      : {}),
+  };
+}
+
+function repeatOptions(
+  names: readonly string[],
+  options: readonly CompletionOptionSpec[],
+): CompletionNode[] {
+  return names.map((name) => node(name, { options: [...options] }));
+}
+
+function buildTopLevelCommandNames(): string[] {
+  return TOP_LEVEL_CLI_COMMANDS.map((entry) => entry.name);
+}
+
+async function loadMcpToolNames(): Promise<{
+  notepad: string[];
+  projectMemory: string[];
+  trace: string[];
+  codeIntel: string[];
+  wiki: string[];
+}> {
+  const envState = process.env.OMX_STATE_SERVER_DISABLE_AUTO_START;
+  const envMemory = process.env.OMX_MEMORY_SERVER_DISABLE_AUTO_START;
+  const envTrace = process.env.OMX_TRACE_SERVER_DISABLE_AUTO_START;
+  const envCodeIntel = process.env.OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START;
+  const envWiki = process.env.OMX_WIKI_SERVER_DISABLE_AUTO_START;
+
+  process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+  process.env.OMX_MEMORY_SERVER_DISABLE_AUTO_START = '1';
+  process.env.OMX_TRACE_SERVER_DISABLE_AUTO_START = '1';
+  process.env.OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START = '1';
+  process.env.OMX_WIKI_SERVER_DISABLE_AUTO_START = '1';
+
+  try {
+    const [
+      { buildMemoryServerTools },
+      { buildTraceServerTools },
+      { buildCodeIntelServerTools },
+      { buildWikiServerTools },
+    ] = await Promise.all([
+      import('../../mcp/memory-server.js'),
+      import('../../mcp/trace-server.js'),
+      import('../../mcp/code-intel-server.js'),
+      import('../../mcp/wiki-server.js'),
+    ]);
+
+    const notepadAliases: Record<string, string> = {
+      read: 'notepad_read',
+      'write-priority': 'notepad_write_priority',
+      'write-working': 'notepad_write_working',
+      'write-manual': 'notepad_write_manual',
+      prune: 'notepad_prune',
+      stats: 'notepad_stats',
+    };
+    const projectMemoryAliases: Record<string, string> = {
+      read: 'project_memory_read',
+      write: 'project_memory_write',
+      'add-note': 'project_memory_add_note',
+      'add-directive': 'project_memory_add_directive',
+    };
+    const traceAliases: Record<string, string> = {
+      timeline: 'trace_timeline',
+      summary: 'trace_summary',
+    };
+    const wikiAliases: Record<string, string> = {
+      ingest: 'wiki_ingest',
+      query: 'wiki_query',
+      lint: 'wiki_lint',
+      add: 'wiki_add',
+      list: 'wiki_list',
+      read: 'wiki_read',
+      delete: 'wiki_delete',
+      refresh: 'wiki_refresh',
+    };
+
+    const namesFromAliases = (
+      tools: Array<{ name: string }>,
+      aliases: Record<string, string>,
+      prefix?: string,
+    ): string[] => {
+      const out = new Set<string>();
+      const aliasedTargets = new Set<string>();
+      for (const [alias, target] of Object.entries(aliases)) {
+        if (tools.some((tool) => tool.name === target)) {
+          out.add(alias);
+          aliasedTargets.add(target);
+        }
+      }
+      if (prefix) {
+        for (const tool of tools) {
+          if (!tool.name.startsWith(prefix) || aliasedTargets.has(tool.name)) continue;
+          out.add(tool.name.slice(prefix.length));
+        }
+      }
+      return [...out].sort();
+    };
+
+    return {
+      notepad: namesFromAliases(buildMemoryServerTools(), notepadAliases, 'notepad_'),
+      projectMemory: namesFromAliases(buildMemoryServerTools(), projectMemoryAliases, 'project_memory_'),
+      trace: namesFromAliases(buildTraceServerTools(), traceAliases, 'trace_'),
+      codeIntel: buildCodeIntelServerTools().map((tool) => tool.name).sort(),
+      wiki: namesFromAliases(buildWikiServerTools(), wikiAliases, 'wiki_'),
+    };
+  } finally {
+    if (typeof envState === 'string') process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = envState;
+    else delete process.env.OMX_STATE_SERVER_DISABLE_AUTO_START;
+    if (typeof envMemory === 'string') process.env.OMX_MEMORY_SERVER_DISABLE_AUTO_START = envMemory;
+    else delete process.env.OMX_MEMORY_SERVER_DISABLE_AUTO_START;
+    if (typeof envTrace === 'string') process.env.OMX_TRACE_SERVER_DISABLE_AUTO_START = envTrace;
+    else delete process.env.OMX_TRACE_SERVER_DISABLE_AUTO_START;
+    if (typeof envCodeIntel === 'string') process.env.OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START = envCodeIntel;
+    else delete process.env.OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START;
+    if (typeof envWiki === 'string') process.env.OMX_WIKI_SERVER_DISABLE_AUTO_START = envWiki;
+    else delete process.env.OMX_WIKI_SERVER_DISABLE_AUTO_START;
+  }
+}
+
+export async function buildCompletionCatalog(): Promise<CompletionNode> {
+  const mcpToolNames = await loadMcpToolNames();
+
+  const ioOptions = [option(['--input']), option(['--json'])] as const;
+  const teamStateSubcommands = TEAM_CLI_SUBCOMMANDS.map((name) => {
+    switch (name) {
+      case 'status':
+        return node(name, { options: [option(['--json']), option(['--tail-lines'])] });
+      case 'await':
+        return node(name, { options: [option(['--timeout-ms']), option(['--after-event-id']), option(['--json'])] });
+      case 'shutdown':
+        return node(name, { options: [option(['--force']), option(['--confirm-issues'])] });
+      case 'api':
+        return node(name, { subcommands: repeatOptions(TEAM_API_OPERATIONS, ioOptions), options: [...ioOptions] });
+      default:
+        return node(name);
+    }
+  });
+
+  return {
+    name: '__root__',
+    options: [
+      option(['--help', '-h']),
+      option(['--version', '-v']),
+      option(['--yolo']),
+      option(['--high']),
+      option(['--xhigh']),
+      option(['--madmax']),
+      option(['--spark']),
+      option(['--madmax-spark']),
+      option(['--notify-temp']),
+      option(['--tmux']),
+      option(['--discord']),
+      option(['--slack']),
+      option(['--telegram']),
+      option(['--custom']),
+      option(['--worktree', '-w']),
+    ],
+    subcommands: [
+      node('launch', {
+        options: [
+          option(['--yolo']),
+          option(['--high']),
+          option(['--xhigh']),
+          option(['--madmax']),
+          option(['--spark']),
+          option(['--madmax-spark']),
+          option(['--notify-temp']),
+          option(['--tmux']),
+          option(['--discord']),
+          option(['--slack']),
+          option(['--telegram']),
+          option(['--custom']),
+          option(['--worktree', '-w']),
+        ],
+      }),
+      node('exec', {
+        options: [
+          option(['--help', '-h']),
+          option(['--yolo']),
+          option(['--high']),
+          option(['--xhigh']),
+          option(['--madmax']),
+          option(['--notify-temp']),
+          option(['--discord']),
+          option(['--slack']),
+          option(['--telegram']),
+          option(['--custom']),
+          option(['--worktree', '-w']),
+        ],
+      }),
+      node('setup', {
+        options: [option(['--force']), option(['--dry-run']), option(['--verbose']), option(['--scope'], ['user', 'project']), option(['--skill-target'], ['codex-home'])],
+      }),
+      node('agents', {
+        subcommands: AGENTS_SUBCOMMANDS.map((name) => node(name, { options: [option(['--scope'], ['user', 'project']), ...(name === 'add' || name === 'remove' ? [option(['--force'])] : [])] })),
+      }),
+      node('agents-init', { options: [option(['--dry-run']), option(['--force']), option(['--verbose'])] }),
+      node('deepinit', { options: [option(['--dry-run']), option(['--force']), option(['--verbose'])] }),
+      node('uninstall', { options: [option(['--dry-run']), option(['--keep-config']), option(['--verbose']), option(['--purge']), option(['--scope'], ['user', 'project'])] }),
+      node('doctor', { options: [option(['--team']), option(['--verbose'])] }),
+      node('cleanup', { options: [option(['--dry-run'])] }),
+      node('ask', { positionalValues: [...ASK_PROVIDERS], options: [option(['-p', '--prompt', '--print']), option(['--agent-prompt'])] }),
+      node('resume'),
+      node('explore', { options: [option(['--prompt']), option(['--prompt-file'])] }),
+      node('session', {
+        subcommands: SESSION_SUBCOMMANDS.map((name) => node(name, {
+          options: [
+            option(['--limit']),
+            option(['--session']),
+            option(['--since']),
+            option(['--project'], ['current', 'all']),
+            option(['--context']),
+            option(['--case-sensitive']),
+            option(['--json']),
+          ],
+        })),
+      }),
+      node('team', {
+        subcommands: teamStateSubcommands,
+        options: [option(['--help', '-h'])],
+      }),
+      node('ralph'),
+      node('autoresearch', {
+        subcommands: AUTORESEARCH_SUBCOMMANDS.map((name) => node(name)),
+        options: [option(['--topic']), option(['--evaluator']), option(['--keep-policy']), option(['--slug']), option(['--resume'])],
+      }),
+      node('completion', { positionalValues: ['bash', 'zsh', 'fish', 'powershell'] }),
+      node('version'),
+      node('tmux-hook', { subcommands: repeatOptions(TMUX_HOOK_SUBCOMMANDS, []) }),
+      node('hooks', { subcommands: repeatOptions(HOOKS_SUBCOMMANDS, []) }),
+      node('hud', { options: [option(['--watch']), option(['--json']), option(['--preset'])] }),
+      node('state', {
+        subcommands: repeatOptions(Object.keys(STATE_OPERATION_MAP), ioOptions),
+      }),
+      node('notepad', { subcommands: repeatOptions(mcpToolNames.notepad, ioOptions), options: [...ioOptions] }),
+      node('project-memory', { subcommands: repeatOptions(mcpToolNames.projectMemory, ioOptions), options: [...ioOptions] }),
+      node('trace', { subcommands: repeatOptions(mcpToolNames.trace, ioOptions), options: [...ioOptions] }),
+      node('code-intel', { subcommands: repeatOptions(mcpToolNames.codeIntel, ioOptions), options: [...ioOptions] }),
+      node('wiki', { subcommands: repeatOptions(mcpToolNames.wiki, ioOptions), options: [...ioOptions] }),
+      node('sparkshell', { options: [option(['--tmux-pane']), option(['--tail-lines'])] }),
+      node('help'),
+      node('status'),
+      node('cancel'),
+      node('reasoning', { positionalValues: ['low', 'medium', 'high', 'xhigh'] }),
+      // Keep top-level names aligned with the shared CLI surface, including hidden aliases.
+      ...buildTopLevelCommandNames()
+        .filter((name) => ![
+          'launch',
+          'exec',
+          'setup',
+          'agents',
+          'agents-init',
+          'deepinit',
+          'uninstall',
+          'doctor',
+          'cleanup',
+          'ask',
+          'resume',
+          'explore',
+          'session',
+          'team',
+          'ralph',
+          'autoresearch',
+          'completion',
+          'version',
+          'tmux-hook',
+          'hooks',
+          'hud',
+          'state',
+          'notepad',
+          'project-memory',
+          'trace',
+          'code-intel',
+          'wiki',
+          'sparkshell',
+          'help',
+          'status',
+          'cancel',
+          'reasoning',
+        ].includes(name))
+        .map((name) => node(name)),
+    ],
+  };
+}

--- a/src/cli/completion/install.ts
+++ b/src/cli/completion/install.ts
@@ -1,0 +1,298 @@
+import { spawnSync } from 'node:child_process';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, join, relative } from 'node:path';
+
+export type SupportedShell = 'bash' | 'zsh' | 'fish' | 'powershell';
+
+export interface CompletionInstallTargets {
+  shell: SupportedShell;
+  scriptPath: string;
+  profilePath?: string;
+}
+
+export interface CompletionInstallResult extends CompletionInstallTargets {
+  changedPaths: string[];
+  backupPaths: string[];
+}
+
+const OMX_COMPLETION_BLOCK_START = '# >>> omx completion >>>';
+const OMX_COMPLETION_BLOCK_END = '# <<< omx completion <<<';
+const BASH_BIN_OVERRIDE_ENV = 'OMX_COMPLETION_BASH_BIN';
+const POWERSHELL_PROFILE_OVERRIDE_ENV = 'OMX_COMPLETION_POWERSHELL_PROFILE';
+const POWERSHELL_BIN_OVERRIDE_ENV = 'OMX_COMPLETION_POWERSHELL_BIN';
+
+type PowerShellBinaryKind = 'pwsh' | 'powershell';
+
+function resolveHome(env: NodeJS.ProcessEnv = process.env): string {
+  return env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
+}
+
+function completionRoot(home: string): string {
+  return join(home, '.omx', 'completions');
+}
+
+function backupRoot(home: string): string {
+  return join(home, '.omx', 'backups', 'completion', new Date().toISOString().replace(/[:]/g, '-'));
+}
+
+function resolveXdgConfigHome(home: string, env: NodeJS.ProcessEnv = process.env): string {
+  return env.XDG_CONFIG_HOME?.trim() || join(home, '.config');
+}
+
+export function upsertManagedBlock(content: string, block: string): { content: string; changed: boolean } {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const managedBlock = `${OMX_COMPLETION_BLOCK_START}\n${block.trim()}\n${OMX_COMPLETION_BLOCK_END}`;
+  const start = normalized.indexOf(OMX_COMPLETION_BLOCK_START);
+
+  if (start >= 0) {
+    const end = normalized.indexOf(OMX_COMPLETION_BLOCK_END, start);
+    if (end >= 0) {
+      const before = normalized.slice(0, start).trimEnd();
+      const after = normalized.slice(end + OMX_COMPLETION_BLOCK_END.length).trimStart();
+      const nextContent = [before, managedBlock, after].filter(Boolean).join('\n\n');
+      return { content: `${nextContent.trimEnd()}\n`, changed: `${normalized.trimEnd()}\n` !== `${nextContent.trimEnd()}\n` };
+    }
+  }
+
+  const trimmed = normalized.trimEnd();
+  const nextContent = trimmed ? `${trimmed}\n\n${managedBlock}\n` : `${managedBlock}\n`;
+  return { content: nextContent, changed: `${normalized.trimEnd()}\n` !== nextContent };
+}
+
+async function backupFile(path: string, home: string): Promise<string | null> {
+  if (!existsSync(path)) return null;
+  const root = backupRoot(home);
+  const relativePath = relative(home, path);
+  const safeRelativePath = relativePath.startsWith('..') || relativePath === ''
+    ? path.replace(/^[/\\]+/, '').replace(/:/g, '')
+    : relativePath;
+  const destination = join(root, safeRelativePath);
+  await mkdir(dirname(destination), { recursive: true });
+  await copyFile(path, destination);
+  return destination;
+}
+
+function normalizePowerShellBinaryName(command: string | null): PowerShellBinaryKind | null {
+  if (!command) return null;
+  const base = basename(command).toLowerCase().replace(/\.exe$/, '');
+  if (base === 'pwsh') return 'pwsh';
+  if (base === 'powershell') return 'powershell';
+  return null;
+}
+
+function resolveBashBinary(env: NodeJS.ProcessEnv = process.env): string {
+  return env[BASH_BIN_OVERRIDE_ENV]?.trim() || 'bash';
+}
+
+function detectBashMajorVersion(env: NodeJS.ProcessEnv = process.env): number | null {
+  const command = resolveBashBinary(env);
+  const result = spawnSync(
+    command,
+    ['-c', 'printf %s "${BASH_VERSINFO[0]:-0}"'],
+    {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      env,
+      windowsHide: true,
+    },
+  );
+  if (result.error || result.status !== 0) return null;
+  const parsed = Number.parseInt(result.stdout.trim(), 10);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function assertSupportedShellInstall(
+  shell: SupportedShell,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (shell !== 'bash') return;
+
+  const bashMajorVersion = detectBashMajorVersion(env);
+  if (bashMajorVersion === null) {
+    throw new Error(
+      `bash completion requires a working Bash 4+ executable. Set ${BASH_BIN_OVERRIDE_ENV} if Bash is installed outside PATH.`,
+    );
+  }
+  if (bashMajorVersion < 4) {
+    throw new Error(
+      `bash completion requires Bash 4+ because the generated script uses associative arrays and mapfile. Detected Bash ${bashMajorVersion}. Install a newer Bash or use zsh/fish/powershell instead.`,
+    );
+  }
+}
+
+function resolvePowerShellFallbackProfilePath(
+  home: string,
+  binaryKind: PowerShellBinaryKind | null,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (process.platform === 'win32') {
+    const directory = binaryKind === 'powershell' ? 'WindowsPowerShell' : 'PowerShell';
+    return join(home, 'Documents', directory, 'Microsoft.PowerShell_profile.ps1');
+  }
+  return join(resolveXdgConfigHome(home, env), 'powershell', 'Microsoft.PowerShell_profile.ps1');
+}
+
+function detectPowerShellBinary(env: NodeJS.ProcessEnv = process.env): string | null {
+  const override = env[POWERSHELL_BIN_OVERRIDE_ENV]?.trim();
+  if (override) return override;
+  for (const command of ['pwsh', 'powershell']) {
+    const result = spawnSync(command, ['-NoLogo', '-NoProfile', '-Command', '$PSVersionTable.PSVersion.ToString()'], {
+      encoding: 'utf-8',
+      stdio: 'ignore',
+      env,
+      windowsHide: true,
+    });
+    if (!result.error && result.status === 0) return command;
+  }
+  return null;
+}
+
+export function resolvePowerShellProfilePath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env[POWERSHELL_PROFILE_OVERRIDE_ENV]?.trim();
+  if (override) return override;
+
+  const home = resolveHome(env);
+  const command = detectPowerShellBinary(env);
+  const binaryKind = normalizePowerShellBinaryName(command);
+  if (command) {
+    const result = spawnSync(
+      command,
+      ['-NoLogo', '-NoProfile', '-Command', '[Console]::Out.Write($PROFILE.CurrentUserCurrentHost)'],
+      {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        env,
+        windowsHide: true,
+      },
+    );
+    if (!result.error && result.status === 0) {
+      const value = result.stdout.trim();
+      if (value) return value;
+    }
+  }
+
+  return resolvePowerShellFallbackProfilePath(home, binaryKind, env);
+}
+
+export function resolveCompletionInstallTargets(
+  shell: SupportedShell,
+  env: NodeJS.ProcessEnv = process.env,
+): CompletionInstallTargets {
+  const home = resolveHome(env);
+  const omxCompletionDir = completionRoot(home);
+
+  switch (shell) {
+    case 'bash':
+      return {
+        shell,
+        scriptPath: join(omxCompletionDir, 'omx.bash'),
+        profilePath: join(home, '.bashrc'),
+      };
+    case 'zsh':
+      return {
+        shell,
+        scriptPath: join(omxCompletionDir, 'omx.zsh'),
+        profilePath: join(home, '.zshrc'),
+      };
+    case 'fish':
+      return {
+        shell,
+        scriptPath: join(resolveXdgConfigHome(home, env), 'fish', 'completions', 'omx.fish'),
+      };
+    case 'powershell':
+      return {
+        shell,
+        scriptPath: join(omxCompletionDir, 'omx.ps1'),
+        profilePath: resolvePowerShellProfilePath({ ...env, HOME: home, USERPROFILE: home }),
+      };
+  }
+}
+
+function buildManagedProfileBlock(shell: Exclude<SupportedShell, 'fish'>, scriptPath: string): string {
+  const normalizedPath = scriptPath.replace(/\\/g, '/');
+  switch (shell) {
+    case 'bash':
+      return [
+        `if [ -f "${normalizedPath}" ]; then`,
+        `  . "${normalizedPath}"`,
+        'fi',
+      ].join('\n');
+    case 'zsh':
+      return [
+        `if [ -f "${normalizedPath}" ]; then`,
+        `  source "${normalizedPath}"`,
+        'fi',
+      ].join('\n');
+    case 'powershell': {
+      const escapedPath = scriptPath.replace(/'/g, "''");
+      return [
+        `$OmxCompletionScript = '${escapedPath}'`,
+        'if (Test-Path $OmxCompletionScript) {',
+        '  . $OmxCompletionScript',
+        '}',
+      ].join('\n');
+    }
+  }
+}
+
+async function writeFileIfChanged(
+  path: string,
+  content: string,
+  backups: string[],
+  backupBeforeWrite: boolean,
+  home: string,
+): Promise<boolean> {
+  const current = existsSync(path) ? await readFile(path, 'utf-8') : null;
+  if (current === content) return false;
+  if (backupBeforeWrite) {
+    const backupPath = await backupFile(path, home);
+    if (backupPath) backups.push(backupPath);
+  }
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, 'utf-8');
+  return true;
+}
+
+export async function installCompletion(
+  shell: SupportedShell,
+  scriptContent: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<CompletionInstallResult> {
+  assertSupportedShellInstall(shell, env);
+
+  const home = resolveHome(env);
+  const targets = resolveCompletionInstallTargets(shell, env);
+  const changedPaths: string[] = [];
+  const backupPaths: string[] = [];
+
+  const scriptChanged = await writeFileIfChanged(
+    targets.scriptPath,
+    scriptContent.trimEnd() + '\n',
+    backupPaths,
+    shell === 'fish',
+    home,
+  );
+  if (scriptChanged) changedPaths.push(targets.scriptPath);
+
+  if (targets.profilePath && shell !== 'fish') {
+    const profileContent = existsSync(targets.profilePath) ? await readFile(targets.profilePath, 'utf-8') : '';
+    const block = buildManagedProfileBlock(shell, targets.scriptPath);
+    const updated = upsertManagedBlock(profileContent, block);
+    const profileChanged = await writeFileIfChanged(
+      targets.profilePath,
+      updated.content,
+      backupPaths,
+      true,
+      home,
+    );
+    if (profileChanged) changedPaths.push(targets.profilePath);
+  }
+
+  return {
+    ...targets,
+    changedPaths,
+    backupPaths,
+  };
+}

--- a/src/cli/completion/render.ts
+++ b/src/cli/completion/render.ts
@@ -1,0 +1,440 @@
+import type { CompletionNode } from './catalog.js';
+
+interface FlatCompletionTables {
+  subcommands: Record<string, string[]>;
+  options: Record<string, string[]>;
+  positionalValues: Record<string, string[]>;
+  optionValues: Record<string, string[]>;
+}
+
+const BASH_ROOT_KEY = '__omx_root__';
+
+function unique(values: readonly string[] | undefined): string[] {
+  if (!values || values.length === 0) return [];
+  return [...new Set(values)];
+}
+
+function flattenCatalog(
+  node: CompletionNode,
+  path = '',
+  tables: FlatCompletionTables = {
+    subcommands: {},
+    options: {},
+    positionalValues: {},
+    optionValues: {},
+  },
+): FlatCompletionTables {
+  tables.subcommands[path] = unique(node.subcommands?.map((entry) => entry.name));
+  tables.options[path] = unique(node.options?.flatMap((entry) => entry.flags));
+  tables.positionalValues[path] = unique(node.positionalValues);
+
+  for (const option of node.options ?? []) {
+    if (!option.values || option.values.length === 0) continue;
+    for (const flag of option.flags) {
+      tables.optionValues[`${path}|${flag}`] = unique(option.values);
+    }
+  }
+
+  for (const child of node.subcommands ?? []) {
+    const childPath = path ? `${path} ${child.name}` : child.name;
+    flattenCatalog(child, childPath, tables);
+  }
+
+  return tables;
+}
+
+function escapeForDoubleQuotes(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function renderBashAssoc(name: string, values: Record<string, string[]>): string {
+  const entries = Object.entries(values)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, list]) => {
+      const normalizedKey = key === '' ? BASH_ROOT_KEY : key;
+      return `  ["${escapeForDoubleQuotes(normalizedKey)}"]="${escapeForDoubleQuotes(list.join(' '))}"`;
+    });
+  return [`declare -A ${name}=(`, ...entries, ')'].join('\n');
+}
+
+function renderZshAssoc(name: string, values: Record<string, string[]>): string {
+  const entries = Object.entries(values)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, list]) => `  ["${escapeForDoubleQuotes(key)}"]="${escapeForDoubleQuotes(list.join(' '))}"`);
+  return [`typeset -A ${name}`, `${name}=(`, ...entries, ')'].join('\n');
+}
+
+function renderFishCaseBlocks(values: Record<string, string[]>): string[] {
+  return Object.entries(values)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .flatMap(([key, list]) => {
+      const caseValue = key === '' ? "''" : `'${key.replace(/'/g, "\\'")}'`;
+      if (list.length === 0) return [
+        `    case ${caseValue}`,
+        '      return 0',
+      ];
+      return [
+        `    case ${caseValue}`,
+        ...list.map((entry) => `      printf '%s\\n' '${entry.replace(/'/g, "\\'")}'`),
+      ];
+    });
+}
+
+function renderPowerShellHashtable(name: string, values: Record<string, string[]>): string {
+  const entries = Object.entries(values)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, list]) => {
+      const escapedKey = key.replace(/'/g, "''");
+      const renderedValues = list.map((entry) => `'${entry.replace(/'/g, "''")}'`).join(', ');
+      return `  '${escapedKey}' = @(${renderedValues})`;
+    });
+  return [`$${name} = @{`, ...entries, '}'].join('\n');
+}
+
+export function renderBashCompletion(catalog: CompletionNode): string {
+  const tables = flattenCatalog(catalog);
+  return [
+    '# omx bash completion',
+    renderBashAssoc('__OMX_SUBCOMMANDS', tables.subcommands),
+    '',
+    renderBashAssoc('__OMX_OPTIONS', tables.options),
+    '',
+    renderBashAssoc('__OMX_POSITIONALS', tables.positionalValues),
+    '',
+    renderBashAssoc('__OMX_OPTION_VALUES', tables.optionValues),
+    '',
+    '__omx_contains() {',
+    '  local needle="$1"',
+    '  shift || true',
+    '  local entry',
+    '  for entry in "$@"; do',
+    '    if [[ "$entry" == "$needle" ]]; then',
+    '      return 0',
+    '    fi',
+    '  done',
+    '  return 1',
+    '}',
+    '',
+    '__omx_list() {',
+    '  local list="$1"',
+    '  if [[ -n "$list" ]]; then',
+    '    printf "%s\\n" $list',
+    '  fi',
+    '}',
+    '',
+    '__omx_join_path() {',
+    '  local path="$1" token="$2"',
+    '  if [[ -z "$path" ]]; then',
+    '    printf "%s" "$token"',
+    '  else',
+    '    printf "%s %s" "$path" "$token"',
+    '  fi',
+    '}',
+    '',
+    '__omx_path_key() {',
+    '  local path="$1"',
+    '  if [[ -z "$path" ]]; then',
+    `    printf "%s" "${BASH_ROOT_KEY}"`,
+    '  else',
+    '    printf "%s" "$path"',
+    '  fi',
+    '}',
+    '',
+    '__omx_option_expects_value() {',
+    '  local path="$1" flag="$2"',
+    '  [[ -n "${__OMX_OPTION_VALUES["$path|$flag"]}" ]]',
+    '}',
+    '',
+    '_omx() {',
+    '  local cur prev path token idx values',
+    '  cur="${COMP_WORDS[COMP_CWORD]}"',
+    '  prev="${COMP_WORDS[COMP_CWORD-1]}"',
+    '  path=""',
+    '  idx=1',
+    '  while (( idx < COMP_CWORD )); do',
+    '    token="${COMP_WORDS[idx]}"',
+    '    if __omx_option_expects_value "$path" "$token"; then',
+    '      ((idx+=2))',
+    '      continue',
+    '    fi',
+    '    mapfile -t values < <(__omx_list "${__OMX_SUBCOMMANDS[$(__omx_path_key "$path")]}")',
+    '    if __omx_contains "$token" "${values[@]}"; then',
+    '      path="$(__omx_join_path "$path" "$token")"',
+    '      ((idx+=1))',
+    '      continue',
+    '    fi',
+    '    mapfile -t values < <(__omx_list "${__OMX_POSITIONALS[$(__omx_path_key "$path")]}")',
+    '    if __omx_contains "$token" "${values[@]}"; then',
+    '      ((idx+=1))',
+      '      continue',
+    '    fi',
+    '    ((idx+=1))',
+    '  done',
+    '  local suggestions="" option_key',
+    '  option_key="$path|$prev"',
+    '  if [[ -n "$prev" && -n "${__OMX_OPTION_VALUES[$option_key]}" ]]; then',
+    '    suggestions="${__OMX_OPTION_VALUES[$option_key]}"',
+    '  else',
+    '    suggestions="${__OMX_SUBCOMMANDS[$(__omx_path_key "$path")]} ${__OMX_OPTIONS[$(__omx_path_key "$path")]} ${__OMX_POSITIONALS[$(__omx_path_key "$path")]}"',
+    '  fi',
+    '  COMPREPLY=( $(compgen -W "$suggestions" -- "$cur") )',
+    '}',
+    '',
+    'complete -F _omx omx',
+    '',
+  ].join('\n');
+}
+
+export function renderZshCompletion(catalog: CompletionNode): string {
+  const tables = flattenCatalog(catalog);
+  return [
+    '#compdef omx',
+    '# omx zsh completion',
+    renderZshAssoc('__OMX_SUBCOMMANDS', tables.subcommands),
+    '',
+    renderZshAssoc('__OMX_OPTIONS', tables.options),
+    '',
+    renderZshAssoc('__OMX_POSITIONALS', tables.positionalValues),
+    '',
+    renderZshAssoc('__OMX_OPTION_VALUES', tables.optionValues),
+    '',
+    '__omx_list() {',
+    '  local list="$1"',
+    '  if [[ -n "$list" ]]; then',
+    '    print -r -- $list',
+    '  fi',
+    '}',
+    '',
+    '__omx_contains() {',
+    '  local needle="$1"',
+    '  shift',
+    '  local entry',
+    '  for entry in "$@"; do',
+    '    if [[ "$entry" == "$needle" ]]; then',
+    '      return 0',
+    '    fi',
+    '  done',
+    '  return 1',
+    '}',
+    '',
+    '__omx_join_path() {',
+    '  local path="$1" token="$2"',
+    '  if [[ -z "$path" ]]; then',
+    '    print -r -- "$token"',
+    '  else',
+    '    print -r -- "$path $token"',
+    '  fi',
+    '}',
+    '',
+    '__omx_option_expects_value() {',
+    '  local path="$1" flag="$2"',
+    '  [[ -n "${__OMX_OPTION_VALUES["$path|$flag"]}" ]]',
+    '}',
+    '',
+    '_omx() {',
+    '  local cur prev path token idx option_key',
+    '  local -a values suggestions',
+    '  cur="${words[CURRENT]}"',
+    '  prev="${words[CURRENT-1]}"',
+    '  path=""',
+    '  idx=2',
+    '  while (( idx < CURRENT )); do',
+    '    token="${words[idx]}"',
+    '    if __omx_option_expects_value "$path" "$token"; then',
+    '      ((idx+=2))',
+    '      continue',
+    '    fi',
+    '    values=(${=__OMX_SUBCOMMANDS[$path]})',
+    '    if __omx_contains "$token" "${values[@]}"; then',
+    '      path="$(__omx_join_path "$path" "$token")"',
+    '      ((idx+=1))',
+    '      continue',
+    '    fi',
+    '    values=(${=__OMX_POSITIONALS[$path]})',
+    '    if __omx_contains "$token" "${values[@]}"; then',
+    '      ((idx+=1))',
+    '      continue',
+    '    fi',
+    '    ((idx+=1))',
+    '  done',
+    '  option_key="$path|$prev"',
+    '  if [[ -n "$prev" && -n "${__OMX_OPTION_VALUES[$option_key]}" ]]; then',
+    '    suggestions=(${=__OMX_OPTION_VALUES[$option_key]})',
+    '  else',
+    '    suggestions=(${=__OMX_SUBCOMMANDS[$path]} ${=__OMX_OPTIONS[$path]} ${=__OMX_POSITIONALS[$path]})',
+    '  fi',
+    '  compadd -- $suggestions',
+    '}',
+    '',
+    'compdef _omx omx',
+    '',
+  ].join('\n');
+}
+
+export function renderFishCompletion(catalog: CompletionNode): string {
+  const tables = flattenCatalog(catalog);
+  return [
+    '# omx fish completion',
+    'function __omx_join_path --argument-names path token',
+    '  if test -z "$path"',
+    '    printf "%s" "$token"',
+    '  else',
+    '    printf "%s %s" "$path" "$token"',
+    '  end',
+    'end',
+    '',
+    'function __omx_get_subcommands --argument-names path',
+    '  switch "$path"',
+    ...renderFishCaseBlocks(tables.subcommands),
+    '  end',
+    'end',
+    '',
+    'function __omx_get_options --argument-names path',
+    '  switch "$path"',
+    ...renderFishCaseBlocks(tables.options),
+    '  end',
+    'end',
+    '',
+    'function __omx_get_positionals --argument-names path',
+    '  switch "$path"',
+    ...renderFishCaseBlocks(tables.positionalValues),
+    '  end',
+    'end',
+    '',
+    'function __omx_get_option_values --argument-names path flag',
+    '  switch "$path|$flag"',
+    ...renderFishCaseBlocks(tables.optionValues),
+    '  end',
+    'end',
+    '',
+    'function __omx_option_expects_value --argument-names path flag',
+    '  set -l values (__omx_get_option_values "$path" "$flag")',
+    '  test (count $values) -gt 0',
+    'end',
+    '',
+    'function __omx_complete',
+    '  set -l words (commandline -opc)',
+    '  set -l current (commandline -ct)',
+    '  if test (count $words) -gt 0; and test "$words[-1]" = "$current"',
+    '    set -e words[-1]',
+    '  end',
+    '  if test (count $words) -gt 0',
+    '    set -e words[1]',
+    '  end',
+    '  set -l path ""',
+    '  set -l idx 1',
+    '  while test $idx -le (count $words)',
+    '    set -l token $words[$idx]',
+    '    if __omx_option_expects_value "$path" "$token"',
+    '      set idx (math $idx + 2)',
+    '      continue',
+    '    end',
+    '    if contains -- "$token" (__omx_get_subcommands "$path")',
+    '      set path (__omx_join_path "$path" "$token")',
+    '      set idx (math $idx + 1)',
+    '      continue',
+    '    end',
+    '    if contains -- "$token" (__omx_get_positionals "$path")',
+    '      set idx (math $idx + 1)',
+    '      continue',
+    '    end',
+    '    set idx (math $idx + 1)',
+    '  end',
+    '  set -l prev ""',
+    '  if test (count $words) -gt 0',
+    '    set prev $words[-1]',
+    '  end',
+    '  if test -n "$prev"; and __omx_option_expects_value "$path" "$prev"',
+    '    __omx_get_option_values "$path" "$prev"',
+    '    return 0',
+    '  end',
+    '  __omx_get_subcommands "$path"',
+    '  __omx_get_options "$path"',
+    '  __omx_get_positionals "$path"',
+    'end',
+    '',
+    'complete -f -c omx -a "(__omx_complete)"',
+    '',
+  ].join('\n');
+}
+
+export function renderPowerShellCompletion(catalog: CompletionNode): string {
+  const tables = flattenCatalog(catalog);
+  return [
+    '# omx PowerShell completion',
+    renderPowerShellHashtable('OmxSubcommands', tables.subcommands),
+    '',
+    renderPowerShellHashtable('OmxOptions', tables.options),
+    '',
+    renderPowerShellHashtable('OmxPositionals', tables.positionalValues),
+    '',
+    renderPowerShellHashtable('OmxOptionValues', tables.optionValues),
+    '',
+    'function Get-OmxList([hashtable]$Table, [string]$Key) {',
+    '  if ($Table.ContainsKey($Key)) { return [string[]]$Table[$Key] }',
+    '  return @()',
+    '}',
+    '',
+    'function Test-OmxContains([string[]]$Items, [string]$Value) {',
+    '  foreach ($Item in $Items) {',
+    '    if ($Item -eq $Value) { return $true }',
+    '  }',
+    '  return $false',
+    '}',
+    '',
+    'function Join-OmxPath([string]$Path, [string]$Token) {',
+    '  if ([string]::IsNullOrEmpty($Path)) { return $Token }',
+    '  return "$Path $Token"',
+    '}',
+    '',
+    'function Get-OmxSuggestions([string[]]$CompletedWords, [string]$WordToComplete) {',
+    '  $path = ""',
+    '  for ($idx = 0; $idx -lt $CompletedWords.Count; $idx++) {',
+    '    $token = $CompletedWords[$idx]',
+    '    $optionKey = "$path|$token"',
+    '    if ($OmxOptionValues.ContainsKey($optionKey)) {',
+    '      $idx += 1',
+    '      continue',
+    '    }',
+    '    $subcommands = Get-OmxList $OmxSubcommands $path',
+    '    if (Test-OmxContains $subcommands $token) {',
+    '      $path = Join-OmxPath $path $token',
+    '      continue',
+    '    }',
+    '    $positionals = Get-OmxList $OmxPositionals $path',
+    '    if (Test-OmxContains $positionals $token) {',
+    '      continue',
+    '    }',
+    '  }',
+    '  if ($CompletedWords.Count -gt 0) {',
+    '    $previous = $CompletedWords[$CompletedWords.Count - 1]',
+    '    $previousKey = "$path|$previous"',
+    '    if ($OmxOptionValues.ContainsKey($previousKey)) {',
+    '      return Get-OmxList $OmxOptionValues $previousKey | Where-Object { $_ -like "$WordToComplete*" }',
+    '    }',
+    '  }',
+    '  $suggestions = @()',
+    '  $suggestions += Get-OmxList $OmxSubcommands $path',
+    '  $suggestions += Get-OmxList $OmxOptions $path',
+    '  $suggestions += Get-OmxList $OmxPositionals $path',
+    '  return $suggestions | Where-Object { $_ -like "$WordToComplete*" } | Select-Object -Unique',
+    '}',
+    '',
+    'Register-ArgumentCompleter -Native -CommandName omx -ScriptBlock {',
+    '  param($WordToComplete, $CommandAst, $CursorPosition)',
+    '  $elements = @($CommandAst.CommandElements | ForEach-Object { $_.Extent.Text })',
+    '  if ($elements.Count -gt 1) {',
+    '    $elements = $elements[1..($elements.Count - 1)]',
+    '  } else {',
+    '    $elements = @()',
+    '  }',
+    '  if ($elements.Count -gt 0 -and $WordToComplete -ne "" -and $elements[-1] -eq $WordToComplete) {',
+    '    $elements = if ($elements.Count -gt 1) { $elements[0..($elements.Count - 2)] } else { @() }',
+    '  }',
+    '  foreach ($Suggestion in Get-OmxSuggestions $elements $WordToComplete) {',
+    "    [System.Management.Automation.CompletionResult]::new($Suggestion, $Suggestion, 'ParameterValue', $Suggestion)",
+    '  }',
+    '}',
+    '',
+  ].join('\n');
+}

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -7,6 +7,8 @@ import { dispatchHookEvent } from '../hooks/extensibility/dispatcher.js';
 import { discoverHookPlugins, isHookPluginsEnabled } from '../hooks/extensibility/loader.js';
 import type { HookPluginDescriptor } from '../hooks/extensibility/types.js';
 
+export const HOOKS_SUBCOMMANDS = ['init', 'status', 'validate', 'test'] as const;
+
 const HELP = `
 Usage:
   omx hooks init       Create .omx/hooks/sample-plugin.mjs scaffold

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import {
   type CleanupResult,
 } from "./cleanup.js";
 import { exploreCommand } from "./explore.js";
+import { completionCommand } from "./completion.js";
 import { sparkshellCommand } from "./sparkshell.js";
 import { agentsInitCommand } from "./agents-init.js";
 import { agentsCommand } from "./agents.js";
@@ -110,6 +111,7 @@ import {
   ensureWorktree,
 } from "../team/worktree.js";
 import { ensureReusableNodeModules } from "../utils/repo-deps.js";
+import { buildTopLevelHelp, TOP_LEVEL_COMMAND_NAMES, TOP_LEVEL_LOCAL_HELP_COMMANDS } from "./top-level-commands.js";
 import {
   OMX_NOTIFY_TEMP_CONTRACT_ENV,
   parseNotifyTempContractFromArgs,
@@ -134,82 +136,7 @@ function resolveDistScript(pkgRoot: string, scriptName: string): string {
   return join(pkgRoot, "dist", "scripts", scriptName);
 }
 
-const HELP = `
-oh-my-codex (omx) - Multi-agent orchestration for Codex CLI
-
-Usage:
-  omx           Launch Codex CLI (HUD auto-attaches only when already inside tmux)
-  omx exec      Run codex exec non-interactively with OMX AGENTS/overlay injection
-  omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md
-  omx uninstall Remove OMX configuration and clean up installed artifacts
-  omx doctor    Check installation health
-  omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
-  omx doctor --team  Check team/swarm runtime health diagnostics
-  omx ask       Ask local provider CLI (claude|gemini) and write artifact output
-  omx resume    Resume a previous interactive Codex session
-  omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
-  omx session   Search prior local session transcripts and history artifacts
-  omx agents-init [path]
-                Bootstrap lightweight AGENTS.md files for a repo/subtree
-  omx agents    Manage Codex native agent TOML files
-  omx deepinit [path]
-                Alias for agents-init (lightweight AGENTS bootstrap only)
-  omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
-  omx ralph     Launch Codex with ralph persistence mode active
-  omx autoresearch Launch thin-supervisor autoresearch with keep/discard/reset parity
-  omx version   Show version information
-  omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
-  omx hooks     Manage hook plugins (init|status|validate|test)
-  omx hud       Show HUD statusline (--watch, --json, --preset=NAME)
-  omx state     Read/write/list OMX mode state via CLI parity surface
-  omx notepad   CLI parity for OMX notepad MCP tools
-  omx project-memory
-                CLI parity for OMX project-memory MCP tools
-  omx trace     CLI parity for OMX trace MCP tools
-  omx code-intel
-                CLI parity for OMX code-intel MCP tools
-  omx wiki      CLI parity for OMX wiki MCP tools
-  omx sparkshell <command> [args...]
-  omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]
-                Run native sparkshell sidecar for direct command execution or explicit tmux-pane summarization
-                (also used as an adaptive backend for qualifying read-only explore tasks)
-  omx help      Show this help message
-  omx status    Show active modes and state
-  omx cancel    Cancel active execution modes
-  omx reasoning Show or set model reasoning effort (low|medium|high|xhigh)
-
-Options:
-  --yolo        Launch Codex in yolo mode (shorthand for: omx launch --yolo)
-  --high        Launch Codex with high reasoning effort
-                (shorthand for: -c model_reasoning_effort="high")
-  --xhigh       Launch Codex with xhigh reasoning effort
-                (shorthand for: -c model_reasoning_effort="xhigh")
-  --madmax      DANGEROUS: bypass Codex approvals and sandbox
-                (alias for --dangerously-bypass-approvals-and-sandbox)
-  --spark       Use the Codex spark model (~1.3x faster) for team workers only
-                Workers get the configured low-complexity team model; leader model unchanged
-  --madmax-spark  spark model for workers + bypass approvals for leader and workers
-                (shorthand for: --spark --madmax)
-  --notify-temp  Enable temporary notification routing for this run/session only
-  --tmux         Launch the interactive leader session in detached tmux
-  --discord      Select Discord provider for temporary notification mode
-  --slack        Select Slack provider for temporary notification mode
-  --telegram     Select Telegram provider for temporary notification mode
-  --custom <name>
-                Select custom/OpenClaw gateway name for temporary notification mode
-  -w, --worktree[=<name>]
-                Launch Codex in a git worktree (detached when no name is given)
-  --force       Force reinstall (overwrite existing files)
-  --dry-run     Show what would be done without doing it
-  --keep-config Skip config.toml cleanup during uninstall
-  --purge       Remove .omx/ cache directory during uninstall
-  --verbose     Show detailed output
-  --scope       Setup scope for "omx setup" only:
-                user | project
-  --skill-target
-                User-scope skills target for "omx setup" only:
-                codex-home
-`;
+const HELP = buildTopLevelHelp();
 
 const REASONING_KEY = "model_reasoning_effort";
 const MODEL_INSTRUCTIONS_FILE_KEY = "model_instructions_file";
@@ -261,6 +188,7 @@ type CliCommand =
   | "cleanup"
   | "ask"
   | "explore"
+  | "completion"
   | "sparkshell"
   | "team"
   | "session"
@@ -277,25 +205,7 @@ type CliCommand =
   | "reasoning"
   | string;
 
-const NESTED_HELP_COMMANDS = new Set<CliCommand>([
-  "ask",
-  "cleanup",
-  "autoresearch",
-  "agents",
-  "agents-init",
-  "deepinit",
-  "exec",
-  "hooks",
-  "hud",
-  "state",
-  "wiki",
-  "ralph",
-  "resume",
-  "session",
-  "sparkshell",
-  "team",
-  "tmux-hook",
-]);
+const NESTED_HELP_COMMANDS = new Set<CliCommand>(TOP_LEVEL_LOCAL_HELP_COMMANDS);
 
 export interface ResolvedCliInvocation {
   command: CliCommand;
@@ -616,35 +526,7 @@ export function buildHudPaneCleanupTargets(
 }
 
 export async function main(args: string[]): Promise<void> {
-  const knownCommands = new Set([
-    "launch",
-    "exec",
-    "setup",
-    "agents",
-    "agents-init",
-    "deepinit",
-    "uninstall",
-    "doctor",
-    "cleanup",
-    "ask",
-    "autoresearch",
-    "explore",
-    "sparkshell",
-    "team",
-    "ralph",
-    "session",
-    "resume",
-    "version",
-    "tmux-hook",
-    "hooks",
-    "hud",
-    "state",
-    "status",
-    "cancel",
-    "help",
-    "--help",
-    "-h",
-  ]);
+  const knownCommands = new Set([...TOP_LEVEL_COMMAND_NAMES, "--help", "-h"]);
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
   const flags = new Set(args.filter((a) => a.startsWith("--")));
@@ -710,6 +592,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "explore":
         await exploreCommand(args.slice(1));
+        break;
+      case "completion":
+        await completionCommand(args.slice(1));
         break;
       case "exec":
         await execWithOverlay(launchArgs);

--- a/src/cli/session-search.ts
+++ b/src/cli/session-search.ts
@@ -21,6 +21,8 @@ Examples:
   omx session search "team api" --project current --json
 `;
 
+export const SESSION_SUBCOMMANDS = ['search'] as const;
+
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
 export interface ParsedSessionSearchArgs {

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -2,7 +2,7 @@ import { executeStateOperation, type StateOperationName } from '../state/operati
 
 const STATE_HELP = `Usage: omx state <read|write|clear|list-active|get-status> [--input <json>] [--json]\n\nExamples:\n  omx state read --input '{"mode":"ralph"}' --json\n  omx state write --input '{"mode":"ralph","active":true,"current_phase":"executing"}' --json\n  omx state clear --input '{"mode":"ralph","all_sessions":true}' --json\n  omx state list-active --json\n  omx state get-status --input '{"mode":"ralph"}' --json`;
 
-const STATE_OPERATION_MAP: Record<string, StateOperationName> = {
+export const STATE_OPERATION_MAP: Record<string, StateOperationName> = {
   read: 'state_read',
   write: 'state_write',
   clear: 'state_clear',

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -175,6 +175,8 @@ Examples:
   omx team api claim-task --input '{"team_name":"my-team","task_id":"1","worker":"worker-1","expected_version":1}' --json
 `;
 
+export const TEAM_CLI_SUBCOMMANDS = ['status', 'await', 'resume', 'shutdown', 'api'] as const;
+
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
 const TEAM_API_OPERATION_REQUIRED_FIELDS: Record<TeamApiOperation, string[]> = {

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -55,6 +55,8 @@ const DEFAULT_CONFIG: TmuxHookConfig = {
   skip_if_scrolling: true,
 };
 
+export const TMUX_HOOK_SUBCOMMANDS = ['init', 'status', 'validate', 'test'] as const;
+
 const HELP = `
 Usage:
   omx tmux-hook init       Create .omx/tmux-hook.json

--- a/src/cli/top-level-commands.ts
+++ b/src/cli/top-level-commands.ts
@@ -1,0 +1,234 @@
+export interface TopLevelCliCommandDescriptor {
+  name: string;
+  helpLines?: string[];
+  ownsLocalHelp?: boolean;
+  visibleInHelp?: boolean;
+}
+
+export const TOP_LEVEL_CLI_COMMANDS: readonly TopLevelCliCommandDescriptor[] = [
+  {
+    name: 'launch',
+    visibleInHelp: false,
+  },
+  {
+    name: 'exec',
+    helpLines: ['  omx exec      Run codex exec non-interactively with OMX AGENTS/overlay injection'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'setup',
+    helpLines: ['  omx setup     Install skills, prompts, MCP servers, and scope-specific AGENTS.md'],
+  },
+  {
+    name: 'uninstall',
+    helpLines: ['  omx uninstall Remove OMX configuration and clean up installed artifacts'],
+  },
+  {
+    name: 'doctor',
+    helpLines: [
+      '  omx doctor    Check installation health',
+      '  omx doctor --team  Check team/swarm runtime health diagnostics',
+    ],
+  },
+  {
+    name: 'cleanup',
+    helpLines: ['  omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'ask',
+    helpLines: ['  omx ask       Ask local provider CLI (claude|gemini) and write artifact output'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'resume',
+    helpLines: ['  omx resume    Resume a previous interactive Codex session'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'explore',
+    helpLines: ['  omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'session',
+    helpLines: ['  omx session   Search prior local session transcripts and history artifacts'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'agents-init',
+    helpLines: [
+      '  omx agents-init [path]',
+      '                Bootstrap lightweight AGENTS.md files for a repo/subtree',
+    ],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'agents',
+    helpLines: ['  omx agents    Manage Codex native agent TOML files'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'deepinit',
+    helpLines: [
+      '  omx deepinit [path]',
+      '                Alias for agents-init (lightweight AGENTS bootstrap only)',
+    ],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'team',
+    helpLines: ['  omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'ralph',
+    helpLines: ['  omx ralph     Launch Codex with ralph persistence mode active'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'autoresearch',
+    helpLines: ['  omx autoresearch Launch thin-supervisor autoresearch with keep/discard/reset parity'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'completion',
+    helpLines: ['  omx completion Install shell completion for bash, zsh, fish, or powershell'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'version',
+    helpLines: ['  omx version   Show version information'],
+  },
+  {
+    name: 'tmux-hook',
+    helpLines: ['  omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'hooks',
+    helpLines: ['  omx hooks     Manage hook plugins (init|status|validate|test)'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'hud',
+    helpLines: ['  omx hud       Show HUD statusline (--watch, --json, --preset=NAME)'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'state',
+    helpLines: ['  omx state     Read/write/list OMX mode state via CLI parity surface'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'notepad',
+    helpLines: ['  omx notepad   CLI parity for OMX notepad MCP tools'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'project-memory',
+    helpLines: [
+      '  omx project-memory',
+      '                CLI parity for OMX project-memory MCP tools',
+    ],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'trace',
+    helpLines: ['  omx trace     CLI parity for OMX trace MCP tools'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'code-intel',
+    helpLines: ['  omx code-intel                CLI parity for OMX code-intel MCP tools'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'wiki',
+    helpLines: ['  omx wiki      CLI parity for OMX wiki MCP tools'],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'sparkshell',
+    helpLines: [
+      '  omx sparkshell <command> [args...]',
+      '  omx sparkshell --tmux-pane <pane-id> [--tail-lines <100-1000>]',
+      '                Run native sparkshell sidecar for direct command execution or explicit tmux-pane summarization',
+      '                (also used as an adaptive backend for qualifying read-only explore tasks)',
+    ],
+    ownsLocalHelp: true,
+  },
+  {
+    name: 'help',
+    helpLines: ['  omx help      Show this help message'],
+  },
+  {
+    name: 'status',
+    helpLines: ['  omx status    Show active modes and state'],
+  },
+  {
+    name: 'cancel',
+    helpLines: ['  omx cancel    Cancel active execution modes'],
+  },
+  {
+    name: 'reasoning',
+    helpLines: ['  omx reasoning Show or set model reasoning effort (low|medium|high|xhigh)'],
+  },
+] as const;
+
+export const TOP_LEVEL_COMMAND_NAMES = TOP_LEVEL_CLI_COMMANDS.map((entry) => entry.name);
+export const TOP_LEVEL_LOCAL_HELP_COMMANDS = TOP_LEVEL_CLI_COMMANDS
+  .filter((entry) => entry.ownsLocalHelp)
+  .map((entry) => entry.name);
+
+const GLOBAL_OPTION_LINES = [
+  '  --yolo        Launch Codex in yolo mode (shorthand for: omx launch --yolo)',
+  '  --high        Launch Codex with high reasoning effort',
+  '                (shorthand for: -c model_reasoning_effort="high")',
+  '  --xhigh       Launch Codex with xhigh reasoning effort',
+  '                (shorthand for: -c model_reasoning_effort="xhigh")',
+  '  --madmax      DANGEROUS: bypass Codex approvals and sandbox',
+  '                (alias for --dangerously-bypass-approvals-and-sandbox)',
+  '  --spark       Use the Codex spark model (~1.3x faster) for team workers only',
+  '                Workers get the configured low-complexity team model; leader model unchanged',
+  '  --madmax-spark  spark model for workers + bypass approvals for leader and workers',
+  '                (shorthand for: --spark --madmax)',
+  '  --notify-temp  Enable temporary notification routing for this run/session only',
+  '  --tmux         Launch the interactive leader session in detached tmux',
+  '  --discord      Select Discord provider for temporary notification mode',
+  '  --slack        Select Slack provider for temporary notification mode',
+  '  --telegram     Select Telegram provider for temporary notification mode',
+  '  --custom <name>',
+  '                Select custom/OpenClaw gateway name for temporary notification mode',
+  '  -w, --worktree[=<name>]',
+  '                Launch Codex in a git worktree (detached when no name is given)',
+  '  --force       Force reinstall (overwrite existing files)',
+  '  --dry-run     Show what would be done without doing it',
+  '  --keep-config Skip config.toml cleanup during uninstall',
+  '  --purge       Remove .omx/ cache directory during uninstall',
+  '  --verbose     Show detailed output',
+  '  --scope       Setup scope for "omx setup" only:',
+  '                user | project',
+  '  --skill-target',
+  '                User-scope skills target for "omx setup" only:',
+  '                codex-home',
+] as const;
+
+export function buildTopLevelHelp(): string {
+  const commandLines = TOP_LEVEL_CLI_COMMANDS
+    .filter((entry) => entry.visibleInHelp !== false)
+    .flatMap((entry) => entry.helpLines ?? []);
+
+  return [
+    '',
+    'oh-my-codex (omx) - Multi-agent orchestration for Codex CLI',
+    '',
+    'Usage:',
+    '  omx           Launch Codex CLI (HUD auto-attaches only when already inside tmux)',
+    ...commandLines,
+    '',
+    'Options:',
+    ...GLOBAL_OPTION_LINES,
+    '',
+  ].join('\n');
+}


### PR DESCRIPTION
Implement direct-install shell completion for bash, zsh, fish, and powershell. Reuse shared CLI metadata for static suggestions, and fail Bash 3.x installs before modifying user profiles.

Constraint: Bash completion requires Bash 4+ features
Confidence: high
Scope-risk: moderate
Reversibility: clean
Tested: npm test
Tested: npm run lint
Tested: npm run check:no-unused
Not-tested: Live Windows PowerShell profile installation on a real Windows host

## Summary

  Add first-party omx completion support so users can install shell completion for OMX directly from the CLI.

  This change adds direct-install completion for bash, zsh, fish, and powershell, keeps static command/subcommand/flag/value
  suggestions aligned with shared CLI metadata, and makes profile updates idempotent.

  It also hardens the Bash path by rejecting Bash 3.x before modifying user profiles, since the generated Bash completion requires
  Bash 4+ features.

  Note: Bash completion intentionally requires Bash 4+; Bash 3.x fails fast without modifying profile files.

  ## Changes

  - add omx completion <bash|zsh|fish|powershell>
  - add completion catalog / renderer / installer implementation
  - add shared top-level command metadata for help + completion alignment
  - reuse exported CLI constants where possible to reduce completion drift
  - add idempotent managed profile/file updates for shell installation
  - reject Bash 3.x installs before mutating user config
  - add README onboarding for shell completion
  - add changelog entry under Unreleased
  - add targeted completion and help-routing tests

  ## Validation

  - [x] npm run build
  - [x] npm test
  - [ ] omx doctor (when setup/config behavior changes)

  Additional targeted verification:

  - [x] npm run lint
  - [x] npm run check:no-unused
  - [x] node --test dist/cli/__tests__/completion.test.js dist/cli/__tests__/nested-help-routing.test.js

  ## Checklist

  - [x] PR is focused and avoids unrelated changes
  - [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
  - [x] Backward-compatibility impact considered

  ## Related

  Closes #