### PR TITLE
Introduce shared run outcome contract for persisted mode state

### DIFF
--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -727,10 +727,17 @@ describe('state-server directory initialization', () => {
 
       const completed = JSON.parse(
         await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-handoff', 'deep-interview-state.json'), 'utf-8'),
-      ) as { active?: boolean; current_phase?: string; completed_at?: string; auto_completed_reason?: string };
+      ) as {
+        active?: boolean;
+        current_phase?: string;
+        completed_at?: string;
+        auto_completed_reason?: string;
+        run_outcome?: string;
+      };
       assert.equal(completed.active, false);
       assert.equal(completed.current_phase, 'completed');
       assert.equal(typeof completed.completed_at, 'string');
+      assert.equal(completed.run_outcome, 'finish');
       assert.match(completed.auto_completed_reason || '', /mode transiting: deep-interview -> ralplan/);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -164,6 +164,10 @@ export function buildStateServerTools() {
 					task_description: { type: "string" },
 					started_at: { type: "string" },
 					completed_at: { type: "string" },
+					run_outcome: {
+						type: "string",
+						enum: ["continue", "finish", "blocked_on_user", "failed", "cancelled"],
+					},
 					error: { type: "string" },
 					state: { type: "object", description: "Additional custom fields" },
 					workingDirectory: { type: "string" },

--- a/src/modes/__tests__/base-ralph-contract.test.ts
+++ b/src/modes/__tests__/base-ralph-contract.test.ts
@@ -53,6 +53,21 @@ describe('modes/base ralph contract integration', () => {
       const updated = await updateModeState('ralph', { current_phase: 'verification' }, wd);
       assert.equal(updated.current_phase, 'verifying');
       assert.equal(updated.ralph_phase_normalized_from, 'verification');
+      assert.equal(updated.run_outcome, 'continue');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('updateModeState persists terminal run outcomes on blocked_on_user', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-ralph-contract-'));
+    try {
+      await startMode('ralph', 'demo', 5, wd);
+      const updated = await updateModeState('ralph', { active: false, current_phase: 'blocked_on_user' }, wd);
+      assert.equal(updated.current_phase, 'blocked_on_user');
+      assert.equal(updated.run_outcome, 'blocked_on_user');
+      assert.equal(updated.active, false);
+      assert.ok(typeof updated.completed_at === 'string' && updated.completed_at.length > 0);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -14,6 +14,7 @@ import {
 import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
 import { syncCanonicalSkillStateForMode } from '../state/skill-active.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
+import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
 import {
   getBaseStateDir,
   getReadScopedStateDirs,
@@ -28,6 +29,7 @@ export interface ModeState {
   iteration: number;
   max_iterations: number;
   current_phase: string;
+  run_outcome?: string;
   task_description?: string;
   started_at: string;
   completed_at?: string;
@@ -72,6 +74,21 @@ function normalizeRalphModeStateOrThrow(state: ModeState): ModeState {
     normalized.ralph_phase_normalized_from = originalPhase;
   }
   return normalized;
+}
+
+function applySharedRunOutcomeContractOrThrow(state: ModeState): ModeState {
+  const validation = applyRunOutcomeContract(state as Record<string, unknown>);
+  if (!validation.ok || !validation.state) {
+    throw new Error(validation.error || 'Invalid run outcome state');
+  }
+  return validation.state as ModeState;
+}
+
+function normalizeModeStateOrThrow(mode: string, state: ModeState): ModeState {
+  const normalized = mode === 'ralph'
+    ? normalizeRalphModeStateOrThrow(state)
+    : state;
+  return applySharedRunOutcomeContractOrThrow(normalized);
 }
 
 function stateDir(projectRoot?: string): string {
@@ -125,9 +142,7 @@ export async function startMode(
   };
 
   const withContext = withModeRuntimeContext({}, stateBase) as ModeState;
-  const state = mode === 'ralph'
-    ? normalizeRalphModeStateOrThrow(withContext)
-    : withContext;
+  const state = normalizeModeStateOrThrow(mode, withContext);
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(state, null, 2));
   if (isTrackedWorkflowMode(mode)) {
     await syncCanonicalSkillStateForMode({
@@ -193,12 +208,13 @@ export async function updateModeState(
   await mkdir(scope.stateDir, { recursive: true });
 
   const updatedBase = { ...current, ...updates };
+  if (!Object.prototype.hasOwnProperty.call(updates, 'run_outcome')) {
+    delete updatedBase.run_outcome;
+  }
   if (mode === 'ralph' && scope.sessionId && typeof updatedBase.owner_omx_session_id !== 'string') {
     updatedBase.owner_omx_session_id = scope.sessionId;
   }
-  const normalizedBase = mode === 'ralph'
-    ? normalizeRalphModeStateOrThrow(updatedBase as ModeState)
-    : updatedBase;
+  const normalizedBase = normalizeModeStateOrThrow(mode, updatedBase as ModeState);
   const updated = withModeRuntimeContext(current, normalizedBase) as ModeState;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(updated, null, 2));
   if (isTrackedWorkflowMode(mode)) {

--- a/src/ralph/contract.ts
+++ b/src/ralph/contract.ts
@@ -3,6 +3,7 @@ export const RALPH_PHASES = [
   'executing',
   'verifying',
   'fixing',
+  'blocked_on_user',
   'complete',
   'failed',
   'cancelled',
@@ -11,7 +12,7 @@ export const RALPH_PHASES = [
 export type RalphPhase = typeof RALPH_PHASES[number];
 
 const RALPH_PHASE_SET = new Set<string>(RALPH_PHASES);
-const RALPH_TERMINAL_PHASE_SET = new Set<RalphPhase>(['complete', 'failed', 'cancelled']);
+const RALPH_TERMINAL_PHASE_SET = new Set<RalphPhase>(['blocked_on_user', 'complete', 'failed', 'cancelled']);
 
 const LEGACY_PHASE_ALIASES: Record<string, RalphPhase> = {
   start: 'starting',
@@ -21,6 +22,8 @@ const LEGACY_PHASE_ALIASES: Record<string, RalphPhase> = {
   verify: 'verifying',
   verification: 'verifying',
   fix: 'fixing',
+  blocked: 'blocked_on_user',
+  'blocked-on-user': 'blocked_on_user',
   complete: 'complete',
   completed: 'complete',
   fail: 'failed',

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -181,7 +181,7 @@ export async function runRalplanConsensus(
       const reviewHistory = buildReviewHistory(drafts, architectReviews, criticReviews);
       await updateRalplanState(cwd, {
         iteration,
-        current_phase: criticReview.verdict === 'approve' ? 'complete' : 'critic-review',
+        current_phase: 'critic-review',
         latest_critic_verdict: criticReview.verdict,
         latest_critic_summary: criticReview.summary,
         review_history: reviewHistory,

--- a/src/runtime/__tests__/run-outcome.test.ts
+++ b/src/runtime/__tests__/run-outcome.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyRunOutcomeContract,
+  inferRunOutcome,
+  isTerminalRunOutcome,
+  normalizeRunOutcome,
+} from '../run-outcome.js';
+
+describe('run outcome contract', () => {
+  it('normalizes legacy outcome aliases', () => {
+    assert.deepEqual(normalizeRunOutcome('completed'), {
+      outcome: 'finish',
+      warning: 'normalized legacy run outcome "completed" -> "finish"',
+    });
+  });
+
+  it('infers continue for active non-terminal state', () => {
+    assert.equal(inferRunOutcome({ active: true, current_phase: 'executing' }), 'continue');
+  });
+
+  it('infers terminal outcomes from terminal phases', () => {
+    assert.equal(inferRunOutcome({ active: false, current_phase: 'complete' }), 'finish');
+    assert.equal(inferRunOutcome({ active: false, current_phase: 'blocked_on_user' }), 'blocked_on_user');
+    assert.equal(inferRunOutcome({ active: false, current_phase: 'failed' }), 'failed');
+    assert.equal(inferRunOutcome({ active: false, current_phase: 'cancelled' }), 'cancelled');
+  });
+
+  it('clears stale completed_at for non-terminal progress', () => {
+    const result = applyRunOutcomeContract({
+      active: true,
+      current_phase: 'executing',
+      completed_at: '2026-04-18T00:00:00.000Z',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.state?.run_outcome, 'continue');
+    assert.equal(result.state?.completed_at, undefined);
+  });
+
+  it('stamps completed_at for terminal outcomes and marks them inactive', () => {
+    const result = applyRunOutcomeContract(
+      {
+        current_phase: 'blocked_on_user',
+      },
+      { nowIso: '2026-04-18T12:00:00.000Z' },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.state?.active, false);
+    assert.equal(result.state?.run_outcome, 'blocked_on_user');
+    assert.equal(result.state?.completed_at, '2026-04-18T12:00:00.000Z');
+    assert.equal(isTerminalRunOutcome(result.state?.run_outcome as never), true);
+  });
+
+  it('rejects contradictory terminal/active combinations', () => {
+    const result = applyRunOutcomeContract({
+      active: true,
+      run_outcome: 'failed',
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error || '', /requires active=false/);
+  });
+});

--- a/src/runtime/run-outcome.ts
+++ b/src/runtime/run-outcome.ts
@@ -1,0 +1,128 @@
+export const RUN_OUTCOMES = [
+  'continue',
+  'finish',
+  'blocked_on_user',
+  'failed',
+  'cancelled',
+] as const;
+
+export type RunOutcome = (typeof RUN_OUTCOMES)[number];
+
+const RUN_OUTCOME_SET = new Set<RunOutcome>(RUN_OUTCOMES);
+const TERMINAL_RUN_OUTCOME_SET = new Set<RunOutcome>([
+  'finish',
+  'blocked_on_user',
+  'failed',
+  'cancelled',
+]);
+
+const RUN_OUTCOME_ALIASES: Record<string, RunOutcome> = {
+  complete: 'finish',
+  completed: 'finish',
+  done: 'finish',
+  blocked: 'blocked_on_user',
+  'blocked-on-user': 'blocked_on_user',
+  cancel: 'cancelled',
+  fail: 'failed',
+  error: 'failed',
+};
+
+const TERMINAL_PHASE_TO_RUN_OUTCOME: Record<string, RunOutcome> = {
+  complete: 'finish',
+  completed: 'finish',
+  blocked: 'blocked_on_user',
+  blocked_on_user: 'blocked_on_user',
+  'blocked-on-user': 'blocked_on_user',
+  failed: 'failed',
+  cancelled: 'cancelled',
+  cancel: 'cancelled',
+};
+
+export interface RunOutcomeValidationResult {
+  ok: boolean;
+  state?: Record<string, unknown>;
+  warning?: string;
+  error?: string;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function isTerminalRunOutcome(outcome: RunOutcome): boolean {
+  return TERMINAL_RUN_OUTCOME_SET.has(outcome);
+}
+
+export function normalizeRunOutcome(rawOutcome: unknown): {
+  outcome?: RunOutcome;
+  warning?: string;
+  error?: string;
+} {
+  const normalized = safeString(rawOutcome).toLowerCase();
+  if (!normalized) return {};
+  if (RUN_OUTCOME_SET.has(normalized as RunOutcome)) {
+    return { outcome: normalized as RunOutcome };
+  }
+  const alias = RUN_OUTCOME_ALIASES[normalized];
+  if (alias) {
+    return {
+      outcome: alias,
+      warning: `normalized legacy run outcome "${rawOutcome}" -> "${alias}"`,
+    };
+  }
+  return {
+    error: `run_outcome must be one of: ${RUN_OUTCOMES.join(', ')}`,
+  };
+}
+
+export function inferRunOutcome(candidate: Record<string, unknown>): RunOutcome {
+  const explicit = normalizeRunOutcome(candidate.run_outcome);
+  if (explicit.outcome) return explicit.outcome;
+
+  const phase = safeString(candidate.current_phase).toLowerCase();
+  if (phase && TERMINAL_PHASE_TO_RUN_OUTCOME[phase]) {
+    return TERMINAL_PHASE_TO_RUN_OUTCOME[phase];
+  }
+
+  if (candidate.active === true) return 'continue';
+  if (safeString(candidate.completed_at)) return 'finish';
+  if (candidate.active === false) return 'finish';
+  return 'continue';
+}
+
+export function applyRunOutcomeContract(
+  candidate: Record<string, unknown>,
+  options?: { nowIso?: string },
+): RunOutcomeValidationResult {
+  const nowIso = options?.nowIso ?? new Date().toISOString();
+  const next: Record<string, unknown> = { ...candidate };
+  const normalized = normalizeRunOutcome(next.run_outcome);
+  if (normalized.error) return { ok: false, error: normalized.error };
+
+  const outcome = normalized.outcome ?? inferRunOutcome(next);
+  next.run_outcome = outcome;
+
+  if (isTerminalRunOutcome(outcome)) {
+    if (next.active === true) {
+      return { ok: false, error: `terminal run outcome "${outcome}" requires active=false` };
+    }
+    next.active = false;
+    if (!safeString(next.completed_at)) {
+      next.completed_at = nowIso;
+    }
+  } else {
+    if (next.active === false) {
+      return { ok: false, error: 'non-terminal run outcome "continue" requires active=true' };
+    }
+    next.active = true;
+    if (safeString(next.completed_at)) {
+      delete next.completed_at;
+    }
+  }
+
+  return {
+    ok: true,
+    state: next,
+    warning: normalized.warning,
+  };
+}

--- a/src/state/__tests__/operations-ralph-phase.test.ts
+++ b/src/state/__tests__/operations-ralph-phase.test.ts
@@ -23,6 +23,28 @@ describe('state operations Ralph phase contract', () => {
       const state = JSON.parse(await readFile(file, 'utf-8'));
       assert.equal(state.current_phase, 'executing');
       assert.equal(state.ralph_phase_normalized_from, 'execution');
+      assert.equal(state.run_outcome, 'continue');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts blocked_on_user as an explicit terminal Ralph outcome', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-phase-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralph',
+        active: false,
+        current_phase: 'blocked_on_user',
+      });
+      assert.equal(response.isError, undefined);
+
+      const file = join(wd, '.omx', 'state', 'ralph-state.json');
+      const state = JSON.parse(await readFile(file, 'utf-8'));
+      assert.equal(state.current_phase, 'blocked_on_user');
+      assert.equal(state.run_outcome, 'blocked_on_user');
+      assert.equal(typeof state.completed_at, 'string');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -16,6 +16,7 @@ import {
 } from '../mcp/state-paths.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
+import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
 import {
   SKILL_ACTIVE_STATE_MODE,
   readSkillActiveState,
@@ -225,6 +226,14 @@ export async function executeStateOperation(
             ...fields,
             ...((customState as Record<string, unknown>) || {}),
           } as Record<string, unknown>;
+          const explicitRunOutcome = Object.prototype.hasOwnProperty.call(fields, 'run_outcome')
+            || (
+              customState != null
+              && Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, 'run_outcome')
+            );
+          if (!explicitRunOutcome) {
+            delete mergedRaw.run_outcome;
+          }
 
           if (
             mode === 'ralph' &&
@@ -250,6 +259,15 @@ export async function executeStateOperation(
             }
             Object.assign(mergedRaw, validation.state);
             ensureRalphArtifacts = true;
+          }
+
+          if (mode !== SKILL_ACTIVE_STATE_MODE) {
+            const runOutcomeValidation = applyRunOutcomeContract(mergedRaw);
+            if (!runOutcomeValidation.ok || !runOutcomeValidation.state) {
+              validationError = runOutcomeValidation.error || 'Invalid run outcome state';
+              return;
+            }
+            Object.assign(mergedRaw, runOutcomeValidation.state);
           }
 
           if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -16,6 +16,7 @@ import {
   readVisibleSkillActiveState,
   syncCanonicalSkillStateForMode,
 } from './skill-active.js';
+import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
 
 interface TransitionStateLike {
   active?: unknown;
@@ -95,7 +96,7 @@ async function completeSourceModeState(
     const existing = await readJsonIfExists(candidatePath);
     if (!existing || existing.active !== true) continue;
 
-    const nextState: TransitionStateLike = {
+    const nextCandidate: TransitionStateLike = {
       ...existing,
       active: false,
       current_phase: 'completed',
@@ -105,6 +106,8 @@ async function completeSourceModeState(
       transition_source: source,
       transition_target_mode: destinationMode,
     };
+    delete nextCandidate.run_outcome;
+    const nextState = applyRunOutcomeContract(nextCandidate, { nowIso }).state as TransitionStateLike;
 
     await mkdir(dirname(candidatePath), { recursive: true });
     await writeFile(candidatePath, JSON.stringify(nextState, null, 2));


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Restore the first sequential #1718 slice by introducing a shared `run_outcome` contract for persisted workflow mode state.

## Changes

- add `src/runtime/run-outcome.ts` with the shared terminal/non-terminal run outcome contract
- apply the shared contract in mode state startup/update flows and MCP `state_write`
- reconcile workflow transitions through `run_outcome` instead of ad hoc completion inference
- extend Ralph/state-server tests to cover `blocked_on_user` and shared run outcome persistence

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `./node_modules/.bin/biome lint src/runtime/run-outcome.ts src/runtime/__tests__/run-outcome.test.ts src/modes/base.ts src/ralph/contract.ts src/state/operations.ts src/state/workflow-transition-reconcile.ts src/mcp/state-server.ts src/mcp/__tests__/state-server.test.ts src/modes/__tests__/base-ralph-contract.test.ts src/state/__tests__/operations-ralph-phase.test.ts`
- [x] `node --test dist/runtime/__tests__/run-outcome.test.js dist/modes/__tests__/base-ralph-contract.test.js dist/state/__tests__/operations-ralph-phase.test.js dist/mcp/__tests__/state-server.test.js`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [ ] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Related #1718
