### PR TITLE
fix(deps): patch transitive dependency vulnerabilities via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1077,9 +1077,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
## Summary
- bump four transitive dependencies to resolve all known CVEs reported by \`npm audit\`
- no \`package.json\` changes required — all updates are within existing semver ranges
- \`npm audit\` now reports **0 vulnerabilities**

## Root cause

\`express\` pulls in \`path-to-regexp@8.3.0\` which contains two ReDoS vulnerabilities (CVSS 7.5 and 5.9).  \`@modelcontextprotocol/sdk\` pulls in \`hono@4.12.8\` and \`@hono/node-server@1.19.11\` which together carry 6 moderate CVEs covering cookie injection, IP restriction bypass, middleware bypass, path traversal, and SSR HTML injection.

Since the MCP SDK uses hono as its HTTP transport and express handles local routing, both dependency trees are on active code paths.

## Changes

\`package-lock.json\` only — lockfile version bumps:

| Package | From | To | CVEs resolved |
|---------|------|----|---------------|
| \`path-to-regexp\` | 8.3.0 | 8.4.2 | GHSA-j3q9 (HIGH ReDoS), GHSA-27v5 (ReDoS) |
| \`hono\` | 4.12.8 | 4.12.14 | GHSA-26pp, GHSA-r5rp, GHSA-xpcf, GHSA-wmmm, GHSA-458j, GHSA-xf4j |
| \`@hono/node-server\` | 1.19.11 | 1.19.14 | serveStatic repeated-slash bypass |
| \`brace-expansion\` | 5.0.4 | 5.0.5 | zero-step sequence DoS |

## Testing

\`\`\`bash
npm audit fix
npm run build   # compiles cleanly
npm audit       # found 0 vulnerabilities
\`\`\`

Closes #1660