### PR TITLE
Require explicit $skill invocation for skill-name routing

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -59,16 +59,18 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(primary, null);
   });
 
-  it('maps analyze keyword to analyze skill', () => {
-    const match = detectPrimaryKeyword('please analyze this workflow');
+  it('maps explicit $analyze invocation to analyze skill', () => {
+    const match = detectPrimaryKeyword('please run $analyze on this workflow');
     assert.ok(match);
     assert.equal(match.skill, 'analyze');
+    assert.equal(match.keyword.toLowerCase(), '$analyze');
   });
 
   it('maps code-review keyword variants to code-review skill', () => {
-    const hyphen = detectPrimaryKeyword('run code-review before merge');
+    const hyphen = detectPrimaryKeyword('run $code-review before merge');
     assert.ok(hyphen);
     assert.equal(hyphen.skill, 'code-review');
+    assert.equal(hyphen.keyword.toLowerCase(), '$code-review');
 
     const spaced = detectPrimaryKeyword('please do a code review');
     assert.ok(spaced);
@@ -105,8 +107,8 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.match(match.keyword.toLowerCase(), /swarm/);
   });
 
-  it('keeps swarm trigger priority aligned with team trigger', () => {
-    const teamMatch = detectKeywords('use team agents for this').find((entry) => entry.skill === 'team');
+  it('keeps swarm trigger priority aligned with explicit team invocation', () => {
+    const teamMatch = detectKeywords('use $team agents for this').find((entry) => entry.skill === 'team');
     const swarmMatch = detectKeywords('use swarm for this').find((entry) => entry.skill === 'team');
 
     assert.ok(teamMatch);
@@ -121,6 +123,11 @@ describe('keyword detector swarm/team compatibility', () => {
 
   it('does not trigger team skill from incidental prose usage', () => {
     const match = detectPrimaryKeyword('the team reviewed the document and shared feedback');
+    assert.equal(match, null);
+  });
+
+  it('does not trigger team from bare skill-name phrasing without $ invocation', () => {
+    const match = detectPrimaryKeyword('please use team agents for this');
     assert.equal(match, null);
   });
 
@@ -147,8 +154,8 @@ describe('keyword detector swarm/team compatibility', () => {
     assert.equal(match.keyword.toLowerCase(), '$ralph');
   });
 
-  it('prefers ralplan over ralph when both keywords are present', () => {
-    const match = detectPrimaryKeyword('use ralph mode but do ralplan first');
+  it('prefers ralplan over ralph follow-up language when both implicit routes are present', () => {
+    const match = detectPrimaryKeyword('keep going but do consensus plan first');
 
     assert.ok(match);
     assert.equal(match.skill, 'ralplan');
@@ -245,10 +252,9 @@ describe('autoresearch keyword detection', () => {
     assert.equal(match.keyword.toLowerCase(), '$autoresearch');
   });
 
-  it('detects explicit implicit-intent autoresearch phrasing', () => {
+  it('does not detect bare autoresearch phrasing without explicit $ invocation', () => {
     const match = detectPrimaryKeyword('please use autoresearch workflow for this mission');
-    assert.ok(match);
-    assert.equal(match.skill, 'autoresearch');
+    assert.equal(match, null);
   });
 
   it('does not trigger autoresearch from incidental prose', () => {
@@ -257,14 +263,32 @@ describe('autoresearch keyword detection', () => {
   });
 });
 
+describe('explicit skill-name invocation requirement', () => {
+  it('does not trigger analyze from bare skill-name usage', () => {
+    assert.equal(detectPrimaryKeyword('please analyze this workflow'), null);
+  });
+
+  it('does not trigger autoresearch from bare skill-name usage', () => {
+    assert.equal(detectPrimaryKeyword('please run autoresearch now'), null);
+  });
+
+  it('does not trigger ralph from bare skill-name usage', () => {
+    assert.equal(detectPrimaryKeyword('please use ralph for this task'), null);
+  });
+
+  it('does not trigger ralplan from bare skill-name usage', () => {
+    assert.equal(detectPrimaryKeyword('please do ralplan first'), null);
+  });
+});
+
 describe('keyword registry coverage', () => {
   it('includes key team/swarm aliases in runtime keyword registry', () => {
     const registryKeywords = new Set(KEYWORD_TRIGGER_DEFINITIONS.map((v) => v.keyword.toLowerCase()));
-    assert.ok(registryKeywords.has('ultraqa'));
-    assert.ok(registryKeywords.has('analyze'));
+    assert.ok(registryKeywords.has('$ultraqa'));
+    assert.ok(registryKeywords.has('$analyze'));
     assert.ok(registryKeywords.has('investigate'));
     assert.ok(registryKeywords.has('code review'));
-    assert.ok(registryKeywords.has('code-review'));
+    assert.ok(registryKeywords.has('$code-review'));
     assert.ok(registryKeywords.has('coordinated team'));
     assert.ok(registryKeywords.has('swarm'));
     assert.ok(registryKeywords.has('coordinated swarm'));
@@ -274,7 +298,7 @@ describe('keyword registry coverage', () => {
     assert.ok(registryKeywords.has('wiki query'));
     assert.ok(registryKeywords.has('wiki add'));
     assert.ok(registryKeywords.has('wiki lint'));
-    assert.ok(registryKeywords.has('autoresearch'));
+    assert.ok(registryKeywords.has('$autoresearch'));
   });
 });
 
@@ -286,7 +310,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       await mkdir(stateDir, { recursive: true });
       const result = await recordSkillActivation({
         stateDir,
-        text: 'please run autopilot and keep going',
+        text: 'please run $autopilot and keep going',
         sessionId: 'sess-1',
         threadId: 'thread-1',
         turnId: 'turn-1',
@@ -944,7 +968,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       await mkdir(stateDir, { recursive: true });
       await recordSkillActivation({
         stateDir,
-        text: 'please run deep interview',
+        text: 'please run $deep-interview',
         nowIso: '2026-02-25T00:00:00.000Z',
       });
 
@@ -1019,7 +1043,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
     const result = await recordSkillActivation({
       stateDir: join('/definitely-missing', 'nested', 'state-dir'),
-      text: 'please run autopilot',
+        text: 'please run $autopilot',
       nowIso: '2026-02-25T00:00:00.000Z',
     });
 
@@ -1041,7 +1065,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           version: 1,
           active: true,
           skill: 'autopilot',
-          keyword: 'autopilot',
+          keyword: '$autopilot',
           phase: 'planning',
           activated_at: '2026-02-25T00:00:00.000Z',
           updated_at: '2026-02-25T00:10:00.000Z',
@@ -1214,7 +1238,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
       const result = await recordSkillActivation({
         stateDir,
-        text: 'please run ralph now',
+        text: 'please run $ralph now',
         nowIso: '2026-02-26T00:00:00.000Z',
       });
 

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -1080,6 +1080,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
 
       assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      assert.equal(result.transition_error, undefined);
       assert.equal(result.activated_at, '2026-02-25T00:00:00.000Z');
       assert.equal(result.updated_at, '2026-02-26T00:00:00.000Z');
     } finally {
@@ -1129,6 +1131,9 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
 
       assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      assert.equal(result.phase, 'planning');
+      assert.equal(result.transition_error, undefined);
       const modeState = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-autopilot', 'autopilot-state.json'), 'utf-8'),
       ) as { current_phase: string; started_at: string; state?: { context_snapshot_path?: string } };
@@ -1203,6 +1208,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
       });
 
       assert.ok(result);
+      assert.equal(result.skill, 'ralph');
+      assert.equal(result.transition_error, undefined);
       const modeState = JSON.parse(await readFile(join(stateDir, 'ralph-state.json'), 'utf-8')) as {
         current_phase: string;
         iteration: number;
@@ -1211,6 +1218,135 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.current_phase, 'verifying');
       assert.equal(modeState.iteration, 3);
       assert.equal(modeState.max_iterations, 10);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('routes bare keep-going continuation to the active autopilot skill instead of generic ralph continuation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-bare-continuation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-autopilot-bare'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-autopilot-bare', SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'planning',
+          activated_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          source: 'keyword-detector',
+          session_id: 'sess-autopilot-bare',
+          active_skills: [
+            {
+              skill: 'autopilot',
+              phase: 'planning',
+              active: true,
+              activated_at: '2026-04-19T00:00:00.000Z',
+              updated_at: '2026-04-19T00:10:00.000Z',
+              session_id: 'sess-autopilot-bare',
+            },
+          ],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-autopilot-bare', 'autopilot-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'execution',
+          started_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          session_id: 'sess-autopilot-bare',
+          state: { context_snapshot_path: '.omx/context/autopilot.md' },
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '\\ keep going now',
+        sessionId: 'sess-autopilot-bare',
+        nowIso: '2026-04-19T00:15:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      assert.equal(result.keyword, '$autopilot');
+      assert.equal(result.transition_error, undefined);
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-autopilot-bare', 'autopilot-state.json'), 'utf-8'),
+      ) as { current_phase: string; state?: { context_snapshot_path?: string } };
+      assert.equal(modeState.current_phase, 'execution');
+      assert.equal(modeState.state?.context_snapshot_path, '.omx/context/autopilot.md');
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autopilot-bare', 'ralph-state.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('routes bare keep-going continuation to the active ralph skill instead of resetting through generic keep-going detection', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-ralph-bare-continuation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-ralph-bare'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-ralph-bare', SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'ralph',
+          keyword: '$ralph',
+          phase: 'executing',
+          activated_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          source: 'keyword-detector',
+          session_id: 'sess-ralph-bare',
+          active_skills: [
+            {
+              skill: 'ralph',
+              phase: 'executing',
+              active: true,
+              activated_at: '2026-04-19T00:00:00.000Z',
+              updated_at: '2026-04-19T00:10:00.000Z',
+              session_id: 'sess-ralph-bare',
+            },
+          ],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-ralph-bare', 'ralph-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'ralph',
+          current_phase: 'verifying',
+          started_at: '2026-04-19T00:00:00.000Z',
+          updated_at: '2026-04-19T00:10:00.000Z',
+          iteration: 7,
+          max_iterations: 50,
+          session_id: 'sess-ralph-bare',
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'keep going now',
+        sessionId: 'sess-ralph-bare',
+        nowIso: '2026-04-19T00:15:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'ralph');
+      assert.equal(result.keyword, '$ralph');
+      assert.equal(result.transition_error, undefined);
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-ralph-bare', 'ralph-state.json'), 'utf-8'),
+      ) as { current_phase: string; iteration: number; max_iterations: number };
+      assert.equal(modeState.current_phase, 'verifying');
+      assert.equal(modeState.iteration, 7);
+      assert.equal(modeState.max_iterations, 50);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -1830,7 +1830,7 @@ exit 0
       await chmod(join(fakeBinDir, 'tmux'), 0o755);
 
       const result = runNotifyHook(cwd, fakeBinDir, codexHome, {
-        'input-messages': ['please use autopilot for this task'],
+        'input-messages': ['please use $autopilot for this task'],
         'last-assistant-message': 'Here is the plan I will follow.',
       });
       assert.equal(result.status, 0, `hook failed: ${result.stderr || result.stdout}`);

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -36,6 +36,12 @@ export interface KeywordMatch {
   priority: number;
 }
 
+const ACTIVE_SKILL_CONTINUATION_PATTERNS: RegExp[] = [
+  /^[\\/]?\s*keep going(?:\s+now)?[.!]?\s*$/i,
+  /^[\\/]?\s*continue(?:\s+now)?[.!]?\s*$/i,
+  /^[\\/]?\s*resume(?:\s+now)?[.!]?\s*$/i,
+];
+
 function safeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
@@ -538,6 +544,59 @@ export function detectPrimaryKeyword(text: string): KeywordMatch | null {
   return matches.length > 0 ? matches[0] : null;
 }
 
+function isActiveSkillContinuationPrompt(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized) return false;
+  return ACTIVE_SKILL_CONTINUATION_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function isNamedActiveSkillContinuationPrompt(text: string, skill: string): boolean {
+  const normalizedSkill = escapeRegex(skill.trim());
+  if (!normalizedSkill) return false;
+  return new RegExp(
+    `^[\\\\/]?\\s*${normalizedSkill}\\b(?:\\s+(?:keep\\s+going|continue|resume))(?:\\s+now)?[.!]?\\s*$`,
+    'i',
+  ).test(text.trim());
+}
+
+function shouldReusePreviousSkillForContinuation(
+  text: string,
+  previous: SkillActiveState | null,
+): boolean {
+  const previousSkill = safeString(previous?.skill).trim();
+  if (!previousSkill || previous?.active !== true || !isTrackedWorkflowMode(previousSkill)) {
+    return false;
+  }
+
+  return isActiveSkillContinuationPrompt(text)
+    || isNamedActiveSkillContinuationPrompt(text, previousSkill);
+}
+
+function resolveContinuationKeywordMatch(
+  text: string,
+  previous: SkillActiveState | null,
+  fallbackMatch: KeywordMatch | null,
+): KeywordMatch | null {
+  const previousSkill = safeString(previous?.skill).trim();
+  if (!previousSkill || previous?.active !== true || !isTrackedWorkflowMode(previousSkill)) {
+    return fallbackMatch;
+  }
+
+  if (extractExplicitSkillInvocations(text).length > 0) {
+    return fallbackMatch;
+  }
+
+  if (!shouldReusePreviousSkillForContinuation(text, previous) && !safeString(fallbackMatch?.keyword).trim().startsWith('$')) {
+    return fallbackMatch;
+  }
+
+  return {
+    keyword: safeString(previous?.keyword).trim() || `$${previousSkill}`,
+    skill: previousSkill,
+    priority: fallbackMatch?.priority ?? 0,
+  };
+}
+
 function initialWorkflowPhaseForMode(mode: TrackedWorkflowMode): SkillActivePhase {
   return mode === 'autoresearch' ? 'executing' : 'planning';
 }
@@ -574,10 +633,6 @@ function selectRootSkillStateCopy(
 }
 
 export async function recordSkillActivation(input: RecordSkillActivationInput): Promise<SkillActiveState | null> {
-  const match = detectPrimaryKeyword(input.text);
-  if (!match) return null;
-
-  const nowIso = input.nowIso ?? new Date().toISOString();
   const rootStatePath = join(input.stateDir, SKILL_ACTIVE_STATE_FILE);
   const sessionStatePath = input.sessionId
     ? join(input.stateDir, 'sessions', input.sessionId, SKILL_ACTIVE_STATE_FILE)
@@ -585,6 +640,14 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
   const previousRoot = await readExistingSkillState(rootStatePath);
   const previousSession = sessionStatePath ? await readExistingSkillState(sessionStatePath) : null;
   const previous = previousSession ?? previousRoot;
+  const match = resolveContinuationKeywordMatch(
+    input.text,
+    previous,
+    detectPrimaryKeyword(input.text),
+  );
+  if (!match) return null;
+
+  const nowIso = input.nowIso ?? new Date().toISOString();
   const hadDeepInterviewLock = previous?.skill === 'deep-interview' && previous?.input_lock?.active === true;
   const matches = detectKeywords(input.text);
   const hasCancelIntent = matches.some((entry) => entry.skill === 'cancel');
@@ -623,6 +686,8 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
   const sameSkill = previous?.active === true && previous.skill === match.skill;
   const sameKeyword = previous?.keyword?.toLowerCase() === match.keyword.toLowerCase();
+  const sameSkillContinuation = sameSkill && shouldReusePreviousSkillForContinuation(input.text, previous);
+  const preserveActivatedAt = sameSkill && (sameKeyword || sameSkillContinuation);
   const previousEntries = listActiveSkills(previous ?? {});
   const previousWorkflowEntries = previousEntries.filter((entry) => (
     isTrackedWorkflowMode(entry.skill)
@@ -699,10 +764,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
 
       const existingEntry = nextWorkflowEntries.find((entry) => entry.skill === requestedMode);
       if (existingEntry) {
-        existingEntry.phase = requestedMode === match.skill ? initialWorkflowPhaseForMode(requestedMode) : existingEntry.phase;
+        existingEntry.phase = requestedMode === match.skill && !sameSkill
+          ? initialWorkflowPhaseForMode(requestedMode)
+          : existingEntry.phase;
         existingEntry.active = true;
         existingEntry.activated_at = requestedMode === match.skill
-          ? (sameSkill && sameKeyword ? existingEntry.activated_at || previous?.activated_at || nowIso : nowIso)
+          ? (preserveActivatedAt ? existingEntry.activated_at || previous?.activated_at || nowIso : nowIso)
           : existingEntry.activated_at;
         existingEntry.updated_at = nowIso;
         existingEntry.session_id = input.sessionId ?? existingEntry.session_id;
@@ -717,7 +784,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           skill: requestedMode,
           phase: requestedMode === match.skill ? initialWorkflowPhaseForMode(requestedMode) : undefined,
           active: true,
-          activated_at: requestedMode === match.skill && sameSkill && sameKeyword
+          activated_at: requestedMode === match.skill && preserveActivatedAt
             ? previous?.activated_at
             : nowIso,
           updated_at: nowIso,
@@ -796,7 +863,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     skill: match.skill,
     keyword: match.keyword,
     phase: initialWorkflowPhaseForMode(match.skill as TrackedWorkflowMode),
-    activated_at: sameSkill && sameKeyword ? previous.activated_at : nowIso,
+    activated_at: preserveActivatedAt ? previous.activated_at : nowIso,
     updated_at: nowIso,
     source: 'keyword-detector',
     session_id: input.sessionId,
@@ -806,7 +873,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       skill: match.skill,
       phase: initialWorkflowPhaseForMode(match.skill as TrackedWorkflowMode),
       active: true,
-      activated_at: sameSkill && sameKeyword ? previous?.activated_at : nowIso,
+      activated_at: preserveActivatedAt ? previous?.activated_at : nowIso,
       updated_at: nowIso,
       session_id: input.sessionId,
       thread_id: input.threadId,

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -6,22 +6,23 @@ export interface KeywordTriggerDefinition {
 }
 
 export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = [
-  { keyword: 'ralph', skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
+  { keyword: '$ralph', skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
   { keyword: "don't stop", skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
   { keyword: 'must complete', skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
   { keyword: 'keep going', skill: 'ralph', priority: 9, guidance: 'Activate ralph persistence loop with verification' },
 
-  { keyword: 'autopilot', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
+  { keyword: '$autopilot', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
   { keyword: 'build me', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
   { keyword: 'I want a', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
 
-  { keyword: 'ultrawork', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
+  { keyword: '$ultrawork', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'ulw', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'parallel', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
-  { keyword: 'ultraqa', skill: 'ultraqa', priority: 8, guidance: 'Activate UltraQA cycling workflow' },
-  { keyword: 'analyze', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },
+  { keyword: '$ultraqa', skill: 'ultraqa', priority: 8, guidance: 'Activate UltraQA cycling workflow' },
+  { keyword: '$analyze', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },
   { keyword: 'investigate', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },
 
+  { keyword: '$deep-interview', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
   { keyword: 'deep interview', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
   { keyword: 'gather requirements', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
   { keyword: 'interview me', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
@@ -29,37 +30,42 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: 'ouroboros', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
   { keyword: 'interview', skill: 'deep-interview', priority: 8, guidance: 'Activate Ouroboros-inspired Socratic ambiguity-gated interview workflow' },
 
+  { keyword: '$plan', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
   { keyword: 'plan this', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
   { keyword: 'plan the', skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
   { keyword: "let's plan", skill: 'plan', priority: 8, guidance: 'Activate planning skill' },
 
-  { keyword: 'ralplan', skill: 'ralplan', priority: 11, guidance: 'Activate consensus planning (planner + architect + critic)' },
+  { keyword: '$ralplan', skill: 'ralplan', priority: 11, guidance: 'Activate consensus planning (planner + architect + critic)' },
   { keyword: 'consensus plan', skill: 'ralplan', priority: 11, guidance: 'Activate consensus planning (planner + architect + critic)' },
 
-  { keyword: 'autoresearch', skill: 'autoresearch', priority: 10, guidance: 'Activate autoresearch validator-gated research loop' },
+  { keyword: '$autoresearch', skill: 'autoresearch', priority: 10, guidance: 'Activate autoresearch validator-gated research loop' },
 
-  { keyword: 'team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
+  { keyword: '$team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
   { keyword: 'swarm', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode (swarm is a compatibility alias for team)' },
   { keyword: 'coordinated team', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode' },
   { keyword: 'coordinated swarm', skill: 'team', priority: 8, guidance: 'Activate coordinated team mode (swarm is a compatibility alias for team)' },
 
-  { keyword: 'cancel', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
+  { keyword: '$cancel', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
   { keyword: 'stop', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
   { keyword: 'abort', skill: 'cancel', priority: 5, guidance: 'Cancel active execution modes' },
 
+  { keyword: '$tdd', skill: 'tdd', priority: 6, guidance: 'Activate test-driven workflow' },
   { keyword: 'tdd', skill: 'tdd', priority: 6, guidance: 'Activate test-driven workflow' },
   { keyword: 'test first', skill: 'tdd', priority: 6, guidance: 'Activate test-driven workflow' },
 
+  { keyword: '$build-fix', skill: 'build-fix', priority: 6, guidance: 'Activate build-fix workflow' },
   { keyword: 'fix build', skill: 'build-fix', priority: 6, guidance: 'Activate build-fix workflow' },
   { keyword: 'type errors', skill: 'build-fix', priority: 6, guidance: 'Activate build-fix workflow' },
 
+  { keyword: '$wiki', skill: 'wiki', priority: 5, guidance: 'Activate the project wiki skill' },
   { keyword: 'wiki query', skill: 'wiki', priority: 5, guidance: 'Activate the project wiki skill for search' },
   { keyword: 'wiki add', skill: 'wiki', priority: 5, guidance: 'Activate the project wiki skill for page creation' },
   { keyword: 'wiki lint', skill: 'wiki', priority: 5, guidance: 'Activate the project wiki skill for wiki health checks' },
 
   { keyword: 'code review', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
-  { keyword: 'code-review', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
+  { keyword: '$code-review', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
   { keyword: 'review code', skill: 'code-review', priority: 6, guidance: 'Activate code-review workflow' },
+  { keyword: '$security-review', skill: 'security-review', priority: 6, guidance: 'Activate security-review workflow' },
   { keyword: 'security review', skill: 'security-review', priority: 6, guidance: 'Activate security-review workflow' },
 ] as const;
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -629,6 +629,112 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("keeps bare keep-going continuation on the active autopilot skill instead of denying with generic ralph overlap", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-bare-continuation-"));
+    try {
+      const sessionId = "sess-autopilot-cont";
+      const sessionDir = join(cwd, ".omx", "state", "sessions", sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        keyword: "$autopilot",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [
+          { skill: "autopilot", phase: "planning", active: true, session_id: sessionId },
+        ],
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "execution",
+        started_at: "2026-04-19T00:00:00.000Z",
+        updated_at: "2026-04-19T00:10:00.000Z",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-autopilot-cont",
+          turn_id: "turn-autopilot-cont",
+          prompt: "\\ keep going now",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "autopilot");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /"keep going" -> ralph/);
+      assert.doesNotMatch(message, /denied workflow keyword/i);
+      assert.doesNotMatch(message, /Unsupported workflow overlap: autopilot \+ ralph\./);
+      assert.doesNotMatch(message, /Prompt-side `\$ralph` activation/);
+      assert.equal(existsSync(join(sessionDir, "ralph-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps bare keep-going continuation on the active ralph skill without resetting through generic keep-going routing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-bare-continuation-"));
+    try {
+      const sessionId = "sess-ralph-cont";
+      const sessionDir = join(cwd, ".omx", "state", "sessions", sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "ralph",
+        keyword: "$ralph",
+        phase: "executing",
+        session_id: sessionId,
+        active_skills: [
+          { skill: "ralph", phase: "executing", active: true, session_id: sessionId },
+        ],
+      });
+      await writeJson(join(sessionDir, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "verifying",
+        started_at: "2026-04-19T00:00:00.000Z",
+        updated_at: "2026-04-19T00:10:00.000Z",
+        iteration: 4,
+        max_iterations: 50,
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralph-cont",
+          turn_id: "turn-ralph-cont",
+          prompt: "keep going now",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "ralph");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /"keep going" -> ralph/);
+      assert.doesNotMatch(message, /denied workflow keyword/i);
+      assert.doesNotMatch(message, /mode transiting:/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("ignores generic wrapper fields so metadata cannot trigger workflow routing or Stop blocking", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-wrapper-metadata-"));
     try {

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -224,7 +224,7 @@ Keyword routing is implemented primarily by native `UserPromptSubmit` hooks and 
 
 Fallback behavior when hook context is unavailable:
 - Explicit `$name` invocations run left-to-right and override implicit keywords.
-- Deterministic workflow keywords route to the matching installed skill. Examples: `analyze` / `investigate` → `$analyze` for read-only deep analysis with ranked synthesis, explicit confidence, and concrete file references; `deep interview`, `interview`, `don't assume`, or `ouroboros` → `$deep-interview`; `ralplan` / `consensus plan` → `$ralplan`; `cancel`, `stop`, or `abort` → `$cancel`.
+- Bare skill names do not activate skills by themselves; skill-name activation requires explicit `$skill` invocation. Natural-language routing phrases may still map to a workflow when they are not just the bare skill name. Examples: `analyze` / `investigate` → `$analyze` for read-only deep analysis with ranked synthesis, explicit confidence, and concrete file references; `deep interview`, `interview`, `don't assume`, or `ouroboros` → `$deep-interview`; `ralplan` / `consensus plan` → `$ralplan`; `cancel`, `stop`, or `abort` → `$cancel`.
 - Keep the detailed keyword list in `src/hooks/keyword-registry.ts`; do not duplicate that table here.
 
 Runtime availability gate:


### PR DESCRIPTION
## Summary
- require explicit `$skill` forms for skill-name keyword registry entries
- keep natural-language workflow phrases that are intentionally routed
- add regression coverage for bare skill-name non-activation and update template guidance

## Testing
- npm run build
- node --test dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npm run lint