### PR TITLE
Teach deep-interview to auto-fanout researcher when external evidence is needed

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -47,6 +47,7 @@ If no flag is provided, use **Standard**.
 - Do not rotate to a new clarity dimension just for coverage when the current answer is still vague; stay on the same thread until one layer deeper, one assumption clearer, or one boundary tighter
 - Before crystallizing, complete at least one explicit pressure pass that revisits an earlier answer with a deeper, assumption-focused, or tradeoff-focused follow-up
 - Gather codebase facts via `explore` before asking user about internals
+- Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect how the interview should frame scope, constraints, or acceptance criteria
 - When session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only brownfield fact gathering; keep prompts narrow and concrete, and keep ambiguous or non-shell-only investigation on the richer normal path and fall back normally if `omx explore` is unavailable.
 - Always run a preflight context intake before the first interview question
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly


### PR DESCRIPTION
## Summary
- teach `deep-interview` to auto-delegate `researcher` when external official guidance materially affects how the interview should frame scope, constraints, or acceptance criteria
- keep the PR intentionally limited to the deep-interview execution policy

## Problem
`deep-interview` already gathers repo-local brownfield facts before asking the user about internals, but it still lacks an explicit rule for when the interview itself should pull in external official guidance. That leaves a gap for version-sensitive frameworks, external API behavior, and best-practice-sensitive intake.

## What changed
- updated `skills/deep-interview/SKILL.md`
- added an execution-policy rule telling deep-interview leaders to auto-delegate `researcher` when external official guidance materially affects interview framing

## Why this design
This keeps the change precise:
- one leader workflow
- one missing external-evidence instruction
- no broader rewrite of the interview system in this PR

It also matches the intended workflow shape: external docs become a support lane for better clarification rather than a separate primary mode.

## Overlap assessment
- follow-up to the specialist-routing/discoverability work already merged
- part of umbrella issue #1723
- distinct from the ultrawork/team/ralplan PRs because this one targets the intake/interview workflow

## Validation
- inspected the updated skill text directly
- verified the scoped diff touches only `skills/deep-interview/SKILL.md`

## Risks / compatibility
- guidance-layer change only
- later PRs still need to lock behavior with regression coverage

## Changed files
- `skills/deep-interview/SKILL.md`
