### PR TITLE
Fix #1743: keep prompt surfaces action-first

### DIFF
--- a/docs/prompt-guidance-contract.md
+++ b/docs/prompt-guidance-contract.md
@@ -86,6 +86,7 @@ Example prompt text:
 ### 2. Automatic follow-through on clear, low-risk, reversible next steps
 
 Contributors should preserve the bias toward continuing useful work automatically instead of asking avoidable confirmation questions.
+Blocked-only asking should be explicit: these surfaces should ask only when a real blocker remains, and they should avoid permission-seeking softeners such as `if you'd like`, `if you want`, `would you like`, and `let me know if you want` when the next safe step is already executable.
 
 Representative locations:
 

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -38,7 +38,8 @@ Default: explore first, ask last.
 - Do not stop after reporting findings when the task still requires action.
 <!-- OMX:GUIDANCE:EXECUTOR:CONSTRAINTS:START -->
 - Default to quality-first, intent-deepening outputs; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
-- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is blocked on an irreversible, side-effectful, or materially scope-changing action or decision.
+- Keep execution action-first; avoid permission-seeking softeners or optional-next-step phrasing when you can safely continue.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
 - More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -21,7 +21,8 @@ You are Planner (Prometheus). Turn requests into actionable work plans. You plan
 - Ask one question at a time when a real planning branch depends on it.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:START -->
 - Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
-- Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
+- Proceed automatically through clear, low-risk planning steps; ask the user only when blocked on preferences, priorities, or materially branching decisions that repo evidence and task history cannot resolve.
+- Keep planning action-first; avoid permission-seeking softeners or optional-next-step phrasing when the next planning step is already clear.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
 - More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->

--- a/prompts/verifier.md
+++ b/prompts/verifier.md
@@ -20,7 +20,8 @@ You are Verifier. Your job is to prove or disprove completion with concrete evid
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
 - More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:END -->
-- Ask only when the acceptance target is materially unclear and cannot be derived from the repo or task history.
+- Ask only when the acceptance target is materially unclear, cannot be derived from the repo or task history, and leaves you blocked on what to verify next.
+- Keep verification action-first; avoid permission-seeking softeners or optional-next-step phrasing when the next proof-gathering step is already clear.
 </ask_gate>
 </constraints>
 

--- a/src/hooks/__tests__/prompt-guidance-contract.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-contract.test.ts
@@ -3,6 +3,14 @@ import assert from 'node:assert/strict';
 import { CORE_ROLE_CONTRACTS, ROOT_TEMPLATE_CONTRACTS } from '../prompt-guidance-contract.js';
 import { assertContractSurface, loadSurface, listTrackedAgentSurfaces } from './prompt-guidance-test-helpers.js';
 
+const PERMISSION_SOFTENER_PATTERNS = [
+  /if you'd like/i,
+  /if you’d like/i,
+  /if you want/i,
+  /would you like/i,
+  /let me know if you want/i,
+];
+
 describe('prompt guidance contract', () => {
   for (const contract of [...ROOT_TEMPLATE_CONTRACTS, ...CORE_ROLE_CONTRACTS]) {
     it(`${contract.id} satisfies the core prompt-guidance contract`, () => {
@@ -16,6 +24,18 @@ describe('prompt guidance contract', () => {
       assert.match(content, /Do not ask or instruct humans to perform ordinary non-destructive, reversible actions/i);
       assert.match(content, /Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities/i);
       assert.doesNotMatch(content, /Run `omx setup` to install all components\. Run `omx doctor` to verify installation\./);
+    }
+  });
+
+  it('tracked AGENTS and core prompt surfaces keep blocked-only asking and reject permission-seeking softeners', () => {
+    const surfaces = [...new Set([...listTrackedAgentSurfaces(), ...CORE_ROLE_CONTRACTS.map((contract) => contract.path)])];
+
+    for (const surface of surfaces) {
+      const content = loadSurface(surface);
+      assert.match(content, /ask .*blocked|blocked.*ask/i, `${surface} should encode blocked-only asking`);
+      for (const pattern of PERMISSION_SOFTENER_PATTERNS) {
+        assert.doesNotMatch(content, pattern, `${surface} should stay action-first and avoid ${pattern}`);
+      }
     }
   });
 });

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -11,6 +11,8 @@ function rx(pattern: string): RegExp {
 const ROOT_TEMPLATE_PATTERNS = [
   rx('quality-first.*intent-deepening responses'),
   rx('clear, low-risk, reversible next steps'),
+  rx('ask only when truly blocked'),
+  rx('permission-seeking softeners'),
   rx('do not ask or instruct humans.*ordinary non-destructive.*reversible actions'),
   rx('OMX runtime manipulation.*agent responsibilities'),
   rx('local overrides?.*non-conflicting instructions'),
@@ -38,18 +40,24 @@ const ROOT_TEMPLATE_PATTERNS = [
 const CORE_ROLE_PATTERNS = {
   executor: [
     rx('quality-first.*intent-deepening outputs'),
+    rx('ask only when the next step is blocked'),
+    rx('permission-seeking softeners'),
     rx('reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('task is grounded and verified'),
   ],
   planner: [
     rx('quality-first.*intent-deepening plan summaries'),
+    rx('ask the user only when blocked'),
+    rx('permission-seeking softeners'),
     rx('reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('plan is grounded in evidence'),
   ],
   verifier: [
     rx('quality-first, evidence-dense summaries'),
+    rx('Ask only when the acceptance target is materially unclear.*blocked'),
+    rx('permission-seeking softeners'),
     rx('proof that matters|tool churn'),
     rx('verdict is grounded'),
     rx('non-conflicting acceptance criteria'),

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -38,7 +38,8 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Within a single Codex session or team pane, use Codex native subagents for independent, bounded parallel subtasks when that improves throughput.
 <!-- OMX:GUIDANCE:OPERATING:START -->
 - Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
-- Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
+- Proceed automatically on clear, low-risk, reversible next steps; ask only when truly blocked on an irreversible, side-effectful, or materially branching action or decision.
+- Keep execution action-first; do not use permission-seeking softeners or optional-next-step phrasing for routine work you can execute safely.
 - Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
 - Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities when they are safe and reversible.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.


### PR DESCRIPTION
## Summary
- strengthen tracked template AGENTS and core prompt contract surfaces toward blocked-only asking
- add focused regression coverage rejecting permission-seeking softeners (`if you'd like`, `if you want`, `would you like`, `let me know if you want`) on tracked AGENTS/core prompt surfaces
- document the blocked-only/action-first prompt contract without widening into catalog-wide cleanup

## Verification
- `npm run build`
- `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js dist/hooks/__tests__/prompt-guidance-wave-two.test.js dist/hooks/__tests__/prompt-guidance-scenarios.test.js dist/hooks/__tests__/prompt-guidance-catalog.test.js`

Fixes #1743