### PR TITLE
fix: preserve the canonical session across descendant SessionStart events

### DIFF
--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -226,6 +226,36 @@ describe('session lifecycle manager', () => {
     }
   });
 
+  it('preserves the canonical session when a descendant subagent SessionStart arrives in the same cwd', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-subagent-'));
+    try {
+      await writeSessionStart(cwd, 'omx-leader-session', {
+        nativeSessionId: 'codex-native-leader',
+      });
+
+      const childPid = process.pid + 1000;
+      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-child', {
+        pid: childPid,
+        platform: process.platform,
+        readParentPid: (pid) => (pid === childPid ? process.pid : null),
+      });
+
+      assert.equal(reconciled.session_id, 'omx-leader-session');
+      assert.equal(reconciled.native_session_id, 'codex-native-leader');
+
+      const persisted = await readSessionState(cwd);
+      assert.equal(persisted?.session_id, 'omx-leader-session');
+      assert.equal(persisted?.native_session_id, 'codex-native-leader');
+
+      const dailyLogPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
+      const dailyLog = await readFile(dailyLogPath, 'utf-8');
+      assert.match(dailyLog, /"event":"session_start_preserved_subagent"/);
+      assert.match(dailyLog, /"native_session_id":"codex-native-child"/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to a fresh canonical session when reconciling without authoritative launch state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-fallback-'));
     try {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -5,6 +5,7 @@
  * and provides structured logging for session events.
  */
 
+import { execFileSync } from 'child_process';
 import { readFile, writeFile, mkdir, unlink, appendFile, rm } from 'fs/promises';
 import { dirname, join } from 'path';
 import { existsSync, readFileSync } from 'fs';
@@ -158,6 +159,7 @@ interface SessionStartOptions {
   pid?: number;
   platform?: NodeJS.Platform;
   nativeSessionId?: string;
+  readParentPid?: (pid: number) => number | null;
 }
 
 function defaultIsPidAlive(pid: number): boolean {
@@ -167,6 +169,52 @@ function defaultIsPidAlive(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+function defaultReadParentPid(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    const commandEnd = stat.lastIndexOf(')');
+    if (commandEnd === -1) return null;
+    const remainder = stat.slice(commandEnd + 1).trim();
+    const fields = remainder.split(/\s+/);
+    if (fields.length < 2) return null;
+    const parentPid = Number(fields[1]);
+    return Number.isFinite(parentPid) && parentPid > 0 ? parentPid : null;
+  } catch {
+    try {
+      const raw = execFileSync('ps', ['-o', 'ppid=', '-p', String(pid)], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      const parentPid = Number.parseInt(raw, 10);
+      return Number.isFinite(parentPid) && parentPid > 0 ? parentPid : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function isDescendantProcess(
+  pid: number,
+  ancestorPid: number,
+  readParentPid: (pid: number) => number | null = defaultReadParentPid,
+): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (!Number.isInteger(ancestorPid) || ancestorPid <= 0) return false;
+
+  const visited = new Set<number>();
+  let currentPid: number | null = pid;
+  let depth = 0;
+
+  while (currentPid && currentPid > 0 && depth < 64 && !visited.has(currentPid)) {
+    if (currentPid === ancestorPid) return true;
+    visited.add(currentPid);
+    currentPid = readParentPid(currentPid);
+    depth += 1;
+  }
+
+  return false;
 }
 
 function parseLinuxProcStartTicks(statContent: string): number | null {
@@ -331,6 +379,29 @@ export async function reconcileNativeSessionStart(
     ? existing.native_session_id.trim()
     : '';
   if (existingNativeSessionId && existingNativeSessionId !== nativeSessionId) {
+    const incomingPid = Number.isInteger(options.pid) && options.pid && options.pid > 0
+      ? options.pid
+      : process.pid;
+    const existingPid = Number.isInteger(existing.pid) && existing.pid > 0
+      ? existing.pid
+      : null;
+    if (
+      existingPid
+      && incomingPid !== existingPid
+      && isDescendantProcess(incomingPid, existingPid, options.readParentPid ?? defaultReadParentPid)
+    ) {
+      const nowIso = new Date().toISOString();
+      await appendToLog(cwd, {
+        event: 'session_start_preserved_subagent',
+        session_id: existing.session_id,
+        native_session_id: nativeSessionId,
+        preserved_native_session_id: existingNativeSessionId,
+        pid: incomingPid,
+        timestamp: nowIso,
+      });
+      return existing;
+    }
+
     return await writeSessionStart(cwd, nativeSessionId, {
       ...options,
       nativeSessionId,


### PR DESCRIPTION
## Summary
- Fix an issue where a descendant subagent started in the same cwd could overwrite the canonical `session.json` entry with its child native session id.
- That session pointer drift could leave the leader session's `ralph-state.json` looking active to later Stop-hook checks.
- Preserve the canonical leader session for descendant SessionStart events and add regression coverage.

## Diagnosis
During reproduction, the following state drift showed up together:
- `.omx/state/session.json` pointed at the subagent session instead of the leader session
- the original leader session still had `sessions/<leader>/ralph-state.json` with `active: true`
- later cleanup / Stop decisions were evaluated against the wrong canonical session, so stale `OMX Ralph is still active` blocks repeated

The root cause was `reconcileNativeSessionStart`: it replaced the canonical session whenever the native session id changed, even when the incoming SessionStart belonged to a descendant process of the still-live leader session.

## Change
- When the incoming SessionStart PID is a **descendant** of the existing canonical session PID, keep the existing root `session.json`
- Keep the previous behavior for a true new top-level session
- Add a regression test that locks the descendant-subagent case

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/hooks/__tests__/session.test.js dist/scripts/__tests__/codex-native-hook.test.js`
