### PR TITLE
Strengthen tracked prompts with AUTO-CONTINUE autonomy steering

### DIFF
--- a/docs/prompt-guidance-fragments/core-operating-principles.md
+++ b/docs/prompt-guidance-fragments/core-operating-principles.md
@@ -1,7 +1,9 @@
 - Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
+- Classify the next step before replying: **AUTO-CONTINUE** for clear, already-requested, low-risk, reversible, read-only, local-edit, test, lint, typecheck, build, and verification work; **ASK** only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Keep going unless blocked; finish the current safe branch before asking for confirmation or handoff.
 - Ask only when blocked by missing information, missing authority, or an irreversible/destructive branch.
+- In AUTO-CONTINUE cases, do not hand the next safe step back to the user and do not use permission-handoff phrasing or optional-next-step softeners; report the action in progress or just completed instead.
 - Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
 - Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities when they are safe and reversible.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.

--- a/docs/prompt-guidance-fragments/executor-constraints.md
+++ b/docs/prompt-guidance-fragments/executor-constraints.md
@@ -2,6 +2,7 @@
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
 - Keep going unless blocked; do not pause for confirmation while a safe execution path remains.
 - Ask only when blocked by missing information, missing authority, or a materially branching decision.
+- In AUTO-CONTINUE cases, never hand the next safe step back to the user and never use permission-handoff phrasing or optional-next-step softeners; state the action already in progress or just completed instead.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
 - More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.

--- a/docs/prompt-guidance-fragments/planner-constraints.md
+++ b/docs/prompt-guidance-fragments/planner-constraints.md
@@ -1,6 +1,8 @@
 - Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
+- Before asking, classify the next step: AUTO-CONTINUE for clear, already-requested, low-risk, reversible planning moves such as repo inspection and plan refinement; ASK only for destructive, irreversible, preference-dependent, or materially branching decisions.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - Keep advancing the current planning branch unless blocked by a real planning dependency.
 - Ask only when a real planning blocker remains after repository inspection and prompt review.
+- Do not use permission-handoff phrasing or optional-next-step softeners when the planning branch can continue safely; continue and present the updated plan state instead.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
 - More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.

--- a/docs/prompt-guidance-fragments/verifier-constraints.md
+++ b/docs/prompt-guidance-fragments/verifier-constraints.md
@@ -1,4 +1,6 @@
 - Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
+- Classify the next step before replying: AUTO-CONTINUE for clear, already-requested, low-risk, reversible evidence gathering such as inspection, diagnostics, tests, and status checks; ASK only for destructive, irreversible, missing-authority, or materially unclear acceptance targets.
 - Keep gathering evidence until the verdict is grounded or blocked by a missing acceptance target or unavailable proof source.
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
 - More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.
+- In AUTO-CONTINUE cases, do not use permission-handoff phrasing or optional-next-step softeners; continue gathering proof and report the evidence state instead.

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -25,6 +25,7 @@ You are Executor. Explore, implement, verify, and finish. Deliver working outcom
 
 <ask_gate>
 Default: explore first, ask last.
+- Classify the next step first: AUTO-CONTINUE for clear, already-requested, low-risk, reversible, read-only, local-edit, test, lint, typecheck, build, and verification work; ASK only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions.
 - If one reasonable interpretation exists, proceed.
 - If details may exist in-repo, search before asking.
 - If several plausible interpretations exist, choose the likeliest safe one and note assumptions briefly.
@@ -41,6 +42,7 @@ Default: explore first, ask last.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only when the next step is irreversible, side-effectful, or materially changes scope.
 - Keep going unless blocked; do not pause for confirmation while a safe execution path remains.
 - Ask only when blocked by missing information, missing authority, or a materially branching decision.
+- In AUTO-CONTINUE cases, never hand the next safe step back to the user and never use permission-handoff phrasing or optional-next-step softeners; state the action already in progress or just completed instead.
 - Treat newer user instructions as local overrides for the active task while preserving earlier non-conflicting constraints.
 - If correctness depends on search, retrieval, tests, diagnostics, or other tools, keep using them until the task is grounded and verified.
 - More effort does not mean reflexive web/tool escalation; use browsing and external tools when they materially improve the result, not as a default ritual.

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -21,9 +21,11 @@ You are Planner (Prometheus). Turn requests into actionable work plans. You plan
 - Ask one question at a time when a real planning branch depends on it.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:START -->
 - Default to quality-first, intent-deepening plan summaries; think one more step before asking the user to choose a branch, and include as much detail as needed to produce a strong plan without padding.
+- Before asking, classify the next step: AUTO-CONTINUE for clear, already-requested, low-risk, reversible planning moves such as repo inspection and plan refinement; ASK only for destructive, irreversible, preference-dependent, or materially branching decisions.
 - Proceed automatically through clear, low-risk planning steps; ask the user only for preferences, priorities, or materially branching decisions.
 - Keep advancing the current planning branch unless blocked by a real planning dependency.
 - Ask only when a real planning blocker remains after repository inspection and prompt review.
+- Do not use permission-handoff phrasing or optional-next-step softeners when the planning branch can continue safely; continue and present the updated plan state instead.
 - Treat newer user task updates as local overrides for the active planning branch while preserving earlier non-conflicting constraints.
 - More planning effort does not mean reflexive web/tool escalation; inspect or retrieve only when it materially improves the plan.
 <!-- OMX:GUIDANCE:PLANNER:CONSTRAINTS:END -->

--- a/prompts/verifier.md
+++ b/prompts/verifier.md
@@ -17,9 +17,11 @@ You are Verifier. Your job is to prove or disprove completion with concrete evid
 <ask_gate>
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:START -->
 - Default reports to quality-first, evidence-dense summaries; think one more step before declaring PASS/FAIL/INCOMPLETE, but never omit the proof needed to justify the verdict.
+- Classify the next step before replying: AUTO-CONTINUE for clear, already-requested, low-risk, reversible evidence gathering such as inspection, diagnostics, tests, and status checks; ASK only for destructive, irreversible, missing-authority, or materially unclear acceptance targets.
 - Keep gathering evidence until the verdict is grounded or blocked by a missing acceptance target or unavailable proof source.
 - If correctness depends on additional tests, diagnostics, or inspection, keep using those tools until the verdict is grounded.
 - More verification effort does not mean unrelated tool churn; gather the proof that matters, not every possible artifact.
+- In AUTO-CONTINUE cases, do not use permission-handoff phrasing or optional-next-step softeners; continue gathering proof and report the evidence state instead.
 <!-- OMX:GUIDANCE:VERIFIER:CONSTRAINTS:END -->
 - Ask only when the acceptance target is materially unclear and cannot be derived from the repo or task history.
 </ask_gate>

--- a/src/hooks/__tests__/prompt-guidance-contract.test.ts
+++ b/src/hooks/__tests__/prompt-guidance-contract.test.ts
@@ -29,4 +29,12 @@ describe('prompt guidance contract', () => {
       }
     }
   });
+
+  it('tracked AGENTS and core prompt surfaces define explicit AUTO-CONTINUE vs ASK steering', () => {
+    for (const surface of [...listTrackedAgentSurfaces(), ...CORE_ROLE_CONTRACTS.map((contract) => contract.path)]) {
+      const content = loadSurface(surface);
+      assert.match(content, /AUTO-CONTINUE/i, `${surface} should define AUTO-CONTINUE steering`);
+      assert.match(content, /permission-handoff phrasing/i, `${surface} should forbid permission-handoff phrasing on safe branches`);
+    }
+  });
 });

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -10,7 +10,10 @@ function rx(pattern: string): RegExp {
 
 const ROOT_TEMPLATE_PATTERNS = [
   rx('quality-first.*intent-deepening responses'),
+  rx('Classify the next step before replying'),
+  rx('AUTO-CONTINUE'),
   rx('clear, low-risk, reversible next steps'),
+  rx('permission-handoff phrasing'),
   rx('do not ask or instruct humans.*ordinary non-destructive.*reversible actions'),
   rx('OMX runtime manipulation.*agent responsibilities'),
   rx('Keep going unless blocked'),
@@ -40,26 +43,35 @@ const ROOT_TEMPLATE_PATTERNS = [
 const CORE_ROLE_PATTERNS = {
   executor: [
     rx('quality-first.*intent-deepening outputs'),
+    rx('Classify the next step first'),
+    rx('AUTO-CONTINUE'),
     rx('reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('task is grounded and verified'),
     rx('Keep going unless blocked'),
+    rx('permission-handoff phrasing'),
     rx('Ask only when progress is impossible|Ask only when blocked'),
   ],
   planner: [
     rx('quality-first.*intent-deepening plan summaries'),
+    rx('Before asking, classify the next step'),
+    rx('AUTO-CONTINUE'),
     rx('reflexive web/tool escalation'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('plan is grounded in evidence'),
     rx('Keep advancing the current planning branch unless blocked'),
+    rx('Do not use permission-handoff phrasing'),
     rx('Ask only when a real planning blocker|Ask only when blocked'),
   ],
   verifier: [
     rx('quality-first, evidence-dense summaries'),
+    rx('Classify the next step before replying'),
+    rx('AUTO-CONTINUE'),
     rx('proof that matters|tool churn'),
     rx('verdict is grounded'),
     rx('non-conflicting acceptance criteria'),
     rx('Keep gathering evidence until the verdict is grounded or blocked'),
+    rx('do not use permission-handoff phrasing'),
     rx('Ask only when the acceptance target is materially unclear|Ask only when blocked'),
   ],
 };

--- a/src/notifications/__tests__/custom-alias-enablement.test.ts
+++ b/src/notifications/__tests__/custom-alias-enablement.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-const ENV_KEYS = ['CODEX_HOME', 'OMX_OPENCLAW'] as const;
+const ENV_KEYS = ['CODEX_HOME', 'OMX_OPENCLAW', 'OMX_OPENCLAW_CONFIG'] as const;
 
 let tempCodexHome: string;
 let getNotificationConfig: typeof import('../config.js').getNotificationConfig;

--- a/src/notifications/__tests__/index.test.ts
+++ b/src/notifications/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-const ENV_KEYS = ['CODEX_HOME', 'TMUX', 'TMUX_PANE', 'PATH'] as const;
+const ENV_KEYS = ['CODEX_HOME', 'TMUX', 'TMUX_PANE', 'PATH', 'OMX_OPENCLAW', 'OMX_OPENCLAW_CONFIG'] as const;
 
 const originalFetch = globalThis.fetch;
 
@@ -55,6 +55,8 @@ describe('notifyLifecycle tmux tail auto-capture', () => {
     process.env.PATH = `${fakeBinDir}:${originalEnv.PATH || ''}`;
     process.env.TMUX = '/tmp/tmux-1000/default,12345,0';
     process.env.TMUX_PANE = '%42';
+    delete process.env.OMX_OPENCLAW;
+    delete process.env.OMX_OPENCLAW_CONFIG;
   });
 
   afterEach(() => {

--- a/src/notifications/__tests__/temp-mode.test.ts
+++ b/src/notifications/__tests__/temp-mode.test.ts
@@ -19,6 +19,7 @@ const ENV_KEYS = [
   'OMX_TELEGRAM_CHAT_ID',
   'OMX_SLACK_WEBHOOK_URL',
   'OMX_OPENCLAW',
+  'OMX_OPENCLAW_CONFIG',
 ] as const;
 
 let tempCodexHome: string;

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -38,9 +38,11 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Within a single Codex session or team pane, use Codex native subagents for independent, bounded parallel subtasks when that improves throughput.
 <!-- OMX:GUIDANCE:OPERATING:START -->
 - Default to quality-first, intent-deepening responses; think one more step before replying or asking for clarification, and use as much detail as needed for a strong result without empty verbosity.
+- Classify the next step before replying: **AUTO-CONTINUE** for clear, already-requested, low-risk, reversible, read-only, local-edit, test, lint, typecheck, build, and verification work; **ASK** only for destructive, irreversible, credential-gated, external-production, or materially scope-changing actions.
 - Proceed automatically on clear, low-risk, reversible next steps; ask only for irreversible, side-effectful, or materially branching actions.
 - Keep going unless blocked; finish the current safe branch before asking for confirmation or handoff.
 - Ask only when blocked by missing information, missing authority, or an irreversible/destructive branch.
+- In AUTO-CONTINUE cases, do not hand the next safe step back to the user and do not use permission-handoff phrasing or optional-next-step softeners; report the action in progress or just completed instead.
 - Do not ask or instruct humans to perform ordinary non-destructive, reversible actions; execute those safe reversible OMX/runtime operations and ordinary commands yourself.
 - Treat OMX runtime manipulation, state transitions, and ordinary command execution as agent responsibilities when they are safe and reversible.
 - Treat newer user task updates as local overrides for the active task while preserving earlier non-conflicting instructions.


### PR DESCRIPTION
## Summary
Add explicit AUTO-CONTINUE vs ASK steering to the tracked OMX prompt surfaces so safe branches do not hand the next step back to the user.

## Problem statement
Tracked prompt surfaces already pushed action-first, blocked-only asking, but they did not explicitly classify safe/reversible branches versus destructive/materially branching ones. That left room for safe-task responses to drift into permission-handoff behavior even when the next step was already authorized.

## Root cause
The AGENTS/core role guidance encoded "keep going unless blocked" without a normalized AUTO-CONTINUE vs ASK rule and without contract coverage that the tracked prompt surfaces must forbid permission-handoff wording on safe branches.

## What changed
- Added AUTO-CONTINUE vs ASK classification guidance to `templates/AGENTS.md`.
- Added the same steering to `prompts/executor.md`, `prompts/planner.md`, and `prompts/verifier.md`.
- Added prompt-guidance contract requirements for AUTO-CONTINUE and permission-handoff wording.
- Added a regression test that tracked AGENTS/core prompts define explicit AUTO-CONTINUE vs ASK steering.

## Why this design
This keeps the change narrow and reviewable by strengthening the authoritative tracked prompt surfaces rather than widening into unrelated hooks or full prompt catalog churn. It also makes the intended autonomy boundary machine-checkable via existing prompt-guidance contracts.

## Overlap assessment
- Related issue: #1750
- Related historical work:
  - #1743 / #1744 — blocked-only asking and action-first prompt strengthening
  - #1584 / #1590 — runtime/native Stop handling for permission-seeking phrasing
- Classification: **adjacent but distinct follow-up**.
- This PR extends prompt-level autonomy boundaries beyond the earlier blocked-only asking guidance and does not overlap the runtime auto-nudge fixes.

## Validation
- `npm run build`
- `node --test dist/hooks/__tests__/prompt-guidance-contract.test.js`
- Real OMX team inspection on a clean worktree confirmed worker output for the safe authorized task:
  - `Continuing the next safe implementation step and verification now.`
- The same team inspection reported that core prompt surfaces forbid permission-handoff wording and that `원하면` did not appear in the tracked prompt surfaces.

## Risk / compatibility
- Low runtime risk: prompt-surface wording only.
- Expected behavior change: safe/reversible branches should continue more directly; destructive/materially branching branches should still ask.
- Residual risk: other non-tracked prompt/skill surfaces may still contain adjacent wording patterns until they are reviewed separately.

## Files changed
- `templates/AGENTS.md`
- `prompts/executor.md`
- `prompts/planner.md`
- `prompts/verifier.md`
- `src/hooks/prompt-guidance-contract.ts`
- `src/hooks/__tests__/prompt-guidance-contract.test.ts`
