### PR TITLE
fix: cap withRalphSteerLock stale-lock retries to prevent unbounded loop

### DIFF
--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -755,10 +755,13 @@ async function readRalphSteerLock(path: string): Promise<RalphSteerLockRecord | 
   }
 }
 
+const RALPH_STEER_LOCK_MAX_RETRIES = 5;
+
 async function withRalphSteerLock<T>(task: () => Promise<T>): Promise<T | null> {
   await mkdir(dirname(ralphSteerLockPath), { recursive: true }).catch(() => {});
 
-  while (true) {
+  let acquired = false;
+  for (let attempt = 0; attempt < RALPH_STEER_LOCK_MAX_RETRIES; attempt++) {
     let handle;
     try {
       handle = await open(ralphSteerLockPath, 'wx');
@@ -767,6 +770,7 @@ async function withRalphSteerLock<T>(task: () => Promise<T>): Promise<T | null> 
         acquired_at: new Date().toISOString(),
       };
       await handle.writeFile(JSON.stringify(payload, null, 2));
+      acquired = true;
       break;
     } catch (error) {
       const code = error !== null && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : '';
@@ -784,6 +788,11 @@ async function withRalphSteerLock<T>(task: () => Promise<T>): Promise<T | null> 
     } finally {
       await handle?.close().catch(() => {});
     }
+  }
+
+  if (!acquired) {
+    lastRalphContinueSteer.last_reason = 'global_lock_exhausted';
+    return null;
   }
 
   try {


### PR DESCRIPTION
## Summary

Replace `while (true)` with a bounded `for` loop (max 5 retries) in `withRalphSteerLock`. When all retries are exhausted without acquiring the lock, the function returns `null` with reason `global_lock_exhausted` instead of spinning indefinitely.

## Root cause

The stale-lock recovery path at line ~779 calls `unlink(lockPath).catch(() => {})` then `continue` without incrementing any attempt counter. If `unlink` fails silently and the lock file reappears as stale on the next read, the loop retries without bound.

## Changes

- `src/scripts/notify-fallback-watcher.ts`:
  - Add `RALPH_STEER_LOCK_MAX_RETRIES = 5` constant
  - Replace `while (true)` with `for (let attempt = 0; attempt < RALPH_STEER_LOCK_MAX_RETRIES; attempt++)`
  - Track `acquired` flag; return `null` with `global_lock_exhausted` reason when exhausted

## Testing

```bash
npm run build
node --test dist/hooks/__tests__/notify-fallback-watcher.test.js
```

The existing `globally debounces Ralph continue steer across concurrent watcher instances` test validates the lock acquisition path. The new cap does not change behavior for the normal case (single stale lock cleared on first retry).

Closes #1653