### PR TITLE
Add the PR2 core run loop for #1718

### DIFF
--- a/src/runtime/__tests__/run-loop.test.ts
+++ b/src/runtime/__tests__/run-loop.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { runUntilTerminal } from '../run-loop.js';
+
+describe('runUntilTerminal', () => {
+  it('continues through non-terminal outcomes until finish', async () => {
+    const seen: string[] = [];
+    const result = await runUntilTerminal(async (iteration) => {
+      const outcome = iteration < 3 ? 'continue' : 'finish';
+      return {
+        outcome,
+        state: { iteration },
+      };
+    }, {
+      onIteration(step) {
+        seen.push(`${step.iteration}:${step.outcome}`);
+      },
+    });
+
+    assert.equal(result.iteration, 3);
+    assert.equal(result.outcome, 'finish');
+    assert.deepEqual(result.history, ['continue', 'continue', 'finish']);
+    assert.deepEqual(seen, ['1:continue', '2:continue', '3:finish']);
+  });
+
+  it('normalizes legacy terminal labels before returning', async () => {
+    const result = await runUntilTerminal(async () => ({
+      outcome: 'completed',
+      state: { ok: true },
+    }));
+
+    assert.equal(result.outcome, 'finish');
+    assert.deepEqual(result.history, ['finish']);
+  });
+
+  it('throws when maxIterations is exceeded without terminal progress', async () => {
+    await assert.rejects(
+      () => runUntilTerminal(async (iteration) => ({
+        outcome: iteration % 2 === 0 ? 'progress' : 'continue',
+        state: { iteration },
+      }), { maxIterations: 3 }),
+      /maxIterations=3/,
+    );
+  });
+});

--- a/src/runtime/run-loop.ts
+++ b/src/runtime/run-loop.ts
@@ -1,0 +1,65 @@
+import {
+  classifyRunOutcome,
+  isTerminalRunOutcome,
+  type RunOutcome,
+  type TerminalRunOutcome,
+} from './run-outcome.js';
+
+export interface RunLoopIteration<TState> {
+  outcome: unknown;
+  state: TState;
+}
+
+export interface NormalizedRunLoopIteration<TState> {
+  iteration: number;
+  outcome: RunOutcome;
+  terminal: boolean;
+  state: TState;
+}
+
+export interface RunLoopTerminalResult<TState> {
+  iteration: number;
+  outcome: TerminalRunOutcome;
+  state: TState;
+  history: RunOutcome[];
+}
+
+export interface RunUntilTerminalOptions<TState> {
+  maxIterations?: number;
+  onIteration?: (result: NormalizedRunLoopIteration<TState>) => Promise<void> | void;
+}
+
+export async function runUntilTerminal<TState>(
+  step: (iteration: number) => Promise<RunLoopIteration<TState>>,
+  options: RunUntilTerminalOptions<TState> = {},
+): Promise<RunLoopTerminalResult<TState>> {
+  const history: RunOutcome[] = [];
+  const maxIterations = options.maxIterations ?? Number.POSITIVE_INFINITY;
+
+  for (let iteration = 1; iteration <= maxIterations; iteration += 1) {
+    const raw = await step(iteration);
+    const outcome = classifyRunOutcome(raw.outcome);
+    history.push(outcome);
+
+    const normalized: NormalizedRunLoopIteration<TState> = {
+      iteration,
+      outcome,
+      terminal: isTerminalRunOutcome(outcome),
+      state: raw.state,
+    };
+
+    await options.onIteration?.(normalized);
+
+    if (normalized.terminal) {
+      const terminalOutcome = normalized.outcome as TerminalRunOutcome;
+      return {
+        iteration,
+        outcome: terminalOutcome,
+        state: raw.state,
+        history,
+      };
+    }
+  }
+
+  throw new Error(`run loop exceeded maxIterations=${maxIterations} without reaching a terminal outcome`);
+}

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -74,6 +74,16 @@ describe('runtime-cli helpers', () => {
     assert.equal(liveBehavior.fixingWithNoWorkers, false);
   });
 
+  it('maps team monitor phases into shared run loop outcomes', async () => {
+    const runtimeCli = await loadRuntimeCliModule();
+
+    assert.equal(runtimeCli.classifySnapshotPhase('team-exec'), 'continue');
+    assert.equal(runtimeCli.classifySnapshotPhase('team-verify'), 'progress');
+    assert.equal(runtimeCli.classifySnapshotPhase('complete'), 'finish');
+    assert.equal(runtimeCli.classifySnapshotPhase('failed'), 'failed');
+    assert.equal(runtimeCli.classifySnapshotPhase('cancelled'), 'cancelled');
+  });
+
   it('reads task results from explicit OMX_TEAM_STATE_ROOT during shutdown collection', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-env-root-cwd-'));
     const explicitStateRoot = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-env-root-state-'));

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -11,9 +11,10 @@ import { readdirSync, readFileSync } from 'fs';
 import { writeFile, rename } from 'fs/promises';
 import { join } from 'path';
 import { startTeam, monitorTeam, shutdownTeam } from './runtime.js';
-import type { TeamRuntime, TeamShutdownSummary, StaleTeamSummary } from './runtime.js';
+import type { TeamRuntime, TeamShutdownSummary, StaleTeamSummary, TeamSnapshot } from './runtime.js';
 import { teamReadConfig as readTeamConfig } from './team-ops.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
+import { runUntilTerminal } from '../runtime/run-loop.js';
 
 async function promptStaleCleanup(summary: StaleTeamSummary): Promise<boolean> {
   process.stderr.write(
@@ -70,6 +71,11 @@ export interface TerminalCliResult {
 export interface LivePaneState {
   paneIds: string[];
   leaderPaneId: string;
+}
+
+interface MonitorLoopState {
+  snap: TeamSnapshot | null;
+  livePaneState: LivePaneState | null;
 }
 
 async function writePanesFile(
@@ -184,6 +190,15 @@ export function buildTerminalCliResult(
       + `Inspect with "omx team status ${teamName} --json" or "omx team api read-stall-state --input '{\"team_name\":\"${teamName}\"}' --json". `
       + `Run "omx team shutdown ${teamName}" (or --force after state capture) when explicit cleanup is desired.\n`,
   };
+}
+
+export function classifySnapshotPhase(
+  phase: string,
+): 'continue' | 'progress' | 'finish' | 'failed' | 'cancelled' {
+  if (phase === 'complete') return 'finish';
+  if (phase === 'failed') return 'failed';
+  if (phase === 'cancelled') return 'cancelled';
+  return phase === 'team-verify' ? 'progress' : 'continue';
 }
 
 export function normalizeAgentTypes(raw: string[], workerCount: number): TeamWorkerProvider[] {
@@ -341,26 +356,35 @@ async function main(): Promise<void> {
     process.stderr.write(`[runtime-cli] Failed to persist pane IDs: ${err}\n`);
   }
 
-  // Poll loop
-  while (pollActive) {
-    await new Promise(r => setTimeout(r, pollIntervalMs));
+  const loopResult = await runUntilTerminal<MonitorLoopState>(async () => {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
 
-    if (!pollActive) break;
+    if (!pollActive) {
+      return {
+        outcome: 'cancelled',
+        state: { snap: null, livePaneState: null as LivePaneState | null },
+      };
+    }
 
     let snap;
     try {
       snap = await monitorTeam(teamName, cwd);
     } catch (err) {
       process.stderr.write(`[runtime-cli] monitorTeam error: ${err}\n`);
-      continue;
+      return {
+        outcome: 'continue',
+        state: { snap: null, livePaneState: null as LivePaneState | null },
+      };
     }
 
     if (!snap) {
       process.stderr.write(`[runtime-cli] monitorTeam returned null\n`);
-      continue;
+      return {
+        outcome: 'continue',
+        state: { snap: null, livePaneState: null as LivePaneState | null },
+      };
     }
 
-    // Refresh pane IDs (workers may have scaled)
     let livePaneState: LivePaneState | null = null;
     try {
       livePaneState = await loadLivePaneState(teamName, cwd);
@@ -376,17 +400,6 @@ async function main(): Promise<void> {
       `[runtime-cli] phase=${snap.phase} pending=${snap.tasks.pending} inProgress=${snap.tasks.in_progress} completed=${snap.tasks.completed} failed=${snap.tasks.failed} dead=${snap.deadWorkers.length} monitorMs=${perfMs.toFixed(0)}\n`,
     );
 
-    // Check completion
-    if (snap.phase === 'complete') {
-      exitWithoutShutdown('complete');
-      return;
-    }
-    if (snap.phase === 'failed' || snap.phase === 'cancelled') {
-      exitWithoutShutdown(snap.phase);
-      return;
-    }
-
-    // Check failure heuristics
     const hasOutstandingWork = (snap.tasks.pending + snap.tasks.in_progress) > 0;
     const liveWorkerPaneCount = livePaneState?.paneIds.length ?? 0;
     const { deadWorkerFailure, fixingWithNoWorkers } = detectDeadWorkerFailure(
@@ -398,11 +411,26 @@ async function main(): Promise<void> {
 
     if (deadWorkerFailure || fixingWithNoWorkers) {
       process.stderr.write(`[runtime-cli] Failure detected: deadWorkerFailure=${deadWorkerFailure} fixingWithNoWorkers=${fixingWithNoWorkers}\n`);
-      // Monitor-detected failure is still not an explicit shutdown request.
-      // Preserve team state for inspection and let the leader decide when to clean up.
-      exitWithoutShutdown('failed');
-      return;
+      return {
+        outcome: 'failed',
+        state: { snap, livePaneState },
+      };
     }
+
+    return {
+      outcome: classifySnapshotPhase(snap.phase),
+      state: { snap, livePaneState },
+    };
+  });
+
+  if (loopResult.outcome === 'finish') {
+    exitWithoutShutdown('complete');
+    return;
+  }
+
+  if (loopResult.outcome === 'failed' || loopResult.outcome === 'cancelled') {
+    exitWithoutShutdown(loopResult.outcome);
+    return;
   }
 }
 


### PR DESCRIPTION
## Summary
Add the PR2 core continue-until-terminal run loop for issue #1718 and route team runtime-cli monitoring through it.

## Problem statement
PR1 established the shared run-outcome vocabulary, but the codebase still lacked a reusable core loop that keeps execution active until a terminal outcome is explicitly reached. In practice, runtime-facing pollers were still open-coding that continuation behavior.

## Root cause
Continuation semantics were still implemented inline inside monitor-style loops rather than as one reusable helper. That kept “continue until terminal outcome” behavior fragmented even after PR1 unified the vocabulary.

## What changed
- Added `src/runtime/run-loop.ts` with `runUntilTerminal`, a reusable helper that:
  - normalizes each step outcome through the shared run-outcome vocabulary
  - keeps iterating on `progress` / `continue`
  - stops only on terminal outcomes (`finish`, `blocked_on_user`, `failed`, `cancelled`)
  - records iteration history and supports iteration callbacks
- Added focused regression coverage in `src/runtime/__tests__/run-loop.test.ts`.
- Updated `src/team/runtime-cli.ts` to route the monitor/poll loop through `runUntilTerminal` instead of open-coding the continuation loop.
- Added `classifySnapshotPhase` coverage in `src/team/__tests__/runtime-cli.test.ts` to keep team monitor phases aligned with the shared run-outcome contract.

## Why this design
This is the narrowest PR2 slice that materially advances issue #1718 without overlapping PR3+ responsibilities. It introduces the shared loop primitive and proves one real integration point, while deferring shared run-state ownership and the Ralph/team/watcher migration to the later PRs.

## Overlap assessment
Follow-up to #1720 / issue #1718.

Adjacent earlier work improved persistence and recovery inside the old architecture, while PR1 introduced the vocabulary layer. This PR is the next sequential slice: it adds the reusable continue-until-terminal loop on top of that contract.

## Validation
- `npm run build`
- `npx biome lint src/runtime/run-loop.ts src/runtime/__tests__/run-loop.test.ts src/team/runtime-cli.ts src/team/__tests__/runtime-cli.test.ts`
- `node --test dist/runtime/__tests__/run-loop.test.js dist/team/__tests__/runtime-cli.test.js dist/pipeline/__tests__/orchestrator.test.js`

## Risk / compatibility
- Narrow scope.
- Behavior change is limited to centralizing existing team runtime-cli continuation semantics under the shared helper.
- This PR does not yet change Ralph/team shared state ownership or watcher responsibilities.

## Files changed
- `src/runtime/run-loop.ts`
- `src/runtime/__tests__/run-loop.test.ts`
- `src/team/runtime-cli.ts`
- `src/team/__tests__/runtime-cli.test.ts`
