### PR TITLE
Require omx question for deep-interview rounds

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -51,7 +51,8 @@ If no flag is provided, use **Standard**.
 - Always run a preflight context intake before the first interview question
 - Reduce user effort: ask only the highest-leverage unresolved question, and never ask the user for codebase facts that can be discovered directly
 - For brownfield work, prefer evidence-backed confirmation questions such as "I found X in Y. Should this change follow that pattern?"
-- In Codex CLI, prefer `omx question` for OMX-owned structured questioning when available; otherwise use `request_user_input` when available, then fall back to concise plain-text one-question turns
+- In Codex CLI, deep-interview uses `omx question` as the required OMX-owned structured questioning path for every interview round
+- If `omx question` is unavailable in the current runtime, treat that as a blocker/error for deep-interview rather than falling back to `request_user_input` or plain-text questioning
 - Re-score ambiguity after each answer and show progress transparently
 - Do not hand off to execution while ambiguity remains above threshold unless user explicitly opts to proceed with warning
 - Do not crystallize or hand off while `Non-goals` or `Decision Boundaries` remain unresolved, even if the weighted ambiguity threshold is met
@@ -145,7 +146,7 @@ Detailed dimensions:
 `Non-goals` and `Decision Boundaries` are mandatory readiness gates. Ask about them early and keep revisiting them until they are explicit.
 
 ### 2b) Ask the question
-Use OMX-owned structured questioning via `omx question` when available (this is the preferred `AskUserQuestion` equivalent) and present:
+Use OMX-owned structured questioning via `omx question` for every interview round (this is the required `AskUserQuestion` equivalent for deep-interview) and present:
 
 ```
 Round {n} | Target: {weakest_dimension} | Ambiguity: {score}%
@@ -296,9 +297,8 @@ Present execution options after artifact generation using explicit handoff contr
 
 <Tool_Usage>
 - Use `explore` for codebase fact gathering
-- Use `omx question` as the OMX-native structured user-input tool for each interview round when available
-- If `omx question` is unavailable in the current runtime, fall back to `request_user_input` when available
-- If structured question tools are unavailable, use plain-text single-question rounds and keep the same stage order
+- Use `omx question` as the OMX-native structured user-input tool for each interview round
+- If `omx question` is unavailable in the current runtime, stop and surface that deep-interview requires the OMX question tool rather than falling back to another questioning path
 - Use `state_write` / `state_read` for resumable mode state
 - Read/write context snapshots under `.omx/context/`
 - Save transcript/spec artifacts under `.omx/interviews/` and `.omx/specs/`

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -149,11 +149,27 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /Do NOT implement directly/i);
 	});
 
-	it("documents omx question as the preferred structured questioning path", () => {
+	it("documents omx question as the required structured questioning path with no fallback", () => {
 		assert.match(deepInterviewSkill, /omx question/i);
 		assert.match(
 			deepInterviewSkill,
-			/preferred `AskUserQuestion` equivalent/i,
+			/required `AskUserQuestion` equivalent/i,
+		);
+		assert.match(
+			deepInterviewSkill,
+			/requires the OMX question tool rather than falling back to another questioning path/i,
+		);
+		assert.doesNotMatch(
+			deepInterviewSkill,
+			/prefer `omx question` when available/i,
+		);
+		assert.doesNotMatch(
+			deepInterviewSkill,
+			/else, use `request_user_input` to present concise multiple-choice options/i,
+		);
+		assert.doesNotMatch(
+			deepInterviewSkill,
+			/fall back to concise plain-text one-question turns/i,
 		);
 	});
 
@@ -230,5 +246,10 @@ describe("cross-skill and AGENTS coherence for deep-interview", () => {
 		}
 		assert.match(templateAgents, /ouroboros/i);
 		assert.match(templateAgents, /Socratic deep interview/i);
+	});
+
+	it("makes template AGENTS explicit about omx question for deep-interview", () => {
+		assert.match(templateAgents, /deep-interview is active.*`omx question`/i);
+		assert.match(templateAgents, /do not substitute `request_user_input` or ad hoc plain-text questioning/i);
 	});
 });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -662,7 +662,7 @@ describe("codex native hook dispatch", () => {
           session_id: sessionId,
           thread_id: "thread-autopilot-cont",
           turn_id: "turn-autopilot-cont",
-          prompt: "\\ keep going now",
+          prompt: "\ keep going now",
         },
         { cwd },
       );
@@ -677,6 +677,37 @@ describe("codex native hook dispatch", () => {
       assert.doesNotMatch(message, /Unsupported workflow overlap: autopilot \+ ralph\./);
       assert.doesNotMatch(message, /Prompt-side `\$ralph` activation/);
       assert.equal(existsSync(join(sessionDir, "ralph-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("clarifies that prompt-side deep-interview activation must use omx question", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-routing-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-deep-interview-msg",
+          thread_id: "thread-deep-interview-msg",
+          turn_id: "turn-deep-interview-msg",
+          prompt: "$deep-interview gather requirements",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "deep-interview");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /\$deep-interview" -> deep-interview/);
+      assert.match(message, /skill: deep-interview activated and initial state initialized at \.omx\/state\/sessions\/sess-deep-interview-msg\/deep-interview-state\.json; write subsequent updates via omx_state MCP\./);
+      assert.match(message, /Deep-interview must ask each interview round via `omx question`/);
+      assert.match(message, /do not fall back to `request_user_input` or plain-text questioning/i);
+      assert.match(message, /Stop remains blocked while a deep-interview question obligation is pending\./);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -734,6 +765,7 @@ describe("codex native hook dispatch", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
 
   it("ignores generic wrapper fields so metadata cannot trigger workflow routing or Stop blocking", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-wrapper-metadata-"));

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -542,6 +542,9 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
   const ralphPromptActivationNote = skillState?.initialized_mode === "ralph"
     ? "Prompt-side `$ralph` activation seeds Ralph workflow state only; it does not invoke `omx ralph`. Use `omx ralph --prd ...` only when you explicitly want the PRD-gated CLI startup path."
     : null;
+  const deepInterviewPromptActivationNote = skillState?.initialized_mode === "deep-interview"
+    ? "Deep-interview must ask each interview round via `omx question`; do not fall back to `request_user_input` or plain-text questioning. Stop remains blocked while a deep-interview question obligation is pending."
+    : null;
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
     if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
@@ -591,6 +594,7 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
         : null,
       promptPriorityMessage,
       initializedStateMessage,
+      deepInterviewPromptActivationNote,
       "Use the durable OMX team runtime via `omx team ...` for coordinated execution; do not replace it with in-process fanout.",
       "If you need runtime syntax, run `omx team --help` yourself.",
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
@@ -606,6 +610,7 @@ function buildAdditionalContextMessage(prompt: string, skillState?: SkillActiveS
         : null,
       promptPriorityMessage,
       `skill: ${skillState.initialized_mode} activated and initial state initialized at ${skillState.initialized_state_path}; write subsequent updates via omx_state MCP.`,
+      deepInterviewPromptActivationNote,
       ralphPromptActivationNote,
       "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules.",
     ].join(" ");

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -231,6 +231,7 @@ Runtime availability gate:
 - Treat `autopilot`, `ralph`, `ultrawork`, `ultraqa`, `team`/`swarm`, and `ecomode` as **OMX runtime workflows**, not generic prompt aliases.
 - Auto-activate runtime workflows only when the current session is actually running under OMX CLI/runtime (for example, launched via `omx`, with OMX session overlay/runtime state available, or when the user explicitly asks to run `omx ...` in the shell).
 - In Codex App or plain Codex sessions without OMX runtime, do **not** treat those keywords alone as activation. Explain that they require OMX CLI runtime support, and continue with the nearest App-safe surface (`deep-interview`, `ralplan`, `plan`, or native subagents) unless the user explicitly wants you to launch OMX from the shell.
+- When deep-interview is active in OMX CLI/runtime, ask interview rounds via `omx question`; do not substitute `request_user_input` or ad hoc plain-text questioning, and respect Stop-hook blocking while a deep-interview question obligation is pending.
 
 <triage_routing>
 ## Triage: advisory prompt-routing context


### PR DESCRIPTION
## Summary
- require deep-interview to use `omx question` for every interview round
- reinforce the no-fallback rule in hook guidance, template AGENTS, and contract tests
- harden question state reads against transient truncated JSON during concurrent writes

## Testing
- npm run build
- npm run lint
- npm run check:no-unused
- node --test dist/question/__tests__/state.test.js dist/cli/__tests__/question.test.js dist/hooks/__tests__/deep-interview-contract.test.js dist/question/__tests__/deep-interview.test.js dist/scripts/__tests__/codex-native-hook.test.js
- npm test
