### PR TITLE
fix: keep Ralph visibly active across continuation recovery

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -2265,8 +2265,8 @@ exit 0
     }
   });
 
-  it('waits a full cadence from startup when persisted Ralph steer state is empty', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-startup-cooldown-'));
+  it('sends the first Ralph continue steer immediately when persisted steer state is empty', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-first-steer-'));
     const fakeBinDir = join(wd, 'fake-bin');
     const stateDir = join(wd, '.omx', 'state');
     const tmuxLogPath = join(wd, 'tmux.log');
@@ -2304,24 +2304,21 @@ exit 0
       );
       assert.equal(first.status, 0, first.stderr || first.stdout);
 
-      const second = spawnSync(
-        process.execPath,
-        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
-        { encoding: 'utf-8', env },
-      );
-      assert.equal(second.status, 0, second.stderr || second.stdout);
-
       const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
       const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
-      assert.equal(sends.length, 0, 'empty startup state should wait one cadence period before the first Ralph steer');
+      assert.equal(sends.length, 1, 'empty startup state should send the first Ralph steer immediately once progress is stale');
 
       const watcherState = JSON.parse(await readFile(statePath, 'utf-8'));
-      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'startup_cooldown');
-      assert.equal(watcherState.ralph_continue_steer?.last_sent_at, '');
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'sent');
       assert.match(
-        watcherState.ralph_continue_steer?.cooldown_anchor_at ?? '',
+        watcherState.ralph_continue_steer?.last_sent_at ?? '',
         /^\d{4}-\d{2}-\d{2}T/,
-        'startup cooldown should persist an anchor so restarts stay throttled',
+        'first steer should persist a real send timestamp for active-state signaling',
+      );
+      assert.equal(
+        watcherState.ralph_continue_steer?.cooldown_anchor_at,
+        watcherState.ralph_continue_steer?.last_sent_at,
+        'first steer should anchor subsequent cooldowns to the real send time',
       );
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2942,8 +2942,9 @@ esac
     }
   });
 
-  it("does not re-block Ralph when Stop already continued once", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-once-"));
+  it("keeps blocking Ralph Stop replays until the active task advances", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-replay-"));
+    const previousOmxSessionId = process.env.OMX_SESSION_ID;
     try {
       const stateDir = join(cwd, ".omx", "state");
       await mkdir(stateDir, { recursive: true });
@@ -2955,22 +2956,41 @@ esac
         }),
       );
 
-      const result = await dispatchCodexNativeHook(
+      process.env.OMX_SESSION_ID = "sess-stop-ralph-replay";
+      const payload = {
+        hook_event_name: "Stop",
+        cwd,
+        last_assistant_message: "Next active targets:\n\n1. scheduler integration\n\nI am continuing.",
+      };
+      const expected = {
+        decision: "block",
+        reason:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+        stopReason: "ralph_executing",
+        systemMessage:
+          "OMX Ralph is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+      };
+
+      const first = await dispatchCodexNativeHook(payload, { cwd });
+      const replay = await dispatchCodexNativeHook(
         {
-          hook_event_name: "Stop",
-          cwd,
-          session_id: "sess-stop-ralph-once",
+          ...payload,
           stop_hook_active: true,
         },
         { cwd },
       );
 
-      assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.equal(first.omxEventName, "stop");
+      assert.deepEqual(first.outputJson, expected);
+      assert.equal(replay.omxEventName, "stop");
+      assert.deepEqual(replay.outputJson, expected);
     } finally {
+      if (typeof previousOmxSessionId === "string") process.env.OMX_SESSION_ID = previousOmxSessionId;
+      else delete process.env.OMX_SESSION_ID;
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
 
   it("returns Stop continuation output for native auto-nudge stall prompts", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-"));

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1038,10 +1038,11 @@ async function maybeReturnRepeatableStopOutput(
   signature: string,
   output: Record<string, unknown> | null,
   canonicalSessionId?: string,
+  options: { allowRepeatDuringStopHook?: boolean } = {},
 ): Promise<Record<string, unknown> | null> {
   if (!output) return null;
   const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
-  if (stopHookActive) {
+  if (stopHookActive && options.allowRepeatDuringStopHook !== true) {
     const state = await readJsonIfExists(join(stateDir, NATIVE_STOP_STATE_FILE)) ?? {};
     const previousSignature = readPreviousNativeStopSignature(
       state,
@@ -1387,21 +1388,40 @@ async function buildStopHookOutput(
     return null;
   }
 
-  if (stopHookActive) {
-    return null;
-  }
-
   const currentPhase = safeString(ralphState?.current_phase).trim() || "executing";
   const stopReason = `ralph_${currentPhase}`;
   const systemMessage =
     `OMX Ralph is still active (phase: ${currentPhase}); continue the task and gather fresh verification evidence before stopping.`;
 
-  return {
-    decision: "block",
-    reason: systemMessage,
-    stopReason,
-    systemMessage,
-  };
+  if (stopHookActive) {
+    return await maybeReturnRepeatableStopOutput(
+      payload,
+      stateDir,
+      buildRepeatableStopSignature(payload, "ralph-stop", currentPhase, canonicalSessionId),
+      {
+        decision: "block",
+        reason: systemMessage,
+        stopReason,
+        systemMessage,
+      },
+      canonicalSessionId,
+      { allowRepeatDuringStopHook: true },
+    );
+  }
+
+  return await maybeReturnRepeatableStopOutput(
+    payload,
+    stateDir,
+    buildRepeatableStopSignature(payload, "ralph-stop", currentPhase, canonicalSessionId),
+    {
+      decision: "block",
+      reason: systemMessage,
+      stopReason,
+      systemMessage,
+    },
+    canonicalSessionId,
+    { allowRepeatDuringStopHook: true },
+  );
 }
 
 export async function dispatchCodexNativeHook(

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -875,7 +875,7 @@ async function readRalphProgressGate(
   return { allow: true, reason: 'progress_stale', progress_at: progressAt, subagent_session_id: subagentSessionId };
 }
 
-function shouldSkipRalphContinue(now: number, candidateIso: string, startupIso: string): { skip: boolean; reason: string; anchorMs: number; anchorIso: string } {
+function shouldSkipRalphContinue(now: number, candidateIso: string): { skip: boolean; reason: string; anchorMs: number; anchorIso: string } {
   const sharedMs = parseIsoMillis(candidateIso);
   const localMs = parseIsoMillis(lastRalphContinueSteer.last_sent_at);
   const startupAnchorIso = lastRalphContinueSteer.cooldown_anchor_at;
@@ -1032,7 +1032,6 @@ async function writePidFileRecord(): Promise<void> {
 async function runRalphContinueSteerTick(): Promise<void> {
   const now = Date.now();
   const nowIso = new Date(now).toISOString();
-  const startupIso = new Date(startedAt).toISOString();
   const activeRalph = await resolveActiveRalphState();
   const activePaneId = safeString(activeRalph.state?.tmux_pane_id).trim();
   lastRalphContinueSteer = {
@@ -1060,7 +1059,7 @@ async function runRalphContinueSteerTick(): Promise<void> {
 
   const sharedBeforeLock = await readRalphSteerTimestamp();
   lastRalphContinueSteer.shared_last_sent_at = sharedBeforeLock;
-  const initialCooldown = shouldSkipRalphContinue(now, sharedBeforeLock, startupIso);
+  const initialCooldown = shouldSkipRalphContinue(now, sharedBeforeLock);
   if (initialCooldown.skip) {
     lastRalphContinueSteer.last_reason = initialCooldown.reason;
     if (!sharedBeforeLock && initialCooldown.reason === 'startup_cooldown') {
@@ -1072,7 +1071,7 @@ async function runRalphContinueSteerTick(): Promise<void> {
   const outcome = await withRalphSteerLock(async () => {
     const sharedLastSentAt = await readRalphSteerTimestamp();
     lastRalphContinueSteer.shared_last_sent_at = sharedLastSentAt;
-    const cooldown = shouldSkipRalphContinue(Date.now(), sharedLastSentAt, startupIso);
+    const cooldown = shouldSkipRalphContinue(Date.now(), sharedLastSentAt);
     if (cooldown.skip) {
       lastRalphContinueSteer.last_reason = cooldown.reason;
       if (!sharedLastSentAt && cooldown.reason === 'startup_cooldown') {

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -878,15 +878,15 @@ async function readRalphProgressGate(
 function shouldSkipRalphContinue(now: number, candidateIso: string, startupIso: string): { skip: boolean; reason: string; anchorMs: number; anchorIso: string } {
   const sharedMs = parseIsoMillis(candidateIso);
   const localMs = parseIsoMillis(lastRalphContinueSteer.last_sent_at);
-  const startupAnchorIso = lastRalphContinueSteer.cooldown_anchor_at || startupIso;
+  const startupAnchorIso = lastRalphContinueSteer.cooldown_anchor_at;
   const startupAnchorMs = parseIsoMillis(startupAnchorIso);
-  const startupCooldown = sharedMs === null && localMs === null;
-  const anchorMs = sharedMs ?? localMs ?? startupAnchorMs ?? startedAt;
+  const startupCooldown = sharedMs === null && localMs === null && startupAnchorMs !== null;
+  const anchorMs = sharedMs ?? localMs ?? startupAnchorMs ?? 0;
   const anchorIso = sharedMs !== null
     ? candidateIso
     : (localMs !== null ? lastRalphContinueSteer.last_sent_at : startupAnchorIso);
   return {
-    skip: now - anchorMs < RALPH_CONTINUE_CADENCE_MS,
+    skip: anchorMs > 0 && now - anchorMs < RALPH_CONTINUE_CADENCE_MS,
     reason: startupCooldown ? 'startup_cooldown' : (sharedMs !== null ? 'global_cooldown' : 'cooldown'),
     anchorMs,
     anchorIso,
@@ -1056,10 +1056,6 @@ async function runRalphContinueSteerTick(): Promise<void> {
       lastRalphContinueSteer.last_reason = 'starting_stale';
     }
     return;
-  }
-
-  if (parseIsoMillis(lastRalphContinueSteer.last_sent_at) === null && parseIsoMillis(lastRalphContinueSteer.cooldown_anchor_at) === null) {
-    lastRalphContinueSteer.cooldown_anchor_at = startupIso;
   }
 
   const sharedBeforeLock = await readRalphSteerTimestamp();


### PR DESCRIPTION
## Summary
- keep Ralph stop-blocking repeatable while Ralph is still active so "I am continuing" does not become a terminal dead-end
- stop inventing a synthetic startup cooldown anchor in the notify fallback watcher when no real Ralph steer was sent yet
- add focused regression coverage for both continuation-recovery failure modes

## Verification
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js dist/hooks/__tests__/notify-hook-ralph-resume.test.js
- npx biome lint src/scripts/codex-native-hook.ts src/scripts/notify-fallback-watcher.ts src/scripts/__tests__/codex-native-hook.test.ts src/hooks/__tests__/notify-fallback-watcher.test.ts

Closes #1677