### PR TITLE
 fix: stop explore wrapper recursion and remove MCP ps polling

### DIFF
--- a/crates/omx-explore/src/main.rs
+++ b/crates/omx-explore/src/main.rs
@@ -12,6 +12,8 @@ const CODEX_BIN_ENV: &str = "OMX_EXPLORE_CODEX_BIN";
 const HARNESS_ROOT_ENV: &str = "OMX_EXPLORE_ROOT";
 const INTERNAL_DIRECT_WRAPPER_FLAG: &str = "--internal-allowlist-direct";
 const INTERNAL_SHELL_WRAPPER_FLAG: &str = "--internal-allowlist-shell";
+const ALLOWLIST_DEPTH_ENV: &str = "OMX_EXPLORE_ALLOWLIST_DEPTH";
+const MAX_ALLOWLIST_DEPTH: u32 = 8;
 const WINDOWS_UNSUPPORTED_ALLOWLIST_MESSAGE: &str =
     "omx explore built-in harness is not ready on Windows because its allowlist runtime relies on POSIX sh/bash wrappers. Set OMX_EXPLORE_BIN to a compatible custom harness, prefer `omx sparkshell` for shell-native read-only lookups, or run `omx doctor` for readiness details.";
 
@@ -39,6 +41,7 @@ struct AttemptResult {
 struct AllowlistEnvironment {
     bin_dir: PathBuf,
     shell_path: PathBuf,
+    startup_env_path: PathBuf,
     _root: TempDirGuard,
 }
 
@@ -225,7 +228,14 @@ fn invoke_codex(args: &Args, model: &str, prompt_contract: &str) -> io::Result<A
         .arg(&final_prompt)
         .env(HARNESS_ROOT_ENV, &args.cwd)
         .env("PATH", &allowlist.bin_dir)
-        .env("SHELL", &allowlist.shell_path);
+        .env("SHELL", &allowlist.shell_path)
+        // Keep explore runs independent from ambient shell startup hooks. The
+        // incident showed a shell-snapshot path that sourced ~/.bashrc when
+        // BASH_ENV was empty, which can re-enter allowlist wrappers.
+        .env("BASH_ENV", &allowlist.startup_env_path)
+        .env("ENV", &allowlist.startup_env_path)
+        .env("PROMPT_COMMAND", "")
+        .env(ALLOWLIST_DEPTH_ENV, "0");
     let output = command.output()?;
 
     let markdown = read_to_string(&output_path).ok();
@@ -508,10 +518,14 @@ fn prepare_allowlist_environment() -> Result<AllowlistEnvironment, String> {
     let shell_path = bin_dir.join("bash");
     write_executable(&shell_path, &bash_wrapper)?;
     write_executable(&bin_dir.join("sh"), &sh_wrapper)?;
+    let startup_env_path = root.path.join("empty-startup.sh");
+    write(&startup_env_path, b"")
+        .map_err(|err| format!("failed to write startup env stub {}: {err}", startup_env_path.display()))?;
 
     Ok(AllowlistEnvironment {
         bin_dir,
         shell_path,
+        startup_env_path,
         _root: root,
     })
 }
@@ -580,18 +594,33 @@ fn build_direct_wrapper(self_exe: &Path, command: &str) -> Result<String, String
 
 fn resolve_host_command(command: &str) -> Option<PathBuf> {
     let candidate = Path::new(command);
-    if candidate.is_absolute() && is_usable_host_command(candidate) {
+    if candidate.is_absolute()
+        && is_usable_host_command(candidate)
+        && !is_within_explore_allowlist_dir(candidate)
+    {
         return Some(candidate.to_path_buf());
     }
 
     let path = env::var_os("PATH")?;
     for entry in env::split_paths(&path) {
+        if is_within_explore_allowlist_dir(&entry) {
+            continue;
+        }
         let resolved = entry.join(command);
-        if is_usable_host_command(&resolved) {
+        if is_usable_host_command(&resolved) && !is_within_explore_allowlist_dir(&resolved) {
             return Some(resolved);
         }
     }
     None
+}
+
+fn is_within_explore_allowlist_dir(path: &Path) -> bool {
+    path.ancestors().any(|ancestor| {
+        ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("omx-explore-allowlist-"))
+    })
 }
 
 fn is_usable_host_command(path: &Path) -> bool {
@@ -617,10 +646,24 @@ fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
+fn checked_allowlist_depth() -> Result<u32, String> {
+    let current = env::var(ALLOWLIST_DEPTH_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(0);
+    if current >= MAX_ALLOWLIST_DEPTH {
+        return Err(format!(
+            "allowlist wrapper recursion depth exceeded safety threshold ({MAX_ALLOWLIST_DEPTH})"
+        ));
+    }
+    Ok(current)
+}
+
 fn run_internal_direct_wrapper<I>(mut args: I) -> Result<(), String>
 where
     I: Iterator<Item = OsString>,
 {
+    let current_depth = checked_allowlist_depth()?;
     let spec = args
         .next()
         .ok_or_else(|| "missing direct wrapper spec".to_string())?;
@@ -630,9 +673,17 @@ where
         .ok_or_else(|| format!("invalid direct wrapper spec: {spec}"))?;
     let forwarded: Vec<String> = args.map(|arg| arg.to_string_lossy().into_owned()).collect();
     validate_direct_command(command_name, &forwarded)?;
+    let real_path = Path::new(real_path);
+    if is_within_explore_allowlist_dir(real_path) {
+        return Err(format!(
+            "allowlisted `{command_name}` resolved back into an omx explore allowlist dir: {}",
+            real_path.display()
+        ));
+    }
 
     let status = Command::new(real_path)
         .args(&forwarded)
+        .env(ALLOWLIST_DEPTH_ENV, (current_depth + 1).to_string())
         .status()
         .map_err(|err| format!("failed to execute allowlisted `{command_name}`: {err}"))?;
     std::process::exit(status.code().unwrap_or(1));
@@ -642,10 +693,18 @@ fn run_internal_shell_wrapper<I>(mut args: I) -> Result<(), String>
 where
     I: Iterator<Item = OsString>,
 {
+    let current_depth = checked_allowlist_depth()?;
     let real_shell = args
         .next()
         .ok_or_else(|| "missing real shell path for internal wrapper".to_string())?;
     let real_shell = real_shell.to_string_lossy().into_owned();
+    let real_shell_path = Path::new(&real_shell);
+    if is_within_explore_allowlist_dir(real_shell_path) {
+        return Err(format!(
+            "allowlisted shell resolved back into an omx explore allowlist dir: {}",
+            real_shell_path.display()
+        ));
+    }
     let forwarded: Vec<String> = args.map(|arg| arg.to_string_lossy().into_owned()).collect();
     let command = validate_shell_invocation(&forwarded)?;
 
@@ -656,6 +715,7 @@ where
     let status = child
         .arg("-lc")
         .arg(&command)
+        .env(ALLOWLIST_DEPTH_ENV, (current_depth + 1).to_string())
         .status()
         .map_err(|err| format!("failed to execute validated shell command: {err}"))?;
     std::process::exit(status.code().unwrap_or(1));
@@ -922,6 +982,20 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
 
+    fn temp_test_root(prefix: &str) -> TempDirGuard {
+        let dir = env::temp_dir().join(format!(
+            "omx-explore-test-{}-{}-{}",
+            prefix,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        create_dir_all(&dir).expect("create temp test root");
+        TempDirGuard { path: dir }
+    }
+
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
@@ -987,7 +1061,7 @@ mod tests {
     #[test]
     fn resolve_codex_binary_resolves_bare_env_override_from_path() {
         let _guard = env_lock();
-        let root = temp_allowlist_dir().expect("temp root");
+        let root = temp_test_root("resolve-codex-binary");
         let bin_dir = root.path.join("bin");
         create_dir_all(&bin_dir).expect("create bin");
         let fake_codex = bin_dir.join("codex-custom");
@@ -1016,7 +1090,7 @@ mod tests {
     #[test]
     fn codex_launch_for_env_node_shebang_uses_host_node_absolute_path() {
         let _guard = env_lock();
-        let root = temp_allowlist_dir().expect("temp root");
+        let root = temp_test_root("env-node");
         let script_path = root.path.join("codex-script");
         write(&script_path, b"#!/usr/bin/env node\nconsole.log(\"ok\");\n").expect("write script");
 
@@ -1031,7 +1105,7 @@ mod tests {
     #[test]
     fn codex_launch_for_posix_package_manager_shim_uses_host_node_and_entrypoint() {
         let _guard = env_lock();
-        let root = temp_allowlist_dir().expect("temp root");
+        let root = temp_test_root("posix-shim");
         let host_bin = root.path.join("host-bin");
         let shim_dir = root.path.join("node_modules").join(".bin");
         let entrypoint = root
@@ -1084,7 +1158,7 @@ exec node "$basedir/../@openai/codex/bin/codex.js" "$@"
     #[test]
     fn resolve_host_command_skips_directory_and_non_executable_path_entries() {
         let _guard = env_lock();
-        let root = temp_allowlist_dir().expect("temp root");
+        let root = temp_test_root("resolve-host-command");
         let bad_bin = root.path.join("bad-bin");
         let blocked_file_bin = root.path.join("blocked-file-bin");
         let good_bin = root.path.join("good-bin");
@@ -1138,7 +1212,7 @@ exec node "$basedir/../@openai/codex/bin/codex.js" "$@"
     #[test]
     fn codex_launch_for_env_node_shebang_skips_non_executable_earlier_node_entry() {
         let _guard = env_lock();
-        let root = temp_allowlist_dir().expect("temp root");
+        let root = temp_test_root("env-node-skip");
         let bad_bin = root.path.join("bad-bin");
         let good_bin = root.path.join("good-bin");
         create_dir_all(&bad_bin).expect("create bad bin");
@@ -1185,7 +1259,7 @@ exec node "$basedir/../@openai/codex/bin/codex.js" "$@"
 
     #[cfg(unix)]
     fn create_host_bin_with_commands(commands: &[&str]) -> (TempDirGuard, PathBuf) {
-        let root = temp_allowlist_dir().expect("temp root");
+        let root = temp_test_root("host-bin");
         let host_bin = root.path.join("host-bin");
         create_dir_all(&host_bin).expect("create host bin");
         for command in commands {
@@ -1269,6 +1343,59 @@ exec node "$basedir/../@openai/codex/bin/codex.js" "$@"
         assert!(wrapper.contains(&self_exe.display().to_string()));
         assert!(wrapper.contains(&format!("pwd:{}", pwd.display())));
         assert!(!wrapper.contains("exit 127"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_direct_wrapper_ignores_allowlist_dirs_in_path_resolution() {
+        let _guard = env_lock();
+        let self_exe = env::current_exe().expect("current exe");
+        let root = temp_allowlist_dir().expect("temp root");
+        let poisoned_bin = root.path.join("omx-explore-allowlist-poison").join("bin");
+        create_dir_all(&poisoned_bin).expect("create poisoned bin");
+        let poisoned_grep = poisoned_bin.join("grep");
+        write(&poisoned_grep, "#!/bin/sh\nexit 0\n").expect("write poisoned grep");
+        #[cfg(unix)]
+        {
+            use std::fs;
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&poisoned_grep)
+                .expect("stat poisoned grep")
+                .permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&poisoned_grep, perms).expect("chmod poisoned grep");
+        }
+
+        let (_host_root, host_bin) = create_host_bin_with_commands(&["bash", "sh", "grep"]);
+        let joined_path = format!("{}:{}", poisoned_bin.display(), host_bin.display());
+        let wrapper = with_path(Path::new(&joined_path), || {
+            build_direct_wrapper(&self_exe, "grep").expect("grep wrapper")
+        });
+
+        assert!(!wrapper.contains(&poisoned_grep.display().to_string()));
+        assert!(wrapper.contains(&host_bin.join("grep").display().to_string()));
+    }
+
+    #[test]
+    fn is_within_explore_allowlist_dir_detects_allowlist_ancestors() {
+        assert!(is_within_explore_allowlist_dir(Path::new(
+            "/tmp/omx-explore-allowlist-123/bin/grep"
+        )));
+        assert!(!is_within_explore_allowlist_dir(Path::new("/usr/bin/grep")));
+    }
+
+    #[test]
+    fn checked_allowlist_depth_rejects_excessive_depth() {
+        let _guard = env_lock();
+        unsafe {
+            env::set_var(ALLOWLIST_DEPTH_ENV, MAX_ALLOWLIST_DEPTH.to_string());
+        }
+        let err = checked_allowlist_depth().expect_err("depth should fail");
+        match env::var_os(ALLOWLIST_DEPTH_ENV) {
+            Some(_) => unsafe { env::remove_var(ALLOWLIST_DEPTH_ENV) },
+            None => {}
+        }
+        assert!(err.contains("recursion depth exceeded"));
     }
 
     #[test]

--- a/src/cli/__tests__/explore.test.ts
+++ b/src/cli/__tests__/explore.test.ts
@@ -147,6 +147,10 @@ set -e
 {
   printf 'PATH=%s\n' "$PATH"
   printf 'SHELL=%s\n' "\${SHELL:-}"
+  printf 'BASH_ENV=%s\n' "\${BASH_ENV:-}"
+  printf 'ENV=%s\n' "\${ENV:-}"
+  printf 'PROMPT_COMMAND=%s\n' "\${PROMPT_COMMAND:-}"
+  printf 'ALLOWLIST_DEPTH=%s\n' "\${OMX_EXPLORE_ALLOWLIST_DEPTH:-}"
   printf 'ALLOWED_STATUS=%s\n' "$allowed_status"
   printf 'BLOCKED_STATUS=%s\n' "$blocked_status"
   printf -- '--ARGV--\n'
@@ -853,6 +857,10 @@ describe('exploreCommand', () => {
         const captured = await readFile(capturePath, 'utf-8');
         assert.match(captured, /PATH=.*omx-explore-allowlist-/);
         assert.match(captured, /SHELL=.*omx-explore-allowlist-.*\/bin\/bash$/m);
+        assert.match(captured, /BASH_ENV=.*empty-startup\.sh/m);
+        assert.match(captured, /ENV=.*empty-startup\.sh/m);
+        assert.match(captured, /PROMPT_COMMAND=$/m);
+        assert.match(captured, /ALLOWLIST_DEPTH=0/m);
         assert.match(captured, /ALLOWED_STATUS=0/);
         assert.match(captured, /BLOCKED_STATUS=(?!0)\d+/);
         assert.match(captured, /--ARGV--[\s\S]*\nexec\n/);

--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -3,12 +3,8 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
-  analyzeDuplicateSiblingState,
-  extractMcpEntrypointMarker,
   isParentProcessAlive,
-  parseProcessTable,
   shouldAutoStartMcpServer,
-  shouldSelfExitForDuplicateSibling,
   type McpServerName,
 } from '../bootstrap.js';
 
@@ -98,8 +94,12 @@ describe('mcp shared stdio lifecycle contract', () => {
     assert.match(src, /process\.exit\(0\)/, 'bootstrap should force child exit after shutdown completes');
     assert.match(src, /SIGTERM/, 'bootstrap should handle SIGTERM');
     assert.match(src, /SIGINT/, 'bootstrap should handle SIGINT');
-    assert.match(src, /analyzeDuplicateSiblingState/, 'bootstrap should keep duplicate sibling detection in the shared layer');
-    assert.match(src, /shouldSelfExitForDuplicateSibling/, 'bootstrap should gate self-exit conservatively in the shared layer');
+    assert.match(src, /createDuplicateCoordinator/, 'bootstrap should keep duplicate coordination in the shared layer');
+    assert.match(src, /once\(['"]data['"],\s*handleFirstTraffic\)/, 'bootstrap should treat first traffic as a one-shot event');
+    assert.doesNotMatch(src, /ps axww -o pid=,ppid=,command=/, 'bootstrap must not shell out to ps in the hot path');
+    assert.doesNotMatch(src, /listProcessTable\(/, 'bootstrap must not call process-table scanners');
+    assert.doesNotMatch(src, /execFileSync\(/, 'bootstrap must not import or call execFileSync for duplicate coordination');
+    assert.doesNotMatch(src, /DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS/, 'bootstrap must not keep duplicate polling intervals');
   });
 
   it('keeps individual server entrypoints free of duplicated raw stdio connect snippets', async () => {
@@ -122,119 +122,5 @@ describe('mcp shared stdio lifecycle contract', () => {
         `${file} should not duplicate raw server.connect(transport) bootstrap`,
       );
     }
-  });
-});
-
-describe('mcp duplicate sibling detection', () => {
-  it('extracts same-entrypoint markers from command lines', () => {
-    assert.equal(
-      extractMcpEntrypointMarker('node /tmp/oh-my-codex/dist/mcp/state-server.js'),
-      'state-server.js',
-    );
-    assert.equal(
-      extractMcpEntrypointMarker('node C:\\\\tmp\\\\oh-my-codex\\\\dist\\\\mcp\\\\trace-server.ts'),
-      'trace-server.ts',
-    );
-    assert.equal(extractMcpEntrypointMarker('node something-else.js'), null);
-  });
-
-  it('parses ps output into process table entries', () => {
-    assert.deepEqual(
-      parseProcessTable('101 55 node /tmp/dist/mcp/state-server.js\n'),
-      [{ pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' }],
-    );
-  });
-
-  it('treats a single instance as unique and no-op', () => {
-    const observation = analyzeDuplicateSiblingState(
-      [{ pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' }],
-      101,
-      55,
-      'state-server.js',
-    );
-
-    assert.equal(observation.status, 'unique');
-    assert.deepEqual(observation.matchingPids, [101]);
-    assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 10_000, 9_000, null),
-      false,
-    );
-  });
-
-  it('prefers the newest same-parent same-entrypoint process as survivor', () => {
-    const processes = [
-      { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
-      { pid: 140, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
-      { pid: 160, ppid: 55, command: 'node /tmp/dist/mcp/memory-server.js' },
-    ];
-
-    const older = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.js');
-    const newest = analyzeDuplicateSiblingState(processes, 140, 55, 'state-server.js');
-
-    assert.equal(older.status, 'older_duplicate');
-    assert.deepEqual(older.newerSiblingPids, [140]);
-    assert.equal(newest.status, 'newest');
-    assert.deepEqual(newest.newerSiblingPids, []);
-  });
-
-  it('only lets older duplicates self-exit after the conservative grace window before traffic', () => {
-    const observation = {
-      status: 'older_duplicate' as const,
-      entrypoint: 'state-server.js',
-      matchingPids: [101, 140],
-      newerSiblingPids: [140],
-    };
-
-    assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 10_500, 9_000, null),
-      false,
-    );
-    assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 11_100, 9_000, null),
-      true,
-    );
-  });
-
-  it('does not self-exit after traffic until the duplicate has remained safely idle long enough', () => {
-    const observation = {
-      status: 'older_duplicate' as const,
-      entrypoint: 'state-server.js',
-      matchingPids: [101, 140],
-      newerSiblingPids: [140],
-    };
-
-    assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 35_000, 1_000, 10_000),
-      false,
-    );
-    assert.equal(
-      shouldSelfExitForDuplicateSibling(observation, 40_500, 1_000, 10_000),
-      false,
-    );
-  });
-
-  it('treats ambiguous duplicate state as no-op', () => {
-    const missingSelf = analyzeDuplicateSiblingState(
-      [{ pid: 140, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' }],
-      101,
-      55,
-      'state-server.js',
-    );
-    const mismatchedSelfMarker = analyzeDuplicateSiblingState(
-      [
-        { pid: 101, ppid: 55, command: 'node /tmp/dist/mcp/memory-server.js' },
-        { pid: 140, ppid: 55, command: 'node /tmp/dist/mcp/state-server.js' },
-      ],
-      101,
-      55,
-      'state-server.js',
-    );
-
-    assert.equal(missingSelf.status, 'ambiguous');
-    assert.equal(mismatchedSelfMarker.status, 'ambiguous');
-    assert.equal(
-      shouldSelfExitForDuplicateSibling(missingSelf, 50_000, 10_000, null),
-      false,
-    );
   });
 });

--- a/src/mcp/__tests__/duplicate-coordination.test.ts
+++ b/src/mcp/__tests__/duplicate-coordination.test.ts
@@ -1,0 +1,423 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createDuplicateCoordinator,
+  resolveDuplicateRegistryDir,
+  type DuplicateCoordinatorDeps,
+} from '../duplicate-coordination.js';
+
+const PARENT_PID = 55;
+const SELF_PID = 101;
+const SERVER_NAME = 'state';
+const PRE_TRAFFIC_GRACE_MS = 25;
+
+type SignalProcess = DuplicateCoordinatorDeps['signalProcess'];
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createSignalProcess(alivePids: Iterable<number> | Set<number>): NonNullable<SignalProcess> {
+  const liveSet = alivePids instanceof Set ? alivePids : new Set(alivePids);
+  return ((pid: number) => {
+    if (liveSet.has(pid)) return true;
+    const error = Object.assign(new Error(`pid ${pid} missing`), { code: 'ESRCH' });
+    throw error;
+  }) as NonNullable<SignalProcess>;
+}
+
+class FakeWatcher {
+  closed = false;
+
+  constructor(
+    private readonly onChange: () => void,
+    private readonly onError: (error: unknown) => void,
+  ) {}
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emitChange(): void {
+    if (this.closed) return;
+    this.onChange();
+  }
+
+  emitError(error: unknown = new Error('watch failed')): void {
+    if (this.closed) return;
+    this.onError(error);
+  }
+}
+
+function createWatchHarness(): {
+  watchers: FakeWatcher[];
+  watchDirectory: NonNullable<DuplicateCoordinatorDeps['watchDirectory']>;
+} {
+  const watchers: FakeWatcher[] = [];
+  return {
+    watchers,
+    watchDirectory: (_directory, onChange, onError) => {
+      const watcher = new FakeWatcher(onChange, onError);
+      watchers.push(watcher);
+      return watcher;
+    },
+  };
+}
+
+async function withTmpDir(run: (tmpRoot: string) => Promise<void>): Promise<void> {
+  const tmpRoot = await mkdtemp(join(tmpdir(), 'omx-dup-coord-'));
+  try {
+    await run(tmpRoot);
+  } finally {
+    await rm(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+function getRegistryDir(tmpRoot: string): string {
+  return resolveDuplicateRegistryDir({
+    parentPid: PARENT_PID,
+    serverName: SERVER_NAME,
+    tmpDir: tmpRoot,
+  });
+}
+
+function getPresencePath(tmpRoot: string, pid: number): string {
+  return join(getRegistryDir(tmpRoot), `presence-${pid}.json`);
+}
+
+function getOwnerPath(tmpRoot: string): string {
+  return join(getRegistryDir(tmpRoot), 'owner.json');
+}
+
+async function readJson(filePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+describe('duplicate coordination runtime registry', () => {
+  it('writes self presence at startup and removes it on dispose', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      const watchHarness = createWatchHarness();
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: () => {},
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID]),
+        watchDirectory: watchHarness.watchDirectory,
+      });
+
+      const presencePath = getPresencePath(tmpRoot, SELF_PID);
+      assert.deepEqual(await readJson(presencePath), {
+        pid: SELF_PID,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        createdAtMs: (await readJson(presencePath) as { createdAtMs: number }).createdAtMs,
+      });
+
+      await coordinator.dispose();
+      await assert.rejects(() => stat(presencePath));
+    });
+  });
+
+  it('garbage-collects stale presence and owner records on startup', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      const registryDir = getRegistryDir(tmpRoot);
+      await mkdir(registryDir, { recursive: true });
+      await writeFile(getPresencePath(tmpRoot, 140), JSON.stringify({
+        pid: 140,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        createdAtMs: 1,
+      }), 'utf8');
+      await writeFile(getOwnerPath(tmpRoot), JSON.stringify({
+        pid: 140,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        claimedAtMs: 2,
+      }), 'utf8');
+
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: () => {},
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID]),
+        watchDirectory: createWatchHarness().watchDirectory,
+      });
+
+      await assert.rejects(() => stat(getPresencePath(tmpRoot, 140)));
+      await assert.rejects(() => stat(getOwnerPath(tmpRoot)));
+      await coordinator.dispose();
+    });
+  });
+
+  it('self-exits after the grace window when a newer live sibling exists before traffic', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      const registryDir = getRegistryDir(tmpRoot);
+      await mkdir(registryDir, { recursive: true });
+      await writeFile(getPresencePath(tmpRoot, 140), JSON.stringify({
+        pid: 140,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        createdAtMs: 1,
+      }), 'utf8');
+
+      const shutdownReasons: string[] = [];
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: (reason) => {
+          shutdownReasons.push(reason);
+        },
+        preTrafficGraceMs: PRE_TRAFFIC_GRACE_MS,
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID, 140]),
+        watchDirectory: createWatchHarness().watchDirectory,
+      });
+
+      await delay(PRE_TRAFFIC_GRACE_MS + 40);
+      assert.deepEqual(shutdownReasons, ['superseded_duplicate_before_traffic']);
+      await coordinator.dispose();
+    });
+  });
+
+  it('self-exits after the grace window when a live foreign owner exists before traffic', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      const registryDir = getRegistryDir(tmpRoot);
+      await mkdir(registryDir, { recursive: true });
+      await writeFile(getOwnerPath(tmpRoot), JSON.stringify({
+        pid: 220,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        claimedAtMs: 1,
+      }), 'utf8');
+
+      const shutdownReasons: string[] = [];
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: (reason) => {
+          shutdownReasons.push(reason);
+        },
+        preTrafficGraceMs: PRE_TRAFFIC_GRACE_MS,
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID, 220]),
+        watchDirectory: createWatchHarness().watchDirectory,
+      });
+
+      await delay(PRE_TRAFFIC_GRACE_MS + 40);
+      assert.deepEqual(shutdownReasons, ['superseded_duplicate_before_traffic']);
+      await coordinator.dispose();
+    });
+  });
+
+  it('re-evaluates duplicate state on watcher events before first traffic', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      const watchHarness = createWatchHarness();
+      const shutdownReasons: string[] = [];
+      const alivePids = new Set([SELF_PID]);
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: (reason) => {
+          shutdownReasons.push(reason);
+        },
+        preTrafficGraceMs: PRE_TRAFFIC_GRACE_MS,
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess(alivePids),
+        watchDirectory: watchHarness.watchDirectory,
+      });
+
+      alivePids.add(140);
+      await writeFile(getPresencePath(tmpRoot, 140), JSON.stringify({
+        pid: 140,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        createdAtMs: 1,
+      }), 'utf8');
+      watchHarness.watchers[0]?.emitChange();
+
+      await delay(PRE_TRAFFIC_GRACE_MS + 40);
+      assert.deepEqual(shutdownReasons, ['superseded_duplicate_before_traffic']);
+      await coordinator.dispose();
+    });
+  });
+
+  it('closes the watcher after first traffic and never duplicate-exits afterward', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      const watchHarness = createWatchHarness();
+      const shutdownReasons: string[] = [];
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: (reason) => {
+          shutdownReasons.push(reason);
+        },
+        preTrafficGraceMs: PRE_TRAFFIC_GRACE_MS,
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID, 140]),
+        watchDirectory: watchHarness.watchDirectory,
+      });
+
+      await coordinator.markFirstTraffic();
+      assert.equal(watchHarness.watchers[0]?.closed, true);
+
+      await writeFile(getPresencePath(tmpRoot, 140), JSON.stringify({
+        pid: 140,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        createdAtMs: 1,
+      }), 'utf8');
+      watchHarness.watchers[0]?.emitChange();
+
+      await delay(PRE_TRAFFIC_GRACE_MS + 40);
+      assert.deepEqual(shutdownReasons, []);
+      await coordinator.dispose();
+    });
+  });
+
+  it('claims owner on first traffic when no live owner exists', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: () => {},
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID]),
+        watchDirectory: createWatchHarness().watchDirectory,
+      });
+
+      await coordinator.markFirstTraffic();
+      const owner = await readJson(getOwnerPath(tmpRoot)) as { pid: number; parentPid: number; serverName: string };
+      assert.equal(owner.pid, SELF_PID);
+      assert.equal(owner.parentPid, PARENT_PID);
+      assert.equal(owner.serverName, SERVER_NAME);
+
+      await coordinator.dispose();
+      await assert.rejects(() => stat(getOwnerPath(tmpRoot)));
+    });
+  });
+
+  it('does not overwrite a live foreign owner on first traffic', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      await mkdir(getRegistryDir(tmpRoot), { recursive: true });
+      await writeFile(getOwnerPath(tmpRoot), JSON.stringify({
+        pid: 220,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        claimedAtMs: 1,
+      }), 'utf8');
+
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: () => {},
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID, 220]),
+        watchDirectory: createWatchHarness().watchDirectory,
+      });
+
+      await coordinator.markFirstTraffic();
+      const owner = await readJson(getOwnerPath(tmpRoot)) as { pid: number };
+      assert.equal(owner.pid, 220);
+      await coordinator.dispose();
+    });
+  });
+
+  it('stays alive when watcher creation fails and does not fall back to polling', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      const registryDir = getRegistryDir(tmpRoot);
+      await mkdir(registryDir, { recursive: true });
+      await writeFile(getPresencePath(tmpRoot, 140), JSON.stringify({
+        pid: 140,
+        parentPid: PARENT_PID,
+        serverName: SERVER_NAME,
+        createdAtMs: 1,
+      }), 'utf8');
+
+      const shutdownReasons: string[] = [];
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: (reason) => {
+          shutdownReasons.push(reason);
+        },
+        preTrafficGraceMs: PRE_TRAFFIC_GRACE_MS,
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID, 140]),
+        watchDirectory: () => {
+          throw new Error('watch unavailable');
+        },
+      });
+
+      await delay(PRE_TRAFFIC_GRACE_MS + 40);
+      assert.deepEqual(shutdownReasons, []);
+      await coordinator.dispose();
+    });
+  });
+
+  it('cleans malformed records conservatively when possible', async () => {
+    await withTmpDir(async (tmpRoot) => {
+      await mkdir(getRegistryDir(tmpRoot), { recursive: true });
+      await writeFile(getPresencePath(tmpRoot, 140), '{not-json', 'utf8');
+      await writeFile(getOwnerPath(tmpRoot), '{still-not-json', 'utf8');
+
+      const coordinator = await createDuplicateCoordinator({
+        parentPid: PARENT_PID,
+        selfPid: SELF_PID,
+        serverName: SERVER_NAME,
+        lifecycleDebugEnabled: false,
+        shutdown: () => {},
+      }, {
+        tmpDir: tmpRoot,
+        signalProcess: createSignalProcess([SELF_PID]),
+        watchDirectory: createWatchHarness().watchDirectory,
+      });
+
+      await assert.rejects(() => stat(getPresencePath(tmpRoot, 140)));
+      await assert.rejects(() => stat(getOwnerPath(tmpRoot)));
+      await coordinator.dispose();
+    });
+  });
+});
+
+describe('duplicate coordination source contract', () => {
+  it('keeps duplicate coordination event-driven and tmpdir-backed', async () => {
+    const src = await readFile(join(process.cwd(), 'src/mcp/duplicate-coordination.ts'), 'utf8');
+
+    assert.match(src, /tmpdir\(/, 'duplicate coordination registry should live under os.tmpdir()');
+    assert.doesNotMatch(src, /state-paths\.js/, 'runtime duplicate coordination must not depend on the persistent .omx/state path helpers');
+    assert.doesNotMatch(src, /watchFile\(/, 'duplicate coordination must not fall back to fs.watchFile polling');
+    assert.doesNotMatch(src, /setInterval\(/, 'duplicate coordination must not use repeating timers');
+  });
+});

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -1,5 +1,8 @@
-import { execFileSync } from 'node:child_process';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  createDuplicateCoordinator,
+  type DuplicateCoordinator,
+} from './duplicate-coordination.js';
 
 export type McpServerName = 'state' | 'memory' | 'code_intel' | 'trace' | 'wiki';
 
@@ -14,162 +17,10 @@ const SERVER_DISABLE_ENV: Record<McpServerName, string> = {
 const GLOBAL_DISABLE_ENV = 'OMX_MCP_SERVER_DISABLE_AUTO_START';
 const LIFECYCLE_DEBUG_ENV = 'OMX_MCP_TRANSPORT_DEBUG';
 const PARENT_WATCHDOG_INTERVAL_MS = 25;
-const DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS = 5_000;
-const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS = 2_000;
-const MCP_ENTRYPOINT_PATTERN = /\b([a-z0-9-]+-server\.(?:[cm]?js|ts))\b/i;
 
 interface StdioLifecycleServer {
   connect(transport: StdioServerTransport): Promise<unknown>;
   close(): Promise<unknown>;
-}
-
-export interface ProcessTableEntry {
-  pid: number;
-  ppid: number;
-  command: string;
-}
-
-export interface DuplicateSiblingObservation {
-  status: 'ambiguous' | 'unique' | 'newest' | 'older_duplicate';
-  entrypoint: string | null;
-  matchingPids: number[];
-  newerSiblingPids: number[];
-}
-
-function normalizeCommand(command: string): string {
-  return command.replace(/\\+/g, '/').trim();
-}
-
-export function extractMcpEntrypointMarker(command: string): string | null {
-  const match = normalizeCommand(command).match(MCP_ENTRYPOINT_PATTERN);
-  return match?.[1]?.toLowerCase() ?? null;
-}
-
-export function parseProcessTable(output: string): ProcessTableEntry[] {
-  return output
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const match = line.match(/^(\d+)\s+(\d+)\s+(.+)$/);
-      if (!match) return null;
-      const pid = Number.parseInt(match[1], 10);
-      const ppid = Number.parseInt(match[2], 10);
-      const command = match[3]?.trim();
-      if (!Number.isInteger(pid) || pid <= 0) return null;
-      if (!Number.isInteger(ppid) || ppid < 0) return null;
-      if (!command) return null;
-      return { pid, ppid, command } satisfies ProcessTableEntry;
-    })
-    .filter((entry): entry is ProcessTableEntry => entry !== null);
-}
-
-export function listProcessTable(
-  readPs: typeof execFileSync = execFileSync,
-): ProcessTableEntry[] | null {
-  if (process.platform === 'win32') {
-    return null;
-  }
-
-  try {
-    const output = readPs('ps', ['axww', '-o', 'pid=,ppid=,command='], {
-      encoding: 'utf-8',
-      windowsHide: true,
-    });
-    return parseProcessTable(output);
-  } catch {
-    return null;
-  }
-}
-
-export function analyzeDuplicateSiblingState(
-  processes: readonly ProcessTableEntry[],
-  currentPid: number,
-  currentParentPid: number,
-  currentEntrypoint: string | null,
-): DuplicateSiblingObservation {
-  if (!currentEntrypoint || !Number.isInteger(currentPid) || currentPid <= 0) {
-    return {
-      status: 'ambiguous',
-      entrypoint: currentEntrypoint,
-      matchingPids: [],
-      newerSiblingPids: [],
-    };
-  }
-
-  const self = processes.find((entry) => entry.pid === currentPid);
-  if (!self || self.ppid !== currentParentPid) {
-    return {
-      status: 'ambiguous',
-      entrypoint: currentEntrypoint,
-      matchingPids: [],
-      newerSiblingPids: [],
-    };
-  }
-
-  const selfMarker = extractMcpEntrypointMarker(self.command);
-  if (selfMarker !== currentEntrypoint) {
-    return {
-      status: 'ambiguous',
-      entrypoint: currentEntrypoint,
-      matchingPids: [],
-      newerSiblingPids: [],
-    };
-  }
-
-  const matching = processes
-    .filter((entry) => entry.ppid === currentParentPid)
-    .filter((entry) => extractMcpEntrypointMarker(entry.command) === currentEntrypoint)
-    .sort((left, right) => left.pid - right.pid);
-
-  if (!matching.some((entry) => entry.pid === currentPid)) {
-    return {
-      status: 'ambiguous',
-      entrypoint: currentEntrypoint,
-      matchingPids: matching.map((entry) => entry.pid),
-      newerSiblingPids: [],
-    };
-  }
-
-  if (matching.length <= 1) {
-    return {
-      status: 'unique',
-      entrypoint: currentEntrypoint,
-      matchingPids: matching.map((entry) => entry.pid),
-      newerSiblingPids: [],
-    };
-  }
-
-  const newerSiblingPids = matching
-    .filter((entry) => entry.pid > currentPid)
-    .map((entry) => entry.pid);
-
-  return {
-    status: newerSiblingPids.length > 0 ? 'older_duplicate' : 'newest',
-    entrypoint: currentEntrypoint,
-    matchingPids: matching.map((entry) => entry.pid),
-    newerSiblingPids,
-  };
-}
-
-export function shouldSelfExitForDuplicateSibling(
-  observation: DuplicateSiblingObservation,
-  nowMs: number,
-  duplicateObservedAtMs: number | null,
-  lastTrafficAtMs: number | null,
-  preTrafficGraceMs = DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_MS,
-): boolean {
-  if (observation.status !== 'older_duplicate') {
-    return false;
-  }
-  if (!Number.isFinite(nowMs) || duplicateObservedAtMs === null || duplicateObservedAtMs > nowMs) {
-    return false;
-  }
-
-  if (lastTrafficAtMs === null) {
-    return nowMs - duplicateObservedAtMs >= preTrafficGraceMs;
-  }
-  return false;
 }
 
 export function isParentProcessAlive(
@@ -208,60 +59,15 @@ export function autoStartStdioMcpServer(
 
   const transport = new StdioServerTransport();
   let shuttingDown = false;
+  let duplicateCoordinator: DuplicateCoordinator | null = null;
   const lifecycleDebugEnabled = env[LIFECYCLE_DEBUG_ENV] === '1';
   const trackedParentPid = Number.isInteger(process.ppid) ? process.ppid : 0;
-  const trackedEntrypoint = extractMcpEntrypointMarker(process.argv[1] ?? '');
-  let lastTrafficAtMs: number | null = null;
-  let duplicateObservedAtMs: number | null = null;
 
   const logLifecycle = (message: string, error?: unknown) => {
     if (!lifecycleDebugEnabled) return;
     const detail = error ? ` ${error instanceof Error ? error.message : String(error)}` : '';
     process.stderr.write(`[omx-${serverName}-server] ${message}${detail}\n`);
   };
-
-  const parentWatchdog = trackedParentPid > 1
-    ? setInterval(() => {
-      if (!isParentProcessAlive(trackedParentPid)) {
-        void shutdown('parent_gone');
-      }
-    }, PARENT_WATCHDOG_INTERVAL_MS)
-    : null;
-  parentWatchdog?.unref();
-  const duplicateSiblingWatchdog = trackedParentPid > 1 && trackedEntrypoint
-    ? setInterval(() => {
-      const processes = listProcessTable();
-      if (!processes) {
-        duplicateObservedAtMs = null;
-        return;
-      }
-
-      const observation = analyzeDuplicateSiblingState(
-        processes,
-        process.pid,
-        trackedParentPid,
-        trackedEntrypoint,
-      );
-
-      if (observation.status !== 'older_duplicate') {
-        duplicateObservedAtMs = null;
-        return;
-      }
-
-      duplicateObservedAtMs ??= Date.now();
-      if (!shouldSelfExitForDuplicateSibling(
-        observation,
-        Date.now(),
-        duplicateObservedAtMs,
-        lastTrafficAtMs,
-      )) {
-        return;
-      }
-
-      void shutdown('superseded_duplicate_before_traffic');
-    }, DUPLICATE_SIBLING_WATCHDOG_INTERVAL_MS)
-    : null;
-  duplicateSiblingWatchdog?.unref();
 
   const shutdown = async (reason: string) => {
     if (shuttingDown) {
@@ -272,14 +78,17 @@ export function autoStartStdioMcpServer(
     if (parentWatchdog) {
       clearInterval(parentWatchdog);
     }
-    if (duplicateSiblingWatchdog) {
-      clearInterval(duplicateSiblingWatchdog);
-    }
-    process.stdin.off('data', handleStdinData);
+    process.stdin.off('data', handleFirstTraffic);
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
     process.off('SIGTERM', handleSigterm);
     process.off('SIGINT', handleSigint);
+
+    try {
+      await duplicateCoordinator?.dispose();
+    } catch (error) {
+      logLifecycle('duplicate coordination dispose failed', error);
+    }
 
     try {
       await server.close();
@@ -291,14 +100,47 @@ export function autoStartStdioMcpServer(
     process.exit(0);
   };
 
+  const parentWatchdog = trackedParentPid > 1
+    ? setInterval(() => {
+      if (!isParentProcessAlive(trackedParentPid)) {
+        void shutdown('parent_gone');
+      }
+    }, PARENT_WATCHDOG_INTERVAL_MS)
+    : null;
+  parentWatchdog?.unref();
+
+  const duplicateCoordinatorPromise = createDuplicateCoordinator({
+    parentPid: trackedParentPid,
+    selfPid: process.pid,
+    serverName,
+    lifecycleDebugEnabled,
+    shutdown,
+  }).then(async (coordinator) => {
+    if (shuttingDown) {
+      await coordinator.dispose();
+      return coordinator;
+    }
+    duplicateCoordinator = coordinator;
+    return coordinator;
+  }).catch((error) => {
+    logLifecycle('duplicate coordination setup failed', error);
+    return null;
+  });
+
   const handleStdinEnd = () => {
     void shutdown('stdin_end');
   };
   const handleStdinClose = () => {
     void shutdown('stdin_close');
   };
-  const handleStdinData = () => {
-    lastTrafficAtMs = Date.now();
+  const handleFirstTraffic = () => {
+    // Duplicate reconciliation must stay off the message hot path. We only react to the
+    // first stdin chunk, then hand coordination off to a one-shot owner claim.
+    void duplicateCoordinatorPromise
+      .then((coordinator) => coordinator?.markFirstTraffic())
+      .catch((error) => {
+        logLifecycle('duplicate coordination first-traffic hook failed', error);
+      });
   };
   const handleSigterm = () => {
     void shutdown('sigterm');
@@ -307,7 +149,7 @@ export function autoStartStdioMcpServer(
     void shutdown('sigint');
   };
 
-  process.stdin.on('data', handleStdinData);
+  process.stdin.once('data', handleFirstTraffic);
   process.stdin.once('end', handleStdinEnd);
   process.stdin.once('close', handleStdinClose);
   process.once('SIGTERM', handleSigterm);
@@ -320,7 +162,7 @@ export function autoStartStdioMcpServer(
 
   server.connect(transport).catch((error) => {
     logLifecycle('server.connect failed', error);
-    process.stdin.off('data', handleStdinData);
+    process.stdin.off('data', handleFirstTraffic);
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
     process.off('SIGTERM', handleSigterm);

--- a/src/mcp/duplicate-coordination.ts
+++ b/src/mcp/duplicate-coordination.ts
@@ -1,0 +1,546 @@
+import { watch as fsWatch } from 'node:fs';
+import { mkdir, open, readdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { McpServerName } from './bootstrap.js';
+
+const DUPLICATE_REGISTRY_VERSION = 'v1';
+const DUPLICATE_REGISTRY_ROOT = ['oh-my-codex', 'mcp-duplicate', DUPLICATE_REGISTRY_VERSION] as const;
+const DEFAULT_PRE_TRAFFIC_GRACE_MS = 2_000;
+const PRESENCE_FILE_PATTERN = /^presence-(\d+)\.json$/;
+const OWNER_FILE_NAME = 'owner.json';
+
+interface PresenceRecord {
+  pid: number;
+  parentPid: number;
+  serverName: McpServerName;
+  createdAtMs: number;
+}
+
+interface OwnerRecord {
+  pid: number;
+  parentPid: number;
+  serverName: McpServerName;
+  claimedAtMs: number;
+}
+
+interface DuplicateRegistryScope {
+  parentPid: number;
+  serverName: McpServerName;
+}
+
+interface RegistrySnapshot {
+  liveOwnerPid: number | null;
+  hasLiveNewerSibling: boolean;
+}
+
+interface DirectoryWatcher {
+  close(): void;
+}
+
+export interface DuplicateCoordinator {
+  markFirstTraffic(): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+export interface DuplicateCoordinatorOptions {
+  parentPid: number;
+  selfPid: number;
+  serverName: McpServerName;
+  lifecycleDebugEnabled: boolean;
+  shutdown: (reason: string) => void | Promise<void>;
+  preTrafficGraceMs?: number;
+}
+
+export interface DuplicateCoordinatorDeps {
+  now?: () => number;
+  signalProcess?: typeof process.kill;
+  tmpDir?: string;
+  watchDirectory?: (
+    directory: string,
+    onChange: () => void,
+    onError: (error: unknown) => void,
+  ) => DirectoryWatcher;
+}
+
+export interface ResolveDuplicateRegistryDirOptions {
+  parentPid: number;
+  serverName: McpServerName;
+  tmpDir?: string;
+}
+
+/**
+ * Keep hot-path duplicate coordination out of .omx/state. This registry is ephemeral,
+ * runtime-only coordination data, so it lives in an OS-local tmpdir scope instead.
+ */
+export function resolveDuplicateRegistryDir(options: ResolveDuplicateRegistryDirOptions): string {
+  return join(
+    options.tmpDir ?? tmpdir(),
+    ...DUPLICATE_REGISTRY_ROOT,
+    resolveUserScope(),
+    String(options.parentPid),
+    options.serverName,
+  );
+}
+
+export async function createDuplicateCoordinator(
+  options: DuplicateCoordinatorOptions,
+  deps: DuplicateCoordinatorDeps = {},
+): Promise<DuplicateCoordinator> {
+  const now = deps.now ?? Date.now;
+  const signalProcess = deps.signalProcess ?? process.kill;
+  const watchDirectory = deps.watchDirectory ?? defaultWatchDirectory;
+  const registryDir = resolveDuplicateRegistryDir({
+    parentPid: options.parentPid,
+    serverName: options.serverName,
+    tmpDir: deps.tmpDir,
+  });
+  const selfPresencePath = getPresencePath(registryDir, options.selfPid);
+  const ownerPath = join(registryDir, OWNER_FILE_NAME);
+  const preTrafficGraceMs = options.preTrafficGraceMs ?? DEFAULT_PRE_TRAFFIC_GRACE_MS;
+
+  let disposed = false;
+  let firstTrafficSeen = false;
+  let duplicateDetectionEnabled = true;
+  let duplicateObservedAtMs: number | null = null;
+  let preTrafficTimer: NodeJS.Timeout | null = null;
+  let watcher: DirectoryWatcher | null = null;
+  let reconcileQueue = Promise.resolve();
+
+  const logLifecycle = (message: string, error?: unknown) => {
+    if (!options.lifecycleDebugEnabled) return;
+    const detail = error ? ` ${error instanceof Error ? error.message : String(error)}` : '';
+    process.stderr.write(`[omx-${options.serverName}-server] ${message}${detail}\n`);
+  };
+
+  const clearGraceTimer = () => {
+    if (preTrafficTimer) {
+      clearTimeout(preTrafficTimer);
+      preTrafficTimer = null;
+    }
+  };
+
+  const clearDuplicateObservation = () => {
+    duplicateObservedAtMs = null;
+    clearGraceTimer();
+  };
+
+  const disablePreTrafficDuplicateDetection = (message: string, error?: unknown) => {
+    if (!duplicateDetectionEnabled) return;
+    duplicateDetectionEnabled = false;
+    clearDuplicateObservation();
+    if (watcher) {
+      watcher.close();
+      watcher = null;
+    }
+    logLifecycle(message, error);
+  };
+
+  const scheduleGraceReconcile = (delayMs: number) => {
+    clearGraceTimer();
+    preTrafficTimer = setTimeout(() => {
+      preTrafficTimer = null;
+      requestReconcile();
+    }, Math.max(0, delayMs));
+    preTrafficTimer.unref();
+  };
+
+  const reconcilePreTraffic = async () => {
+    if (disposed || firstTrafficSeen || !duplicateDetectionEnabled) {
+      clearDuplicateObservation();
+      return;
+    }
+
+    try {
+      const snapshot = await scanRegistryState(
+        registryDir,
+        {
+          parentPid: options.parentPid,
+          serverName: options.serverName,
+        },
+        options.selfPid,
+        signalProcess,
+      );
+
+      if (disposed || firstTrafficSeen || !duplicateDetectionEnabled) {
+        clearDuplicateObservation();
+        return;
+      }
+
+      const hasLiveForeignOwner = snapshot.liveOwnerPid !== null && snapshot.liveOwnerPid !== options.selfPid;
+      const duplicateCondition = hasLiveForeignOwner || snapshot.hasLiveNewerSibling;
+      if (!duplicateCondition) {
+        clearDuplicateObservation();
+        return;
+      }
+
+      const observedAtMs = duplicateObservedAtMs ?? now();
+      duplicateObservedAtMs = observedAtMs;
+      const elapsedMs = now() - observedAtMs;
+      if (elapsedMs >= preTrafficGraceMs) {
+        clearGraceTimer();
+        if (!disposed && !firstTrafficSeen) {
+          void Promise.resolve(options.shutdown('superseded_duplicate_before_traffic'));
+        }
+        return;
+      }
+
+      scheduleGraceReconcile(preTrafficGraceMs - elapsedMs);
+    } catch (error) {
+      // Registry read failures are ambiguous; stay alive rather than risk a wrong self-exit.
+      clearDuplicateObservation();
+      logLifecycle('duplicate coordination reconcile skipped; staying alive', error);
+    }
+  };
+
+  const requestReconcile = () => {
+    reconcileQueue = reconcileQueue
+      .catch(() => undefined)
+      .then(reconcilePreTraffic);
+  };
+
+  try {
+    await mkdir(registryDir, { recursive: true });
+    await gcRegistryDir(
+      registryDir,
+      {
+        parentPid: options.parentPid,
+        serverName: options.serverName,
+      },
+      signalProcess,
+    );
+    await writeFile(selfPresencePath, JSON.stringify({
+      pid: options.selfPid,
+      parentPid: options.parentPid,
+      serverName: options.serverName,
+      createdAtMs: now(),
+    } satisfies PresenceRecord), 'utf8');
+  } catch (error) {
+    logLifecycle('duplicate coordination unavailable; staying alive', error);
+    return {
+      async markFirstTraffic() {},
+      async dispose() {},
+    } satisfies DuplicateCoordinator;
+  }
+
+  try {
+    watcher = watchDirectory(
+      registryDir,
+      () => {
+        requestReconcile();
+      },
+      (error) => {
+        // We intentionally do not fall back to polling here. Losing the hint is safer
+        // than reintroducing steady-state file polling into the hot path.
+        disablePreTrafficDuplicateDetection('duplicate coordination watch disabled; staying alive', error);
+      },
+    );
+  } catch (error) {
+    duplicateDetectionEnabled = false;
+    logLifecycle('duplicate coordination watch unavailable; staying alive', error);
+  }
+
+  if (duplicateDetectionEnabled) {
+    requestReconcile();
+  }
+
+  return {
+    async markFirstTraffic() {
+      if (disposed || firstTrafficSeen) return;
+      firstTrafficSeen = true;
+      clearGraceTimer();
+      if (watcher) {
+        watcher.close();
+        watcher = null;
+      }
+
+      try {
+        await claimOwner({
+          ownerPath,
+          parentPid: options.parentPid,
+          selfPid: options.selfPid,
+          serverName: options.serverName,
+          now,
+          signalProcess,
+        });
+      } catch (error) {
+        logLifecycle('duplicate owner claim skipped', error);
+      }
+    },
+
+    async dispose() {
+      if (disposed) return;
+      disposed = true;
+      clearGraceTimer();
+      if (watcher) {
+        watcher.close();
+        watcher = null;
+      }
+
+      await unlinkIfExists(selfPresencePath);
+
+      try {
+        const ownerRecord = await readOwnerRecord(ownerPath, {
+          parentPid: options.parentPid,
+          serverName: options.serverName,
+        });
+        if (ownerRecord.status === 'valid' && ownerRecord.value.pid === options.selfPid) {
+          await unlinkIfExists(ownerPath);
+        }
+      } catch {
+        // Cleanup is best-effort during shutdown.
+      }
+    },
+  } satisfies DuplicateCoordinator;
+}
+
+function defaultWatchDirectory(
+  directory: string,
+  onChange: () => void,
+  onError: (error: unknown) => void,
+): DirectoryWatcher {
+  const watcher = fsWatch(directory, { persistent: false }, () => {
+    onChange();
+  });
+  watcher.on('error', onError);
+  return watcher;
+}
+
+function sanitizePathSegment(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^\.+$/, '');
+  return sanitized || 'nouid';
+}
+
+function resolveUserScope(): string {
+  if (typeof process.getuid === 'function') {
+    return sanitizePathSegment(String(process.getuid()));
+  }
+
+  const username = process.env.USERNAME?.trim();
+  if (username) return sanitizePathSegment(username);
+  return 'nouid';
+}
+
+function getPresencePath(registryDir: string, pid: number): string {
+  return join(registryDir, `presence-${pid}.json`);
+}
+
+function isAliveForCoordination(
+  pid: number,
+  signalProcess: typeof process.kill,
+): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    signalProcess(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException | undefined)?.code === 'EPERM';
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function isPresenceRecord(value: unknown, scope: DuplicateRegistryScope, expectedPid: number): value is PresenceRecord {
+  if (!isObjectRecord(value)) return false;
+  return value.serverName === scope.serverName
+    && value.parentPid === scope.parentPid
+    && value.pid === expectedPid
+    && isPositiveInteger(value.createdAtMs);
+}
+
+function isOwnerRecord(value: unknown, scope: DuplicateRegistryScope): value is OwnerRecord {
+  if (!isObjectRecord(value)) return false;
+  return value.serverName === scope.serverName
+    && value.parentPid === scope.parentPid
+    && isPositiveInteger(value.pid)
+    && isPositiveInteger(value.claimedAtMs);
+}
+
+type RecordReadResult<T> =
+  | { status: 'missing' }
+  | { status: 'malformed' }
+  | { status: 'valid'; value: T };
+
+async function readJsonRecord<T>(
+  filePath: string,
+  validate: (value: unknown) => value is T,
+): Promise<RecordReadResult<T>> {
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!validate(parsed)) {
+      return { status: 'malformed' };
+    }
+    return { status: 'valid', value: parsed };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT') return { status: 'missing' };
+    if (error instanceof SyntaxError) return { status: 'malformed' };
+    throw error;
+  }
+}
+
+async function readOwnerRecord(
+  ownerPath: string,
+  scope: DuplicateRegistryScope,
+): Promise<RecordReadResult<OwnerRecord>> {
+  return readJsonRecord(ownerPath, (value): value is OwnerRecord => isOwnerRecord(value, scope));
+}
+
+async function unlinkIfExists(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+async function gcRegistryDir(
+  registryDir: string,
+  scope: DuplicateRegistryScope,
+  signalProcess: typeof process.kill,
+): Promise<void> {
+  const entryNames = await readdir(registryDir);
+
+  for (const entryName of entryNames) {
+    const presenceMatch = entryName.match(PRESENCE_FILE_PATTERN);
+    if (presenceMatch) {
+      const expectedPid = Number.parseInt(presenceMatch[1], 10);
+      const presencePath = join(registryDir, entryName);
+      const presence = await readJsonRecord(
+        presencePath,
+        (value): value is PresenceRecord => isPresenceRecord(value, scope, expectedPid),
+      );
+      if (presence.status === 'missing') continue;
+      if (presence.status === 'malformed' || !isAliveForCoordination(presence.value.pid, signalProcess)) {
+        await unlinkIfExists(presencePath);
+      }
+      continue;
+    }
+
+    if (entryName === OWNER_FILE_NAME) {
+      const ownerPath = join(registryDir, entryName);
+      const owner = await readOwnerRecord(ownerPath, scope);
+      if (owner.status === 'missing') continue;
+      if (owner.status === 'malformed' || !isAliveForCoordination(owner.value.pid, signalProcess)) {
+        await unlinkIfExists(ownerPath);
+      }
+    }
+  }
+}
+
+async function scanRegistryState(
+  registryDir: string,
+  scope: DuplicateRegistryScope,
+  selfPid: number,
+  signalProcess: typeof process.kill,
+): Promise<RegistrySnapshot> {
+  const entryNames = await readdir(registryDir);
+  let liveOwnerPid: number | null = null;
+  let hasLiveNewerSibling = false;
+
+  for (const entryName of entryNames) {
+    const presenceMatch = entryName.match(PRESENCE_FILE_PATTERN);
+    if (presenceMatch) {
+      const expectedPid = Number.parseInt(presenceMatch[1], 10);
+      const presencePath = join(registryDir, entryName);
+      const presence = await readJsonRecord(
+        presencePath,
+        (value): value is PresenceRecord => isPresenceRecord(value, scope, expectedPid),
+      );
+      if (presence.status === 'missing') continue;
+      if (presence.status === 'malformed') {
+        await unlinkIfExists(presencePath);
+        continue;
+      }
+      if (!isAliveForCoordination(presence.value.pid, signalProcess)) {
+        await unlinkIfExists(presencePath);
+        continue;
+      }
+      if (presence.value.pid > selfPid) {
+        hasLiveNewerSibling = true;
+      }
+      continue;
+    }
+
+    if (entryName === OWNER_FILE_NAME) {
+      const ownerPath = join(registryDir, entryName);
+      const owner = await readOwnerRecord(ownerPath, scope);
+      if (owner.status === 'missing') continue;
+      if (owner.status === 'malformed') {
+        await unlinkIfExists(ownerPath);
+        continue;
+      }
+      if (!isAliveForCoordination(owner.value.pid, signalProcess)) {
+        await unlinkIfExists(ownerPath);
+        continue;
+      }
+      liveOwnerPid = owner.value.pid;
+    }
+  }
+
+  return { liveOwnerPid, hasLiveNewerSibling };
+}
+
+interface ClaimOwnerOptions {
+  ownerPath: string;
+  parentPid: number;
+  selfPid: number;
+  serverName: McpServerName;
+  now: () => number;
+  signalProcess: typeof process.kill;
+}
+
+/**
+ * Owner is only a pre-traffic hint. It is not authoritative transport truth, so we
+ * claim it once on first traffic and never heartbeat or overwrite a live foreign owner.
+ */
+async function claimOwner(options: ClaimOwnerOptions): Promise<void> {
+  const scope = {
+    parentPid: options.parentPid,
+    serverName: options.serverName,
+  } satisfies DuplicateRegistryScope;
+  const ownerRecord = await readOwnerRecord(options.ownerPath, scope);
+
+  let shouldAttemptClaim = false;
+  if (ownerRecord.status === 'missing') {
+    shouldAttemptClaim = true;
+  } else if (ownerRecord.status === 'malformed') {
+    await unlinkIfExists(options.ownerPath);
+    shouldAttemptClaim = true;
+  } else if (ownerRecord.value.pid === options.selfPid) {
+    return;
+  } else if (!isAliveForCoordination(ownerRecord.value.pid, options.signalProcess)) {
+    await unlinkIfExists(options.ownerPath);
+    shouldAttemptClaim = true;
+  } else {
+    return;
+  }
+
+  if (!shouldAttemptClaim) return;
+
+  const handle = await open(options.ownerPath, 'wx').catch(async (error: NodeJS.ErrnoException) => {
+    if (error.code === 'EEXIST') return null;
+    throw error;
+  });
+  if (!handle) return;
+
+  try {
+    await handle.writeFile(JSON.stringify({
+      pid: options.selfPid,
+      parentPid: options.parentPid,
+      serverName: options.serverName,
+      claimedAtMs: options.now(),
+    } satisfies OwnerRecord), 'utf8');
+  } finally {
+    await handle.close();
+  }
+}


### PR DESCRIPTION
## Summary

This PR packages the two incident-related fixes that matter for recurrence prevention:

1. **Primary fix** — stop `omx explore` allowlist wrapper recursion
2. **Secondary mitigation** — remove shared MCP steady-state `ps axww` duplicate polling from the hot path

The live incident was not just “high memory usage” in the abstract. It was a combined failure:
- `omx explore` wrapper recursion caused the runaway process explosion
- old-main MCP duplicate polling via `ps axww -o pid=,ppid=,command=` amplified CPU and memory pressure once the process table became huge

This PR fixes the primary trigger and also includes the existing MCP polling mitigation so both parts of the incident chain are addressed together.

## Changes

### Commit 1 — `fix(explore): stop allowlist wrapper recursion`

- prevent allowlisted commands/shells from resolving back into `omx-explore-allowlist-*`
- isolate shell startup for explore subprocesses using inert `BASH_ENV` / `ENV`
- clear `PROMPT_COMMAND` for the explore subprocess
- add wrapper recursion-depth protection with `OMX_EXPLORE_ALLOWLIST_DEPTH`
- extend explore tests to assert the new env hardening and resolution behavior

### Commit 2 — `fix(mcp): replace duplicate watchdog with event-driven coordinator`

- remove shared bootstrap `ps axww -o pid=,ppid=,command=` polling from MCP duplicate coordination
- replace it with tmpdir-backed, event-driven, pre-traffic-only coordination
- preserve post-traffic duplicate safety while eliminating the recurring process-table scan amplifier

## Why this PR is bundled

The two fixes are intentionally kept as **two separate commits** but shipped together in **one PR** because they map directly to the same incident chain:

- **primary trigger**: `omx explore` recursion
- **secondary amplifier**: MCP `ps axww` polling

The fixes remain logically separable, but operationally they belong in the same incident-response bundle.

## Validation

### Core checks
- [x] `cargo test -p omx-explore-harness`
- [x] `cargo build -p omx-explore-harness`
- [x] `npm run build`
- [x] `npm exec -- biome lint crates/omx-explore/src/main.rs src/cli/__tests__/explore.test.ts src/mcp/bootstrap.ts src/mcp/duplicate-coordination.ts src/mcp/__tests__/bootstrap.test.ts src/mcp/__tests__/duplicate-coordination.test.ts`
- [x] `npx tsc --noEmit --pretty false`
- [x] `node --test dist/mcp/__tests__/bootstrap.test.js dist/mcp/__tests__/duplicate-coordination.test.js dist/mcp/__tests__/server-lifecycle.test.js dist/cli/__tests__/cleanup.test.js`

### Focused manual smoke
- [x] `omx explore` smoke with `OMX_EXPLORE_BIN=target/debug/omx-explore-harness`
  - verified `BASH_ENV` points to allowlist `empty-startup.sh`
  - verified `ENV` points to allowlist `empty-startup.sh`
  - verified `PROMPT_COMMAND` is empty
  - verified `OMX_EXPLORE_ALLOWLIST_DEPTH=0`

### Reproduction / incident-shape verification
- [x] deterministic guided old-main vs fixed explore repro
- [x] combined incident-shape old-main vs fixed-combined repro

## Evidence summary

### 1. Live incident evidence

The live incident showed a runaway process family around:

```text
/bin/bash /tmp/omx-explore-allowlist-.../bin/grep ^CUDA Version
```

Operator-side observation reported approximately:
- ~220k owned processes
- ~226k owned `bash` processes
- ~120k+ identical wrapper-chain instances

Killing the runaway process group restored the host to a normal state.

### 2. Deterministic guided explore repro

A deterministic guided repro was built using the real old-main `omx explore` path and the real old-main explore harness, while forcing the same wrapper self-resolution / recursion class to trigger reliably.

Result:
- old-main: runaway / bounded kill
- fixed branch: bounded normal exit

This is not claimed as a byte-for-byte replay of the original incident. It is a deterministic reproduction of the same bug class using the real old-main code path.

### 3. Stress and combined severity evidence

Additional severity runs showed:
- very large aggregate process-tree RSS values
- CPU saturation
- meaningful real host memory pressure

Most incident-like combined repro:
- old-main planning roots + old-main explore recursion root
- peak aggregate tree RSS: ~181.77GB
- peak `MemAvailable` drop: ~38.11GB

The corresponding fixed-combined repro (same planning roots, fixed explore root) stayed bounded:
- peak aggregate tree RSS: ~4.26GB
- peak `MemAvailable` drop: ~5.23GB
- wrapper recursion count: 0

That is the strongest evidence that the incident chain is materially addressed.

## Memory interpretation note

Some guided stress runs produced aggregate process-tree RSS values above 100GB. Those figures are useful severity indicators, but they are not identical to unique host physical-memory usage because summing per-process RSS overcounts shared pages.

To ground that, a separate PSS / `MemAvailable` run showed:
- aggregate tree RSS: ~126GB
- `MemAvailable` drop: ~18GB
- sampled PSS estimate: ~9.5GB

So the correct engineering interpretation is:
- severe process storm
- severe CPU pressure
- very large aggregate process-tree RSS
- meaningful real host memory pressure

## Notes on `npm test`

The repository-wide `npm test` suite is still not fully PR-clean here because of a **pre-existing `autoresearch` timeout/hang** that reproduces on both `main` and this branch.

This PR did not modify `autoresearch`, and the focused validation above covers the changed code paths directly.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1692

Issue: https://github.com/Yeachan-Heo/oh-my-codex/issues/1692
