### PR TITLE
Fix issue #1635 stale leader HUD team startup phase

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -461,6 +461,40 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('prefers canonical team phase over stale team detail current_phase', async () => {
+    await withTempRepo('omx-hud-canonical-team-phase-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-team-phase';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      const teamDir = join(rootStateDir, 'team', 'alpha');
+      await mkdir(sessionDir, { recursive: true });
+      await mkdir(teamDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'team',
+        phase: 'starting',
+        session_id: sessionId,
+        active_skills: [{ skill: 'team', phase: 'starting', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'alpha',
+        current_phase: 'starting',
+      }));
+      await writeFile(join(teamDir, 'phase.json'), JSON.stringify({
+        current_phase: 'team-exec',
+        max_fix_attempts: 3,
+        current_fix_attempt: 0,
+        transitions: [],
+        updated_at: new Date().toISOString(),
+      }));
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.team, { active: true, team_name: 'alpha', current_phase: 'team-exec' });
+    });
+  });
+
   it('surfaces approved combined workflow state from canonical multi-skill data', async () => {
     await withTempRepo('omx-hud-canonical-combined-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -14,6 +14,7 @@ import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import type { RuntimeSnapshot } from '../runtime/bridge.js';
 import { getReadScopedStateFilePaths, getReadScopedStatePaths, readCurrentSessionId } from '../mcp/state-paths.js';
+import { teamReadPhase as readTeamPhase } from '../team/team-ops.js';
 import { readUsableSessionState } from '../hooks/session.js';
 import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
 import type {
@@ -349,6 +350,26 @@ function mergePhase<T extends { active?: boolean; current_phase?: string }>(
   return { active: true, current_phase: canonicalPhase } as T;
 }
 
+async function readCanonicalTeamPhase(cwd: string, teamDetail: TeamStateForHud | null): Promise<string | undefined> {
+  const teamName = sanitizeOptionalString(teamDetail?.team_name);
+  if (!teamName) return undefined;
+  const phaseState = await readTeamPhase(teamName, cwd).catch(() => null);
+  return sanitizeOptionalString(phaseState?.current_phase);
+}
+
+function mergeTeamPhase(
+  detail: TeamStateForHud | null,
+  canonicalSkillPhase?: string,
+  canonicalTeamPhase?: string,
+): TeamStateForHud | null {
+  const canonicalPhase = canonicalTeamPhase || canonicalSkillPhase;
+  if (detail?.active === true) {
+    return canonicalPhase ? { ...detail, current_phase: canonicalPhase } : detail;
+  }
+  if (!canonicalPhase) return null;
+  return { active: true, current_phase: canonicalPhase };
+}
+
 /** Read all state files and build the full render context */
 export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFAULT_HUD_CONFIG): Promise<HudRenderContext> {
   const version = readVersion();
@@ -412,8 +433,13 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
   const ultraqa = canonicalSkills.has('ultraqa') || useCompatibilityFallback
     ? mergePhase(ultraqaDetail?.active === true ? ultraqaDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultraqa'))
     : null;
+  const canonicalTeamPhase = await readCanonicalTeamPhase(cwd, teamDetail?.active === true ? teamDetail : null);
   const team = canonicalSkills.has('team') || useCompatibilityFallback
-    ? mergePhase(teamDetail?.active === true ? teamDetail : null, canonicalPhaseForSkill(canonicalSkills, 'team'))
+    ? mergeTeamPhase(
+      teamDetail?.active === true ? teamDetail : null,
+      canonicalPhaseForSkill(canonicalSkills, 'team'),
+      canonicalTeamPhase,
+    )
     : null;
   const autoresearch = canonicalSkills.has('autoresearch') || useCompatibilityFallback
     ? mergePhase(


### PR DESCRIPTION
## Summary
- fix issue #1635 by making HUD team state prefer the canonical `team/<name>/phase.json` phase over stale session team detail
- add a regression test covering the stale `starting` detail vs canonical `team-exec` phase case

## Root cause
The leader UI/HUD can keep rendering the team as `starting` because `team-state.json` is initialized early and may lag while workers continue booting, and the HUD previously trusted that stale team detail. The durable canonical team phase is already written in `team/<name>/phase.json`, but HUD state assembly did not consult it for active team rendering.

## Verification
- `npm run build`
- `node --test dist/hud/__tests__/state.test.js`
- `npm run lint -- src/hud/state.ts src/hud/__tests__/state.test.ts`

Closes #1635.
