### PR TITLE
Teach ultrawork leaders to auto-fanout researcher when external evidence is needed

### DIFF
--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -29,6 +29,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork enab
 - Fire all independent agent calls simultaneously -- never serialize independent work
 - Always pass the `model` parameter explicitly when delegating
 - Read `docs/shared/agent-tiers.md` before first delegation for agent selection guidance
+- Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow
 - Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests)
 - Run quick commands (git status, file reads, simple checks) in the foreground
 </Execution_Policy>


### PR DESCRIPTION
## Summary
- teach `ultrawork` leaders to auto-delegate `researcher` when task correctness depends on official docs, version-aware framework guidance, best practices, or external dependency behavior
- keep this PR intentionally minimal: one skill contract, one line, one behavior clarification

## Problem
The repo already defines `researcher` as the external-docs/reference specialist, but `ultrawork` still under-specifies the leader behavior for when external evidence should be gathered automatically instead of relying on operator phrasing or memory.

## What changed
- updated `skills/ultrawork/SKILL.md`
- added an explicit execution-policy rule telling ultrawork leaders to auto-delegate `researcher` as an evidence lane when external official guidance materially affects correctness

## Why this design
This is the smallest useful first step for #1723:
- it improves one high-leverage leader workflow immediately
- it does not broaden scope into other leader modes yet
- it keeps later PRs free to handle `team`, `ralplan`, `deep-interview`, `researcher` hardening, and evals independently

## Overlap assessment
- follow-up to the already-merged specialist-routing/discoverability work (#1715 / #1717)
- adjacent to the open `researcher` workflow/eval PRs, but distinct: this PR specifically teaches the `ultrawork` leader to auto-fanout `researcher`
- part of umbrella issue #1723

## Validation
- inspected the updated skill text directly
- verified the scoped diff touches only `skills/ultrawork/SKILL.md`

## Risks / compatibility
- behavior is guidance-layer only in this PR; no runtime code path changes
- follow-up PRs are still needed to wire the same expectation into other leader workflows and to lock it with regression coverage

## Changed files
- `skills/ultrawork/SKILL.md`
