### PR TITLE
Automate release-body contributor metadata in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -149,6 +151,8 @@ jobs:
     needs: [build-native]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v8
         with:
           path: release-artifacts
@@ -181,11 +185,16 @@ jobs:
           name: native-release-assets
           path: release-assets/*
           if-no-files-found: error
+      - name: Generate release body
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node dist/scripts/generate-release-body.js --template RELEASE_BODY.md --out RELEASE_BODY.generated.md
       - name: Attach native assets to GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           name: ${{ github.ref_name }}
-          body_path: RELEASE_BODY.md
+          body_path: RELEASE_BODY.generated.md
           files: release-assets/*
           fail_on_unmatched_files: true
       - name: Write release summary

--- a/src/scripts/__tests__/generate-release-body.test.ts
+++ b/src/scripts/__tests__/generate-release-body.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import {
+  buildFullChangelogLine,
+  generateReleaseBody,
+  renderContributorsSection,
+  type Contributor,
+} from '../generate-release-body.js';
+
+function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = {}): string {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return String(result.stdout || '').trim();
+}
+
+const TEMPLATE = `# oh-my-codex v0.0.0
+
+## Summary
+
+Custom summary that must stay intact.
+
+## Fixed
+
+- Keep this handwritten section.
+
+## Verification
+
+- npm test
+
+## Contributors
+
+Outdated contributor text.
+
+**Full Changelog**: [\`v0.0.0...v0.0.1\`](https://github.com/example/compare/v0.0.0...v0.0.1)
+`;
+
+describe('generate-release-body', () => {
+  it('preserves custom sections while refreshing contributors and compare metadata from git', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-generate-release-body-'));
+    try {
+      git(root, ['init']);
+      git(root, ['config', 'user.name', 'Release Bot']);
+      git(root, ['config', 'user.email', 'release@example.com']);
+      git(root, ['remote', 'add', 'origin', 'https://github.com/example/oh-my-codex.git']);
+
+      await writeFile(join(root, 'RELEASE_BODY.md'), TEMPLATE);
+      await writeFile(join(root, 'notes.txt'), 'base\n');
+      git(root, ['add', '.']);
+      git(root, ['commit', '-m', 'base']);
+      git(root, ['tag', 'v0.12.0']);
+
+      await writeFile(join(root, 'notes.txt'), 'alice\n');
+      git(root, ['add', 'notes.txt']);
+      git(root, ['commit', '-m', 'alice change'], { GIT_AUTHOR_NAME: 'Alice Example', GIT_AUTHOR_EMAIL: 'alice@example.com' });
+
+      await writeFile(join(root, 'notes.txt'), 'bob\n');
+      git(root, ['add', 'notes.txt']);
+      git(root, ['commit', '-m', 'bob change'], { GIT_AUTHOR_NAME: 'Bob Example', GIT_AUTHOR_EMAIL: 'bob@example.com' });
+      git(root, ['tag', 'v0.13.0']);
+
+      await generateReleaseBody({
+        cwd: root,
+        templatePath: 'RELEASE_BODY.md',
+        outPath: 'RELEASE_BODY.generated.md',
+        currentTag: 'v0.13.0',
+      });
+
+      const generated = await readFile(join(root, 'RELEASE_BODY.generated.md'), 'utf-8');
+      assert.match(generated, /^# oh-my-codex v0.13.0/m);
+      assert.match(generated, /Custom summary that must stay intact\./);
+      assert.match(generated, /Keep this handwritten section\./);
+      assert.match(generated, /## Contributors\n\nThanks to Alice Example and Bob Example for contributing to this release\./);
+      assert.match(generated, /\*\*Full Changelog\*\*: \[`v0\.12\.0\.\.\.v0\.13\.0`\]\(https:\/\/github\.com\/example\/oh-my-codex\/compare\/v0\.12\.0\.\.\.v0\.13\.0\)/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers GitHub contributor handles when compare metadata is available', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-generate-release-body-gh-'));
+    try {
+      await writeFile(join(root, 'RELEASE_BODY.md'), TEMPLATE);
+      const originalFetch = global.fetch;
+      global.fetch = (async () => new Response(JSON.stringify({
+        commits: [
+          { author: { login: 'alice', html_url: 'https://github.com/alice' } },
+          { author: { login: 'bob', html_url: 'https://github.com/bob' } },
+          { author: { login: 'alice', html_url: 'https://github.com/alice' } },
+        ],
+      }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+
+      try {
+        await generateReleaseBody({
+          cwd: root,
+          templatePath: 'RELEASE_BODY.md',
+          outPath: 'RELEASE_BODY.generated.md',
+          currentTag: 'v0.13.1',
+          previousTag: 'v0.13.0',
+          repo: 'example/oh-my-codex',
+          githubToken: 'test-token',
+        });
+      } finally {
+        global.fetch = originalFetch;
+      }
+
+      const generated = await readFile(join(root, 'RELEASE_BODY.generated.md'), 'utf-8');
+      assert.match(generated, /Thanks to \[@alice\]\(https:\/\/github\.com\/alice\) and \[@bob\]\(https:\/\/github\.com\/bob\) for contributing to this release\./);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+
+  it('fails validation when the template is missing required metadata anchors', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-generate-release-body-invalid-'));
+    try {
+      await writeFile(join(root, 'RELEASE_BODY.md'), `# oh-my-codex v0.0.0
+
+## Summary
+
+Missing required sections.
+`);
+      await assert.rejects(
+        generateReleaseBody({
+          cwd: root,
+          templatePath: 'RELEASE_BODY.md',
+          outPath: 'RELEASE_BODY.generated.md',
+          currentTag: 'v0.13.1',
+          previousTag: 'v0.13.0',
+          repo: 'example/oh-my-codex',
+        }),
+        /missing section: ## Contributors|missing the Full Changelog line/,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('renders contributor and changelog helpers for edge cases', () => {
+    const contributors: Contributor[] = [];
+    assert.equal(renderContributorsSection(contributors), 'Thanks to the contributors who made this release possible.');
+    assert.equal(
+      buildFullChangelogLine('example/oh-my-codex', 'v0.13.1', 'v0.13.0'),
+      '**Full Changelog**: [`v0.13.0...v0.13.1`](https://github.com/example/oh-my-codex/compare/v0.13.0...v0.13.1)',
+    );
+    assert.equal(
+      buildFullChangelogLine('example/oh-my-codex', 'v0.1.0'),
+      '**Full Changelog**: [`v0.1.0`](https://github.com/example/oh-my-codex/releases/tag/v0.1.0)',
+    );
+  });
+});

--- a/src/scripts/__tests__/generate-release-body.test.ts
+++ b/src/scripts/__tests__/generate-release-body.test.ts
@@ -45,6 +45,7 @@ Outdated contributor text.
 describe('generate-release-body', () => {
   it('preserves custom sections while refreshing contributors and compare metadata from git', async () => {
     const root = await mkdtemp(join(tmpdir(), 'omx-generate-release-body-'));
+    const originalGitHubRepository = process.env.GITHUB_REPOSITORY;
     try {
       git(root, ['init']);
       git(root, ['config', 'user.name', 'Release Bot']);
@@ -66,6 +67,7 @@ describe('generate-release-body', () => {
       git(root, ['commit', '-m', 'bob change'], { GIT_AUTHOR_NAME: 'Bob Example', GIT_AUTHOR_EMAIL: 'bob@example.com' });
       git(root, ['tag', 'v0.13.0']);
 
+      delete process.env.GITHUB_REPOSITORY;
       await generateReleaseBody({
         cwd: root,
         templatePath: 'RELEASE_BODY.md',
@@ -80,6 +82,11 @@ describe('generate-release-body', () => {
       assert.match(generated, /## Contributors\n\nThanks to Alice Example and Bob Example for contributing to this release\./);
       assert.match(generated, /\*\*Full Changelog\*\*: \[`v0\.12\.0\.\.\.v0\.13\.0`\]\(https:\/\/github\.com\/example\/oh-my-codex\/compare\/v0\.12\.0\.\.\.v0\.13\.0\)/);
     } finally {
+      if (originalGitHubRepository === undefined) {
+        delete process.env.GITHUB_REPOSITORY;
+      } else {
+        process.env.GITHUB_REPOSITORY = originalGitHubRepository;
+      }
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/src/scripts/generate-release-body.ts
+++ b/src/scripts/generate-release-body.ts
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+export interface Contributor {
+  displayName: string;
+  login?: string;
+  url?: string;
+}
+
+interface CompareCommit {
+  author?: {
+    login?: string;
+    html_url?: string;
+  } | null;
+  commit?: {
+    author?: {
+      name?: string;
+    } | null;
+  } | null;
+}
+
+interface CompareResponse {
+  commits?: CompareCommit[];
+}
+
+interface GenerateReleaseBodyOptions {
+  templatePath: string;
+  outPath: string;
+  currentTag?: string;
+  previousTag?: string;
+  repo?: string;
+  githubToken?: string;
+  cwd?: string;
+}
+
+function usage(): never {
+  console.error('Usage: node scripts/generate-release-body.mjs --template <path> --out <path> [--current-tag <tag>] [--previous-tag <tag>] [--repo <owner/name>]');
+  process.exit(1);
+}
+
+function arg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  return process.argv[index + 1];
+}
+
+function runGit(args: string[], cwd: string, allowFailure = false): string {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  });
+  if (result.status !== 0) {
+    if (allowFailure) return '';
+    throw new Error(`git ${args.join(' ')} failed: ${(result.stderr || result.stdout || '').trim()}`.trim());
+  }
+  return String(result.stdout || '').trim();
+}
+
+function resolveRepositoryFromRemote(cwd: string): string | undefined {
+  const remote = runGit(['config', '--get', 'remote.origin.url'], cwd, true);
+  if (!remote) return undefined;
+  const httpsMatch = remote.match(/github\.com[:/](.+?)(?:\.git)?$/);
+  return httpsMatch?.[1];
+}
+
+export function resolveCurrentTag(cwd: string, explicit?: string): string {
+  if (explicit) return explicit;
+  if (process.env.GITHUB_REF_NAME) return process.env.GITHUB_REF_NAME;
+  const described = runGit(['describe', '--tags', '--exact-match'], cwd, true);
+  if (described) return described;
+  throw new Error('unable to determine current release tag; pass --current-tag or set GITHUB_REF_NAME');
+}
+
+export function resolvePreviousTag(cwd: string, currentTag: string, explicit?: string): string | undefined {
+  if (explicit) return explicit;
+  const tags = runGit(['tag', '--list', 'v*', '--sort=-v:refname'], cwd, true)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (tags.length === 0) return undefined;
+  const currentIndex = tags.indexOf(currentTag);
+  if (currentIndex >= 0) return tags.slice(currentIndex + 1).find(Boolean);
+  return tags.find((tag) => tag !== currentTag);
+}
+
+function normalizeContributors(contributors: Contributor[]): Contributor[] {
+  const deduped = new Map<string, Contributor>();
+  for (const contributor of contributors) {
+    const login = contributor.login?.trim();
+    const displayName = contributor.displayName.trim();
+    if (!displayName && !login) continue;
+    const key = (login || displayName).toLowerCase();
+    if (!deduped.has(key)) {
+      deduped.set(key, {
+        displayName: displayName || `@${login}`,
+        ...(login ? { login } : {}),
+        ...(contributor.url ? { url: contributor.url } : {}),
+      });
+    }
+  }
+  return [...deduped.values()].sort((left, right) => {
+    const leftKey = (left.login || left.displayName).toLowerCase();
+    const rightKey = (right.login || right.displayName).toLowerCase();
+    return leftKey.localeCompare(rightKey);
+  });
+}
+
+export function formatContributor(contributor: Contributor): string {
+  if (contributor.login && contributor.url) {
+    return `[@${contributor.login}](${contributor.url})`;
+  }
+  if (contributor.login) {
+    return `@${contributor.login}`;
+  }
+  if (contributor.url) {
+    return `[${contributor.displayName}](${contributor.url})`;
+  }
+  return contributor.displayName;
+}
+
+function joinHumanList(values: string[]): string {
+  if (values.length === 0) return 'the contributors';
+  if (values.length === 1) return values[0]!;
+  if (values.length === 2) return `${values[0]} and ${values[1]}`;
+  return `${values.slice(0, -1).join(', ')}, and ${values.at(-1)}`;
+}
+
+export function renderContributorsSection(contributors: Contributor[]): string {
+  const normalized = normalizeContributors(contributors);
+  if (normalized.length === 0) {
+    return 'Thanks to the contributors who made this release possible.';
+  }
+  return `Thanks to ${joinHumanList(normalized.map((contributor) => formatContributor(contributor)))} for contributing to this release.`;
+}
+
+export function buildFullChangelogLine(repo: string, currentTag: string, previousTag?: string): string {
+  if (!repo) {
+    throw new Error('unable to determine GitHub repository; pass --repo or set GITHUB_REPOSITORY');
+  }
+  if (previousTag) {
+    return `**Full Changelog**: [\`${previousTag}...${currentTag}\`](https://github.com/${repo}/compare/${previousTag}...${currentTag})`;
+  }
+  return `**Full Changelog**: [\`${currentTag}\`](https://github.com/${repo}/releases/tag/${currentTag})`;
+}
+
+function replaceTitle(markdown: string, currentTag: string): string {
+  if (!/^#\s+/m.test(markdown)) {
+    throw new Error('release body template is missing a top-level title');
+  }
+  return markdown.replace(/^#\s+.*$/m, `# oh-my-codex ${currentTag}`);
+}
+
+function findSectionEnd(lines: string[], startIndex: number): number {
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    if (/^##\s+/.test(lines[index] ?? '')) return index;
+    if (/^\*\*Full Changelog\*\*:/.test(lines[index] ?? '')) return index;
+  }
+  return lines.length;
+}
+
+export function replaceSectionBody(markdown: string, heading: string, body: string): string {
+  const lines = markdown.split(/\r?\n/);
+  const headingLine = `## ${heading}`;
+  const startIndex = lines.findIndex((line) => line.trim() === headingLine);
+  if (startIndex === -1) {
+    throw new Error(`release body template is missing section: ${headingLine}`);
+  }
+  const endIndex = findSectionEnd(lines, startIndex);
+  lines.splice(startIndex + 1, endIndex - startIndex - 1, '', ...body.split('\n'), '');
+  return `${lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd()}\n`;
+}
+
+export function replaceFullChangelogLine(markdown: string, fullChangelogLine: string): string {
+  const lines = markdown.split(/\r?\n/);
+  const lineIndex = lines.findIndex((line) => /^\*\*Full Changelog\*\*:/.test(line));
+  if (lineIndex === -1) {
+    throw new Error('release body template is missing the Full Changelog line');
+  }
+  lines[lineIndex] = fullChangelogLine;
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+function parseShortlogLine(line: string): Contributor | undefined {
+  const match = line.match(/^\s*\d+\s+(.+?)(?:\s+<[^>]+>)?$/);
+  if (!match) return undefined;
+  const displayName = match[1]?.trim();
+  if (!displayName) return undefined;
+  return { displayName };
+}
+
+export function getGitContributors(cwd: string, currentTag: string, previousTag?: string): Contributor[] {
+  const range = previousTag ? `${previousTag}..${currentTag}` : currentTag;
+  const shortlog = runGit(['shortlog', '-sne', range], cwd, true);
+  if (!shortlog) return [];
+  return normalizeContributors(shortlog.split(/\r?\n/).map((line) => parseShortlogLine(line)).filter((value): value is Contributor => Boolean(value)));
+}
+
+export async function getGitHubCompareContributors(
+  repo: string,
+  currentTag: string,
+  previousTag: string,
+  githubToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Contributor[]> {
+  const response = await fetchImpl(`https://api.github.com/repos/${repo}/compare/${previousTag}...${currentTag}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${githubToken}`,
+      'User-Agent': 'oh-my-codex-release-body-generator',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub compare API failed (${response.status})`);
+  }
+  const payload = await response.json() as CompareResponse;
+  const contributors = (payload.commits ?? []).map((commit) => {
+    if (commit.author?.login) {
+      return {
+        displayName: `@${commit.author.login}`,
+        login: commit.author.login,
+        ...(commit.author.html_url ? { url: commit.author.html_url } : {}),
+      } satisfies Contributor;
+    }
+    const name = commit.commit?.author?.name?.trim();
+    return name ? { displayName: name } satisfies Contributor : undefined;
+  }).filter((value): value is Contributor => Boolean(value));
+  return normalizeContributors(contributors);
+}
+
+export async function resolveContributors(options: {
+  cwd: string;
+  repo?: string;
+  currentTag: string;
+  previousTag?: string;
+  githubToken?: string;
+}): Promise<Contributor[]> {
+  const { cwd, repo, currentTag, previousTag, githubToken } = options;
+  if (repo && previousTag && githubToken) {
+    try {
+      return await getGitHubCompareContributors(repo, currentTag, previousTag, githubToken);
+    } catch (error) {
+      console.error(`[generate-release-body] falling back to git shortlog: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return getGitContributors(cwd, currentTag, previousTag);
+}
+
+export async function generateReleaseBody(options: GenerateReleaseBodyOptions): Promise<string> {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const templatePath = resolve(cwd, options.templatePath);
+  const outPath = resolve(cwd, options.outPath);
+  const currentTag = resolveCurrentTag(cwd, options.currentTag);
+  const previousTag = resolvePreviousTag(cwd, currentTag, options.previousTag);
+  const repo = options.repo || process.env.GITHUB_REPOSITORY || resolveRepositoryFromRemote(cwd);
+  const contributors = await resolveContributors({
+    cwd,
+    repo,
+    currentTag,
+    previousTag,
+    githubToken: options.githubToken || process.env.GITHUB_TOKEN,
+  });
+
+  let markdown = readFileSync(templatePath, 'utf-8');
+  markdown = replaceTitle(markdown, currentTag);
+  markdown = replaceSectionBody(markdown, 'Contributors', renderContributorsSection(contributors));
+  markdown = replaceFullChangelogLine(markdown, buildFullChangelogLine(repo || '', currentTag, previousTag));
+  writeFileSync(outPath, markdown);
+  return markdown;
+}
+
+async function main(): Promise<void> {
+  const templatePath = arg('--template');
+  const outPath = arg('--out');
+  if (!templatePath || !outPath) usage();
+  await generateReleaseBody({
+    templatePath,
+    outPath,
+    currentTag: arg('--current-tag'),
+    previousTag: arg('--previous-tag'),
+    repo: arg('--repo'),
+  });
+  console.log(resolve(process.cwd(), outPath));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/src/verification/__tests__/explore-harness-release-workflow.test.ts
+++ b/src/verification/__tests__/explore-harness-release-workflow.test.ts
@@ -31,6 +31,7 @@ describe('native release workflow', () => {
     assert.match(workflow, /actions\/upload-artifact@v4/);
     assert.match(workflow, /actions\/download-artifact@v8/);
     assert.match(workflow, /softprops\/action-gh-release@v3/);
+    assert.match(workflow, /generate-release-body\.js/);
     assert.match(workflow, /omx-explore-harness/);
     assert.match(workflow, /omx-sparkshell/);
     assert.match(workflow, /native-release-manifest\.json/);
@@ -52,6 +53,8 @@ describe('native release workflow', () => {
 
     assert.match(workflow, /verify-version-sync:[\s\S]*Verify version sync against workspace crates[\s\S]*node --input-type=module/);
     assert.match(workflow, /publish-native-assets:[\s\S]*npm run build[\s\S]*node dist\/scripts\/generate-native-release-manifest\.js/);
+    assert.match(workflow, /publish-native-assets:[\s\S]*Generate release body[\s\S]*node dist\/scripts\/generate-release-body\.js --template RELEASE_BODY\.md --out RELEASE_BODY\.generated\.md/);
+    assert.match(workflow, /body_path:\s*RELEASE_BODY\.generated\.md/);
     assert.match(workflow, /smoke-verify-native:[\s\S]*npm run build[\s\S]*node dist\/scripts\/verify-native-release-assets\.js/);
     assert.match(workflow, /smoke-packed-install:[\s\S]*npm run build[\s\S]*Smoke test packed install boot \+ core commands[\s\S]*npm run smoke:packed-install/);
     assert.match(workflow, /publish-npm:[\s\S]*Verify version sync against workspace crates[\s\S]*npm pack --dry-run/);


### PR DESCRIPTION
## Summary
- generate a release body artifact from `RELEASE_BODY.md` so CI refreshes bounded metadata instead of uploading the template verbatim
- derive `## Contributors` and `**Full Changelog**` metadata from the active release range while preserving the repo's custom release sections
- verify the workflow wiring and generator behavior with focused tests

## Testing
- npm run build
- node --test dist/scripts/__tests__/generate-release-body.test.js dist/verification/__tests__/explore-harness-release-workflow.test.js
- npx biome lint .github/workflows/release.yml src/scripts/generate-release-body.ts src/scripts/__tests__/generate-release-body.test.ts src/verification/__tests__/explore-harness-release-workflow.test.ts

## Issue
- closes #1623
