### PR TITLE
fix: preserve Unicode characters in wiki titleToSlug

### DIFF
--- a/src/wiki/__tests__/slug-nonascii.test.ts
+++ b/src/wiki/__tests__/slug-nonascii.test.ts
@@ -2,17 +2,21 @@ import { describe, it } from 'node:test';
 import { expect } from './test-helpers.js';
 import { titleToSlug } from '../storage.js';
 
-describe('titleToSlug non-ASCII fallback', () => {
+describe('titleToSlug non-ASCII support', () => {
   it('Latin titles unchanged', () => {
     expect(titleToSlug('Auth Architecture')).toBe('auth-architecture.md');
   });
 
-  it('CJK title must not produce bare .md', () => {
-    expect(titleToSlug('日本語ドキュメント')).toMatch(/^page-[0-9a-f]{8}\.md$/);
+  it('CJK title preserves characters in slug', () => {
+    expect(titleToSlug('日本語ドキュメント')).toBe('日本語ドキュメント.md');
   });
 
-  it('Korean title must not produce bare .md', () => {
-    expect(titleToSlug('인증 아키텍처')).toMatch(/^page-[0-9a-f]{8}\.md$/);
+  it('Korean title preserves characters in slug', () => {
+    expect(titleToSlug('인증 아키텍처')).toBe('인증-아키텍처.md');
+  });
+
+  it('mixed Latin and CJK preserves both', () => {
+    expect(titleToSlug('My 프로젝트 Setup')).toBe('my-프로젝트-setup.md');
   });
 
   it('empty string must not produce bare .md', () => {
@@ -25,5 +29,9 @@ describe('titleToSlug non-ASCII fallback', () => {
 
   it('different CJK titles produce different slugs', () => {
     expect(titleToSlug('日本語')).not.toBe(titleToSlug('中文'));
+  });
+
+  it('accented Latin characters are preserved', () => {
+    expect(titleToSlug('café résumé')).toBe('café-résumé.md');
   });
 });

--- a/src/wiki/storage.ts
+++ b/src/wiki/storage.ts
@@ -340,7 +340,8 @@ export function appendLog(root: string, entry: WikiLogEntry): void {
 export function titleToSlug(title: string): string {
   const base = title
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
+    .normalize('NFC')
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
     .replace(/^-|-$/g, '')
     .slice(0, 64);
 


### PR DESCRIPTION
## Summary
- replace the ASCII-only slug regex with a Unicode-property-aware alternative so CJK, Cyrillic, Arabic, and accented Latin characters are retained in wiki page filenames
- add NFC normalization to ensure consistent slug output across platforms
- update non-ASCII slug tests to verify character preservation instead of hash fallback

## Root cause

`titleToSlug` uses `/[^a-z0-9]+/g` which strips every non-ASCII character. For CJK input the entire base becomes empty, falling through to a numeric hash that produces opaque filenames like `page-0ad85f66.md`. Mixed titles silently drop the non-ASCII portion.

## Changes

- `src/wiki/storage.ts` — `titleToSlug`:
  - Add `.normalize('NFC')` to canonicalize composed Unicode forms
  - Replace `/[^a-z0-9]+/g` with `/[^\p{L}\p{N}]+/gu` (Unicode letter + digit aware)

- `src/wiki/__tests__/slug-nonascii.test.ts`:
  - CJK/Korean tests now assert readable slug output instead of hash fallback
  - Added mixed Latin+CJK and accented Latin test cases

## Before / After

| Title | Before | After |
|-------|--------|-------|
| `프로젝트 설정 가이드` | `page-0ad85f66.md` | `프로젝트-설정-가이드.md` |
| `日本語ドキュメント` | `page-7e1bdb55.md` | `日本語ドキュメント.md` |
| `My 프로젝트 Setup` | `my-setup.md` | `my-프로젝트-setup.md` |
| `Auth Architecture` | `auth-architecture.md` | `auth-architecture.md` |

## Testing

```bash
npm run build
node --test dist/wiki/__tests__/slug-nonascii.test.js dist/wiki/__tests__/storage.test.js
# 37 passed, 0 failed
```

Closes #1641