### PR TITLE
fix(mcp): allow post-traffic duplicate siblings to self-exit after extended idle

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -203,6 +203,7 @@ describe('mcp duplicate sibling detection', () => {
       newerSiblingPids: [140],
     };
 
+    // Well within the 5-minute post-traffic idle window — must stay alive.
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 35_000, 1_000, 10_000),
       false,
@@ -210,6 +211,61 @@ describe('mcp duplicate sibling detection', () => {
     assert.equal(
       shouldSelfExitForDuplicateSibling(observation, 40_500, 1_000, 10_000),
       false,
+    );
+  });
+
+  it('self-exits after traffic once the post-traffic idle window elapses', () => {
+    const observation = {
+      status: 'older_duplicate' as const,
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 140],
+      newerSiblingPids: [140],
+    };
+
+    // lastTraffic=10_000, duplicateObserved=1_000, now=311_000
+    // idle since lastTraffic: 301_000 ms (> 300_000 ms default)
+    // idle since duplicateObserved: 310_000 ms (> 300_000 ms)
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 311_000, 1_000, 10_000),
+      true,
+    );
+  });
+
+  it('stays alive when post-traffic idle window has not fully elapsed', () => {
+    const observation = {
+      status: 'older_duplicate' as const,
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 140],
+      newerSiblingPids: [140],
+    };
+
+    // lastTraffic=10_000, duplicateObserved=1_000, now=309_000
+    // idle since lastTraffic: 299_000 ms (< 300_000 ms default)
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 309_000, 1_000, 10_000),
+      false,
+    );
+  });
+
+  it('uses the later of lastTraffic and duplicateObserved as the idle anchor', () => {
+    const observation = {
+      status: 'older_duplicate' as const,
+      entrypoint: 'state-server.js',
+      matchingPids: [101, 140],
+      newerSiblingPids: [140],
+    };
+
+    // duplicateObserved=200_000 (later than lastTraffic=10_000)
+    // idle anchor = max(10_000, 200_000) = 200_000
+    // now=499_000 → idle since anchor: 299_000 ms (< 300_000 ms)
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 499_000, 200_000, 10_000),
+      false,
+    );
+    // now=501_000 → idle since anchor: 301_000 ms (> 300_000 ms)
+    assert.equal(
+      shouldSelfExitForDuplicateSibling(observation, 501_000, 200_000, 10_000),
+      true,
     );
   });
 

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -16,6 +16,7 @@ const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
 const PARENT_WATCHDOG_INTERVAL_MS = 25;
 const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
 const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
+const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 300_000;
 const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 
 interface StdioLifecycleServer {
@@ -158,6 +159,7 @@ export function shouldSelfExitForDuplicateSibling(
   duplicateObservedAtMs: number | null,
   lastTrafficAtMs: number | null,
   preTrafficGraceMs = DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
+  postTrafficIdleMs = DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS,
 ): boolean {
   if (observation.status !== 'older_duplicate') {
     return false;
@@ -169,7 +171,13 @@ export function shouldSelfExitForDuplicateSibling(
   if (lastTrafficAtMs === null) {
     return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
   }
-  return false;
+
+  if (!Number.isFinite(lastTrafficAtMs) || lastTrafficAtMs > nowMs) {
+    return false;
+  }
+
+  const safeIdleAnchorMs = Math.max(lastTrafficAtMs, duplicateObservedAtMs);
+  return nowMs - safeIdleAnchorMs >= postTrafficIdleMs;
 }
 
 export function isParentProcessAlive(
@@ -258,7 +266,10 @@ export function autoStartStdioMcpServer(
         return;
       }
 
-      void shutdown('superseded_duplicate_before_traffic');
+      const reason = lastTrafficAtMs === null
+        ? 'superseded_duplicate_before_traffic'
+        : 'superseded_duplicate_idle';
+      void shutdown(reason);
     }, DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS)
     : null;
   duplicateSiblingWatchdog?.unref();


### PR DESCRIPTION
## Summary
- restore post-traffic idle self-exit for duplicate MCP stdio siblings with a conservative 5-minute window
- use `Math.max(lastTrafficAtMs, duplicateObservedAtMs)` as the idle anchor so late-detected duplicates get the full grace period
- distinguish `superseded_duplicate_before_traffic` and `superseded_duplicate_idle` shutdown reasons for lifecycle debugging
- add regression tests covering the post-traffic exit boundary, the idle-window-not-elapsed case, and the late-observation anchor case

## Root cause

PR #1596 (commit c47abf9) disabled post-traffic duplicate self-exit entirely to fix `state_write` "Transport closed" errors during resume/reconcile (#1594). The original 30-second idle window was too short for resume scenarios, so it was replaced with an unconditional `return false`.

The trade-off was sound for the 30-second window, but the unconditional fallback has no upper bound. In long-running Codex sessions with periodic reconnects, older siblings that have received traffic accumulate indefinitely — up to 40 processes per session (expected: 5), with ~2.4 GB total RAM waste observed across 15 sessions.

## Changes

- `src/mcp/bootstrap.ts`:
  - Add `DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS = 300_000` (5 minutes)
  - Add `postTrafficIdleMs` parameter to `shouldSelfExitForDuplicateSibling` with the 300s default
  - Replace `return false` with idle-anchor-based exit gate: `nowMs - Math.max(lastTrafficAtMs, duplicateObservedAtMs) >= postTrafficIdleMs`
  - Validate `lastTrafficAtMs` (finite, not future) before the idle check
  - Emit `superseded_duplicate_idle` shutdown reason for the post-traffic path

- `src/mcp/__tests__/bootstrap.test.ts`:
  - Add `self-exits after traffic once the post-traffic idle window elapses`
  - Add `stays alive when post-traffic idle window has not fully elapsed`
  - Add `uses the later of lastTraffic and duplicateObserved as the idle anchor`
  - Preserve existing pre-traffic and short-idle-window assertions unchanged

## Why 5 minutes instead of 30 seconds

The original 30-second window triggered Transport closed errors because resume/reconcile can leave the older transport idle for an unpredictable period before the client sends its next request. A 5-minute window covers even slow resume scenarios (observed resume times are well under 2 minutes) while placing a finite upper bound on process accumulation.

Worst-case leak with this fix: one extra process per server type per 5-minute reconnection burst, vs. unbounded accumulation today.

## Verification

```bash
npm run build
node --test dist/mcp/__tests__/bootstrap.test.js
# 18 passed, 0 failed
npx biome lint src/mcp/bootstrap.ts src/mcp/__tests__/bootstrap.test.ts
# No fixes applied
```

Closes #1665.