### PR TITLE
Fix #1671: preserve local AGENTS.md during auto-update

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -120,7 +120,7 @@ describe('maybeCheckAndPromptUpdate', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
     const originalLog = console.log;
     const prompts: string[] = [];
-    const setupCalls: Array<{ force?: boolean }> = [];
+    const setupCalls: unknown[] = [];
     console.log = (...args: unknown[]) => {
       prompts.push(args.map((arg) => String(arg)).join(' '));
     };
@@ -138,10 +138,39 @@ describe('maybeCheckAndPromptUpdate', () => {
         });
       });
 
-      assert.deepEqual(setupCalls, [{ force: true }]);
+      assert.deepEqual(setupCalls, [{}]);
       assert.match(prompts.join('\n'), /Updated to v0\.9\.0/);
     } finally {
       console.log = originalLog;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves local config semantics by avoiding force setup during auto-update', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
+    let receivedOptions: unknown;
+
+    try {
+      await withInteractiveTty(async () => {
+        await maybeCheckAndPromptUpdate(cwd, {
+          getCurrentVersion: async () => '0.13.0',
+          fetchLatestVersion: async () => '0.13.1',
+          askYesNo: async () => true,
+          runGlobalUpdate: () => ({ ok: true, stderr: '' }),
+          setup: async (options) => {
+            receivedOptions = options ?? {};
+          },
+        });
+      });
+
+      assert.deepEqual(receivedOptions, {});
+      assert.equal(
+        typeof receivedOptions === 'object' &&
+          receivedOptions !== null &&
+          'force' in receivedOptions,
+        false,
+      );
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -174,7 +174,7 @@ export async function maybeCheckAndPromptUpdate(
   const result = updateDependencies.runGlobalUpdate();
 
   if (result.ok) {
-    await updateDependencies.setup({ force: true });
+    await updateDependencies.setup();
     console.log(`[omx] Updated to v${latest}. Restart to use new code.`);
   } else {
     console.log('[omx] Update failed. Run manually: npm install -g oh-my-codex@latest');


### PR DESCRIPTION
## Summary
- stop auto-update from running destructive setup --force refreshes
- preserve explicit user-invoked `omx setup --force` behavior
- add targeted regression coverage for the update-triggered setup path

## Testing
- npm run build
- node --test dist/cli/__tests__/update.test.js
- node --test dist/cli/__tests__/setup-scope.test.js

Closes #1671