### PR TITLE
fix: resolve project root by walking to .omx instead of hardcoded depth

### DIFF
--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
-import { dirname, join, posix, resolve, win32 } from 'node:path';
+import { basename, dirname, join, posix, resolve, win32 } from 'node:path';
 import { omxStateDir } from '../utils/paths.js';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
 
@@ -121,6 +121,11 @@ async function statMsIfExists(path: string | null): Promise<number> {
 }
 
 function stateDirToProjectRoot(stateDir: string): string {
+  let current = resolve(stateDir);
+  while (current !== dirname(current)) {
+    if (basename(current) === '.omx') return dirname(current);
+    current = dirname(current);
+  }
   return dirname(dirname(stateDir));
 }
 


### PR DESCRIPTION
## Summary

Replace the hardcoded `dirname(dirname(stateDir))` in `stateDirToProjectRoot` with an upward walk that finds the nearest `.omx` directory and returns its parent.

## Root cause

`stateDirToProjectRoot` (leader-activity.ts:123) assumes the state directory is always exactly `.omx/state` — two levels below the project root:

```typescript
function stateDirToProjectRoot(stateDir: string): string {
  return dirname(dirname(stateDir));
}
```

When called with a session-scoped path like `.omx/state/sessions/<id>/`, the double-dirname produces `.omx/state` instead of the actual project root. This causes `readBranchGitActivityMsForPath` to execute git commands (`rev-parse`, `symbolic-ref`, `show`) in the wrong directory, silently returning `NaN` for all git activity signals.

The degradation is silent — no error is thrown. `isLeaderRuntimeStale` simply loses its git signal and falls back to HUD and runtime-activity timestamps only.

## Changes

- `src/team/leader-activity.ts`:
  - Add `basename` to the `node:path` import
  - Replace hardcoded double-dirname with an upward walk to the nearest `.omx` directory
  - Preserve the original double-dirname as a fallback for non-`.omx` paths

## Testing

```bash
npm run build
node --test dist/team/__tests__/leader-activity.test.js
```

The existing `readBranchGitActivityMsForPath` and `isLeaderRuntimeStale` tests validate the git activity polling path. This change only affects path resolution, not polling logic.

Closes #1654