### PR TITLE
docs: add Shift+Enter tmux troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ omx doctor --team
 
 Only use the forced team shutdown for a team you have confirmed is dead or intentionally abandoned.
 
+If `Shift+Enter` still submits instead of inserting a newline inside an OMX-managed tmux session, see [Troubleshooting execution readiness](./docs/troubleshooting.md#shiftenter-submits-instead-of-inserting-a-newline-in-tmux-backed-omx-sessions). Current OMX already enables tmux extended-key forwarding around its own Codex launch paths, so a persistent failure is usually a tmux terminal-capability/discoverability problem rather than a net-new OMX feature gap.
+
 ### Explore and sparkshell
 
 - `omx explore --prompt "..."` is for read-only repository lookup

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,3 +54,56 @@ omx doctor --team
 ```
 
 Do not force-shutdown a team that may still have useful live panes or worker state. Prefer `omx team status <team-name>` and `tmux ls` first when unsure.
+
+## Shift+Enter submits instead of inserting a newline in tmux-backed OMX sessions
+
+This is usually **not** a net-new OMX feature gap.
+
+OMX already carries the tmux-side preservation work from issue `#1271` / PR `#1273` (`4405f582`, “Preserve Shift+Enter inside tmux-backed OMX launches”), and current `dev` still enables tmux `extended-keys=always` around OMX-owned Codex launch paths:
+
+- in-tmux launches wrap Codex with `withTmuxExtendedKeys(...)` in `src/cli/index.ts`
+- detached tmux launches acquire the same protection through the detached leader bootstrap/cleanup path in `src/cli/index.ts`
+- regression tests still cover the enable/restore/lease behavior in `src/cli/__tests__/index.test.ts`
+
+So if `Shift+Enter` still behaves like plain `Enter`, the narrowest likely causes are:
+
+1. **tmux is not actually forwarding extended keys for the reporter's terminal path**
+   - tmux only forwards the richer key event when the attached terminal is detected as supporting extended keys
+   - `tmux show -gv extended-keys` can say `always`, but forwarding can still fail if the terminal capability is missing or not detected
+2. **the reporter is not in the OMX-owned tmux launch path**
+   - for example, reproducing in a different pane/session than the one OMX launched or after attaching through a different client path
+3. **terminal-specific capability mismatch**
+   - some terminals need an explicit tmux `terminal-features` hint for `extkeys`
+
+### Operator checks
+
+Run these from the same tmux client/session where the failure happens:
+
+```bash
+tmux show -gv extended-keys
+tmux info | grep extkeys
+tmux show -gv terminal-features
+printf '%s\n' "$TERM" "$TERM_PROGRAM"
+```
+
+Expected first check: `always` while OMX is actively running Codex in that tmux-managed path.
+
+If `extended-keys` is **not** `always` during the failing session, that points to an OMX launch-path bug/regression.
+
+If `extended-keys` **is** `always`, but `Shift+Enter` still submits, the likely problem is terminal capability discovery or upstream Codex terminal-input interpretation rather than OMX submission logic.
+
+### Typical environment fix
+
+If your terminal supports extended keys but tmux does not detect it automatically, add an `extkeys` feature hint in `~/.tmux.conf` and restart tmux:
+
+```tmux
+set -as terminal-features ',xterm-256color:extkeys'
+```
+
+Adjust the terminal pattern if your client advertises a different terminfo name.
+
+### Maintainer triage guidance
+
+- **Open a code fix** only if you can show current `dev` fails to set `extended-keys=always` on the live OMX-owned tmux launch path.
+- **Close as environment limitation** if current `dev` sets the tmux option correctly but the reporter's terminal path still does not forward the richer key event.
+- **Prefer a docs follow-up** when the root problem is discoverability/operator guidance rather than a broken OMX codepath.


### PR DESCRIPTION
## Summary
- add a README pointer to Shift+Enter troubleshooting for tmux-backed OMX sessions
- document that current OMX already enables tmux extended-key forwarding on its managed launch paths
- add operator checks and maintainer triage guidance to separate tmux/terminal capability issues from real OMX regressions

## Testing
- npm run build
- npm run lint
- npm test *(currently fails on pre-existing `dist/utils/__tests__/paths.test.js` launcher-path assertions unrelated to these docs changes)*

## Related
- issue #1682