### PR TITLE
Promote shared run-state for #1718 PR3

### DIFF
--- a/src/modes/__tests__/base-run-state.test.ts
+++ b/src/modes/__tests__/base-run-state.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { cancelMode, startMode, updateModeState } from '../base.js';
+import { readRunState } from '../../runtime/run-state.js';
+
+describe('modes/base shared run-state sync', () => {
+  it('creates shared run-state on mode start in root scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-run-state-root-'));
+    try {
+      await startMode('ralplan', 'shared run state root scope', 5, wd);
+
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'run-state.json')), true);
+      const runState = await readRunState(wd);
+      assert.ok(runState);
+      assert.equal(runState?.mode, 'ralplan');
+      assert.equal(runState?.active, true);
+      assert.equal(runState?.outcome, 'continue');
+      assert.equal(runState?.current_phase, 'starting');
+      assert.equal(runState?.task_description, 'shared run state root scope');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('creates shared run-state in the current session scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-run-state-session-'));
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-run-state' }));
+
+      await startMode('ralph', 'shared run state session scope', 5, wd);
+
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'sessions', 'sess-run-state', 'run-state.json')), true);
+      const runState = await readRunState(wd);
+      assert.ok(runState);
+      assert.equal(runState?.mode, 'ralph');
+      assert.equal(runState?.active, true);
+      assert.equal(runState?.outcome, 'continue');
+      assert.equal(runState?.owner_omx_session_id, 'sess-run-state');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('syncs terminal finish outcome into shared run-state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-run-state-finish-'));
+    try {
+      await startMode('ralplan', 'finish run state', 5, wd);
+      await updateModeState('ralplan', {
+        active: false,
+        current_phase: 'complete',
+        completed_at: '2026-04-18T00:00:00.000Z',
+      }, wd);
+
+      const runState = await readRunState(wd);
+      assert.ok(runState);
+      assert.equal(runState?.active, false);
+      assert.equal(runState?.outcome, 'finish');
+      assert.equal(runState?.current_phase, 'complete');
+      assert.equal(runState?.completed_at, '2026-04-18T00:00:00.000Z');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('syncs cancelled outcome into shared run-state when cancelling a mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-run-state-cancel-'));
+    try {
+      await startMode('ralplan', 'cancel run state', 5, wd);
+      await cancelMode('ralplan', wd);
+
+      const runState = await readRunState(wd);
+      assert.ok(runState);
+      assert.equal(runState?.active, false);
+      assert.equal(runState?.outcome, 'cancelled');
+      assert.equal(runState?.current_phase, 'cancelled');
+      assert.equal(typeof runState?.completed_at, 'string');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -21,6 +21,7 @@ import {
   getStatePath,
   resolveStateScope,
 } from '../mcp/state-paths.js';
+import { syncRunStateFromModeState } from '../runtime/run-state.js';
 
 export interface ModeState {
   active: boolean;
@@ -129,6 +130,7 @@ export async function startMode(
     ? normalizeRalphModeStateOrThrow(withContext)
     : withContext;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(state, null, 2));
+  await syncRunStateFromModeState(state, projectRoot, scope.sessionId);
   if (isTrackedWorkflowMode(mode)) {
     await syncCanonicalSkillStateForMode({
       cwd: projectRoot ?? process.cwd(),
@@ -201,6 +203,7 @@ export async function updateModeState(
     : updatedBase;
   const updated = withModeRuntimeContext(current, normalizedBase) as ModeState;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(updated, null, 2));
+  await syncRunStateFromModeState(updated, projectRoot, scope.sessionId);
   if (isTrackedWorkflowMode(mode)) {
     await syncCanonicalSkillStateForMode({
       cwd: projectRoot ?? process.cwd(),

--- a/src/runtime/run-state.ts
+++ b/src/runtime/run-state.ts
@@ -1,0 +1,165 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+
+import { getStateFilePath, resolveStateScope } from '../mcp/state-paths.js';
+import {
+  classifyRunOutcome,
+  isTerminalRunOutcome,
+  normalizeRunOutcome,
+  type RunOutcome,
+} from './run-outcome.js';
+
+const RUN_STATE_FILENAME = 'run-state.json';
+
+export interface RunStateLike {
+  active?: unknown;
+  mode?: unknown;
+  current_phase?: unknown;
+  task_description?: unknown;
+  started_at?: unknown;
+  completed_at?: unknown;
+  iteration?: unknown;
+  max_iterations?: unknown;
+  error?: unknown;
+  outcome?: unknown;
+  run_outcome?: unknown;
+  owner_omx_session_id?: unknown;
+  [key: string]: unknown;
+}
+
+export interface RunState {
+  version: 1;
+  mode: string;
+  active: boolean;
+  outcome: RunOutcome;
+  updated_at: string;
+  current_phase?: string;
+  task_description?: string;
+  started_at?: string;
+  completed_at?: string;
+  iteration?: number;
+  max_iterations?: number;
+  error?: string;
+  owner_omx_session_id?: string;
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function optionalFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function terminalOutcomeFromPhase(phase: string | undefined): RunOutcome | null {
+  if (!phase) return null;
+  const normalizedPhase = normalizeRunOutcome(phase);
+  return normalizedPhase && isTerminalRunOutcome(normalizedPhase) ? normalizedPhase : null;
+}
+
+export function deriveRunOutcomeFromModeState(state: RunStateLike): RunOutcome {
+  if (state.active === true) return 'continue';
+
+  const explicitOutcome = normalizeRunOutcome(state.outcome ?? state.run_outcome);
+  if (explicitOutcome) return explicitOutcome;
+
+  const phaseOutcome = terminalOutcomeFromPhase(optionalString(state.current_phase));
+  if (phaseOutcome) return phaseOutcome;
+
+  if (optionalString(state.error)) return 'failed';
+  if (optionalString(state.completed_at)) return 'finish';
+
+  return classifyRunOutcome(state.current_phase);
+}
+
+export function buildRunState(
+  state: RunStateLike,
+  existing?: Partial<RunState> | null,
+  nowIso: string = new Date().toISOString(),
+): RunState {
+  const outcome = deriveRunOutcomeFromModeState(state);
+  const active = state.active === true;
+  const next: RunState = {
+    version: 1,
+    mode: optionalString(state.mode) ?? optionalString(existing?.mode) ?? 'unknown',
+    active,
+    outcome,
+    updated_at: nowIso,
+  };
+
+  const currentPhase = optionalString(state.current_phase);
+  if (currentPhase) next.current_phase = currentPhase;
+
+  const taskDescription = optionalString(state.task_description);
+  if (taskDescription) next.task_description = taskDescription;
+
+  const startedAt = optionalString(state.started_at) ?? optionalString(existing?.started_at);
+  if (startedAt) next.started_at = startedAt;
+
+  const completedAt = active
+    ? undefined
+    : optionalString(state.completed_at)
+      ?? (isTerminalRunOutcome(outcome) ? optionalString(existing?.completed_at) ?? nowIso : undefined);
+  if (completedAt) next.completed_at = completedAt;
+
+  const iteration = optionalFiniteNumber(state.iteration);
+  if (iteration !== undefined) next.iteration = iteration;
+
+  const maxIterations = optionalFiniteNumber(state.max_iterations);
+  if (maxIterations !== undefined) next.max_iterations = maxIterations;
+
+  const error = optionalString(state.error);
+  if (error) next.error = error;
+
+  const ownerSessionId = optionalString(state.owner_omx_session_id);
+  if (ownerSessionId) next.owner_omx_session_id = ownerSessionId;
+
+  return next;
+}
+
+function getRunStatePath(workingDirectory?: string, sessionId?: string): string {
+  return getStateFilePath(RUN_STATE_FILENAME, workingDirectory, sessionId);
+}
+
+async function writeAtomicFile(path: string, data: string): Promise<void> {
+  const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  await writeFile(tmpPath, data, 'utf-8');
+  try {
+    await rename(tmpPath, path);
+  } catch (error) {
+    await unlink(tmpPath).catch(() => {});
+    throw error;
+  }
+}
+
+export async function readRunState(
+  workingDirectory?: string,
+  explicitSessionId?: string,
+): Promise<RunState | null> {
+  const scope = await resolveStateScope(workingDirectory, explicitSessionId);
+  const path = getRunStatePath(workingDirectory, scope.sessionId);
+  if (!existsSync(path)) return null;
+
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as RunState;
+  } catch {
+    return null;
+  }
+}
+
+export async function syncRunStateFromModeState(
+  state: RunStateLike,
+  workingDirectory?: string,
+  explicitSessionId?: string,
+): Promise<RunState> {
+  const scope = await resolveStateScope(workingDirectory, explicitSessionId);
+  const path = getRunStatePath(workingDirectory, scope.sessionId);
+  await mkdir(scope.stateDir, { recursive: true });
+
+  const existing = await readRunState(workingDirectory, scope.sessionId);
+  const next = buildRunState(state, existing);
+  await writeAtomicFile(path, JSON.stringify(next, null, 2));
+  return next;
+}


### PR DESCRIPTION
## Summary
Promote shared run-state above mode-local persistence for issue #1718 PR3.

## Problem statement
PR1 and PR2 established shared run outcomes and the first reusable continuation loop, but run lifecycle ownership was still trapped inside per-mode state files. That meant the repo still lacked one shared lifecycle record above individual mode implementations.

## Root cause
Mode lifecycle start/update/cancel paths persisted only mode-specific state. Even with shared run-outcome vocabulary, there was no single shared run-state file that mirrored lifecycle ownership across root/session scopes.

## What changed
- Added `src/runtime/run-state.ts` as the shared run-state helper.
- Defined shared `RunState` derivation from mode state, including root/session-scoped storage and terminal outcome synchronization.
- Updated `src/modes/base.ts` so `startMode` and `updateModeState` now sync the shared run-state file alongside existing mode-state files.
- Added focused regression coverage in `src/modes/__tests__/base-run-state.test.ts` for:
  - root-scoped run-state creation
  - session-scoped run-state creation
  - terminal finish synchronization
  - cancel synchronization

## Why this design
This keeps PR3 aligned with the issue’s sequence: shared run-state is introduced as a canonical lifecycle layer without yet migrating Ralph/team/Stop-hook/watcher behavior onto it. Existing mode-state files remain intact as compatibility surfaces while later PRs move ownership onto the shared contract.

## Overlap assessment
Follow-up to #1720 and #1721 under issue #1718.

This is distinct from earlier persistence hardening PRs because it introduces the shared lifecycle storage layer itself rather than only improving recovery within the existing architecture.

## Validation
- `npm run build`
- `npx biome lint src/runtime/run-state.ts src/modes/base.ts src/modes/__tests__/base-run-state.test.ts`
- `node --test dist/modes/__tests__/base-run-state.test.js dist/modes/__tests__/base-session-scope.test.js dist/mcp/__tests__/state-server.test.js`

## Risk / compatibility
- Moderate but reviewable scope.
- Existing mode-state files are preserved; shared run-state is additive in this PR.
- Ralph/team/Stop-hook/watcher ownership still remains for PR4/PR5.

## Files changed
- `src/runtime/run-state.ts`
- `src/modes/base.ts`
- `src/modes/__tests__/base-run-state.test.ts`
