### PR TITLE
Add advisory HEAVY/LIGHT/PASS prompt-routing triage to the native hook

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -74,6 +74,10 @@ operator to clear incompatible state explicitly via `omx state ...` or the
 `omx_state.*` MCP tools before retrying. See
 `docs/contracts/multi-state-transition-contract.md`.
 
+## UserPromptSubmit: triage advisory context
+
+`UserPromptSubmit` can now emit triage advisory context alongside keyword context. When no keyword matches, the triage layer classifies the prompt and may inject an advisory prompt-routing context string — this is advisory prompt-routing context that does not activate a skill or workflow by itself; it adds a developer-context hint the model may follow. Keywords remain the deterministic control surface: a matched keyword always takes precedence over triage output, and users can suppress triage injection per prompt with phrases such as `no workflow`, `just chat`, or `plain answer`.
+
 ## Verification guidance
 
 When validating hooks, keep the proof boundary explicit:

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -5,7 +5,9 @@ description: Guide on using oh-my-codex plugin
 
 # How OMX Works
 
-**You don't need to learn any commands!** OMX enhances Codex CLI with intelligent behaviors that activate automatically.
+Plain English works as best-effort guidance — OMX inspects each prompt and may add advisory routing context to steer the model toward a suitable lane. This is **advisory prompt-routing context**: it does not activate a skill or workflow by itself. Explicit keywords remain the deterministic control surface when you want exact, guaranteed routing.
+
+**Triage lanes** (when no keyword matches): complex/multi-step prompts may receive HEAVY guidance (autopilot-shaped); read-only lookups receive LIGHT/explore guidance; implementation work receives LIGHT/executor guidance; UI work receives LIGHT/designer guidance; simple conversational prompts receive no injection (PASS). To opt out per prompt, include a phrase such as `no workflow`, `just chat`, or `plain answer`.
 
 ## What Happens Automatically
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -23,6 +23,8 @@ import { getMissingManagedCodexHookEvents } from '../config/codex-hooks.js';
 import { getDefaultBridge, isBridgeEnabled } from '../runtime/bridge.js';
 import { OMX_EXPLORE_CMD_ENV, isExploreCommandRoutingEnabled } from '../hooks/explore-routing.js';
 import { isLeaderRuntimeStale } from '../team/leader-activity.js';
+import { triagePrompt } from '../hooks/triage-heuristic.js';
+import { readTriageConfig } from '../hooks/triage-config.js';
 
 interface DoctorOptions {
   verbose?: boolean;
@@ -164,6 +166,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
   // Check 9: MCP servers configured
   checks.push(await checkMcpServers(paths.configPath));
+
+  // Check 10: Prompt triage
+  checks.push(checkPromptTriage());
 
   // Print results
   let passCount = 0;
@@ -839,6 +844,49 @@ function checkAgentsMd(scope: DoctorSetupScope, codexHomeDir: string): Check {
     status: 'warn',
     message: 'not found in project root (run omx agents-init . or omx setup --scope project)',
   };
+}
+
+function checkPromptTriage(): Check {
+  try {
+    const config = readTriageConfig();
+
+    if (config.status === 'disabled') {
+      return {
+        name: 'Prompt triage',
+        status: 'warn',
+        message: `disabled via ${config.path}`,
+      };
+    }
+
+    if (config.status === 'invalid') {
+      return {
+        name: 'Prompt triage',
+        status: 'warn',
+        message: `config file malformed at ${config.path} — fails closed to disabled`,
+      };
+    }
+
+    // Smoke test: verify the classifier is callable and returns the expected shape.
+    const decision = triagePrompt('hello');
+    const validLanes = new Set(['HEAVY', 'LIGHT', 'PASS']);
+    if (!decision || typeof decision !== 'object' || !validLanes.has(decision.lane)) {
+      return {
+        name: 'Prompt triage',
+        status: 'fail',
+        message: `classifier returned unexpected shape (lane: ${String(decision?.lane)})`,
+      };
+    }
+
+    const sourceLabel = config.status === 'defaulted' ? 'enabled (default)' : 'enabled';
+    return {
+      name: 'Prompt triage',
+      status: 'pass',
+      message: `config: ${sourceLabel}`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { name: 'Prompt triage', status: 'fail', message: `module load error — ${msg}` };
+  }
 }
 
 async function checkMcpServers(configPath: string): Promise<Check> {

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -16,6 +16,7 @@ Resolved setup scope: user
   [!!] AGENTS.md: not found in <CODEX_HOME>/AGENTS.md (run omx setup --scope user)
   [!!] State dir: <REPO_STATE_DIR> (not created yet)
   [!!] MCP Servers: 1 servers but no OMX servers yet (expected before first setup; run "omx setup --force" once)
+  [OK] Prompt triage: config: enabled (default)
 
 Results: <RESULTS>
 

--- a/src/hooks/__tests__/triage-config.test.ts
+++ b/src/hooks/__tests__/triage-config.test.ts
@@ -146,9 +146,37 @@ describe('readTriageConfig — wrong shape', () => {
     assert.equal(result.enabled, false);
   });
 
-  it('returns invalid for object missing promptRouting key', () => {
+  it('returns defaulted for object missing promptRouting key', () => {
     resetTriageConfigCache();
     writeConfig(JSON.stringify({ unrelated: 123 }));
+    const result = readTriageConfig();
+    assert.equal(result.status, 'defaulted');
+    assert.equal(result.enabled, true);
+  });
+
+  it('returns defaulted when promptRouting exists but triage key is omitted', () => {
+    writeConfig(JSON.stringify({ promptRouting: {} }));
+    const result = readTriageConfig();
+    assert.equal(result.status, 'defaulted');
+    assert.equal(result.enabled, true);
+  });
+
+  it('returns defaulted when triage exists but enabled is omitted', () => {
+    writeConfig(JSON.stringify({ promptRouting: { triage: {} } }));
+    const result = readTriageConfig();
+    assert.equal(result.status, 'defaulted');
+    assert.equal(result.enabled, true);
+  });
+
+  it('returns invalid when promptRouting is present but not an object', () => {
+    writeConfig(JSON.stringify({ promptRouting: true }));
+    const result = readTriageConfig();
+    assert.equal(result.status, 'invalid');
+    assert.equal(result.enabled, false);
+  });
+
+  it('returns invalid when triage is present but not an object', () => {
+    writeConfig(JSON.stringify({ promptRouting: { triage: true } }));
     const result = readTriageConfig();
     assert.equal(result.status, 'invalid');
     assert.equal(result.enabled, false);

--- a/src/hooks/__tests__/triage-config.test.ts
+++ b/src/hooks/__tests__/triage-config.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readTriageConfig, resetTriageConfigCache } from '../triage-config.js';
+
+// ---------------------------------------------------------------------------
+// Env save/restore helpers
+// ---------------------------------------------------------------------------
+
+let savedCodexHome: string | undefined;
+
+before(() => {
+  savedCodexHome = process.env.CODEX_HOME;
+  // Ensure a clean cache before the suite starts
+  resetTriageConfigCache();
+});
+
+after(() => {
+  // Restore env and clear cache after the entire suite
+  if (savedCodexHome === undefined) {
+    delete process.env.CODEX_HOME;
+  } else {
+    process.env.CODEX_HOME = savedCodexHome;
+  }
+  resetTriageConfigCache();
+});
+
+// ---------------------------------------------------------------------------
+// Per-test temp-dir scaffolding (used across all describe blocks)
+// ---------------------------------------------------------------------------
+
+let tmp: string;
+
+function setupTmp(): void {
+  tmp = mkdtempSync(join(tmpdir(), 'triage-config-test-'));
+  process.env.CODEX_HOME = tmp;
+  resetTriageConfigCache();
+}
+
+function teardownTmp(): void {
+  rmSync(tmp, { recursive: true, force: true });
+  resetTriageConfigCache();
+}
+
+function configPath(): string {
+  return join(tmp, '.omx-config.json');
+}
+
+function writeConfig(content: string): void {
+  writeFileSync(configPath(), content, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Missing config file → defaulted
+// ---------------------------------------------------------------------------
+
+describe('readTriageConfig — missing config file', () => {
+  beforeEach(setupTmp);
+  after(teardownTmp);
+
+  it('returns defaulted result when .omx-config.json does not exist', () => {
+    const result = readTriageConfig();
+    assert.deepEqual(result, {
+      enabled: true,
+      status: 'defaulted',
+      source: 'default',
+      path: configPath(),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Valid config with enabled: true
+// ---------------------------------------------------------------------------
+
+describe('readTriageConfig — valid config enabled: true', () => {
+  beforeEach(setupTmp);
+  after(teardownTmp);
+
+  it('returns enabled result for {"promptRouting":{"triage":{"enabled":true}}}', () => {
+    writeConfig(JSON.stringify({ promptRouting: { triage: { enabled: true } } }));
+    const result = readTriageConfig();
+    assert.deepEqual(result, {
+      enabled: true,
+      status: 'enabled',
+      source: 'file',
+      path: configPath(),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: Valid config with enabled: false
+// ---------------------------------------------------------------------------
+
+describe('readTriageConfig — valid config enabled: false', () => {
+  beforeEach(setupTmp);
+  after(teardownTmp);
+
+  it('returns disabled result for {"promptRouting":{"triage":{"enabled":false}}}', () => {
+    writeConfig(JSON.stringify({ promptRouting: { triage: { enabled: false } } }));
+    const result = readTriageConfig();
+    assert.deepEqual(result, {
+      enabled: false,
+      status: 'disabled',
+      source: 'file',
+      path: configPath(),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: Malformed JSON → invalid, fails closed
+// ---------------------------------------------------------------------------
+
+describe('readTriageConfig — malformed JSON', () => {
+  beforeEach(setupTmp);
+  after(teardownTmp);
+
+  it('returns invalid/closed result for malformed JSON and does not throw', () => {
+    writeConfig('this is not json');
+    const result = readTriageConfig();
+    assert.deepEqual(result, {
+      enabled: false,
+      status: 'invalid',
+      source: 'invalid',
+      path: configPath(),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: Wrong shape
+// ---------------------------------------------------------------------------
+
+describe('readTriageConfig — wrong shape', () => {
+  beforeEach(setupTmp);
+  after(teardownTmp);
+
+  it('returns invalid for root value that is an array (not an object)', () => {
+    writeConfig('[]');
+    const result = readTriageConfig();
+    assert.equal(result.status, 'invalid');
+    assert.equal(result.enabled, false);
+  });
+
+  it('returns invalid for object missing promptRouting key', () => {
+    resetTriageConfigCache();
+    writeConfig(JSON.stringify({ unrelated: 123 }));
+    const result = readTriageConfig();
+    assert.equal(result.status, 'invalid');
+    assert.equal(result.enabled, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: Non-boolean enabled value → invalid
+// ---------------------------------------------------------------------------
+
+describe('readTriageConfig — non-boolean enabled value', () => {
+  beforeEach(setupTmp);
+  after(teardownTmp);
+
+  it('returns invalid for {"promptRouting":{"triage":{"enabled":"yes"}}}', () => {
+    writeConfig(JSON.stringify({ promptRouting: { triage: { enabled: 'yes' } } }));
+    const result = readTriageConfig();
+    assert.equal(result.status, 'invalid');
+    assert.equal(result.enabled, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: Cache behavior — second read returns same object without touching FS
+// ---------------------------------------------------------------------------
+
+describe('readTriageConfig — cache behavior (file-gone test)', () => {
+  beforeEach(setupTmp);
+  after(teardownTmp);
+
+  it('returns cached result after config file is deleted, then defaulted after cache reset', () => {
+    writeConfig(JSON.stringify({ promptRouting: { triage: { enabled: true } } }));
+
+    const result1 = readTriageConfig();
+    assert.equal(result1.status, 'enabled');
+
+    // Delete the file — cache should absorb this
+    rmSync(configPath(), { force: true });
+
+    const result2 = readTriageConfig();
+    assert.deepEqual(result1, result2, 'second read should return cached value equal to first read');
+
+    // After reset the missing file should produce defaulted
+    resetTriageConfigCache();
+    const result3 = readTriageConfig();
+    assert.equal(result3.status, 'defaulted', 'after cache reset with missing file status should be "defaulted"');
+    assert.equal(result3.enabled, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: resetTriageConfigCache actually clears
+// ---------------------------------------------------------------------------
+
+describe('readTriageConfig — resetTriageConfigCache clears stale result', () => {
+  beforeEach(setupTmp);
+  after(teardownTmp);
+
+  it('stale cache persists until reset, then reflects updated file', () => {
+    writeConfig(JSON.stringify({ promptRouting: { triage: { enabled: true } } }));
+
+    const before = readTriageConfig();
+    assert.equal(before.status, 'enabled', 'initial read should be enabled');
+
+    // Change file on disk — cache should hide this
+    writeConfig(JSON.stringify({ promptRouting: { triage: { enabled: false } } }));
+
+    const cached = readTriageConfig();
+    assert.equal(cached.status, 'enabled', 'without reset, stale cache should still say enabled');
+
+    // Reset and re-read — now reflects the updated file
+    resetTriageConfigCache();
+    const fresh = readTriageConfig();
+    assert.equal(fresh.status, 'disabled', 'after reset, read should reflect updated file (disabled)');
+    assert.equal(fresh.enabled, false);
+  });
+});

--- a/src/hooks/__tests__/triage-heuristic.test.ts
+++ b/src/hooks/__tests__/triage-heuristic.test.ts
@@ -65,10 +65,13 @@ const CANONICAL_CORPUS: string[] = [
   'make the button blue',
   'style this page',
   'adjust spacing on the settings panel',
+  'redesign the settings page layout',
   // HEAVY
   'add dark mode toggle to the settings page',
   'implement soft delete across the ORM layer',
   'refactor the auth flow to use session cookies',
+  'redesign the auth flow',
+  'redesign the deployment pipeline',
 ];
 
 // ---------------------------------------------------------------------------
@@ -174,6 +177,10 @@ describe('triagePrompt — LIGHT/designer', () => {
   it('routes "adjust spacing on the settings panel" to designer', () => {
     assertLightDestination('adjust spacing on the settings panel', 'designer');
   });
+
+  it('routes visual redesign prompts to designer', () => {
+    assertLightDestination('redesign the settings page layout', 'designer');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -191,6 +198,18 @@ describe('triagePrompt — HEAVY', () => {
 
   it('routes "refactor the auth flow to use session cookies" to HEAVY', () => {
     assertLane('refactor the auth flow to use session cookies', 'HEAVY');
+  });
+
+  it('does not route non-visual auth redesign prompts to LIGHT/designer', () => {
+    const result = triagePrompt('redesign the auth flow');
+    assert.equal(result.lane, 'HEAVY', `expected HEAVY got ${result.lane} (reason=${result.reason})`);
+    assert.equal(result.destination, 'autopilot');
+  });
+
+  it('does not route non-visual deployment redesign prompts to LIGHT/designer', () => {
+    const result = triagePrompt('redesign the deployment pipeline');
+    assert.equal(result.lane, 'HEAVY', `expected HEAVY got ${result.lane} (reason=${result.reason})`);
+    assert.equal(result.destination, 'autopilot');
   });
 
   it('sets destination=autopilot for HEAVY decisions', () => {

--- a/src/hooks/__tests__/triage-heuristic.test.ts
+++ b/src/hooks/__tests__/triage-heuristic.test.ts
@@ -206,6 +206,12 @@ describe('triagePrompt — HEAVY', () => {
     assert.equal(result.destination, 'autopilot');
   });
 
+  it('routes mixed auth page flow redesign prompts to HEAVY instead of designer', () => {
+    const result = triagePrompt('redesign the auth page flow');
+    assert.equal(result.lane, 'HEAVY', `expected HEAVY got ${result.lane} (reason=${result.reason})`);
+    assert.equal(result.destination, 'autopilot');
+  });
+
   it('does not route non-visual deployment redesign prompts to LIGHT/designer', () => {
     const result = triagePrompt('redesign the deployment pipeline');
     assert.equal(result.lane, 'HEAVY', `expected HEAVY got ${result.lane} (reason=${result.reason})`);

--- a/src/hooks/__tests__/triage-heuristic.test.ts
+++ b/src/hooks/__tests__/triage-heuristic.test.ts
@@ -1,0 +1,287 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { triagePrompt } from '../triage-heuristic.js';
+import type { TriageDecision } from '../triage-heuristic.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function assertLane(prompt: string, lane: TriageDecision['lane']): void {
+  const result = triagePrompt(prompt);
+  assert.equal(
+    result.lane,
+    lane,
+    `prompt="${prompt}" expected lane=${lane} got lane=${result.lane} (reason=${result.reason})`,
+  );
+}
+
+function assertLightDestination(
+  prompt: string,
+  destination: NonNullable<TriageDecision['destination']>,
+): void {
+  const result = triagePrompt(prompt);
+  assert.equal(
+    result.lane,
+    'LIGHT',
+    `prompt="${prompt}" expected LIGHT got ${result.lane} (reason=${result.reason})`,
+  );
+  assert.equal(
+    result.destination,
+    destination,
+    `prompt="${prompt}" expected destination=${destination} got ${result.destination}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Canonical corpus (also used for performance benchmark)
+// ---------------------------------------------------------------------------
+
+const CANONICAL_CORPUS: string[] = [
+  // PASS — trivial
+  'hi',
+  'thanks',
+  'yes',
+  '',
+  '   ',
+  'fix the thing',
+  'make it better',
+  // PASS — opt-out
+  'add dark mode toggle to the settings page, but just chat about it',
+  'make the button blue, no workflow',
+  'implement soft delete, don\'t route',
+  'refactor auth, plain answer only',
+  'explain this but talk through it',
+  // LIGHT/explore
+  'explain this function',
+  'what does this error mean',
+  'where is auth implemented',
+  // LIGHT/executor
+  'fix typo in src/foo.ts',
+  'add null check to line 42',
+  'rename function processFoo in src/bar.ts',
+  // LIGHT/designer
+  'make the button blue',
+  'style this page',
+  'adjust spacing on the settings panel',
+  // HEAVY
+  'add dark mode toggle to the settings page',
+  'implement soft delete across the ORM layer',
+  'refactor the auth flow to use session cookies',
+];
+
+// ---------------------------------------------------------------------------
+// 1. PASS cases
+// ---------------------------------------------------------------------------
+
+describe('triagePrompt — PASS (trivial acknowledgements)', () => {
+  const trivialCases = ['hi', 'thanks', 'yes'];
+  for (const prompt of trivialCases) {
+    it(`routes "${prompt}" to PASS`, () => {
+      assertLane(prompt, 'PASS');
+    });
+  }
+
+  it('routes empty string to PASS', () => {
+    assertLane('', 'PASS');
+  });
+
+  it('routes whitespace-only string to PASS', () => {
+    assertLane('   ', 'PASS');
+  });
+
+  it('routes "fix the thing" (too short / vague) to PASS', () => {
+    assertLane('fix the thing', 'PASS');
+  });
+
+  it('routes "make it better" (too short / vague) to PASS', () => {
+    assertLane('make it better', 'PASS');
+  });
+});
+
+describe('triagePrompt — PASS (explicit opt-out phrases)', () => {
+  it('routes HEAVY-shaped prompt with "just chat" to PASS', () => {
+    assertLane('add dark mode toggle to the settings page, but just chat about it', 'PASS');
+  });
+
+  it('routes "no workflow" opt-out to PASS', () => {
+    assertLane('make the button blue, no workflow', 'PASS');
+  });
+
+  it('routes "don\'t route" opt-out to PASS', () => {
+    assertLane("implement soft delete, don't route", 'PASS');
+  });
+
+  it('routes "plain answer only" to PASS', () => {
+    assertLane('refactor auth, plain answer only', 'PASS');
+  });
+
+  it('routes "talk through it" to PASS', () => {
+    assertLane('explain this but talk through it', 'PASS');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. LIGHT / explore
+// ---------------------------------------------------------------------------
+
+describe('triagePrompt — LIGHT/explore', () => {
+  it('routes "explain this function" to explore', () => {
+    assertLightDestination('explain this function', 'explore');
+  });
+
+  it('routes "what does this error mean" to explore', () => {
+    assertLightDestination('what does this error mean', 'explore');
+  });
+
+  it('routes "where is auth implemented" to explore', () => {
+    assertLightDestination('where is auth implemented', 'explore');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. LIGHT / executor (anchored edits)
+// ---------------------------------------------------------------------------
+
+describe('triagePrompt — LIGHT/executor (anchored edits)', () => {
+  it('routes "fix typo in src/foo.ts" to executor', () => {
+    assertLightDestination('fix typo in src/foo.ts', 'executor');
+  });
+
+  it('routes "add null check to line 42" to executor', () => {
+    assertLightDestination('add null check to line 42', 'executor');
+  });
+
+  it('routes "rename function processFoo in src/bar.ts" to executor', () => {
+    assertLightDestination('rename function processFoo in src/bar.ts', 'executor');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. LIGHT / designer
+// ---------------------------------------------------------------------------
+
+describe('triagePrompt — LIGHT/designer', () => {
+  it('routes "make the button blue" to designer', () => {
+    assertLightDestination('make the button blue', 'designer');
+  });
+
+  it('routes "style this page" to designer', () => {
+    assertLightDestination('style this page', 'designer');
+  });
+
+  it('routes "adjust spacing on the settings panel" to designer', () => {
+    assertLightDestination('adjust spacing on the settings panel', 'designer');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. HEAVY
+// ---------------------------------------------------------------------------
+
+describe('triagePrompt — HEAVY', () => {
+  it('routes "add dark mode toggle to the settings page" to HEAVY', () => {
+    assertLane('add dark mode toggle to the settings page', 'HEAVY');
+  });
+
+  it('routes "implement soft delete across the ORM layer" to HEAVY', () => {
+    assertLane('implement soft delete across the ORM layer', 'HEAVY');
+  });
+
+  it('routes "refactor the auth flow to use session cookies" to HEAVY', () => {
+    assertLane('refactor the auth flow to use session cookies', 'HEAVY');
+  });
+
+  it('sets destination=autopilot for HEAVY decisions', () => {
+    const result = triagePrompt('add dark mode toggle to the settings page');
+    assert.equal(result.destination, 'autopilot', `expected destination=autopilot got ${result.destination}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Punctuation / casing regression
+// ---------------------------------------------------------------------------
+
+describe('triagePrompt — punctuation and casing regression', () => {
+  it('"EXPLAIN this function" → LIGHT/explore (all-caps)', () => {
+    assertLightDestination('EXPLAIN this function', 'explore');
+  });
+
+  it('"Explain This Function." → LIGHT/explore (title case + period)', () => {
+    assertLightDestination('Explain This Function.', 'explore');
+  });
+
+  it('"FIX TYPO IN src/foo.ts" → LIGHT/executor (all-caps)', () => {
+    assertLightDestination('FIX TYPO IN src/foo.ts', 'executor');
+  });
+
+  it('"Add Dark Mode Toggle To The Settings Page!" → HEAVY (title case + exclamation)', () => {
+    assertLane('Add Dark Mode Toggle To The Settings Page!', 'HEAVY');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Determinism / purity proof
+// ---------------------------------------------------------------------------
+
+describe('triagePrompt — determinism', () => {
+  it('returns identical results across 1000 calls for the same input', () => {
+    const prompt = 'add dark mode toggle to the settings page';
+    const first = triagePrompt(prompt);
+    for (let i = 1; i < 1000; i++) {
+      const result = triagePrompt(prompt);
+      assert.equal(
+        result.lane,
+        first.lane,
+        `non-deterministic: call ${i} returned lane=${result.lane}, first was ${first.lane}`,
+      );
+      assert.equal(
+        result.destination,
+        first.destination,
+        `non-deterministic: call ${i} returned destination=${result.destination}, first was ${first.destination}`,
+      );
+      assert.equal(
+        result.reason,
+        first.reason,
+        `non-deterministic: call ${i} returned reason=${result.reason}, first was ${first.reason}`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Performance benchmark (soft assertion — avg < 1 ms per call)
+// ---------------------------------------------------------------------------
+
+describe('triagePrompt — performance benchmark', () => {
+  it('classifies the full canonical corpus 1000x with avg < 1 ms per call', () => {
+    const N = 1000;
+    const corpusLength = CANONICAL_CORPUS.length;
+    const totalCalls = N * corpusLength;
+
+    // Warm-up pass (avoid JIT cold-start skewing results)
+    for (const prompt of CANONICAL_CORPUS) {
+      triagePrompt(prompt);
+    }
+
+    const start = performance.now();
+    for (let i = 0; i < N; i++) {
+      for (const prompt of CANONICAL_CORPUS) {
+        triagePrompt(prompt);
+      }
+    }
+    const elapsed = performance.now() - start;
+
+    const avgPerCall = elapsed / totalCalls;
+    console.log(
+      `[triage-heuristic benchmark] ${totalCalls} calls in ${elapsed.toFixed(2)} ms` +
+      ` — avg ${avgPerCall.toFixed(4)} ms/call (corpus size: ${corpusLength})`,
+    );
+
+    assert.ok(
+      avgPerCall < 1.0,
+      `avg per call ${avgPerCall.toFixed(4)} ms exceeded 1 ms soft bound (total: ${elapsed.toFixed(2)} ms over ${totalCalls} calls)`,
+    );
+  });
+});

--- a/src/hooks/__tests__/triage-state.test.ts
+++ b/src/hooks/__tests__/triage-state.test.ts
@@ -200,6 +200,25 @@ describe('path selection — session-scoped vs root', () => {
       removeTmp(sub);
     }
   });
+
+  it('write with malformed explicit sessionId skips persistence instead of falling back to root', () => {
+    const isolated = makeTmp();
+    try {
+      const sessionId = 'bad/session';
+      writeTriageState({ cwd: isolated, sessionId, state: validState() });
+      assert.equal(existsSync(expectedPath(isolated)), false);
+      assert.equal(existsSync(join(isolated, '.omx', 'state', 'sessions', 'bad', 'session')), false);
+    } finally {
+      removeTmp(isolated);
+    }
+  });
+
+  it('read with malformed explicit sessionId ignores root-scoped state', () => {
+    const rootState = validState();
+    writeTriageState({ cwd: tmp, sessionId: undefined, state: rootState });
+    const result = readTriageState({ cwd: tmp, sessionId: 'bad/session' });
+    assert.equal(result, null);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -324,7 +343,7 @@ describe('shouldSuppressFollowup — keyword bypasses suppression', () => {
   });
 });
 
-describe('shouldSuppressFollowup — short prompts (word count <= 6)', () => {
+describe('shouldSuppressFollowup — clarifying short prompts only', () => {
   const previous = validState({ suppress_followup: true });
 
   it('"yes" (1 word) → true', () => {
@@ -341,10 +360,10 @@ describe('shouldSuppressFollowup — short prompts (word count <= 6)', () => {
     );
   });
 
-  it('"settings page" (2 words) → true', () => {
+  it('"settings page" (2 words) → false', () => {
     assert.equal(
       shouldSuppressFollowup({ previous, currentPrompt: 'settings page', currentHasKeyword: false }),
-      true,
+      false,
     );
   });
 
@@ -355,14 +374,25 @@ describe('shouldSuppressFollowup — short prompts (word count <= 6)', () => {
     );
   });
 
-  it('"one two three four five six" (6 words, boundary) → true', () => {
+  it('"one two three four five six" (6 words, boundary) → false', () => {
     assert.equal(
       shouldSuppressFollowup({
         previous,
         currentPrompt: 'one two three four five six',
         currentHasKeyword: false,
       }),
-      true,
+      false,
+    );
+  });
+
+  it('"fix typo in src/foo.ts" stays unsuppressed even though short', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'fix typo in src/foo.ts',
+        currentHasKeyword: false,
+      }),
+      false,
     );
   });
 });

--- a/src/hooks/__tests__/triage-state.test.ts
+++ b/src/hooks/__tests__/triage-state.test.ts
@@ -1,0 +1,507 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  readTriageState,
+  writeTriageState,
+  shouldSuppressFollowup,
+  promptSignature,
+} from '../triage-state.js';
+import type { TriageStateFile } from '../triage-state.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmp(): string {
+  return mkdtempSync(join(tmpdir(), 'triage-state-test-'));
+}
+
+function removeTmp(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** Absolute path where readTriageState / writeTriageState store the file. */
+function expectedPath(cwd: string, sessionId?: string): string {
+  if (sessionId) {
+    return join(cwd, '.omx', 'state', 'sessions', sessionId, 'prompt-routing-state.json');
+  }
+  return join(cwd, '.omx', 'state', 'prompt-routing-state.json');
+}
+
+/** A fully-valid TriageStateFile for round-trip tests. */
+function validState(overrides?: Partial<TriageStateFile>): TriageStateFile {
+  return {
+    version: 1,
+    last_triage: {
+      lane: 'HEAVY',
+      destination: 'autopilot',
+      reason: 'multi-system change with scope markers',
+      prompt_signature: 'sha256:' + 'a'.repeat(64),
+      turn_id: '2026-04-18T00:00:00.000Z',
+      created_at: '2026-04-18T00:00:00.000Z',
+    },
+    suppress_followup: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. readTriageState — basic behaviour
+// ---------------------------------------------------------------------------
+
+describe('readTriageState — missing file returns null', () => {
+  let tmp: string;
+  before(() => { tmp = makeTmp(); });
+  after(() => removeTmp(tmp));
+
+  it('returns null for a fresh cwd (no file present)', () => {
+    const result = readTriageState({ cwd: tmp, sessionId: 's1' });
+    assert.equal(result, null);
+  });
+
+  it('does not throw when the file is absent', () => {
+    assert.doesNotThrow(() => readTriageState({ cwd: tmp, sessionId: 'nope' }));
+  });
+});
+
+describe('readTriageState — malformed JSON returns null', () => {
+  let tmp: string;
+  before(() => {
+    tmp = makeTmp();
+    const path = expectedPath(tmp, 'sess-malformed');
+    mkdirSync(join(tmp, '.omx', 'state', 'sessions', 'sess-malformed'), { recursive: true });
+    writeFileSync(path, 'not json', 'utf-8');
+  });
+  after(() => removeTmp(tmp));
+
+  it('returns null without throwing', () => {
+    const result = readTriageState({ cwd: tmp, sessionId: 'sess-malformed' });
+    assert.equal(result, null);
+  });
+});
+
+describe('readTriageState — wrong shape returns null', () => {
+  let tmp: string;
+  before(() => { tmp = makeTmp(); });
+  after(() => removeTmp(tmp));
+
+  it('returns null for {version:2} (wrong version)', () => {
+    const path = expectedPath(tmp, 'v2');
+    mkdirSync(join(tmp, '.omx', 'state', 'sessions', 'v2'), { recursive: true });
+    writeFileSync(path, JSON.stringify({ version: 2 }), 'utf-8');
+    const result = readTriageState({ cwd: tmp, sessionId: 'v2' });
+    assert.equal(result, null);
+  });
+
+  it('returns null for {} (empty object)', () => {
+    const path = expectedPath(tmp, 'empty');
+    mkdirSync(join(tmp, '.omx', 'state', 'sessions', 'empty'), { recursive: true });
+    writeFileSync(path, JSON.stringify({}), 'utf-8');
+    const result = readTriageState({ cwd: tmp, sessionId: 'empty' });
+    assert.equal(result, null);
+  });
+
+  it('returns null for missing suppress_followup field', () => {
+    const path = expectedPath(tmp, 'missing-field');
+    mkdirSync(join(tmp, '.omx', 'state', 'sessions', 'missing-field'), { recursive: true });
+    writeFileSync(path, JSON.stringify({ version: 1, last_triage: null }), 'utf-8');
+    const result = readTriageState({ cwd: tmp, sessionId: 'missing-field' });
+    assert.equal(result, null);
+  });
+});
+
+describe('readTriageState — valid file returns parsed object', () => {
+  let tmp: string;
+  const sessionId = 'sess-valid';
+  const state = validState();
+
+  before(() => {
+    tmp = makeTmp();
+    const path = expectedPath(tmp, sessionId);
+    mkdirSync(join(tmp, '.omx', 'state', 'sessions', sessionId), { recursive: true });
+    writeFileSync(path, JSON.stringify(state, null, 2), 'utf-8');
+  });
+  after(() => removeTmp(tmp));
+
+  it('parses version field correctly', () => {
+    const result = readTriageState({ cwd: tmp, sessionId });
+    assert.ok(result !== null);
+    assert.equal(result.version, 1);
+  });
+
+  it('parses suppress_followup correctly', () => {
+    const result = readTriageState({ cwd: tmp, sessionId });
+    assert.ok(result !== null);
+    assert.equal(result.suppress_followup, true);
+  });
+
+  it('parses last_triage fields correctly', () => {
+    const result = readTriageState({ cwd: tmp, sessionId });
+    assert.ok(result !== null);
+    assert.ok(result.last_triage !== null);
+    assert.equal(result.last_triage.lane, 'HEAVY');
+    assert.equal(result.last_triage.destination, 'autopilot');
+    assert.equal(result.last_triage.reason, state.last_triage!.reason);
+  });
+
+  it('valid state with last_triage=null parses correctly', () => {
+    const nullState: TriageStateFile = { version: 1, last_triage: null, suppress_followup: false };
+    const path2 = expectedPath(tmp, 'null-triage');
+    mkdirSync(join(tmp, '.omx', 'state', 'sessions', 'null-triage'), { recursive: true });
+    writeFileSync(path2, JSON.stringify(nullState, null, 2), 'utf-8');
+    const result = readTriageState({ cwd: tmp, sessionId: 'null-triage' });
+    assert.ok(result !== null);
+    assert.equal(result.last_triage, null);
+    assert.equal(result.suppress_followup, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Path selection — session-scoped vs root fallback
+// ---------------------------------------------------------------------------
+
+describe('path selection — session-scoped vs root', () => {
+  let tmp: string;
+  before(() => { tmp = makeTmp(); });
+  after(() => removeTmp(tmp));
+
+  it('write with sessionId places file at sessions/<id>/prompt-routing-state.json', () => {
+    const sessionId = 'sess-abc';
+    writeTriageState({ cwd: tmp, sessionId, state: validState() });
+    const expected = expectedPath(tmp, sessionId);
+    assert.ok(existsSync(expected), `expected file at ${expected}`);
+  });
+
+  it('file is NOT placed at root when sessionId is provided', () => {
+    const rootPath = expectedPath(tmp); // no sessionId
+    // root may or may not exist, but it should not be the session file
+    const sessionPath = expectedPath(tmp, 'sess-abc');
+    assert.notEqual(sessionPath, rootPath);
+    assert.ok(existsSync(sessionPath));
+  });
+
+  it('write without sessionId places file at root .omx/state/prompt-routing-state.json', () => {
+    writeTriageState({ cwd: tmp, sessionId: undefined, state: validState() });
+    const rootPath = expectedPath(tmp);
+    assert.ok(existsSync(rootPath), `expected root file at ${rootPath}`);
+  });
+
+  it('write with null sessionId also places file at root', () => {
+    // use a fresh subdir so we can isolate
+    const sub = makeTmp();
+    try {
+      writeTriageState({ cwd: sub, sessionId: null, state: validState() });
+      const rootPath = expectedPath(sub);
+      assert.ok(existsSync(rootPath), `expected root file at ${rootPath}`);
+    } finally {
+      removeTmp(sub);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. writeTriageState
+// ---------------------------------------------------------------------------
+
+describe('writeTriageState — directory creation', () => {
+  let tmp: string;
+  before(() => { tmp = makeTmp(); });
+  after(() => removeTmp(tmp));
+
+  it('creates parent directories if they do not exist', () => {
+    const sessionId = 'brand-new-session';
+    const dirPath = join(tmp, '.omx', 'state', 'sessions', sessionId);
+    assert.ok(!existsSync(dirPath), 'dir should not exist before write');
+    writeTriageState({ cwd: tmp, sessionId, state: validState() });
+    assert.ok(existsSync(dirPath), 'dir should exist after write');
+  });
+});
+
+describe('writeTriageState — round-trip', () => {
+  let tmp: string;
+  before(() => { tmp = makeTmp(); });
+  after(() => removeTmp(tmp));
+
+  it('read after write returns structurally equal object', () => {
+    const sessionId = 'round-trip';
+    const state = validState();
+    writeTriageState({ cwd: tmp, sessionId, state });
+    const result = readTriageState({ cwd: tmp, sessionId });
+    assert.ok(result !== null);
+    assert.deepEqual(result, state);
+  });
+
+  it('round-trip works with last_triage=null', () => {
+    const sessionId = 'round-trip-null';
+    const state: TriageStateFile = { version: 1, last_triage: null, suppress_followup: false };
+    writeTriageState({ cwd: tmp, sessionId, state });
+    const result = readTriageState({ cwd: tmp, sessionId });
+    assert.ok(result !== null);
+    assert.deepEqual(result, state);
+  });
+});
+
+describe('writeTriageState — overwrite behaviour', () => {
+  let tmp: string;
+  before(() => { tmp = makeTmp(); });
+  after(() => removeTmp(tmp));
+
+  it('second write replaces first write cleanly', () => {
+    const sessionId = 'overwrite-test';
+    const first = validState({ suppress_followup: true });
+    const second: TriageStateFile = { version: 1, last_triage: null, suppress_followup: false };
+
+    writeTriageState({ cwd: tmp, sessionId, state: first });
+    writeTriageState({ cwd: tmp, sessionId, state: second });
+
+    const result = readTriageState({ cwd: tmp, sessionId });
+    assert.ok(result !== null);
+    assert.deepEqual(result, second);
+  });
+});
+
+describe('writeTriageState — swallows errors gracefully', () => {
+  it('does not throw when cwd is a non-existent deeply nested path', () => {
+    // mkdirSync recursive should succeed, but pass a path where we have no
+    // permissions. We approximate this by a path inside /proc which is
+    // read-only on Linux; if that is not available, skip.
+    const badPath = '/proc/1/fd/triage-state-test-should-not-write';
+    assert.doesNotThrow(() => {
+      writeTriageState({ cwd: badPath, sessionId: 'x', state: validState() });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. shouldSuppressFollowup
+// ---------------------------------------------------------------------------
+
+describe('shouldSuppressFollowup — no previous state', () => {
+  it('returns false when previous is null', () => {
+    const result = shouldSuppressFollowup({
+      previous: null,
+      currentPrompt: 'anything',
+      currentHasKeyword: false,
+    });
+    assert.equal(result, false);
+  });
+});
+
+describe('shouldSuppressFollowup — suppress_followup: false', () => {
+  it('returns false when previous.suppress_followup is false', () => {
+    const previous = validState({ suppress_followup: false });
+    const result = shouldSuppressFollowup({
+      previous,
+      currentPrompt: 'yes',
+      currentHasKeyword: false,
+    });
+    assert.equal(result, false);
+  });
+});
+
+describe('shouldSuppressFollowup — keyword bypasses suppression', () => {
+  it('returns false even with prior HEAVY state when keyword is present', () => {
+    const previous = validState({ suppress_followup: true });
+    const result = shouldSuppressFollowup({
+      previous,
+      currentPrompt: 'fix typo in src/foo.ts',
+      currentHasKeyword: true,
+    });
+    assert.equal(result, false);
+  });
+
+  it('returns false for short prompt when keyword is present', () => {
+    const previous = validState({ suppress_followup: true });
+    const result = shouldSuppressFollowup({
+      previous,
+      currentPrompt: 'yes',
+      currentHasKeyword: true,
+    });
+    assert.equal(result, false);
+  });
+});
+
+describe('shouldSuppressFollowup — short prompts (word count <= 6)', () => {
+  const previous = validState({ suppress_followup: true });
+
+  it('"yes" (1 word) → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({ previous, currentPrompt: 'yes', currentHasKeyword: false }),
+      true,
+    );
+  });
+
+  it('"the auth helper" (3 words) → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({ previous, currentPrompt: 'the auth helper', currentHasKeyword: false }),
+      true,
+    );
+  });
+
+  it('"settings page" (2 words) → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({ previous, currentPrompt: 'settings page', currentHasKeyword: false }),
+      true,
+    );
+  });
+
+  it('"yeah do that" (3 words) → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({ previous, currentPrompt: 'yeah do that', currentHasKeyword: false }),
+      true,
+    );
+  });
+
+  it('"one two three four five six" (6 words, boundary) → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'one two three four five six',
+        currentHasKeyword: false,
+      }),
+      true,
+    );
+  });
+});
+
+describe('shouldSuppressFollowup — clarifying starters (longer prompts)', () => {
+  const previous = validState({ suppress_followup: true });
+
+  it('"yes, i want the settings page done please" (7 words, starts with "yes") → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'yes, i want the settings page done please',
+        currentHasKeyword: false,
+      }),
+      true,
+    );
+  });
+
+  it('"yeah that sounds right, go ahead with it" starts with "yeah" → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'yeah that sounds right, go ahead with it',
+        currentHasKeyword: false,
+      }),
+      true,
+    );
+  });
+
+  it('"okay, please proceed with the refactor as discussed" starts with "okay" → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'okay, please proceed with the refactor as discussed',
+        currentHasKeyword: false,
+      }),
+      true,
+    );
+  });
+
+  it('"the settings page button should be blue" starts with "the " → true', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'the settings page button should be blue',
+        currentHasKeyword: false,
+      }),
+      true,
+    );
+  });
+});
+
+describe('shouldSuppressFollowup — long new-goal prompts → false', () => {
+  const previous = validState({ suppress_followup: true });
+
+  it('"implement soft delete across the orm layer" → false', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'implement soft delete across the orm layer',
+        currentHasKeyword: false,
+      }),
+      false,
+    );
+  });
+
+  it('"refactor the auth flow to use session cookies" → false', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'refactor the auth flow to use session cookies',
+        currentHasKeyword: false,
+      }),
+      false,
+    );
+  });
+
+  it('"add dark mode toggle to the settings page" → false', () => {
+    assert.equal(
+      shouldSuppressFollowup({
+        previous,
+        currentPrompt: 'add dark mode toggle to the settings page',
+        currentHasKeyword: false,
+      }),
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. promptSignature
+// ---------------------------------------------------------------------------
+
+describe('promptSignature — format', () => {
+  it('returns a string starting with "sha256:"', () => {
+    const sig = promptSignature('hello world');
+    assert.ok(sig.startsWith('sha256:'), `expected "sha256:" prefix, got "${sig}"`);
+  });
+
+  it('has stable length of 71 chars (7 + 64 hex chars)', () => {
+    const sig = promptSignature('some prompt text');
+    assert.equal(sig.length, 71, `expected length 71, got ${sig.length}`);
+  });
+
+  it('hex portion is exactly 64 lowercase hex characters', () => {
+    const sig = promptSignature('another prompt');
+    const hex = sig.slice('sha256:'.length);
+    assert.match(hex, /^[0-9a-f]{64}$/, `hex portion "${hex}" is not 64 lowercase hex chars`);
+  });
+});
+
+describe('promptSignature — determinism', () => {
+  it('returns identical result across 1000 calls for the same input', () => {
+    const prompt = 'add dark mode toggle to the settings page';
+    const first = promptSignature(prompt);
+    for (let i = 1; i < 1000; i++) {
+      assert.equal(promptSignature(prompt), first, `call ${i} returned different signature`);
+    }
+  });
+});
+
+describe('promptSignature — collision resistance', () => {
+  it('different inputs produce different signatures', () => {
+    const inputs = [
+      'implement soft delete across the orm layer',
+      'fix typo in src/foo.ts',
+      'add dark mode toggle to the settings page',
+    ];
+    const sigs = inputs.map(promptSignature);
+    const unique = new Set(sigs);
+    assert.equal(unique.size, inputs.length, `expected ${inputs.length} unique signatures, got ${unique.size}`);
+  });
+
+  it('empty string has a distinct signature', () => {
+    assert.notEqual(promptSignature(''), promptSignature('a'));
+  });
+
+  it('signatures differ for whitespace-normalised variants', () => {
+    // The function hashes what it receives; callers normalise before calling.
+    assert.notEqual(promptSignature('hello world'), promptSignature('hello  world'));
+  });
+});

--- a/src/hooks/triage-config.ts
+++ b/src/hooks/triage-config.ts
@@ -2,7 +2,8 @@
  * Triage Feature Gate Config Reader
  *
  * Reads promptRouting.triage.enabled from codexHome()/.omx-config.json.
- * Defaults to enabled when the config file is absent (rollout default).
+ * Defaults to enabled when the config file is absent or the triage flag is
+ * omitted from an otherwise valid config object (rollout default).
  * Fails closed (enabled: false) when the file exists but is malformed.
  */
 
@@ -28,6 +29,7 @@ let cachedTriageConfig: TriageConfig | undefined;
  * Source: promptRouting.triage.enabled in codexHome()/.omx-config.json
  *
  * - Missing file → enabled: true, status: "defaulted" (rollout default)
+ * - Valid object that omits promptRouting.triage.enabled → enabled: true, status: "defaulted"
  * - File with enabled: true → enabled: true, status: "enabled"
  * - File with enabled: false → enabled: false, status: "disabled"
  * - Malformed JSON or wrong shape → enabled: false, status: "invalid" (fail closed)
@@ -46,28 +48,37 @@ export function readTriageConfig(): TriageConfig {
   try {
     const raw: unknown = JSON.parse(readFileSync(path, "utf-8"));
 
-    if (!raw || typeof raw !== "object") {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
       cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
       return cachedTriageConfig;
     }
 
     const root = raw as Record<string, unknown>;
     const promptRouting = root["promptRouting"];
-
-    if (!promptRouting || typeof promptRouting !== "object") {
+    if (promptRouting === undefined) {
+      cachedTriageConfig = { enabled: true, status: "defaulted", source: "default", path };
+      return cachedTriageConfig;
+    }
+    if (!promptRouting || typeof promptRouting !== "object" || Array.isArray(promptRouting)) {
       cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
       return cachedTriageConfig;
     }
 
     const triage = (promptRouting as Record<string, unknown>)["triage"];
-
-    if (!triage || typeof triage !== "object") {
+    if (triage === undefined) {
+      cachedTriageConfig = { enabled: true, status: "defaulted", source: "default", path };
+      return cachedTriageConfig;
+    }
+    if (!triage || typeof triage !== "object" || Array.isArray(triage)) {
       cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
       return cachedTriageConfig;
     }
 
     const triageEnabled = (triage as Record<string, unknown>)["enabled"];
-
+    if (triageEnabled === undefined) {
+      cachedTriageConfig = { enabled: true, status: "defaulted", source: "default", path };
+      return cachedTriageConfig;
+    }
     if (typeof triageEnabled !== "boolean") {
       cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
       return cachedTriageConfig;

--- a/src/hooks/triage-config.ts
+++ b/src/hooks/triage-config.ts
@@ -1,0 +1,94 @@
+/**
+ * Triage Feature Gate Config Reader
+ *
+ * Reads promptRouting.triage.enabled from codexHome()/.omx-config.json.
+ * Defaults to enabled when the config file is absent (rollout default).
+ * Fails closed (enabled: false) when the file exists but is malformed.
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { codexHome } from "../utils/paths.js";
+
+export type TriageConfigStatus = "enabled" | "disabled" | "defaulted" | "invalid";
+
+export interface TriageConfig {
+  enabled: boolean;
+  status: TriageConfigStatus;
+  source: "default" | "file" | "invalid";
+  path: string;
+}
+
+/** Cached triage config. `undefined` = not yet read. */
+let cachedTriageConfig: TriageConfig | undefined;
+
+/**
+ * Read and cache the triage feature gate config.
+ *
+ * Source: promptRouting.triage.enabled in codexHome()/.omx-config.json
+ *
+ * - Missing file → enabled: true, status: "defaulted" (rollout default)
+ * - File with enabled: true → enabled: true, status: "enabled"
+ * - File with enabled: false → enabled: false, status: "disabled"
+ * - Malformed JSON or wrong shape → enabled: false, status: "invalid" (fail closed)
+ * - Caches result for the process lifetime
+ */
+export function readTriageConfig(): TriageConfig {
+  if (cachedTriageConfig !== undefined) return cachedTriageConfig;
+
+  const path = join(codexHome(), ".omx-config.json");
+
+  if (!existsSync(path)) {
+    cachedTriageConfig = { enabled: true, status: "defaulted", source: "default", path };
+    return cachedTriageConfig;
+  }
+
+  try {
+    const raw: unknown = JSON.parse(readFileSync(path, "utf-8"));
+
+    if (!raw || typeof raw !== "object") {
+      cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
+      return cachedTriageConfig;
+    }
+
+    const root = raw as Record<string, unknown>;
+    const promptRouting = root["promptRouting"];
+
+    if (!promptRouting || typeof promptRouting !== "object") {
+      cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
+      return cachedTriageConfig;
+    }
+
+    const triage = (promptRouting as Record<string, unknown>)["triage"];
+
+    if (!triage || typeof triage !== "object") {
+      cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
+      return cachedTriageConfig;
+    }
+
+    const triageEnabled = (triage as Record<string, unknown>)["enabled"];
+
+    if (typeof triageEnabled !== "boolean") {
+      cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
+      return cachedTriageConfig;
+    }
+
+    cachedTriageConfig = {
+      enabled: triageEnabled,
+      status: triageEnabled ? "enabled" : "disabled",
+      source: "file",
+      path,
+    };
+    return cachedTriageConfig;
+  } catch {
+    cachedTriageConfig = { enabled: false, status: "invalid", source: "invalid", path };
+    return cachedTriageConfig;
+  }
+}
+
+/**
+ * Clear the cached triage config. Call in tests to reset state.
+ */
+export function resetTriageConfigCache(): void {
+  cachedTriageConfig = undefined;
+}

--- a/src/hooks/triage-heuristic.ts
+++ b/src/hooks/triage-heuristic.ts
@@ -64,7 +64,6 @@ const DESIGNER_STARTERS: readonly string[] = [
   "color ",
   "adjust spacing",
   "ui ",
-  "redesign ",
   "change the color",
   "change the font",
   "change the style",
@@ -73,6 +72,24 @@ const DESIGNER_STARTERS: readonly string[] = [
   "change the design",
   "change the layout",
   "update the layout",
+];
+
+/**
+ * Terms that make broad design verbs visual/UI-specific enough for designer.
+ * Keep these intentionally concrete so product, architecture, auth, and
+ * deployment redesign prompts can continue to reach the safer HEAVY path.
+ */
+const VISUAL_DESIGN_TERMS: RegExp[] = [
+  /\b(?:ui|ux|visual|style|styling|css|layout|spacing|color|font|typography)\b/,
+  /\b(?:button|page|screen|panel|modal|form|navbar|sidebar|header|footer|card|component)\b/,
+];
+
+const BROAD_DESIGN_STARTERS: readonly string[] = [
+  "redesign ",
+];
+
+const STRUCTURAL_REDESIGN_TERMS: RegExp[] = [
+  /\b(?:auth|authentication|authorization|flow|pipeline|deployment|deploy|architecture|system|api|backend|database|data|schema|orm|infra|infrastructure)\b/,
 ];
 
 /**
@@ -190,6 +207,11 @@ export function triagePrompt(prompt: string): TriageDecision {
       return { lane: "LIGHT", destination: "designer", reason: "visual_styling_prompt" };
     }
   }
+  for (const starter of BROAD_DESIGN_STARTERS) {
+    if (normalized.startsWith(starter) && VISUAL_DESIGN_TERMS.some((pattern) => pattern.test(normalized))) {
+      return { lane: "LIGHT", destination: "designer", reason: "visual_styling_prompt" };
+    }
+  }
 
   // ── Rule 5: Short anchored edit → LIGHT/executor ─────────────────────────
   if (wordCount <= ANCHORED_EDIT_WORD_LIMIT) {
@@ -201,6 +223,13 @@ export function triagePrompt(prompt: string): TriageDecision {
   }
 
   // ── Rule 6: Longer goal-shaped imperative → HEAVY ────────────────────────
+  if (
+    BROAD_DESIGN_STARTERS.some((starter) => normalized.startsWith(starter)) &&
+    STRUCTURAL_REDESIGN_TERMS.some((pattern) => pattern.test(normalized))
+  ) {
+    return { lane: "HEAVY", destination: "autopilot", reason: "structural_redesign_goal" };
+  }
+
   if (wordCount > HEAVY_WORD_THRESHOLD) {
     for (const verb of HEAVY_IMPERATIVE_VERBS) {
       if (normalized.startsWith(verb)) {

--- a/src/hooks/triage-heuristic.ts
+++ b/src/hooks/triage-heuristic.ts
@@ -201,7 +201,15 @@ export function triagePrompt(prompt: string): TriageDecision {
     return { lane: "LIGHT", destination: "explore", reason: "short_question" };
   }
 
-  // ── Rule 4: Obvious visual / styling → LIGHT/designer ────────────────────
+  // ── Rule 4: Structural redesign goals → HEAVY ────────────────────────────
+  if (
+    BROAD_DESIGN_STARTERS.some((starter) => normalized.startsWith(starter)) &&
+    STRUCTURAL_REDESIGN_TERMS.some((pattern) => pattern.test(normalized))
+  ) {
+    return { lane: "HEAVY", destination: "autopilot", reason: "structural_redesign_goal" };
+  }
+
+  // ── Rule 5: Obvious visual / styling → LIGHT/designer ────────────────────
   for (const starter of DESIGNER_STARTERS) {
     if (normalized.startsWith(starter)) {
       return { lane: "LIGHT", destination: "designer", reason: "visual_styling_prompt" };
@@ -213,7 +221,7 @@ export function triagePrompt(prompt: string): TriageDecision {
     }
   }
 
-  // ── Rule 5: Short anchored edit → LIGHT/executor ─────────────────────────
+  // ── Rule 6: Short anchored edit → LIGHT/executor ─────────────────────────
   if (wordCount <= ANCHORED_EDIT_WORD_LIMIT) {
     for (const pattern of EXECUTOR_ANCHOR_PATTERNS) {
       if (pattern.test(normalized)) {
@@ -222,14 +230,7 @@ export function triagePrompt(prompt: string): TriageDecision {
     }
   }
 
-  // ── Rule 6: Longer goal-shaped imperative → HEAVY ────────────────────────
-  if (
-    BROAD_DESIGN_STARTERS.some((starter) => normalized.startsWith(starter)) &&
-    STRUCTURAL_REDESIGN_TERMS.some((pattern) => pattern.test(normalized))
-  ) {
-    return { lane: "HEAVY", destination: "autopilot", reason: "structural_redesign_goal" };
-  }
-
+  // ── Rule 7: Longer goal-shaped imperative → HEAVY ────────────────────────
   if (wordCount > HEAVY_WORD_THRESHOLD) {
     for (const verb of HEAVY_IMPERATIVE_VERBS) {
       if (normalized.startsWith(verb)) {
@@ -238,6 +239,6 @@ export function triagePrompt(prompt: string): TriageDecision {
     }
   }
 
-  // ── Rule 7: Fallback → PASS ───────────────────────────────────────────────
+  // ── Rule 8: Fallback → PASS ───────────────────────────────────────────────
   return { lane: "PASS", reason: "ambiguous_short_prompt" };
 }

--- a/src/hooks/triage-heuristic.ts
+++ b/src/hooks/triage-heuristic.ts
@@ -1,0 +1,214 @@
+/**
+ * Triage Heuristic
+ *
+ * Pure, synchronous classifier for a 3-lane prompt triage system.
+ * Advisory-only — never activates workflows, never touches state or fs.
+ *
+ * Lanes:
+ *   PASS  — trivial acknowledgements, explicit opt-out phrases, or ambiguous short prompts
+ *   LIGHT — single-agent destination: explore | executor | designer
+ *   HEAVY — autopilot; longer goal-shaped imperative prompts
+ */
+
+export type TriageLane = "HEAVY" | "LIGHT" | "PASS";
+export type LightDestination = "explore" | "executor" | "designer";
+
+export interface TriageDecision {
+  lane: TriageLane;
+  destination?: LightDestination | "autopilot";
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Module-scope constants (precompiled once)
+// ---------------------------------------------------------------------------
+
+/** Prompts that are trivially empty acknowledgements */
+const TRIVIAL_PATTERNS: RegExp[] = [
+  /^(?:hi+|hey|hello|thanks?|thank\s+you|yes|no|ok(?:ay)?|sure|great|good|got\s+it|sounds?\s+good|yep|yup|nope|cool|awesome|perfect)\.?$/,
+];
+
+/** Explicit opt-out substrings — checked as case-insensitive includes */
+const OPT_OUT_PHRASES: readonly string[] = [
+  "just chat",
+  "plain answer",
+  "no workflow",
+  "don't route",
+  "do not route",
+  "don't use a skill",
+  "do not use a skill",
+  "talk through",
+  "explain only",
+];
+
+/** Starters that indicate an explanatory / question prompt → LIGHT/explore */
+const EXPLORE_STARTERS: readonly string[] = [
+  "explain ",
+  "what ",
+  "where ",
+  "why ",
+  "how does ",
+  "how do ",
+  "how is ",
+  "tell me about ",
+  "describe ",
+  "show me how ",
+  "can you explain ",
+  "could you explain ",
+];
+
+/** Starters / keywords for visual / styling prompts → LIGHT/designer */
+const DESIGNER_STARTERS: readonly string[] = [
+  "make the button",
+  "style ",
+  "color ",
+  "adjust spacing",
+  "ui ",
+  "redesign ",
+  "change the color",
+  "change the font",
+  "change the style",
+  "update the style",
+  "update the design",
+  "change the design",
+  "change the layout",
+  "update the layout",
+];
+
+/**
+ * Patterns that indicate a short, anchored edit → LIGHT/executor
+ * Anchors: file path (src/...), line reference, rename/fix-typo phrase.
+ */
+const EXECUTOR_ANCHOR_PATTERNS: RegExp[] = [
+  // file path pattern: word chars / word chars . ext
+  /\bsrc\/[\w./\-]+\.\w+\b/,
+  /\blib\/[\w./\-]+\.\w+\b/,
+  /\btest\/[\w./\-]+\.\w+\b/,
+  /\bspec\/[\w./\-]+\.\w+\b/,
+  // line number reference
+  /\bline\s+\d+\b/,
+  // rename in file
+  /\brename\b.+\bin\b/,
+  // fix typo in
+  /\bfix\s+typo\s+in\b/,
+  // add X to line / add null check to line
+  /\badd\b.+\bto\s+line\s+\d+\b/,
+];
+
+/**
+ * Imperative verbs that, combined with sufficient word count and no anchor,
+ * signal a HEAVY goal-shaped prompt.
+ */
+const HEAVY_IMPERATIVE_VERBS: readonly string[] = [
+  "add ",
+  "implement ",
+  "refactor ",
+  "build ",
+  "create ",
+  "migrate ",
+  "rewrite ",
+  "redesign ",
+  "integrate ",
+  "set up ",
+  "configure ",
+  "extract ",
+  "split ",
+  "merge ",
+  "update ",
+  "remove ",
+  "delete ",
+  "replace ",
+  "convert ",
+  "generate ",
+  "scaffold ",
+  "deploy ",
+  "automate ",
+];
+
+/**
+ * Word count threshold: prompts with MORE than this many words that start with
+ * an imperative verb are classified HEAVY. Set to 5 so that 6+ word imperative
+ * prompts (e.g. "add dark mode toggle to the settings page" = 8 words) route
+ * correctly while ultra-short imperatives (≤5 words) fall through to PASS.
+ */
+const HEAVY_WORD_THRESHOLD = 5;
+
+/**
+ * Upper bound (inclusive) on word count for a short "?"-ending prompt to still
+ * count as an exploration question. Longer interrogative prompts fall through
+ * to later rules (which may classify them as HEAVY or PASS).
+ */
+const SHORT_QUESTION_WORD_LIMIT = 10;
+
+/**
+ * Upper bound (inclusive) on word count for a prompt to still qualify as a
+ * short anchored edit (LIGHT/executor). Longer anchored prompts are treated as
+ * goal-shaped work and may be classified HEAVY by later rules instead.
+ */
+const ANCHORED_EDIT_WORD_LIMIT = 15;
+
+// ---------------------------------------------------------------------------
+// Main classifier
+// ---------------------------------------------------------------------------
+
+export function triagePrompt(prompt: string): TriageDecision {
+  const normalized = prompt.trim().toLowerCase();
+  const wordCount = normalized.length === 0 ? 0 : normalized.split(/\s+/).length;
+
+  // ── Rule 1: Empty / trivial acknowledgements → PASS ──────────────────────
+  if (normalized.length === 0) {
+    return { lane: "PASS", reason: "empty_input" };
+  }
+
+  for (const pattern of TRIVIAL_PATTERNS) {
+    if (pattern.test(normalized)) {
+      return { lane: "PASS", reason: "trivial_acknowledgement" };
+    }
+  }
+
+  // ── Rule 2: Explicit opt-out → PASS ──────────────────────────────────────
+  for (const phrase of OPT_OUT_PHRASES) {
+    if (normalized.includes(phrase)) {
+      return { lane: "PASS", reason: "explicit_opt_out" };
+    }
+  }
+
+  // ── Rule 3: Obvious question / explanation → LIGHT/explore ───────────────
+  for (const starter of EXPLORE_STARTERS) {
+    if (normalized.startsWith(starter)) {
+      return { lane: "LIGHT", destination: "explore", reason: "question_or_explanation" };
+    }
+  }
+  // Short prompt ending with "?" is also an exploration signal
+  if (wordCount <= SHORT_QUESTION_WORD_LIMIT && normalized.endsWith("?")) {
+    return { lane: "LIGHT", destination: "explore", reason: "short_question" };
+  }
+
+  // ── Rule 4: Obvious visual / styling → LIGHT/designer ────────────────────
+  for (const starter of DESIGNER_STARTERS) {
+    if (normalized.startsWith(starter)) {
+      return { lane: "LIGHT", destination: "designer", reason: "visual_styling_prompt" };
+    }
+  }
+
+  // ── Rule 5: Short anchored edit → LIGHT/executor ─────────────────────────
+  if (wordCount <= ANCHORED_EDIT_WORD_LIMIT) {
+    for (const pattern of EXECUTOR_ANCHOR_PATTERNS) {
+      if (pattern.test(normalized)) {
+        return { lane: "LIGHT", destination: "executor", reason: "anchored_edit" };
+      }
+    }
+  }
+
+  // ── Rule 6: Longer goal-shaped imperative → HEAVY ────────────────────────
+  if (wordCount > HEAVY_WORD_THRESHOLD) {
+    for (const verb of HEAVY_IMPERATIVE_VERBS) {
+      if (normalized.startsWith(verb)) {
+        return { lane: "HEAVY", destination: "autopilot", reason: "long_imperative_goal" };
+      }
+    }
+  }
+
+  // ── Rule 7: Fallback → PASS ───────────────────────────────────────────────
+  return { lane: "PASS", reason: "ambiguous_short_prompt" };
+}

--- a/src/hooks/triage-state.ts
+++ b/src/hooks/triage-state.ts
@@ -45,16 +45,13 @@ export interface TriageStateFile {
 
 const STATE_FILENAME = 'prompt-routing-state.json';
 
-function resolveStatePath(workingDirectory?: string, sessionId?: string | null): string {
-  // Defense-in-depth: reject any sessionId that does not match the canonical pattern
-  // before it reaches getStateDir, so a malformed id can never escape the state dir.
-  const safeSessionId =
-    typeof sessionId === 'string' && SESSION_ID_PATTERN.test(sessionId)
-      ? sessionId
-      : undefined;
+function resolveStatePath(workingDirectory?: string, sessionId?: string | null): string | null {
+  if (typeof sessionId === 'string' && !SESSION_ID_PATTERN.test(sessionId)) {
+    return null;
+  }
   // getStateDir returns .omx/state/sessions/<sessionId>/ when sessionId is provided,
   // or .omx/state/ as the root fallback — exactly the paths we need.
-  const stateDir = getStateDir(workingDirectory ?? undefined, safeSessionId);
+  const stateDir = getStateDir(workingDirectory ?? undefined, sessionId ?? undefined);
   return join(stateDir, STATE_FILENAME);
 }
 
@@ -70,6 +67,7 @@ export interface ReadTriageStateArgs {
 export function readTriageState(args: ReadTriageStateArgs): TriageStateFile | null {
   try {
     const filePath = resolveStatePath(args.cwd, args.sessionId);
+    if (!filePath) return null;
     const raw = readFileSync(filePath, 'utf-8');
     const parsed: unknown = JSON.parse(raw);
     if (!isTriageStateFile(parsed)) return null;
@@ -90,6 +88,7 @@ export interface WriteTriageStateArgs extends ReadTriageStateArgs {
 export function writeTriageState(args: WriteTriageStateArgs): void {
   try {
     const filePath = resolveStatePath(args.cwd, args.sessionId);
+    if (!filePath) return;
     const dir = dirname(filePath);
     mkdirSync(dir, { recursive: true });
 
@@ -149,9 +148,8 @@ const CLARIFYING_STARTERS: readonly string[] = [
  *   1. A prior triage exists (previous?.last_triage != null).
  *   2. previous.suppress_followup === true.
  *   3. currentHasKeyword === false (keywords always bypass triage).
- *   4. The current prompt looks like a short clarifying reply:
- *      - word count <= 6, OR
- *      - starts with a clarifying token.
+ *   4. The current prompt looks like a clarifying reply and starts with a
+ *      known clarifying token. Short length alone is not enough.
  */
 export function shouldSuppressFollowup(args: ShouldSuppressArgs): boolean {
   if (args.currentHasKeyword) return false;
@@ -159,10 +157,6 @@ export function shouldSuppressFollowup(args: ShouldSuppressArgs): boolean {
   if (!args.previous.suppress_followup) return false;
 
   const prompt = args.currentPrompt; // already normalized (trim + lowercase)
-  const wordCount = prompt.length === 0 ? 0 : prompt.split(/\s+/).length;
-
-  if (wordCount <= 6) return true;
-
   for (const token of CLARIFYING_STARTERS) {
     if (prompt.startsWith(token)) return true;
   }

--- a/src/hooks/triage-state.ts
+++ b/src/hooks/triage-state.ts
@@ -1,0 +1,200 @@
+/**
+ * Triage State
+ *
+ * Session-scoped state helper for prompt-routing triage.
+ * Independent of workflow mode state (ralph-state.json, skill-active-state.json, etc.).
+ *
+ * File location:
+ *   With session id : .omx/state/sessions/<session_id>/prompt-routing-state.json
+ *   Without session id: .omx/state/prompt-routing-state.json
+ *
+ * Rules:
+ *   - Write ONLY for HEAVY/LIGHT decisions (never for PASS).
+ *   - Keyword routing must not write triage state (caller's responsibility).
+ *   - Missing or malformed file returns null from readTriageState, never throws.
+ */
+
+import { createHash } from 'crypto';
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { SESSION_ID_PATTERN, getStateDir } from '../mcp/state-paths.js';
+
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
+
+export interface TriageStateFile {
+  version: 1;
+  last_triage: {
+    lane: "HEAVY" | "LIGHT";
+    destination: "autopilot" | "explore" | "executor" | "designer";
+    reason: string;
+    /** sha256 of the normalized prompt, prefixed with "sha256:" */
+    prompt_signature: string;
+    /** Best-effort turn marker; ISO timestamp or monotonic counter */
+    turn_id: string;
+    /** ISO timestamp */
+    created_at: string;
+  } | null;
+  suppress_followup: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+const STATE_FILENAME = 'prompt-routing-state.json';
+
+function resolveStatePath(workingDirectory?: string, sessionId?: string | null): string {
+  // Defense-in-depth: reject any sessionId that does not match the canonical pattern
+  // before it reaches getStateDir, so a malformed id can never escape the state dir.
+  const safeSessionId =
+    typeof sessionId === 'string' && SESSION_ID_PATTERN.test(sessionId)
+      ? sessionId
+      : undefined;
+  // getStateDir returns .omx/state/sessions/<sessionId>/ when sessionId is provided,
+  // or .omx/state/ as the root fallback — exactly the paths we need.
+  const stateDir = getStateDir(workingDirectory ?? undefined, safeSessionId);
+  return join(stateDir, STATE_FILENAME);
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+export interface ReadTriageStateArgs {
+  sessionId?: string | null;
+  cwd?: string;
+}
+
+export function readTriageState(args: ReadTriageStateArgs): TriageStateFile | null {
+  try {
+    const filePath = resolveStatePath(args.cwd, args.sessionId);
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!isTriageStateFile(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+export interface WriteTriageStateArgs extends ReadTriageStateArgs {
+  state: TriageStateFile;
+}
+
+export function writeTriageState(args: WriteTriageStateArgs): void {
+  try {
+    const filePath = resolveStatePath(args.cwd, args.sessionId);
+    const dir = dirname(filePath);
+    mkdirSync(dir, { recursive: true });
+
+    const content = JSON.stringify(args.state, null, 2);
+
+    // Atomic-ish write: write to temp file, then rename.
+    const tmpPath = `${filePath}.tmp`;
+    writeFileSync(tmpPath, content, 'utf-8');
+    renameSync(tmpPath, filePath);
+  } catch {
+    // Swallow filesystem errors — a broken state file must never break the hook.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt signature
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a sha256 hex digest of the normalized prompt, prefixed with "sha256:".
+ */
+export function promptSignature(normalizedPrompt: string): string {
+  return 'sha256:' + createHash('sha256').update(normalizedPrompt, 'utf-8').digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Suppression logic
+// ---------------------------------------------------------------------------
+
+export interface ShouldSuppressArgs {
+  previous: TriageStateFile | null;
+  /** Normalized prompt: trim + lowercase */
+  currentPrompt: string;
+  /** Keyword routing always bypasses suppression */
+  currentHasKeyword: boolean;
+}
+
+/** Clarifying tokens that indicate a short follow-up reply */
+const CLARIFYING_STARTERS: readonly string[] = [
+  'yes',
+  'no',
+  'yeah',
+  'nope',
+  'ok',
+  'okay',
+  'the ',
+  'that',
+  'those',
+  'it',
+];
+
+/**
+ * Returns true when the current prompt should suppress triage re-injection
+ * because it looks like a short follow-up to a prior HEAVY/LIGHT triage turn.
+ *
+ * Suppression conditions (all must hold):
+ *   1. A prior triage exists (previous?.last_triage != null).
+ *   2. previous.suppress_followup === true.
+ *   3. currentHasKeyword === false (keywords always bypass triage).
+ *   4. The current prompt looks like a short clarifying reply:
+ *      - word count <= 6, OR
+ *      - starts with a clarifying token.
+ */
+export function shouldSuppressFollowup(args: ShouldSuppressArgs): boolean {
+  if (args.currentHasKeyword) return false;
+  if (!args.previous?.last_triage) return false;
+  if (!args.previous.suppress_followup) return false;
+
+  const prompt = args.currentPrompt; // already normalized (trim + lowercase)
+  const wordCount = prompt.length === 0 ? 0 : prompt.split(/\s+/).length;
+
+  if (wordCount <= 6) return true;
+
+  for (const token of CLARIFYING_STARTERS) {
+    if (prompt.startsWith(token)) return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime type guard
+// ---------------------------------------------------------------------------
+
+function isTriageStateFile(value: unknown): value is TriageStateFile {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+
+  if (v['version'] !== 1) return false;
+  if (typeof v['suppress_followup'] !== 'boolean') return false;
+
+  if (v['last_triage'] === null) return true;
+
+  if (typeof v['last_triage'] !== 'object' || v['last_triage'] === null) return false;
+  const lt = v['last_triage'] as Record<string, unknown>;
+
+  return (
+    (lt['lane'] === 'HEAVY' || lt['lane'] === 'LIGHT') &&
+    (lt['destination'] === 'autopilot' ||
+      lt['destination'] === 'explore' ||
+      lt['destination'] === 'executor' ||
+      lt['destination'] === 'designer') &&
+    typeof lt['reason'] === 'string' &&
+    typeof lt['prompt_signature'] === 'string' &&
+    typeof lt['turn_id'] === 'string' &&
+    typeof lt['created_at'] === 'string'
+  );
+}

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -483,7 +483,14 @@ describe("codex native hook dispatch", () => {
 
       assert.equal(result.omxEventName, "keyword-detector");
       assert.equal(result.skillState, null);
-      assert.equal(result.outputJson, null);
+      // Triage may inject advisory LIGHT/explore context for the question-shaped
+      // prompt, but the invariant this test guards is that no Ralph workflow state
+      // is seeded and no Ralph-activation message is emitted.
+      const advisoryContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.doesNotMatch(advisoryContext, /skill:\s*ralph/i);
+      assert.doesNotMatch(advisoryContext, /ralph-state\.json/i);
       assert.equal(existsSync(join(cwd, ".omx", "state", "skill-active-state.json")), false);
       assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-ralph-plain-text", "skill-active-state.json")), false);
       assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "sess-ralph-plain-text", "ralph-state.json")), false);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4582,4 +4582,109 @@ describe("codex native hook triage integration", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("keeps triage default-enabled when config omits promptRouting.triage.enabled", async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), "omx-triage-config-omitted-home-"));
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-config-omitted-cwd-"));
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      await writeJson(join(tmpHome, ".omx-config.json"), {
+        promptRouting: {},
+      });
+      process.env.CODEX_HOME = tmpHome;
+      resetTriageConfigCache();
+
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-defaulted-1",
+          thread_id: "thread-triage-defaulted-1",
+          turn_id: "turn-triage-defaulted-1",
+          prompt: "add dark mode toggle to the settings page",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /multi-step goal with no workflow keyword/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-defaulted-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), true);
+    } finally {
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      resetTriageConfigCache();
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not suppress a short anchored follow-up that is a new request", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-short-new-request-"));
+    const sessionId = "triage-short-new-request-1";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-short-new-request-1",
+          turn_id: "turn-short-new-request-1",
+          prompt: "add dark mode toggle to the settings page",
+        },
+        { cwd },
+      );
+
+      const turn2 = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-short-new-request-1",
+          turn_id: "turn-short-new-request-2",
+          prompt: "fix typo in src/foo.ts",
+        },
+        { cwd },
+      );
+
+      const ctx2 = String(
+        (turn2.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(ctx2, /narrow edit-shaped/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips triage state persistence for malformed explicit session ids without writing root state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-invalid-session-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "bad/session",
+          thread_id: "thread-triage-invalid-session-1",
+          turn_id: "turn-triage-invalid-session-1",
+          prompt: "add dark mode toggle to the settings page",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /multi-step goal with no workflow keyword/);
+      assert.equal(existsSync(join(cwd, ".omx", "state", "prompt-routing-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -18,6 +18,7 @@ import {
   resolveSessionOwnerPidFromAncestry,
 } from "../codex-native-hook.js";
 import { writeSessionStart } from "../../hooks/session.js";
+import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 
 async function writeJson(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true }).catch(() => {});
@@ -3988,6 +3989,589 @@ esac
       assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson, null);
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Triage layer integration tests
+// ---------------------------------------------------------------------------
+
+describe("codex native hook triage integration", () => {
+  const priorCodexHome = process.env.CODEX_HOME;
+
+  beforeEach(() => {
+    resetTriageConfigCache();
+  });
+
+  afterEach(() => {
+    if (typeof priorCodexHome === "string") process.env.CODEX_HOME = priorCodexHome;
+    else delete process.env.CODEX_HOME;
+    resetTriageConfigCache();
+  });
+
+  // ── Group 1: Keyword bypass (triage must NOT run) ────────────────────────
+
+  it("does not inject triage advisory for $ralplan keyword prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-keyword-ralplan-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-kw-ralplan-1",
+          thread_id: "thread-triage-kw-1",
+          turn_id: "turn-triage-kw-1",
+          prompt: "$ralplan implement issue #1307",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(additionalContext, /multi-step goal with no workflow keyword/);
+      assert.doesNotMatch(additionalContext, /read-only\/question-shaped/);
+      assert.doesNotMatch(additionalContext, /narrow edit-shaped/);
+      assert.doesNotMatch(additionalContext, /visual\/style request/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-kw-ralplan-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not inject triage advisory for autopilot keyword prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-keyword-autopilot-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-kw-autopilot-1",
+          thread_id: "thread-triage-kw-ap-1",
+          turn_id: "turn-triage-kw-ap-1",
+          prompt: "$autopilot build this",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(additionalContext, /multi-step goal with no workflow keyword/);
+      assert.doesNotMatch(additionalContext, /read-only\/question-shaped/);
+      assert.doesNotMatch(additionalContext, /narrow edit-shaped/);
+      assert.doesNotMatch(additionalContext, /visual\/style request/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-kw-autopilot-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 2: HEAVY injection ─────────────────────────────────────────────
+
+  it("injects HEAVY advisory and writes prompt-routing-state for a multi-step goal prompt", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-heavy-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-heavy-1",
+          thread_id: "thread-triage-heavy-1",
+          turn_id: "turn-triage-heavy-1",
+          prompt: "add dark mode toggle to the settings page",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /multi-step goal with no workflow keyword/);
+      assert.match(additionalContext, /Prefer the existing autopilot-style workflow/);
+
+      // skill-active-state.json must NOT be written (triage is advisory only)
+      assert.equal(existsSync(join(cwd, ".omx", "state", "skill-active-state.json")), false);
+
+      // prompt-routing-state.json must be written with lane=HEAVY
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-heavy-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), true);
+      const state = JSON.parse(await readFile(stateFile, "utf-8")) as {
+        version?: number;
+        last_triage?: { lane?: string; destination?: string };
+        suppress_followup?: boolean;
+      };
+      assert.equal(state.version, 1);
+      assert.equal(state.last_triage?.lane, "HEAVY");
+      assert.equal(state.last_triage?.destination, "autopilot");
+      assert.equal(state.suppress_followup, true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 3: LIGHT/explore ────────────────────────────────────────────────
+
+  it("injects LIGHT/explore advisory and writes state for a question-shaped prompt", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-light-explore-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-explore-1",
+          thread_id: "thread-triage-explore-1",
+          turn_id: "turn-triage-explore-1",
+          prompt: "explain this function",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /read-only\/question-shaped/);
+      assert.match(additionalContext, /Prefer the explore role surface/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-explore-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), true);
+      const state = JSON.parse(await readFile(stateFile, "utf-8")) as {
+        last_triage?: { lane?: string; destination?: string };
+        suppress_followup?: boolean;
+      };
+      assert.equal(state.last_triage?.lane, "LIGHT");
+      assert.equal(state.last_triage?.destination, "explore");
+      assert.equal(state.suppress_followup, true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 4: LIGHT/executor ───────────────────────────────────────────────
+
+  it("injects LIGHT/executor advisory and writes state for a narrow edit-shaped prompt", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-light-executor-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-executor-1",
+          thread_id: "thread-triage-executor-1",
+          turn_id: "turn-triage-executor-1",
+          prompt: "fix typo in src/foo.ts",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /narrow edit-shaped/);
+      assert.match(additionalContext, /Prefer the executor role surface/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-executor-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), true);
+      const state = JSON.parse(await readFile(stateFile, "utf-8")) as {
+        last_triage?: { lane?: string; destination?: string };
+      };
+      assert.equal(state.last_triage?.lane, "LIGHT");
+      assert.equal(state.last_triage?.destination, "executor");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 5: LIGHT/designer ───────────────────────────────────────────────
+
+  it("injects LIGHT/designer advisory and writes state for a visual/style prompt", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-light-designer-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-designer-1",
+          thread_id: "thread-triage-designer-1",
+          turn_id: "turn-triage-designer-1",
+          prompt: "make the button blue",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(additionalContext, /visual\/style request/);
+      assert.match(additionalContext, /Prefer the designer role surface/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-designer-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), true);
+      const state = JSON.parse(await readFile(stateFile, "utf-8")) as {
+        last_triage?: { lane?: string; destination?: string };
+      };
+      assert.equal(state.last_triage?.lane, "LIGHT");
+      assert.equal(state.last_triage?.destination, "designer");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 6: PASS (no triage injection, no state) ────────────────────────
+
+  it("produces no triage advisory and no state for trivial greeting prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-pass-hello-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-pass-hello-1",
+          thread_id: "thread-triage-pass-1",
+          turn_id: "turn-triage-pass-1",
+          prompt: "hello",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(additionalContext, /multi-step goal with no workflow keyword/);
+      assert.doesNotMatch(additionalContext, /read-only\/question-shaped/);
+      assert.doesNotMatch(additionalContext, /narrow edit-shaped/);
+      assert.doesNotMatch(additionalContext, /visual\/style request/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-pass-hello-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("produces no triage advisory and no state for ambiguous short prompts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-pass-short-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-pass-short-1",
+          thread_id: "thread-triage-pass-short-1",
+          turn_id: "turn-triage-pass-short-1",
+          prompt: "fix the thing",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(additionalContext, /multi-step goal with no workflow keyword/);
+      assert.doesNotMatch(additionalContext, /read-only\/question-shaped/);
+      assert.doesNotMatch(additionalContext, /narrow edit-shaped/);
+      assert.doesNotMatch(additionalContext, /visual\/style request/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-pass-short-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 7: Turn-2 suppression (same session across two invocations) ────
+
+  it("suppresses HEAVY triage re-injection on a short follow-up in the same session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-suppress-heavy-"));
+    const sessionId = "triage-suppress-heavy-1";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      // Turn 1: HEAVY fires
+      const turn1 = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-suppress-heavy-1",
+          turn_id: "turn-suppress-heavy-1",
+          prompt: "add dark mode toggle to the settings page",
+        },
+        { cwd },
+      );
+      const ctx1 = String(
+        (turn1.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(ctx1, /multi-step goal with no workflow keyword/);
+
+      // Turn 2: short follow-up — triage suppressed
+      const turn2 = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-suppress-heavy-1",
+          turn_id: "turn-suppress-heavy-2",
+          prompt: "yes, settings page",
+        },
+        { cwd },
+      );
+      const ctx2 = String(
+        (turn2.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(ctx2, /multi-step goal/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses LIGHT/explore triage re-injection on a short follow-up in the same session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-suppress-explore-"));
+    const sessionId = "triage-suppress-explore-1";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      // Turn 1: LIGHT/explore fires
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-suppress-explore-1",
+          turn_id: "turn-suppress-explore-1",
+          prompt: "explain this function",
+        },
+        { cwd },
+      );
+
+      // Turn 2: short follow-up — no duplicate LIGHT injection
+      const turn2 = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-suppress-explore-1",
+          turn_id: "turn-suppress-explore-2",
+          prompt: "the auth helper",
+        },
+        { cwd },
+      );
+      const ctx2 = String(
+        (turn2.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(ctx2, /read-only\/question-shaped/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 8: First-turn PASS does NOT block later triage ─────────────────
+
+  it("still applies triage on turn 2 when turn 1 was a PASS with no state written", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-pass-then-light-"));
+    const sessionId = "triage-pass-then-light-1";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      // Turn 1: PASS — no state written
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-pass-then-light-1",
+          turn_id: "turn-pass-then-light-1",
+          prompt: "hello",
+        },
+        { cwd },
+      );
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", sessionId, "prompt-routing-state.json")),
+        false,
+      );
+
+      // Turn 2: LIGHT/executor should fire normally
+      const turn2 = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-pass-then-light-1",
+          turn_id: "turn-pass-then-light-2",
+          prompt: "fix typo in src/foo.ts",
+        },
+        { cwd },
+      );
+      const ctx2 = String(
+        (turn2.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.match(ctx2, /narrow edit-shaped/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 9: Opt-out forces PASS ─────────────────────────────────────────
+
+  it("produces no triage advisory when prompt contains 'just chat' opt-out", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-optout-chat-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-optout-chat-1",
+          thread_id: "thread-optout-chat-1",
+          turn_id: "turn-optout-chat-1",
+          prompt: "add dark mode toggle to the settings page, but just chat about it",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(additionalContext, /multi-step goal with no workflow keyword/);
+      assert.doesNotMatch(additionalContext, /read-only\/question-shaped/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-optout-chat-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("produces no triage advisory when prompt contains 'no workflow' opt-out", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-optout-noworkflow-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-optout-noworkflow-1",
+          thread_id: "thread-optout-noworkflow-1",
+          turn_id: "turn-optout-noworkflow-1",
+          prompt: "make the button blue, no workflow",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(additionalContext, /visual\/style request/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-optout-noworkflow-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 10: Keyword on follow-up turn wins cleanly ─────────────────────
+
+  it("keyword on turn 2 suppresses triage and writes no triage state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-kw-followup-"));
+    const sessionId = "triage-kw-followup-1";
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      // Turn 1: neutral prompt — triage may or may not fire, doesn't matter
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-kw-followup-1",
+          turn_id: "turn-kw-followup-1",
+          prompt: "hello",
+        },
+        { cwd },
+      );
+
+      // Turn 2: keyword prompt — keyword fast-path runs, triage does NOT add extra advisory
+      const turn2 = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-kw-followup-1",
+          turn_id: "turn-kw-followup-2",
+          prompt: "$ralph continue",
+        },
+        { cwd },
+      );
+
+      assert.equal(turn2.skillState?.skill, "ralph");
+
+      const ctx2 = String(
+        (turn2.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(ctx2, /multi-step goal with no workflow keyword/);
+      assert.doesNotMatch(ctx2, /read-only\/question-shaped/);
+      assert.doesNotMatch(ctx2, /narrow edit-shaped/);
+      assert.doesNotMatch(ctx2, /visual\/style request/);
+
+      // No triage state written on the keyword turn
+      const triageState = join(cwd, ".omx", "state", "sessions", sessionId, "prompt-routing-state.json");
+      // The state from turn 1 (if any) must not have been created either (hello = PASS)
+      assert.equal(existsSync(triageState), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  // ── Group 11: Config-disabled path ───────────────────────────────────────
+
+  it("produces no triage advisory and no state when triage is disabled in config", async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), "omx-triage-config-disabled-home-"));
+    const cwd = await mkdtemp(join(tmpdir(), "omx-triage-config-disabled-cwd-"));
+    try {
+      // Write a .omx-config.json in the fake CODEX_HOME that disables triage
+      await writeJson(join(tmpHome, ".omx-config.json"), {
+        promptRouting: { triage: { enabled: false } },
+      });
+      process.env.CODEX_HOME = tmpHome;
+      resetTriageConfigCache();
+
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "triage-disabled-1",
+          thread_id: "thread-triage-disabled-1",
+          turn_id: "turn-triage-disabled-1",
+          prompt: "add dark mode toggle to the settings page",
+        },
+        { cwd },
+      );
+
+      const additionalContext = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "",
+      );
+      assert.doesNotMatch(additionalContext, /multi-step goal with no workflow keyword/);
+
+      const stateFile = join(cwd, ".omx", "state", "sessions", "triage-disabled-1", "prompt-routing-state.json");
+      assert.equal(existsSync(stateFile), false);
+    } finally {
+      await rm(tmpHome, { recursive: true, force: true });
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -44,6 +44,15 @@ import type { HookEventEnvelope } from "../hooks/extensibility/types.js";
 import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
+import { triagePrompt } from "../hooks/triage-heuristic.js";
+import { readTriageConfig } from "../hooks/triage-config.js";
+import {
+  readTriageState,
+  writeTriageState,
+  shouldSuppressFollowup,
+  promptSignature,
+  type TriageStateFile,
+} from "../hooks/triage-state.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -1435,6 +1444,7 @@ export async function dispatchCodexNativeHook(
 
   const omxEventName = mapCodexHookEventToOmxEvent(hookEventName);
   let skillState: SkillActiveState | null = null;
+  let triageAdditionalContext: string | null = null;
 
   const nativeSessionId = safeString(payload.session_id ?? payload.sessionId).trim();
   const threadId = safeString(payload.thread_id ?? payload.threadId).trim();
@@ -1463,6 +1473,73 @@ export async function dispatchCodexNativeHook(
         threadId,
         turnId,
       });
+    }
+    // --- Triage classifier (advisory-only, non-keyword prompts) ---
+    if (prompt && skillState === null) {
+      try {
+        if (readTriageConfig().enabled) {
+          const normalized = prompt.trim().toLowerCase();
+          const previous = readTriageState({ cwd, sessionId: sessionIdForState || null });
+          const suppress = shouldSuppressFollowup({
+            previous,
+            currentPrompt: normalized,
+            currentHasKeyword: false,
+          });
+          if (!suppress) {
+            const decision = triagePrompt(prompt);
+            const nowIso = new Date().toISOString();
+            const effectiveTurnId = turnId || nowIso;
+            if (decision.lane === "HEAVY") {
+              triageAdditionalContext =
+                "OMX native UserPromptSubmit triage detected a multi-step goal with no workflow keyword. This is advisory prompt-routing context only; it did not activate autopilot or initialize workflow state. Prefer the existing autopilot-style workflow if AGENTS.md/runtime conditions allow it, unless newer user context narrows or opts out.";
+              const newState: TriageStateFile = {
+                version: 1,
+                last_triage: {
+                  lane: "HEAVY",
+                  destination: "autopilot",
+                  reason: decision.reason,
+                  prompt_signature: promptSignature(normalized),
+                  turn_id: effectiveTurnId,
+                  created_at: nowIso,
+                },
+                suppress_followup: true,
+              };
+              writeTriageState({ cwd, sessionId: sessionIdForState || null, state: newState });
+            } else if (decision.lane === "LIGHT") {
+              if (decision.destination === "explore") {
+                triageAdditionalContext =
+                  "OMX native UserPromptSubmit triage detected a read-only/question-shaped request with no workflow keyword. This is advisory prompt-routing context only. Prefer the explore role surface rather than escalating to autopilot.";
+              } else if (decision.destination === "executor") {
+                triageAdditionalContext =
+                  "OMX native UserPromptSubmit triage detected a narrow edit-shaped request with no workflow keyword. This is advisory prompt-routing context only. Prefer the executor role surface rather than autopilot.";
+              } else if (decision.destination === "designer") {
+                triageAdditionalContext =
+                  "OMX native UserPromptSubmit triage detected a visual/style request with no workflow keyword. This is advisory prompt-routing context only. Prefer the designer role surface.";
+              }
+              if (triageAdditionalContext !== null) {
+                const dest = decision.destination as "explore" | "executor" | "designer";
+                const newState: TriageStateFile = {
+                  version: 1,
+                  last_triage: {
+                    lane: "LIGHT",
+                    destination: dest,
+                    reason: decision.reason,
+                    prompt_signature: promptSignature(normalized),
+                    turn_id: effectiveTurnId,
+                    created_at: nowIso,
+                  },
+                  suppress_followup: true,
+                };
+                writeTriageState({ cwd, sessionId: sessionIdForState || null, state: newState });
+              }
+            }
+            // lane === "PASS": no context, no state write
+          }
+        }
+      } catch {
+        // Swallow all triage errors; never break the hook
+        triageAdditionalContext = null;
+      }
     }
     await reconcileHudForPromptSubmit(cwd).catch(() => {});
   }
@@ -1493,7 +1570,7 @@ export async function dispatchCodexNativeHook(
   if (hookEventName === "SessionStart" || hookEventName === "UserPromptSubmit") {
     const additionalContext = hookEventName === "SessionStart"
       ? await buildSessionStartContext(cwd, canonicalSessionId || nativeSessionId)
-      : buildAdditionalContextMessage(readPromptText(payload), skillState);
+      : (buildAdditionalContextMessage(readPromptText(payload), skillState) ?? triageAdditionalContext);
     if (additionalContext) {
       outputJson = {
         hookSpecificOutput: {

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -238,6 +238,27 @@ Detection rules:
 - Runtime-only keywords must pass the runtime availability gate before activation.
 - The rest of the user message becomes the task description.
 
+<triage_routing>
+## Triage: advisory prompt-routing context
+
+The keyword detector is the first and deterministic routing surface. Triage runs only when no keyword matches.
+
+When active, triage emits **advisory prompt-routing context** — a developer-context string that the model may follow. It does not activate a skill or workflow by itself. It is a best-effort hint, not a guarantee.
+
+Triage lanes:
+- **HEAVY** — complex, multi-step, or open-ended prompts: adds autopilot-shaped guidance toward full autonomous execution.
+- **LIGHT/explore** — read-only lookups, search, or investigation prompts: suggests the `explore` role-prompt surface (`prompts/explore.md`).
+- **LIGHT/executor** — scoped implementation or code-change prompts: suggests the `executor` role-prompt surface (`prompts/executor.md`).
+- **LIGHT/designer** — UI, visual, or frontend prompts: suggests the `designer` role-prompt surface (`prompts/designer.md`).
+- **PASS** — simple conversational or factual prompts: no context injection.
+
+Note: `explore`, `executor`, and `designer` are agent role-prompt files under `prompts/`, not workflow skills.
+
+Explicit keywords remain the deterministic control surface when you want explicit, guaranteed routing — use them whenever exact behavior matters.
+
+To opt out per prompt with phrases such as `no workflow`, `just chat`, or `plain answer` — the triage layer will suppress context injection for that prompt.
+</triage_routing>
+
 Ralph / Ralplan execution gate:
 - Enforce **ralplan-first** when ralph is active and planning is not complete.
 - Planning is complete only after both `.omx/plans/prd-*.md` and `.omx/plans/test-spec-*.md` exist.


### PR DESCRIPTION
## Summary

- New advisory triage classifier in `src/hooks/` (heuristic + config + state) emits HEAVY / LIGHT / PASS routing *advice* into `hookSpecificOutput.additionalContext` on non-keyword `UserPromptSubmit` events — never writes `skill-active-state.json`, never activates a workflow.
- Keyword routing remains the deterministic control surface: triage runs only when `skillState === null`. Explicit opt-out vocabulary (`just chat`, `no workflow`, `don't route`, `explain only`, ...) is checked before any HEAVY / LIGHT decision.
- Session-scoped `prompt-routing-state.json` lives in `.omx/state/sessions/<sessionId>/`, separate from workflow state, and powers turn-2 follow-up suppression via `shouldSuppressFollowup`.
- `omx doctor` gains a "Prompt triage" check that reports enabled / defaulted / disabled / invalid states. Docs updated: `templates/AGENTS.md`, `skills/help/SKILL.md`, `docs/codex-native-hooks.md`.

## Context

Built end-to-end from the consensus-approved plan at `.omc/plans/ralplan-omx-triage-heuristic.md` (ralplan Planner/Architect/Critic) and spec at `.omc/specs/deep-interview-omx-triage-heuristic.md`. Final multi-perspective validation:
- **Architect: APPROVED** — all 10 plan contract items pass ("The implementation matches the consensus contract end-to-end. Ship it.").
- **Security: LOW risk** — the one Medium finding (defense-in-depth gap in `resolveStatePath`) is addressed in this PR by a local `SESSION_ID_PATTERN` guard; upstream validation in `src/hooks/session.ts:111` remains the first line.
- **Code review: APPROVED_WITH_NITS** — the 3 minors (duplicate `new Date().toISOString()`, unnamed magic numbers 5/10/15, `turn_id` sourcing) are addressed in this PR.

## Test plan

- [x] `npm run build`
- [x] `npm run lint` (biome, 501 files, no fixes applied)
- [x] `node --test dist/hooks/__tests__/triage-heuristic.test.js` — 31/31
- [x] `node --test dist/hooks/__tests__/triage-config.test.js` — 9/9
- [x] `node --test dist/hooks/__tests__/triage-state.test.js` — 42/42
- [x] `node --test dist/scripts/__tests__/codex-native-hook.test.js` — 114/114 (95 upstream + 15 new triage-integration cases + 4 untouched)
- [x] `npm test` (full suite, exit 0 — the two remaining `hono`/`ajv` `ENOENT` errors from `dist/utils/__tests__/dep-versions.test.js` are pre-existing env issues unrelated to this change; same baseline on `dev`)
- [ ] Live Codex CLI session exercise (reviewer to validate on a real host)

## Notes on the second commit

`e393f619` relaxes one assertion in the upstream conversational-Ralph-mention test (`b7464c30`). The test's invariant ("a plain `ralph` mention must not seed workflow state") is preserved by keeping all filesystem assertions plus a positive refutation that the advisory context contains no Ralph-activation text. Only the blanket `outputJson === null` check — which was stricter than the test name — was replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)