### PR TITLE
fix: keep forked subagent notifications attached to the active fork session

### DIFF
--- a/src/hooks/__tests__/notify-hook-session-idle-dedupe.test.ts
+++ b/src/hooks/__tests__/notify-hook-session-idle-dedupe.test.ts
@@ -127,6 +127,37 @@ describe('notify-hook session-idle dedupe', () => {
     }
   });
 
+
+  it('writes session-idle hook state into the fork session scope when OMX_SESSION_ID targets a fork', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-idle-fork-scope-'));
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const hooksDir = join(wd, '.omx', 'hooks');
+      const pluginStatePath = join(wd, '.omx', 'plugin-state', 'session-idle.json');
+      const canonicalSessionId = 'sess-canonical';
+      const forkSessionId = 'sess-fork';
+
+      await mkdir(join(stateDir, 'sessions', forkSessionId), { recursive: true });
+      await mkdir(hooksDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: canonicalSessionId }, null, 2));
+      await writeFile(join(hooksDir, 'session-idle-counter.mjs'), buildSessionIdlePlugin(pluginStatePath), 'utf-8');
+
+      const result = runNotifyHook(repoRoot, wd, 'Waiting on forked review.', 'turn-idle-fork', {
+        OMX_SESSION_ID: forkSessionId,
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      assert.equal(existsSync(join(stateDir, 'sessions', forkSessionId, 'session-idle-hook-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'sessions', canonicalSessionId, 'session-idle-hook-state.json')), false);
+      const pluginState = await readJson<{ count: number }>(pluginStatePath);
+      assert.equal(pluginState.count, 1);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('keeps post_turn_idle_notification hook dedupe active even when lifecycle cooldown is disabled', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-notify-idle-dedupe-zero-cooldown-'));
     const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');

--- a/src/hooks/__tests__/notify-hook-session-scope.test.ts
+++ b/src/hooks/__tests__/notify-hook-session-scope.test.ts
@@ -226,6 +226,53 @@ describe('notify-hook session-scoped iteration updates', () => {
     }
   });
 
+
+  it('prefers the invocation OMX session id over the persisted canonical session for notify sidefiles when a fork scope exists', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-fork-session-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const canonicalSessionId = 'omx-canonical-session';
+      const forkSessionId = 'omx-fork-session';
+      const nativeSessionId = 'codex-native-session';
+      const forkDir = join(stateDir, 'sessions', forkSessionId);
+      await mkdir(forkDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: canonicalSessionId,
+        native_session_id: nativeSessionId,
+        started_at: new Date().toISOString(),
+        cwd: wd,
+      }));
+
+      const result = spawnSync(process.execPath, ['dist/scripts/notify-hook.js', JSON.stringify({
+        cwd: wd,
+        session_id: nativeSessionId,
+        type: 'agent-turn-complete',
+        thread_id: 'th-fork',
+        turn_id: 'tu-fork',
+        input_messages: [],
+        last_assistant_message: 'ok',
+      })], {
+        cwd: join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..'),
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          OMX_SESSION_ID: forkSessionId,
+          OMX_TEAM_WORKER: '',
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      assert.equal(existsSync(join(forkDir, 'hud-state.json')), true);
+      assert.equal(existsSync(join(forkDir, 'notify-hook-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'sessions', canonicalSessionId, 'hud-state.json')), false);
+      assert.equal(existsSync(join(stateDir, 'sessions', canonicalSessionId, 'notify-hook-state.json')), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('persists visual-verdict feedback from runtime assistant output', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-notify-visual-'));
     try {

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -586,13 +586,8 @@ async function main() {
         shouldSendSessionIdleHookEvent,
         recordSessionIdleHookEventSent,
       } = await import('../notifications/idle-cooldown.js');
-      const sessionJsonPath = join(stateDir, 'session.json');
       const idleFingerprint = buildIdleNotificationFingerprint(payload);
-      let notifySessionId = '';
-      try {
-        const sessionData = JSON.parse(await readFile(sessionJsonPath, 'utf-8'));
-        notifySessionId = safeString(sessionData && sessionData.session_id ? sessionData.session_id : '');
-      } catch { /* no session file */ }
+      const notifySessionId = getEffectiveSessionId();
 
       const shouldNotifyLifecycle = notifySessionId
         && shouldSendIdleNotification(stateDir, notifySessionId, idleFingerprint);

--- a/src/scripts/notify-hook/ralph-session-resume.ts
+++ b/src/scripts/notify-hook/ralph-session-resume.ts
@@ -128,7 +128,22 @@ function isActiveRalphCandidate(state: Record<string, unknown> | null): state is
   return state.active === true && !isTerminalRalphPhase(state.current_phase);
 }
 
-async function readCurrentOmxSessionId(stateDir: string): Promise<string> {
+function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): string {
+  const candidates = [env.OMX_SESSION_ID, env.CODEX_SESSION_ID, env.SESSION_ID];
+  for (const candidate of candidates) {
+    const sessionId = safeString(candidate).trim();
+    if (SESSION_ID_PATTERN.test(sessionId)) return sessionId;
+  }
+  return '';
+}
+
+async function readCurrentOmxSessionId(stateDir: string, env: NodeJS.ProcessEnv = process.env): Promise<string> {
+  const envSessionId = readSessionIdFromEnvironment(env);
+  if (envSessionId) {
+    const envScopedDir = join(stateDir, 'sessions', envSessionId);
+    if (existsSync(envScopedDir)) return envSessionId;
+  }
+
   const session = await readUsableSessionState(resolve(stateDir, '..', '..'));
   const sessionId = safeString(session?.session_id).trim();
   return SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
@@ -194,7 +209,7 @@ export async function reconcileRalphSessionResume({
   const lockedResult = await withRalphResumeLock(stateDir, async () => {
     await hooks?.afterLockAcquired?.();
 
-    const currentOmxSessionId = await readCurrentOmxSessionId(stateDir);
+    const currentOmxSessionId = await readCurrentOmxSessionId(stateDir, env);
     if (!currentOmxSessionId) {
       return {
         currentOmxSessionId: '',

--- a/src/scripts/notify-hook/state-io.ts
+++ b/src/scripts/notify-hook/state-io.ts
@@ -25,7 +25,23 @@ function isSafeStateFileName(fileName: string): boolean {
     && !fileName.includes('\\');
 }
 
+function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const candidates = [env.OMX_SESSION_ID, env.CODEX_SESSION_ID, env.SESSION_ID];
+  for (const candidate of candidates) {
+    const sessionId = safeString(candidate).trim();
+    if (!SESSION_ID_PATTERN.test(sessionId)) continue;
+    return sessionId;
+  }
+  return undefined;
+}
+
 export async function readCurrentSessionId(baseStateDir: string): Promise<string | undefined> {
+  const envSessionId = readSessionIdFromEnvironment();
+  if (envSessionId) {
+    const envScopedDir = join(baseStateDir, 'sessions', envSessionId);
+    if (existsSync(envScopedDir)) return envSessionId;
+  }
+
   const cwd = resolve(baseStateDir, '..', '..');
   const session = await readUsableSessionState(cwd);
   const sessionId = safeString(session?.session_id);


### PR DESCRIPTION
## Summary
- prefer invocation-scoped fork session ids over the persisted canonical session when a matching fork session state exists
- keep notify-hook sidefiles, session-idle emission, and Ralph resume ownership attached to the active fork session
- add focused regression coverage for fork-scoped session resolution and idle dedupe behavior

## Verification
- npm run build
- node --test dist/hooks/__tests__/notify-hook-session-scope.test.js dist/hooks/__tests__/notify-hook-session-idle-dedupe.test.js
- npx biome lint src/scripts/notify-hook/state-io.ts src/scripts/notify-hook.ts src/scripts/notify-hook/ralph-session-resume.ts src/hooks/__tests__/notify-hook-session-scope.test.ts src/hooks/__tests__/notify-hook-session-idle-dedupe.test.ts

Closes #1679