### PR TITLE
Keep prompt routing anchored to the latest user turn

### DIFF
--- a/src/hooks/__tests__/notify-hook-cross-worktree-heartbeat.test.ts
+++ b/src/hooks/__tests__/notify-hook-cross-worktree-heartbeat.test.ts
@@ -51,6 +51,38 @@ function runWorkerNotify(
 }
 
 describe('notify-hook cross-worktree heartbeat resolution', () => {
+  it('logs only the latest user input preview instead of concatenating prior inputs', async () => {
+    await withTempDir(async (root) => {
+      const cwd = join(root, 'latest-input-preview');
+      await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+
+      const payload = {
+        cwd,
+        type: 'agent-turn-complete',
+        'thread-id': 'thread-latest-preview',
+        'turn-id': 'turn-latest-preview',
+        'input-messages': ['上一轮 query', '本轮 query'],
+        'last-assistant-message': 'ok',
+      };
+
+      const result = spawnSync(process.execPath, [NOTIFY_HOOK_SCRIPT.pathname, JSON.stringify(payload)], {
+        encoding: 'utf8',
+        env: { ...process.env, TMUX: '', TMUX_PANE: '' },
+      });
+
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+      const turnLogPath = join(cwd, '.omx', 'logs', `turns-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const lines = (await readFile(turnLogPath, 'utf8')).trim().split('\n');
+      const entry = JSON.parse(lines[lines.length - 1]) as {
+        input_preview?: string;
+        input_message_count?: number;
+      };
+      assert.equal(entry.input_preview, '本轮 query');
+      assert.equal(entry.input_message_count, 2);
+    });
+  });
+
   it('writes heartbeat under OMX_TEAM_STATE_ROOT even when payload cwd is a different worktree', async () => {
     await withTempDir(async (root) => {
       const leaderCwd = join(root, 'leader');

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -381,6 +381,58 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("adds execution handoff context for non-keyword prompts that authorize implementation", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-execution-handoff-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-exec-handoff",
+          thread_id: "thread-exec-handoff",
+          turn_id: "turn-exec-handoff",
+          prompt: "按照这个plan开始执行优化",
+        },
+        { cwd },
+      );
+
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /execution handoff/i);
+      assert.match(message, /Do not restate the prior plan/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("adds latest-followup priority context for short same-thread follow-up prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-followup-priority-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-followup-priority",
+          thread_id: "thread-followup-priority",
+          turn_id: "turn-followup-priority",
+          prompt: "这些优化都做了么",
+        },
+        { cwd },
+      );
+
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /same-thread follow-up/i);
+      assert.match(message, /prefer it over older unresolved prompts/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("clarifies that prompt-side $ralph activation does not invoke the PRD-gated CLI path", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-routing-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -80,6 +80,18 @@ const STABLE_FINAL_RECOMMENDATION_PATTERNS = [
 ] as const;
 const RELEASE_READINESS_FINALIZE_SYSTEM_MESSAGE =
   "OMX release-readiness detected a stable final recommendation with no active worker tasks; emit one concise final decision summary and finalize.";
+const EXECUTION_HANDOFF_PATTERNS = [
+  /^(?:好|好的|行|可以|那就|那现在)?[，,\s]*(?:开始|继续|直接)\s*(?:执行|优化|实现|修改|修复)\b/u,
+  /(?:按照|按|基于)(?:这个|上述|当前)?\s*(?:plan|计划|方案).{0,16}(?:开始|继续|直接)?\s*(?:执行|优化|实现|修改|修复)/u,
+  /(?:不用|别|不要).{0,6}讨论/u,
+  /\b(?:start|begin|go ahead(?: and)?|proceed(?: now)?)\s+(?:to\s+)?(?:implement|execute|apply|fix)\b/i,
+  /\b(?:according to|based on)\s+(?:the|this|that)\s+plan\b.{0,20}\b(?:start|begin|proceed(?: now)?|go ahead(?: and)?)\b/i,
+] as const;
+const SHORT_FOLLOWUP_PRIORITY_PATTERNS = [
+  /^(?:继续|接着|然后|那就|那现在|还有(?:一个)?问题|这些优化都做了么|这些都做了么|现在呢|本轮|当前轮|这一轮)/u,
+  /(?:按照|按|基于)(?:这个|上述|当前)?(?:plan|计划|方案)/u,
+  /\b(?:follow up|latest request|this turn|current turn|newest request)\b/i,
+] as const;
 
 function safeString(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -94,6 +106,34 @@ function safePositiveInteger(value: unknown): number | null {
   if (typeof value === "string" && value.trim() !== "") {
     const parsed = Number.parseInt(value.trim(), 10);
     if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  }
+  return null;
+}
+
+function normalizePromptSignalText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function looksLikeExecutionHandoffPrompt(prompt: string): boolean {
+  const normalized = normalizePromptSignalText(prompt);
+  if (!normalized) return false;
+  return EXECUTION_HANDOFF_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function looksLikeShortFollowupPrompt(prompt: string): boolean {
+  const normalized = normalizePromptSignalText(prompt);
+  if (!normalized) return false;
+  if (looksLikeExecutionHandoffPrompt(normalized)) return true;
+  if (normalized.length > 240) return false;
+  return SHORT_FOLLOWUP_PRIORITY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function buildPromptPriorityMessage(prompt: string): string | null {
+  if (looksLikeExecutionHandoffPrompt(prompt)) {
+    return "Newest user input is an execution handoff for the current task. Treat it as authorization to act now against the latest approved plan/request. Do not restate the prior plan unless the user explicitly asks for a recap or status update.";
+  }
+  if (looksLikeShortFollowupPrompt(prompt)) {
+    return "Newest user input is a same-thread follow-up. Answer that latest follow-up directly and prefer it over older unresolved prompts when choosing what to do next.";
   }
   return null;
 }
@@ -459,9 +499,10 @@ async function buildSessionStartContext(
 
 function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveState | null): string | null {
   if (!prompt) return null;
+  const promptPriorityMessage = buildPromptPriorityMessage(prompt);
   const matches = detectKeywords(prompt);
   const match = detectPrimaryKeyword(prompt);
-  if (!match) return null;
+  if (!match) return promptPriorityMessage;
   const detectedKeywordMessage = matches.length > 1
     ? `OMX native UserPromptSubmit detected workflow keywords ${matches.map((entry) => `"${entry.keyword}" -> ${entry.skill}`).join(", ")}.`
     : `OMX native UserPromptSubmit detected workflow keyword "${match.keyword}" -> ${match.skill}.`;
@@ -487,6 +528,7 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
     return [
       `OMX native UserPromptSubmit denied workflow keyword "${match.keyword}" -> ${match.skill}.`,
       skillState.transition_error,
+      promptPriorityMessage,
       'Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.',
     ].join(' ');
   }
@@ -499,6 +541,7 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
       deferredSkills.length > 0
         ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
         : null,
+      promptPriorityMessage,
       skillState.initialized_mode && skillState.initialized_state_path
         ? `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`
         : null,
@@ -520,6 +563,7 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
       deferredSkills.length > 0
         ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
         : null,
+      promptPriorityMessage,
       initializedStateMessage,
       "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
       "If you need runtime syntax, run `omx team --help` yourself.",
@@ -534,13 +578,14 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
       deferredSkills.length > 0
         ? `planning preserved over simultaneous execution follow-up; deferred skills: ${deferredSkills.join(", ")}.`
         : null,
+      promptPriorityMessage,
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
       ralphPromptActivationNote,
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].join(" ");
   }
 
-  return `${detectedKeywordMessage} Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.`;
+  return [detectedKeywordMessage, promptPriorityMessage, "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules."].filter(Boolean).join(" ");
 }
 
 function parseTeamWorkerEnv(rawValue: string): { teamName: string; workerName: string } | null {

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -238,14 +238,19 @@ async function main() {
   }
 
   // 1. Log the turn
+  const normalizedInputMessages = normalizeInputMessages(payload);
+  const latestInputPreview = safeString(
+    normalizedInputMessages.length > 0
+      ? normalizedInputMessages[normalizedInputMessages.length - 1]
+      : '',
+  ).slice(0, 200);
   const logEntry = {
     timestamp: new Date().toISOString(),
     type: payload.type || 'agent-turn-complete',
     thread_id: payload['thread-id'] || payload.thread_id,
     turn_id: payload['turn-id'] || payload.turn_id,
-    input_preview: (payload['input-messages'] || payload.input_messages || [])
-      .map((m: any) => m.slice(0, 100))
-      .join('; '),
+    input_preview: latestInputPreview,
+    input_message_count: normalizedInputMessages.length,
     output_preview: (payload['last-assistant-message'] || payload.last_assistant_message || '')
       .slice(0, 200),
   };


### PR DESCRIPTION
## Summary
- detect natural-language execution handoffs and short same-thread follow-ups in the native prompt-submit hook
- prioritize the latest user turn in injected context so execution confirmations do not fall back into plan restatement
- log only the latest user input preview in notify-hook turn logs instead of concatenating prior inputs
- add focused regression tests for both behaviors

## Why
Two failures showed up in real Codex/OMX usage:
1. responses could appear to target an older query because turn previews were built from the whole `input_messages` array
2. after a user said to start executing, the model could still restate the previous plan because natural-language execution handoffs were not surfaced as a high-priority context signal

This patch keeps the latest turn explicit at both layers.

## Testing
- `node --test dist/scripts/__tests__/codex-native-hook.test.js`
- `node --test dist/hooks/__tests__/notify-hook-cross-worktree-heartbeat.test.js`
