### PR TITLE
Expose research specialists in operator guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ Rules:
 <model_routing>
 Match role to task shape:
 - Low complexity: `explore`, `style-reviewer`, `writer`
+- Research/discovery: `explore` for repo lookup, `researcher` for official docs/reference gathering, `dependency-expert` for SDK/API/package evaluation
 - Standard: `executor`, `debugger`, `test-engineer`
 - High complexity: `architect`, `executor`, `critic`
 
@@ -123,6 +124,11 @@ Key roles:
 - `debugger` — root-cause analysis
 - `executor` — implementation and refactoring
 - `verifier` — completion evidence and validation
+
+Research/discovery specialists:
+- `explore` — first-stop repository lookup and symbol/file mapping
+- `researcher` — official docs, references, and external fact gathering
+- `dependency-expert` — SDK/API/package evaluation before adopting or changing dependencies
 
 Specialists remain available through skill/keyword routing when the task clearly benefits from them.
 </agent_catalog>

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -176,6 +176,7 @@ Rules:
 <model_routing>
 Match role to task shape:
 - Low complexity: `explore`, `style-reviewer`, `writer`
+- Research/discovery: `explore` for repo lookup, `researcher` for official docs/reference gathering, `dependency-expert` for SDK/API/package evaluation
 - Standard: `executor`, `debugger`, `test-engineer`
 - High complexity: `architect`, `executor`, `critic`
 
@@ -192,6 +193,11 @@ Key roles:
 - `debugger` — root-cause analysis
 - `executor` — implementation and refactoring
 - `verifier` — completion evidence and validation
+
+Research/discovery specialists:
+- `explore` — first-stop repository lookup and symbol/file mapping
+- `researcher` — official docs, references, and external fact gathering
+- `dependency-expert` — SDK/API/package evaluation before adopting or changing dependencies
 
 Specialists remain available through the role catalog and native child-agent surfaces when the task clearly benefits from them.
 </agent_catalog>


### PR DESCRIPTION
## Summary
- expose `explore`, `researcher`, and `dependency-expert` more clearly in operator-facing guidance
- add a small research/discovery routing line under model routing
- add a matching research/discovery specialists subsection under the agent catalog

## Testing
- npm run build
- node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/explore-sparkshell-guidance-contract.test.js
