### PR TITLE
fix(hud): prevent shell injection and regex injection in git helpers

### DIFF
--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -6,7 +6,7 @@
 
 import { readFile } from 'fs/promises';
 import { readFileSync } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { omxStateDir } from '../utils/paths.js';
@@ -216,8 +216,9 @@ function runGit(cwd: string, args: string[]): string | null {
           const config = readGitLayoutFile(gitLayout.gitDir, 'config')
             ?? readGitLayoutFile(gitLayout.commonDir, 'config');
           if (config) {
+            const escaped = remoteName.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
             const re = new RegExp(
-              `\\[remote "${remoteName}"\\][\\s\\S]*?url\\s*=\\s*(.+)`,
+              `\\[remote "${escaped}"\\][\\s\\S]*?url\\s*=\\s*(.+)`,
               'm',
             );
             const m = config.match(re);
@@ -248,7 +249,7 @@ function runGit(cwd: string, args: string[]): string | null {
 
 function runGitExec(cwd: string, args: string[]): string | null {
   try {
-    return execSync(`git ${args.join(' ')}`, {
+    return execFileSync('git', args, {
       cwd,
       encoding: 'utf-8',
       timeout: 2000,


### PR DESCRIPTION
## Summary

- replace `execSync` string interpolation with `execFileSync` array form in `runGitExec` to prevent shell metacharacter injection via crafted `.git/config` remote names
- escape `remoteName` before `RegExp` interpolation in the Windows direct-read code path to prevent regex injection
- no functional change: `execFileSync('git', args)` produces identical output to `execSync(\`git \${args.join(' ')}\`)` for all valid git arguments

Fixes #1649

## Detail

`runGitExec` previously joined the args array into a shell string:

```typescript
execSync(`git ${args.join(' ')}`, { cwd, ... })
```

This passes through `sh -c` (or `cmd /c` on Windows), so shell metacharacters in any element of `args` are interpreted. The call chain `readGitRemoteUrl → runGit → runGitExec` can pass `remoteName` sourced from `.git/config`, which is attacker-controlled in a malicious repository.

The fix switches to `execFileSync('git', args, ...)` which invokes `git` directly without a shell, matching the pattern already used in `leader-activity.ts` and other spawn sites in this project.

The regex injection fix escapes `remoteName` before interpolating it into `new RegExp(...)`, preventing crafted remote names from altering regex semantics or triggering ReDoS.

## Test plan

- [x] `npm run build` passes (tsc clean)
- [ ] Existing HUD tests pass (no HUD behavior change — only the process invocation method changes)
- [ ] Manual: open a repository with a normal remote — HUD displays repo name correctly