### PR TITLE
refactor: adopt shared run continuation helper in Stop-hook and watcher surfaces

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -2514,6 +2514,58 @@ exit 0
     }
   });
 
+  it('treats an explicit blocked_on_user run_outcome as terminal for Ralph continue steer', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-blocked-on-user-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    const stateDir = join(wd, '.omx', 'state');
+    const watcherStatePath = join(stateDir, 'notify-fallback-state.json');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
+        active: true,
+        current_phase: 'executing',
+        run_outcome: 'blocked_on_user',
+        tmux_pane_id: '%42',
+      }, null, 2));
+      await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
+        last_progress_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+      }, null, 2));
+      await writeFile(watcherStatePath, JSON.stringify({
+        ralph_continue_steer: {
+          last_sent_at: new Date(Date.now() - 61_000).toISOString(),
+        },
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const run = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        {
+          encoding: 'utf-8',
+          env: buildCleanNotifyEnv({
+            PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          }),
+        },
+      );
+      assert.equal(run.status, 0, run.stderr || run.stdout);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf8').catch(() => '');
+      const sends = tmuxLog.match(/send-keys -t %42 -l Ralph loop active continue \[OMX_TMUX_INJECT\]/g) || [];
+      assert.equal(sends.length, 0, 'blocked_on_user should suppress Ralph continue steer');
+
+      const watcherState = JSON.parse(await readFile(watcherStatePath, 'utf-8'));
+      assert.equal(watcherState.ralph_continue_steer?.active, false);
+      assert.equal(watcherState.ralph_continue_steer?.last_reason, 'terminal');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('globally debounces Ralph continue steer across concurrent watcher instances', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-ralph-global-debounce-'));
     const fakeBinDir = join(wd, 'fake-bin');

--- a/src/runtime/__tests__/run-outcome.test.ts
+++ b/src/runtime/__tests__/run-outcome.test.ts
@@ -7,6 +7,7 @@ import {
   isTerminalRunOutcome,
   normalizeRunOutcome,
 } from '../run-outcome.js';
+import { shouldContinueRun } from '../run-loop.js';
 
 describe('run outcome contract', () => {
   it('normalizes legacy outcome aliases', () => {
@@ -59,5 +60,21 @@ describe('run outcome contract', () => {
     });
     assert.equal(result.ok, false);
     assert.match(result.error || '', /requires active=false/);
+  });
+
+  it('suppresses continuation when an explicit terminal run_outcome is present', () => {
+    assert.equal(shouldContinueRun({
+      active: true,
+      current_phase: 'executing',
+      run_outcome: 'blocked_on_user',
+    }), false);
+  });
+
+  it('continues non-terminal runs when the outcome is continue', () => {
+    assert.equal(shouldContinueRun({
+      active: true,
+      current_phase: 'executing',
+      run_outcome: 'continue',
+    }), true);
   });
 });

--- a/src/runtime/run-loop.ts
+++ b/src/runtime/run-loop.ts
@@ -1,0 +1,41 @@
+import { inferRunOutcome, isTerminalRunOutcome, type RunOutcome } from './run-outcome.js';
+
+export interface RunContinuationStateLike {
+  current_phase?: unknown;
+  run_outcome?: unknown;
+  active?: unknown;
+  completed_at?: unknown;
+  [key: string]: unknown;
+}
+
+export interface RunContinuationSnapshot {
+  outcome: RunOutcome;
+  terminal: boolean;
+  phase: string;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function getRunContinuationSnapshot(
+  candidate: RunContinuationStateLike | null | undefined,
+  options: { phaseFallback?: string } = {},
+): RunContinuationSnapshot | null {
+  if (!candidate || typeof candidate !== 'object') return null;
+  const outcome = inferRunOutcome(candidate as Record<string, unknown>);
+  const phase = safeString(candidate.current_phase) || options.phaseFallback || 'active';
+  return {
+    outcome,
+    terminal: isTerminalRunOutcome(outcome),
+    phase,
+  };
+}
+
+export function shouldContinueRun(
+  candidate: RunContinuationStateLike | null | undefined,
+  options: { phaseFallback?: string } = {},
+): boolean {
+  const snapshot = getRunContinuationSnapshot(candidate, options);
+  return snapshot !== null && !snapshot.terminal;
+}

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1989,6 +1989,33 @@ esac
     }
   });
 
+  it("does not block Stop when an explicit blocked_on_user run_outcome is present on a mode state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-autopilot-blocked-outcome-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "autopilot-state.json"), {
+        active: true,
+        current_phase: "execution",
+        run_outcome: "blocked_on_user",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-autopilot-blocked-outcome",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("returns Stop continuation output while Ultrawork is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ultrawork-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -45,6 +45,7 @@ import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import { reconcileHudForPromptSubmit } from "../hud/reconcile.js";
 import { onSessionStart as buildWikiSessionStartContext } from "../wiki/lifecycle.js";
 import { readAutoresearchCompletionStatus, readAutoresearchModeState } from "../autoresearch/skill-validation.js";
+import { shouldContinueRun } from "../runtime/run-loop.js";
 import { triagePrompt } from "../hooks/triage-heuristic.js";
 import { readTriageConfig } from "../hooks/triage-config.js";
 import {
@@ -77,7 +78,7 @@ export interface NativeHookDispatchResult {
   outputJson: Record<string, unknown> | null;
 }
 
-const TERMINAL_RALPH_PHASES = new Set(["complete", "failed", "cancelled"]);
+const TERMINAL_RALPH_PHASES = new Set(["blocked_on_user", "complete", "failed", "cancelled"]);
 const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
 const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);
@@ -234,12 +235,7 @@ async function readActiveRalphState(
     const sessionScoped = await readJsonIfExists(
       join(stateDir, "sessions", sessionId, "ralph-state.json"),
     );
-    if (
-      sessionScoped?.active === true
-      && !TERMINAL_RALPH_PHASES.has(
-        safeString(sessionScoped.current_phase).trim().toLowerCase(),
-      )
-    ) {
+    if (sessionScoped?.active === true && shouldContinueRun(sessionScoped)) {
       return sessionScoped;
     }
   }
@@ -247,7 +243,7 @@ async function readActiveRalphState(
   if (sessionCandidates.length > 0) return null;
 
   const direct = await readJsonIfExists(join(stateDir, "ralph-state.json"));
-  if (direct?.active === true && !TERMINAL_RALPH_PHASES.has(safeString(direct.current_phase).trim().toLowerCase())) {
+  if (direct?.active === true && shouldContinueRun(direct)) {
     return direct;
   }
 
@@ -257,12 +253,7 @@ async function readActiveRalphState(
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const candidate = await readJsonIfExists(join(sessionsRoot, entry.name, "ralph-state.json"));
-    if (
-      candidate?.active === true
-      && !TERMINAL_RALPH_PHASES.has(
-        safeString(candidate.current_phase).trim().toLowerCase(),
-      )
-    ) {
+    if (candidate?.active === true && shouldContinueRun(candidate)) {
       return candidate;
     }
   }
@@ -701,7 +692,7 @@ async function buildModeBasedStopOutput(
   const state = sessionId
     ? await readModeStateForSession(mode, sessionId, cwd)
     : await readModeState(mode, cwd);
-  if (state?.active !== true || !isNonTerminalPhase(state.current_phase)) return null;
+  if (!state || !shouldContinueRun(state)) return null;
   const phase = formatPhase(state.current_phase);
   return {
     decision: "block",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -78,7 +78,6 @@ export interface NativeHookDispatchResult {
   outputJson: Record<string, unknown> | null;
 }
 
-const TERMINAL_RALPH_PHASES = new Set(["blocked_on_user", "complete", "failed", "cancelled"]);
 const TERMINAL_MODE_PHASES = new Set(["complete", "failed", "cancelled"]);
 const SKILL_STOP_BLOCKERS = new Set(["ralplan"]);
 const TEAM_TERMINAL_TASK_STATUSES = new Set(["completed", "failed"]);

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -36,6 +36,7 @@ import { listNotifyCanonicalActiveTeams } from './notify-hook/active-team.js';
 import { sameFilePath } from '../utils/paths.js';
 import { validateSessionId } from '../mcp/state-paths.js';
 import { TEAM_NAME_SAFE_PATTERN } from '../team/contracts.js';
+import { shouldContinueRun } from '../runtime/run-loop.js';
 
 function argValue(name: string, fallback = ''): string {
   const idx = process.argv.indexOf(name);
@@ -145,7 +146,7 @@ const watcherOwnerToken = `${process.pid}-${startedAt}-${Math.random().toString(
 const RALPH_CONTINUE_TEXT = 'Ralph loop active continue';
 const RALPH_CONTINUE_CADENCE_MS = 60_000;
 const RALPH_STEER_LOCK_STALE_MS = 30_000;
-const RALPH_TERMINAL_PHASES = new Set(['complete', 'failed', 'cancelled']);
+const RALPH_TERMINAL_PHASES = new Set(['blocked_on_user', 'complete', 'failed', 'cancelled']);
 const RALPH_STARTING_PHASE_TIMEOUT_MS = RALPH_CONTINUE_CADENCE_MS * 2;
 const QUIET_ONCE_EVENT_TYPES = new Set(['watcher_start', 'watcher_once_complete']);
 
@@ -474,6 +475,7 @@ function normalizeRalphContinueSteerState(raw: Record<string, unknown> | null | 
 function hasRalphTerminalState(raw: Record<string, unknown> | null | undefined): boolean {
   if (!raw || typeof raw !== 'object') return true;
   if (raw.active !== true) return true;
+  if (!shouldContinueRun(raw)) return true;
   const phase = safeString(raw.current_phase).trim().toLowerCase();
   if (phase && RALPH_TERMINAL_PHASES.has(phase)) return true;
   if (isStaleRalphStartingPhase(raw)) return true;


### PR DESCRIPTION
## Summary
Respect the shared `run_outcome` contract when OMX decides whether persistent runtime surfaces should keep pushing a run forward.

## Problem
PR #1733 introduced the shared `run_outcome` contract, but some persistence-critical runtime paths still decided continuation from older local heuristics such as `active + current_phase` alone.

That left a contract gap in the exact places that decide whether OMX should keep going:
- native `Stop` continuation checks
- fallback Ralph continue-steer terminal detection

## What changed
- added `src/runtime/run-loop.ts` with a small shared continuation helper over `run_outcome`
- updated `src/scripts/codex-native-hook.ts` to use the helper for persisted mode/Ralph Stop continuation decisions
- updated `src/scripts/notify-fallback-watcher.ts` so Ralph continue-steer treats explicit `blocked_on_user` outcomes as terminal
- added focused regression coverage in runtime, native Stop-hook, and fallback watcher tests

## Why this design
This keeps the slice narrow while moving real persistence decisions onto the new shared contract.

Instead of attempting the full core run loop rewrite in one PR, this PR hardens the first two runtime surfaces where continuation semantics matter most. That makes the next migration slices safer and reduces drift between persisted state meaning and runtime behavior.

## Overlap assessment
- **Follow-up** to #1718 and merged PR #1733
- **Adjacent but distinct** from earlier stop-hook / watcher hardening issues: this PR specifically adopts the new shared `run_outcome` contract in continuation decisions rather than adding another one-off heuristic fix

## Validation
- [x] `npm run build`
- [x] `./node_modules/.bin/biome lint src/runtime/run-loop.ts src/runtime/__tests__/run-outcome.test.ts src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts src/scripts/notify-fallback-watcher.ts src/hooks/__tests__/notify-fallback-watcher.test.ts`
- [x] `node --test dist/runtime/__tests__/run-outcome.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/hooks/__tests__/notify-fallback-watcher.test.js`

## Risks / compatibility
- narrow runtime behavior change only in persistence-sensitive continuation checks
- no user-facing workflow removal
- no broad watcher/hook architecture rewrite in this slice

## Changed files
- `src/runtime/run-loop.ts`
- `src/runtime/__tests__/run-outcome.test.ts`
- `src/scripts/codex-native-hook.ts`
- `src/scripts/__tests__/codex-native-hook.test.ts`
- `src/scripts/notify-fallback-watcher.ts`
- `src/hooks/__tests__/notify-fallback-watcher.test.ts`

Related #1736
