### PR TITLE
Install autoresearch skill during setup

### DIFF
--- a/src/catalog/__tests__/schema.test.ts
+++ b/src/catalog/__tests__/schema.test.ts
@@ -75,4 +75,12 @@ describe('catalog schema', () => {
     assert.equal(aiSlopCleaner?.category, 'shortcut');
     assert.equal(aiSlopCleaner?.status, 'active');
   });
+
+  it('includes autoresearch as an active built-in skill', () => {
+    const parsed = validateCatalogManifest(readSourceManifest());
+    const autoresearch = parsed.skills.find((skill) => skill.name === 'autoresearch');
+
+    assert.equal(autoresearch?.category, 'execution');
+    assert.equal(autoresearch?.status, 'active');
+  });
 });

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-04-18T00:57:32.991Z",
+  "generatedAt": "2026-04-18T08:54:56.317Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 39,
+    "skillCount": 40,
     "promptCount": 30,
-    "activeSkillCount": 25,
+    "activeSkillCount": 26,
     "activeAgentCount": 18
   },
   "coreSkills": [
@@ -53,6 +53,13 @@
     },
     {
       "name": "ultraqa",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "autoresearch",
       "category": "execution",
       "status": "active",
       "core": false,

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -38,6 +38,11 @@
       "status": "active"
     },
     {
+      "name": "autoresearch",
+      "category": "execution",
+      "status": "active"
+    },
+    {
       "name": "swarm",
       "category": "execution",
       "status": "alias",

--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -68,6 +68,7 @@ describe('omx setup skills overwrite behavior', () => {
       assert.equal(installed.has('analyze'), true);
       assert.equal(installed.has('team'), true);
       assert.equal(installed.has('worker'), true);
+      assert.equal(installed.has('autoresearch'), true);
       assert.equal(installed.has('swarm'), false);
       assert.equal(installed.has('ecomode'), false);
       assert.equal(installed.has('ultraqa'), true);
@@ -83,6 +84,10 @@ describe('omx setup skills overwrite behavior', () => {
       assert.match(
         await readFile(join(skillsDir, 'analyze', 'SKILL.md'), 'utf-8'),
         /^---\nname: analyze/m,
+      );
+      assert.match(
+        await readFile(join(skillsDir, 'autoresearch', 'SKILL.md'), 'utf-8'),
+        /^---\nname: autoresearch/m,
       );
     } finally {
       process.chdir(previousCwd);

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -46,6 +46,13 @@
       "internalRequired": false
     },
     {
+      "name": "autoresearch",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "swarm",
       "category": "execution",
       "status": "alias",


### PR DESCRIPTION
## Summary
- add autoresearch to the active skill catalog so setup installs the shipped skill
- sync generated catalog artifacts
- add setup/schema regression coverage for autoresearch installation

## Verification
- npm run build
- node --test dist/cli/__tests__/setup-skills-overwrite.test.js dist/catalog/__tests__/schema.test.js dist/catalog/__tests__/generator.test.js
- node dist/scripts/generate-catalog-docs.js --check
