### PR TITLE
Teach planner guidance to auto-fanout researcher before handoff

### DIFF
--- a/docs/prompt-guidance-fragments/planner-investigation.md
+++ b/docs/prompt-guidance-fragments/planner-investigation.md
@@ -1,1 +1,2 @@
 3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+4) If official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect the plan, auto-delegate `researcher` before finalizing the handoff instead of planning from repo-local recall alone.

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -40,10 +40,12 @@ Interpret implementation requests as planning requests only when this role is ex
 3. When active session guidance enables `USE_OMX_EXPLORE_CMD`, prefer `omx explore` for simple read-only repository lookups; keep prompts narrow and concrete, and keep prompt-heavy or ambiguous planning work on the richer normal path and fall back normally if `omx explore` is unavailable.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->
 3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+4) If official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect the plan, auto-delegate `researcher` before finalizing the handoff instead of planning from repo-local recall alone.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->
 4. Ask about preferences only when a real branch depends on them.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:START -->
 3) If correctness depends on repository inspection, prompt review, or other tools, keep using them until the plan is grounded in evidence.
+4) If official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect the plan, auto-delegate `researcher` before finalizing the handoff instead of planning from repo-local recall alone.
 <!-- OMX:GUIDANCE:PLANNER:INVESTIGATION:END -->
 5. Stop planning when the plan becomes actionable.
 </explore>


### PR DESCRIPTION
## Summary
- teach planner-level guidance to auto-delegate `researcher` before finalizing a plan when official docs, version-aware guidance, best practices, or external dependency behavior materially affect correctness
- keep the prompt and fragment contract in sync

## Problem
The workflow-entry PRs in this series teach `ultrawork`, `team`, `ralplan`, and `deep-interview` to pull external evidence when needed, but the core `planner` guidance still lacked the same explicit rule. That left a gap between workflow-entry expectations and the underlying planning prompt contract.

## What changed
- updated `prompts/planner.md`
- updated `docs/prompt-guidance-fragments/planner-investigation.md`
- added the planner-level rule to auto-delegate `researcher` before handoff when external official guidance materially affects the plan

## Why this design
This keeps the series coherent:
- workflow entry points gain the behavior
- planner guidance itself also reflects the same expectation
- fragment-sync tests keep the prompt contract stable

## Overlap assessment
- follow-up to the workflow-entry PRs in this series, not a duplicate
- part of umbrella issue #1723
- distinct because it locks the core planner guidance rather than only the skill entry points

## Validation
- `npm run build`
- `node --test dist/hooks/__tests__/prompt-guidance-fragments.test.js dist/hooks/__tests__/prompt-guidance-contract.test.js`

## Risks / compatibility
- prompt/guidance-only change; no runtime/state-machine logic changes
- broader regression coverage for all leader modes can still land separately later if needed

## Changed files
- `prompts/planner.md`
- `docs/prompt-guidance-fragments/planner-investigation.md`
