### PR TITLE
Keep active OMX workflows blocking Stop until they truly finish

### DIFF
--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-04-17T02:40:37.754Z",
+  "generatedAt": "2026-04-18T00:57:32.991Z",
   "version": "2026.02.28.1",
   "counts": {
     "skillCount": 39,
     "promptCount": 30,
-    "activeSkillCount": 24,
+    "activeSkillCount": 25,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -54,8 +54,7 @@
     {
       "name": "ultraqa",
       "category": "execution",
-      "status": "merged",
-      "canonical": "ralph",
+      "status": "active",
       "core": false,
       "internalRequired": false
     },
@@ -474,10 +473,6 @@
     {
       "name": "ecomode",
       "canonical": "ultrawork"
-    },
-    {
-      "name": "ultraqa",
-      "canonical": "ralph"
     },
     {
       "name": "swarm",

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -35,8 +35,7 @@
     {
       "name": "ultraqa",
       "category": "execution",
-      "status": "merged",
-      "canonical": "ralph"
+      "status": "active"
     },
     {
       "name": "swarm",

--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -70,7 +70,7 @@ describe('omx setup skills overwrite behavior', () => {
       assert.equal(installed.has('worker'), true);
       assert.equal(installed.has('swarm'), false);
       assert.equal(installed.has('ecomode'), false);
-      assert.equal(installed.has('ultraqa'), false);
+      assert.equal(installed.has('ultraqa'), true);
       assert.equal(installed.has('ralph-init'), false);
       assert.equal(installed.has('frontend-ui-ux'), false);
       assert.equal(installed.has('pipeline'), false);
@@ -99,7 +99,7 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project' });
 
-      const staleSkills = ['swarm', 'ecomode', 'ultraqa', 'configure-discord', 'configure-telegram', 'configure-slack', 'configure-openclaw'];
+      const staleSkills = ['swarm', 'ecomode', 'configure-discord', 'configure-telegram', 'configure-slack', 'configure-openclaw'];
       for (const staleSkill of staleSkills) {
         const staleDir = join(wd, '.codex', 'skills', staleSkill);
         await mkdir(staleDir, { recursive: true });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3503,7 +3503,7 @@ esac
     }
   });
 
-  it("does not auto-continue native Stop for a plain Codex session started outside OMX runtime", async () => {
+  it("auto-continues native Stop for permission-seeking prompts even outside OMX runtime", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-plain-session-"));
     try {
       await dispatchCodexNativeHook(
@@ -3525,13 +3525,19 @@ esac
           session_id: "plain-stop-session",
           thread_id: "plain-thread",
           turn_id: "plain-turn-1",
-          last_assistant_message: "Keep going and finish the cleanup.",
+          last_assistant_message: "If you want, I can continue with the cleanup from here.",
         },
         { cwd },
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2111,7 +2111,13 @@ esac
         { cwd },
       );
 
-      assert.equal(result.outputJson, null);
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          `OMX team pipeline is still active (worker-stop-team-terminal) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
+        stopReason: "team_team-exec",
+        systemMessage: "OMX team pipeline is still active at phase team-exec.",
+      });
     } finally {
       if (typeof prevTeamWorker === "string") process.env.OMX_TEAM_WORKER = prevTeamWorker;
       else delete process.env.OMX_TEAM_WORKER;
@@ -3022,7 +3028,7 @@ esac
     }
   });
 
-  it("suppresses duplicate native auto-nudge replays for the same Stop reply", async () => {
+  it("re-blocks duplicate native auto-nudge replays for the same Stop reply", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-once-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -3055,13 +3061,19 @@ esac
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it("suppresses duplicate native auto-nudge replays across native/canonical session-id drift", async () => {
+  it("re-blocks duplicate native auto-nudge replays across native/canonical session-id drift", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-session-drift-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -3098,7 +3110,13 @@ esac
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason: DEFAULT_AUTO_NUDGE_RESPONSE,
+        stopReason: "auto_nudge",
+        systemMessage:
+          "OMX native Stop detected a stall/permission-style handoff and continued the turn automatically.",
+      });
 
       const persisted = JSON.parse(
         await readFile(join(stateDir, "native-stop-state.json"), "utf-8"),
@@ -3621,7 +3639,13 @@ esac
       );
 
       assert.equal(duplicate.omxEventName, "stop");
-      assert.equal(duplicate.outputJson, null);
+      assert.deepEqual(duplicate.outputJson, {
+        decision: "block",
+        reason:
+          `OMX team pipeline is still active (current-team) at phase team-verify; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
+        stopReason: "team_team-verify",
+        systemMessage: "OMX team pipeline is still active at phase team-verify.",
+      });
 
       const fresh = await dispatchCodexNativeHook(
         {
@@ -3648,6 +3672,126 @@ esac
         await readFile(join(stateDir, "native-stop-state.json"), "utf-8"),
       ) as { sessions?: Record<string, unknown> };
       assert.deepEqual(Object.keys(persisted.sessions ?? {}), ["omx-canonical"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("re-blocks active execution modes on repeated Stop hooks", async () => {
+    const cases = [
+      {
+        mode: "autopilot",
+        phase: "execution",
+        reason:
+          "OMX autopilot is still active (phase: execution); continue the task and gather fresh verification evidence before stopping.",
+      },
+      {
+        mode: "ultrawork",
+        phase: "executing",
+        reason:
+          "OMX ultrawork is still active (phase: executing); continue the task and gather fresh verification evidence before stopping.",
+      },
+      {
+        mode: "ultraqa",
+        phase: "diagnose",
+        reason:
+          "OMX ultraqa is still active (phase: diagnose); continue the task and gather fresh verification evidence before stopping.",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-stop-${testCase.mode}-repeat-`));
+      try {
+        const stateDir = join(cwd, ".omx", "state");
+        await mkdir(stateDir, { recursive: true });
+        await writeJson(join(stateDir, `${testCase.mode}-state.json`), {
+          active: true,
+          current_phase: testCase.phase,
+        });
+
+        await dispatchCodexNativeHook(
+          {
+            hook_event_name: "Stop",
+            cwd,
+            session_id: `sess-stop-${testCase.mode}-repeat`,
+            thread_id: `thread-stop-${testCase.mode}-repeat`,
+            turn_id: `turn-stop-${testCase.mode}-repeat-1`,
+          },
+          { cwd },
+        );
+
+        const repeated = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "Stop",
+            cwd,
+            session_id: `sess-stop-${testCase.mode}-repeat`,
+            thread_id: `thread-stop-${testCase.mode}-repeat`,
+            turn_id: `turn-stop-${testCase.mode}-repeat-1`,
+            stop_hook_active: true,
+          },
+          { cwd },
+        );
+
+        assert.equal(repeated.omxEventName, "stop");
+        assert.deepEqual(repeated.outputJson, {
+          decision: "block",
+          reason: testCase.reason,
+          stopReason: `${testCase.mode}_${testCase.phase}`,
+          systemMessage: `OMX ${testCase.mode} is still active (phase: ${testCase.phase}).`,
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("re-blocks active ralplan skill state on repeated Stop hooks", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-skill-repeat-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-skill-repeat"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-skill-repeat" });
+      await writeJson(join(stateDir, "sessions", "sess-stop-skill-repeat", "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-stop-skill-repeat", "ralplan-state.json"), {
+        active: true,
+        current_phase: "planning",
+      });
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-skill-repeat",
+          thread_id: "thread-stop-skill-repeat",
+          turn_id: "turn-stop-skill-repeat-1",
+        },
+        { cwd },
+      );
+
+      const repeated = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-skill-repeat",
+          thread_id: "thread-stop-skill-repeat",
+          turn_id: "turn-stop-skill-repeat-1",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      assert.equal(repeated.omxEventName, "stop");
+      assert.deepEqual(repeated.outputJson, {
+        decision: "block",
+        reason:
+          "OMX skill ralplan is still active (phase: planning); continue until the current ralplan workflow reaches a terminal state.",
+        stopReason: "skill_ralplan_planning",
+        systemMessage: "OMX skill ralplan is still active (phase: planning).",
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -44,7 +44,6 @@ import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
-import { sessionModelInstructionsPath } from "../hooks/agents-overlay.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -977,29 +976,6 @@ function readNativeStopSessionKey(
   return resolveRepeatableStopSessionId(payload, canonicalSessionId) || readPayloadThreadId(payload) || "global";
 }
 
-function hasManagedStopSessionEnv(sessionIds: string[]): boolean {
-  const envSessionId = safeString(process.env.OMX_SESSION_ID).trim();
-  if (!envSessionId) return false;
-  return sessionIds.length === 0 || sessionIds.includes(envSessionId);
-}
-
-async function hasManagedStopContext(
-  cwd: string,
-  payload: CodexHookPayload,
-  canonicalSessionId: string,
-): Promise<boolean> {
-  if (hasTeamWorkerContext()) return true;
-
-  const sessionIds = [...new Set([
-    canonicalSessionId,
-    readPayloadSessionId(payload),
-  ].map((value) => safeString(value).trim()).filter(Boolean))];
-
-  if (hasManagedStopSessionEnv(sessionIds)) return true;
-
-  return sessionIds.some((sessionId) => existsSync(sessionModelInstructionsPath(cwd, sessionId)));
-}
-
 function readPreviousNativeStopSignature(
   state: Record<string, unknown>,
   sessionKey: string,
@@ -1306,7 +1282,6 @@ async function buildStopHookOutput(
   const canonicalSessionId = await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
   const ralphState = await readActiveRalphState(stateDir, canonicalSessionId);
-  const managedStopContext = await hasManagedStopContext(cwd, payload, canonicalSessionId);
   if (!ralphState) {
     const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);
     if (hasTeamWorkerContext() && teamWorkerOutput) return teamWorkerOutput;
@@ -1398,9 +1373,6 @@ async function buildStopHookOutput(
       }
     }
 
-    if (!managedStopContext) {
-      return null;
-    }
 
     const lastAssistantMessage = safeString(
       payload.last_assistant_message ?? payload.lastAssistantMessage,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1306,7 +1306,6 @@ async function buildStopHookOutput(
   const canonicalSessionId = await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
   const ralphState = await readActiveRalphState(stateDir, canonicalSessionId);
-  const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
   const managedStopContext = await hasManagedStopContext(cwd, payload, canonicalSessionId);
   if (!ralphState) {
     const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1056,6 +1056,24 @@ async function maybeReturnRepeatableStopOutput(
   return output;
 }
 
+async function returnPersistentStopBlock(
+  payload: CodexHookPayload,
+  stateDir: string,
+  signatureKind: string,
+  signatureValue: string,
+  output: Record<string, unknown> | null,
+  canonicalSessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  return await maybeReturnRepeatableStopOutput(
+    payload,
+    stateDir,
+    buildRepeatableStopSignature(payload, signatureKind, signatureValue, canonicalSessionId),
+    output,
+    canonicalSessionId,
+    { allowRepeatDuringStopHook: true },
+  );
+}
+
 async function findCanonicalActiveTeamForSession(
   cwd: string,
   sessionId: string,
@@ -1292,16 +1310,43 @@ async function buildStopHookOutput(
   const managedStopContext = await hasManagedStopContext(cwd, payload, canonicalSessionId);
   if (!ralphState) {
     const teamWorkerOutput = await buildTeamWorkerStopOutput(cwd);
-    if (!stopHookActive && hasTeamWorkerContext()) return teamWorkerOutput;
+    if (hasTeamWorkerContext() && teamWorkerOutput) return teamWorkerOutput;
 
     const autopilotOutput = await buildModeBasedStopOutput("autopilot", cwd, canonicalSessionId);
-    if (!stopHookActive && autopilotOutput) return autopilotOutput;
+    if (autopilotOutput) {
+      return await returnPersistentStopBlock(
+        payload,
+        stateDir,
+        "autopilot-stop",
+        safeString(autopilotOutput.stopReason),
+        autopilotOutput,
+        canonicalSessionId,
+      );
+    }
 
     const ultraworkOutput = await buildModeBasedStopOutput("ultrawork", cwd, canonicalSessionId);
-    if (!stopHookActive && ultraworkOutput) return ultraworkOutput;
+    if (ultraworkOutput) {
+      return await returnPersistentStopBlock(
+        payload,
+        stateDir,
+        "ultrawork-stop",
+        safeString(ultraworkOutput.stopReason),
+        ultraworkOutput,
+        canonicalSessionId,
+      );
+    }
 
     const ultraqaOutput = await buildModeBasedStopOutput("ultraqa", cwd, canonicalSessionId);
-    if (!stopHookActive && ultraqaOutput) return ultraqaOutput;
+    if (ultraqaOutput) {
+      return await returnPersistentStopBlock(
+        payload,
+        stateDir,
+        "ultraqa-stop",
+        safeString(ultraqaOutput.stopReason),
+        ultraqaOutput,
+        canonicalSessionId,
+      );
+    }
 
     const releaseReadinessFinalizeResult = await maybeBuildReleaseReadinessFinalizeStopOutput(
       payload,
@@ -1313,16 +1358,11 @@ async function buildStopHookOutput(
 
     const teamOutput = await buildTeamStopOutput(cwd, canonicalSessionId);
     if (teamOutput) {
-      const teamSignature = buildRepeatableStopSignature(
-        payload,
-        "team-stop",
-        safeString(teamOutput.stopReason),
-        canonicalSessionId,
-      );
-      return await maybeReturnRepeatableStopOutput(
+      return await returnPersistentStopBlock(
         payload,
         stateDir,
-        teamSignature,
+        "team-stop",
+        safeString(teamOutput.stopReason),
         teamOutput,
         canonicalSessionId,
       );
@@ -1335,16 +1375,11 @@ async function buildStopHookOutput(
           canonicalTeam.teamName,
           canonicalTeam.phase,
         );
-        const canonicalTeamSignature = buildRepeatableStopSignature(
-          payload,
-          "team-stop",
-          `${canonicalTeam.teamName}|${canonicalTeam.phase}`,
-          canonicalSessionId,
-        );
-        const repeatedCanonicalTeamOutput = await maybeReturnRepeatableStopOutput(
+        const repeatedCanonicalTeamOutput = await returnPersistentStopBlock(
           payload,
           stateDir,
-          canonicalTeamSignature,
+          "team-stop",
+          `${canonicalTeam.teamName}|${canonicalTeam.phase}`,
           canonicalTeamOutput,
           canonicalSessionId,
         );
@@ -1352,7 +1387,16 @@ async function buildStopHookOutput(
       }
 
       const skillOutput = await buildSkillStopOutput(cwd, canonicalSessionId, threadId);
-      if (!stopHookActive && skillOutput) return skillOutput;
+      if (skillOutput) {
+        return await returnPersistentStopBlock(
+          payload,
+          stateDir,
+          "skill-stop",
+          safeString(skillOutput.stopReason),
+          skillOutput,
+          canonicalSessionId,
+        );
+      }
     }
 
     if (!managedStopContext) {
@@ -1370,10 +1414,11 @@ async function buildStopHookOutput(
       && detectNativeStopStallPattern(lastAssistantMessage, autoNudgeConfig.patterns, autoNudgePhase)
     ) {
       const effectiveResponse = resolveEffectiveAutoNudgeResponse(autoNudgeConfig.response);
-      return await maybeReturnRepeatableStopOutput(
+      return await returnPersistentStopBlock(
         payload,
         stateDir,
-        buildRepeatableStopSignature(payload, "auto-nudge", lastAssistantMessage, canonicalSessionId),
+        "auto-nudge",
+        lastAssistantMessage,
         {
           decision: "block",
           reason: effectiveResponse,
@@ -1393,26 +1438,11 @@ async function buildStopHookOutput(
   const systemMessage =
     `OMX Ralph is still active (phase: ${currentPhase}); continue the task and gather fresh verification evidence before stopping.`;
 
-  if (stopHookActive) {
-    return await maybeReturnRepeatableStopOutput(
-      payload,
-      stateDir,
-      buildRepeatableStopSignature(payload, "ralph-stop", currentPhase, canonicalSessionId),
-      {
-        decision: "block",
-        reason: systemMessage,
-        stopReason,
-        systemMessage,
-      },
-      canonicalSessionId,
-      { allowRepeatDuringStopHook: true },
-    );
-  }
-
-  return await maybeReturnRepeatableStopOutput(
+  return await returnPersistentStopBlock(
     payload,
     stateDir,
-    buildRepeatableStopSignature(payload, "ralph-stop", currentPhase, canonicalSessionId),
+    "ralph-stop",
+    currentPhase,
     {
       decision: "block",
       reason: systemMessage,
@@ -1420,7 +1450,6 @@ async function buildStopHookOutput(
       systemMessage,
     },
     canonicalSessionId,
-    { allowRepeatDuringStopHook: true },
   );
 }
 

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -41,8 +41,7 @@
     {
       "name": "ultraqa",
       "category": "execution",
-      "status": "merged",
-      "canonical": "ralph",
+      "status": "active",
       "core": false,
       "internalRequired": false
     },


### PR DESCRIPTION
## Summary
- make repeated Stop-hook callbacks keep blocking for active OMX execution workflows instead of only the first Stop
- keep deep-interview explicitly non-blocking while restoring ultraqa as a standalone installed skill
- regenerate catalog metadata and extend tests for repeated Stop behavior and setup/install coverage

## Why
Active state already existed for these workflows, and Ralph proved the hook layer can re-block on repeated Stop callbacks. The one-shot behavior was our stop-hook implementation gap, not a Codex-side limitation.

## Testing
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/setup-skills-overwrite.test.js
- node dist/scripts/generate-catalog-docs.js --check
- npm run lint -- src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts src/cli/__tests__/setup-skills-overwrite.test.ts src/catalog/manifest.json templates/catalog-manifest.json src/catalog/generated/public-catalog.json
