### PR TITLE
fix(hud): backport git helper injection hardening to main

### DIFF
--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -6,7 +6,7 @@
 
 import { readFile } from 'fs/promises';
 import { readFileSync } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { omxStateDir } from '../utils/paths.js';
@@ -215,8 +215,9 @@ function runGit(cwd: string, args: string[]): string | null {
           const config = readGitLayoutFile(gitLayout.gitDir, 'config')
             ?? readGitLayoutFile(gitLayout.commonDir, 'config');
           if (config) {
+            const escaped = remoteName.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
             const re = new RegExp(
-              `\\[remote "${remoteName}"\\][\\s\\S]*?url\\s*=\\s*(.+)`,
+              `\\[remote "${escaped}"\\][\\s\\S]*?url\\s*=\\s*(.+)`,
               'm',
             );
             const m = config.match(re);
@@ -247,7 +248,7 @@ function runGit(cwd: string, args: string[]): string | null {
 
 function runGitExec(cwd: string, args: string[]): string | null {
   try {
-    return execSync(`git ${args.join(' ')}`, {
+    return execFileSync('git', args, {
       cwd,
       encoding: 'utf-8',
       timeout: 2000,


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Backport the already-merged HUD git-helper hardening from `dev` onto `main` so the current release line no longer retains the known injection path that was fixed in #1652.

This PR intentionally stays in the narrow release-line/backport lane rather than introducing any new fix design.

## Changes

- replace shell-based git invocation in `src/hud/state.ts` with `execFileSync('git', args, ...)`
- escape `remoteName` before regex interpolation in the HUD git-config parsing path
- keep the patch scoped to the exact hardening already merged on `dev`

## Why target `main`

Current `main` / `v0.13.1` still reproduces the HUD git-helper injection path, while `dev` already contains the merged fix from #1652.

This matches the repo's recent `main`-targeted pattern more than a normal feature/fix PR:

- the problem is already understood and already tracked upstream (#1649, #1659)
- the fix already exists and is merged on `dev` (#1652)
- the backport applies cleanly onto current `main`
- keeping `main` scoped to a narrow release-line hardening is lower risk than waiting with a known fixed-on-dev issue still present on the release branch

## Validation

- [x] `git cherry-pick --no-commit 24601f17e40532e9fca409c4e56e1f5ebec54746` applies cleanly onto current `main`
- [x] built-code PoC on current `main` reproduces the marker-file execution path
- [x] built-code PoC on the cherry-picked/backport branch no longer executes the marker-file path
- [x] `node --test dist/hud/__tests__/state.test.js`
- [ ] `npm run build` *(see note below)*
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)

Build note:
- Local backport validation previously completed `npm run build` successfully on the cherry-picked branch.
- A later repeated build attempt hit a local `dist/` cleanup race (`ENOTEMPTY: directory not empty, rmdir 'dist/cli'`) after overlapping validation runs in the same worktree. That looks like a local validation artifact rather than a change-specific failure, but I am leaving the checkbox honest instead of overstating it.

## Risk summary

- Narrow risk: one-file release-line backport of the already-merged `dev` hardening only.
- Low compatibility risk: matches the existing `dev` implementation rather than diverging from it.
- Known gap: I did not rerun the full `npm test` / smoke suite on this backport branch.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #1705
Related: #1652
Related: #1649
Related: #1659
