### PR TITLE
Add research specialist routing eval coverage

### DIFF
--- a/docs/qa/research-specialist-eval-surface-2026-04-18.md
+++ b/docs/qa/research-specialist-eval-surface-2026-04-18.md
@@ -1,0 +1,36 @@
+# Research Specialist Eval Surface - 2026-04-18
+
+Date: **2026-04-18**
+Scope: issue **#1714** — routing and quality regression coverage for `researcher`, `dependency-expert`, and `explore`
+
+## What this verification surface guarantees
+
+- representative routing fixtures exist for:
+  - `explore`
+  - `researcher`
+  - `dependency-expert`
+  - mixed `explore + researcher`
+  - mixed `explore + dependency-expert`
+- role output-contract checks assert:
+  - `researcher` keeps source URLs, official-doc preference, and version-note language
+  - `dependency-expert` keeps candidate-comparison, maintenance/license/risk language
+  - `explore` stays local/read-only and returns absolute-path/relationship guidance
+
+## Current regression surfaces
+
+| Surface | Files | Coverage |
+|---|---|---|
+| routing heuristics | `src/team/__tests__/role-router.test.ts` | direct role routing for local exploration, official-doc research, and dependency evaluation prompts |
+| execution handoff staffing | `src/team/__tests__/followup-planner.test.ts` | mixed-lane staffing fixtures for `explore + researcher` and `explore + dependency-expert` |
+| role output contracts | `src/hooks/__tests__/prompt-guidance-wave-two.test.ts` | prompt-level output-shape and boundary checks for the three specialist roles |
+
+## Verification commands
+
+- `npm run build`
+- `node --test dist/team/__tests__/role-router.test.js dist/team/__tests__/followup-planner.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js`
+
+## Deliberate non-goals
+
+- no new benchmark harness
+- no live web-quality scoring
+- no separate runtime/e2e infrastructure beyond existing test surfaces

--- a/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
@@ -30,6 +30,25 @@ describe('prompt guidance wave two contract', () => {
     assert.match(researcher, /source-reference evidence/i);
   });
 
+  it('research specialists keep explicit output-contract fixtures for source preference and boundary discipline', () => {
+    const researcher = loadSurface('prompts/researcher.md');
+    const dependencyExpert = loadSurface('prompts/dependency-expert.md');
+    const explore = loadSurface('prompts/explore.md');
+
+    assert.match(researcher, /Always include source URLs/i);
+    assert.match(researcher, /Prefer official documentation over third-party summaries/i);
+    assert.match(researcher, /Version compatibility is noted when relevant|Version Notes/i);
+
+    assert.match(dependencyExpert, /Compare at least 2 candidates|multiple candidates/i);
+    assert.match(dependencyExpert, /license compatibility/i);
+    assert.match(dependencyExpert, /maintenance activity|download stats/i);
+    assert.match(dependencyExpert, /Risks/i);
+
+    assert.match(explore, /ALL paths are absolute/i);
+    assert.match(explore, /Relationships between files\/patterns explained/i);
+    assert.match(explore, /Read-only/i);
+  });
+
   it('security and verifier-adjacent prompts preserve merge-if-green as downstream context', () => {
     assert.match(loadSurface('prompts/security-reviewer.md'), /merge if CI green/i);
     assert.match(loadSurface('prompts/critic.md'), /later workflow condition|downstream context/i);

--- a/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-wave-two.test.ts
@@ -36,8 +36,8 @@ describe('prompt guidance wave two contract', () => {
     const explore = loadSurface('prompts/explore.md');
 
     assert.match(researcher, /Always include source URLs/i);
-    assert.match(researcher, /Prefer official documentation over third-party summaries/i);
-    assert.match(researcher, /Version compatibility is noted when relevant|Version Notes/i);
+    assert.match(researcher, /Prefer official documentation.*over third-party summaries/i);
+    assert.match(researcher, /Version compatibility or version uncertainty is noted when relevant|### Version Note/i);
 
     assert.match(dependencyExpert, /Compare at least 2 candidates|multiple candidates/i);
     assert.match(dependencyExpert, /license compatibility/i);

--- a/src/team/__tests__/followup-planner.test.ts
+++ b/src/team/__tests__/followup-planner.test.ts
@@ -78,6 +78,30 @@ describe('followup-planner', () => {
     assert.equal(plan.verificationPlan.checkpoints.length, 3);
   });
 
+  it('allocates explore plus researcher lanes for mixed local+official-doc follow-up', () => {
+    const plan = buildFollowupStaffingPlan(
+      'team',
+      'Find which files implement session refresh in the repo, then research the official docs and version compatibility notes for the auth SDK',
+      ['executor', 'explore', 'researcher', 'verifier'],
+      { workerCount: 3, fallbackRole: 'executor' },
+    );
+
+    assert.ok(plan.allocations.some((allocation) => allocation.role === 'explore' && allocation.reason.includes('primary')));
+    assert.ok(plan.allocations.some((allocation) => allocation.role === 'researcher' && allocation.reason.includes('specialist')));
+  });
+
+  it('allocates explore plus dependency-expert lanes for mixed local+dependency evaluation follow-up', () => {
+    const plan = buildFollowupStaffingPlan(
+      'team',
+      'Map which local packages currently handle logging, then compare replacement npm packages for license risk, maintenance, and migration path',
+      ['dependency-expert', 'executor', 'explore', 'verifier'],
+      { workerCount: 3, fallbackRole: 'executor' },
+    );
+
+    assert.ok(plan.allocations.some((allocation) => allocation.role === 'explore' && allocation.reason.includes('primary')));
+    assert.ok(plan.allocations.some((allocation) => allocation.role === 'dependency-expert' && allocation.reason.includes('specialist')));
+  });
+
   it('recognizes short approved team follow-up shortcuts in English and Korean', () => {
     assert.equal(
       isApprovedExecutionFollowupShortcut('team', 'team', { planningComplete: true }),

--- a/src/team/__tests__/role-router.test.ts
+++ b/src/team/__tests__/role-router.test.ts
@@ -117,6 +117,39 @@ describe('role-router', () => {
       assert.equal(result.confidence, 'high');
     });
 
+    it('routes local file and symbol lookup tasks to explore', () => {
+      const result = routeTaskToRole(
+        'Find auth refresh wiring',
+        'Map which files and symbols implement the local session refresh flow in this repo',
+        'team-exec',
+        'executor',
+      );
+      assert.equal(result.role, 'explore');
+      assert.equal(result.confidence, 'high');
+    });
+
+    it('routes external official-doc research tasks to researcher', () => {
+      const result = routeTaskToRole(
+        'Research official docs',
+        'Check the official docs and version compatibility notes for the upstream auth SDK',
+        'team-exec',
+        'executor',
+      );
+      assert.equal(result.role, 'researcher');
+      assert.equal(result.confidence, 'high');
+    });
+
+    it('routes dependency evaluation tasks to dependency-expert', () => {
+      const result = routeTaskToRole(
+        'Evaluate logging SDK options',
+        'Compare npm packages for maintenance, license compatibility, migration path, and download stats',
+        'team-exec',
+        'executor',
+      );
+      assert.equal(result.role, 'dependency-expert');
+      assert.equal(result.confidence, 'high');
+    });
+
     it('routes documentation tasks to writer', () => {
       const result = routeTaskToRole('Update docs', 'Write README and migration guide for the new API', 'team-exec', 'executor');
       assert.equal(result.role, 'writer');

--- a/src/team/__tests__/role-router.test.ts
+++ b/src/team/__tests__/role-router.test.ts
@@ -156,6 +156,17 @@ describe('role-router', () => {
       assert.equal(result.confidence, 'high');
     });
 
+    it('keeps changelog and docs deliverables on the writer lane even when research keywords appear', () => {
+      const changelog = routeTaskToRole(
+        'Update changelog',
+        'Write changelog notes and refresh the release docs with version compatibility details from the official docs',
+        'team-exec',
+        'executor',
+      );
+      assert.equal(changelog.role, 'writer');
+      assert.equal(changelog.confidence, 'high');
+    });
+
     it('routes security tasks to security-reviewer', () => {
       const result = routeTaskToRole('Security audit', 'Check for XSS and injection vulnerabilities', 'team-verify', 'executor');
       assert.equal(result.role, 'security-reviewer');
@@ -167,6 +178,18 @@ describe('role-router', () => {
       assert.equal(result.role, 'executor');
       assert.equal(result.confidence, 'medium');
       assert.match(result.reason, /implementation/i);
+    });
+
+    it('does not route SDK replacement implementation work to dependency-expert', () => {
+      const result = routeTaskToRole(
+        'Replace auth SDK integration',
+        'Implement the SDK replacement by updating client modules, wiring new API calls, and refactoring imports across the flow',
+        'team-exec',
+        'executor',
+      );
+      assert.equal(result.role, 'executor');
+      assert.equal(result.confidence, 'medium');
+      assert.match(result.reason, /implementation lane|implementation-heavy/i);
     });
 
     it('routes refactoring tasks to code-simplifier', () => {

--- a/src/team/followup-planner.ts
+++ b/src/team/followup-planner.ts
@@ -122,6 +122,19 @@ function chooseAvailableRole(
   return availableRoles[0] ?? fallbackRole;
 }
 
+function chooseDistinctAvailableRole(
+  availableRoles: readonly string[],
+  preferredRoles: readonly string[],
+  fallbackRole: string,
+  disallowedRoles: readonly string[],
+): string {
+  for (const role of preferredRoles) {
+    if (!disallowedRoles.includes(role) && availableRoles.includes(role)) return role;
+  }
+  if (!disallowedRoles.includes(fallbackRole) && availableRoles.includes(fallbackRole)) return fallbackRole;
+  return availableRoles.find((role) => !disallowedRoles.includes(role)) ?? fallbackRole;
+}
+
 function mergeAllocation(
   allocations: FollowupAllocation[],
   role: string,
@@ -204,26 +217,49 @@ function pickSpecialistRole(
   task: string,
   availableRoles: readonly string[],
   fallbackRole: string,
+  primaryRole: string,
 ): string {
   const normalizedTask = task.toLowerCase();
+  const wantsExplore = /\b(?:find|locate|look up|lookup|map|search|trace|which files?|where(?:\s+is|\s+are)?)\b/.test(normalizedTask)
+    && /\b(?:file|files|symbol|symbols|repo|repository|codebase|path|paths|usage|usages|relationship|relationships|implementation|local)\b/.test(normalizedTask);
+  const wantsDependencyExpert = /\b(?:dependency|dependencies|package|packages|sdk|sdks|library|libraries|framework|frameworks|npm|pypi|license|maintenance|migration path|download stats?)\b/.test(normalizedTask)
+    && /\b(?:adopt|assess|choose|compare|evaluate|recommend|replace|select|swap|risk)\b/.test(normalizedTask);
+  const wantsResearcher = /\b(?:official docs?|upstream docs?|vendor docs?|reference|references|api docs?|release notes?|version(?:ing)?|compatib(?:ility|le)|research)\b/.test(normalizedTask);
+
+  if (wantsExplore && wantsDependencyExpert) {
+    return chooseDistinctAvailableRole(
+      availableRoles,
+      primaryRole === 'explore' ? ['dependency-expert', 'researcher'] : ['explore', 'dependency-expert'],
+      fallbackRole,
+      [primaryRole],
+    );
+  }
+  if (wantsExplore && wantsResearcher) {
+    return chooseDistinctAvailableRole(
+      availableRoles,
+      primaryRole === 'explore' ? ['researcher', 'dependency-expert'] : ['explore', 'researcher'],
+      fallbackRole,
+      [primaryRole],
+    );
+  }
 
   if (/(security|auth|authorization|authentication|xss|injection|cve|vulnerability)/.test(normalizedTask)) {
-    return chooseAvailableRole(availableRoles, ['security-reviewer', 'architect'], fallbackRole);
+    return chooseDistinctAvailableRole(availableRoles, ['security-reviewer', 'architect'], fallbackRole, [primaryRole]);
   }
   if (/(debug|regression|root cause|stack trace|incident|flaky)/.test(normalizedTask)) {
-    return chooseAvailableRole(availableRoles, ['debugger', 'architect'], fallbackRole);
+    return chooseDistinctAvailableRole(availableRoles, ['debugger', 'architect'], fallbackRole, [primaryRole]);
   }
   if (/(build|compile|tsc|type error|lint)/.test(normalizedTask)) {
-    return chooseAvailableRole(availableRoles, ['build-fixer', 'debugger'], fallbackRole);
+    return chooseDistinctAvailableRole(availableRoles, ['build-fixer', 'debugger'], fallbackRole, [primaryRole]);
   }
   if (/(ui|ux|layout|css|responsive|design|frontend)/.test(normalizedTask)) {
-    return chooseAvailableRole(availableRoles, ['designer'], fallbackRole);
+    return chooseDistinctAvailableRole(availableRoles, ['designer'], fallbackRole, [primaryRole]);
   }
   if (/(readme|docs|documentation|changelog|migration)/.test(normalizedTask)) {
-    return chooseAvailableRole(availableRoles, ['writer'], fallbackRole);
+    return chooseDistinctAvailableRole(availableRoles, ['writer'], fallbackRole, [primaryRole]);
   }
 
-  return chooseAvailableRole(availableRoles, ['architect', 'researcher'], fallbackRole);
+  return chooseDistinctAvailableRole(availableRoles, ['architect', 'researcher'], fallbackRole, [primaryRole]);
 }
 
 export function buildFollowupStaffingPlan(
@@ -255,7 +291,7 @@ export function buildFollowupStaffingPlan(
       mergeAllocation(allocations, qualityRole, 1, 'verification + regression lane');
     }
     if (workerCount >= 3) {
-      const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole);
+      const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole, primaryRole);
       mergeAllocation(allocations, specialistRole, 1, 'specialist support lane');
     }
     if (workerCount >= 4) {
@@ -271,7 +307,7 @@ export function buildFollowupStaffingPlan(
     mergeAllocation(allocations, architectRole, 1, 'final architecture / completion sign-off');
 
     if (workerCount >= 4) {
-      const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole);
+      const specialistRole = pickSpecialistRole(task, availableAgentTypes, primaryRole, primaryRole);
       mergeAllocation(allocations, specialistRole, workerCount - 3, 'parallel specialist follow-up capacity');
     }
   }

--- a/src/team/role-router.ts
+++ b/src/team/role-router.ts
@@ -101,6 +101,27 @@ const DESIGN_INTENT = /\b(?:design|layout|style)\b|\b(?:build|create)\b.*\b(?:ui
 const BUILD_FIX_INTENT = /\b(?:build|compile|tsc|type error|compilation)\b|(?:빌드|컴파일|타입 오류)/i;
 const CLEANUP_INTENT = /\b(?:clean up|consolidate|reduce complexity|refactor|simplify)\b|(?:정리|단순화|리팩터)/i;
 const SECURITY_DOMAIN = /\b(?:auth|authentication|authorization|cve|injection|owasp|security|vulnerability|xss)\b|(?:보안|인증|인가|취약점)/i;
+const LOCAL_EXPLORATION_VERB = /\b(?:find|locate|look up|lookup|map|search|trace|where(?:\s+is|\s+are)?|which files?|what files?)\b/i;
+const LOCAL_EXPLORATION_SUBJECT = /\b(?:file|files|symbol|symbols|repo|repository|codebase|path|paths|usage|usages|reference|references|relationship|relationships|wiring|flow|implementation|local)\b/i;
+const DEPENDENCY_EVALUATION_SIGNAL = /\b(?:dependency|dependencies|package|packages|sdk|sdks|library|libraries|framework|frameworks|crate|crates|npm|pypi|crates\.io|license|licenses|maintenance|download stats?|migration path|vendor)\b/i;
+const DEPENDENCY_EVALUATION_VERB = /\b(?:adopt|assess|choose|compare|evaluate|recommend|replace|select|swap)\b/i;
+const RESEARCH_SIGNAL = /\b(?:official docs?|upstream docs?|vendor docs?|reference|references|api docs?|release notes?|changelog|version(?:ing)?|compatib(?:ility|le)|research)\b/i;
+
+function isLocalExplorationTask(text: string): boolean {
+  return LOCAL_EXPLORATION_VERB.test(text) && LOCAL_EXPLORATION_SUBJECT.test(text);
+}
+
+function isDependencyEvaluationTask(text: string): boolean {
+  return DEPENDENCY_EVALUATION_SIGNAL.test(text)
+    && (
+      DEPENDENCY_EVALUATION_VERB.test(text)
+      || /\b(?:candidate|compare|maintenance|migration|risk|replace|replacement)\b/i.test(text)
+    );
+}
+
+function isResearchTask(text: string): boolean {
+  return RESEARCH_SIGNAL.test(text) && !isLocalExplorationTask(text) && !isDependencyEvaluationTask(text);
+}
 
 function inferLaneIntent(text: string): LaneIntent {
   if (BUILD_FIX_INTENT.test(text) && /\b(?:fix|resolve|repair)\b|(?:수정|해결)/i.test(text)) return 'build-fix';
@@ -152,6 +173,30 @@ export function routeTaskToRole(
       role: 'debugger',
       confidence: 'high',
       reason: 'primary intent is investigation/debugging',
+    };
+  }
+
+  if (isLocalExplorationTask(text)) {
+    return {
+      role: 'explore',
+      confidence: 'high',
+      reason: 'primary intent is local codebase/file/symbol exploration',
+    };
+  }
+
+  if (isDependencyEvaluationTask(text)) {
+    return {
+      role: 'dependency-expert',
+      confidence: 'high',
+      reason: 'primary intent is external dependency/package evaluation',
+    };
+  }
+
+  if (isResearchTask(text)) {
+    return {
+      role: 'researcher',
+      confidence: 'high',
+      reason: 'primary intent is external documentation/reference research',
     };
   }
 

--- a/src/team/role-router.ts
+++ b/src/team/role-router.ts
@@ -104,23 +104,48 @@ const SECURITY_DOMAIN = /\b(?:auth|authentication|authorization|cve|injection|ow
 const LOCAL_EXPLORATION_VERB = /\b(?:find|locate|look up|lookup|map|search|trace|where(?:\s+is|\s+are)?|which files?|what files?)\b/i;
 const LOCAL_EXPLORATION_SUBJECT = /\b(?:file|files|symbol|symbols|repo|repository|codebase|path|paths|usage|usages|reference|references|relationship|relationships|wiring|flow|implementation|local)\b/i;
 const DEPENDENCY_EVALUATION_SIGNAL = /\b(?:dependency|dependencies|package|packages|sdk|sdks|library|libraries|framework|frameworks|crate|crates|npm|pypi|crates\.io|license|licenses|maintenance|download stats?|migration path|vendor)\b/i;
-const DEPENDENCY_EVALUATION_VERB = /\b(?:adopt|assess|choose|compare|evaluate|recommend|replace|select|swap)\b/i;
+const DEPENDENCY_EVALUATION_VERB = /\b(?:adopt|assess|choose|compare|evaluate|recommend|select)\b/i;
+const DEPENDENCY_EVALUATION_CONTEXT = /\b(?:candidate|candidates|comparison|download stats?|license|licenses|maintenance|migration path|options?|risk|trade-?offs?|vendor)\b/i;
+const DEPENDENCY_IMPLEMENTATION_SIGNAL = /\b(?:adapter|api|call sites?|client|clients|code(?:path|paths)?|endpoint|endpoints|flow|flows|handler|handlers|implementation|imports?|integrat(?:e|ion)|module|modules|refactor|wire)\b/i;
 const RESEARCH_SIGNAL = /\b(?:official docs?|upstream docs?|vendor docs?|reference|references|api docs?|release notes?|changelog|version(?:ing)?|compatib(?:ility|le)|research)\b/i;
+const RESEARCH_VERB = /\b(?:check|consult|investigate|look up|lookup|read|research|review|study|verify)\b/i;
+const DOCS_DELIVERABLE_VERB = /\b(?:add|document|draft|edit|prepare|publish|refresh|revise|update|write)\b/i;
+const DOCS_DELIVERABLE_NOUN = /\b(?:api docs?|changelog|comments?|documentation|docs?|guide|guides|readme|release notes?)\b/i;
 
 function isLocalExplorationTask(text: string): boolean {
   return LOCAL_EXPLORATION_VERB.test(text) && LOCAL_EXPLORATION_SUBJECT.test(text);
 }
 
+function isDocumentationDeliverableTask(text: string): boolean {
+  return PRIMARY_DOCS_INTENT.test(text) || (DOCS_DELIVERABLE_VERB.test(text) && DOCS_DELIVERABLE_NOUN.test(text));
+}
+
+function isImplementationHeavyDependencyTask(text: string): boolean {
+  return DEPENDENCY_EVALUATION_SIGNAL.test(text)
+    && IMPLEMENTATION_INTENT.test(text)
+    && DEPENDENCY_IMPLEMENTATION_SIGNAL.test(text)
+    && /\b(?:adopt|migrate|port|replace|replacement|swap|upgrade|wire)\b/i.test(text)
+    && !/\b(?:assess|choose|compare|evaluate|options?|recommend|select|trade-?offs?)\b/i.test(text);
+}
+
 function isDependencyEvaluationTask(text: string): boolean {
+  if (isDocumentationDeliverableTask(text) || isImplementationHeavyDependencyTask(text)) {
+    return false;
+  }
+
   return DEPENDENCY_EVALUATION_SIGNAL.test(text)
     && (
       DEPENDENCY_EVALUATION_VERB.test(text)
-      || /\b(?:candidate|compare|maintenance|migration|risk|replace|replacement)\b/i.test(text)
+      || DEPENDENCY_EVALUATION_CONTEXT.test(text)
     );
 }
 
 function isResearchTask(text: string): boolean {
-  return RESEARCH_SIGNAL.test(text) && !isLocalExplorationTask(text) && !isDependencyEvaluationTask(text);
+  return RESEARCH_SIGNAL.test(text)
+    && (RESEARCH_VERB.test(text) || /\b(?:compatib(?:ility|le)|official docs?|release notes?|upstream docs?|vendor docs?|version(?:ing)?)\b/i.test(text))
+    && !isDocumentationDeliverableTask(text)
+    && !isLocalExplorationTask(text)
+    && !isDependencyEvaluationTask(text);
 }
 
 function inferLaneIntent(text: string): LaneIntent {
@@ -181,6 +206,14 @@ export function routeTaskToRole(
       role: 'explore',
       confidence: 'high',
       reason: 'primary intent is local codebase/file/symbol exploration',
+    };
+  }
+
+  if (isImplementationHeavyDependencyTask(text)) {
+    return {
+      role: fallbackRole,
+      confidence: 'medium',
+      reason: 'dependency/sdk terms appear inside implementation-heavy replacement work, so using fallback implementation lane',
     };
   }
 


### PR DESCRIPTION
## Summary
- add routing heuristics for local exploration, external docs research, and dependency evaluation tasks
- extend follow-up staffing to allocate distinct research specialists for mixed local+external work
- add targeted regression coverage plus a QA note for the new research-specialist eval surface

## Testing
- npm run build
- node --test dist/team/__tests__/role-router.test.js dist/team/__tests__/followup-planner.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js
