### PR TITLE
Add OMX-owned blocking question flow for deep-interview

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -51,7 +51,7 @@ If no flag is provided, use **Standard**.
 - Always run a preflight context intake before the first interview question
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
-- In Codex CLI, prefer `request_user_input` when available; if unavailable, fall back to concise plain-text one-question turns
+- In Codex CLI, prefer `omx question` for OMX-owned structured questioning when available; otherwise use `request_user_input` when available, then fall back to concise plain-text one-question turns
 - Re-score ambiguity after each answer and show progress transparently
 - Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning
 - Do not crystallize or hand off while `Non-goals` or `Decision Boundaries` remain unresolved, even if the weighted ambiguity threshold is met
@@ -145,7 +145,7 @@ Detailed dimensions:
 `Non-goals` and `Decision Boundaries` are mandatory readiness gates. Ask about them early and keep revisiting them until they are explicit.
 
 ### 2b) Ask the question
-Use structured user-input tooling available in the runtime (`AskUserQuestion` / equivalent) and present:
+Use OMX-owned structured questioning via `omx question` when available (this is the preferred `AskUserQuestion` equivalent) and present:
 
 ```
 Round {n} | Target: {weakest_dimension} | Ambiguity: {score}%
@@ -296,7 +296,8 @@ Present execution options after artifact generation using explicit handoff contr
 
 <Tool_Usage>
 - Use `explore` for codebase fact gathering
-- Use `request_user_input` / structured user-input tool for each interview round when available
+- Use `omx question` as the OMX-native structured user-input tool for each interview round when available
+- If `omx question` is unavailable in the current runtime, fall back to `request_user_input` when available
 - If structured question tools are unavailable, use plain-text single-question rounds and keep the same stage order
 - Use `state_write` / `state_read` for resumable mode state
 - Read/write context snapshots under `.omx/context/`

--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
+import { OmxQuestionError } from "../../question/client.js";
 import {
 	type AutoresearchStructuredQuestionAsker,
 	type AutoresearchQuestionIO,
@@ -298,6 +299,57 @@ describe("runAutoresearchNoviceBridge", () => {
 
 			assert.equal(result.slug, "ux-eval");
 			assert.equal(result.resultPath, join(repo, ".omx", "specs", "autoresearch-ux-eval", "result.json"));
+		} finally {
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("does not fall back to plain prompts when question policy denies structured questions", async () => {
+		const repo = await initWorkspace();
+		try {
+			await mkdir(join(repo, ".omx", "state", "sessions", "sess-autoresearch"), {
+				recursive: true,
+			});
+			await writeFile(
+				join(repo, ".omx", "state", "session.json"),
+				JSON.stringify({ session_id: "sess-autoresearch" }),
+			);
+			await writeFile(
+				join(
+					repo,
+					".omx",
+					"state",
+					"sessions",
+					"sess-autoresearch",
+					"autoresearch-state.json",
+				),
+				JSON.stringify({ mode: "autoresearch", active: true }),
+			);
+
+			await assert.rejects(
+				() =>
+					withMockedTty(() =>
+						runAutoresearchNoviceBridge(
+							repo,
+							{},
+							makeFakeIo([
+								"should not be used",
+								"should not be used",
+							]),
+							async () => {
+								throw new OmxQuestionError(
+									"active_execution_mode_blocked",
+									"omx question is unavailable while auto-executing workflows are active: autoresearch.",
+								);
+							},
+						),
+					),
+				(error) => {
+					assert.ok(error instanceof OmxQuestionError);
+					assert.equal(error.code, "active_execution_mode_blocked");
+					return true;
+				},
+			);
 		} finally {
 			await rm(repo, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/autoresearch-guided.test.ts
+++ b/src/cli/__tests__/autoresearch-guided.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import {
+	type AutoresearchStructuredQuestionAsker,
 	type AutoresearchQuestionIO,
 	buildAutoresearchDeepInterviewPrompt,
 	parseInitArgs,
@@ -45,6 +46,64 @@ function makeFakeIo(answers: string[]): AutoresearchQuestionIO {
 			return queue.shift() ?? "";
 		},
 		close(): void {},
+	};
+}
+
+function makeFakeStructuredQuestionAsker(
+	answers: string[],
+	questions: Array<{ question: string; options: string[]; allowOther: boolean }> = [],
+): AutoresearchStructuredQuestionAsker {
+	const queue = [...answers];
+	return async (input) => {
+		questions.push({
+			question: input.question,
+			options: input.options.map((option) => option.value),
+			allowOther: input.allow_other,
+		});
+		const next = queue.shift() ?? "";
+		const matchingOption = input.options.find((option) => option.value === next);
+		if (matchingOption) {
+			return {
+				ok: true,
+				question_id: `q-${questions.length}`,
+				prompt: {
+					header: input.header,
+					question: input.question,
+					options: input.options,
+					allow_other: input.allow_other,
+					other_label: input.other_label ?? "Other",
+					multi_select: input.multi_select ?? false,
+					source: input.source,
+				},
+				answer: {
+					kind: "option",
+					value: matchingOption.value,
+					selected_labels: [matchingOption.label],
+					selected_values: [matchingOption.value],
+				},
+			};
+		}
+
+		return {
+			ok: true,
+			question_id: `q-${questions.length}`,
+			prompt: {
+				header: input.header,
+				question: input.question,
+				options: input.options,
+				allow_other: input.allow_other,
+				other_label: input.other_label ?? "Other",
+				multi_select: input.multi_select ?? false,
+				source: input.source,
+			},
+			answer: {
+				kind: "other",
+				value: next,
+				selected_labels: [input.other_label ?? "Other"],
+				selected_values: [next],
+				other_text: next,
+			},
+		};
 	};
 }
 
@@ -216,6 +275,71 @@ describe("buildAutoresearchDeepInterviewPrompt", () => {
 });
 
 describe("runAutoresearchNoviceBridge", () => {
+	it("falls back to plain terminal prompts when omx question is unavailable", async () => {
+		const repo = await initWorkspace();
+		try {
+			const result = await withMockedTty(() =>
+				runAutoresearchNoviceBridge(
+					repo,
+					{},
+					makeFakeIo([
+						"Improve evaluator UX",
+						"Passing evaluator output",
+						"node scripts/eval.js",
+						"pass_only",
+						"ux-eval",
+						"launch",
+					]),
+					async () => {
+						throw new Error("omx question requires tmux for OMX-owned question UI rendering in this session.");
+					},
+				),
+			);
+
+			assert.equal(result.slug, "ux-eval");
+			assert.equal(result.resultPath, join(repo, ".omx", "specs", "autoresearch-ux-eval", "result.json"));
+		} finally {
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("uses structured omx-question prompts and resumes from returned stdout answers", async () => {
+		const repo = await initWorkspace();
+		const askedQuestions: Array<{ question: string; options: string[]; allowOther: boolean }> = [];
+		try {
+			const result = await withMockedTty(() =>
+				runAutoresearchNoviceBridge(
+					repo,
+					{},
+					makeFakeIo([]),
+					makeFakeStructuredQuestionAsker(
+						[
+							"Improve evaluator UX",
+							"Passing evaluator output",
+							"node scripts/eval.js",
+							"pass_only",
+							"ux-eval",
+							"launch",
+						],
+						askedQuestions,
+					),
+				),
+			);
+
+			assert.equal(result.slug, "ux-eval");
+			assert.equal(result.resultPath, join(repo, ".omx", "specs", "autoresearch-ux-eval", "result.json"));
+			assert.equal(askedQuestions.length, 6);
+			assert.equal(askedQuestions[0]?.question, "Research topic/goal");
+			assert.deepEqual(askedQuestions[0]?.options, []);
+			assert.equal(askedQuestions[0]?.allowOther, true);
+			assert.match(askedQuestions[5]?.question || "", /Next step/);
+			assert.deepEqual(askedQuestions[5]?.options, ["launch", "refine"]);
+			assert.equal(askedQuestions[5]?.allowOther, false);
+		} finally {
+			await rm(repo, { recursive: true, force: true });
+		}
+	});
+
 	it("loops through refine further before launching and writes canonical spec artifacts", async () => {
 		const repo = await initWorkspace();
 		try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -881,6 +881,7 @@ describe("commandOwnsLocalHelp", () => {
       "adapt",
       "agents-init",
       "ask",
+      "question",
       "autoresearch",
       "deepinit",
       "hooks",
@@ -925,6 +926,13 @@ describe("resolveCliInvocation", () => {
   it("resolves ask to ask command", () => {
     assert.deepEqual(resolveCliInvocation(["ask", "claude", "hello"]), {
       command: "ask",
+      launchArgs: [],
+    });
+  });
+
+  it("resolves question to question command", () => {
+    assert.deepEqual(resolveCliInvocation(["question", "--input", "{}"]), {
+      command: "question",
       launchArgs: [],
     });
   });

--- a/src/cli/__tests__/nested-help-routing.test.ts
+++ b/src/cli/__tests__/nested-help-routing.test.ts
@@ -26,6 +26,7 @@ describe('nested help routing', () => {
   for (const [argv, expectedUsage] of [
     [['adapt', '--help'], /Usage:\s*omx adapt <target> <probe\|status\|init\|envelope\|doctor>/i],
     [['ask', '--help'], /Usage:\s*omx ask <claude\|gemini> <question or task>/i],
+    [['question', '--help'], /omx question - OMX-owned blocking user question entrypoint/i],
     [['autoresearch', '--help'], /hard-deprecated legacy command surface[\s\S]*\$autoresearch/i],
     [['hud', '--help'], /Usage:\s*\n\s*omx hud\s+Show current HUD state/i],
     [['hooks', '--help'], /Usage:\s*\n\s*omx hooks init/i],

--- a/src/cli/__tests__/question.test.ts
+++ b/src/cli/__tests__/question.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, it } from 'node:test';
+import { readdir } from 'node:fs/promises';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..', '..');
+const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
+const tempDirs: string[] = [];
+
+async function makeRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-question-cli-'));
+  tempDirs.push(cwd);
+  await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions'), { recursive: true });
+  await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-q' }));
+  return cwd;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('omx question CLI', () => {
+  it('hard-fails worker contexts before UI launch', async () => {
+    const cwd = await makeRepo();
+    const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+      const child = spawn(process.execPath, [omxBin, 'question', '--input', JSON.stringify({
+        question: 'Pick one',
+        options: ['A'],
+        allow_other: true,
+      }), '--json'], {
+        cwd,
+        env: { ...process.env, OMX_TEAM_WORKER: 'demo/worker-1', OMX_AUTO_UPDATE: '0' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+      child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+    assert.equal(result.code, 1);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.error.code, 'worker_blocked');
+    assert.deepEqual(await readdir(join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions')), []);
+  });
+
+  it('blocks until an answer is written and returns structured payload', async () => {
+    const cwd = await makeRepo();
+    const input = JSON.stringify({
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }],
+      allow_other: true,
+      source: 'deep-interview',
+      type: 'multi-answerable',
+      session_id: 'sess-q',
+    });
+
+    const child = spawn(process.execPath, [omxBin, 'question', '--input', input, '--json'], {
+      cwd,
+      env: { ...process.env, OMX_AUTO_UPDATE: '0', OMX_NOTIFY_FALLBACK: '0', OMX_HOOK_DERIVED_SIGNALS: '0', OMX_QUESTION_TEST_RENDERER: 'noop' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+
+    const questionsDir = join(cwd, '.omx', 'state', 'sessions', 'sess-q', 'questions');
+    let recordFile = '';
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      try {
+        const { readdir } = await import('node:fs/promises');
+        const entries = await readdir(questionsDir);
+        recordFile = entries.find((entry) => entry.endsWith('.json')) || '';
+        if (recordFile) break;
+      } catch {}
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    assert.notEqual(recordFile, '', `expected question record file, stderr=${stderr}`);
+    const recordPath = join(questionsDir, recordFile);
+    const record = JSON.parse(await readFile(recordPath, 'utf-8')) as { question_id: string };
+    await writeFile(recordPath, JSON.stringify({
+      kind: 'omx.question/v1',
+      question_id: record.question_id,
+      session_id: 'sess-q',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      status: 'answered',
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }],
+      allow_other: true,
+      other_label: 'Other',
+      type: 'multi-answerable',
+      multi_select: true,
+      source: 'deep-interview',
+      answer: {
+        kind: 'other',
+        value: 'free text answer',
+        selected_labels: ['Other'],
+        selected_values: ['free text answer'],
+        other_text: 'free text answer',
+      },
+    }, null, 2));
+
+    const exitCode = await new Promise<number | null>((resolve) => child.on('close', resolve));
+    assert.equal(exitCode, 0, stderr || stdout);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.answer.value, 'free text answer');
+    assert.equal(payload.prompt.source, 'deep-interview');
+    assert.equal(payload.prompt.type, 'multi-answerable');
+  });
+});

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -5,6 +5,12 @@ import {
 	slugifyMissionName,
 } from "../autoresearch/contracts.js";
 import {
+	OmxQuestionError,
+	type OmxQuestionSuccessPayload,
+} from "../question/client.js";
+import type { QuestionType } from "../question/types.js";
+import { runDeepInterviewQuestion } from "../question/deep-interview.js";
+import {
 	type AutoresearchDeepInterviewResult,
 	type AutoresearchSeedInputs,
 	isLaunchReadyEvaluatorCommand,
@@ -32,6 +38,21 @@ export interface AutoresearchQuestionIO {
 	close(): void;
 }
 
+export interface AutoresearchStructuredQuestionInput {
+	header?: string;
+	question: string;
+	options: Array<{ label: string; value: string; description?: string }>;
+	allow_other: boolean;
+	other_label?: string;
+	multi_select?: boolean;
+	type?: QuestionType;
+	source?: string;
+}
+
+export type AutoresearchStructuredQuestionAsker = (
+	input: AutoresearchStructuredQuestionInput,
+) => Promise<OmxQuestionSuccessPayload>;
+
 function createQuestionIO(): AutoresearchQuestionIO {
 	const rl = createInterface({ input: process.stdin, output: process.stdout });
 	return {
@@ -48,7 +69,33 @@ async function promptWithDefault(
 	io: AutoresearchQuestionIO,
 	prompt: string,
 	currentValue?: string,
+	structuredQuestion?: AutoresearchStructuredQuestionAsker,
 ): Promise<string> {
+	if (structuredQuestion) {
+		const trimmedCurrentValue = currentValue?.trim() || "";
+		const response = await structuredQuestion({
+			header: "Deep Interview / Autoresearch",
+			question: prompt,
+			options: trimmedCurrentValue
+				? [
+						{
+							label: "Keep current value",
+							value: trimmedCurrentValue,
+							description: trimmedCurrentValue,
+						},
+				  ]
+				: [],
+			allow_other: true,
+			other_label: trimmedCurrentValue
+				? "Enter a different value"
+				: "Enter your response",
+			source: "deep-interview",
+		});
+		const answerValue = response.answer.other_text?.trim()
+			|| (typeof response.answer.value === "string" ? response.answer.value.trim() : "");
+		return answerValue || trimmedCurrentValue || "";
+	}
+
 	const suffix = currentValue?.trim() ? ` [${currentValue.trim()}]` : "";
 	const answer = await io.question(`${prompt}${suffix}\n> `);
 	return answer.trim() || currentValue?.trim() || "";
@@ -57,7 +104,35 @@ async function promptWithDefault(
 async function promptAction(
 	io: AutoresearchQuestionIO,
 	launchReady: boolean,
+	structuredQuestion?: AutoresearchStructuredQuestionAsker,
 ): Promise<"launch" | "refine"> {
+	if (structuredQuestion) {
+		const response = await structuredQuestion({
+			header: "Deep Interview / Autoresearch",
+			question: `Next step (default: ${launchReady ? "launch" : "refine further"})`,
+			options: [
+				{
+					label: "Launch",
+					value: "launch",
+					description: "Finalize artifacts and hand off to $autoresearch.",
+				},
+				{
+					label: "Refine further",
+					value: "refine",
+					description: "Keep clarifying before launch.",
+				},
+			],
+			allow_other: false,
+			source: "deep-interview",
+		});
+		const answerValue = typeof response.answer.value === "string"
+			? response.answer.value.trim().toLowerCase()
+			: "";
+		if (answerValue === "launch") return "launch";
+		if (answerValue === "refine") return "refine";
+		throw new Error('Structured question returned an invalid next-step answer.');
+	}
+
 	const answer = (
 		await io.question(
 			`\nNext step [launch/refine further] (default: ${launchReady ? "launch" : "refine further"})\n> `,
@@ -70,6 +145,34 @@ async function promptAction(
 	if (answer === "refine further" || answer === "refine" || answer === "r")
 		return "refine";
 	throw new Error('Please choose either "launch" or "refine further".');
+}
+
+function createStructuredQuestionAsker(
+	repoRoot: string,
+): AutoresearchStructuredQuestionAsker {
+	return (input) =>
+		runDeepInterviewQuestion(
+			{
+				header: input.header,
+				question: input.question,
+				options: input.options,
+				allow_other: input.allow_other,
+				other_label: input.other_label ?? "Other",
+				type: input.type,
+				multi_select: input.multi_select ?? false,
+				source: input.source ?? "deep-interview",
+			},
+			{ cwd: repoRoot },
+		);
+}
+
+function shouldFallbackFromStructuredQuestion(error: unknown): boolean {
+	if (error instanceof OmxQuestionError) {
+		return true;
+	}
+
+	const message = error instanceof Error ? error.message : String(error);
+	return /omx question/i.test(message);
 }
 
 function ensureLaunchReadyEvaluator(command: string): void {
@@ -174,6 +277,7 @@ export async function runAutoresearchNoviceBridge(
 	repoRoot: string,
 	seedInputs: AutoresearchSeedInputs = {},
 	io: AutoresearchQuestionIO = createQuestionIO(),
+	structuredQuestion?: AutoresearchStructuredQuestionAsker,
 ): Promise<InitAutoresearchResult> {
 	if (!process.stdin.isTTY) {
 		throw new Error(
@@ -186,40 +290,75 @@ export async function runAutoresearchNoviceBridge(
 	let keepPolicy: AutoresearchKeepPolicy =
 		seedInputs.keepPolicy || "score_improvement";
 	let slug = seedInputs.slug?.trim() || "";
+	let activeStructuredQuestion = structuredQuestion;
+	let warnedAboutStructuredQuestionFallback = false;
+
+	const withStructuredQuestionFallback = async <T>(
+		operation: (question?: AutoresearchStructuredQuestionAsker) => Promise<T>,
+	): Promise<T> => {
+		if (!activeStructuredQuestion) return operation();
+		try {
+			return await operation(activeStructuredQuestion);
+		} catch (error) {
+			if (!shouldFallbackFromStructuredQuestion(error)) throw error;
+			activeStructuredQuestion = undefined;
+			if (!warnedAboutStructuredQuestionFallback) {
+				warnedAboutStructuredQuestionFallback = true;
+				console.warn(
+					`[omx] warning: structured question UI unavailable (${error instanceof Error ? error.message : String(error)}). Falling back to plain terminal prompts.`,
+				);
+			}
+			return operation();
+		}
+	};
 
 	try {
 		while (true) {
-			topic = await promptWithDefault(io, "Research topic/goal", topic);
+			topic = await withStructuredQuestionFallback((question) =>
+				promptWithDefault(io, "Research topic/goal", topic, question),
+			);
 			if (!topic) {
 				throw new Error("Research topic is required.");
 			}
 
-			const evaluatorIntent = await promptWithDefault(
-				io,
-				"\nHow should OMX judge success? Describe it in plain language",
-				topic,
+			const evaluatorIntent = await withStructuredQuestionFallback((question) =>
+				promptWithDefault(
+					io,
+					"\nHow should OMX judge success? Describe it in plain language",
+					topic,
+					question,
+				),
 			);
-			evaluatorCommand = await promptWithDefault(
-				io,
-				"\nEvaluator command (leave placeholder to refine further; must output {pass:boolean, score?:number} JSON before launch)",
-				evaluatorCommand ||
-					`TODO replace with evaluator command for: ${evaluatorIntent}`,
+			evaluatorCommand = await withStructuredQuestionFallback((question) =>
+				promptWithDefault(
+					io,
+					"\nEvaluator command (leave placeholder to refine further; must output {pass:boolean, score?:number} JSON before launch)",
+					evaluatorCommand ||
+						`TODO replace with evaluator command for: ${evaluatorIntent}`,
+					question,
+				),
 			);
 
-			const keepPolicyInput = await promptWithDefault(
-				io,
-				"\nKeep policy [score_improvement/pass_only]",
-				keepPolicy,
+			const keepPolicyInput = await withStructuredQuestionFallback((question) =>
+				promptWithDefault(
+					io,
+					"\nKeep policy [score_improvement/pass_only]",
+					keepPolicy,
+					question,
+				),
 			);
 			keepPolicy =
 				keepPolicyInput.trim().toLowerCase() === "pass_only"
 					? "pass_only"
 					: "score_improvement";
 
-			slug = await promptWithDefault(
-				io,
-				"\nMission slug",
-				slug || slugifyMissionName(topic),
+			slug = await withStructuredQuestionFallback((question) =>
+				promptWithDefault(
+					io,
+					"\nMission slug",
+					slug || slugifyMissionName(topic),
+					question,
+				),
 			);
 			slug = slugifyMissionName(slug);
 
@@ -237,7 +376,9 @@ export async function runAutoresearchNoviceBridge(
 				`Launch readiness: ${deepInterview.launchReady ? "ready" : deepInterview.blockedReasons.join(" ")}`,
 			);
 
-			const action = await promptAction(io, deepInterview.launchReady);
+			const action = await withStructuredQuestionFallback((question) =>
+				promptAction(io, deepInterview.launchReady, question),
+			);
 			if (action === "refine") continue;
 			return materializeAutoresearchDeepInterviewResult(deepInterview);
 		}
@@ -249,5 +390,10 @@ export async function runAutoresearchNoviceBridge(
 export async function guidedAutoresearchSetup(
 	repoRoot: string,
 ): Promise<InitAutoresearchResult> {
-	return runAutoresearchNoviceBridge(repoRoot);
+	return runAutoresearchNoviceBridge(
+		repoRoot,
+		{},
+		createQuestionIO(),
+		createStructuredQuestionAsker(repoRoot),
+	);
 }

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -8,6 +8,7 @@ import {
 	OmxQuestionError,
 	type OmxQuestionSuccessPayload,
 } from "../question/client.js";
+import { evaluateQuestionPolicy } from "../question/policy.js";
 import type { QuestionType } from "../question/types.js";
 import { runDeepInterviewQuestion } from "../question/deep-interview.js";
 import {
@@ -166,8 +167,26 @@ function createStructuredQuestionAsker(
 		);
 }
 
+async function ensureStructuredQuestionFallbackAllowed(
+	repoRoot: string,
+): Promise<void> {
+	const policy = await evaluateQuestionPolicy({ cwd: repoRoot });
+	if (policy.allowed || policy.fallbackAllowed !== false) return;
+	throw new OmxQuestionError(
+		policy.code ?? "question_policy_denied",
+		policy.message ?? "Structured questions are unavailable in the current OMX workflow context.",
+	);
+}
+
 function shouldFallbackFromStructuredQuestion(error: unknown): boolean {
 	if (error instanceof OmxQuestionError) {
+		if (
+			error.code === "worker_blocked"
+			|| error.code === "team_blocked"
+			|| error.code === "active_execution_mode_blocked"
+		) {
+			return false;
+		}
 		return true;
 	}
 
@@ -390,6 +409,7 @@ export async function runAutoresearchNoviceBridge(
 export async function guidedAutoresearchSetup(
 	repoRoot: string,
 ): Promise<InitAutoresearchResult> {
+	await ensureStructuredQuestionFallbackAllowed(repoRoot);
 	return runAutoresearchNoviceBridge(
 		repoRoot,
 		{},

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import { hudCommand } from "../hud/index.js";
 import { teamCommand } from "./team.js";
 import { ralphCommand } from "./ralph.js";
 import { askCommand } from "./ask.js";
+import { questionCommand } from "./question.js";
 import { stateCommand } from "./state.js";
 import {
   cleanupCommand,
@@ -148,6 +149,7 @@ Usage:
   omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx question  OMX-owned blocking question UI entrypoint for agent-invoked user questions
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
   omx resume    Resume a previous interactive Codex session
   omx explore   Default read-only exploration entrypoint (may adaptively use sparkshell backend)
@@ -264,6 +266,7 @@ type CliCommand =
   | "doctor"
   | "cleanup"
   | "ask"
+  | "question"
   | "adapt"
   | "explore"
   | "sparkshell"
@@ -284,6 +287,7 @@ type CliCommand =
 
 const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "ask",
+  "question",
   "cleanup",
   "adapt",
   "autoresearch",
@@ -647,6 +651,7 @@ export async function main(args: string[]): Promise<void> {
     "doctor",
     "cleanup",
     "ask",
+    "question",
     "autoresearch",
     "explore",
     "sparkshell",
@@ -721,6 +726,9 @@ export async function main(args: string[]): Promise<void> {
       }
       case "ask":
         await askCommand(args.slice(1));
+        break;
+      case "question":
+        await questionCommand(args.slice(1));
         break;
       case "adapt":
         await adaptCommand(args.slice(1));

--- a/src/cli/question.ts
+++ b/src/cli/question.ts
@@ -1,0 +1,206 @@
+import { evaluateQuestionPolicy } from '../question/policy.js';
+import {
+  createQuestionRecord,
+  markQuestionTerminalError,
+  markQuestionPrompting,
+  waitForQuestionTerminalState,
+} from '../question/state.js';
+import { launchQuestionRenderer } from '../question/renderer.js';
+import { normalizeQuestionInput } from '../question/types.js';
+import { runQuestionUi } from '../question/ui.js';
+
+export const QUESTION_HELP = `omx question - OMX-owned blocking user question entrypoint
+
+Usage:
+  omx question --input '<json>' [--json]
+  omx question --ui --state-path <absolute-or-relative-record-path>
+
+Options:
+  --help, -h           Show this help message
+  --input <json>       JSON object with question/options schema; blocks until answered
+  --input=<json>       Same as --input
+  --json               Emit compact JSON on stdout for machine callers
+  --ui                 Internal renderer mode; renders the OMX question UI for an existing state record
+  --state-path <path>  Question record path used by --ui mode
+
+Input schema:
+  {
+    "header": "Optional short heading",
+    "question": "What should OMX do next?",
+    "options": [
+      {"label": "Proceed", "value": "proceed", "description": "Continue"},
+      {"label": "Revise", "value": "revise"}
+    ],
+    "allow_other": true,
+    "other_label": "Other",
+    "type": "single-answerable",
+    "multi_select": false,
+    "source": "deep-interview",
+    "session_id": "optional-session-id"
+  }
+
+Notes:
+  - 'type' accepts 'single-answerable' or 'multi-answerable'; legacy 'multi_select' is still accepted.
+  - options may be [] only when allow_other is true, for a free-text-only prompt.
+  - machine callers should use --json and read stdout; the command does not return
+    until the user selected a predefined option or submitted Other text.
+`;
+
+interface ParsedQuestionArgs {
+  help: boolean;
+  json: boolean;
+  ui: boolean;
+  input?: string;
+  statePath?: string;
+}
+
+function parseQuestionArgs(args: string[]): ParsedQuestionArgs {
+  const parsed: ParsedQuestionArgs = { help: false, json: false, ui: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h' || arg === 'help') {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === '--json') {
+      parsed.json = true;
+      continue;
+    }
+    if (arg === '--ui') {
+      parsed.ui = true;
+      continue;
+    }
+    if (arg === '--input') {
+      const next = args[index + 1];
+      if (!next) throw new Error('Missing JSON value after --input');
+      parsed.input = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--input=')) {
+      parsed.input = arg.slice('--input='.length);
+      continue;
+    }
+    if (arg === '--state-path') {
+      const next = args[index + 1];
+      if (!next) throw new Error('Missing path value after --state-path');
+      parsed.statePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--state-path=')) {
+      parsed.statePath = arg.slice('--state-path='.length);
+      continue;
+    }
+    throw new Error(`Unknown question argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function printJson(payload: unknown, compact: boolean): void {
+  console.log(JSON.stringify(payload, null, compact ? 0 : 2));
+}
+
+function extractErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function questionCommand(args: string[]): Promise<void> {
+  const parsed = parseQuestionArgs(args);
+  if (parsed.help || args.length === 0) {
+    console.log(QUESTION_HELP);
+    return;
+  }
+
+  if (parsed.ui) {
+    if (!parsed.statePath) throw new Error('--ui requires --state-path');
+    await runQuestionUi(parsed.statePath);
+    return;
+  }
+
+  if (!parsed.input) throw new Error('omx question requires --input in normal mode');
+
+  let rawInput: unknown;
+  try {
+    rawInput = JSON.parse(parsed.input);
+  } catch (error) {
+    throw new Error(`--input must be valid JSON: ${(error as Error).message}`);
+  }
+
+  const input = normalizeQuestionInput(rawInput);
+  const cwd = process.cwd();
+  const policy = await evaluateQuestionPolicy({ cwd, explicitSessionId: input.session_id });
+  if (!policy.allowed) {
+    printJson({
+      ok: false,
+      error: {
+        code: policy.code,
+        message: policy.message,
+      },
+    }, parsed.json);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { record, recordPath } = await createQuestionRecord(cwd, input, policy.sessionId);
+
+  let finalRecord;
+  try {
+    const renderer = launchQuestionRenderer({
+      cwd,
+      recordPath,
+      sessionId: policy.sessionId,
+    });
+    await markQuestionPrompting(recordPath, renderer);
+    finalRecord = await waitForQuestionTerminalState(recordPath);
+  } catch (error) {
+    const message = extractErrorMessage(error);
+    await markQuestionTerminalError(
+      recordPath,
+      'error',
+      'question_runtime_failed',
+      message,
+    );
+    printJson({
+      ok: false,
+      question_id: record.question_id,
+      session_id: record.session_id,
+      error: {
+        code: 'question_runtime_failed',
+        message,
+      },
+    }, parsed.json);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (finalRecord.status !== 'answered' || !finalRecord.answer) {
+    printJson({
+      ok: false,
+      question_id: finalRecord.question_id,
+      error: finalRecord.error ?? {
+        code: 'question_not_answered',
+        message: `Question ended with status ${finalRecord.status}.`,
+      },
+    }, parsed.json);
+    process.exitCode = 1;
+    return;
+  }
+
+  printJson({
+    ok: true,
+    question_id: finalRecord.question_id,
+    session_id: finalRecord.session_id,
+    prompt: {
+      header: finalRecord.header,
+      question: finalRecord.question,
+      options: finalRecord.options,
+      allow_other: finalRecord.allow_other,
+      other_label: finalRecord.other_label,
+      type: finalRecord.type,
+      multi_select: finalRecord.multi_select,
+      source: finalRecord.source,
+    },
+    answer: finalRecord.answer,
+  }, parsed.json);
+}

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -149,6 +149,14 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /Do NOT implement directly/i);
 	});
 
+	it("documents omx question as the preferred structured questioning path", () => {
+		assert.match(deepInterviewSkill, /omx question/i);
+		assert.match(
+			deepInterviewSkill,
+			/preferred `AskUserQuestion` equivalent/i,
+		);
+	});
+
 	it("preserves clarified intent and boundary constraints across execution handoff", () => {
 		assert.match(
 			deepInterviewSkill,

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -624,7 +624,17 @@ describe('keyword detector skill-active-state lifecycle', () => {
       );
       await writeFile(
         join(stateDir, 'sessions', 'sess-handoff', 'deep-interview-state.json'),
-        JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'intent-first' }, null, 2),
+        JSON.stringify({
+          active: true,
+          mode: 'deep-interview',
+          current_phase: 'intent-first',
+          question_enforcement: {
+            obligation_id: 'obligation-handoff',
+            source: 'omx-question',
+            status: 'pending',
+            requested_at: '2026-04-09T23:59:00.000Z',
+          },
+        }, null, 2),
       );
 
       const result = await recordSkillActivation({
@@ -639,9 +649,16 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
       const completed = JSON.parse(
         await readFile(join(stateDir, 'sessions', 'sess-handoff', 'deep-interview-state.json'), 'utf-8'),
-      ) as { active?: boolean; current_phase?: string };
+      ) as {
+        active?: boolean;
+        current_phase?: string;
+        question_enforcement?: { status?: string; clear_reason?: string; cleared_at?: string };
+      };
       assert.equal(completed.active, false);
       assert.equal(completed.current_phase, 'completed');
+      assert.equal(completed.question_enforcement?.status, 'cleared');
+      assert.equal(completed.question_enforcement?.clear_reason, 'handoff');
+      assert.ok(completed.question_enforcement?.cleared_at);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -932,6 +949,69 @@ describe('keyword detector skill-active-state lifecycle', () => {
       ) as { active: boolean; mode: string };
       assert.equal(modeState.active, true);
       assert.equal(modeState.mode, 'deep-interview');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('clears stale pending deep-interview question enforcement when deep-interview is reactivated', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-deep-interview-reactivation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(join(stateDir, 'sessions', 'sess-reactivate'), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', 'sess-reactivate', DEEP_INTERVIEW_STATE_FILE),
+        JSON.stringify({
+          active: false,
+          mode: 'deep-interview',
+          current_phase: 'completed',
+          started_at: '2026-04-10T00:00:00.000Z',
+          updated_at: '2026-04-10T00:10:00.000Z',
+          completed_at: '2026-04-10T00:10:00.000Z',
+          question_enforcement: {
+            obligation_id: 'obligation-reactivate',
+            source: 'omx-question',
+            status: 'pending',
+            requested_at: '2026-04-10T00:05:00.000Z',
+          },
+        }, null, 2),
+      );
+
+      await persistDeepInterviewModeState(
+        stateDir,
+        {
+          version: 1,
+          active: true,
+          skill: 'deep-interview',
+          keyword: 'deep interview',
+          phase: 'planning',
+          activated_at: '2026-04-10T00:11:00.000Z',
+          updated_at: '2026-04-10T00:11:00.000Z',
+          source: 'keyword-detector',
+          session_id: 'sess-reactivate',
+          input_lock: {
+            active: true,
+            scope: 'deep-interview-auto-approval',
+            acquired_at: '2026-04-10T00:11:00.000Z',
+            blocked_inputs: [...DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS],
+            message: DEEP_INTERVIEW_INPUT_LOCK_MESSAGE,
+          },
+        },
+        '2026-04-10T00:11:00.000Z',
+        null,
+        { sessionId: 'sess-reactivate' },
+      );
+
+      const reactivated = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-reactivate', DEEP_INTERVIEW_STATE_FILE), 'utf-8'),
+      ) as {
+        active?: boolean;
+        question_enforcement?: { status?: string; clear_reason?: string; cleared_at?: string };
+      };
+      assert.equal(reactivated.active, true);
+      assert.equal(reactivated.question_enforcement?.status, 'cleared');
+      assert.equal(reactivated.question_enforcement?.clear_reason, 'handoff');
+      assert.ok(reactivated.question_enforcement?.cleared_at);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -29,6 +29,10 @@ import {
   type TrackedWorkflowMode,
 } from '../state/workflow-transition.js';
 import { reconcileWorkflowTransition } from '../state/workflow-transition-reconcile.js';
+import {
+  clearDeepInterviewQuestionObligation,
+  type DeepInterviewQuestionEnforcementState,
+} from '../question/deep-interview.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -129,7 +133,7 @@ const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedCon
   ultraqa: { mode: 'ultraqa', initialPhase: 'planning' },
 };
 
-interface DeepInterviewModeState {
+export interface DeepInterviewModeState {
   active: boolean;
   mode: 'deep-interview';
   current_phase: string;
@@ -140,6 +144,7 @@ interface DeepInterviewModeState {
   thread_id?: string;
   turn_id?: string;
   input_lock?: DeepInterviewInputLock;
+  question_enforcement?: DeepInterviewQuestionEnforcementState;
 }
 
 function createDeepInterviewInputLock(nowIso: string, previous?: DeepInterviewInputLock): DeepInterviewInputLock {
@@ -241,6 +246,7 @@ export async function persistDeepInterviewModeState(
       thread_id: input.threadId ?? previousModeState?.thread_id,
       turn_id: input.turnId ?? previousModeState?.turn_id,
       ...(nextSkill.input_lock ? { input_lock: nextSkill.input_lock } : {}),
+      ...(previousModeState?.question_enforcement ? { question_enforcement: previousModeState.question_enforcement } : {}),
     };
     await writeFile(statePath, JSON.stringify(nextState, null, 2));
     return;
@@ -250,6 +256,7 @@ export async function persistDeepInterviewModeState(
   if (!previousModeState?.active && !hadActiveDeepInterview) return;
 
   const releasedInputLock = nextSkill?.skill === 'deep-interview' ? nextSkill.input_lock : previousSkill?.input_lock;
+  const questionExitReason = nextSkill?.skill === 'deep-interview' && nextSkill.active === false ? 'abort' : 'handoff';
   const nextState: DeepInterviewModeState = {
     active: false,
     mode: 'deep-interview',
@@ -261,6 +268,15 @@ export async function persistDeepInterviewModeState(
     thread_id: input.threadId ?? previousModeState?.thread_id ?? previousSkill?.thread_id,
     turn_id: input.turnId ?? previousModeState?.turn_id ?? previousSkill?.turn_id,
     ...(releasedInputLock ? { input_lock: releasedInputLock } : {}),
+    ...(previousModeState?.question_enforcement
+      ? {
+          question_enforcement: clearDeepInterviewQuestionObligation(
+            previousModeState.question_enforcement,
+            questionExitReason,
+            new Date(nowIso),
+          ),
+        }
+      : {}),
   };
   await writeFile(statePath, JSON.stringify(nextState, null, 2));
 }

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -236,6 +236,11 @@ export async function persistDeepInterviewModeState(
   const previousModeState = await readExistingDeepInterviewState(statePath);
 
   if (nextSkill?.skill === 'deep-interview' && nextSkill.active) {
+    const nextQuestionEnforcement = clearDeepInterviewQuestionObligation(
+      previousModeState?.question_enforcement,
+      'handoff',
+      new Date(nowIso),
+    );
     const nextState: DeepInterviewModeState = {
       active: true,
       mode: 'deep-interview',
@@ -246,7 +251,7 @@ export async function persistDeepInterviewModeState(
       thread_id: input.threadId ?? previousModeState?.thread_id,
       turn_id: input.turnId ?? previousModeState?.turn_id,
       ...(nextSkill.input_lock ? { input_lock: nextSkill.input_lock } : {}),
-      ...(previousModeState?.question_enforcement ? { question_enforcement: previousModeState.question_enforcement } : {}),
+      ...(nextQuestionEnforcement ? { question_enforcement: nextQuestionEnforcement } : {}),
     };
     await writeFile(statePath, JSON.stringify(nextState, null, 2));
     return;

--- a/src/question/__tests__/client.test.ts
+++ b/src/question/__tests__/client.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  OmxQuestionError,
+  runOmxQuestion,
+  type OmxQuestionProcessRunner,
+} from '../client.js';
+
+function makeRunner(stdout: unknown, code = 0, stderr = ''): OmxQuestionProcessRunner {
+  return async () => ({
+    code,
+    stdout: typeof stdout === 'string' ? stdout : JSON.stringify(stdout),
+    stderr,
+  });
+}
+
+describe('runOmxQuestion', () => {
+  it('parses a successful blocking stdout payload', async () => {
+    const result = await runOmxQuestion(
+      {
+        question: 'What next?',
+        options: [{ label: 'Launch', value: 'launch' }],
+        allow_other: true,
+        source: 'deep-interview',
+      },
+      {
+        cwd: '/repo',
+        argv1: '/repo/dist/cli/omx.js',
+        runner: makeRunner({
+          ok: true,
+          question_id: 'q-1',
+          session_id: 'sess-1',
+          prompt: {
+            question: 'What next?',
+            options: [{ label: 'Launch', value: 'launch' }],
+            allow_other: true,
+            other_label: 'Other',
+            type: 'single-answerable',
+            multi_select: false,
+            source: 'deep-interview',
+          },
+          answer: {
+            kind: 'option',
+            value: 'launch',
+            selected_labels: ['Launch'],
+            selected_values: ['launch'],
+          },
+        }),
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.answer.value, 'launch');
+    assert.equal(result.prompt.source, 'deep-interview');
+    assert.equal(result.prompt.type, 'single-answerable');
+  });
+
+  it('throws explicit question errors from stdout payloads', async () => {
+    await assert.rejects(
+      runOmxQuestion(
+        {
+          question: 'What next?',
+          options: [{ label: 'Launch', value: 'launch' }],
+          allow_other: false,
+        },
+        {
+          cwd: '/repo',
+          argv1: '/repo/dist/cli/omx.js',
+          runner: makeRunner({
+            ok: false,
+            error: {
+              code: 'team_blocked',
+              message: 'omx question is unavailable while this session owns active team mode.',
+            },
+          }, 1),
+        },
+      ),
+      (error) => {
+        assert.ok(error instanceof OmxQuestionError);
+        assert.equal(error.code, 'team_blocked');
+        assert.match(error.message, /team_blocked/);
+        return true;
+      },
+    );
+  });
+});

--- a/src/question/__tests__/deep-interview.test.ts
+++ b/src/question/__tests__/deep-interview.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import { OmxQuestionError, type OmxQuestionProcessRunner } from '../client.js';
+import { runDeepInterviewQuestion } from '../deep-interview.js';
+
+const tempDirs: string[] = [];
+
+async function makeRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-deep-interview-question-'));
+  tempDirs.push(cwd);
+  await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-di'), { recursive: true });
+  await writeFile(
+    join(cwd, '.omx', 'state', 'session.json'),
+    JSON.stringify({ session_id: 'sess-di' }, null, 2),
+  );
+  await writeFile(
+    join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json'),
+    JSON.stringify({
+      active: true,
+      mode: 'deep-interview',
+      current_phase: 'intent-first',
+      started_at: '2026-04-19T00:00:00.000Z',
+      updated_at: '2026-04-19T00:00:00.000Z',
+      session_id: 'sess-di',
+    }, null, 2),
+  );
+  return cwd;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('runDeepInterviewQuestion', () => {
+  it('tracks a pending obligation before omx question returns and satisfies it afterward', async () => {
+    const cwd = await makeRepo();
+    const statePath = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json');
+    let inFlightQuestionStatus = '';
+
+    const runner: OmxQuestionProcessRunner = async () => {
+      const inFlightState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+        question_enforcement?: { status?: string };
+      };
+      inFlightQuestionStatus = inFlightState.question_enforcement?.status ?? '';
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          ok: true,
+          question_id: 'question-1',
+          session_id: 'sess-di',
+          prompt: {
+            question: 'What should happen next?',
+            options: [{ label: 'Launch', value: 'launch' }],
+            allow_other: false,
+            other_label: 'Other',
+            multi_select: false,
+            source: 'deep-interview',
+          },
+          answer: {
+            kind: 'option',
+            value: 'launch',
+            selected_labels: ['Launch'],
+            selected_values: ['launch'],
+          },
+        }),
+        stderr: '',
+      };
+    };
+
+    const result = await runDeepInterviewQuestion(
+      {
+        question: 'What should happen next?',
+        options: [{ label: 'Launch', value: 'launch' }],
+        allow_other: false,
+      },
+      {
+        cwd,
+        argv1: '/repo/dist/cli/omx.js',
+        runner,
+      },
+    );
+
+    assert.equal(result.question_id, 'question-1');
+    assert.equal(inFlightQuestionStatus, 'pending');
+
+    const finalState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+      question_enforcement?: {
+        obligation_id?: string;
+        status?: string;
+        question_id?: string;
+        satisfied_at?: string;
+      };
+    };
+    assert.equal(finalState.question_enforcement?.status, 'satisfied');
+    assert.equal(finalState.question_enforcement?.question_id, 'question-1');
+    assert.ok(finalState.question_enforcement?.obligation_id);
+    assert.ok(finalState.question_enforcement?.satisfied_at);
+  });
+
+  it('clears the pending obligation when omx question fails after being attempted', async () => {
+    const cwd = await makeRepo();
+    const statePath = join(cwd, '.omx', 'state', 'sessions', 'sess-di', 'deep-interview-state.json');
+
+    await assert.rejects(
+      runDeepInterviewQuestion(
+        {
+          question: 'What should happen next?',
+          options: [{ label: 'Launch', value: 'launch' }],
+          allow_other: false,
+        },
+        {
+          cwd,
+          argv1: '/repo/dist/cli/omx.js',
+          runner: async () => ({
+            code: 1,
+            stdout: JSON.stringify({
+              ok: false,
+              error: {
+                code: 'team_blocked',
+                message: 'omx question is unavailable while this session owns active team mode.',
+              },
+            }),
+            stderr: '',
+          }),
+        },
+      ),
+      (error) => {
+        assert.ok(error instanceof OmxQuestionError);
+        assert.equal(error.code, 'team_blocked');
+        return true;
+      },
+    );
+
+    const finalState = JSON.parse(await readFile(statePath, 'utf-8')) as {
+      question_enforcement?: {
+        status?: string;
+        clear_reason?: string;
+        cleared_at?: string;
+      };
+    };
+    assert.equal(finalState.question_enforcement?.status, 'cleared');
+    assert.equal(finalState.question_enforcement?.clear_reason, 'error');
+    assert.ok(finalState.question_enforcement?.cleared_at);
+  });
+});

--- a/src/question/__tests__/policy.test.ts
+++ b/src/question/__tests__/policy.test.ts
@@ -31,6 +31,7 @@ describe('evaluateQuestionPolicy', () => {
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-1', env: { ...process.env, OMX_TEAM_WORKER: 'demo/worker-1' } });
     assert.equal(result.allowed, false);
     assert.equal(result.code, 'worker_blocked');
+    assert.equal(result.fallbackAllowed, false);
   });
 
   it('blocks canonical active team ownership for the current session', async () => {
@@ -60,6 +61,7 @@ describe('evaluateQuestionPolicy', () => {
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-team', env: { ...process.env, OMX_TEAM_WORKER: '' } });
     assert.equal(result.allowed, false);
     assert.equal(result.code, 'team_blocked');
+    assert.equal(result.fallbackAllowed, false);
   });
 
   it('blocks active execution-like workflows for the current session', async () => {
@@ -70,6 +72,7 @@ describe('evaluateQuestionPolicy', () => {
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-ralph', env: { ...process.env, OMX_TEAM_WORKER: '' } });
     assert.equal(result.allowed, false);
     assert.equal(result.code, 'active_execution_mode_blocked');
+    assert.equal(result.fallbackAllowed, false);
   });
 
   it('does not falsely block from another session team state', async () => {
@@ -107,5 +110,6 @@ describe('evaluateQuestionPolicy', () => {
     await writeFile(join(sessionDir, 'deep-interview-state.json'), JSON.stringify({ mode: 'deep-interview', active: true }));
     const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-di', env: { ...process.env, OMX_TEAM_WORKER: '' } });
     assert.equal(result.allowed, true);
+    assert.equal(result.fallbackAllowed, true);
   });
 });

--- a/src/question/__tests__/policy.test.ts
+++ b/src/question/__tests__/policy.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import { evaluateQuestionPolicy } from '../policy.js';
+
+const tempDirs: string[] = [];
+
+async function makeRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-question-policy-'));
+  tempDirs.push(cwd);
+  await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+  return cwd;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => import('node:fs/promises').then(({ rm }) => rm(dir, { recursive: true, force: true }))));
+});
+
+describe('evaluateQuestionPolicy', () => {
+  it('allows non-team leader sessions with no blocked modes', async () => {
+    const cwd = await makeRepo();
+    await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-1' }));
+    const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-1', env: { ...process.env, OMX_TEAM_WORKER: '' } });
+    assert.equal(result.allowed, true);
+  });
+
+  it('blocks worker contexts immediately', async () => {
+    const cwd = await makeRepo();
+    const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-1', env: { ...process.env, OMX_TEAM_WORKER: 'demo/worker-1' } });
+    assert.equal(result.allowed, false);
+    assert.equal(result.code, 'worker_blocked');
+  });
+
+  it('blocks canonical active team ownership for the current session', async () => {
+    const cwd = await makeRepo();
+    const teamRoot = join(cwd, '.omx', 'state', 'team', 'alpha');
+    await mkdir(teamRoot, { recursive: true });
+    await writeFile(join(teamRoot, 'manifest.v2.json'), JSON.stringify({
+      schema_version: 2,
+      name: 'alpha',
+      task: 'demo',
+      leader: { session_id: 'sess-team', worker_id: 'leader-fixed', role: 'coordinator' },
+      policy: { display_mode: 'auto', worker_launch_mode: 'interactive', dispatch_mode: 'hook_preferred_with_fallback', dispatch_ack_timeout_ms: 2000 },
+      governance: { approvals: 'leader', merge_strategy: 'sequential' },
+      lifecycle_profile: 'default',
+      permissions_snapshot: { sandbox_mode: 'workspace-write', approval_policy: 'never' },
+      tmux_session: 'alpha:0',
+      worker_count: 1,
+      workers: [],
+      next_task_id: 1,
+      created_at: new Date().toISOString(),
+      leader_pane_id: null,
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+    }));
+    await writeFile(join(teamRoot, 'phase.json'), JSON.stringify({ current_phase: 'team-exec', max_fix_attempts: 3, current_fix_attempt: 0, transitions: [], updated_at: new Date().toISOString() }));
+    const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-team', env: { ...process.env, OMX_TEAM_WORKER: '' } });
+    assert.equal(result.allowed, false);
+    assert.equal(result.code, 'team_blocked');
+  });
+
+  it('blocks active execution-like workflows for the current session', async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-ralph');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({ mode: 'ralph', active: true }));
+    const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-ralph', env: { ...process.env, OMX_TEAM_WORKER: '' } });
+    assert.equal(result.allowed, false);
+    assert.equal(result.code, 'active_execution_mode_blocked');
+  });
+
+  it('does not falsely block from another session team state', async () => {
+    const cwd = await makeRepo();
+    const teamRoot = join(cwd, '.omx', 'state', 'team', 'beta');
+    await mkdir(teamRoot, { recursive: true });
+    await writeFile(join(teamRoot, 'manifest.v2.json'), JSON.stringify({
+      schema_version: 2,
+      name: 'beta',
+      task: 'demo',
+      leader: { session_id: 'sess-other', worker_id: 'leader-fixed', role: 'coordinator' },
+      policy: { display_mode: 'auto', worker_launch_mode: 'interactive', dispatch_mode: 'hook_preferred_with_fallback', dispatch_ack_timeout_ms: 2000 },
+      governance: { approvals: 'leader', merge_strategy: 'sequential' },
+      lifecycle_profile: 'default',
+      permissions_snapshot: { sandbox_mode: 'workspace-write', approval_policy: 'never' },
+      tmux_session: 'beta:0',
+      worker_count: 1,
+      workers: [],
+      next_task_id: 1,
+      created_at: new Date().toISOString(),
+      leader_pane_id: null,
+      hud_pane_id: null,
+      resize_hook_name: null,
+      resize_hook_target: null,
+    }));
+    await writeFile(join(teamRoot, 'phase.json'), JSON.stringify({ current_phase: 'team-exec', max_fix_attempts: 3, current_fix_attempt: 0, transitions: [], updated_at: new Date().toISOString() }));
+    const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-main', env: { ...process.env, OMX_TEAM_WORKER: '' } });
+    assert.equal(result.allowed, true);
+  });
+
+  it('allows deep-interview state when no execution-like workflow is active', async () => {
+    const cwd = await makeRepo();
+    const sessionDir = join(cwd, '.omx', 'state', 'sessions', 'sess-di');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, 'deep-interview-state.json'), JSON.stringify({ mode: 'deep-interview', active: true }));
+    const result = await evaluateQuestionPolicy({ cwd, explicitSessionId: 'sess-di', env: { ...process.env, OMX_TEAM_WORKER: '' } });
+    assert.equal(result.allowed, true);
+  });
+});

--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  formatQuestionAnswerForInjection,
+  injectQuestionAnswerToPane,
+  launchQuestionRenderer,
+  resolveQuestionRendererStrategy,
+} from '../renderer.js';
+
+describe('resolveQuestionRendererStrategy', () => {
+  it('prefers inside-tmux when TMUX is present', () => {
+    assert.equal(
+      resolveQuestionRendererStrategy({ TMUX: '/tmp/tmux-demo' } as NodeJS.ProcessEnv, '/usr/bin/tmux'),
+      'inside-tmux',
+    );
+  });
+
+  it('falls back to detached-tmux when tmux exists but TMUX is absent', () => {
+    assert.equal(
+      resolveQuestionRendererStrategy({} as NodeJS.ProcessEnv, '/usr/bin/tmux'),
+      'detached-tmux',
+    );
+  });
+
+  it('uses noop test renderer override when requested', () => {
+    assert.equal(
+      resolveQuestionRendererStrategy({ OMX_QUESTION_TEST_RENDERER: 'noop' } as NodeJS.ProcessEnv, '/usr/bin/tmux'),
+      'test-noop',
+    );
+  });
+});
+
+describe('launchQuestionRenderer', () => {
+  it('opens an interactive foreground split when already inside tmux', () => {
+    const calls: string[][] = [];
+    const result = launchQuestionRenderer(
+      {
+        cwd: '/repo',
+        recordPath: '/repo/.omx/state/sessions/s1/questions/question-1.json',
+        sessionId: 's1',
+        nowIso: '2026-04-19T00:00:00.000Z',
+        env: { TMUX: '/tmp/tmux-demo', TMUX_PANE: '%11' } as NodeJS.ProcessEnv,
+      },
+      {
+        strategy: 'inside-tmux',
+        execTmux: (args) => {
+          calls.push(args);
+          return '%42\n';
+        },
+      },
+    );
+
+    assert.equal(result.renderer, 'tmux-pane');
+    assert.equal(result.target, '%42');
+    assert.equal(result.return_target, '%11');
+    assert.equal(result.return_transport, 'tmux-send-keys');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.[0], 'split-window');
+    assert.ok(!calls[0]?.includes('-d'));
+  });
+
+  it('uses detached sessions outside tmux', () => {
+    const calls: string[][] = [];
+    const result = launchQuestionRenderer(
+      {
+        cwd: '/repo',
+        recordPath: '/repo/.omx/state/sessions/s1/questions/question-2.json',
+        nowIso: '2026-04-19T00:00:00.000Z',
+      },
+      {
+        strategy: 'detached-tmux',
+        execTmux: (args) => {
+          calls.push(args);
+          return 'omx-question-question-2\n';
+        },
+      },
+    );
+
+    assert.equal(result.renderer, 'tmux-session');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.[0], 'new-session');
+    assert.ok(calls[0]?.includes('-d'));
+  });
+});
+
+describe('question answer injection', () => {
+  it('formats other answers into a single-line continuation-safe prompt', () => {
+    assert.equal(
+      formatQuestionAnswerForInjection({
+        kind: 'other',
+        value: 'hello\nworld',
+        selected_labels: ['Other'],
+        selected_values: ['hello\nworld'],
+        other_text: 'hello\nworld',
+      }),
+      '[omx question answered] hello world',
+    );
+  });
+
+  it('injects the answered text back into the requester pane and submits separately', () => {
+    const calls: string[][] = [];
+    const ok = injectQuestionAnswerToPane(
+      '%11',
+      {
+        kind: 'option',
+        value: 'proceed',
+        selected_labels: ['Proceed'],
+        selected_values: ['proceed'],
+      },
+      (args) => {
+        calls.push(args);
+        return '';
+      },
+    );
+
+    assert.equal(ok, true);
+    assert.deepEqual(calls, [
+      ['send-keys', '-t', '%11', '-l', '--', '[omx question answered] proceed'],
+      ['send-keys', '-t', '%11', 'Enter'],
+      ['send-keys', '-t', '%11', 'Enter'],
+      ['send-keys', '-t', '%11', 'Enter'],
+    ]);
+  });
+});

--- a/src/question/__tests__/state.test.ts
+++ b/src/question/__tests__/state.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import {
+  createQuestionRecord,
+  getQuestionRecordPath,
+  markQuestionAnswered,
+  readQuestionRecord,
+  waitForQuestionTerminalState,
+} from '../state.js';
+
+const tempDirs: string[] = [];
+
+async function makeRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-question-state-'));
+  tempDirs.push(cwd);
+  return cwd;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('question state', () => {
+  it('creates records under session-scoped question state and reads them back', async () => {
+    const cwd = await makeRepo();
+    const { record, recordPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-1');
+
+    assert.equal(recordPath, getQuestionRecordPath(cwd, record.question_id, 'sess-1'));
+    const loaded = await readQuestionRecord(recordPath);
+    assert.equal(loaded?.question, 'Pick one');
+    assert.equal(loaded?.type, 'single-answerable');
+  });
+
+  it('waits for terminal answered state and returns free-text other values exactly', async () => {
+    const cwd = await makeRepo();
+    const { recordPath } = await createQuestionRecord(cwd, {
+      question: 'Pick one',
+      options: [{ label: 'A', value: 'a' }],
+      allow_other: true,
+      other_label: 'Other',
+      multi_select: false,
+    }, 'sess-2');
+
+    const waiter = waitForQuestionTerminalState(recordPath, { pollIntervalMs: 10, timeoutMs: 2000 });
+    setTimeout(() => {
+      void markQuestionAnswered(recordPath, {
+        kind: 'other',
+        value: 'custom text',
+        selected_labels: ['Other'],
+        selected_values: ['custom text'],
+        other_text: 'custom text',
+      });
+    }, 50);
+
+    const finalRecord = await waiter;
+    assert.equal(finalRecord.answer?.value, 'custom text');
+    assert.equal(finalRecord.status, 'answered');
+  });
+});

--- a/src/question/__tests__/types.test.ts
+++ b/src/question/__tests__/types.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { normalizeQuestionInput } from '../types.js';
+
+describe('normalizeQuestionInput', () => {
+  it('allows free-text-only prompts when allow_other is true', () => {
+    const result = normalizeQuestionInput({
+      question: 'Describe the desired evaluator command',
+      options: [],
+      allow_other: true,
+      source: 'deep-interview',
+    });
+
+    assert.equal(result.question, 'Describe the desired evaluator command');
+    assert.deepEqual(result.options, []);
+    assert.equal(result.allow_other, true);
+    assert.equal(result.type, 'single-answerable');
+  });
+
+  it('normalizes explicit multi-answerable type', () => {
+    const result = normalizeQuestionInput({
+      question: 'Pick one or more',
+      options: ['A', 'B'],
+      allow_other: false,
+      type: 'multi-answerable',
+    });
+
+    assert.equal(result.type, 'multi-answerable');
+    assert.equal(result.multi_select, true);
+  });
+
+  it('keeps legacy multi_select compatibility', () => {
+    const result = normalizeQuestionInput({
+      question: 'Pick one or more',
+      options: ['A', 'B'],
+      allow_other: false,
+      multi_select: true,
+    });
+
+    assert.equal(result.type, 'multi-answerable');
+    assert.equal(result.multi_select, true);
+  });
+
+  it('rejects conflicting explicit single-answerable type', () => {
+    assert.throws(
+      () => normalizeQuestionInput({ question: 'Pick one', options: ['A'], allow_other: false, type: 'single-answerable', multi_select: true }),
+      /type=single-answerable conflicts with multi_select=true/,
+    );
+  });
+
+  it('rejects empty options when allow_other is false', () => {
+    assert.throws(
+      () => normalizeQuestionInput({ question: 'Pick one', options: [], allow_other: false }),
+      /options must be a non-empty array unless allow_other is true/,
+    );
+  });
+});

--- a/src/question/__tests__/ui.test.ts
+++ b/src/question/__tests__/ui.test.ts
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { describe, it } from 'node:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createQuestionRecord, markQuestionPrompting, readQuestionRecord } from '../state.js';
+import { formatQuestionAnswerForInjection } from '../renderer.js';
+import {
+  applyInteractiveSelectionKey,
+  createInitialInteractiveSelectionState,
+  promptForSelectionsWithArrows,
+  renderInteractiveQuestionFrame,
+  runQuestionUi,
+} from '../ui.js';
+import type { QuestionRecord } from '../types.js';
+
+class FakeTtyInput extends EventEmitter {
+  isTTY = true;
+  rawMode = false;
+
+  setRawMode(mode: boolean): void {
+    this.rawMode = mode;
+  }
+
+  resume(): void {}
+  pause(): void {}
+}
+
+class FakeTtyOutput {
+  isTTY = true;
+  chunks: string[] = [];
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+    return true;
+  }
+
+  toString(): string {
+    return this.chunks.join('');
+  }
+}
+
+function makeRecord(overrides: Partial<QuestionRecord> = {}): QuestionRecord {
+  return {
+    kind: 'omx.question/v1',
+    question_id: 'question-1',
+    created_at: '2026-04-19T00:00:00.000Z',
+    updated_at: '2026-04-19T00:00:00.000Z',
+    status: 'prompting',
+    question: 'Pick one',
+    options: [
+      { label: 'Alpha', value: 'alpha' },
+      { label: 'Beta', value: 'beta' },
+    ],
+    allow_other: true,
+    other_label: 'Other',
+    multi_select: false,
+    type: 'single-answerable',
+    ...overrides,
+  };
+}
+
+describe('question ui injection metadata', () => {
+  it('persists return-target metadata for answered questions', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-'));
+    try {
+      const { recordPath } = await createQuestionRecord(cwd, {
+        question: 'Pick one',
+        options: [{ label: 'A', value: 'a' }],
+        allow_other: true,
+        other_label: 'Other',
+        multi_select: false,
+        type: 'single-answerable',
+      }, 'sess-ui');
+
+      await markQuestionPrompting(recordPath, {
+        renderer: 'tmux-pane',
+        target: '%42',
+        launched_at: '2026-04-19T00:00:00.000Z',
+        return_target: '%11',
+        return_transport: 'tmux-send-keys',
+      });
+
+      const loaded = await readQuestionRecord(recordPath);
+      assert.equal(loaded?.renderer?.return_target, '%11');
+      assert.equal(loaded?.renderer?.return_transport, 'tmux-send-keys');
+      assert.equal(
+        formatQuestionAnswerForInjection({
+          kind: 'other',
+          value: 'hello can you hear me',
+          selected_labels: ['Other'],
+          selected_values: ['hello can you hear me'],
+          other_text: 'hello can you hear me',
+        }),
+        '[omx question answered] hello can you hear me',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('question ui arrow navigation', () => {
+  it('moves single-select cursor with up/down arrows and submits current selection on Enter', () => {
+    const record = makeRecord();
+    let state = createInitialInteractiveSelectionState();
+
+    state = applyInteractiveSelectionKey(record, state, { name: 'down' }).state;
+    assert.equal(state.cursorIndex, 1);
+
+    state = applyInteractiveSelectionKey(record, state, { name: 'down' }).state;
+    assert.equal(state.cursorIndex, 2);
+
+    state = applyInteractiveSelectionKey(record, state, { name: 'up' }).state;
+    assert.equal(state.cursorIndex, 1);
+
+    const submit = applyInteractiveSelectionKey(record, state, { name: 'enter' });
+    assert.equal(submit.submit, true);
+    assert.equal(submit.state.cursorIndex, 1);
+  });
+
+  it('toggles multi-select choices with Space and requires a choice before Enter', () => {
+    const record = makeRecord({ multi_select: true, type: 'multi-answerable', allow_other: false });
+    let state = createInitialInteractiveSelectionState();
+
+    let update = applyInteractiveSelectionKey(record, state, { name: 'enter' });
+    assert.equal(update.submit, false);
+    assert.match(update.state.error ?? '', /Select one or more options/);
+
+    state = update.state;
+    state = applyInteractiveSelectionKey(record, state, { name: 'space' }).state;
+    assert.deepEqual(state.selectedIndices, [0]);
+
+    state = applyInteractiveSelectionKey(record, state, { name: 'down' }).state;
+    state = applyInteractiveSelectionKey(record, state, { name: 'space' }).state;
+    assert.deepEqual(state.selectedIndices, [0, 1]);
+
+    update = applyInteractiveSelectionKey(record, state, { name: 'enter' });
+    assert.equal(update.submit, true);
+    assert.deepEqual(update.state.selectedIndices, [0, 1]);
+  });
+
+  it('renders navigation instructions with checkbox markers', () => {
+    const frame = renderInteractiveQuestionFrame(
+      makeRecord({ multi_select: true, type: 'multi-answerable' }),
+      {
+        cursorIndex: 1,
+        selectedIndices: [0],
+      },
+    );
+
+    assert.match(frame, /Use ↑\/↓ to move, Space to toggle, Enter to submit\./);
+    assert.match(frame, /\[x\] 1\. Alpha/);
+    assert.match(frame, /› \[ \] 2\. Beta/);
+  });
+
+  it('collects arrow-based selection in interactive mode', async () => {
+    const input = new FakeTtyInput();
+    const output = new FakeTtyOutput();
+    const promise = promptForSelectionsWithArrows(makeRecord(), { input, output });
+
+    queueMicrotask(() => {
+      input.emit('keypress', '', { name: 'down' });
+      input.emit('keypress', '', { name: 'enter' });
+    });
+
+    const selections = await promise;
+    assert.deepEqual(selections, [2]);
+    assert.equal(input.rawMode, false);
+    assert.match(output.toString(), /Use ↑\/↓ to move, Enter to select\./);
+  });
+
+  it('writes answered state from arrow-key interaction', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-question-ui-run-'));
+    try {
+      const { recordPath } = await createQuestionRecord(
+        cwd,
+        {
+          question: 'Pick one',
+          options: [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b' },
+          ],
+          allow_other: false,
+          other_label: 'Other',
+          multi_select: false,
+          type: 'single-answerable',
+        },
+        'sess-ui-run',
+      );
+
+      const input = new FakeTtyInput();
+      const output = new FakeTtyOutput();
+      const runPromise = runQuestionUi(recordPath, { input, output });
+
+      setTimeout(() => {
+        input.emit('keypress', '', { name: 'down' });
+        input.emit('keypress', '', { name: 'enter' });
+      }, 25);
+
+      await runPromise;
+      const loaded = await readQuestionRecord(recordPath);
+      assert.equal(loaded?.status, 'answered');
+      assert.equal(loaded?.answer?.kind, 'option');
+      assert.equal(loaded?.answer?.value, 'b');
+      assert.equal(loaded?.type, 'single-answerable');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/question/client.ts
+++ b/src/question/client.ts
@@ -1,0 +1,154 @@
+import { spawn } from 'node:child_process';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
+import type { QuestionAnswer, QuestionInput } from './types.js';
+
+export interface OmxQuestionSuccessPayload {
+  ok: true;
+  question_id: string;
+  session_id?: string;
+  prompt: QuestionInput;
+  answer: QuestionAnswer;
+}
+
+export interface OmxQuestionErrorPayload {
+  ok: false;
+  question_id?: string;
+  session_id?: string;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+export type OmxQuestionPayload = OmxQuestionSuccessPayload | OmxQuestionErrorPayload;
+
+export interface OmxQuestionClientOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  argv1?: string | null;
+  runner?: OmxQuestionProcessRunner;
+}
+
+export interface OmxQuestionProcessResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type OmxQuestionProcessRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+) => Promise<OmxQuestionProcessResult>;
+
+export class OmxQuestionError extends Error {
+  readonly code: string;
+  readonly payload?: OmxQuestionErrorPayload;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+
+  constructor(
+    code: string,
+    message: string,
+    options: {
+      payload?: OmxQuestionErrorPayload;
+      stdout?: string;
+      stderr?: string;
+      exitCode?: number | null;
+    } = {},
+  ) {
+    super(`${code}: ${message}`);
+    this.name = 'OmxQuestionError';
+    this.code = code;
+    this.payload = options.payload;
+    this.stdout = options.stdout ?? '';
+    this.stderr = options.stderr ?? '';
+    this.exitCode = options.exitCode ?? null;
+  }
+}
+
+export async function defaultOmxQuestionProcessRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<OmxQuestionProcessResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+function parseQuestionStdout(stdout: string, stderr: string, exitCode: number | null): OmxQuestionPayload {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new OmxQuestionError('question_no_stdout', 'omx question did not emit a JSON response on stdout.', {
+      stdout,
+      stderr,
+      exitCode,
+    });
+  }
+
+  try {
+    return JSON.parse(trimmed) as OmxQuestionPayload;
+  } catch (error) {
+    throw new OmxQuestionError(
+      'question_invalid_stdout',
+      `omx question emitted invalid JSON on stdout: ${(error as Error).message}`,
+      { stdout, stderr, exitCode },
+    );
+  }
+}
+
+export async function runOmxQuestion(
+  input: Partial<QuestionInput> & { question: string },
+  options: OmxQuestionClientOptions = {},
+): Promise<OmxQuestionSuccessPayload> {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const omxBin = resolveOmxCliEntryPath({ argv1: options.argv1, cwd, env });
+  if (!omxBin) {
+    throw new OmxQuestionError('question_cli_not_found', 'Could not resolve the omx CLI entrypoint for blocking question execution.');
+  }
+
+  const runner = options.runner ?? defaultOmxQuestionProcessRunner;
+  const result = await runner(
+    process.execPath,
+    [omxBin, 'question', '--json', '--input', JSON.stringify(input)],
+    { cwd, env },
+  );
+  const payload = parseQuestionStdout(result.stdout, result.stderr, result.code);
+
+  if (!payload.ok) {
+    throw new OmxQuestionError(payload.error.code, payload.error.message, {
+      payload,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.code,
+    });
+  }
+
+  if (result.code !== 0) {
+    throw new OmxQuestionError(
+      'question_nonzero_exit',
+      `omx question returned an answer but exited with code ${result.code}.`,
+      { stdout: result.stdout, stderr: result.stderr, exitCode: result.code },
+    );
+  }
+
+  return payload;
+}

--- a/src/question/deep-interview.ts
+++ b/src/question/deep-interview.ts
@@ -1,0 +1,180 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { getStateFilePath, readCurrentSessionId } from '../mcp/state-paths.js';
+import {
+  runOmxQuestion,
+  type OmxQuestionClientOptions,
+  type OmxQuestionSuccessPayload,
+} from './client.js';
+import type { QuestionInput } from './types.js';
+
+const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
+
+export interface DeepInterviewQuestionEnforcementState {
+  obligation_id: string;
+  source: 'omx-question';
+  status: 'pending' | 'satisfied' | 'cleared';
+  requested_at: string;
+  question_id?: string;
+  satisfied_at?: string;
+  cleared_at?: string;
+  clear_reason?: 'handoff' | 'abort' | 'error';
+}
+
+interface DeepInterviewStateRecord {
+  updated_at?: string;
+  question_enforcement?: DeepInterviewQuestionEnforcementState;
+  [key: string]: unknown;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function buildObligationId(now = new Date()): string {
+  return `deep-interview-question-${now.toISOString().replace(/[:.]/g, '-')}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+async function readDeepInterviewStateIfExists(
+  cwd: string,
+  sessionId?: string,
+): Promise<DeepInterviewStateRecord | null> {
+  const statePath = getStateFilePath(DEEP_INTERVIEW_STATE_FILE, cwd, sessionId);
+  try {
+    return JSON.parse(await readFile(statePath, 'utf-8')) as DeepInterviewStateRecord;
+  } catch {
+    return null;
+  }
+}
+
+async function writeDeepInterviewState(
+  cwd: string,
+  state: DeepInterviewStateRecord,
+  sessionId?: string,
+): Promise<void> {
+  const statePath = getStateFilePath(DEEP_INTERVIEW_STATE_FILE, cwd, sessionId);
+  await mkdir(dirname(statePath), { recursive: true });
+  await writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+export function createDeepInterviewQuestionObligation(
+  now = new Date(),
+): DeepInterviewQuestionEnforcementState {
+  return {
+    obligation_id: buildObligationId(now),
+    source: 'omx-question',
+    status: 'pending',
+    requested_at: now.toISOString(),
+  };
+}
+
+export function isPendingDeepInterviewQuestionEnforcement(
+  enforcement: Partial<DeepInterviewQuestionEnforcementState> | null | undefined,
+): enforcement is DeepInterviewQuestionEnforcementState {
+  return safeString(enforcement?.obligation_id).trim() !== ''
+    && safeString(enforcement?.status).trim().toLowerCase() === 'pending';
+}
+
+export function satisfyDeepInterviewQuestionObligation(
+  enforcement: DeepInterviewQuestionEnforcementState,
+  questionId: string,
+  now = new Date(),
+): DeepInterviewQuestionEnforcementState {
+  return {
+    ...enforcement,
+    status: 'satisfied',
+    question_id: questionId,
+    satisfied_at: now.toISOString(),
+    cleared_at: undefined,
+    clear_reason: undefined,
+  };
+}
+
+export function clearDeepInterviewQuestionObligation(
+  enforcement: DeepInterviewQuestionEnforcementState | undefined,
+  reason: 'handoff' | 'abort' | 'error',
+  now = new Date(),
+): DeepInterviewQuestionEnforcementState | undefined {
+  if (!enforcement) return undefined;
+  if (enforcement.status !== 'pending') return enforcement;
+  return {
+    ...enforcement,
+    status: 'cleared',
+    cleared_at: now.toISOString(),
+    clear_reason: reason,
+  };
+}
+
+export async function updateDeepInterviewQuestionEnforcement(
+  cwd: string,
+  sessionId: string | undefined,
+  updater: (
+    current: DeepInterviewQuestionEnforcementState | undefined,
+  ) => DeepInterviewQuestionEnforcementState | undefined,
+): Promise<DeepInterviewStateRecord | null> {
+  if (!safeString(sessionId).trim()) return null;
+  const state = await readDeepInterviewStateIfExists(cwd, sessionId);
+  if (!state) return null;
+
+  const nextEnforcement = updater(state.question_enforcement);
+  const nextState: DeepInterviewStateRecord = {
+    ...state,
+    updated_at: new Date().toISOString(),
+    ...(nextEnforcement ? { question_enforcement: nextEnforcement } : {}),
+  };
+  if (!nextEnforcement) {
+    delete nextState.question_enforcement;
+  }
+
+  await writeDeepInterviewState(cwd, nextState, sessionId);
+  return nextState;
+}
+
+export async function runDeepInterviewQuestion(
+  input: Partial<QuestionInput> & { question: string },
+  options: OmxQuestionClientOptions = {},
+): Promise<OmxQuestionSuccessPayload> {
+  const cwd = options.cwd ?? process.cwd();
+  const sessionId = safeString(input.session_id).trim() || await readCurrentSessionId(cwd);
+  const obligation = createDeepInterviewQuestionObligation();
+
+  await updateDeepInterviewQuestionEnforcement(
+    cwd,
+    sessionId,
+    () => obligation,
+  );
+
+  try {
+    const result = await runOmxQuestion(
+      {
+        ...input,
+        source: input.source ?? 'deep-interview',
+        ...(sessionId ? { session_id: sessionId } : {}),
+      },
+      options,
+    );
+
+    await updateDeepInterviewQuestionEnforcement(
+      cwd,
+      sessionId,
+      (current) => (
+        current?.obligation_id === obligation.obligation_id
+          ? satisfyDeepInterviewQuestionObligation(current, result.question_id)
+          : current
+      ),
+    );
+
+    return result;
+  } catch (error) {
+    await updateDeepInterviewQuestionEnforcement(
+      cwd,
+      sessionId,
+      (current) => (
+        current?.obligation_id === obligation.obligation_id
+          ? clearDeepInterviewQuestionObligation(current, 'error')
+          : current
+      ),
+    );
+    throw error;
+  }
+}

--- a/src/question/policy.ts
+++ b/src/question/policy.ts
@@ -1,0 +1,101 @@
+import { listNotifyCanonicalActiveTeams, type NotifyCanonicalActiveTeam } from '../scripts/notify-hook/active-team.js';
+import { readCurrentSessionId } from '../mcp/state-paths.js';
+import { listActiveSkills, readVisibleSkillActiveState } from '../state/skill-active.js';
+import { readActiveWorkflowModes } from '../state/workflow-transition.js';
+
+const BLOCKED_EXECUTION_SKILLS = new Set([
+  'autopilot',
+  'autoresearch',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
+]);
+
+export interface QuestionPolicyDecision {
+  allowed: boolean;
+  sessionId?: string;
+  code?: 'worker_blocked' | 'team_blocked' | 'active_execution_mode_blocked';
+  message?: string;
+  activeModes: string[];
+  activeSkills: string[];
+  activeTeams: NotifyCanonicalActiveTeam[];
+}
+
+export interface EvaluateQuestionPolicyOptions {
+  cwd: string;
+  explicitSessionId?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function hasWorkerContext(env: NodeJS.ProcessEnv): boolean {
+  return safeString(env.OMX_TEAM_WORKER).trim() !== '';
+}
+
+export async function evaluateQuestionPolicy(
+  options: EvaluateQuestionPolicyOptions,
+): Promise<QuestionPolicyDecision> {
+  const env = options.env ?? process.env;
+  const sessionId = options.explicitSessionId || await readCurrentSessionId(options.cwd);
+
+  if (hasWorkerContext(env)) {
+    return {
+      allowed: false,
+      sessionId,
+      code: 'worker_blocked',
+      message: 'omx question is unavailable for OMX team workers; only non-team leader sessions may ask user questions.',
+      activeModes: [],
+      activeSkills: [],
+      activeTeams: [],
+    };
+  }
+
+  const [activeModes, skillState, activeTeams] = await Promise.all([
+    readActiveWorkflowModes(options.cwd, sessionId),
+    readVisibleSkillActiveState(options.cwd, sessionId),
+    sessionId ? listNotifyCanonicalActiveTeams(options.cwd, sessionId) : Promise.resolve([]),
+  ]);
+
+  const activeSkills = listActiveSkills(skillState ?? {}).map((entry) => entry.skill);
+
+  if (activeTeams.length > 0) {
+    const summary = activeTeams.map((team) => `${team.teamName} (${team.phase})`).join(', ');
+    return {
+      allowed: false,
+      sessionId,
+      code: 'team_blocked',
+      message: `omx question is unavailable while this session owns active team mode: ${summary}.`,
+      activeModes,
+      activeSkills,
+      activeTeams,
+    };
+  }
+
+  const blockedModes = activeModes.filter((mode) => BLOCKED_EXECUTION_SKILLS.has(mode));
+  const blockedSkills = activeSkills.filter((skill) => BLOCKED_EXECUTION_SKILLS.has(skill));
+  const blocked = [...new Set([...blockedModes, ...blockedSkills])];
+
+  if (blocked.length > 0) {
+    return {
+      allowed: false,
+      sessionId,
+      code: 'active_execution_mode_blocked',
+      message: `omx question is unavailable while auto-executing workflows are active: ${blocked.join(', ')}.`,
+      activeModes,
+      activeSkills,
+      activeTeams,
+    };
+  }
+
+  return {
+    allowed: true,
+    sessionId,
+    activeModes,
+    activeSkills,
+    activeTeams,
+  };
+}

--- a/src/question/policy.ts
+++ b/src/question/policy.ts
@@ -17,6 +17,7 @@ export interface QuestionPolicyDecision {
   sessionId?: string;
   code?: 'worker_blocked' | 'team_blocked' | 'active_execution_mode_blocked';
   message?: string;
+  fallbackAllowed?: boolean;
   activeModes: string[];
   activeSkills: string[];
   activeTeams: NotifyCanonicalActiveTeam[];
@@ -48,6 +49,7 @@ export async function evaluateQuestionPolicy(
       sessionId,
       code: 'worker_blocked',
       message: 'omx question is unavailable for OMX team workers; only non-team leader sessions may ask user questions.',
+      fallbackAllowed: false,
       activeModes: [],
       activeSkills: [],
       activeTeams: [],
@@ -69,6 +71,7 @@ export async function evaluateQuestionPolicy(
       sessionId,
       code: 'team_blocked',
       message: `omx question is unavailable while this session owns active team mode: ${summary}.`,
+      fallbackAllowed: false,
       activeModes,
       activeSkills,
       activeTeams,
@@ -85,6 +88,7 @@ export async function evaluateQuestionPolicy(
       sessionId,
       code: 'active_execution_mode_blocked',
       message: `omx question is unavailable while auto-executing workflows are active: ${blocked.join(', ')}.`,
+      fallbackAllowed: false,
       activeModes,
       activeSkills,
       activeTeams,
@@ -93,6 +97,7 @@ export async function evaluateQuestionPolicy(
 
   return {
     allowed: true,
+    fallbackAllowed: true,
     sessionId,
     activeModes,
     activeSkills,

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -1,0 +1,158 @@
+import { execFileSync } from 'node:child_process';
+import { basename } from 'node:path';
+import { parsePaneIdFromTmuxOutput, shellEscapeSingle } from '../hud/tmux.js';
+import { sanitizeReplyInput } from '../notifications/reply-listener.js';
+import { getCurrentTmuxPaneId } from '../notifications/tmux.js';
+import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
+import { resolveOmxCliEntryPath } from '../utils/paths.js';
+import type { QuestionAnswer, QuestionRendererState } from './types.js';
+
+export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'test-noop' | 'unsupported';
+
+export interface LaunchQuestionRendererOptions {
+  cwd: string;
+  recordPath: string;
+  sessionId?: string;
+  env?: NodeJS.ProcessEnv;
+  nowIso?: string;
+}
+
+export type ExecTmuxSync = (args: string[]) => string;
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function isPaneId(value: string | null | undefined): value is string {
+  return typeof value === 'string' && /^%\d+$/.test(value.trim());
+}
+
+export function resolveQuestionRendererStrategy(
+  env: NodeJS.ProcessEnv = process.env,
+  tmuxBinary = resolveTmuxBinaryForPlatform(),
+): QuestionRendererStrategy {
+  if (safeString(env.OMX_QUESTION_TEST_RENDERER).trim() === 'noop') return 'test-noop';
+  if (safeString(env.TMUX).trim() !== '') return 'inside-tmux';
+  if (tmuxBinary) return 'detached-tmux';
+  return 'unsupported';
+}
+
+function buildQuestionUiCommand(recordPath: string, sessionId?: string): string {
+  const omxBin = resolveOmxCliEntryPath() || process.argv[1];
+  if (!omxBin) throw new Error('Unable to resolve OMX CLI entry path for question UI launch.');
+  const sessionPrefix = sessionId ? `OMX_SESSION_ID=${shellEscapeSingle(sessionId)} ` : '';
+  return `${sessionPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} question --ui --state-path ${shellEscapeSingle(recordPath)}`;
+}
+
+function defaultExecTmux(args: string[]): string {
+  const tmux = resolveTmuxBinaryForPlatform();
+  if (!tmux) throw new Error('tmux is unavailable; omx question requires tmux for OMX-owned question UI rendering.');
+  return execFileSync(tmux, args, {
+    encoding: 'utf-8',
+    ...(process.platform === 'win32' ? { windowsHide: true } : {}),
+  });
+}
+
+function resolveReturnTarget(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const envPane = safeString(env.TMUX_PANE).trim();
+  if (isPaneId(envPane)) return envPane;
+  const detectedPane = getCurrentTmuxPaneId();
+  return isPaneId(detectedPane) ? detectedPane : undefined;
+}
+
+export function formatQuestionAnswerForInjection(answer: QuestionAnswer): string {
+  const prefix = '[omx question answered]';
+  if (answer.kind === 'other') {
+    return sanitizeReplyInput(`${prefix} ${answer.other_text ?? String(answer.value)}`);
+  }
+  if (answer.kind === 'multi') {
+    const raw = Array.isArray(answer.value) ? answer.value.join(', ') : String(answer.value);
+    return sanitizeReplyInput(`${prefix} ${raw}`);
+  }
+  return sanitizeReplyInput(`${prefix} ${String(answer.value)}`);
+}
+
+export function injectQuestionAnswerToPane(
+  paneId: string,
+  answer: QuestionAnswer,
+  execTmux: ExecTmuxSync = defaultExecTmux,
+): boolean {
+  if (!isPaneId(paneId)) return false;
+  const text = formatQuestionAnswerForInjection(answer);
+  if (!text) return false;
+
+  execTmux(['send-keys', '-t', paneId, '-l', '--', text]);
+  execTmux(['send-keys', '-t', paneId, 'Enter']);
+  execTmux(['send-keys', '-t', paneId, 'Enter']);
+  execTmux(['send-keys', '-t', paneId, 'Enter']);
+  return true;
+}
+
+export function launchQuestionRenderer(
+  options: LaunchQuestionRendererOptions,
+  deps: {
+    strategy?: QuestionRendererStrategy;
+    execTmux?: ExecTmuxSync;
+  } = {},
+): QuestionRendererState {
+  const strategy = deps.strategy ?? resolveQuestionRendererStrategy(options.env ?? process.env);
+  const execTmux = deps.execTmux ?? defaultExecTmux;
+  const launchedAt = options.nowIso ?? new Date().toISOString();
+  const command = buildQuestionUiCommand(options.recordPath, options.sessionId);
+
+  if (strategy === 'inside-tmux') {
+    const rawPane = execTmux([
+      'split-window',
+      '-v',
+      '-l',
+      '12',
+      '-P',
+      '-F',
+      '#{pane_id}',
+      '-c',
+      options.cwd,
+      command,
+    ]);
+    const paneId = parsePaneIdFromTmuxOutput(rawPane);
+    if (!paneId) throw new Error('Failed to create tmux split pane for omx question UI.');
+    const returnTarget = resolveReturnTarget(options.env ?? process.env);
+    return {
+      renderer: 'tmux-pane',
+      target: paneId,
+      launched_at: launchedAt,
+      ...(returnTarget ? { return_target: returnTarget, return_transport: 'tmux-send-keys' } : {}),
+    };
+  }
+
+  if (strategy === 'detached-tmux') {
+    const baseName = basename(options.recordPath, '.json').replace(/[^A-Za-z0-9_-]+/g, '-').slice(0, 32) || 'question';
+    const sessionName = `omx-question-${baseName}`;
+    const output = execTmux([
+      'new-session',
+      '-d',
+      '-P',
+      '-F',
+      '#{session_name}',
+      '-s',
+      sessionName,
+      '-c',
+      options.cwd,
+      command,
+    ]).trim();
+    return {
+      renderer: 'tmux-session',
+      target: output || sessionName,
+      launched_at: launchedAt,
+    };
+  }
+
+  if (strategy === 'test-noop') {
+    return {
+      renderer: 'tmux-session',
+      target: 'test-noop-renderer',
+      launched_at: launchedAt,
+    };
+  }
+
+  throw new Error('omx question requires tmux for OMX-owned question UI rendering in this session.');
+}

--- a/src/question/state.ts
+++ b/src/question/state.ts
@@ -1,0 +1,149 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { getStateDir } from '../mcp/state-paths.js';
+import { writeAtomic } from '../team/state.js';
+import { sleep } from '../utils/sleep.js';
+import { getNormalizedQuestionType } from './types.js';
+import type {
+  QuestionAnswer,
+  QuestionInput,
+  QuestionRecord,
+  QuestionRendererState,
+  QuestionStatus,
+} from './types.js';
+
+const QUESTION_NAMESPACE = 'questions';
+const DEFAULT_POLL_INTERVAL_MS = 100;
+
+function buildQuestionId(now = new Date()): string {
+  return `question-${now.toISOString().replace(/[:.]/g, '-')}-$${Math.random().toString(16).slice(2, 10)}`.replace('$', '');
+}
+
+export function getQuestionStateDir(cwd: string, sessionId?: string): string {
+  return join(getStateDir(cwd, sessionId), QUESTION_NAMESPACE);
+}
+
+export function getQuestionRecordPath(cwd: string, questionId: string, sessionId?: string): string {
+  return join(getQuestionStateDir(cwd, sessionId), `${questionId}.json`);
+}
+
+export async function writeQuestionRecord(recordPath: string, record: QuestionRecord): Promise<void> {
+  await mkdir(dirname(recordPath), { recursive: true });
+  await writeAtomic(recordPath, `${JSON.stringify(record, null, 2)}\n`);
+}
+
+export async function readQuestionRecord(recordPath: string): Promise<QuestionRecord | null> {
+  if (!existsSync(recordPath)) return null;
+  const parsed = JSON.parse(await readFile(recordPath, 'utf-8')) as QuestionRecord;
+  return parsed;
+}
+
+export async function createQuestionRecord(
+  cwd: string,
+  input: QuestionInput,
+  sessionId?: string,
+  now = new Date(),
+): Promise<{ recordPath: string; record: QuestionRecord }> {
+  const questionId = buildQuestionId(now);
+  const nowIso = now.toISOString();
+  const record: QuestionRecord = {
+    kind: 'omx.question/v1',
+    question_id: questionId,
+    ...(sessionId ? { session_id: sessionId } : {}),
+    created_at: nowIso,
+    updated_at: nowIso,
+    status: 'pending',
+    ...(input.header ? { header: input.header } : {}),
+    question: input.question,
+    options: input.options,
+    allow_other: input.allow_other,
+    other_label: input.other_label,
+    multi_select: input.multi_select,
+    type: getNormalizedQuestionType(input),
+    ...(input.source ? { source: input.source } : {}),
+  };
+  const recordPath = getQuestionRecordPath(cwd, questionId, sessionId);
+  await writeQuestionRecord(recordPath, record);
+  return { recordPath, record };
+}
+
+export async function updateQuestionRecord(
+  recordPath: string,
+  updater: (record: QuestionRecord) => QuestionRecord,
+): Promise<QuestionRecord> {
+  const current = await readQuestionRecord(recordPath);
+  if (!current) throw new Error(`Question record not found: ${recordPath}`);
+  const updated = updater(current);
+  await writeQuestionRecord(recordPath, updated);
+  return updated;
+}
+
+export async function markQuestionPrompting(
+  recordPath: string,
+  renderer: QuestionRendererState,
+): Promise<QuestionRecord> {
+  return updateQuestionRecord(recordPath, (record) => ({
+    ...record,
+    status: 'prompting',
+    updated_at: new Date().toISOString(),
+    renderer,
+  }));
+}
+
+export async function markQuestionAnswered(
+  recordPath: string,
+  answer: QuestionAnswer,
+): Promise<QuestionRecord> {
+  return updateQuestionRecord(recordPath, (record) => ({
+    ...record,
+    status: 'answered',
+    updated_at: new Date().toISOString(),
+    answer,
+    error: undefined,
+  }));
+}
+
+export async function markQuestionTerminalError(
+  recordPath: string,
+  status: Extract<QuestionStatus, 'aborted' | 'error'>,
+  code: string,
+  message: string,
+): Promise<QuestionRecord> {
+  return updateQuestionRecord(recordPath, (record) => ({
+    ...record,
+    status,
+    updated_at: new Date().toISOString(),
+    error: {
+      code,
+      message,
+      at: new Date().toISOString(),
+    },
+  }));
+}
+
+export function isTerminalQuestionStatus(status: QuestionStatus): boolean {
+  return status === 'answered' || status === 'aborted' || status === 'error';
+}
+
+export async function waitForQuestionTerminalState(
+  recordPath: string,
+  options: {
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+  } = {},
+): Promise<QuestionRecord> {
+  const pollIntervalMs = Math.max(10, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+  const timeoutMs = options.timeoutMs;
+  const startedAt = Date.now();
+
+  while (true) {
+    const record = await readQuestionRecord(recordPath);
+    if (!record) throw new Error(`Question record not found while waiting: ${recordPath}`);
+    if (isTerminalQuestionStatus(record.status)) return record;
+    if (typeof timeoutMs === 'number' && timeoutMs >= 0 && Date.now() - startedAt > timeoutMs) {
+      throw new Error(`Timed out waiting for question answer after ${timeoutMs}ms`);
+    }
+    await sleep(pollIntervalMs);
+  }
+}

--- a/src/question/types.ts
+++ b/src/question/types.ts
@@ -1,0 +1,154 @@
+export interface QuestionOption {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+export type QuestionType = 'single-answerable' | 'multi-answerable';
+
+export interface QuestionInput {
+  header?: string;
+  question: string;
+  options: QuestionOption[];
+  allow_other: boolean;
+  other_label: string;
+  multi_select: boolean;
+  type?: QuestionType;
+  source?: string;
+  session_id?: string;
+}
+
+export type QuestionRendererKind = 'tmux-pane' | 'tmux-session';
+
+export interface QuestionAnswer {
+  kind: 'option' | 'other' | 'multi';
+  value: string | string[];
+  selected_labels: string[];
+  selected_values: string[];
+  other_text?: string;
+}
+
+export type QuestionStatus = 'pending' | 'prompting' | 'answered' | 'aborted' | 'error';
+
+export interface QuestionRendererState {
+  renderer: QuestionRendererKind;
+  target: string;
+  launched_at: string;
+  return_target?: string;
+  return_transport?: 'tmux-send-keys';
+}
+
+export interface QuestionRecord {
+  kind: 'omx.question/v1';
+  question_id: string;
+  session_id?: string;
+  created_at: string;
+  updated_at: string;
+  status: QuestionStatus;
+  header?: string;
+  question: string;
+  options: QuestionOption[];
+  allow_other: boolean;
+  other_label: string;
+  multi_select: boolean;
+  type?: QuestionType;
+  source?: string;
+  renderer?: QuestionRendererState;
+  answer?: QuestionAnswer;
+  error?: {
+    code: string;
+    message: string;
+    at: string;
+  };
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function normalizeOption(raw: unknown, index: number): QuestionOption {
+  if (typeof raw === 'string') {
+    const label = raw.trim();
+    if (!label) throw new Error(`options[${index}] must be a non-empty string`);
+    return { label, value: label };
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`options[${index}] must be a string or object`);
+  }
+  const label = safeString((raw as Record<string, unknown>).label).trim();
+  const value = safeString((raw as Record<string, unknown>).value).trim() || label;
+  const description = safeString((raw as Record<string, unknown>).description).trim() || undefined;
+  if (!label) throw new Error(`options[${index}].label must be a non-empty string`);
+  if (!value) throw new Error(`options[${index}].value must be a non-empty string`);
+  return { label, value, ...(description ? { description } : {}) };
+}
+
+function parseQuestionType(raw: unknown): QuestionType | undefined {
+  const normalized = safeString(raw).trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === 'multi-answerable' || normalized === 'multi-select') return 'multi-answerable';
+  if (normalized === 'single-answerable' || normalized === 'single-select') return 'single-answerable';
+  throw new Error('type must be one of: single-answerable, multi-answerable');
+}
+
+export function getNormalizedQuestionType(input: {
+  type?: QuestionType;
+  multi_select?: boolean;
+}): QuestionType {
+  return input.type ?? (input.multi_select === true ? 'multi-answerable' : 'single-answerable');
+}
+
+export function isMultiAnswerableQuestion(input: {
+  type?: QuestionType;
+  multi_select?: boolean;
+}): boolean {
+  return getNormalizedQuestionType(input) === 'multi-answerable';
+}
+
+export function normalizeQuestionInput(raw: unknown): QuestionInput {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('question input must be a JSON object');
+  }
+
+  const input = raw as Record<string, unknown>;
+  const question = safeString(input.question).trim();
+  const header = safeString(input.header).trim() || undefined;
+  const source = safeString(input.source).trim() || undefined;
+  const session_id = safeString(input.session_id).trim() || undefined;
+  const other_label = safeString(input.other_label).trim() || 'Other';
+  const allow_other = input.allow_other !== false;
+  const rawMultiSelect = input.multi_select;
+  const parsedType = parseQuestionType(input.type);
+  const rawOptions = Array.isArray(input.options) ? input.options : [];
+
+  if (!question) throw new Error('question must be a non-empty string');
+  if (rawOptions.length === 0 && !allow_other) {
+    throw new Error('options must be a non-empty array unless allow_other is true');
+  }
+
+  if (parsedType === 'single-answerable' && rawMultiSelect === true) {
+    throw new Error('type=single-answerable conflicts with multi_select=true');
+  }
+  if (parsedType === 'multi-answerable' && rawMultiSelect === false) {
+    throw new Error('type=multi-answerable conflicts with multi_select=false');
+  }
+
+  const options = rawOptions.map(normalizeOption);
+  const type = getNormalizedQuestionType({
+    type: parsedType,
+    multi_select: rawMultiSelect === true,
+  });
+  const multi_select = type === 'multi-answerable';
+
+  return {
+    ...(header ? { header } : {}),
+    question,
+    options,
+    allow_other,
+    other_label,
+    multi_select,
+    type,
+    ...(source ? { source } : {}),
+    ...(session_id ? { session_id } : {}),
+  };
+}

--- a/src/question/ui.ts
+++ b/src/question/ui.ts
@@ -1,0 +1,399 @@
+import { emitKeypressEvents } from 'node:readline';
+import { createInterface as createPromptInterface } from 'node:readline/promises';
+import { stdin as defaultInput, stdout as defaultOutput } from 'node:process';
+import { injectQuestionAnswerToPane } from './renderer.js';
+import { markQuestionAnswered, markQuestionTerminalError, readQuestionRecord } from './state.js';
+import { isMultiAnswerableQuestion } from './types.js';
+import type { QuestionAnswer, QuestionRecord } from './types.js';
+
+interface QuestionUiInput {
+  isTTY?: boolean;
+  on(event: 'keypress', listener: (str: string, key: KeyLike) => void): this;
+  off(event: 'keypress', listener: (str: string, key: KeyLike) => void): this;
+  resume?(): void;
+  pause?(): void;
+  setRawMode?(mode: boolean): void;
+}
+
+interface QuestionUiOutput {
+  isTTY?: boolean;
+  write(chunk: string): boolean;
+}
+
+interface QuestionUiDeps {
+  input?: QuestionUiInput;
+  output?: QuestionUiOutput;
+}
+
+interface InteractiveSelectionState {
+  cursorIndex: number;
+  selectedIndices: number[];
+  error?: string;
+}
+
+interface SelectionUpdate {
+  state: InteractiveSelectionState;
+  submit: boolean;
+}
+
+interface KeyLike {
+  name?: string;
+  ctrl?: boolean;
+  sequence?: string;
+}
+
+function getOptionLabels(record: QuestionRecord): string[] {
+  const labels = record.options.map((option, index) => `${index + 1}. ${option.label}`);
+  if (record.allow_other) {
+    labels.push(`${record.options.length + 1}. ${record.other_label}`);
+  }
+  return labels;
+}
+
+function renderOptions(record: QuestionRecord): string[] {
+  return getOptionLabels(record).map((label) => `  [ ] ${label}`);
+}
+
+function parseSelection(raw: string, optionCount: number, multiSelect: boolean): number[] | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parts = multiSelect ? trimmed.split(',') : [trimmed];
+  const values = parts
+    .map((part) => Number.parseInt(part.trim(), 10))
+    .filter((value) => Number.isFinite(value));
+  if (values.length === 0) return null;
+  if (!multiSelect && values.length !== 1) return null;
+  if (values.some((value) => value < 1 || value > optionCount)) return null;
+  return [...new Set(values)];
+}
+
+function buildAnswer(record: QuestionRecord, selections: number[], otherText?: string): QuestionAnswer {
+  const optionCount = record.options.length;
+  const otherIndex = optionCount + 1;
+  const selectedOptions = selections
+    .filter((value) => value <= optionCount)
+    .map((value) => record.options[value - 1]);
+  const selected_labels = selectedOptions.map((option) => option.label);
+  const selected_values = selectedOptions.map((option) => option.value);
+  const includesOther = record.allow_other && selections.includes(otherIndex);
+
+  if (isMultiAnswerableQuestion(record)) {
+    const values = includesOther && otherText ? [...selected_values, otherText] : selected_values;
+    const labels = includesOther && otherText ? [...selected_labels, record.other_label] : selected_labels;
+    return {
+      kind: 'multi',
+      value: values,
+      selected_labels: labels,
+      selected_values: values,
+      ...(includesOther && otherText ? { other_text: otherText } : {}),
+    };
+  }
+
+  if (includesOther) {
+    if (!otherText) throw new Error('Other response text is required.');
+    return {
+      kind: 'other',
+      value: otherText,
+      selected_labels: [record.other_label],
+      selected_values: [otherText],
+      other_text: otherText,
+    };
+  }
+
+  const selected = selectedOptions[0];
+  if (!selected) throw new Error('No option selected.');
+  return {
+    kind: 'option',
+    value: selected.value,
+    selected_labels: [selected.label],
+    selected_values: [selected.value],
+  };
+}
+
+function maybeInjectAnswer(record: QuestionRecord, answer: QuestionAnswer): void {
+  const target = record.renderer?.return_target;
+  const transport = record.renderer?.return_transport;
+  if (!target || transport !== 'tmux-send-keys') return;
+  try {
+    injectQuestionAnswerToPane(target, answer);
+  } catch {
+    // Best-effort continuation nudge only; stdout return path remains canonical.
+  }
+}
+
+function supportsInteractiveArrowUi(input: QuestionUiInput, output: QuestionUiOutput): boolean {
+  return Boolean(input.isTTY && output.isTTY && typeof input.setRawMode === 'function');
+}
+
+function toggleSelection(selectedIndices: number[], index: number): number[] {
+  return selectedIndices.includes(index)
+    ? selectedIndices.filter((value) => value !== index)
+    : [...selectedIndices, index].sort((left, right) => left - right);
+}
+
+export function createInitialInteractiveSelectionState(): InteractiveSelectionState {
+  return {
+    cursorIndex: 0,
+    selectedIndices: [],
+  };
+}
+
+export function applyInteractiveSelectionKey(
+  record: QuestionRecord,
+  state: InteractiveSelectionState,
+  key: KeyLike,
+): SelectionUpdate {
+  const optionCount = getOptionLabels(record).length;
+  if (optionCount === 0) throw new Error('Interactive question UI requires at least one selectable option.');
+
+  const moveCursor = (delta: number): SelectionUpdate => ({
+    submit: false,
+    state: {
+      ...state,
+      cursorIndex: (state.cursorIndex + delta + optionCount) % optionCount,
+      error: undefined,
+    },
+  });
+
+  if (key.name === 'up') return moveCursor(-1);
+  if (key.name === 'down') return moveCursor(1);
+
+  if (key.sequence && /^[1-9]$/.test(key.sequence)) {
+    const explicitIndex = Number.parseInt(key.sequence, 10) - 1;
+    if (explicitIndex < optionCount) {
+      return {
+        submit: !isMultiAnswerableQuestion(record),
+        state: {
+          ...state,
+          cursorIndex: explicitIndex,
+          selectedIndices: isMultiAnswerableQuestion(record) ? toggleSelection(state.selectedIndices, explicitIndex) : state.selectedIndices,
+          error: undefined,
+        },
+      };
+    }
+  }
+
+  if (key.name === 'space') {
+    if (!isMultiAnswerableQuestion(record)) {
+      return {
+        submit: true,
+        state: {
+          ...state,
+          error: undefined,
+        },
+      };
+    }
+    return {
+      submit: false,
+      state: {
+        ...state,
+        selectedIndices: toggleSelection(state.selectedIndices, state.cursorIndex),
+        error: undefined,
+      },
+    };
+  }
+
+  if (key.name === 'return' || key.name === 'enter') {
+    if (!isMultiAnswerableQuestion(record)) {
+      return {
+        submit: true,
+        state: {
+          ...state,
+          error: undefined,
+        },
+      };
+    }
+    if (state.selectedIndices.length > 0) {
+      return {
+        submit: true,
+        state: {
+          ...state,
+          error: undefined,
+        },
+      };
+    }
+    return {
+      submit: false,
+      state: {
+        ...state,
+        error: 'Select one or more options with Space before pressing Enter.',
+      },
+    };
+  }
+
+  return { submit: false, state };
+}
+
+export function renderInteractiveQuestionFrame(
+  record: QuestionRecord,
+  state: InteractiveSelectionState,
+): string {
+  const optionLabels = getOptionLabels(record);
+  const lines: string[] = [];
+
+  if (record.header) lines.push(record.header);
+  lines.push(record.question, '');
+
+  optionLabels.forEach((label, index) => {
+    const isActive = state.cursorIndex === index;
+    const isChecked = isMultiAnswerableQuestion(record) ? state.selectedIndices.includes(index) : isActive;
+    lines.push(`${isActive ? '›' : ' '} [${isChecked ? 'x' : ' '}] ${label}`);
+  });
+
+  lines.push('');
+  lines.push(
+    isMultiAnswerableQuestion(record)
+      ? 'Use ↑/↓ to move, Space to toggle, Enter to submit.'
+      : 'Use ↑/↓ to move, Enter to select.',
+  );
+
+  if (state.error) lines.push(state.error);
+  return `${lines.join('\n')}\n`;
+}
+
+export async function promptForSelectionsWithArrows(
+  record: QuestionRecord,
+  deps: QuestionUiDeps = {},
+): Promise<number[]> {
+  const input = deps.input ?? defaultInput;
+  const output = deps.output ?? defaultOutput;
+  if (!supportsInteractiveArrowUi(input, output)) {
+    throw new Error('Interactive arrow UI requires TTY stdin/stdout with raw-mode support.');
+  }
+
+  return new Promise<number[]>((resolve, reject) => {
+    let state = createInitialInteractiveSelectionState();
+    let finished = false;
+
+    const cleanup = () => {
+      input.off('keypress', onKeypress);
+      input.setRawMode?.(false);
+      input.pause?.();
+      output.write('\u001b[?25h');
+    };
+
+    const finish = (selections: number[]) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      output.write('\n');
+      resolve(selections);
+    };
+
+    const fail = (error: Error) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      output.write('\n');
+      reject(error);
+    };
+
+    const render = () => {
+      output.write('\u001b[H\u001b[J');
+      output.write('\u001b[?25l');
+      output.write(renderInteractiveQuestionFrame(record, state));
+    };
+
+    const onKeypress = (_: string, key: KeyLike) => {
+      if (key.ctrl && key.name === 'c') {
+        fail(new Error('Question UI cancelled by user.'));
+        return;
+      }
+
+      const update = applyInteractiveSelectionKey(record, state, key);
+      state = update.state;
+      render();
+      if (!update.submit) return;
+
+      if (isMultiAnswerableQuestion(record)) {
+        finish(state.selectedIndices.map((index) => index + 1));
+        return;
+      }
+      finish([state.cursorIndex + 1]);
+    };
+
+    emitKeypressEvents(input as NodeJS.ReadableStream);
+    input.setRawMode?.(true);
+    input.resume?.();
+    input.on('keypress', onKeypress);
+    render();
+  });
+}
+
+async function promptForSelectionsWithNumbers(
+  record: QuestionRecord,
+  deps: QuestionUiDeps = {},
+): Promise<number[]> {
+  const input = deps.input ?? defaultInput;
+  const output = deps.output ?? defaultOutput;
+  const rl = createPromptInterface({ input: input as NodeJS.ReadableStream, output: output as NodeJS.WritableStream });
+  try {
+    output.write('\n');
+    if (record.header) output.write(`${record.header}\n`);
+    output.write(`${record.question}\n\n`);
+    output.write(`${renderOptions(record).join('\n')}\n\n`);
+
+    const optionCount = record.options.length + (record.allow_other ? 1 : 0);
+    const prompt = isMultiAnswerableQuestion(record)
+      ? 'Choose one or more options by number (comma-separated): '
+      : 'Choose an option by number: ';
+
+    let selections: number[] | null = null;
+    while (!selections) {
+      selections = parseSelection(await rl.question(prompt), optionCount, isMultiAnswerableQuestion(record));
+      if (!selections) output.write('Invalid selection. Please try again.\n');
+    }
+    return selections;
+  } finally {
+    rl.close();
+  }
+}
+
+async function promptForOtherText(
+  label: string,
+  deps: QuestionUiDeps = {},
+): Promise<string> {
+  const input = deps.input ?? defaultInput;
+  const output = deps.output ?? defaultOutput;
+  const rl = createPromptInterface({ input: input as NodeJS.ReadableStream, output: output as NodeJS.WritableStream });
+  try {
+    while (true) {
+      const candidate = (await rl.question(`${label}: `)).trim();
+      if (candidate) return candidate;
+      output.write('Please enter a response.\n');
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+export async function runQuestionUi(recordPath: string, deps: QuestionUiDeps = {}): Promise<void> {
+  const record = await readQuestionRecord(recordPath);
+  if (!record) throw new Error(`Question record not found: ${recordPath}`);
+
+  const input = deps.input ?? defaultInput;
+  const output = deps.output ?? defaultOutput;
+
+  try {
+    const selections = supportsInteractiveArrowUi(input, output)
+      ? await promptForSelectionsWithArrows(record, { input, output })
+      : await promptForSelectionsWithNumbers(record, { input, output });
+
+    let otherText: string | undefined;
+    if (record.allow_other && selections.includes(record.options.length + 1)) {
+      otherText = await promptForOtherText(record.other_label, { input, output });
+    }
+
+    const answer = buildAnswer(record, selections, otherText);
+    await markQuestionAnswered(recordPath, answer);
+    maybeInjectAnswer(record, answer);
+  } catch (error) {
+    await markQuestionTerminalError(
+      recordPath,
+      'error',
+      'question_ui_failed',
+      error instanceof Error ? error.message : String(error),
+    );
+    throw error;
+  }
+}

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -2970,6 +2970,247 @@ esac
     }
   });
 
+  it("blocks Stop when deep-interview has a pending omx question obligation", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-question-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-deep-interview-question"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-deep-interview-question" });
+      await writeJson(join(stateDir, "sessions", "sess-stop-deep-interview-question", "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-stop-deep-interview-question",
+        thread_id: "thread-stop-deep-interview-question",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-stop-deep-interview-question", "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        session_id: "sess-stop-deep-interview-question",
+        thread_id: "thread-stop-deep-interview-question",
+        question_enforcement: {
+          obligation_id: "obligation-1",
+          source: "omx-question",
+          status: "pending",
+          requested_at: "2026-04-19T03:20:00.000Z",
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-deep-interview-question",
+          thread_id: "thread-stop-deep-interview-question",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "Deep interview is still active (phase: intent-first) and has a pending structured question obligation; use `omx question` before stopping.",
+        stopReason: "deep_interview_question_required",
+        systemMessage:
+          "OMX deep-interview is still active (phase: intent-first) and requires a structured question via omx question before stopping.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps blocking pending deep-interview question Stop replays until the obligation changes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-question-replay-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-deep-interview-question-replay"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-deep-interview-question-replay" });
+      await writeJson(join(stateDir, "sessions", "sess-stop-deep-interview-question-replay", "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-stop-deep-interview-question-replay",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-stop-deep-interview-question-replay", "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        question_enforcement: {
+          obligation_id: "obligation-replay",
+          source: "omx-question",
+          status: "pending",
+          requested_at: "2026-04-19T03:20:00.000Z",
+        },
+      });
+
+      const payload = {
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-stop-deep-interview-question-replay",
+      };
+      const expected = {
+        decision: "block",
+        reason:
+          "Deep interview is still active (phase: intent-first) and has a pending structured question obligation; use `omx question` before stopping.",
+        stopReason: "deep_interview_question_required",
+        systemMessage:
+          "OMX deep-interview is still active (phase: intent-first) and requires a structured question via omx question before stopping.",
+      };
+
+      const first = await dispatchCodexNativeHook(payload, { cwd });
+      const replay = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+
+      assert.equal(first.omxEventName, "stop");
+      assert.deepEqual(first.outputJson, expected);
+      assert.equal(replay.omxEventName, "stop");
+      assert.deepEqual(replay.outputJson, expected);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block Stop once the deep-interview question obligation is satisfied or cleared", async () => {
+    for (const status of ["satisfied", "cleared"] as const) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-stop-deep-interview-question-${status}-`));
+      try {
+        const stateDir = join(cwd, ".omx", "state");
+        await mkdir(join(stateDir, "sessions", `sess-stop-deep-interview-question-${status}`), { recursive: true });
+        await writeJson(join(stateDir, "session.json"), { session_id: `sess-stop-deep-interview-question-${status}` });
+        await writeJson(join(stateDir, "sessions", `sess-stop-deep-interview-question-${status}`, "skill-active-state.json"), {
+          version: 1,
+          active: true,
+          skill: "deep-interview",
+          phase: "planning",
+          session_id: `sess-stop-deep-interview-question-${status}`,
+        });
+        await writeJson(join(stateDir, "sessions", `sess-stop-deep-interview-question-${status}`, "deep-interview-state.json"), {
+          active: true,
+          mode: "deep-interview",
+          current_phase: "intent-first",
+          question_enforcement: {
+            obligation_id: `obligation-${status}`,
+            source: "omx-question",
+            status,
+            requested_at: "2026-04-19T03:20:00.000Z",
+            ...(status === "satisfied"
+              ? { question_id: "question-1", satisfied_at: "2026-04-19T03:21:00.000Z" }
+              : { cleared_at: "2026-04-19T03:21:00.000Z", clear_reason: "error" }),
+          },
+        });
+
+        const result = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "Stop",
+            cwd,
+            session_id: `sess-stop-deep-interview-question-${status}`,
+          },
+          { cwd },
+        );
+
+        assert.equal(result.omxEventName, "stop");
+        assert.equal(result.outputJson, null);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("ignores pending deep-interview question obligations from another session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-question-foreign-session-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-other"), { recursive: true });
+      await mkdir(join(stateDir, "sessions", "sess-current"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-current" });
+      await writeJson(join(stateDir, "sessions", "sess-other", "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-other",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-other", "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        question_enforcement: {
+          obligation_id: "obligation-foreign",
+          source: "omx-question",
+          status: "pending",
+          requested_at: "2026-04-19T03:20:00.000Z",
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-current",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks a new same-session deep-interview question obligation even after an earlier round was satisfied", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-deep-interview-question-next-round-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "sess-stop-deep-interview-question-next-round"), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-stop-deep-interview-question-next-round" });
+      await writeJson(join(stateDir, "sessions", "sess-stop-deep-interview-question-next-round", "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-stop-deep-interview-question-next-round",
+      });
+      await writeJson(join(stateDir, "sessions", "sess-stop-deep-interview-question-next-round", "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        question_enforcement: {
+          obligation_id: "obligation-next-round",
+          source: "omx-question",
+          status: "pending",
+          requested_at: "2026-04-19T03:22:00.000Z",
+          question_id: "question-old-round",
+          satisfied_at: "2026-04-19T03:21:00.000Z",
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-deep-interview-question-next-round",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.deepEqual(result.outputJson, {
+        decision: "block",
+        reason:
+          "Deep interview is still active (phase: intent-first) and has a pending structured question obligation; use `omx question` before stopping.",
+        stopReason: "deep_interview_question_required",
+        systemMessage:
+          "OMX deep-interview is still active (phase: intent-first) and requires a structured question via omx question before stopping.",
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("ignores root skill-active fallback from a different thread when evaluating Stop", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-foreign-thread-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -55,6 +55,7 @@ import {
   promptSignature,
   type TriageStateFile,
 } from "../hooks/triage-state.js";
+import { isPendingDeepInterviewQuestionEnforcement } from "../question/deep-interview.js";
 
 type CodexHookEventName =
   | "SessionStart"
@@ -985,6 +986,51 @@ async function readStopAutoNudgePhase(
   return modePhase === "intent-first" ? "planning" : "";
 }
 
+async function buildDeepInterviewQuestionStopOutput(
+  cwd: string,
+  sessionId: string,
+  threadId: string,
+): Promise<{ output: Record<string, unknown>; obligationId: string } | null> {
+  const modeState = await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId);
+  if (!modeState || modeState.active !== true) return null;
+
+  const phase = formatPhase(modeState.current_phase, "planning");
+  if (TERMINAL_MODE_PHASES.has(phase.toLowerCase()) || phase === "completing") {
+    return null;
+  }
+
+  const canonicalState = await readVisibleSkillActiveState(cwd, sessionId);
+  if (canonicalState) {
+    const blocker = listActiveSkills(canonicalState).find((entry) => (
+      entry.skill === "deep-interview"
+      && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+    ));
+    if (!blocker) return null;
+  }
+
+  const questionEnforcement = safeObject(modeState.question_enforcement);
+  if (!isPendingDeepInterviewQuestionEnforcement(questionEnforcement)) {
+    return null;
+  }
+
+  const obligationId = safeString(questionEnforcement.obligation_id).trim();
+  if (!obligationId) return null;
+
+  const systemMessage =
+    `OMX deep-interview is still active (phase: ${phase}) and requires a structured question via omx question before stopping.`;
+
+  return {
+    obligationId,
+    output: {
+      decision: "block",
+      reason:
+        `Deep interview is still active (phase: ${phase}) and has a pending structured question obligation; use \`omx question\` before stopping.`,
+      stopReason: "deep_interview_question_required",
+      systemMessage,
+    },
+  };
+}
+
 function resolveRepeatableStopSessionId(
   payload: CodexHookPayload,
   canonicalSessionId?: string,
@@ -1423,6 +1469,22 @@ async function buildStopHookOutput(
     }
 
     if (canonicalSessionId) {
+      const deepInterviewQuestionOutput = await buildDeepInterviewQuestionStopOutput(
+        cwd,
+        canonicalSessionId,
+        threadId,
+      );
+      if (deepInterviewQuestionOutput) {
+        return await returnPersistentStopBlock(
+          payload,
+          stateDir,
+          "deep-interview-question-stop",
+          deepInterviewQuestionOutput.obligationId,
+          deepInterviewQuestionOutput.output,
+          canonicalSessionId,
+        );
+      }
+
       const canonicalTeam = await findCanonicalActiveTeamForSession(cwd, canonicalSessionId);
       if (canonicalTeam) {
         const canonicalTeamOutput = buildTeamStopOutputForPhase(

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -17,6 +17,7 @@ import {
   syncCanonicalSkillStateForMode,
 } from './skill-active.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { clearDeepInterviewQuestionObligation } from '../question/deep-interview.js';
 
 interface TransitionStateLike {
   active?: unknown;
@@ -106,6 +107,18 @@ async function completeSourceModeState(
       transition_source: source,
       transition_target_mode: destinationMode,
     };
+    if (sourceMode === 'deep-interview') {
+      const nextQuestionEnforcement = clearDeepInterviewQuestionObligation(
+        existing.question_enforcement as Parameters<typeof clearDeepInterviewQuestionObligation>[0],
+        'handoff',
+        new Date(nowIso),
+      );
+      if (nextQuestionEnforcement) {
+        nextCandidate.question_enforcement = nextQuestionEnforcement;
+      } else {
+        delete nextCandidate.question_enforcement;
+      }
+    }
     delete nextCandidate.run_outcome;
     const nextState = applyRunOutcomeContract(nextCandidate, { nowIso }).state as TransitionStateLike;
 


### PR DESCRIPTION
## Summary
- add the `omx question` blocking CLI/UI flow with persisted question records, renderer return-path injection, and client/runtime helpers
- route deep-interview/autoresearch structured questions through the OMX-owned question path and block native Stop when a required deep-interview question obligation is pending
- add canonical `single-answerable` / `multi-answerable` question typing while preserving legacy `multi_select` compatibility and arrow-key checkbox UX

## Testing
- `npm run build`
- `node --test dist/question/__tests__/types.test.js dist/question/__tests__/state.test.js dist/question/__tests__/ui.test.js dist/question/__tests__/client.test.js dist/question/__tests__/deep-interview.test.js dist/cli/__tests__/question.test.js dist/cli/__tests__/autoresearch-guided.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- live `omx question` multi-answerable UI run answered `alpha, beta, gamma`

## Notes
- A full `npm test` run was started but interrupted before completion during long team-runtime suites; the focused regressions above passed.
