### PR TITLE
fix: verify process identity before reaping stale notify-fallback-watcher PID

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -685,6 +685,7 @@ describe("reapStaleNotifyFallbackWatcher", () => {
       const killed: Array<{ pid: number; signal?: NodeJS.Signals }> = [];
 
       await reapStaleNotifyFallbackWatcher(pidPath, {
+        isWatcherProcess: () => true,
         tryKillPid(pid, signal) {
           killed.push({ pid, signal });
           return true;
@@ -737,6 +738,7 @@ describe("reapStaleNotifyFallbackWatcher", () => {
       const warned: Array<{ message: unknown; meta: unknown }> = [];
       await reapStaleNotifyFallbackWatcher(pidPath, {
         readFile: async (path, encoding) => readFile(path, encoding),
+        isWatcherProcess: () => true,
         tryKillPid() {
           throw new Error("permission denied");
         },
@@ -1936,7 +1938,37 @@ exit 0
     ]);
   });
 
-  it("buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach", () => {
+  it("reapStaleNotifyFallbackWatcher skips kill when process identity does not match a watcher", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-reap-pid-identity-"));
+    const pidPath = join(cwd, "watcher.pid");
+    await writeFile(pidPath, JSON.stringify({ pid: 99999, started_at: new Date().toISOString() }));
+
+    const killed: number[] = [];
+    await reapStaleNotifyFallbackWatcher(pidPath, {
+      isWatcherProcess: () => false,
+      tryKillPid: (pid) => { killed.push(pid); return true; },
+    });
+
+    assert.equal(killed.length, 0, "should not kill a process that is not a watcher");
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("reapStaleNotifyFallbackWatcher sends SIGTERM only after confirming watcher identity", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-reap-pid-confirmed-"));
+    const pidPath = join(cwd, "watcher.pid");
+    await writeFile(pidPath, JSON.stringify({ pid: 12345, started_at: new Date().toISOString() }));
+
+    const killed: number[] = [];
+    await reapStaleNotifyFallbackWatcher(pidPath, {
+      isWatcherProcess: () => true,
+      tryKillPid: (pid) => { killed.push(pid); return true; },
+    });
+
+    assert.deepEqual(killed, [12345], "should SIGTERM the verified watcher process");
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+    it("buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach", () => {
     const steps = buildDetachedSessionFinalizeSteps(
       "omx-demo",
       "%12",

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1968,6 +1968,65 @@ exit 0
     await rm(cwd, { recursive: true, force: true });
   });
 
+  it("reuses legacy plain-text PID parsing without widening stale reap semantics across PID reuse", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-reap-legacy-pid-"));
+    try {
+      const pidPath = join(cwd, "watcher.pid");
+      await writeFile(pidPath, "12345\n", "utf-8");
+
+      const observed: number[] = [];
+      await reapStaleNotifyFallbackWatcher(pidPath, {
+        isWatcherProcess(pid) {
+          observed.push(pid);
+          return false;
+        },
+        tryKillPid: (pid) => {
+          observed.push(pid);
+          return true;
+        },
+      });
+
+      assert.deepEqual(
+        observed,
+        [12345],
+        "legacy plain-text PID files should still identity-check reused PIDs before any kill",
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("reaps watcher-record PIDs only after the record path confirms watcher identity across PID reuse", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-reap-record-pid-"));
+    try {
+      const pidPath = join(cwd, "watcher.pid");
+      await writeFile(
+        pidPath,
+        JSON.stringify({ pid: 54321, started_at: "2026-04-05T00:00:00.000Z" }),
+        "utf-8",
+      );
+
+      const observed: Array<{ step: "identity" | "kill"; pid: number }> = [];
+      await reapStaleNotifyFallbackWatcher(pidPath, {
+        isWatcherProcess(pid) {
+          observed.push({ step: "identity", pid });
+          return true;
+        },
+        tryKillPid(pid) {
+          observed.push({ step: "kill", pid });
+          return true;
+        },
+      });
+
+      assert.deepEqual(observed, [
+        { step: "identity", pid: 54321 },
+        { step: "kill", pid: 54321 },
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
     it("buildDetachedSessionFinalizeSteps keeps schedule after split-capture and before attach", () => {
     const steps = buildDetachedSessionFinalizeSteps(
       "omx-demo",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3044,6 +3044,48 @@ function parseWatcherPidFile(content: string): number | null {
   }
 }
 
+interface WatcherPidRecord {
+  pid: number;
+  startedAt: string | null;
+}
+
+function parseWatcherPidRecord(content: string): WatcherPidRecord | null {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as { pid?: unknown; started_at?: unknown };
+    if (
+      typeof parsed.pid !== "number" ||
+      !Number.isFinite(parsed.pid) ||
+      parsed.pid <= 0
+    ) {
+      return null;
+    }
+    return {
+      pid: parsed.pid,
+      startedAt: typeof parsed.started_at === "string" ? parsed.started_at : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isLikelyOmxWatcherProcess(
+  pid: number,
+  execFileSyncFn: typeof execFileSync = execFileSync,
+): boolean {
+  try {
+    const cmd = execFileSyncFn("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf-8",
+      timeout: 2000,
+      windowsHide: true,
+    }) as string;
+    return cmd.includes("notify-fallback-watcher") || cmd.includes("hook-derived-watcher");
+  } catch {
+    return false;
+  }
+}
+
 export async function reapStaleNotifyFallbackWatcher(
   pidPath: string,
   deps: {
@@ -3052,6 +3094,7 @@ export async function reapStaleNotifyFallbackWatcher(
     tryKillPid?: (pid: number, signal?: NodeJS.Signals) => boolean;
     hasErrnoCode?: (error: unknown, code: string) => boolean;
     warn?: (message?: unknown, ...optionalParams: unknown[]) => void;
+    isWatcherProcess?: (pid: number) => boolean;
   } = {},
 ): Promise<void> {
   const exists = deps.exists ?? existsSync;
@@ -3062,11 +3105,12 @@ export async function reapStaleNotifyFallbackWatcher(
   const tryKillPidImpl = deps.tryKillPid ?? tryKillPid;
   const hasErrnoCodeImpl = deps.hasErrnoCode ?? hasErrnoCode;
   const warn = deps.warn ?? console.warn;
+  const isWatcherProcessImpl = deps.isWatcherProcess ?? isLikelyOmxWatcherProcess;
 
   try {
-    const prevPid = parseWatcherPidFile(await readFileImpl(pidPath, "utf-8"));
-    if (prevPid) {
-      tryKillPidImpl(prevPid, "SIGTERM");
+    const record = parseWatcherPidRecord(await readFileImpl(pidPath, "utf-8"));
+    if (record && isWatcherProcessImpl(record.pid)) {
+      tryKillPidImpl(record.pid, "SIGTERM");
     }
   } catch (error: unknown) {
     if (!hasErrnoCodeImpl(error, "ESRCH")) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3066,6 +3066,11 @@ function parseWatcherPidRecord(content: string): WatcherPidRecord | null {
       startedAt: typeof parsed.started_at === "string" ? parsed.started_at : null,
     };
   } catch {
+    // Fallback: plain-text numeric PID (legacy format)
+    const pid = Number.parseInt(trimmed, 10);
+    if (Number.isFinite(pid) && pid > 0) {
+      return { pid, startedAt: null };
+    }
     return null;
   }
 }
@@ -3073,7 +3078,13 @@ function parseWatcherPidRecord(content: string): WatcherPidRecord | null {
 function isLikelyOmxWatcherProcess(
   pid: number,
   execFileSyncFn: typeof execFileSync = execFileSync,
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
+  if (platform === "win32") {
+    // ps is unavailable on native Windows; fall back to unconditional reap
+    // to preserve the pre-identity-check behavior on opted-in Windows hosts.
+    return true;
+  }
   try {
     const cmd = execFileSyncFn("ps", ["-p", String(pid), "-o", "command="], {
       encoding: "utf-8",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3032,12 +3032,15 @@ function parseWatcherPidFile(content: string): number | null {
   const trimmed = content.trim();
   if (!trimmed) return null;
   try {
-    const parsed = JSON.parse(trimmed) as { pid?: unknown };
-    return typeof parsed.pid === "number" &&
-      Number.isFinite(parsed.pid) &&
-      parsed.pid > 0
-      ? parsed.pid
-      : null;
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === "number") {
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+    }
+    const pid =
+      typeof parsed === "object" && parsed !== null
+        ? (parsed as { pid?: unknown }).pid
+        : undefined;
+    return typeof pid === "number" && Number.isFinite(pid) && pid > 0 ? pid : null;
   } catch {
     const pid = Number.parseInt(trimmed, 10);
     return Number.isFinite(pid) && pid > 0 ? pid : null;
@@ -3053,26 +3056,24 @@ function parseWatcherPidRecord(content: string): WatcherPidRecord | null {
   const trimmed = content.trim();
   if (!trimmed) return null;
   try {
-    const parsed = JSON.parse(trimmed) as { pid?: unknown; started_at?: unknown };
-    if (
-      typeof parsed.pid !== "number" ||
-      !Number.isFinite(parsed.pid) ||
-      parsed.pid <= 0
-    ) {
-      return null;
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === "object" && parsed !== null) {
+      const { pid, started_at: startedAtRaw } = parsed as {
+        pid?: unknown;
+        started_at?: unknown;
+      };
+      if (typeof pid === "number" && Number.isFinite(pid) && pid > 0) {
+        return {
+          pid,
+          startedAt: typeof startedAtRaw === "string" ? startedAtRaw : null,
+        };
+      }
     }
-    return {
-      pid: parsed.pid,
-      startedAt: typeof parsed.started_at === "string" ? parsed.started_at : null,
-    };
   } catch {
-    // Fallback: plain-text numeric PID (legacy format)
-    const pid = Number.parseInt(trimmed, 10);
-    if (Number.isFinite(pid) && pid > 0) {
-      return { pid, startedAt: null };
-    }
-    return null;
   }
+
+  const pid = parseWatcherPidFile(trimmed);
+  return pid ? { pid, startedAt: null } : null;
 }
 
 function isLikelyOmxWatcherProcess(


### PR DESCRIPTION
## Summary
- add `isLikelyOmxWatcherProcess` that checks the process command line via `ps` before sending SIGTERM, preventing PID-reuse false kills
- add `parseWatcherPidRecord` to extract both `pid` and `started_at` from the watcher PID file (the `started_at` field was already written but never read)
- update `reapStaleNotifyFallbackWatcher` to use identity verification before signaling, with an injectable `isWatcherProcess` dependency for testability
- update existing tests to pass the new dependency and add two regression tests for the identity-check gate

## Root cause

`reapStaleNotifyFallbackWatcher` (`src/cli/index.ts:3047`) reads a PID from a file and sends `SIGTERM` without verifying that the target process is actually a notify-fallback-watcher. If the original watcher exits and the OS reassigns the PID to an unrelated process, `SIGTERM` reaches the wrong target.

This is the same PID-reuse pattern that was previously identified and fixed in `reply-listener.ts` via #158 and #278, but was not addressed in the notify-fallback-watcher code path.

## Changes

- `src/cli/index.ts`:
  - Add `WatcherPidRecord` interface and `parseWatcherPidRecord` function that extracts both `pid` and `started_at`
  - Add `isLikelyOmxWatcherProcess` that runs `ps -p <pid> -o command=` and checks for watcher process signatures
  - Add `isWatcherProcess` to `reapStaleNotifyFallbackWatcher` deps interface
  - Replace bare `parseWatcherPidFile` + unconditional `tryKillPid` with `parseWatcherPidRecord` + identity-gated kill
- `src/cli/__tests__/index.test.ts`:
  - Add `isWatcherProcess: () => true` to existing tests that expect kill behavior
  - Add "skips kill when process identity does not match" regression test
  - Add "sends SIGTERM only after confirming watcher identity" regression test

## Testing

```bash
npm run build
node --test --test-name-pattern="reap|watcher.*identity|watcher.*confirmed" dist/cli/__tests__/index.test.js
# 8 passed, 0 failed
npx biome lint src/cli/index.ts src/cli/__tests__/index.test.ts
```

Closes #1657