### PR TITLE
Track OMX-shipped skill provenance separately from installed skill metadata

### DIFF
--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -17,8 +17,59 @@ describe('omx setup skills overwrite behavior', () => {
       await setup({ scope: 'project' });
 
       const wikiSkill = join(wd, '.codex', 'skills', 'wiki', 'SKILL.md');
+      const provenanceManifestPath = join(
+        wd,
+        '.codex',
+        'skills',
+        '.system',
+        'omx-installed-skills.json',
+      );
       assert.equal(existsSync(wikiSkill), true);
-      assert.match(await readFile(wikiSkill, 'utf-8'), /^---\nname: wiki/m);
+      const manifest = JSON.parse(await readFile(provenanceManifestPath, 'utf-8')) as {
+        skills: Record<string, { origin: string; source: string }>;
+      };
+      assert.deepEqual(manifest.skills.wiki, {
+        origin: 'omx',
+        source: 'repo-shipped',
+      });
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('records shipped OMX skills in a provenance manifest without changing installed or shipped skill metadata', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const installedHelpSkill = join(wd, '.codex', 'skills', 'help', 'SKILL.md');
+      const shippedHelpSkill = join(previousCwd, 'skills', 'help', 'SKILL.md');
+      const provenanceManifestPath = join(
+        wd,
+        '.codex',
+        'skills',
+        '.system',
+        'omx-installed-skills.json',
+      );
+      const manifest = JSON.parse(await readFile(provenanceManifestPath, 'utf-8')) as {
+        schema_version: number;
+        generated_at: string;
+        skills: Record<string, { origin: string; source: string }>;
+      };
+
+      assert.equal(manifest.schema_version, 1);
+      assert.equal(typeof manifest.generated_at, 'string');
+      assert.deepEqual(manifest.skills.help, {
+        origin: 'omx',
+        source: 'repo-shipped',
+      });
+      assert.match(await readFile(installedHelpSkill, 'utf-8'), /^name: help$/m);
+      assert.match(await readFile(shippedHelpSkill, 'utf-8'), /^name: help$/m);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -184,9 +235,23 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project' });
       assert.equal(await readFile(customSkillPath, 'utf-8'), '---\nname: my-custom-skill\ndescription: local custom skill\n---\n');
+      const manifestAfterInstall = JSON.parse(
+        await readFile(
+          join(wd, '.codex', 'skills', '.system', 'omx-installed-skills.json'),
+          'utf-8',
+        ),
+      ) as { skills: Record<string, unknown> };
+      assert.equal('my-custom-skill' in manifestAfterInstall.skills, false);
 
       await setup({ scope: 'project', force: true });
       assert.equal(await readFile(customSkillPath, 'utf-8'), '---\nname: my-custom-skill\ndescription: local custom skill\n---\n');
+      const manifestAfterForce = JSON.parse(
+        await readFile(
+          join(wd, '.codex', 'skills', '.system', 'omx-installed-skills.json'),
+          'utf-8',
+        ),
+      ) as { skills: Record<string, unknown> };
+      assert.equal('my-custom-skill' in manifestAfterForce.skills, false);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -27,6 +27,7 @@ import {
   detectLegacySkillRootOverlap,
   omxPlansDir,
   omxLogsDir,
+  omxInstalledSkillsManifestPath,
 } from "../utils/paths.js";
 import {
   buildMergedConfig,
@@ -339,6 +340,71 @@ export function parseSkillFrontmatter(
 export async function validateSkillFile(skillMdPath: string): Promise<void> {
   const content = await readFile(skillMdPath, "utf-8");
   parseSkillFrontmatter(content, skillMdPath);
+}
+
+interface InstalledOmxSkillsManifestMetadata {
+  schema_version: 1;
+  generated_at: string;
+  skills: Record<
+    string,
+    {
+      origin: "omx";
+      source: "repo-shipped";
+    }
+  >;
+}
+
+function tryParseInstalledOmxSkillsManifest(
+  content: string,
+): InstalledOmxSkillsManifestMetadata | null {
+  try {
+    const parsed = JSON.parse(content) as Partial<InstalledOmxSkillsManifestMetadata>;
+    if (
+      parsed?.schema_version !== 1 ||
+      typeof parsed.generated_at !== "string" ||
+      parsed.skills == null ||
+      typeof parsed.skills !== "object"
+    ) {
+      return null;
+    }
+    return parsed as InstalledOmxSkillsManifestMetadata;
+  } catch {
+    return null;
+  }
+}
+
+function buildInstalledOmxSkillsManifest(
+  skillNames: readonly string[],
+  existingContent?: string,
+): string {
+  const skills = Object.fromEntries(
+    [...new Set(skillNames)]
+      .sort((left, right) => left.localeCompare(right))
+      .map((skillName) => [
+        skillName,
+        {
+          origin: "omx" as const,
+          source: "repo-shipped" as const,
+        },
+      ]),
+  );
+  const existingManifest = existingContent
+    ? tryParseInstalledOmxSkillsManifest(existingContent)
+    : null;
+  const generatedAt =
+    existingManifest &&
+      JSON.stringify(existingManifest.skills) === JSON.stringify(skills)
+      ? existingManifest.generated_at
+      : new Date().toISOString();
+  return JSON.stringify(
+    {
+      schema_version: 1 as const,
+      generated_at: generatedAt,
+      skills,
+    },
+    null,
+    2,
+  ) + "\n";
 }
 
 async function buildLegacySkillOverlapNotice(
@@ -1530,6 +1596,17 @@ export async function installSkills(
       const sfStat = await stat(sfPath);
       if (!sfStat.isFile()) continue;
       const dstPath = join(skillDst, sf);
+      if (sf === "SKILL.md") {
+        await syncManagedContent(
+          await readFile(sfPath, "utf-8"),
+          dstPath,
+          summary,
+          backupContext,
+          options,
+          `skill ${skillName}/${sf}`,
+        );
+        continue;
+      }
       await syncManagedFileFromDisk(
         sfPath,
         dstPath,
@@ -1540,6 +1617,23 @@ export async function installSkills(
       );
     }
   }
+
+  const omxSkillsManifestPath = omxInstalledSkillsManifestPath(dstDir);
+  const existingManifestContent = existsSync(omxSkillsManifestPath)
+    ? await readFile(omxSkillsManifestPath, "utf-8")
+    : undefined;
+
+  await syncManagedContent(
+    buildInstalledOmxSkillsManifest(
+      installableSkills.map((skill) => skill.name),
+      existingManifestContent,
+    ),
+    omxSkillsManifestPath,
+    summary,
+    backupContext,
+    options,
+    "skill provenance manifest",
+  );
 
   if (options.force && manifest && existsSync(dstDir)) {
     for (const staleSkill of staleCandidateSkillNames) {

--- a/src/utils/__tests__/installed-skill-origin.test.ts
+++ b/src/utils/__tests__/installed-skill-origin.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import {
+  listInstalledSkillDirectories,
+  omxInstalledSkillsManifestPath,
+} from "../paths.js";
+
+describe("installed skill provenance", () => {
+  let originalCodexHome: string | undefined;
+
+  beforeEach(() => {
+    originalCodexHome = process.env.CODEX_HOME;
+  });
+
+  afterEach(() => {
+    if (typeof originalCodexHome === "string") {
+      process.env.CODEX_HOME = originalCodexHome;
+    } else {
+      delete process.env.CODEX_HOME;
+    }
+  });
+
+  it("marks OMX-shipped skills from the per-root manifest while preserving project/user origins for custom skills", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "omx-skill-origin-project-"));
+    const codexHomeRoot = await mkdtemp(join(tmpdir(), "omx-skill-origin-codex-"));
+    process.env.CODEX_HOME = codexHomeRoot;
+
+    try {
+      const projectHelpDir = join(projectRoot, ".codex", "skills", "help");
+      const projectCustomDir = join(projectRoot, ".codex", "skills", "custom-project");
+      const userPlanDir = join(codexHomeRoot, "skills", "plan");
+      const userCustomDir = join(codexHomeRoot, "skills", "custom-user");
+
+      await mkdir(projectHelpDir, { recursive: true });
+      await mkdir(projectCustomDir, { recursive: true });
+      await mkdir(userPlanDir, { recursive: true });
+      await mkdir(userCustomDir, { recursive: true });
+      await mkdir(join(projectRoot, ".codex", "skills", ".system"), {
+        recursive: true,
+      });
+      await mkdir(join(codexHomeRoot, "skills", ".system"), {
+        recursive: true,
+      });
+
+      await writeFile(join(projectHelpDir, "SKILL.md"), "# project help\n");
+      await writeFile(join(projectCustomDir, "SKILL.md"), "# project custom\n");
+      await writeFile(join(userPlanDir, "SKILL.md"), "# user plan\n");
+      await writeFile(join(userCustomDir, "SKILL.md"), "# user custom\n");
+
+      await writeFile(
+        omxInstalledSkillsManifestPath(join(projectRoot, ".codex", "skills")),
+        JSON.stringify(
+          {
+            schema_version: 1,
+            generated_at: "2026-04-17T00:00:00.000Z",
+            skills: {
+              help: { origin: "omx", source: "repo-shipped" },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFile(
+        omxInstalledSkillsManifestPath(join(codexHomeRoot, "skills")),
+        JSON.stringify(
+          {
+            schema_version: 1,
+            generated_at: "2026-04-17T00:00:00.000Z",
+            skills: {
+              plan: { origin: "omx", source: "repo-shipped" },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const skills = await listInstalledSkillDirectories(projectRoot);
+      assert.deepEqual(
+        skills.map((skill) => ({
+          name: skill.name,
+          origin: skill.origin,
+          scope: skill.scope,
+        })),
+        [
+          { name: "custom-project", origin: "project", scope: "project" },
+          { name: "help", origin: "omx", scope: "project" },
+          { name: "custom-user", origin: "user", scope: "user" },
+          { name: "plan", origin: "omx", scope: "user" },
+        ],
+      );
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+      await rm(codexHomeRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/__tests__/skill-display.test.ts
+++ b/src/utils/__tests__/skill-display.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getSkillDisplayLabel } from "../skill-display.js";
+
+describe("getSkillDisplayLabel", () => {
+  it("prefixes OMX-installed skills without mutating their canonical name", () => {
+    assert.equal(
+      getSkillDisplayLabel({
+        name: "plan",
+        origin: "omx",
+      }),
+      "OMX: plan",
+    );
+  });
+
+  it("leaves non-OMX skill names unchanged", () => {
+    assert.equal(
+      getSkillDisplayLabel({
+        name: "custom-project",
+        origin: "project",
+      }),
+      "custom-project",
+    );
+    assert.equal(
+      getSkillDisplayLabel({
+        name: "github:gh-fix-ci",
+        origin: "user",
+      }),
+      "github:gh-fix-ci",
+    );
+  });
+});

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -145,11 +145,25 @@ export function legacyUserSkillsDir(): string {
 }
 
 export type InstalledSkillScope = "project" | "user";
+export type InstalledSkillOrigin = "omx" | "user" | "project" | "unknown";
+
+export interface InstalledOmxSkillsManifest {
+  schema_version: 1;
+  generated_at: string;
+  skills: Record<
+    string,
+    {
+      origin: "omx";
+      source: "repo-shipped";
+    }
+  >;
+}
 
 export interface InstalledSkillDirectory {
   name: string;
   path: string;
   scope: InstalledSkillScope;
+  origin: InstalledSkillOrigin;
 }
 
 export interface SkillRootOverlapReport {
@@ -166,9 +180,58 @@ export interface SkillRootOverlapReport {
   mismatchedSkillNames: string[];
 }
 
+export function omxInstalledSkillsSystemDir(skillsRoot: string): string {
+  return join(skillsRoot, ".system");
+}
+
+export function omxInstalledSkillsManifestPath(skillsRoot: string): string {
+  return join(omxInstalledSkillsSystemDir(skillsRoot), "omx-installed-skills.json");
+}
+
+async function readInstalledOmxSkillsManifest(
+  skillsRoot: string,
+): Promise<InstalledOmxSkillsManifest | null> {
+  const manifestPath = omxInstalledSkillsManifestPath(skillsRoot);
+  if (!existsSync(manifestPath)) return null;
+
+  try {
+    const parsed = JSON.parse(
+      await readFile(manifestPath, "utf-8"),
+    ) as Partial<InstalledOmxSkillsManifest>;
+    if (
+      parsed?.schema_version !== 1 ||
+      parsed.generated_at == null ||
+      parsed.skills == null ||
+      typeof parsed.skills !== "object"
+    ) {
+      return null;
+    }
+    return parsed as InstalledOmxSkillsManifest;
+  } catch {
+    return null;
+  }
+}
+
+function classifyInstalledSkillOrigin(
+  skillName: string,
+  scope: InstalledSkillScope,
+  omxSkillNames: ReadonlySet<string>,
+): InstalledSkillOrigin {
+  if (omxSkillNames.has(skillName)) return "omx";
+  switch (scope) {
+    case "project":
+      return "project";
+    case "user":
+      return "user";
+    default:
+      return "unknown";
+  }
+}
+
 async function readInstalledSkillsFromDir(
   dir: string,
   scope: InstalledSkillScope,
+  omxSkillNames: ReadonlySet<string> = new Set<string>(),
 ): Promise<InstalledSkillDirectory[]> {
   if (!existsSync(dir)) return [];
 
@@ -179,6 +242,7 @@ async function readInstalledSkillsFromDir(
       name: entry.name,
       path: join(dir, entry.name),
       scope,
+      origin: classifyInstalledSkillOrigin(entry.name, scope, omxSkillNames),
     }))
     .filter((entry) => existsSync(join(entry.path, "SKILL.md")))
     .sort((a, b) => a.name.localeCompare(b.name));
@@ -200,7 +264,9 @@ export async function listInstalledSkillDirectories(
   const seenNames = new Set<string>();
 
   for (const { dir, scope } of orderedDirs) {
-    const skills = await readInstalledSkillsFromDir(dir, scope);
+    const manifest = await readInstalledOmxSkillsManifest(dir);
+    const omxSkillNames = new Set(Object.keys(manifest?.skills ?? {}));
+    const skills = await readInstalledSkillsFromDir(dir, scope, omxSkillNames);
     for (const skill of skills) {
       if (seenNames.has(skill.name)) continue;
       seenNames.add(skill.name);

--- a/src/utils/skill-display.ts
+++ b/src/utils/skill-display.ts
@@ -1,0 +1,12 @@
+import type { InstalledSkillDirectory, InstalledSkillOrigin } from "./paths.js";
+
+export interface SkillDisplayDescriptor {
+  name: string;
+  origin: InstalledSkillOrigin;
+}
+
+export function getSkillDisplayLabel(
+  skill: Pick<InstalledSkillDirectory, "name" | "origin"> | SkillDisplayDescriptor,
+): string {
+  return skill.origin === "omx" ? `OMX: ${skill.name}` : skill.name;
+}


### PR DESCRIPTION
## Summary
Introduce explicit provenance metadata for OMX-shipped installed skills without mutating installed `SKILL.md` canonical metadata.

## Problem
We want users to distinguish OMX-shipped skills from other skill sources more easily, but rewriting installed skill frontmatter names broadens scope and can affect surfaces beyond Codex `/skills`.

## What this changes
- writes an OMX-installed-skills sidecar manifest under `.codex/skills/.system/omx-installed-skills.json` during setup
- annotates installed skill discovery with explicit `origin` metadata (`omx`, `project`, `user`, `unknown`)
- adds a dedicated `getSkillDisplayLabel()` helper so future surfaces can opt into `OMX:` labels without changing canonical skill identity
- keeps installed and shipped `SKILL.md` frontmatter names unchanged

## Why this approach
This separates provenance from canonical naming so display decoration can happen at render time instead of by mutating installed skill metadata. That keeps invocation behavior stable and gives future `/skills`-adjacent surfaces a safe foundation for source-aware labeling.

## Non-goals
- renaming canonical skills
- changing invocation behavior
- changing installation precedence, loading, or dedupe
- relabeling user-created, project-local, or plugin skills by mutating their metadata
- claiming that Codex `/skills` already consumes the new manifest

## Acceptance criteria covered here
- setup records OMX-shipped installed skills in a sidecar manifest
- canonical installed `SKILL.md` contents remain unchanged
- installed skill discovery can identify OMX origin explicitly
- display labels can be decorated from provenance without changing canonical names

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/setup-skills-overwrite.test.js dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-skill-validation.test.js dist/utils/__tests__/installed-skill-origin.test.js dist/utils/__tests__/skill-display.test.js`
