### PR TITLE
Fix macOS detached startup regression for omx --madmax --high

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1511,7 +1511,9 @@ describe("detached tmux new-session sequencing", () => {
     assert.match(leaderCmd!, /acquireTmuxExtendedKeysLease/);
     assert.match(leaderCmd!, /omx_detached_session_cleanup\(\)/);
     assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0 INT TERM HUP;/);
+    assert.match(leaderCmd!, /exec 3<&0;/);
     assert.match(leaderCmd!, /omx_codex_pid=\$!;/);
+    assert.match(leaderCmd!, /<\&3 &/);
     assert.match(leaderCmd!, /wait "\$omx_codex_pid";/);
     assert.match(leaderCmd!, /kill -TERM "\$omx_codex_pid"/);
     assert.match(leaderCmd!, /releaseTmuxExtendedKeysLease/);
@@ -1519,6 +1521,75 @@ describe("detached tmux new-session sequencing", () => {
     assert.match(leaderCmd!, /tmux kill-session -t/);
     assert.match(leaderCmd!, /"omx-demo"/);
     assert.match(leaderCmd!, /exit \$status/);
+  });
+
+  it("detached leader command keeps stdin open for the Codex child", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-stdin-"));
+    const fakeBin = join(cwd, "bin");
+    const stdinLogPath = join(cwd, "stdin.log");
+
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, "codex"),
+        `#!/bin/sh
+if IFS= read -r line; then
+  printf 'stdin:%s\n' "$line" > "${stdinLogPath}"
+else
+  printf 'stdin:EOF\n' > "${stdinLogPath}"
+fi
+`,
+      );
+      await chmod(join(fakeBin, "codex"), 0o755);
+      await writeFile(
+        join(fakeBin, "tmux"),
+        `#!/bin/sh
+case "$1" in
+  display-message)
+    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\n'
+    else
+      printf '0\n'
+    fi
+    ;;
+  show-options)
+    printf 'off\n'
+    ;;
+  set-option|kill-session)
+    ;;
+esac
+exit 0
+`,
+      );
+      await chmod(join(fakeBin, "tmux"), 0o755);
+
+      const steps = buildDetachedSessionBootstrapSteps(
+        "omx-demo",
+        cwd,
+        buildTmuxPaneCommand("codex", [], "/bin/sh"),
+        "'node' '/tmp/omx.js' 'hud' '--watch'",
+        null,
+      );
+      const leaderCmd = steps[0]?.args.at(-1);
+      assert.equal(typeof leaderCmd, "string");
+
+      const result = (await import("node:child_process")).spawnSync("/bin/sh", ["-c", leaderCmd!], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          HOME: cwd,
+        },
+        input: "hello from leader\n",
+        encoding: "utf-8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const stdinLog = await readFile(stdinLogPath, "utf-8");
+      assert.match(stdinLog, /stdin:hello from leader/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it("detached leader command preserves cwd and cleanup without shell-quote breakage", async () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1618,6 +1618,7 @@ function buildDetachedSessionLeaderCommand(
 ): string {
   const wrapped = [
     buildTmuxExtendedKeysAcquireShellSnippet(cwd),
+    'exec 3<&0;',
     'omx_codex_pid="";',
     "omx_detached_session_cleanup() {",
     "status=$?;",
@@ -1626,6 +1627,7 @@ function buildDetachedSessionLeaderCommand(
     'kill -TERM "$omx_codex_pid" 2>/dev/null || true;',
     'wait "$omx_codex_pid" 2>/dev/null || true;',
     "fi;",
+    'exec 3<&- 2>/dev/null || true;',
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
     'if [ "$status" -lt 128 ]; then',
     `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
@@ -1633,7 +1635,7 @@ function buildDetachedSessionLeaderCommand(
     "exit $status;",
     "};",
     "trap omx_detached_session_cleanup 0 INT TERM HUP;",
-    `${codexCmd} &`,
+    `${codexCmd} <&3 &`,
     "omx_codex_pid=$!;",
     'wait "$omx_codex_pid";',
   ].join(" ");


### PR DESCRIPTION
## Summary
- preserve stdin for the backgrounded Codex child in detached tmux leader launches
- keep the 0.13.0 detached-leader signal-cleanup hardening intact
- add regression coverage proving the detached leader command still delivers stdin to Codex

## Root cause
The 0.13.0 detached leader wrapper started backgrounding Codex so the shell could trap SIGHUP/TERM and clean up orphaned children. Backgrounding the child without preserving fd 0 meant Codex immediately saw EOF on startup in detached interactive launches, which matches the macOS arm64 report for `omx --madmax --high`.

## Testing
- npm run build
- npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts
- node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js
- changed-file tsc/LSP diagnostics (0 errors)

Closes #1627