### PR TITLE
Fix watcher/team path joins for invalid session and team identifiers (#1650)

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1068,6 +1068,48 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('ignores invalid session_id before watcher session path joins', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-invalid-session-id-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalWatcherTeamFixture(wd, {
+        teamName: 'dispatch-team',
+        sessionId: 'safe-session',
+        ownerSessionId: 'safe-session',
+        coarseState: 'inactive',
+      });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({
+        session_id: '../escape',
+        cwd: wd,
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+      }, null, 2));
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          }),
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      assert.equal(tmuxLog, '', 'invalid session_id should not reach session-scoped or canonical follow-up joins');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 
   it('skips fallback watcher leader nudges when the leader is not stale even if mailbox messages exist', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-leader-nudge-fresh-'));
@@ -3176,6 +3218,182 @@ exit 0
       assert.ok(!logEntries.some((entry: { type?: string; reason?: string }) => (
         entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
       )), 'ownerless canonical team must not defer parent-loss shutdown');
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid session_id before resolving session-scoped team paths', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-invalid-session-team-path-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-invalid-session-team-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    const maliciousTeamDir = join(stateDir, 'team', 'dispatch-team');
+    const sessionPath = join(stateDir, 'session.json');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(maliciousTeamDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeSessionStart(wd, 'sess-valid');
+      const validSession = JSON.parse(await readFile(sessionPath, 'utf-8')) as Record<string, unknown>;
+      await writeFile(sessionPath, JSON.stringify({
+        ...validSession,
+        session_id: '../team/dispatch-team',
+      }, null, 2));
+
+      await writeFile(join(maliciousTeamDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: 'dispatch-team',
+        current_phase: 'team-exec',
+      }, null, 2));
+      await writeFile(join(maliciousTeamDir, 'config.json'), JSON.stringify({
+        name: 'dispatch-team',
+        tmux_session: 'dispatch-team:0',
+        leader_pane_id: '%99',
+        workers: [
+          { name: 'worker-1', pane_id: '%42' },
+        ],
+      }, null, 2));
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        }
+      );
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
+      )));
+      assert.ok(!logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+      )), 'invalid session_id must not be used for session-scoped team path resolution');
+    } finally {
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child, 4000).catch(() => {});
+      }
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid team_name before resolving watcher team paths', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-invalid-team-path-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-invalid-team-home-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    const validTeamDir = join(stateDir, 'team', 'dispatch-team');
+    let child: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(join(wd, '.omx', 'logs'), { recursive: true });
+      await mkdir(validTeamDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeFile(join(stateDir, 'team-state.json'), JSON.stringify({
+        active: true,
+        team_name: '../team/dispatch-team',
+        current_phase: 'team-exec',
+      }, null, 2));
+      await writeFile(join(validTeamDir, 'config.json'), JSON.stringify({
+        name: 'dispatch-team',
+        tmux_session: 'dispatch-team:0',
+        leader_pane_id: '%99',
+        workers: [
+          { name: 'worker-1', pane_id: '%42' },
+        ],
+      }, null, 2));
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+
+      const shortLivedParent = spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(0), 10)'], {
+        stdio: 'ignore',
+      });
+      assert.ok(shortLivedParent.pid, 'expected short-lived parent pid');
+      const parentPid = shortLivedParent.pid as number;
+      await once(shortLivedParent, 'exit');
+
+      child = spawn(
+        process.execPath,
+        [
+          watcherScript,
+          '--cwd',
+          wd,
+          '--notify-script',
+          notifyHook,
+          '--poll-ms',
+          '50',
+          '--parent-pid',
+          String(parentPid),
+          '--max-lifetime-ms',
+          '5000',
+        ],
+        {
+          cwd: wd,
+          stdio: 'ignore',
+          env: buildCleanNotifyEnv({ HOME: tempHome, PATH: `${fakeBinDir}:${process.env.PATH || ''}` }),
+        }
+      );
+
+      await waitForExit(child, 4000);
+      assert.equal(child.exitCode, 0);
+
+      const logEntries = (await readFile(logPath, 'utf-8')).trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+      assert.ok(logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_stop' && entry.reason === 'parent_gone'
+      )));
+      assert.ok(!logEntries.some((entry: { type?: string; reason?: string }) => (
+        entry.type === 'watcher_parent_guard' && entry.reason === 'parent_gone_deferred_for_active_team'
+      )), 'invalid team_name must not be used for watcher team path resolution');
     } finally {
       if (child && isPidAlive(child.pid)) {
         child.kill('SIGTERM');

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -788,6 +788,75 @@ describe('notify-hook team leader nudge', () => {
     });
   });
 
+  it('ignores invalid team_name before canonical leader follow-up team path joins', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCanonicalTeamFixture(cwd, {
+        teamName: 'canonical-safe',
+        sessionId: 'sess-canonical-safe',
+        ownerSessionId: 'sess-canonical-safe',
+        coarseState: 'inactive',
+      });
+      const teamRoot = join(cwd, '.omx', 'state', 'team');
+      await mkdir(join(teamRoot, '..-bad-team'), { recursive: true });
+      await writeJson(join(teamRoot, '..-bad-team', 'manifest.v2.json'), {
+        schema_version: 2,
+        name: '..-bad-team',
+        task: 'invalid canonical fallback fixture',
+        leader: { session_id: 'sess-canonical-safe', worker_id: 'leader-fixed', role: 'coordinator' },
+        tmux_session: 'bad:0',
+        leader_pane_id: '%666',
+        hud_pane_id: null,
+        resize_hook_name: null,
+        resize_hook_target: null,
+        worker_count: 1,
+        next_task_id: 1,
+        workers: [{ name: 'worker-1', index: 1, pane_id: '%666', role: 'executor' }],
+        created_at: new Date().toISOString(),
+        policy: {
+          worker_launch_mode: 'interactive',
+          display_mode: 'split_pane',
+          dispatch_mode: 'hook_preferred_with_fallback',
+          dispatch_ack_timeout_ms: 2000,
+        },
+        governance: {
+          delegation_only: false,
+          plan_approval_required: false,
+          nested_teams_allowed: false,
+          one_team_per_leader_session: true,
+          cleanup_requires_all_workers_inactive: true,
+        },
+        lifecycle_profile: 'default',
+        permissions_snapshot: {
+          approval_mode: 'never',
+          sandbox_mode: 'danger-full-access',
+          network_access: true,
+        },
+      });
+      await writeJson(join(teamRoot, '..-bad-team', 'phase.json'), {
+        current_phase: 'team-exec',
+        updated_at: new Date().toISOString(),
+        transitions: [],
+      });
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-canonical-safe',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /-t %97/, 'should still target the valid canonical leader pane');
+      assert.doesNotMatch(tmuxLog, /%666/, 'invalid canonical team names must be ignored before joins');
+      assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'valid canonical fallback should still fire idle nudge');
+    });
+  });
+
   it('nudges leader via tmux send-keys when team is active and mailbox has messages', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
@@ -3051,6 +3120,73 @@ exit 0
       const nudgeEvent = events.find((e: { type: string }) => e.type === 'team_leader_nudge');
       assert.ok(nudgeEvent);
       assert.equal(nudgeEvent.reason, 'stale_leader_with_messages');
+    });
+  });
+
+  it('rejects invalid team_name before leader follow-up team path joins', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const validTeamName = 'valid-team';
+      const validTeamDir = join(stateDir, 'team', validTeamName);
+      const workersDir = join(validTeamDir, 'workers');
+      const nowIso = new Date().toISOString();
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(workersDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'session.json'), { session_id: 'sess-current' });
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: '../team/valid-team',
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(validTeamDir, 'manifest.v2.json'), {
+        schema_version: 2,
+        name: validTeamName,
+        task: 'invalid team path repro',
+        leader: {
+          session_id: 'sess-current',
+          worker_id: 'leader-fixed',
+          role: 'coordinator',
+        },
+        policy: {
+          worker_launch_mode: 'interactive',
+          display_mode: 'split_pane',
+          dispatch_mode: 'hook_preferred_with_fallback',
+          dispatch_ack_timeout_ms: 2000,
+        },
+        tmux_session: 'valid-team:0',
+        leader_pane_id: '%94',
+        worker_count: 1,
+        workers: [
+          { name: 'worker-1', index: 1, pane_id: '%10', role: 'executor' },
+        ],
+        created_at: nowIso,
+      });
+      await mkdir(join(workersDir, 'worker-1'), { recursive: true });
+      await writeJson(join(workersDir, 'worker-1', 'status.json'), {
+        state: 'idle',
+        updated_at: nowIso,
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_SESSION_ID: 'sess-current',
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      if (existsSync(tmuxLogPath)) {
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.doesNotMatch(tmuxLog, /send-keys/, 'invalid team_name must not be used for leader follow-up path resolution');
+      }
     });
   });
 });

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -34,6 +34,8 @@ import {
 } from '../subagents/tracker.js';
 import { listNotifyCanonicalActiveTeams } from './notify-hook/active-team.js';
 import { sameFilePath } from '../utils/paths.js';
+import { validateSessionId } from '../mcp/state-paths.js';
+import { TEAM_NAME_SAFE_PATTERN } from '../team/contracts.js';
 
 function argValue(name: string, fallback = ''): string {
   const idx = process.argv.indexOf(name);
@@ -48,6 +50,21 @@ function asNumber(value: string | number | undefined, fallback: number): number 
 
 function safeString(v: unknown): string {
   return typeof v === 'string' ? v : '';
+}
+
+function normalizeValidSessionId(value: unknown): string {
+  const trimmed = safeString(value).trim();
+  if (!trimmed) return '';
+  try {
+    return validateSessionId(trimmed) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function normalizeValidTeamName(value: unknown): string {
+  const trimmed = safeString(value).trim();
+  return TEAM_NAME_SAFE_PATTERN.test(trimmed) ? trimmed : '';
 }
 
 function parsePositivePid(value: unknown): number | null {
@@ -523,8 +540,8 @@ async function resolveActiveModeState(mode: string): Promise<ActiveModeResult> {
   const session = await readSessionState(cwd);
   if (session?.session_id) {
     if (isSessionStateAuthoritativeForCwd(session, cwd)) {
-      currentSessionId = safeString(session.session_id).trim();
-      currentSessionIsLive = !isSessionStale(session);
+      currentSessionId = normalizeValidSessionId(session.session_id);
+      currentSessionIsLive = currentSessionId !== '' && !isSessionStale(session);
     }
     if (currentSessionId && currentSessionIsLive) {
       candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
@@ -590,8 +607,8 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
   let currentSessionIsLive = false;
   const session = await readSessionState(cwd);
   if (session?.session_id) {
-    currentSessionId = safeString(session.session_id).trim();
-    currentSessionIsLive = !isSessionStale(session);
+    currentSessionId = normalizeValidSessionId(session.session_id);
+    currentSessionIsLive = currentSessionId !== '' && !isSessionStale(session);
     if (currentSessionId && currentSessionIsLive) {
       candidateDirs.push(join(stateDir, 'sessions', currentSessionId));
     }
@@ -610,7 +627,7 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
       .catch(() => null);
     if (!parsed || typeof parsed !== 'object' || parsed.active !== true) continue;
 
-    const teamName = safeString(parsed.team_name).trim();
+    const teamName = normalizeValidTeamName(parsed.team_name);
     if (!teamName) continue;
 
     const teamConfigDir = join(stateDir, 'team', teamName);
@@ -653,7 +670,9 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
 
   const canonicalFallbackTeams = await listNotifyCanonicalActiveTeams(cwd, currentSessionId).catch(() => []);
   for (const team of canonicalFallbackTeams) {
-    const teamConfigDir = join(stateDir, 'team', team.teamName);
+    const teamName = normalizeValidTeamName(team.teamName);
+    if (!teamName) continue;
+    const teamConfigDir = join(stateDir, 'team', teamName);
     const manifestPath = join(teamConfigDir, 'manifest.v2.json');
     const configPath = join(teamConfigDir, 'config.json');
     const teamConfigPath = existsSync(manifestPath) ? manifestPath : configPath;
@@ -678,10 +697,10 @@ async function resolveActiveTeamState(): Promise<ActiveTeamResult> {
       path: team.path,
       state: {
         active: true,
-        team_name: team.teamName,
+        team_name: teamName,
         current_phase: team.phase,
       },
-      team_name: team.teamName,
+      team_name: teamName,
       pane_count: paneStatus.paneCount,
     };
   }

--- a/src/scripts/notify-hook/active-team.ts
+++ b/src/scripts/notify-hook/active-team.ts
@@ -3,6 +3,7 @@ import { readdir } from 'fs/promises';
 import { join } from 'path';
 import { readTeamManifestV2, readTeamPhase } from '../../team/state.js';
 import { resolveCanonicalTeamStateRoot } from '../../team/state-root.js';
+import { TEAM_NAME_SAFE_PATTERN } from '../../team/contracts.js';
 import { isTerminalPhase, safeString } from './utils.js';
 
 export interface NotifyCanonicalActiveTeam {
@@ -28,7 +29,7 @@ export async function listNotifyCanonicalActiveTeams(
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const teamName = entry.name.trim();
-    if (!teamName) continue;
+    if (!teamName || !TEAM_NAME_SAFE_PATTERN.test(teamName)) continue;
 
     const [manifest, phaseState] = await Promise.all([
       readTeamManifestV2(teamName, cwd),

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -23,6 +23,8 @@ import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
 import { writeTeamLeaderAttention } from '../../team/state.js';
 import { readLatestTeamProgressEvidenceMs } from '../../team/progress-evidence.js';
+import { validateSessionId } from '../../mcp/state-paths.js';
+import { TEAM_NAME_SAFE_PATTERN } from '../../team/contracts.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const LEADER_PANE_SAME_CLASSIFIED_STATE_SUPPRESSED_REASON = 'pane_already_shows_same_classified_state';
@@ -33,6 +35,21 @@ const ACK_LIKE_PATTERNS = [
   /^(?:ok|okay|k|roger|copy|received|got it|understood|sounds good)[.!]*$/i,
   /^(?:on it|will do|i(?:'|')ll do it|working on it)[.!]*$/i,
 ];
+
+function normalizeValidSessionId(value) {
+  const trimmed = safeString(value).trim();
+  if (!trimmed) return '';
+  try {
+    return validateSessionId(trimmed) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function normalizeValidTeamName(value) {
+  const trimmed = safeString(value).trim();
+  return TEAM_NAME_SAFE_PATTERN.test(trimmed) ? trimmed : '';
+}
 
 export function resolveLeaderNudgeIntervalMs() {
   const raw = safeString(process.env.OMX_TEAM_LEADER_NUDGE_MS || '');
@@ -251,8 +268,9 @@ async function resolveCurrentSessionId(stateDir) {
     || process.env.SESSION_ID
     || '',
   ).trim();
-  if (fromEnv) return fromEnv;
-  return safeString((await readUsableSessionState(resolve(stateDir, '..', '..')))?.session_id).trim();
+  const envSessionId = normalizeValidSessionId(fromEnv);
+  if (envSessionId) return envSessionId;
+  return normalizeValidSessionId((await readUsableSessionState(resolve(stateDir, '..', '..')))?.session_id);
 }
 
 async function readWorkerStatusSnapshot(stateDir, teamName, workerName) {
@@ -601,7 +619,7 @@ export async function maybeNudgeTeamLeader({
       if (!existsSync(teamStatePath)) continue;
       const parsed = JSON.parse(await readFile(teamStatePath, 'utf-8'));
       if (!parsed) continue;
-      const teamName = safeString(parsed.team_name || '').trim();
+      const teamName = normalizeValidTeamName(parsed.team_name || '');
       if (!teamName) continue;
 
       const phaseSnapshot = await readTeamPhaseSnapshot(stateDir, teamName, nowIso);
@@ -619,7 +637,9 @@ export async function maybeNudgeTeamLeader({
 
   const canonicalFallbackTeams = await listNotifyCanonicalActiveTeams(cwd, currentSessionId).catch(() => []);
   for (const team of canonicalFallbackTeams) {
-    candidateTeamNames.add(team.teamName);
+    const teamName = normalizeValidTeamName(team.teamName);
+    if (!teamName) continue;
+    candidateTeamNames.add(teamName);
   }
 
   // Use pre-computed staleness (captured before HUD state was updated this turn)


### PR DESCRIPTION
## Summary
- validate watcher session ids with the existing shared session contract before any session-scoped state join
- validate canonical/coarse team names with the existing shared team contract before any leader follow-up team join
- add focused regression tests for invalid session_id and team_name path-join cases

## Verification
- npm run build
- node --test dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js
- npx biome lint src/scripts/notify-fallback-watcher.ts src/scripts/notify-hook/active-team.ts src/scripts/notify-hook/team-leader-nudge.ts src/hooks/__tests__/notify-fallback-watcher.test.ts src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts