### PR TITLE
fix: quote processSpec.command in worker shell startup

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1077,7 +1077,7 @@ describe('buildWorkerStartupCommand', () => {
 
       assert.match(cmd, new RegExp(escapeRegExp(`OMX_LEADER_NODE_PATH=${nodePath}`)));
       assert.match(cmd, new RegExp(escapeRegExp(`OMX_LEADER_CLI_PATH=${codexPath}`)));
-      assert.match(cmd, new RegExp(escapeRegExp(`export PATH='\\''${fakeBin}'\\'':$PATH; exec ${codexPath}`)));
+      assert.match(cmd, new RegExp(escapeRegExp(`export PATH='\\''${fakeBin}'\\'':$PATH; exec '\\''${codexPath}'\\''`)));
       assert.doesNotMatch(cmd, /export PATH='\\''node'\\'':\$PATH/);
       assert.doesNotMatch(cmd, / exec codex(?:\s|')/);
     } finally {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -823,9 +823,10 @@ export function buildWorkerStartupCommand(
   }
 
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
-  const pathPrefix = leaderNodeDir ? `export PATH='${leaderNodeDir}':$PATH; ` : '';
+  const pathPrefix = leaderNodeDir ? `export PATH=${shellQuoteSingle(leaderNodeDir)}:$PATH; ` : '';
   const quotedArgs = processSpec.args.map(shellQuoteSingle).join(' ');
-  const cliInvocation = quotedArgs.length > 0 ? `exec ${processSpec.command} ${quotedArgs}` : `exec ${processSpec.command}`;
+  const quotedCommand = shellQuoteSingle(processSpec.command);
+  const cliInvocation = quotedArgs.length > 0 ? `exec ${quotedCommand} ${quotedArgs}` : `exec ${quotedCommand}`;
   const rcPrefix = launchSpec.rcFile ? `if [ -f ${launchSpec.rcFile} ]; then source ${launchSpec.rcFile}; fi; ` : '';
   const inner = `${rcPrefix}${pathPrefix}${cliInvocation}`;
   const envParts = Object.entries(startupEnv).map(([key, value]) => `${key}=${value}`);


### PR DESCRIPTION
## Summary
- apply `shellQuoteSingle()` to `processSpec.command` in `buildWorkerStartupCommand`, matching the quoting already applied to `processSpec.args` on the preceding line
- replace the manual single-quote template for `leaderNodeDir` with `shellQuoteSingle()` so paths containing embedded single-quote characters are escaped correctly
- update the POSIX leader path regression test to expect the quoted command format

## Root cause

`buildWorkerStartupCommand` (line 828) interpolates `processSpec.command` directly into a POSIX shell string without `shellQuoteSingle()`:

```typescript
// args are correctly quoted
const quotedArgs = processSpec.args.map(shellQuoteSingle).join(' ');
// command is NOT quoted
const cliInvocation = `exec ${processSpec.command} ${quotedArgs}`;
```

If the resolved binary path contains spaces or shell metacharacters (e.g. via `OMX_LEADER_NODE_PATH` pointing to a directory with spaces), the resulting `exec` invocation can split or inject into the worker shell.

Same file line 826: `leaderNodeDir` uses manual template quoting (`'${leaderNodeDir}'`) that does not escape embedded single-quote characters, which can break out of the quote boundary.

## Changes

- `src/team/tmux-session.ts` — `buildWorkerStartupCommand`:
  - Line 826: replace `export PATH='${leaderNodeDir}'` with `export PATH=${shellQuoteSingle(leaderNodeDir)}`
  - Line 828: introduce `quotedCommand = shellQuoteSingle(processSpec.command)` and use it in the `exec` invocation
- `src/team/__tests__/tmux-session.test.ts`:
  - Update "resolves POSIX leader paths" assertion regex to expect the quoted command format (`'\\''...codex'\\''` instead of bare `...codex`)

## Testing

```bash
npm run build
node --test dist/team/__tests__/tmux-session.test.js
# 167 passed, 0 failed
npx biome lint src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts
```

Closes #1640