### PR TITLE
fix: replace synchronous execFileSync with async execFile in leader git polling

### DIFF
--- a/src/team/leader-activity.ts
+++ b/src/team/leader-activity.ts
@@ -1,4 +1,7 @@
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 import { existsSync, statSync } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, posix, resolve, win32 } from 'node:path';
@@ -57,7 +60,7 @@ function resolveGitOutputPath(cwd: string, gitPath: string | null): string | nul
  *
  * See: https://github.com/Yeachan-Heo/oh-my-codex/issues/1100
  */
-function tryReadGitValue(cwd: string, args: string[]): string | null {
+async function tryReadGitValue(cwd: string, args: string[]): Promise<string | null> {
   if (process.platform === 'win32') {
     try {
       const gitLayout = findGitLayout(cwd);
@@ -93,19 +96,18 @@ function tryReadGitValue(cwd: string, args: string[]): string | null {
     } catch { /* fall through */ }
   }
 
-  return tryReadGitValueExec(cwd, args);
+  return await tryReadGitValueExec(cwd, args);
 }
 
-function tryReadGitValueExec(cwd: string, args: string[]): string | null {
+async function tryReadGitValueExec(cwd: string, args: string[]): Promise<string | null> {
   try {
-    const value = execFileSync('git', args, {
+    const { stdout } = await execFileAsync('git', args, {
       cwd,
       encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 2000,
       windowsHide: true,
-    }).trim();
-    return value || null;
+    });
+    return stdout.trim() || null;
   } catch {
     return null;
   }
@@ -125,15 +127,15 @@ function stateDirToProjectRoot(stateDir: string): string {
 }
 
 export async function readBranchGitActivityMsForPath(cwd: string): Promise<number> {
-  const gitDir = tryReadGitValue(cwd, ['rev-parse', '--git-dir']);
+  const gitDir = await tryReadGitValue(cwd, ['rev-parse', '--git-dir']);
   if (!gitDir) return Number.NaN;
 
-  const branch = tryReadGitValue(cwd, ['symbolic-ref', '--quiet', '--short', 'HEAD']);
-  const headLogPath = tryReadGitValue(cwd, ['rev-parse', '--git-path', 'logs/HEAD']);
+  const branch = await tryReadGitValue(cwd, ['symbolic-ref', '--quiet', '--short', 'HEAD']);
+  const headLogPath = await tryReadGitValue(cwd, ['rev-parse', '--git-path', 'logs/HEAD']);
   const branchLogPath = branch
-    ? tryReadGitValue(cwd, ['rev-parse', '--git-path', `logs/refs/heads/${branch}`])
+    ? await tryReadGitValue(cwd, ['rev-parse', '--git-path', `logs/refs/heads/${branch}`])
     : null;
-  const headCommitEpoch = tryReadGitValue(cwd, ['show', '-s', '--format=%ct', 'HEAD']);
+  const headCommitEpoch = await tryReadGitValue(cwd, ['show', '-s', '--format=%ct', 'HEAD']);
 
   const [headLogMs, branchLogMs] = await Promise.all([
     statMsIfExists(resolveGitOutputPath(cwd, headLogPath)),


### PR DESCRIPTION
## Summary

Replace `execFileSync` with promisified `execFile` in `tryReadGitValueExec` so leader git activity polling yields the event loop instead of blocking it.

This is a follow-up to #1618 / PR #1619, which added an in-process cache to reduce the frequency of git exec calls. The caching addressed the CPU/syspolicyd hotspot but did not change the synchronous execution pattern — each cache miss still blocks the event loop.

## Root cause

`tryReadGitValueExec` (leader-activity.ts:99) uses `execFileSync` with a 2-second timeout. It is called up to 4 times per polling cycle from `readBranchGitActivityMsForPath`:

1. `git rev-parse --git-dir`
2. `git symbolic-ref --quiet --short HEAD`
3. `git rev-parse --git-path logs/HEAD`
4. `git rev-parse --git-path logs/refs/heads/<branch>`

All four calls are sequential and synchronous, creating a worst-case 8-second event loop block per cache miss cycle. During this block, other async tasks in the watcher (dispatch drain, leader nudge, auto-nudge) are delayed.

## Changes

- `src/team/leader-activity.ts`:
  - Replace `import { execFileSync }` with `import { execFile }` + `promisify`
  - Convert `tryReadGitValueExec` from sync to async (`Promise<string | null>`)
  - Convert `tryReadGitValue` to async (it delegates to `tryReadGitValueExec`)
  - Add `await` to all `tryReadGitValue` calls in `readBranchGitActivityMsForPath`

Since `readBranchGitActivityMsForPath` and all its callers are already `async`, no structural changes are needed beyond adding `await`.

## Testing

```bash
npm run build
node --test dist/team/__tests__/leader-activity.test.js
```

## Note on Windows path

The Windows-specific fast path in `tryReadGitValue` reads git state directly from `.git/` files without shelling out, so it was already non-blocking. The sync-to-async change only affects the `tryReadGitValueExec` fallback used on non-Windows platforms.

Closes #1656