### PR TITLE
Badge OMX-installed skill descriptions in /skills

### DIFF
--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -18,7 +18,35 @@ describe('omx setup skills overwrite behavior', () => {
 
       const wikiSkill = join(wd, '.codex', 'skills', 'wiki', 'SKILL.md');
       assert.equal(existsSync(wikiSkill), true);
-      assert.match(await readFile(wikiSkill, 'utf-8'), /^---\nname: wiki/m);
+      assert.ok((await readFile(wikiSkill, 'utf-8')).includes('description: "[OMX] '));
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('adds an [OMX] description badge to installed shipped skills without changing the shipped source files', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const installedHelpSkill = join(wd, '.codex', 'skills', 'help', 'SKILL.md');
+      const shippedHelpSkill = join(previousCwd, 'skills', 'help', 'SKILL.md');
+
+      assert.ok(
+        (await readFile(installedHelpSkill, 'utf-8')).includes(
+          'description: "[OMX] Guide on using oh-my-codex plugin"',
+        ),
+      );
+      assert.ok(
+        (await readFile(shippedHelpSkill, 'utf-8')).includes(
+          'description: Guide on using oh-my-codex plugin',
+        ),
+      );
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -187,6 +215,27 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project', force: true });
       assert.equal(await readFile(customSkillPath, 'utf-8'), '---\nname: my-custom-skill\ndescription: local custom skill\n---\n');
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not keep stacking the [OMX] description badge on repeated setup runs', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+      await setup({ scope: 'project' });
+
+      const installedHelpSkill = join(wd, '.codex', 'skills', 'help', 'SKILL.md');
+      const content = await readFile(installedHelpSkill, 'utf-8');
+      const matches = content.match(/\[OMX\] Guide on using oh-my-codex plugin/g) ?? [];
+      assert.equal(matches.length, 1);
+      assert.doesNotMatch(content, /\[OMX\] \[OMX\]/);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -341,6 +341,29 @@ export async function validateSkillFile(skillMdPath: string): Promise<void> {
   parseSkillFrontmatter(content, skillMdPath);
 }
 
+function rewriteInstalledSkillDescriptionBadge(
+  content: string,
+  filePath = "SKILL.md",
+): string {
+  const metadata = parseSkillFrontmatter(content, filePath);
+  const badgePrefix = "[OMX] ";
+  const displayDescription = metadata.description.startsWith(badgePrefix)
+    ? metadata.description
+    : `${badgePrefix}${metadata.description}`;
+
+  return content.replace(
+    /^---\r?\n([\s\S]*?)\r?\n---/,
+    (frontmatterBlock, body) => {
+      const rewrittenBody = body.replace(
+        /^([ \t]*)description:(.*)$/m,
+        (_line: string, indent: string) =>
+          `${indent}description: ${JSON.stringify(displayDescription)}`,
+      );
+      return frontmatterBlock.replace(body, rewrittenBody);
+    },
+  );
+}
+
 async function buildLegacySkillOverlapNotice(
   scope: SetupScope,
 ): Promise<LegacySkillOverlapNotice> {
@@ -1530,6 +1553,20 @@ export async function installSkills(
       const sfStat = await stat(sfPath);
       if (!sfStat.isFile()) continue;
       const dstPath = join(skillDst, sf);
+      if (sf === "SKILL.md") {
+        await syncManagedContent(
+          rewriteInstalledSkillDescriptionBadge(
+            await readFile(sfPath, "utf-8"),
+            sfPath,
+          ),
+          dstPath,
+          summary,
+          backupContext,
+          options,
+          `skill ${skillName}/${sf}`,
+        );
+        continue;
+      }
       await syncManagedFileFromDisk(
         sfPath,
         dstPath,


### PR DESCRIPTION
## Summary
- prepend `[OMX]` to the installed descriptions of repo-shipped OMX skills during setup
- leave skill names and invocation behavior unchanged
- keep source `skills/*/SKILL.md` files untouched while avoiding repeated badge stacking on refresh

## Why
Codex currently surfaces installed skill descriptions in `/skills`, so this gives OMX-shipped skills an obvious visual marker without renaming the skills themselves.

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/setup-skills-overwrite.test.js dist/cli/__tests__/setup-refresh.test.js dist/cli/__tests__/setup-scope.test.js dist/cli/__tests__/setup-skill-validation.test.js`
- `codex debug prompt-input` in a temp project after `omx setup --scope project` (confirmed `[OMX]` in OMX-shipped skill descriptions)