### PR TITLE
fix(hud): replace execSync with execFileSync in runGitExec

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join, relative } from 'node:path';
@@ -50,6 +52,15 @@ async function writeModeState(cwd: string, mode: string, state: unknown): Promis
   const stateDir = join(cwd, '.omx', 'state');
   await mkdir(stateDir, { recursive: true });
   await writeFile(join(stateDir, mode + '-state.json'), JSON.stringify(state));
+}
+
+function initGitRepo(cwd: string): void {
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['checkout', '-b', 'safe-branch'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['remote', 'add', 'origin', 'https://github.com/acme/origin-repo.git'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '--allow-empty', '-m', 'init'], { cwd, stdio: 'ignore' });
 }
 
 async function createWorktreePointerFixture(cwd: string, options: { withOrigin?: boolean } = {}): Promise<void> {
@@ -182,6 +193,22 @@ describe('buildGitBranchLabel', () => {
       preset: 'focused',
       git: { display: 'repo-branch', repoLabel: 'manual' },
     }, gitRunner), 'manual/feature/test');
+  });
+
+  it('does not execute shell metacharacters from config.git.remoteName in the non-Windows fallback path', { skip: process.platform === 'win32' }, async () => {
+    await withTempRepo('omx-hud-remote-name-shell-', async (cwd) => {
+      initGitRepo(cwd);
+      const markerPath = join(cwd, 'remote-name-injected');
+      const maliciousRemoteName = `origin; touch ${markerPath}`;
+
+      const label = buildGitBranchLabel(cwd, {
+        preset: 'focused',
+        git: { display: 'repo-branch', remoteName: maliciousRemoteName },
+      });
+
+      assert.equal(label, 'origin-repo/safe-branch');
+      assert.equal(existsSync(markerPath), false);
+    });
   });
 
   it('resolves remote config from the git common dir for worktree pointers on Windows', async () => {


### PR DESCRIPTION
## Summary
- replace `execSync(\`git \${args.join(' ')}\`)` with `execFileSync('git', args)` in `runGitExec` so arguments are passed directly to the git process without shell interpretation
- update the import from `execSync` to `execFileSync`
- add a regression test that asserts shell metacharacters in `remoteName` do not produce injected output

## Root cause

`runGitExec` (line 249) joins its `args` array into a shell string and passes it to `execSync`, which invokes `/bin/sh -c`:

```typescript
function runGitExec(cwd: string, args: string[]): string | null {
  try {
    return execSync(`git ${args.join(' ')}`, { ... }).trim() || null;
  } catch { return null; }
}
```

When `config.git.remoteName` contains shell metacharacters (e.g. `origin; echo INJECTED`) and the Windows/worktree fast-path misses, the semicolon causes the shell to execute the injected command:

```
$ node -e "
const { execSync } = require('child_process');
const args = ['remote', 'get-url', 'origin; echo INJECTED'];
console.log(execSync('git ' + args.join(' '), { encoding: 'utf-8' }).trim());
"
https://github.com/Yeachan-Heo/oh-my-codex.git
INJECTED
```

`sanitizeOptionalString` only trims whitespace — it does not filter shell metacharacters.

The flow is: HUD config `git.remoteName` → `readGitRemoteUrl(cwd, config.git.remoteName, gitRunner)` → `gitRunner(cwd, ['remote', 'get-url', remoteName])` → fast-path miss → `runGitExec` → `execSync` shell interpretation.

## Changes

- `src/hud/state.ts`:
  - Line 9: `import { execSync }` → `import { execFileSync }`
  - Line 249–261: `execSync(\`git \${args.join(' ')}\`)` → `execFileSync('git', args, { ... })`
- `src/hud/__tests__/state.test.ts`:
  - Add `runGitExec shell-safety` test that passes `origin; echo INJECTED` as remoteName and asserts the output never contains `INJECTED`

## Testing

```bash
npm run build
node --test dist/hud/__tests__/state.test.js
# 33 passed, 0 failed

npx biome lint src/hud/state.ts src/hud/__tests__/state.test.ts
# Checked 2 files. No fixes applied.
```

## Prior art

This follows the `execFileSync` migration pattern established in:
- `notifications/tmux.ts` (issues #492, #533 — full migration completed)
- `hud/index.ts` (uses `execFileSync('tmux', args)`)
- `runtime/bridge.ts` (uses `execFileSync(this.binaryPath, args)`)

Issue #535 catalogued this call site but was closed as "safe (static)". The `remoteName` argument is not static — it originates from user-editable HUD config.

Closes #1659