### PR TITLE
Teach team leaders to auto-fanout researcher when external evidence is needed

### DIFF
--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -109,6 +109,7 @@ Before launching `omx team`, require a grounded context snapshot:
    - unknowns/open questions
    - likely codebase touchpoints
 4. If ambiguity remains high, run `explore` first for brownfield facts, then run `$deep-interview --quick <task>` before team launch.
+5. If current correctness depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, auto-delegate `researcher` as an evidence lane before or alongside worker launch instead of relying on repo-local recall alone.
 
 Do not start worker panes until this gate is satisfied; if forced to proceed quickly, state explicit scope/risk limitations in the launch report.
 


### PR DESCRIPTION
## Summary
- teach the `$team` leader contract to auto-delegate `researcher` when external official guidance materially affects correctness before/alongside worker launch
- keep the PR intentionally tiny and limited to the team pre-context gate

## Problem
`$team` already has a pre-context gate for repo-local ambiguity handling, but it still leaves a gap for tasks where correctness depends on external official docs or version-aware guidance. That invites repo-local recall or ad hoc operator phrasing instead of intentional external evidence gathering.

## What changed
- updated `skills/team/SKILL.md`
- added a pre-context intake rule telling team leaders to auto-delegate `researcher` as an evidence lane when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect correctness

## Why this design
This keeps the change narrow and reviewable:
- one leader workflow
- one insertion point
- one missing behavior clarified

It also preserves the intended OMX model: `researcher` supports the team leader with evidence instead of replacing the team workflow.

## Overlap assessment
- follow-up to the specialist-routing/discoverability work already merged
- part of umbrella issue #1723
- distinct from the ultrawork PR because this one applies the same expectation to the team pre-launch gate

## Validation
- inspected the updated skill text directly
- verified the scoped diff touches only `skills/team/SKILL.md`

## Risks / compatibility
- guidance-layer change only; no runtime/state-machine changes in this PR
- follow-up PRs are still needed for `ralplan`, `deep-interview`, `researcher` hardening, and regression coverage

## Changed files
- `skills/team/SKILL.md`
