### PR TITLE
Introduce the PR1 shared run-outcome contract for #1718

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -74,6 +74,18 @@ operator to clear incompatible state explicitly via `omx state ...` or the
 `omx_state.*` MCP tools before retrying. See
 `docs/contracts/multi-state-transition-contract.md`.
 
+## Run outcome vocabulary note
+
+For Issue #1718 PR1, native Stop/continuation readers should treat shared run
+outcomes as:
+
+- terminal: `finish`, `blocked_on_user`, `failed`, `cancelled`
+- non-terminal: `progress`, `continue`
+
+Legacy labels such as `complete`, `completed`, and `finished` remain compatible
+surface wording for now, but readers should normalize them to the shared
+`finish` meaning instead of treating each spelling as its own contract.
+
 ## UserPromptSubmit: triage advisory context
 
 `UserPromptSubmit` can now emit triage advisory context alongside keyword context. When no keyword matches, the triage layer classifies the prompt and may inject an advisory prompt-routing context string — this is advisory prompt-routing context that does not activate a skill or workflow by itself; it adds a developer-context hint the model may follow. Keywords remain the deterministic control surface: a matched keyword always takes precedence over triage output, and users can suppress triage injection per prompt with phrases such as `no workflow`, `just chat`, or `plain answer`.

--- a/docs/contracts/run-outcome-contract.md
+++ b/docs/contracts/run-outcome-contract.md
@@ -1,0 +1,85 @@
+# Run outcome contract (Issue #1718 PR1)
+
+This document captures the narrow PR1 contract for Issue #1718: introduce a
+shared terminal/non-terminal run outcome vocabulary before changing runtime
+ownership or adding the later reusable run loop.
+
+## Canonical run outcomes
+
+PR1 should normalize lifecycle readers and writers onto these meanings:
+
+### Terminal outcomes
+
+- `finish` — successful terminal completion
+- `blocked_on_user` — terminal wait that requires explicit user input before a
+  new run should start
+- `failed` — terminal error/failure
+- `cancelled` — terminal operator/runtime cancellation
+
+### Non-terminal outcomes
+
+- `progress` — work advanced but the run is still active
+- `continue` — the current run remains active and should keep going rather than
+  finalizing
+
+## Compatibility mapping expected in PR1
+
+Brownfield surfaces already use several words for the same idea. PR1 should not
+rewrite every public string yet, but it should make the shared meaning explicit.
+
+| Existing label | Shared meaning |
+| --- | --- |
+| `complete`, `completed`, `finished` | `finish` |
+| active non-terminal mode/team phase | `continue` / `progress` |
+| stop-hook block because work is still active | `continue` |
+| cancellation phase/status | `cancelled` |
+| explicit failure phase/status | `failed` |
+
+`blocked_on_user` is the missing canonical term today. PR1 should introduce it
+as contract vocabulary even where the first implementation still adapts from
+older pause/wait wording.
+
+## Vocabulary mismatches found during review
+
+1. **Successful terminal state is fragmented** across `finish`, `finished`,
+   `complete`, and `completed`.
+2. **Non-terminal continuation is mostly implicit** in stop-hook and idle
+   notification logic instead of being named as a shared run outcome.
+3. **`blocked_on_user` is not yet a first-class shared term**, which makes
+   user-wait terminalization harder to reason about consistently.
+
+## Smallest central file set for PR1
+
+The current review indicates the smallest high-value implementation slice is:
+
+- `src/scripts/codex-native-hook.ts`
+  - replace local non-terminal/terminal checks with the shared run outcome
+    contract while preserving current Stop behavior
+- `src/scripts/notify-hook/utils.ts`
+  - make terminal phase detection read from the shared contract vocabulary
+- `src/team/orchestrator.ts`
+  - keep team terminal phases aligned with the shared contract instead of local
+    terminal assumptions
+- `src/team/phase-controller.ts`
+  - preserve reopen/terminal handling through the same shared helpers
+- `src/team/runtime-cli.ts`
+  - normalize terminal CLI output through the shared outcome mapping, while
+    keeping the current CLI-facing `completed|failed` output compatibility
+
+## Focused regression coverage for PR1
+
+The most relevant existing tests to update are:
+
+- `src/scripts/__tests__/codex-native-hook.test.ts`
+- `src/hooks/__tests__/notify-hook-modules.test.ts`
+- `src/team/__tests__/orchestrator.test.ts`
+- `src/team/__tests__/phase-controller.test.ts`
+- `src/team/__tests__/runtime-cli.test.ts`
+
+## Out of scope for PR1
+
+- reusable continue-until-terminal run loop semantics
+- moving ownership into shared run-state storage
+- Ralph/team/runtime ownership reshaping beyond contract adoption
+
+Those belong to PR2+ from `.omx/context/issue-1718-pr-plan.md`.

--- a/src/runtime/run-outcome.ts
+++ b/src/runtime/run-outcome.ts
@@ -1,0 +1,75 @@
+export const TERMINAL_RUN_OUTCOMES = [
+  'finish',
+  'blocked_on_user',
+  'failed',
+  'cancelled',
+] as const;
+
+export const NON_TERMINAL_RUN_OUTCOMES = [
+  'progress',
+  'continue',
+] as const;
+
+export const RUN_OUTCOMES = [
+  ...NON_TERMINAL_RUN_OUTCOMES,
+  ...TERMINAL_RUN_OUTCOMES,
+] as const;
+
+export type TerminalRunOutcome = (typeof TERMINAL_RUN_OUTCOMES)[number];
+export type NonTerminalRunOutcome = (typeof NON_TERMINAL_RUN_OUTCOMES)[number];
+export type RunOutcome = (typeof RUN_OUTCOMES)[number];
+
+const TERMINAL_RUN_OUTCOME_SET = new Set<string>(TERMINAL_RUN_OUTCOMES);
+const NON_TERMINAL_RUN_OUTCOME_SET = new Set<string>(NON_TERMINAL_RUN_OUTCOMES);
+
+const RUN_OUTCOME_ALIASES: Readonly<Record<string, RunOutcome>> = {
+  finish: 'finish',
+  finished: 'finish',
+  complete: 'finish',
+  completed: 'finish',
+  done: 'finish',
+  blocked_on_user: 'blocked_on_user',
+  failed: 'failed',
+  fail: 'failed',
+  error: 'failed',
+  cancelled: 'cancelled',
+  canceled: 'cancelled',
+  cancel: 'cancelled',
+  aborted: 'cancelled',
+  abort: 'cancelled',
+  progress: 'progress',
+  continue: 'continue',
+  continued: 'continue',
+} as const;
+
+function normalizeRunOutcomeValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+export function normalizeRunOutcome(value: unknown): RunOutcome | null {
+  const normalized = normalizeRunOutcomeValue(value);
+  if (!normalized) return null;
+  return RUN_OUTCOME_ALIASES[normalized] ?? null;
+}
+
+export function classifyRunOutcome(value: unknown): RunOutcome {
+  return normalizeRunOutcome(value) ?? 'progress';
+}
+
+export function isTerminalRunOutcome(value: unknown): value is TerminalRunOutcome {
+  const normalized = normalizeRunOutcome(value);
+  return normalized !== null && TERMINAL_RUN_OUTCOME_SET.has(normalized);
+}
+
+export function isNonTerminalRunOutcome(value: unknown): value is NonTerminalRunOutcome {
+  const normalized = normalizeRunOutcome(value);
+  return normalized !== null && NON_TERMINAL_RUN_OUTCOME_SET.has(normalized);
+}
+
+export function isNonTerminalRunState(value: unknown): boolean {
+  return isNonTerminalRunOutcome(classifyRunOutcome(value));
+}
+
+export function isTerminalRunState(value: unknown): boolean {
+  return isTerminalRunOutcome(classifyRunOutcome(value));
+}

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -45,6 +45,7 @@ import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
 import { readAutoresearchCompletionStatus, readAutoresearchModeState } from "../autoresearch/skill-validation.js";
+import { isTerminalRunState } from "../runtime/run-outcome.js";
 import { triagePrompt } from "../hooks/triage-heuristic.js";
 import { readTriageConfig } from "../hooks/triage-config.js";
 import {
@@ -77,8 +78,6 @@ export interface NativeHookDispatchResult {
   outputJson: Record<string, unknown> | null;
 }
 
-const TERMINAL_RALPH_PHASES = new Set(["complete", "failed", "cancelled"]);
-const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
 const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);
 const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
@@ -199,7 +198,7 @@ async function readJsonIfExists(path: string): Promise<Record<string, unknown> |
 
 function isNonTerminalPhase(value: unknown): boolean {
   const phase = safeString(value).trim().toLowerCase();
-  return phase !== "" && !TERMINAL_MODE_PHASES.has(phase);
+  return phase !== "" && !isTerminalRunState(phase);
 }
 
 function formatPhase(value: unknown, fallback = "active"): string {
@@ -236,7 +235,7 @@ async function readActiveRalphState(
     );
     if (
       sessionScoped?.active === true
-      && !TERMINAL_RALPH_PHASES.has(
+      && !isTerminalRunState(
         safeString(sessionScoped.current_phase).trim().toLowerCase(),
       )
     ) {
@@ -247,7 +246,7 @@ async function readActiveRalphState(
   if (sessionCandidates.length > 0) return null;
 
   const direct = await readJsonIfExists(join(stateDir, "ralph-state.json"));
-  if (direct?.active === true && !TERMINAL_RALPH_PHASES.has(safeString(direct.current_phase).trim().toLowerCase())) {
+  if (direct?.active === true && !isTerminalRunState(safeString(direct.current_phase).trim().toLowerCase())) {
     return direct;
   }
 
@@ -259,7 +258,7 @@ async function readActiveRalphState(
     const candidate = await readJsonIfExists(join(sessionsRoot, entry.name, "ralph-state.json"));
     if (
       candidate?.active === true
-      && !TERMINAL_RALPH_PHASES.has(
+      && !isTerminalRunState(
         safeString(candidate.current_phase).trim().toLowerCase(),
       )
     ) {
@@ -886,7 +885,7 @@ async function readBlockingSkillForStop(
         "planning",
       ),
     );
-    if (TERMINAL_MODE_PHASES.has(phase.toLowerCase()) || phase === "completing") {
+    if (isTerminalRunState(phase) || phase === "completing") {
       continue;
     }
 

--- a/src/scripts/notify-hook/utils.ts
+++ b/src/scripts/notify-hook/utils.ts
@@ -1,3 +1,5 @@
+import { isTerminalRunState } from '../../runtime/run-outcome.js';
+
 /**
  * Pure utility helpers shared across notify-hook modules.
  * No I/O, no side effects.
@@ -27,5 +29,5 @@ export function clampPct(value: any): number | null {
 }
 
 export function isTerminalPhase(phase: string): boolean {
-  return phase === 'complete' || phase === 'failed' || phase === 'cancelled';
+  return isTerminalRunState(phase);
 }

--- a/src/team/__tests__/run-outcome-contract.test.ts
+++ b/src/team/__tests__/run-outcome-contract.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  canResumeTeamState,
+  createTeamState,
+  isTerminalPhase as isTerminalTeamPhase,
+  type TeamPhase,
+  type TerminalPhase,
+} from '../orchestrator.js';
+import {
+  isTerminalTeamDispatchRequestStatus,
+  isTerminalTeamTaskStatus,
+  type TeamDispatchRequestStatus,
+  type TeamTaskStatus,
+} from '../contracts.js';
+import { isTerminalPhase as isNotifyHookTerminalPhase } from '../../scripts/notify-hook/utils.js';
+
+const TERMINAL_PHASES: TerminalPhase[] = ['complete', 'failed', 'cancelled'];
+const NON_TERMINAL_PHASES: TeamPhase[] = ['team-plan', 'team-prd', 'team-exec', 'team-verify', 'team-fix'];
+const TERMINAL_TASK_STATUSES: TeamTaskStatus[] = ['completed', 'failed'];
+const NON_TERMINAL_TASK_STATUSES: TeamTaskStatus[] = ['pending', 'blocked', 'in_progress'];
+const TERMINAL_DISPATCH_STATUSES: TeamDispatchRequestStatus[] = ['delivered', 'failed'];
+const NON_TERMINAL_DISPATCH_STATUSES: TeamDispatchRequestStatus[] = ['pending', 'notified'];
+
+describe('run outcome contract regressions', () => {
+  it('keeps terminal phase detection aligned across central team surfaces', () => {
+    for (const phase of TERMINAL_PHASES) {
+      assert.equal(isTerminalTeamPhase(phase), true, `${phase} should be terminal for team orchestration`);
+      assert.equal(isNotifyHookTerminalPhase(phase), true, `${phase} should be terminal for notify-hook`);
+    }
+
+    for (const phase of NON_TERMINAL_PHASES) {
+      assert.equal(isTerminalTeamPhase(phase), false, `${phase} should stay non-terminal for team orchestration`);
+      assert.equal(isNotifyHookTerminalPhase(phase), false, `${phase} should stay non-terminal for notify-hook`);
+    }
+  });
+
+  it('treats active non-terminal team phases as resumable progress states', () => {
+    for (const phase of NON_TERMINAL_PHASES) {
+      const state = {
+        ...createTeamState(`progress-${phase}`),
+        phase,
+        active: true,
+      };
+      assert.equal(canResumeTeamState(state), true, `${phase} should remain resumable while active`);
+    }
+  });
+
+  it('treats terminal team phases as non-resumable outcomes', () => {
+    for (const phase of TERMINAL_PHASES) {
+      const state = {
+        ...createTeamState(`terminal-${phase}`),
+        phase,
+        active: false,
+      };
+      assert.equal(canResumeTeamState(state), false, `${phase} should stop resuming once terminal`);
+    }
+  });
+
+  it('keeps team task statuses split cleanly between progress and terminal outcomes', () => {
+    for (const status of TERMINAL_TASK_STATUSES) {
+      assert.equal(isTerminalTeamTaskStatus(status), true, `${status} should stay terminal`);
+    }
+
+    for (const status of NON_TERMINAL_TASK_STATUSES) {
+      assert.equal(isTerminalTeamTaskStatus(status), false, `${status} should stay non-terminal`);
+    }
+  });
+
+  it('keeps team dispatch statuses split cleanly between in-flight and terminal outcomes', () => {
+    for (const status of TERMINAL_DISPATCH_STATUSES) {
+      assert.equal(isTerminalTeamDispatchRequestStatus(status), true, `${status} should stay terminal`);
+    }
+
+    for (const status of NON_TERMINAL_DISPATCH_STATUSES) {
+      assert.equal(isTerminalTeamDispatchRequestStatus(status), false, `${status} should stay non-terminal`);
+    }
+  });
+});

--- a/src/team/orchestrator.ts
+++ b/src/team/orchestrator.ts
@@ -4,11 +4,11 @@
  * Leverages Codex CLI's native multi_agent feature for multi-agent coordination.
  * Provides the staged pipeline: plan -> prd -> exec -> verify -> fix (loop)
  */
+import { isTerminalRunState } from '../runtime/run-outcome.js';
 
 export type TeamPhase = 'team-plan' | 'team-prd' | 'team-exec' | 'team-verify' | 'team-fix';
 export type TerminalPhase = 'complete' | 'failed' | 'cancelled';
 import type { TeamTask } from './state.js';
-const TERMINAL_PHASES: readonly TerminalPhase[] = ['complete', 'failed', 'cancelled'];
 const FIX_LOOP_EXCEEDED_REASON = 'team-fix loop limit reached';
 
 export interface TeamState {
@@ -42,7 +42,7 @@ export function isValidTransition(from: TeamPhase, to: TeamPhase | TerminalPhase
 }
 
 export function isTerminalPhase(phase: TeamPhase | TerminalPhase): phase is TerminalPhase {
-  return TERMINAL_PHASES.includes(phase as TerminalPhase);
+  return isTerminalRunState(phase);
 }
 
 export function canResumeTeamState(state: TeamState): boolean {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -180,7 +180,7 @@ async function syncRootTeamModeStateOnTerminalPhase(
   phase: TeamPhase | TerminalPhase,
   cwd: string,
 ): Promise<void> {
-  if (phase !== 'complete' && phase !== 'failed' && phase !== 'cancelled') return;
+  if (!isTerminalPhase(phase)) return;
 
   try {
     const teamState = await readModeState('team', cwd);


### PR DESCRIPTION
## Summary
Introduce the PR1 shared run-outcome vocabulary for issue #1718 and align the first terminal-state readers around it.

## Problem statement
Issue #1718 proposes moving persistence semantics into the OMX core run contract, but the current codebase still spreads terminal-state meaning across fragmented labels like `complete`, `completed`, `finished`, and ad-hoc terminal checks. That makes it harder to reason about what is truly terminal versus what should continue.

## Root cause
The existing runtime surfaces did not have one shared vocabulary for run outcomes. Team phase readers, notify-hook terminal checks, and related docs/tests each encoded their own terminal assumptions, so “successful terminal state” and “still active / continue” semantics were not named in one place.

## What changed
- Added `src/runtime/run-outcome.ts` as the shared PR1 run-outcome vocabulary module.
- Defined canonical terminal outcomes: `finish`, `blocked_on_user`, `failed`, `cancelled`.
- Defined canonical non-terminal outcomes: `progress`, `continue`.
- Added compatibility normalization so existing labels like `complete`, `completed`, and `finished` map to shared `finish` semantics.
- Updated `src/scripts/notify-hook/utils.ts` to read terminality from the shared contract instead of a local hard-coded set.
- Updated `src/team/orchestrator.ts` and `src/team/runtime.ts` to use the shared terminal helper for team terminal-phase decisions.
- Updated `src/scripts/codex-native-hook.ts` to use the shared terminal-state helper for Ralph/mode Stop-gating reads instead of duplicated terminal sets.
- Added focused regression coverage in `src/team/__tests__/run-outcome-contract.test.ts`.
- Added PR1 contract documentation in `docs/contracts/run-outcome-contract.md` and a native-hook note in `docs/codex-native-hooks.md`.

## Why this design
This keeps PR1 narrow, reviewable, and safe. It does not yet introduce the new core run loop or shared run-state ownership; it only establishes the common vocabulary and updates the first central readers to depend on it. That matches the issue’s required 5-PR sequence and reduces the chance of mixing architectural migration work too early.

## Overlap assessment
Adjacent but distinct.

Related earlier work hardened the existing persistence stack rather than changing the core contract:
- #1681 “fix: keep Ralph visibly active across continuation recovery”
- #1484 “fix(notify): Stop Ralph steer after stale starting phase”
- #1043 “fix(watcher): keep team fallback orchestration alive while live worker panes remain”
- #1026 “Deprecate omx team ralph and remove linked team↔Ralph lifecycle machinery”

This PR does not replace those fixes. It creates the shared vocabulary layer that later PRs in #1718 will use to migrate the deeper runtime semantics.

## Validation
- `npm run build`
- `npx biome lint docs/codex-native-hooks.md docs/contracts/run-outcome-contract.md src/runtime/run-outcome.ts src/scripts/codex-native-hook.ts src/scripts/notify-hook/utils.ts src/team/orchestrator.ts src/team/runtime.ts src/team/__tests__/run-outcome-contract.test.ts`
- `node --test dist/team/__tests__/run-outcome-contract.test.js dist/team/__tests__/orchestrator.test.js dist/hooks/__tests__/notify-hook-modules.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `node --test dist/team/__tests__/phase-controller.test.js dist/team/__tests__/runtime-cli.test.js`

## Risk / compatibility
- Low-risk / narrow scope.
- Existing public labels remain compatible through normalization; this PR does not force a repo-wide rename yet.
- `blocked_on_user` is introduced as canonical contract vocabulary, but deeper runtime ownership changes are intentionally deferred to later PRs.
- The broader full-suite verification was not rerun; validation here is targeted to the PR1 surfaces.

## Files changed
- `src/runtime/run-outcome.ts`
- `src/scripts/codex-native-hook.ts`
- `src/scripts/notify-hook/utils.ts`
- `src/team/orchestrator.ts`
- `src/team/runtime.ts`
- `src/team/__tests__/run-outcome-contract.test.ts`
- `docs/contracts/run-outcome-contract.md`
- `docs/codex-native-hooks.md`
