### PR TITLE
Isolate fresh sessions from stale task-scoped startup context

### DIFF
--- a/src/hooks/__tests__/agents-overlay.test.ts
+++ b/src/hooks/__tests__/agents-overlay.test.ts
@@ -136,6 +136,21 @@ describe("generateOverlay", () => {
     assert.ok(overlay.includes("iteration 1/5"));
   });
 
+  it("does not inherit stale root active modes into a fresh session overlay", async () => {
+    await writeFile(
+      join(tempDir, ".omx", "state", "ralph-state.json"),
+      JSON.stringify({
+        active: true,
+        iteration: 9,
+        max_iterations: 10,
+        current_phase: "executing",
+      }),
+    );
+
+    const overlay = await generateOverlay(tempDir, "fresh-session-isolation");
+    assert.equal(overlay.includes("ralph"), false);
+  });
+
   it("lists both approved combined workflow members from canonical skill state", async () => {
     const sessionId = "combined-session";
     const sessionDir = join(tempDir, ".omx", "state", "sessions", sessionId);
@@ -342,6 +357,22 @@ describe("resolveSessionOrchestrationMode", () => {
     assert.equal(mode, "team");
   });
 
+  it("does not inherit root skill-active orchestration mode into a fresh session", async () => {
+    await writeFile(
+      join(tempDir, ".omx", "state", "skill-active-state.json"),
+      JSON.stringify({
+        active: true,
+        skill: "team",
+      }),
+    );
+
+    const mode = await resolveSessionOrchestrationMode(
+      tempDir,
+      "fresh-session-isolation",
+    );
+    assert.equal(mode, "default");
+  });
+
   it("reads persisted team skill state from the current session scope", async () => {
     const sessionId = "sess-team";
     const sessionDir = join(tempDir, ".omx", "state", "sessions", sessionId);
@@ -391,7 +422,7 @@ describe("resolveSessionOrchestrationMode", () => {
     assert.equal(mode, "default");
   });
 
-  it("falls back to root team skill state only when no session-scoped skill state exists", async () => {
+  it("does not inherit root team skill state into a fresh session without session-scoped state", async () => {
     const sessionId = "sess-root-fallback";
     await writeFile(
       join(tempDir, ".omx", "state", "skill-active-state.json"),
@@ -399,7 +430,7 @@ describe("resolveSessionOrchestrationMode", () => {
     );
 
     const mode = await resolveSessionOrchestrationMode(tempDir, sessionId);
-    assert.equal(mode, "team");
+    assert.equal(mode, "default");
   });
 
   it("active mode summary follows canonical session skill state instead of stale root mode files", async () => {

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -202,6 +202,30 @@ describe('session lifecycle manager', () => {
     }
   });
 
+  it('starts a fresh canonical session when a new native SessionStart arrives after an earlier native session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-fresh-'));
+    try {
+      await writeSessionStart(cwd, 'omx-old-session', {
+        nativeSessionId: 'codex-native-old',
+      });
+
+      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-new', {
+        pid: 54321,
+        platform: 'win32',
+      });
+
+      assert.equal(reconciled.session_id, 'codex-native-new');
+      assert.equal(reconciled.native_session_id, 'codex-native-new');
+      assert.equal(reconciled.pid, 54321);
+
+      const persisted = await readSessionState(cwd);
+      assert.equal(persisted?.session_id, 'codex-native-new');
+      assert.equal(persisted?.native_session_id, 'codex-native-new');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to a fresh canonical session when reconciling without authoritative launch state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-fallback-'));
     try {

--- a/src/hooks/agents-overlay.ts
+++ b/src/hooks/agents-overlay.ts
@@ -174,6 +174,9 @@ async function isRalphActive(
   cwd: string,
   sessionId?: string,
 ): Promise<boolean> {
+  if (sessionId && !existsSync(getStateDir(cwd, sessionId))) {
+    return false;
+  }
   const refs = await listModeStateFilesWithScopePreference(cwd, sessionId);
   const ralphRef = refs.find((ref) => ref.mode === "ralph");
   if (!ralphRef) return false;
@@ -201,6 +204,9 @@ async function readActiveModes(
   cwd: string,
   sessionId?: string,
 ): Promise<string> {
+  if (sessionId && !existsSync(getStateDir(cwd, sessionId))) {
+    return "";
+  }
   const refs = await listModeStateFilesWithScopePreference(cwd, sessionId);
   const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
   const canonicalSkills = new Map(
@@ -326,6 +332,9 @@ export async function resolveSessionOrchestrationMode(
 ): Promise<SessionOrchestrationMode> {
   if (activeSkill === "team") return "team";
   if (activeSkill) return "default";
+  if (sessionId && !existsSync(getStateDir(cwd, sessionId))) {
+    return "default";
+  }
 
   const scopedStateDirs = await getReadScopedStateDirs(cwd, sessionId);
   for (const stateDir of scopedStateDirs) {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -327,6 +327,16 @@ export async function reconcileNativeSessionStart(
     });
   }
 
+  const existingNativeSessionId = typeof existing.native_session_id === 'string'
+    ? existing.native_session_id.trim()
+    : '';
+  if (existingNativeSessionId && existingNativeSessionId !== nativeSessionId) {
+    return await writeSessionStart(cwd, nativeSessionId, {
+      ...options,
+      nativeSessionId,
+    });
+  }
+
   const pid = Number.isInteger(options.pid) && options.pid && options.pid > 0
     ? options.pid
     : process.pid;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -324,6 +324,89 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("starts a fresh native session without inheriting stale task-scoped context", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-isolation-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const priorSessionId = "omx-old-session";
+      await mkdir(join(stateDir, "sessions", priorSessionId), { recursive: true });
+      await writeSessionStart(cwd, priorSessionId, {
+        nativeSessionId: "codex-native-old",
+      });
+      await writeJson(join(stateDir, "sessions", priorSessionId, "ralph-state.json"), {
+        active: true,
+        current_phase: "executing",
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [priorSessionId]: {
+            session_id: priorSessionId,
+            leader_thread_id: "leader-1",
+            updated_at: new Date().toISOString(),
+            threads: {
+              "leader-1": {
+                thread_id: "leader-1",
+                kind: "leader",
+                first_seen_at: new Date().toISOString(),
+                last_seen_at: new Date().toISOString(),
+                turn_count: 1,
+              },
+              "sub-1": {
+                thread_id: "sub-1",
+                kind: "subagent",
+                first_seen_at: new Date().toISOString(),
+                last_seen_at: new Date().toISOString(),
+                turn_count: 1,
+              },
+            },
+          },
+        },
+      });
+      await writeFile(
+        join(cwd, ".omx", "notepad.md"),
+        [
+          "# OMX Notepad",
+          "",
+          "## PRIORITY",
+          "Preserve durable project guidance.",
+          "",
+          "## WORKING MEMORY",
+          "[2026-04-06T00:33:44Z] stale UI rework context snapshot .omx/context/ui-rework-plan-01-20260406T003344Z.md",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "codex-native-new",
+        },
+        {
+          cwd,
+          sessionOwnerPid: process.pid,
+        },
+      );
+
+      const sessionState = JSON.parse(
+        await readFile(join(stateDir, "session.json"), "utf-8"),
+      ) as { session_id?: string; native_session_id?: string };
+      assert.equal(sessionState.session_id, "codex-native-new");
+      assert.equal(sessionState.native_session_id, "codex-native-new");
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /\[Priority notes\]/);
+      assert.match(additionalContext, /Preserve durable project guidance/);
+      assert.doesNotMatch(additionalContext, /stale UI rework context snapshot/);
+      assert.doesNotMatch(additionalContext, /\[Subagents\]/);
+      assert.doesNotMatch(additionalContext, /ralph phase: executing/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("resolves the Codex owner from ancestry without mistaking codex-native-hook wrappers for Codex", () => {
     const commands = new Map<number, string>([
       [2100, 'sh -c node "/repo/dist/scripts/codex-native-hook.js"'],

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19,7 +19,7 @@ import {
   writeTeamPhase,
 } from "../team/state.js";
 import { omxNotepadPath, omxProjectMemoryPath } from "../utils/paths.js";
-import { getStateFilePath } from "../mcp/state-paths.js";
+import { getStateFilePath, getStatePath } from "../mcp/state-paths.js";
 import {
   detectKeywords,
   detectPrimaryKeyword,
@@ -387,7 +387,7 @@ async function buildSessionStartContext(
 
   const modeSummaries: string[] = [];
   for (const mode of ["ralph", "autopilot", "ultrawork", "ultraqa", "ralplan", "deep-interview", "team"] as const) {
-    const state = await readModeState(mode, cwd);
+    const state = await readJsonIfExists(getStatePath(mode, cwd, sessionId));
     if (state?.active !== true || !isNonTerminalPhase(state.current_phase)) continue;
     if (mode === "team") {
       const teamName = safeString(state.team_name).trim();
@@ -435,9 +435,22 @@ async function buildSessionStartContext(
   if (existsSync(omxNotepadPath(cwd))) {
     try {
       const notepad = await readFile(omxNotepadPath(cwd), "utf-8");
-      const compact = notepad.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).slice(0, 3).join(" ");
-      if (compact) {
-        sections.push(`[Notepad]\n- ${compact.slice(0, 220)}`);
+      const header = "## PRIORITY";
+      const idx = notepad.indexOf(header);
+      if (idx >= 0) {
+        const nextHeader = notepad.indexOf("\n## ", idx + header.length);
+        const section = (
+          nextHeader < 0
+            ? notepad.slice(idx + header.length)
+            : notepad.slice(idx + header.length, nextHeader)
+        )
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .join(" ");
+        if (section) {
+          sections.push(`[Priority notes]\n- ${section.slice(0, 220)}`);
+        }
       }
     } catch {
       // best effort only


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Fix issue #1624's fresh-session context pollution by keeping new sessions from inheriting stale native session scope, root-fallback active modes, and WORKING MEMORY excerpts from prior tasks.

## Changes

- start a fresh canonical session when native SessionStart arrives with a new native session id after an older native-backed session
- fail closed for fresh explicit-session overlay/orchestration reads until session-scoped state exists, instead of falling back to stale root workflow state
- narrow SessionStart notepad injection to PRIORITY notes and keep stale WORKING MEMORY/subagent/task-phase context out of fresh sessions
- add fresh-session isolation regressions for session reconciliation, overlay startup reads, and SessionStart additionalContext

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] targeted regressions: `node --test --test-name-pattern 'preserves canonical OMX session scope when native SessionStart arrives with a different id|preserves canonical session id while reconciling native SessionStart metadata|starts a fresh canonical session when a new native SessionStart arrives after an earlier native session|does not inherit stale root active modes into a fresh session overlay|does not inherit root skill-active orchestration mode into a fresh session|does not inherit root team skill state into a fresh session without session-scoped state|starts a fresh native session without inheriting stale task-scoped context|includes persisted project-memory summary in SessionStart context' dist/hooks/__tests__/session.test.js dist/hooks/__tests__/agents-overlay.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- [x] `npx biome lint src/hooks/session.ts src/hooks/agents-overlay.ts src/scripts/codex-native-hook.ts src/hooks/__tests__/session.test.ts src/hooks/__tests__/agents-overlay.test.ts src/scripts/__tests__/codex-native-hook.test.ts`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1624
