### PR TITLE
Teach ralplan leaders to auto-fanout researcher before planning handoff

### DIFF
--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -80,6 +80,7 @@ Before consensus planning or execution handoff, ensure a grounded context snapsh
    - unknowns/open questions
    - likely codebase touchpoints
 4. If ambiguity remains high, gather brownfield facts first. When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups with narrow, concrete prompts; otherwise use the richer normal explore path. Then run `$deep-interview --quick <task>` before continuing.
+5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, auto-delegate `researcher` before finalizing the planning handoff so execution does not start from repo-local recall alone.
 
 Do not hand off to execution modes until this intake is complete; if urgency forces progress, explicitly document the risk tradeoffs.
 


### PR DESCRIPTION
## Summary
- teach `ralplan` leaders to auto-delegate `researcher` before planning handoff when correctness depends on official docs, version-aware guidance, best practices, or external dependency behavior
- keep the PR intentionally limited to the ralplan intake contract

## Problem
`ralplan` already gathers brownfield context and can route to deep-interview for ambiguity, but it still leaves a planning gap when the plan itself depends on external official guidance. Without that instruction, planning can still solidify around repo-local recall or stale framework assumptions.

## What changed
- updated `skills/ralplan/SKILL.md`
- added a pre-context intake rule telling ralplan leaders to auto-delegate `researcher` before finalizing planning handoff when external official guidance materially affects the plan

## Why this design
This is the smallest useful planning-lane change:
- one workflow
- one insertion point
- one missing external-evidence expectation

It keeps the planning lane honest without broadening into a full planner prompt rewrite.

## Overlap assessment
- follow-up to the already-merged specialist-routing/discoverability work
- part of umbrella issue #1723
- distinct from the ultrawork/team PRs because this one targets the planning handoff path

## Validation
- inspected the updated skill text directly
- verified the scoped diff touches only `skills/ralplan/SKILL.md`

## Risks / compatibility
- guidance-layer change only
- later PRs still need to cover `deep-interview`, `researcher` hardening, and regression checks

## Changed files
- `skills/ralplan/SKILL.md`
