### PR TITLE
Preserve explicit run outcomes in Ralph/state persistence for #1718 PR4

### DIFF
--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -15,6 +15,7 @@ import { reconcileWorkflowTransition } from '../state/workflow-transition-reconc
 import { syncCanonicalSkillStateForMode } from '../state/skill-active.js';
 import { validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { syncRunStateFromModeState } from '../runtime/run-state.js';
 import {
   getBaseStateDir,
   getReadScopedStateDirs,
@@ -144,6 +145,7 @@ export async function startMode(
   const withContext = withModeRuntimeContext({}, stateBase) as ModeState;
   const state = normalizeModeStateOrThrow(mode, withContext);
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(state, null, 2));
+  await syncRunStateFromModeState(state, projectRoot, scope.sessionId);
   if (isTrackedWorkflowMode(mode)) {
     await syncCanonicalSkillStateForMode({
       cwd: projectRoot ?? process.cwd(),
@@ -217,6 +219,7 @@ export async function updateModeState(
   const normalizedBase = normalizeModeStateOrThrow(mode, updatedBase as ModeState);
   const updated = withModeRuntimeContext(current, normalizedBase) as ModeState;
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(updated, null, 2));
+  await syncRunStateFromModeState(updated, projectRoot, scope.sessionId);
   if (isTrackedWorkflowMode(mode)) {
     await syncCanonicalSkillStateForMode({
       cwd: projectRoot ?? process.cwd(),

--- a/src/runtime/run-outcome.ts
+++ b/src/runtime/run-outcome.ts
@@ -1,33 +1,51 @@
-export const RUN_OUTCOMES = [
-  'continue',
+export const TERMINAL_RUN_OUTCOMES = [
   'finish',
   'blocked_on_user',
   'failed',
   'cancelled',
 ] as const;
 
+export const NON_TERMINAL_RUN_OUTCOMES = [
+  'progress',
+  'continue',
+] as const;
+
+export const RUN_OUTCOMES = [
+  ...NON_TERMINAL_RUN_OUTCOMES,
+  ...TERMINAL_RUN_OUTCOMES,
+] as const;
+
+export type TerminalRunOutcome = (typeof TERMINAL_RUN_OUTCOMES)[number];
+export type NonTerminalRunOutcome = (typeof NON_TERMINAL_RUN_OUTCOMES)[number];
 export type RunOutcome = (typeof RUN_OUTCOMES)[number];
 
-const RUN_OUTCOME_SET = new Set<RunOutcome>(RUN_OUTCOMES);
-const TERMINAL_RUN_OUTCOME_SET = new Set<RunOutcome>([
-  'finish',
-  'blocked_on_user',
-  'failed',
-  'cancelled',
-]);
+const TERMINAL_RUN_OUTCOME_SET = new Set<string>(TERMINAL_RUN_OUTCOMES);
+const NON_TERMINAL_RUN_OUTCOME_SET = new Set<string>(NON_TERMINAL_RUN_OUTCOMES);
+const RUN_OUTCOME_SET = new Set<string>(RUN_OUTCOMES);
 
-const RUN_OUTCOME_ALIASES: Record<string, RunOutcome> = {
+const RUN_OUTCOME_ALIASES: Readonly<Record<string, RunOutcome>> = {
+  finish: 'finish',
+  finished: 'finish',
   complete: 'finish',
   completed: 'finish',
   done: 'finish',
   blocked: 'blocked_on_user',
   'blocked-on-user': 'blocked_on_user',
-  cancel: 'cancelled',
+  blocked_on_user: 'blocked_on_user',
+  failed: 'failed',
   fail: 'failed',
   error: 'failed',
-};
+  cancelled: 'cancelled',
+  canceled: 'cancelled',
+  cancel: 'cancelled',
+  aborted: 'cancelled',
+  abort: 'cancelled',
+  progress: 'progress',
+  continue: 'continue',
+  continued: 'continue',
+} as const;
 
-const TERMINAL_PHASE_TO_RUN_OUTCOME: Record<string, RunOutcome> = {
+const TERMINAL_PHASE_TO_RUN_OUTCOME: Readonly<Record<string, TerminalRunOutcome>> = {
   complete: 'finish',
   completed: 'finish',
   blocked: 'blocked_on_user',
@@ -38,6 +56,12 @@ const TERMINAL_PHASE_TO_RUN_OUTCOME: Record<string, RunOutcome> = {
   cancel: 'cancelled',
 };
 
+export interface RunOutcomeNormalizationResult {
+  outcome?: RunOutcome;
+  warning?: string;
+  error?: string;
+}
+
 export interface RunOutcomeValidationResult {
   ok: boolean;
   state?: Record<string, unknown>;
@@ -45,34 +69,50 @@ export interface RunOutcomeValidationResult {
   error?: string;
 }
 
+function normalizeRunOutcomeValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
-export function isTerminalRunOutcome(outcome: RunOutcome): boolean {
-  return TERMINAL_RUN_OUTCOME_SET.has(outcome);
-}
-
-export function normalizeRunOutcome(rawOutcome: unknown): {
-  outcome?: RunOutcome;
-  warning?: string;
-  error?: string;
-} {
-  const normalized = safeString(rawOutcome).toLowerCase();
+export function normalizeRunOutcome(value: unknown): RunOutcomeNormalizationResult {
+  const normalized = normalizeRunOutcomeValue(value);
   if (!normalized) return {};
-  if (RUN_OUTCOME_SET.has(normalized as RunOutcome)) {
+  if (RUN_OUTCOME_SET.has(normalized)) {
     return { outcome: normalized as RunOutcome };
   }
   const alias = RUN_OUTCOME_ALIASES[normalized];
   if (alias) {
     return {
       outcome: alias,
-      warning: `normalized legacy run outcome "${rawOutcome}" -> "${alias}"`,
+      warning: `normalized legacy run outcome "${value}" -> "${alias}"`,
     };
   }
-  return {
-    error: `run_outcome must be one of: ${RUN_OUTCOMES.join(', ')}`,
-  };
+  return { error: `run_outcome must be one of: ${RUN_OUTCOMES.join(', ')}` };
+}
+
+export function classifyRunOutcome(value: unknown): RunOutcome {
+  return normalizeRunOutcome(value).outcome ?? 'progress';
+}
+
+export function isTerminalRunOutcome(value: unknown): value is TerminalRunOutcome {
+  const normalized = normalizeRunOutcome(value).outcome;
+  return normalized !== undefined && TERMINAL_RUN_OUTCOME_SET.has(normalized);
+}
+
+export function isNonTerminalRunOutcome(value: unknown): value is NonTerminalRunOutcome {
+  const normalized = normalizeRunOutcome(value).outcome;
+  return normalized !== undefined && NON_TERMINAL_RUN_OUTCOME_SET.has(normalized);
+}
+
+export function isNonTerminalRunState(value: unknown): boolean {
+  return isNonTerminalRunOutcome(classifyRunOutcome(value));
+}
+
+export function isTerminalRunState(value: unknown): boolean {
+  return isTerminalRunOutcome(classifyRunOutcome(value));
 }
 
 export function inferRunOutcome(candidate: Record<string, unknown>): RunOutcome {
@@ -112,7 +152,7 @@ export function applyRunOutcomeContract(
     }
   } else {
     if (next.active === false) {
-      return { ok: false, error: 'non-terminal run outcome "continue" requires active=true' };
+      return { ok: false, error: `non-terminal run outcome "${outcome}" requires active=true` };
     }
     next.active = true;
     if (safeString(next.completed_at)) {

--- a/src/runtime/run-state.ts
+++ b/src/runtime/run-state.ts
@@ -1,0 +1,165 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+
+import { getStateFilePath, resolveStateScope } from '../mcp/state-paths.js';
+import {
+  classifyRunOutcome,
+  isTerminalRunOutcome,
+  normalizeRunOutcome,
+  type RunOutcome,
+} from './run-outcome.js';
+
+const RUN_STATE_FILENAME = 'run-state.json';
+
+export interface RunStateLike {
+  active?: unknown;
+  mode?: unknown;
+  current_phase?: unknown;
+  task_description?: unknown;
+  started_at?: unknown;
+  completed_at?: unknown;
+  iteration?: unknown;
+  max_iterations?: unknown;
+  error?: unknown;
+  outcome?: unknown;
+  run_outcome?: unknown;
+  owner_omx_session_id?: unknown;
+  [key: string]: unknown;
+}
+
+export interface RunState {
+  version: 1;
+  mode: string;
+  active: boolean;
+  outcome: RunOutcome;
+  updated_at: string;
+  current_phase?: string;
+  task_description?: string;
+  started_at?: string;
+  completed_at?: string;
+  iteration?: number;
+  max_iterations?: number;
+  error?: string;
+  owner_omx_session_id?: string;
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function optionalFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function terminalOutcomeFromPhase(phase: string | undefined): RunOutcome | null {
+  if (!phase) return null;
+  const normalizedPhase = normalizeRunOutcome(phase).outcome;
+  return normalizedPhase && isTerminalRunOutcome(normalizedPhase) ? normalizedPhase : null;
+}
+
+export function deriveRunOutcomeFromModeState(state: RunStateLike): RunOutcome {
+  if (state.active === true) return 'continue';
+
+  const explicitOutcome = normalizeRunOutcome(state.outcome ?? state.run_outcome).outcome;
+  if (explicitOutcome) return explicitOutcome;
+
+  const phaseOutcome = terminalOutcomeFromPhase(optionalString(state.current_phase));
+  if (phaseOutcome) return phaseOutcome;
+
+  if (optionalString(state.error)) return 'failed';
+  if (optionalString(state.completed_at)) return 'finish';
+
+  return classifyRunOutcome(state.current_phase);
+}
+
+export function buildRunState(
+  state: RunStateLike,
+  existing?: Partial<RunState> | null,
+  nowIso: string = new Date().toISOString(),
+): RunState {
+  const outcome = deriveRunOutcomeFromModeState(state);
+  const active = state.active === true;
+  const next: RunState = {
+    version: 1,
+    mode: optionalString(state.mode) ?? optionalString(existing?.mode) ?? 'unknown',
+    active,
+    outcome,
+    updated_at: nowIso,
+  };
+
+  const currentPhase = optionalString(state.current_phase);
+  if (currentPhase) next.current_phase = currentPhase;
+
+  const taskDescription = optionalString(state.task_description);
+  if (taskDescription) next.task_description = taskDescription;
+
+  const startedAt = optionalString(state.started_at) ?? optionalString(existing?.started_at);
+  if (startedAt) next.started_at = startedAt;
+
+  const completedAt = active
+    ? undefined
+    : optionalString(state.completed_at)
+      ?? (isTerminalRunOutcome(outcome) ? optionalString(existing?.completed_at) ?? nowIso : undefined);
+  if (completedAt) next.completed_at = completedAt;
+
+  const iteration = optionalFiniteNumber(state.iteration);
+  if (iteration !== undefined) next.iteration = iteration;
+
+  const maxIterations = optionalFiniteNumber(state.max_iterations);
+  if (maxIterations !== undefined) next.max_iterations = maxIterations;
+
+  const error = optionalString(state.error);
+  if (error) next.error = error;
+
+  const ownerSessionId = optionalString(state.owner_omx_session_id);
+  if (ownerSessionId) next.owner_omx_session_id = ownerSessionId;
+
+  return next;
+}
+
+function getRunStatePath(workingDirectory?: string, sessionId?: string): string {
+  return getStateFilePath(RUN_STATE_FILENAME, workingDirectory, sessionId);
+}
+
+async function writeAtomicFile(path: string, data: string): Promise<void> {
+  const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  await writeFile(tmpPath, data, 'utf-8');
+  try {
+    await rename(tmpPath, path);
+  } catch (error) {
+    await unlink(tmpPath).catch(() => {});
+    throw error;
+  }
+}
+
+export async function readRunState(
+  workingDirectory?: string,
+  explicitSessionId?: string,
+): Promise<RunState | null> {
+  const scope = await resolveStateScope(workingDirectory, explicitSessionId);
+  const path = getRunStatePath(workingDirectory, scope.sessionId);
+  if (!existsSync(path)) return null;
+
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as RunState;
+  } catch {
+    return null;
+  }
+}
+
+export async function syncRunStateFromModeState(
+  state: RunStateLike,
+  workingDirectory?: string,
+  explicitSessionId?: string,
+): Promise<RunState> {
+  const scope = await resolveStateScope(workingDirectory, explicitSessionId);
+  const path = getRunStatePath(workingDirectory, scope.sessionId);
+  await mkdir(scope.stateDir, { recursive: true });
+
+  const existing = await readRunState(workingDirectory, scope.sessionId);
+  const next = buildRunState(state, existing);
+  await writeAtomicFile(path, JSON.stringify(next, null, 2));
+  return next;
+}


### PR DESCRIPTION
## Summary
- preserve explicit run outcomes when Ralph-oriented state becomes terminal
- thread the shared run-outcome contract through mode/state persistence helpers
- add regression coverage for blocked-on-user normalization in state surfaces

## Problem
Issue #1718 is migrating OMX from stop-interception-heavy persistence toward an explicit terminal-action contract. PR3 introduced shared run-state, but the remaining persistence-facing state helpers still treated terminal outcomes inconsistently.

In practice that meant Ralph/state writes could normalize phases without reliably preserving a machine-readable terminal outcome, especially for `blocked_on_user`. That made later PR4/PR5 work harder because the persistence layer was still dropping part of the shared contract.

## Root cause
The shared `run-outcome` helpers existed, but several state consumers still behaved as if phase normalization and lifecycle persistence were separate concerns:
- `modes/base.ts` normalized Ralph phases without applying the shared run-outcome contract
- `state/operations.ts` and `state-server.ts` accepted Ralph writes without always preserving terminal outcome metadata
- workflow transition reconciliation completed older states without stamping the canonical run outcome
- `run-state.ts` expected the older `normalizeRunOutcome` return shape and did not align cleanly with the richer normalization result used by recovered PR4 work

## What changed
- rebuilt `src/runtime/run-outcome.ts` into a single shared contract layer that supports:
  - legacy alias normalization
  - terminal/non-terminal helpers
  - inferred outcomes from phase/active state
  - `applyRunOutcomeContract(...)` validation + stamping
- applied that shared contract in mode persistence and state writes:
  - `src/modes/base.ts`
  - `src/state/operations.ts`
  - `src/state/workflow-transition-reconcile.ts`
- extended Ralph/state contracts to treat `blocked_on_user` as a first-class terminal phase where needed:
  - `src/ralph/contract.ts`
  - `src/mcp/state-server.ts`
- updated `src/runtime/run-state.ts` to consume the newer normalization result shape cleanly
- added/updated focused regressions for:
  - run outcome normalization
  - Ralph blocked-on-user persistence
  - state write / state server behavior

## Why this design
This keeps PR4 scoped to persistence propagation rather than widening into watcher/native-hook semantics prematurely.

The key design choice here is: **mode/state layers should preserve the shared contract exactly, not reinterpret it ad hoc**. That gives the later Stop-hook / watcher migration a stable persistence substrate.

## Overlap assessment
This is a **follow-up** to the already-landed Issue #1718 slices on `dev`:
- PR #1733 delivered the shared run-outcome contract foundation
- PR #1737 delivered the core continuation helper adoption

This PR does not redo those changes. It carries the next persistence-facing slice forward by making Ralph/state consumers preserve the shared outcome semantics, especially `blocked_on_user`.

It also supersedes a failed local team-run artifact that produced an auto-checkpoint commit. I rewrote that recovered work into a Lore-format final commit and removed the raw checkpoint commit from the delivery branch.

## Validation
- `npm run build`
- `node --test dist/runtime/__tests__/run-outcome.test.js dist/modes/__tests__/base-ralph-contract.test.js dist/state/__tests__/operations-ralph-phase.test.js dist/mcp/__tests__/state-server.test.js`

## Risks / compatibility
- This still uses the existing public term `blocked_on_user`; the broader `user_interlude` rename remains future work.
- Team/Ralph runtime integration behavior is not fully migrated here; that belongs to later Issue #1718 slices.
- Because `run-outcome.ts` is shared, regressions here could affect other lifecycle readers if they relied on the older return shape.

## Changed files
- `src/runtime/run-outcome.ts`
- `src/runtime/run-state.ts`
- `src/runtime/__tests__/run-outcome.test.ts`
- `src/modes/base.ts`
- `src/modes/__tests__/base-ralph-contract.test.ts`
- `src/state/operations.ts`
- `src/state/workflow-transition-reconcile.ts`
- `src/state/__tests__/operations-ralph-phase.test.ts`
- `src/ralph/contract.ts`
- `src/mcp/state-server.ts`
- `src/mcp/__tests__/state-server.test.ts`
