### PR TITLE
Restore runUntilTerminal runtime helper coverage

### DIFF
--- a/src/runtime/__tests__/run-loop.test.ts
+++ b/src/runtime/__tests__/run-loop.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { runUntilTerminal } from '../run-loop.js';
+
+describe('runUntilTerminal', () => {
+  it('continues through non-terminal outcomes until finish', async () => {
+    const seen: string[] = [];
+    const result = await runUntilTerminal(
+      async (iteration) => ({
+        outcome: iteration < 3 ? 'continue' : 'finish',
+        state: { iteration },
+      }),
+      {
+        onIteration(step) {
+          seen.push(`${step.iteration}:${step.outcome}`);
+        },
+      },
+    );
+
+    assert.equal(result.iteration, 3);
+    assert.equal(result.outcome, 'finish');
+    assert.deepEqual(result.history, ['continue', 'continue', 'finish']);
+    assert.deepEqual(seen, ['1:continue', '2:continue', '3:finish']);
+  });
+
+  it('normalizes legacy terminal labels before returning', async () => {
+    const result = await runUntilTerminal(async () => ({
+      outcome: 'completed',
+      state: { ok: true },
+    }));
+
+    assert.equal(result.outcome, 'finish');
+    assert.deepEqual(result.history, ['finish']);
+  });
+
+  it('throws when maxIterations is exceeded without terminal progress', async () => {
+    await assert.rejects(
+      () =>
+        runUntilTerminal(
+          async (iteration) => ({
+            outcome: iteration % 2 === 0 ? 'progress' : 'continue',
+            state: { iteration },
+          }),
+          { maxIterations: 3 },
+        ),
+      /maxIterations=3/,
+    );
+  });
+});

--- a/src/runtime/run-loop.ts
+++ b/src/runtime/run-loop.ts
@@ -1,4 +1,34 @@
-import { inferRunOutcome, isTerminalRunOutcome, type RunOutcome } from './run-outcome.js';
+import {
+  classifyRunOutcome,
+  inferRunOutcome,
+  isTerminalRunOutcome,
+  type RunOutcome,
+  type TerminalRunOutcome,
+} from './run-outcome.js';
+
+export interface RunLoopIteration<TState> {
+  outcome: unknown;
+  state: TState;
+}
+
+export interface NormalizedRunLoopIteration<TState> {
+  iteration: number;
+  outcome: RunOutcome;
+  terminal: boolean;
+  state: TState;
+}
+
+export interface RunLoopTerminalResult<TState> {
+  iteration: number;
+  outcome: TerminalRunOutcome;
+  state: TState;
+  history: RunOutcome[];
+}
+
+export interface RunUntilTerminalOptions<TState> {
+  maxIterations?: number;
+  onIteration?: (result: NormalizedRunLoopIteration<TState>) => Promise<void> | void;
+}
 
 export interface RunContinuationStateLike {
   current_phase?: unknown;
@@ -16,6 +46,41 @@ export interface RunContinuationSnapshot {
 
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function runUntilTerminal<TState>(
+  step: (iteration: number) => Promise<RunLoopIteration<TState>>,
+  options: RunUntilTerminalOptions<TState> = {},
+): Promise<RunLoopTerminalResult<TState>> {
+  const history: RunOutcome[] = [];
+  const maxIterations = options.maxIterations ?? Number.POSITIVE_INFINITY;
+
+  for (let iteration = 1; iteration <= maxIterations; iteration += 1) {
+    const raw = await step(iteration);
+    const outcome = classifyRunOutcome(raw.outcome);
+    const terminal = isTerminalRunOutcome(outcome);
+    history.push(outcome);
+
+    const normalized: NormalizedRunLoopIteration<TState> = {
+      iteration,
+      outcome,
+      terminal,
+      state: raw.state,
+    };
+
+    await options.onIteration?.(normalized);
+
+    if (terminal) {
+      return {
+        iteration,
+        outcome,
+        state: raw.state,
+        history,
+      };
+    }
+  }
+
+  throw new Error(`run loop exceeded maxIterations=${maxIterations} without reaching a terminal outcome`);
 }
 
 export function getRunContinuationSnapshot(


### PR DESCRIPTION
## Summary
- restore `runUntilTerminal` in the runtime run-loop module
- add focused runtime tests covering terminal looping, alias normalization, and max iteration failure
- keep the helper aligned with shared `run_outcome` normalization semantics

## Testing
- npm run build
- node --test dist/runtime/__tests__/run-loop.test.js dist/runtime/__tests__/run-outcome.test.js dist/runtime/__tests__/bridge.test.js
- npm run lint
