### PR TITLE
Strengthen tracked prompt surfaces toward blocked-only asking

### DIFF
--- a/docs/prompt-guidance-fragments/core-operating-principles.md
+++ b/docs/prompt-guidance-fragments/core-operating-principles.md
@@ -1,5 +1,7 @@
 - Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
+- Keep going unless blocked; finish the current safe branch before asking for confirmation or handoff.
+- Ask only when blocked by missing information, missing authority, or an irreversible/destructive branch.
 - Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
 - Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities when they are safe and reversible.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.

--- a/docs/prompt-guidance-fragments/executor-constraints.md
+++ b/docs/prompt-guidance-fragments/executor-constraints.md
@@ -1,5 +1,7 @@
 - Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Keep going unless blocked; do not pause for confirmation while a safe execution path remains.
+- Ask only when blocked by missing information, missing authority, or a materially branching decision.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
 - More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.

--- a/docs/prompt-guidance-fragments/planner-constraints.md
+++ b/docs/prompt-guidance-fragments/planner-constraints.md
@@ -1,4 +1,6 @@
 - Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
+- Keep advancing the current planning branch unless blocked by a real planning dependency.
+- Ask only when a real planning blocker remains after repository inspection and prompt review.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
 - More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.

--- a/docs/prompt-guidance-fragments/verifier-constraints.md
+++ b/docs/prompt-guidance-fragments/verifier-constraints.md
@@ -1,3 +1,4 @@
 - Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
+- Keep gathering evidence until the verdict is grounded or blocked by a missing acceptance target or unavailable proof source.
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
 - More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -39,6 +39,8 @@ Default: explore first, ask last.
 <!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:START -->
 - Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Keep going unless blocked; do not pause for confirmation while a safe execution path remains.
+- Ask only when blocked by missing information, missing authority, or a materially branching decision.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
 - More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -22,6 +22,8 @@ You are Planner (Prometheus). Turn requests into actionable work plans. You plan
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:START -->
 - Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
+- Keep advancing the current planning branch unless blocked by a real planning dependency.
+- Ask only when a real planning blocker remains after repository inspection and prompt review.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
 - More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->

--- a/prompts/verifier.md
+++ b/prompts/verifier.md
@@ -17,6 +17,7 @@ You are Verifier. Your job is to prove or disprove completion with concrete evid
 <ask_gate>
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:START -->
 - Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
+- Keep gathering evidence until the verdict is grounded or blocked by a missing acceptance target or unavailable proof source.
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
 - More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:END -->

--- a/src/hooks/__tests__/prompt-guidance-contract.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-contract.test.ts
@@ -18,4 +18,15 @@ describe('prompt guidance contract', () => {
       assert.doesNotMatch(content, /Run `omx setup` to install all components\. Run `omx doctor` to verify installation\./);
     }
   });
+
+  it('tracked AGENTS and core prompt surfaces stay action-first and avoid permission-seeking softeners', () => {
+    const banned = [/if you[’']d like/i, /if you want/i, /would you like/i, /let me know if you want/i];
+
+    for (const surface of [...listTrackedAgentSurfaces(), ...CORE_ROLE_CONTRACTS.map((contract) => contract.path)]) {
+      const content = loadSurface(surface);
+      for (const pattern of banned) {
+        assert.doesNotMatch(content, pattern, `${surface} should not contain permission-seeking softeners matching ${pattern}`);
+      }
+    }
+  });
 });

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -13,6 +13,8 @@ const ROOT_TEMPLATE_PATTERNS = [
   rx('clear, low-risk, reversible next steps'),
   rx('do not ask or instruct humans.*ordinary non-destructive.*reversible actions'),
   rx('OMX runtime manipulation.*agent responsibilities'),
+  rx('Keep going unless blocked'),
+  rx('Ask only when blocked|Ask only when progress is impossible'),
   rx('local overrides?.*non-conflicting instructions'),
   rx('reflexive web/tool escalation'),
   rx('Choose the lane before acting'),
@@ -41,18 +43,24 @@ const CORE_ROLE_PATTERNS = {
     rx('reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('task is grounded and verified'),
+    rx('Keep going unless blocked'),
+    rx('Ask only when progress is impossible|Ask only when blocked'),
   ],
   planner: [
     rx('quality-first.*intent-deepening plan summaries'),
     rx('reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('plan is grounded in evidence'),
+    rx('Keep advancing the current planning branch unless blocked'),
+    rx('Ask only when a real planning blocker|Ask only when blocked'),
   ],
   verifier: [
     rx('quality-first, evidence-dense summaries'),
     rx('proof that matters|tool churn'),
     rx('verdict is grounded'),
     rx('non-conflicting acceptance criteria'),
+    rx('Keep gathering evidence until the verdict is grounded or blocked'),
+    rx('Ask only when the acceptance target is materially unclear|Ask only when blocked'),
   ],
 };
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -39,6 +39,8 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 <!-- OMX:GUIDANCE:OPERATING:START -->
 - Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
+- Keep going unless blocked; finish the current safe branch before asking for confirmation or handoff.
+- Ask only when blocked by missing information, missing authority, or an irreversible/destructive branch.
 - Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
 - Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities when they are safe and reversible.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.


### PR DESCRIPTION
## Summary

Strengthen the tracked OMX prompt-guidance contract so the core AGENTS/core-role surfaces stay action-first on safe branches and avoid permission-seeking softeners.

## Problem statement

The tracked prompt-guidance contract already encoded quality-first, evidence-backed behavior, but it did not explicitly lock two things strongly enough on the tracked surfaces:

1. keep-going semantics while a safe branch remains
2. regression coverage against permission-seeking softeners such as `if you'd like` / `if you want`

That left room for drift back toward hesitant follow-up phrasing even when the next step was clear, low-risk, and reversible.

## Root cause

The contract patterns in `src/hooks/prompt-guidance-contract.ts` did not require blocked-only asking / keep-going wording on the tracked AGENTS/core prompt surfaces, and the tests did not fail when those surfaces reintroduced permission-seeking softeners.

## What changed

- strengthened the tracked root/template AGENTS contract with explicit:
  - `Keep going unless blocked`
  - blocked-only asking semantics
- strengthened the tracked core-role contract for:
  - `prompts/executor.md`
  - `prompts/planner.md`
  - `prompts/verifier.md`
- added regression coverage that fails if tracked AGENTS/core prompt surfaces contain:
  - `if you'd like` / `if you’d like`
  - `if you want`
  - `would you like`
  - `let me know if you want`
- applied the minimal wording updates needed to the synced guidance fragments and generated tracked surfaces

## Why this design

This keeps the scope narrow and reviewable:

- lock the contract first
- cover the exact softeners we want to prevent on the tracked surfaces
- avoid a repo-wide prompt rewrite in the same PR

That makes this a focused contract-locking slice rather than a broad style cleanup.

## Overlap assessment

**Classification:** Net-new follow-up in the prompt-guidance contract area.

I checked recent issues/PRs for prompt-guidance / action-first / permission-seeking overlap and did not find an existing issue or PR already scoped to banning these softeners on the tracked AGENTS/core surfaces.

## Validation

- `npm run build`
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-fragments.test.js`

## Risks / compatibility

- Intentional narrow scope: this PR only locks the tracked AGENTS/core-role surfaces.
- Other prompt/skill surfaces outside the tracked contract may still contain softer phrasing and can be handled in follow-up slices.

## Changed files

- `docs/prompt-guidance-fragments/core-operating-principles.md`
- `docs/prompt-guidance-fragments/executor-constraints.md`
- `docs/prompt-guidance-fragments/planner-constraints.md`
- `docs/prompt-guidance-fragments/verifier-constraints.md`
- `templates/AGENTS.md`
- `prompts/executor.md`
- `prompts/planner.md`
- `prompts/verifier.md`
- `src/hooks/prompt-guidance-contract.ts`
- `src/hooks/__tests__/prompt-guidance-contract.test.ts`

## Issue

Closes #1743

## Target-base diff classification

**Regression coverage / contract locking** with a narrow tracked-surface guidance tightening on top.