### PR TITLE
Fix false-positive Ralph workflow activation from plain-text mentions

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -134,6 +134,18 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match, null);
   });
 
+  it('does not trigger ralph from plain conversational mention', () => {
+    const match = detectPrimaryKeyword('why does ralph keep blocking stop?');
+    assert.equal(match, null);
+  });
+
+  it('still triggers ralph for explicit $ralph invocation', () => {
+    const match = detectPrimaryKeyword('$ralph continue verification');
+    assert.ok(match);
+    assert.equal(match.skill, 'ralph');
+    assert.equal(match.keyword.toLowerCase(), '$ralph');
+  });
+
   it('prefers ralplan over ralph when both keywords are present', () => {
     const match = detectPrimaryKeyword('use ralph mode but do ralplan first');
 
@@ -983,6 +995,30 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.current_phase, 'execution');
       assert.equal(modeState.started_at, '2026-02-25T00:00:00.000Z');
       assert.equal(modeState.state?.context_snapshot_path, '.omx/context/existing.md');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not persist Ralph workflow state for a plain conversational mention', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralph-plain-text-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'why does ralph keep blocking stop?',
+        sessionId: 'sess-plain-ralph',
+        threadId: 'thread-plain-ralph',
+        turnId: 'turn-plain-ralph',
+        nowIso: '2026-04-17T00:00:00.000Z',
+      });
+
+      assert.equal(result, null);
+      assert.equal(existsSync(join(stateDir, SKILL_ACTIVE_STATE_FILE)), false);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-plain-ralph', SKILL_ACTIVE_STATE_FILE)), false);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-plain-ralph', 'ralph-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -353,9 +353,9 @@ const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> =
   priority: entry.priority,
 }));
 
-const KEYWORDS_REQUIRING_INTENT = new Set(['team', 'swarm', 'stop', 'abort', 'parallel']);
+const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'swarm', 'stop', 'abort', 'parallel']);
 
-type IntentKeyword = 'team' | 'swarm' | 'stop' | 'abort' | 'parallel';
+type IntentKeyword = 'ralph' | 'team' | 'swarm' | 'stop' | 'abort' | 'parallel';
 
 /**
  * Per-keyword intent patterns used when a keyword is in KEYWORDS_REQUIRING_INTENT.
@@ -370,6 +370,13 @@ type IntentKeyword = 'team' | 'swarm' | 'stop' | 'abort' | 'parallel';
  * CI output like "running 8 tests in parallel" does not trigger ultrawork.
  */
 const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
+  ralph: [
+    /(?:^|[^\w])\$(?:ralph)\b/i,
+    /\/prompts:ralph\b/i,
+    /\b(?:use|run|start|enable|launch|invoke|activate|resume|continue)\s+(?:a\s+|an\s+|the\s+)?ralph\b/i,
+    /^(?:please\s+)?ralph\s+(?:continue|resume|start|run|go|keep\s+going|ship|fix|implement|execute|verify|complete)\b/i,
+    /\bralph\s+(?:mode|workflow|loop)\b/i,
+  ],
   team: [
     /(?:^|[^\w])\$(?:team)\b/i,
     /\/prompts:team\b/i,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -464,6 +464,33 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("does not activate Ralph workflow state from a plain conversational mention", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-plain-text-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-ralph-plain-text",
+          thread_id: "thread-ralph-plain-text",
+          turn_id: "turn-ralph-plain-text",
+          prompt: "why does ralph keep blocking stop?",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState, null);
+      assert.equal(result.outputJson, null);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "skill-active-state.json")), false);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-ralph-plain-text", "skill-active-state.json")), false);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-ralph-plain-text", "ralph-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("clarifies that prompt-side $ralph activation does not invoke the PRD-gated CLI path", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-routing-"));
     try {


### PR DESCRIPTION
## Summary
- require explicit Ralph intent before prompt-submit keyword detection seeds workflow state
- preserve explicit `$ralph` activation and directive-style Ralph commands
- add regression coverage for plain conversational mentions in both keyword-detector and native hook paths

## Testing
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npx biome lint src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts src/scripts/__tests__/codex-native-hook.test.ts

Closes #1696