### PR TITLE
Prepare the 0.13.1 hotfix release cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-04-16
+
+Hotfix release for the detached tmux startup regression introduced in `0.13.0`.
+
+### Fixed
+- **Detached tmux stdin preservation** — detached leader shells now keep Codex stdin attached during background startup, so `omx --madmax --high` and related detached launch paths no longer exit immediately on macOS/iTerm2-style interactive sessions. (PR [#1631](https://github.com/Yeachan-Heo/oh-my-codex/pull/1631), issues [#1627](https://github.com/Yeachan-Heo/oh-my-codex/issues/1627), [#1628](https://github.com/Yeachan-Heo/oh-my-codex/issues/1628))
+
+### Changed
+- **Release metadata sync** — Node/Cargo package metadata, lockfiles, changelog, release body, release notes, and release-readiness docs aligned to `0.13.1`.
+
 ## [0.13.0] - 2026-04-16
 
 Minor release for the new `omx adapt` surface, stronger Ralph / runtime session authority, safer cross-platform launch behavior, and another broad pass over hook, HUD, notification, and release-process correctness.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,11 +32,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.13.0"
+version = "0.13.1"
 
 [[package]]
 name = "omx-mux"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "fs2",
  "serde",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "omx-mux",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.13.0"
+version = "0.13.1"
 
 edition = "2021"
 license = "MIT"

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,63 +1,22 @@
-# oh-my-codex v0.13.0
+# oh-my-codex v0.13.1
 
-**Adapt foundations, Ralph/session authority hardening, safer launch paths, and quieter hook/HUD workflows**
+## Summary
 
-`0.13.0` is the `v0.12.6..v0.13.0` minor release train. It adds the first `omx adapt` foundation for persistent external targets, tightens Ralph and native Stop session authority, hardens explore/Windows/detached launch paths, and refreshes setup/release workflow guardrails across 56 first-parent PR merges.
+`0.13.1` is a focused hotfix release after `v0.13.0` that ships the detached tmux stdin-preservation fix for Codex startup. It supersedes the `0.13.0` detached-launch regression where interactive detached starts could immediately exit because the Codex child lost stdin when the leader shell backgrounded it.
 
-## Highlights
+## Fixed
 
-- **`omx adapt` foundation** — new adapter-owned CLI/reporting surfaces for persistent targets start with OpenClaw and Hermes, linking canonical planning artifacts while keeping writes under `.omx/adapters/<target>/...` (#1600, #1599, #1598).
-- **Ralph and native Stop authority** — prompt-side Ralph activation, PRD CLI startup, tmux Ralph nudges, session assignment, and permission-seeking Stop continuation now respect session ownership more consistently (#1604, #1608, #1591, #1590, #1611).
-- **Safer platform launch paths** — explore/codex resolution skips unusable PATH entries, handles sandboxed POSIX shims, fails closed before Windows paths reach POSIX wrappers, and cleans detached leader children on signal exit (#1562, #1610, #1605).
-- **Quieter hooks, HUD, and notifications** — live-session HUD binding, startup/dispatch regression coverage, Slack mention parsing, macOS stale-polling git-probe reduction, hook metadata routing, and receiving-agent ownership guidance reduce stale/noisy automation (#1573, #1595, #1585, #1619, #1611).
-- **Release/setup workflow hygiene** — wiki setup registration, native-hook doctor coverage, explicit `dev` PR-base guidance, and dependency refreshes keep operator and release paths aligned (#1571, #1546, #1567, #1575, #1576, #1577, #1578).
-
-## What's Changed
-
-### Added
-- `omx adapt` foundation for OMX-owned adapter artifacts, probe/status/doctor reports, envelopes, and canonical planning linkage (PR [#1600](https://github.com/Yeachan-Heo/oh-my-codex/pull/1600))
-- OpenClaw adapter observation for local config, gateways, hook mappings, and lifecycle bridge evidence (PR [#1599](https://github.com/Yeachan-Heo/oh-my-codex/pull/1599))
-- Hermes adapter observation for ACP, gateway, session-store, and bootstrap evidence (PR [#1598](https://github.com/Yeachan-Heo/oh-my-codex/pull/1598))
-
-### Fixed — Ralph / runtime authority
-- Ralph assignment, tmux Ralph nudges, and PRD startup semantics now stay session-scoped and explicit (PRs [#1604](https://github.com/Yeachan-Heo/oh-my-codex/pull/1604), [#1608](https://github.com/Yeachan-Heo/oh-my-codex/pull/1608), [#1591](https://github.com/Yeachan-Heo/oh-my-codex/pull/1591))
-- Native Stop resumes permission-seeking handoffs and stays stable across session-id drift (PR [#1590](https://github.com/Yeachan-Heo/oh-my-codex/pull/1590), direct commit `4377e1e`)
-- Native hook metadata can no longer hijack real prompt routing (PR [#1611](https://github.com/Yeachan-Heo/oh-my-codex/pull/1611))
-- Resumed MCP state writers survive duplicate reconcile/self-teardown paths (PR [#1596](https://github.com/Yeachan-Heo/oh-my-codex/pull/1596))
-
-### Fixed — Launch / platform / worktree safety
-- Explore resolves usable node/Codex paths across unusable PATH entries and sandboxed pnpm-style shims (PRs [#1562](https://github.com/Yeachan-Heo/oh-my-codex/pull/1562), [#1610](https://github.com/Yeachan-Heo/oh-my-codex/pull/1610))
-- Windows explore fails closed before POSIX allowlist fallback can run on Windows paths (direct commit `72b1e5d`)
-- Detached leader signal exits terminate child Codex processes (PR [#1605](https://github.com/Yeachan-Heo/oh-my-codex/pull/1605))
-- Windows cleanup and stale worktree startup paths are more resilient (PRs [#1589](https://github.com/Yeachan-Heo/oh-my-codex/pull/1589), [#1582](https://github.com/Yeachan-Heo/oh-my-codex/pull/1582))
-
-### Fixed — Hooks / HUD / notifications
-- HUD stays bound to the live OMX session instead of stale root scope (PR [#1573](https://github.com/Yeachan-Heo/oh-my-codex/pull/1573))
-- Leader stale polling reduces repeated git probes on macOS so long-running sessions do less redundant repo work (PR [#1619](https://github.com/Yeachan-Heo/oh-my-codex/pull/1619))
-- Queued startup and dispatch lock behavior is protected by regression coverage (PR [#1595](https://github.com/Yeachan-Heo/oh-my-codex/pull/1595))
-- Slack mention environment parsing has dedicated coverage (PR [#1585](https://github.com/Yeachan-Heo/oh-my-codex/pull/1585))
-- Safe reversible runtime work is now receiving-agent-owned in generated guidance (direct commit `76e808e`)
-
-### Fixed — Setup / release workflows
-- Wiki setup registration stays aligned with shipped assets (PR [#1571](https://github.com/Yeachan-Heo/oh-my-codex/pull/1571))
-- Native-hook doctor coverage surfaces config drift clearly (PR [#1546](https://github.com/Yeachan-Heo/oh-my-codex/pull/1546))
-- Contributor guidance makes `dev` the normal PR base (PR [#1567](https://github.com/Yeachan-Heo/oh-my-codex/pull/1567))
-- Release workflow and TypeScript/Biome dependencies were refreshed (PRs [#1575](https://github.com/Yeachan-Heo/oh-my-codex/pull/1575), [#1576](https://github.com/Yeachan-Heo/oh-my-codex/pull/1576), [#1577](https://github.com/Yeachan-Heo/oh-my-codex/pull/1577), [#1578](https://github.com/Yeachan-Heo/oh-my-codex/pull/1578))
+- **Detached tmux startup regression** — the detached leader wrapper now preserves stdin for the Codex child during background launch, restoring successful startup for real interactive paths like `omx --madmax --high`. (PR [#1631](https://github.com/Yeachan-Heo/oh-my-codex/pull/1631), issues [#1627](https://github.com/Yeachan-Heo/oh-my-codex/issues/1627), [#1628](https://github.com/Yeachan-Heo/oh-my-codex/issues/1628))
+- **Regression coverage** — release scope includes focused CLI regression coverage proving the detached leader command keeps stdin open for the Codex child while preserving detached cleanup behavior.
 
 ## Verification
 
-- `npm run build` ✅
-- `npm run lint` ✅
-- `npm test` ✅
-- `npm run test:recent-bug-regressions` ✅
-- `node --test dist/cli/__tests__/version-sync-contract.test.js` ✅
-- `npm run smoke:packed-install` ✅
+- `npm run build`
+- `npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts`
+- `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js`
 
 ## Contributors
 
-- [@Yeachan-Heo](https://github.com/Yeachan-Heo) (Bellman)
-- [@lifrary](https://github.com/lifrary)
-- [@gujishh](https://github.com/gujishh)
-- [@dependabot](https://github.com/dependabot)
+Thanks to [@Arsture](https://github.com/Arsture) for the sharp detached-launch diagnosis and reproduction detail that made the hotfix path obvious.
 
-**Full Changelog**: [`v0.12.6...v0.13.0`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.12.6...v0.13.0)
+**Full Changelog**: [`v0.13.0...v0.13.1`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.13.0...v0.13.1)

--- a/docs/qa/release-readiness-0.13.1.md
+++ b/docs/qa/release-readiness-0.13.1.md
@@ -1,0 +1,36 @@
+# Release Readiness Verdict - 0.13.1
+
+Date: **2026-04-16**
+Target version: **0.13.1**
+Comparison base: **`v0.13.0..origin/dev`**
+Verdict: **GO** ✅
+
+`0.13.1` is a narrow hotfix release for the detached tmux stdin startup regression introduced in `0.13.0`.
+
+## Scope reviewed
+
+### Detached startup regression
+- `src/cli/index.ts` — detached leader wrapper startup path
+- `src/cli/__tests__/index.test.ts` — detached leader stdin-preservation regression coverage
+
+### Release collateral
+- `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`
+- `CHANGELOG.md`, `RELEASE_BODY.md`
+- `docs/release-notes-0.13.1.md`
+
+## Validation evidence
+
+| Check | Command | Result |
+|---|---|---|
+| Build | `npm run build` | PASS |
+| Targeted lint | `npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts` | PASS |
+| Targeted regression tests | `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js` | PASS |
+
+## Risk assessment
+
+- The code diff is intentionally narrow and localized to the detached leader wrapper plus focused tests.
+- This is a release-critical startup fix; broader matrix validation is delegated to the release workflow triggered by the tag.
+
+## Final verdict
+
+Release **0.13.1** is **ready for release commit/tag cut from `origin/dev`** on the basis of the passing targeted hotfix validation above.

--- a/docs/release-notes-0.13.1.md
+++ b/docs/release-notes-0.13.1.md
@@ -1,0 +1,23 @@
+# Release notes — 0.13.1
+
+## Summary
+
+`0.13.1` is a focused hotfix release after `0.13.0` that restores detached interactive Codex startup.
+
+## Fixed
+
+- **Detached tmux startup no longer drops Codex stdin** — the detached leader wrapper now preserves stdin while backgrounding Codex, so interactive detached launches like `omx --madmax --high` no longer exit immediately on startup. (PR [#1631](https://github.com/Yeachan-Heo/oh-my-codex/pull/1631), issues [#1627](https://github.com/Yeachan-Heo/oh-my-codex/issues/1627), [#1628](https://github.com/Yeachan-Heo/oh-my-codex/issues/1628))
+- **Detached-launch regression coverage** — CLI regression tests now assert that the detached leader command keeps stdin open for the Codex child while preserving leader cleanup semantics.
+
+## Verification evidence
+
+Release verification evidence is recorded in `docs/qa/release-readiness-0.13.1.md`.
+
+- `npm run build` ✅
+- `npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts` ✅
+- `node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js` ✅
+
+## Remaining risk
+
+- This is a narrow local hotfix pass, not a full GitHub Actions matrix rerun.
+- The strongest evidence is focused regression coverage plus the exact detached wrapper diff; this cut was not revalidated in a separate packaged macOS install before release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- cut the focused 0.13.1 hotfix release from dev after merging PR #1631
- align Node/Cargo metadata, changelog, release body, release notes, and release-readiness docs to 0.13.1
- scope the release collateral to the detached tmux stdin startup regression fixed in #1631

## Validation
- npm run build
- npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts
- node --test dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js

## Links
- fixes #1627
- fixes #1628