### PR TITLE
Docs: clarify real execution readiness after OMX setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ If you want the default OMX experience, start here:
 ```bash
 npm install -g @openai/codex oh-my-codex
 omx setup
+omx doctor
+codex login status
+omx exec --skip-git-repo-check -C "$(pwd)" "Reply with exactly OMX-EXEC-OK"
 omx --madmax --high
 ```
 
@@ -131,6 +134,23 @@ These are operator/support surfaces:
 - `omx setup` installs prompts, skills, config, and AGENTS scaffolding
 - `omx doctor` verifies the install when something seems wrong
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow
+
+Important: `omx doctor` is necessary but not the full readiness boundary for real work. Before treating an install as ready, also verify:
+
+```bash
+codex login status
+omx exec --skip-git-repo-check -C "$(pwd)" "Reply with exactly OMX-EXEC-OK"
+```
+
+If `omx doctor --team` fails because stale team state still references a dead tmux session, the normal recovery path is:
+
+```bash
+omx team shutdown <team-name> --force --confirm-issues
+omx cancel
+omx doctor --team
+```
+
+If `omx doctor` is green but real execution still fails, verify that the active runtime `~/.codex` is the one that actually contains the expected auth and provider/base-url configuration. This matters especially in custom HOME, profile, container, or wrapper-managed environments.
 
 ### Explore and sparkshell
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -32,7 +32,9 @@
       <h2>Installation</h2>
       <pre><code>npm install -g @openai/codex oh-my-codex
 omx setup
-omx doctor</code></pre>
+omx doctor
+codex login status
+omx exec --skip-git-repo-check -C "$(pwd)" "Reply with exactly OMX-EXEC-OK"</code></pre>
 
       <h2>Recommended Launch</h2>
       <pre><code>omx --xhigh --madmax   # trusted environments
@@ -54,6 +56,12 @@ omx                    # standard launch</code></pre>
       <pre><code>OMX_BYPASS_DEFAULT_SYSTEM_PROMPT=0 omx
 OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx</code></pre>
 
+      <h2>Execution Readiness Check</h2>
+      <p><code>omx doctor</code> is necessary, but it is not the full proof boundary for real work. Before treating an install as ready, verify both auth and a real execution path:</p>
+      <pre><code>codex login status
+omx exec --skip-git-repo-check -C "$(pwd)" "Reply with exactly OMX-EXEC-OK"</code></pre>
+      <p>If both commands succeed, the runtime is ready for real Codex-backed work. If <code>doctor</code> is green but the smoke test still fails, treat the install as not ready yet.</p>
+
       <h2>Troubleshooting</h2>
       <table>
         <thead><tr><th>Issue</th><th>What to check</th></tr></thead>
@@ -62,6 +70,8 @@ OMX_MODEL_INSTRUCTIONS_FILE=/path/to/instructions.md omx</code></pre>
           <tr><td>Prompts not available</td><td>Confirm files exist in <code>~/.codex/prompts/</code> and re-run <code>omx setup</code>.</td></tr>
           <tr><td>Skills not loading</td><td>Verify <code>~/.codex/skills/*/SKILL.md</code> files were installed.</td></tr>
           <tr><td>Doctor reports config issues</td><td>Run <code>omx doctor</code> and apply the suggested fixes.</td></tr>
+          <tr><td><code>omx doctor</code> is green but <code>omx exec</code> still fails</td><td>Run <code>codex login status</code> and verify the active runtime <code>~/.codex</code> contains the expected auth and provider/base-URL config.</td></tr>
+          <tr><td><code>omx doctor --team</code> fails because an old team references a dead tmux session</td><td>Clean the stale runtime with <code>omx team shutdown &lt;team-name&gt; --force --confirm-issues</code>, then run <code>omx cancel</code> and <code>omx doctor --team</code> again.</td></tr>
         </tbody>
       </table>
     </main>


### PR DESCRIPTION
## Summary
- add a real execution readiness check to the getting-started path
- document that `omx doctor` is necessary but not sufficient to prove real execution readiness
- add troubleshooting guidance for stale `doctor --team` state and active `~/.codex` mismatches

## Problem
The current docs make `omx doctor` feel like the setup success boundary, but in real operator environments that is not always enough.

A runtime can look healthy at the install/doctor layer while real Codex-backed execution is still broken. That creates a misleading green state for operators.

## Root cause
The docs covered install and doctor flows well, but did not explicitly distinguish:
- install success
- doctor success
- real execution success

They also did not document a common stale-team recovery path for dead tmux-session references.

## What changed
- updated `docs/getting-started.html` to include:
  - `codex login status`
  - a minimal `omx exec` smoke test
  - a short execution-readiness section
  - troubleshooting entries for green-doctor / broken-exec and stale `doctor --team`
- updated `README.md` to add:
  - a post-setup real execution smoke test
  - a short explanation that `omx doctor` is not the full readiness boundary
  - a concise stale-team cleanup flow
  - a note to verify the active runtime `~/.codex` in custom HOME / profile / wrapper-managed environments

## Overlap assessment
Net-new.

I opened issue #1626 first and did not find an existing issue/PR covering this exact docs gap.

## Validation
- `git diff --check`

## Risks
- no rendered docs preview was run
- wording intentionally keeps quick-start lightweight and leaves deeper operator edge cases out of the main path

## Changed files
- `README.md`
- `docs/getting-started.html`

Closes #1626
