### PR TITLE
Keep UserPromptSubmit success quiet and reconcile completed workflow state

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1040,7 +1040,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
-  it('denies switching away from a standalone workflow without explicit clear', async () => {
+  it('auto-completes autopilot when explicit handoff moves to ralph', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-skill-switch-deny-'));
     const stateDir = join(cwd, '.omx', 'state');
     const statePath = join(stateDir, SKILL_ACTIVE_STATE_FILE);
@@ -1067,9 +1067,10 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
 
       assert.ok(result);
-      assert.equal(result.skill, 'autopilot');
-      assert.match(String(result.transition_error), /Unsupported workflow overlap: autopilot \+ ralph\./);
-      assert.equal(result.activated_at, '2026-02-25T00:00:00.000Z');
+      assert.equal(result.skill, 'ralph');
+      assert.equal(result.transition_error, undefined);
+      assert.equal(result.transition_message, 'mode transiting: autopilot -> ralph');
+      assert.equal(result.activated_at, '2026-02-26T00:00:00.000Z');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -74,6 +74,17 @@ const TEAM_COMM_TOOL_NAMES: Set<string> = new Set([...LEGACY_TEAM_MCP_TOOLS]);
 
 const stateWriteQueues = new Map<string, Promise<void>>();
 
+function safeString(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function isStateEffectivelyActive(
+	state: { active?: unknown; completed_at?: unknown } | null | undefined,
+): boolean {
+	if (!state || state.active !== true) return false;
+	return safeString(state.completed_at).trim() === "";
+}
+
 async function listStateSessionIds(cwd: string): Promise<string[]> {
 	const sessionsDir = join(getStateDir(cwd), "sessions");
 	if (!existsSync(sessionsDir)) return [];
@@ -397,7 +408,7 @@ export async function handleStateToolCall(request: {
 							Object.assign(mergedRaw, validation.state);
 							ensureRalphArtifacts = true;
 						}
-						if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
+						if (isTrackedWorkflowMode(mode) && isStateEffectivelyActive(mergedRaw)) {
 							try {
 								if (!effectiveSessionId) {
 									for (const sessionId of await listStateSessionIds(cwd)) {
@@ -448,7 +459,7 @@ export async function handleStateToolCall(request: {
 						await syncCanonicalSkillStateForMode({
 							cwd,
 						mode,
-						active: data.active === true,
+								active: isStateEffectivelyActive(data),
 						currentPhase: typeof data.current_phase === "string" ? data.current_phase : undefined,
 						sessionId: effectiveSessionId,
 					});
@@ -546,7 +557,7 @@ export async function handleStateToolCall(request: {
 							const data = JSON.parse(
 								await readFile(join(stateDir, f), "utf-8"),
 							);
-							if (data.active) {
+							if (isStateEffectivelyActive(data)) {
 								active.push(mode);
 							}
 						} catch (e) {
@@ -585,7 +596,7 @@ export async function handleStateToolCall(request: {
 								await readFile(join(stateDir, f), "utf-8"),
 							);
 							statuses[m] = {
-								active: data.active,
+								active: isStateEffectivelyActive(data),
 								phase: data.current_phase,
 								path: join(stateDir, f),
 								data,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -362,8 +362,7 @@ describe("codex native hook dispatch", () => {
 
       assert.equal(result.omxEventName, "keyword-detector");
       assert.equal(result.skillState?.skill, "ralplan");
-      assert.ok(result.outputJson, "UserPromptSubmit should emit developer context");
-      assert.match(JSON.stringify(result.outputJson), /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.equal(result.outputJson, null);
 
       const statePath = join(cwd, ".omx", "state", "skill-active-state.json");
       assert.equal(existsSync(statePath), true);
@@ -399,13 +398,7 @@ describe("codex native hook dispatch", () => {
 
       assert.equal(result.omxEventName, "keyword-detector");
       assert.equal(result.skillState?.skill, "ralph");
-      const message = String(
-        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
-      );
-      assert.match(message, /\$ralph" -> ralph/);
-      assert.match(message, /skill: ralph activated and initial state initialized at \.omx\/state\/sessions\/sess-ralph-msg\/ralph-state\.json; write subsequent updates via omx_state MCP\./);
-      assert.match(message, /Prompt-side `\$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`\./);
-      assert.match(message, /Use `omx ralph --prd \.\.\.` only when you explicitly want the PRD-gated CLI startup path\./);
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -543,12 +536,7 @@ export async function onHookEvent(event) {
 
       assert.equal(result.omxEventName, "keyword-detector");
       assert.equal(result.skillState?.skill, "team");
-      assert.match(
-        JSON.stringify(result.outputJson),
-        /skill: team activated and initial state initialized at \.omx\/state\/team-state\.json; write subsequent updates via omx_state MCP\./,
-      );
-      assert.match(JSON.stringify(result.outputJson), /Use the durable OMX team runtime via `omx team \.\.\.`/);
-      assert.match(JSON.stringify(result.outputJson), /If you need runtime syntax, run `omx team --help` yourself\./);
+      assert.equal(result.outputJson, null);
 
       const state = JSON.parse(
         await readFile(join(cwd, ".omx", "state", "team-state.json"), "utf-8"),
@@ -602,7 +590,7 @@ export async function onHookEvent(event) {
     }
   });
 
-  it("surfaces transition success output for allowlisted prompt-submit handoffs", async () => {
+  it("keeps allowlisted prompt-submit handoffs silent while still reconciling state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-transition-success-"));
     try {
       const sessionDir = join(cwd, ".omx", "state", "sessions", "sess-handoff-1");
@@ -632,13 +620,62 @@ export async function onHookEvent(event) {
         { cwd },
       );
 
-      assert.match(JSON.stringify(result.outputJson), /mode transiting: deep-interview -> ralplan/);
+      assert.equal(result.outputJson, null);
       const completed = JSON.parse(await readFile(join(sessionDir, "deep-interview-state.json"), "utf-8")) as {
         active?: boolean;
         current_phase?: string;
       };
       assert.equal(completed.active, false);
       assert.equal(completed.current_phase, "completed");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps autopilot to ralph prompt-submit handoff silent while reconciling state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-ralph-handoff-"));
+    try {
+      const sessionDir = join(cwd, ".omx", "state", "sessions", "sess-handoff-2");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "validation",
+        started_at: "2026-02-25T00:00:00.000Z",
+      });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "validation",
+        session_id: "sess-handoff-2",
+        active_skills: [{ skill: "autopilot", phase: "validation", active: true, session_id: "sess-handoff-2" }],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-handoff-2",
+          thread_id: "thread-handoff-2",
+          turn_id: "turn-handoff-2",
+          prompt: "$ralph should fix this",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+      const completed = JSON.parse(await readFile(join(sessionDir, "autopilot-state.json"), "utf-8")) as {
+        active?: boolean;
+        current_phase?: string;
+      };
+      assert.equal(completed.active, false);
+      assert.equal(completed.current_phase, "completed");
+      const ralph = JSON.parse(await readFile(join(sessionDir, "ralph-state.json"), "utf-8")) as {
+        active?: boolean;
+        mode?: string;
+      };
+      assert.equal(ralph.active, true);
+      assert.equal(ralph.mode, "ralph");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -661,16 +698,9 @@ export async function onHookEvent(event) {
         { cwd },
       );
 
-      const message = String(
-        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || '',
-      );
-      assert.match(message, /\$ralplan" -> ralplan/);
-      assert.match(message, /\$team" -> team/);
-      assert.match(message, /\$ralph" -> ralph/);
-      assert.doesNotMatch(message, /mode transiting:/);
-      assert.match(message, /planning preserved over simultaneous execution follow-up; deferred skills: team, ralph\./);
-      assert.match(message, /skill: ralplan activated and initial state initialized at \.omx\/state\/sessions\/sess-multi-1\/ralplan-state\.json; write subsequent updates via omx_state MCP\./);
-      assert.doesNotMatch(message, /Use the durable OMX team runtime via `omx team \.\.\.`/);
+      assert.equal(result.outputJson, null);
+      assert.equal(result.skillState?.skill, "ralplan");
+      assert.deepEqual(result.skillState?.deferred_skills, ["team", "ralph"]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -459,29 +459,8 @@ async function buildSessionStartContext(
 
 function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveState | null): string | null {
   if (!prompt) return null;
-  const matches = detectKeywords(prompt);
   const match = detectPrimaryKeyword(prompt);
   if (!match) return null;
-  const detectedKeywordMessage = matches.length > 1
-    ? `OMX native UserPromptSubmit detected workflow keywords ${matches.map((entry) => `"${entry.keyword}" -> ${entry.skill}`).join(", ")}.`
-    : `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`;
-  const activeSkills = Array.isArray(skillState?.active_skills)
-    ? skillState.active_skills.map((entry) => entry.skill)
-    : [];
-  const deferredSkills = Array.isArray(skillState?.deferred_skills)
-    ? skillState.deferred_skills
-    : [];
-  const teamDetected = activeSkills.includes("team");
-  const ralphPromptActivationNote = skillState?.initialized_mode === "ralph"
-    ? "Prompt-side `$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`. Use `omx ralph --prd ...` only when you explicitly want the PRD-gated CLI startup path."
-    : null;
-  const combinedTransitionMessage = (() => {
-    if (!skillState?.transition_message) return null;
-    if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
-    const source = skillState.transition_message.match(/^mode transiting: (.+?) -> /)?.[1];
-    if (!source) return skillState.transition_message;
-    return `mode transiting: ${source} -> ${activeSkills.join(" + ")}`;
-  })();
 
   if (skillState?.transition_error) {
     return [
@@ -490,57 +469,7 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
       'Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.',
     ].join(' ');
   }
-
-  if (skillState?.transition_message) {
-    return [
-      detectedKeywordMessage,
-      combinedTransitionMessage,
-      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
-      deferredSkills.length > 0
-        ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
-        : null,
-      skillState.initialized_mode && skillState.initialized_state_path
-        ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
-        : null,
-      teamDetected
-        ? "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout."
-        : null,
-      teamDetected ? "If you need runtime syntax, run `omx team --help` yourself." : null,
-      'Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.',
-    ].filter(Boolean).join(' ');
-  }
-
-  if (teamDetected) {
-    const initializedStateMessage = skillState?.initialized_mode && skillState.initialized_state_path
-      ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
-      : null;
-    return [
-      detectedKeywordMessage,
-      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
-      deferredSkills.length > 0
-        ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
-        : null,
-      initializedStateMessage,
-      "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
-      "If you need runtime syntax, run `omx team --help` yourself.",
-      "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
-    ].filter(Boolean).join(" ");
-  }
-
-  if (skillState?.initialized_mode && skillState.initialized_state_path) {
-    return [
-      detectedKeywordMessage,
-      activeSkills.length > 1 ? `active skills: ${activeSkills.join(", ")}.` : null,
-      deferredSkills.length > 0
-        ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
-        : null,
-      `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
-      ralphPromptActivationNote,
-      "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
-    ].join(" ");
-  }
-
-  return `${detectedKeywordMessage} Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.`;
+  return null;
 }
 
 function parseTeamWorkerEnv(rawValue: string): { teamName: string; workerName: string } | null {

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -58,6 +58,13 @@ describe('workflow transition rules', () => {
     assert.equal(ralplanToRalph.kind, 'auto-complete');
     assert.deepEqual(ralplanToRalph.autoCompleteModes, ['ralplan']);
     assert.deepEqual(ralplanToRalph.resultingModes, ['ultrawork', 'ralph']);
+
+    const autopilotToRalph = evaluateWorkflowTransition(['autopilot'], 'ralph');
+    assert.equal(autopilotToRalph.allowed, true);
+    assert.equal(autopilotToRalph.kind, 'auto-complete');
+    assert.deepEqual(autopilotToRalph.autoCompleteModes, ['autopilot']);
+    assert.deepEqual(autopilotToRalph.resultingModes, ['ralph']);
+    assert.equal(autopilotToRalph.transitionMessage, 'mode transiting: autopilot -> ralph');
   });
 
   it('builds rollback denial guidance for execution-to-planning transitions', () => {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -82,6 +82,15 @@ async function writeAtomicFile(path: string, data: string): Promise<void> {
   }
 }
 
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function isStateEffectivelyActive(state: { active?: unknown; completed_at?: unknown } | null | undefined): boolean {
+  if (!state || state.active !== true) return false;
+  return safeString(state.completed_at).trim() === '';
+}
+
 function readModeSupportsStrictValidation(mode: string): mode is SupportedStateReadMode {
   return SUPPORTED_STATE_READ_MODES.includes(mode as SupportedStateReadMode);
 }
@@ -135,7 +144,7 @@ export async function listStateStatuses(
       try {
         const data = JSON.parse(await readFile(join(stateDir, file), 'utf-8'));
         statuses[currentMode] = {
-          active: data.active,
+          active: isStateEffectivelyActive(data),
           phase: data.current_phase,
           path: join(stateDir, file),
           data,
@@ -252,7 +261,7 @@ export async function executeStateOperation(
             ensureRalphArtifacts = true;
           }
 
-          if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
+          if (isTrackedWorkflowMode(mode) && isStateEffectivelyActive(mergedRaw)) {
             try {
               if (!effectiveSessionId) {
                 for (const sessionId of await listStateSessionIds(cwd)) {
@@ -301,7 +310,7 @@ export async function executeStateOperation(
           await syncCanonicalSkillStateForMode({
             cwd,
             mode,
-            active: data.active === true,
+            active: isStateEffectivelyActive(data),
             currentPhase: typeof data.current_phase === 'string' ? data.current_phase : undefined,
             sessionId: effectiveSessionId,
             source: 'state-operations',

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -35,6 +35,11 @@ function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
+function isStateEffectivelyActive(state: TransitionStateLike | null | undefined): boolean {
+  if (!state || state.active !== true) return false;
+  return safeString(state.completed_at).trim() === '';
+}
+
 async function readJsonIfExists(
   path: string,
   options?: { mode?: TrackedWorkflowMode; throwOnParseError?: boolean },
@@ -68,7 +73,7 @@ async function visibleTrackedModes(cwd: string, sessionId?: string): Promise<Tra
         mode,
         throwOnParseError: true,
       });
-      if (state?.active === true) {
+      if (isStateEffectivelyActive(state)) {
         visibleModes.add(mode);
       }
     }
@@ -93,13 +98,14 @@ async function completeSourceModeState(
 
   for (const candidatePath of candidatePaths) {
     const existing = await readJsonIfExists(candidatePath);
-    if (!existing || existing.active !== true) continue;
+    if (!isStateEffectivelyActive(existing)) continue;
+    const activeExisting = existing as TransitionStateLike;
 
     const nextState: TransitionStateLike = {
-      ...existing,
+      ...activeExisting,
       active: false,
       current_phase: 'completed',
-      completed_at: safeString(existing.completed_at).trim() || nowIso,
+      completed_at: safeString(activeExisting.completed_at).trim() || nowIso,
       auto_completed_reason: transitionMessage,
       completion_note: `Auto-completed ${sourceMode} during allowlisted transition to ${destinationMode}.`,
       transition_source: source,

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+import { getStatePath } from '../mcp/state-paths.js';
 
 export const TRACKED_WORKFLOW_MODES = [
   'autopilot',
@@ -26,6 +26,7 @@ const AUTO_COMPLETE_TRANSITIONS = new Set([
   'ralplan->team',
   'ralplan->ralph',
   'ralplan->autopilot',
+  'autopilot->ralph',
 ]);
 
 const PLANNING_LIKE_MODES = new Set<TrackedWorkflowMode>([
@@ -44,6 +45,11 @@ const EXECUTION_LIKE_MODES = new Set<TrackedWorkflowMode>([
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+function isStateEffectivelyActive(state: { active?: unknown; completed_at?: unknown } | null | undefined): boolean {
+  if (!state || state.active !== true) return false;
+  return safeString(state.completed_at).trim() === '';
 }
 
 function normalizeTrackedModes(modes: Iterable<string>): TrackedWorkflowMode[] {
@@ -216,12 +222,17 @@ export async function readActiveWorkflowModes(
   const activeModes: TrackedWorkflowMode[] = [];
 
   for (const mode of TRACKED_WORKFLOW_MODES) {
-    const candidatePaths = await getReadScopedStatePaths(mode, cwd, sessionId);
+    const candidatePaths = sessionId
+      ? [getStatePath(mode, cwd, sessionId), getStatePath(mode, cwd)]
+      : [getStatePath(mode, cwd)];
     for (const candidatePath of candidatePaths) {
       if (!existsSync(candidatePath)) continue;
       try {
-        const parsed = JSON.parse(await readFile(candidatePath, 'utf-8')) as { active?: unknown };
-        if (parsed.active === true) {
+        const parsed = JSON.parse(await readFile(candidatePath, 'utf-8')) as {
+          active?: unknown;
+          completed_at?: unknown;
+        };
+        if (isStateEffectivelyActive(parsed)) {
           activeModes.push(mode);
         }
         break;


### PR DESCRIPTION
Summary:
- silence successful UserPromptSubmit activations and allowlisted handoffs so hook output only appears for actionable denials
- treat workflow state with completed_at as inactive across transition, state operations, and MCP status surfaces
- allow autopilot -> ralph prompt-submit handoff and update keyword-detector/codex-native-hook regressions

Testing:
- npm run build
- node --test dist/state/__tests__/workflow-transition.test.js
- node --test --test-name-pattern="records keyword activation from UserPromptSubmit payloads|clarifies that prompt-side \$ralph activation does not invoke the PRD-gated CLI path|nudges \$team prompt-submit routing toward omx team runtime usage|unsupported workflow overlaps on prompt submit|allowlisted prompt-submit handoffs|autopilot to ralph prompt-submit handoff|planning and execution workflows are invoked together" dist/scripts/__tests__/codex-native-hook.test.js
- node --test --test-name-pattern="auto-completes autopilot when explicit handoff moves to ralph" dist/hooks/__tests__/keyword-detector.test.js

Notes:
- test:recent-bug-regressions:compiled still shows existing launch-fallback failures unrelated to this change.