### PR TITLE
Hard-deprecate autoresearch CLI/tmux launch and add validator-gated $autoresearch skill flow

### DIFF
--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: autoresearch
+description: Stateful validator-gated research loop with native-hook persistence
+---
+
+# Autoresearch
+
+Autoresearch is the skill-first replacement for the deprecated `omx autoresearch` command.
+It keeps the useful measured-research loop, but it now runs as a native-hook stateful workflow instead of a direct CLI or tmux launch surface.
+
+## Use when
+- You want a Ralph-ish persistent research loop
+- The task should keep nudging until explicit validation evidence exists
+- You want init-time choice between script validation and prompt+architect validation
+
+## Do not use when
+- You want the old `omx autoresearch` command surface (hard-deprecated)
+- You want detached tmux or split-pane launch parity
+- You have not decided the validation regime yet
+
+## Core contract
+1. **Init chooses validation mode.** Pick exactly one:
+   - `mission-validator-script`
+   - `prompt-architect-artifact`
+2. **Persist mode state** in `.omx/state/.../autoresearch-state.json` including:
+   - `validation_mode`
+   - `completion_artifact_path`
+   - `mission_validator_command` **or** `validator_prompt`
+   - optional `output_artifact_path`
+3. **Completion is artifact-gated.** The loop does not stop because the model says “done”, because a stop hook fired once, or because several turns were no-ops.
+4. **Direct CLI launch is gone.** Use `$deep-interview --autoresearch` for intake and `$autoresearch` for execution.
+
+## Completion artifact contract
+
+### `mission-validator-script`
+The completion artifact must exist and record a passing validator result, for example:
+
+```json
+{
+  "status": "passed",
+  "passed": true,
+  "summary": "metric improved beyond baseline"
+}
+```
+
+### `prompt-architect-artifact`
+The completion artifact must include both an architect approval verdict and an output artifact path, for example:
+
+```json
+{
+  "validator_prompt": "Review the research output against the mission.",
+  "architect_review": { "verdict": "approved" },
+  "output_artifact_path": ".omx/specs/autoresearch-demo/report.md"
+}
+```
+
+## Recommended flow
+1. Run `$deep-interview --autoresearch` to clarify mission + evaluator.
+2. Materialize `.omx/specs/autoresearch-{slug}/mission.md`, `sandbox.md`, and `result.json`.
+3. Start `$autoresearch` with the chosen validation mode stored in mode state.
+4. Let stop-hook / auto-nudge continue until the completion artifact satisfies the chosen validation mode.
+5. Finish only after the validator artifact is complete.
+
+## Migration note
+- `omx autoresearch` is hard-deprecated.
+- No direct CLI launch.
+- No tmux split-pane launch.
+- No noop-count completion gate.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -30,12 +30,12 @@ Execution quality is usually bottlenecked by intent clarity, not just missing im
 - **Quick (`--quick`)**: fast pre-PRD pass; target threshold `<= 0.30`; max rounds 5
 - **Standard (`--standard`, default)**: full requirement interview; target threshold `<= 0.20`; max rounds 12
 - **Deep (`--deep`)**: high-rigor exploration; target threshold `<= 0.15`; max rounds 20
-- **Autoresearch (`--autoresearch`)**: same interview rigor as Standard, but specialized for `omx autoresearch` launch readiness and `.omx/specs/` mission/sandbox artifact handoff
+- **Autoresearch (`--autoresearch`)**: same interview rigor as Standard, but specialized for `$autoresearch` mission readiness and `.omx/specs/` artifact handoff
 
 If no flag is provided, use **Standard**.
 
 <Mode_Flags>
-- **`--autoresearch`**: switch the interview into autoresearch-intake mode for `omx autoresearch` handoff. In this mode, the interview should converge on a launch-ready research mission, write canonical artifacts under `.omx/specs/`, and preserve the explicit `refine further` vs `launch` boundary for downstream CLI intake.
+- **`--autoresearch`**: switch the interview into autoresearch-intake mode for `$autoresearch` handoff. In this mode, the interview should converge on a validator-ready research mission, write canonical artifacts under `.omx/specs/`, and preserve the explicit `refine further` vs `launch` boundary for downstream skill intake.
 </Mode_Flags>
 </Depth_Profiles>
 
@@ -217,7 +217,7 @@ Spec should include:
 
 ### Autoresearch specialization
 
-When the clarified task is specifically about `omx autoresearch`, or the skill is invoked with `--autoresearch`, keep the interview domain-specific and emit launch-consumable artifacts without skipping clarification.
+When the clarified task is specifically about `$autoresearch`, or the skill is invoked with `--autoresearch`, keep the interview domain-specific and emit skill-consumable artifacts without skipping clarification.
 
 - **Accepted seed inputs:** `topic`, `evaluator`, `keep-policy`, `slug`, existing mission draft text, and prior evaluator examples/templates
 - **Required interview focus:** mission clarity, evaluator readiness, keep policy, slug/session naming, and whether the draft is ready to launch now or should refine further
@@ -235,8 +235,8 @@ When the clarified task is specifically about `omx autoresearch`, or the skill i
   - `sandbox.md`
   - `result.json`
 - **Launch-readiness rule:** mark the draft as **not launch-ready** while the evaluator command still contains placeholder markers such as `<...>`, `TODO`, `TBD`, `REPLACE_ME`, `CHANGEME`, or `your-command-here`
-- **Structured result contract:** `result.json` should point to the draft + mission/sandbox artifacts and carry the finalized `topic`, `evaluatorCommand`, `keepPolicy`, `slug`, `launchReady`, and `blockedReasons` fields so `omx autoresearch` can consume it directly
-- **Confirmation bridge:** after artifact generation, offer at least `refine further` and `launch`; do not launch detached tmux until the user explicitly confirms `launch`
+- **Structured result contract:** `result.json` should point to the draft + mission/sandbox artifacts and carry the finalized `topic`, `evaluatorCommand`, `keepPolicy`, `slug`, `launchReady`, and `blockedReasons` fields so `$autoresearch` can consume it directly
+- **Confirmation bridge:** after artifact generation, offer at least `refine further` and `launch`; do not run direct CLI launch or detached/split tmux launch, and only hand off to `$autoresearch` after explicit confirmation
 - **Handoff rule:** downstream execution must preserve the clarified mission intent, evaluator expectations, decision boundaries, and launch-readiness status from this artifact rather than bypassing the draft review step
 
 ## Phase 5: Execution Bridge

--- a/src/autoresearch/__tests__/skill-validation.test.ts
+++ b/src/autoresearch/__tests__/skill-validation.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  assessAutoresearchCompletionState,
+  normalizeAutoresearchValidationMode,
+} from '../skill-validation.js';
+
+describe('autoresearch skill validation', () => {
+  it('normalizes the supported validation modes', () => {
+    assert.equal(normalizeAutoresearchValidationMode('mission-validator-script'), 'mission-validator-script');
+    assert.equal(normalizeAutoresearchValidationMode('prompt-architect-artifact'), 'prompt-architect-artifact');
+    assert.equal(normalizeAutoresearchValidationMode('unknown-mode'), null);
+  });
+
+  it('treats missing validation mode as incomplete', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-skill-validation-'));
+    try {
+      const result = await assessAutoresearchCompletionState({ active: true }, cwd);
+      assert.equal(result.complete, false);
+      assert.equal(result.reason, 'missing_validation_mode');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('requires a validator pass artifact for mission-validator-script mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-validator-script-'));
+    try {
+      const artifactPath = join(cwd, '.omx', 'specs', 'autoresearch-demo', 'completion.json');
+      await mkdir(join(cwd, '.omx', 'specs', 'autoresearch-demo'), { recursive: true });
+      await writeFile(artifactPath, JSON.stringify({ status: 'running' }, null, 2));
+
+      const incomplete = await assessAutoresearchCompletionState({
+        active: true,
+        validation_mode: 'mission-validator-script',
+        mission_validator_command: 'node scripts/validate.js',
+        completion_artifact_path: artifactPath,
+      }, cwd);
+      assert.equal(incomplete.complete, false);
+      assert.equal(incomplete.reason, 'validator_not_passed');
+
+      await writeFile(artifactPath, JSON.stringify({ status: 'passed', passed: true }, null, 2));
+      const complete = await assessAutoresearchCompletionState({
+        active: true,
+        validation_mode: 'mission-validator-script',
+        mission_validator_command: 'node scripts/validate.js',
+        completion_artifact_path: artifactPath,
+      }, cwd);
+      assert.equal(complete.complete, true);
+      assert.equal(complete.reason, 'validator_passed');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('requires prompt, architect approval, and output artifact for prompt-architect-artifact mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-architect-validation-'));
+    try {
+      const artifactDir = join(cwd, '.omx', 'specs', 'autoresearch-demo');
+      const completionPath = join(artifactDir, 'completion.json');
+      const outputPath = join(artifactDir, 'report.md');
+      await mkdir(artifactDir, { recursive: true });
+      await writeFile(outputPath, '# Report\n', 'utf-8');
+      await writeFile(completionPath, JSON.stringify({
+        architect_review: { verdict: 'reject' },
+        output_artifact_path: outputPath,
+      }, null, 2));
+
+      const rejected = await assessAutoresearchCompletionState({
+        active: true,
+        validation_mode: 'prompt-architect-artifact',
+        validator_prompt: 'Review the research output.',
+        completion_artifact_path: completionPath,
+      }, cwd);
+      assert.equal(rejected.complete, false);
+      assert.equal(rejected.reason, 'missing_architect_approval');
+
+      await writeFile(completionPath, JSON.stringify({
+        validator_prompt: 'Review the research output.',
+        architect_review: { verdict: 'approved' },
+        output_artifact_path: outputPath,
+      }, null, 2));
+      const approved = await assessAutoresearchCompletionState({
+        active: true,
+        validation_mode: 'prompt-architect-artifact',
+        validator_prompt: 'Review the research output.',
+        completion_artifact_path: completionPath,
+      }, cwd);
+      assert.equal(approved.complete, true);
+      assert.equal(approved.reason, 'architect_approved');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/autoresearch/skill-validation.ts
+++ b/src/autoresearch/skill-validation.ts
@@ -1,0 +1,196 @@
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { getReadScopedStatePaths } from '../mcp/state-paths.js';
+
+export type AutoresearchValidationMode = 'mission-validator-script' | 'prompt-architect-artifact';
+
+export interface AutoresearchCompletionStatus {
+  complete: boolean;
+  reason: string;
+  validationMode: AutoresearchValidationMode | null;
+  artifactPath: string | null;
+  outputArtifactPath?: string | null;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function safeObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+}
+
+function safeBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function lookupString(raw: Record<string, unknown> | null, ...keys: string[]): string {
+  if (!raw) return '';
+  for (const key of keys) {
+    const direct = safeString(raw[key]);
+    if (direct) return direct;
+  }
+  const nestedState = safeObject(raw.state);
+  if (nestedState) {
+    for (const key of keys) {
+      const nested = safeString(nestedState[key]);
+      if (nested) return nested;
+    }
+  }
+  return '';
+}
+
+function lookupBoolean(raw: Record<string, unknown> | null, ...keys: string[]): boolean | null {
+  if (!raw) return null;
+  for (const key of keys) {
+    const direct = safeBoolean(raw[key]);
+    if (direct !== null) return direct;
+  }
+  const nestedState = safeObject(raw.state);
+  if (nestedState) {
+    for (const key of keys) {
+      const nested = safeBoolean(nestedState[key]);
+      if (nested !== null) return nested;
+    }
+  }
+  return null;
+}
+
+export function normalizeAutoresearchValidationMode(value: unknown): AutoresearchValidationMode | null {
+  const normalized = safeString(value).toLowerCase();
+  if (normalized === 'mission-validator-script') return 'mission-validator-script';
+  if (normalized === 'prompt-architect-artifact') return 'prompt-architect-artifact';
+  return null;
+}
+
+function resolveMaybeRelativePath(cwd: string, rawPath: string): string {
+  if (!rawPath) return rawPath;
+  return rawPath.startsWith('/') ? rawPath : join(cwd, rawPath);
+}
+
+function deriveDefaultArtifactPath(cwd: string, rawState: Record<string, unknown> | null): string | null {
+  const slug = lookupString(rawState, 'slug', 'mission_slug', 'missionSlug');
+  if (!slug) return null;
+  return join(cwd, '.omx', 'specs', `autoresearch-${slug}`, 'completion.json');
+}
+
+function resolveArtifactPath(cwd: string, rawState: Record<string, unknown> | null): string | null {
+  const explicit = lookupString(
+    rawState,
+    'completion_artifact_path',
+    'completionArtifactPath',
+    'validator_artifact_path',
+    'validatorArtifactPath',
+  );
+  if (explicit) return resolveMaybeRelativePath(cwd, explicit);
+  return deriveDefaultArtifactPath(cwd, rawState);
+}
+
+async function readJsonIfExists(path: string | null): Promise<Record<string, unknown> | null> {
+  if (!path || !existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function isPassingStatus(value: unknown): boolean {
+  const normalized = safeString(value).toLowerCase();
+  return ['pass', 'passed', 'complete', 'completed', 'success', 'succeeded', 'approved'].includes(normalized);
+}
+
+function hasArchitectApproval(artifact: Record<string, unknown> | null): boolean {
+  if (!artifact) return false;
+  const direct = lookupBoolean(artifact, 'architect_approved', 'architectApproved', 'approved');
+  if (direct === true) return true;
+  const architectReview = safeObject(artifact.architect_review) ?? safeObject(artifact.architectReview);
+  const architectValidation = safeObject(artifact.architect_validation) ?? safeObject(artifact.architectValidation);
+  return isPassingStatus(architectReview?.verdict) || isPassingStatus(architectValidation?.verdict);
+}
+
+function resolveOutputArtifactPath(
+  cwd: string,
+  rawState: Record<string, unknown> | null,
+  artifact: Record<string, unknown> | null,
+): string | null {
+  const explicit = lookupString(rawState, 'output_artifact_path', 'outputArtifactPath')
+    || lookupString(artifact, 'output_artifact_path', 'outputArtifactPath');
+  if (!explicit) return null;
+  return resolveMaybeRelativePath(cwd, explicit);
+}
+
+export async function assessAutoresearchCompletionState(
+  rawState: Record<string, unknown> | null,
+  cwd: string,
+): Promise<AutoresearchCompletionStatus> {
+  const validationMode = normalizeAutoresearchValidationMode(
+    lookupString(rawState, 'validation_mode', 'validationMode'),
+  );
+  if (!rawState) {
+    return { complete: false, reason: 'missing_mode_state', validationMode: null, artifactPath: null };
+  }
+  if (!validationMode) {
+    return { complete: false, reason: 'missing_validation_mode', validationMode: null, artifactPath: resolveArtifactPath(cwd, rawState) };
+  }
+
+  const artifactPath = resolveArtifactPath(cwd, rawState);
+  const artifact = await readJsonIfExists(artifactPath);
+  if (!artifactPath) {
+    return { complete: false, reason: 'missing_completion_artifact_path', validationMode, artifactPath: null };
+  }
+  if (!artifact) {
+    return { complete: false, reason: 'missing_or_invalid_completion_artifact', validationMode, artifactPath };
+  }
+
+  if (validationMode === 'mission-validator-script') {
+    const validatorCommand = lookupString(rawState, 'mission_validator_command', 'missionValidatorCommand')
+      || lookupString(safeObject(rawState.mission_validator), 'command');
+    if (!validatorCommand) {
+      return { complete: false, reason: 'missing_mission_validator_command', validationMode, artifactPath };
+    }
+    if (lookupBoolean(artifact, 'passed', 'complete', 'completed', 'valid') === true || isPassingStatus(artifact.status)) {
+      return { complete: true, reason: 'validator_passed', validationMode, artifactPath };
+    }
+    return { complete: false, reason: 'validator_not_passed', validationMode, artifactPath };
+  }
+
+  const validatorPrompt = lookupString(rawState, 'validator_prompt', 'validatorPrompt')
+    || lookupString(artifact, 'validator_prompt', 'validatorPrompt');
+  if (!validatorPrompt) {
+    return { complete: false, reason: 'missing_validator_prompt', validationMode, artifactPath };
+  }
+  const outputArtifactPath = resolveOutputArtifactPath(cwd, rawState, artifact);
+  if (!outputArtifactPath || !existsSync(outputArtifactPath)) {
+    return { complete: false, reason: 'missing_output_artifact', validationMode, artifactPath, outputArtifactPath };
+  }
+  if (!hasArchitectApproval(artifact)) {
+    return { complete: false, reason: 'missing_architect_approval', validationMode, artifactPath, outputArtifactPath };
+  }
+  return { complete: true, reason: 'architect_approved', validationMode, artifactPath, outputArtifactPath };
+}
+
+export async function readAutoresearchModeState(
+  cwd: string,
+  sessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  const candidates = await getReadScopedStatePaths('autoresearch', cwd, sessionId);
+  for (const candidatePath of candidates) {
+    if (!existsSync(candidatePath)) continue;
+    try {
+      return JSON.parse(await readFile(candidatePath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export async function readAutoresearchCompletionStatus(
+  cwd: string,
+  sessionId?: string,
+): Promise<AutoresearchCompletionStatus> {
+  const state = await readAutoresearchModeState(cwd, sessionId);
+  return assessAutoresearchCompletionState(state, cwd);
+}

--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -1,433 +1,309 @@
-import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { parseSandboxContract } from '../../autoresearch/contracts.js';
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
 import {
-  isLaunchReadyEvaluatorCommand,
-  resolveAutoresearchDeepInterviewResult,
-  writeAutoresearchDeepInterviewArtifacts,
-  writeAutoresearchDraftArtifact,
-} from '../autoresearch-intake.js';
+	type AutoresearchQuestionIO,
+	buildAutoresearchDeepInterviewPrompt,
+	parseInitArgs,
+	runAutoresearchNoviceBridge,
+} from "../autoresearch-guided.js";
 import {
-  buildAutoresearchDeepInterviewPrompt,
-  initAutoresearchMission,
-  parseInitArgs,
-  checkTmuxAvailable,
-  runAutoresearchNoviceBridge,
-  spawnAutoresearchTmux,
-  type AutoresearchQuestionIO,
-} from '../autoresearch-guided.js';
-import { OMX_ENTRY_PATH_ENV, OMX_STARTUP_CWD_ENV } from '../../utils/paths.js';
+	isLaunchReadyEvaluatorCommand,
+	resolveAutoresearchDeepInterviewResult,
+	writeAutoresearchDeepInterviewArtifacts,
+	writeAutoresearchDraftArtifact,
+} from "../autoresearch-intake.js";
 
-async function initRepo(): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-guided-test-'));
-  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
-  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
-  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
-  const { writeFile } = await import('node:fs/promises');
-  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
-  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
-  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
-  return cwd;
+async function initWorkspace(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "omx-autoresearch-guided-test-"));
 }
 
 function withMockedTty<T>(fn: () => Promise<T>): Promise<T> {
-  const descriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
-  Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
-  return fn().finally(() => {
-    if (descriptor) {
-      Object.defineProperty(process.stdin, 'isTTY', descriptor);
-    } else {
-      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
-    }
-  });
+	const descriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+	Object.defineProperty(process.stdin, "isTTY", {
+		configurable: true,
+		value: true,
+	});
+	return fn().finally(() => {
+		if (descriptor) {
+			Object.defineProperty(process.stdin, "isTTY", descriptor);
+		} else {
+			Object.defineProperty(process.stdin, "isTTY", {
+				configurable: true,
+				value: false,
+			});
+		}
+	});
 }
 
 function makeFakeIo(answers: string[]): AutoresearchQuestionIO {
-  const queue = [...answers];
-  return {
-    async question(): Promise<string> {
-      return queue.shift() ?? '';
-    },
-    close(): void {},
-  };
+	const queue = [...answers];
+	return {
+		async question(): Promise<string> {
+			return queue.shift() ?? "";
+		},
+		close(): void {},
+	};
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+describe("parseInitArgs", () => {
+	it("parses all flags with space-separated values", () => {
+		const result = parseInitArgs([
+			"--topic",
+			"my topic",
+			"--evaluator",
+			"node eval.js",
+			"--keep-policy",
+			"pass_only",
+			"--slug",
+			"my-slug",
+		]);
+		assert.equal(result.topic, "my topic");
+		assert.equal(result.evaluatorCommand, "node eval.js");
+		assert.equal(result.keepPolicy, "pass_only");
+		assert.equal(result.slug, "my-slug");
+	});
 
-describe('initAutoresearchMission', () => {
-  it('creates mission.md with correct content', async () => {
-    const repo = await initRepo();
-    try {
-      const result = await initAutoresearchMission({
-        topic: 'Improve test coverage for the auth module',
-        evaluatorCommand: 'node scripts/eval.js',
-        keepPolicy: 'score_improvement',
-        slug: 'auth-coverage',
-        repoRoot: repo,
-      });
+	it("parses all flags with = syntax", () => {
+		const result = parseInitArgs([
+			"--topic=my topic",
+			"--evaluator=node eval.js",
+			"--keep-policy=score_improvement",
+			"--slug=my-slug",
+		]);
+		assert.equal(result.topic, "my topic");
+		assert.equal(result.evaluatorCommand, "node eval.js");
+		assert.equal(result.keepPolicy, "score_improvement");
+		assert.equal(result.slug, "my-slug");
+	});
 
-      assert.equal(result.slug, 'auth-coverage');
-      assert.equal(result.missionDir, join(repo, 'missions', 'auth-coverage'));
+	it("returns partial result when some flags are missing", () => {
+		const result = parseInitArgs(["--topic", "my topic"]);
+		assert.equal(result.topic, "my topic");
+		assert.equal(result.evaluatorCommand, undefined);
+		assert.equal(result.keepPolicy, undefined);
+		assert.equal(result.slug, undefined);
+	});
 
-      const missionContent = await readFile(join(result.missionDir, 'mission.md'), 'utf-8');
-      assert.match(missionContent, /# Mission/);
-      assert.match(missionContent, /Improve test coverage for the auth module/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
+	it("throws on invalid keep-policy", () => {
+		assert.throws(
+			() => parseInitArgs(["--keep-policy", "invalid"]),
+			/must be one of/,
+		);
+	});
 
-  it('creates sandbox.md with valid YAML frontmatter', async () => {
-    const repo = await initRepo();
-    try {
-      const result = await initAutoresearchMission({
-        topic: 'Optimize database queries',
-        evaluatorCommand: 'node scripts/eval-perf.js',
-        keepPolicy: 'pass_only',
-        slug: 'db-perf',
-        repoRoot: repo,
-      });
+	it("throws on unknown flags", () => {
+		assert.throws(
+			() => parseInitArgs(["--unknown-flag", "value"]),
+			/Unknown init flag: --unknown-flag/,
+		);
+	});
 
-      const sandboxContent = await readFile(join(result.missionDir, 'sandbox.md'), 'utf-8');
-      assert.match(sandboxContent, /^---\n/);
-      assert.match(sandboxContent, /evaluator:/);
-      assert.match(sandboxContent, /command: node scripts\/eval-perf\.js/);
-      assert.match(sandboxContent, /format: json/);
-      assert.match(sandboxContent, /keep_policy: pass_only/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('generated sandbox.md passes parseSandboxContract validation', async () => {
-    const repo = await initRepo();
-    try {
-      const result = await initAutoresearchMission({
-        topic: 'Fix flaky tests',
-        evaluatorCommand: 'bash run-tests.sh',
-        keepPolicy: 'score_improvement',
-        slug: 'flaky-tests',
-        repoRoot: repo,
-      });
-
-      const sandboxContent = await readFile(join(result.missionDir, 'sandbox.md'), 'utf-8');
-      const parsed = parseSandboxContract(sandboxContent);
-      assert.equal(parsed.evaluator.command, 'bash run-tests.sh');
-      assert.equal(parsed.evaluator.format, 'json');
-      assert.equal(parsed.evaluator.keep_policy, 'score_improvement');
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('throws if mission directory already exists', async () => {
-    const repo = await initRepo();
-    try {
-      const missionDir = join(repo, 'missions', 'existing');
-      await mkdir(missionDir, { recursive: true });
-
-      await assert.rejects(
-        () => initAutoresearchMission({
-          topic: 'duplicate',
-          evaluatorCommand: 'echo ok',
-          keepPolicy: 'pass_only',
-          slug: 'existing',
-          repoRoot: repo,
-        }),
-        /already exists/,
-      );
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
+	it("sanitizes slug via slugifyMissionName", () => {
+		const result = parseInitArgs(["--slug", "../../etc/cron.d/omx"]);
+		assert.ok(result.slug);
+		assert.doesNotMatch(result.slug!, /\.\./);
+		assert.doesNotMatch(result.slug!, /\//);
+	});
 });
 
-describe('parseInitArgs', () => {
-  it('parses all flags with space-separated values', () => {
-    const result = parseInitArgs([
-      '--topic', 'my topic',
-      '--evaluator', 'node eval.js',
-      '--keep-policy', 'pass_only',
-      '--slug', 'my-slug',
-    ]);
-    assert.equal(result.topic, 'my topic');
-    assert.equal(result.evaluatorCommand, 'node eval.js');
-    assert.equal(result.keepPolicy, 'pass_only');
-    assert.equal(result.slug, 'my-slug');
-  });
+describe("autoresearch intake draft artifacts", () => {
+	it("writes a canonical deep-interview autoresearch draft artifact from vague input", async () => {
+		const repo = await initWorkspace();
+		try {
+			const artifact = await writeAutoresearchDraftArtifact({
+				repoRoot: repo,
+				topic: "Improve onboarding for first-time contributors",
+				keepPolicy: "score_improvement",
+				seedInputs: { topic: "Improve onboarding for first-time contributors" },
+			});
 
-  it('parses all flags with = syntax', () => {
-    const result = parseInitArgs([
-      '--topic=my topic',
-      '--evaluator=node eval.js',
-      '--keep-policy=score_improvement',
-      '--slug=my-slug',
-    ]);
-    assert.equal(result.topic, 'my topic');
-    assert.equal(result.evaluatorCommand, 'node eval.js');
-    assert.equal(result.keepPolicy, 'score_improvement');
-    assert.equal(result.slug, 'my-slug');
-  });
+			assert.match(
+				artifact.path,
+				/\.omx\/specs\/deep-interview-autoresearch-improve-onboarding-for-first-time-contributors\.md$/,
+			);
+			assert.equal(artifact.launchReady, false);
+			assert.match(artifact.content, /## Mission Draft/);
+			assert.match(artifact.content, /## Evaluator Draft/);
+			assert.match(artifact.content, /## Launch Readiness/);
+			assert.match(artifact.content, /## Seed Inputs/);
+			assert.match(artifact.content, /## Confirmation Bridge/);
+			assert.match(artifact.content, /TODO replace with evaluator command/i);
+		} finally {
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
 
-  it('returns partial result when some flags are missing', () => {
-    const result = parseInitArgs(['--topic', 'my topic']);
-    assert.equal(result.topic, 'my topic');
-    assert.equal(result.evaluatorCommand, undefined);
-    assert.equal(result.keepPolicy, undefined);
-    assert.equal(result.slug, undefined);
-  });
+	it("rejects placeholder evaluator commands and accepts concrete commands", () => {
+		assert.equal(isLaunchReadyEvaluatorCommand("TODO replace me"), false);
+		assert.equal(isLaunchReadyEvaluatorCommand("node scripts/eval.js"), true);
+		assert.equal(isLaunchReadyEvaluatorCommand("bash scripts/eval.sh"), true);
+	});
 
-  it('throws on invalid keep-policy', () => {
-    assert.throws(
-      () => parseInitArgs(['--keep-policy', 'invalid']),
-      /must be one of/,
-    );
-  });
+	it("writes launch-consumable mission/sandbox/result artifacts and resolves them back", async () => {
+		const repo = await initWorkspace();
+		try {
+			const artifacts = await writeAutoresearchDeepInterviewArtifacts({
+				repoRoot: repo,
+				topic: "Measure onboarding friction",
+				evaluatorCommand: "node scripts/eval.js",
+				keepPolicy: "pass_only",
+				slug: "onboarding-friction",
+				seedInputs: { topic: "Measure onboarding friction" },
+			});
 
-  it('throws on unknown flags', () => {
-    assert.throws(
-      () => parseInitArgs(['--unknown-flag', 'value']),
-      /Unknown init flag: --unknown-flag/,
-    );
-  });
+			assert.match(
+				artifacts.draftArtifactPath,
+				/deep-interview-autoresearch-onboarding-friction\.md$/,
+			);
+			assert.match(
+				artifacts.missionArtifactPath,
+				/autoresearch-onboarding-friction\/mission\.md$/,
+			);
+			assert.match(
+				artifacts.sandboxArtifactPath,
+				/autoresearch-onboarding-friction\/sandbox\.md$/,
+			);
+			assert.match(
+				artifacts.resultPath,
+				/autoresearch-onboarding-friction\/result\.json$/,
+			);
 
-  it('sanitizes slug via slugifyMissionName', () => {
-    const result = parseInitArgs(['--slug', '../../etc/cron.d/omx']);
-    assert.ok(result.slug);
-    assert.doesNotMatch(result.slug!, /\.\./);
-    assert.doesNotMatch(result.slug!, /\//);
-  });
+			const resolved = await resolveAutoresearchDeepInterviewResult(repo, {
+				slug: "onboarding-friction",
+			});
+			assert.ok(resolved);
+			assert.equal(resolved?.compileTarget.slug, "onboarding-friction");
+			assert.equal(resolved?.compileTarget.keepPolicy, "pass_only");
+			assert.equal(resolved?.launchReady, true);
+			assert.match(
+				resolved?.missionContent || "",
+				/Measure onboarding friction/,
+			);
+			assert.match(
+				resolved?.sandboxContent || "",
+				/command: node scripts\/eval\.js/,
+			);
+		} finally {
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
 });
 
-describe('checkTmuxAvailable', () => {
-  it('returns a boolean', () => {
-    const result = checkTmuxAvailable();
-    assert.equal(typeof result, 'boolean');
-  });
+describe("buildAutoresearchDeepInterviewPrompt", () => {
+	it("activates deep-interview --autoresearch and includes seed inputs", () => {
+		const prompt = buildAutoresearchDeepInterviewPrompt({
+			topic: "Investigate flaky tests",
+			evaluatorCommand: "node scripts/eval.js",
+			keepPolicy: "score_improvement",
+			slug: "flaky-tests",
+		});
 
-  it('launches background tmux sessions with an absolute omx entry path even from a relative launcher', async () => {
-    const repo = await initRepo();
-    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-guided-bin-'));
-    const startupCwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-guided-start-'));
-    const missionDir = join(repo, 'missions', 'demo');
-    const tmuxLog = join(repo, 'tmux.log');
-    const previousPath = process.env.PATH;
-    const previousEntryPath = process.env[OMX_ENTRY_PATH_ENV];
-    const previousStartupCwd = process.env[OMX_STARTUP_CWD_ENV];
-
-    try {
-      await mkdir(missionDir, { recursive: true });
-      const launcherDir = join(startupCwd, 'dist', 'cli');
-      const launcherPath = join(launcherDir, 'omx.js');
-      await mkdir(launcherDir, { recursive: true });
-      await writeFile(launcherPath, '#!/usr/bin/env node\n', 'utf-8');
-
-      const fakeTmuxPath = join(fakeBin, 'tmux');
-      await writeFile(
-        fakeTmuxPath,
-        `#!/bin/sh
-printf '%s\n' "$*" >>"${tmuxLog}"
-case "$1" in
-  -V)
-    exit 0
-    ;;
-  has-session)
-    exit 1
-    ;;
-  new-session)
-    exit 0
-    ;;
-  *)
-    exit 0
-    ;;
-esac
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeTmuxPath], { stdio: 'ignore' });
-
-      process.env.PATH = `${fakeBin}:${previousPath || ''}`;
-      delete process.env[OMX_ENTRY_PATH_ENV];
-      process.env[OMX_STARTUP_CWD_ENV] = startupCwd;
-
-      const previousArgv = process.argv;
-      process.argv = [previousArgv[0] || 'node', 'dist/cli/omx.js'];
-      try {
-        spawnAutoresearchTmux(missionDir, 'demo');
-      } finally {
-        process.argv = previousArgv;
-      }
-
-      const tmuxOutput = await readFile(tmuxLog, 'utf-8');
-      assert.match(tmuxOutput, /new-session -d -s omx-autoresearch-demo/);
-      assert.match(tmuxOutput, new RegExp(escapeRegExp(launcherPath)));
-      assert.doesNotMatch(tmuxOutput, /dist\/cli\/omx\.js autoresearch/);
-    } finally {
-      if (typeof previousPath === 'string') process.env.PATH = previousPath;
-      else delete process.env.PATH;
-      if (typeof previousEntryPath === 'string') process.env[OMX_ENTRY_PATH_ENV] = previousEntryPath;
-      else delete process.env[OMX_ENTRY_PATH_ENV];
-      if (typeof previousStartupCwd === 'string') process.env[OMX_STARTUP_CWD_ENV] = previousStartupCwd;
-      else delete process.env[OMX_STARTUP_CWD_ENV];
-      await rm(repo, { recursive: true, force: true });
-      await rm(fakeBin, { recursive: true, force: true });
-      await rm(startupCwd, { recursive: true, force: true });
-    }
-  });
+		assert.match(prompt, /\$deep-interview --autoresearch/);
+		assert.match(
+			prompt,
+			/Do not launch tmux or run `omx autoresearch` yourself/,
+		);
+		assert.match(prompt, /deep-interview-autoresearch-\{slug\}\.md/);
+		assert.match(prompt, /autoresearch-\{slug\}\/mission\.md/);
+		assert.match(prompt, /- topic: Investigate flaky tests/);
+		assert.match(prompt, /- evaluator: node scripts\/eval\.js/);
+		assert.match(prompt, /- keep_policy: score_improvement/);
+		assert.match(prompt, /- slug: flaky-tests/);
+	});
 });
 
-describe('autoresearch intake draft artifacts', () => {
-  it('writes a canonical deep-interview autoresearch draft artifact from vague input', async () => {
-    const repo = await initRepo();
-    try {
-      const artifact = await writeAutoresearchDraftArtifact({
-        repoRoot: repo,
-        topic: 'Improve onboarding for first-time contributors',
-        keepPolicy: 'score_improvement',
-        seedInputs: { topic: 'Improve onboarding for first-time contributors' },
-      });
+describe("runAutoresearchNoviceBridge", () => {
+	it("loops through refine further before launching and writes canonical spec artifacts", async () => {
+		const repo = await initWorkspace();
+		try {
+			const result = await withMockedTty(() =>
+				runAutoresearchNoviceBridge(
+					repo,
+					{},
+					makeFakeIo([
+						"Improve evaluator UX",
+						"Make success measurable",
+						"TODO replace with evaluator command",
+						"score_improvement",
+						"ux-eval",
+						"refine further",
+						"Improve evaluator UX",
+						"Passing evaluator output",
+						"node scripts/eval.js",
+						"pass_only",
+						"ux-eval",
+						"launch",
+					]),
+				),
+			);
 
-      assert.match(artifact.path, /\.omx\/specs\/deep-interview-autoresearch-improve-onboarding-for-first-time-contributors\.md$/);
-      assert.equal(artifact.launchReady, false);
-      assert.match(artifact.content, /## Mission Draft/);
-      assert.match(artifact.content, /## Evaluator Draft/);
-      assert.match(artifact.content, /## Launch Readiness/);
-      assert.match(artifact.content, /## Seed Inputs/);
-      assert.match(artifact.content, /## Confirmation Bridge/);
-      assert.match(artifact.content, /TODO replace with evaluator command/i);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
+			const draftContent = await readFile(
+				join(repo, ".omx", "specs", "deep-interview-autoresearch-ux-eval.md"),
+				"utf-8",
+			);
+			const resultContent = await readFile(result.resultPath, "utf-8");
+			const missionContent = await readFile(
+				result.missionArtifactPath,
+				"utf-8",
+			);
+			const sandboxContent = await readFile(
+				result.sandboxArtifactPath,
+				"utf-8",
+			);
 
-  it('rejects placeholder evaluator commands and accepts concrete commands', () => {
-    assert.equal(isLaunchReadyEvaluatorCommand('TODO replace me'), false);
-    assert.equal(isLaunchReadyEvaluatorCommand('node scripts/eval.js'), true);
-    assert.equal(isLaunchReadyEvaluatorCommand('bash scripts/eval.sh'), true);
-  });
+			assert.equal(
+				result.artifactDir,
+				join(repo, ".omx", "specs", "autoresearch-ux-eval"),
+			);
+			assert.equal(result.slug, "ux-eval");
+			assert.match(draftContent, /Launch-ready: yes/);
+			assert.match(resultContent, /"launchReady": true/);
+			assert.match(missionContent, /Improve evaluator UX/);
+			assert.match(sandboxContent, /command: node scripts\/eval\.js/);
+			assert.match(sandboxContent, /keep_policy: pass_only/);
+		} finally {
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
 
-  it('writes launch-consumable mission/sandbox/result artifacts and resolves them back', async () => {
-    const repo = await initRepo();
-    try {
-      const artifacts = await writeAutoresearchDeepInterviewArtifacts({
-        repoRoot: repo,
-        topic: 'Measure onboarding friction',
-        evaluatorCommand: 'node scripts/eval.js',
-        keepPolicy: 'pass_only',
-        slug: 'onboarding-friction',
-        seedInputs: { topic: 'Measure onboarding friction' },
-      });
+	it("uses seeded novice inputs while still requiring confirmation-driven launch", async () => {
+		const repo = await initWorkspace();
+		try {
+			const result = await withMockedTty(() =>
+				runAutoresearchNoviceBridge(
+					repo,
+					{
+						topic: "Seeded topic",
+						evaluatorCommand: "node scripts/eval.js",
+						keepPolicy: "score_improvement",
+						slug: "seeded-topic",
+					},
+					makeFakeIo(["", "", "", "", "", "launch"]),
+				),
+			);
 
-      assert.match(artifacts.draftArtifactPath, /deep-interview-autoresearch-onboarding-friction\.md$/);
-      assert.match(artifacts.missionArtifactPath, /autoresearch-onboarding-friction\/mission\.md$/);
-      assert.match(artifacts.sandboxArtifactPath, /autoresearch-onboarding-friction\/sandbox\.md$/);
-      assert.match(artifacts.resultPath, /autoresearch-onboarding-friction\/result\.json$/);
-
-      const resolved = await resolveAutoresearchDeepInterviewResult(repo, { slug: 'onboarding-friction' });
-      assert.ok(resolved);
-      assert.equal(resolved?.compileTarget.slug, 'onboarding-friction');
-      assert.equal(resolved?.compileTarget.keepPolicy, 'pass_only');
-      assert.equal(resolved?.launchReady, true);
-      assert.match(resolved?.missionContent || '', /Measure onboarding friction/);
-      assert.match(resolved?.sandboxContent || '', /command: node scripts\/eval\.js/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-});
-
-describe('buildAutoresearchDeepInterviewPrompt', () => {
-  it('activates deep-interview --autoresearch and includes seed inputs', () => {
-    const prompt = buildAutoresearchDeepInterviewPrompt({
-      topic: 'Investigate flaky tests',
-      evaluatorCommand: 'node scripts/eval.js',
-      keepPolicy: 'score_improvement',
-      slug: 'flaky-tests',
-    });
-
-    assert.match(prompt, /\$deep-interview --autoresearch/);
-    assert.match(prompt, /deep-interview-autoresearch-\{slug\}\.md/);
-    assert.match(prompt, /autoresearch-\{slug\}\/mission\.md/);
-    assert.match(prompt, /- topic: Investigate flaky tests/);
-    assert.match(prompt, /- evaluator: node scripts\/eval\.js/);
-    assert.match(prompt, /- keep_policy: score_improvement/);
-    assert.match(prompt, /- slug: flaky-tests/);
-  });
-});
-
-describe('runAutoresearchNoviceBridge', () => {
-  it('loops through refine further before launching and writes draft + mission files', async () => {
-    const repo = await initRepo();
-    try {
-      const result = await withMockedTty(() => runAutoresearchNoviceBridge(
-        repo,
-        {},
-        makeFakeIo([
-          'Improve evaluator UX',
-          'Make success measurable',
-          'TODO replace with evaluator command',
-          'score_improvement',
-          'ux-eval',
-          'refine further',
-          'Improve evaluator UX',
-          'Passing evaluator output',
-          'node scripts/eval.js',
-          'pass_only',
-          'ux-eval',
-          'launch',
-        ]),
-      ));
-
-      const draftContent = await readFile(join(repo, '.omx', 'specs', 'deep-interview-autoresearch-ux-eval.md'), 'utf-8');
-      const resultContent = await readFile(join(repo, '.omx', 'specs', 'autoresearch-ux-eval', 'result.json'), 'utf-8');
-      const missionContent = await readFile(join(result.missionDir, 'mission.md'), 'utf-8');
-      const sandboxContent = await readFile(join(result.missionDir, 'sandbox.md'), 'utf-8');
-
-      assert.equal(result.slug, 'ux-eval');
-      assert.match(draftContent, /Launch-ready: yes/);
-      assert.match(resultContent, /"launchReady": true/);
-      assert.match(missionContent, /Improve evaluator UX/);
-      assert.match(sandboxContent, /command: node scripts\/eval\.js/);
-      assert.match(sandboxContent, /keep_policy: pass_only/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('uses seeded novice inputs while still requiring confirmation-driven launch', async () => {
-    const repo = await initRepo();
-    try {
-      const result = await withMockedTty(() => runAutoresearchNoviceBridge(
-        repo,
-        {
-          topic: 'Seeded topic',
-          evaluatorCommand: 'node scripts/eval.js',
-          keepPolicy: 'score_improvement',
-          slug: 'seeded-topic',
-        },
-        makeFakeIo([
-          '',
-          '',
-          '',
-          '',
-          '',
-          'launch',
-        ]),
-      ));
-
-      const draftContent = await readFile(join(repo, '.omx', 'specs', 'deep-interview-autoresearch-seeded-topic.md'), 'utf-8');
-      assert.equal(result.slug, 'seeded-topic');
-      assert.match(draftContent, /- topic: Seeded topic/);
-      assert.match(draftContent, /- evaluator: node scripts\/eval\.js/);
-      assert.match(draftContent, /Launch-ready: yes/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
+			const draftContent = await readFile(
+				join(
+					repo,
+					".omx",
+					"specs",
+					"deep-interview-autoresearch-seeded-topic.md",
+				),
+				"utf-8",
+			);
+			assert.equal(
+				result.resultPath,
+				join(repo, ".omx", "specs", "autoresearch-seeded-topic", "result.json"),
+			);
+			assert.equal(result.slug, "seeded-topic");
+			assert.match(draftContent, /- topic: Seeded topic/);
+			assert.match(draftContent, /- evaluator: node scripts\/eval\.js/);
+			assert.match(draftContent, /Launch-ready: yes/);
+		} finally {
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/cli/__tests__/autoresearch.test.ts
+++ b/src/cli/__tests__/autoresearch.test.ts
@@ -1,24 +1,17 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readdirSync, realpathSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync, realpathSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { autoresearchCommand, normalizeAutoresearchCodexArgs, parseAutoresearchArgs } from '../autoresearch.js';
-
-function withMockedTty<T>(fn: () => Promise<T>): Promise<T> {
-  const descriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
-  Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
-  return fn().finally(() => {
-    if (descriptor) {
-      Object.defineProperty(process.stdin, 'isTTY', descriptor);
-    } else {
-      Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
-    }
-  });
-}
+import {
+  AUTORESEARCH_DEPRECATION_MESSAGE,
+  autoresearchCommand,
+  normalizeAutoresearchCodexArgs,
+  parseAutoresearchArgs,
+} from '../autoresearch.js';
 
 function runOmx(
   cwd: string,
@@ -28,7 +21,7 @@ function runOmx(
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
   const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
-  const r = spawnSync(process.execPath, [omxBin, ...argv], {
+  const result = spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',
     env: {
@@ -39,7 +32,7 @@ function runOmx(
       ...envOverrides,
     },
   });
-  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '', error: r.error?.message };
+  return { status: result.status, stdout: result.stdout || '', stderr: result.stderr || '', error: result.error?.message };
 }
 
 async function initRepo(): Promise<string> {
@@ -52,12 +45,6 @@ async function initRepo(): Promise<string> {
   execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
   execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
   return cwd;
-}
-
-async function installFakePs(fakeBin: string): Promise<void> {
-  const fakePsPath = join(fakeBin, 'ps');
-  await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n', 'utf-8');
-  execFileSync('chmod', ['+x', fakePsPath], { stdio: 'ignore' });
 }
 
 describe('normalizeAutoresearchCodexArgs', () => {
@@ -74,57 +61,7 @@ describe('normalizeAutoresearchCodexArgs', () => {
   });
 });
 
-describe('omx autoresearch', () => {
-  it('documents autoresearch in top-level help', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-help-'));
-    try {
-      const result = runOmx(cwd, ['--help']);
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stdout, /omx autoresearch\s+Launch thin-supervisor autoresearch with keep\/discard\/reset parity/i);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('routes autoresearch --help to command-local help', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-local-help-'));
-    try {
-      const result = runOmx(cwd, ['autoresearch', '--help']);
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stdout, /Usage:[\s\S]*omx autoresearch run <mission-dir>/i);
-      assert.match(result.stdout, /omx autoresearch init/i);
-      assert.match(result.stdout, /--topic\/\.\.\./i);
-      assert.match(result.stdout, /deep-interview/i);
-      assert.match(result.stdout, /human entrypoint/i);
-      assert.doesNotMatch(result.stdout, /oh-my-codex \(omx\) - Multi-agent orchestration for Codex CLI/i);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('documents --resume in command-local help', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-resume-help-'));
-    try {
-      const result = runOmx(cwd, ['autoresearch', '--help']);
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stdout, /--resume <run-id>/i);
-      assert.match(result.stdout, /run-tagged/i);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it('fails fast when mission dir is missing', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-missing-arg-'));
-    try {
-      const result = runOmx(cwd, ['autoresearch']);
-      assert.notEqual(result.status, 0, result.stderr || result.stdout);
-      assert.match(`${result.stderr}\n${result.stdout}`, /mission-dir|Usage:\s*omx autoresearch <mission-dir>/i);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
+describe('parseAutoresearchArgs', () => {
   it('treats top-level topic/evaluator flags as seeded deep-interview input', () => {
     const parsed = parseAutoresearchArgs(['--topic', 'Improve docs', '--evaluator', 'node eval.js', '--slug', 'docs-run']);
     assert.equal(parsed.guided, true);
@@ -143,7 +80,7 @@ describe('omx autoresearch', () => {
     assert.deepEqual(flagged.initArgs, ['--topic', 'Ship feature']);
   });
 
-  it('parses explicit run subcommand without breaking bare mission-dir execution', () => {
+  it('parses explicit run subcommand without breaking bare mission-dir parsing', () => {
     const runParsed = parseAutoresearchArgs(['run', 'missions/demo', '--model', 'gpt-5']);
     assert.equal(runParsed.runSubcommand, true);
     assert.equal(runParsed.missionDir, 'missions/demo');
@@ -154,718 +91,88 @@ describe('omx autoresearch', () => {
     assert.equal(bareParsed.missionDir, 'missions/demo');
     assert.deepEqual(bareParsed.codexArgs, ['--model', 'gpt-5']);
   });
+});
 
-
-  it('resolves guided deep-interview artifacts by seeded slug even when file mtimes predate launch timestamp', async () => {
-    const repo = await initRepo();
-    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-deep-interview-mtime-bin-'));
+describe('omx autoresearch hard deprecation', () => {
+  it('documents autoresearch as deprecated in top-level help', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-help-'));
     try {
-      const fakeCodexPath = join(fakeBin, 'codex');
-      await writeFile(
-        fakeCodexPath,
-        `#!/bin/sh
-if [ "$1" = "exec" ]; then
-  candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
-  head_commit=$(git rev-parse HEAD)
-  cat >"$candidate_file" <<'EOF'
-{
-  "status": "abort",
-  "candidate_commit": null,
-  "base_commit": "HEAD_PLACEHOLDER",
-  "description": "stop after guided handoff",
-  "notes": ["fake codex exec"],
-  "created_at": "2026-03-18T00:00:00.000Z"
-}
-EOF
-  perl -0pi -e "s/HEAD_PLACEHOLDER/$head_commit/g" "$candidate_file"
-  exit 0
-fi
-mkdir -p "$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch"
-cat >"$OMX_TEST_REPO_ROOT/.omx/specs/deep-interview-autoresearch-test-launch.md" <<'EOF'
-# Deep Interview Autoresearch Draft — test-launch
-
-## Mission Draft
-Investigate flaky onboarding behavior
-
-## Evaluator Draft
-node scripts/eval.js
-
-## Keep Policy
-score_improvement
-
-## Session Slug
-test-launch
-
-## Seed Inputs
-- topic: (none)
-- evaluator: (none)
-- keep_policy: (none)
-- slug: (none)
-
-## Launch Readiness
-Launch-ready: yes
-- Evaluator command is concrete and can be compiled into sandbox.md
-
-## Confirmation Bridge
-- refine further
-- launch
-EOF
-cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/mission.md" <<'EOF'
-# Mission
-
-Investigate flaky onboarding behavior
-EOF
-cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/sandbox.md" <<'EOF'
----
-evaluator:
-  command: node scripts/eval.js
-  format: json
-  keep_policy: score_improvement
----
-EOF
-cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/result.json" <<'EOF'
-{
-  "kind": "omx.autoresearch.deep-interview/v1",
-  "compileTarget": {
-    "topic": "Investigate flaky onboarding behavior",
-    "evaluatorCommand": "node scripts/eval.js",
-    "keepPolicy": "score_improvement",
-    "slug": "test-launch",
-    "repoRoot": "${repo}"
-  },
-  "draftArtifactPath": "${repo}/.omx/specs/deep-interview-autoresearch-test-launch.md",
-  "missionArtifactPath": "${repo}/.omx/specs/autoresearch-test-launch/mission.md",
-  "sandboxArtifactPath": "${repo}/.omx/specs/autoresearch-test-launch/sandbox.md",
-  "launchReady": true,
-  "blockedReasons": []
-}
-EOF
-touch -t 202603180000 "$OMX_TEST_REPO_ROOT/.omx/specs/deep-interview-autoresearch-test-launch.md"
-touch -t 202603180000 "$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/mission.md"
-touch -t 202603180000 "$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/sandbox.md"
-touch -t 202603180000 "$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/result.json"
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
-      await installFakePs(fakeBin);
-
-      const result = runOmx(repo, ['autoresearch', '--topic', 'Investigate flaky onboarding behavior', '--evaluator', 'node scripts/eval.js', '--slug', 'test-launch'], {
-        PATH: `${fakeBin}:${process.env.PATH || ''}`,
-        OMX_TEST_REPO_ROOT: repo,
-      });
+      const result = runOmx(cwd, ['--help']);
       assert.equal(result.status, 0, result.stderr || result.stdout);
-
-      const missionContent = await readFile(join(repo, 'missions', 'test-launch', 'mission.md'), 'utf-8');
-      const sandboxContent = await readFile(join(repo, 'missions', 'test-launch', 'sandbox.md'), 'utf-8');
-      assert.match(missionContent, /Investigate flaky onboarding behavior/);
-      assert.match(sandboxContent, /command: node scripts\/eval\.js/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-      await rm(fakeBin, { recursive: true, force: true });
-    }
-  });
-
-  it('launches interactive deep-interview intake, materializes mission files, and then prefers split-pane handoff', async () => {
-    const repo = await initRepo();
-    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-deep-interview-bin-'));
-    try {
-      const codexLog = join(repo, 'codex-launch.log');
-      const tmuxLog = join(repo, 'guided-tmux.log');
-      const fakeCodexPath = join(fakeBin, 'codex');
-      await writeFile(
-        fakeCodexPath,
-        `#!/bin/sh
-printf '%s\n' "$*" >>"${codexLog}"
-if [ "$1" = "exec" ]; then
-candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
-head_commit=$(git rev-parse HEAD)
-cat >"$candidate_file" <<'EOF'
-{
-  "status": "abort",
-  "candidate_commit": null,
-  "base_commit": "HEAD_PLACEHOLDER",
-  "description": "stop after guided handoff",
-  "notes": ["fake codex exec"],
-  "created_at": "2026-03-18T00:00:00.000Z"
-}
-EOF
-perl -0pi -e "s/HEAD_PLACEHOLDER/$head_commit/g" "$candidate_file"
-exit 0
-fi
-mkdir -p "$OMX_TEST_REPO_ROOT/.omx/specs/deep-int"
-mkdir -p "$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch"
-cat >"$OMX_TEST_REPO_ROOT/.omx/specs/deep-interview-autoresearch-test-launch.md" <<'EOF'
-# Deep Interview Autoresearch Draft — test-launch
-
-## Mission Draft
-Investigate flaky onboarding behavior
-
-## Evaluator Draft
-node scripts/eval.js
-
-## Keep Policy
-score_improvement
-
-## Session Slug
-test-launch
-
-## Seed Inputs
-- topic: (none)
-- evaluator: (none)
-- keep_policy: (none)
-- slug: (none)
-
-## Launch Readiness
-Launch-ready: yes
-- Evaluator command is concrete and can be compiled into sandbox.md
-
-## Confirmation Bridge
-- refine further
-- launch
-EOF
-cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/mission.md" <<'EOF'
-# Mission
-
-Investigate flaky onboarding behavior
-EOF
-cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/sandbox.md" <<'EOF'
----
-evaluator:
-  command: node scripts/eval.js
-  format: json
-  keep_policy: score_improvement
----
-EOF
-cat >"$OMX_TEST_REPO_ROOT/.omx/specs/autoresearch-test-launch/result.json" <<'EOF'
-{
-  "kind": "omx.autoresearch.deep-interview/v1",
-  "compileTarget": {
-    "topic": "Investigate flaky onboarding behavior",
-    "evaluatorCommand": "node scripts/eval.js",
-    "keepPolicy": "score_improvement",
-    "slug": "test-launch",
-    "repoRoot": "${repo}"
-  },
-  "draftArtifactPath": "${repo}/.omx/specs/deep-interview-autoresearch-test-launch.md",
-  "missionArtifactPath": "${repo}/.omx/specs/autoresearch-test-launch/mission.md",
-  "sandboxArtifactPath": "${repo}/.omx/specs/autoresearch-test-launch/sandbox.md",
-  "launchReady": true,
-  "blockedReasons": []
-}
-EOF
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
-      await installFakePs(fakeBin);
-
-      const fakeTmuxPath = join(fakeBin, 'tmux');
-      await writeFile(
-        fakeTmuxPath,
-        `#!/bin/sh
-printf '%s\n' "$*" >>"${tmuxLog}"
-case "$1" in
-  -V)
-    printf 'tmux 3.4\n'
-    exit 0
-    ;;
-  display-message)
-    case "$*" in
-      *"#{pane_id}"*) printf '%%42\n' ;;
-      *"#{pane_current_path}"*) printf '%s\n' "$OMX_TEST_REPO_ROOT" ;;
-      *"#S"*) printf 'devsession\n' ;;
-      *) printf 'devsession\n' ;;
-    esac
-    exit 0
-    ;;
-  list-panes)
-    exit 0
-    ;;
-  split-window)
-    last=""
-    for arg in "$@"; do
-      last="$arg"
-    done
-    printf '%%2\n'
-    if printf '%s' "$last" | grep -q 'autoresearch '; then
-      /bin/sh -lc "$last"
-    fi
-    exit 0
-    ;;
-  attach-session|set-option|set-hook|kill-session|kill-pane)
-    exit 0
-    ;;
-  *)
-    exit 0
-    ;;
-esac
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeTmuxPath], { stdio: 'ignore' });
-
-      const result = runOmx(repo, ['autoresearch', '--topic', 'Investigate flaky onboarding behavior', '--evaluator', 'node scripts/eval.js', '--slug', 'test-launch'], {
-        PATH: `${fakeBin}:${process.env.PATH || ''}`,
-        OMX_TEST_REPO_ROOT: repo,
-        TMUX: '/tmp/fake-tmux,12345,0',
-        TMUX_PANE: '%42',
-      });
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-
-      const codexArgs = await readFile(codexLog, 'utf-8');
-      const tmuxOutput = await readFile(tmuxLog, 'utf-8');
-      assert.match(codexArgs, /\$deep-interview --autoresearch/);
-      assert.match(tmuxOutput, /split-window -h -t %42 -d -P -F #\{pane_id\} -c/);
-
-      const missionContent = await readFile(join(repo, 'missions', 'test-launch', 'mission.md'), 'utf-8');
-      const sandboxContent = await readFile(join(repo, 'missions', 'test-launch', 'sandbox.md'), 'utf-8');
-      assert.match(missionContent, /Investigate flaky onboarding behavior/);
-      assert.match(sandboxContent, /command: node scripts\/eval\.js/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-      await rm(fakeBin, { recursive: true, force: true });
-    }
-  });
-
-  it('uses split-window launch for explicit run inside tmux while preserving the interview pane', async () => {
-    const repo = await initRepo();
-    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-run-split-bin-'));
-    try {
-      const missionDir = join(repo, 'missions', 'demo');
-      const tmuxLog = join(repo, 'tmux.log');
-      await mkdir(missionDir, { recursive: true });
-      await mkdir(join(repo, 'scripts'), { recursive: true });
-      await writeFile(join(missionDir, 'mission.md'), '# Mission\nSplit pane launch.\n', 'utf-8');
-      await writeFile(
-        join(missionDir, 'sandbox.md'),
-        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
-        'utf-8',
-      );
-      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
-      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'add autoresearch mission'], { cwd: repo, stdio: 'ignore' });
-
-      const fakeCodexPath = join(fakeBin, 'codex');
-      await writeFile(
-        fakeCodexPath,
-        `#!/bin/sh
-candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
-head_commit=$(git rev-parse HEAD)
-cat >"$candidate_file" <<'EOF'
-{
-  "status": "abort",
-  "candidate_commit": null,
-  "base_commit": "HEAD_PLACEHOLDER",
-  "description": "stop after split launch",
-  "notes": ["fake codex exec"],
-  "created_at": "2026-03-18T00:00:00.000Z"
-}
-EOF
-perl -0pi -e "s/HEAD_PLACEHOLDER/$head_commit/g" "$candidate_file"
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
-      await installFakePs(fakeBin);
-
-      const fakeTmuxPath = join(fakeBin, 'tmux');
-      await writeFile(
-        fakeTmuxPath,
-        `#!/bin/sh
-printf '%s\n' "$*" >>"${tmuxLog}"
-case "$1" in
-  -V)
-    printf 'tmux 3.4\n'
-    exit 0
-    ;;
-  display-message)
-    case "$*" in
-      *"#{pane_id}"*) printf '%%9\n' ;;
-      *"#{pane_current_path}"*) printf '${repo}\n' ;;
-      *"#S"*) printf 'devsess\n' ;;
-      *) printf '0\n' ;;
-    esac
-    exit 0
-    ;;
-  list-panes)
-    printf '%%9\tzsh\tomx autoresearch\n'
-    exit 0
-    ;;
-  split-window)
-    last=""
-    for arg in "$@"; do
-      last="$arg"
-    done
-    if printf '%s' "$last" | grep -q 'hud --watch'; then
-      printf '%%3\n'
-      exit 0
-    fi
-    printf '%%2\n'
-    /bin/sh -lc "$last"
-    exit 0
-    ;;
-  set-option|select-pane)
-    exit 0
-    ;;
-  *)
-    exit 0
-    ;;
-esac
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeTmuxPath], { stdio: 'ignore' });
-
-      const result = runOmx(repo, ['autoresearch', 'run', missionDir, '--model', 'gpt-5'], {
-        PATH: `${fakeBin}:${process.env.PATH || ''}`,
-        OMX_TEST_REPO_ROOT: repo,
-        TMUX: '/tmp/fake-tmux,12345,0',
-        TMUX_PANE: '%9',
-      });
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-
-      const tmuxOutput = await readFile(tmuxLog, 'utf-8');
-      assert.match(tmuxOutput, /split-window -h -t %9 -d -P -F #\{pane_id\} -c/);
-      assert.match(tmuxOutput, /'autoresearch' '\/tmp\/[^']+\/missions\/demo' '--model' 'gpt-5'/);
-      assert.doesNotMatch(tmuxOutput, /kill-pane -t %9/);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-      await rm(fakeBin, { recursive: true, force: true });
-    }
-  });
-
-  it('falls back to foreground execution when tmux split-window fails', async () => {
-    const repo = await initRepo();
-    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-run-fallback-bin-'));
-    try {
-      const missionDir = join(repo, 'missions', 'demo');
-      await mkdir(missionDir, { recursive: true });
-      await mkdir(join(repo, 'scripts'), { recursive: true });
-      await writeFile(join(missionDir, 'mission.md'), '# Mission\nFallback launch.\n', 'utf-8');
-      await writeFile(
-        join(missionDir, 'sandbox.md'),
-        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
-        'utf-8',
-      );
-      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
-      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'add autoresearch mission'], { cwd: repo, stdio: 'ignore' });
-
-      const fakeCodexPath = join(fakeBin, 'codex');
-      await writeFile(
-        fakeCodexPath,
-        `#!/bin/sh
-candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
-head_commit=$(git rev-parse HEAD)
-cat >"$candidate_file" <<'EOF'
-{
-  "status": "abort",
-  "candidate_commit": null,
-  "base_commit": "HEAD_PLACEHOLDER",
-  "description": "stop after foreground fallback",
-  "notes": ["fake codex exec"],
-  "created_at": "2026-03-18T00:00:00.000Z"
-}
-EOF
-perl -0pi -e "s/HEAD_PLACEHOLDER/$head_commit/g" "$candidate_file"
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
-      await installFakePs(fakeBin);
-
-      const fakeTmuxPath = join(fakeBin, 'tmux');
-      await writeFile(
-        fakeTmuxPath,
-        `#!/bin/sh
-case "$1" in
-  -V)
-    printf 'tmux 3.4\n'
-    exit 0
-    ;;
-  display-message)
-    case "$*" in
-      *"#{pane_id}"*) printf '%%9\n' ;;
-      *"#{pane_current_path}"*) printf '${repo}\n' ;;
-      *"#S"*) printf 'devsess\n' ;;
-      *) printf '0\n' ;;
-    esac
-    exit 0
-    ;;
-  list-panes)
-    printf '%%9\tzsh\tomx autoresearch\n'
-    exit 0
-    ;;
-  split-window)
-    exit 1
-    ;;
-  set-option|select-pane)
-    exit 0
-    ;;
-  *)
-    exit 0
-    ;;
-esac
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeTmuxPath], { stdio: 'ignore' });
-
-      const result = runOmx(repo, ['autoresearch', 'run', missionDir], {
-        PATH: `${fakeBin}:${process.env.PATH || ''}`,
-        OMX_TEST_REPO_ROOT: repo,
-        TMUX: '/tmp/fake-tmux,12345,0',
-        TMUX_PANE: '%9',
-      });
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-
-      const logsRoot = join(repo, '.omx', 'logs', 'autoresearch');
-      const [runId] = readdirSync(logsRoot, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name);
-      assert.ok(runId);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-      await rm(fakeBin, { recursive: true, force: true });
-    }
-  });
-
-  it('rejects mission directories outside a git repo', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-outside-git-'));
-    try {
-      await writeFile(join(cwd, 'mission.md'), '# Mission\n', 'utf-8');
-      await writeFile(join(cwd, 'sandbox.md'), '---\nevaluator:\n  command: node eval.js\n---\n', 'utf-8');
-
-      const result = runOmx(cwd, ['autoresearch', cwd]);
-      assert.notEqual(result.status, 0, result.stderr || result.stdout);
-      assert.match(`${result.stderr}\n${result.stdout}`, /git repo|git repository|inside a git repo/i);
+      assert.match(result.stdout, /omx autoresearch\s+\[DEPRECATED\] Use \$autoresearch; direct CLI launch removed/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('rejects missing mission.md inside an in-repo mission dir', async () => {
-    const repo = await initRepo();
+  it('routes autoresearch --help to local deprecation help', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-local-help-'));
     try {
-      const missionDir = join(repo, 'missions', 'demo');
-      await mkdir(missionDir, { recursive: true });
-      await writeFile(join(missionDir, 'sandbox.md'), '---\nevaluator:\n  command: node eval.js\n---\n', 'utf-8');
-
-      const result = runOmx(repo, ['autoresearch', missionDir]);
-      assert.notEqual(result.status, 0, result.stderr || result.stdout);
-      assert.match(`${result.stderr}\n${result.stdout}`, /mission\.md/i);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('rejects missing sandbox.md inside an in-repo mission dir', async () => {
-    const repo = await initRepo();
-    try {
-      const missionDir = join(repo, 'missions', 'demo');
-      await mkdir(missionDir, { recursive: true });
-      await writeFile(join(missionDir, 'mission.md'), '# Mission\n', 'utf-8');
-
-      const result = runOmx(repo, ['autoresearch', missionDir]);
-      assert.notEqual(result.status, 0, result.stderr || result.stdout);
-      assert.match(`${result.stderr}\n${result.stdout}`, /sandbox\.md/i);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('rejects sandbox.md without evaluator frontmatter', async () => {
-    const repo = await initRepo();
-    try {
-      const missionDir = join(repo, 'missions', 'demo');
-      await mkdir(missionDir, { recursive: true });
-      await writeFile(join(missionDir, 'mission.md'), '# Mission\n', 'utf-8');
-      await writeFile(join(missionDir, 'sandbox.md'), 'No frontmatter here.\n', 'utf-8');
-
-      const result = runOmx(repo, ['autoresearch', missionDir]);
-      assert.notEqual(result.status, 0, result.stderr || result.stdout);
-      assert.match(`${result.stderr}\n${result.stdout}`, /frontmatter|evaluator/i);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('rejects autoresearch launch when root ralph mode is already active', async () => {
-    const repo = await initRepo();
-    try {
-      const missionDir = join(repo, 'missions', 'demo');
-      await mkdir(missionDir, { recursive: true });
-      await writeFile(join(missionDir, 'mission.md'), '# Mission\n', 'utf-8');
-      await writeFile(
-        join(missionDir, 'sandbox.md'),
-        '---\nevaluator:\n  command: node eval.js\n  format: json\n---\nStay inside the mission boundary.\n',
-        'utf-8',
-      );
-      await mkdir(join(repo, '.omx', 'state'), { recursive: true });
-      await writeFile(
-        join(repo, '.omx', 'state', 'ralph-state.json'),
-        JSON.stringify({
-          active: true,
-          mode: 'ralph',
-          iteration: 0,
-          max_iterations: 50,
-          current_phase: 'executing',
-          task_description: 'existing root ralph lane',
-          started_at: '2026-03-14T00:00:00.000Z',
-        }, null, 2),
-        'utf-8',
-      );
-
-      const result = runOmx(repo, ['autoresearch', missionDir]);
-      assert.notEqual(result.status, 0, result.stderr || result.stdout);
-      assert.match(`${result.stderr}\n${result.stdout}`, /Cannot start autoresearch: ralph is already active/i);
-
-      const worktreesRoot = join(repo, '.omx', 'worktrees');
-      assert.equal(existsSync(worktreesRoot), false, 'expected launch to abort before creating autoresearch worktree');
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-    }
-  });
-
-  it('launches codex exec for autoresearch turns without shelling out to cat', async () => {
-    const repo = await initRepo();
-    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-fake-bin-'));
-    try {
-      const missionDir = join(repo, 'missions', 'demo');
-      await mkdir(missionDir, { recursive: true });
-      await mkdir(join(repo, 'scripts'), { recursive: true });
-      await writeFile(join(missionDir, 'mission.md'), '# Mission\nWrite a noop candidate artifact.\n', 'utf-8');
-      await writeFile(
-        join(missionDir, 'sandbox.md'),
-        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
-        'utf-8',
-      );
-      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
-      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'add autoresearch mission'], { cwd: repo, stdio: 'ignore' });
-
-      const fakeCatPath = join(fakeBin, 'cat');
-      await writeFile(
-        fakeCatPath,
-        `#!/bin/sh
-printf 'unexpected cat invocation\\n' >&2
-exit 97
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeCatPath], { stdio: 'ignore' });
-
-      const fakeCodexPath = join(fakeBin, 'codex');
-      await writeFile(
-        fakeCodexPath,
-        `#!/bin/sh
-printf 'fake-codex:%s\\n' "$*" >&2
-while IFS= read -r _; do
-  :
-done
-candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
-head_commit=$(git rev-parse HEAD)
-printf '{\\n  "status": "abort",\\n  "candidate_commit": null,\\n  "base_commit": "%s",\\n  "description": "stop after first exec",\\n  "notes": ["fake codex exec"],\\n  "created_at": "2026-03-15T00:00:00.000Z"\\n}\\n' "$head_commit" >"$candidate_file"
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
-      await installFakePs(fakeBin);
-
-      const result = runOmx(
-        repo,
-        ['autoresearch', missionDir, '--dangerously-bypass-approvals-and-sandbox'],
-        { PATH: `${fakeBin}:${process.env.PATH || ''}`, OMX_TEST_REPO_ROOT: repo },
-      );
-
+      const result = runOmx(cwd, ['autoresearch', '--help']);
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stderr, /fake-codex:exec --dangerously-bypass-approvals-and-sandbox -/);
+      assert.match(result.stdout, /hard-deprecated legacy command surface/i);
+      assert.match(result.stdout, /\$deep-interview --autoresearch/i);
+      assert.match(result.stdout, /\$autoresearch/i);
+      assert.match(result.stdout, /prompt-architect-artifact/i);
+      assert.doesNotMatch(result.stdout, /oh-my-codex \(omx\) - Multi-agent orchestration for Codex CLI/i);
     } finally {
-      await rm(repo, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  for (const argv of [
+    ['autoresearch'],
+    ['autoresearch', 'init'],
+    ['autoresearch', 'run', 'missions/demo'],
+    ['autoresearch', 'missions/demo'],
+    ['autoresearch', '--resume', 'run-123'],
+    ['autoresearch', '--topic', 'Flaky onboarding'],
+  ]) {
+    it(`fails legacy invocation: omx ${argv.join(' ')}`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-autoresearch-fail-'));
+      try {
+        const result = runOmx(cwd, argv);
+        assert.notEqual(result.status, 0);
+        const output = `${result.stdout}\n${result.stderr}`;
+        assert.match(output, /hard-deprecated/i);
+        assert.match(output, /\$autoresearch/i);
+        assert.match(output, /Direct CLI launch, resume, run, bare mission-dir aliases, and tmux split-pane launch are no longer supported/i);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it('never invokes codex or tmux on the deprecated path', async () => {
+    const cwd = await initRepo();
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-noexec-bin-'));
+    const codexLog = join(cwd, 'codex.log');
+    const tmuxLog = join(cwd, 'tmux.log');
+    try {
+      await writeFile(join(fakeBin, 'codex'), `#!/bin/sh\necho codex >> ${JSON.stringify(codexLog)}\nexit 99\n`, 'utf-8');
+      await writeFile(join(fakeBin, 'tmux'), `#!/bin/sh\necho tmux >> ${JSON.stringify(tmuxLog)}\nexit 99\n`, 'utf-8');
+      execFileSync('chmod', ['+x', join(fakeBin, 'codex')], { stdio: 'ignore' });
+      execFileSync('chmod', ['+x', join(fakeBin, 'tmux')], { stdio: 'ignore' });
+
+      const result = runOmx(cwd, ['autoresearch', 'run', 'missions/demo'], {
+        PATH: `${fakeBin}:${process.env.PATH || ''}`,
+      });
+      assert.notEqual(result.status, 0);
+      assert.equal(existsSync(codexLog), false);
+      assert.equal(existsSync(tmuxLog), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
       await rm(fakeBin, { recursive: true, force: true });
     }
   });
 
-  it('stops after repeated noop turns', async () => {
-    const repo = await initRepo();
-    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-autoresearch-noop-bin-'));
-    try {
-      const missionDir = join(repo, 'missions', 'demo');
-      await mkdir(missionDir, { recursive: true });
-      await mkdir(join(repo, 'scripts'), { recursive: true });
-      await writeFile(join(missionDir, 'mission.md'), '# Mission\nKeep returning noop.\n', 'utf-8');
-      await writeFile(
-        join(missionDir, 'sandbox.md'),
-        '---\nevaluator:\n  command: node scripts/eval.js\n  format: json\n  keep_policy: pass_only\n---\nStay inside the mission boundary.\n',
-        'utf-8',
-      );
-      await writeFile(join(repo, 'scripts', 'eval.js'), "process.stdout.write(JSON.stringify({ pass: true }));\n", 'utf-8');
-      execFileSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore' });
-      execFileSync('git', ['commit', '-m', 'add autoresearch noop mission'], { cwd: repo, stdio: 'ignore' });
-
-      const fakeCodexPath = join(fakeBin, 'codex');
-      await writeFile(
-        fakeCodexPath,
-        `#!/bin/sh
-cat >/dev/null
-candidate_file=$(find "$OMX_TEST_REPO_ROOT/.omx/logs/autoresearch" -name candidate.json | head -n 1)
-head_commit=$(git rev-parse HEAD)
-cat >"$candidate_file" <<EOF
-{
-  "status": "noop",
-  "candidate_commit": null,
-  "base_commit": "$head_commit",
-  "description": "noop from fake codex exec",
-  "notes": ["fake noop"],
-  "created_at": "2026-03-15T00:00:00.000Z"
-}
-EOF
-`,
-        'utf-8',
-      );
-      execFileSync('chmod', ['+x', fakeCodexPath], { stdio: 'ignore' });
-      await installFakePs(fakeBin);
-
-      const result = runOmx(
-        repo,
-        ['autoresearch', missionDir, '--dangerously-bypass-approvals-and-sandbox'],
-        { PATH: `${fakeBin}:${process.env.PATH || ''}`, OMX_TEST_REPO_ROOT: repo },
-      );
-
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-
-      const state = JSON.parse(await readFile(join(repo, '.omx', 'state', 'autoresearch-state.json'), 'utf-8')) as {
-        active: boolean;
-      };
-      assert.equal(state.active, false);
-
-      const logsRoot = join(repo, '.omx', 'logs', 'autoresearch');
-      const [runId] = readdirSync(logsRoot, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name);
-      assert.ok(runId);
-
-      const manifest = JSON.parse(await readFile(join(logsRoot, runId, 'manifest.json'), 'utf-8')) as {
-        status: string;
-        stop_reason: string | null;
-        completed_at: string | null;
-      };
-      assert.equal(manifest.status, 'stopped');
-      assert.equal(manifest.stop_reason, 'repeated noop limit reached (3)');
-      assert.match(manifest.completed_at || '', /^\d{4}-\d{2}-\d{2}T/);
-
-      const ledger = JSON.parse(await readFile(join(logsRoot, runId, 'iteration-ledger.json'), 'utf-8')) as {
-        entries: Array<{ decision: string }>;
-      };
-      assert.deepEqual(ledger.entries.map((entry) => entry.decision), ['baseline', 'noop', 'noop', 'noop']);
-
-      const resumeResult = runOmx(repo, ['autoresearch', '--resume', runId]);
-      assert.notEqual(resumeResult.status, 0, resumeResult.stderr || resumeResult.stdout);
-      assert.match(`${resumeResult.stderr}\n${resumeResult.stdout}`, /autoresearch_resume_terminal_run/i);
-    } finally {
-      await rm(repo, { recursive: true, force: true });
-      await rm(fakeBin, { recursive: true, force: true });
-    }
+  it('throws the same deprecation guidance from the command entrypoint', async () => {
+    await assert.rejects(
+      async () => autoresearchCommand(['run', 'missions/demo']),
+      (error: unknown) => {
+        assert.match(String(error), new RegExp(AUTORESEARCH_DEPRECATION_MESSAGE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+        return true;
+      },
+    );
   });
 });

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -26,7 +26,7 @@ describe('nested help routing', () => {
   for (const [argv, expectedUsage] of [
     [['adapt', '--help'], /Usage:\s*omx adapt <target> <probe\|status\|init\|envelope\|doctor>/i],
     [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
-    [['autoresearch', '--help'], /Usage:[\s\S]*omx autoresearch <mission-dir>/i],
+    [['autoresearch', '--help'], /hard-deprecated legacy command surface[\s\S]*\$autoresearch/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],
     [['state', '--help'], /Usage:\s*omx state <read\|write\|clear\|list-active\|get-status>/i],

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -24,7 +24,7 @@ describe('omx session help', () => {
       const mainHelp = runOmx(cwd, ['--help']);
       assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
       assert.match(mainHelp.stdout, /omx resume\s+Resume a previous interactive Codex session/i);
-      assert.match(mainHelp.stdout, /omx autoresearch\s+Launch thin-supervisor autoresearch with keep\/discard\/reset parity/i);
+      assert.match(mainHelp.stdout, /omx autoresearch\s+\[DEPRECATED\] Use \$autoresearch; direct CLI launch removed/i);
       assert.match(mainHelp.stdout, /omx session\s+Search prior local session transcripts/i);
 
       const sessionHelp = runOmx(cwd, ['session', '--help']);

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -90,9 +90,9 @@ export function buildAutoresearchDeepInterviewPrompt(
 
   return [
     '$deep-interview --autoresearch',
-    'Run the deep-interview skill in autoresearch mode for `omx autoresearch`.',
+    'Run the deep-interview skill in autoresearch mode for `$autoresearch`.',
     'Guide the user through research topic definition, evaluator readiness, keep policy, and slug/session naming.',
-    'Do not launch tmux or run `omx autoresearch` yourself.',
+    'Do not launch tmux or run `omx autoresearch` yourself; direct CLI launch is deprecated. Hand off to `$autoresearch` after confirmation.',
     'When the user confirms launch and the evaluator is concrete, write/update these canonical artifacts under `.omx/specs/`:',
     '- `deep-interview-autoresearch-{slug}.md`',
     '- `autoresearch-{slug}/mission.md`',

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -1,279 +1,253 @@
-import { createInterface } from 'readline/promises';
-import { execFileSync, spawnSync } from 'child_process';
-import { existsSync } from 'fs';
-import { mkdir, writeFile } from 'fs/promises';
-import { dirname, join, relative, resolve } from 'path';
-import { fileURLToPath } from 'url';
-import { type AutoresearchKeepPolicy, parseSandboxContract, slugifyMissionName } from '../autoresearch/contracts.js';
-import { resolveOmxEntryPath } from '../utils/paths.js';
+import { dirname } from "node:path";
+import { createInterface } from "readline/promises";
 import {
-  buildMissionContent,
-  buildSandboxContent,
-  type AutoresearchDeepInterviewResult,
-  type AutoresearchSeedInputs,
-  isLaunchReadyEvaluatorCommand,
-  writeAutoresearchDeepInterviewArtifacts,
-} from './autoresearch-intake.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+	type AutoresearchKeepPolicy,
+	slugifyMissionName,
+} from "../autoresearch/contracts.js";
+import {
+	type AutoresearchDeepInterviewResult,
+	type AutoresearchSeedInputs,
+	isLaunchReadyEvaluatorCommand,
+	writeAutoresearchDeepInterviewArtifacts,
+} from "./autoresearch-intake.js";
 
 export interface InitAutoresearchOptions {
-  topic: string;
-  evaluatorCommand: string;
-  keepPolicy: AutoresearchKeepPolicy;
-  slug: string;
-  repoRoot: string;
+	topic: string;
+	evaluatorCommand: string;
+	keepPolicy: AutoresearchKeepPolicy;
+	slug: string;
+	repoRoot: string;
 }
 
 export interface InitAutoresearchResult {
-  missionDir: string;
-  slug: string;
+	slug: string;
+	artifactDir: string;
+	missionArtifactPath: string;
+	sandboxArtifactPath: string;
+	resultPath: string;
 }
 
 export interface AutoresearchQuestionIO {
-  question(prompt: string): Promise<string>;
-  close(): void;
-}
-
-function shellQuote(s: string): string {
-  return "'" + s.replace(/'/g, "'\\''") + "'";
+	question(prompt: string): Promise<string>;
+	close(): void;
 }
 
 function createQuestionIO(): AutoresearchQuestionIO {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  return {
-    question(prompt: string) {
-      return rl.question(prompt);
-    },
-    close() {
-      rl.close();
-    },
-  };
+	const rl = createInterface({ input: process.stdin, output: process.stdout });
+	return {
+		question(prompt: string) {
+			return rl.question(prompt);
+		},
+		close() {
+			rl.close();
+		},
+	};
 }
 
-async function promptWithDefault(io: AutoresearchQuestionIO, prompt: string, currentValue?: string): Promise<string> {
-  const suffix = currentValue?.trim() ? ` [${currentValue.trim()}]` : '';
-  const answer = await io.question(`${prompt}${suffix}\n> `);
-  return answer.trim() || currentValue?.trim() || '';
+async function promptWithDefault(
+	io: AutoresearchQuestionIO,
+	prompt: string,
+	currentValue?: string,
+): Promise<string> {
+	const suffix = currentValue?.trim() ? ` [${currentValue.trim()}]` : "";
+	const answer = await io.question(`${prompt}${suffix}\n> `);
+	return answer.trim() || currentValue?.trim() || "";
 }
 
-async function promptAction(io: AutoresearchQuestionIO, launchReady: boolean): Promise<'launch' | 'refine'> {
-  const answer = (await io.question(`\nNext step [launch/refine further] (default: ${launchReady ? 'launch' : 'refine further'})\n> `)).trim().toLowerCase();
-  if (!answer) {
-    return launchReady ? 'launch' : 'refine';
-  }
-  if (answer === 'launch') {
-    return 'launch';
-  }
-  if (answer === 'refine further' || answer === 'refine' || answer === 'r') {
-    return 'refine';
-  }
-  throw new Error('Please choose either "launch" or "refine further".');
+async function promptAction(
+	io: AutoresearchQuestionIO,
+	launchReady: boolean,
+): Promise<"launch" | "refine"> {
+	const answer = (
+		await io.question(
+			`\nNext step [launch/refine further] (default: ${launchReady ? "launch" : "refine further"})\n> `,
+		)
+	)
+		.trim()
+		.toLowerCase();
+	if (!answer) return launchReady ? "launch" : "refine";
+	if (answer === "launch") return "launch";
+	if (answer === "refine further" || answer === "refine" || answer === "r")
+		return "refine";
+	throw new Error('Please choose either "launch" or "refine further".');
 }
 
 function ensureLaunchReadyEvaluator(command: string): void {
-  if (!isLaunchReadyEvaluatorCommand(command)) {
-    throw new Error('Evaluator command is still a placeholder/template. Refine further before launch.');
-  }
+	if (!isLaunchReadyEvaluatorCommand(command)) {
+		throw new Error(
+			"Evaluator command is still a placeholder/template. Refine further before launch.",
+		);
+	}
 }
 
 export function buildAutoresearchDeepInterviewPrompt(
-  seedInputs: AutoresearchSeedInputs = {},
+	seedInputs: AutoresearchSeedInputs = {},
 ): string {
-  const seedLines = [
-    `- topic: ${seedInputs.topic?.trim() || '(none)'}`,
-    `- evaluator: ${seedInputs.evaluatorCommand?.trim() || '(none)'}`,
-    `- keep_policy: ${seedInputs.keepPolicy || '(none)'}`,
-    `- slug: ${seedInputs.slug?.trim() || '(none)'}`,
-  ];
+	const seedLines = [
+		`- topic: ${seedInputs.topic?.trim() || "(none)"}`,
+		`- evaluator: ${seedInputs.evaluatorCommand?.trim() || "(none)"}`,
+		`- keep_policy: ${seedInputs.keepPolicy || "(none)"}`,
+		`- slug: ${seedInputs.slug?.trim() || "(none)"}`,
+	];
 
-  return [
-    '$deep-interview --autoresearch',
-    'Run the deep-interview skill in autoresearch mode for `$autoresearch`.',
-    'Guide the user through research topic definition, evaluator readiness, keep policy, and slug/session naming.',
-    'Do not launch tmux or run `omx autoresearch` yourself; direct CLI launch is deprecated. Hand off to `$autoresearch` after confirmation.',
-    'When the user confirms launch and the evaluator is concrete, write/update these canonical artifacts under `.omx/specs/`:',
-    '- `deep-interview-autoresearch-{slug}.md`',
-    '- `autoresearch-{slug}/mission.md`',
-    '- `autoresearch-{slug}/sandbox.md`',
-    '- `autoresearch-{slug}/result.json`',
-    'Use the contract and helper functions in `src/cli/autoresearch-intake.ts` for the artifact shape.',
-    'If the evaluator command still contains placeholders or the user has not confirmed launch, keep refining instead of finalizing launch-ready output.',
-    '',
-    'Seed inputs:',
-    ...seedLines,
-  ].join('\n');
+	return [
+		"$deep-interview --autoresearch",
+		"Run the deep-interview skill in autoresearch mode for `$autoresearch`.",
+		"Guide the user through research topic definition, evaluator readiness, keep policy, and slug/session naming.",
+		"Do not launch tmux or run `omx autoresearch` yourself; direct CLI launch is deprecated. Hand off to `$autoresearch` after confirmation.",
+		"When the user confirms launch and the evaluator is concrete, write/update these canonical artifacts under `.omx/specs/`:",
+		"- `deep-interview-autoresearch-{slug}.md`",
+		"- `autoresearch-{slug}/mission.md`",
+		"- `autoresearch-{slug}/sandbox.md`",
+		"- `autoresearch-{slug}/result.json`",
+		"Use the contract and helper functions in `src/cli/autoresearch-intake.ts` for the artifact shape.",
+		"If the evaluator command still contains placeholders or the user has not confirmed launch, keep refining instead of finalizing launch-ready output.",
+		"",
+		"Seed inputs:",
+		...seedLines,
+	].join("\n");
 }
 
 export async function materializeAutoresearchDeepInterviewResult(
-  result: AutoresearchDeepInterviewResult,
+	result: AutoresearchDeepInterviewResult,
 ): Promise<InitAutoresearchResult> {
-  ensureLaunchReadyEvaluator(result.compileTarget.evaluatorCommand);
-  return initAutoresearchMission(result.compileTarget);
+	ensureLaunchReadyEvaluator(result.compileTarget.evaluatorCommand);
+	return {
+		slug: result.compileTarget.slug,
+		artifactDir: dirname(result.resultPath),
+		missionArtifactPath: result.missionArtifactPath,
+		sandboxArtifactPath: result.sandboxArtifactPath,
+		resultPath: result.resultPath,
+	};
 }
 
-export async function initAutoresearchMission(opts: InitAutoresearchOptions): Promise<InitAutoresearchResult> {
-  const missionsRoot = join(opts.repoRoot, 'missions');
-  const missionDir = join(missionsRoot, opts.slug);
-
-  const rel = relative(missionsRoot, missionDir);
-  if (!rel || rel.startsWith('..') || resolve(rel) === resolve(missionDir)) {
-    throw new Error('Invalid slug: resolves outside missions/ directory.');
-  }
-
-  if (existsSync(missionDir)) {
-    throw new Error(`Mission directory already exists: ${missionDir}`);
-  }
-
-  await mkdir(missionDir, { recursive: true });
-
-  const missionContent = buildMissionContent(opts.topic);
-  const sandboxContent = buildSandboxContent(opts.evaluatorCommand, opts.keepPolicy);
-
-  parseSandboxContract(sandboxContent);
-
-  await writeFile(join(missionDir, 'mission.md'), missionContent, 'utf-8');
-  await writeFile(join(missionDir, 'sandbox.md'), sandboxContent, 'utf-8');
-
-  return { missionDir, slug: opts.slug };
-}
-
-export function parseInitArgs(args: readonly string[]): Partial<InitAutoresearchOptions> {
-  const result: Partial<InitAutoresearchOptions> = {};
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    const next = args[i + 1];
-    if ((arg === '--topic') && next) {
-      result.topic = next;
-      i++;
-    } else if ((arg === '--evaluator') && next) {
-      result.evaluatorCommand = next;
-      i++;
-    } else if ((arg === '--keep-policy') && next) {
-      const normalized = next.trim().toLowerCase();
-      if (normalized !== 'pass_only' && normalized !== 'score_improvement') {
-        throw new Error('--keep-policy must be one of: score_improvement, pass_only');
-      }
-      result.keepPolicy = normalized;
-      i++;
-    } else if ((arg === '--slug') && next) {
-      result.slug = slugifyMissionName(next);
-      i++;
-    } else if (arg.startsWith('--topic=')) {
-      result.topic = arg.slice('--topic='.length);
-    } else if (arg.startsWith('--evaluator=')) {
-      result.evaluatorCommand = arg.slice('--evaluator='.length);
-    } else if (arg.startsWith('--keep-policy=')) {
-      const normalized = arg.slice('--keep-policy='.length).trim().toLowerCase();
-      if (normalized !== 'pass_only' && normalized !== 'score_improvement') {
-        throw new Error('--keep-policy must be one of: score_improvement, pass_only');
-      }
-      result.keepPolicy = normalized;
-    } else if (arg.startsWith('--slug=')) {
-      result.slug = slugifyMissionName(arg.slice('--slug='.length));
-    } else if (arg.startsWith('--')) {
-      throw new Error(`Unknown init flag: ${arg.split('=')[0]}`);
-    }
-  }
-  return result;
+export function parseInitArgs(
+	args: readonly string[],
+): Partial<InitAutoresearchOptions> {
+	const result: Partial<InitAutoresearchOptions> = {};
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		const next = args[i + 1];
+		if (arg === "--topic" && next) {
+			result.topic = next;
+			i++;
+		} else if (arg === "--evaluator" && next) {
+			result.evaluatorCommand = next;
+			i++;
+		} else if (arg === "--keep-policy" && next) {
+			const normalized = next.trim().toLowerCase();
+			if (normalized !== "pass_only" && normalized !== "score_improvement") {
+				throw new Error(
+					"--keep-policy must be one of: score_improvement, pass_only",
+				);
+			}
+			result.keepPolicy = normalized;
+			i++;
+		} else if (arg === "--slug" && next) {
+			result.slug = slugifyMissionName(next);
+			i++;
+		} else if (arg.startsWith("--topic=")) {
+			result.topic = arg.slice("--topic=".length);
+		} else if (arg.startsWith("--evaluator=")) {
+			result.evaluatorCommand = arg.slice("--evaluator=".length);
+		} else if (arg.startsWith("--keep-policy=")) {
+			const normalized = arg
+				.slice("--keep-policy=".length)
+				.trim()
+				.toLowerCase();
+			if (normalized !== "pass_only" && normalized !== "score_improvement") {
+				throw new Error(
+					"--keep-policy must be one of: score_improvement, pass_only",
+				);
+			}
+			result.keepPolicy = normalized;
+		} else if (arg.startsWith("--slug=")) {
+			result.slug = slugifyMissionName(arg.slice("--slug=".length));
+		} else if (arg.startsWith("--")) {
+			throw new Error(`Unknown init flag: ${arg.split("=")[0]}`);
+		}
+	}
+	return result;
 }
 
 export async function runAutoresearchNoviceBridge(
-  repoRoot: string,
-  seedInputs: AutoresearchSeedInputs = {},
-  io: AutoresearchQuestionIO = createQuestionIO(),
+	repoRoot: string,
+	seedInputs: AutoresearchSeedInputs = {},
+	io: AutoresearchQuestionIO = createQuestionIO(),
 ): Promise<InitAutoresearchResult> {
-  if (!process.stdin.isTTY) {
-    throw new Error('Guided setup requires an interactive terminal. Use <mission-dir> or init --topic/--evaluator/--keep-policy/--slug for non-interactive use.');
-  }
+	if (!process.stdin.isTTY) {
+		throw new Error(
+			"Guided setup requires an interactive terminal. Use `--topic/--evaluator/--keep-policy/--slug` to seed deep-interview intake before launching `$autoresearch`.",
+		);
+	}
 
-  let topic = seedInputs.topic?.trim() || '';
-  let evaluatorCommand = seedInputs.evaluatorCommand?.trim() || '';
-  let keepPolicy: AutoresearchKeepPolicy = seedInputs.keepPolicy || 'score_improvement';
-  let slug = seedInputs.slug?.trim() || '';
+	let topic = seedInputs.topic?.trim() || "";
+	let evaluatorCommand = seedInputs.evaluatorCommand?.trim() || "";
+	let keepPolicy: AutoresearchKeepPolicy =
+		seedInputs.keepPolicy || "score_improvement";
+	let slug = seedInputs.slug?.trim() || "";
 
-  try {
-    while (true) {
-      topic = await promptWithDefault(io, 'Research topic/goal', topic);
-      if (!topic) {
-        throw new Error('Research topic is required.');
-      }
+	try {
+		while (true) {
+			topic = await promptWithDefault(io, "Research topic/goal", topic);
+			if (!topic) {
+				throw new Error("Research topic is required.");
+			}
 
-      const evaluatorIntent = await promptWithDefault(io, '\nHow should OMX judge success? Describe it in plain language', topic);
-      evaluatorCommand = await promptWithDefault(
-        io,
-        '\nEvaluator command (leave placeholder to refine further; must output {pass:boolean, score?:number} JSON before launch)',
-        evaluatorCommand || `TODO replace with evaluator command for: ${evaluatorIntent}`,
-      );
+			const evaluatorIntent = await promptWithDefault(
+				io,
+				"\nHow should OMX judge success? Describe it in plain language",
+				topic,
+			);
+			evaluatorCommand = await promptWithDefault(
+				io,
+				"\nEvaluator command (leave placeholder to refine further; must output {pass:boolean, score?:number} JSON before launch)",
+				evaluatorCommand ||
+					`TODO replace with evaluator command for: ${evaluatorIntent}`,
+			);
 
-      const keepPolicyInput = await promptWithDefault(io, '\nKeep policy [score_improvement/pass_only]', keepPolicy);
-      keepPolicy = keepPolicyInput.trim().toLowerCase() === 'pass_only' ? 'pass_only' : 'score_improvement';
+			const keepPolicyInput = await promptWithDefault(
+				io,
+				"\nKeep policy [score_improvement/pass_only]",
+				keepPolicy,
+			);
+			keepPolicy =
+				keepPolicyInput.trim().toLowerCase() === "pass_only"
+					? "pass_only"
+					: "score_improvement";
 
-      slug = await promptWithDefault(io, '\nMission slug', slug || slugifyMissionName(topic));
-      slug = slugifyMissionName(slug);
+			slug = await promptWithDefault(
+				io,
+				"\nMission slug",
+				slug || slugifyMissionName(topic),
+			);
+			slug = slugifyMissionName(slug);
 
-      const deepInterview = await writeAutoresearchDeepInterviewArtifacts({
-        repoRoot,
-        topic,
-        evaluatorCommand,
-        keepPolicy,
-        slug,
-        seedInputs,
-      });
+			const deepInterview = await writeAutoresearchDeepInterviewArtifacts({
+				repoRoot,
+				topic,
+				evaluatorCommand,
+				keepPolicy,
+				slug,
+				seedInputs,
+			});
 
-      console.log(`\nDraft saved: ${deepInterview.draftArtifactPath}`);
-      console.log(`Launch readiness: ${deepInterview.launchReady ? 'ready' : deepInterview.blockedReasons.join(' ')}`);
+			console.log(`\nDraft saved: ${deepInterview.draftArtifactPath}`);
+			console.log(
+				`Launch readiness: ${deepInterview.launchReady ? "ready" : deepInterview.blockedReasons.join(" ")}`,
+			);
 
-      const action = await promptAction(io, deepInterview.launchReady);
-      if (action === 'refine') {
-        continue;
-      }
-
-      return materializeAutoresearchDeepInterviewResult(deepInterview);
-    }
-  } finally {
-    io.close();
-  }
+			const action = await promptAction(io, deepInterview.launchReady);
+			if (action === "refine") continue;
+			return materializeAutoresearchDeepInterviewResult(deepInterview);
+		}
+	} finally {
+		io.close();
+	}
 }
 
-export async function guidedAutoresearchSetup(repoRoot: string): Promise<InitAutoresearchResult> {
-  return runAutoresearchNoviceBridge(repoRoot);
-}
-
-export function checkTmuxAvailable(): boolean {
-  const result = spawnSync('tmux', ['-V'], { stdio: 'pipe',
-      windowsHide: true,
-    });
-  return result.status === 0;
-}
-
-export function spawnAutoresearchTmux(missionDir: string, slug: string): void {
-  if (!checkTmuxAvailable()) {
-    throw new Error('tmux is required for background autoresearch execution. Install tmux and try again.');
-  }
-
-  const sessionName = `omx-autoresearch-${slug}`;
-  const hasSession = spawnSync('tmux', ['has-session', '-t', sessionName], { stdio: 'pipe',
-      windowsHide: true,
-    });
-  if (hasSession.status === 0) {
-    throw new Error(
-      `tmux session "${sessionName}" already exists.\n`
-      + `  Attach: tmux attach -t ${sessionName}\n`
-      + `  Kill:   tmux kill-session -t ${sessionName}`,
-    );
-  }
-
-  const omxPath = resolveOmxEntryPath() ?? resolve(join(__dirname, 'omx.js'));
-  const cmd = `${shellQuote(process.execPath)} ${shellQuote(omxPath)} autoresearch ${shellQuote(missionDir)}`;
-
-  execFileSync('tmux', ['new-session', '-d', '-s', sessionName, cmd], { stdio: 'ignore',
-      windowsHide: true,
-    });
-
-  console.log(`\nAutoresearch launched in background tmux session.`);
-  console.log(`  Session:  ${sessionName}`);
-  console.log(`  Mission:  ${missionDir}`);
-  console.log(`  Attach:   tmux attach -t ${sessionName}`);
+export async function guidedAutoresearchSetup(
+	repoRoot: string,
+): Promise<InitAutoresearchResult> {
+	return runAutoresearchNoviceBridge(repoRoot);
 }

--- a/src/cli/autoresearch.ts
+++ b/src/cli/autoresearch.ts
@@ -1,122 +1,43 @@
-import { execFileSync, spawnSync } from 'child_process';
-import { readFileSync } from 'fs';
-import { ensureWorktree, planWorktreeTarget } from '../team/worktree.js';
-import { loadAutoresearchMissionContract } from '../autoresearch/contracts.js';
-import {
-  countTrailingAutoresearchNoops,
-  finalizeAutoresearchRunState,
-  loadAutoresearchRunManifest,
-  materializeAutoresearchMissionToWorktree,
-  prepareAutoresearchRuntime,
-  processAutoresearchCandidate,
-  resumeAutoresearchRuntime,
-  buildAutoresearchRunTag,
-} from '../autoresearch/runtime.js';
-import { assertModeStartAllowed } from '../modes/base.js';
-import {
-  buildAutoresearchDeepInterviewPrompt,
-  initAutoresearchMission,
-  materializeAutoresearchDeepInterviewResult,
-  parseInitArgs,
-} from './autoresearch-guided.js';
-import {
-  listAutoresearchDeepInterviewDraftPaths,
-  listAutoresearchDeepInterviewResultPaths,
-  resolveAutoresearchDeepInterviewResult,
-} from './autoresearch-intake.js';
 import { CODEX_BYPASS_FLAG, MADMAX_FLAG } from './constants.js';
-import { restoreStandaloneHudPane, enableMouseScrolling } from '../team/tmux-session.js';
-import { resolveOmxEntryPath } from '../utils/paths.js';
+import { parseInitArgs } from './autoresearch-guided.js';
 
-export const AUTORESEARCH_HELP = `omx autoresearch - Launch OMX autoresearch with thin-supervisor parity semantics
+export const AUTORESEARCH_DEPRECATION_MESSAGE = [
+  'omx autoresearch is hard-deprecated.',
+  'Use the `$autoresearch` skill for the hook-native persistent loop.',
+  'Use `$deep-interview --autoresearch` to create or refine mission artifacts before execution.',
+  'Direct CLI launch, resume, run, bare mission-dir aliases, and tmux split-pane launch are no longer supported.',
+].join(' ');
+
+export const AUTORESEARCH_HELP = `omx autoresearch - Hard-deprecated legacy command surface
 
 Usage:
-  omx autoresearch                                                (human entrypoint: launch Codex CLI deep-interview intake, then execute)
+  omx autoresearch --help
+
+Deprecated legacy forms (all fail intentionally):
+  omx autoresearch
   omx autoresearch [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
   omx autoresearch init [--topic T] [--evaluator CMD] [--keep-policy P] [--slug S]
-  omx autoresearch run <mission-dir> [codex-args...]              (agent/explicit execution entrypoint)
-  omx autoresearch <mission-dir> [codex-args...]                  (compatibility alias for run)
+  omx autoresearch run <mission-dir> [codex-args...]
+  omx autoresearch <mission-dir> [codex-args...]
   omx autoresearch --resume <run-id> [codex-args...]
 
-Arguments:
-  (no args)        Launch an interactive Codex session that activates deep-interview --autoresearch,
-                   writes .omx/specs artifacts, then launches only after explicit confirmation.
-  --topic/...      Seed the deep-interview intake with draft values; still requires refinement/confirmation before launch.
-  init             Bare init is an interactive deep-interview alias on TTYs; init with flags is the expert scaffold path.
-  run              Execute a crystallized autoresearch mission, preferring tmux split-pane launch when available.
-  <mission-dir>    Directory inside a git repository containing mission.md and sandbox.md
-  <run-id>         Existing autoresearch run id from .omx/logs/autoresearch/<run-id>/manifest.json
-
-Behavior:
-  - deep-interview intake writes canonical artifacts under .omx/specs before launch
-  - validates mission.md and sandbox.md
-  - requires sandbox.md YAML frontmatter with evaluator.command and evaluator.format=json
-  - fresh launch creates a run-tagged autoresearch/<slug>/<run-tag> lane
-  - supervisor records baseline, candidate, keep/discard/reset, and results artifacts under .omx/logs/autoresearch/
-  - run prefers interview|autoresearch split-pane launch inside tmux, with foreground fallback on failure
-  - --resume loads the authoritative per-run manifest and continues from the last kept commit
+Migration:
+  - Use \`$deep-interview --autoresearch\` to clarify the mission and write canonical artifacts under \`.omx/specs/autoresearch-{slug}/\`
+  - Use \`$autoresearch "your mission"\` for the stateful validator-gated execution loop
+  - Choose validation mode at init:
+      1. mission-validator-script
+      2. prompt-architect-artifact
+  - Completion now depends on validator evidence, not repeated no-ops or detached tmux launch parity
 `;
 
-const AUTORESEARCH_APPEND_INSTRUCTIONS_ENV = 'OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE';
-const AUTORESEARCH_MAX_CONSECUTIVE_NOOPS = 3;
-
-function buildAutoresearchDeepInterviewAppendix(): string {
-  return [
-    '<autoresearch_deep_interview_mode>',
-    'You are in OMX autoresearch intake mode.',
-    'Run the deep-interview skill in autoresearch mode and clarify the research mission before launch.',
-    'Do not start tmux, do not launch `omx autoresearch`, and do not bypass the user confirmation boundary.',
-    'When the user confirms launch and the evaluator is concrete, persist canonical artifacts under `.omx/specs/` using the contracts in `src/cli/autoresearch-intake.ts`.',
-    '- Required outputs: `deep-interview-autoresearch-{slug}.md`, `autoresearch-{slug}/mission.md`, `autoresearch-{slug}/sandbox.md`, `autoresearch-{slug}/result.json`.',
-    '- If the evaluator is still a placeholder or the user wants to refine further, keep interviewing instead of finalizing launch-ready output.',
-    '</autoresearch_deep_interview_mode>',
-  ].join('\n');
-}
-
-async function writeAutoresearchDeepInterviewAppendixFile(repoRoot: string): Promise<string> {
-  const { mkdir, writeFile } = await import('node:fs/promises');
-  const { join } = await import('node:path');
-  const dir = join(repoRoot, '.omx', 'autoresearch');
-  await mkdir(dir, { recursive: true });
-  const path = join(dir, 'deep-interview-session-instructions.md');
-  await writeFile(path, `${buildAutoresearchDeepInterviewAppendix()}\n`, 'utf-8');
-  return path;
-}
-
-async function runGuidedAutoresearchDeepInterview(
-  repoRoot: string,
-  seedArgs?: ReturnType<typeof parseInitArgs>,
-): Promise<Awaited<ReturnType<typeof initAutoresearchMission>>> {
-  const previousInstructionsFile = process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
-  const appendixPath = await writeAutoresearchDeepInterviewAppendixFile(repoRoot);
-  const existingResultPaths = new Set(await listAutoresearchDeepInterviewResultPaths(repoRoot));
-  const existingDraftPaths = new Set(await listAutoresearchDeepInterviewDraftPaths(repoRoot));
-  process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = appendixPath;
-
-  try {
-    const { launchWithHud } = await import('./index.js');
-    await launchWithHud([buildAutoresearchDeepInterviewPrompt(seedArgs ?? {})]);
-  } finally {
-    if (typeof previousInstructionsFile === 'string') {
-      process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = previousInstructionsFile;
-    } else {
-      delete process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
-    }
-  }
-
-  const result = await resolveAutoresearchDeepInterviewResult(repoRoot, {
-    excludeResultPaths: existingResultPaths,
-    excludeDraftPaths: existingDraftPaths,
-  });
-  if (!result) {
-    throw new Error('autoresearch deep-interview did not produce .omx/specs launch artifacts.');
-  }
-  if (!result.launchReady) {
-    throw new Error(
-      `autoresearch deep-interview exited without a launch-ready result. ${result.blockedReasons.join(' ') || 'Refine the interview result and retry.'}`,
-    );
-  }
-  return materializeAutoresearchDeepInterviewResult(result);
+export interface ParsedAutoresearchArgs {
+  missionDir: string | null;
+  runId: string | null;
+  codexArgs: string[];
+  guided?: boolean;
+  initArgs?: string[];
+  seedArgs?: ReturnType<typeof parseInitArgs>;
+  runSubcommand?: boolean;
 }
 
 export function normalizeAutoresearchCodexArgs(codexArgs: readonly string[]): string[] {
@@ -148,52 +69,9 @@ export function normalizeAutoresearchCodexArgs(codexArgs: readonly string[]): st
   return normalized;
 }
 
-function runAutoresearchTurn(worktreePath: string, instructionsFile: string, codexArgs: string[]): void {
-  const prompt = readFileSync(instructionsFile, 'utf-8');
-  const launchArgs = ['exec', ...normalizeAutoresearchCodexArgs(codexArgs), '-'];
-  const result = spawnSync('codex', launchArgs, {
-    cwd: worktreePath,
-    stdio: ['pipe', 'inherit', 'inherit'],
-    input: prompt,
-    encoding: 'utf-8',
-    env: process.env,
-      windowsHide: true,
-    });
-
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    process.exitCode = typeof result.status === 'number' ? result.status : 1;
-    throw new Error(`autoresearch_codex_exec_failed:${result.status ?? 'unknown'}`);
-  }
-}
-
-export interface ParsedAutoresearchArgs {
-  missionDir: string | null;
-  runId: string | null;
-  codexArgs: string[];
-  guided?: boolean;
-  initArgs?: string[];
-  seedArgs?: ReturnType<typeof parseInitArgs>;
-  runSubcommand?: boolean;
-}
-
-function resolveRepoRoot(cwd: string): string {
-  return execFileSync('git', ['rev-parse', '--show-toplevel'], {
-    cwd,
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-      windowsHide: true,
-    }).trim();
-}
-
 export function parseAutoresearchArgs(args: readonly string[]): ParsedAutoresearchArgs {
   const values = [...args];
   if (values.length === 0) {
-    if (!process.stdin.isTTY) {
-      throw new Error(`mission-dir is required.\n${AUTORESEARCH_HELP}`);
-    }
     return { missionDir: null, runId: null, codexArgs: [], guided: true };
   }
 
@@ -205,244 +83,29 @@ export function parseAutoresearchArgs(args: readonly string[]): ParsedAutoresear
     return { missionDir: '--help', runId: null, codexArgs: [] };
   }
   if (first === '--resume') {
-    const runId = values[1]?.trim();
-    if (!runId) {
-      throw new Error(`--resume requires <run-id>.\n${AUTORESEARCH_HELP}`);
-    }
-    return { missionDir: null, runId, codexArgs: values.slice(2) };
+    return { missionDir: null, runId: values[1]?.trim() || null, codexArgs: values.slice(2) };
   }
   if (first.startsWith('--resume=')) {
-    const runId = first.slice('--resume='.length).trim();
-    if (!runId) {
-      throw new Error(`--resume requires <run-id>.\n${AUTORESEARCH_HELP}`);
-    }
-    return { missionDir: null, runId, codexArgs: values.slice(1) };
+    return { missionDir: null, runId: first.slice('--resume='.length).trim() || null, codexArgs: values.slice(1) };
   }
   if (first === 'run') {
-    const missionDir = values[1]?.trim();
-    if (!missionDir) {
-      throw new Error(`run requires <mission-dir>.\n${AUTORESEARCH_HELP}`);
-    }
-    return { missionDir, runId: null, codexArgs: values.slice(2), runSubcommand: true };
+    return { missionDir: values[1]?.trim() || null, runId: null, codexArgs: values.slice(2), runSubcommand: true };
   }
   if (first.startsWith('-')) {
-    const seedArgs = parseInitArgs(values);
-    return { missionDir: null, runId: null, codexArgs: [], guided: true, seedArgs };
+    return { missionDir: null, runId: null, codexArgs: [], guided: true, seedArgs: parseInitArgs(values) };
   }
   return { missionDir: first, runId: null, codexArgs: values.slice(1) };
 }
 
-async function runAutoresearchLoop(
-  codexArgs: string[],
-  runtime: {
-    instructionsFile: string;
-    manifestFile: string;
-    repoRoot: string;
-    worktreePath: string;
-  },
-  missionDir: string,
-): Promise<void> {
-  const previousInstructionsFile = process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
-  const originalCwd = process.cwd();
-  process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = runtime.instructionsFile;
-
-  try {
-    while (true) {
-      runAutoresearchTurn(runtime.worktreePath, runtime.instructionsFile, codexArgs);
-
-      const contract = await loadAutoresearchMissionContract(missionDir);
-      const { run_id: runId } = JSON.parse(readFileSync(runtime.manifestFile, 'utf-8')) as { run_id: string };
-      const manifest = await loadAutoresearchRunManifest(runtime.repoRoot, runId);
-      const decision = await processAutoresearchCandidate(contract, manifest, runtime.repoRoot);
-      if (decision === 'abort' || decision === 'error') {
-        return;
-      }
-      if (decision === 'noop') {
-        const trailingNoops = await countTrailingAutoresearchNoops(manifest.ledger_file);
-        if (trailingNoops >= AUTORESEARCH_MAX_CONSECUTIVE_NOOPS) {
-          await finalizeAutoresearchRunState(runtime.repoRoot, manifest.run_id, {
-            status: 'stopped',
-            stopReason: `repeated noop limit reached (${AUTORESEARCH_MAX_CONSECUTIVE_NOOPS})`,
-          });
-          return;
-        }
-      }
-      process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = runtime.instructionsFile;
-    }
-  } finally {
-    process.chdir(originalCwd);
-    if (typeof previousInstructionsFile === 'string') {
-      process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV] = previousInstructionsFile;
-    } else {
-      delete process.env[AUTORESEARCH_APPEND_INSTRUCTIONS_ENV];
-    }
-  }
-}
-
-function checkTmuxAvailable(): boolean {
-  const result = spawnSync('tmux', ['-V'], { stdio: 'pipe',
-      windowsHide: true,
-    });
-  return result.status === 0;
-}
-
-function tmuxDisplay(target: string, format: string): string | null {
-  const result = spawnSync('tmux', ['display-message', '-p', '-t', target, format], { encoding: 'utf-8',
-      windowsHide: true,
-    });
-  if (result.error || result.status !== 0) return null;
-  const value = (result.stdout || '').trim();
-  return value || null;
-}
-
-function listHudWatchPaneIdsInCurrentWindow(currentPaneId?: string): string[] {
-  if (!currentPaneId) return [];
-  const result = spawnSync(
-    'tmux',
-    ['list-panes', '-t', currentPaneId, '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}'],
-    { encoding: 'utf-8' },
-  );
-  if (result.error || result.status !== 0) return [];
-  return (result.stdout || '')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => line.split('\t'))
-    .filter((parts) => parts.length >= 3)
-    .map(([paneId = '', currentCommand = '', startCommand = '']) => ({ paneId, currentCommand, startCommand }))
-    .filter((pane) => pane.paneId.startsWith('%'))
-    .filter((pane) => pane.paneId !== currentPaneId)
-    .filter((pane) => /\bomx\b.*\bhud\b.*--watch/i.test(pane.startCommand || ''))
-    .map((pane) => pane.paneId);
-}
-
-function launchAutoresearchInSplitPane(args: {
-  currentPaneId: string;
-  repoRoot: string;
-  missionDir: string;
-  codexArgs: string[];
-}): boolean {
-  if (!checkTmuxAvailable()) return false;
-
-  const paneId = tmuxDisplay(args.currentPaneId, '#{pane_id}');
-  if (!paneId) return false;
-  const sessionName = tmuxDisplay(paneId, '#S');
-  const currentCwd = tmuxDisplay(paneId, '#{pane_current_path}') || args.repoRoot;
-  const existingHudPaneIds = listHudWatchPaneIdsInCurrentWindow(paneId);
-
-  const omxPath = resolveOmxEntryPath();
-  if (!omxPath) return false;
-  // Re-enter through the bare compatibility alias so the new pane executes immediately
-  // instead of recursively taking the split-pane branch again.
-  const launchArgs = ['autoresearch', args.missionDir, ...args.codexArgs];
-  const command = [process.execPath, omxPath, ...launchArgs]
-    .map((part) => `'${part.replace(/'/g, `'\\''`)}'`)
-    .join(' ');
-
-  const split = spawnSync(
-    'tmux',
-    ['split-window', '-h', '-t', paneId, '-d', '-P', '-F', '#{pane_id}', '-c', currentCwd, command],
-    { encoding: 'utf-8' },
-  );
-  if (split.error || split.status !== 0) {
-    return false;
-  }
-
-  if (sessionName && process.env.OMX_MOUSE !== '0') {
-    enableMouseScrolling(sessionName);
-  }
-  if (existingHudPaneIds.length === 0) {
-    restoreStandaloneHudPane(paneId, currentCwd);
-  }
-  console.log(`Autoresearch launched in split pane next to interview pane.`);
-  return true;
-}
-
-async function executeAutoresearchMissionRun(missionDir: string, codexArgs: string[]): Promise<void> {
-  const contract = await loadAutoresearchMissionContract(missionDir);
-  await assertModeStartAllowed('autoresearch', contract.repoRoot);
-  const runTag = buildAutoresearchRunTag();
-  const plan = planWorktreeTarget({
-    cwd: contract.repoRoot,
-    scope: 'autoresearch',
-    mode: { enabled: true, detached: false, name: contract.missionSlug },
-    worktreeTag: runTag,
-  });
-  const ensured = ensureWorktree(plan);
-  if (!ensured.enabled) {
-    throw new Error('autoresearch worktree planning unexpectedly disabled');
-  }
-
-  const worktreeContract = await materializeAutoresearchMissionToWorktree(contract, ensured.worktreePath);
-  const runtime = await prepareAutoresearchRuntime(worktreeContract, contract.repoRoot, ensured.worktreePath, { runTag });
-  await runAutoresearchLoop(codexArgs, runtime, worktreeContract.missionDir);
+function shouldShowHelp(args: readonly string[]): boolean {
+  return args.length > 0 && args.every((arg) => arg === '--help' || arg === '-h' || arg === 'help');
 }
 
 export async function autoresearchCommand(args: string[]): Promise<void> {
-  const parsed = parseAutoresearchArgs(args);
-  if (parsed.missionDir === '--help') {
+  if (shouldShowHelp(args)) {
     console.log(AUTORESEARCH_HELP);
     return;
   }
 
-  if (parsed.guided) {
-    const repoRoot = resolveRepoRoot(process.cwd());
-    let result;
-    if (parsed.initArgs && parsed.initArgs.length > 0) {
-      const initOpts = parseInitArgs(parsed.initArgs);
-      if (!initOpts.topic || !initOpts.evaluatorCommand || !initOpts.slug) {
-        throw new Error(
-          'init requires --topic, --evaluator, and --slug flags.\n'
-          + 'Optional: --keep-policy (default: score_improvement)\n\n'
-          + `${AUTORESEARCH_HELP}`,
-        );
-      }
-      result = await initAutoresearchMission({
-        topic: initOpts.topic,
-        evaluatorCommand: initOpts.evaluatorCommand,
-        keepPolicy: initOpts.keepPolicy || 'score_improvement',
-        slug: initOpts.slug,
-        repoRoot,
-      });
-    } else {
-      result = await runGuidedAutoresearchDeepInterview(repoRoot, parsed.seedArgs);
-    }
-
-    const currentPaneId = process.env.TMUX_PANE?.trim();
-    if (currentPaneId && launchAutoresearchInSplitPane({
-      currentPaneId,
-      repoRoot,
-      missionDir: result.missionDir,
-      codexArgs: [],
-    })) {
-      return;
-    }
-
-    await executeAutoresearchMissionRun(result.missionDir, []);
-    return;
-  }
-
-  if (parsed.runId) {
-    const repoRoot = resolveRepoRoot(process.cwd());
-    await assertModeStartAllowed('autoresearch', repoRoot);
-    const manifest = await loadAutoresearchRunManifest(repoRoot, parsed.runId);
-    const runtime = await resumeAutoresearchRuntime(repoRoot, parsed.runId);
-    await runAutoresearchLoop(parsed.codexArgs, runtime, manifest.mission_dir);
-    return;
-  }
-
-  if (parsed.runSubcommand) {
-    const repoRoot = resolveRepoRoot(process.cwd());
-    const currentPaneId = process.env.TMUX_PANE?.trim();
-    if (currentPaneId && launchAutoresearchInSplitPane({
-      currentPaneId,
-      repoRoot,
-      missionDir: parsed.missionDir as string,
-      codexArgs: parsed.codexArgs,
-    })) {
-      return;
-    }
-  }
-
-  await executeAutoresearchMissionRun(parsed.missionDir as string, parsed.codexArgs);
+  throw new Error(`${AUTORESEARCH_DEPRECATION_MESSAGE}\n\n${AUTORESEARCH_HELP}`);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -159,7 +159,7 @@ Usage:
                 Alias for agents-init (lightweight AGENTS bootstrap only)
   omx team      Spawn parallel worker panes in tmux and bootstrap inbox/task state
   omx ralph     Launch Codex with ralph persistence mode active
-  omx autoresearch Launch thin-supervisor autoresearch with keep/discard/reset parity
+  omx autoresearch [DEPRECATED] Use $autoresearch; direct CLI launch removed
   omx version   Show version information
   omx tmux-hook Manage tmux prompt injection workaround (init|status|validate|test)
   omx hooks     Manage hook plugins (init|status|validate|test)

--- a/src/compat/fixtures/help.stdout.txt
+++ b/src/compat/fixtures/help.stdout.txt
@@ -10,7 +10,7 @@ Usage:
   omx cleanup   Kill orphaned OMX MCP server processes from prior sessions
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
-  omx autoresearch Launch thin-supervisor autoresearch with keep/discard/reset parity
+  omx autoresearch [DEPRECATED] Use $autoresearch; direct CLI launch removed
   omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
   omx session   Search prior local session transcripts and history artifacts
   omx agents-init [path]

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -195,7 +195,7 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /launch/i);
 		assert.match(
 			deepInterviewSkill,
-			/do not launch detached tmux until the user explicitly confirms/i,
+			/do not run direct CLI launch or detached\/split tmux launch, and only hand off to `\$autoresearch` after explicit confirmation/i,
 		);
 		assert.match(deepInterviewSkill, /<\.\.\.>/i);
 		assert.match(deepInterviewSkill, /TODO/i);

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -236,6 +236,26 @@ describe('keyword detector swarm/team compatibility', () => {
   });
 });
 
+describe('autoresearch keyword detection', () => {
+  it('detects explicit $autoresearch invocation', () => {
+    const match = detectPrimaryKeyword('please run $autoresearch now');
+    assert.ok(match);
+    assert.equal(match.skill, 'autoresearch');
+    assert.equal(match.keyword.toLowerCase(), '$autoresearch');
+  });
+
+  it('detects explicit implicit-intent autoresearch phrasing', () => {
+    const match = detectPrimaryKeyword('please use autoresearch workflow for this mission');
+    assert.ok(match);
+    assert.equal(match.skill, 'autoresearch');
+  });
+
+  it('does not trigger autoresearch from incidental prose', () => {
+    const match = detectPrimaryKeyword('Karpathy did autoresearch before native hooks existed');
+    assert.equal(match, null);
+  });
+});
+
 describe('keyword registry coverage', () => {
   it('includes key team/swarm aliases in runtime keyword registry', () => {
     const registryKeywords = new Set(KEYWORD_TRIGGER_DEFINITIONS.map((v) => v.keyword.toLowerCase()));
@@ -253,6 +273,7 @@ describe('keyword registry coverage', () => {
     assert.ok(registryKeywords.has('wiki query'));
     assert.ok(registryKeywords.has('wiki add'));
     assert.ok(registryKeywords.has('wiki lint'));
+    assert.ok(registryKeywords.has('autoresearch'));
   });
 });
 
@@ -498,6 +519,59 @@ describe('keyword detector skill-active-state lifecycle', () => {
         await readFile(join(stateDir, 'sessions', 'sess-visible', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
       ) as { active_skills?: Array<{ skill: string }> };
       assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['team', 'ralph', 'ultrawork']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('seeds executing state for autoresearch prompt-submit activation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autoresearch-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$autoresearch continue the mission',
+        sessionId: 'sess-autoresearch',
+        nowIso: '2026-04-17T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autoresearch');
+      assert.equal(result.phase, 'executing');
+      assert.equal(result.initialized_mode, 'autoresearch');
+      assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-autoresearch/autoresearch-state.json');
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-autoresearch', 'autoresearch-state.json'), 'utf-8'),
+      ) as { mode: string; active: boolean; current_phase: string };
+      assert.equal(modeState.mode, 'autoresearch');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'executing');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves the planning skill when ralplan and autoresearch are invoked together', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autoresearch-planning-precedence-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan $autoresearch wire the mission loop',
+        sessionId: 'sess-autoresearch-precedence',
+        nowIso: '2026-04-17T00:05:00.000Z',
+      });
+
+      assert.equal(result?.transition_error, undefined);
+      assert.equal(result?.skill, 'ralplan');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['ralplan']);
+      assert.deepEqual(result?.deferred_skills, ['autoresearch']);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autoresearch-precedence', 'ralplan-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autoresearch-precedence', 'autoresearch-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -1653,6 +1653,124 @@ exit 0
     });
   });
 
+  it('keeps autoresearch active when assistant claims completion without validator evidence', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
+        active: true,
+        skill: 'autoresearch',
+        keyword: '$autoresearch',
+        phase: 'executing',
+        source: 'keyword-detector',
+        session_id: 'sess-managed',
+      });
+      await writeJson(join(sessionStateDir, 'autoresearch-state.json'), {
+        active: true,
+        mode: 'autoresearch',
+        current_phase: 'executing',
+        session_id: 'sess-managed',
+        validation_mode: 'mission-validator-script',
+        mission_validator_command: 'node scripts/validate.js',
+        completion_artifact_path: '.omx/specs/autoresearch-demo/completion.json',
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'All tests pass. Completed with summary.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase: string;
+        autoresearch_completion_reason?: string;
+      };
+      assert.equal(skillState.active, true);
+      assert.equal(skillState.phase, 'executing');
+      assert.equal(skillState.autoresearch_completion_reason, 'missing_or_invalid_completion_artifact');
+    });
+  });
+
+  it('completes autoresearch when validator artifact passes', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const specDir = join(cwd, '.omx', 'specs', 'autoresearch-demo');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await mkdir(specDir, { recursive: true });
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
+        active: true,
+        skill: 'autoresearch',
+        keyword: '$autoresearch',
+        phase: 'reviewing',
+        source: 'keyword-detector',
+        session_id: 'sess-managed',
+      });
+      await writeJson(join(sessionStateDir, 'autoresearch-state.json'), {
+        active: true,
+        mode: 'autoresearch',
+        current_phase: 'reviewing',
+        session_id: 'sess-managed',
+        validation_mode: 'mission-validator-script',
+        mission_validator_command: 'node scripts/validate.js',
+        completion_artifact_path: '.omx/specs/autoresearch-demo/completion.json',
+      });
+      await writeJson(join(specDir, 'completion.json'), {
+        status: 'passed',
+        passed: true,
+      });
+
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
+        'last-assistant-message': 'Completed with final summary after validator pass.',
+      });
+      assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);
+
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase: string;
+        autoresearch_completion_reason?: string;
+      };
+      assert.equal(skillState.active, false);
+      assert.equal(skillState.phase, 'completing');
+      assert.equal(skillState.autoresearch_completion_reason, 'validator_passed');
+    });
+  });
+
   it('releases the deep-interview input lock on success', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -90,7 +90,7 @@ export const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
 export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'] as const;
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
 
-type StatefulSkillMode = 'deep-interview' | 'autopilot' | 'ralph' | 'ralplan' | 'ultrawork' | 'ultraqa' | 'team';
+type StatefulSkillMode = 'deep-interview' | 'autopilot' | 'ralph' | 'ralplan' | 'ultrawork' | 'ultraqa' | 'team' | 'autoresearch';
 
 interface StatefulSkillSeedConfig {
   mode: StatefulSkillMode;
@@ -106,6 +106,7 @@ const PLANNING_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
 
 const EXECUTION_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
   'autopilot',
+  'autoresearch',
   'ralph',
   'team',
   'ultrawork',
@@ -115,6 +116,7 @@ const EXECUTION_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
 const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedConfig> = {
   'deep-interview': { mode: 'deep-interview', initialPhase: 'intent-first' },
   autopilot: { mode: 'autopilot', initialPhase: 'planning' },
+  autoresearch: { mode: 'autoresearch', initialPhase: 'executing' },
   ralph: { mode: 'ralph', initialPhase: 'starting', includeIteration: true },
   ralplan: { mode: 'ralplan', initialPhase: 'planning' },
   team: { mode: 'team', initialPhase: 'starting', scope: 'root' },
@@ -353,9 +355,9 @@ const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> =
   priority: entry.priority,
 }));
 
-const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'swarm', 'stop', 'abort', 'parallel']);
+const KEYWORDS_REQUIRING_INTENT = new Set(['team', 'swarm', 'stop', 'abort', 'parallel', 'autoresearch']);
 
-type IntentKeyword = 'ralph' | 'team' | 'swarm' | 'stop' | 'abort' | 'parallel';
+type IntentKeyword = 'team' | 'swarm' | 'stop' | 'abort' | 'parallel' | 'autoresearch';
 
 /**
  * Per-keyword intent patterns used when a keyword is in KEYWORDS_REQUIRING_INTENT.
@@ -412,6 +414,12 @@ const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
     /\b(?:use|run|enable|start|activate|launch)\s+(?:in\s+)?parallel\b/i,
     /\bparallel\s+(?:mode|execution|workers?|agents?|tasks?)\b/i,
     /\brun\s+(?:tasks?|agents?|workers?)\s+in\s+parallel\b/i,
+  ],
+  autoresearch: [
+    /(?:^|[^\w])\$(?:autoresearch)\b/i,
+    /\/autoresearch\b/i,
+    /\b(?:use|run|start|enable|launch|invoke|activate)\s+(?:the\s+)?autoresearch\b/i,
+    /\bautoresearch\s+(?:mode|workflow|skill|loop)\b/i,
   ],
 };
 
@@ -513,6 +521,10 @@ export function detectKeywords(text: string): KeywordMatch[] {
 export function detectPrimaryKeyword(text: string): KeywordMatch | null {
   const matches = detectKeywords(text);
   return matches.length > 0 ? matches[0] : null;
+}
+
+function initialWorkflowPhaseForMode(mode: TrackedWorkflowMode): SkillActivePhase {
+  return mode === 'autoresearch' ? 'executing' : 'planning';
 }
 
 function resolveRequestedWorkflowSkills(requestedWorkflowSkills: TrackedWorkflowMode[]): {
@@ -632,7 +644,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           active: previous?.active ?? nextWorkflowEntries.length > 0,
           skill: previous?.skill || match.skill,
           keyword: previous?.keyword || match.keyword,
-          phase: previous?.phase || 'planning',
+          phase: previous?.phase || initialWorkflowPhaseForMode(match.skill),
           activated_at: previous?.activated_at || nowIso,
           updated_at: nowIso,
           source: 'keyword-detector',
@@ -672,7 +684,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
       const existingEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
       if (existingEntry) {
-        existingEntry.phase = requestedMode === match.skill ? 'planning' : existingEntry.phase;
+        existingEntry.phase = requestedMode === match.skill ? initialWorkflowPhaseForMode(requestedMode) : existingEntry.phase;
         existingEntry.active = true;
         existingEntry.activated_at = requestedMode === match.skill
           ? (sameSkill && sameKeyword ? existingEntry.activated_at || previous?.activated_at || nowIso : nowIso)
@@ -688,7 +700,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         ...nextWorkflowEntries,
         {
           skill: requestedMode,
-          phase: requestedMode === match.skill ? 'planning' : undefined,
+          phase: requestedMode === match.skill ? initialWorkflowPhaseForMode(requestedMode) : undefined,
           active: true,
           activated_at: requestedMode === match.skill && sameSkill && sameKeyword
             ? previous?.activated_at
@@ -702,13 +714,13 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     }
 
     const primaryEntry = nextWorkflowEntries.find((entry) => entry.skill === match.skill) ?? nextWorkflowEntries[0];
-    const primarySkill = primaryEntry?.skill || match.skill;
+    const primarySkill = (primaryEntry?.skill || match.skill) as TrackedWorkflowMode;
     const workflowState: SkillActiveState = {
       version: 1,
       active: true,
       skill: primarySkill,
       keyword: primarySkill === match.skill ? match.keyword : `$${primarySkill}`,
-      phase: primaryEntry?.phase || 'planning',
+      phase: primaryEntry?.phase || initialWorkflowPhaseForMode(primarySkill),
       activated_at: primaryEntry?.activated_at || nowIso,
       updated_at: nowIso,
       source: 'keyword-detector',
@@ -768,7 +780,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     active: true,
     skill: match.skill,
     keyword: match.keyword,
-    phase: 'planning',
+    phase: initialWorkflowPhaseForMode(match.skill as TrackedWorkflowMode),
     activated_at: sameSkill && sameKeyword ? previous.activated_at : nowIso,
     updated_at: nowIso,
     source: 'keyword-detector',
@@ -777,7 +789,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     turn_id: input.turnId,
     active_skills: [{
       skill: match.skill,
-      phase: 'planning',
+      phase: initialWorkflowPhaseForMode(match.skill as TrackedWorkflowMode),
       active: true,
       activated_at: sameSkill && sameKeyword ? previous?.activated_at : nowIso,
       updated_at: nowIso,

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -355,9 +355,9 @@ const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> =
   priority: entry.priority,
 }));
 
-const KEYWORDS_REQUIRING_INTENT = new Set(['team', 'swarm', 'stop', 'abort', 'parallel', 'autoresearch']);
+const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'swarm', 'stop', 'abort', 'parallel', 'autoresearch']);
 
-type IntentKeyword = 'team' | 'swarm' | 'stop' | 'abort' | 'parallel' | 'autoresearch';
+type IntentKeyword = 'ralph' | 'team' | 'swarm' | 'stop' | 'abort' | 'parallel' | 'autoresearch';
 
 /**
  * Per-keyword intent patterns used when a keyword is in KEYWORDS_REQUIRING_INTENT.

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -36,6 +36,8 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'ralplan', skill: 'ralplan', priority: 11, guidance: 'Activate consensus planning (planner + architect + critic)' },
   { keyword: 'consensus plan', skill: 'ralplan', priority: 11, guidance: 'Activate consensus planning (planner + architect + critic)' },
 
+  { keyword: 'autoresearch', skill: 'autoresearch', priority: 10, guidance: 'Activate autoresearch validator-gated research loop' },
+
   { keyword: 'team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
   { keyword: 'swarm', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode (swarm is a compatibility alias for team)' },
   { keyword: 'coordinated team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2699,6 +2699,78 @@ esac
     }
   });
 
+  it("blocks Stop while autoresearch is active without validator completion", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-autoresearch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-autoresearch"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-autoresearch", cwd });
+      await writeJson(join(stateDir, "sessions", "sess-stop-autoresearch", "autoresearch-state.json"), {
+        active: true,
+        mode: "autoresearch",
+        current_phase: "executing",
+        session_id: "sess-stop-autoresearch",
+        validation_mode: "mission-validator-script",
+        mission_validator_command: "node scripts/validate.js",
+        completion_artifact_path: '.omx/specs/autoresearch-demo/completion.json',
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-autoresearch",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: "OMX autoresearch is still active (phase: executing); continue until validator evidence is complete before stopping.",
+        stopReason: "autoresearch_executing",
+        systemMessage: "OMX autoresearch is still active (phase: executing); continue until validator evidence is complete before stopping.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows Stop once autoresearch validator evidence is complete", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-autoresearch-complete-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const specDir = join(cwd, '.omx', 'specs', 'autoresearch-demo');
+      await mkdir(join(stateDir, "sessions", "sess-stop-autoresearch-complete"), { recursive: true });
+      await mkdir(specDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-autoresearch-complete", cwd });
+      await writeJson(join(stateDir, "sessions", "sess-stop-autoresearch-complete", "autoresearch-state.json"), {
+        active: true,
+        mode: "autoresearch",
+        current_phase: "reviewing",
+        session_id: "sess-stop-autoresearch-complete",
+        validation_mode: "mission-validator-script",
+        mission_validator_command: "node scripts/validate.js",
+        completion_artifact_path: '.omx/specs/autoresearch-demo/completion.json',
+      });
+      await writeJson(join(specDir, 'completion.json'), { status: 'passed', passed: true });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-autoresearch-complete",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop solely because deep-interview is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2771,6 +2771,39 @@ esac
     }
   });
 
+  it("does not block Stop from stale root autoresearch state when the explicit session has no scoped autoresearch state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-root-autoresearch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const specDir = join(cwd, '.omx', 'specs', 'autoresearch-demo');
+      await mkdir(join(stateDir, 'sessions', 'sess-current'), { recursive: true });
+      await mkdir(specDir, { recursive: true });
+      await writeJson(join(stateDir, 'session.json'), { session_id: 'sess-current', cwd });
+      await writeJson(join(stateDir, 'autoresearch-state.json'), {
+        active: true,
+        mode: 'autoresearch',
+        current_phase: 'executing',
+        validation_mode: 'mission-validator-script',
+        mission_validator_command: 'node scripts/validate.js',
+        completion_artifact_path: '.omx/specs/autoresearch-demo/completion.json',
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: 'Stop',
+          cwd,
+          session_id: 'sess-current',
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, 'stop');
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block Stop solely because deep-interview is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -44,6 +44,8 @@ import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
+import { sessionModelInstructionsPath } from "../hooks/agents-overlay.js";
+import { readAutoresearchCompletionStatus, readAutoresearchModeState } from "../autoresearch/skill-validation.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -194,6 +196,17 @@ function isNonTerminalPhase(value: unknown): boolean {
 function formatPhase(value: unknown, fallback = "active"): string {
   const phase = safeString(value).trim();
   return phase || fallback;
+}
+
+async function readActiveAutoresearchState(
+  cwd: string,
+  sessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  const normalizedSessionId = sessionId?.trim() || undefined;
+  const state = await readAutoresearchModeState(cwd, normalizedSessionId);
+  if (state?.active !== true) return null;
+  if (!isNonTerminalPhase(state.current_phase ?? state.currentPhase ?? 'executing')) return null;
+  return state;
 }
 
 async function readActiveRalphState(
@@ -1283,6 +1296,28 @@ async function buildStopHookOutput(
   const threadId = readPayloadThreadId(payload);
   const ralphState = await readActiveRalphState(stateDir, canonicalSessionId);
   if (!ralphState) {
+    const autoresearchState = await readActiveAutoresearchState(cwd, canonicalSessionId);
+    if (autoresearchState) {
+      const completion = await readAutoresearchCompletionStatus(cwd, canonicalSessionId?.trim() || undefined);
+      if (!completion.complete) {
+        const currentPhase = safeString(autoresearchState.current_phase ?? autoresearchState.currentPhase).trim() || 'executing';
+        const systemMessage = `OMX autoresearch is still active (phase: ${currentPhase}); continue until validator evidence is complete before stopping.`;
+        return await maybeReturnRepeatableStopOutput(
+          payload,
+          stateDir,
+          buildRepeatableStopSignature(payload, 'autoresearch-stop', `${currentPhase}|${completion.reason}`, canonicalSessionId),
+          {
+            decision: 'block',
+            reason: systemMessage,
+            stopReason: `autoresearch_${currentPhase}`,
+            systemMessage,
+          },
+          canonicalSessionId,
+          { allowRepeatDuringStopHook: true },
+        );
+      }
+    }
+
     const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);
     if (hasTeamWorkerContext() && teamWorkerOutput) return teamWorkerOutput;
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -44,7 +44,6 @@ import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
-import { sessionModelInstructionsPath } from "../hooks/agents-overlay.js";
 import { readAutoresearchCompletionStatus, readAutoresearchModeState } from "../autoresearch/skill-validation.js";
 
 type CodexHookEventName =

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -203,6 +203,7 @@ async function readActiveAutoresearchState(
   sessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const normalizedSessionId = sessionId?.trim() || undefined;
+  if (!normalizedSessionId) return null;
   const state = await readAutoresearchModeState(cwd, normalizedSessionId);
   if (state?.active !== true) return null;
   if (!isNonTerminalPhase(state.current_phase ?? state.currentPhase ?? 'executing')) return null;
@@ -1298,7 +1299,7 @@ async function buildStopHookOutput(
   if (!ralphState) {
     const autoresearchState = await readActiveAutoresearchState(cwd, canonicalSessionId);
     if (autoresearchState) {
-      const completion = await readAutoresearchCompletionStatus(cwd, canonicalSessionId?.trim() || undefined);
+      const completion = await readAutoresearchCompletionStatus(cwd, canonicalSessionId!.trim());
       if (!completion.complete) {
         const currentPhase = safeString(autoresearchState.current_phase ?? autoresearchState.currentPhase).trim() || 'executing';
         const systemMessage = `OMX autoresearch is still active (phase: ${currentPhase}); continue until validator evidence is complete before stopping.`;

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -21,6 +21,7 @@ import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPaneInput } from './team-tmux-guard.js';
 import { stripOrchestrationIntentTags } from './orchestration-intent.js';
 import { buildCapturePaneArgv, DEFAULT_MARKER, tmuxHookExplicitlyDisablesInjection } from '../tmux-hook-engine.js';
+import { readAutoresearchCompletionStatus } from '../../autoresearch/skill-validation.js';
 import {
   isManagedOmxSession,
   resolveManagedCurrentPane,
@@ -523,9 +524,25 @@ export async function maybeAutoNudge({ cwd, stateDir, logsDir, payload }) {
 
   try {
     if (skillState) {
-      const inferredPhase = inferSkillPhaseFromText(lastMessage, skillState.phase);
+      const previousPhase = normalizeSkillPhase(skillState.phase);
+      const inferredPhase = inferSkillPhaseFromText(lastMessage, previousPhase);
       skillState.phase = inferredPhase;
       skillState.active = inferredPhase !== 'completing';
+
+      if (skillState.skill === 'autoresearch') {
+        const completion = await readAutoresearchCompletionStatus(cwd, invocationSessionId);
+        skillState.validation_mode = completion.validationMode;
+        skillState.autoresearch_completion_reason = completion.reason;
+        skillState.completion_artifact_path = completion.artifactPath;
+        if (completion.complete) {
+          skillState.phase = 'completing';
+          skillState.active = false;
+        } else if (inferredPhase === 'completing') {
+          skillState.phase = previousPhase === 'completing' ? 'reviewing' : previousPhase;
+          skillState.active = true;
+        }
+      }
+
       skillState.updated_at = new Date().toISOString();
       releaseReason = inferDeepInterviewReleaseReason({ skillState, latestUserInput, lastMessage });
       await persistSkillActiveState(stateDir, invocationSessionId, skillState);

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -58,6 +58,12 @@ describe('workflow transition rules', () => {
     assert.equal(ralplanToRalph.kind, 'auto-complete');
     assert.deepEqual(ralplanToRalph.autoCompleteModes, ['ralplan']);
     assert.deepEqual(ralplanToRalph.resultingModes, ['ultrawork', 'ralph']);
+
+    const ralplanToAutoresearch = evaluateWorkflowTransition(['ralplan'], 'autoresearch');
+    assert.equal(ralplanToAutoresearch.allowed, true);
+    assert.equal(ralplanToAutoresearch.kind, 'auto-complete');
+    assert.deepEqual(ralplanToAutoresearch.autoCompleteModes, ['ralplan']);
+    assert.deepEqual(ralplanToAutoresearch.resultingModes, ['autoresearch']);
   });
 
   it('builds rollback denial guidance for execution-to-planning transitions', () => {

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -53,6 +53,13 @@ describe('workflow transition rules', () => {
     assert.deepEqual(interviewToRalplan.resultingModes, ['ralplan']);
     assert.equal(interviewToRalplan.transitionMessage, 'mode transiting: deep-interview -> ralplan');
 
+    const interviewToAutoresearch = evaluateWorkflowTransition(['deep-interview'], 'autoresearch');
+    assert.equal(interviewToAutoresearch.allowed, true);
+    assert.equal(interviewToAutoresearch.kind, 'auto-complete');
+    assert.deepEqual(interviewToAutoresearch.autoCompleteModes, ['deep-interview']);
+    assert.deepEqual(interviewToAutoresearch.resultingModes, ['autoresearch']);
+    assert.equal(interviewToAutoresearch.transitionMessage, 'mode transiting: deep-interview -> autoresearch');
+
     const ralplanToRalph = evaluateWorkflowTransition(['ralplan', 'ultrawork'], 'ralph');
     assert.equal(ralplanToRalph.allowed, true);
     assert.equal(ralplanToRalph.kind, 'auto-complete');

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -26,16 +26,17 @@ const AUTO_COMPLETE_TRANSITIONS = new Set([
   'ralplan->team',
   'ralplan->ralph',
   'ralplan->autopilot',
+  'ralplan->autoresearch',
 ]);
 
 const PLANNING_LIKE_MODES = new Set<TrackedWorkflowMode>([
   'deep-interview',
   'ralplan',
-  'autoresearch',
 ]);
 
 const EXECUTION_LIKE_MODES = new Set<TrackedWorkflowMode>([
   'autopilot',
+  'autoresearch',
   'team',
   'ralph',
   'ultrawork',

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -23,6 +23,7 @@ const ALLOWED_OVERLAP_PAIRS = new Set([
 
 const AUTO_COMPLETE_TRANSITIONS = new Set([
   'deep-interview->ralplan',
+  'deep-interview->autoresearch',
   'ralplan->team',
   'ralplan->ralph',
   'ralplan->autopilot',


### PR DESCRIPTION
## Summary
- hard-deprecate the `omx autoresearch` direct CLI/tmux launch surface and replace its help/error path with explicit migration guidance
- add a validator-gated `$autoresearch` skill contract plus completion-state readers for `mission-validator-script` and `prompt-architect-artifact`
- keep native stop-hook + auto-nudge persistence blocked until validator evidence is complete, and update keyword/state wiring plus docs/tests for the new flow

## Why
`omx autoresearch` existed before Codex had native hooks. Now that native hooks exist, the useful part is the persistent validator/evaluator loop, not the legacy direct-launch surface.

## What changed
- all legacy `omx autoresearch` launch/run/resume/mission-dir forms now fail intentionally with hard-deprecation guidance
- new `skills/autoresearch/SKILL.md` defines the stateful replacement workflow
- autoresearch completion is artifact-gated and chosen at init:
  - `mission-validator-script`
  - `prompt-architect-artifact`
- native Stop keeps firing/blocking until validator evidence is complete
- notify auto-nudge refuses to mark `$autoresearch` complete just because the model says "done"
- deep-interview handoff/docs now point to `$autoresearch`, not direct CLI/tmux launch

## Validation
- `npm run build`
- `node --test dist/cli/__tests__/autoresearch.test.js dist/hooks/__tests__/notify-hook-auto-nudge.test.js dist/scripts/__tests__/codex-native-hook.test.js`

## Notes
- scope intentionally stays on: **autoresearch CLI/tmux direct launch hard deprecation + validator-gated `$autoresearch` skill flow**
