### PR TITLE
Keep ask-user-question delivery attached to the live launch path

### DIFF
--- a/src/notifications/__tests__/index.test.ts
+++ b/src/notifications/__tests__/index.test.ts
@@ -99,6 +99,95 @@ describe('notifyLifecycle tmux tail auto-capture', () => {
     }
   });
 
+
+  it('awaits ask-user-question OpenClaw dispatch so reply routing stays on the live launch path', async () => {
+    let openClawCalls = 0;
+    let openClawResolved = false;
+
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? String(input) : input.url;
+      if (!url.includes('127.0.0.1:18789')) {
+        return new Response('', { status: 200 });
+      }
+      openClawCalls += 1;
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      openClawResolved = true;
+      return new Response('', { status: 200 });
+    };
+
+    writeFileSync(join(codexHome, '.omx-config.json'), JSON.stringify({
+      notifications: {
+        enabled: true,
+        verbosity: 'verbose',
+        webhook: {
+          enabled: true,
+          url: 'https://example.com/hook',
+        },
+        events: {
+          'ask-user-question': { enabled: true },
+          'session-start': { enabled: true },
+        },
+        openclaw: {
+          enabled: true,
+          gateways: {
+            local: { type: 'http', url: 'http://127.0.0.1:18789/hooks/agent' },
+          },
+          hooks: {
+            'ask-user-question': {
+              enabled: true,
+              gateway: 'local',
+              instruction: 'ask {{question}}',
+            },
+            'session-start': {
+              enabled: true,
+              gateway: 'local',
+              instruction: 'start {{sessionId}}',
+            },
+          },
+        },
+      },
+    }, null, 2));
+
+    process.env.OMX_OPENCLAW = '1';
+    const { resetOpenClawConfigCache } = await import('../../openclaw/config.js');
+    resetOpenClawConfigCache();
+
+    const projectPath = mkdtempSync(join(tmpdir(), 'omx-notify-index-project-ask-'));
+    const { notifyLifecycle } = await import(`../index.js?ask-user-question-await=${Date.now()}`);
+
+    const askStarted = Date.now();
+    const askResult = await notifyLifecycle('ask-user-question', {
+      sessionId: `sess-ask-${Date.now()}`,
+      projectPath,
+      question: 'Need approval?',
+    });
+    const askElapsed = Date.now() - askStarted;
+
+    assert.ok(askResult);
+    assert.equal(askResult.anySuccess, true);
+    assert.equal(openClawCalls, 1);
+    assert.equal(openClawResolved, true);
+    assert.ok(askElapsed >= 50, `ask-user-question should await OpenClaw dispatch, got ${askElapsed}ms`);
+
+    openClawCalls = 0;
+    openClawResolved = false;
+    const startStarted = Date.now();
+    const startResult = await notifyLifecycle('session-start', {
+      sessionId: `sess-start-${Date.now()}`,
+      projectPath,
+    });
+    const startElapsed = Date.now() - startStarted;
+
+    assert.ok(startResult);
+    assert.equal(startResult.anySuccess, true);
+    assert.equal(openClawCalls, 1);
+    assert.equal(openClawResolved, false, 'session-start should keep fire-and-forget OpenClaw dispatch');
+    assert.ok(startElapsed < 50, `session-start should stay non-blocking, got ${startElapsed}ms`);
+
+    rmSync(projectPath, { recursive: true, force: true });
+    delete process.env.OMX_OPENCLAW;
+  });
+
   it('keeps auto-capturing tmux tail for live session-idle notifications', async () => {
     writeFakeTmux(fakeBinDir, 'waiting for live input');
 

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -294,8 +294,7 @@ export async function notifyLifecycle(
       if (openClawAllowed) {
         try {
           const { wakeOpenClaw } = await import("../openclaw/index.js");
-          // Non-blocking: do not await to avoid delaying notification return
-          void wakeOpenClaw(openClawEvent, {
+          const openClawContext = {
             sessionId: payload.sessionId,
             projectPath: payload.projectPath,
             tmuxSession: payload.tmuxSession,
@@ -305,7 +304,15 @@ export async function notifyLifecycle(
             tmuxTail: payload.tmuxTail,
             // Reply context env vars are read inside wakeOpenClaw;
             // callers do not need to pass them explicitly.
-          });
+          };
+          if (openClawEvent === "ask-user-question") {
+            // ask-user-question must launch through the current foreground hook path
+            // so downstream answer routing stays attached to the live session.
+            await wakeOpenClaw(openClawEvent, openClawContext);
+          } else {
+            // Other lifecycle hooks remain fire-and-forget to avoid delaying notification return.
+            void wakeOpenClaw(openClawEvent, openClawContext);
+          }
         } catch {
           // OpenClaw failures must never affect notification dispatch
         }

--- a/src/openclaw/index.ts
+++ b/src/openclaw/index.ts
@@ -1,7 +1,9 @@
 /**
  * OpenClaw Integration - Public API
  *
- * Wakes OpenClaw gateways on hook events. Non-blocking, fire-and-forget.
+ * Wakes OpenClaw gateways on hook events.
+ * Most lifecycle events remain fire-and-forget, but callers may await
+ * ask-user-question delivery so downstream reply routing stays attached.
  *
  * Usage (from notify hook via wakeOpenClaw):
  *   wakeOpenClaw("session-start", { sessionId, projectPath: directory });
@@ -64,8 +66,8 @@ function buildWhitelistedContext(context: OpenClawContext): OpenClawContext {
  * Wake the OpenClaw gateway mapped to a hook event.
  *
  * This is the main entry point called from the notify hook.
- * Non-blocking, swallows all errors. Returns null if OpenClaw
- * is not configured or the event is not mapped.
+ * Errors are swallowed and null is returned when OpenClaw is not configured
+ * or the event is not mapped.
  *
  * @param event - The hook event type
  * @param context - Context data for template variable interpolation


### PR DESCRIPTION
ask-user-question notifications were still using the fire-and-forget OpenClaw wake path, so the hook could return before the downstream launch/runtime bridge attached reply routing to the active session. This change keeps the existing non-blocking behavior for other lifecycle notifications, but awaits ask-user-question dispatch so the question flow stays on the foreground launch path.\n\nThe regression test proves the narrower contract directly: ask-user-question waits for OpenClaw dispatch, while session-start stays fire-and-forget.

Constraint: The fix must stay narrow and must not slow unrelated lifecycle notifications

Rejected: Make all OpenClaw lifecycle dispatches blocking | would broaden latency and behavior changes beyond ask-user-question

Confidence: medium

Scope-risk: narrow

Reversibility: clean

Directive: Preserve ask-user-question as the only awaited OpenClaw lifecycle dispatch unless reply-routing semantics change upstream

Tested: npm run build

Tested: node --test dist/notifications/__tests__/index.test.js dist/openclaw/__tests__/index.test.js dist/hooks/__tests__/openclaw-setup-contract.test.js

Tested: npx biome lint src/notifications/index.ts src/openclaw/index.ts src/notifications/__tests__/index.test.ts

Tested: npx tsc --noEmit --pretty false --project tsconfig.json
