### PR TITLE
Docs: separate green doctor from real execution readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $team 3:executor "execute the approved plan in parallel"
 ```
 
 That is the main path.
+Before you treat the runtime as ready, run the quick-start smoke test below: `omx doctor` verifies the install shape, while `omx exec` proves the active Codex runtime can actually authenticate and complete a model call from the current environment.
 Start OMX strongly, clarify first when needed, approve the plan, then choose `$team` for coordinated parallel execution or `$ralph` for the persistent completion loop.
 
 ## What OMX is for
@@ -90,11 +91,21 @@ If you want plain Codex with no extra workflow layer, you probably do not need O
 
 - Node.js 20+
 - Codex CLI installed: `npm install -g @openai/codex`
-- Codex auth configured
+- Codex auth configured and visible in the same shell/profile that will run OMX
 - `tmux` on macOS/Linux if you want the recommended durable team runtime
 - `psmux` on native Windows only if you intentionally want the less-supported Windows team path
 
 ### A good first session
+
+After install, check both boundaries:
+
+```bash
+omx doctor
+codex login status
+omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"
+```
+
+`omx doctor` catches missing OMX files, hooks, and runtime prerequisites. The real smoke test catches auth, profile, and provider/base-URL problems that only appear when Codex performs an actual request.
 
 Launch OMX the recommended way:
 
@@ -135,10 +146,12 @@ Most users should think of OMX as **better task routing + better workflow + bett
 ## Start here if you are new
 
 1. Run `omx setup`
-2. Launch with `omx --madmax --high`
-3. Use `$deep-interview "..."` when the request or boundaries are still unclear
-4. Use `$ralplan "..."` to approve the plan and review tradeoffs
-5. Choose `$team` for coordinated parallel execution or `$ralph` for persistent completion loops
+2. Run `omx doctor`
+3. Run a real execution smoke test: `codex login status` and `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"`
+4. Launch with `omx --madmax --high`
+5. Use `$deep-interview "..."` when the request or boundaries are still unclear
+6. Use `$ralplan "..."` to approve the plan and review tradeoffs
+7. Choose `$team` for coordinated parallel execution or `$ralph` for persistent completion loops
 
 ## Recommended workflow
 
@@ -177,7 +190,7 @@ These are operator/support surfaces:
 - `omx setup` installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and OMX-managed native Codex hooks in `.codex/hooks.json`
   - setup refresh preserves non-OMX hook entries in `.codex/hooks.json` and only rewrites OMX-managed wrappers
   - `omx uninstall` removes OMX-managed wrappers from `.codex/hooks.json` but keeps the file when user hooks remain
-- `omx doctor` verifies the install when something seems wrong
+- `omx doctor` verifies the install when something seems wrong; it does not prove that the active Codex profile can make an authenticated model call
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow
 
 For non-team sessions, native Codex hooks are now the canonical lifecycle surface:
@@ -186,6 +199,24 @@ For non-team sessions, native Codex hooks are now the canonical lifecycle surfac
 - `omx tmux-hook` / notify-hook / derived watcher = tmux + runtime fallback paths
 
 See [Codex native hook mapping](./docs/codex-native-hooks.md) for the current native / fallback matrix.
+
+
+### Troubleshooting false-green readiness
+
+A green `omx doctor` means the install and local runtime wiring look sane. If real execution still fails, check the environment Codex actually uses:
+
+- Run `codex login status` and `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"` from the same shell/profile that will launch OMX.
+- In custom HOME, profile, container, or service shells, confirm the active `~/.codex` (or `CODEX_HOME`) is the one with the expected auth and config. Do not assume your normal user `~/.codex` is visible there.
+- If you depend on a local OpenAI-compatible proxy, confirm the active `~/.codex/config.toml` includes the expected `openai_base_url`; otherwise a proxy-issued key can be sent to the default endpoint and fail with `401 Unauthorized`, `Missing bearer or basic authentication in header`, or `Incorrect API key provided`.
+- If `omx doctor --team` or resume reports a stale team such as `resume_blocker` or a missing tmux session, clean the dead runtime state before retrying:
+
+```bash
+omx team shutdown <team-name> --force --confirm-issues
+omx cancel
+omx doctor --team
+```
+
+Only use the forced team shutdown for a team you have confirmed is dead or intentionally abandoned.
 
 ### Explore and sparkshell
 
@@ -251,6 +282,7 @@ If this happens, try:
 - [Skills reference](./docs/skills.html)
 - [Codex native hook mapping](./docs/codex-native-hooks.md)
 - [Integrations](./docs/integrations.html)
+- [Troubleshooting execution readiness](./docs/troubleshooting.md)
 - [OpenClaw / notification gateway guide](./docs/openclaw-integration.md)
 - [Contributing](./CONTRIBUTING.md)
 - [Changelog](./CHANGELOG.md)

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -14,6 +14,8 @@ This page is the canonical answer to:
 For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of source control.
 `omx uninstall` removes only the OMX-managed wrapper entries from `.codex/hooks.json`; if user hooks remain, the file stays in place.
 
+`omx doctor` can confirm that these files exist and are shaped correctly. It does not prove that the same shell/profile can complete an authenticated Codex request; use `codex login status` plus a real `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"` smoke test for that boundary.
+
 ## Ownership split
 
 - **Native Codex hooks**: `.codex/hooks.json`
@@ -85,3 +87,4 @@ When validating hooks, keep the proof boundary explicit:
    - behavior came from notify-hook / derived watcher / tmux runtime, not native Codex hooks
 
 Do not claim “native hooks work” when only tmux or synthetic notify fallback paths were exercised.
+Likewise, do not claim real execution readiness from hook/install evidence alone; validate an actual Codex execution in the active runtime profile when diagnosing auth or provider issues.

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -33,6 +33,9 @@
       <pre><code>npm install -g @openai/codex oh-my-codex
 omx setup
 omx doctor</code></pre>
+      <p><code>omx doctor</code> verifies the install shape. Before treating the runtime as ready, also prove that the active Codex profile can perform a real request:</p>
+      <pre><code>codex login status
+omx exec --skip-git-repo-check -C . &quot;Reply with exactly OMX-EXEC-OK&quot;</code></pre>
 
       <h2>Recommended Launch</h2>
       <pre><code>omx --xhigh --madmax   # trusted environments
@@ -42,6 +45,7 @@ omx                    # standard launch</code></pre>
       <ol>
         <li>Create or enter a project directory.</li>
         <li>Run <code>omx setup</code> to install prompts, skills, AGENTS.md, and configuration.</li>
+        <li>Run <code>omx doctor</code>, then the <code>codex login status</code> plus <code>omx exec</code> smoke test above.</li>
         <li>Start Codex CLI with <code>omx</code>.</li>
         <li>Use <code>$deep-interview "clarify the auth change"</code> when intent or boundaries are still unclear.</li>
         <li>Use <code>$ralplan "approve the auth plan and review tradeoffs"</code> to lock the implementation plan.</li>
@@ -63,8 +67,13 @@ OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx</code></pre>
           <tr><td>Prompts not available</td><td>Confirm files exist in <code>~/.codex/prompts/</code> and re-run <code>omx setup</code>.</td></tr>
           <tr><td>Skills not loading</td><td>Verify <code>~/.codex/skills/*/SKILL.md</code> files were installed.</td></tr>
           <tr><td>Doctor reports config issues</td><td>Run <code>omx doctor</code> and apply the suggested fixes.</td></tr>
+          <tr><td>Doctor is green but execution fails</td><td>Run <code>codex login status</code> and <code>omx exec --skip-git-repo-check -C . &quot;Reply with exactly OMX-EXEC-OK&quot;</code> from the same shell/profile. A green doctor is install evidence, not proof of authenticated model execution.</td></tr>
+          <tr><td>Custom or profile HOME cannot authenticate</td><td>Check the active <code>~/.codex</code> or <code>CODEX_HOME</code>. Containers, profile shells, and service users may not see the same auth/config as your normal user home.</td></tr>
+          <tr><td>Local proxy or compatible endpoint returns 401</td><td>If you use a proxy, verify the active <code>~/.codex/config.toml</code> contains the expected <code>openai_base_url</code>. Proxy keys sent to the wrong endpoint can look like missing bearer auth or an incorrect API key.</td></tr>
+          <tr><td><code>omx doctor --team</code> sees a dead tmux team</td><td>If the team is intentionally abandoned, run <code>omx team shutdown &lt;team-name&gt; --force --confirm-issues</code>, then <code>omx cancel</code>, then <code>omx doctor --team</code>.</td></tr>
         </tbody>
       </table>
+      <p class="muted">Need deeper operator help? See <a href="./troubleshooting.md">Troubleshooting execution readiness</a>.</p>
     </main>
 
     <footer>

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -27,6 +27,11 @@
         <li><a href="./openclaw-integration.md">OpenClaw / Generic Notification Gateway Integration Guide</a></li>
       </ul>
 
+      <h2>Operator Troubleshooting</h2>
+      <ul>
+        <li><a href="./troubleshooting.md">Execution readiness after setup and doctor</a></li>
+      </ul>
+
       <h2>Localized Prompt-Tuning Guides</h2>
       <ul>
         <li><a href="./openclaw-integration.ko.md">한국어</a></li>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,56 @@
+# Troubleshooting execution readiness
+
+Use this page when OMX appears installed but real Codex execution still fails.
+
+## Install success vs real execution success
+
+`omx setup` and `omx doctor` validate OMX's local install surface: prompts, skills, AGENTS scaffolding, config files, hooks, and runtime prerequisites. They do not guarantee that the active Codex profile can authenticate and complete a model request.
+
+After `omx doctor`, run a real smoke test from the same shell, HOME, and project directory you will use for OMX:
+
+```bash
+codex login status
+omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"
+```
+
+Treat the boundary this way:
+
+- `omx doctor` green: install and local runtime wiring look sane.
+- `codex login status` green: the active Codex profile can see login state.
+- `omx exec ...` returns `OMX-EXEC-OK`: real execution, auth, provider routing, and current working-directory assumptions are working together.
+
+## Green doctor, but `omx exec` fails with auth errors
+
+Common failure strings include `401 Unauthorized`, `Missing bearer or basic authentication in header`, or `Incorrect API key provided`.
+
+Check the active runtime profile, not only your normal login shell:
+
+1. Print `HOME` and `CODEX_HOME` in the shell that launches OMX.
+2. Confirm that the active `~/.codex` or `CODEX_HOME` contains the expected auth and `config.toml`.
+3. Re-run `codex login status` from that same shell.
+
+Custom HOME, container, profile, CI, and service-user environments often have a different `~/.codex` from the machine's main user. A working Codex setup in one home does not automatically make another home ready.
+
+## Local proxy or `openai_base_url` mismatch
+
+If your setup depends on an OpenAI-compatible local proxy or gateway, verify that the active runtime config contains the matching base URL:
+
+```toml
+openai_base_url = "http://localhost:8317/v1"
+```
+
+Use your actual proxy URL. If the profile-local `~/.codex/config.toml` is missing `openai_base_url`, Codex may send the proxy-issued key to the default endpoint. That can make setup and doctor look fine while real execution fails with 401-style auth errors.
+
+## Stale `doctor --team` or dead tmux session state
+
+`omx doctor --team`, `omx team resume`, or startup diagnostics can fail when a previous team state references a tmux session that no longer exists. The state may mention `resume_blocker`, or the dead session may be recorded under `.omx/state/team/<team-name>/config.json` or `manifest.v2.json`.
+
+If the team is intentionally abandoned and no live tmux session remains, clean it up with:
+
+```bash
+omx team shutdown <team-name> --force --confirm-issues
+omx cancel
+omx doctor --team
+```
+
+Do not force-shutdown a team that may still have useful live panes or worker state. Prefer `omx team status <team-name>` and `tmux ls` first when unsure.


### PR DESCRIPTION
## Summary
- keep the quick-start path lean while adding a real post-doctor smoke test
- add operator troubleshooting for stale team tmux state, custom HOME/CODEX_HOME splits, and local proxy `openai_base_url` mismatches
- clarify in native-hook docs that install/hook proof is not the same as authenticated execution proof

## Testing
- git diff --check
- npm run build

## Changed files
- README.md
- docs/getting-started.html
- docs/codex-native-hooks.md
- docs/integrations.html
- docs/troubleshooting.md